### PR TITLE
fix(codex): restore memory recall from plugin tools

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -15,6 +15,7 @@ import {
   type EmbeddedRunAttemptResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentWorkspaceDir } from "openclaw/plugin-sdk/agent-runtime";
+import { buildMemorySystemPromptAddition } from "openclaw/plugin-sdk/core";
 import type { CodexDynamicToolSpec, JsonValue } from "./protocol.js";
 import { isJsonObject } from "./protocol.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
@@ -164,8 +165,9 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
   memoryToolNames: readonly string[];
 }): Promise<CodexWorkspaceBootstrapContext> {
   try {
-    const memoryToolsAvailable =
-      params.memoryToolNames.length > 0 &&
+    const memoryToolsAvailable = params.memoryToolNames.length > 0;
+    const canRouteWorkspaceMemoryThroughTools =
+      memoryToolsAvailable &&
       canRouteCodexWorkspaceMemoryThroughTools({
         config: params.params.config,
         agentId: params.params.agentId ?? params.sessionAgentId,
@@ -183,7 +185,7 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
       contextMode: params.params.bootstrapContextMode,
       runKind: params.params.bootstrapContextRunKind,
     });
-    const memoryToolRoutedBootstrapFiles = memoryToolsAvailable
+    const memoryToolRoutedBootstrapFiles = canRouteWorkspaceMemoryThroughTools
       ? selectCodexWorkspaceMemoryReferenceFiles({
           bootstrapFiles,
           workspaceDir: params.resolvedWorkspace,
@@ -197,7 +199,7 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
       }),
     );
     const contextFiles = buildBootstrapContextForFiles(
-      memoryToolsAvailable
+      canRouteWorkspaceMemoryThroughTools
         ? bootstrapFiles.filter(
             (file) =>
               !isCodexWorkspaceRootMemoryBootstrapFile({
@@ -218,16 +220,15 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
         targetWorkspaceDir: params.effectiveWorkspace,
       }),
     );
+    const injectOpenClawPromptContext = shouldInjectCodexOpenClawPromptContext(params.params);
     const promptContextFiles = selectCodexWorkspacePromptContextFiles(contextFiles, {
-      excludeMemory: memoryToolsAvailable,
+      excludeMemory: canRouteWorkspaceMemoryThroughTools,
       memoryWorkspaceDir: params.effectiveWorkspace,
     });
-    const developerInstructionFiles = shouldInjectCodexOpenClawPromptContext(params.params)
+    const developerInstructionFiles = injectOpenClawPromptContext
       ? selectCodexWorkspaceInheritedDeveloperInstructionFiles(contextFiles)
       : [];
-    const turnScopedDeveloperInstructionFiles = shouldInjectCodexOpenClawPromptContext(
-      params.params,
-    )
+    const turnScopedDeveloperInstructionFiles = injectOpenClawPromptContext
       ? selectCodexWorkspaceTurnScopedDeveloperInstructionFiles(contextFiles)
       : [];
     const heartbeatReferenceFiles = selectCodexWorkspaceHeartbeatReferenceFiles(contextFiles);
@@ -241,17 +242,19 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
       memoryReferenceFiles,
       memoryToolRoutedBootstrapFiles,
       memoryToolNames: [...params.memoryToolNames],
-      memoryToolRouted: memoryToolsAvailable,
+      memoryToolRouted: canRouteWorkspaceMemoryThroughTools,
       promptContext: renderCodexWorkspaceBootstrapPromptContext(promptContextFiles),
       developerInstructions:
         renderCodexWorkspaceThreadDeveloperInstructions(developerInstructionFiles),
       turnScopedDeveloperInstructions: renderCodexWorkspaceCollaborationDeveloperInstructions(
         turnScopedDeveloperInstructionFiles,
       ),
-      memoryCollaborationInstructions: shouldInjectCodexOpenClawPromptContext(params.params)
-        ? renderCodexWorkspaceMemoryReference({
+      memoryCollaborationInstructions: injectOpenClawPromptContext
+        ? renderCodexWorkspaceMemoryCollaborationInstructions({
             files: memoryReferenceFiles,
             toolNames: params.memoryToolNames,
+            includeRecallInstructions: memoryToolsAvailable,
+            citationsMode: params.params.config?.memory?.citations,
           })
         : undefined,
       heartbeatCollaborationInstructions:
@@ -777,6 +780,48 @@ function selectCodexWorkspaceMemoryReferenceFiles(params: {
       );
     })
     .toSorted(compareCodexBootstrapFiles);
+}
+
+function renderCodexWorkspaceMemoryCollaborationInstructions(params: {
+  files: EmbeddedContextFile[];
+  toolNames: readonly string[];
+  includeRecallInstructions: boolean;
+  citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
+}): string | undefined {
+  const toolNames = params.toolNames.map((name) => normalizeCodexDynamicToolName(name));
+  const recallInstructions = params.includeRecallInstructions
+    ? renderCodexMemoryRecallInstructions({
+        toolNames,
+        citationsMode: params.citationsMode,
+      })
+    : undefined;
+  const referenceInstructions = renderCodexWorkspaceMemoryReference({
+    files: params.files,
+    toolNames,
+  });
+  return joinCodexCollaborationSections(recallInstructions, referenceInstructions);
+}
+
+function renderCodexMemoryRecallInstructions(params: {
+  toolNames: readonly string[];
+  citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
+}): string | undefined {
+  const pluginInstructions = buildMemorySystemPromptAddition({
+    availableTools: new Set(params.toolNames),
+    citationsMode: params.citationsMode,
+  });
+  return pluginInstructions?.trim() ? pluginInstructions : undefined;
+}
+
+function joinCodexCollaborationSections(
+  ...sections: Array<string | undefined>
+): string | undefined {
+  const joined = sections
+    .map((section) => section?.trim())
+    .filter(isNonEmptyString)
+    .join("\n\n")
+    .trim();
+  return joined || undefined;
 }
 
 /**

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resetDiagnosticEventsForTest } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { clearInternalHooks, resetGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
+import { clearMemoryPluginState } from "openclaw/plugin-sdk/memory-host-core";
 import { clearPluginCommands } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { afterEach, beforeEach, expect, vi } from "vitest";
@@ -512,6 +513,7 @@ export function setupRunAttemptTestHooks(): void {
     testing.clearPendingCodexNativeHookRelayUnregistersForTests();
     resetCodexRateLimitCacheForTests();
     nativeHookRelayTesting.clearNativeHookRelaysForTests();
+    clearMemoryPluginState();
     clearPluginCommands();
     resetAgentEventsForTest();
     resetDiagnosticEventsForTest();

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -12,6 +12,10 @@ import {
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { initializeGlobalHookRunner, registerInternalHook } from "openclaw/plugin-sdk/hook-runtime";
+import {
+  clearMemoryPluginState,
+  registerMemoryCapability,
+} from "openclaw/plugin-sdk/memory-host-core";
 import { registerPluginCommand } from "openclaw/plugin-sdk/plugin-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
@@ -107,6 +111,23 @@ function expectResumeRequest(
   for (const [key, value] of Object.entries(params)) {
     expect(requestParams?.[key]).toEqual(value);
   }
+}
+
+function registerTestMemoryRecallPrompt(): void {
+  clearMemoryPluginState();
+  registerMemoryCapability("test-memory-core", {
+    promptBuilder: ({ availableTools }) => {
+      const hasMemorySearch = availableTools.has("memory_search");
+      const hasMemoryGet = availableTools.has("memory_get");
+      if (!hasMemorySearch && !hasMemoryGet) {
+        return [];
+      }
+      const guidance = hasMemorySearch
+        ? "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search before answering."
+        : "Before answering anything about prior work, decisions, dates, people, preferences, or todos that already point to a specific memory file or note: run memory_get before answering.";
+      return ["## Memory Recall", guidance, ""];
+    },
+  });
 }
 
 async function writeExistingBinding(
@@ -2203,6 +2224,7 @@ describe("runCodexAppServerAttempt", () => {
     await fs.writeFile(path.join(workspaceDir, "TOOLS.md"), toolGuidance);
     await fs.writeFile(path.join(workspaceDir, "USER.md"), userProfile);
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+    registerTestMemoryRecallPrompt();
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("memory_search"),
       createRuntimeDynamicTool("memory_get"),
@@ -2240,6 +2262,8 @@ describe("runCodexAppServerAttempt", () => {
     expect(collaborationInstructions).toContain(
       "MEMORY.md exists in the active agent workspace as a memory file, not an instruction file",
     );
+    expect(collaborationInstructions).toContain("## Memory Recall");
+    expect(collaborationInstructions).toContain("Before answering anything about prior work");
     expect(collaborationInstructions).toContain("memory_search");
     expect(collaborationInstructions).toContain("memory_get");
     expect(collaborationInstructions).not.toContain(memorySummary);
@@ -2253,6 +2277,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).not.toContain(memorySummary);
     expect(inputText).not.toContain("OpenClaw Workspace Memory");
     expect(inputText).not.toContain("MEMORY.md exists in the active agent workspace");
+    expect(inputText).not.toContain("## Memory Recall");
     expect(inputText).not.toContain("memory_search");
     expect(inputText).not.toContain("memory_get");
     expect(inputText).not.toContain("Codex loads AGENTS.md natively");
@@ -2405,6 +2430,7 @@ describe("runCodexAppServerAttempt", () => {
     const memorySummary = "Memory summary goes here.";
     await fs.mkdir(workspaceDir, { recursive: true });
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+    registerTestMemoryRecallPrompt();
     testing.setOpenClawCodingToolsFactoryForTests(() => [createRuntimeDynamicTool("memory_get")]);
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
@@ -2418,6 +2444,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).not.toContain("memory_search");
     expect(inputText).not.toContain(memorySummary);
     expect(collaborationInstructions).toContain("OpenClaw Workspace Memory");
+    expect(collaborationInstructions).toContain("## Memory Recall");
     expect(collaborationInstructions).toContain("memory_get");
     expect(collaborationInstructions).not.toContain("memory_search");
     expect(collaborationInstructions).not.toContain(memorySummary);
@@ -2430,6 +2457,36 @@ describe("runCodexAppServerAttempt", () => {
       injectedChars: 0,
       truncated: false,
     });
+  });
+
+  it("adds memory recall guidance when only daily memory files exist", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const dailyMemory = "Credit-card signup dates live in daily memory.";
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "memory", "2026-05-20.md"), dailyMemory);
+    registerTestMemoryRecallPrompt();
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("memory_search"),
+      createRuntimeDynamicTool("memory_get"),
+    ]);
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    setAgentWorkspaceForTest(params, workspaceDir);
+
+    const { collaborationInstructions, inputText, systemPromptReport } =
+      await buildCodexTurnContextForTest(params, workspaceDir);
+
+    expect(collaborationInstructions).toContain("## Memory Recall");
+    expect(collaborationInstructions).toContain("Before answering anything about prior work");
+    expect(collaborationInstructions).not.toContain("OpenClaw Workspace Memory");
+    expect(collaborationInstructions).not.toContain(dailyMemory);
+    expect(inputText).not.toContain("## Memory Recall");
+    expect(inputText).not.toContain(dailyMemory);
+    expect(systemPromptReport.injectedWorkspaceFiles).not.toContainEqual(
+      expect.objectContaining({ name: "2026-05-20.md" }),
+    );
   });
 
   it("reports MEMORY.md as truncated when no-tool fallback exceeds the bootstrap budget", async () => {
@@ -2595,6 +2652,7 @@ describe("runCodexAppServerAttempt", () => {
     const memorySummary = "Memory summary goes here.";
     await fs.mkdir(workspaceDir, { recursive: true });
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+    registerTestMemoryRecallPrompt();
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("memory_search"),
       createRuntimeDynamicTool("memory_get"),
@@ -2604,12 +2662,13 @@ describe("runCodexAppServerAttempt", () => {
     params.runtimePlan = createCodexRuntimePlanFixture();
     setAgentWorkspaceForTest(params, path.join(tempDir, "memory-workspace"));
 
-    const { inputText, systemPromptReport } = await buildCodexTurnContextForTest(
-      params,
-      workspaceDir,
-    );
+    const { collaborationInstructions, inputText, systemPromptReport } =
+      await buildCodexTurnContextForTest(params, workspaceDir);
     expect(inputText).not.toContain("OpenClaw Workspace Memory");
     expect(inputText).toContain(memorySummary);
+    expect(collaborationInstructions).toContain("## Memory Recall");
+    expect(collaborationInstructions).not.toContain("OpenClaw Workspace Memory");
+    expect(collaborationInstructions).not.toContain(memorySummary);
 
     const fileStats = new Map(
       systemPromptReport.injectedWorkspaceFiles.map((file) => [file.name, file]),

--- a/src/plugin-sdk/codex-native-task-runtime.ts
+++ b/src/plugin-sdk/codex-native-task-runtime.ts
@@ -1,7 +1,6 @@
 // Private helper surface for the bundled Codex plugin. This is intentionally
-// local-only so Codex can mirror app-server native subagents into OpenClaw's
-// task registry without promoting detached task mutation helpers to the public
-// plugin SDK.
+// local-only so Codex app-server wiring can use host runtime helpers without
+// promoting them to the public plugin SDK.
 
 export {
   CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX,

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -59,6 +59,7 @@ import {
   loadOpenClawPlugins,
   type PluginLoadOptions,
   PluginLoadReentryError,
+  restoreCachedMemoryPromptState,
   resolveRuntimePluginRegistry,
 } from "./loader.js";
 import {
@@ -3682,6 +3683,55 @@ module.exports = { id: "throws-after-import", register() {} };`,
     await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual(
       expectedArtifacts,
     );
+  });
+
+  it("restores cached memory prompt state from activate:false snapshot loads", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "snapshot-memory-prompt",
+      filename: "snapshot-memory-prompt.cjs",
+      body: `module.exports = {
+        id: "snapshot-memory-prompt",
+        kind: "memory",
+        register(api) {
+          api.registerMemoryCapability({
+            promptBuilder({ availableTools }) {
+              return availableTools.has("memory_search")
+                ? ["## Snapshot Memory", "Search cached memory first."]
+                : [];
+            },
+          });
+        },
+      };`,
+    });
+    const options = {
+      activate: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["snapshot-memory-prompt"],
+          slots: { memory: "snapshot-memory-prompt" },
+        },
+      },
+      onlyPluginIds: ["snapshot-memory-prompt"],
+    } satisfies PluginLoadOptions;
+
+    const registry = loadOpenClawPlugins(options);
+
+    expect(registry.plugins.find((entry) => entry.id === "snapshot-memory-prompt")?.status).toBe(
+      "loaded",
+    );
+    expect(getMemoryCapabilityRegistration()).toBeUndefined();
+    expect(buildMemoryPromptSection({ availableTools: new Set(["memory_search"]) })).toEqual([]);
+
+    const restored = restoreCachedMemoryPromptState(options);
+
+    expect(restored?.pluginId).toBe("snapshot-memory-prompt");
+    expect(buildMemoryPromptSection({ availableTools: new Set(["memory_search"]) })).toEqual([
+      "## Snapshot Memory",
+      "Search cached memory first.",
+    ]);
   });
 
   it("uses discovery registration mode for non-activating loads", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -828,6 +828,78 @@ function getReusableCachedPluginRegistry(params: {
   };
 }
 
+function getReusableCachedPluginStateForLoadOptions(
+  options: PluginLoadOptions = {},
+): CachedPluginState | undefined {
+  const activationCandidates: PluginLoadOptions[] = [
+    options,
+    { ...options, activate: false },
+    { ...options, activate: true },
+  ];
+  const candidateOptions: PluginLoadOptions[] = activationCandidates.flatMap((candidate) => [
+    candidate,
+    { ...candidate, toolDiscovery: true },
+  ]);
+  for (const candidate of candidateOptions) {
+    const loadContext = resolvePluginLoadCacheContext(candidate);
+    const cached = getReusableCachedPluginRegistry({
+      cacheKey: loadContext.cacheKey,
+      onlyPluginIds: loadContext.onlyPluginIds,
+      runtimeSubagentMode: loadContext.runtimeSubagentMode,
+      options: candidate,
+    });
+    if (cached) {
+      return cached.state;
+    }
+  }
+  const activeRegistry = getActivePluginRegistry() ?? undefined;
+  const activeCacheKey = getActivePluginRegistryKey();
+  if (!activeRegistry || !activeCacheKey) {
+    return undefined;
+  }
+  for (const candidate of candidateOptions) {
+    const loadContext = resolvePluginLoadCacheContext(candidate);
+    const activeCachedState =
+      getCachedPluginRegistry(activeCacheKey, loadContext.onlyPluginIds) ??
+      getCachedPluginRegistry(activeCacheKey);
+    if (!activeCachedState) {
+      continue;
+    }
+    if (
+      scopedPluginLoadOptionsMatchWiderActiveCacheKey(candidate, activeCacheKey, activeRegistry) ||
+      pluginToolDiscoveryOptionsMatchActiveCacheKey(candidate, activeCacheKey)
+    ) {
+      return activeCachedState;
+    }
+  }
+  return undefined;
+}
+
+export function restoreCachedMemoryPromptState(
+  options: PluginLoadOptions = {},
+): ReturnType<typeof getMemoryCapabilityRegistration> {
+  const cached = getReusableCachedPluginStateForLoadOptions(options);
+  const memoryCapability = cached?.memoryCapability;
+  if (!memoryCapability?.capability.promptBuilder) {
+    return undefined;
+  }
+  const cachedPromptSupplements = cached?.memoryPromptSupplements ?? [];
+  const cachedPromptSupplementPluginIds = new Set(
+    cachedPromptSupplements.map((registration) => registration.pluginId),
+  );
+  restoreMemoryPluginState({
+    capability: memoryCapability,
+    corpusSupplements: listMemoryCorpusSupplements(),
+    promptSupplements: [
+      ...listMemoryPromptSupplements().filter(
+        (registration) => !cachedPromptSupplementPluginIds.has(registration.pluginId),
+      ),
+      ...cachedPromptSupplements,
+    ],
+  });
+  return getMemoryCapabilityRegistration();
+}
+
 function resolveBundledPackageRootForCache(stockRoot?: string): string | undefined {
   if (!stockRoot) {
     return undefined;
@@ -1975,6 +2047,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     const dreamingEngineId = resolveDreamingSidecarEngineId({ cfg, memorySlot });
     const pluginLoadStartMs = performance.now();
     let pluginLoadAttemptCount = 0;
+    let snapshotMemoryCapability: ReturnType<typeof getMemoryCapabilityRegistration>;
+    let snapshotMemoryCorpusSupplements: ReturnType<typeof listMemoryCorpusSupplements> = [];
+    let snapshotMemoryPromptSupplements: ReturnType<typeof listMemoryPromptSupplements> = [];
 
     for (const candidate of orderedCandidates) {
       const manifestRecord = manifestByRoot.get(candidate.rootDir);
@@ -2700,6 +2775,32 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         );
         // Snapshot loads should not replace process-global runtime prompt state.
         if (!shouldActivate) {
+          const registeredMemoryCapability = getMemoryCapabilityRegistration();
+          if (registeredMemoryCapability?.pluginId === record.id) {
+            snapshotMemoryCapability = registeredMemoryCapability;
+          }
+          const registeredMemoryCorpusSupplements = listMemoryCorpusSupplements().filter(
+            (registration) => registration.pluginId === record.id,
+          );
+          if (registeredMemoryCorpusSupplements.length > 0) {
+            snapshotMemoryCorpusSupplements = [
+              ...snapshotMemoryCorpusSupplements.filter(
+                (registration) => registration.pluginId !== record.id,
+              ),
+              ...registeredMemoryCorpusSupplements,
+            ];
+          }
+          const registeredMemoryPromptSupplements = listMemoryPromptSupplements().filter(
+            (registration) => registration.pluginId === record.id,
+          );
+          if (registeredMemoryPromptSupplements.length > 0) {
+            snapshotMemoryPromptSupplements = [
+              ...snapshotMemoryPromptSupplements.filter(
+                (registration) => registration.pluginId !== record.id,
+              ),
+              ...registeredMemoryPromptSupplements,
+            ];
+          }
           restoreRegisteredAgentHarnesses(previousAgentHarnesses);
           restoreRegisteredCompactionProviders(previousCompactionProviders);
           restoreDetachedTaskLifecycleRuntimeRegistration(previousDetachedTaskRuntimeRegistration);
@@ -2794,14 +2895,20 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           commands: listRegisteredPluginCommands(),
           detachedTaskRuntimeRegistration: getDetachedTaskLifecycleRuntimeRegistration(),
           interactiveHandlers: listPluginInteractiveHandlers(),
-          memoryCapability: getMemoryCapabilityRegistration(),
-          memoryCorpusSupplements: listMemoryCorpusSupplements(),
+          memoryCapability: shouldActivate
+            ? getMemoryCapabilityRegistration()
+            : snapshotMemoryCapability,
+          memoryCorpusSupplements: shouldActivate
+            ? listMemoryCorpusSupplements()
+            : snapshotMemoryCorpusSupplements,
           registry,
           agentHarnesses: listRegisteredAgentHarnesses(),
           compactionProviders: listRegisteredCompactionProviders(),
           embeddingProviders: listRegisteredEmbeddingProviders(),
           memoryEmbeddingProviders: listRegisteredMemoryEmbeddingProviders(),
-          memoryPromptSupplements: listMemoryPromptSupplements(),
+          memoryPromptSupplements: shouldActivate
+            ? listMemoryPromptSupplements()
+            : snapshotMemoryPromptSupplements,
         },
         onlyPluginIds,
       );

--- a/src/plugins/memory-runtime.test.ts
+++ b/src/plugins/memory-runtime.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const resolveRuntimePluginRegistryMock =
   vi.fn<typeof import("./loader.js").resolveRuntimePluginRegistry>();
+const restoreCachedMemoryPromptStateMock =
+  vi.fn<typeof import("./loader.js").restoreCachedMemoryPromptState>();
 const getLoadedRuntimePluginRegistryMock =
   vi.fn<typeof import("./active-runtime-registry.js").getLoadedRuntimePluginRegistry>();
 const ensureStandaloneRuntimePluginRegistryLoadedMock = vi.hoisted(() =>
@@ -13,6 +15,11 @@ const ensureStandaloneRuntimePluginRegistryLoadedMock = vi.hoisted(() =>
 const applyPluginAutoEnableMock =
   vi.fn<typeof import("../config/plugin-auto-enable.js").applyPluginAutoEnable>();
 const getMemoryRuntimeMock = vi.fn<typeof import("./memory-state.js").getMemoryRuntime>();
+const getMemoryCapabilityRegistrationMock =
+  vi.fn<typeof import("./memory-state.js").getMemoryCapabilityRegistration>();
+const getActivePluginRuntimeSubagentModeMock = vi.fn<
+  typeof import("./runtime.js").getActivePluginRuntimeSubagentMode
+>(() => "default");
 const resolveAgentWorkspaceDirMock =
   vi.fn<typeof import("../agents/agent-scope.js").resolveAgentWorkspaceDir>();
 const resolveDefaultAgentIdMock = vi.fn<
@@ -30,6 +37,7 @@ vi.mock("../agents/agent-scope.js", () => ({
 
 vi.mock("./loader.js", () => ({
   resolveRuntimePluginRegistry: resolveRuntimePluginRegistryMock,
+  restoreCachedMemoryPromptState: restoreCachedMemoryPromptStateMock,
 }));
 
 vi.mock("./active-runtime-registry.js", () => ({
@@ -41,9 +49,15 @@ vi.mock("./runtime/standalone-runtime-registry-loader.js", () => ({
 }));
 
 vi.mock("./memory-state.js", () => ({
+  getMemoryCapabilityRegistration: () => getMemoryCapabilityRegistrationMock(),
   getMemoryRuntime: () => getMemoryRuntimeMock(),
 }));
 
+vi.mock("./runtime.js", () => ({
+  getActivePluginRuntimeSubagentMode: () => getActivePluginRuntimeSubagentModeMock(),
+}));
+
+let ensureActiveMemoryCapability: typeof import("./memory-runtime.js").ensureActiveMemoryCapability;
 let getActiveMemorySearchManager: typeof import("./memory-runtime.js").getActiveMemorySearchManager;
 let resolveActiveMemoryBackendConfig: typeof import("./memory-runtime.js").resolveActiveMemoryBackendConfig;
 let closeActiveMemorySearchManager: typeof import("./memory-runtime.js").closeActiveMemorySearchManager;
@@ -114,6 +128,7 @@ function setAutoEnabledMemoryRuntime() {
 function expectNoMemoryRuntimeBootstrap() {
   expect(applyPluginAutoEnableMock).not.toHaveBeenCalled();
   expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
+  expect(restoreCachedMemoryPromptStateMock).not.toHaveBeenCalled();
   expect(getLoadedRuntimePluginRegistryMock).not.toHaveBeenCalled();
   expect(ensureStandaloneRuntimePluginRegistryLoadedMock).not.toHaveBeenCalled();
 }
@@ -148,16 +163,21 @@ describe("memory runtime auto-enable loading", () => {
   beforeEach(async () => {
     vi.resetModules();
     ({
+      ensureActiveMemoryCapability,
       getActiveMemorySearchManager,
       resolveActiveMemoryBackendConfig,
       closeActiveMemorySearchManager,
       closeActiveMemorySearchManagers,
     } = await import("./memory-runtime.js"));
     resolveRuntimePluginRegistryMock.mockReset();
+    restoreCachedMemoryPromptStateMock.mockReset();
     getLoadedRuntimePluginRegistryMock.mockReset();
     ensureStandaloneRuntimePluginRegistryLoadedMock.mockReset();
     applyPluginAutoEnableMock.mockReset();
     getMemoryRuntimeMock.mockReset();
+    getMemoryCapabilityRegistrationMock.mockReset();
+    getActivePluginRuntimeSubagentModeMock.mockReset();
+    getActivePluginRuntimeSubagentModeMock.mockReturnValue("default");
     resolveAgentWorkspaceDirMock.mockReset();
     resolveDefaultAgentIdMock.mockClear();
     applyPluginAutoEnableMock.mockImplementation((params) => ({
@@ -316,6 +336,113 @@ describe("memory runtime auto-enable loading", () => {
     });
 
     expect(getLoadedRuntimePluginRegistryMock).toHaveBeenCalled();
+    expect(ensureStandaloneRuntimePluginRegistryLoadedMock).not.toHaveBeenCalled();
+  });
+
+  it("restores cached memory prompt state without force-loading the active registry", () => {
+    const rawConfig = {
+      plugins: {
+        slots: {
+          memory: "memory-core",
+        },
+      },
+    };
+    const capability = {
+      pluginId: "memory-core",
+      capability: {
+        promptBuilder: () => ["## Memory Recall", "Search memory first."],
+      },
+    };
+    const staleCapability = {
+      pluginId: "memory-lancedb",
+      capability: {
+        promptBuilder: () => ["## Stale Memory", "Do not use stale memory."],
+      },
+    };
+    let registeredCapability: typeof capability | typeof staleCapability | undefined =
+      staleCapability;
+    getActivePluginRuntimeSubagentModeMock.mockReturnValue("gateway-bindable");
+    getLoadedRuntimePluginRegistryMock.mockReturnValue({
+      plugins: [
+        { id: "telegram", status: "loaded" },
+        { id: "memory-core", status: "loaded" },
+        { id: "codex", status: "loaded" },
+      ],
+    } as never);
+    getMemoryCapabilityRegistrationMock.mockImplementation(() => registeredCapability as never);
+    restoreCachedMemoryPromptStateMock.mockImplementation(() => {
+      registeredCapability = capability;
+      return undefined as never;
+    });
+
+    const result = ensureActiveMemoryCapability({
+      cfg: rawConfig as never,
+      pluginId: "memory-core",
+    });
+
+    expect(result).toBe(capability);
+    expect(getLoadedRuntimePluginRegistryMock).toHaveBeenCalledWith({
+      requiredPluginIds: ["memory-core"],
+    });
+    expect(restoreCachedMemoryPromptStateMock).toHaveBeenCalledWith({
+      config: rawConfig,
+      onlyPluginIds: ["memory-core"],
+      workspaceDir: "/resolved-workspace",
+      runtimeOptions: { allowGatewaySubagentBinding: true },
+      preferBuiltPluginArtifacts: true,
+    });
+    expect(ensureStandaloneRuntimePluginRegistryLoadedMock).not.toHaveBeenCalled();
+  });
+
+  it("does not restore cached state when the selected prompt capability is already registered", () => {
+    const rawConfig = {
+      plugins: {
+        slots: {
+          memory: "memory-core",
+        },
+      },
+    };
+    const capability = {
+      pluginId: "memory-core",
+      capability: {
+        promptBuilder: () => ["## Memory Recall", "Search memory first."],
+      },
+    };
+    getMemoryCapabilityRegistrationMock.mockReturnValue(capability as never);
+
+    const result = ensureActiveMemoryCapability({
+      cfg: rawConfig as never,
+      pluginId: "memory-core",
+    });
+
+    expect(result).toBe(capability);
+    expect(getLoadedRuntimePluginRegistryMock).not.toHaveBeenCalled();
+    expect(restoreCachedMemoryPromptStateMock).not.toHaveBeenCalled();
+    expect(ensureStandaloneRuntimePluginRegistryLoadedMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores prompt capabilities from non-selected memory plugins", () => {
+    const rawConfig = {
+      plugins: {
+        slots: {
+          memory: "memory-core",
+        },
+      },
+    };
+    getMemoryCapabilityRegistrationMock.mockReturnValue({
+      pluginId: "memory-lancedb",
+      capability: {
+        promptBuilder: () => ["## Stale Memory", "Do not use stale memory."],
+      },
+    } as never);
+
+    const result = ensureActiveMemoryCapability({
+      cfg: rawConfig as never,
+      pluginId: "memory-lancedb",
+    });
+
+    expect(result).toBeUndefined();
+    expect(getLoadedRuntimePluginRegistryMock).not.toHaveBeenCalled();
     expect(ensureStandaloneRuntimePluginRegistryLoadedMock).not.toHaveBeenCalled();
   });
 

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -4,7 +4,9 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveUserPath } from "../utils.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
 import { normalizePluginsConfig } from "./config-state.js";
-import { getMemoryRuntime } from "./memory-state.js";
+import { restoreCachedMemoryPromptState } from "./loader.js";
+import { getMemoryCapabilityRegistration, getMemoryRuntime } from "./memory-state.js";
+import { getActivePluginRuntimeSubagentMode } from "./runtime.js";
 import { ensureStandaloneRuntimePluginRegistryLoaded } from "./runtime/standalone-runtime-registry-loader.js";
 
 /** Resolves the configured memory slot to the single runtime plugin that may load memory. */
@@ -30,6 +32,72 @@ function resolveMemoryRuntimeWorkspaceDir(cfg: OpenClawConfig): string | undefin
   return resolveUserPath(dir);
 }
 
+type MemoryRuntimeLoadOptions = Parameters<
+  typeof ensureStandaloneRuntimePluginRegistryLoaded
+>[0]["loadOptions"];
+
+function buildMemoryRuntimeLoadOptions(params: {
+  cfg: OpenClawConfig;
+  pluginIds: string[];
+  workspaceDir: string | undefined;
+}): MemoryRuntimeLoadOptions {
+  const gatewayBindable = getActivePluginRuntimeSubagentMode() === "gateway-bindable";
+  return {
+    config: params.cfg,
+    onlyPluginIds: params.pluginIds,
+    workspaceDir: params.workspaceDir,
+    ...(gatewayBindable
+      ? {
+          runtimeOptions: { allowGatewaySubagentBinding: true as const },
+          preferBuiltPluginArtifacts: true,
+        }
+      : {}),
+  };
+}
+
+function getSelectedMemoryPromptCapability(memoryPluginIds: readonly string[]) {
+  const current = getMemoryCapabilityRegistration();
+  if (!current?.capability.promptBuilder || !memoryPluginIds.includes(current.pluginId)) {
+    return undefined;
+  }
+  return current;
+}
+
+/** Ensures the configured memory plugin's prompt capability is registered. */
+export function ensureActiveMemoryCapability(params: { cfg?: OpenClawConfig; pluginId?: string }) {
+  if (!params.cfg) {
+    return undefined;
+  }
+  const memoryPluginIds = resolveMemoryRuntimePluginIds(params.cfg);
+  if (memoryPluginIds.length === 0) {
+    return undefined;
+  }
+  if (params.pluginId && !memoryPluginIds.includes(params.pluginId)) {
+    return undefined;
+  }
+  const selectedCapability = getSelectedMemoryPromptCapability(memoryPluginIds);
+  if (selectedCapability) {
+    return selectedCapability;
+  }
+  const loadedRegistry = getLoadedRuntimePluginRegistry({ requiredPluginIds: memoryPluginIds });
+  const loadedCapability = getSelectedMemoryPromptCapability(memoryPluginIds);
+  if (loadedCapability) {
+    return loadedCapability;
+  }
+  if (!loadedRegistry) {
+    return undefined;
+  }
+  const workspaceDir = resolveMemoryRuntimeWorkspaceDir(params.cfg);
+  restoreCachedMemoryPromptState({
+    ...buildMemoryRuntimeLoadOptions({
+      cfg: params.cfg,
+      pluginIds: memoryPluginIds,
+      workspaceDir,
+    }),
+  });
+  return getSelectedMemoryPromptCapability(memoryPluginIds);
+}
+
 function ensureMemoryRuntime(cfg?: OpenClawConfig) {
   const current = getMemoryRuntime();
   if (current || !cfg) {
@@ -46,11 +114,11 @@ function ensureMemoryRuntime(cfg?: OpenClawConfig) {
   const workspaceDir = resolveMemoryRuntimeWorkspaceDir(cfg);
   ensureStandaloneRuntimePluginRegistryLoaded({
     requiredPluginIds: onlyPluginIds,
-    loadOptions: {
-      config: cfg,
-      onlyPluginIds,
+    loadOptions: buildMemoryRuntimeLoadOptions({
+      cfg,
+      pluginIds: onlyPluginIds,
       workspaceDir,
-    },
+    }),
   });
   return getMemoryRuntime();
 }

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -17,6 +17,7 @@ type MockRegistryToolEntry = {
 const loadOpenClawPluginsMock = vi.fn();
 const resolveRuntimePluginRegistryMock = vi.fn();
 const applyPluginAutoEnableMock = vi.fn();
+const ensureActiveMemoryCapabilityMock = vi.fn();
 
 vi.mock("./loader.js", () => ({
   loadOpenClawPlugins: (params: unknown) => loadOpenClawPluginsMock(params),
@@ -28,6 +29,10 @@ vi.mock("./loader.js", () => ({
 
 vi.mock("../config/plugin-auto-enable.js", () => ({
   applyPluginAutoEnable: (params: unknown) => applyPluginAutoEnableMock(params),
+}));
+
+vi.mock("./memory-runtime.js", () => ({
+  ensureActiveMemoryCapability: (params: unknown) => ensureActiveMemoryCapabilityMock(params),
 }));
 
 let resolvePluginTools: typeof import("./tools.js").resolvePluginTools;
@@ -496,6 +501,7 @@ describe("resolvePluginTools optional tools", () => {
       loadOpenClawPluginsMock(params),
     );
     applyPluginAutoEnableMock.mockReset();
+    ensureActiveMemoryCapabilityMock.mockReset();
     applyPluginAutoEnableMock.mockImplementation(({ config }: { config: unknown }) => ({
       config,
       changes: [],
@@ -2433,6 +2439,339 @@ describe("resolvePluginTools optional tools", () => {
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
+  it("activates selected memory capability using the effective runtime config", () => {
+    const config = {
+      plugins: {
+        enabled: true,
+        allow: ["memory-core"],
+        load: { paths: [] },
+        entries: {
+          "memory-core": { enabled: true },
+        },
+        slots: { memory: "none" },
+      },
+    };
+    const runtimeConfig = {
+      ...config,
+      plugins: {
+        ...config.plugins,
+        slots: { memory: "memory-core" },
+      },
+    };
+    installToolManifestSnapshot({
+      config,
+      plugin: {
+        id: "memory-core",
+        origin: "bundled",
+        enabledByDefault: false,
+        channels: [],
+        providers: [],
+        contracts: {
+          tools: ["memory_search"],
+        },
+      },
+    });
+    setActivePluginRegistry(
+      {
+        plugins: [{ id: "memory-core", status: "loaded" }],
+        tools: [
+          {
+            pluginId: "memory-core",
+            optional: false,
+            source: "/tmp/memory-core.js",
+            names: ["memory_search"],
+            declaredNames: ["memory_search"],
+            factory: () => makeTool("memory_search"),
+          },
+        ],
+        diagnostics: [],
+      } as never,
+      "gateway-startup",
+      "gateway-bindable",
+      "/tmp",
+    );
+    resolveRuntimePluginRegistryMock.mockReturnValue(undefined);
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({
+        context: { ...createContext(), config, runtimeConfig },
+        toolAllowlist: ["memory_search"],
+        allowGatewaySubagentBinding: true,
+      }),
+    );
+
+    expectResolvedToolNames(tools, ["memory_search"]);
+    expect(ensureActiveMemoryCapabilityMock).toHaveBeenCalledWith({
+      cfg: runtimeConfig,
+      pluginId: "memory-core",
+    });
+  });
+
+  it("does not activate selected memory capability when memory tools are denylisted", () => {
+    const config = {
+      plugins: {
+        enabled: true,
+        allow: ["memory-core"],
+        load: { paths: [] },
+        entries: {
+          "memory-core": { enabled: true },
+        },
+        slots: { memory: "memory-core" },
+      },
+    };
+    installToolManifestSnapshot({
+      config,
+      plugin: {
+        id: "memory-core",
+        origin: "bundled",
+        enabledByDefault: false,
+        channels: [],
+        providers: [],
+        contracts: {
+          tools: ["memory_search"],
+        },
+      },
+    });
+    const memoryFactory = vi.fn(() => makeTool("memory_search"));
+    setActivePluginRegistry(
+      {
+        plugins: [{ id: "memory-core", status: "loaded" }],
+        tools: [
+          {
+            pluginId: "memory-core",
+            optional: false,
+            source: "/tmp/memory-core.js",
+            names: ["memory_search"],
+            declaredNames: ["memory_search"],
+            factory: memoryFactory,
+          },
+        ],
+        diagnostics: [],
+      } as never,
+      "gateway-startup",
+      "gateway-bindable",
+      "/tmp",
+    );
+    resolveRuntimePluginRegistryMock.mockReturnValue(undefined);
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({
+        context: { ...createContext(), config },
+        toolAllowlist: ["memory_search"],
+        toolDenylist: ["memory_search"],
+        allowGatewaySubagentBinding: true,
+      }),
+    );
+
+    expectResolvedToolNames(tools, []);
+    expect(memoryFactory).not.toHaveBeenCalled();
+    expect(ensureActiveMemoryCapabilityMock).not.toHaveBeenCalled();
+  });
+
+  it("does not activate selected memory capability for manifest-unavailable memory tools", () => {
+    const config = {
+      plugins: {
+        enabled: true,
+        allow: ["memory-core"],
+        load: { paths: [] },
+        entries: {
+          "memory-core": { enabled: true, config: {} },
+        },
+        slots: { memory: "memory-core" },
+      },
+    };
+    installToolManifestSnapshot({
+      config,
+      plugin: {
+        id: "memory-core",
+        origin: "bundled",
+        enabledByDefault: false,
+        channels: [],
+        providers: [],
+        contracts: {
+          tools: ["memory_search"],
+        },
+        toolMetadata: {
+          memory_search: {
+            configSignals: [
+              {
+                rootPath: "plugins.entries.memory-core.config",
+                required: ["enabledSearch"],
+              },
+            ],
+          },
+        },
+      },
+    });
+    const memoryFactory = vi.fn(() => makeTool("memory_search"));
+    setActivePluginRegistry(
+      {
+        plugins: [{ id: "memory-core", status: "loaded" }],
+        tools: [
+          {
+            pluginId: "memory-core",
+            optional: false,
+            source: "/tmp/memory-core.js",
+            names: ["memory_search"],
+            declaredNames: ["memory_search"],
+            factory: memoryFactory,
+          },
+        ],
+        diagnostics: [],
+      } as never,
+      "gateway-startup",
+      "gateway-bindable",
+      "/tmp",
+    );
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({
+        context: { ...createContext(), config },
+        toolAllowlist: ["memory_search"],
+        allowGatewaySubagentBinding: true,
+      }),
+    );
+
+    expectResolvedToolNames(tools, []);
+    expect(memoryFactory).not.toHaveBeenCalled();
+    expect(ensureActiveMemoryCapabilityMock).not.toHaveBeenCalled();
+  });
+
+  it("restores the selected memory capability when cached memory descriptors are exposed", () => {
+    const config = {
+      plugins: {
+        enabled: true,
+        allow: ["memory-core"],
+        load: { paths: [] },
+        entries: {
+          "memory-core": { enabled: true },
+        },
+        slots: { memory: "memory-core" },
+      },
+    };
+    installToolManifestSnapshot({
+      config,
+      plugin: {
+        id: "memory-core",
+        origin: "bundled",
+        enabledByDefault: false,
+        channels: [],
+        providers: [],
+        contracts: {
+          tools: ["memory_get", "memory_search"],
+        },
+      },
+    });
+    const memoryFactory = vi.fn(() => [makeTool("memory_search"), makeTool("memory_get")]);
+    setActivePluginRegistry(
+      {
+        plugins: [{ id: "memory-core", status: "loaded" }],
+        tools: [
+          {
+            pluginId: "memory-core",
+            optional: false,
+            source: "/tmp/memory-core.js",
+            names: ["memory_search", "memory_get"],
+            declaredNames: ["memory_search", "memory_get"],
+            factory: memoryFactory,
+          },
+        ],
+        diagnostics: [],
+      } as never,
+      "gateway-startup",
+      "gateway-bindable",
+      "/tmp",
+    );
+    resolveRuntimePluginRegistryMock.mockReturnValue(undefined);
+    const context = { ...createContext(), config };
+
+    const first = resolvePluginTools(
+      createResolveToolsParams({
+        context,
+        toolAllowlist: ["memory_search", "memory_get"],
+        allowGatewaySubagentBinding: true,
+      }),
+    );
+    expectResolvedToolNames(first, ["memory_search", "memory_get"]);
+    expect(memoryFactory).toHaveBeenCalledTimes(1);
+
+    memoryFactory.mockClear();
+    ensureActiveMemoryCapabilityMock.mockClear();
+    const cachedTools = resolvePluginTools(
+      createResolveToolsParams({
+        context,
+        toolAllowlist: ["memory_search", "memory_get"],
+        allowGatewaySubagentBinding: true,
+      }),
+    );
+
+    expectResolvedToolNames(cachedTools, ["memory_search", "memory_get"]);
+    expect(memoryFactory).not.toHaveBeenCalled();
+    expect(ensureActiveMemoryCapabilityMock).toHaveBeenCalledWith({
+      cfg: config,
+      pluginId: "memory-core",
+    });
+  });
+
+  it("does not restore memory capability for same-named tools from another plugin", () => {
+    const config = {
+      plugins: {
+        enabled: true,
+        allow: ["memory-core", "memory-helper"],
+        load: { paths: [] },
+        entries: {
+          "memory-core": { enabled: true },
+          "memory-helper": { enabled: true },
+        },
+        slots: { memory: "memory-core" },
+      },
+    };
+    installToolManifestSnapshot({
+      config,
+      plugin: {
+        id: "memory-helper",
+        origin: "bundled",
+        enabledByDefault: false,
+        channels: [],
+        providers: [],
+        contracts: {
+          tools: ["memory_search"],
+        },
+      },
+    });
+    setActivePluginRegistry(
+      {
+        plugins: [{ id: "memory-helper", status: "loaded" }],
+        tools: [
+          {
+            pluginId: "memory-helper",
+            optional: false,
+            source: "/tmp/memory-helper.js",
+            names: ["memory_search"],
+            declaredNames: ["memory_search"],
+            factory: () => makeTool("memory_search"),
+          },
+        ],
+        diagnostics: [],
+      } as never,
+      "gateway-startup",
+      "gateway-bindable",
+      "/tmp",
+    );
+    resolveRuntimePluginRegistryMock.mockReturnValue(undefined);
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({
+        context: { ...createContext(), config },
+        toolAllowlist: ["memory_search"],
+        allowGatewaySubagentBinding: true,
+      }),
+    );
+
+    expectResolvedToolNames(tools, ["memory_search"]);
+    expect(ensureActiveMemoryCapabilityMock).not.toHaveBeenCalled();
+  });
+
   it("does not let disabled bundled tool owners poison explicit runtime allowlists", () => {
     const config = {
       plugins: {
@@ -2504,6 +2843,10 @@ describe("resolvePluginTools optional tools", () => {
     expect(memorySearchFactory).toHaveBeenCalledTimes(1);
     expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+    expect(ensureActiveMemoryCapabilityMock).toHaveBeenCalledWith({
+      cfg: config,
+      pluginId: "memory-core",
+    });
   });
 
   it("falls back from a loaded channel registry without matching tool entries", () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -17,6 +17,7 @@ import {
 } from "./manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import { hasManifestToolAvailability } from "./manifest-tool-availability.js";
+import { ensureActiveMemoryCapability } from "./memory-runtime.js";
 import type { PluginMetadataManifestView } from "./plugin-metadata-snapshot.types.js";
 import type { PluginRegistry, PluginToolRegistration } from "./registry-types.js";
 import { withPluginRuntimePluginScope } from "./runtime/gateway-request-scope.js";
@@ -76,6 +77,7 @@ const log = createSubsystemLogger("plugins/tools");
 const PLUGIN_TOOL_FACTORY_WARN_TOTAL_MS = 5_000;
 const PLUGIN_TOOL_FACTORY_WARN_FACTORY_MS = 1_000;
 const PLUGIN_TOOL_FACTORY_SUMMARY_LIMIT = 20;
+const MEMORY_TOOL_NAMES = new Set(["memory_search", "memory_get"]);
 
 const pluginToolMeta = new WeakMap<AnyAgentTool, PluginToolMeta>();
 const scopedPluginTools = new WeakMap<AnyAgentTool, Map<string, AnyAgentTool>>();
@@ -323,6 +325,38 @@ function readPluginToolName(tool: unknown): string {
   }
   // Optional-tool allowlists need a best-effort name before full shape validation.
   return typeof tool.name === "string" ? tool.name.trim() : "";
+}
+
+function isSelectedMemoryTool(params: {
+  config: PluginLoadOptions["config"];
+  pluginId: string;
+  toolName: string;
+}): boolean {
+  if (!MEMORY_TOOL_NAMES.has(normalizeToolName(params.toolName))) {
+    return false;
+  }
+  const plugins = normalizePluginsConfig(params.config?.plugins);
+  return plugins.slots.memory === params.pluginId;
+}
+
+function ensureActiveMemoryCapabilityForVisibleTools(params: {
+  config: PluginLoadOptions["config"];
+  tools: readonly AnyAgentTool[];
+}): void {
+  for (const tool of params.tools) {
+    const meta = pluginToolMeta.get(tool);
+    if (
+      meta &&
+      isSelectedMemoryTool({
+        config: params.config,
+        pluginId: meta.pluginId,
+        toolName: tool.name,
+      })
+    ) {
+      ensureActiveMemoryCapability({ cfg: params.config, pluginId: meta.pluginId });
+      return;
+    }
+  }
 }
 
 function toElapsedMs(value: number): number {
@@ -1042,6 +1076,7 @@ export function resolvePluginTools(params: {
   const allowlist = normalizeAllowlist(params.toolAllowlist);
   const denylist = normalizeDenylist(params.toolDenylist);
   const configCacheKeyMemo = createPluginToolDescriptorConfigCacheKeyMemo();
+  const availabilityConfig = params.context.runtimeConfig ?? context.config;
   let currentRuntimeConfigForDescriptorCache: PluginLoadOptions["config"] | null | undefined =
     params.context.runtimeConfig;
   if (currentRuntimeConfigForDescriptorCache === undefined && params.context.getRuntimeConfig) {
@@ -1054,7 +1089,7 @@ export function resolvePluginTools(params: {
   const cached = resolveCachedPluginTools({
     snapshot,
     config: context.config,
-    availabilityConfig: params.context.runtimeConfig ?? context.config,
+    availabilityConfig,
     env,
     allowlist,
     denylist,
@@ -1073,6 +1108,7 @@ export function resolvePluginTools(params: {
     (pluginId) => !cached.handledPluginIds.has(pluginId),
   );
   if (runtimePluginIds.length === 0) {
+    ensureActiveMemoryCapabilityForVisibleTools({ config: availabilityConfig, tools });
     return tools;
   }
   const loadOptions = buildPluginRuntimeLoadOptions(context, {
@@ -1113,6 +1149,7 @@ export function resolvePluginTools(params: {
           ", ",
         )}]`,
       );
+      ensureActiveMemoryCapabilityForVisibleTools({ config: availabilityConfig, tools });
       return tools;
     }
   }
@@ -1169,7 +1206,7 @@ export function resolvePluginTools(params: {
       ? filterManifestToolNamesForAvailability({
           plugin: manifestPlugin,
           toolNames: availabilityNames,
-          config: params.context.runtimeConfig ?? context.config,
+          config: availabilityConfig,
           env,
           hasAuthForProvider: params.hasAuthForProvider,
         }).filter(
@@ -1247,7 +1284,7 @@ export function resolvePluginTools(params: {
           return isManifestToolNameAvailable({
             plugin: manifestPlugin,
             toolName,
-            config: params.context.runtimeConfig ?? context.config,
+            config: availabilityConfig,
             env,
             hasAuthForProvider: params.hasAuthForProvider,
           });
@@ -1399,5 +1436,6 @@ export function resolvePluginTools(params: {
     }
   }
 
+  ensureActiveMemoryCapabilityForVisibleTools({ config: availabilityConfig, tools });
   return tools;
 }


### PR DESCRIPTION
## Summary

- Alternative to #91594; this draft leaves #91594 open and undisturbed.
- Restore native Codex memory recall by activating the selected memory plugin prompt capability only when the returned visible tools include the selected plugin's `memory_search` or `memory_get`.
- Keep the shared infrastructure touch narrow: visible selected memory tools and selected memory prompt capability must stay in sync with the same effective availability/runtime config used for tool visibility.
- Keep Codex prompt assembly passive: Codex builds the memory prompt text but does not force memory capability activation from the prompt path.
- No new config option, environment variable, CLI flag, public SDK/API surface, or Codex-local fallback recall policy.

## Linked context

Related: #91594, #87383

This is a narrower alternative to #91594. #87383 correctly stopped pasting raw native Codex workspace `MEMORY.md` into ordinary tool-enabled turns, but the Codex app-server path could still show memory tools without having the selected memory plugin prompt capability active. That made first-turn personalized recommendations skip saved constraints until the model corrected later.

## Real behavior proof (required for external PRs)

- Behavior addressed: Native Codex turns could receive searchable memory tools without using the selected memory plugin's recall guidance, so a first-turn personalized recommendation could ignore saved user constraints.
- Real environment tested: Exact current PR head `5f3800b075f56470ed248e05ae1f16f0bdb66433` on an OpenClaw gateway, via a Telegram direct route with `codex`, `memory-core`, and `telegram` loaded. Runtime path was the PR checkout build at `/home/<redacted>/workplace/openclaw-codex-memory-tool-resolution/dist/index.js`.
- Exact steps or command run after this patch: Built runtime artifacts with `node scripts/build-all.mjs qaRuntime`, restarted the OpenClaw gateway service from the PR checkout, sent a Telegram direct-route prompt asking which credit card to get next after meeting an Amex Platinum signup bonus, then inspected the Codex rollout and OpenClaw trajectory for that run.
- Evidence after fix (redacted runtime log and trajectory excerpt):

```text
current PR head: 5f3800b075f56470ed248e05ae1f16f0bdb66433
runtime: OpenClaw gateway from PR checkout, Telegram direct route
loaded plugins included: brave, codex, memory-core, telegram
model: openai/gpt-5.5

service/runtime evidence:
  2026-06-10T02:53:52Z service started from /home/<redacted>/workplace/openclaw-codex-memory-tool-resolution/dist/index.js
  2026-06-10T02:54:08Z http server listening (4 plugins: brave, codex, memory-core, telegram)
  2026-06-10T02:54:09Z gateway ready
  2026-06-10T02:54:10Z Telegram provider started

redacted inbound request:
  2026-06-10T02:54:59Z Telegram direct-route prompt asking which card to get next after the Amex Platinum signup bonus

compiled prompt checks:
  Deferred searchable OpenClaw dynamic tools listed=true
  memory_search mentioned=true
  memory_get mentioned=true
  ## Memory Recall present=true
  ## Codex Memory Tool Loading present=false
  raw root MEMORY.md paste present=false

Codex rollout:
  /home/<redacted>/.openclaw/agents/main/agent/codex-home/sessions/2026/06/10/rollout-2026-06-10T02-55-01-019eaf74-6603-74c2-898b-3be117a19d53.jsonl

OpenClaw trajectory:
  /home/<redacted>/.openclaw/agents/main/sessions/01ad6fb1-25fe-4092-b75b-9b441c9800cc.trajectory.jsonl

first relevant tool events:
  2026-06-10T02:55:24.966Z tool.call memory_search query="credit cards Amex Platinum Chase Sapphire travel points card rewards 5/24 SUB bonus Ruben preferences" corpus="all" maxResults=5
  2026-06-10T02:55:25.373Z tool.result memory_search success=true
  2026-06-10T02:55:52.856Z tool.call memory_get path="memory/2026-05-20.md" from=3 lines=18
  2026-06-10T02:55:52.870Z tool.result memory_get success=true
  2026-06-10T02:55:57.925Z tool.call memory_get path="memory/2026-06-09.md" from=3 lines=8
  2026-06-10T02:55:57.936Z tool.result memory_get success=true
  2026-06-10T02:57:23.649Z tool.call message action="send"
  2026-06-10T02:57:25.626Z tool.result message success=true

redacted memory facts applied by the model before answering:
  existing card mix included an already-held Sapphire product
  no business-card applications
  Chase applications should be treated as off the board because of 5/24 status

visible answer behavior:
  recommended a non-Chase next card
  explicitly accounted for the saved no-business-card, already-held-Sapphire, and 5/24 constraints before ranking options
```

- Observed result after fix: On exact PR head, Codex loaded the selected memory plugin recall guidance in the compiled prompt, called `memory_search` and `memory_get` before the first Telegram answer, read the relevant saved card-planning memory, and applied those saved constraints in the first recommendation.
- What was not tested: Other harness/channel paths were not live-tested. Not every memory engine was tested; the live proof used bundled `memory-core`.
- Proof limitations or environment constraints: Private user, channel, and memory details are redacted. The run did not need the removed Codex-specific loading fallback: `## Codex Memory Tool Loading` was absent, while the selected memory plugin's `## Memory Recall` guidance was present and memory tools were still called before the answer.
- Before evidence: Before the fix, a Telegram direct-route run had `memory_search`, `memory_get`, and `tool_search` available, but `## Memory Recall` was absent; no memory tool calls were made before the answer, and the visible answer hedged on card eligibility rather than applying the saved history before recommending.

## Tests and validation

Current draft head validated: `5f3800b075f56470ed248e05ae1f16f0bdb66433`.

- `pnpm exec oxfmt --check extensions/codex/src/app-server/attempt-context.ts extensions/codex/src/app-server/run-attempt-test-harness.ts extensions/codex/src/app-server/run-attempt.test.ts src/plugin-sdk/codex-native-task-runtime.ts src/plugins/memory-runtime.test.ts src/plugins/memory-runtime.ts src/plugins/tools.optional.test.ts src/plugins/tools.ts`
- `pnpm exec oxlint extensions/codex/src/app-server/attempt-context.ts extensions/codex/src/app-server/run-attempt-test-harness.ts extensions/codex/src/app-server/run-attempt.test.ts src/plugin-sdk/codex-native-task-runtime.ts src/plugins/memory-runtime.test.ts src/plugins/memory-runtime.ts src/plugins/tools.optional.test.ts src/plugins/tools.ts`
- `node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts src/plugins/memory-runtime.test.ts extensions/codex/src/app-server/attempt-context.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `git diff --check`
- `pnpm tsgo:prod && pnpm tsgo:test`
- `node scripts/build-all.mjs qaRuntime`
- Exact-head live Telegram proof above after `node scripts/build-all.mjs qaRuntime`

Regression coverage added or updated:

- cached memory tool descriptors still activate the selected prompt capability
- same-named memory tools from a non-selected plugin do not activate the prompt capability
- effective runtime config is used for memory tool visibility and prompt activation
- disabled, denylisted, or manifest-filtered memory tools do not activate prompt capability
- stale prompt capability from a non-selected memory plugin is ignored
- Codex app-server memory recall guidance is present for root and daily memory paths without raw memory injection
- restored close-manager coverage remains no-bootstrap/no-reload

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `Yes` for tool/prompt routing behavior only; no auth, secrets, network, or tool schema surface is added.

What is the highest-risk area? Native Codex memory tool visibility and selected memory prompt capability activation.

How is that risk mitigated? Activation is gated on already-visible selected-plugin `memory_search`/`memory_get` tools, uses the same effective availability/runtime config as tool visibility, ignores stale non-selected memory prompt capabilities, avoids new public SDK/config surface, and is covered by focused plugin and Codex app-server tests.

## Current review state

Next action: maintainer review and PR CI on this draft.

Waiting on: ClawSweeper/maintainer review of the exact-head proof and the implementation concern around request-time registry activation.

Bot/reviewer comments addressed: ClawSweeper requested exact-head real Codex memory proof showing `memory_search` and `memory_get` before the first personalized answer. This body now includes exact-head Telegram direct-route proof for `5f3800b075f56470ed248e05ae1f16f0bdb66433`. ClawSweeper also raised a separate implementation concern around request-time registry activation; that code concern remains for maintainer review or a follow-up patch.

