### PR TITLE
fix(test): exclude browser cache dirs from copyDirIfExists in live test staging

### DIFF
--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -251,6 +251,48 @@ describe("installTestEnv", () => {
     expect(process.env.TEST_PROFILE_ONLY).toBeUndefined();
   });
 
+  it("excludes browser cache and recording directories during live test staging", () => {
+    const realHome = createTempHome();
+
+    // Auth file that should be copied
+    writeFile(path.join(realHome, ".gemini", "auth.json"), '{"key":"value"}\n');
+
+    // Cache directories that should be excluded
+    const cacheDirs = [
+      path.join(realHome, ".gemini", "antigravity-browser-profile", "Default", "Cache", "Cache_Data", "data_0"),
+      path.join(realHome, ".gemini", "antigravity-browser-profile", "Default", "GPUCache", "index"),
+      path.join(realHome, ".gemini", "antigravity", "browser_recordings", "session.json"),
+      path.join(realHome, ".gemini", "Service Worker", "CacheStorage", "index"),
+    ];
+    for (const cacheFile of cacheDirs) {
+      writeFile(cacheFile, "cache-data");
+    }
+
+    process.env.HOME = realHome;
+    process.env.USERPROFILE = realHome;
+    process.env.OPENCLAW_LIVE_TEST = "1";
+    process.env.OPENCLAW_LIVE_TEST_QUIET = "1";
+
+    const testEnv = installTestEnv();
+    cleanupFns.push(testEnv.cleanup);
+
+    // Auth file should be copied
+    expect(
+      fs.existsSync(path.join(testEnv.tempHome, ".gemini", "auth.json")),
+    ).toBe(true);
+
+    // Cache directories should NOT be copied
+    expect(
+      fs.existsSync(path.join(testEnv.tempHome, ".gemini", "antigravity-browser-profile")),
+    ).toBe(false);
+    expect(
+      fs.existsSync(path.join(testEnv.tempHome, ".gemini", "antigravity", "browser_recordings")),
+    ).toBe(false);
+    expect(
+      fs.existsSync(path.join(testEnv.tempHome, ".gemini", "Service Worker", "CacheStorage")),
+    ).toBe(false);
+  });
+
   it("falls back to parsing ~/.profile when bash is unavailable", async () => {
     const realHome = createTempHome();
     writeFile(path.join(realHome, ".profile"), "export TEST_PROFILE_ONLY=from-profile\n");

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -249,6 +249,15 @@ function ensureParentDir(targetPath: string): void {
   fs.mkdirSync(path.dirname(targetPath), { recursive: true });
 }
 
+const COPY_EXCLUDE_SEGMENTS = new Set([
+  "Cache",
+  "Cache_Data",
+  "GPUCache",
+  "browser_recordings",
+  "antigravity-browser-profile",
+  "CacheStorage",
+]);
+
 function copyDirIfExists(sourcePath: string, targetPath: string): void {
   if (!fs.existsSync(sourcePath)) {
     return;
@@ -257,6 +266,10 @@ function copyDirIfExists(sourcePath: string, targetPath: string): void {
   fs.cpSync(sourcePath, targetPath, {
     recursive: true,
     force: true,
+    filter: (src) => {
+      const segments = src.split(path.sep);
+      return !segments.some((seg) => COPY_EXCLUDE_SEGMENTS.has(seg));
+    },
   });
 }
 


### PR DESCRIPTION
## Problem

`test/test-env.ts` `copyDirIfExists` uses `fs.cpSync` with `{ recursive: true, force: true }` but no `filter` option. When `.gemini` contains a browser profile (e.g. from the Antigravity browser), the entire multi-GB cache is copied blindly into the temp test home, causing ENOSPC.

Fixes #91893

## Changes

- Add `COPY_EXCLUDE_SEGMENTS` set with known cache/recording directory names: `Cache`, `Cache_Data`, `GPUCache`, `browser_recordings`, `antigravity-browser-profile`, `CacheStorage`
- Add `filter` callback to `fs.cpSync` in `copyDirIfExists` that skips any path containing these segments
- Auth files like `.gemini/auth.json` continue to be copied normally
- Add regression test verifying cache dirs are excluded while auth files are preserved

## Real behavior proof

**Behavior or issue addressed:** `copyDirIfExists` copies multi-GB browser cache directories during live test staging, causing ENOSPC

**Real environment tested:** Linux (Debian 12 bookworm, WSL2), Node v24.16.0, commit `abf75e1f`

**Exact steps or command run after this patch:**
```bash
cd /root/.openclaw/workspace/openclaw-repo
node scripts/run-vitest.mjs run test/test-env.test.ts
```

**Evidence after fix:**
```
[test] starting test/vitest/vitest.tooling.config.ts

 RUN  v4.1.7 /root/.openclaw/workspace/openclaw-repo

 ✓ tooling test/test-env.test.ts (5 tests) 385ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  09:11:01
   Duration  3.79s (transform 5.20s, setup 4.53s, import 692ms, tests 385ms, environment 0ms)

[test] passed 1 Vitest shard in 22.94s
```

**Observed result after fix:** All 5 tests pass, including the new regression test that verifies `antigravity-browser-profile`, `browser_recordings`, and `CacheStorage` directories are excluded from copying while `.gemini/auth.json` is still copied.

**What was not tested:** Live ENOSPC reproduction with actual multi-GB cache directories (would require creating large temp artifacts). The fix is validated through source inspection and unit tests with small fixtures.