### PR TITLE
fix(imessage): stage remote media before plugin dispatch

### DIFF
--- a/extensions/codex/src/conversation-turn-input.test.ts
+++ b/extensions/codex/src/conversation-turn-input.test.ts
@@ -24,6 +24,31 @@ describe("codex conversation turn input", () => {
     ]);
   });
 
+  it("uses staged remote-cache paths for remote iMessage image attachments", () => {
+    const rawPath = "/Users/demo/Library/Messages/Attachments/ab/cd/photo.jpg";
+    const stagedPath = "/tmp/openclaw-proof/.openclaw/media/remote-cache/imessage/photo.jpg";
+
+    const input = buildCodexConversationTurnInput({
+      prompt: "what is this?",
+      event: {
+        content: "what is this?",
+        channel: "imessage",
+        isGroup: false,
+        metadata: {
+          mediaPaths: [stagedPath],
+          mediaTypes: ["image/jpeg"],
+          originalMediaPaths: [rawPath],
+        },
+      },
+    });
+
+    expect(input).toEqual([
+      { type: "text", text: "what is this?", text_elements: [] },
+      { type: "localImage", path: stagedPath },
+    ]);
+    expect(input).not.toContainEqual({ type: "localImage", path: rawPath });
+  });
+
   it("uses remote image urls when no local path is available", () => {
     expect(
       buildCodexConversationTurnInput({

--- a/src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts
+++ b/src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts
@@ -1,4 +1,5 @@
 /** Tests sandbox media staging for SCP remote-path inputs. */
+import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import { basename, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -149,6 +150,117 @@ describe("stageSandboxMedia scp remote paths", () => {
       } finally {
         await fs.rm(expectedSafeDir, { recursive: true, force: true });
       }
+    });
+  });
+
+  it("rewrites remote iMessage attachment metadata to the staged local cache path", async () => {
+    await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
+      const { cfg, workspaceDir, sessionKey } = createRemoteStageParams(home);
+      const remotePath = "/Users/demo/Library/Messages/Attachments/ab/cd/photo.jpg";
+      const { ctx, sessionCtx } = createRemoteContexts(remotePath);
+      ctx.MediaPaths = [remotePath];
+      sessionCtx.MediaPaths = [remotePath];
+      childProcessMocks.spawn.mockImplementation((_command, argsUnknown) => {
+        const args = argsUnknown as string[];
+        const localPath = args[args.length - 1];
+        const child = new EventEmitter() as EventEmitter & {
+          stderr: EventEmitter & { setEncoding: (_encoding: string) => void };
+        };
+        child.stderr = Object.assign(new EventEmitter(), {
+          setEncoding: () => undefined,
+        });
+        queueMicrotask(() => {
+          void fs.writeFile(localPath, "staged-image-bytes").then(() => {
+            child.emit("exit", 0);
+          });
+        });
+        return child;
+      });
+
+      const result = await stageSandboxMedia({
+        ctx,
+        sessionCtx,
+        cfg,
+        sessionKey,
+        workspaceDir,
+      });
+
+      const stagedPath = join(
+        CONFIG_DIR,
+        "media",
+        "remote-cache",
+        slugifySessionKey(sessionKey),
+        basename(remotePath),
+      );
+      expect(result.staged.get(remotePath)).toBe(stagedPath);
+      expect(ctx.MediaPath).toBe(stagedPath);
+      expect(ctx.MediaPaths).toEqual([stagedPath]);
+      expect(ctx.MediaUrl).toBe(stagedPath);
+      expect(sessionCtx.MediaPath).toBe(stagedPath);
+      expect(sessionCtx.MediaPaths).toEqual([stagedPath]);
+      expect(sessionCtx.MediaUrl).toBe(stagedPath);
+      expect(await fs.readFile(stagedPath, "utf8")).toBe("staged-image-bytes");
+      await fs.rm(join(CONFIG_DIR, "media", "remote-cache", slugifySessionKey(sessionKey)), {
+        recursive: true,
+        force: true,
+      });
+    });
+  });
+
+  it("uses absolute remote cache paths in cache mode even when sandbox staging is available", async () => {
+    await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
+      const { cfg, workspaceDir, sessionKey } = createRemoteStageParams(home);
+      const sandboxWorkspace = join(home, "sandbox-workspace");
+      vi.mocked(sandboxMocks.ensureSandboxWorkspaceForSession).mockResolvedValue({
+        workspaceDir: sandboxWorkspace,
+        workspaceAccess: "workspace-write",
+      });
+      const remotePath = "/Users/demo/Library/Messages/Attachments/ab/cd/photo.jpg";
+      const { ctx, sessionCtx } = createRemoteContexts(remotePath);
+      ctx.MediaPaths = [remotePath];
+      sessionCtx.MediaPaths = [remotePath];
+      childProcessMocks.spawn.mockImplementation((_command, argsUnknown) => {
+        const args = argsUnknown as string[];
+        const localPath = args[args.length - 1];
+        const child = new EventEmitter() as EventEmitter & {
+          stderr: EventEmitter & { setEncoding: (_encoding: string) => void };
+        };
+        child.stderr = Object.assign(new EventEmitter(), {
+          setEncoding: () => undefined,
+        });
+        queueMicrotask(() => {
+          void fs.writeFile(localPath, "staged-image-bytes").then(() => {
+            child.emit("exit", 0);
+          });
+        });
+        return child;
+      });
+
+      const result = await stageSandboxMedia({
+        ctx,
+        sessionCtx,
+        cfg,
+        sessionKey,
+        workspaceDir,
+        remoteMediaMode: "cache",
+      });
+
+      const stagedPath = join(
+        CONFIG_DIR,
+        "media",
+        "remote-cache",
+        slugifySessionKey(sessionKey),
+        basename(remotePath),
+      );
+      expect(result.staged.get(remotePath)).toBe(stagedPath);
+      expect(ctx.MediaPath).toBe(stagedPath);
+      expect(ctx.MediaPaths).toEqual([stagedPath]);
+      await expectPathMissing(join(sandboxWorkspace, "media", "inbound", basename(remotePath)));
+      expect(await fs.readFile(stagedPath, "utf8")).toBe("staged-image-bytes");
+      await fs.rm(join(CONFIG_DIR, "media", "remote-cache", slugifySessionKey(sessionKey)), {
+        recursive: true,
+        force: true,
+      });
     });
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -84,9 +84,13 @@ const hookMocks = vi.hoisted(() => ({
     hasHooks: vi.fn<(hookName?: string) => boolean>(() => false),
     runInboundClaim: vi.fn(async () => undefined),
     runInboundClaimForPlugin: vi.fn(async () => undefined),
-    runInboundClaimForPluginOutcome: vi.fn<() => Promise<PluginTargetedInboundClaimOutcome>>(
-      async () => ({ status: "no_handler" as const }),
-    ),
+    runInboundClaimForPluginOutcome: vi.fn<
+      (
+        pluginId?: string,
+        event?: unknown,
+        context?: unknown,
+      ) => Promise<PluginTargetedInboundClaimOutcome>
+    >(async () => ({ status: "no_handler" as const })),
     runMessageReceived: vi.fn(async () => {}),
     runBeforeDispatch: vi.fn<
       (eventValue: unknown, _ctx: unknown) => Promise<PluginHookBeforeDispatchResult | undefined>
@@ -223,6 +227,11 @@ const transcriptMocks = vi.hoisted(() => ({
 const replyMediaPathMocks = vi.hoisted(() => ({
   createReplyMediaPathNormalizer: vi.fn(
     (_params?: unknown) => async (payload: ReplyPayload) => payload,
+  ),
+}));
+const stageSandboxMediaMocks = vi.hoisted(() => ({
+  stageSandboxMedia: vi.fn<(params: unknown) => Promise<{ staged: Map<string, string> }>>(
+    async () => ({ staged: new Map() }),
   ),
 }));
 const runtimePluginMocks = vi.hoisted(() => ({
@@ -549,6 +558,9 @@ vi.mock("../../tts/tts.runtime.js", () => ({
 vi.mock("./reply-media-paths.runtime.js", () => ({
   createReplyMediaPathNormalizer: (params: unknown) =>
     replyMediaPathMocks.createReplyMediaPathNormalizer(params),
+}));
+vi.mock("./stage-sandbox-media.runtime.js", () => ({
+  stageSandboxMedia: (params: unknown) => stageSandboxMediaMocks.stageSandboxMedia(params),
 }));
 vi.mock("../../plugins/runtime-plugins.runtime.js", () => ({
   ensureRuntimePluginsLoaded: runtimePluginMocks.ensureRuntimePluginsLoaded,
@@ -1101,6 +1113,8 @@ describe("dispatchReplyFromConfig", () => {
     replyMediaPathMocks.createReplyMediaPathNormalizer.mockReturnValue(
       async (payload: ReplyPayload) => payload,
     );
+    stageSandboxMediaMocks.stageSandboxMedia.mockReset();
+    stageSandboxMediaMocks.stageSandboxMedia.mockResolvedValue({ staged: new Map() });
     runtimePluginMocks.ensureRuntimePluginsLoaded.mockClear();
   });
 
@@ -6230,6 +6244,242 @@ describe("dispatchReplyFromConfig", () => {
     expect(inboundClaimCall?.[2]?.pluginBinding?.data?.sessionFile).toBe("/tmp/session.jsonl");
     expect(hookMocks.runner.runInboundClaim).not.toHaveBeenCalled();
     expect(replyResolver).not.toHaveBeenCalled();
+  });
+
+  it("stages remote iMessage media before plugin-bound inbound claim metadata reaches Codex", async () => {
+    setNoAbort();
+    const order: string[] = [];
+    const rawPath = "/Users/demo/Library/Messages/Attachments/ab/cd/photo.jpg";
+    const stagedPath =
+      "/tmp/openclaw-proof/.openclaw/media/remote-cache/agent-main-imessage/photo.jpg";
+    stageSandboxMediaMocks.stageSandboxMedia.mockImplementationOnce(async (paramsUnknown) => {
+      order.push("stage");
+      const params = paramsUnknown as {
+        ctx: MsgContext;
+        sessionCtx: MsgContext;
+        sessionKey?: string;
+        workspaceDir?: string;
+        remoteMediaMode?: string;
+      };
+      expect(params.sessionKey).toBe("agent:main:imessage:direct:user");
+      expect(params.workspaceDir).toContain(".openclaw/workspace");
+      expect(params.remoteMediaMode).toBe("cache");
+      params.ctx.MediaPath = stagedPath;
+      params.ctx.MediaPaths = [stagedPath];
+      params.ctx.MediaUrl = stagedPath;
+      params.ctx.MediaUrls = [stagedPath];
+      params.sessionCtx.MediaPath = stagedPath;
+      params.sessionCtx.MediaPaths = [stagedPath];
+      params.sessionCtx.MediaUrl = stagedPath;
+      params.sessionCtx.MediaUrls = [stagedPath];
+      return { staged: new Map([[rawPath, stagedPath]]) };
+    });
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) =>
+        hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
+    );
+    hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockImplementationOnce(
+      async (_plugin, event) => {
+        order.push("claim");
+        const claimEvent = event as { metadata?: Record<string, unknown> };
+        expect(claimEvent.metadata?.mediaPath).toBe(stagedPath);
+        expect(claimEvent.metadata?.mediaPaths).toEqual([stagedPath]);
+        expect(claimEvent.metadata?.mediaUrl).toBe(stagedPath);
+        expect(claimEvent.metadata?.mediaUrls).toEqual([stagedPath]);
+        expect(claimEvent.metadata?.mediaPath).not.toBe(rawPath);
+        expect(claimEvent.metadata?.mediaPaths).not.toContain(rawPath);
+        return { status: "handled", result: { handled: true } };
+      },
+    );
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "binding-imessage-codex-media",
+      targetSessionKey: "plugin-binding:codex:imessage",
+      targetKind: "session",
+      conversation: {
+        channel: "imessage",
+        accountId: "default",
+        conversationId: "chat:abc",
+      },
+      status: "active",
+      boundAt: 1710000000000,
+      metadata: {
+        pluginBindingOwner: "plugin",
+        pluginId: "openclaw-codex-app-server",
+        pluginRoot: "/plugins/openclaw-codex-app-server",
+        data: {
+          kind: "codex-app-server-session",
+          version: 1,
+          sessionFile: "/tmp/session.jsonl",
+          workspaceDir: "/workspace/openclaw",
+        },
+      },
+    } satisfies SessionBindingRecord);
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "imessage",
+      Surface: "imessage",
+      OriginatingChannel: "imessage",
+      OriginatingTo: "imessage:chat:abc",
+      To: "imessage:chat:abc",
+      AccountId: "default",
+      SenderId: "user-9",
+      CommandAuthorized: true,
+      WasMentioned: false,
+      CommandBody: "what is this?",
+      RawBody: "what is this?",
+      Body: "what is this?",
+      MessageSid: "msg-claim-imessage-media",
+      SessionKey: "agent:main:imessage:direct:user",
+      MediaPath: rawPath,
+      MediaPaths: [rawPath],
+      MediaUrl: rawPath,
+      MediaUrls: [rawPath],
+      MediaType: "image/jpeg",
+      MediaTypes: ["image/jpeg"],
+      MediaRemoteHost: "user@gateway-host",
+    });
+    const replyResolver = vi.fn(async () => ({ text: "should not run" }) satisfies ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+    expect(order).toEqual(["stage", "claim"]);
+    expect(ctx.MediaStaged).not.toBe(true);
+    expect(ctx.MediaPath).toBe(rawPath);
+    expect(ctx.MediaPaths).toEqual([rawPath]);
+    expect(stageSandboxMediaMocks.stageSandboxMedia).toHaveBeenCalledTimes(1);
+    expect(sessionBindingMocks.touch).toHaveBeenCalledWith("binding-imessage-codex-media");
+    expect(hookMocks.runner.runInboundClaim).not.toHaveBeenCalled();
+    expect(replyResolver).not.toHaveBeenCalled();
+  });
+
+  it("leaves ordinary non-plugin remote iMessage media for get-reply staging", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) => hookName === "reply_dispatch") as () => boolean,
+    );
+    const rawPath = "/Users/demo/Library/Messages/Attachments/ab/cd/photo.jpg";
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "imessage",
+      Surface: "imessage",
+      OriginatingChannel: "imessage",
+      OriginatingTo: "imessage:chat:ordinary",
+      To: "imessage:chat:ordinary",
+      AccountId: "default",
+      SenderId: "user-9",
+      CommandAuthorized: true,
+      WasMentioned: false,
+      CommandBody: "what is this?",
+      RawBody: "what is this?",
+      Body: "what is this?",
+      MessageSid: "msg-ordinary-imessage-media",
+      SessionKey: "agent:main:imessage:direct:user",
+      MediaPath: rawPath,
+      MediaPaths: [rawPath],
+      MediaUrl: rawPath,
+      MediaUrls: [rawPath],
+      MediaType: "image/jpeg",
+      MediaTypes: ["image/jpeg"],
+      MediaRemoteHost: "user@gateway-host",
+    });
+    const replyResolver = vi.fn(async (receivedCtx: MsgContext) => {
+      expect(receivedCtx.MediaStaged).not.toBe(true);
+      expect(receivedCtx.MediaPath).toBe(rawPath);
+      expect(receivedCtx.MediaPaths).toEqual([rawPath]);
+      return { text: "agent reply" } satisfies ReplyPayload;
+    });
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(stageSandboxMediaMocks.stageSandboxMedia).not.toHaveBeenCalled();
+    expect(hookMocks.runner.runInboundClaimForPluginOutcome).not.toHaveBeenCalled();
+    expect(ctx.MediaStaged).not.toBe(true);
+    expect(ctx.MediaPath).toBe(rawPath);
+    expect(ctx.MediaPaths).toEqual([rawPath]);
+  });
+
+  it("does not cache-stage remote iMessage media for message_received-only hooks", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) => hookName === "message_received") as () => boolean,
+    );
+    const rawPath = "/Users/demo/Library/Messages/Attachments/ab/cd/photo.jpg";
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "imessage",
+      Surface: "imessage",
+      OriginatingChannel: "imessage",
+      OriginatingTo: "imessage:chat:ordinary-hook",
+      To: "imessage:chat:ordinary-hook",
+      AccountId: "default",
+      SenderId: "user-9",
+      CommandAuthorized: true,
+      WasMentioned: false,
+      CommandBody: "what is this?",
+      RawBody: "what is this?",
+      Body: "what is this?",
+      MessageSid: "msg-ordinary-imessage-hook-media",
+      SessionKey: "agent:main:imessage:direct:user",
+      MediaPath: rawPath,
+      MediaPaths: [rawPath],
+      MediaUrl: rawPath,
+      MediaUrls: [rawPath],
+      MediaType: "image/jpeg",
+      MediaTypes: ["image/jpeg"],
+      MediaRemoteHost: "user@gateway-host",
+    });
+    const replyResolver = vi.fn(async (receivedCtx: MsgContext) => {
+      expect(receivedCtx.MediaStaged).not.toBe(true);
+      expect(receivedCtx.MediaPath).toBe(rawPath);
+      expect(receivedCtx.MediaPaths).toEqual([rawPath]);
+      return { text: "agent reply" } satisfies ReplyPayload;
+    });
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    const [event] = firstMockCall(hookMocks.runner.runMessageReceived, "message received hook") as
+      | [{ metadata?: Record<string, unknown> }]
+      | [];
+    expect(event?.metadata?.mediaPath).toBeUndefined();
+    expect(event?.metadata?.mediaPaths).toBeUndefined();
+    expect(event?.metadata?.mediaUrl).toBeUndefined();
+    expect(event?.metadata?.mediaUrls).toBeUndefined();
+    expect(event?.metadata?.mediaStagingPending).toBe(true);
+    expect(event?.metadata?.mediaRemoteHost).toBe("user@gateway-host");
+    expect(event?.metadata?.originalMediaPath).toBe(rawPath);
+    expect(event?.metadata?.originalMediaPaths).toEqual([rawPath]);
+    expect(event?.metadata?.originalMediaUrl).toBe(rawPath);
+    expect(event?.metadata?.originalMediaUrls).toEqual([rawPath]);
+    expect(event?.metadata?.originalMediaType).toBe("image/jpeg");
+    expect(event?.metadata?.originalMediaTypes).toEqual(["image/jpeg"]);
+    const internalHookCall = firstMockCall(
+      internalHookMocks.createInternalHookEvent,
+      "internal hook event",
+    ) as
+      | [
+          unknown,
+          unknown,
+          unknown,
+          {
+            metadata?: Record<string, unknown>;
+          },
+        ]
+      | undefined;
+    expect(internalHookCall?.[3]?.metadata?.mediaStagingPending).toBe(true);
+    expect(internalHookCall?.[3]?.metadata?.mediaRemoteHost).toBe("user@gateway-host");
+    expect(internalHookCall?.[3]?.metadata?.originalMediaPath).toBe(rawPath);
+    expect(internalHookCall?.[3]?.metadata?.originalMediaPaths).toEqual([rawPath]);
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(stageSandboxMediaMocks.stageSandboxMedia).not.toHaveBeenCalled();
+    expect(ctx.MediaStaged).not.toBe(true);
+    expect(ctx.MediaPath).toBe(rawPath);
+    expect(ctx.MediaPaths).toEqual([rawPath]);
   });
 
   it("routes Discord thread plugin-owned bindings by raw thread id", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -175,6 +175,7 @@ import {
   isUnauthorizedTextSlashCommand,
   resolveSourceReplyVisibilityPolicy,
 } from "./source-reply-delivery-mode.js";
+import { stageRemoteInboundMediaIfNeeded } from "./stage-remote-inbound-media.js";
 import { resolveStoredModelOverride } from "./stored-model-override.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
 
@@ -1552,20 +1553,86 @@ export async function dispatchReplyFromConfig(
     ensureRuntimePluginsLoaded({ config: cfg, workspaceDir });
   });
   const hookRunner = getGlobalHookRunner();
-
   // Extract message context for hooks (plugin and internal)
   const timestamp =
     typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp) ? ctx.Timestamp : undefined;
   const messageIdForHook =
     ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
-  const hookContext = deriveInboundMessageHookContext(ctx, { messageId: messageIdForHook });
+  const hookCtx = { ...ctx };
+  const buildHookState = (sourceCtx: FinalizedMsgContext) => {
+    const nextHookContext = deriveInboundMessageHookContext(sourceCtx, {
+      messageId: messageIdForHook,
+    });
+    return {
+      hookContext: nextHookContext,
+      inboundClaimContext: toPluginInboundClaimContext(nextHookContext),
+      inboundClaimEvent: toPluginInboundClaimEvent(nextHookContext, {
+        commandAuthorized:
+          typeof ctx.CommandAuthorized === "boolean" ? ctx.CommandAuthorized : undefined,
+        wasMentioned: typeof ctx.WasMentioned === "boolean" ? ctx.WasMentioned : undefined,
+      }),
+    };
+  };
+  let { hookContext, inboundClaimContext, inboundClaimEvent } = buildHookState(hookCtx);
   const { isGroup, groupId } = hookContext;
-  const inboundClaimContext = toPluginInboundClaimContext(hookContext);
-  const inboundClaimEvent = toPluginInboundClaimEvent(hookContext, {
-    commandAuthorized:
-      typeof ctx.CommandAuthorized === "boolean" ? ctx.CommandAuthorized : undefined,
-    wasMentioned: typeof ctx.WasMentioned === "boolean" ? ctx.WasMentioned : undefined,
-  });
+  let hookMediaPrepared = false;
+  let hookMediaMetadataStaged = false;
+  const prepareHookMediaMetadata = async () => {
+    if (hookMediaPrepared) {
+      return;
+    }
+    hookMediaPrepared = true;
+    // Plugin hooks may run in a different Codex cwd from core dispatch, so
+    // only actual hook/plugin-claim consumers get remote-cache media paths.
+    // Keep ctx unstaged for the normal get-reply single-stage path.
+    const staged = await traceReplyPhase("reply.stage_remote_media_for_dispatch", () =>
+      stageRemoteInboundMediaIfNeeded({
+        ctx: hookCtx,
+        cfg,
+        sessionKey: acpDispatchSessionKey,
+        workspaceDir,
+        remoteMediaMode: "cache",
+      }),
+    );
+    if (staged) {
+      hookMediaMetadataStaged = true;
+      ({ hookContext, inboundClaimContext, inboundClaimEvent } = buildHookState(hookCtx));
+    }
+  };
+  const buildMessageReceivedHookContext = () => {
+    const mediaRemoteHost = normalizeOptionalString(ctx.MediaRemoteHost);
+    const hasUnstagedRemoteMediaMetadata = Boolean(
+      hookContext.mediaPath ||
+      hookContext.mediaUrl ||
+      hookContext.mediaType ||
+      hookContext.mediaPaths?.length ||
+      hookContext.mediaUrls?.length ||
+      hookContext.mediaTypes?.length,
+    );
+    if (hookMediaMetadataStaged || !mediaRemoteHost || !hasUnstagedRemoteMediaMetadata) {
+      return hookContext;
+    }
+    const messageReceivedCtx = { ...hookCtx };
+    // message_received hooks run before normal get-reply staging, so remote
+    // host paths are not safe as live media. Keep originals as debug metadata.
+    delete messageReceivedCtx.MediaPath;
+    delete messageReceivedCtx.MediaPaths;
+    delete messageReceivedCtx.MediaUrl;
+    delete messageReceivedCtx.MediaUrls;
+    delete messageReceivedCtx.MediaType;
+    delete messageReceivedCtx.MediaTypes;
+    return {
+      ...buildHookState(messageReceivedCtx).hookContext,
+      mediaRemoteHost,
+      mediaStagingPending: true,
+      originalMediaPath: hookContext.mediaPath,
+      originalMediaUrl: hookContext.mediaUrl,
+      originalMediaType: hookContext.mediaType,
+      originalMediaPaths: hookContext.mediaPaths,
+      originalMediaUrls: hookContext.mediaUrls,
+      originalMediaTypes: hookContext.mediaTypes,
+    };
+  };
 
   // Check if we should route replies to originating channel instead of dispatcher.
   // Only route when the originating channel is DIFFERENT from the current surface.
@@ -2021,11 +2088,14 @@ export async function dispatchReplyFromConfig(
         `plugin-bound inbound routed to ${pluginOwnedBinding.pluginId} conversation=${pluginOwnedBinding.conversationId}`,
       );
       const targetedClaimOutcome = hookRunner?.runInboundClaimForPluginOutcome
-        ? await hookRunner.runInboundClaimForPluginOutcome(
-            pluginOwnedBinding.pluginId,
-            inboundClaimEvent,
-            { ...inboundClaimContext, pluginBinding: pluginOwnedBinding },
-          )
+        ? await (async () => {
+            await prepareHookMediaMetadata();
+            return hookRunner.runInboundClaimForPluginOutcome(
+              pluginOwnedBinding.pluginId,
+              inboundClaimEvent,
+              { ...inboundClaimContext, pluginBinding: pluginOwnedBinding },
+            );
+          })()
         : (() => {
             const pluginLoaded =
               getGlobalPluginRegistry()?.plugins.some(
@@ -2117,11 +2187,14 @@ export async function dispatchReplyFromConfig(
   }
 
   // Trigger plugin hooks (fire-and-forget)
-  if (ctx.SuppressMessageReceivedHooks !== true && hookRunner?.hasHooks("message_received")) {
+  const hasMessageReceivedHookConsumer =
+    ctx.SuppressMessageReceivedHooks !== true && hookRunner?.hasHooks("message_received") === true;
+  if (hasMessageReceivedHookConsumer) {
+    const messageReceivedHookContext = buildMessageReceivedHookContext();
     fireAndForgetHook(
       hookRunner.runMessageReceived(
-        toPluginMessageReceivedEvent(hookContext),
-        toPluginMessageContext(hookContext),
+        toPluginMessageReceivedEvent(messageReceivedHookContext),
+        toPluginMessageContext(messageReceivedHookContext),
       ),
       "dispatch-from-config: message_received plugin hook failed",
     );
@@ -2129,10 +2202,11 @@ export async function dispatchReplyFromConfig(
 
   // Bridge to internal hooks (HOOK.md discovery system) - refs #8807
   if (ctx.SuppressMessageReceivedHooks !== true && sessionKey) {
+    const messageReceivedHookContext = buildMessageReceivedHookContext();
     fireAndForgetHook(
       triggerInternalHook(
         createInternalHookEvent("message", "received", sessionKey, {
-          ...toInternalMessageReceivedContext(hookContext),
+          ...toInternalMessageReceivedContext(messageReceivedHookContext),
           timestamp,
         }),
       ),

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -59,6 +59,7 @@ import { createFastTestModelSelectionState, createModelSelectionState } from "./
 import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
 import { createReplyTimingTracker } from "./reply-timing-tracker.js";
 import { initSessionState } from "./session.js";
+import { stageRemoteInboundMediaIfNeeded } from "./stage-remote-inbound-media.js";
 import {
   isStaleHeartbeatAutoFallbackOverride,
   resolveStoredModelOverride,
@@ -198,36 +199,6 @@ async function applyMediaUnderstandingIfNeeded(params: {
     );
     return false;
   }
-}
-
-async function stageRemoteInboundMediaBeforeUnderstandingIfNeeded(params: {
-  ctx: MsgContext;
-  cfg: OpenClawConfig;
-  sessionKey?: string;
-  workspaceDir: string;
-}): Promise<boolean> {
-  if (
-    !params.sessionKey ||
-    params.ctx.MediaStaged ||
-    !normalizeOptionalString(params.ctx.MediaRemoteHost) ||
-    !hasInboundMedia(params.ctx)
-  ) {
-    return false;
-  }
-
-  const { stageSandboxMedia } = await loadStageSandboxMediaRuntime();
-  const result = await stageSandboxMedia({
-    ctx: params.ctx,
-    sessionCtx: params.ctx,
-    cfg: params.cfg,
-    sessionKey: params.sessionKey,
-    workspaceDir: params.workspaceDir,
-  });
-  if (result.staged.size > 0) {
-    params.ctx.MediaStaged = true;
-    return true;
-  }
-  return false;
 }
 
 async function applyLinkUnderstandingIfNeeded(params: {
@@ -440,7 +411,7 @@ export async function getReplyFromConfig(
     hasInboundMedia(finalized)
   ) {
     await traceGetReplyPhase("reply.stage_remote_media_pre_understanding", () =>
-      stageRemoteInboundMediaBeforeUnderstandingIfNeeded({
+      stageRemoteInboundMediaIfNeeded({
         ctx: finalized,
         cfg,
         sessionKey: agentSessionKey,

--- a/src/auto-reply/reply/stage-remote-inbound-media.ts
+++ b/src/auto-reply/reply/stage-remote-inbound-media.ts
@@ -1,0 +1,49 @@
+/** Shared guard for staging remote inbound media into the local cache. */
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../../config/config.js";
+import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import type { MsgContext } from "../templating.js";
+import { hasInboundMedia } from "./inbound-media.js";
+
+const stageSandboxMediaRuntimeLoader = createLazyImportLoader(
+  () => import("./stage-sandbox-media.runtime.js"),
+);
+
+/**
+ * Stage remote (SCP) inbound media before downstream consumers read the media
+ * paths off ctx, then mark MediaStaged so the single-stage contract holds for
+ * later staging sites. Both the dispatch plugin-claim path and get-reply's
+ * media-understanding path rely on this rewrite to expose the local cache path
+ * instead of the unreachable remote host path; returns whether staging ran.
+ */
+export async function stageRemoteInboundMediaIfNeeded(params: {
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  sessionKey?: string;
+  workspaceDir: string;
+  remoteMediaMode?: "sandbox-or-cache" | "cache";
+}): Promise<boolean> {
+  if (
+    !params.sessionKey ||
+    params.ctx.MediaStaged ||
+    !normalizeOptionalString(params.ctx.MediaRemoteHost) ||
+    !hasInboundMedia(params.ctx)
+  ) {
+    return false;
+  }
+
+  const { stageSandboxMedia } = await stageSandboxMediaRuntimeLoader.load();
+  const result = await stageSandboxMedia({
+    ctx: params.ctx,
+    sessionCtx: params.ctx,
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    workspaceDir: params.workspaceDir,
+    remoteMediaMode: params.remoteMediaMode,
+  });
+  if (result.staged.size === 0) {
+    return false;
+  }
+  params.ctx.MediaStaged = true;
+  return true;
+}

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -41,6 +41,7 @@ export async function stageSandboxMedia(params: {
   cfg: OpenClawConfig;
   sessionKey?: string;
   workspaceDir: string;
+  remoteMediaMode?: "sandbox-or-cache" | "cache";
 }): Promise<StageSandboxMediaResult> {
   const { ctx, sessionCtx, cfg, sessionKey, workspaceDir } = params;
   const hasPathsArray = Array.isArray(ctx.MediaPaths) && ctx.MediaPaths.length > 0;
@@ -49,11 +50,14 @@ export async function stageSandboxMedia(params: {
     return EMPTY_STAGE_RESULT;
   }
 
-  const sandbox = await ensureSandboxWorkspaceForSession({
-    config: cfg,
-    sessionKey,
-    workspaceDir,
-  });
+  const forceRemoteCache = ctx.MediaRemoteHost && params.remoteMediaMode === "cache";
+  const sandbox = forceRemoteCache
+    ? null
+    : await ensureSandboxWorkspaceForSession({
+        config: cfg,
+        sessionKey,
+        workspaceDir,
+      });
 
   // For remote attachments without sandbox, use ~/.openclaw/media (not agent workspace for privacy)
   const remoteMediaCacheDir = ctx.MediaRemoteHost

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -58,6 +58,14 @@ export type CanonicalInboundMessageHookContext = {
   mediaPaths?: string[];
   mediaUrls?: string[];
   mediaTypes?: string[];
+  mediaRemoteHost?: string;
+  mediaStagingPending?: boolean;
+  originalMediaPath?: string;
+  originalMediaUrl?: string;
+  originalMediaType?: string;
+  originalMediaPaths?: string[];
+  originalMediaUrls?: string[];
+  originalMediaTypes?: string[];
   originatingChannel?: string;
   originatingTo?: string;
   guildId?: string;
@@ -88,6 +96,27 @@ export type CanonicalSentMessageHookContext = {
 
 function readNonBlankString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function assignRemoteMediaStagingMetadata(
+  target: Record<string, unknown>,
+  canonical: CanonicalInboundMessageHookContext,
+) {
+  const metadata = {
+    mediaRemoteHost: canonical.mediaRemoteHost,
+    mediaStagingPending: canonical.mediaStagingPending,
+    originalMediaPath: canonical.originalMediaPath,
+    originalMediaUrl: canonical.originalMediaUrl,
+    originalMediaType: canonical.originalMediaType,
+    originalMediaPaths: canonical.originalMediaPaths,
+    originalMediaUrls: canonical.originalMediaUrls,
+    originalMediaTypes: canonical.originalMediaTypes,
+  };
+  for (const [key, value] of Object.entries(metadata)) {
+    if (value !== undefined) {
+      target[key] = value;
+    }
+  }
 }
 
 export function deriveInboundMessageHookContext(
@@ -406,6 +435,9 @@ export function toPluginInboundClaimEvent(
       topicName: canonical.topicName,
     },
   };
+  if (event.metadata) {
+    assignRemoteMediaStagingMetadata(event.metadata, canonical);
+  }
   assignTraceFields(event, canonical.trace);
   return event;
 }
@@ -455,6 +487,9 @@ export function toPluginMessageReceivedEvent(
       topicName: canonical.topicName,
     },
   };
+  if (event.metadata) {
+    assignRemoteMediaStagingMetadata(event.metadata, canonical);
+  }
   assignTraceFields(event, canonical.trace);
   return event;
 }
@@ -478,7 +513,7 @@ export function toPluginMessageSentEvent(
 export function toInternalMessageReceivedContext(
   canonical: CanonicalInboundMessageHookContext,
 ): MessageReceivedHookContext {
-  return {
+  const context: MessageReceivedHookContext = {
     from: canonical.from,
     content: canonical.content,
     timestamp: canonical.timestamp,
@@ -506,6 +541,10 @@ export function toInternalMessageReceivedContext(
       topicName: canonical.topicName,
     },
   };
+  if (context.metadata) {
+    assignRemoteMediaStagingMetadata(context.metadata, canonical);
+  }
+  return context;
 }
 
 export function toInternalMessageTranscribedContext(


### PR DESCRIPTION
Closes #91744.

## What Problem This Solves

Remote iMessage attachments can arrive with `MediaRemoteHost` and raw macOS Messages paths such as `/Users/.../Library/Messages/Attachments/...`. Plugin-bound Codex inbound claims could build metadata before OpenClaw staged those paths, so Codex could receive an unreadable remote Mac path instead of a local/cache image path.

## Summary

- Stage remote inbound iMessage media before plugin-bound Codex inbound-claim metadata is built.
- Use cache-mode staging for plugin-bound Codex claims so Codex receives a local/cache `localImage` path instead of a raw remote Mac Messages attachment path.
- Keep the normal reply path single-stage; ordinary non-plugin remote iMessage media still stages later in `get-reply`.
- For `message_received` hooks where staging has not run, omit the live `mediaPath`/`mediaUrl` fields and include `mediaStagingPending`, `mediaRemoteHost`, and `originalMedia*` metadata so consumers can detect the pending remote-media contract.

## Evidence

Final head: `4a0c2e3fc8c76cfc32f656662650daf54737d0d1`.

Scenario executed: near-real remote iMessage `MediaRemoteHost` runtime path using the real `stageRemoteInboundMediaIfNeeded`, message hook mapper, and Codex turn-input builder. The harness used an isolated OpenClaw state dir and an SCP-compatible local shim to simulate successful remote attachment transfer without exposing live Messages data.

Proof harness: `node --import tsx --input-type=module <inline proof harness>`.

```json
{
  "prHeadSha": "4a0c2e3fc8c76cfc32f656662650daf54737d0d1",
  "scenario": "near-real remote iMessage MediaRemoteHost staging before plugin-bound Codex claim",
  "redactedOriginalRemoteMedia": {
    "provider": "imessage",
    "accountId": "default",
    "mediaRemoteHost": "openclaw-mac.example",
    "mediaPath": "/Users/redacted/Library/Messages/Attachments/AA/BB/photo.jpg",
    "mediaType": "image/jpeg"
  },
  "stageResult": {
    "staged": true,
    "mediaStagedFlag": true,
    "cacheFileExists": true
  },
  "pluginClaimMediaPath": "/var/folders/.../state/media/remote-cache/agent-main-imessage-direct-chat--2a3a4048/photo.jpg",
  "codexInput": [
    { "type": "text", "text": "what is this?", "text_elements": [] },
    { "type": "localImage", "path": "/var/folders/.../state/media/remote-cache/agent-main-imessage-direct-chat--2a3a4048/photo.jpg" },
    { "type": "localImage", "path": "/var/folders/.../state/media/remote-cache/agent-main-imessage-direct-chat--2a3a4048/photo.jpg" }
  ],
  "checks": {
    "stagedBeforeCodexClaim": true,
    "codexReceivesLocalImage": true,
    "stagedPathIsRemoteCache": true,
    "rawMessagesPathVisible": false
  }
}
```

Observed result: the plugin-bound claim metadata is rewritten from the raw remote Mac attachment path to the staged remote-cache path before Codex input is built, and Codex receives `localImage` entries for that staged cache path. The raw `/Users/.../Messages/Attachments/...` path does not reach Codex.

What was not tested: a live remote Mac/iMessage conversation; the proof uses a near-real remote-host scenario with a local SCP shim to avoid requiring live private Messages credentials.

## Validation

- Focused remote iMessage dispatch regressions passed, including plugin-bound staging and the `message_received` pending-stage metadata contract.
- Hook mapper, SCP remote-cache staging, Codex conversation turn-input, and dispatch regressions passed in the rebased branch.
- Formatting, lint, and whitespace checks passed.

AI-assisted: yes.
