### PR TITLE
fix(history): strip stream-error prefix before real content

### DIFF
--- a/src/agents/stream-message-shared.ts
+++ b/src/agents/stream-message-shared.ts
@@ -94,6 +94,14 @@ export function buildAssistantMessageWithZeroUsage(params: {
 // to a live stream-error turn (and the repair pass remains idempotent).
 export const STREAM_ERROR_FALLBACK_TEXT = "[assistant turn failed before producing content]";
 
+export function stripStreamErrorFallbackPrefix(text: string): string {
+  if (!text.startsWith(STREAM_ERROR_FALLBACK_TEXT)) {
+    return text;
+  }
+  const rest = text.slice(STREAM_ERROR_FALLBACK_TEXT.length);
+  return rest.trim().length > 0 ? rest : text;
+}
+
 export function buildStreamErrorAssistantMessage(params: {
   model: StreamModelDescriptor;
   errorMessage: string;

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -1,6 +1,9 @@
 // Gateway agent prompt builder.
 // Converts conversation entries into the latest-message-plus-history prompt.
-import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
+import {
+  STREAM_ERROR_FALLBACK_TEXT,
+  stripStreamErrorFallbackPrefix,
+} from "../agents/stream-message-shared.js";
 import { buildHistoryContextFromEntries, type HistoryEntry } from "../auto-reply/reply/history.js";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
 
@@ -20,7 +23,7 @@ function safeBody(body: unknown): string {
 }
 
 function toPromptEntry(entry: ConversationEntry): HistoryEntry | null {
-  const body = safeBody(entry.entry.body);
+  const body = stripStreamErrorFallbackPrefix(safeBody(entry.entry.body));
   if (
     entry.role === "assistant" &&
     entry.internalStreamError === true &&


### PR DESCRIPTION
Fixes #91503.

## Summary
- add a helper that removes the internal stream-error fallback prefix only when real content follows it
- apply the helper while building agent-visible conversation history
- keep pure fallback sentinel turns intact so internal replay/repair behavior is preserved

## Testing
- Not run locally; full repository checkout/download was not available in this environment.