### PR TITLE
fix: preserve non-oneOf protocol schema array order

### DIFF
--- a/scripts/lib/codex-app-server-protocol-source.ts
+++ b/scripts/lib/codex-app-server-protocol-source.ts
@@ -385,10 +385,19 @@ export function normalizeGeneratedTypeScript(text: string): string {
     .replaceAll("| null | null", "| null");
 }
 
-export function canonicalizeCodexAppServerProtocolJson(value: unknown): unknown {
+// Sort typed-object arrays for schema keywords whose item order does not affect
+// payload validity; preserve order everywhere else, especially prefixItems.
+const typeSortedSchemaArrayKeys = new Set(["anyOf", "enum", "oneOf", "required"]);
+
+export function canonicalizeCodexAppServerProtocolJson(
+  value: unknown,
+  parentKey?: string,
+): unknown {
   if (Array.isArray(value)) {
-    const items = value.map(canonicalizeCodexAppServerProtocolJson);
-    return sortCodexProtocolJsonArrayByType(items);
+    const items = value.map((item) => canonicalizeCodexAppServerProtocolJson(item));
+    return parentKey !== undefined && typeSortedSchemaArrayKeys.has(parentKey)
+      ? sortCodexProtocolJsonArrayByType(items)
+      : items;
   }
 
   if (!isPlainObject(value)) {
@@ -397,7 +406,7 @@ export function canonicalizeCodexAppServerProtocolJson(value: unknown): unknown 
 
   const sorted: Record<string, unknown> = {};
   const entries = Object.entries(value)
-    .map(([key, child]) => [key, canonicalizeCodexAppServerProtocolJson(child)] as const)
+    .map(([key, child]) => [key, canonicalizeCodexAppServerProtocolJson(child, key)] as const)
     .toSorted(([left], [right]) => {
       if (left < right) {
         return -1;

--- a/test/scripts/codex-app-server-protocol-source.test.ts
+++ b/test/scripts/codex-app-server-protocol-source.test.ts
@@ -206,16 +206,31 @@ describe("Codex app-server protocol JSON canonicalizer", () => {
 `);
   });
 
-  it("sorts arrays only when plain object items expose top-level type values", () => {
+  it("sorts typed-object arrays only for order-insensitive schema keywords", () => {
     expect(
       canonicalizeCodexAppServerProtocolJson({
-        enum: ["z", "a"],
+        anyOf: [
+          { z: 1, type: "string" },
+          { type: "integer", a: 2 },
+        ],
+        enum: [
+          { z: 1, type: "z" },
+          { type: "a", a: 2 },
+        ],
         mixed: [{ type: "b" }, "item", { type: "a" }],
         oneOf: [
-          { title: "Second", z: true },
-          { a: true, title: "First" },
+          { type: "object", z: true },
+          { a: true, type: "array" },
+          { type: "object", z: false },
         ],
-        required: ["z", "a"],
+        prefixItems: [
+          { z: 1, type: "string" },
+          { type: "number", a: 2 },
+        ],
+        required: [
+          { z: 1, type: "z" },
+          { type: "a", a: 2 },
+        ],
         typed: [
           { type: "beta", z: 1 },
           { type: "alpha", z: 2 },
@@ -223,16 +238,31 @@ describe("Codex app-server protocol JSON canonicalizer", () => {
         ],
       }),
     ).toEqual({
-      enum: ["z", "a"],
+      anyOf: [
+        { a: 2, type: "integer" },
+        { type: "string", z: 1 },
+      ],
+      enum: [
+        { a: 2, type: "a" },
+        { type: "z", z: 1 },
+      ],
       mixed: [{ type: "b" }, "item", { type: "a" }],
       oneOf: [
-        { title: "Second", z: true },
-        { a: true, title: "First" },
+        { a: true, type: "array" },
+        { type: "object", z: true },
+        { type: "object", z: false },
       ],
-      required: ["z", "a"],
+      prefixItems: [
+        { type: "string", z: 1 },
+        { a: 2, type: "number" },
+      ],
+      required: [
+        { a: 2, type: "a" },
+        { type: "z", z: 1 },
+      ],
       typed: [
-        { type: "alpha", z: 2 },
         { type: "beta", z: 1 },
+        { type: "alpha", z: 2 },
         { type: "beta", z: 3 },
       ],
     });


### PR DESCRIPTION
## Summary

- Address ClawSweeper feedback from #91507 by making Codex protocol JSON array sorting context-aware.
- Sort typed-object arrays under order-insensitive schema keywords: `anyOf`, `enum`, `oneOf`, and `required`.
- Preserve item order for `prefixItems`, generic typed arrays, and other arrays while still recursively canonicalizing object keys.
- Add focused regression coverage proving the allowlisted keys sort and `prefixItems` order is preserved.

## Verification

- `node scripts/run-vitest.mjs test/scripts/codex-app-server-protocol-source.test.ts`
- `node scripts/run-oxlint.mjs scripts/lib/codex-app-server-protocol-source.ts test/scripts/codex-app-server-protocol-source.test.ts`
- `git diff --check`
- generated JSON parse + canonical stability check over `extensions/codex/src/app-server/protocol-generated/json/**/*.json`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true pnpm codex-app-server:protocol:check` against sibling `../codex` at `rust-v0.139.0`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean: no accepted/actionable findings
