### PR TITLE
feat(gateway): expose version on health probes

### DIFF
--- a/src/gateway/server-http.probe.test.ts
+++ b/src/gateway/server-http.probe.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./server-http.test-harness.js";
 import type { ReadinessChecker } from "./server/readiness.js";
 import { withTempConfig } from "./test-temp-config.js";
+import { VERSION } from "../version.js";
 
 type GatewayServerHarness = Parameters<typeof dispatchRequest>[0];
 type GatewayRequestOptions = Parameters<typeof createRequest>[0];
@@ -256,7 +257,7 @@ describe("gateway probe endpoints", () => {
         const { res, getBody } = await sendGatewayRequest(server, { path: "/healthz" });
 
         expect(res.statusCode).toBe(200);
-        expect(getBody()).toBe(JSON.stringify({ ok: true, status: "live" }));
+        expect(getBody()).toBe(JSON.stringify({ ok: true, status: "live", version: VERSION }));
       },
     });
   });
@@ -274,7 +275,7 @@ describe("gateway probe endpoints", () => {
         const { res, getBody } = await sendGatewayRequest(server, { path: "/healthz" });
 
         expect(res.statusCode).toBe(200);
-        expect(getBody()).toBe(JSON.stringify({ ok: true, status: "live" }));
+        expect(getBody()).toBe(JSON.stringify({ ok: true, status: "live", version: VERSION }));
         expect(getRuntimeConfig).not.toHaveBeenCalled();
       },
     });
@@ -298,7 +299,9 @@ describe("gateway probe endpoints", () => {
         await dispatchRequest(server, healthReq, healthResponse.res);
 
         expect(healthResponse.res.statusCode).toBe(200);
-        expect(healthResponse.getBody()).toBe(JSON.stringify({ ok: true, status: "live" }));
+        expect(healthResponse.getBody()).toBe(
+          JSON.stringify({ ok: true, status: "live", version: VERSION }),
+        );
 
         const readyReq = createRequest({ path: "/readyz" });
         const readyResponse = createResponse();

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -12,6 +12,7 @@ import type { WebSocketServer } from "ws";
 import { resolveBundledChannelGatewayAuthBypassPaths } from "../channels/plugins/gateway-auth-bypass.js";
 import { getRuntimeConfig } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { VERSION } from "../version.js";
 import {
   createDiagnosticTraceContext,
   runWithDiagnosticTraceContext,
@@ -317,7 +318,7 @@ async function handleGatewayProbeRequest(
     }
   } else {
     statusCode = 200;
-    body = JSON.stringify({ ok: true, status });
+    body = JSON.stringify({ ok: true, status, version: VERSION });
   }
   res.statusCode = statusCode;
   res.end(method === "HEAD" ? undefined : body);


### PR DESCRIPTION
Fixes #91795.

## Summary
- include the runtime `VERSION` in live health probe responses (`/health`, `/healthz`)
- keep readiness probe behavior unchanged
- update probe tests for the additive response field

## Testing
- Not run locally; full repository checkout/download was not available in this environment.