### PR TITLE
fix(github-copilot): claude-opus-4.8 is native 1M context + thinking (not 128K)

### DIFF
--- a/extensions/github-copilot/model-metadata.ts
+++ b/extensions/github-copilot/model-metadata.ts
@@ -36,6 +36,18 @@ const STATIC_MODEL_OVERRIDES = new Map<string, Partial<ModelDefinitionConfig>>([
     },
   ],
   [
+    "claude-opus-4.8",
+    {
+      name: "Claude Opus 4.8",
+      api: "anthropic-messages",
+      reasoning: true,
+      contextWindow: 1_000_000,
+      maxTokens: 64_000,
+      thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+      compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
+    },
+  ],
+  [
     "gpt-5.5",
     {
       name: "GPT-5.5",

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -121,6 +121,22 @@ describe("github-copilot model defaults", () => {
       });
     });
 
+    it("uses static metadata overrides for claude-opus-4.8 (native 1M + thinking)", () => {
+      const def = buildCopilotModelDefinition("claude-opus-4.8");
+      expect(def).toEqual({
+        id: "claude-opus-4.8",
+        name: "Claude Opus 4.8",
+        api: "anthropic-messages",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_000_000,
+        maxTokens: 64_000,
+        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+        compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
+      });
+    });
+
     it("trims whitespace from model id", () => {
       const def = buildCopilotModelDefinition("  gpt-4o  ");
       expect(def.id).toBe("gpt-4o");

--- a/extensions/github-copilot/openclaw.plugin.json
+++ b/extensions/github-copilot/openclaw.plugin.json
@@ -46,9 +46,10 @@
             "id": "claude-opus-4.8",
             "name": "Claude Opus 4.8",
             "api": "anthropic-messages",
+            "reasoning": true,
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
+            "contextWindow": 1000000,
+            "maxTokens": 64000,
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
           },
           {


### PR DESCRIPTION
## What

Fix `github-copilot/claude-opus-4.8` metadata so it reflects its real capabilities: **native 1M context window** + **adaptive thinking** (reasoning efforts `low/medium/high/xhigh/max`).

- `model-metadata.ts`: add a `STATIC_MODEL_OVERRIDES` entry for `claude-opus-4.8` (1M ctx, `maxTokens` 64k, `reasoning: true`, `thinkingLevelMap`, `supportedReasoningEfforts`), mirroring the existing `claude-opus-4.7-1m-internal` shape.
- `openclaw.plugin.json`: bump the bundled manifest row for `claude-opus-4.8` from `contextWindow: 128000` / `maxTokens: 8192` to `1000000` / `64000` and add `reasoning: true`. **This manifest value is what seeds the session context budget**, so it must be correct independently of the defaults helper.
- `models.test.ts`: add an assertion that `buildCopilotModelDefinition("claude-opus-4.8")` resolves to the 1M + thinking definition.

Fixes #91869.

## Why

PR #88547 added `claude-opus-4.8` by mirroring the 4.7 row, which carried over `contextWindow: 128000` and no reasoning support. But Opus 4.8 is **natively 1M** on the Anthropic API / Bedrock / Vertex — no `-1m` suffix, no beta header, no long-context premium (per Anthropic's 4.8 release notes). The hard-coded 128K silently caps entitled users and disables thinking.

## Real behavior proof

**Behavior addressed**: On an account entitled to `claude-opus-4.8` via GitHub Copilot, `openclaw models list` showed 128k and the session context budget (`/status` → `Context: x/128k`) capped at 128k with no thinking.

**Real environment tested**: OpenClaw 2026.6.1 (2e08f0f), Debian, provider `github-copilot` authenticated against a real Copilot subscription (live `api.githubcopilot.com`).

**Upstream `/models` response for the affected account** (abridged), proving the capability is real:

```
claude-opus-4.8
  max_context_window_tokens: 1000000
  max_prompt_tokens:         936000
  max_output_tokens:         64000
  reasoning_effort:          [low, medium, high, xhigh, max]
  adaptive_thinking:         true
  vision:                    true
```

(For contrast the same response returns `claude-opus-4.7` = 1,000,000, while `claude-opus-4.7-high` / `-xhigh` = 200,000, confirming the 4.8 row was simply wrong rather than an intentional cap.)

**After applying the equivalent change locally** (manifest ctx → 1,000,000 + override), a real session shows `Context: 148k/1.0m` and a `thinking=high` turn on `github-copilot/claude-opus-4.8` runs successfully (verified end-to-end).

## Tests

- `node scripts/run-vitest.mjs extensions/github-copilot/models.test.ts`

(Adds one assertion; existing 4.7-1m-internal / gpt-5.5 override assertions remain.)

## Notes

- This is the static-catalog fix. The deeper "prefer live `/models` over static manifest" work is tracked separately in #88548; this PR is the immediate, low-risk correctness bump for an already-shipping model.
