### PR TITLE
fix(memory): abort search embeddings on tool timeout

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -104,6 +104,39 @@ function formatBatchSourceCounts(counts: Record<string, number>): string {
   );
 }
 
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) {
+    return;
+  }
+  throw signal.reason instanceof Error ? signal.reason : new Error("memory embedding aborted");
+}
+
+function combineAbortSignals(left: AbortSignal, right?: AbortSignal): AbortSignal {
+  if (!right) {
+    return left;
+  }
+  const abortSignalAny = (AbortSignal as typeof AbortSignal & {
+    any?: (signals: AbortSignal[]) => AbortSignal;
+  }).any;
+  if (typeof abortSignalAny === "function") {
+    return abortSignalAny([left, right]);
+  }
+  const controller = new AbortController();
+  const abort = (signal: AbortSignal) => {
+    if (!controller.signal.aborted) {
+      controller.abort(signal.reason);
+    }
+  };
+  for (const signal of [left, right]) {
+    if (signal.aborted) {
+      abort(signal);
+    } else {
+      signal.addEventListener("abort", () => abort(signal), { once: true });
+    }
+  }
+  return controller.signal;
+}
+
 export function splitSourceWideEmbeddingChunks<T>(chunks: T[], maxRequests: number): T[][] {
   const limit = Math.max(1, Math.floor(maxRequests));
   const batches: T[][] = [];
@@ -493,7 +526,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     });
   }
 
-  protected async embedQueryWithRetry(text: string): Promise<number[]> {
+  protected async embedQueryWithRetry(text: string, signal?: AbortSignal): Promise<number[]> {
     const provider = this.provider;
     if (!provider) {
       throw new Error("Cannot embed query in FTS-only mode (no embedding provider)");
@@ -501,17 +534,23 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     try {
       return await runMemoryEmbeddingRetryLoop({
         run: async () => {
+          throwIfAborted(signal);
           const timeoutMs = this.resolveEmbeddingTimeout("query");
           log.debug("memory embeddings: query start", { provider: provider.id, timeoutMs });
           return await runEmbeddingOperationWithTimeout({
             timeoutMs,
             message: `memory embeddings query timed out after ${Math.round(timeoutMs / 1000)}s`,
-            run: async (signal) => await provider.embedQuery(text, { signal }),
+            run: async (timeoutSignal) =>
+              await provider.embedQuery(text, {
+                signal: combineAbortSignals(timeoutSignal, signal),
+              }),
           });
         },
         isRetryable: isRetryableMemoryEmbeddingError,
         waitForRetry: async (delayMs) => {
+          throwIfAborted(signal);
           await this.waitForEmbeddingRetry(delayMs, "retrying query");
+          throwIfAborted(signal);
         },
         maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
         baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -590,6 +590,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       sessionKey?: string;
       qmdSearchModeOverride?: "query" | "search" | "vsearch";
       onDebug?: (debug: MemorySearchRuntimeDebug) => void;
+      signal?: AbortSignal;
       /** When set, only these chunk sources are considered (must be enabled for this manager). */
       sources?: MemorySource[];
     },
@@ -758,7 +759,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
     let queryVec: number[];
     try {
-      queryVec = await this.embedQueryWithRetry(cleaned);
+      queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal);
     } catch (err) {
       const message = formatErrorMessage(err);
       const activatedFallback = this.shouldFallbackOnError(err)
@@ -778,7 +779,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           return [];
         }
         keywordResults = await loadKeywordResults();
-        queryVec = await this.embedQueryWithRetry(cleaned);
+        queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal);
       } else if (!this.provider && this.fts.enabled && this.fts.available) {
         log.warn(`memory search: embeddings unavailable; using keyword-only results: ${message}`);
         return this.selectScoredResults(keywordResults, maxResults, minScore, 0);

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -83,14 +83,20 @@ export const testing = {
 
 async function runMemorySearchToolWithDeadline<T>(params: {
   timeoutMs: number;
-  run: () => Promise<T>;
+  run: (signal: AbortSignal) => Promise<T>;
 }): Promise<{ status: "ok"; value: T } | { status: "unavailable"; error: string }> {
+  const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<"timeout">((resolve) => {
-    timer = setTimeout(() => resolve("timeout"), params.timeoutMs);
+    timer = setTimeout(() => {
+      controller.abort(
+        new Error(`memory_search timed out after ${Math.round(params.timeoutMs / 1000)}s`),
+      );
+      resolve("timeout");
+    }, params.timeoutMs);
     timer.unref?.();
   });
-  const task = params.run();
+  const task = params.run(controller.signal);
   task.catch(() => undefined);
 
   try {
@@ -382,7 +388,7 @@ export function createMemorySearchTool(options: {
 
         const outcome = await runMemorySearchToolWithDeadline({
           timeoutMs: MEMORY_SEARCH_TOOL_TIMEOUT_MS,
-          run: async () => {
+          run: async (signal) => {
             const { resolveMemoryBackendConfig } = await loadMemoryToolRuntime();
             const shouldQuerySupplements = requestedCorpus === "wiki" || requestedCorpus === "all";
             const shouldQueryMemory = requestedCorpus !== "wiki" && !cooldown;
@@ -457,6 +463,7 @@ export function createMemorySearchTool(options: {
                   onDebug: (debug: MemorySearchRuntimeDebug) => {
                     runtimeDebug.push(debug);
                   },
+                  signal,
                   ...(searchSources ? { sources: searchSources } : {}),
                 };
                 try {


### PR DESCRIPTION
Fixes #91718.

## Summary
- create an `AbortController` for the `memory_search` tool-level deadline
- thread the signal through `manager.search()` to query embedding
- combine the tool deadline signal with each embedding operation timeout signal so hanging provider fetches are cancelled

## Testing
- Not run locally; full repository checkout/download was not available in this environment.