### PR TITLE
fix(memory): gracefully degrade when embedding provider is unregistered

### DIFF
--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -471,7 +471,22 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       // Clear the cached rejected promise so subsequent calls can retry
       // initialization instead of being permanently stuck with a stale failure.
       this.providerInitPromise = null;
-      throw err;
+      const message = formatErrorMessage(err);
+      const isUnknownProvider = message.startsWith("Unknown memory embedding provider:");
+      if (isUnknownProvider) {
+        // Gracefully degrade: the configured embedding provider plugin is not
+        // installed or not registered. Set FTS-only mode so the CLI and
+        // memory status still work instead of crashing.
+        this.applyProviderResult({
+          provider: null,
+          requestedProvider: this.requestedProvider,
+          providerUnavailableReason: message,
+        });
+        this.providerKey = this.computeProviderKey();
+        this.batch = this.resolveBatchConfig();
+      } else {
+        throw err;
+      }
     } finally {
       if (this.providerInitialized) {
         this.providerInitPromise = null;

--- a/extensions/memory-core/src/memory/manager.unknown-provider-degradation.test.ts
+++ b/extensions/memory-core/src/memory/manager.unknown-provider-degradation.test.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
+import type { MemoryIndexManager } from "./manager.js";
+import "./test-runtime-mocks.js";
+
+const createEmbeddingProviderMock = vi.hoisted(() =>
+  vi.fn(async () => {
+    throw new Error("Unknown memory embedding provider: nonexistent-provider");
+  }),
+);
+
+vi.mock("./embeddings.js", () => ({
+  createEmbeddingProvider: createEmbeddingProviderMock,
+  resolveEmbeddingProviderAdapterId: () => undefined,
+  resolveEmbeddingProviderAdapterTransport: () => "remote" as const,
+  resolveEmbeddingProviderFallbackModel: () => "fts-only",
+}));
+
+describe("memory manager unknown provider graceful degradation", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+  let workspaceDir = "";
+  let indexPath = "";
+  let manager: MemoryIndexManager | null = null;
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-unknown-provider-"));
+  });
+
+  beforeEach(async () => {
+    createEmbeddingProviderMock.mockClear();
+    workspaceDir = path.join(fixtureRoot, `case-${caseId++}`);
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "Test memory note.\n\nAlpha topic.");
+    indexPath = path.join(workspaceDir, "index.sqlite");
+  });
+
+  afterEach(async () => {
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await closeAllMemorySearchManagers();
+  });
+
+  afterAll(async () => {
+    await closeAllMemorySearchManagers();
+    if (fixtureRoot) {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  async function createManager(
+    params: { provider?: string; vectorEnabled?: boolean } = {},
+  ): Promise<MemoryIndexManager> {
+    const store =
+      params.vectorEnabled === undefined
+        ? { path: indexPath }
+        : { path: indexPath, vector: { enabled: params.vectorEnabled } };
+    const cfg = {
+      memory: { backend: "builtin" },
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: params.provider ?? "nonexistent-provider",
+            model: "",
+            store,
+            cache: { enabled: false },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    if (!result.manager) {
+      throw new Error(result.error ?? "manager missing");
+    }
+    manager = result.manager as unknown as MemoryIndexManager;
+    return manager;
+  }
+
+  it("does not crash on probeEmbeddingAvailability when provider is unknown", async () => {
+    const memoryManager = await createManager();
+
+    const probeResult = await memoryManager.probeEmbeddingAvailability();
+    expect(probeResult.ok).toBe(false);
+    expect(probeResult.error).toContain("Unknown memory embedding provider");
+  });
+
+  it("reports fts-only lifecycle after probe when provider is unknown", async () => {
+    const memoryManager = await createManager();
+
+    await memoryManager.probeEmbeddingAvailability();
+
+    const status = memoryManager.status();
+    expect(status.custom?.providerState?.mode).toBe("fts-only");
+    expect(status.custom?.providerState?.reason).toContain("Unknown memory embedding provider");
+  });
+});


### PR DESCRIPTION
## Summary

When a configured embedding provider (e.g. `openai`) has no registered adapter — typically because the provider plugin is not installed — `ensureProviderInitialized()` previously let the `Unknown memory embedding provider` error propagate, crashing the CLI on `openclaw memory status --index`.

Now the error is caught and the manager gracefully degrades to FTS-only mode, setting `providerUnavailableReason` so that `openclaw memory status` still works and shows the real problem instead of a stack trace.

This addresses the unregistered-provider crash path reported in #91778. The broader index-metadata/vector-search failure tracked in that issue remains outside this diff.

## Change Type

- [x] Bug fix

## Scope

- [x] Memory / storage

## Linked Issue

- Refs #91778 (unregistered-provider diagnostic crash path only; the broader index-metadata/vector-search failure remains open)

## Motivation

Issue #91778 reports `memory_search` vector search broken since v2026.6.1. Users with `provider: "openai-compatible"` or `provider: "openai"` configured but without the corresponding provider plugin installed get a CLI crash on `openclaw memory status --index`, preventing any diagnosis or recovery.

Root cause: `createEmbeddingProvider()` → `getAdapter()` throws `Error("Unknown memory embedding provider: <id>")` when the provider plugin is not installed. This error propagates through `loadProviderResult()` → `ensureProviderInitialized()` → `probeEmbeddingAvailability()` → CLI crash. The user never gets to see what is wrong.

This PR only fixes the unregistered-provider crash path. The remaining index-metadata and vector-search recovery behavior in #91778 is outside the scope of this diff.

## Changes

**File**: `extensions/memory-core/src/memory/manager.ts`

In `ensureProviderInitialized()`, catch `Unknown memory embedding provider:` errors specifically and degrade to FTS-only mode instead of propagating the error:

- Detect the error by checking `message.startsWith("Unknown memory embedding provider:")`
- Call `applyProviderResult({ provider: null, requestedProvider, providerUnavailableReason: message })` to set the correct FTS-only lifecycle state
- Other provider initialization errors (timeouts, auth failures, rate limits) still propagate as before

**File**: `extensions/memory-core/src/memory/manager.unknown-provider-degradation.test.ts` (new)

2 tests covering the degradation path:
1. `probeEmbeddingAvailability()` returns `{ ok: false, error }` instead of throwing
2. `status().custom.providerState` is `{ mode: "fts-only", reason: "Unknown memory embedding provider: ..." }`

No new imports, no config changes, no default surface changes.

## Real Behavior Proof

- Behavior addressed: `openclaw memory status --index` crashes with `Unknown memory embedding provider: <id>` when the configured embedding provider plugin is not installed, preventing any diagnosis or recovery.
- Real environment tested: Linux (RHEL), Node.js 22.22, local checkout on branch `fix/memory-index-metadata-missing-91778` at commit `df80fe7`, dev build via `node scripts/run-node.mjs`.
- Exact steps or command run after this patch: Set `agents.defaults.memorySearch.provider` to `"nonexistent-embedding-provider"` in `~/.openclaw/openclaw.json`, then run `node scripts/run-node.mjs memory status --index`
- Evidence after fix: Terminal output from the current PR head (`df80fe7`) showing CLI no longer crashes when an unregistered embedding provider is configured. The manager degrades to FTS-only mode with a clear error message instead of a stack trace. Copied live output from `node scripts/run-node.mjs memory status --index` with `provider: "nonexistent-embedding-provider"`:

```
Memory Search (main)
Provider: nonexistent-embedding-provider (requested: nonexistent-embedding-provider)
Sources: memory
Indexed: 0/49 files · 0 chunks
Dirty: yes
Embeddings: unavailable
Embeddings error: Unknown memory embedding provider: nonexistent-embedding-provider
Index identity: index metadata is missing
Vector search: paused until memory is rebuilt
Fix: Run: openclaw memory status --index --agent main
Semantic vectors: unavailable
FTS: ready
Index error: Memory sync unavailable: embedding provider "nonexistent-embedding-provider" is configured but unavailable. Reason: Unknown memory embedding provider: nonexistent-embedding-provider. lifecycle={"mode":"fts-only","reason":"Unknown memory embedding provider: nonexistent-embedding-provider","attemptedProviderId":"nonexistent-embedding-provider"}
```

Before-fix comparison (installed build without the openai provider plugin, `provider: "openai"` configured):

```
$ openclaw memory status --index
[openclaw] Failed to start CLI: Error: Unknown memory embedding provider: openai
    at getAdapter (embeddings.ts:49:11)
    at createEmbeddingProvider (embeddings.ts:138:26)
    at MemoryIndexManager.loadProviderResult (manager.ts:162:58)
    → CLI exits with error code 1, no status output
```

- Observed result after fix: `ensureProviderInitialized()` catches the `Unknown memory embedding provider` error and degrades to FTS-only mode. The CLI no longer crashes; users see `Embeddings: unavailable`, `Embeddings error: Unknown memory embedding provider: ...`, `Index identity: index metadata is missing`, and `Semantic vectors: unavailable`. FTS search still works. The lifecycle state is correctly set to `{"mode":"fts-only","reason":"Unknown memory embedding provider: ...","attemptedProviderId":"..."}`.
- What was not tested: Full end-to-end vector indexing with a working embedding provider after the fix. The `assertRequiredProviderAvailable` path in sync is intentionally unchanged: explicit provider requests that fail should still block sync from silently downgrading an existing vector index.

## Risks

- **Low risk**: The catch is narrow — only `Unknown memory embedding provider:` errors are caught and degraded. All other provider init errors (auth, network, timeout) still propagate as before.
- **Additive**: The degradation only activates when `getAdapter()` throws for an unregistered provider. Previously this was a guaranteed crash; now it is a graceful FTS-only fallback with a clear error message.
- **No config/default surface changes**: No new config keys, env vars, or defaults introduced.
- **Scope limitation**: This PR only addresses the unregistered-provider crash path. The broader index-metadata and vector-search recovery tracked in #91778 remains open and is not closed by merging this PR.
