### PR TITLE
fix(gateway): allow Gemini CLI image-capable models

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1780,6 +1780,18 @@ export async function resolveGatewayModelSupportsImages(params: {
       ) {
         return true;
       }
+      if (
+        normalizedProvider === "google-gemini-cli" &&
+        normalizedCandidates.some(
+          (candidate) =>
+            candidate === "pro" ||
+            candidate === "flash" ||
+            candidate === "flash-lite" ||
+            candidate.startsWith("gemini-"),
+        )
+      ) {
+        return true;
+      }
       return false;
     }
     if (
@@ -1790,6 +1802,18 @@ export async function resolveGatewayModelSupportsImages(params: {
           candidate === "sonnet" ||
           candidate === "haiku" ||
           candidate.startsWith("claude-"),
+      )
+    ) {
+      return true;
+    }
+    if (
+      normalizedProvider === "google-gemini-cli" &&
+      normalizedCandidates.some(
+        (candidate) =>
+          candidate === "pro" ||
+          candidate === "flash" ||
+          candidate === "flash-lite" ||
+          candidate.startsWith("gemini-"),
       )
     ) {
       return true;


### PR DESCRIPTION
Fixes #91739.

## Summary
- treat `google-gemini-cli` Gemini-family models as image-capable in the gateway attachment gate
- mirror the existing CLI-backend capability shim used for `claude-cli`
- preserve rejection for non-Gemini/text-only models

## Testing
- Not run locally; full repository checkout/download was not available in this environment.