### PR TITLE
feat(plugins): support toolsAllow in subagent runtime API

### DIFF
--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -17,6 +17,7 @@ export type SubagentRunParams = {
   lightContext?: boolean;
   deliver?: boolean;
   idempotencyKey?: string;
+  toolsAllow?: string[];
 };
 
 export type SubagentRunResult = {


### PR DESCRIPTION
## Summary

What problem does this PR solve?
   Currently, plugins using the runtime.subagent.run API cannot specify a restricted set of tools for the subagent to use. This limits the ability to delegate specialized, sandboxed tasks where only a subset of capabilities (e.g., only "

Why does this matter now?
   As multi-agent delegation patterns become more common (especially for complex expert-agent workflows), the orchestrating plugin needs a standard way to enforce tool allowlists at the subagent runtime boundary to ensure safety and specialized behavior.

What is the intended outcome?
* Extends SubagentRunParams to include an optional toolsAllow array of strings.
* Enables plugins to pass tool IDs (or patterns like *) to downstream agent runners via the standard runtime API.

What is intentionally out of scope?
This PR focuses on the Plugin Runtime API boundary. The actual enforcement of these tools in the Gateway and Embedded Agent Runner is handled by the core  execution engine which already understands the toolsAllow parameter.

What does success look like?
Plugins can successfully pass toolsAllow to runtime.subagent.run, and the parameter is correctly propagated to the underlying agent runner.

What should reviewers focus on?
* Consistency of the toolsAllow naming with other parts of the system (e.g., Cron jobs and Embedded Runner params).
* Correct placement in SubagentRunParams.

## Linked context

Which issue does this close?

Closes # (N/A - Internal API expansion)

Which issues, PRs, or discussions are related?

Related #N/A 

Was this requested by a maintainer or owner?
No

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:Lack of toolsAllow in the subagent runtime type definitions
- Real environment tested:Local development environment (Linux).
- Exact steps or command run after this patch:
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
<img width="427" height="164" alt="image" src="https://github.com/user-attachments/assets/c5e1c5b7-f2c6-4c08-9469-92adda74857f" /> I wrote a plugin and verified it worked.

- Observed result after fix: Running pnpm tsc in src/plugins/runtime succeeds with the new field usage.


## Tests and validation

Which commands did you run?
pnpm tsc, pnpm build, pnpm gateway:watch

What regression coverage was added or updated?
Updated the SubagentRunParams interface.

If no test was added, why not?
This is a type-level expansion for an existing interface. Existing tests for the subagent runtime (e.g., src/plugins/runtime/index.test.ts) continue to  pass as the field is optional.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
No
Did config, environment, or migration behavior change? (`Yes/No`)
No
Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
No
What is the highest-risk area?
Compatibility with internal agent runners that expect this field.
How is that risk mitigated?
The field is optional and aligns with the existing toolsAllow field already supported by the EmbeddedAgentRunner.
## Current review state

What is the next action?

What is still waiting on author, maintainer, CI, or external proof?

Which bot or reviewer comments were addressed?

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
