### PR TITLE
fix(webchat): finalize provider failure lifecycle

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -5198,6 +5198,8 @@ describe("runAgentTurnWithFallback", () => {
   });
 
   it("uses compact generic copy for raw external chat errors when verbose is off", async () => {
+    const agentEvents = await import("../../infra/agent-events.js");
+    const emitAgentEvent = vi.mocked(agentEvents.emitAgentEvent);
     state.runEmbeddedAgentMock.mockRejectedValueOnce(
       new Error("INVALID_ARGUMENT: some other failure"),
     );
@@ -5210,7 +5212,7 @@ describe("runAgentTurnWithFallback", () => {
         Provider: "whatsapp",
         MessageSid: "msg",
       } as unknown as TemplateContext,
-      opts: {},
+      opts: { runId: "run-provider-failure" } as GetReplyOptions,
       typingSignals: createMockTypingSignaler(),
       blockReplyPipeline: null,
       blockStreamingEnabled: false,
@@ -5230,6 +5232,21 @@ describe("runAgentTurnWithFallback", () => {
     if (result.kind === "final") {
       expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
     }
+    const terminalFailureEvent = emitAgentEvent.mock.calls
+      .map((call) => call[0])
+      .find((event) => {
+        if (!event || typeof event !== "object") {
+          return false;
+        }
+        const data = (event as { data?: Record<string, unknown> }).data;
+        return (
+          (event as { runId?: unknown }).runId === "run-provider-failure" &&
+          (event as { stream?: unknown }).stream === "lifecycle" &&
+          data?.phase === "error" &&
+          data.finalFailure === true
+        );
+      });
+    expect(terminalFailureEvent).toBeDefined();
   });
 
   it("uses heartbeat failure copy for raw external errors during heartbeat runs", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -5243,7 +5243,7 @@ describe("runAgentTurnWithFallback", () => {
           (event as { runId?: unknown }).runId === "run-provider-failure" &&
           (event as { stream?: unknown }).stream === "lifecycle" &&
           data?.phase === "error" &&
-          data.finalFailure === true
+          data.fallbackExhaustedFailure === true
         );
       });
     expect(terminalFailureEvent).toBeDefined();

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2940,7 +2940,7 @@ export async function runAgentTurnWithFallback(params: {
           phase: "error",
           error: message,
           endedAt: Date.now(),
-          finalFailure: true,
+          fallbackExhaustedFailure: true,
         },
       });
       params.replyOperation?.fail("run_failed", err);

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2932,6 +2932,17 @@ export async function runAgentTurnWithFallback(params: {
         cfg: params.followupRun.run.config,
       });
 
+      emitAgentEvent({
+        runId,
+        ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          error: message,
+          endedAt: Date.now(),
+          finalFailure: true,
+        },
+      });
       params.replyOperation?.fail("run_failed", err);
       return {
         kind: "final",

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2641,6 +2641,47 @@ describe("agent event handler", () => {
     expect(agentRunSeq.has("run-terminal-error")).toBe(false);
   });
 
+  it("finalizes fallback-exhausted lifecycle errors without waiting for retry grace", () => {
+    vi.useFakeTimers();
+    const { broadcast, clearAgentRunContext, agentRunSeq, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-terminal-error",
+      lifecycleErrorRetryGraceMs: 100,
+    });
+    registerAgentRunContext("run-terminal-final-failure", {
+      sessionKey: "session-terminal-error",
+    });
+
+    handler({
+      runId: "run-terminal-final-failure",
+      seq: 1,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: {
+        phase: "error",
+        error: "LLM request failed: network connection error.",
+        finalFailure: true,
+      },
+    });
+
+    const finalPayload = chatBroadcastCalls(broadcast).at(-1)?.[1] as {
+      state?: string;
+      runId?: string;
+      errorMessage?: string;
+    };
+    expect(finalPayload.state).toBe("error");
+    expect(finalPayload.runId).toBe("run-terminal-final-failure");
+    expect(finalPayload.errorMessage).toContain("network connection error");
+    expect(clearAgentRunContext).toHaveBeenCalledWith("run-terminal-final-failure");
+    expect(agentRunSeq.has("run-terminal-final-failure")).toBe(false);
+    expect(
+      persistGatewaySessionLifecycleEventMock.mock.calls.some(
+        ([params]) =>
+          (params as { event?: { data?: { finalFailure?: boolean } } }).event?.data
+            ?.finalFailure === true,
+      ),
+    ).toBe(true);
+  });
+
   it("keeps deferred lifecycle-error cleanup across later non-terminal events", () => {
     vi.useFakeTimers();
     const { broadcast, clearAgentRunContext, agentRunSeq, handler } = createHarness({

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2659,7 +2659,7 @@ describe("agent event handler", () => {
       data: {
         phase: "error",
         error: "LLM request failed: network connection error.",
-        finalFailure: true,
+        fallbackExhaustedFailure: true,
       },
     });
 
@@ -2676,8 +2676,8 @@ describe("agent event handler", () => {
     expect(
       persistGatewaySessionLifecycleEventMock.mock.calls.some(
         ([params]) =>
-          (params as { event?: { data?: { finalFailure?: boolean } } }).event?.data
-            ?.finalFailure === true,
+          (params as { event?: { data?: { fallbackExhaustedFailure?: boolean } } }).event?.data
+            ?.fallbackExhaustedFailure === true,
       ),
     ).toBe(true);
   });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1232,11 +1232,11 @@ export function createAgentEventHandler({
     if (lifecyclePhase === "error") {
       clearBufferedChatState(clientRunId);
       const skipChatErrorFinal = isChatSendRunActive(evt.runId) && !chatLink;
-      const isFinalFailure = evt.data?.finalFailure === true;
+      const isFallbackExhaustedFailure = evt.data?.fallbackExhaustedFailure === true;
       // Per-attempt provider errors keep the retry grace so fallback can reuse
       // the runId. Once the runner marks fallback as exhausted, clear chat state
       // immediately so webchat sessions do not stay in progress until the timer.
-      if (isAborted || isFinalFailure || lifecycleErrorRetryGraceMs <= 0) {
+      if (isAborted || isFallbackExhaustedFailure || lifecycleErrorRetryGraceMs <= 0) {
         finalizeLifecycleEvent(evt, { skipChatErrorFinal });
       } else {
         scheduleTerminalLifecycleError(evt, { skipChatErrorFinal });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1232,7 +1232,11 @@ export function createAgentEventHandler({
     if (lifecyclePhase === "error") {
       clearBufferedChatState(clientRunId);
       const skipChatErrorFinal = isChatSendRunActive(evt.runId) && !chatLink;
-      if (isAborted || lifecycleErrorRetryGraceMs <= 0) {
+      const isFinalFailure = evt.data?.finalFailure === true;
+      // Per-attempt provider errors keep the retry grace so fallback can reuse
+      // the runId. Once the runner marks fallback as exhausted, clear chat state
+      // immediately so webchat sessions do not stay in progress until the timer.
+      if (isAborted || isFinalFailure || lifecycleErrorRetryGraceMs <= 0) {
         finalizeLifecycleEvent(evt, { skipChatErrorFinal });
       } else {
         scheduleTerminalLifecycleError(evt, { skipChatErrorFinal });

--- a/test/scripts/check-deadcode-unused-files.test.ts
+++ b/test/scripts/check-deadcode-unused-files.test.ts
@@ -208,7 +208,9 @@ src/a.ts: src/a.ts
 
     await resultPromise;
 
-    expect(calls[0]).toMatchObject({
+    const call = calls[0] as { command: string };
+    expect(path.basename(call.command)).toBe("pnpm");
+    expect(call).toMatchObject({
       args: [
         "--config.minimum-release-age=0",
         "dlx",
@@ -224,7 +226,6 @@ src/a.ts: src/a.ts
         "--files",
         "--no-config-hints",
       ],
-      command: "pnpm",
       options: {
         detached: process.platform !== "win32",
         shell: false,


### PR DESCRIPTION
Fixes #91730

## Summary
- Emit a marked final lifecycle error after embedded provider fallback is exhausted.
- Let the gateway finalize that marked error immediately while preserving retry grace for per-attempt fallback errors.
- Cover both the final-failure marker and the immediate gateway cleanup path with focused regression tests.
- Stabilize the deadcode unused-files test against CI resolving `pnpm` as an absolute runner path while preserving exact args/options checks.

## Verification
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts src/gateway/server-chat.agent-events.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts ui/src/ui/chat/run-lifecycle.test.ts ui/src/ui/session-run-state.test.ts ui/src/ui/app-chat.test.ts src/gateway/session-lifecycle-state.test.ts`
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts`
- `node scripts/run-vitest.mjs test/scripts/openclaw-e2e-instance.test.ts`
- `node scripts/run-vitest.mjs test/scripts/check-deadcode-unused-files.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts`
- `corepack pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts src/gateway/server-chat.ts src/gateway/server-chat.agent-events.test.ts`
- `node scripts/run-oxlint.mjs src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts src/gateway/server-chat.ts src/gateway/server-chat.agent-events.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 test/scripts/check-deadcode-unused-files.test.ts`
- `node scripts/run-oxlint.mjs test/scripts/check-deadcode-unused-files.test.ts`
- `git diff --check`
- `corepack pnpm openclaw --version` -> `OpenClaw 2026.6.2 (c604b58)`

## Real behavior proof
Behavior addressed: OpenClaw-native provider failures that exhaust fallback now produce a final lifecycle error signal, so the gateway clears the webchat run and persists terminal failed session state immediately instead of leaving the session in progress/running.

Real environment tested: Patched local checkout `/Users/andy/openclaw-91730-provider-failure` on macOS, head `c604b584263bd554d5246dd5d8437b48add0aa4f`, build `OpenClaw 2026.6.2 (c604b58)`, isolated temp `OPENCLAW_HOME=/tmp/openclaw-91730-proof-cifix-IYxcUk`, gateway on loopback port `18796`, token auth with a throwaway proof token, default dev agent model `openai/gpt-5.5`, and deliberately invalid `OPENAI_API_KEY=sk-openc*************alid`. The provider failure used the real embedded runtime against OpenAI Responses websocket/HTTP endpoints; no provider mock was used for this proof.

Exact steps or command run after this patch: Started the temp gateway with `OPENCLAW_HOME=/tmp/openclaw-91730-proof-cifix-IYxcUk OPENAI_API_KEY=<invalid> corepack pnpm openclaw gateway run --dev --reset --port 18796 --auth token --token <throwaway> --tailscale off --compact --verbose`. Connected a loopback backend WebSocket client with shared-token auth and scopes `operator.read,operator.write`, verified `health` and an empty `sessions.list`, then sent `chat.send` with `sessionKey=agent:dev:main`, `message=PR91895_PROOF_TRIGGER provider failure lifecycle ci-fix`, and `idempotencyKey=pr91895-proof-cifix-20260610T0231`. After the terminal chat event, queried `sessions.list`, `chat.history`, and `health`, then stopped the temp gateway cleanly.

Evidence after fix: Gateway logs showed the real runtime starting the turn and contacting OpenAI, then failing on invalid auth:

```text
OpenClaw 2026.6.2 (c604b58)
[ws] ⇄ res ✓ chat.send 5ms runId=pr91895-proof-cifix-20260610T0231
[diagnostic] session turn created: runId=pr91895-proof-cifix-20260610T0231 sessionId=354fa727-3b28-46a9-9045-f52efd334c1b sessionKey=agent:dev:main agentId=dev channel=webchat trigger=user
[agent/embedded] ... failed to connect to websocket: HTTP error: 401 Unauthorized, url: wss://api.openai.com/v1/responses
[agent/embedded] ... Incorrect API key provided: sk-openc*************alid ... auth error code: invalid_api_key
[ws] -> event agent ... stream=lifecycle ... phase=error
[diagnostic] session state: sessionId=354fa727-3b28-46a9-9045-f52efd334c1b sessionKey=agent:dev:main prev=processing new=idle reason="run_completed" queueDepth=0
[diagnostic] run cleared: sessionId=354fa727-3b28-46a9-9045-f52efd334c1b totalActive=0
[model-fallback/decision] model fallback decision: decision=candidate_failed requested=openai/gpt-5.5 candidate=openai/gpt-5.5 reason=rate_limit next=none detail=unexpected status 401 Unauthorized ... auth error code: invalid_api_key
[ws] -> event agent ... stream=lifecycle ... phase=fallback_step
[ws] -> event agent ... stream=lifecycle ... phase=error
[diagnostic] message processed: channel=webchat ... sessionKey=agent:dev:main outcome=completed
[shutdown] completed cleanly in 110ms
```

The proof client observed the terminal chat event:

```json
{
  "chatSendAck": { "runId": "pr91895-proof-cifix-20260610T0231", "status": "started" },
  "terminalChatEvent": {
    "runId": "pr91895-proof-cifix-20260610T0231",
    "sessionKey": "agent:dev:main",
    "state": "error",
    "errorMessage": "unexpected status 401 Unauthorized: Incorrect API key provided: sk-openc*************alid..."
  }
}
```

A settled `sessions.list` after `message_completed` showed terminal failed state and no active run:

```json
{
  "key": "agent:dev:main",
  "sessionId": "354fa727-3b28-46a9-9045-f52efd334c1b",
  "status": "failed",
  "startedAt": 1781083947833,
  "endedAt": 1781083966242,
  "runtimeMs": 18409,
  "modelProvider": "openai",
  "model": "gpt-5.5",
  "agentRuntime": { "id": "codex", "source": "implicit" },
  "deliveryContext": { "channel": "webchat" },
  "lastChannel": "webchat",
  "hasActiveRun": false
}
```

The same proof client also saw `healthBefore.ok=true`, `healthAfter.ok=true`, `healthAfter.sessionCount=1`, `historySummary.ok=true`, and `historySummary.messageCount=1`.

Observed result after fix: The live temp-gateway turn produced a visible terminal `chat` error event, cleared the active run (`totalActive=0`), and persisted the session as `status:"failed"` with `endedAt`, `runtimeMs`, and `hasActiveRun:false`. Health remained OK after the failure, and the temp proof gateway was stopped cleanly after the proof.

What was not tested: I did not reproduce the exact reporter environment of Linux plus OpenAI OAuth on `openai/gpt-5.4-mini`; the proof uses the same OpenClaw-native provider failure class with a deliberately invalid OpenAI API key so it can be reproduced safely without live credentials. At the time of this final proof update, GitHub Actions and ClawSweeper re-review still need to run on the amended head.