### PR TITLE
docs: link ClawHub plugin validation fixes guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1374,6 +1374,7 @@
                 "pages": [
                   "clawhub/cli",
                   "clawhub/publishing",
+                  "clawhub/plugin-validation-fixes",
                   "clawhub/skill-format",
                   "clawhub/soul-format",
                   "clawhub/auth",


### PR DESCRIPTION
## Summary
- Add the ClawHub plugin validation fixes page to OpenClaw docs navigation.
- Keep the page source in ClawHub; the OpenClaw docs pipeline mirrors it from `openclaw/clawhub`.
- The ClawHub source page is now on `openclaw/clawhub@main` via https://github.com/openclaw/clawhub/pull/2579.

## Proof
```bash
git diff --check origin/main...HEAD
OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=/Users/patrickerichsen/Git/openclaw/clawhub pnpm check:docs
```

`pnpm check:docs` synced 20 ClawHub doc assets and reported `broken_links=0`.

## Related
- Plugin Inspector author remediation metadata: https://github.com/openclaw/plugin-inspector/pull/35
- ClawHub validation UI/CLI/email integration: https://github.com/openclaw/clawhub/pull/2579
