### PR TITLE
fix(cron): snapshot final-call tokens for isolated runs

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -949,6 +949,7 @@ async function finalizeCronRun(params: {
     runMeta: finalRunResult.meta?.agentMeta,
   });
   const usage = finalRunResult.meta?.agentMeta?.usage;
+  const lastCallUsage = finalRunResult.meta?.agentMeta?.lastCallUsage;
   const promptTokens = finalRunResult.meta?.agentMeta?.promptTokens;
   const modelUsed =
     finalRunResult.meta?.agentMeta?.model ??
@@ -986,7 +987,7 @@ async function finalizeCronRun(params: {
     const input = usage.input ?? 0;
     const output = usage.output ?? 0;
     const totalTokens = deriveSessionTotalTokens({
-      usage,
+      usage: lastCallUsage ?? usage,
       contextTokens,
       promptTokens,
     });


### PR DESCRIPTION
Fixes #91716.

## Summary
- use `agentMeta.lastCallUsage` for the cron isolated-agent context snapshot when available
- keep cumulative `usage` for input/output token and cost accounting
- preserve the existing fallback to cumulative usage for providers that do not publish a last-call snapshot

## Testing
- Not run locally; full repository checkout/download was not available in this environment, so this PR is limited to the source-inspected one-line fix described in the issue.