### PR TITLE
fix(github-copilot): claude-opus-4.8 context window to 1M with reasoning support

### DIFF
--- a/extensions/github-copilot/model-metadata.ts
+++ b/extensions/github-copilot/model-metadata.ts
@@ -44,6 +44,18 @@ const STATIC_MODEL_OVERRIDES = new Map<string, Partial<ModelDefinitionConfig>>([
       maxTokens: 128_000,
     },
   ],
+  [
+    "claude-opus-4.8",
+    {
+      name: "Claude Opus 4.8",
+      api: "anthropic-messages",
+      reasoning: true,
+      contextWindow: 1_000_000,
+      maxTokens: 64_000,
+      input: ["text", "image"],
+      compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
+    },
+  ],
 ]);
 
 function isCopilotGeminiModelId(modelId: string): boolean {

--- a/extensions/github-copilot/openclaw.plugin.json
+++ b/extensions/github-copilot/openclaw.plugin.json
@@ -47,9 +47,13 @@
             "name": "Claude Opus 4.8",
             "api": "anthropic-messages",
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+            "contextWindow": 1000000,
+            "maxTokens": 64000,
+            "reasoning": true,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "compat": {
+              "supportedReasoningEfforts": ["low", "medium", "high", "xhigh", "max"]
+            }
           },
           {
             "id": "claude-sonnet-4.6",


### PR DESCRIPTION
## Summary

Updates  model metadata in the GitHub Copilot plugin to match live Copilot  endpoint capabilities.

## Changes

****
- Added  to  with:
  -  (was 128,000 — the default)
  -  (was 8,192)
  - 
  - 
  - 

****
- Updated the bundled manifest entry for  with the same values.

## Why

Copilot's live  endpoint returns  and  for . The bundled catalog was mirroring  metadata which carries . This caused:
- Session context budgets capped at 128K (visible in  → )
- No adaptive thinking/reasoning support despite upstream supporting it

Fixes #91869.

## Test Results

```
✓ extensions/github-copilot/models.test.ts (38 tests) — 64ms
✓ extensions/github-copilot/index.test.ts (16 tests) — 1.93s
```