### PR TITLE
test(ci): expect 16vcpu runners for QA-Lab parity and live lanes

### DIFF
--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1396,7 +1396,7 @@ describe("package artifact reuse", () => {
       "run_live_discord",
     ]) {
       expect(qaWorkflow).toMatch(
-        new RegExp(`${jobName}:[\\s\\S]*?runs-on: blacksmith-8vcpu-ubuntu-2404`, "u"),
+        new RegExp(`${jobName}:[\\s\\S]*?runs-on: blacksmith-16vcpu-ubuntu-2404`, "u"),
       );
     }
     expectTextToIncludeAll(liveE2eWorkflow, [


### PR DESCRIPTION
## Problem

`build-artifacts` (`core-support-boundary`) currently fails on `main` itself and on every PR whose merge ref includes current `main`:

```
AssertionError: expected 'name: QA-Lab - All Lanes...' to match /run_mock_parity:[\s\S]*?runs-on: blacksmith-8vcpu-ubuntu-2404/u
```

Failing `main` push runs (unrelated commits, same assertion):
- https://github.com/openclaw/openclaw/actions/runs/27261976003
- https://github.com/openclaw/openclaw/actions/runs/27262302738

## Cause

d07cd4c9 ("fix(ci): give QA builds larger runners") moved `run_mock_parity`, `run_live_matrix`, `run_live_matrix_sharded`, `run_live_telegram`, and `run_live_discord` in `.github/workflows/qa-live-transports-convex.yml` from `blacksmith-8vcpu-ubuntu-2404` to `blacksmith-16vcpu-ubuntu-2404`, but the "keeps release QA and repo E2E lanes off scarce 32-core runners" assertion in `test/scripts/package-acceptance-workflow.test.ts` still expects the 8vcpu label for those five jobs. The assertion is a deterministic readFileSync + regex match against the workflow file, so it fails on every run that includes both commits. The breaking push's own run was cancelled by the immediately following push, so the failure first surfaced on later runs.

## Fix

One line: update the expected label to `blacksmith-16vcpu-ubuntu-2404`. The intent is unchanged - the QA lanes stay off the scarce 32-core runners.

## Real behavior proof

Behavior or issue addressed: the `run_mock_parity`/`run_live_*` runner-label assertion in `test/scripts/package-acceptance-workflow.test.ts` contradicts the real `.github/workflows/qa-live-transports-convex.yml` on current `main`, so `core-support-boundary` inside `build-artifacts` fails for every merge ref that includes d07cd4c9 (see the two `main` push runs linked above for live before-fix failures).

Real environment tested: Windows host, Node v24.15.0, against the real workflow file content of `openclaw/openclaw@3b180d5d9919` (current `main` head at the time of the run).

Exact steps or command run after this patch:

```
node replay-assertion.mjs qa-workflow-main.yml
```

where `replay-assertion.mjs` rebuilds the identical regex the assertion constructs, for both the old expectation and this PR's expectation:

```js
const qaWorkflow = readFileSync(path, "utf8");
const jobs = ["run_mock_parity", "run_live_matrix", "run_live_matrix_sharded",
  "run_live_telegram", "run_live_discord"];
for (const label of ["blacksmith-8vcpu-ubuntu-2404", "blacksmith-16vcpu-ubuntu-2404"]) {
  for (const jobName of jobs) {
    const re = new RegExp(`${jobName}:[\\s\\S]*?runs-on: ${label}`, "u");
    console.log(`  ${jobName}: ${re.test(qaWorkflow) ? "MATCH" : "NO MATCH (assertion fails)"}`);
  }
}
```

Evidence after fix: copied live console output from the command above:

```
workflow source: .github/workflows/qa-live-transports-convex.yml at openclaw/openclaw@3b180d5d9919
workflow bytes: 30336

expectation: runs-on: blacksmith-8vcpu-ubuntu-2404  (current expectation on main)
  run_mock_parity: NO MATCH (assertion fails)
  run_live_matrix: NO MATCH (assertion fails)
  run_live_matrix_sharded: NO MATCH (assertion fails)
  run_live_telegram: NO MATCH (assertion fails)
  run_live_discord: NO MATCH (assertion fails)

expectation: runs-on: blacksmith-16vcpu-ubuntu-2404  (this PR)
  run_mock_parity: MATCH
  run_live_matrix: MATCH
  run_live_matrix_sharded: MATCH
  run_live_telegram: MATCH
  run_live_discord: MATCH
```

Observed result after fix: with the old 8vcpu expectation the assertion fails for all five jobs against the real current workflow content (reproducing the failing check); with this PR's 16vcpu expectation all five assertions match, so `core-support-boundary` no longer trips on the runner labels.

What was not tested: no full repository suite run on this host; this change is a one-line expectation update and the replay above exercises the exact regex contract the assertion builds. No workflow file behavior is changed by this PR.

## Verification

- Current `main` `.github/workflows/qa-live-transports-convex.yml`: all five listed jobs use `runs-on: blacksmith-16vcpu-ubuntu-2404` (no job in the assertion's list remains on the 8vcpu label).
- The two linked `main` push runs show the exact failing assertion inside the `core-support-boundary` lane of `build-artifacts`.
- After this change the regex matches the current workflow content for all five job names.
