### PR TITLE
perf(memory): target session delta syncs with the dirty set instead of full directory scans

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.targeted-delta.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.targeted-delta.test.ts
@@ -1,0 +1,183 @@
+// Memory Core tests cover session delta sync targeting: event-driven delta
+// syncs pass the dirty set as explicit targets (skipping the sessions-dir
+// enumeration), and fall back to a full enumeration at most once per
+// reconcile window so out-of-band deletions still get pruned.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  resolveSessionTranscriptsDirForAgent,
+  type OpenClawConfig,
+  type ResolvedMemorySearchConfig,
+} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
+
+type RecordedSync = { reason?: string; force?: boolean; sessionFiles?: string[] };
+
+class TargetedDeltaHarness extends MemoryManagerSyncOps {
+  protected readonly cfg = {} as OpenClawConfig;
+  protected readonly agentId = "main";
+  protected readonly settings = {
+    sync: {
+      sessions: {
+        deltaBytes: 100_000,
+        deltaMessages: 50,
+        postCompactionForce: true,
+      },
+    },
+  } as ResolvedMemorySearchConfig;
+  protected readonly batch = {
+    enabled: false,
+    wait: false,
+    concurrency: 1,
+    pollIntervalMs: 0,
+    timeoutMs: 0,
+  };
+  protected readonly vector = { enabled: false, available: false };
+  protected readonly cache = { enabled: false };
+  protected providerUnavailableReason?: string;
+  protected providerLifecycle = { mode: "active" as const, providerId: "test" };
+  protected db: DatabaseSync;
+
+  readonly syncCalls: RecordedSync[] = [];
+
+  constructor(protected readonly workspaceDir = "/tmp/openclaw-test-workspace") {
+    super();
+    this.sources.add("sessions");
+    this.db = {
+      prepare: () => ({ all: () => [], get: () => undefined, run: () => undefined }),
+    } as unknown as DatabaseSync;
+  }
+
+  async runDeltaBatch(pendingFiles: string[]): Promise<void> {
+    for (const file of pendingFiles) {
+      this.sessionPendingFiles.add(file);
+    }
+    await (
+      this as unknown as { processSessionDeltaBatch: () => Promise<void> }
+    ).processSessionDeltaBatch();
+  }
+
+  addDirtyFile(sessionFile: string): void {
+    this.sessionsDirtyFiles.add(sessionFile);
+  }
+
+  setLastReconcileAt(ms: number): void {
+    (this as unknown as { lastSessionPruneReconcileAt: number }).lastSessionPruneReconcileAt = ms;
+  }
+
+  lastReconcileAt(): number {
+    return (this as unknown as { lastSessionPruneReconcileAt: number }).lastSessionPruneReconcileAt;
+  }
+
+  async runFullSessionSync(): Promise<void> {
+    await (
+      this as unknown as { syncSessionFiles: (p: unknown) => Promise<unknown> }
+    ).syncSessionFiles({ needsFullReindex: true });
+  }
+
+  protected computeProviderKey(): string {
+    return "test";
+  }
+
+  protected async sync(params?: RecordedSync): Promise<void> {
+    this.syncCalls.push(params ?? {});
+  }
+
+  protected async withTimeout<T>(promise: Promise<T>): Promise<T> {
+    return await promise;
+  }
+
+  protected getIndexConcurrency(): number {
+    return 1;
+  }
+
+  protected pruneEmbeddingCacheIfNeeded(): void {}
+
+  protected resetProviderInitializationForRetry(): void {}
+
+  protected assertRequiredProviderAvailable(): void {}
+
+  protected async indexFile(): Promise<void> {}
+}
+
+// Archive artifacts route through the direct mark-dirty branch of the delta
+// batch, so tests need no transcript fixtures or delta accounting.
+function archiveSessionFile(name: string): string {
+  return path.join(
+    resolveSessionTranscriptsDirForAgent("main"),
+    `${name}.jsonl.reset.2026-01-01T00-00-00.000Z`,
+  );
+}
+
+describe("session delta sync targeting", () => {
+  let stateDir = "";
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-targeted-delta-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("passes the dirty set as sync targets inside the reconcile window", async () => {
+    const harness = new TargetedDeltaHarness();
+    harness.setLastReconcileAt(Date.now());
+    const archived = archiveSessionFile("thread-a");
+
+    await harness.runDeltaBatch([archived]);
+
+    expect(harness.syncCalls).toEqual([{ reason: "session-delta", sessionFiles: [archived] }]);
+  });
+
+  it("includes leftover dirty files from earlier syncs in the targets", async () => {
+    const harness = new TargetedDeltaHarness();
+    harness.setLastReconcileAt(Date.now());
+    const leftover = archiveSessionFile("thread-leftover");
+    const fresh = archiveSessionFile("thread-fresh");
+    harness.addDirtyFile(leftover);
+
+    await harness.runDeltaBatch([fresh]);
+
+    expect(harness.syncCalls).toHaveLength(1);
+    expect(harness.syncCalls[0]?.reason).toBe("session-delta");
+    expect(new Set(harness.syncCalls[0]?.sessionFiles)).toEqual(new Set([leftover, fresh]));
+  });
+
+  it("falls back to a full enumeration once the reconcile window elapses", async () => {
+    // lastSessionPruneReconcileAt starts at 0, so the first active delta sync
+    // reconciles with a full enumeration unless a prior prune already ran.
+    const harness = new TargetedDeltaHarness();
+
+    await harness.runDeltaBatch([archiveSessionFile("thread-b")]);
+
+    expect(harness.syncCalls).toEqual([{ reason: "session-delta" }]);
+  });
+
+  it("advances the reconcile timestamp after an authoritative prune", async () => {
+    await fs.mkdir(resolveSessionTranscriptsDirForAgent("main"), { recursive: true });
+    const harness = new TargetedDeltaHarness();
+
+    await harness.runFullSessionSync();
+
+    expect(harness.lastReconcileAt()).toBeGreaterThan(0);
+  });
+
+  it("does not advance the reconcile timestamp when the scan fails", async () => {
+    await fs.mkdir(resolveSessionTranscriptsDirForAgent("main"), { recursive: true });
+    const harness = new TargetedDeltaHarness();
+    vi.spyOn(fs, "readdir").mockRejectedValueOnce(
+      Object.assign(new Error("nfs blip"), { code: "EIO" }),
+    );
+
+    await harness.runFullSessionSync();
+
+    expect(harness.lastReconcileAt()).toBe(0);
+  });
+});

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -128,6 +128,11 @@ const VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = "chunks_fts";
 const EMBEDDING_CACHE_TABLE = "embedding_cache";
 const SESSION_DIRTY_DEBOUNCE_MS = 5000;
+// Targeted delta syncs skip the sessions-dir enumeration entirely, so rows for
+// files deleted out-of-band (another process/node on shared storage) are only
+// pruned by full enumerations. Force one full-enumeration delta sync at most
+// this often to bound how long such stale rows can linger in search.
+const SESSION_PRUNE_RECONCILE_INTERVAL_MS = 15 * 60 * 1000;
 const SESSION_DELTA_READ_CHUNK_BYTES = 64 * 1024;
 const SESSION_SYNC_YIELD_EVERY = 10;
 const SOURCE_WIDE_SESSION_INDEX_FLUSH_FILES = 128;
@@ -274,6 +279,10 @@ export abstract class MemoryManagerSyncOps {
   protected sessionsDirty = false;
   private readonly memoryWatchPressureWarning: MemoryWatchPressureWarningState = { shown: false };
   protected sessionsDirtyFiles = new Set<string>();
+  // Epoch ms of the last completed session stale-row prune (authoritative full
+  // enumeration). Starts at 0 so the first active delta sync reconciles unless
+  // the startup catch-up sync already did.
+  private lastSessionPruneReconcileAt = 0;
   protected sessionPendingFiles = new Set<string>();
   protected sessionDeltas = new Map<
     string,
@@ -1426,7 +1435,16 @@ export abstract class MemoryManagerSyncOps {
       shouldSync = true;
     }
     if (shouldSync) {
-      void this.sync({ reason: "session-delta" }).catch((err: unknown) => {
+      // The dirty set already names every transcript this sync must index, so
+      // pass it through and skip the sessions-dir enumeration (expensive on
+      // networked filesystems). Periodically fall back to a full enumeration
+      // so out-of-band deletions still get their stale index rows pruned.
+      const reconcileDue =
+        Date.now() - this.lastSessionPruneReconcileAt >= SESSION_PRUNE_RECONCILE_INTERVAL_MS;
+      const syncParams = reconcileDue
+        ? { reason: "session-delta" }
+        : { reason: "session-delta", sessionFiles: Array.from(this.sessionsDirtyFiles) };
+      void this.sync(syncParams).catch((err: unknown) => {
         log.warn(`memory sync failed (session-delta): ${String(err)}`);
       });
     }
@@ -1876,6 +1894,9 @@ export abstract class MemoryManagerSyncOps {
           await yieldAfterStaleSessionRow();
         }
       }
+      // A completed authoritative prune is the reconciliation point targeted
+      // delta syncs rely on; record it so they keep skipping enumerations.
+      this.lastSessionPruneReconcileAt = Date.now();
     };
 
     if (params.deferIndex) {


### PR DESCRIPTION
## Summary

Every 5s-debounced session delta sync calls `sync({ reason: "session-delta" })` with no targets, so `syncSessionFiles` performs a **full sessions-directory enumeration** — and then skips every listed file that is not in the dirty set anyway. The enumeration's only unique contribution to a delta sync is stale-row prune reconciliation; the indexing work is fully determined by `sessionsDirtyFiles`, which the engine populated from transcript events before triggering the sync.

On networked filesystems these scans are expensive: an NFSv4.1 profile of a real deployment measured full listings of `agents/main/sessions` at **3.4–3.8s each** (~100 entries; the client requests a broad READDIR attribute set, which the backing server satisfies with per-entry metadata reads). Trace-level attribution later showed the *specific* scans that profile captured came from per-save archive-retention cleanup — fixed separately in #91957 — not from memory delta syncs (that deployment does not run memory session sync). The per-scan cost numbers still stand, and they are what every delta sync pays on such storage whenever memory session sync **is** enabled.

This PR makes delta syncs use the targeted path that already exists (`runMemoryTargetedSessionSync`):

- `processSessionDeltaBatch` now passes the accumulated dirty set as explicit `sessionFiles` targets → the sessions-dir enumeration is skipped entirely. The targeted path clears only the synced files from the dirty set (files dirtied mid-sync survive) and retains targets as dirty on failure.
- **Bounded reconciliation:** at most once per `SESSION_PRUNE_RECONCILE_INTERVAL_MS` (15 min), a delta sync falls back to the full enumeration so index rows for files deleted out-of-band (another process/node on shared storage) still get pruned. The timestamp only advances when an authoritative prune actually completed, so a failed scan retries on the next batch.
- Boot catch-up, interval-with-dirty-files, CLI/forced, and full-reindex syncs keep their full enumerations unchanged — those are the intended reconciliation points.

### Behavior notes

- **Indexing outcomes are unchanged.** The full path already skipped non-dirty files during delta syncs; only the prune cadence shifts from per-batch (~5s) to the bounded window (≤15 min during activity). Idle agents are unchanged (no delta syncs → no scans, before and after).
- Targeted syncs are sessions-only by existing contract, so a delta sync no longer incidentally flushes dirty memory-source files; those still sync via their own watch debounce and interval triggers.
- Stacked on #91091 deliberately: the now-rarer full enumerations are exactly the scans #91091 makes authoritative (`{ ok, files }`), so a failed reconcile scan cannot prune and dirty state is retained for retry.

Identified while decomposing the NFS readdir-load report behind the #91081 discussion (its "avoid full scans when a targeted dirty-file set exists" recommendation). With this change, deployments running memory session sync stop paying a full directory scan per delta batch; the remaining enumeration cost (boot catch-up, periodic reconcile, qmd export, and the store-save retention sweeps addressed by #91957) is the much smaller surface the coalescing/TTL discussion in #91081 addresses separately.

## Verification

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-sync-ops.targeted-delta.test.ts extensions/memory-core/src/memory/manager-sync-ops.prune-guard.test.ts extensions/memory-core/src/memory/manager-targeted-sync.test.ts extensions/memory-core/src/memory/manager-session-sync-state.test.ts` — **19/19** (5 new).
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-sync-ops.archive-delta-bypass.test.ts` — **4/4**.
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` — clean. `node scripts/run-oxlint.mjs` on touched files — clean.
- New tests cover: targeted params within the reconcile window; accumulated dirty set (leftovers from earlier syncs) included in targets; full-enumeration fallback at window expiry (and at boot, timestamp 0); reconcile timestamp advancing only after an authoritative prune; failed scan leaving the timestamp unset so the next batch retries.
- Not run here: live NFS before/after trace. The report's verification protocol applies directly — count `scandir` events on the sessions dir during steady-state activity; expected: one per 15-min reconcile window instead of one per 5s delta batch.

