### PR TITLE
fix(message): plumb maxLinesPerMessage from channel config into CLI send formatting

### DIFF
--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -580,6 +580,27 @@ describe("sendMessage", () => {
     });
   });
 
+  it("resolves defaultAccount maxLinesPerMessage when accountId is omitted", async () => {
+    await sendMessage({
+      cfg: {
+        channels: {
+          forum: {
+            maxLinesPerMessage: 50,
+            defaultAccount: "bot1",
+            accounts: { bot1: { maxLinesPerMessage: 30 } },
+          },
+        },
+      },
+      channel: "forum",
+      to: "123456",
+      content: "hi",
+    });
+
+    expectDeliveryCallFields({
+      formatting: { maxLinesPerMessage: 30 },
+    });
+  });
+
   it("omits formatting when no parseMode and no maxLinesPerMessage configured", async () => {
     await sendMessage({
       cfg: {},

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -531,4 +531,65 @@ describe("sendMessage", () => {
       queuePolicy: "best_effort",
     });
   });
+
+  it("passes maxLinesPerMessage from channel config into delivery formatting", async () => {
+    await sendMessage({
+      cfg: { channels: { forum: { maxLinesPerMessage: 50 } } },
+      channel: "forum",
+      to: "123456",
+      content: "hi",
+    });
+
+    expectDeliveryCallFields({
+      formatting: { maxLinesPerMessage: 50 },
+    });
+  });
+
+  it("resolves account-level maxLinesPerMessage over channel-level default", async () => {
+    await sendMessage({
+      cfg: {
+        channels: {
+          forum: {
+            maxLinesPerMessage: 50,
+            accounts: { bot1: { maxLinesPerMessage: 30 } },
+          },
+        },
+      },
+      channel: "forum",
+      to: "123456",
+      content: "hi",
+      accountId: "bot1",
+    });
+
+    expectDeliveryCallFields({
+      formatting: { maxLinesPerMessage: 30 },
+    });
+  });
+
+  it("includes both parseMode and maxLinesPerMessage in formatting when both are set", async () => {
+    await sendMessage({
+      cfg: { channels: { forum: { maxLinesPerMessage: 25 } } },
+      channel: "forum",
+      to: "123456",
+      content: "hi",
+      parseMode: "HTML",
+    });
+
+    expectDeliveryCallFields({
+      formatting: { parseMode: "HTML", maxLinesPerMessage: 25 },
+    });
+  });
+
+  it("omits formatting when no parseMode and no maxLinesPerMessage configured", async () => {
+    await sendMessage({
+      cfg: {},
+      channel: "forum",
+      to: "123456",
+      content: "hi",
+    });
+
+    expectDeliveryCallFields({
+      formatting: undefined,
+    });
+  });
 });

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -7,6 +7,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import type { PollInput } from "../../polls.js";
 import { normalizePollInput } from "../../polls.js";
+import { normalizeAccountId } from "../../routing/account-id.js";
+import { resolveAccountEntry } from "../../routing/account-lookup.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { resolveMessageChannelSelection } from "./channel-selection.js";
 import {
@@ -298,6 +300,53 @@ async function resolveGatewayIdempotencyKey(idempotencyKey?: string): Promise<st
   return randomIdempotencyKey();
 }
 
+type ChannelMaxLinesConfig = {
+  maxLinesPerMessage?: number;
+  accounts?: Record<string, { maxLinesPerMessage?: number }>;
+};
+
+function resolveMaxLinesPerMessage(
+  cfg: OpenClawConfig | undefined,
+  channel?: string,
+  accountId?: string,
+): number | undefined {
+  if (!channel) {
+    return undefined;
+  }
+  const channelsConfig = cfg?.channels as Record<string, unknown> | undefined;
+  const channelSection = (channelsConfig?.[channel] ??
+    (cfg as Record<string, unknown> | undefined)?.[channel]) as
+    | ChannelMaxLinesConfig
+    | undefined;
+  if (!channelSection) {
+    return undefined;
+  }
+  const normalizedAccountId = normalizeAccountId(accountId);
+  const accounts = channelSection.accounts;
+  if (accounts && typeof accounts === "object") {
+    const direct = resolveAccountEntry(accounts, normalizedAccountId);
+    if (typeof direct?.maxLinesPerMessage === "number") {
+      return direct.maxLinesPerMessage;
+    }
+  }
+  return typeof channelSection.maxLinesPerMessage === "number"
+    ? channelSection.maxLinesPerMessage
+    : undefined;
+}
+
+function buildSendFormatting(
+  parseMode?: "HTML",
+  maxLinesPerMessage?: number,
+): { parseMode?: "HTML"; maxLinesPerMessage?: number } | undefined {
+  if (!parseMode && maxLinesPerMessage == null) {
+    return undefined;
+  }
+  return {
+    ...(parseMode ? { parseMode } : {}),
+    ...(maxLinesPerMessage != null ? { maxLinesPerMessage } : {}),
+  };
+}
+
 export async function sendMessage(params: MessageSendParams): Promise<MessageSendResult> {
   const cfg = await resolveMessageConfig(params.cfg);
   const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
@@ -391,7 +440,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       signal: params.abortSignal,
       silent: params.silent,
       mediaAccess: params.mediaAccess,
-      formatting: params.parseMode ? { parseMode: params.parseMode } : undefined,
+      formatting: buildSendFormatting(params.parseMode, resolveMaxLinesPerMessage(cfg, channel, params.accountId)),
       mirror: params.mirror
         ? {
             ...params.mirror,

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -315,8 +315,7 @@ function resolveMaxLinesPerMessage(
     return undefined;
   }
   const channelsConfig = cfg?.channels as Record<string, unknown> | undefined;
-  const channelSection = (channelsConfig?.[channel] ??
-    (cfg as Record<string, unknown> | undefined)?.[channel]) as
+  const channelSection = channelsConfig?.[channel] as
     | ChannelMaxLinesConfig
     | undefined;
   if (!channelSection) {

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -302,6 +302,7 @@ async function resolveGatewayIdempotencyKey(idempotencyKey?: string): Promise<st
 
 type ChannelMaxLinesConfig = {
   maxLinesPerMessage?: number;
+  defaultAccount?: string;
   accounts?: Record<string, { maxLinesPerMessage?: number }>;
 };
 
@@ -321,7 +322,8 @@ function resolveMaxLinesPerMessage(
   if (!channelSection) {
     return undefined;
   }
-  const normalizedAccountId = normalizeAccountId(accountId);
+  const effectiveAccountId = accountId ?? channelSection.defaultAccount;
+  const normalizedAccountId = normalizeAccountId(effectiveAccountId);
   const accounts = channelSection.accounts;
   if (accounts && typeof accounts === "object") {
     const direct = resolveAccountEntry(accounts, normalizedAccountId);


### PR DESCRIPTION
## Summary

Fixes #91860

The `sendMessage` entrypoint (used by `openclaw message send` CLI) only forwarded `parseMode` into the formatting options passed to `sendDurableMessageBatch`. The channel-level `maxLinesPerMessage` config value was never included, so CLI sends always fell back to the Discord extension default of 17 lines per chunk — even when the config explicitly set a higher value.

## Changes

**`src/infra/outbound/message.ts`**
- Added `resolveMaxLinesPerMessage()` — resolves the `maxLinesPerMessage` setting from channel config with account-level override support, honoring the channel `defaultAccount` config when `accountId` is omitted. Follows the same generic channel config access pattern used by `resolveChunkMode()` and `resolveTextChunkLimit()` in `auto-reply/chunk.ts`.
- Added `buildSendFormatting()` helper — constructs the formatting options object, returning `undefined` when both `parseMode` and `maxLinesPerMessage` are absent (preserving existing behavior for channels without this config).
- Changed the `formatting:` parameter in the `sendDurableMessageBatch` call to include the resolved `maxLinesPerMessage` alongside `parseMode`.

### Account resolution fix (commit 84929c6)

Addressed ClawSweeper P2 finding: when `accountId` is omitted, the resolver now reads `channelSection.defaultAccount` before normalizing, so `channels.discord.defaultAccount: "work"` with `accounts.work.maxLinesPerMessage: 50` correctly resolves to 50 — instead of falling back to `accounts.default.maxLinesPerMessage`.

Resolution order:
1. `accountId` explicitly provided → normalize and use it
2. `accountId` omitted → check `channelSection.defaultAccount` → use that
3. Normalized account has `maxLinesPerMessage` in accounts map → return it
4. Fall back to root `channelSection.maxLinesPerMessage`
5. No config → return `undefined` (adapter default applies)

## How it works

1. The Discord outbound adapter chunker already reads `ctx?.formatting?.maxLinesPerMessage` (in `extensions/discord/src/outbound-adapter.ts`)
2. The agent reply path works correctly because the Discord monitor explicitly calls `resolveDiscordMaxLinesPerMessage()` and passes it through formatting options
3. The CLI send path was missing this plumbing — `formatting` was only populated with `parseMode`
4. This fix adds generic channel config resolution (not Discord-specific) so any channel with `maxLinesPerMessage` config benefits

## Real behavior proof

**Behavior or issue addressed**: `openclaw message send --channel discord` ignores `channels.discord.maxLinesPerMessage` config and always splits at 17 lines (`DEFAULT_MAX_LINES`). The formatting parameter only included `parseMode` and never plumbed `maxLinesPerMessage` from channel config.

**Real environment tested**: OpenClaw 2026.6.5 (5181e4f), Linux x64, Node v24.14.1. Tests run on the fix branch in the full openclaw repo checkout at `/mnt/data/repos/forks/openclaw`.

**Exact steps or command run after the patch**:
```
$ cd /mnt/data/repos/forks/openclaw
$ git checkout fix/91860-cli-send-maxlines-per-message
$ node scripts/run-vitest.mjs run src/infra/outbound/message.test.ts
```

Before fix — the formatting line in `sendMessage()` was:
```typescript
// line 394 on upstream/main
formatting: params.parseMode ? { parseMode: params.parseMode } : undefined,
// maxLinesPerMessage NEVER included — always undefined for CLI sends
```

After fix — the formatting line becomes:
```typescript
// line 444 on fix branch
formatting: buildSendFormatting(params.parseMode, resolveMaxLinesPerMessage(cfg, channel, params.accountId)),
// resolves maxLinesPerMessage from channel config → account override → defaultAccount
```

**Evidence after fix**:

Terminal output from `node scripts/run-vitest.mjs run src/infra/outbound/message.test.ts`:
```
[test] starting test/vitest/vitest.infra.config.ts

 RUN  v4.1.7 /mnt/data/repos/forks/openclaw

 ✓ infra src/infra/outbound/message.test.ts (16 tests) 10372ms

 Test Files  1 passed (1)
       Tests  16 passed (16)
    Start at  19:11:20
    Duration  12.35s (transform 3.69s, setup 1.23s, import 43ms, tests 10.37s, environment 0ms)

[test] passed 1 Vitest shard in 19.19s
```

All 16 tests pass, including 5 new tests specifically covering the `maxLinesPerMessage` plumbing:
- `passes maxLinesPerMessage from channel config into delivery formatting`
- `resolves account-level maxLinesPerMessage over channel-level default`
- `includes both parseMode and maxLinesPerMessage in formatting when both are set`
- `resolves defaultAccount maxLinesPerMessage when accountId is omitted`
- `omits formatting when no parseMode and no maxLinesPerMessage configured`

Code path trace showing the full resolution chain:
```
sendMessage(params)
  → resolveMaxLinesPerMessage(cfg, "discord", undefined)
    → channelSection = cfg.channels.discord
    → effectiveAccountId = channelSection.defaultAccount ?? "default"
    → accounts[effectiveAccountId].maxLinesPerMessage (e.g. 50)
  → buildSendFormatting(parseMode, 50)
    → { maxLinesPerMessage: 50 }
  → sendDurableMessageBatch(formatting: { maxLinesPerMessage: 50 })
  → Discord outbound adapter reads ctx.formatting.maxLinesPerMessage
  → chunkDiscordTextWithMode(text, { maxLines: 50 })  // uses configured value ✓
```

**Observed result after fix**: The `formatting` parameter passed to `sendDurableMessageBatch` now includes `maxLinesPerMessage` resolved from channel config. The Discord outbound adapter's chunker (`chunkDiscordTextWithMode`) receives the configured `maxLines` value instead of falling back to `DEFAULT_MAX_LINES = 17`. The resolution follows the same `defaultAccount` → account override pattern as the existing `resolveDefaultDiscordAccountId` helper.

**What was not tested**: Live `openclaw message send` CLI end-to-end with a real Discord channel (would require deploying the patched build). The code path is verified through unit tests that mock the config and assert the `formatting` field passed to `sendDurableMessageBatch`. The Discord outbound adapter's consumption of `formatting.maxLinesPerMessage` is already covered by existing adapter tests upstream.
