### PR TITLE
fix(gateway): add google-gemini-cli image capability shim (fixes #91739)

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -2466,6 +2466,23 @@ describe("resolveGatewayModelSupportsImages", () => {
     ).resolves.toBe(true);
   });
 
+  test("treats google-gemini-cli Gemini models as image-capable even when catalog metadata is stale or missing", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "gemini-3.5-flash",
+        provider: "google-gemini-cli",
+        loadGatewayModelCatalog: async () => [
+          {
+            id: "gemini-3.5-flash",
+            name: "Gemini 3.5 Flash",
+            provider: "google-gemini-cli",
+            input: ["text"],
+          },
+        ],
+      }),
+    ).resolves.toBe(true);
+  });
+
   test("matches catalog model ids case-insensitively for explicit providers", async () => {
     await expect(
       resolveGatewayModelSupportsImages({

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -2466,7 +2466,7 @@ describe("resolveGatewayModelSupportsImages", () => {
     ).resolves.toBe(true);
   });
 
-  test("treats google-gemini-cli Gemini models as image-capable even when catalog metadata is stale or missing", async () => {
+  test("treats google-gemini-cli Gemini models as image-capable even when catalog metadata is stale", async () => {
     await expect(
       resolveGatewayModelSupportsImages({
         model: "gemini-3.5-flash",
@@ -2481,6 +2481,49 @@ describe("resolveGatewayModelSupportsImages", () => {
         ],
       }),
     ).resolves.toBe(true);
+  });
+
+  test("treats google-gemini-cli Gemini CLI aliases as image-capable with stale catalog metadata", async () => {
+    const aliases = ["pro", "flash", "flash-lite"];
+    for (const alias of aliases) {
+      await expect(
+        resolveGatewayModelSupportsImages({
+          model: alias,
+          provider: "google-gemini-cli",
+          loadGatewayModelCatalog: async () => [
+            {
+              id: alias,
+              name: alias,
+              provider: "google-gemini-cli",
+              input: ["text"],
+            },
+          ],
+        }),
+      ).resolves.toBe(true);
+    }
+  });
+
+  test("treats google-gemini-cli Gemini models as image-capable when model entry is missing from catalog entirely", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "gemini-3.5-flash",
+        provider: "google-gemini-cli",
+        loadGatewayModelCatalog: async () => [],
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("treats google-gemini-cli CLI aliases as image-capable when model entry is missing from catalog entirely", async () => {
+    const aliases = ["pro", "flash", "flash-lite"];
+    for (const alias of aliases) {
+      await expect(
+        resolveGatewayModelSupportsImages({
+          model: alias,
+          provider: "google-gemini-cli",
+          loadGatewayModelCatalog: async () => [],
+        }),
+      ).resolves.toBe(true);
+    }
   });
 
   test("matches catalog model ids case-insensitively for explicit providers", async () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1782,7 +1782,13 @@ export async function resolveGatewayModelSupportsImages(params: {
       }
       if (
         normalizedProvider === "google-gemini-cli" &&
-        normalizedCandidates.some((candidate) => candidate.startsWith("gemini-"))
+        normalizedCandidates.some(
+          (candidate) =>
+            candidate === "pro" ||
+            candidate === "flash" ||
+            candidate === "flash-lite" ||
+            candidate.startsWith("gemini-"),
+        )
       ) {
         return true;
       }
@@ -1802,7 +1808,13 @@ export async function resolveGatewayModelSupportsImages(params: {
     }
     if (
       normalizedProvider === "google-gemini-cli" &&
-      normalizedCandidates.some((candidate) => candidate.startsWith("gemini-"))
+      normalizedCandidates.some(
+        (candidate) =>
+          candidate === "pro" ||
+          candidate === "flash" ||
+          candidate === "flash-lite" ||
+          candidate.startsWith("gemini-"),
+      )
     ) {
       return true;
     }

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1780,6 +1780,12 @@ export async function resolveGatewayModelSupportsImages(params: {
       ) {
         return true;
       }
+      if (
+        normalizedProvider === "google-gemini-cli" &&
+        normalizedCandidates.some((candidate) => candidate.startsWith("gemini-"))
+      ) {
+        return true;
+      }
       return false;
     }
     if (
@@ -1791,6 +1797,12 @@ export async function resolveGatewayModelSupportsImages(params: {
           candidate === "haiku" ||
           candidate.startsWith("claude-"),
       )
+    ) {
+      return true;
+    }
+    if (
+      normalizedProvider === "google-gemini-cli" &&
+      normalizedCandidates.some((candidate) => candidate.startsWith("gemini-"))
     ) {
       return true;
     }


### PR DESCRIPTION
### Summary

- **Problem**: Google Gemini CLI (`google-gemini-cli`) rejects image attachments with `UnsupportedAttachmentError: active model does not accept image inputs`, even though the same Gemini model accepts images when called directly via the Gemini CLI or through the PAYG `google-aistudio` backend.
- **Root Cause**: `resolveGatewayModelSupportsImages` in `src/gateway/session-utils.ts` has hardcoded image-capability shims for `microsoft-foundry` (GPT/OpenAI models) and `claude-cli` (Claude models), but no equivalent shim for `google-gemini-cli`. When the model catalog entry lacks `image` in its `input` array, the function returns `false` for all `google-gemini-cli` models.
- **Fix**: Add a `google-gemini-cli` provider shim that recognizes Gemini-family models (`gemini-*`) and the three registered CLI aliases (`pro`, `flash`, `flash-lite`) as image-capable, following the exact same pattern as the existing `claude-cli` shim (which covers `opus`/`sonnet`/`haiku`/`claude-*`).
- **What changed**:
  - `src/gateway/session-utils.ts` — added `google-gemini-cli` image-capability shim covering `pro`/`flash`/`flash-lite`/`gemini-*` in both the with-catalog-entry path and the without-catalog-entry path
  - `src/gateway/session-utils.test.ts` — added 4 test cases: stale catalog metadata, alias coverage, missing catalog entry, and missing catalog entry with aliases
- **What did NOT change (scope boundary)**:
  - Other CLI providers (each already has its own shim or correct catalog metadata)
  - Non-Gemini Google models routed through `google-gemini-cli`
  - The model catalog itself — the shim is a runtime safety net, not a catalog data fix

### Reproduction

1. Configure a `google-gemini-cli` backend with a Gemini model (e.g. `gemini-3.5-flash`, `pro`, `flash`, or `flash-lite`)
2. Send an image attachment through the Gateway to that model
3. **Before this PR**: Gateway returns `UnsupportedAttachmentError: attachment <name>: active model does not accept image inputs` because `resolveGatewayModelSupportsImages` returns `false`
4. **After this PR**: The image is accepted and forwarded to the Gemini CLI for processing

### Real behavior proof

**Behavior or issue addressed (91739)**: `google-gemini-cli` Gemini-family models (`gemini-*`) and their registered CLI aliases (`pro`, `flash`, `flash-lite`) are now recognized as image-capable by the Gateway attachment validation path. This covers both the case where a persisted model catalog entry has stale `input: ["text"]` metadata and the case where the model entry is missing from the catalog entirely (the catalog-load or find step fails).

**Real environment tested**: Linux, Node 22 — `node scripts/run-vitest.mjs src/gateway/session-utils.test.ts` across 3 Vitest shards (gateway-core, gateway-server, gateway-client)

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/gateway/session-utils.test.ts -t "google-gemini-cli|claude-cli.*Claude|Foundry.*GPT"`

**Evidence after fix**:
```text
 ✓ resolveGatewayModelSupportsImages > keeps Foundry GPT deployments image-capable
 ✓ resolveGatewayModelSupportsImages > treats claude-cli Claude models as image-capable
 ✓ resolveGatewayModelSupportsImages > treats google-gemini-cli Gemini models as image-capable even when catalog metadata is stale
 ✓ resolveGatewayModelSupportsImages > treats google-gemini-cli Gemini CLI aliases as image-capable with stale catalog metadata
 ✓ resolveGatewayModelSupportsImages > treats google-gemini-cli Gemini models as image-capable when model entry is missing from catalog entirely
 ✓ resolveGatewayModelSupportsImages > treats google-gemini-cli CLI aliases as image-capable when model entry is missing from catalog entirely
```

All 18 matching assertions pass across 3 shards (gateway-core, gateway-server, gateway-client). The full `session-utils.test.ts` file also passes (all tests green).

**Observed result after fix**: The `resolveGatewayModelSupportsImages` function now returns `true` for all four `google-gemini-cli` identifier patterns:
- Full model IDs (`gemini-3.5-flash`, `gemini-2.5-pro`) — matched by the `gemini-*` prefix
- Registered CLI aliases (`pro`, `flash`, `flash-lite`) — matched by exact name checks, mirroring the `claude-cli` alias pattern (`opus`/`sonnet`/`haiku`)
In both scenarios tested: stale text-only catalog rows and empty/missing catalog entries. Existing shims for `microsoft-foundry` and `claude-cli` continue to work unchanged.

**What was not tested**: Live Gateway round-trip with a real Google Gemini CLI OAuth session was not driven — this headless Linux environment lacks Google OAuth credentials. The fix is validated at the capability-detection layer which gates attachment acceptance before the CLI is invoked. End-to-end image processing quality (resolution, format handling) is outside scope.

**Repro confirmation**: The four new test cases verify that:
- Before the shim, a `google-gemini-cli` model entry with `input: ["text"]` causes the function to return `false` (rejecting images); after, it returns `true`
- Before the shim, missing catalog entries also cause `false`; after, they return `true` for both full model IDs and registered aliases

### Risk / Mitigation

- **Risk**: The shim could incorrectly mark a future non-vision Gemini model as image-capable.
  **Mitigation**: The shim is bounded to `google-gemini-cli` provider only. The `pro`/`flash`/`flash-lite` aliases are the three registered Gemini CLI aliases that are backed by vision-capable Gemini models. The `gemini-` prefix covers all current Gemini-family models (Flash, Pro, Ultra) which all support image input. If a text-only variant is released, it would either use a different provider or a model name that doesn't match these patterns.
- **Risk**: The shim duplicates the same logic in two code paths (with and without catalog entry).
  **Mitigation**: This is intentional and matches the existing `claude-cli` pattern. Consistency reduces review friction.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway runtime (attachment validation / model capability detection)
- [x] Model catalog / provider capability shims

### Regression Test Plan

- `node scripts/run-vitest.mjs src/gateway/session-utils.test.ts`

### Review Findings Addressed

- **[P1] Include `pro`, `flash`, and `flash-lite` in both Google CLI shim paths** (c603e6d): Added exact alias matching alongside the `gemini-*` prefix check in both the with-catalog-entry and without-catalog-entry paths.
- **[P1] Add test for missing catalog rows**: Added two test cases — "when model entry is missing from catalog entirely" for both full model IDs and aliases, using `loadGatewayModelCatalog: async () => []`.
- **[P2] Cover Gemini CLI aliases in the image shim**: Same fix as P1 above — all three registered aliases (`pro`, `flash`, `flash-lite`) are now matched explicitly.

### Linked Issue/PR

Fixes #91739
