### PR TITLE
fix(schema): clean tool schemas for Gemini model ids

### DIFF
--- a/src/agents/agent-tools-parameter-schema.ts
+++ b/src/agents/agent-tools-parameter-schema.ts
@@ -769,8 +769,11 @@ function normalizeToolParameterSchemaUncached(
   //
   // Normalize once here so callers can always pass `tools` through unchanged.
   const normalizedProvider = normalizeLowercaseStringOrEmpty(options?.modelProvider);
+  const normalizedModelId = normalizeLowercaseStringOrEmpty(options?.modelId);
   const isGeminiProvider =
-    normalizedProvider.includes("google") || normalizedProvider.includes("gemini");
+    normalizedProvider.includes("google") ||
+    normalizedProvider.includes("gemini") ||
+    normalizedModelId.includes("gemini");
   const isAnthropicProvider = normalizedProvider.includes("anthropic");
   const unsupportedToolSchemaKeywords = resolveUnsupportedToolSchemaKeywords(options?.modelCompat);
   const omitEmptyArrayItems = shouldOmitEmptyArrayItems(options?.modelCompat);

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -642,6 +642,27 @@ describe("normalizeToolParameterSchema", () => {
     expect(parentId?.anyOf).toBeUndefined();
     expect(count?.oneOf).toBeUndefined();
   });
+
+  it("applies Gemini schema cleaning for OpenAI-compatible Gemini model ids", () => {
+    const cleaned = normalizeToolParameterSchema(
+      {
+        type: "object",
+        properties: {
+          sessionKey: { anyOf: [{ type: "string" }, { type: "null" }] },
+          agentId: { anyOf: [{ type: "string" }, { type: "null" }] },
+        },
+      },
+      {
+        modelProvider: "jjcc",
+        modelId: "gemini-3.1-pro-preview",
+      },
+    ) as { properties?: Record<string, { type?: unknown; anyOf?: unknown }> };
+
+    expect(cleaned.properties?.sessionKey?.type).toBe("string");
+    expect(cleaned.properties?.sessionKey?.anyOf).toBeUndefined();
+    expect(cleaned.properties?.agentId?.type).toBe("string");
+    expect(cleaned.properties?.agentId?.anyOf).toBeUndefined();
+  });
 });
 
 function makeTool(parameters: TSchema): AnyAgentTool {


### PR DESCRIPTION
Fixes #91542.

## Summary
- detect Gemini compatibility from `modelId` as well as provider name
- apply existing Gemini schema cleaning for OpenAI-compatible providers routing Gemini models
- add coverage for nullable `anyOf` cron-style properties under a `jjcc` Gemini model id

## Testing
- Not run locally; full repository checkout/download was not available in this environment.