### PR TITLE
fix(cron): treat disabled heartbeat as queued one-shot success

### DIFF
--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -449,6 +449,40 @@ describe("CronService", () => {
     await stopCronAndCleanup(cron, store);
   });
 
+  it("deletes a queued one-shot main job when immediate heartbeat is disabled", async () => {
+    const runHeartbeatOnce = vi.fn(async () => ({
+      status: "skipped" as const,
+      reason: "disabled",
+    }));
+    const { store, cron, enqueueSystemEvent, requestHeartbeat, events } = await createCronHarness({
+      runHeartbeatOnce,
+    });
+    if (!events) {
+      throw new Error("missing event harness");
+    }
+    const job = await addMainOneShotHelloJob(cron, {
+      atMs: Date.parse("2025-12-13T00:00:02.000Z"),
+      name: "one-shot heartbeat disabled",
+    });
+
+    vi.setSystemTime(new Date("2025-12-13T00:00:02.000Z"));
+    await vi.runOnlyPendingTimersAsync();
+    const finished = await events.waitFor(
+      (evt) => evt.jobId === job.id && evt.action === "finished",
+    );
+
+    expect(runHeartbeatOnce).toHaveBeenCalledTimes(1);
+    expectMainSystemEventPosted(enqueueSystemEvent, { text: "hello", jobId: job.id });
+    expect(requestHeartbeat).not.toHaveBeenCalled();
+    expect(finished.status).toBe("ok");
+    expect(finished.error).toBeUndefined();
+
+    const jobs = await cron.list({ includeDisabled: true });
+    expect(jobs.find((j) => j.id === job.id)).toBeUndefined();
+
+    await stopCronAndCleanup(cron, store);
+  });
+
   it("runs an isolated job without posting a fallback summary to main", async () => {
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
     const { store, cron, enqueueSystemEvent, requestHeartbeat, events } =

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1517,6 +1517,9 @@ async function executeMainSessionCronJob(
       return { status: "ok", summary: text, sessionKey: cronRunSessionKey };
     }
     if (heartbeatResult.status === "skipped") {
+      if (heartbeatResult.reason === "disabled") {
+        return { status: "ok", summary: text, sessionKey: cronRunSessionKey };
+      }
       return {
         status: "skipped",
         error: heartbeatResult.reason,


### PR DESCRIPTION
## Summary
- treat a main-session one-shot cron run as successful when its system event was already queued and the immediate heartbeat returns `skipped: disabled`
- preserve existing retry/fallback behavior for busy heartbeat skips and existing skipped behavior for other non-disabled heartbeat skip reasons
- add a regression test covering the reported scheduled `at` job cleanup path

Fixes #91775.

## Real behavior proof
- **Behavior or issue addressed**: One-shot `at` cron jobs targeting the main session could enqueue their system event, receive `runHeartbeatOnce` as `skipped: disabled`, and then be recorded as a skipped disabled job instead of completing and deleting after success. This PR treats the already-queued system event as the successful cron run when the immediate heartbeat is disabled.
- **Real environment tested**: Local OpenClaw PR checkout `/Users/andy/openclaw-91775-cron-at-disabled`, branch `codex/91775-one-shot-cron-disabled`, head `14fa02bec77d08192b735c0f4a4f7c3dd3e2e`, built CLI `OpenClaw 2026.6.2 (14fa02b)`. Temp gateway only, isolated state at `/tmp/openclaw-91775-proof.1yKdY6/state`, port `19775`, channels skipped. Temp gateway was stopped after proof.
- **Exact steps or command run after this patch**:
```sh
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs src/cron/service.runs-one-shot-main-job-disables-it.test.ts
node scripts/run-vitest.mjs src/cron/service.runs-one-shot-main-job-disables-it.test.ts src/cron/service/timer.regression.test.ts src/cron/normalize.test.ts
pnpm exec oxfmt --check --threads=1 src/cron/service/timer.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed -- src/cron/service/timer.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts

git log --format='%h %an <%ae> %s' upstream/main..HEAD

OPENCLAW_STATE_DIR=/tmp/openclaw-91775-proof.1yKdY6/state \
OPENCLAW_CONFIG_PATH=/tmp/openclaw-91775-proof.1yKdY6/state/openclaw.json \
OPENCLAW_SKIP_CHANNELS=1 \
node scripts/run-node.mjs gateway run --port 19775 --auth none --bind loopback --allow-unconfigured --ws-log compact --verbose

node scripts/run-node.mjs gateway health --url ws://127.0.0.1:19775 --token <temp> --json
node scripts/run-node.mjs system heartbeat disable --url ws://127.0.0.1:19775 --token <temp> --json
node scripts/run-node.mjs cron status --url ws://127.0.0.1:19775 --token <temp> --json
node scripts/run-node.mjs cron add pr91794-proof-20260610T005858Z --at +15s --session main --system-event PR91794_PROOF_EVENT_20260610T005858Z --wake now --delete-after-run --url ws://127.0.0.1:19775 --token <temp> --json
node scripts/run-node.mjs cron runs --id 4a7028a8-1ffe-432a-8481-a855c6629c90 --limit 5 --url ws://127.0.0.1:19775 --token <temp>
node scripts/run-node.mjs cron list --all --json --url ws://127.0.0.1:19775 --token <temp>
node scripts/run-node.mjs cron get 4a7028a8-1ffe-432a-8481-a855c6629c90 --url ws://127.0.0.1:19775 --token <temp>
sqlite3 /tmp/openclaw-91775-proof.1yKdY6/state/state/openclaw.sqlite '<queries below>'
```
- **Evidence after fix**:
```text
$ node scripts/run-vitest.mjs src/cron/service.runs-one-shot-main-job-disables-it.test.ts
Test Files  1 passed (1)
Tests  13 passed (13)

$ node scripts/run-vitest.mjs src/cron/service.runs-one-shot-main-job-disables-it.test.ts src/cron/service/timer.regression.test.ts src/cron/normalize.test.ts
Test Files  3 passed (3)
Tests  111 passed (111)

$ pnpm exec oxfmt --check --threads=1 src/cron/service/timer.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts
All matched files use the correct format.

$ OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed -- src/cron/service/timer.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts
[check:changed] lanes=core, coreTests
[check:changed] completed successfully

$ git log --format='%h %an <%ae> %s' upstream/main..HEAD
14fa02bec7 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(cron): keep one-shot main jobs after disabled heartbeat
```

Live temp-gateway proof:
```json
// gateway health excerpt
{
  "ok": true,
  "defaultAgentId": "main",
  "agents": [{ "agentId": "main", "heartbeat": { "enabled": true, "every": "30m", "target": "none" }}]
}

// system heartbeat disable
{ "ok": true, "enabled": false }

// cron status before scheduling
{ "enabled": true, "storePath": "/tmp/openclaw-91775-proof.1yKdY6/state/cron/jobs.json", "jobs": 0, "nextWakeAtMs": null }

// cron add
{
  "id": "4a7028a8-1ffe-432a-8481-a855c6629c90",
  "name": "pr91794-proof-20260610T005858Z",
  "enabled": true,
  "deleteAfterRun": true,
  "schedule": { "kind": "at", "at": "2026-06-10T00:59:14.187Z" },
  "sessionTarget": "main",
  "wakeMode": "now",
  "payload": { "kind": "systemEvent", "text": "PR91794_PROOF_EVENT_20260610T005858Z" },
  "state": { "nextRunAtMs": 1781053154187 }
}

// cron runs after due time
{
  "entries": [{
    "ts": 1781053154198,
    "jobId": "4a7028a8-1ffe-432a-8481-a855c6629c90",
    "action": "finished",
    "status": "ok",
    "summary": "PR91794_PROOF_EVENT_20260610T005858Z",
    "runAtMs": 1781053154191,
    "durationMs": 5,
    "nextRunAtMs": 1781053154187,
    "deliveryStatus": "not-requested",
    "sessionKey": "agent:main:cron:4a7028a8-1ffe-432a-8481-a855c6629c90:run:1781053154191"
  }],
  "total": 1
}

// cron list --all after run
{ "jobs": [], "total": 0, "deliveryPreviews": {} }

// cron get after run
GatewayClientRequestError: cron job not found: 4a7028a8-1ffe-432a-8481-a855c6629c90
```

SQLite proof from the same temp gateway state:
```json
// cron_run_logs row
[{
  "job_id": "4a7028a8-1ffe-432a-8481-a855c6629c90",
  "seq": 1,
  "status": "ok",
  "error": null,
  "summary": "PR91794_PROOF_EVENT_20260610T005858Z",
  "delivery_status": "not-requested",
  "session_key": "agent:main:cron:4a7028a8-1ffe-432a-8481-a855c6629c90:run:1781053154191",
  "run_at_ms": 1781053154191,
  "duration_ms": 5,
  "next_run_at_ms": 1781053154187
}]

// matching cron_jobs rows after deleteAfterRun cleanup
[{ "matching_rows": 0 }]

// task_runs row showing the queued cron task/session marker
[{
  "task_id": "f5cd38bf-8abf-4da8-9ca5-f579e15b2d0c",
  "runtime": "cron",
  "source_id": "4a7028a8-1ffe-432a-8481-a855c6629c90",
  "run_id": "cron:4a7028a8-1ffe-432a-8481-a855c6629c90:1781053154191",
  "status": "succeeded",
  "delivery_status": "not_applicable",
  "child_session_key": "agent:main:cron:4a7028a8-1ffe-432a-8481-a855c6629c90:run:1781053154191",
  "label": "pr91794-proof-20260610T005858Z",
  "task": "pr91794-proof-20260610T005858Z",
  "terminal_summary": "PR91794_PROOF_EVENT_20260610T005858Z"
}]
```
- **Observed result after fix**: With heartbeats disabled in a real temp gateway, a real CLI-created main-session one-shot `at` job queued the cron task/session marker, finished with `status: "ok"`, wrote the marker to cron run history, and was removed by `deleteAfterRun` (`cron list --all` empty, `cron get` returns not found, and SQLite `cron_jobs` matching row count is 0). No skipped `disabled` zombie job remained.
- **What was not tested**: I did not run this against production OpenClaw state or live chat channels. The proof used an isolated temp gateway with channels skipped, because this bug is in cron main-session scheduling and heartbeat-disabled handoff, not provider/channel delivery.

## Tests
- `node scripts/run-vitest.mjs src/cron/service.runs-one-shot-main-job-disables-it.test.ts`
- `node scripts/run-vitest.mjs src/cron/service.runs-one-shot-main-job-disables-it.test.ts src/cron/service/timer.regression.test.ts src/cron/normalize.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/cron/service/timer.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed -- src/cron/service/timer.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts`

@clawsweeper re-review
