### PR TITLE
feat(plugin-sdk): surface accountId on agent hook context

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -301,7 +301,7 @@ tool invocations before the command runs. It receives:
 - `event.toolName`, currently always `"exec"`
 - `event.host`, one of `"gateway"`, `"sandbox"`, or `"node"`
 - context fields such as `ctx.agentId`, `ctx.sessionKey`,
-  `ctx.messageProvider`, and `ctx.channelId`
+  `ctx.messageProvider`, `ctx.channelId`, and `ctx.accountId`
 
 Return a `Record<string, string>` to merge into the exec environment. Handlers
 run in priority order; later results override earlier results for the same
@@ -379,6 +379,9 @@ session key or delivery metadata.
 
 When sender identity is available, agent hook contexts also include:
 
+- `ctx.accountId` - channel-account identifier the turn belongs to, in
+  multi-account channel deployments (e.g. Feishu apps A / B / C under one
+  gateway). Populated when the run carries an account origin.
 - `ctx.senderId` - channel-scoped sender ID (e.g. Feishu `open_id`, Discord
   user ID). Populated when the run originates from a user message with known
   sender metadata.

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -146,6 +146,11 @@ export type HookContext = {
   approvalReviewerDeviceId?: string;
   trace?: DiagnosticTraceContext;
   channelId?: string;
+  /** Channel account the run belongs to — the account's own identity, sourced from the
+   * canonical `PluginHookAgentContext.accountId`; feeds account-aware tool hooks such as
+   * `resolve_exec_env`. Distinct from `turnSourceAccountId` below, which carries the
+   * approval-routing source of an originating turn, not the run's own account. */
+  accountId?: string;
   /** Originating channel for approval delivery routing; mirrors exec approval turn-source fields. */
   turnSourceChannel?: string;
   turnSourceTo?: string;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1496,6 +1496,7 @@ export function createExecTool(
         sessionKey: defaults?.sessionKey ?? context?.hookContext?.sessionKey,
         messageProvider: defaults?.messageProvider,
         channelId: defaults?.currentChannelId ?? context?.hookContext?.channelId,
+        accountId: defaults?.accountId ?? context?.hookContext?.accountId,
         ...(defaults?.channelContext ? { channelContext: defaults.channelContext } : {}),
       },
     );

--- a/src/agents/harness/hook-context.test.ts
+++ b/src/agents/harness/hook-context.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentHookContext } from "./hook-context.js";
+
+describe("buildAgentHookContext", () => {
+  it("carries accountId through to the plugin hook context", () => {
+    expect(buildAgentHookContext({ runId: "r1", accountId: "acct-1" }).accountId).toBe("acct-1");
+  });
+
+  it("omits accountId when absent, matching the sparse context contract", () => {
+    expect("accountId" in buildAgentHookContext({ runId: "r1" })).toBe(false);
+  });
+});

--- a/src/agents/harness/hook-context.ts
+++ b/src/agents/harness/hook-context.ts
@@ -29,6 +29,7 @@ export type AgentHarnessHookContext = {
   messageProvider?: string;
   trigger?: string;
   channelId?: string;
+  accountId?: string;
   contextTokenBudget?: number;
   contextWindowSource?: PluginHookContextWindowSource;
   contextWindowReferenceTokens?: number;
@@ -55,6 +56,7 @@ export function buildAgentHookContext(params: AgentHarnessHookContext): PluginHo
     ...(params.channel ? { channel: params.channel } : {}),
     ...(params.trigger ? { trigger: params.trigger } : {}),
     ...(params.channelId ? { channelId: params.channelId } : {}),
+    ...(params.accountId ? { accountId: params.accountId } : {}),
     ...(params.contextTokenBudget ? { contextTokenBudget: params.contextTokenBudget } : {}),
     ...(params.contextWindowSource ? { contextWindowSource: params.contextWindowSource } : {}),
     ...(params.contextWindowReferenceTokens

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -683,6 +683,7 @@ export function createOpenClawTools(
     ...(options?.agentSessionKey ? { sessionKey: options.agentSessionKey } : {}),
     ...(options?.sessionId ? { sessionId: options.sessionId } : {}),
     ...(options?.currentChannelId ? { channelId: options.currentChannelId } : {}),
+    ...(options?.agentAccountId ? { accountId: options.agentAccountId } : {}),
     loopDetection: resolveToolLoopDetectionConfig({ cfg: resolvedConfig, agentId: hookAgentId }),
   };
   const hookContext = {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1075,6 +1075,7 @@ export async function getReplyFromConfig(
               currentChannelId: sessionCtx.OriginatingTo ?? ctx.OriginatingTo ?? ctx.To,
               messageTo: sessionCtx.OriginatingTo ?? ctx.OriginatingTo ?? ctx.To,
               senderId: sessionCtx.SenderId ?? ctx.SenderId,
+              accountId: sessionCtx.AccountId ?? ctx.AccountId,
             }),
             ...buildAgentHookContextIdentityFields({
               trigger: hookTrigger,

--- a/src/plugins/hook-agent-context.test.ts
+++ b/src/plugins/hook-agent-context.test.ts
@@ -73,6 +73,7 @@ describe("buildAgentHookContextChannelFields", () => {
       channelId: "c1",
       chatId: "c1",
       senderId: "user-123",
+      accountId: undefined,
     });
   });
 
@@ -88,7 +89,36 @@ describe("buildAgentHookContextChannelFields", () => {
       channelId: "1472750640760623226",
       chatId: "1472750640760623226",
       senderId: undefined,
+      accountId: undefined,
     });
+  });
+
+  it("surfaces accountId when supplied", () => {
+    expect(
+      buildAgentHookContextChannelFields({
+        messageProvider: "test",
+        accountId: "acct-1",
+      }).accountId,
+    ).toBe("acct-1");
+  });
+
+  it("accepts the legacy `agentAccountId` alias from existing runtime params", () => {
+    expect(
+      buildAgentHookContextChannelFields({
+        messageProvider: "test",
+        agentAccountId: "acct-1",
+      }).accountId,
+    ).toBe("acct-1");
+  });
+
+  it("prefers `accountId` when both names are present", () => {
+    expect(
+      buildAgentHookContextChannelFields({
+        messageProvider: "test",
+        accountId: "acct-canonical",
+        agentAccountId: "acct-legacy",
+      }).accountId,
+    ).toBe("acct-canonical");
   });
 });
 

--- a/src/plugins/hook-agent-context.ts
+++ b/src/plugins/hook-agent-context.ts
@@ -107,9 +107,13 @@ export function buildAgentHookContextChannelFields(params: {
   currentChannelId?: string | null;
   messageTo?: string | null;
   senderId?: string | null;
+  accountId?: string | null;
+  /** Alias for `accountId` so existing `RunEmbeddedAgentParams`-shaped call sites
+   * spread through unchanged; `accountId` wins. Follow-up: migrate and retire. */
+  agentAccountId?: string | null;
 }): Pick<
   PluginHookAgentContext,
-  "channel" | "channelId" | "chatId" | "messageProvider" | "senderId"
+  "channel" | "channelId" | "chatId" | "messageProvider" | "senderId" | "accountId"
 > {
   const channel = resolveAgentHookChannel(params);
   const channelId = resolveAgentHookChannelId(params);
@@ -119,6 +123,7 @@ export function buildAgentHookContextChannelFields(params: {
     channelId,
     chatId: channelId,
     senderId: normalizeOptionalString(params.senderId),
+    accountId: normalizeOptionalString(params.accountId ?? params.agentAccountId),
   };
 }
 

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -282,6 +282,9 @@ export type PluginHookAgentContext = {
   senderId?: string;
   trigger?: string;
   channelId?: string;
+  /** Channel-account id the turn belongs to. Canonical seam for account-aware
+   * plugins; `sessionKey` does not reliably encode it (group/cron shapes). */
+  accountId?: string;
   /** Resolved effective context-token budget after model/config/agent caps. */
   contextTokenBudget?: number;
   /** Source that supplied the resolved context-token budget. */


### PR DESCRIPTION
## TL;DR

Adds an optional `accountId` to the plugin **agent hook context** so account-aware plugins can read which channel account a turn belongs to, instead of reverse-engineering it from `sessionKey` (which doesn't carry it for group or cron runs). Fully additive.

**Maintainer decision requested:** `accountId` becomes part of the public plugin SDK hook context. The name mirrors the `accountId` already on the hook *event* types (e.g. `before_agent_run`) — this just brings the *context* in line. OK to lock in `accountId` as the canonical field?

## Why

Multi-account deployments (several Feishu apps / Slack workspaces on one instance) already track an `accountId` internally for routing and auth, but plugins receiving agent hooks have no reliable way to recover it:

- `sessionKey` only encodes the account on some surfaces — **absent** in group conversations (`agent:<id>:<provider>:group:<chatId>`) and cron runs (`agent:main:cron:<job>:run:<id>`).
- Indexing a store by `sessionKey` races when multiple bots are @-ed in one group at the same time.

Surfacing the turn-bound `accountId` at the runtime seam lets a plugin stay **stateless** across DM / group-multi-bot / cron / subagent with a single hook — no sessionKey parsing, no shared-store workaround.

## What changed

- **`PluginHookAgentContext`** — new optional `accountId?: string` (public SDK surface).
- **`buildAgentHookContextChannelFields`** — surfaces `accountId`, following the exact pattern the shared builder already uses for `channel` / `chatId` / `senderId`. Accepts the existing internal `agentAccountId` as an alias so all current spread call sites forward it for free (no rename churn); `accountId` wins. Alias is commented with a follow-up to unify the internal name.
- **Harness path** (`buildAgentHookContext`) — threads `accountId` through, so `agent_end` / compaction / `before_agent_run` hooks get it instead of having it dropped by the context rebuild.
- **Dispatch sites** — `resolve_exec_env` (`bash-tools.exec.ts`) and `before_agent_reply` (`get-reply.ts`) source `accountId` from real adjacent fields, mirroring the sibling `sessionKey` / `channelId` reads.
- **`docs/plugins/hooks.md`** — documents `ctx.accountId`.

10 files, +61/-3.

## Compatibility

Fully additive. Plugins that don't read `accountId` are unaffected; every internal caller keeps working unchanged via the `agentAccountId` alias. `tsgo` core/extensions/test-src all green — no caller type-breaks.

## Real behavior proof

- **Behavior addressed:** `accountId` was unreachable by plugin agent hooks for group/cron turns (their `sessionKey` carries no account segment); this surfaces it on the hook context.
- **Real environment tested:** Local OpenClaw gateway (`openclaw gateway`) on macOS with an isolated state dir, plus the compiled `dist` plugin SDK barrel driven directly via `node`.
- **Exact steps or command run after this patch:**
  - `openclaw gateway --allow-unconfigured --auth none` with a local probe plugin registered.
  - `openclaw cron add --session isolated --account <acct> ...` then `openclaw cron run <jobId>` — a real agent turn whose delivery names a channel account.
  - `node` against the compiled SDK with the cron param shape (imports `buildAgentHookContextChannelFields` from `openclaw/plugin-sdk/agent-harness-runtime`).
- **Evidence after fix:** copied console output.

  ```
  $ node ./runtime-proof.mjs   # compiled dist SDK, cron isolated-runner param shape
  cron fields: {"channelId":"telegram","accountId":"feishu-proof-account-a"}   # cron sessionKey carries no account, accountId still resolved
  precedence : {"accountId":"acct-canonical"}                                   # canonical accountId wins over legacy agentAccountId alias
  absent     : {"channelId":"discord"}                                          # omitted when the run carries no account
  PROOF OK
  ```

  ```
  $ openclaw cron runs --id <jobId>   # real gateway cron agent turn, persisted record
  "status": "ok", "provider": "...", "sessionKey": "agent:main:cron:<job>:run:<id>",
  "delivery": { "resolved": { "accountId": "feishu-proof-account-a" } }   # account resolved end-to-end through the run
  ```

- **Observed result after fix:** the compiled hook-context builder returns the channel account for the cron shape, prefers the canonical `accountId` over the legacy alias, and omits it when no account is present; the real cron turn resolves the same account end-to-end.
- **What was not tested:** a live print of `ctx.accountId` from inside a third-party plugin hook during the turn — that's chicken-and-egg pre-merge (needs this change shipped in a gateway with a consuming plugin). It exercises the same builder the live dispatch uses; happy to add that capture as a follow-up once it lands.

## Verification

- `tsgo` core / extensions / test-src lanes: green.
- New unit coverage: `hook-agent-context.test.ts` (accountId surfacing / `agentAccountId` alias / canonical precedence) and `hook-context.test.ts` (harness ctx carries vs. omits accountId — guards the `agent_end` rebuild path).
- Adjacent hook callsite suites green: `get-reply.before-agent-reply`, `bash-tools.exec.resolve-env-hook`, `cli-runner.before-agent-reply-cron`, `harness/agent-end-side-effects`, `harness/lifecycle-hook-helpers`.
- `oxfmt --check`, `oxlint`, docs format check clean. Rebased on latest `main`; CI green.

Refs #87668
