### PR TITLE
fix(ios): clean up notification settings state

### DIFF
--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -53,8 +53,7 @@ struct SettingsProTab: View {
     @State var suppressCredentialPersist = false
     @State var locationStatusText: String?
     @State var previousLocationModeRaw: String = OpenClawLocationMode.off.rawValue
-    @State var notificationStatusText = "Checking"
-    @State var notificationActionText = "Request Access"
+    @State var notificationStatus: SettingsNotificationStatus = .checking
     @State var diagnosticsLastRunText = "Not run"
     @State var diagnosticsIssueCount: Int?
     @State var showTalkIssueDetails = false

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -65,7 +65,7 @@ extension SettingsProTab {
                     title: "Notifications",
                     detail: "Approval and event alert channel",
                     value: self.notificationStatusText,
-                    color: self.notificationStatusText == "Allowed" ? OpenClawBrand.ok : .secondary)
+                    color: self.notificationStatus.color)
                 Divider().padding(.leading, 60)
                 self.diagnosticCheckRow(
                     icon: "rectangle.on.rectangle",
@@ -166,7 +166,7 @@ extension SettingsProTab {
             gatewayConnected: self.gatewayDiagnosticConnected,
             discoveredGatewayCount: self.gatewayController.gateways.count,
             talkConfigLoaded: self.gatewayDiagnosticTalkConfigLoaded,
-            notificationStatusText: self.notificationStatusText)
+            notificationsAllowed: self.notificationStatus == .allowed)
         self.diagnosticsIssueCount = issueCount
         self.diagnosticsLastRunText = SettingsDiagnostics.timestamp(Date())
     }
@@ -431,8 +431,8 @@ extension SettingsProTab {
     }
 
     func handleNotificationAction() {
-        if self.notificationStatusText == "Allowed" || self.notificationStatusText == "Not Allowed" {
-            self.openSystemSettings()
+        if self.notificationStatus.shouldOpenNotificationSettings {
+            self.openNotificationSettings()
             return
         }
 
@@ -443,28 +443,14 @@ extension SettingsProTab {
                 .sound,
             ])) ?? false
             await MainActor.run {
-                self.notificationStatusText = granted ? "Allowed" : "Not Allowed"
-                self.notificationActionText = granted ? "Open System Settings" : "Open System Settings"
+                self.notificationStatus = granted ? .allowed : .notAllowed
             }
         }
     }
 
     @MainActor
     func applyNotificationStatus(_ status: UNAuthorizationStatus) {
-        switch status {
-        case .authorized, .provisional, .ephemeral:
-            self.notificationStatusText = "Allowed"
-            self.notificationActionText = "Open System Settings"
-        case .denied:
-            self.notificationStatusText = "Not Allowed"
-            self.notificationActionText = "Open System Settings"
-        case .notDetermined:
-            self.notificationStatusText = "Not Set"
-            self.notificationActionText = "Request Access"
-        @unknown default:
-            self.notificationStatusText = "Unknown"
-            self.notificationActionText = "Open System Settings"
-        }
+        self.notificationStatus = SettingsNotificationStatus(status)
     }
 
     func persistGatewayToken(_ value: String) {
@@ -485,8 +471,8 @@ extension SettingsProTab {
             instanceId: instanceId)
     }
 
-    func openSystemSettings() {
-        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+    func openNotificationSettings() {
+        guard let url = URL(string: UIApplication.openNotificationSettingsURLString) else { return }
         UIApplication.shared.open(url)
     }
 
@@ -785,5 +771,13 @@ extension SettingsProTab {
         case .whileUsing: "While Using"
         case .always: "Always"
         }
+    }
+
+    var notificationStatusText: String {
+        self.notificationStatus.text
+    }
+
+    var notificationActionText: String {
+        self.notificationStatus.actionTitle
     }
 }

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -492,7 +492,7 @@ extension SettingsProTab {
                 title: "Notifications",
                 detail: "Approvals and event alerts from OpenClaw.",
                 value: self.notificationStatusText,
-                color: self.notificationStatusText == "Allowed" ? OpenClawBrand.ok : .secondary)
+                color: self.notificationStatus.color)
 
             ProCard(radius: SettingsLayout.cardRadius) {
                 VStack(alignment: .leading, spacing: 12) {
@@ -501,7 +501,7 @@ extension SettingsProTab {
                     } label: {
                         Label(
                             self.notificationActionText,
-                            systemImage: self.notificationStatusText == "Allowed" ? "gear" : "bell.badge")
+                            systemImage: self.notificationStatus.actionIcon)
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.borderedProminent)

--- a/apps/ios/Sources/Design/SettingsProTabSupport.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSupport.swift
@@ -1,6 +1,7 @@
 import Darwin
 import OpenClawKit
 import SwiftUI
+import UserNotifications
 
 enum SettingsRoute: Hashable {
     case gateway
@@ -65,6 +66,63 @@ struct SettingsApprovalRow: View {
     }
 }
 
+enum SettingsNotificationStatus: Equatable {
+    case checking
+    case allowed
+    case notAllowed
+    case notSet
+    case unknown
+
+    init(_ status: UNAuthorizationStatus) {
+        switch status {
+        case .authorized, .provisional, .ephemeral:
+            self = .allowed
+        case .denied:
+            self = .notAllowed
+        case .notDetermined:
+            self = .notSet
+        @unknown default:
+            self = .unknown
+        }
+    }
+
+    var text: String {
+        switch self {
+        case .checking: "Checking"
+        case .allowed: "Allowed"
+        case .notAllowed: "Not Allowed"
+        case .notSet: "Not Set"
+        case .unknown: "Unknown"
+        }
+    }
+
+    var actionTitle: String {
+        switch self {
+        case .notSet, .checking:
+            "Request Access"
+        case .allowed, .notAllowed, .unknown:
+            "Open System Settings"
+        }
+    }
+
+    var actionIcon: String {
+        self == .allowed ? "gear" : "bell.badge"
+    }
+
+    var color: Color {
+        self == .allowed ? OpenClawBrand.ok : .secondary
+    }
+
+    var shouldOpenNotificationSettings: Bool {
+        switch self {
+        case .allowed, .notAllowed, .unknown:
+            true
+        case .checking, .notSet:
+            false
+        }
+    }
+}
+
 enum SettingsDiagnosticIssue: String, Equatable, CaseIterable {
     case gatewayOffline
     case discoveryUnavailable
@@ -77,13 +135,13 @@ enum SettingsDiagnostics {
         gatewayConnected: Bool,
         discoveredGatewayCount: Int,
         talkConfigLoaded: Bool,
-        notificationStatusText: String) -> [SettingsDiagnosticIssue]
+        notificationsAllowed: Bool) -> [SettingsDiagnosticIssue]
     {
         var issues: [SettingsDiagnosticIssue] = []
         if !gatewayConnected { issues.append(.gatewayOffline) }
         if discoveredGatewayCount == 0 { issues.append(.discoveryUnavailable) }
         if gatewayConnected, !talkConfigLoaded { issues.append(.talkConfigMissing) }
-        if notificationStatusText != "Allowed" { issues.append(.notificationsUnavailable) }
+        if !notificationsAllowed { issues.append(.notificationsUnavailable) }
         return issues
     }
 
@@ -91,13 +149,13 @@ enum SettingsDiagnostics {
         gatewayConnected: Bool,
         discoveredGatewayCount: Int,
         talkConfigLoaded: Bool,
-        notificationStatusText: String) -> Int
+        notificationsAllowed: Bool) -> Int
     {
         self.issues(
             gatewayConnected: gatewayConnected,
             discoveredGatewayCount: discoveredGatewayCount,
             talkConfigLoaded: talkConfigLoaded,
-            notificationStatusText: notificationStatusText).count
+            notificationsAllowed: notificationsAllowed).count
     }
 
     static func timestamp(_ date: Date) -> String {

--- a/apps/ios/Tests/SettingsNetworkingHelpersTests.swift
+++ b/apps/ios/Tests/SettingsNetworkingHelpersTests.swift
@@ -8,7 +8,7 @@ import Testing
                 gatewayConnected: false,
                 discoveredGatewayCount: 0,
                 talkConfigLoaded: false,
-                notificationStatusText: "Not Set") == [
+                notificationsAllowed: false) == [
                     .gatewayOffline,
                     .discoveryUnavailable,
                     .notificationsUnavailable,
@@ -21,13 +21,13 @@ import Testing
                 gatewayConnected: true,
                 discoveredGatewayCount: 1,
                 talkConfigLoaded: false,
-                notificationStatusText: "Allowed") == [.talkConfigMissing])
+                notificationsAllowed: true) == [.talkConfigMissing])
         #expect(
             SettingsDiagnostics.issueCount(
                 gatewayConnected: true,
                 discoveredGatewayCount: 1,
                 talkConfigLoaded: true,
-                notificationStatusText: "Allowed") == 0)
+                notificationsAllowed: true) == 0)
     }
 
     @Test func parseHostPortParsesIPv4() {


### PR DESCRIPTION
## Summary

- Replace notification settings string state with typed state.
- Open the app notification Settings page via `UIApplication.openNotificationSettingsURLString`.

> [!WARNING]
> Local proof used beta macOS/Xcode.

## Real behavior proof

- Behavior addressed: iOS notification settings action opens the app notification settings page and no longer depends on UI strings for control flow.
- Real environment tested: physical iPhone, local OpenClaw iOS build signed with personal team `5KE88HWMKJ`.
- Exact steps or command run after this patch: opened OpenClaw on device, entered demo setup code, tapped Settings -> Notifications -> Open System Settings.
- Evidence after fix: physical-device recording: <img width="320" alt="ScreenRecording_06-10-2026 14-55-02_1" src="https://github.com/user-attachments/assets/869d5202-b697-4be4-8e00-e9ba3cf7138c" />
- Observed result after fix: notification settings opened correctly on device.
- What was not tested: App Store/TestFlight build.

## Tests and validation

- `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -configuration Debug build`
- `xcodebuild test -project apps/ios/OpenClaw.xcodeproj -scheme OpenClawLogicTests -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5'`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Risk checklist

- [x] User-visible behavior changed
- [ ] Config, environment, or migration behavior changed
- [ ] Security, auth, secrets, network, or tool execution behavior changed

Highest risk: iOS Settings deep-link behavior. Mitigation: verified on physical device.

## Current review state

Ready for maintainer review; waiting on CI.
