### PR TITLE
fix(logging): release stuck session lanes after drained abort

### DIFF
--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -102,6 +102,7 @@ function resetMocks() {
   mocks.waitForEmbeddedAgentRunEnd.mockReset();
   mocks.getDiagnosticSessionActivitySnapshot.mockReset();
   mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({});
+  mocks.resetCommandLane.mockReturnValue(0);
   mocks.diag.debug.mockReset();
   mocks.diag.warn.mockReset();
 }
@@ -167,6 +168,7 @@ describe("stuck session recovery", () => {
     });
     mocks.abortEmbeddedAgentRun.mockReturnValue(true);
     mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.resetCommandLane.mockReturnValue(1);
 
     const outcome = await recoverStuckDiagnosticSession({
       sessionId: "session-1",
@@ -176,7 +178,9 @@ describe("stuck session recovery", () => {
     });
 
     expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledWith("session-1");
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:main:main");
     expect(outcome.status).toBe("aborted");
+    expect(outcome).toMatchObject({ released: 1 });
     expect(warnLogMessages().some((m) => m.includes("reclaiming stale active run"))).toBe(true);
   });
   it("aborts an active embedded run when active abort recovery is enabled", async () => {
@@ -197,10 +201,11 @@ describe("stuck session recovery", () => {
     expect(mocks.resetCommandLane).not.toHaveBeenCalled();
   });
 
-  it("returns an abort outcome for a stale tool call on an active embedded run", async () => {
+  it("releases the session lane after a clean active-run abort when diagnostic queue depth remains", async () => {
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-tool");
     mocks.abortEmbeddedAgentRun.mockReturnValue(true);
     mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.resetCommandLane.mockReturnValue(1);
 
     const outcome = await recoverStuckDiagnosticSession({
       sessionId: "session-tool",
@@ -220,11 +225,13 @@ describe("stuck session recovery", () => {
       aborted: true,
       drained: true,
       forceCleared: false,
-      released: 0,
+      released: 1,
     });
     expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledWith("session-tool");
     expect(mocks.waitForEmbeddedAgentRunEnd).toHaveBeenCalledWith("session-tool", 15_000);
-    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith(
+      "session:agent:main:telegram:group:-1003821464158:topic:4836",
+    );
   });
 
   it("logs stopped cron context when aborting an active embedded run", async () => {
@@ -367,6 +374,7 @@ describe("stuck session recovery", () => {
     mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
     mocks.abortEmbeddedAgentRun.mockReturnValue(true);
     mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.resetCommandLane.mockReturnValue(1);
 
     await recoverStuckDiagnosticSession({
       sessionId: "queued-reply-session",
@@ -379,10 +387,10 @@ describe("stuck session recovery", () => {
     expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledWith("queued-reply-session");
     expect(mocks.waitForEmbeddedAgentRunEnd).toHaveBeenCalledWith("queued-reply-session", 15_000);
     expect(mocks.forceClearEmbeddedAgentRun).not.toHaveBeenCalled();
-    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:main:main");
     expect(warnLogMessages()).toEqual([
-      "stuck session recovery: sessionId=queued-reply-session sessionKey=agent:main:main age=720s action=abort_embedded_run aborted=true drained=true released=0",
-      "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=true drained=true forceCleared=false released=0",
+      "stuck session recovery: sessionId=queued-reply-session sessionKey=agent:main:main age=720s action=abort_embedded_run aborted=true drained=true released=1",
+      "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=true drained=true forceCleared=false released=1",
     ]);
   });
 

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -246,8 +246,10 @@ export async function recoverStuckDiagnosticSession(
     }
 
     const queuedCount = sessionLane ? getCommandLaneSnapshot(sessionLane).queuedCount : 0;
+    const queuedDiagnosticSessionWork = (params.queueDepth ?? 0) > 0;
     const released =
-      sessionLane && (queuedCount > 0 || !activeSessionId || !aborted || !drained)
+      sessionLane &&
+      (queuedCount > 0 || queuedDiagnosticSessionWork || !activeSessionId || !aborted || !drained)
         ? resetCommandLane(sessionLane)
         : 0;
 


### PR DESCRIPTION
Fixes #91700.

## Summary

Stuck-session recovery now resets the session lane when an active embedded/reply run aborts and drains cleanly but the diagnostic session still reports queued work. This covers the `aborted=true`, `drained=true`, command-lane `queuedCount=0`, diagnostic `queueDepth>0` wedge where the old recovery cycle returned `released=0` and left the agent silent until later watchdog cycles.

## Root cause

`recoverStuckDiagnosticSession` only reset the session lane after abort/drain when the command-lane snapshot had queued work, no active session existed, or abort/drain failed. The queued inbound work reported by diagnostics lives in session state (`queueDepth`) and can be nonzero even when command-lane `queuedCount` is zero, so a cleanly aborted dead run skipped lane reconciliation.

## What changed

- Treat nonzero diagnostic session `queueDepth` as a reason to reset the resolved session lane after recovery has already cleared or aborted the active work.
- Preserve the existing active-owner safeguard: active embedded/reply work is still observe-only unless active-abort recovery is enabled or stale-progress reclaim applies.
- Preserve the unregistered active-lane safeguard: if there is no registered active session but the command lane still has active work, recovery keeps the lane instead of resetting it.
- Update focused recovery coverage for both active embedded handles and active reply work without a handle.

## Real behavior proof

Behavior or issue addressed: `recoverStuckDiagnosticSession` with `queueDepth=1`, a clean `aborted=true` / `drained=true` result, and command-lane `queuedCount=0` now releases the lane on the first recovery cycle instead of returning `released=0`.

Real environment tested: Local OpenClaw source checkout at `upstream/main` head `9a1f2022b127f27312eeb7f57e42d477bddf2c19` plus this patch, on macOS, using the repo Node/pnpm toolchain. The deterministic proof drives the real `recoverStuckDiagnosticSession` module in the logging runtime test harness so the diagnostic queue-depth and session-lane reset contract can be isolated.

Exact steps or command run after this patch:

```text
# before-fix check in a temporary detached worktree at upstream/main, with only the new regression expectations applied
node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.runtime.test.ts

# after-fix checks on this branch
node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.integration.test.ts
node scripts/run-vitest.mjs src/logging/diagnostic.test.ts
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run check:changed
```

Evidence after fix: copied terminal output from the local OpenClaw checkout after applying this patch:

```text
$ node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
[test] starting test/vitest/vitest.logging.config.ts
 RUN  v4.1.7 /Users/andy/openclaw-91700-stuck-recovery
 Test Files  1 passed (1)
      Tests  20 passed (20)
[test] passed 1 Vitest shard in 5.62s

$ node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.integration.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
[test] passed 1 Vitest shard in 17.43s

$ node scripts/run-vitest.mjs src/logging/diagnostic.test.ts
 Test Files  1 passed (1)
      Tests  68 passed (68)
[test] passed 1 Vitest shard in 12.55s

$ OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run check:changed
[check:changed] lanes=core, coreTests
[check:changed] src/logging/diagnostic-stuck-session-recovery.runtime.test.ts: core test
[check:changed] src/logging/diagnostic-stuck-session-recovery.runtime.ts: core production
PASS direct dependency pin guard: checked 467 directly declared dependency specs across 156 tracked package manifests; 0 violations.
PASS package patch guard: no new pnpm patches; 4 legacy patches allowlisted.
runtime-sidecar-loaders: local runtime sidecar loaders look OK.
Import cycle check: 0 runtime value cycle(s).
```

Before evidence optional: in a temporary detached `upstream/main` worktree with only the new regression expectations applied, the same focused command failed before the runtime fix:

```text
FAIL src/logging/diagnostic-stuck-session-recovery.runtime.test.ts > stuck session recovery > releases the session lane after a clean active-run abort when diagnostic queue depth remains
-   "released": 1,
+   "released": 0,

FAIL src/logging/diagnostic-stuck-session-recovery.runtime.test.ts > stuck session recovery > reclaims a stale active embedded run with queued work and no forward progress (#85639)
AssertionError: expected "vi.fn()" to be called with arguments: [ 'session:agent:main:main' ]
Number of calls: 0
```

Observed result after fix: The focused recovery path now calls `resetCommandLane("session:agent:main:telegram:group:-1003821464158:topic:4836")` and returns an aborted recovery outcome with `released: 1` for the clean abort/drain plus diagnostic `queueDepth=1` case, so the diagnostic session queue is cleared by the recovery coordinator on the first cycle.

Additional runtime proof after ClawSweeper review: I also ran a standalone local runtime harness against PR head `f099341c8693167f97ded78909632ffd57feecad` using the actual `recoverStuckDiagnosticSession`, embedded-run registry, and command-lane modules, not Vitest mocks. It creates the issue shape with an active embedded run, command-lane `activeCount=1`, command-lane `queuedCount=0`, and diagnostic `queueDepth=1`; the embedded abort drains cleanly and the recovery now releases the lane immediately. It then enqueues follow-up same-lane work to prove the lane is usable again.

```text
$ node --import tsx --input-type=module <runtime proof harness>
[diagnostic] stuck session recovery: sessionId=proof-stuck-session sessionKey=agent:proof:whatsapp:dm:redacted age=720s action=abort_embedded_run aborted=true drained=true released=1
[diagnostic] stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=proof-stuck-session sessionKey=agent:proof:whatsapp:dm:redacted activeSessionId=proof-stuck-session activeWorkKind=embedded_run lane=session:agent:proof:whatsapp:dm:redacted aborted=true drained=true forceCleared=false released=1
{
  "build": "PR #91801 head f099341c8693167f97ded78909632ffd57feecad",
  "lane": "session:agent:proof:whatsapp:dm:redacted",
  "exactBranchInputs": {
    "activeEmbeddedRun": true,
    "commandLaneQueuedCountBefore": 0,
    "commandLaneActiveCountBefore": 1,
    "diagnosticQueueDepth": 1
  },
  "outcome": {
    "status": "aborted",
    "action": "abort_embedded_run",
    "sessionId": "proof-stuck-session",
    "sessionKey": "agent:proof:whatsapp:dm:redacted",
    "activeSessionId": "proof-stuck-session",
    "activeWorkKind": "embedded_run",
    "aborted": true,
    "drained": true,
    "forceCleared": false,
    "released": 1,
    "lane": "session:agent:proof:whatsapp:dm:redacted"
  },
  "abortCalls": 1,
  "afterRecovery": {
    "activeCount": 0,
    "queuedCount": 0,
    "generation": 1
  },
  "followUp": "queued-work-resumed",
  "afterFollowUp": {
    "activeCount": 0,
    "queuedCount": 0,
    "generation": 1
  }
}
```

What was not tested: I did not run a live WhatsApp group/DM gateway reproduction or a full external deployment. The proof is local source-level runtime evidence around the recovery routine and its lane-reset contract.

## Validation

```text
node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.integration.test.ts
node scripts/run-vitest.mjs src/logging/diagnostic.test.ts
git diff --check
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run check:changed
```

Notes:

- `pnpm run check:changed` initially attempted to delegate to Blacksmith Testbox, but the installed Crabbox was `0.20.0` and the repo requires `>=0.22.0` for that provider. I reran the selected changed-check lanes locally with `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1`; they completed successfully.

