### PR TITLE
fix(ci): disable memory slot in release smoke config

### DIFF
--- a/scripts/openclaw-cross-os-release-checks.ts
+++ b/scripts/openclaw-cross-os-release-checks.ts
@@ -128,6 +128,10 @@ export function buildCrossOsReleaseSmokePluginAllowlist(providerMeta) {
   return [...new Set([providerMeta.extensionId, ...RELEASE_SMOKE_PLUGIN_ALLOWLIST_BASE])];
 }
 
+export function buildCrossOsReleaseSmokeMemorySlotConfigArgs() {
+  return ["config", "set", "plugins.slots.memory", JSON.stringify("none"), "--strict-json"];
+}
+
 function shouldSeedProviderConfigModels(providerMeta) {
   return (
     typeof providerMeta.baseUrl === "string" || typeof providerMeta.timeoutSeconds === "number"
@@ -2312,6 +2316,14 @@ async function runInstalledModelsSet(params) {
   });
   await runInstalledCli({
     cliPath: params.cliPath,
+    args: buildCrossOsReleaseSmokeMemorySlotConfigArgs(),
+    cwd: params.cwd,
+    env: params.env,
+    logPath: params.logPath,
+    timeoutMs: 2 * 60 * 1000,
+  });
+  await runInstalledCli({
+    cliPath: params.cliPath,
     args: ["config", "set", "agents.defaults.skipBootstrap", "true", "--strict-json"],
     cwd: params.cwd,
     env: params.env,
@@ -3230,6 +3242,13 @@ async function runModelsSet(params) {
       JSON.stringify(buildCrossOsReleaseSmokePluginAllowlist(params.providerConfig)),
       "--strict-json",
     ],
+    logPath: params.logPath,
+    timeoutMs: 2 * 60 * 1000,
+  });
+  await runOpenClaw({
+    lane: params.lane,
+    env: params.env,
+    args: buildCrossOsReleaseSmokeMemorySlotConfigArgs(),
     logPath: params.logPath,
     timeoutMs: 2 * 60 * 1000,
   });

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -21,6 +21,7 @@ import {
   agentOutputHasExpectedOkMarker,
   agentTurnUsedEmbeddedFallback,
   buildCrossOsReleaseSmokePluginAllowlist,
+  buildCrossOsReleaseSmokeMemorySlotConfigArgs,
   buildDiscordFetchInit,
   buildPackagedUpgradeUpdateArgs,
   buildReleaseOnboardArgs,
@@ -546,6 +547,14 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       "phone-control",
       "talk-voice",
     ]);
+    expect(allowlist).not.toContain("memory-core");
+    expect(buildCrossOsReleaseSmokeMemorySlotConfigArgs()).toEqual([
+      "config",
+      "set",
+      "plugins.slots.memory",
+      JSON.stringify("none"),
+      "--strict-json",
+    ]);
   });
 
   it("can stage packaged-upgrade baselines without npm lifecycle scripts", () => {
@@ -597,6 +606,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     expect(source).toContain('agentRuntime: { id: "openclaw" }');
     expect(source).toContain('"--merge"');
     expect(source).toContain(providerOverride);
+    expect(source.match(/args: buildCrossOsReleaseSmokeMemorySlotConfigArgs\(\)/g)).toHaveLength(2);
     expect(source).not.toContain("models.providers.${params.providerConfig.extensionId}.baseUrl");
     expect(source).toContain('"--timeout",\n    String(CROSS_OS_AGENT_TURN_TIMEOUT_SECONDS)');
     const agentTurnArgCalls = source.match(/buildReleaseAgentTurnArgs\(sessionId\)/g) ?? [];


### PR DESCRIPTION
## Summary
- set `plugins.slots.memory` to `"none"` in both cross-OS release smoke config paths after writing the focused plugin allowlist
- add focused coverage that the release smoke disables the default memory slot instead of only removing `memory-core` from `plugins.allow`

## Validation
- `corepack pnpm test:serial test/scripts/openclaw-cross-os-release-checks.test.ts`
- `corepack pnpm check:changed`
- `git diff --check`

Credit: source finding from ClawSweeper for openclaw/openclaw@7662a17b08bbc99483dad95b2657f869377df1b7; original commit author @steipete.