### PR TITLE
fix(update): route Linux service auto-updates through handoff

### DIFF
--- a/src/infra/supervisor-markers.test.ts
+++ b/src/infra/supervisor-markers.test.ts
@@ -41,9 +41,28 @@ describe("detectRespawnSupervisor", () => {
     );
   });
 
-  it("detects systemd only from non-blank platform-specific hints", () => {
+  it("detects systemd from non-blank platform-specific hints", () => {
     expect(detectRespawnSupervisor({ INVOCATION_ID: "abc123" }, "linux")).toBe("systemd");
     expect(detectRespawnSupervisor({ JOURNAL_STREAM: "" }, "linux")).toBeNull();
+    expect(
+      detectRespawnSupervisor(
+        {
+          OPENCLAW_SERVICE_MARKER: "openclaw",
+          OPENCLAW_SERVICE_KIND: "gateway",
+        },
+        "linux",
+        { includeLinuxOpenClawServiceMarker: true },
+      ),
+    ).toBe("systemd");
+    expect(
+      detectRespawnSupervisor(
+        {
+          OPENCLAW_SERVICE_MARKER: "openclaw",
+          OPENCLAW_SERVICE_KIND: "worker",
+        },
+        "linux",
+      ),
+    ).toBeNull();
   });
 
   it("detects scheduled-task supervision on Windows from either hint family", () => {
@@ -70,7 +89,7 @@ describe("detectRespawnSupervisor", () => {
     ).toBeNull();
   });
 
-  it("ignores service markers on non-Windows platforms and unknown platforms", () => {
+  it("ignores service markers on unknown platforms", () => {
     expect(
       detectRespawnSupervisor(
         {

--- a/src/infra/supervisor-markers.ts
+++ b/src/infra/supervisor-markers.ts
@@ -22,6 +22,10 @@ export const SUPERVISOR_HINT_ENV_VARS = [
 /** Supported supervisor families that can respawn the gateway after update/restart handoff. */
 export type RespawnSupervisor = "launchd" | "systemd" | "schtasks";
 
+type DetectRespawnSupervisorOptions = {
+  includeLinuxOpenClawServiceMarker?: boolean;
+};
+
 function hasAnyHint(env: NodeJS.ProcessEnv, keys: readonly string[]): boolean {
   return keys.some((key) => {
     const value = env[key];
@@ -43,22 +47,27 @@ function isCurrentGatewayLaunchdJob(env: NodeJS.ProcessEnv): boolean {
 export function detectRespawnSupervisor(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
+  options: DetectRespawnSupervisorOptions = {},
 ): RespawnSupervisor | null {
+  const isOpenClawGatewayServiceMarker =
+    env.OPENCLAW_SERVICE_MARKER?.trim() === "openclaw" &&
+    env.OPENCLAW_SERVICE_KIND?.trim() === "gateway";
   if (platform === "darwin") {
     return hasAnyHint(env, SUPERVISOR_HINTS.launchd) || isCurrentGatewayLaunchdJob(env)
       ? "launchd"
       : null;
   }
   if (platform === "linux") {
-    return hasAnyHint(env, SUPERVISOR_HINTS.systemd) ? "systemd" : null;
+    return hasAnyHint(env, SUPERVISOR_HINTS.systemd) ||
+      (options.includeLinuxOpenClawServiceMarker === true && isOpenClawGatewayServiceMarker)
+      ? "systemd"
+      : null;
   }
   if (platform === "win32") {
     if (hasAnyHint(env, SUPERVISOR_HINTS.schtasks)) {
       return "schtasks";
     }
-    const marker = env.OPENCLAW_SERVICE_MARKER?.trim();
-    const serviceKind = env.OPENCLAW_SERVICE_KIND?.trim();
-    return marker && serviceKind === "gateway" ? "schtasks" : null;
+    return isOpenClawGatewayServiceMarker ? "schtasks" : null;
   }
   return null;
 }

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -608,6 +608,41 @@ describe("update-startup", () => {
     });
   });
 
+  it("uses a systemd managed-service handoff instead of spawning the updater under the gateway", async () => {
+    mockPackageInstallStatus();
+    mockNpmChannelTag("beta", "2.0.0-beta.1");
+    detectRespawnSupervisorMock.mockReturnValue("systemd");
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    process.env.OPENCLAW_SERVICE_KIND = "gateway";
+
+    await runGatewayUpdateCheck({
+      cfg: createBetaAutoUpdateConfig(),
+      log: { info: vi.fn() },
+      isNixMode: false,
+      allowInTests: true,
+    });
+
+    expect(detectRespawnSupervisorMock).toHaveBeenCalledWith(process.env, process.platform, {
+      includeLinuxOpenClawServiceMarker: true,
+    });
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
+    expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        root: "/opt/openclaw",
+        timeoutMs: 45 * 60 * 1000,
+        channel: "beta",
+        restartDelayMs: 2000,
+        supervisor: "systemd",
+      }),
+    );
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledWith({
+      delayMs: 2000,
+      reason: "update.auto",
+      skipCooldown: true,
+      skipDeferral: true,
+    });
+  });
+
   it("scheduleGatewayUpdateCheck returns a cleanup function", () => {
     mockPackageUpdateStatus("latest", "2.0.0");
 

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -315,7 +315,9 @@ async function runAutoUpdateCommand(params: {
   timeoutMs: number;
   root?: string;
 }): Promise<AutoUpdateRunResult> {
-  const supervisor = detectRespawnSupervisor(process.env, process.platform);
+  const supervisor = detectRespawnSupervisor(process.env, process.platform, {
+    includeLinuxOpenClawServiceMarker: true,
+  });
   if (supervisor) {
     return await startManagedServiceAutoUpdateHandoff({
       channel: params.channel,


### PR DESCRIPTION
## Summary
- Treat Linux OpenClaw gateway service markers as systemd supervision signals for update handoff detection.
- Keep Windows scheduled-task marker behavior intact while preventing Linux managed auto-update from falling back to a direct child `openclaw update` spawn.
- Add regression coverage for the marker detection gap and for systemd auto-update using the managed handoff/restart path instead of `runCommandWithTimeout`.

## Real behavior proof
- **Behavior addressed**: Linux Gateway auto-update with only generic OpenClaw service markers (`OPENCLAW_SERVICE_MARKER=openclaw`, `OPENCLAW_SERVICE_KIND=gateway`) previously was not classified as supervised, so startup auto-update could spawn `openclaw update --yes --channel ... --json` as a child of the live Gateway process. This patch classifies that Linux marker set as `systemd`, which routes auto-update through `startManagedServiceUpdateHandoff` and avoids invoking the direct updater under the Gateway process tree.
- **Real environment tested**: PR #91833 head `1fd06a257acfe83531400b19e954e4704a011e28`; local source checkout `/Users/andy/openclaw-91823-auto-update-handoff`; live Lima Ubuntu Linux aarch64 VM with user systemd running; transient user service `openclaw-gateway.service` started by `systemd-run --user`; compiled PR bundle from `node scripts/tsdown-build.mjs`.
- **Exact steps or command run after this patch**:
  ```sh
  node scripts/run-vitest.mjs src/infra/update-startup.test.ts src/infra/supervisor-markers.test.ts src/infra/update-managed-service-handoff.test.ts src/infra/process-respawn.test.ts src/cli/update-cli.test.ts
  pnpm exec oxfmt --check --threads=1 src/infra/update-startup.test.ts src/infra/supervisor-markers.ts src/infra/supervisor-markers.test.ts src/infra/update-startup.ts src/infra/process-respawn.test.ts
  git diff --check
  node scripts/tsdown-build.mjs
  limactl shell memory-mcp-test -- systemd-run --user --unit=openclaw-gateway --property=Restart=always --property=RestartSec=1 --setenv=OPENCLAW_SERVICE_MARKER=openclaw --setenv=OPENCLAW_SERVICE_KIND=gateway --setenv=OPENCLAW_PROOF_DIR=/tmp/openclaw-91823-proof --setenv=OPENCLAW_PROOF_WORKTREE=/Users/andy/openclaw-91823-auto-update-handoff /usr/bin/node /Users/andy/openclaw-91823-auto-update-handoff/.artifacts/issue-91823-systemd-proof/gateway-service.mjs
  limactl shell memory-mcp-test -- systemctl --user --no-pager status openclaw-gateway.service
  limactl shell memory-mcp-test -- cat /tmp/openclaw-91823-proof/gateway.log /tmp/openclaw-91823-proof/update.log /tmp/openclaw-update-run-handoff-<redacted>/handoff.log
  ```
- **Evidence after fix**:
  ```text
  Local tests:
  unit-fast 5 passed; infra 42 passed; cli 129 passed
  oxfmt --check: passed
  git diff --check: passed

  Linux user service proof:
  Running as unit: openclaw-gateway.service

  openclaw-gateway.service status:
    Loaded: loaded (/run/user/501/systemd/transient/openclaw-gateway.service; transient)
    Active: active (running)
    CGroup: /user.slice/user-501.slice/user@501.service/app.slice/openclaw-gateway.service
            /usr/bin/node .../issue-91823-systemd-proof/gateway-service.mjs

  gateway.log:
    gateway-start supervisor=systemd serviceMarker=openclaw serviceKind=gateway cgroup=.../openclaw-gateway.service
    handoff-started command="openclaw update --yes --channel beta --timeout 15" logPath=/tmp/openclaw-update-run-handoff-<redacted>/handoff.log
    gateway-start supervisor=systemd serviceMarker=openclaw serviceKind=gateway cgroup=.../openclaw-gateway.service
    gateway-healthy-after-restart healthPath=/tmp/openclaw-91823-proof/gateway-health.json

  update.log:
    fake-update-start argv=["update","--yes","--json","--channel","beta","--timeout","15"] OPENCLAW_UPDATE_RUN_HANDOFF=1 serviceMarker=null serviceKind=null cgroup=.../openclaw-update-proof-<redacted>.scope
    fake-update-exit cgroup=.../openclaw-update-proof-<redacted>.scope

  handoff.log:
    starting managed update command: openclaw update --yes --channel beta --timeout 15
    managed update command pid=<redacted>
    managed update command exited code=0 signal=null

  gateway-health.json:
    ok=true supervisor=systemd cgroup=.../openclaw-gateway.service
  ```
- **Observed result after fix**: In a real Linux user systemd service, the PR-head detector returned `systemd` from only the OpenClaw gateway service markers, the managed handoff started via `systemd-run --user --scope`, the updater ran in an `openclaw-update-*.scope` cgroup outside `openclaw-gateway.service`, supervisor marker env was stripped from the updater process, and `openclaw-gateway.service` restarted to a healthy process.
- **What was not tested**: a destructive package-manager swap against an actual npm release. The Linux proof used a safe fake updater command to avoid mutating package state while exercising the PR's compiled detector and production managed-service handoff code under user systemd.

## Verification
- `corepack pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs src/infra/update-startup.test.ts src/infra/supervisor-markers.test.ts src/infra/update-managed-service-handoff.test.ts src/infra/process-respawn.test.ts src/cli/update-cli.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/infra/update-startup.test.ts src/infra/supervisor-markers.ts src/infra/supervisor-markers.test.ts src/infra/update-startup.ts src/infra/process-respawn.test.ts`
- `git diff --check`
- Live Linux systemd user-service proof as described above.

Fixes #91823.
