### PR TITLE
fix(ui): prevent workboard cards from collapsing in crowded columns

### DIFF
--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -358,6 +358,7 @@
   min-height: 0;
   padding: 10px;
   display: grid;
+  grid-auto-rows: max-content;
   gap: 10px;
   align-content: start;
   overflow-y: auto;


### PR DESCRIPTION
Fixes #91717.

## Summary
- set `grid-auto-rows: max-content` on `.workboard-column__cards`
- let crowded Workboard columns scroll instead of squeezing card rows below their content height
- preserve existing card layout and sparse-column behavior

## Testing
- Not run locally; full repository checkout/download was not available in this environment.