### PR TITLE
fix(agents): restore runtime context fallback for heartbeat prompts

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3892,6 +3892,7 @@ export async function runEmbeddedAttempt(
             emptyTranscriptMode: params.suppressNextUserMessagePersistence
               ? "model-prompt"
               : "runtime-event",
+            unmatchedTranscriptMode: params.trigger === "heartbeat" ? "runtime-context" : undefined,
           });
           const promptForSession = buildCurrentInboundPrompt({
             context: params.currentInboundContext,

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -138,6 +138,25 @@ describe("runtime context prompt submission", () => {
     });
   });
 
+  it("keeps implicit runtime context alongside explicit runtime blocks", () => {
+    const effectiveText = "exec completed (abc123, code 0) :: output text";
+    const explicitRuntimeContext = [
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+      "secret runtime context",
+      "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+    ].join("\n");
+
+    expect(
+      resolveRuntimeContextPromptParts({
+        effectivePrompt: [effectiveText, "", explicitRuntimeContext].join("\n"),
+        transcriptPrompt: "[OpenClaw heartbeat poll]",
+      }),
+    ).toEqual({
+      prompt: "[OpenClaw heartbeat poll]",
+      runtimeContext: [effectiveText, "", explicitRuntimeContext].join("\n"),
+    });
+  });
+
   it("extracts multiple hidden runtime context blocks", () => {
     const effectivePrompt = [
       "runtime prefix",

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -131,6 +131,7 @@ describe("runtime context prompt submission", () => {
       resolveRuntimeContextPromptParts({
         effectivePrompt,
         transcriptPrompt: "[OpenClaw heartbeat poll]",
+        unmatchedTranscriptMode: "runtime-context",
       }),
     ).toEqual({
       prompt: "[OpenClaw heartbeat poll]",
@@ -150,10 +151,24 @@ describe("runtime context prompt submission", () => {
       resolveRuntimeContextPromptParts({
         effectivePrompt: [effectiveText, "", explicitRuntimeContext].join("\n"),
         transcriptPrompt: "[OpenClaw heartbeat poll]",
+        unmatchedTranscriptMode: "runtime-context",
       }),
     ).toEqual({
       prompt: "[OpenClaw heartbeat poll]",
       runtimeContext: [effectiveText, "", explicitRuntimeContext].join("\n"),
+    });
+  });
+
+  it("does not treat unmatched user prompt text as implicit runtime context", () => {
+    const effectivePrompt = ["media note", "reply hint", "user body"].join("\n\n");
+
+    expect(
+      resolveRuntimeContextPromptParts({
+        effectivePrompt,
+        transcriptPrompt: ["media note", "user body"].join("\n\n"),
+      }),
+    ).toEqual({
+      prompt: ["media note", "user body"].join("\n\n"),
     });
   });
 

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -159,6 +159,24 @@ describe("runtime context prompt submission", () => {
     });
   });
 
+  it("does not duplicate implicit runtime context in a hook-expanded model prompt", () => {
+    const effectivePrompt = "exec completed (abc123, code 0) :: output text";
+    const transcriptPrompt = "[OpenClaw heartbeat poll]";
+
+    expect(
+      resolveRuntimeContextPromptParts({
+        effectivePrompt,
+        transcriptPrompt,
+        modelPrompt: ["hook prefix", effectivePrompt, "hook suffix"].join("\n\n"),
+        unmatchedTranscriptMode: "runtime-context",
+      }),
+    ).toEqual({
+      prompt: transcriptPrompt,
+      modelPrompt: ["hook prefix", transcriptPrompt, "hook suffix"].join("\n\n"),
+      runtimeContext: effectivePrompt,
+    });
+  });
+
   it("does not treat unmatched user prompt text as implicit runtime context", () => {
     const effectivePrompt = ["media note", "reply hint", "user body"].join("\n\n");
 

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -115,6 +115,29 @@ describe("runtime context prompt submission", () => {
     });
   });
 
+  it("uses effective text as implicit runtime context when transcriptPrompt is not found", () => {
+    // Heartbeat/exec-event scenario: transcriptPrompt is a placeholder
+    // (e.g. "[OpenClaw heartbeat poll]") that doesn't appear in the
+    // actual effective prompt (e.g. exec event output). The fallback
+    // extracts the entire effective text as hidden runtime context so
+    // it persists via custom_message for subsequent model turns.
+    const effectivePrompt = [
+      "An async command you ran earlier has completed.",
+      "exec completed (abc123, code 0) :: output text",
+      "Please relay the command output.",
+    ].join("\n\n");
+
+    expect(
+      resolveRuntimeContextPromptParts({
+        effectivePrompt,
+        transcriptPrompt: "[OpenClaw heartbeat poll]",
+      }),
+    ).toEqual({
+      prompt: "[OpenClaw heartbeat poll]",
+      runtimeContext: effectivePrompt,
+    });
+  });
+
   it("extracts multiple hidden runtime context blocks", () => {
     const effectivePrompt = [
       "runtime prefix",

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -119,10 +119,21 @@ export function resolveRuntimeContextPromptParts(params: {
       : undefined;
   // The hidden context is whatever remains after removing the last visible
   // prompt occurrence, plus any explicit internal runtime-context block.
+  // When transcriptPrompt is defined but not found in effectivePrompt
+  // (e.g. heartbeat placeholder "[OpenClaw heartbeat poll]" vs exec event),
+  // use the extracted text as implicit runtime context so it persists via
+  // custom_message for subsequent model turns (restored legacy fallback).
   const runtimeContext =
     [hiddenRuntimeContext, extracted.runtimeContext]
       .filter((value): value is string => Boolean(value?.trim()))
-      .join("\n\n") || (!prompt.trim() ? extracted.text.trim() : undefined);
+      .join("\n\n") ||
+    (transcriptPrompt !== undefined &&
+    hiddenRuntimeContext === undefined &&
+    extracted.runtimeContext === undefined
+      ? extracted.text.trim()
+      : !prompt.trim()
+        ? extracted.text.trim()
+        : undefined);
   if (!prompt.trim()) {
     return runtimeContext
       ? {

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -76,6 +76,18 @@ function removeLastPromptOccurrence(text: string, prompt: string): string | null
     .trim();
 }
 
+function replaceLastPromptOccurrence(
+  text: string,
+  prompt: string,
+  replacement: string,
+): string | null {
+  const index = text.lastIndexOf(prompt);
+  if (index === -1) {
+    return null;
+  }
+  return `${text.slice(0, index)}${replacement}${text.slice(index + prompt.length)}`;
+}
+
 /**
  * Separates user-authored prompt text from hidden runtime context. Transcript
  * prompt stays user-visible; model prompt may carry runtime-only additions that
@@ -99,7 +111,7 @@ export function resolveRuntimeContextPromptParts(params: {
       : shouldExtractInternalRuntimeContext
         ? extractInternalRuntimeContext(params.modelPrompt)
         : { text: params.modelPrompt };
-  const modelPromptText = modelPrompt?.text ?? transcriptPrompt ?? extracted.text;
+  let modelPromptText = modelPrompt?.text ?? transcriptPrompt ?? extracted.text;
   const prompt = transcriptPrompt ?? extracted.text;
   if (!prompt.trim() && params.emptyTranscriptMode === "model-prompt") {
     return {
@@ -128,6 +140,11 @@ export function resolveRuntimeContextPromptParts(params: {
     params.unmatchedTranscriptMode === "runtime-context" && hiddenRuntimeContext === undefined
       ? extracted.text.trim()
       : undefined;
+  if (implicitRuntimeContext && modelPrompt && transcriptPrompt !== undefined) {
+    modelPromptText =
+      replaceLastPromptOccurrence(modelPrompt.text, extracted.text, transcriptPrompt) ??
+      modelPromptText;
+  }
   const runtimeContext =
     [hiddenRuntimeContext, implicitRuntimeContext, extracted.runtimeContext]
       .filter((value): value is string => Boolean(value?.trim()))

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -86,6 +86,7 @@ export function resolveRuntimeContextPromptParts(params: {
   transcriptPrompt?: string;
   modelPrompt?: string;
   emptyTranscriptMode?: EmptyTranscriptMode;
+  unmatchedTranscriptMode?: "runtime-context";
 }): RuntimeContextPromptParts {
   const transcriptPrompt = params.transcriptPrompt;
   const shouldExtractInternalRuntimeContext = transcriptPrompt !== undefined;
@@ -124,7 +125,7 @@ export function resolveRuntimeContextPromptParts(params: {
   // use the extracted text as implicit runtime context so it persists via
   // custom_message for subsequent model turns (restored legacy fallback).
   const implicitRuntimeContext =
-    transcriptPrompt !== undefined && hiddenRuntimeContext === undefined
+    params.unmatchedTranscriptMode === "runtime-context" && hiddenRuntimeContext === undefined
       ? extracted.text.trim()
       : undefined;
   const runtimeContext =

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -123,17 +123,14 @@ export function resolveRuntimeContextPromptParts(params: {
   // (e.g. heartbeat placeholder "[OpenClaw heartbeat poll]" vs exec event),
   // use the extracted text as implicit runtime context so it persists via
   // custom_message for subsequent model turns (restored legacy fallback).
-  const runtimeContext =
-    [hiddenRuntimeContext, extracted.runtimeContext]
-      .filter((value): value is string => Boolean(value?.trim()))
-      .join("\n\n") ||
-    (transcriptPrompt !== undefined &&
-    hiddenRuntimeContext === undefined &&
-    extracted.runtimeContext === undefined
+  const implicitRuntimeContext =
+    transcriptPrompt !== undefined && hiddenRuntimeContext === undefined
       ? extracted.text.trim()
-      : !prompt.trim()
-        ? extracted.text.trim()
-        : undefined);
+      : undefined;
+  const runtimeContext =
+    [hiddenRuntimeContext, implicitRuntimeContext, extracted.runtimeContext]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .join("\n\n") || (!prompt.trim() ? extracted.text.trim() : undefined);
   if (!prompt.trim()) {
     return runtimeContext
       ? {


### PR DESCRIPTION
## Summary

- **Problem**: During the `pi-embedded-runner` → `embedded-agent-runner` refactor, `resolveRuntimeContextPromptParts` lost a legacy fallback. When `transcriptPrompt` is defined but not a substring of `effectivePrompt` (e.g. heartbeat placeholder `[OpenClaw heartbeat poll]` vs exec event output), the effective text should be used as implicit `runtimeContext`. Without it, `buildRuntimeContextCustomMessage` skips creating the `custom_message`, and the model doesn't receive the runtime context on heartbeat turns.
- **Why now**: Discovered while investigating exec background completion notification behavior — exec events trigger a heartbeat wake, but the runtime context containing the exec result was silently dropped.
- **Outcome**: Restored the fallback so exec event data flows correctly through `runtimeContext` → `buildRuntimeContextCustomMessage` → `custom_message`.
- **Intentionally out of scope**: Persisting the custom_message across turns (current ephemeral design is intentional per 0503853c29 — only visible on the current turn).
- **Success**: Unit test covers the fallback path; temporary console.log in `attempt.ts` confirmed `runtimeContextForHook` is populated (303 chars) and `custom_message` is created.
- **Reviewer focus**: The condition `transcriptPrompt !== undefined && hiddenRuntimeContext === undefined && extracted.runtimeContext === undefined` — verify it correctly distinguishes "not found in text" from "found but no surrounding context."

## Linked context

No related issue directly — discovered while investigating exec background completion notification behavior.

This is a refactoring omission: the fallback was present in the old `pi-embedded-runner` and lost during the rename/restructure to `embedded-agent-runner`.

- Related: [#85341](https://github.com/openclaw/openclaw/pull/85341) — the refactor that moved `pi-embedded-runner` to `embedded-agent-runner`, where the fallback was dropped.
- Related: [#86875](https://github.com/openclaw/openclaw/pull/86875) — subsequent fix to `resolveRuntimeContextPromptParts` for hook context handling.

## Real behavior proof

- **Behavior or issue addressed**: Exec-event heartbeat wake does not inject runtime context `custom_message` into model messages.
- **Real environment tested**: Local gateway with `agent model: zte/Qwen3-235B-A22B`, ran exec command, triggered heartbeat.
- **Exact steps or command run after this patch**: Added temporary `console.log` at the `buildRuntimeContextCustomMessage` call site, rebuilt, ran gateway, executed `exec sleep 5 background=true`, waited for heartbeat wake.
- Evidence after fix (terminal capture): 
  ```
  [runtime-context-v] hook present, chars: 303; 
  [runtime-context-v] custom msg created: true
  ```
  Full evidence (temp logging code + log output): https://github.com/openclaw/openclaw/pull/91817#issuecomment-4666190162
- **Observed result after fix**: `runtimeContextForHook` contains the exec event text (303 chars), `buildRuntimeContextCustomMessage` successfully creates the `custom_message`.
- **What was not tested**: The actual model response to the custom_message (depends on provider/model behavior). Verification limited to confirming the custom_message object is built and injected into `messagesForCurrentPrompt`.
- **Proof limitations**: The custom_message is ephemeral (not persisted to transcript/jsonl), so proof relies on temporary logging at the construction site. The unit test in `runtime-context-prompt.test.ts` provides structural coverage of the extraction logic.
- **Before evidence**: Without the fix, `runtimeContextForHook` is `undefined` → `buildRuntimeContextCustomMessage(undefined)` returns `undefined` → no custom_message created. This is the current behavior on `main`.

## Tests and validation

- `pnpm test src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts`: 22/22 pass.
- Added test `"uses effective text as implicit runtime context when transcriptPrompt is not found"` — covers the exact heartbeat/exec-event fallback scenario.
- All existing tests for marker-based runtime context extraction, modelPrompt splitting, and runtime-only events remain unchanged.
- Also ran live gateway test (described above) with temporary logging to verify the fix triggers on actual exec events.

## Risk checklist

- **Did user-visible behavior change?** `No` — internal runtime context; only affects model-visible messages on exec-event heartbeat turns (restoring behavior that existed in pi-embedded-runner).
- **Did config, environment, or migration behavior change?** `No`
- **Did security, auth, secrets, network, or tool execution behavior change?** `No`
- **What is the highest-risk area?** The fallback condition `transcriptPrompt !== undefined && hiddenRuntimeContext === undefined && extracted.runtimeContext === undefined` — if a future caller passes a `transcriptPrompt` that unintentionally doesn't match `effectivePrompt`, the entire effective text becomes `runtimeContext`. This is narrowly scoped and was the previous behavior.
- **How is that risk mitigated?** Unit test covering the exact fallback path; gated by three conditions that ensure it only fires when no other context mechanism provided data.

## Current review state

- **Next action**: Author ready for review.
- **Waiting on**: None.
- **Comments addressed**: N/A (first review).