### PR TITLE
Share channel draft chunking resolver

### DIFF
--- a/docs/plugins/sdk-channel-outbound.md
+++ b/docs/plugins/sdk-channel-outbound.md
@@ -92,7 +92,7 @@ Runtime send helpers also live on `channel-outbound`:
 - `sendDurableMessageBatch(...)`
 - `withDurableMessageSendContext(...)`
 - `deliverInboundReplyWithMessageSendContext(...)`
-- draft streaming/progress helpers such as `resolveChannelStreamingPreviewChunk(...)`
+- draft streaming/progress helpers such as `resolveChannelDraftStreamingChunking(...)`
 
 `sendDurableMessageBatch(...)` returns one explicit outcome:
 

--- a/extensions/discord/src/draft-chunking.test.ts
+++ b/extensions/discord/src/draft-chunking.test.ts
@@ -1,5 +1,4 @@
 // Discord tests cover draft chunking plugin behavior.
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
 import { resolveDiscordDraftStreamingChunking } from "./draft-chunking.js";
 import { EMPTY_DISCORD_TEST_CONFIG } from "./test-support/config.js";
@@ -10,56 +9,6 @@ describe("resolveDiscordDraftStreamingChunking", () => {
       minChars: 200,
       maxChars: 800,
       breakPreference: "paragraph",
-    });
-  });
-
-  it("clamps requested draft chunk sizes to the resolved text limit", () => {
-    const cfg = {
-      channels: {
-        discord: {
-          textChunkLimit: 500,
-          draftChunk: {
-            minChars: 900,
-            maxChars: 1200,
-            breakPreference: "sentence",
-          },
-        },
-      },
-    } as OpenClawConfig;
-
-    expect(resolveDiscordDraftStreamingChunking(cfg)).toEqual({
-      minChars: 500,
-      maxChars: 500,
-      breakPreference: "sentence",
-    });
-  });
-
-  it("prefers account draft chunking over channel defaults", () => {
-    const cfg = {
-      channels: {
-        discord: {
-          draftChunk: {
-            minChars: 200,
-            maxChars: 800,
-            breakPreference: "paragraph",
-          },
-          accounts: {
-            ops: {
-              draftChunk: {
-                minChars: 25,
-                maxChars: 75,
-                breakPreference: "newline",
-              },
-            },
-          },
-        },
-      },
-    } as OpenClawConfig;
-
-    expect(resolveDiscordDraftStreamingChunking(cfg, "ops")).toEqual({
-      minChars: 25,
-      maxChars: 75,
-      breakPreference: "newline",
     });
   });
 });

--- a/extensions/discord/src/draft-chunking.ts
+++ b/extensions/discord/src/draft-chunking.ts
@@ -1,44 +1,16 @@
 // Discord plugin module implements draft chunking behavior.
-import { resolveChannelStreamingPreviewChunk } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  resolveChannelDraftStreamingChunking,
+  type ChannelDraftStreamingChunking,
+} from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
-import { resolveAccountEntry } from "openclaw/plugin-sdk/routing";
-import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { DISCORD_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
-
-const DEFAULT_DISCORD_DRAFT_STREAM_MIN = 200;
-const DEFAULT_DISCORD_DRAFT_STREAM_MAX = 800;
 
 export function resolveDiscordDraftStreamingChunking(
   cfg: OpenClawConfig,
   accountId?: string | null,
-): {
-  minChars: number;
-  maxChars: number;
-  breakPreference: "paragraph" | "newline" | "sentence";
-} {
-  const textLimit = resolveTextChunkLimit(cfg, "discord", accountId, {
+): ChannelDraftStreamingChunking {
+  return resolveChannelDraftStreamingChunking(cfg, "discord", accountId, {
     fallbackLimit: DISCORD_TEXT_CHUNK_LIMIT,
   });
-  const normalizedAccountId = normalizeAccountId(accountId);
-  const accountCfg = resolveAccountEntry(cfg?.channels?.discord?.accounts, normalizedAccountId);
-  const draftCfg =
-    resolveChannelStreamingPreviewChunk(accountCfg) ??
-    resolveChannelStreamingPreviewChunk(cfg?.channels?.discord);
-
-  const maxRequested = Math.max(
-    1,
-    Math.floor(draftCfg?.maxChars ?? DEFAULT_DISCORD_DRAFT_STREAM_MAX),
-  );
-  const maxChars = Math.max(1, Math.min(maxRequested, textLimit));
-  const minRequested = Math.max(
-    1,
-    Math.floor(draftCfg?.minChars ?? DEFAULT_DISCORD_DRAFT_STREAM_MIN),
-  );
-  const minChars = Math.min(minRequested, maxChars);
-  const breakPreference =
-    draftCfg?.breakPreference === "newline" || draftCfg?.breakPreference === "sentence"
-      ? draftCfg.breakPreference
-      : "paragraph";
-  return { minChars, maxChars, breakPreference };
 }

--- a/extensions/telegram/src/bot.helpers.test.ts
+++ b/extensions/telegram/src/bot.helpers.test.ts
@@ -64,46 +64,4 @@ describe("resolveTelegramDraftStreamingChunking", () => {
       breakPreference: "paragraph",
     });
   });
-
-  it("clamps to telegram.textChunkLimit", () => {
-    const cfg: OpenClawConfig = {
-      channels: { telegram: { allowFrom: ["*"], textChunkLimit: 150 } },
-    };
-    const chunking = resolveTelegramDraftStreamingChunking(cfg, "default");
-    expect(chunking).toEqual({
-      minChars: 150,
-      maxChars: 150,
-      breakPreference: "paragraph",
-    });
-  });
-
-  it("supports per-account overrides", () => {
-    const cfg: OpenClawConfig = {
-      channels: {
-        telegram: {
-          allowFrom: ["*"],
-          accounts: {
-            default: {
-              allowFrom: ["*"],
-              streaming: {
-                preview: {
-                  chunk: {
-                    minChars: 10,
-                    maxChars: 20,
-                    breakPreference: "sentence",
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    };
-    const chunking = resolveTelegramDraftStreamingChunking(cfg, "default");
-    expect(chunking).toEqual({
-      minChars: 10,
-      maxChars: 20,
-      breakPreference: "sentence",
-    });
-  });
 });

--- a/extensions/telegram/src/draft-chunking.ts
+++ b/extensions/telegram/src/draft-chunking.ts
@@ -1,44 +1,16 @@
 // Telegram plugin module implements draft chunking behavior.
-import { resolveChannelStreamingPreviewChunk } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  resolveChannelDraftStreamingChunking,
+  type ChannelDraftStreamingChunking,
+} from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
-import { resolveAccountEntry } from "openclaw/plugin-sdk/routing";
-import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
-
-const DEFAULT_TELEGRAM_DRAFT_STREAM_MIN = 200;
-const DEFAULT_TELEGRAM_DRAFT_STREAM_MAX = 800;
 
 export function resolveTelegramDraftStreamingChunking(
   cfg: OpenClawConfig | undefined,
   accountId?: string | null,
-): {
-  minChars: number;
-  maxChars: number;
-  breakPreference: "paragraph" | "newline" | "sentence";
-} {
-  const textLimit = resolveTextChunkLimit(cfg, "telegram", accountId, {
+): ChannelDraftStreamingChunking {
+  return resolveChannelDraftStreamingChunking(cfg, "telegram", accountId, {
     fallbackLimit: TELEGRAM_TEXT_CHUNK_LIMIT,
   });
-  const normalizedAccountId = normalizeAccountId(accountId);
-  const accountCfg = resolveAccountEntry(cfg?.channels?.telegram?.accounts, normalizedAccountId);
-  const draftCfg =
-    resolveChannelStreamingPreviewChunk(accountCfg) ??
-    resolveChannelStreamingPreviewChunk(cfg?.channels?.telegram);
-
-  const maxRequested = Math.max(
-    1,
-    Math.floor(draftCfg?.maxChars ?? DEFAULT_TELEGRAM_DRAFT_STREAM_MAX),
-  );
-  const maxChars = Math.max(1, Math.min(maxRequested, textLimit));
-  const minRequested = Math.max(
-    1,
-    Math.floor(draftCfg?.minChars ?? DEFAULT_TELEGRAM_DRAFT_STREAM_MIN),
-  );
-  const minChars = Math.min(minRequested, maxChars);
-  const breakPreference =
-    draftCfg?.breakPreference === "newline" || draftCfg?.breakPreference === "sentence"
-      ? draftCfg.breakPreference
-      : "paragraph";
-  return { minChars, maxChars, breakPreference };
 }

--- a/src/channels/draft-streaming-chunking.ts
+++ b/src/channels/draft-streaming-chunking.ts
@@ -1,0 +1,47 @@
+// Shared resolver for channel live-preview draft chunk thresholds.
+import { resolveTextChunkLimit } from "../auto-reply/chunk.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveAccountEntry } from "../routing/account-lookup.js";
+import { normalizeAccountId } from "../routing/session-key.js";
+import type { ChannelId } from "./plugins/types.core.js";
+import { resolveChannelStreamingPreviewChunk, type StreamingCompatEntry } from "./streaming.js";
+
+const DEFAULT_DRAFT_STREAM_MIN = 200;
+const DEFAULT_DRAFT_STREAM_MAX = 800;
+
+export type ChannelDraftStreamingChunking = {
+  minChars: number;
+  maxChars: number;
+  breakPreference: "paragraph" | "newline" | "sentence";
+};
+
+type ChannelDraftStreamingConfig = StreamingCompatEntry & {
+  accounts?: Record<string, StreamingCompatEntry | undefined>;
+};
+
+export function resolveChannelDraftStreamingChunking(
+  cfg: OpenClawConfig | undefined,
+  channelId: ChannelId,
+  accountId: string | null | undefined,
+  opts: { fallbackLimit: number },
+): ChannelDraftStreamingChunking {
+  const textLimit = resolveTextChunkLimit(cfg, channelId, accountId, {
+    fallbackLimit: opts.fallbackLimit,
+  });
+  const normalizedAccountId = normalizeAccountId(accountId);
+  const channelCfg = cfg?.channels?.[channelId] as ChannelDraftStreamingConfig | undefined;
+  const accountCfg = resolveAccountEntry(channelCfg?.accounts, normalizedAccountId);
+  const draftCfg =
+    resolveChannelStreamingPreviewChunk(accountCfg) ??
+    resolveChannelStreamingPreviewChunk(channelCfg);
+
+  const maxRequested = Math.max(1, Math.floor(draftCfg?.maxChars ?? DEFAULT_DRAFT_STREAM_MAX));
+  const maxChars = Math.max(1, Math.min(maxRequested, textLimit));
+  const minRequested = Math.max(1, Math.floor(draftCfg?.minChars ?? DEFAULT_DRAFT_STREAM_MIN));
+  const minChars = Math.min(minRequested, maxChars);
+  const breakPreference =
+    draftCfg?.breakPreference === "newline" || draftCfg?.breakPreference === "sentence"
+      ? draftCfg.breakPreference
+      : "paragraph";
+  return { minChars, maxChars, breakPreference };
+}

--- a/src/plugin-sdk/channel-outbound.draft-chunking.test.ts
+++ b/src/plugin-sdk/channel-outbound.draft-chunking.test.ts
@@ -1,0 +1,90 @@
+// Tests shared channel draft chunking resolution exposed through plugin-sdk/channel-outbound.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { resolveChannelDraftStreamingChunking } from "./channel-outbound.js";
+
+describe("resolveChannelDraftStreamingChunking", () => {
+  it("returns draft stream defaults when channel config is unset", () => {
+    expect(
+      resolveChannelDraftStreamingChunking(undefined, "telegram", "default", {
+        fallbackLimit: 4096,
+      }),
+    ).toEqual({
+      minChars: 200,
+      maxChars: 800,
+      breakPreference: "paragraph",
+    });
+  });
+
+  it("clamps requested draft chunk sizes to the resolved text limit", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        discord: {
+          textChunkLimit: 500,
+          streaming: {
+            preview: {
+              chunk: {
+                minChars: 900,
+                maxChars: 1200,
+                breakPreference: "sentence",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      resolveChannelDraftStreamingChunking(cfg, "discord", undefined, {
+        fallbackLimit: 2000,
+      }),
+    ).toEqual({
+      minChars: 500,
+      maxChars: 500,
+      breakPreference: "sentence",
+    });
+  });
+
+  it("prefers account draft chunking over channel defaults", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          allowFrom: ["*"],
+          streaming: {
+            preview: {
+              chunk: {
+                minChars: 200,
+                maxChars: 800,
+                breakPreference: "paragraph",
+              },
+            },
+          },
+          accounts: {
+            default: {
+              allowFrom: ["*"],
+              streaming: {
+                preview: {
+                  chunk: {
+                    minChars: 10,
+                    maxChars: 20,
+                    breakPreference: "newline",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      resolveChannelDraftStreamingChunking(cfg, "telegram", "default", {
+        fallbackLimit: 4096,
+      }),
+    ).toEqual({
+      minChars: 10,
+      maxChars: 20,
+      breakPreference: "newline",
+    });
+  });
+});

--- a/src/plugin-sdk/channel-outbound.ts
+++ b/src/plugin-sdk/channel-outbound.ts
@@ -45,6 +45,8 @@ export {
 export type { FinalizableDraftStreamState } from "../channels/draft-stream-controls.js";
 export { createDraftStreamLoop } from "../channels/draft-stream-loop.js";
 export type { DraftStreamLoop } from "../channels/draft-stream-loop.js";
+export { resolveChannelDraftStreamingChunking } from "../channels/draft-streaming-chunking.js";
+export type { ChannelDraftStreamingChunking } from "../channels/draft-streaming-chunking.js";
 export { createRuntimeOutboundDelegates } from "../channels/plugins/runtime-forwarders.js";
 export { createChannelRunQueue } from "./channel-lifecycle.core.js";
 export type {


### PR DESCRIPTION
Summary:
- Move duplicated Discord/Telegram draft chunk sizing into one `channel-outbound` SDK helper.
- Keep channel wrappers as platform-cap shims and move shared behavior coverage to the SDK helper.

Proof:
- `node scripts/run-vitest.mjs src/plugin-sdk/channel-outbound.draft-chunking.test.ts extensions/discord/src/draft-chunking.test.ts extensions/telegram/src/bot.helpers.test.ts`
- `OPENCLAW_LOCAL_CHECK_MODE=throttled node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test-pr-91874.tsbuildinfo`
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check`
- `pnpm exec oxfmt --check --threads=1 docs/plugins/sdk-channel-outbound.md extensions/discord/src/draft-chunking.test.ts extensions/discord/src/draft-chunking.ts extensions/telegram/src/bot.helpers.test.ts extensions/telegram/src/draft-chunking.ts src/channels/draft-streaming-chunking.ts src/plugin-sdk/channel-outbound.ts src/plugin-sdk/channel-outbound.draft-chunking.test.ts`
- `git diff --check`
- Telegram bot-to-bot mock-SUT smoke before rebase: threaded SUT reply observed and mock OpenAI requests `1`.
