### PR TITLE
fix(diagnostics): release wedged session lane when stuck-session recovery aborts a run with queued session work

### DIFF
--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -161,6 +161,116 @@ describe("stuck session recovery integration", () => {
     expect(getQueueSize(lane)).toBe(0);
   });
 
+  it("releases a wedged lane after a clean abort when session work remains queued (#91700)", async () => {
+    const sessionKey = "agent:main:wedged-delivery";
+    const sessionId = "wedged-delivery-session";
+    const lane = resolveEmbeddedSessionLane(sessionKey);
+    const operation = createReplyOperation({
+      sessionKey,
+      sessionId,
+      resetTriggered: false,
+    });
+    operation.setPhase("running");
+    // Cancel settles the registry (clean abort+drain) while the lane task that
+    // hosted the run stays wedged, mirroring a hang past the run's own cleanup.
+    operation.attachBackend({
+      kind: "embedded",
+      cancel: () => queueMicrotask(() => operation.complete()),
+      isStreaming: () => false,
+    });
+    void enqueueCommandInLane(lane, () => new Promise<never>(() => {}), {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+    expect(getQueueSize(lane)).toBe(1);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId,
+      sessionKey,
+      ageMs: 720_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      action: "abort_embedded_run",
+      aborted: true,
+      drained: true,
+      forceCleared: false,
+      released: 1,
+    });
+    const queued = enqueueCommandInLane(lane, async () => "drained", {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+    await expect(Promise.race([queued, delay(100)])).resolves.toBe("drained");
+  });
+
+  it("does not reset a lane that unwedged and started a queued turn during the abort (#91700)", async () => {
+    const sessionKey = "agent:main:unwedged-during-abort";
+    const sessionId = "unwedged-during-abort-session";
+    const lane = resolveEmbeddedSessionLane(sessionKey);
+    const operation = createReplyOperation({
+      sessionKey,
+      sessionId,
+      resetTriggered: false,
+    });
+    operation.setPhase("running");
+    let markHostStarted!: () => void;
+    const hostStarted = new Promise<void>((resolve) => {
+      markHostStarted = resolve;
+    });
+    // Host task frees the lane on abort; the queued turn then pumps to active
+    // and only it settles the registry, so the drain resolves with fresh work
+    // already running — the race the queueDepth reset must not clobber.
+    const host = enqueueCommandInLane(
+      lane,
+      () =>
+        new Promise<"aborted">((resolve) => {
+          markHostStarted();
+          operation.abortSignal.addEventListener("abort", () => resolve("aborted"), {
+            once: true,
+          });
+        }),
+      { warnAfterMs: Number.MAX_SAFE_INTEGER },
+    );
+    let releaseFreshTurn!: (value: "done") => void;
+    const freshTurn = enqueueCommandInLane(
+      lane,
+      () => {
+        operation.complete();
+        return new Promise<"done">((resolve) => {
+          releaseFreshTurn = resolve;
+        });
+      },
+      { warnAfterMs: Number.MAX_SAFE_INTEGER },
+    );
+    await hostStarted;
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId,
+      sessionKey,
+      ageMs: 720_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+    });
+
+    await expect(host).resolves.toBe("aborted");
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      aborted: true,
+      drained: true,
+      released: 0,
+    });
+    // The fresh turn still owns the lane slot: later work must wait for it.
+    const third = enqueueCommandInLane(lane, async () => "third", {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+    await expect(Promise.race([third, delay(100)])).resolves.toBe("blocked");
+    releaseFreshTurn("done");
+    await expect(freshTurn).resolves.toBe("done");
+    await expect(third).resolves.toBe("third");
+  });
+
   it("does not reset a blocked lane while unregistered lane work is still active", async () => {
     const sessionKey = "agent:main:unregistered-work";
     const sessionId = "unregistered-work-session";

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   forceClearEmbeddedAgentRun: vi.fn(),
   isEmbeddedAgentRunActive: vi.fn(),
   isEmbeddedAgentRunHandleActive: vi.fn(),
+  getCommandLaneActiveTaskIds: vi.fn(),
   getCommandLaneSnapshot: vi.fn(),
   resetCommandLane: vi.fn(),
   resolveActiveEmbeddedRunSessionId: vi.fn(),
@@ -61,6 +62,7 @@ vi.mock("../agents/embedded-agent-runner/lanes.js", () => ({
 }));
 
 vi.mock("../process/command-queue.js", () => ({
+  getCommandLaneActiveTaskIds: mocks.getCommandLaneActiveTaskIds,
   getCommandLaneSnapshot: mocks.getCommandLaneSnapshot,
   resetCommandLane: mocks.resetCommandLane,
 }));
@@ -94,6 +96,8 @@ function resetMocks() {
     generation: 0,
   });
   mocks.resetCommandLane.mockReset();
+  mocks.getCommandLaneActiveTaskIds.mockReset();
+  mocks.getCommandLaneActiveTaskIds.mockReturnValue([]);
   mocks.resolveActiveEmbeddedRunSessionId.mockReset();
   mocks.resolveActiveEmbeddedRunSessionIdBySessionFile.mockReset();
   mocks.resolveActiveEmbeddedRunHandleSessionId.mockReset();
@@ -167,6 +171,7 @@ describe("stuck session recovery", () => {
     });
     mocks.abortEmbeddedAgentRun.mockReturnValue(true);
     mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.resetCommandLane.mockReturnValue(1);
 
     const outcome = await recoverStuckDiagnosticSession({
       sessionId: "session-1",
@@ -201,6 +206,7 @@ describe("stuck session recovery", () => {
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-tool");
     mocks.abortEmbeddedAgentRun.mockReturnValue(true);
     mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.resetCommandLane.mockReturnValue(1);
 
     const outcome = await recoverStuckDiagnosticSession({
       sessionId: "session-tool",
@@ -220,10 +226,62 @@ describe("stuck session recovery", () => {
       aborted: true,
       drained: true,
       forceCleared: false,
-      released: 0,
+      released: 1,
     });
     expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledWith("session-tool");
     expect(mocks.waitForEmbeddedAgentRunEnd).toHaveBeenCalledWith("session-tool", 15_000);
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith(
+      "session:agent:main:telegram:group:-1003821464158:topic:4836",
+    );
+  });
+
+  it("keeps the lane when a fresh queued turn started during the abort despite stale queue depth", async () => {
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-fresh");
+    mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+    mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.getCommandLaneActiveTaskIds.mockReturnValueOnce([101]).mockReturnValueOnce([202]);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "session-fresh",
+      sessionKey: "agent:main:main",
+      ageMs: 720_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      action: "abort_embedded_run",
+      aborted: true,
+      drained: true,
+      released: 0,
+    });
+    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
+  });
+
+  it("keeps the lane when a fresh turn started during the abort even with lane-queued work", async () => {
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-fresh-queued");
+    mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+    mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.getCommandLaneActiveTaskIds.mockReturnValueOnce([101]).mockReturnValueOnce([202]);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:main:main",
+      queuedCount: 1,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "session-fresh-queued",
+      sessionKey: "agent:main:main",
+      ageMs: 720_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+    });
+
+    expect(outcome).toMatchObject({ status: "aborted", aborted: true, released: 0 });
     expect(mocks.resetCommandLane).not.toHaveBeenCalled();
   });
 
@@ -367,6 +425,7 @@ describe("stuck session recovery", () => {
     mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
     mocks.abortEmbeddedAgentRun.mockReturnValue(true);
     mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.resetCommandLane.mockReturnValue(1);
 
     await recoverStuckDiagnosticSession({
       sessionId: "queued-reply-session",
@@ -379,10 +438,10 @@ describe("stuck session recovery", () => {
     expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledWith("queued-reply-session");
     expect(mocks.waitForEmbeddedAgentRunEnd).toHaveBeenCalledWith("queued-reply-session", 15_000);
     expect(mocks.forceClearEmbeddedAgentRun).not.toHaveBeenCalled();
-    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:main:main");
     expect(warnLogMessages()).toEqual([
-      "stuck session recovery: sessionId=queued-reply-session sessionKey=agent:main:main age=720s action=abort_embedded_run aborted=true drained=true released=0",
-      "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=true drained=true forceCleared=false released=0",
+      "stuck session recovery: sessionId=queued-reply-session sessionKey=agent:main:main age=720s action=abort_embedded_run aborted=true drained=true released=1",
+      "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=true drained=true forceCleared=false released=1",
     ]);
   });
 

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -9,7 +9,11 @@ import {
   resolveActiveEmbeddedRunHandleSessionId,
   resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
 } from "../agents/embedded-agent-runner/runs.js";
-import { getCommandLaneSnapshot, resetCommandLane } from "../process/command-queue.js";
+import {
+  getCommandLaneActiveTaskIds,
+  getCommandLaneSnapshot,
+  resetCommandLane,
+} from "../process/command-queue.js";
 import { getDiagnosticSessionActivitySnapshot } from "./diagnostic-run-activity.js";
 import { diagnosticLogger as diag } from "./diagnostic-runtime.js";
 import {
@@ -135,6 +139,9 @@ export async function recoverStuckDiagnosticSession(
         params.sessionId)
       : (fileActiveWorkSessionId ?? params.sessionId);
     const sessionLane = key ? resolveEmbeddedSessionLane(key) : null;
+    const preAbortActiveTaskIds = new Set(
+      sessionLane ? getCommandLaneActiveTaskIds(sessionLane) : [],
+    );
     let aborted = false;
     let drained = true;
     let forceCleared = false;
@@ -246,8 +253,18 @@ export async function recoverStuckDiagnosticSession(
     }
 
     const queuedCount = sessionLane ? getCommandLaneSnapshot(sessionLane).queuedCount : 0;
+    // A task id active now but not before the abort means the lane already
+    // unwedged and pumped fresh work; resetting it would double-run the lane.
+    const laneStartedFreshTask =
+      sessionLane !== null &&
+      getCommandLaneActiveTaskIds(sessionLane).some((id) => !preAbortActiveTaskIds.has(id));
+    // Queued turns ride the session queue (params.queueDepth), not only the lane
+    // queue; without this signal a cleanly aborted wedged lane never resets.
+    const hasQueuedSessionWork = (params.queueDepth ?? 0) > 0;
     const released =
-      sessionLane && (queuedCount > 0 || !activeSessionId || !aborted || !drained)
+      sessionLane &&
+      !laneStartedFreshTask &&
+      (queuedCount > 0 || hasQueuedSessionWork || !activeSessionId || !aborted || !drained)
         ? resetCommandLane(sessionLane)
         : 0;
 

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -484,6 +484,15 @@ export function getCommandLaneSnapshot(lane: string = CommandLane.Main): Command
   return createCommandLaneSnapshot(state);
 }
 
+/**
+ * Active task ids for a lane. Ids are process-monotonic, so recovery can
+ * detect a turn that started after a point in time it captured earlier.
+ */
+export function getCommandLaneActiveTaskIds(lane: string = CommandLane.Main): number[] {
+  const state = getQueueState().lanes.get(normalizeLane(lane));
+  return state ? [...state.activeTaskIds] : [];
+}
+
 export function getCommandLaneSnapshots(): CommandLaneSnapshot[] {
   return Array.from(getQueueState().lanes.values(), createCommandLaneSnapshot).toSorted((a, b) =>
     a.lane.localeCompare(b.lane),


### PR DESCRIPTION
### Summary

- **Problem**: Issue #91700 — on a WhatsApp group session, stuck-session recovery aborts the dead embedded run cleanly (`aborted=true drained=true`) but logs `released=0` on every watchdog cycle. The session lane stays wedged, all inbound stays queued behind the dead run, and the agent stays silent for ~15 more minutes (≈7 watchdog cycles) before the lane self-clears. A follow-up comment reproduces the identical `aborted=true drained=true released=0` signature on a 1:1 WhatsApp chat, with the queued user messages lost.
- **Root cause**: `recoverStuckDiagnosticSession` in `src/logging/diagnostic-stuck-session-recovery.runtime.ts` gates `resetCommandLane` on the command-lane snapshot's `queuedCount` only. Queued user turns are tracked in the session-level queue — the `queueDepth` that the stall diagnostic reports and passes into the recovery request — which is a different structure from the lane's own queue. With a clean abort (`aborted=true`, `drained=true`, an active session id, lane `queuedCount=0`) the gate evaluates to `released=0`, so a wedged lane active slot is never reset. `abortAndDrainEmbeddedAgentRun` only force-clears when abort or drain fails, so the cleanly-aborted-but-wedged shape never escalates either. Worse, the miss is unrecoverable on later sweeps: once the run registries are settled by the first abort, subsequent recovery passes resolve no active session and hit the unregistered-active-lane `keep_lane` safeguard (which correctly cannot distinguish a wedged dead slot from live unregistered work), so the release can only ever happen in the same pass as the abort — exactly the pass that currently skips it.
- **Fix**: include the session-level queue signal in the release gate, and guard the whole gate against the fresh-turn race. After the abort path, the lane is reset when either the lane queue (`queuedCount > 0`) or the session queue (`params.queueDepth > 0`) has waiting work. Because the request's `queueDepth` is sampled at sweep time, recovery additionally verifies the lane has not already unwedged on its own: it captures the lane's active task ids before the abort, and if a task id is active at the gate that was not active before the abort, the lane already pumped fresh work and the reset is skipped — releasing it then would clear a live turn's slot and let later session work run concurrently on a `maxConcurrent=1` lane. Task ids are process-monotonic, so a fresh turn is always a new id. The guard suppresses every reset arm, which also closes the same pre-existing (narrower) race on the lane-queue arm; when a fresh turn owns the slot, lane-queued entries drain naturally behind it, and a fresh turn that itself wedges is caught by the next recovery cycle, whose pre-abort capture includes it. With a released lane, `recoveryOutcomeClearsQueuedSessionState` clears the queued diagnostic state in the same cycle, so recovery converges on the first attempt instead of one-cycle-per-queued-turn.
- **What changed**:
  - `src/logging/diagnostic-stuck-session-recovery.runtime.ts` — capture pre-abort lane active task ids; add `hasQueuedSessionWork` (session `queueDepth`) to the lane release gate; suppress the whole gate when a fresh task id appeared during the abort.
  - `src/process/command-queue.ts` — new read-only helper `getCommandLaneActiveTaskIds` exposing a lane's active task ids; no command-queue behavior change.
  - `src/logging/diagnostic-stuck-session-recovery.runtime.test.ts` — two existing cases that pinned the `released=0` gap (clean abort with `queueDepth: 1`) now assert the lane is released; new cases asserting a fresh task id at the gate skips the reset despite stale `queueDepth`, with and without lane-queued work.
  - `src/logging/diagnostic-stuck-session-recovery.integration.test.ts` — two new regression cases against the real reply-run registry and command-queue lanes: (1) a clean abort that settles the registry while the lane task stays wedged, with session work queued, releases the lane and immediately drains new inbound; (2) a lane that unwedges mid-abort and pumps a queued turn before the gate is left untouched (`released=0`) and the fresh turn keeps exclusive lane ownership.
- **What did NOT change (scope boundary)**:
  - The active-owner skip, the stale-progress reclaim threshold, and the unregistered-active-lane `keep_lane` safeguard are unchanged and still return before the release gate.
  - The recovery coordinator, the attention classifier, `abortAndDrainEmbeddedAgentRun`, and all command-queue mutation paths are unchanged.
  - The engagement-latency half of the report (the prolonged `recovery=none` window and `recovery_skipped_active_owner` deferrals refreshing progress) is intentionally out of scope; it lives at the activity-touch layer and needs its own change.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. A group or DM session's run wedges past its own settlement (for example a hang at the final-reply/delivery transition): the lane's active slot stays occupied, the lane queue is empty, and user turns wait in the session queue (`queueDepth > 0`).
2. The stuck-session watchdog engages and recovery aborts the run cleanly: `aborted=true drained=true forceCleared=false`.
3. **Before this PR**: the release gate sees lane `queuedCount=0` plus a successful abort and skips `resetCommandLane` (`released=0`); the wedged lane slot survives, the same stall re-fires on later sweeps, and the coordinator burns one watchdog cycle per queued turn (~2.5 min each) before the lane finally clears.
4. **After this PR**: `queueDepth > 0` triggers `resetCommandLane` on the first recovery cycle (`released=1`), the lane pumps queued work immediately, and the recovery outcome clears the queued diagnostic state in the same cycle. If the lane instead unwedged on its own during the abort and already started a fresh queued turn, the gate detects the new active task id and leaves the lane alone.

### Real behavior proof

**Behavior addressed (#91700)**: after stuck-session recovery cleanly aborts a session's run, a wedged session lane with session-level queued work is released on the first recovery cycle instead of never (`released=0` loop), so queued inbound drains immediately instead of starving for ~7 watchdog cycles; a lane that already unwedged and started a fresh turn is left untouched.

**Real environment tested (Linux, Node 22 — Vitest against the production recovery runtime, the real reply-run registry, and the real command-queue lanes)**: the integration cases drive `recoverStuckDiagnosticSession` end-to-end through `createReplyOperation`/`abortAndDrainEmbeddedAgentRun` and genuinely wedged or mid-abort-unwedging `enqueueCommandInLane` tasks, then prove lane behavior by observing whether subsequently enqueued tasks drain or stay serialized.

**Exact steps or command run after this patch**: `pnpm test src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts src/process/command-queue.test.ts` (30 passed), full sweep over all `src/logging` test files plus `src/process/command-queue.test.ts` (335+ tests passed across 3 shards), `pnpm tsgo` (exit 0), `node scripts/run-oxlint.mjs` and `pnpm format:check` on the four changed files (clean).

**Evidence after fix (Vitest output)**:

```text
 Test Files  3 passed (3)
      Tests  30 passed (30)
```

**Observed result after fix**: the wedged-lane integration case observes `status=aborted aborted=true drained=true forceCleared=false released=1` and a fresh lane task resolving immediately after recovery; the unwedged-mid-abort case observes `released=0` with the fresh turn keeping exclusive lane ownership (a later enqueue stays blocked until the fresh turn completes); the runtime cases observe `resetCommandLane` invoked for the session lane where main reports `released=0`, and not invoked when a fresh task id appears at the gate.

**What was not tested**: a live WhatsApp gateway round-trip on the reporter's deployment; the wedge shape (clean abort settling the registry while the hosting lane task stays hung) and the fresh-turn race are reproduced deterministically against the production registry and lane implementations instead.

**Repro confirmation**: with the production change stashed, the wedged-lane integration case fails on the exact reported shape — `expected released: 1, received released: 0`; with only the unguarded queue-depth arm applied (no fresh-turn guard), the unwedged-mid-abort case fails with `expected released: 0, received released: 1` — so the tests cover both the original gap and the guard.

### Risk / Mitigation

- **Risk**: resetting a lane whose active slot belongs to a fresh, legitimate turn that started between drain and gate. **Mitigation**: the session-queue arm compares the gate-time active task ids against the pre-abort capture and skips the reset when a new id appears; task ids are process-monotonic so a fresh turn is always detected, and a dedicated integration regression pins this.
- **Risk**: stale diagnostic `queueDepth` bookkeeping triggering a spurious lane reset. **Mitigation**: recovery only reaches the gate for sessions stalled past the watchdog thresholds with the active-owner and unregistered-active-lane safeguards intact, the fresh-turn guard suppresses the reset whenever the lane is demonstrably making progress, and resetting a healthy idle lane is a no-op (`released=0`, nothing queued to pump).

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Diagnostics / logging
- [x] Sessions / storage

### Linked Issue/PR

Fixes #91700
