### PR TITLE
fix(codex): clean up app-server sidecar on any binding resolution (fixes #91537)

### DIFF
--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -386,6 +386,58 @@ describe("codex conversation binding", () => {
     await expect(fs.stat(sidecar)).rejects.toHaveProperty("code", "ENOENT");
   });
 
+  it("clears the Codex app-server sidecar when a pending bind is approved", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const sidecar = `${sessionFile}.codex-app-server.json`;
+    await fs.writeFile(sidecar, JSON.stringify({ schemaVersion: 1, threadId: "thread-1" }));
+
+    await handleCodexConversationBindingResolved({
+      status: "approved",
+      decision: "allow-once",
+      request: {
+        data: {
+          kind: "codex-app-server-session",
+          version: 1,
+          sessionFile,
+          workspaceDir: tempDir,
+        },
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "channel:1",
+        },
+      },
+    });
+
+    await expect(fs.stat(sidecar)).rejects.toHaveProperty("code", "ENOENT");
+  });
+
+  it("is a safe no-op when an approved binding has no sidecar yet", async () => {
+    const sessionFile = path.join(tempDir, "no-sidecar-session.jsonl");
+    // No sidecar file written — simulating yolo auto-approval before the
+    // app-server starts. The call must not throw.
+
+    await expect(
+      handleCodexConversationBindingResolved({
+        status: "approved",
+        decision: "allow-once",
+        request: {
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+          conversation: {
+            channel: "discord",
+            accountId: "default",
+            conversationId: "channel:1",
+          },
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("consumes inbound bound messages when command authorization is absent", async () => {
     const result = await handleCodexConversationInboundClaim(
       {

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -306,13 +306,16 @@ export async function handleCodexConversationInboundClaim(
 export async function handleCodexConversationBindingResolved(
   event: PluginConversationBindingResolvedEvent,
 ): Promise<void> {
-  if (event.status !== "denied") {
-    return;
-  }
   const data = readCodexConversationBindingDataRecord(event.request.data ?? {});
   if (!data || data.kind !== "codex-app-server-session") {
     return;
   }
+  // Clean up the pending sidecar on any resolution (approved or denied).
+  // In yolo/auto-approved mode the event fires with status "approved" and
+  // the sidecar must be removed just as it is for denied bindings.
+  // clearCodexAppServerBinding is a no-op when the sidecar is absent,
+  // so calling it for an approved binding that has not yet written a
+  // sidecar is safe.
   await clearCodexAppServerBinding(data.sessionFile);
 }
 


### PR DESCRIPTION
### Summary

- **Problem**: In yolo mode, Codex app-server sidecar binding files (`.codex-app-server.json`) are never cleaned up after a conversation binding request is resolved, causing unbounded accumulation in `~/.openclaw/agents/*/sessions/` (3,952+ files observed after ~2 weeks).
- **Root Cause**: `handleCodexConversationBindingResolved` guarded the sidecar cleanup behind `if (event.status !== "denied") return`. In yolo/auto-approved mode the event fires with `status: "approved"`, so the guard skipped cleanup entirely.
- **Fix**: Remove the status guard so the sidecar is cleaned on any resolution (approved or denied). `clearCodexAppServerBinding` is a no-op when the sidecar file is absent, so calling it for approved bindings that haven't written a sidecar yet is safe.
- **What changed**:
  - `extensions/codex/src/conversation-binding.ts` — Remove the `status !== "denied"` early-return from `handleCodexConversationBindingResolved` so cleanup runs on both "approved" and "denied" resolutions.
- **What did NOT change (scope boundary)**:
  - Does not add a startup/idle binding-file sweep for pre-existing stale files (separate concern, better addressed in a follow-up).
  - Does not alter the `clearCodexAppServerBindingForThread` lifecycle in `run-attempt.ts` (run-level teardown is orthogonal).
  - Does not touch guardian approval policy or yolo/exec mode selection.

### Reproduction

1. Configure Codex plugin with `mode: "yolo"` (the default).
2. Start a Codex conversation binding.
3. Observe that `handleCodexConversationBindingResolved` is invoked with `status: "approved"`.
4. **Before this PR**: The sidecar file is never removed because the handler returns early.
5. **After this PR**: The sidecar file is unconditionally cleaned after resolution.

### Real behavior proof

**Behavior or issue addressed (91537)**: The `handleCodexConversationBindingResolved` handler now cleans up the Codex app-server binding sidecar on any resolution status, preventing file accumulation in yolo/auto-approved mode.

**Real environment tested**: Linux, Node 22 — Vitest (fake timers) against `handleCodexConversationBindingResolved` and `clearCodexAppServerBinding`.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs extensions/codex/src/conversation-binding.test.ts`

**Evidence after fix**:
```text
RUN  v4.1.7 /home/0668001395/openclawProject1

 Test Files  1 passed (1)
      Tests  22 passed (22)
   Start at  14:35:17
   Duration  13.73s

[test] passed 1 Vitest shard in 24.71s
```

**Observed result after fix**: All 22 tests pass, including the two new tests:
- `"clears the Codex app-server sidecar when a pending bind is approved"` — verifies the sidecar is deleted on `status: "approved"` resolution
- `"is a safe no-op when an approved binding has no sidecar yet"` — verifies the handler does not throw when called before the app-server writes a sidecar

The existing `"clears the Codex app-server sidecar when a pending bind is denied"` test continues to pass unchanged.

**What was not tested**: End-to-end yolo session with a live Codex app-server process was not driven (the fix is a pure state-machine change — `clearCodexAppServerBinding` behavior is unchanged, only the triggering condition changed). Long-running accumulation scenario (weeks of sessions) was not reproduced.

**Repro confirmation**: The new `"clears the Codex app-server sidecar when a pending bind is approved"` test creates a sidecar file, calls the handler with `status: "approved"`, and asserts `ENOENT` — the same pattern as the existing `"denied"` test. Before the patch this test would have failed (the handler would return early without deleting the file); after the patch it passes.

### Risk / Mitigation

- **Risk**: Calling `clearCodexAppServerBinding` on an approved binding whose sidecar was already written could delete a still-needed sidecar.
  **Mitigation**: `clearCodexAppServerBinding` is only called from the _resolution_ handler, which fires once when the pending bind request transitions from pending → resolved. At that point the sidecar is either (a) absent (yolo auto-approval before app-server start) → no-op, or (b) present (guardian flow where the sidecar was written during the pending phase) → should be removed because the resolution supersedes it. The active binding record used by run-attempt is managed separately via `writeCodexAppServerBinding` / `clearCodexAppServerBindingForThread`.
- **Risk**: Pre-existing stale sidecars from before this fix are not cleaned.
  **Mitigation**: Documented as out of scope. A one-time manual cleanup or a follow-up idle sweep can address those.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] extensions: codex

### Regression Test Plan

- `node scripts/run-vitest.mjs extensions/codex/src/conversation-binding.test.ts`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/session-binding.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #91537
