### PR TITLE
fix(telegram): audit follow-ups — block-mode chunk config, dedupe bucket cleanup, grammy contract trust

### DIFF
--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -161,6 +161,7 @@ Telegram:
 
 - Uses `sendMessage` + `editMessageText` preview updates across DMs and group/topics.
 - Final text edits the active preview in place; long finals reuse that message for the first chunk and send only the remaining chunks.
+- `block` mode rotates the preview into a new message at `streaming.preview.chunk.maxChars` (default 800, capped at Telegram's 4096 edit limit); other modes grow one preview up to 4096 characters.
 - `progress` mode keeps tool progress in an editable status draft, clears that draft at completion, and sends the final answer through normal delivery.
 - If the final edit fails before the completed text is confirmed, OpenClaw uses normal final delivery and cleans up the stale preview.
 - Preview streaming is skipped when Telegram block streaming is explicitly enabled (to avoid double-streaming).

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -340,16 +340,11 @@ export const registerTelegramHandlers = ({
     entities: undefined,
     ...(params.date != null ? { date: params.date } : {}),
   });
+  // grammy's Context.getFile reads update state via `this`; keep the receiver bound.
   const buildSyntheticContext = (
-    ctx: Pick<TelegramContext, "me"> & { getFile?: unknown },
+    ctx: Pick<TelegramContext, "me" | "getFile">,
     message: Message,
-  ): TelegramContext => {
-    const getFile =
-      typeof ctx.getFile === "function"
-        ? (ctx.getFile as TelegramContext["getFile"]).bind(ctx as object)
-        : async () => ({});
-    return { message, me: ctx.me, getFile };
-  };
+  ): TelegramContext => ({ message, me: ctx.me, getFile: ctx.getFile.bind(ctx) });
 
   const MULTI_SELECT_PREFIX = "OC_MULTI|";
   const MULTI_SELECT_TOGGLE_PREFIX = `${MULTI_SELECT_PREFIX}toggle|`;
@@ -464,7 +459,7 @@ export const registerTelegramHandlers = ({
       }),
     );
   const buildCallbackSyntheticTextContext = (params: {
-    ctx: Pick<TelegramContext, "me"> & { getFile?: unknown };
+    ctx: Pick<TelegramContext, "me" | "getFile">;
     callbackMessage: Message;
     callback: { from?: Message["from"] };
     text: string;
@@ -1266,10 +1261,7 @@ export const registerTelegramHandlers = ({
   type TelegramGroupAllowContext = Awaited<ReturnType<typeof resolveTelegramGroupAllowFromContext>>;
   type TelegramEventAuthorizationMode = "reaction" | "callback-scope" | "callback-allowlist";
   type TelegramEventAuthorizationContext = TelegramGroupAllowContext & { dmPolicy: DmPolicy };
-  const getChat =
-    typeof (bot.api as { getChat?: unknown }).getChat === "function"
-      ? (bot.api as { getChat: TelegramGetChat }).getChat.bind(bot.api)
-      : undefined;
+  const getChat: TelegramGetChat = bot.api.getChat.bind(bot.api);
 
   const TELEGRAM_EVENT_AUTH_RULES: Record<
     TelegramEventAuthorizationMode,

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1327,6 +1327,66 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.update).toHaveBeenCalledWith("HelloWorld");
   });
 
+  it("sizes block-mode preview chunks from streaming.preview.chunk", async () => {
+    const draftStream = createDraftStream();
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onPartialReply?.({ text: "Hello" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "block",
+      cfg: {
+        channels: {
+          telegram: { streaming: { preview: { chunk: { minChars: 100, maxChars: 600 } } } },
+        },
+      },
+      telegramCfg: { streaming: { mode: "block" } },
+    });
+
+    expectDraftStreamParams({ maxChars: 600 });
+  });
+
+  it("uses the shared block chunk default when block mode has no chunk config", async () => {
+    const draftStream = createDraftStream();
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onPartialReply?.({ text: "Hello" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "block",
+      telegramCfg: { streaming: { mode: "block" } },
+    });
+
+    expectDraftStreamParams({ maxChars: 800 });
+  });
+
+  it("keeps the Telegram edit cap for non-block previews regardless of chunk config", async () => {
+    const draftStream = createDraftStream();
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onPartialReply?.({ text: "Hello" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      cfg: {
+        channels: {
+          telegram: { streaming: { preview: { chunk: { maxChars: 600 } } } },
+        },
+      },
+      telegramCfg: { streaming: { mode: "partial" } },
+    });
+
+    expectDraftStreamParams({ maxChars: 4096 });
+  });
+
   it("streams text-only finals into the answer message", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -104,6 +104,7 @@ import {
 } from "./bot/native-quote.js";
 import type { TelegramStreamMode } from "./bot/types.js";
 import { resolveTelegramInlineButtons, type TelegramInlineButtons } from "./button-types.js";
+import { resolveTelegramDraftStreamingChunking } from "./draft-chunking.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
 import {
   buildTelegramErrorScopeKey,
@@ -824,7 +825,14 @@ export const dispatchTelegramMessage = async ({
     );
     replyFenceGeneration = undefined;
   };
-  const draftMaxChars = Math.min(textLimit, 4096);
+  // Block mode sizes preview rotation steps from streaming.preview.chunk (same
+  // contract as Discord's block chunker). Other modes keep one growing preview
+  // capped at Telegram's 4096 edit limit. The stream has no min-flush concept,
+  // so minChars/breakPreference do not apply here.
+  const draftMaxChars =
+    streamMode === "block"
+      ? Math.min(resolveTelegramDraftStreamingChunking(cfg, route.accountId).maxChars, 4096)
+      : Math.min(textLimit, 4096);
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "telegram",

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -27,7 +27,6 @@ import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/r
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { resolveTelegramInlineButtons, type TelegramInlineButtons } from "../button-types.js";
@@ -59,7 +58,6 @@ const VOICE_FORBIDDEN_MARKER = "VOICE_MESSAGES_FORBIDDEN";
 const CAPTION_TOO_LONG_RE = /caption is too long/i;
 const GrammyErrorCtor: typeof GrammyError | undefined =
   typeof GrammyError === "function" ? GrammyError : undefined;
-const silentReplyLogger = createSubsystemLogger("telegram/silent-reply");
 
 type DeliveryProgress = ReplyThreadDeliveryProgress & {
   deliveredCount: number;
@@ -754,18 +752,6 @@ export async function deliverReplies(params: {
       surface: "telegram",
     }),
   );
-  const originalExactSilentCount = candidateReplies.filter(
-    (reply) => typeof reply.text === "string" && reply.text.trim().toUpperCase() === "NO_REPLY",
-  ).length;
-  if (originalExactSilentCount > 0) {
-    silentReplyLogger.debug("telegram delivery normalized NO_REPLY candidates", {
-      hasSessionKey: Boolean(params.sessionKeyForInternalHooks),
-      hasChatId: params.chatId.length > 0,
-      originalCount: candidateReplies.length,
-      normalizedCount: normalizedReplies.length,
-      originalExactSilentCount,
-    });
-  }
   for (const originalReply of normalizedReplies) {
     let reply = originalReply;
     const mediaList = reply?.mediaUrls?.length

--- a/extensions/telegram/src/state-migrations.test.ts
+++ b/extensions/telegram/src/state-migrations.test.ts
@@ -461,6 +461,12 @@ describe("telegram state migrations", () => {
           [replayKey]: now,
         },
       });
+      legacyStore.register("legacy-bucket-lock", {
+        scopeKey: "old-session-store",
+        namespace: "ops:lock",
+        bucketId: "00",
+        entries: {},
+      });
 
       const cfg = {
         channels: {
@@ -485,6 +491,7 @@ describe("telegram state migrations", () => {
         kind: "plugin-state-import",
         pluginId: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID,
         namespace: dispatchNamespace,
+        cleanupWhenEmpty: true,
       });
       if (!plan || plan.kind !== "plugin-state-import") {
         throw new Error("expected Telegram message dispatch plugin-state import plan");
@@ -520,9 +527,23 @@ describe("telegram state migrations", () => {
         );
       }
 
+      // The plan stays detectable while legacy bucket rows remain so doctor --fix
+      // can finish by deleting the retired source namespace.
       const plansAfterImport = await detectTelegramLegacyStateMigrations({ cfg, env });
       expect(
         plansAfterImport.some(
+          (candidate) =>
+            candidate.kind === "plugin-state-import" &&
+            candidate.sourcePath === "plugin state:telegram.message-dispatch-dedupe:ops",
+        ),
+      ).toBe(true);
+
+      await plan.removeSource?.();
+      expect(legacyStore.entries()).toHaveLength(0);
+
+      const plansAfterCleanup = await detectTelegramLegacyStateMigrations({ cfg, env });
+      expect(
+        plansAfterCleanup.some(
           (candidate) =>
             candidate.kind === "plugin-state-import" &&
             candidate.sourcePath === "plugin state:telegram.message-dispatch-dedupe:ops",

--- a/extensions/telegram/src/state-migrations.ts
+++ b/extensions/telegram/src/state-migrations.ts
@@ -5,7 +5,6 @@ import type { ChannelLegacyStateMigrationPlan } from "openclaw/plugin-sdk/channe
 import { resolveChannelAllowFromPath } from "openclaw/plugin-sdk/channel-pairing";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
-  type PersistentDedupeEntry,
   type PersistentDedupeLegacyJsonImportEntry,
   createPersistentDedupeImportEntry,
   listPersistentDedupeLegacyJsonFileEntries,
@@ -130,20 +129,37 @@ function remainingMessageDispatchDedupeTtlMs(seenAt: number, now: number): numbe
   return ttlMs > 0 ? ttlMs : undefined;
 }
 
-function listTelegramLegacyMessageDispatchPluginStateEntries(params: {
+function openTelegramLegacyMessageDispatchBucketStore(env: NodeJS.ProcessEnv) {
+  return createPluginStateSyncKeyedStore<unknown>("telegram", {
+    namespace: TELEGRAM_MESSAGE_DISPATCH_LEGACY_BUCKET_NAMESPACE,
+    maxEntries: TELEGRAM_MESSAGE_DISPATCH_LEGACY_BUCKET_MAX_ENTRIES,
+    env,
+  });
+}
+
+function readTelegramLegacyMessageDispatchBuckets(params: {
   accountId: string;
   env: NodeJS.ProcessEnv;
   now?: number;
-}): PersistentDedupeLegacyJsonImportEntry[] {
-  const store = createPluginStateSyncKeyedStore<unknown>("telegram", {
-    namespace: TELEGRAM_MESSAGE_DISPATCH_LEGACY_BUCKET_NAMESPACE,
-    maxEntries: TELEGRAM_MESSAGE_DISPATCH_LEGACY_BUCKET_MAX_ENTRIES,
-    env: params.env,
-  });
+}): { importEntries: PersistentDedupeLegacyJsonImportEntry[]; recordKeys: string[] } {
+  const store = openTelegramLegacyMessageDispatchBucketStore(params.env);
   const latestSeenAtByKey = new Map<string, number>();
+  const recordKeys: string[] = [];
   for (const entry of store.entries()) {
     const record = readLegacyMessageDispatchDedupeRecord(entry.value);
-    if (!record || record.namespace !== params.accountId) {
+    if (!record) {
+      continue;
+    }
+    // Lock rows persist as `<accountId>:lock` buckets without dedupe entries;
+    // track them as removable so cleanup empties the retired namespace.
+    const ownsRecord =
+      record.namespace === params.accountId ||
+      record.namespace.startsWith(`${params.accountId}:`);
+    if (!ownsRecord) {
+      continue;
+    }
+    recordKeys.push(entry.key);
+    if (record.namespace !== params.accountId) {
       continue;
     }
     for (const [key, seenAt] of Object.entries(record.entries)) {
@@ -151,7 +167,7 @@ function listTelegramLegacyMessageDispatchPluginStateEntries(params: {
     }
   }
   const now = params.now ?? Date.now();
-  return [...latestSeenAtByKey.entries()].flatMap(([key, seenAt]) => {
+  const importEntries = [...latestSeenAtByKey.entries()].flatMap(([key, seenAt]) => {
     const ttlMs = remainingMessageDispatchDedupeTtlMs(seenAt, now);
     return ttlMs == null
       ? []
@@ -166,33 +182,17 @@ function listTelegramLegacyMessageDispatchPluginStateEntries(params: {
           }),
         ];
   });
+  return { importEntries, recordKeys };
 }
 
-function hasCurrentMessageDispatchDedupeTargets(params: {
-  namespace: string;
-  entries: PersistentDedupeLegacyJsonImportEntry[];
+function removeTelegramLegacyMessageDispatchBuckets(params: {
+  accountId: string;
   env: NodeJS.ProcessEnv;
-}): boolean {
-  const store = createPluginStateSyncKeyedStore<PersistentDedupeEntry>(
-    TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID,
-    {
-      namespace: params.namespace,
-      maxEntries: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_MAX_ENTRIES,
-      defaultTtlMs: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS,
-      env: params.env,
-    },
-  );
-  const existingByKey = new Map(store.entries().map((entry) => [entry.key, entry.value]));
-  return params.entries.every((entry) => {
-    const existingValue = existingByKey.get(entry.key);
-    return (
-      existingValue != null &&
-      !shouldReplacePersistentDedupeEntry({
-        existingValue,
-        incomingValue: entry.value,
-      })
-    );
-  });
+}): void {
+  const store = openTelegramLegacyMessageDispatchBucketStore(params.env);
+  for (const key of readTelegramLegacyMessageDispatchBuckets(params).recordKeys) {
+    store.delete(key);
+  }
 }
 
 function mapTelegramMessageDispatchDedupeImportEntries(params: {
@@ -491,19 +491,15 @@ function detectTelegramMessageDispatchLegacyStateMigration(params: {
           }),
       };
     });
-    let pluginStateEntries: PersistentDedupeLegacyJsonImportEntry[];
+    let legacyRecordKeys: string[];
     try {
-      pluginStateEntries = listTelegramLegacyMessageDispatchPluginStateEntries({
-        accountId,
-        env,
-      });
+      legacyRecordKeys = readTelegramLegacyMessageDispatchBuckets({ accountId, env }).recordKeys;
     } catch {
-      pluginStateEntries = [];
+      legacyRecordKeys = [];
     }
-    if (
-      pluginStateEntries.length === 0 ||
-      hasCurrentMessageDispatchDedupeTargets({ namespace, entries: pluginStateEntries, env })
-    ) {
+    // Emit the plan while any retired bucket rows remain (even TTL-expired ones)
+    // so doctor --fix imports live entries and then deletes the legacy source.
+    if (legacyRecordKeys.length === 0) {
       return jsonPlans;
     }
     const pluginStatePlan: ChannelLegacyStateMigrationPlan = {
@@ -516,14 +512,12 @@ function detectTelegramMessageDispatchLegacyStateMigration(params: {
       maxEntries: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_MAX_ENTRIES,
       defaultTtlMs: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS,
       scopeKey: "",
+      cleanupWhenEmpty: true,
       preview: `- Telegram message dispatch dedupe: plugin state (${TELEGRAM_MESSAGE_DISPATCH_LEGACY_BUCKET_NAMESPACE}) → plugin state (${namespace})`,
       shouldReplaceExistingEntry: ({ existingValue, incomingValue }) =>
         shouldReplacePersistentDedupeEntry({ existingValue, incomingValue }),
-      readEntries: () =>
-        listTelegramLegacyMessageDispatchPluginStateEntries({
-          accountId,
-          env,
-        }),
+      readEntries: () => readTelegramLegacyMessageDispatchBuckets({ accountId, env }).importEntries,
+      removeSource: () => removeTelegramLegacyMessageDispatchBuckets({ accountId, env }),
     };
     return jsonPlans.concat(pluginStatePlan);
   });

--- a/src/channels/plugins/legacy-state-migration.types.ts
+++ b/src/channels/plugins/legacy-state-migration.types.ts
@@ -18,6 +18,8 @@ export type ChannelLegacyStateMigrationPlan =
       stateDir?: string;
       cleanupSource?: "rename";
       cleanupWhenEmpty?: boolean;
+      /** Deletes a non-file legacy source (e.g. plugin-state rows) once all entries are covered. */
+      removeSource?: () => void | Promise<void>;
       preview?: string;
       shouldReplaceExistingEntry?: (params: {
         key: string;

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -1122,6 +1122,55 @@ describe("doctor legacy state migrations", () => {
     });
   });
 
+  it("removes plugin-state legacy sources through removeSource once covered", async () => {
+    const root = await makeTempRoot();
+    const removeSource = vi.fn();
+    const removeEmptySource = vi.fn();
+    mockedChannelMigrationPlans.plans = [
+      {
+        kind: "plugin-state-import",
+        label: "Test bucket cache",
+        sourcePath: "plugin state:test.legacy-buckets",
+        targetPath: "plugin state:test.bucket-cache",
+        pluginId: "telegram",
+        namespace: "test.bucket-cache",
+        maxEntries: 4,
+        scopeKey: "",
+        removeSource,
+        readEntries: () => [{ key: "default", value: { body: "bucket" } }],
+      },
+      {
+        kind: "plugin-state-import",
+        label: "Test empty bucket cache",
+        sourcePath: "plugin state:test.legacy-empty",
+        targetPath: "plugin state:test.empty-cache",
+        pluginId: "telegram",
+        namespace: "test.empty-cache",
+        maxEntries: 4,
+        scopeKey: "",
+        cleanupWhenEmpty: true,
+        removeSource: removeEmptySource,
+        readEntries: () => [],
+      },
+    ];
+
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(removeSource).toHaveBeenCalledTimes(1);
+    expect(removeEmptySource).toHaveBeenCalledTimes(1);
+    expect(result.changes).toContain(
+      "Removed Test bucket cache legacy source (plugin state:test.legacy-buckets)",
+    );
+    expect(result.changes).toContain(
+      "Removed Test empty bucket cache legacy source (plugin state:test.legacy-empty)",
+    );
+  });
+
   it("replaces existing plugin-state entries when a channel import plan asks for it", async () => {
     const root = await makeTempRoot();
     const sourcePath = path.join(root, "legacy-cache.json");

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -1712,6 +1712,14 @@ async function runLegacyMigrationPlans(
             warnings,
           });
         }
+        if (allEntriesCovered && plan.removeSource) {
+          try {
+            await plan.removeSource();
+            changes.push(`Removed ${plan.label} legacy source (${plan.sourcePath})`);
+          } catch (err) {
+            warnings.push(`Failed removing ${plan.label} legacy source: ${String(err)}`);
+          }
+        }
       });
       continue;
     }


### PR DESCRIPTION
## Summary

Follow-ups from the telegram audit series (#91871, #91874, #91876, #91904):

- **Wire `streaming.preview.chunk` into telegram block mode.** `channels.telegram.streaming.preview.chunk.maxChars` now sizes preview rotation steps when `streaming.mode: "block"`, matching how Discord consults the chunk config only for its block chunker. Other modes keep one growing preview at Telegram's 4096 edit cap, so default (`partial`) behavior is unchanged. Behavior note: block mode without explicit config moves from 4096 to the shared 800-char default, aligning telegram with Discord/SDK block chunk sizing. Doctor already migrates legacy `draftChunk` keys into this config for telegram, so it is no longer a silent no-op.
- **Delete retired dispatch dedupe buckets after doctor import.** Adds an optional `removeSource` hook to plugin-state-import migration plans (invoked only once every legacy entry is covered) and telegram now deletes the retired `telegram.message-dispatch-dedupe` bucket rows, including `:lock` rows, after importing into the SDK dedupe namespace from #91904. The plan keeps emitting while any legacy rows remain (even TTL-expired), so previously-imported installs get swept on their next `doctor --fix`, after which detection goes quiet. This also deletes the `hasCurrentMessageDispatchDedupeTargets` gate.
- **Trust grammy's API contract in handler seams.** `buildSyntheticContext` requires `getFile` (drops the `async () => ({})` fallback) and `getChat` binds `bot.api.getChat` directly — grammy's `Api` declares it concretely. Removes the NO_REPLY pre-count debug block in delivery (the SDK payload projection already normalizes NO_REPLY).

## Verification

Regression proof — the new tests fail on `main`'s production code and pass with this branch:

- `sizes block-mode preview chunks from streaming.preview.chunk` ✗ on main (got 4096, config ignored) → ✓
- `uses the shared block chunk default when block mode has no chunk config` ✗ on main → ✓
- `removes plugin-state legacy sources through removeSource once covered` ✗ on main (hook missing) → ✓
- `migrates shipped Telegram message dispatch plugin-state buckets` lifecycle ✗ on main (legacy rows linger, plan never re-emitted for cleanup) → ✓

Local (worktree, `node scripts/run-vitest.mjs`): bot-message-dispatch (124), state-migrations (8), doctor-state-migrations (46), bot.test (147), bot/delivery + helpers + media-dedup suites — all green.

Remote: `blacksmith testbox run --id tbx_01ktrf67rfpa02v4xd82bjv7jv` → `pnpm check:changed` green (tsgo core/test/extensions lanes, oxlint, import cycles, guards). An earlier run caught a `Pick<TelegramContext, ...>` mismatch at `bot-handlers.runtime.ts:473`; fixed by tightening `buildCallbackSyntheticTextContext` and re-run green.

Not tested: live Telegram block-mode streaming against a real bot.
