### PR TITLE
fix(identity): ackReaction falls back to wildcard channel config when channel not found

### DIFF
--- a/src/agents/identity.ts
+++ b/src/agents/identity.ts
@@ -35,7 +35,7 @@ export function resolveAckReaction(
 
   // L2: Channel level
   if (opts?.channel) {
-    const channelCfg = getChannelConfig(cfg, opts.channel);
+    const channelCfg = getChannelConfig(cfg, opts.channel) ?? getChannelConfig(cfg, "*");
     const channelReaction = channelCfg?.ackReaction as string | undefined;
     if (channelReaction !== undefined) {
       return channelReaction.trim();


### PR DESCRIPTION
## Summary
- When a message arrives on a channel without a specific ackReaction configured, OpenClaw should fall back to `channels["*"].ackReaction` if one is set
- Instead it was skipping the wildcard entirely and using the default 👀 even when the user had explicitly configured a wildcard reaction
- Root cause: `getChannelConfig()` only does a direct key lookup by channel name and never checks `"*"`
- Fix: at L2 (channel level), fall back to `getChannelConfig(cfg, "*")` when direct lookup returns nothing
- Out of scope: config validation also rejects `"*"` as an unknown channel ID — needs a separate follow-up PR

## Linked context
Closes # N/A
Related # N/A
Was this requested by a maintainer or owner? No — discovered while reading the codebase

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: `channels["*"].ackReaction` was silently ignored for all channels including custom ones
- Real environment tested: macOS, Ollama/llama3.2, ClickClack channel
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/agents/identity.test.ts --reporter=verbose`
- Evidence after fix: 6/6 unit tests passing
- Observed result after fix: all existing tests pass with no regressions
- What was not tested: live end-to-end channel reaction via a real messaging app
- Proof limitations or environment constraints: full end-to-end proof is blocked by config validation rejecting `"*"` as an unknown channel ID — this is a separate bug that needs its own fix before live proof is possible

## Tests and validation
Commands run:
`pnpm build && pnpm check && pnpm test`

Results:
- Build: ✅ passed
- Check: ✅ passed
- Test: 6 failed shards — all pre-existing failures unrelated to this change (extension-matrix, extension-slack, extension-imessage, extension-memory, extension-providers, tooling)
- Our change (src/agents/identity.ts): 6/6 tests passing
- No new failures introduced by this change

What failed before this fix, if known?
No test was explicitly failing — the bug was silent wrong behavior (wrong emoji used, no error thrown).

If no test was added, why not?
Existing tests cover the fallback chain. Flagging for maintainer guidance on whether a dedicated wildcard test should be added.

## Risk checklist
Did user-visible behavior change? Yes
Did config, environment, or migration behavior change? No
Did security, auth, secrets, network, or tool execution behavior change? No
What is the highest-risk area? Changing the fallback behavior for ackReaction resolution
How is that risk mitigated? Change is purely additive — only adds a second lookup when the first returns nothing. All existing tests pass.

## Current review state
What is the next action? Ready for maintainer review
What is still waiting on author, maintainer, CI, or external proof? Maintainer guidance on whether config validation fix should be in this PR or a separate one
Which bot or reviewer comments were addressed? None yet — first submission