### PR TITLE
fix(memory-core): keep QMD JSON search one-shot

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -703,6 +703,55 @@ describe("QmdMemoryManager", () => {
     await manager?.close();
   });
 
+  it("keeps one-shot CLI searches from scheduling session-start updates", async () => {
+    cfg = {
+      ...cfg,
+      agents: {
+        ...cfg.agents,
+        defaults: {
+          ...cfg.agents?.defaults,
+          workspace: workspaceDir,
+          memorySearch: {
+            ...cfg.agents?.defaults?.memorySearch,
+            sync: { watch: false, onSessionStart: true, onSearch: true },
+          },
+        },
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "search",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", "[]");
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "cli" });
+
+    await expect(
+      manager.search("glacier", { sessionKey: "agent:main:cli:memory-search" }),
+    ).resolves.toStrictEqual([]);
+    await manager.close();
+
+    const updateCalls = spawnMock.mock.calls
+      .map((call: unknown[]) => call[1] as string[])
+      .filter((args: string[]) => args[0] === "update" || args[0] === "embed");
+    expect(updateCalls).toStrictEqual([]);
+    expect(
+      spawnMock.mock.calls.some((call: unknown[]) => (call[1] as string[])?.[0] === "search"),
+    ).toBe(true);
+  });
+
   it("can be configured to block startup on boot update", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -376,6 +376,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private queuedForcedRuns = 0;
   private dirty = false;
   private closed = false;
+  private mode: QmdManagerMode = "full";
   private readonly closeSignal: Promise<void>;
   private resolveCloseSignal!: () => void;
   private db: SqliteDatabase | null = null;
@@ -449,6 +450,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private async initialize(mode: QmdManagerMode): Promise<void> {
+    this.mode = mode;
     const startTime = Date.now();
     this.bootstrapCollections();
     if (mode === "status") {
@@ -1729,6 +1731,9 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private async maybeWarmSession(sessionKey?: string): Promise<void> {
+    if (this.mode === "cli") {
+      return;
+    }
     if (!this.syncSettings?.onSessionStart) {
       return;
     }
@@ -1743,6 +1748,9 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private async maybeSyncDirtySearchState(): Promise<void> {
+    if (this.mode === "cli") {
+      return;
+    }
     if (!this.syncSettings?.onSearch || !this.dirty) {
       return;
     }


### PR DESCRIPTION
## Summary

Fixes #91821.

`openclaw memory search <query> --json` could print valid JSON with the QMD backend and then stay alive because the one-shot QMD CLI manager could still schedule session-start/search sync work. `withManager()` closes the manager after JSON output, and `close()` waits for pending QMD update/embed work, so a background sync can keep the CLI process alive after the result has already been written.

This keeps the repair in the QMD lifecycle boundary: CLI-mode QMD managers still initialize without watchers or boot timers, and now also skip session/search-triggered sync scheduling during one-shot searches. JSON output remains prompt; best-effort recall tracking is not moved into the blocking JSON path.

## Verification

- `node scripts/run-vitest.mjs extensions/memory-core/src/cli.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts` — 192 passed
- `pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/cli.runtime.ts extensions/memory-core/src/cli.test.ts extensions/memory-core/src/memory/qmd-manager.ts extensions/memory-core/src/memory/qmd-manager.test.ts` — clean
- `git diff --check` — clean
- `git log --format='%h %an <%ae> %s' upstream/main..HEAD` — `4137a2ab05 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(memory-core): keep qmd json search one-shot`

## Real behavior proof

Behavior addressed: QMD-backed `memory search --json` exits after printing successful JSON even when sync settings would otherwise trigger session/search update work. The proof uses a stub `qmd` binary that returns valid search JSON and intentionally never exits for `qmd update`/`qmd embed`; if the CLI schedules the old background update path, the command times out.

Real environment tested: macOS source checkout `/Users/andy/openclaw-91821-memory-json-exit`, Node 24.15.0, rebuilt local `dist/index.js`, temporary `OPENCLAW_CONFIG_PATH`, temporary `OPENCLAW_STATE_DIR`, QMD backend enabled, `memorySearch.sync.onSessionStart=true`, `memorySearch.sync.onSearch=true`, fake `qmd` command on PATH logging every invocation.

Exact steps or command run after this patch:

```bash
node dist/index.js memory search "QMD proof token" --json
```

Evidence after fix:

```json
{
  "proof": "PR91837_QMD_JSON_EXIT_STUB",
  "command": "node dist/index.js memory search \"QMD proof token\" --json",
  "config": {
    "backend": "qmd",
    "sync": {
      "onSessionStart": true,
      "onSearch": true
    },
    "qmdUpdateStubWouldHang": true
  },
  "exit": {
    "code": 0,
    "signal": null
  },
  "timedOut": false,
  "durationMs": 4020,
  "stdout": "{\n  \"results\": [\n    {\n      \"path\": \"memory/proof.md\",\n      \"startLine\": 1,\n      \"endLine\": 1,\n      \"score\": 0.91,\n      \"snippet\": \"@@ -1,1\\nQMD proof token from stub\",\n      \"source\": \"memory\"\n    }\n  ]\n}",
  "stderr": "[memory] qmd manager initialized for agent \"main\" mode=cli collections=1 durationMs=210\n[memory] failed to read qmd index stats: Error: unable to open database file",
  "qmdCalls": [
    ["collection", "list", "--json"],
    ["collection", "add", "<temp-workspace>", "--name", "workspace-main", "--mask", "**/*.md"],
    ["search", "QMD proof token", "--json", "-n", "4", "-c", "workspace-main"]
  ],
  "backgroundUpdateCallCount": 0
}
```

Observed result after fix: the CLI printed a valid JSON result and exited with status 0 before the 7s proof timeout. The QMD invocation log shows collection setup and search only; no `qmd update` or `qmd embed` command was spawned, so the intentionally hanging update path was not reached.

What was not tested: a live installed QMD binary and real QMD index. The proof is a faithful process-lifecycle stub for the reported exit hang: it exercises the OpenClaw CLI, config loading, QMD manager creation, QMD collection/search subprocess calls, JSON output, and process exit behavior.

