### PR TITLE
fix(test): skip live auth browser caches

### DIFF
--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -133,6 +133,29 @@ describe("installTestEnv", () => {
       path.join(realHome, ".codex", "sessions", "2026", "02", "26", "rollout.jsonl"),
       "session\n",
     );
+    writeFile(path.join(realHome, ".gemini", "oauth_creds.json"), '{"token":"gemini"}\n');
+    writeFile(path.join(realHome, ".gemini", "settings.json"), '{"theme":"dark"}\n');
+    writeFile(
+      path.join(
+        realHome,
+        ".gemini",
+        "antigravity-browser-profile",
+        "Default",
+        "Cache",
+        "Cache_Data",
+        "blob",
+      ),
+      "cached-browser-bytes\n",
+    );
+    writeFile(
+      path.join(realHome, ".gemini", "antigravity", "browser_recordings", "session.webm"),
+      "recording\n",
+    );
+    writeFile(path.join(realHome, ".gemini", "GPUCache", "data.bin"), "gpu-cache\n");
+    writeFile(
+      path.join(realHome, ".gemini", "Service Worker", "CacheStorage", "cache.bin"),
+      "worker-cache\n",
+    );
 
     setTestEnvValue("HOME", realHome);
     setTestEnvValue("USERPROFILE", realHome);
@@ -214,6 +237,18 @@ describe("installTestEnv", () => {
     expect(fs.existsSync(path.join(testEnv.tempHome, ".codex", "auth.json"))).toBe(true);
     expect(fs.existsSync(path.join(testEnv.tempHome, ".codex", "config.toml"))).toBe(true);
     expect(fs.existsSync(path.join(testEnv.tempHome, ".codex", "sessions"))).toBe(false);
+    expect(fs.existsSync(path.join(testEnv.tempHome, ".gemini", "oauth_creds.json"))).toBe(true);
+    expect(fs.existsSync(path.join(testEnv.tempHome, ".gemini", "settings.json"))).toBe(true);
+    expect(
+      fs.existsSync(path.join(testEnv.tempHome, ".gemini", "antigravity-browser-profile")),
+    ).toBe(false);
+    expect(
+      fs.existsSync(path.join(testEnv.tempHome, ".gemini", "antigravity", "browser_recordings")),
+    ).toBe(false);
+    expect(fs.existsSync(path.join(testEnv.tempHome, ".gemini", "GPUCache"))).toBe(false);
+    expect(
+      fs.existsSync(path.join(testEnv.tempHome, ".gemini", "Service Worker", "CacheStorage")),
+    ).toBe(false);
   });
 
   it("allows explicit live runs against the real HOME", () => {

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -135,6 +135,8 @@ describe("installTestEnv", () => {
     );
     writeFile(path.join(realHome, ".gemini", "oauth_creds.json"), '{"token":"gemini"}\n');
     writeFile(path.join(realHome, ".gemini", "settings.json"), '{"theme":"dark"}\n');
+    writeFile(path.join(realHome, ".gemini", "commands", "Cache", "review.toml"), "prompt\n");
+    writeFile(path.join(realHome, ".minimax", "Cache", "credentials.json"), "minimax\n");
     writeFile(
       path.join(
         realHome,
@@ -150,6 +152,10 @@ describe("installTestEnv", () => {
     writeFile(
       path.join(realHome, ".gemini", "antigravity", "browser_recordings", "session.webm"),
       "recording\n",
+    );
+    writeFile(
+      path.join(realHome, ".gemini", "cli-browser-profile", "Default", "History"),
+      "browser-history\n",
     );
     writeFile(path.join(realHome, ".gemini", "GPUCache", "data.bin"), "gpu-cache\n");
     writeFile(
@@ -240,11 +246,20 @@ describe("installTestEnv", () => {
     expect(fs.existsSync(path.join(testEnv.tempHome, ".gemini", "oauth_creds.json"))).toBe(true);
     expect(fs.existsSync(path.join(testEnv.tempHome, ".gemini", "settings.json"))).toBe(true);
     expect(
+      fs.existsSync(path.join(testEnv.tempHome, ".gemini", "commands", "Cache", "review.toml")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(testEnv.tempHome, ".minimax", "Cache", "credentials.json")),
+    ).toBe(true);
+    expect(
       fs.existsSync(path.join(testEnv.tempHome, ".gemini", "antigravity-browser-profile")),
     ).toBe(false);
     expect(
       fs.existsSync(path.join(testEnv.tempHome, ".gemini", "antigravity", "browser_recordings")),
     ).toBe(false);
+    expect(fs.existsSync(path.join(testEnv.tempHome, ".gemini", "cli-browser-profile"))).toBe(
+      false,
+    );
     expect(fs.existsSync(path.join(testEnv.tempHome, ".gemini", "GPUCache"))).toBe(false);
     expect(
       fs.existsSync(path.join(testEnv.tempHome, ".gemini", "Service Worker", "CacheStorage")),

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -31,6 +31,15 @@ const LIVE_EXTERNAL_AUTH_FILES = [
   ".codex/auth.json",
   ".codex/config.toml",
 ] as const;
+const LIVE_EXTERNAL_AUTH_EXCLUDED_DIRS = new Set([
+  "antigravity-browser-profile",
+  "browser_recordings",
+  "Cache",
+  "Cache_Data",
+  "Code Cache",
+  "GPUCache",
+  "CacheStorage",
+]);
 const requireFromHere = createRequire(import.meta.url);
 
 type LegacyConfigCompatApi = typeof import("../src/commands/doctor/shared/legacy-config-compat.js");
@@ -264,7 +273,21 @@ function ensureParentDir(targetPath: string): void {
   fs.mkdirSync(path.dirname(targetPath), { recursive: true });
 }
 
-function copyDirIfExists(sourcePath: string, targetPath: string): void {
+function shouldStageLiveExternalAuthPath(sourceRoot: string, sourcePath: string): boolean {
+  const relativePath = path.relative(sourceRoot, sourcePath);
+  if (!relativePath || relativePath.startsWith("..")) {
+    return true;
+  }
+  return relativePath
+    .split(path.sep)
+    .every((segment) => !LIVE_EXTERNAL_AUTH_EXCLUDED_DIRS.has(segment));
+}
+
+function copyDirIfExists(
+  sourcePath: string,
+  targetPath: string,
+  options?: { filter?: (sourcePath: string) => boolean },
+): void {
   if (!fs.existsSync(sourcePath)) {
     return;
   }
@@ -272,6 +295,7 @@ function copyDirIfExists(sourcePath: string, targetPath: string): void {
   fs.cpSync(sourcePath, targetPath, {
     recursive: true,
     force: true,
+    filter: options?.filter,
   });
 }
 
@@ -423,7 +447,10 @@ function stageLiveTestState(params: {
   copyLiveAuthProfiles(realStateDir, tempStateDir);
 
   for (const authDir of LIVE_EXTERNAL_AUTH_DIRS) {
-    copyDirIfExists(path.join(params.realHome, authDir), path.join(params.tempHome, authDir));
+    const sourcePath = path.join(params.realHome, authDir);
+    copyDirIfExists(sourcePath, path.join(params.tempHome, authDir), {
+      filter: (entryPath) => shouldStageLiveExternalAuthPath(sourcePath, entryPath),
+    });
   }
   for (const authFile of LIVE_EXTERNAL_AUTH_FILES) {
     copyFileIfExists(path.join(params.realHome, authFile), path.join(params.tempHome, authFile));

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -31,15 +31,14 @@ const LIVE_EXTERNAL_AUTH_FILES = [
   ".codex/auth.json",
   ".codex/config.toml",
 ] as const;
-const LIVE_EXTERNAL_AUTH_EXCLUDED_DIRS = new Set([
+// Keep Gemini credentials and user configuration; only generated browser data can be dropped.
+const LIVE_GEMINI_EXCLUDED_PATHS = [
   "antigravity-browser-profile",
-  "browser_recordings",
-  "Cache",
-  "Cache_Data",
-  "Code Cache",
+  "antigravity/browser_recordings",
+  "cli-browser-profile",
   "GPUCache",
-  "CacheStorage",
-]);
+  "Service Worker/CacheStorage",
+] as const;
 const requireFromHere = createRequire(import.meta.url);
 
 type LegacyConfigCompatApi = typeof import("../src/commands/doctor/shared/legacy-config-compat.js");
@@ -273,14 +272,16 @@ function ensureParentDir(targetPath: string): void {
   fs.mkdirSync(path.dirname(targetPath), { recursive: true });
 }
 
-function shouldStageLiveExternalAuthPath(sourceRoot: string, sourcePath: string): boolean {
+function shouldStageLiveGeminiPath(sourceRoot: string, sourcePath: string): boolean {
   const relativePath = path.relative(sourceRoot, sourcePath);
   if (!relativePath || relativePath.startsWith("..")) {
     return true;
   }
-  return relativePath
-    .split(path.sep)
-    .every((segment) => !LIVE_EXTERNAL_AUTH_EXCLUDED_DIRS.has(segment));
+  const normalizedPath = relativePath.split(path.sep).join("/");
+  return !LIVE_GEMINI_EXCLUDED_PATHS.some(
+    (excludedPath) =>
+      normalizedPath === excludedPath || normalizedPath.startsWith(`${excludedPath}/`),
+  );
 }
 
 function copyDirIfExists(
@@ -448,9 +449,11 @@ function stageLiveTestState(params: {
 
   for (const authDir of LIVE_EXTERNAL_AUTH_DIRS) {
     const sourcePath = path.join(params.realHome, authDir);
-    copyDirIfExists(sourcePath, path.join(params.tempHome, authDir), {
-      filter: (entryPath) => shouldStageLiveExternalAuthPath(sourcePath, entryPath),
-    });
+    const filter =
+      authDir === ".gemini"
+        ? (entryPath: string) => shouldStageLiveGeminiPath(sourcePath, entryPath)
+        : undefined;
+    copyDirIfExists(sourcePath, path.join(params.tempHome, authDir), { filter });
   }
   for (const authFile of LIVE_EXTERNAL_AUTH_FILES) {
     copyFileIfExists(path.join(params.realHome, authFile), path.join(params.tempHome, authFile));


### PR DESCRIPTION
## Summary

- Prevent live test auth staging from copying generated browser profile, cache, and recording trees from external auth directories such as `.gemini`.
- Preserve staged auth/config files, including `.gemini/oauth_creds.json` and `.gemini/settings.json`.
- Keep the filter limited to external auth directory staging so `.openclaw/credentials` and plugin state copying are unchanged.

## Linked context

Closes #91893

Related #91893

Was this requested by a maintainer or owner? No.

## Real behavior proof (required for external PRs)

- Behavior addressed: live test HOME staging no longer copies generated `.gemini` browser cache/profile/recording trees while preserving Gemini auth files.
- Real environment tested: local macOS temp checkout with `OPENCLAW_LIVE_TEST=1`, using a temporary HOME containing `.gemini` auth files plus cache-like browser directories.
- Exact steps or command run after this patch: `node --import tsx --input-type=module` with a temp HOME fixture, importing `installTestEnv` from `test/test-env.ts`, then checking the staged temp HOME.
- Evidence after fix:

```json
{
  "tempHomeDiffers": true,
  "copiedGeminiOauth": true,
  "copiedGeminiSettings": true,
  "skippedBrowserProfile": true,
  "skippedRecordings": true,
  "skippedGpuCache": true,
  "skippedServiceWorkerCache": true
}
```

- Observed result after fix: the live test temp HOME kept Gemini auth files but did not stage the generated browser profile, recordings, GPU cache, or service worker cache trees.
- What was not tested: a real multi-GB Antigravity profile was not copied or created.
- Proof limitations or environment constraints: the proof uses small cache-shaped fixtures to avoid intentionally consuming disk space.
- Before evidence: current `origin/main` has `copyDirIfExists` using recursive `fs.cpSync` with no filter for `.gemini` staging.

## Tests and validation

- `node scripts/run-vitest.mjs test/test-env.test.ts` passed, 4 tests.
- `pnpm exec oxfmt --check --threads=1 test/test-env.ts test/test-env.test.ts` passed.
- `pnpm changed:lanes --json` selected only `tooling`.
- `git diff --check` passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm check:changed` passed.

Direct `pnpm check:changed` could not start because the local Crabbox binary failed its basic sanity check before running the gate.

Regression coverage adds `.gemini` auth files plus generated browser cache/profile fixtures to the existing live HOME staging test.

## Risk checklist

Did user-visible behavior change? No.

Did config, environment, or migration behavior change? No.

Did security, auth, secrets, network, or tool execution behavior change? No.

What is the highest-risk area? Over-filtering live test auth staging.

How is that risk mitigated? The filter applies only to external auth directory staging and the regression test proves Gemini auth/settings files still copy.

## Current review state

What is the next action? Maintainer review.

What is still waiting on author, maintainer, CI, or external proof? CI and ClawSweeper review.

Which bot or reviewer comments were addressed? None yet.
