### PR TITLE
fix(embedded-agent-runner): treat the run's own no-op in-place session rewrite as benign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
-- **Session rewrite fencing:** accept byte-identical, same-inode session rewrites across timestamp changes while keeping changed bytes and oversized unverifiable snapshots fail-closed. (#91797) Thanks @gucasbrg.
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.
 - **Control UI workspace avatars:** inline validated agent avatar files in bootstrap and identity responses so Personal card images render without unauthenticated avatar-route requests, while preserving configured emoji precedence. (#102892, #97602) Thanks @LZY3538.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
+- **Session rewrite fencing:** accept byte-identical, same-inode session rewrites across timestamp changes while keeping changed bytes and oversized unverifiable snapshots fail-closed. (#91797) Thanks @gucasbrg.
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.
 - **Control UI workspace avatars:** inline validated agent avatar files in bootstrap and identity responses so Personal card images render without unauthenticated avatar-route requests, while preserving configured emoji precedence. (#102892, #97602) Thanks @LZY3538.

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -2016,6 +2016,36 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(2);
   });
 
+  it("allows a byte-identical in-place rewrite while the prompt lock is released", async () => {
+    const sessionFile = await createTempSessionFile();
+    const oldTime = new Date("2020-01-01T00:00:00.000Z");
+    await fs.utimes(sessionFile, oldTime, oldTime);
+    const before = await fs.stat(sessionFile, { bigint: true });
+    const originalBytes = await fs.readFile(sessionFile);
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocalIdenticalRewrite = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocalIdenticalRewrite,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await fs.writeFile(sessionFile, originalBytes);
+    const after = await fs.stat(sessionFile, { bigint: true });
+
+    expect(after.dev).toBe(before.dev);
+    expect(after.ino).toBe(before.ino);
+    expect(after.size).toBe(before.size);
+    expect(after.mtimeNs).not.toBe(before.mtimeNs);
+    expect(await fs.readFile(sessionFile)).toEqual(originalBytes);
+    await expect(controller.reacquireAfterPrompt()).resolves.toBeUndefined();
+    expect(controller.hasSessionTakeover()).toBe(false);
+    expect(acquireSessionWriteLockLocalIdenticalRewrite).toHaveBeenCalledTimes(2);
+    expect(release).toHaveBeenCalledTimes(1);
+    await controller.dispose();
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
   it("trusts owned writes after accepting ctime-only fingerprint drift", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});
@@ -2064,39 +2094,38 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(3);
   });
 
-  it("allows ctime-only fingerprint drift for large transcript snapshots", async () => {
+  it("allows metadata drift for digest-backed transcript snapshots", async () => {
     const sessionFile = await createTempSessionFile();
     await fs.writeFile(sessionFile, Buffer.alloc(8 * 1024 * 1024 + 1, "x"));
+    const oldTime = new Date("2020-01-01T00:00:00.000Z");
+    await fs.utimes(sessionFile, oldTime, oldTime);
+    const before = await fs.stat(sessionFile, { bigint: true });
     const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocalLargeCtimeDrift = vi.fn(async () => ({ release }));
+    const acquireSessionWriteLockLocalDigestDrift = vi.fn(async () => ({ release }));
     const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocalLargeCtimeDrift,
+      acquireSessionWriteLock: acquireSessionWriteLockLocalDigestDrift,
       lockOptions: { ...lockOptions, sessionFile },
     });
 
     await controller.releaseForPrompt();
+    const newTime = new Date("2021-01-01T00:00:00.000Z");
+    await fs.utimes(sessionFile, newTime, newTime);
+    const after = await fs.stat(sessionFile, { bigint: true });
 
-    const stableStat = await fs.stat(sessionFile, { bigint: true });
-    const driftedStat = cloneBigIntStatWith(stableStat, {
-      ctimeNs: stableStat.ctimeNs + 1_000_000n,
-    });
-    const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (target, options) => {
-      if (target === sessionFile && options?.bigint === true) {
-        return driftedStat;
-      }
-      throw new Error(`unexpected stat call for ${String(target)}`);
-    });
-
-    try {
-      await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
-    } finally {
-      statSpy.mockRestore();
-    }
+    expect(after.dev).toBe(before.dev);
+    expect(after.ino).toBe(before.ino);
+    expect(after.size).toBe(before.size);
+    expect(after.mtimeNs).not.toBe(before.mtimeNs);
+    await expect(controller.reacquireAfterPrompt()).resolves.toBeUndefined();
     expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
   });
 
-  it("rejects same-size transcript rewrites with restored mtime", async () => {
+  it("rejects same-inode, same-size transcript rewrites when one byte changes", async () => {
     const sessionFile = await createTempSessionFile();
+    const oldTime = new Date("2020-01-01T00:00:00.000Z");
+    await fs.utimes(sessionFile, oldTime, oldTime);
+    const before = await fs.stat(sessionFile, { bigint: true });
     const release = vi.fn(async () => {});
     const acquireSessionWriteLockLocalSameSizeRewrite = vi.fn(async () => ({ release }));
     const controller = await createEmbeddedAttemptSessionLockController({
@@ -2105,29 +2134,46 @@ describe("embedded attempt session lock lifecycle", () => {
     });
 
     await controller.releaseForPrompt();
-
-    const stableStat = await fs.stat(sessionFile, { bigint: true });
     await fs.writeFile(sessionFile, '{"type":"sessioN"}\n', "utf8");
-    const driftedStat = cloneBigIntStatWith(stableStat, {
-      ctimeNs: stableStat.ctimeNs + 1_000_000n,
-    });
-    const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (target, options) => {
-      if (target === sessionFile && options?.bigint === true) {
-        return driftedStat;
-      }
-      throw new Error(`unexpected stat call for ${String(target)}`);
-    });
+    const after = await fs.stat(sessionFile, { bigint: true });
 
-    try {
-      await expect(controller.withSessionWriteLock(() => "finalize")).rejects.toBeInstanceOf(
-        EmbeddedAttemptSessionTakeoverError,
-      );
-    } finally {
-      statSpy.mockRestore();
-    }
+    expect(after.dev).toBe(before.dev);
+    expect(after.ino).toBe(before.ino);
+    expect(after.size).toBe(before.size);
+    await expect(controller.reacquireAfterPrompt()).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
     expect(controller.hasSessionTakeover()).toBe(true);
     expect(acquireSessionWriteLockLocalSameSizeRewrite).toHaveBeenCalledTimes(2);
     expect(release).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed when a metadata-only snapshot is too large to verify", async () => {
+    const sessionFile = await createTempSessionFile();
+    await fs.truncate(sessionFile, 32 * 1024 * 1024 + 1);
+    const oldTime = new Date("2020-01-01T00:00:00.000Z");
+    await fs.utimes(sessionFile, oldTime, oldTime);
+    const before = await fs.stat(sessionFile, { bigint: true });
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocalOversizeDrift = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocalOversizeDrift,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    const newTime = new Date("2021-01-01T00:00:00.000Z");
+    await fs.utimes(sessionFile, newTime, newTime);
+    const after = await fs.stat(sessionFile, { bigint: true });
+
+    expect(after.dev).toBe(before.dev);
+    expect(after.ino).toBe(before.ino);
+    expect(after.size).toBe(before.size);
+    expect(after.mtimeNs).not.toBe(before.mtimeNs);
+    await expect(controller.reacquireAfterPrompt()).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
   });
 
   it("still rejects external edits after the prompt stream lock is reacquired", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -132,13 +132,13 @@ const MAX_BENIGN_SESSION_FENCE_ADVANCE_BYTES = 1024 * 1024;
 const MAX_BENIGN_SESSION_FENCE_REWRITE_BYTES = 8 * 1024 * 1024;
 const MAX_BENIGN_SESSION_FENCE_REWRITE_RESULT_BYTES =
   MAX_BENIGN_SESSION_FENCE_REWRITE_BYTES + MAX_BENIGN_SESSION_FENCE_ADVANCE_BYTES;
-const MAX_BENIGN_SESSION_FENCE_CTIME_DIGEST_BYTES = 32 * 1024 * 1024;
+const MAX_BENIGN_SESSION_FENCE_CONTENT_DIGEST_BYTES = 32 * 1024 * 1024;
 const MAX_SAFE_FILE_OFFSET = BigInt(Number.MAX_SAFE_INTEGER);
 
 type SessionFileFenceSnapshot = {
   fingerprint: SessionFileFingerprint;
+  bytes?: Buffer;
   digest?: string;
-  text?: string;
 };
 
 function sameSessionFileFingerprint(
@@ -167,7 +167,7 @@ function sameSessionFileIdentity(
   return Boolean(left?.exists && right.exists && left.dev === right.dev && left.ino === right.ino);
 }
 
-function sameSessionFileContentMetadata(
+function sameSessionFileIdentityAndSize(
   left: SessionFileFingerprint | undefined,
   right: SessionFileFingerprint,
 ): boolean {
@@ -176,8 +176,7 @@ function sameSessionFileContentMetadata(
     right.exists &&
     left.dev === right.dev &&
     left.ino === right.ino &&
-    left.size === right.size &&
-    left.mtimeNs === right.mtimeNs,
+    left.size === right.size,
   );
 }
 
@@ -614,13 +613,13 @@ async function readSessionFileFenceSnapshot(
     try {
       return {
         fingerprint,
-        text: await fs.readFile(sessionFile, "utf8"),
+        bytes: await fs.readFile(sessionFile),
       };
     } catch {
       return { fingerprint };
     }
   }
-  if (fingerprint.size > BigInt(MAX_BENIGN_SESSION_FENCE_CTIME_DIGEST_BYTES)) {
+  if (fingerprint.size > BigInt(MAX_BENIGN_SESSION_FENCE_CONTENT_DIGEST_BYTES)) {
     return { fingerprint };
   }
   return {
@@ -729,28 +728,30 @@ async function classifyOwnedSessionFileInitialization(params: {
     : resolvedChange;
 }
 
-async function sessionFenceCtimeDriftIsBenign(params: {
+async function sessionFenceByteIdenticalRewriteIsBenign(params: {
   sessionFile: string;
   previous: SessionFileFenceSnapshot | undefined;
   current: SessionFileFingerprint;
 }): Promise<boolean> {
+  const previous = params.previous;
   if (
-    !sameSessionFileContentMetadata(params.previous?.fingerprint, params.current) ||
-    params.previous?.fingerprint.exists !== true ||
+    previous?.fingerprint.exists !== true ||
     !params.current.exists ||
-    params.previous.fingerprint.ctimeNs === params.current.ctimeNs
+    !sameSessionFileIdentityAndSize(previous.fingerprint, params.current)
   ) {
     return false;
   }
-  if (params.previous.text === undefined) {
-    if (params.previous.digest === undefined) {
+  // Truncate-and-rewrite keeps inode and size while advancing timestamps.
+  // Only exact bytes may make that metadata-only fence drift trustworthy.
+  if (previous.bytes === undefined) {
+    if (previous.digest === undefined) {
       return false;
     }
     const currentDigest = await readSessionFileDigest(params.sessionFile);
-    return currentDigest !== undefined && currentDigest === params.previous.digest;
+    return currentDigest !== undefined && currentDigest === previous.digest;
   }
   try {
-    return (await fs.readFile(params.sessionFile, "utf8")) === params.previous.text;
+    return previous.bytes.equals(await fs.readFile(params.sessionFile));
   } catch {
     return false;
   }
@@ -766,7 +767,7 @@ async function classifySessionFenceRewrite(params: {
   if (
     !params.previous?.fingerprint.exists ||
     !params.current.exists ||
-    !params.previous.text ||
+    params.previous.bytes === undefined ||
     !sameSessionFileIdentity(params.previous.fingerprint, params.current) ||
     (!params.allowAnyMessage &&
       params.current.size > BigInt(MAX_BENIGN_SESSION_FENCE_REWRITE_RESULT_BYTES)) ||
@@ -783,7 +784,7 @@ async function classifySessionFenceRewrite(params: {
   if (!currentText.endsWith("\n")) {
     return undefined;
   }
-  const previousLines = splitSessionFileLines(params.previous.text);
+  const previousLines = splitSessionFileLines(params.previous.bytes.toString("utf8"));
   const currentLines = splitSessionFileLines(currentText);
   if (currentLines.length <= previousLines.length) {
     return undefined;
@@ -1492,7 +1493,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
 
     if (
-      await sessionFenceCtimeDriftIsBenign({
+      await sessionFenceByteIdenticalRewriteIsBenign({
         sessionFile: params.lockOptions.sessionFile,
         previous: fenceSnapshot,
         current,


### PR DESCRIPTION
## What Problem This Solves

Long streaming turns can falsely abort with `EmbeddedAttemptSessionTakeoverError` when the active session transcript is rewritten in place with identical bytes while the prompt lock is released. The file keeps the same device, inode, and size, but `mtime` and `ctime` advance, so the metadata fence changes even though session state does not.

Historical field evidence from the original contributor reproduced this on Matrix with OpenClaw 2026.6.1 and 2026.6.5: long multi-tool turns failed roughly once in three before the patch, while 15 consecutive long turns and then a full day completed without a takeover after an equivalent bundled-dist patch.

The exact current natural writer that performs the no-op rewrite remains unknown. This PR fixes the file-state invariant without hard-coding a suspected writer.

## Why This Change Was Made

The original one-character patch relaxed the equal-line-count transcript classifier. That implementation no longer applies to current main, and logical transcript migration is not the right proof of byte identity.

The rewritten fix uses the existing bounded fence snapshot owner:

- files through 8 MiB retain raw bytes and require `Buffer.equals`;
- files above 8 MiB through 32 MiB retain the existing SHA-256 digest and require digest equality;
- files above 32 MiB remain metadata-only and fail closed;
- every accepted rewrite must retain device, inode, and size;
- the logical transcript rewrite classifier and its strict non-growth guard remain unchanged.

This keeps takeover detection intact for same-size changed content while accepting only content-identical metadata drift.

## User Impact

Byte-identical in-place transcript rewrites no longer cancel an otherwise valid agent turn. Same-inode, same-size content changes still trigger takeover protection, and oversized snapshots that cannot be content-verified remain rejected.

Release-note credit: Thanks @gucasbrg.

## Evidence

Exact repaired-source proof used a fresh sanitized direct-AWS Crabbox lease with public networking, no Tailscale, no IAM role, no hydration, a temporary home, Node 24.15.0, and the trusted untrusted-source bootstrap. The final rebased head `adc4f08b39988bcf0c881364ee35dd2b8f741c5c` retains the patch-identical two-file repair from tested head `fb1be692e8183b75b7abcce274d5aa5cdd4b5b4a`; exact-head CI run `29108605564` passed on pre-rebase head `000663d0116deb83b136937d8383d5f3b9047ead`, and `scripts/pr prepare-run` accepted that recent-rebase evidence after the final wrapper sync.

- `run_dc69db532c3f`: 4/4 verbose real-Linux-filesystem boundary tests passed: exact rewrite accepted, one-byte same-inode/same-size rewrite rejected, digest-backed metadata drift accepted, and snapshots above 32 MiB rejected.
- `run_12f4672f607c`: 116/116 `attempt.session-lock.test.ts` tests passed.
- `run_2087d599a7e2`: 67/67 direct SessionManager sibling tests passed.
- `run_b79a12bb16ef`: `check:changed` passed core production and test tsgo, changed-file lint with zero findings, attribution, and selected architecture/guard checks.
- Final branch-mode Codex autoreview after main sync: clean at 0.87, no accepted/actionable findings.
- Exact-head CI run `29108605564` on pre-rebase head `000663d0116deb83b136937d8383d5f3b9047ead`: passed all selected jobs.
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 91797`: passed on the final wrapper-synced head.

Commands executed inside the sanitized Linux checkout:

```text
/usr/local/bin/pnpm test src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts -- --reporter=verbose --testNamePattern 'byte-identical|digest-backed|same-inode|metadata-only'
/usr/local/bin/pnpm test src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
/usr/local/bin/pnpm test src/agents/embedded-agent-runner/session-manager-init.test.ts src/agents/sessions/session-manager.test.ts
/usr/bin/env CI=1 OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 /usr/local/bin/pnpm check:changed
```

Historical Matrix proof was against patched released bundles, not the final current-main source head. Current-head proof therefore establishes the invariant through the real Linux filesystem/controller path rather than a fresh Matrix deployment.

Related: #91699 (broader owned-write publication work; distinct scope).
