### PR TITLE
fix(agents): retry same model across short rate-limit windows

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -10,9 +10,12 @@ import {
   loadRunOverflowCompactionHarness,
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
+  mockedIsFailoverAssistantError,
+  mockedIsRateLimitAssistantError,
   mockedLog,
   mockedRunEmbeddedAttempt,
   mockedResolveModelAsync,
+  mockedSleepWithAbort,
   overflowBaseRunParams,
   resetRunOverflowCompactionHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
@@ -406,6 +409,71 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       result: "success",
       stage: "assistant",
     });
+  });
+
+  it("records same-model rate-limit retries without a profile-rotation trace", async () => {
+    const rateLimitMessage =
+      "429 rate_limit_exceeded: requests per minute exceeded; Retry-After: 30";
+    mockedClassifyFailoverReason.mockImplementation((raw) =>
+      raw.includes("429") ? "rate_limit" : null,
+    );
+    mockedIsFailoverAssistantError.mockImplementation((assistant) =>
+      Boolean(assistant?.errorMessage?.includes("429")),
+    );
+    mockedIsRateLimitAssistantError.mockImplementation((assistant) =>
+      Boolean(assistant?.errorMessage?.includes("429")),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "error",
+          provider: "openai",
+          model: "gpt-5.5",
+          errorMessage: rateLimitMessage,
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Recovered after a short rate-limit wait."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [{ type: "text", text: "Recovered after a short rate-limit wait." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-same-model-rate-limit-trace",
+    });
+
+    expect(mockedSleepWithAbort).toHaveBeenCalledWith(30_000, undefined);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.meta.executionTrace?.fallbackUsed).toBe(false);
+    expect(result.meta.executionTrace?.attempts).toMatchObject([
+      {
+        provider: "openai",
+        model: "gpt-5.5",
+        result: "same_model_rate_limit",
+        reason: "rate_limit",
+        stage: "assistant",
+      },
+      {
+        provider: "openai",
+        model: "gpt-5.5",
+        result: "success",
+        stage: "assistant",
+      },
+    ]);
   });
 
   it("auto-activates strict-agentic for unconfigured GPT-5 openai runs and surfaces the blocked state", async () => {

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -118,6 +118,9 @@ export const mockedResolveContextEngine = vi.fn(async () => mockedContextEngine)
 export const mockedResolveContextEngineOwnerPluginId = vi.fn(() => undefined);
 export const mockedBuildAgentRuntimePlan = vi.fn(() => ({}));
 export const mockedRunPostCompactionSideEffects = vi.fn(async () => {});
+export const mockedSleepWithAbort = vi.fn(
+  async (_ms: number, _abortSignal?: AbortSignal) => undefined,
+);
 export const mockedEnsureRuntimePluginsLoaded = vi.fn<(params?: unknown) => void>();
 export const mockedResolveModelAsync = vi.fn(
   async (): Promise<MockResolveModelResult> => ({
@@ -171,6 +174,7 @@ type MockCoerceToFailoverError = (
 ) => unknown;
 type MockDescribeFailoverError = (err: unknown) => MockFailoverErrorDescription;
 type MockResolveFailoverStatus = (reason: string) => number | undefined;
+type MockAssistantErrorProbe = (assistant?: { errorMessage?: string }) => boolean;
 export class MockedFailoverError extends Error {
   constructor(message: string) {
     super(message);
@@ -215,7 +219,7 @@ export const mockedFormatAssistantErrorText = vi.fn(() => "");
 export const mockedIsAuthAssistantError = vi.fn(() => false);
 export const mockedIsBillingAssistantError = vi.fn(() => false);
 export const mockedIsCompactionFailureError = vi.fn(() => false);
-export const mockedIsFailoverAssistantError = vi.fn(() => false);
+export const mockedIsFailoverAssistantError = vi.fn<MockAssistantErrorProbe>(() => false);
 export const mockedIsFailoverErrorMessage = vi.fn(() => false);
 export const mockedIsLikelyContextOverflowError = vi.fn((msg?: string) => {
   const lower = normalizeLowercaseStringOrEmpty(msg ?? "");
@@ -228,7 +232,7 @@ export const mockedIsLikelyContextOverflowError = vi.fn((msg?: string) => {
 });
 export const mockedParseImageSizeError = vi.fn(() => null);
 export const mockedParseImageDimensionError = vi.fn(() => null);
-export const mockedIsRateLimitAssistantError = vi.fn(() => false);
+export const mockedIsRateLimitAssistantError = vi.fn<MockAssistantErrorProbe>(() => false);
 export const mockedIsTimeoutErrorMessage = vi.fn(() => false);
 export const mockedPickFallbackThinkingLevel = vi.fn<(params?: unknown) => ThinkLevel | null>(
   () => null,
@@ -466,6 +470,8 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   mockedShouldPreferExplicitConfigApiKeyAuth.mockReturnValue(false);
   mockedRunPostCompactionSideEffects.mockReset();
   mockedRunPostCompactionSideEffects.mockResolvedValue(undefined);
+  mockedSleepWithAbort.mockReset();
+  mockedSleepWithAbort.mockResolvedValue(undefined);
 }
 
 /** Install module mocks, import the runner, and return the mocked entrypoint. */
@@ -482,6 +488,9 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
 
   vi.doMock("../../context-engine/init.js", () => ({
     ensureContextEnginesInitialized: vi.fn(),
+  }));
+  vi.doMock("../../infra/backoff.js", () => ({
+    sleepWithAbort: mockedSleepWithAbort,
   }));
   vi.doMock("../../context-engine/registry.js", () => ({
     resolveContextEngine: mockedResolveContextEngine,

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -152,9 +152,11 @@ import {
   resolveFinalAssistantVisibleText,
   resolveMaxRunRetryIterations,
   resolveReportedModelRef,
+  MAX_SAME_MODEL_RATE_LIMIT_RETRIES,
   resolveOverloadFailoverBackoffMs,
   resolveOverloadProfileRotationLimit,
   resolveRateLimitProfileRotationLimit,
+  resolveSameModelRateLimitBackoffMs,
   type RuntimeAuthState,
   scrubAnthropicRefusalMagic,
 } from "./run/helpers.js";
@@ -1212,6 +1214,7 @@ export async function runEmbeddedAgent(
       let lastContextBudgetStatus: EmbeddedAgentMeta["contextBudgetStatus"];
       let runLoopIterations = 0;
       let overloadProfileRotations = 0;
+      let sameModelRateLimitRetries = 0;
       let planningOnlyRetryAttempts = 0;
       let reasoningOnlyRetryAttempts = 0;
       let emptyResponseRetryAttempts = 0;
@@ -1371,6 +1374,27 @@ export async function runEmbeddedAgent(
           }
           throw err;
         }
+      };
+      const maybeRetrySameModelRateLimit = async (): Promise<boolean> => {
+        if (sameModelRateLimitRetries >= MAX_SAME_MODEL_RATE_LIMIT_RETRIES) {
+          return false;
+        }
+        const delayMs = resolveSameModelRateLimitBackoffMs(sameModelRateLimitRetries);
+        log.warn(
+          `rate-limit same-model retry ${sameModelRateLimitRetries + 1}/${MAX_SAME_MODEL_RATE_LIMIT_RETRIES} for ${sanitizeForLog(provider)}/${sanitizeForLog(modelId)}: delayMs=${delayMs}`,
+        );
+        try {
+          await sleepWithAbort(delayMs, params.abortSignal);
+        } catch (err) {
+          if (params.abortSignal?.aborted) {
+            const abortErr = new Error("Operation aborted", { cause: err });
+            abortErr.name = "AbortError";
+            throw abortErr;
+          }
+          throw err;
+        }
+        sameModelRateLimitRetries += 1;
+        return true;
       };
       // Resolve the context engine once and reuse across retries to avoid
       // repeated initialization/connection overhead per attempt.
@@ -2882,6 +2906,7 @@ export async function runEmbeddedAgent(
             warn: (message) => log.warn(message),
             maybeMarkAuthProfileFailure,
             maybeEscalateRateLimitProfileFallback,
+            maybeRetrySameModelRateLimit,
             maybeBackoffBeforeOverloadFailover,
             advanceAuthProfile: advanceAttemptAuthProfile,
           });

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -156,6 +156,7 @@ import {
   resolveOverloadFailoverBackoffMs,
   resolveOverloadProfileRotationLimit,
   resolveRateLimitProfileRotationLimit,
+  resolveNextSameModelRateLimitRetryCount,
   resolveSameModelRateLimitBackoffMs,
   type RuntimeAuthState,
   scrubAnthropicRefusalMagic,
@@ -1214,7 +1215,7 @@ export async function runEmbeddedAgent(
       let lastContextBudgetStatus: EmbeddedAgentMeta["contextBudgetStatus"];
       let runLoopIterations = 0;
       let overloadProfileRotations = 0;
-      let sameModelRateLimitRetries = 0;
+      let consecutiveSameModelRateLimitRetries = 0;
       let planningOnlyRetryAttempts = 0;
       let reasoningOnlyRetryAttempts = 0;
       let emptyResponseRetryAttempts = 0;
@@ -1376,12 +1377,12 @@ export async function runEmbeddedAgent(
         }
       };
       const maybeRetrySameModelRateLimit = async (): Promise<boolean> => {
-        if (sameModelRateLimitRetries >= MAX_SAME_MODEL_RATE_LIMIT_RETRIES) {
+        if (consecutiveSameModelRateLimitRetries >= MAX_SAME_MODEL_RATE_LIMIT_RETRIES) {
           return false;
         }
-        const delayMs = resolveSameModelRateLimitBackoffMs(sameModelRateLimitRetries);
+        const delayMs = resolveSameModelRateLimitBackoffMs(consecutiveSameModelRateLimitRetries);
         log.warn(
-          `rate-limit same-model retry ${sameModelRateLimitRetries + 1}/${MAX_SAME_MODEL_RATE_LIMIT_RETRIES} for ${sanitizeForLog(provider)}/${sanitizeForLog(modelId)}: delayMs=${delayMs}`,
+          `rate-limit same-model retry ${consecutiveSameModelRateLimitRetries + 1}/${MAX_SAME_MODEL_RATE_LIMIT_RETRIES} for ${sanitizeForLog(provider)}/${sanitizeForLog(modelId)}: delayMs=${delayMs}`,
         );
         try {
           await sleepWithAbort(delayMs, params.abortSignal);
@@ -1393,7 +1394,10 @@ export async function runEmbeddedAgent(
           }
           throw err;
         }
-        sameModelRateLimitRetries += 1;
+        consecutiveSameModelRateLimitRetries = resolveNextSameModelRateLimitRetryCount({
+          retriesSoFar: consecutiveSameModelRateLimitRetries,
+          retriedSameModelRateLimit: true,
+        });
         return true;
       };
       // Resolve the context engine once and reuse across retries to avoid
@@ -2926,9 +2930,19 @@ export async function runEmbeddedAgent(
             if (assistantFailoverOutcome.retryKind === "same_model_idle_timeout") {
               sameModelIdleTimeoutRetries += 1;
             }
+            if (assistantFailoverOutcome.retryKind !== "same_model_rate_limit") {
+              consecutiveSameModelRateLimitRetries = resolveNextSameModelRateLimitRetryCount({
+                retriesSoFar: consecutiveSameModelRateLimitRetries,
+                retriedSameModelRateLimit: false,
+              });
+            }
             lastRetryFailoverReason = assistantFailoverOutcome.lastRetryFailoverReason;
             continue;
           }
+          consecutiveSameModelRateLimitRetries = resolveNextSameModelRateLimitRetryCount({
+            retriesSoFar: consecutiveSameModelRateLimitRetries,
+            retriedSameModelRateLimit: false,
+          });
           if (assistantFailoverOutcome.action === "throw") {
             traceAttempts.push({
               provider: activeErrorContext.provider,

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -157,7 +157,7 @@ import {
   resolveOverloadProfileRotationLimit,
   resolveRateLimitProfileRotationLimit,
   resolveNextSameModelRateLimitRetryCount,
-  resolveSameModelRateLimitBackoffMs,
+  resolveSameModelRateLimitRetryDelayMs,
   type RuntimeAuthState,
   scrubAnthropicRefusalMagic,
 } from "./run/helpers.js";
@@ -1058,6 +1058,8 @@ export async function runEmbeddedAgent(
       const profileFailureStore = pluginHarnessOwnsTransport ? attemptAuthProfileStore : authStore;
       let profileIndex = 0;
       const traceAttempts: TraceAttempt[] = [];
+      const traceAttemptUsesFallback = (attempt: TraceAttempt): boolean =>
+        attempt.result === "rotate_profile" || attempt.result === "fallback_model";
 
       const initialThinkLevel = resolveInitialThinkLevel({
         requested: params.thinkLevel,
@@ -1376,11 +1378,16 @@ export async function runEmbeddedAgent(
           throw err;
         }
       };
-      const maybeRetrySameModelRateLimit = async (): Promise<boolean> => {
+      const maybeRetrySameModelRateLimit = async (retry?: {
+        retryAfterSeconds?: number;
+      }): Promise<boolean> => {
         if (consecutiveSameModelRateLimitRetries >= MAX_SAME_MODEL_RATE_LIMIT_RETRIES) {
           return false;
         }
-        const delayMs = resolveSameModelRateLimitBackoffMs(consecutiveSameModelRateLimitRetries);
+        const delayMs = resolveSameModelRateLimitRetryDelayMs({
+          retriesSoFar: consecutiveSameModelRateLimitRetries,
+          retryAfterSeconds: retry?.retryAfterSeconds,
+        });
         log.warn(
           `rate-limit same-model retry ${consecutiveSameModelRateLimitRetries + 1}/${MAX_SAME_MODEL_RATE_LIMIT_RETRIES} for ${sanitizeForLog(provider)}/${sanitizeForLog(modelId)}: delayMs=${delayMs}`,
         );
@@ -2890,6 +2897,7 @@ export async function runEmbeddedAgent(
               !fallbackConfigured &&
               canRestartForLiveSwitch &&
               sameModelIdleTimeoutRetries < MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES,
+            allowSameModelRateLimitRetry: rateLimitProfileRotations < rateLimitProfileRotationLimit,
             assistantProfileFailureReason,
             lastProfileId,
             modelId,
@@ -2916,14 +2924,17 @@ export async function runEmbeddedAgent(
           });
           overloadProfileRotations = assistantFailoverOutcome.overloadProfileRotations;
           if (assistantFailoverOutcome.action === "retry") {
+            const retryTraceResult =
+              assistantFailoverOutcome.retryKind === "same_model_rate_limit"
+                ? "same_model_rate_limit"
+                : assistantFailoverOutcome.retryKind === "same_model_idle_timeout" ||
+                    assistantFailoverReason === "timeout"
+                  ? "timeout"
+                  : "rotate_profile";
             traceAttempts.push({
               provider: activeErrorContext.provider,
               model: activeErrorContext.model,
-              result:
-                assistantFailoverOutcome.retryKind === "same_model_idle_timeout" ||
-                assistantFailoverReason === "timeout"
-                  ? "timeout"
-                  : "rotate_profile",
+              result: retryTraceResult,
               ...(assistantFailoverReason ? { reason: assistantFailoverReason } : {}),
               stage: "assistant",
             });
@@ -3693,7 +3704,7 @@ export async function runEmbeddedAgent(
                         },
                       ]
                     : undefined,
-                fallbackUsed: traceAttempts.length > 0,
+                fallbackUsed: traceAttempts.some(traceAttemptUsesFallback),
                 runner: "embedded",
               },
               requestShaping: {

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -44,6 +44,7 @@ function makeParams(overrides: Partial<Params> = {}): Params {
     warn: vi.fn(),
     maybeMarkAuthProfileFailure: vi.fn(async () => {}),
     maybeEscalateRateLimitProfileFallback: vi.fn(),
+    maybeRetrySameModelRateLimit: vi.fn(async () => false),
     maybeBackoffBeforeOverloadFailover: vi.fn(async () => {}),
     advanceAuthProfile: vi.fn(async () => false),
   };
@@ -105,6 +106,60 @@ describe("handleAssistantFailover", () => {
       await markSettled;
       await vi.waitFor(() => expect(events).toEqual(["advance", "mark-start", "mark-finish"]));
       expect(events).toEqual(["advance", "mark-start", "mark-finish"]);
+    });
+
+    it("retries the same model before spending a rate-limit profile rotation", async () => {
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBe("same_model_rate_limit");
+      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
+      expect(maybeEscalateRateLimitProfileFallback).not.toHaveBeenCalled();
+      expect(advanceAuthProfile).not.toHaveBeenCalled();
+    });
+
+    it("falls back to profile rotation after the same-model rate-limit budget is exhausted", async () => {
+      const maybeRetrySameModelRateLimit = vi.fn(async () => false);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBeUndefined();
+      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
+      expect(maybeEscalateRateLimitProfileFallback).toHaveBeenCalledTimes(1);
+      expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
     });
 
     it("does not log profile-specific warnings without a failed profile id", async () => {

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -119,6 +119,131 @@ describe("handleAssistantFailover", () => {
           failoverReason: "rate_limit",
           billingFailure: false,
           rateLimitFailure: true,
+          lastAssistant: {
+            errorMessage: "HTTP 429 Too Many Requests: requests per minute exceeded",
+          } as Params["lastAssistant"],
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBe("same_model_rate_limit");
+      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
+      expect(maybeEscalateRateLimitProfileFallback).not.toHaveBeenCalled();
+      expect(advanceAuthProfile).not.toHaveBeenCalled();
+    });
+
+    it("does not spend same-model retry budget on quota-style rate limits", async () => {
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          lastAssistant: {
+            errorMessage:
+              "You exceeded your current quota, please check your plan and billing details.",
+          } as Params["lastAssistant"],
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBeUndefined();
+      expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+      expect(maybeEscalateRateLimitProfileFallback).toHaveBeenCalledTimes(1);
+      expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not treat bare 429 quota_exceeded as a short-window throttle", async () => {
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          lastAssistant: {
+            errorMessage: "Provider API error (429): Quota exceeded [code=quota_exceeded]",
+          } as Params["lastAssistant"],
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBeUndefined();
+      expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+      expect(maybeEscalateRateLimitProfileFallback).toHaveBeenCalledTimes(1);
+      expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows RESOURCE_EXHAUSTED messages with short-window 429 hints", async () => {
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          lastAssistant: {
+            errorMessage: "429 RESOURCE_EXHAUSTED: tokens per minute limit exceeded",
+          } as Params["lastAssistant"],
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBe("same_model_rate_limit");
+      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
+      expect(maybeEscalateRateLimitProfileFallback).not.toHaveBeenCalled();
+      expect(advanceAuthProfile).not.toHaveBeenCalled();
+    });
+
+    it("allows quota wording when it points at a per-minute throttle", async () => {
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          lastAssistant: {
+            errorMessage:
+              "Quota exceeded for quota metric 'Generate requests per minute' and limit 'Generate requests per minute per project'.",
+          } as Params["lastAssistant"],
           maybeRetrySameModelRateLimit,
           maybeEscalateRateLimitProfileFallback,
           advanceAuthProfile,
@@ -146,6 +271,9 @@ describe("handleAssistantFailover", () => {
           failoverReason: "rate_limit",
           billingFailure: false,
           rateLimitFailure: true,
+          lastAssistant: {
+            errorMessage: "429 rate_limit_exceeded: too many requests per minute",
+          } as Params["lastAssistant"],
           maybeRetrySameModelRateLimit,
           maybeEscalateRateLimitProfileFallback,
           advanceAuthProfile,

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -24,6 +24,7 @@ function makeParams(overrides: Partial<Params> = {}): Params {
     timedOutDuringCompaction: false,
     timedOutDuringToolExecution: false,
     allowSameModelIdleTimeoutRetry: false,
+    allowSameModelRateLimitRetry: true,
     assistantProfileFailureReason: null,
     lastProfileId: undefined,
     modelId: model,
@@ -134,8 +135,40 @@ describe("handleAssistantFailover", () => {
       }
       expect(outcome.retryKind).toBe("same_model_rate_limit");
       expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
+      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledWith({});
       expect(maybeEscalateRateLimitProfileFallback).not.toHaveBeenCalled();
       expect(advanceAuthProfile).not.toHaveBeenCalled();
+    });
+
+    it("honors disabled rate-limit profile rotations before same-model retry", async () => {
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          allowSameModelRateLimitRetry: false,
+          lastAssistant: {
+            errorMessage: "HTTP 429 Too Many Requests: requests per minute exceeded",
+          } as Params["lastAssistant"],
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBeUndefined();
+      expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+      expect(maybeEscalateRateLimitProfileFallback).toHaveBeenCalledTimes(1);
+      expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
     });
 
     it("does not spend same-model retry budget on quota-style rate limits", async () => {
@@ -197,6 +230,133 @@ describe("handleAssistantFailover", () => {
       expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
       expect(maybeEscalateRateLimitProfileFallback).toHaveBeenCalledTimes(1);
       expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not treat generic rate-limit text as a short-window throttle", async () => {
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          lastAssistant: {
+            errorMessage: "rate limit exceeded",
+          } as Params["lastAssistant"],
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBeUndefined();
+      expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+      expect(maybeEscalateRateLimitProfileFallback).toHaveBeenCalledTimes(1);
+      expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not spend same-model retry budget when Retry-After is long", async () => {
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          lastAssistant: {
+            errorMessage: "429 rate_limit_exceeded; Retry-After: 3600",
+          } as Params["lastAssistant"],
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBeUndefined();
+      expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+      expect(maybeEscalateRateLimitProfileFallback).toHaveBeenCalledTimes(1);
+      expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not spend same-model retry budget when Retry-After date is beyond the retry budget", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-06-11T00:00:00.000Z"));
+      try {
+        const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+        const maybeEscalateRateLimitProfileFallback = vi.fn();
+        const advanceAuthProfile = vi.fn(async () => true);
+
+        const outcome = await handleAssistantFailover(
+          makeParams({
+            initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+            failoverReason: "rate_limit",
+            billingFailure: false,
+            rateLimitFailure: true,
+            lastAssistant: {
+              errorMessage: "429 rate_limit_exceeded; Retry-After: Thu, 11 Jun 2026 01:05:00 GMT",
+            } as Params["lastAssistant"],
+            maybeRetrySameModelRateLimit,
+            maybeEscalateRateLimitProfileFallback,
+            advanceAuthProfile,
+          }),
+        );
+
+        expect(outcome.action).toBe("retry");
+        if (outcome.action !== "retry") {
+          return;
+        }
+        expect(outcome.retryKind).toBeUndefined();
+        expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+        expect(maybeEscalateRateLimitProfileFallback).toHaveBeenCalledTimes(1);
+        expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("allows short Retry-After intervals to use same-model retry", async () => {
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          lastAssistant: {
+            errorMessage: "429 rate_limit_exceeded; Retry-After: 30 seconds",
+          } as Params["lastAssistant"],
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBe("same_model_rate_limit");
+      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
+      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledWith({ retryAfterSeconds: 30 });
+      expect(maybeEscalateRateLimitProfileFallback).not.toHaveBeenCalled();
+      expect(advanceAuthProfile).not.toHaveBeenCalled();
     });
 
     it("allows RESOURCE_EXHAUSTED messages with short-window 429 hints", async () => {

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -27,7 +27,7 @@ type AssistantFailoverOutcome =
       action: "retry";
       overloadProfileRotations: number;
       lastRetryFailoverReason: FailoverReason | null;
-      retryKind?: "same_model_idle_timeout";
+      retryKind?: "same_model_idle_timeout" | "same_model_rate_limit";
     }
   | {
       action: "throw";
@@ -83,6 +83,7 @@ export async function handleAssistantFailover(params: {
     failoverModel: string;
     logFallbackDecision: (decision: "fallback_model", extra?: { status?: number }) => void;
   }) => void;
+  maybeRetrySameModelRateLimit: () => Promise<boolean>;
   maybeBackoffBeforeOverloadFailover: (reason: FailoverReason | null) => Promise<void>;
   advanceAuthProfile: () => Promise<boolean>;
 }): Promise<AssistantFailoverOutcome> {
@@ -103,6 +104,16 @@ export async function handleAssistantFailover(params: {
       }),
     };
   };
+  const sameModelRateLimitRetry = (): AssistantFailoverOutcome => ({
+    action: "retry",
+    overloadProfileRotations,
+    retryKind: "same_model_rate_limit",
+    lastRetryFailoverReason: mergeRetryFailoverReason({
+      previous: params.previousRetryFailoverReason,
+      failoverReason: params.failoverReason,
+      timedOut: params.timedOut || params.idleTimedOut,
+    }),
+  });
 
   if (decision.action === "rotate_profile") {
     const failedProfileId = params.lastProfileId;
@@ -154,6 +165,12 @@ export async function handleAssistantFailover(params: {
     }
 
     if (params.failoverReason === "rate_limit") {
+      // Minute-scale RPM windows can clear without spending a profile rotation
+      // or model fallback. Keep the retry bounded; once exhausted, continue
+      // through the existing rate-limit escalation path.
+      if (await params.maybeRetrySameModelRateLimit()) {
+        return sameModelRateLimitRetry();
+      }
       params.maybeEscalateRateLimitProfileFallback({
         failoverProvider: params.activeErrorContext.provider,
         failoverModel: params.activeErrorContext.model,

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -35,6 +35,27 @@ type AssistantFailoverOutcome =
       error: FailoverError;
     };
 
+const LONG_WINDOW_RATE_LIMIT_RE =
+  /\b(?:daily|weekly|monthly|tokens per day|requests per day|usage limit|subscription|insufficient[_ -]?quota|current quota|quota[_ -]?exceeded|quota exceeded)\b/i;
+const SHORT_RATE_LIMIT_WINDOW_RE =
+  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|retry[- ]after)\b/i;
+const SHORT_WINDOW_RATE_LIMIT_RE =
+  /\b(?:429|rate[_ -]?limit(?:ed|[_ -]?exceeded)?|too many (?:concurrent )?requests|requests per minute|rpm|tokens per minute|tpm|throttl(?:e|ed|ing|ingexception)|model_cooldown|retry[- ]after)\b|请求过于频繁|调用频率|频率限制/i;
+
+function isShortWindowRateLimitMessage(message: string | undefined): boolean {
+  const raw = message?.trim();
+  if (!raw) {
+    return false;
+  }
+  if (LONG_WINDOW_RATE_LIMIT_RE.test(raw) && !SHORT_RATE_LIMIT_WINDOW_RE.test(raw)) {
+    return false;
+  }
+  // Providers such as Gemini use quota wording for per-minute RPM/TPM
+  // throttles. Treat quota as long-window only when no short-window hint is
+  // present; hard daily/usage/subscription limits are filtered above.
+  return SHORT_WINDOW_RATE_LIMIT_RE.test(raw);
+}
+
 /**
  * Applies an assistant-stage failover decision and returns the next run action.
  * It owns auth-profile rotation, overload/rate-limit escalation, same-model
@@ -168,7 +189,10 @@ export async function handleAssistantFailover(params: {
       // Minute-scale RPM windows can clear without spending a profile rotation
       // or model fallback. Keep the retry bounded; once exhausted, continue
       // through the existing rate-limit escalation path.
-      if (await params.maybeRetrySameModelRateLimit()) {
+      if (
+        isShortWindowRateLimitMessage(params.lastAssistant?.errorMessage) &&
+        (await params.maybeRetrySameModelRateLimit())
+      ) {
         return sameModelRateLimitRetry();
       }
       params.maybeEscalateRateLimitProfileFallback({

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -34,26 +34,80 @@ type AssistantFailoverOutcome =
       overloadProfileRotations: number;
       error: FailoverError;
     };
+type ShortWindowRateLimitRetry = {
+  retryAfterSeconds?: number;
+};
 
 const LONG_WINDOW_RATE_LIMIT_RE =
   /\b(?:daily|weekly|monthly|tokens per day|requests per day|usage limit|subscription|insufficient[_ -]?quota|current quota|quota[_ -]?exceeded|quota exceeded)\b/i;
 const SHORT_RATE_LIMIT_WINDOW_RE =
-  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|retry[- ]after)\b/i;
+  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm)\b/i;
 const SHORT_WINDOW_RATE_LIMIT_RE =
-  /\b(?:429|rate[_ -]?limit(?:ed|[_ -]?exceeded)?|too many (?:concurrent )?requests|requests per minute|rpm|tokens per minute|tpm|throttl(?:e|ed|ing|ingexception)|model_cooldown|retry[- ]after)\b|请求过于频繁|调用频率|频率限制/i;
+  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|model_cooldown)\b|请求过于频繁|调用频率|频率限制/i;
+const RETRY_AFTER_VALUE_RE = /\bretry[- ]after\b\s*:?\s*(?:in\s*)?([^\r\n;]+)/i;
+const RETRY_AFTER_SECONDS_RE =
+  /^(\d+(?:\.\d+)?)(?:\s*(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m))?\b/i;
+const MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS = 60;
 
-function isShortWindowRateLimitMessage(message: string | undefined): boolean {
+function parseRetryAfterSeconds(message: string): number | null {
+  const valueText = RETRY_AFTER_VALUE_RE.exec(message)?.[1]?.trim();
+  if (!valueText) {
+    return null;
+  }
+  const secondsMatch = RETRY_AFTER_SECONDS_RE.exec(valueText);
+  if (secondsMatch?.[1]) {
+    const value = Number(secondsMatch[1]);
+    if (!Number.isFinite(value) || value < 0) {
+      return null;
+    }
+    const unit = secondsMatch[2]?.toLowerCase();
+    if (
+      unit?.startsWith("m") &&
+      unit !== "ms" &&
+      !unit.startsWith("msec") &&
+      !unit.startsWith("millisecond")
+    ) {
+      return value * 60;
+    }
+    if (unit === "ms" || unit?.startsWith("msec") || unit?.startsWith("millisecond")) {
+      return value / 1000;
+    }
+    return value;
+  }
+  const retryAtMs = Date.parse(valueText);
+  if (!Number.isFinite(retryAtMs)) {
+    return null;
+  }
+  return Math.max(0, (retryAtMs - Date.now()) / 1000);
+}
+
+function resolveShortWindowRateLimitRetry(
+  message: string | undefined,
+): ShortWindowRateLimitRetry | null {
   const raw = message?.trim();
   if (!raw) {
-    return false;
+    return null;
   }
-  if (LONG_WINDOW_RATE_LIMIT_RE.test(raw) && !SHORT_RATE_LIMIT_WINDOW_RE.test(raw)) {
-    return false;
+  const retryAfterSeconds = parseRetryAfterSeconds(raw);
+  if (retryAfterSeconds !== null && retryAfterSeconds > MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS) {
+    return null;
+  }
+  const shortRetryAfter =
+    retryAfterSeconds !== null && retryAfterSeconds <= MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS;
+  const hasShortWindowSignal = SHORT_RATE_LIMIT_WINDOW_RE.test(raw);
+  if (RETRY_AFTER_VALUE_RE.test(raw) && retryAfterSeconds === null && !hasShortWindowSignal) {
+    return null;
+  }
+  if (LONG_WINDOW_RATE_LIMIT_RE.test(raw) && !hasShortWindowSignal && !shortRetryAfter) {
+    return null;
   }
   // Providers such as Gemini use quota wording for per-minute RPM/TPM
   // throttles. Treat quota as long-window only when no short-window hint is
   // present; hard daily/usage/subscription limits are filtered above.
-  return SHORT_WINDOW_RATE_LIMIT_RE.test(raw);
+  if (!SHORT_WINDOW_RATE_LIMIT_RE.test(raw) && !shortRetryAfter) {
+    return null;
+  }
+  return retryAfterSeconds !== null ? { retryAfterSeconds } : {};
 }
 
 /**
@@ -73,6 +127,7 @@ export async function handleAssistantFailover(params: {
   timedOutDuringCompaction: boolean;
   timedOutDuringToolExecution: boolean;
   allowSameModelIdleTimeoutRetry: boolean;
+  allowSameModelRateLimitRetry: boolean;
   assistantProfileFailureReason: AuthProfileFailureReason | null;
   lastProfileId?: string;
   modelId: string;
@@ -104,7 +159,7 @@ export async function handleAssistantFailover(params: {
     failoverModel: string;
     logFallbackDecision: (decision: "fallback_model", extra?: { status?: number }) => void;
   }) => void;
-  maybeRetrySameModelRateLimit: () => Promise<boolean>;
+  maybeRetrySameModelRateLimit: (retry?: ShortWindowRateLimitRetry) => Promise<boolean>;
   maybeBackoffBeforeOverloadFailover: (reason: FailoverReason | null) => Promise<void>;
   advanceAuthProfile: () => Promise<boolean>;
 }): Promise<AssistantFailoverOutcome> {
@@ -189,9 +244,11 @@ export async function handleAssistantFailover(params: {
       // Minute-scale RPM windows can clear without spending a profile rotation
       // or model fallback. Keep the retry bounded; once exhausted, continue
       // through the existing rate-limit escalation path.
+      const shortWindowRetry = resolveShortWindowRateLimitRetry(params.lastAssistant?.errorMessage);
       if (
-        isShortWindowRateLimitMessage(params.lastAssistant?.errorMessage) &&
-        (await params.maybeRetrySameModelRateLimit())
+        params.allowSameModelRateLimitRetry &&
+        shortWindowRetry &&
+        (await params.maybeRetrySameModelRateLimit(shortWindowRetry))
       ) {
         return sameModelRateLimitRetry();
       }

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -7,6 +7,7 @@ import {
   buildErrorAgentMeta,
   resolveFinalAssistantRawText,
   resolveFinalAssistantVisibleText,
+  resolveSameModelRateLimitBackoffMs,
 } from "./helpers.js";
 
 function makeAssistantMessage(
@@ -82,6 +83,24 @@ describe("resolveFinalAssistantVisibleText", () => {
     ]);
 
     expect(resolveFinalAssistantRawText(lastAssistant)).toBe("<final>keep this</final>");
+  });
+});
+
+describe("resolveSameModelRateLimitBackoffMs", () => {
+  it("waits 20s before the first same-model retry", () => {
+    expect(resolveSameModelRateLimitBackoffMs(0)).toBe(20_000);
+  });
+
+  it("waits 40s before the second same-model retry", () => {
+    expect(resolveSameModelRateLimitBackoffMs(1)).toBe(40_000);
+  });
+
+  it("caps at 60s if the retry count is ever raised further", () => {
+    expect(resolveSameModelRateLimitBackoffMs(10)).toBe(60_000);
+  });
+
+  it("is deterministic so RPM windows clear predictably", () => {
+    expect(resolveSameModelRateLimitBackoffMs(1)).toBe(resolveSameModelRateLimitBackoffMs(1));
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -87,12 +87,10 @@ describe("resolveFinalAssistantVisibleText", () => {
 });
 
 describe("resolveSameModelRateLimitBackoffMs", () => {
-  it("waits 20s before the first same-model retry", () => {
-    expect(resolveSameModelRateLimitBackoffMs(0)).toBe(20_000);
-  });
-
-  it("waits 40s before the second same-model retry", () => {
-    expect(resolveSameModelRateLimitBackoffMs(1)).toBe(40_000);
+  it("waits 10s/20s/30s linearly before the 1st/2nd/3rd same-model retry", () => {
+    expect(resolveSameModelRateLimitBackoffMs(0)).toBe(10_000);
+    expect(resolveSameModelRateLimitBackoffMs(1)).toBe(20_000);
+    expect(resolveSameModelRateLimitBackoffMs(2)).toBe(30_000);
   });
 
   it("caps at 60s if the retry count is ever raised further", () => {
@@ -100,7 +98,7 @@ describe("resolveSameModelRateLimitBackoffMs", () => {
   });
 
   it("is deterministic so RPM windows clear predictably", () => {
-    expect(resolveSameModelRateLimitBackoffMs(1)).toBe(resolveSameModelRateLimitBackoffMs(1));
+    expect(resolveSameModelRateLimitBackoffMs(2)).toBe(resolveSameModelRateLimitBackoffMs(2));
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -7,6 +7,7 @@ import {
   buildErrorAgentMeta,
   resolveFinalAssistantRawText,
   resolveFinalAssistantVisibleText,
+  resolveNextSameModelRateLimitRetryCount,
   resolveSameModelRateLimitBackoffMs,
 } from "./helpers.js";
 
@@ -99,6 +100,34 @@ describe("resolveSameModelRateLimitBackoffMs", () => {
 
   it("is deterministic so RPM windows clear predictably", () => {
     expect(resolveSameModelRateLimitBackoffMs(2)).toBe(resolveSameModelRateLimitBackoffMs(2));
+  });
+});
+
+describe("resolveNextSameModelRateLimitRetryCount", () => {
+  it("counts only consecutive same-model rate-limit retries", () => {
+    let retriesSoFar = 0;
+
+    retriesSoFar = resolveNextSameModelRateLimitRetryCount({
+      retriesSoFar,
+      retriedSameModelRateLimit: true,
+    });
+    retriesSoFar = resolveNextSameModelRateLimitRetryCount({
+      retriesSoFar,
+      retriedSameModelRateLimit: true,
+    });
+    expect(retriesSoFar).toBe(2);
+
+    retriesSoFar = resolveNextSameModelRateLimitRetryCount({
+      retriesSoFar,
+      retriedSameModelRateLimit: false,
+    });
+    expect(retriesSoFar).toBe(0);
+
+    retriesSoFar = resolveNextSameModelRateLimitRetryCount({
+      retriesSoFar,
+      retriedSameModelRateLimit: true,
+    });
+    expect(retriesSoFar).toBe(1);
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   resolveFinalAssistantVisibleText,
   resolveNextSameModelRateLimitRetryCount,
   resolveSameModelRateLimitBackoffMs,
+  resolveSameModelRateLimitRetryDelayMs,
 } from "./helpers.js";
 
 function makeAssistantMessage(
@@ -100,6 +101,35 @@ describe("resolveSameModelRateLimitBackoffMs", () => {
 
   it("is deterministic so RPM windows clear predictably", () => {
     expect(resolveSameModelRateLimitBackoffMs(2)).toBe(resolveSameModelRateLimitBackoffMs(2));
+  });
+});
+
+describe("resolveSameModelRateLimitRetryDelayMs", () => {
+  it("honors a short provider Retry-After when it is longer than the fixed backoff", () => {
+    expect(
+      resolveSameModelRateLimitRetryDelayMs({
+        retriesSoFar: 0,
+        retryAfterSeconds: 30,
+      }),
+    ).toBe(30_000);
+  });
+
+  it("keeps the existing fixed backoff when Retry-After is shorter", () => {
+    expect(
+      resolveSameModelRateLimitRetryDelayMs({
+        retriesSoFar: 1,
+        retryAfterSeconds: 5,
+      }),
+    ).toBe(20_000);
+  });
+
+  it("caps provider Retry-After at the same short-window retry ceiling", () => {
+    expect(
+      resolveSameModelRateLimitRetryDelayMs({
+        retriesSoFar: 0,
+        retryAfterSeconds: 120,
+      }),
+    ).toBe(60_000);
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -40,9 +40,10 @@ const DEFAULT_MAX_RATE_LIMIT_PROFILE_ROTATIONS = 1;
 // Same-model in-place rate_limit retry: provider RPM caps reset on a
 // minute scale, so wait out the current provider/model window before spending
 // a profile rotation or model failover.
-export const MAX_SAME_MODEL_RATE_LIMIT_RETRIES = 2;
-const SAME_MODEL_RATE_LIMIT_INITIAL_BACKOFF_MS = 20_000;
-const SAME_MODEL_RATE_LIMIT_BACKOFF_FACTOR = 2;
+export const MAX_SAME_MODEL_RATE_LIMIT_RETRIES = 3;
+// Linear step: retriesSoFar=0 -> 10s, 1 -> 20s, 2 -> 30s. Total wait across the
+// 3-retry budget is 60s, roughly one RPM window.
+const SAME_MODEL_RATE_LIMIT_BACKOFF_STEP_MS = 10_000;
 const SAME_MODEL_RATE_LIMIT_MAX_BACKOFF_MS = 60_000;
 
 export function resolveOverloadFailoverBackoffMs(cfg?: OpenClawConfig): number {
@@ -61,13 +62,11 @@ export function resolveRateLimitProfileRotationLimit(cfg?: OpenClawConfig): numb
 
 /**
  * Backoff before the next same-model rate_limit retry, given how many such
- * retries already happened. No jitter: the wait must be deterministic so RPM
+ * retries already happened. Linear and deterministic (no jitter) so RPM
  * windows clear predictably and tests can assert exact values.
  */
 export function resolveSameModelRateLimitBackoffMs(retriesSoFar: number): number {
-  const attempt = Math.max(0, retriesSoFar);
-  const delay =
-    SAME_MODEL_RATE_LIMIT_INITIAL_BACKOFF_MS * SAME_MODEL_RATE_LIMIT_BACKOFF_FACTOR ** attempt;
+  const delay = SAME_MODEL_RATE_LIMIT_BACKOFF_STEP_MS * (Math.max(0, retriesSoFar) + 1);
   return Math.min(SAME_MODEL_RATE_LIMIT_MAX_BACKOFF_MS, delay);
 }
 

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -37,6 +37,14 @@ const DEFAULT_OVERLOAD_FAILOVER_BACKOFF_MS = 0;
 const DEFAULT_MAX_OVERLOAD_PROFILE_ROTATIONS = 1;
 const DEFAULT_MAX_RATE_LIMIT_PROFILE_ROTATIONS = 1;
 
+// Same-model in-place rate_limit retry: provider RPM caps reset on a
+// minute scale, so wait out the current provider/model window before spending
+// a profile rotation or model failover.
+export const MAX_SAME_MODEL_RATE_LIMIT_RETRIES = 2;
+const SAME_MODEL_RATE_LIMIT_INITIAL_BACKOFF_MS = 20_000;
+const SAME_MODEL_RATE_LIMIT_BACKOFF_FACTOR = 2;
+const SAME_MODEL_RATE_LIMIT_MAX_BACKOFF_MS = 60_000;
+
 export function resolveOverloadFailoverBackoffMs(cfg?: OpenClawConfig): number {
   return cfg?.auth?.cooldowns?.overloadedBackoffMs ?? DEFAULT_OVERLOAD_FAILOVER_BACKOFF_MS;
 }
@@ -49,6 +57,18 @@ export function resolveRateLimitProfileRotationLimit(cfg?: OpenClawConfig): numb
   return (
     cfg?.auth?.cooldowns?.rateLimitedProfileRotations ?? DEFAULT_MAX_RATE_LIMIT_PROFILE_ROTATIONS
   );
+}
+
+/**
+ * Backoff before the next same-model rate_limit retry, given how many such
+ * retries already happened. No jitter: the wait must be deterministic so RPM
+ * windows clear predictably and tests can assert exact values.
+ */
+export function resolveSameModelRateLimitBackoffMs(retriesSoFar: number): number {
+  const attempt = Math.max(0, retriesSoFar);
+  const delay =
+    SAME_MODEL_RATE_LIMIT_INITIAL_BACKOFF_MS * SAME_MODEL_RATE_LIMIT_BACKOFF_FACTOR ** attempt;
+  return Math.min(SAME_MODEL_RATE_LIMIT_MAX_BACKOFF_MS, delay);
 }
 
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -70,6 +70,13 @@ export function resolveSameModelRateLimitBackoffMs(retriesSoFar: number): number
   return Math.min(SAME_MODEL_RATE_LIMIT_MAX_BACKOFF_MS, delay);
 }
 
+export function resolveNextSameModelRateLimitRetryCount(params: {
+  retriesSoFar: number;
+  retriedSameModelRateLimit: boolean;
+}): number {
+  return params.retriedSameModelRateLimit ? Math.max(0, params.retriesSoFar) + 1 : 0;
+}
+
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
 const ANTHROPIC_MAGIC_STRING_REPLACEMENT = "ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)";
 

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -70,6 +70,17 @@ export function resolveSameModelRateLimitBackoffMs(retriesSoFar: number): number
   return Math.min(SAME_MODEL_RATE_LIMIT_MAX_BACKOFF_MS, delay);
 }
 
+export function resolveSameModelRateLimitRetryDelayMs(params: {
+  retriesSoFar: number;
+  retryAfterSeconds?: number;
+}): number {
+  const backoffMs = resolveSameModelRateLimitBackoffMs(params.retriesSoFar);
+  const retryAfterMs = Number.isFinite(params.retryAfterSeconds)
+    ? Math.ceil(Math.max(0, params.retryAfterSeconds ?? 0) * 1000)
+    : 0;
+  return Math.max(backoffMs, Math.min(SAME_MODEL_RATE_LIMIT_MAX_BACKOFF_MS, retryAfterMs));
+}
+
 export function resolveNextSameModelRateLimitRetryCount(params: {
   retriesSoFar: number;
   retriedSameModelRateLimit: boolean;

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -74,6 +74,7 @@ export type TraceAttempt = {
     | "surface_error"
     | "candidate_failed"
     | "rotate_profile"
+    | "same_model_rate_limit"
     | "fallback_model"
     | "aborted"
     | "error";


### PR DESCRIPTION
## Summary

- Retry assistant-stage short-window rate limits on the same provider/model/profile before spending profile rotation or model fallback budget.
- Use a bounded deterministic retry budget of 10s, 20s, and 30s so common minute-scale RPM/TPM windows can clear without adding unbounded latency.
- Keep quota, usage-limit, subscription, daily/monthly, and bare quota-exceeded 429 failures on the existing escalation path; allow quota wording only when it carries explicit RPM/TPM/per-minute hints.

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/helpers.test.ts src/agents/embedded-agent-runner/run/assistant-failover.test.ts`
- `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run/assistant-failover.ts src/agents/embedded-agent-runner/run/assistant-failover.test.ts src/agents/embedded-agent-runner/run/helpers.ts src/agents/embedded-agent-runner/run/helpers.test.ts`
- `git diff --check upstream/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` — clean before the final conflict-free rebase; no review rerun after the final upstream rebase per maintainer instruction.
