### PR TITLE
fix(cron): report SQLite state path in cron status

### DIFF
--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import {
   completeTaskRunByRunId,
   createRunningTaskRun,
@@ -253,7 +254,8 @@ export async function status(state: CronServiceState) {
     await ensureLoadedForRead(state);
     return {
       enabled: state.deps.cronEnabled,
-      storePath: state.deps.storePath,
+      storePath: resolveOpenClawStateSqlitePath(),
+      legacyStorePath: state.deps.storePath,
       jobs: state.store?.jobs.length ?? 0,
       nextWakeAtMs: state.deps.cronEnabled ? (nextWakeAtMs(state) ?? null) : null,
     };


### PR DESCRIPTION
Fixes #91766.

## Summary
- report the shared SQLite state database path from `cron.status` as `storePath`
- preserve the legacy JSON cron store key/path as `legacyStorePath` for diagnostics
- leave cron persistence and run-log behavior unchanged

## Testing
- Not run locally; full repository checkout/download was not available in this environment.