### PR TITLE
fix(codex): validate maintained app-server types

### DIFF
--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -19,6 +19,7 @@ import {
   resolveOpenClawExecPolicyForCodexAppServer,
   resolveCodexPluginsPolicy,
   shouldAutoApproveCodexAppServerApprovals,
+  withMcpElicitationsApprovalPolicy,
 } from "./config.js";
 
 type RuntimeOptionsParams = NonNullable<Parameters<typeof resolveCodexAppServerRuntimeOptions>[0]>;
@@ -26,6 +27,20 @@ type RuntimeOptionsParams = NonNullable<Parameters<typeof resolveCodexAppServerR
 function resolveRuntimeForTest(params: RuntimeOptionsParams = {}) {
   return resolveCodexAppServerRuntimeOptions({ env: {}, requirementsToml: null, ...params });
 }
+
+describe("withMcpElicitationsApprovalPolicy", () => {
+  it("returns a complete granular policy for Codex", () => {
+    expect(withMcpElicitationsApprovalPolicy("never")).toEqual({
+      granular: {
+        mcp_elicitations: true,
+        request_permissions: false,
+        rules: false,
+        sandbox_approval: false,
+        skill_approval: false,
+      },
+    });
+  });
+});
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -59,8 +59,8 @@ export type CodexAppServerEffectiveApprovalPolicy =
         mcp_elicitations: boolean;
         rules: boolean;
         sandbox_approval: boolean;
-        request_permissions?: boolean;
-        skill_approval?: boolean;
+        request_permissions: boolean;
+        skill_approval: boolean;
       };
     };
 export type CodexAppServerSandboxMode = "read-only" | "workspace-write" | "danger-full-access";
@@ -814,6 +814,8 @@ export function withMcpElicitationsApprovalPolicy(
         mcp_elicitations: true,
         rules: false,
         sandbox_approval: false,
+        request_permissions: false,
+        skill_approval: false,
       },
     };
   }
@@ -822,6 +824,8 @@ export function withMcpElicitationsApprovalPolicy(
       mcp_elicitations: true,
       rules: true,
       sandbox_approval: true,
+      request_permissions: true,
+      skill_approval: true,
     },
   };
 }

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -2,6 +2,23 @@
 export type JsonValue = null | boolean | number | string | JsonValue[] | JsonObject;
 export type JsonObject = { [key: string]: JsonValue };
 export type CodexServiceTier = string;
+export type CodexApprovalPolicy =
+  | "untrusted"
+  | "on-failure"
+  | "on-request"
+  | {
+      granular: {
+        sandbox_approval: boolean;
+        rules: boolean;
+        skill_approval: boolean;
+        request_permissions: boolean;
+        mcp_elicitations: boolean;
+      };
+    }
+  | "never";
+export type CodexApprovalsReviewer = "user" | "auto_review" | "guardian_subagent";
+export type CodexSandboxMode = "read-only" | "workspace-write" | "danger-full-access";
+export type CodexPersonality = "none" | "friendly" | "pragmatic";
 
 export type CodexAppServerRequestMethod = keyof CodexAppServerRequestResultMap | (string & {});
 export type CodexAppServerRequestParams<M extends CodexAppServerRequestMethod> =
@@ -50,11 +67,16 @@ export type CodexInitializeResponse = {
   userAgent?: string;
 };
 
+export type CodexTextElement = {
+  byteRange: { start: number; end: number };
+  placeholder: string | null;
+};
+
 export type CodexUserInput =
   | {
       type: "text";
       text: string;
-      text_elements?: JsonValue[];
+      text_elements: CodexTextElement[];
     }
   | {
       type: "image";
@@ -81,10 +103,10 @@ export type CodexThreadStartParams = JsonObject & {
   cwd?: string;
   model?: string;
   modelProvider?: string | null;
-  personality?: string | null;
-  approvalPolicy?: string | JsonObject;
-  approvalsReviewer?: string | null;
-  sandbox?: string;
+  personality?: CodexPersonality | null;
+  approvalPolicy?: CodexApprovalPolicy | null;
+  approvalsReviewer?: CodexApprovalsReviewer | null;
+  sandbox?: CodexSandboxMode | null;
   serviceTier?: CodexServiceTier | null;
   dynamicTools?: CodexDynamicToolSpec[] | null;
   developerInstructions?: string;
@@ -98,10 +120,10 @@ export type CodexThreadResumeParams = JsonObject & {
   threadId: string;
   model?: string;
   modelProvider?: string | null;
-  personality?: string | null;
-  approvalPolicy?: string | JsonObject;
-  approvalsReviewer?: string | null;
-  sandbox?: string;
+  personality?: CodexPersonality | null;
+  approvalPolicy?: CodexApprovalPolicy | null;
+  approvalsReviewer?: CodexApprovalsReviewer | null;
+  sandbox?: CodexSandboxMode | null;
   serviceTier?: CodexServiceTier | null;
   config?: JsonObject;
   developerInstructions?: string;
@@ -119,7 +141,7 @@ export type CodexThreadForkParams = CodexThreadStartParams & {
   threadId: string;
   baseInstructions?: string;
   ephemeral?: boolean;
-  threadSource?: string | JsonObject;
+  threadSource?: "user" | "subagent" | "memory_consolidation" | null;
   excludeTurns?: boolean;
 };
 
@@ -147,25 +169,37 @@ export type CodexTurnInterruptParams = JsonObject & {
 
 export type CodexTurnStartParams = JsonObject & {
   threadId: string;
-  input?: CodexUserInput[];
+  input: CodexUserInput[];
   cwd?: string;
   model?: string;
-  approvalPolicy?: string | JsonObject;
-  approvalsReviewer?: string | null;
+  approvalPolicy?: CodexApprovalPolicy | null;
+  approvalsReviewer?: CodexApprovalsReviewer | null;
   sandboxPolicy?: CodexSandboxPolicy;
   serviceTier?: CodexServiceTier | null;
   effort?: string | null;
-  personality?: string | null;
+  personality?: CodexPersonality | null;
   environments?: CodexTurnEnvironmentParams[] | null;
   collaborationMode?: {
-    mode: string;
-    settings: JsonObject & {
+    mode: "plan" | "default";
+    settings: {
+      model: string;
+      reasoning_effort: string | null;
       developer_instructions: string | null;
     };
   } | null;
 };
 
-export type CodexSandboxPolicy = string | JsonObject;
+export type CodexSandboxPolicy =
+  | { type: "dangerFullAccess" }
+  | { type: "readOnly"; networkAccess: boolean }
+  | { type: "externalSandbox"; networkAccess: "restricted" | "enabled" }
+  | {
+      type: "workspaceWrite";
+      writableRoots: string[];
+      networkAccess: boolean;
+      excludeTmpdirEnvVar: boolean;
+      excludeSlashTmp: boolean;
+    };
 
 export type CodexTurnStartResponse = {
   turn: CodexTurn;
@@ -173,11 +207,11 @@ export type CodexTurnStartResponse = {
 
 export type CodexTurn = {
   id: string;
-  threadId: string;
+  threadId?: string;
   status?: string;
-  error?: CodexErrorNotification["error"];
-  startedAt?: string | null;
-  completedAt?: string | null;
+  error?: CodexErrorNotification["error"] | null;
+  startedAt?: number | null;
+  completedAt?: number | null;
   durationMs?: number | null;
   items: CodexThreadItem[];
 };
@@ -298,10 +332,7 @@ export type CodexDynamicToolCallOutputContentItem =
 export type CodexErrorNotification = {
   error: {
     message?: string;
-    codexErrorInfo?: {
-      message?: string;
-      [key: string]: unknown;
-    };
+    codexErrorInfo?: string | JsonObject | null;
     [key: string]: unknown;
   };
   message?: string;

--- a/scripts/check-codex-app-server-protocol.ts
+++ b/scripts/check-codex-app-server-protocol.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 // Check Codex App Server Protocol script supports OpenClaw repository automation.
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -80,6 +81,7 @@ async function main(): Promise<void> {
 
   try {
     await compareGeneratedProtocolMirror(source.jsonRoot);
+    await checkMaintainedProtocolTypes(source.typescriptRoot);
 
     for (const check of checks) {
       const filePath = path.join(source.typescriptRoot, check.file);
@@ -114,6 +116,102 @@ async function main(): Promise<void> {
   console.log(
     `Codex app-server generated protocol matches OpenClaw bridge assumptions: ${source.codexRepo}`,
   );
+}
+
+async function checkMaintainedProtocolTypes(sourceRoot: string): Promise<void> {
+  // Turn responses are normalized into a uniform projector shape before their
+  // checked-in JSON schemas validate them. Probe only raw contracts consumed directly.
+  const probePath = path.join(sourceRoot, "openclaw-protocol-compatibility.ts");
+  const protocolPath = path.resolve(process.cwd(), "extensions/codex/src/app-server/protocol.ts");
+  const protocolImport = relativeTypeScriptImport(probePath, protocolPath);
+  const generatedImport = (file: string) =>
+    relativeTypeScriptImport(probePath, path.join(sourceRoot, file));
+  const probe = `
+import type {
+  CodexDynamicToolSpec,
+  CodexDynamicToolCallParams,
+  CodexErrorNotification,
+  CodexModelListResponse,
+  CodexThreadForkParams,
+  CodexThreadForkResponse,
+  CodexThreadResumeParams,
+  CodexThreadResumeResponse,
+  CodexThreadStartParams,
+  CodexThreadStartResponse,
+  CodexTurnEnvironmentParams,
+  CodexTurnInterruptParams,
+  CodexTurnStartParams,
+} from ${JSON.stringify(protocolImport)};
+import type { DynamicToolCallParams } from ${JSON.stringify(generatedImport("v2/DynamicToolCallParams.ts"))};
+import type { DynamicToolSpec } from ${JSON.stringify(generatedImport("v2/DynamicToolSpec.ts"))};
+import type { ErrorNotification } from ${JSON.stringify(generatedImport("v2/ErrorNotification.ts"))};
+import type { ModelListResponse } from ${JSON.stringify(generatedImport("v2/ModelListResponse.ts"))};
+import type { ThreadForkParams } from ${JSON.stringify(generatedImport("v2/ThreadForkParams.ts"))};
+import type { ThreadForkResponse } from ${JSON.stringify(generatedImport("v2/ThreadForkResponse.ts"))};
+import type { ThreadResumeParams } from ${JSON.stringify(generatedImport("v2/ThreadResumeParams.ts"))};
+import type { ThreadResumeResponse } from ${JSON.stringify(generatedImport("v2/ThreadResumeResponse.ts"))};
+import type { ThreadStartParams } from ${JSON.stringify(generatedImport("v2/ThreadStartParams.ts"))};
+import type { ThreadStartResponse } from ${JSON.stringify(generatedImport("v2/ThreadStartResponse.ts"))};
+import type { TurnEnvironmentParams } from ${JSON.stringify(generatedImport("v2/TurnEnvironmentParams.ts"))};
+import type { TurnInterruptParams } from ${JSON.stringify(generatedImport("v2/TurnInterruptParams.ts"))};
+import type { TurnStartParams } from ${JSON.stringify(generatedImport("v2/TurnStartParams.ts"))};
+
+type Assert<T extends true> = T;
+type Assignable<From, To> = [From] extends [To] ? true : false;
+
+type ProtocolCompatibilityChecks = [
+  Assert<Assignable<CodexDynamicToolSpec, DynamicToolSpec>>,
+  Assert<Assignable<CodexTurnEnvironmentParams, TurnEnvironmentParams>>,
+  Assert<Assignable<CodexThreadStartParams, ThreadStartParams>>,
+  Assert<Assignable<CodexThreadResumeParams, ThreadResumeParams>>,
+  Assert<Assignable<CodexThreadForkParams, ThreadForkParams>>,
+  Assert<Assignable<CodexTurnInterruptParams, TurnInterruptParams>>,
+  Assert<Assignable<CodexTurnStartParams, TurnStartParams>>,
+  Assert<
+    Assignable<
+      Omit<DynamicToolCallParams, "arguments">,
+      Omit<CodexDynamicToolCallParams, "arguments">
+    >
+  >,
+  Assert<Assignable<ErrorNotification, CodexErrorNotification>>,
+  Assert<Assignable<ModelListResponse, CodexModelListResponse>>,
+  Assert<Assignable<ThreadForkResponse, CodexThreadForkResponse>>,
+  Assert<Assignable<ThreadResumeResponse, CodexThreadResumeResponse>>,
+  Assert<Assignable<ThreadStartResponse, CodexThreadStartResponse>>,
+];
+
+export type { ProtocolCompatibilityChecks };
+`;
+  await fs.writeFile(probePath, probe);
+  const result = spawnSync(
+    process.execPath,
+    [
+      "scripts/run-tsgo.mjs",
+      "--ignoreConfig",
+      "--noEmit",
+      "--strict",
+      "--skipLibCheck",
+      "--module",
+      "nodenext",
+      "--moduleResolution",
+      "nodenext",
+      probePath,
+    ],
+    { cwd: process.cwd(), encoding: "utf8" },
+  );
+  if (result.error) {
+    failures.push(`maintained protocol types: failed to start tsgo (${result.error.message})`);
+    return;
+  }
+  if (result.status !== 0) {
+    const output = `${result.stdout}${result.stderr}`.trim();
+    failures.push(`maintained protocol types differ from generated Codex types\n${output}`);
+  }
+}
+
+function relativeTypeScriptImport(fromFile: string, toFile: string): string {
+  const relative = path.relative(path.dirname(fromFile), toFile).replaceAll(path.sep, "/");
+  return relative.startsWith(".") ? relative : `./${relative}`;
 }
 
 async function compareGeneratedProtocolMirror(sourceJsonRoot: string): Promise<void> {

--- a/scripts/check-codex-app-server-protocol.ts
+++ b/scripts/check-codex-app-server-protocol.ts
@@ -189,6 +189,7 @@ export type { ProtocolCompatibilityChecks };
       "scripts/run-tsgo.mjs",
       "--ignoreConfig",
       "--noEmit",
+      "--allowImportingTsExtensions",
       "--strict",
       "--skipLibCheck",
       "--module",

--- a/scripts/lib/codex-app-server-protocol-source.ts
+++ b/scripts/lib/codex-app-server-protocol-source.ts
@@ -163,6 +163,7 @@ export async function generateExperimentalCodexAppServerProtocolSource(
   repoRoot = process.cwd(),
 ): Promise<GeneratedCodexAppServerProtocolSource> {
   const { codexRepo } = await resolveCodexAppServerProtocolSource(repoRoot);
+  await validateCodexProtocolSourceVersion({ codexRepo, repoRoot });
   const root = await fs.mkdtemp(path.join(repoRoot, ".tmp-codex-app-server-protocol-"));
   const generatedRoot = path.join(root, "generated");
   const typescriptRoot = path.join(root, "typescript");
@@ -190,6 +191,40 @@ export async function generateExperimentalCodexAppServerProtocolSource(
     jsonRoot,
     cleanup,
   };
+}
+
+export function readCargoWorkspacePackageVersion(manifest: string): string | undefined {
+  const header = /^\[workspace\.package\]\s*$/m.exec(manifest);
+  if (!header) {
+    return undefined;
+  }
+  const remainder = manifest.slice(header.index + header[0].length);
+  const nextSection = /^\[/m.exec(remainder);
+  const workspacePackage = remainder.slice(0, nextSection?.index ?? remainder.length);
+  return /^version\s*=\s*"([^"]+)"\s*$/m.exec(workspacePackage)?.[1];
+}
+
+async function validateCodexProtocolSourceVersion(params: {
+  codexRepo: string;
+  repoRoot: string;
+}): Promise<void> {
+  const packageManifest = JSON.parse(
+    await fs.readFile(path.join(params.repoRoot, "extensions/codex/package.json"), "utf8"),
+  ) as { dependencies?: Record<string, unknown> };
+  const expectedVersion = packageManifest.dependencies?.["@openai/codex"];
+  if (typeof expectedVersion !== "string" || expectedVersion.length === 0) {
+    throw new Error("extensions/codex/package.json must pin @openai/codex to an exact version");
+  }
+  const cargoManifest = await fs.readFile(
+    path.join(params.codexRepo, "codex-rs/Cargo.toml"),
+    "utf8",
+  );
+  const sourceVersion = readCargoWorkspacePackageVersion(cargoManifest);
+  if (sourceVersion !== expectedVersion) {
+    throw new Error(
+      `Codex protocol source version ${sourceVersion ?? "<unknown>"} does not match @openai/codex ${expectedVersion}. Check out rust-v${expectedVersion} in ${params.codexRepo}.`,
+    );
+  }
 }
 
 async function collectCodexRepoCandidates(repoRoot: string): Promise<string[]> {
@@ -331,31 +366,28 @@ function runCargoProtocolGenerator(codexRepo: string, args: string[]): void {
     cwd: codexRepo,
     stdio: "inherit",
   });
+  if (result.error) {
+    throw new Error(`Failed to start cargo: ${result.error.message}`, { cause: result.error });
+  }
   if (result.status !== 0) {
     throw new Error(`cargo ${args.join(" ")} failed with exit code ${result.status ?? "unknown"}`);
   }
 }
 
 function formatGeneratedTypeScript(repoRoot: string, root: string): void {
-  const command = resolveCodexProtocolPnpmCommand([
-    "exec",
-    "oxfmt",
-    "--write",
-    "--threads=1",
-    root,
-  ]);
-  const result = spawnSync(command.command, command.args, {
+  const formatter = path.join(repoRoot, "node_modules/oxfmt/bin/oxfmt");
+  const result = spawnSync(process.execPath, [formatter, "--write", "--threads=1", root], {
     cwd: repoRoot,
-    env: command.env ?? process.env,
-    shell: command.shell,
     stdio: "inherit",
-    windowsVerbatimArguments: command.windowsVerbatimArguments,
   });
+  if (result.error) {
+    throw new Error(`Failed to start protocol formatter: ${result.error.message}`, {
+      cause: result.error,
+    });
+  }
   if (result.status !== 0) {
     throw new Error(
-      `pnpm exec oxfmt --write --threads=1 ${root} failed with exit code ${
-        result.status ?? "unknown"
-      }`,
+      `oxfmt --write --threads=1 ${root} failed with exit code ${result.status ?? "unknown"}`,
     );
   }
 }

--- a/test/scripts/codex-app-server-protocol-source.test.ts
+++ b/test/scripts/codex-app-server-protocol-source.test.ts
@@ -6,6 +6,7 @@ import {
   buildCodexProtocolExportArgs,
   canonicalizeCodexAppServerProtocolJson,
   formatCodexAppServerProtocolJsonText,
+  readCargoWorkspacePackageVersion,
   resolveCodexAppServerProtocolSource,
   resolveCodexProtocolCargoTargetDir,
   resolveCodexProtocolMinFreeBytes,
@@ -26,6 +27,25 @@ afterEach(() => {
 });
 
 describe("codex app-server protocol source resolver", () => {
+  it("reads the Codex workspace package version", () => {
+    expect(
+      readCargoWorkspacePackageVersion(`
+[workspace]
+members = []
+
+[workspace.package]
+version = "0.139.0"
+edition = "2024"
+
+[workspace.dependencies]
+serde = "1"
+`),
+    ).toBe("0.139.0");
+    expect(readCargoWorkspacePackageVersion('[workspace.package]\nversion = "0.140.0"\n')).toBe(
+      "0.140.0",
+    );
+  });
+
   it("uses the app-server protocol export binary instead of compiling the full codex cli", () => {
     expect(buildCodexProtocolExportArgs("/codex/codex-rs/Cargo.toml", "/tmp/protocol")).toEqual([
       "run",


### PR DESCRIPTION
## Summary

- validate OpenClaw's maintained Codex app-server request and raw inbound types against temporary TypeScript generated from the pinned Codex source
- keep only the selected JSON schemas in the repository; no generated TypeScript files are committed
- reject protocol generation from a Codex checkout whose Cargo workspace version differs from the pinned `@openai/codex` version
- tighten stale maintained types found by the comparison, including approval policies, sandbox policy, user input elements, collaboration mode, thread source, turn timestamps, and nullable error metadata
- make granular MCP-elicitation approval policies include every field required by Codex 0.139.0

The generated TypeScript tree is used only as a temporary compile-time oracle. Turn payloads that OpenClaw deliberately normalizes into its uniform projector shape remain covered by the exact checked-in JSON schemas and runtime validators.

## Verification

- `OPENCLAW_CODEX_REPO=<rust-v0.139.0 checkout> pnpm codex-app-server:protocol:check` — passed; generated 614 temporary TypeScript files and validated maintained contracts
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/config.test.ts test/scripts/codex-app-server-protocol-source.test.ts` — 111 tests passed
- `node scripts/run-tsgo.mjs -p extensions/codex/tsconfig.json --pretty false` — passed locally and on Azure Crabbox
- final autoreview over the two-commit branch diff — clean, no actionable findings

Azure Crabbox proof used `cbx_6371d51e4891`. The protocol generator and focused tests passed there. The broader build advanced through core, SDK declarations, and plugin artifacts, then hit an unrelated missing `ui/config/control-ui-chunking.ts` file in the raw synced workspace. `check:changed` could not run in that raw workspace because it does not contain Git metadata.

## Risk

No user-facing runtime behavior or config surface is added. The primary risk is future Codex protocol drift; the new version-locked temporary generation and directional assignability checks fail the protocol gate when maintained types become incompatible.
