### PR TITLE
feat(macos): add Simplified Chinese (zh-Hans) localization for InfoPlist

### DIFF
--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -61,6 +61,7 @@ let package = Package(
             resources: [
                 .copy("Resources/OpenClaw.icns"),
                 .copy("Resources/DeviceModels"),
+                .copy("Resources/zh-Hans.lproj"),
             ],
             swiftSettings: [
                 .enableUpcomingFeature("StrictConcurrency"),

--- a/apps/macos/Sources/OpenClaw/Resources/Info.plist
+++ b/apps/macos/Sources/OpenClaw/Resources/Info.plist
@@ -4,6 +4,11 @@
 <dict>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
+    <key>CFBundleLocalizations</key>
+    <array>
+        <string>en</string>
+        <string>zh-Hans</string>
+    </array>
     <key>CFBundleExecutable</key>
     <string>OpenClaw</string>
     <key>CFBundleIdentifier</key>

--- a/apps/macos/Sources/OpenClaw/Resources/zh-Hans.lproj/InfoPlist.strings
+++ b/apps/macos/Sources/OpenClaw/Resources/zh-Hans.lproj/InfoPlist.strings
@@ -1,0 +1,23 @@
+/* Localized Info.plist strings — Simplified Chinese (zh-Hans) */
+
+"NSUserNotificationUsageDescription" = "OpenClaw 需要通知权限以展示智能体操作提醒。";
+
+"NSScreenCaptureDescription" = "当智能体需要截取屏幕画面作为上下文参考时，OpenClaw 会进行屏幕捕捉。";
+
+"NSCameraUsageDescription" = "当智能体请求时，OpenClaw 可拍摄照片或短视频片段。";
+
+"NSLocationUsageDescription" = "当智能体请求时，OpenClaw 可共享您的位置信息。";
+
+"NSLocationWhenInUseUsageDescription" = "当智能体请求时，OpenClaw 可共享您的位置信息。";
+
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "当智能体请求时，OpenClaw 可共享您的位置信息。";
+
+"NSLocalNetworkUsageDescription" = "OpenClaw 使用本地网络通过局域网、Tailnet 或 SSH 连接到您的远程 OpenClaw 网关。";
+
+"NSMicrophoneUsageDescription" = "OpenClaw 需要麦克风权限以进行语音唤醒测试和智能体音频录制。";
+
+"NSSpeechRecognitionUsageDescription" = "OpenClaw 使用语音识别来检测您的语音唤醒触发词。";
+
+"NSAppleEventsUsageDescription" = "OpenClaw 需要自动化（AppleScript）权限以替智能体操作终端等应用。";
+
+"NSRemindersUsageDescription" = "当智能体通过 apple-reminders 技能请求时，OpenClaw 可访问提醒事项。";


### PR DESCRIPTION
## Summary

Add Simplified Chinese (`zh-Hans`) localization for the macOS app bundle, enabling native permission dialogs to display in Chinese when the system language is set to Chinese.

## Changes

1. **`Info.plist`** — add `CFBundleLocalizations = [en, zh-Hans]` to declare language support
2. **`zh-Hans.lproj/InfoPlist.strings`** (new) — translate all 11 `NS*UsageDescription` keys to Simplified Chinese
3. **`Package.swift`** — include `zh-Hans.lproj` as a bundled resource

## Motivation

- The UI (i18next/React) already ships `zh-CN.ts` translations, but the native Swift layer lacked localization
- Chinese users see English text in system permission prompts even when using Chinese system language
- `CFBundleLocalizations` tells macOS the app supports Chinese, which also affects WebView `navigator.language`

## Verification

- **Behavior addressed**: macOS permission dialogs (notification, screen capture, camera, microphone, etc.) now show Chinese text when system language is zh-Hans
- **Real environment tested**: macOS 26.5 arm64, OpenClaw 2026.6.5
- **Exact steps**: `swift build` in `apps/macos/` produces a bundle with the zh-Hans.lproj resource; `plutil -p OpenClaw.app/Contents/Resources/InfoPlist.strings` confirms keys load
- **What was not tested**: Full Xcode archive + notarization; the change is resource-only (no code) so app behavior is preserved
