### PR TITLE
fix(ui): reload WebChat history for deferred thinking

### DIFF
--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -1676,7 +1676,13 @@ describe("connectGateway", () => {
     });
 
     expect(host.chatRunId).toBeNull();
-    expect(host.chatMessages).toEqual([persistedUser]);
+    expect(host.chatMessages).toEqual([
+      persistedUser,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Final answer" }],
+      },
+    ]);
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
     expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
     expect(
@@ -1846,7 +1852,13 @@ describe("connectGateway", () => {
     await Promise.resolve();
 
     expect(host.chatRunId).toBeNull();
-    expect(host.chatMessages).toEqual([persistedUser]);
+    expect(host.chatMessages).toEqual([
+      persistedUser,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Tool-backed final answer" }],
+      },
+    ]);
     expect(host.toolStreamOrder).toHaveLength(0);
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
     expect(loadChatHistoryMock).toHaveBeenCalledWith(host);

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -1654,10 +1654,6 @@ describe("connectGateway", () => {
     host.chatRunId = "main-run-reasoning";
     host.chatMessages = [persistedUser];
     loadChatHistoryMock.mockClear();
-    loadChatHistoryMock.mockImplementationOnce(async () => {
-      host.chatMessages = [persistedUser, persistedAssistant];
-      return undefined;
-    });
 
     client.emitEvent({
       event: "session.message",
@@ -1680,7 +1676,7 @@ describe("connectGateway", () => {
     });
 
     expect(host.chatRunId).toBeNull();
-    expect(host.chatMessages).toEqual([persistedUser, persistedAssistant]);
+    expect(host.chatMessages).toEqual([persistedUser]);
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
     expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
     expect(
@@ -1826,10 +1822,6 @@ describe("connectGateway", () => {
     emitToolResultEvent(client);
     expect(host.toolStreamOrder).toHaveLength(1);
     loadChatHistoryMock.mockClear();
-    loadChatHistoryMock.mockImplementationOnce(async () => {
-      host.chatMessages = [persistedUser, persistedAssistant];
-      return undefined;
-    });
 
     client.emitEvent({
       event: "session.message",
@@ -1854,7 +1846,7 @@ describe("connectGateway", () => {
     await Promise.resolve();
 
     expect(host.chatRunId).toBeNull();
-    expect(host.chatMessages).toEqual([persistedUser, persistedAssistant]);
+    expect(host.chatMessages).toEqual([persistedUser]);
     expect(host.toolStreamOrder).toHaveLength(0);
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
     expect(loadChatHistoryMock).toHaveBeenCalledWith(host);

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -5,6 +5,7 @@ import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "../../../src/gateway/events.js";
 import type { ActivityEntry } from "./activity-model.ts";
 import { connectGateway, resolveControlUiClientVersion } from "./app-gateway.ts";
 import type { GatewayHelloOk } from "./gateway.ts";
+import type { SessionsListResult } from "./types.ts";
 import type { ChatQueueItem } from "./ui-types.ts";
 
 const loadChatHistoryMock = vi.hoisted(() => vi.fn(async () => undefined));
@@ -141,6 +142,7 @@ type TestGatewayHost = Parameters<typeof connectGateway>[0] & {
   chatSideResult: unknown;
   chatSideResultTerminalRuns: Set<string>;
   chatStream: string | null;
+  sessionsResult: SessionsListResult | null;
   updateComplete?: Promise<unknown>;
   chatToolMessages: Record<string, unknown>[];
   activityEntries: ActivityEntry[];
@@ -429,7 +431,7 @@ describe("connectGateway", () => {
         ts: 0,
         path: "",
         count: 1,
-        defaults: {},
+        defaults: { contextTokens: null, model: null, modelProvider: null },
         sessions: [
           {
             key: "main",

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -1653,6 +1653,21 @@ describe("connectGateway", () => {
     };
     host.chatRunId = "main-run-reasoning";
     host.chatMessages = [persistedUser];
+    host.sessionsResult = {
+      count: 1,
+      defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+      path: "",
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          status: "done",
+          hasActiveRun: false,
+          updatedAt: Date.now(),
+        },
+      ],
+      ts: Date.now(),
+    };
     loadChatHistoryMock.mockClear();
 
     client.emitEvent({
@@ -1662,6 +1677,9 @@ describe("connectGateway", () => {
         message: persistedAssistant,
       },
     });
+    expect(host.chatRunId).toBe("main-run-reasoning");
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+
     client.emitEvent({
       event: "chat",
       payload: {

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -1531,6 +1531,232 @@ describe("connectGateway", () => {
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
   });
 
+  it("does not apply deferred transcript thinking from a different session final", () => {
+    const { host, client } = connectHostGateway();
+    host.chatRunId = "main-run-cross-session";
+    (
+      host as typeof host & {
+        pendingSessionMessageReloadSessionKey?: string | null;
+        pendingSessionMessageReloadHasThinking?: boolean;
+      }
+    ).pendingSessionMessageReloadSessionKey = "agent:other:main";
+    (
+      host as typeof host & {
+        pendingSessionMessageReloadSessionKey?: string | null;
+        pendingSessionMessageReloadHasThinking?: boolean;
+      }
+    ).pendingSessionMessageReloadHasThinking = true;
+    loadChatHistoryMock.mockClear();
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "main-run-cross-session",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Final answer" }],
+        },
+      },
+    });
+
+    expect(host.chatRunId).toBeNull();
+    expect(host.chatMessages).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Final answer" }],
+      },
+    ]);
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+  });
+
+  it("does not reload the selected chat for a deferred thinking final from a previous session", () => {
+    const { host, client } = connectHostGateway();
+    host.sessionKey = "agent:other:main";
+    host.chatRunId = "main-run-after-switch";
+    (
+      host as typeof host & {
+        pendingSessionMessageReloadSessionKey?: string | null;
+        pendingSessionMessageReloadHasThinking?: boolean;
+      }
+    ).pendingSessionMessageReloadSessionKey = "main";
+    (
+      host as typeof host & {
+        pendingSessionMessageReloadSessionKey?: string | null;
+        pendingSessionMessageReloadHasThinking?: boolean;
+      }
+    ).pendingSessionMessageReloadHasThinking = true;
+    loadChatHistoryMock.mockClear();
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "main-run-after-switch",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Final answer" }],
+        },
+      },
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+  });
+
+  it("does not arm deferred transcript thinking from user message text", () => {
+    const { host, client } = connectHostGateway();
+    host.chatRunId = "main-run-user-thinking-tag";
+    loadChatHistoryMock.mockClear();
+
+    client.emitEvent({
+      event: "session.message",
+      payload: {
+        sessionKey: "main",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "literal <thinking>example</thinking>" }],
+        },
+      },
+    });
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "main-run-user-thinking-tag",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Final answer" }],
+        },
+      },
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+  });
+
+  it("reloads deferred transcript thinking after a renderable final assistant payload", () => {
+    const { host, client } = connectHostGateway();
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "Think then answer" }],
+      timestamp: 100,
+    };
+    const persistedAssistant = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "private reasoning" },
+        { type: "text", text: "Final answer" },
+      ],
+      timestamp: 101,
+    };
+    host.chatRunId = "main-run-reasoning";
+    host.chatMessages = [persistedUser];
+    loadChatHistoryMock.mockClear();
+    loadChatHistoryMock.mockImplementationOnce(async () => {
+      host.chatMessages = [persistedUser, persistedAssistant];
+      return undefined;
+    });
+
+    client.emitEvent({
+      event: "session.message",
+      payload: {
+        sessionKey: "main",
+        message: persistedAssistant,
+      },
+    });
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "main-run-reasoning",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Final answer" }],
+        },
+      },
+    });
+
+    expect(host.chatRunId).toBeNull();
+    expect(host.chatMessages).toEqual([persistedUser, persistedAssistant]);
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
+    expect(
+      (
+        host as typeof host & {
+          pendingSessionMessageReloadSessionKey?: string | null;
+          pendingSessionMessageReloadHasThinking?: boolean;
+        }
+      ).pendingSessionMessageReloadSessionKey,
+    ).toBeNull();
+    expect(
+      (
+        host as typeof host & {
+          pendingSessionMessageReloadSessionKey?: string | null;
+          pendingSessionMessageReloadHasThinking?: boolean;
+        }
+      ).pendingSessionMessageReloadHasThinking,
+    ).toBe(false);
+  });
+
+  it("reloads deferred transcript thinking for selected global alias finals", () => {
+    const { host, client } = connectHostGateway();
+    const persistedAssistant = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "private global reasoning" },
+        { type: "text", text: "Final answer" },
+      ],
+    };
+    host.sessionKey = "agent:main:main";
+    host.chatRunId = "global-run-reasoning";
+    (host as typeof host & { applySettings?: ReturnType<typeof vi.fn> }).applySettings = vi.fn();
+    loadChatHistoryMock.mockClear();
+
+    client.emitEvent({
+      event: "session.message",
+      payload: {
+        sessionKey: "global",
+        agentId: "main",
+        message: persistedAssistant,
+      },
+    });
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "global-run-reasoning",
+        sessionKey: "global",
+        agentId: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Final answer" }],
+        },
+      },
+    });
+
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
+    expect(
+      (
+        host as typeof host & {
+          pendingSessionMessageReloadSessionKey?: string | null;
+          pendingSessionMessageReloadHasThinking?: boolean;
+        }
+      ).pendingSessionMessageReloadSessionKey,
+    ).toBeNull();
+    expect(
+      (
+        host as typeof host & {
+          pendingSessionMessageReloadSessionKey?: string | null;
+          pendingSessionMessageReloadHasThinking?: boolean;
+        }
+      ).pendingSessionMessageReloadHasThinking,
+    ).toBe(false);
+  });
+
   it("keeps source-reply finals live even when message tool events were seen", () => {
     const { host, client } = connectHostGateway();
     host.chatRunId = "main-run-with-message-tool";
@@ -1578,6 +1804,60 @@ describe("connectGateway", () => {
     ]);
     expect(host.toolStreamOrder).toHaveLength(1);
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
+  });
+
+  it("reloads deferred transcript thinking after a tool-backed renderable final payload", async () => {
+    const { host, client } = connectHostGateway();
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "Use a tool, then think" }],
+      timestamp: 100,
+    };
+    const persistedAssistant = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "private tool reasoning" },
+        { type: "text", text: "Tool-backed final answer" },
+      ],
+      timestamp: 101,
+    };
+    host.chatRunId = "main-run-tool-reasoning";
+    host.chatMessages = [persistedUser];
+    emitToolResultEvent(client);
+    expect(host.toolStreamOrder).toHaveLength(1);
+    loadChatHistoryMock.mockClear();
+    loadChatHistoryMock.mockImplementationOnce(async () => {
+      host.chatMessages = [persistedUser, persistedAssistant];
+      return undefined;
+    });
+
+    client.emitEvent({
+      event: "session.message",
+      payload: {
+        sessionKey: "main",
+        message: persistedAssistant,
+      },
+    });
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "main-run-tool-reasoning",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Tool-backed final answer" }],
+        },
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(host.chatRunId).toBeNull();
+    expect(host.chatMessages).toEqual([persistedUser, persistedAssistant]);
+    expect(host.toolStreamOrder).toHaveLength(0);
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
   });
 
   it("replays deferred session.message reloads after legacy silent final payload", () => {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -35,7 +35,7 @@ import {
 } from "./app-tool-stream.ts";
 import { shouldReloadHistoryForFinalEvent } from "./chat-event-reload.ts";
 import { loadChatComposerSnapshot, restoreChatComposerState } from "./chat/composer-persistence.ts";
-import { extractText, extractThinking } from "./chat/message-extract.ts";
+import { extractThinking } from "./chat/message-extract.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
 import { parseChatSideResult, type ChatSideResult } from "./chat/side-result.ts";
 import { formatConnectError } from "./connect-error.ts";
@@ -985,11 +985,6 @@ function handleTerminalChatEvent(
       return false;
     }
     const completedRunId = runId ?? null;
-    dropTransientDeferredThinkingFinalMessage(
-      host,
-      payload,
-      opts.deferredSessionMessageHasThinking === true,
-    );
     void loadChatHistory(host as unknown as ChatState).finally(() => {
       if (completedRunId && host.chatRunId && host.chatRunId !== completedRunId) {
         return;
@@ -1002,44 +997,6 @@ function handleTerminalChatEvent(
   resetToolStream(toolHost);
   flushQueue();
   return false;
-}
-
-function dropTransientDeferredThinkingFinalMessage(
-  host: GatewayHost,
-  payload: ChatEventPayload | undefined,
-  deferredSessionMessageHasThinking: boolean,
-): void {
-  if (!deferredSessionMessageHasThinking || payload?.state !== "final" || !payload.message) {
-    return;
-  }
-  if (extractThinking(payload.message)) {
-    return;
-  }
-  const chatState = host as unknown as ChatState;
-  const messages = chatState.chatMessages;
-  if (!Array.isArray(messages) || messages.length === 0) {
-    return;
-  }
-  if (!messageMatchesTransientFinalPayload(messages[messages.length - 1], payload.message)) {
-    return;
-  }
-  chatState.chatMessages = messages.slice(0, -1);
-}
-
-function messageMatchesTransientFinalPayload(message: unknown, payloadMessage: unknown): boolean {
-  if (!message || typeof message !== "object") {
-    return false;
-  }
-  const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
-  if (role && role !== "assistant") {
-    return false;
-  }
-  if (extractThinking(message)) {
-    return false;
-  }
-  const messageText = extractText(message)?.trim();
-  const payloadText = extractText(payloadMessage)?.trim();
-  return Boolean(messageText && payloadText && messageText === payloadText);
 }
 
 function isEventForDifferentActiveRun(
@@ -1111,7 +1068,6 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
     deferredReloadHost.pendingSessionMessageReloadHasThinking = false;
   }
   if (finalEventNeedsHistoryReload && !historyReloaded && !terminalEventIsForDifferentActiveRun) {
-    dropTransientDeferredThinkingFinalMessage(host, payload, deferredSessionMessageHasThinking);
     void loadChatHistory(host as unknown as ChatState);
     return;
   }

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -1139,6 +1139,16 @@ function handleSessionMessageGatewayEvent(
     return;
   }
   const sessionMatchesHost = sessionMessageMatchesHost(host, sessionKey, payload?.agentId);
+  if (
+    host.chatRunId &&
+    sessionKey &&
+    sessionMatchesHost &&
+    sessionMessagePayloadHasThinking(payload)
+  ) {
+    deferredReloadHost.pendingSessionMessageReloadSessionKey = sessionKey;
+    deferredReloadHost.pendingSessionMessageReloadHasThinking = true;
+    return;
+  }
   const runIdBeforeApply = host.chatRunId;
   const result = applySessionsChangedEvent(host as unknown as SessionsState, payload);
   if (result.applied && result.clearedChatRun) {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -35,6 +35,7 @@ import {
 } from "./app-tool-stream.ts";
 import { shouldReloadHistoryForFinalEvent } from "./chat-event-reload.ts";
 import { loadChatComposerSnapshot, restoreChatComposerState } from "./chat/composer-persistence.ts";
+import { extractThinking } from "./chat/message-extract.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
 import { parseChatSideResult, type ChatSideResult } from "./chat/side-result.ts";
 import { formatConnectError } from "./connect-error.ts";
@@ -90,6 +91,7 @@ import {
   resolveUiSelectedGlobalAgentId,
 } from "./session-key.ts";
 import type { UiSettings } from "./storage.ts";
+import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 import type {
   AgentsListResult,
   PresenceEntry,
@@ -157,6 +159,7 @@ type GatewayHost = {
 
 type GatewayHostWithDeferredSessionMessageReload = GatewayHost & {
   pendingSessionMessageReloadSessionKey?: string | null;
+  pendingSessionMessageReloadHasThinking?: boolean;
 };
 
 type SessionDefaultsSnapshot = {
@@ -174,6 +177,13 @@ type GatewayHostWithShutdownMessage = GatewayHost & {
 type GatewayHostWithSideResults = GatewayHost & {
   chatSideResult?: ChatSideResult | null;
   chatSideResultTerminalRuns?: Set<string>;
+};
+
+type SessionMessageGatewayPayload = {
+  sessionKey?: string;
+  agentId?: string;
+  runId?: unknown;
+  message?: unknown;
 };
 
 const SESSIONS_CHANGED_RELOAD_DEBOUNCE_MS = 5_000;
@@ -552,6 +562,17 @@ function sessionMessageMatchesHost(
   );
 }
 
+function sessionMessagePayloadHasThinking(
+  payload: SessionMessageGatewayPayload | undefined,
+): boolean {
+  const message = payload?.message;
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
+  return role === "assistant" && typeof extractThinking(message) === "string";
+}
+
 function chatSideResultAgentScopeMatches(host: GatewayHost, sideResult: ChatSideResult): boolean {
   return globalAgentScopeMatches(host, sideResult.sessionKey, sideResult.agentId);
 }
@@ -921,6 +942,7 @@ function handleTerminalChatEvent(
   payload: ChatEventPayload | undefined,
   state: ReturnType<typeof handleChatEvent>,
   activeRunIdBeforeEvent: string | null,
+  opts: { deferredSessionMessageHasThinking?: boolean } = {},
 ): boolean {
   if (state !== "final" && state !== "error" && state !== "aborted") {
     return false;
@@ -953,7 +975,12 @@ function handleTerminalChatEvent(
   // response; an immediate transcript reload replaces the optimistic user bubble
   // with the persisted copy and causes a visible disappear/reappear flicker.
   if (hadToolEvents && state === "final") {
-    if (activeRunIdBeforeEvent && !shouldReloadHistoryForFinalEvent(payload)) {
+    if (
+      activeRunIdBeforeEvent &&
+      !shouldReloadHistoryForFinalEvent(payload, {
+        deferredSessionMessageHasThinking: opts.deferredSessionMessageHasThinking,
+      })
+    ) {
       flushQueue();
       return false;
     }
@@ -1006,19 +1033,31 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
     payload,
     activeRunIdBeforeEvent,
   );
-  const historyReloaded = handleTerminalChatEvent(host, payload, state, activeRunIdBeforeEvent);
   const deferredReloadHost = host as GatewayHostWithDeferredSessionMessageReload;
   const deferredSessionKey = deferredReloadHost.pendingSessionMessageReloadSessionKey?.trim();
   const payloadSessionKey = payload?.sessionKey?.trim();
+  const deferredSessionMessageHasThinking = Boolean(
+    deferredReloadHost.pendingSessionMessageReloadHasThinking === true &&
+    deferredSessionKey &&
+    payloadSessionKey &&
+    areUiSessionKeysEquivalent(deferredSessionKey, payloadSessionKey) &&
+    sessionMessageMatchesHost(host, payloadSessionKey, payload?.agentId),
+  );
+  const historyReloaded = handleTerminalChatEvent(host, payload, state, activeRunIdBeforeEvent, {
+    deferredSessionMessageHasThinking,
+  });
   const finalEventNeedsHistoryReload =
-    state === "final" && shouldReloadHistoryForFinalEvent(payload);
+    state === "final" &&
+    shouldReloadHistoryForFinalEvent(payload, {
+      deferredSessionMessageHasThinking,
+    });
   const shouldResolveDeferredSessionMessageReload = Boolean(
     deferredSessionKey &&
     payloadSessionKey &&
     areUiSessionKeysEquivalent(deferredSessionKey, payloadSessionKey) &&
     isTerminalChatState(state) &&
     !terminalEventIsForDifferentActiveRun &&
-    areUiSessionKeysEquivalent(payloadSessionKey, host.sessionKey) &&
+    sessionMessageMatchesHost(host, payloadSessionKey, payload?.agentId) &&
     !host.chatRunId,
   );
   const shouldReplayDeferredSessionMessageReload =
@@ -1026,6 +1065,7 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
     (state !== "final" || finalEventNeedsHistoryReload);
   if (shouldResolveDeferredSessionMessageReload) {
     deferredReloadHost.pendingSessionMessageReloadSessionKey = null;
+    deferredReloadHost.pendingSessionMessageReloadHasThinking = false;
   }
   if (finalEventNeedsHistoryReload && !historyReloaded && !terminalEventIsForDifferentActiveRun) {
     void loadChatHistory(host as unknown as ChatState);
@@ -1074,6 +1114,7 @@ function flushChatQueueAfterSessionRunReconcile(
     (!eventSessionKey || areUiSessionKeysEquivalent(eventSessionKey, pendingSessionKey))
   ) {
     deferredReloadHost.pendingSessionMessageReloadSessionKey = null;
+    deferredReloadHost.pendingSessionMessageReloadHasThinking = false;
     const reloadSessionKey = pendingSessionKey;
     void Promise.resolve(loadChatHistory(host as unknown as ChatState)).finally(() => {
       if (areUiSessionKeysEquivalent(host.sessionKey, reloadSessionKey)) {
@@ -1090,7 +1131,7 @@ function flushChatQueueAfterSessionRunReconcile(
 
 function handleSessionMessageGatewayEvent(
   host: GatewayHost,
-  payload: { sessionKey?: string; agentId?: string; runId?: unknown } | undefined,
+  payload: SessionMessageGatewayPayload | undefined,
 ) {
   const deferredReloadHost = host as GatewayHostWithDeferredSessionMessageReload;
   const sessionKey = payload?.sessionKey?.trim();
@@ -1103,6 +1144,9 @@ function handleSessionMessageGatewayEvent(
   if (result.applied && result.clearedChatRun) {
     if (sessionMatchesHost) {
       deferredReloadHost.pendingSessionMessageReloadSessionKey = sessionKey;
+      deferredReloadHost.pendingSessionMessageReloadHasThinking =
+        deferredReloadHost.pendingSessionMessageReloadHasThinking ||
+        sessionMessagePayloadHasThinking(payload);
     }
     if (flushChatQueueAfterSessionRunReconcile(host, result, payload, runIdBeforeApply)) {
       return;
@@ -1118,6 +1162,9 @@ function handleSessionMessageGatewayEvent(
   // first LLM delta arrives.
   if (host.chatRunId) {
     deferredReloadHost.pendingSessionMessageReloadSessionKey = sessionKey;
+    deferredReloadHost.pendingSessionMessageReloadHasThinking =
+      deferredReloadHost.pendingSessionMessageReloadHasThinking ||
+      sessionMessagePayloadHasThinking(payload);
     const refreshStartedAt = Date.now();
     const runIdBeforeRefresh = host.chatRunId;
     void loadSessions(host as unknown as SessionsState, {
@@ -1136,6 +1183,7 @@ function handleSessionMessageGatewayEvent(
     return;
   }
   deferredReloadHost.pendingSessionMessageReloadSessionKey = null;
+  deferredReloadHost.pendingSessionMessageReloadHasThinking = false;
   void loadChatHistory(host as unknown as ChatState);
 }
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -35,7 +35,7 @@ import {
 } from "./app-tool-stream.ts";
 import { shouldReloadHistoryForFinalEvent } from "./chat-event-reload.ts";
 import { loadChatComposerSnapshot, restoreChatComposerState } from "./chat/composer-persistence.ts";
-import { extractThinking } from "./chat/message-extract.ts";
+import { extractText, extractThinking } from "./chat/message-extract.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
 import { parseChatSideResult, type ChatSideResult } from "./chat/side-result.ts";
 import { formatConnectError } from "./connect-error.ts";
@@ -985,6 +985,11 @@ function handleTerminalChatEvent(
       return false;
     }
     const completedRunId = runId ?? null;
+    dropTransientDeferredThinkingFinalMessage(
+      host,
+      payload,
+      opts.deferredSessionMessageHasThinking === true,
+    );
     void loadChatHistory(host as unknown as ChatState).finally(() => {
       if (completedRunId && host.chatRunId && host.chatRunId !== completedRunId) {
         return;
@@ -997,6 +1002,44 @@ function handleTerminalChatEvent(
   resetToolStream(toolHost);
   flushQueue();
   return false;
+}
+
+function dropTransientDeferredThinkingFinalMessage(
+  host: GatewayHost,
+  payload: ChatEventPayload | undefined,
+  deferredSessionMessageHasThinking: boolean,
+): void {
+  if (!deferredSessionMessageHasThinking || payload?.state !== "final" || !payload.message) {
+    return;
+  }
+  if (extractThinking(payload.message)) {
+    return;
+  }
+  const chatState = host as unknown as ChatState;
+  const messages = chatState.chatMessages;
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return;
+  }
+  if (!messageMatchesTransientFinalPayload(messages[messages.length - 1], payload.message)) {
+    return;
+  }
+  chatState.chatMessages = messages.slice(0, -1);
+}
+
+function messageMatchesTransientFinalPayload(message: unknown, payloadMessage: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
+  if (role && role !== "assistant") {
+    return false;
+  }
+  if (extractThinking(message)) {
+    return false;
+  }
+  const messageText = extractText(message)?.trim();
+  const payloadText = extractText(payloadMessage)?.trim();
+  return Boolean(messageText && payloadText && messageText === payloadText);
 }
 
 function isEventForDifferentActiveRun(
@@ -1068,6 +1111,7 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
     deferredReloadHost.pendingSessionMessageReloadHasThinking = false;
   }
   if (finalEventNeedsHistoryReload && !historyReloaded && !terminalEventIsForDifferentActiveRun) {
+    dropTransientDeferredThinkingFinalMessage(host, payload, deferredSessionMessageHasThinking);
     void loadChatHistory(host as unknown as ChatState);
     return;
   }

--- a/ui/src/ui/chat-event-reload.test.ts
+++ b/ui/src/ui/chat-event-reload.test.ts
@@ -35,6 +35,40 @@ describe("shouldReloadHistoryForFinalEvent", () => {
     ).toBe(false);
   });
 
+  it("returns true when a deferred transcript message has thinking missing from the final payload", () => {
+    expect(
+      shouldReloadHistoryForFinalEvent(
+        {
+          runId: "run-1",
+          sessionKey: "main",
+          state: "final",
+          message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+        },
+        { deferredSessionMessageHasThinking: true },
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when the final payload already carries the deferred thinking block", () => {
+    expect(
+      shouldReloadHistoryForFinalEvent(
+        {
+          runId: "run-1",
+          sessionKey: "main",
+          state: "final",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "private reasoning" },
+              { type: "text", text: "done" },
+            ],
+          },
+        },
+        { deferredSessionMessageHasThinking: true },
+      ),
+    ).toBe(false);
+  });
+
   it("returns false when final event includes a legacy assistant text payload without role", () => {
     expect(
       shouldReloadHistoryForFinalEvent({

--- a/ui/src/ui/chat-event-reload.ts
+++ b/ui/src/ui/chat-event-reload.ts
@@ -1,5 +1,5 @@
 // Control UI module implements chat event reload behavior.
-import { extractText } from "./chat/message-extract.ts";
+import { extractText, extractThinking } from "./chat/message-extract.ts";
 import type { ChatEventPayload } from "./controllers/chat.ts";
 import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 
@@ -21,8 +21,19 @@ function hasRenderableAssistantFinalMessage(message: unknown): boolean {
   return typeof text === "string" && text.trim() !== "" && !SILENT_REPLY_PATTERN.test(text);
 }
 
-export function shouldReloadHistoryForFinalEvent(payload?: ChatEventPayload): boolean {
-  return Boolean(
-    payload && payload.state === "final" && !hasRenderableAssistantFinalMessage(payload.message),
-  );
+function hasThinkingBlock(message: unknown): boolean {
+  return Boolean(message && typeof message === "object" && extractThinking(message));
+}
+
+export function shouldReloadHistoryForFinalEvent(
+  payload?: ChatEventPayload,
+  opts: { deferredSessionMessageHasThinking?: boolean } = {},
+): boolean {
+  if (!payload || payload.state !== "final") {
+    return false;
+  }
+  if (opts.deferredSessionMessageHasThinking === true && !hasThinkingBlock(payload.message)) {
+    return true;
+  }
+  return !hasRenderableAssistantFinalMessage(payload.message);
 }

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2438,6 +2438,55 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatMessages).toEqual([persistedUser, liveAssistant]);
   });
 
+  it("keeps a newer repeated final when stale history has older reasoning with the same text", async () => {
+    const olderUser = {
+      role: "user",
+      content: [{ type: "text", text: "First ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const olderReasoningAssistant = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "older private reasoning" },
+        { type: "text", text: "Repeated final" },
+      ],
+      timestamp: 100,
+      __openclaw: { seq: 2 },
+    };
+    const newerUser = {
+      role: "user",
+      content: [{ type: "text", text: "Ask again" }],
+      timestamp: 200,
+    };
+    const newerLiveAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "Repeated final" }],
+      timestamp: 300,
+    };
+    const history = createDeferred<{ messages: unknown[]; thinkingLevel: string }>();
+    const request = vi.fn(() => history.promise);
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [olderUser, olderReasoningAssistant],
+    });
+
+    const load = loadChatHistory(state);
+    state.chatMessages = [olderUser, olderReasoningAssistant, newerUser, newerLiveAssistant];
+    history.resolve({
+      messages: [olderUser, olderReasoningAssistant],
+      thinkingLevel: "low",
+    });
+    await load;
+
+    expect(state.chatMessages).toEqual([
+      olderUser,
+      olderReasoningAssistant,
+      newerUser,
+      newerLiveAssistant,
+    ]);
+  });
+
   it("keeps active streamed assistant text when history reload returns a stale snapshot", async () => {
     const persistedUser = {
       role: "user",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1629,7 +1629,7 @@ describe("loadChatHistory filtering", () => {
     expect(state.chatThinkingLevel).toBe("medium");
   });
 
-  it("restores a deferred reasoning final after the transient final is removed", async () => {
+  it("replaces a live final with a persisted reasoning final when history is current", async () => {
     const persistedUser = {
       role: "user",
       content: [{ type: "text", text: "Think then answer" }],
@@ -1643,6 +1643,10 @@ describe("loadChatHistory filtering", () => {
       ],
       timestamp: 101,
     };
+    const liveAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "Final answer" }],
+    };
     const request = vi.fn().mockResolvedValue({
       messages: [persistedUser, persistedAssistant],
       thinkingLevel: "low",
@@ -1650,7 +1654,7 @@ describe("loadChatHistory filtering", () => {
     const state = createState({
       connected: true,
       client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser],
+      chatMessages: [persistedUser, liveAssistant],
     });
 
     await loadChatHistory(state);
@@ -2363,6 +2367,73 @@ describe("loadChatHistory retry handling", () => {
 
     expect(state.chatMessages).toEqual([persistedUser, optimisticUser, optimisticAssistant]);
     expect(state.chatStream).toBeNull();
+  });
+
+  it("dedupes a late terminal final when history catches up with the reasoning final", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "Think then answer" }],
+      __openclaw: { seq: 1 },
+    };
+    const persistedAssistant = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "private reasoning" },
+        { type: "text", text: "Final answer" },
+      ],
+      __openclaw: { seq: 2 },
+    };
+    const liveAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "Final answer" }],
+    };
+    const history = createDeferred<{ messages: unknown[]; thinkingLevel: string }>();
+    const request = vi.fn(() => history.promise);
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+    });
+
+    const load = loadChatHistory(state);
+    state.chatMessages = [persistedUser, liveAssistant];
+    history.resolve({
+      messages: [persistedUser, persistedAssistant],
+      thinkingLevel: "low",
+    });
+    await load;
+
+    expect(state.chatMessages).toEqual([persistedUser, persistedAssistant]);
+    expect(state.chatMessages).not.toContain(liveAssistant);
+  });
+
+  it("keeps a late terminal final when history reload returns a stale snapshot", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "Think then answer" }],
+      __openclaw: { seq: 1 },
+    };
+    const liveAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "Final answer" }],
+    };
+    const history = createDeferred<{ messages: unknown[]; thinkingLevel: string }>();
+    const request = vi.fn(() => history.promise);
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+    });
+
+    const load = loadChatHistory(state);
+    state.chatMessages = [persistedUser, liveAssistant];
+    history.resolve({
+      messages: [persistedUser],
+      thinkingLevel: "low",
+    });
+    await load;
+
+    expect(state.chatMessages).toEqual([persistedUser, liveAssistant]);
   });
 
   it("keeps active streamed assistant text when history reload returns a stale snapshot", async () => {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1646,6 +1646,7 @@ describe("loadChatHistory filtering", () => {
     const liveAssistant = {
       role: "assistant",
       content: [{ type: "text", text: "Final answer" }],
+      timestamp: 200,
     };
     const request = vi.fn().mockResolvedValue({
       messages: [persistedUser, persistedAssistant],
@@ -2386,6 +2387,7 @@ describe("loadChatHistory retry handling", () => {
     const liveAssistant = {
       role: "assistant",
       content: [{ type: "text", text: "Final answer" }],
+      timestamp: 200,
     };
     const history = createDeferred<{ messages: unknown[]; thinkingLevel: string }>();
     const request = vi.fn(() => history.promise);

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1629,6 +1629,38 @@ describe("loadChatHistory filtering", () => {
     expect(state.chatThinkingLevel).toBe("medium");
   });
 
+  it("restores a deferred reasoning final after the transient final is removed", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "Think then answer" }],
+      timestamp: 100,
+    };
+    const persistedAssistant = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "private reasoning" },
+        { type: "text", text: "Final answer" },
+      ],
+      timestamp: 101,
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser, persistedAssistant],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedUser, persistedAssistant]);
+    expect(
+      state.chatMessages.filter((message) => requireRecord(message).role === "assistant"),
+    ).toHaveLength(1);
+  });
+
   it("omits literal global agentId until selected/default agent is known", async () => {
     const request = vi.fn().mockResolvedValue({ messages: [] });
     const state = createState({

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -251,21 +251,31 @@ function historyHasSameOrNewerDisplayMessage(
   historyMessages: unknown[],
   signature: string,
   message: unknown,
+  previousMessages: unknown[] = [],
 ): boolean {
   return historyMessages.some((historyMessage) => {
     if (messageDisplaySignature(historyMessage) !== signature) {
       return false;
-    }
-    const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
-    if (role === "assistant" && extractThinking(historyMessage) && !extractThinking(message)) {
-      return true;
     }
     const timestamp = messageTimestampMs(message);
     if (timestamp == null) {
       return true;
     }
     const historyTimestamp = messageTimestampMs(historyMessage);
-    return historyTimestamp != null && historyTimestamp >= timestamp;
+    if (historyTimestamp != null && historyTimestamp >= timestamp) {
+      return true;
+    }
+    const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
+    return (
+      role === "assistant" &&
+      Boolean(extractThinking(historyMessage)) &&
+      !extractThinking(message) &&
+      !previousMessages.some(
+        (previousMessage) =>
+          messageDisplaySignature(previousMessage) === signature &&
+          Boolean(extractThinking(previousMessage)),
+      )
+    );
   });
 }
 
@@ -342,7 +352,9 @@ function collectLateOptimisticTailMessages(
     if (!signature) {
       return [];
     }
-    if (historyHasSameOrNewerDisplayMessage(historyMessages, signature, message)) {
+    if (
+      historyHasSameOrNewerDisplayMessage(historyMessages, signature, message, previousMessages)
+    ) {
       continue;
     }
     lateTail.push(message);

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -252,13 +252,13 @@ function historyHasSameOrNewerDisplayMessage(
   signature: string,
   message: unknown,
 ): boolean {
-  const timestamp = messageTimestampMs(message);
-  if (timestamp == null) {
-    return false;
-  }
   return historyMessages.some((historyMessage) => {
     if (messageDisplaySignature(historyMessage) !== signature) {
       return false;
+    }
+    const timestamp = messageTimestampMs(message);
+    if (timestamp == null) {
+      return true;
     }
     const historyTimestamp = messageTimestampMs(historyMessage);
     return historyTimestamp != null && historyTimestamp >= timestamp;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -5,7 +5,7 @@ import {
   isAssistantHeartbeatAckForDisplay,
   stripHeartbeatTokenForDisplay,
 } from "../chat/heartbeat-display.ts";
-import { extractText } from "../chat/message-extract.ts";
+import { extractText, extractThinking } from "../chat/message-extract.ts";
 import { reconcileChatRunLifecycle } from "../chat/run-lifecycle.ts";
 import {
   appendTerminalAssistantMessage,
@@ -255,6 +255,10 @@ function historyHasSameOrNewerDisplayMessage(
   return historyMessages.some((historyMessage) => {
     if (messageDisplaySignature(historyMessage) !== signature) {
       return false;
+    }
+    const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
+    if (role === "assistant" && extractThinking(historyMessage) && !extractThinking(message)) {
+      return true;
     }
     const timestamp = messageTimestampMs(message);
     if (timestamp == null) {


### PR DESCRIPTION
Fixes #91727.

## Summary

WebChat now keeps a deferred persisted assistant `session.message` with thinking/reasoning pending while the local run is active, then reloads the selected transcript after the terminal final when that final payload only contains renderable answer text. The repaint restores the persisted reasoning block without a manual browser refresh and avoids leaving a duplicate text-only final.

## Root cause

The terminal final path avoided `loadChatHistory()` whenever the final carried renderable assistant text. A prior `session.message` could already contain the persisted assistant message with a thinking block, but a session-row refresh could clear the local run before the final arrived. The final was then appended as a text-only assistant message and the UI could keep both the persisted reasoning final and the live text-only final.

## What changed

- Track thinking-bearing `session.message` payloads for the selected/equivalent session while a WebChat run is active.
- Keep those deferred thinking reloads pending until the matching terminal `chat` event, instead of letting the session-row refresh clear the run early.
- Reload history when the terminal final lacks the deferred thinking block.
- Preserve the existing no-reload path for normal renderable finals with no deferred thinking to recover.
- Dedupe text-only late finals when persisted history has the same assistant final plus thinking, while preserving newer repeated finals from stale history.
- Keep the cross-session/global-alias and literal user thinking-text guards covered.

## Real behavior proof

Behavior or issue addressed: WebChat receives a persisted assistant `session.message` with a `thinking` block during an active run, then receives a terminal `chat` final payload that only contains renderable final text. The fixed behavior is that WebChat reloads the selected transcript, renders the persisted reasoning block, and does not leave a duplicate text-only final answer bubble.

Real environment tested: Local OpenClaw source checkout at PR head `f68625750c83ef3eeb08fee396801b28e474fab3` on macOS. The repo Control UI ran through the Vite e2e server and the actual WebChat renderer ran in Playwright Chromium. The browser connected to a gateway-shaped WebSocket endpoint with the selected session row loaded as `reasoningLevel: "low"`.

Exact steps or command run after this patch:
```text
node --import tsx --input-type=module <<'NODE'
# Launch the repo Vite e2e server.
# Open /chat in Playwright Chromium.
# Load the Sessions view once so the selected WebChat session has reasoningLevel: low.
# Return to Chat and send a user prompt.
# Emit session.message with persisted assistant thinking plus final text.
# Set chat.history to that persisted transcript.
# Emit the timestamped terminal chat final payload with only final text.
# Wait for chat.history, screenshot WebChat, and count final/reasoning text in the real DOM.
NODE
```

Evidence after fix: Copied live browser proof output from the command above:
```json
{
  "head": "f68625750c83ef3eeb08fee396801b28e474fab3",
  "workingTreeStatus": "clean",
  "scenario": "WebChat deferred session.message thinking followed by timestamped terminal final payload without thinking",
  "browser": "Playwright Chromium",
  "sessionKey": "main",
  "activeSessionReasoningLevel": "low",
  "activeSessionThinkingLevel": "low",
  "sessionsListRequests": 1,
  "chatHistoryRequests": 2,
  "finalAnswerCount": 1,
  "reasoningCount": 1,
  "thinkingBlockCount": 1,
  "observedFinalText": "Final answer proof marker 91810",
  "observedReasoningText": "private reasoning proof marker 91810",
  "screenshotPath": "/Users/andy/openclaw-91810/.artifacts/pr-91810-proof/webchat-deferred-reasoning-current-head.png"
}
```

Observed result after fix: The WebChat DOM contained exactly one `Final answer proof marker 91810`, exactly one `private reasoning proof marker 91810`, and exactly one `.chat-thinking` block. The rendered assistant bubble contained the persisted reasoning block plus the final answer; the text-only terminal final did not remain as a duplicate.

What was not tested: I did not run a live external provider WebChat session because the reported bug is the Control UI/gateway event ordering after the provider has already produced a persisted assistant message. The browser proof exercises the real WebChat renderer and gateway message path without provider credentials.

## Validation

```text
node scripts/run-vitest.mjs ui/src/ui/chat-event-reload.test.ts ui/src/ui/app-gateway.node.test.ts ui/src/ui/controllers/chat.test.ts
```

Result: 3 files passed, 199 tests passed.

```text
node scripts/run-vitest.mjs ui/src/ui/app-gateway.node.test.ts
```

Result: 1 file passed, 67 tests passed.

```text
pnpm check:test-types
```

Result: passed.

```text
pnpm exec oxfmt --check --threads=1 ui/src/ui/app-gateway.ts ui/src/ui/chat-event-reload.ts ui/src/ui/app-gateway.node.test.ts ui/src/ui/chat-event-reload.test.ts ui/src/ui/controllers/chat.ts ui/src/ui/controllers/chat.test.ts
```

Result: all matched files use the correct format.

```text
git diff --check
```

Result: no whitespace errors.

Commit author verification:

```text
f68625750c Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(ui): preserve repeated late finals
ebb1d35195 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> test(ui): type session result fixtures
02e6638a0a Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(ui): keep deferred reasoning reload pending
e4508934f3 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(ui): preserve final during deferred history reload
39faf8a7ed Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(ui): avoid duplicate deferred-thinking final
260f6a5aec Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(ui): reload webchat history for deferred thinking
```
