### PR TITLE
feat(discord): allow requireMention to ignore mass mentions

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -1444,6 +1444,44 @@ describe("preflightDiscordMessage", () => {
     expect(preflight.wasMentioned).toBe(true);
   });
 
+  it("does not treat @everyone as a mention when ignoreMassMentions=true", async () => {
+    const channelId = "channel-everyone-ignored";
+    const guildId = "guild-everyone-ignored";
+    const message = createDiscordMessage({
+      id: "m-everyone-ignored",
+      channelId,
+      content: "@everyone standup time!",
+      mentionedEveryone: true,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Peter",
+      },
+    });
+
+    const result = await runGuildPreflight({
+      channelId,
+      guildId,
+      message,
+      discordConfig: {
+        botId: "openclaw-bot",
+      } as DiscordConfig,
+      guildEntries: {
+        [guildId]: {
+          channels: {
+            [channelId]: {
+              enabled: true,
+              requireMention: true,
+              ignoreMassMentions: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("accepts allowlisted guild messages when guild object is missing", async () => {
     const message = createDiscordMessage({
       id: "m-guild-id-only",

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -434,11 +434,6 @@ export async function preflightDiscordMessage(
   const explicitlyMentioned = Boolean(
     botId && message.mentionedUsers?.some((user: User) => user.id === botId),
   );
-  const hasAnyMention =
-    !isDirectMessage &&
-    ((message.mentionedUsers?.length ?? 0) > 0 ||
-      (message.mentionedRoles?.length ?? 0) > 0 ||
-      (message.mentionedEveryone && (!author.bot || sender.isPluralKit)));
   const hasUserOrRoleMention =
     !isDirectMessage &&
     ((message.mentionedUsers?.length ?? 0) > 0 || (message.mentionedRoles?.length ?? 0) > 0);
@@ -506,6 +501,11 @@ export async function preflightDiscordMessage(
     channelMatchMeta,
     channelId: messageChannelId,
   });
+  const ignoreMassMentions =
+    channelConfig?.ignoreMassMentions ?? guildInfo?.ignoreMassMentions ?? false;
+  const massMentionCountsAsMention =
+    message.mentionedEveryone && !ignoreMassMentions && (!author.bot || sender.isPluralKit);
+  const hasAnyMention = !isDirectMessage && (hasUserOrRoleMention || massMentionCountsAsMention);
   const channelAccess = resolveDiscordPreflightChannelAccess({
     isGuildMessage,
     isGroupDm,
@@ -584,7 +584,7 @@ export async function preflightDiscordMessage(
     isExplicitlyMentioned: explicitlyMentioned,
     mentionRegexes,
     mentionText,
-    mentionedEveryone: message.mentionedEveryone,
+    mentionedEveryone: massMentionCountsAsMention,
     referencedAuthorId: message.referencedMessage?.author?.id,
     senderIsPluralKit: sender.isPluralKit,
     transcript: preflightTranscript,

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -51,6 +51,10 @@ export type DiscordGuildChannelConfig = {
    * Default: false.
    */
   ignoreOtherMentions?: boolean;
+  /**
+   * If true, @everyone/@here do not satisfy requireMention. Default: false.
+   */
+  ignoreMassMentions?: boolean;
   /** Optional tool policy overrides for this channel. */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
@@ -84,6 +88,10 @@ export type DiscordGuildEntry = {
    * Default: false.
    */
   ignoreOtherMentions?: boolean;
+  /**
+   * If true, @everyone/@here do not satisfy requireMention. Default: false.
+   */
+  ignoreMassMentions?: boolean;
   /** Optional tool policy overrides for this guild (used when channel override is missing). */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;


### PR DESCRIPTION
Fixes #91415.

## Summary
- add `ignoreMassMentions` to Discord guild and channel config
- keep the default behavior where `@everyone` / `@here` satisfy `requireMention`
- when enabled, exclude mass mentions from Discord mention gating while preserving explicit user/role mention behavior
- add preflight coverage for the new option

## Testing
- Not run locally; full repository checkout/download was not available in this environment.