### PR TITLE
fix(state): tolerate chmod failures when opening the state database

### DIFF
--- a/src/state/openclaw-state-db.permissions.test.ts
+++ b/src/state/openclaw-state-db.permissions.test.ts
@@ -34,10 +34,14 @@ const {
   runOpenClawStateWriteTransaction,
 } = await import("./openclaw-state-db.js");
 
-function enotsupError(): Error {
-  const err = new Error("ENOTSUP: operation not supported, chmod") as NodeJS.ErrnoException;
-  err.code = "ENOTSUP";
+function chmodError(code: string): Error {
+  const err = new Error(`${code}: chmod failed`) as NodeJS.ErrnoException;
+  err.code = code;
   return err;
+}
+
+function enotsupError(): Error {
+  return chmodError("ENOTSUP");
 }
 
 describe("state database permission hardening without chmod support", () => {
@@ -62,6 +66,28 @@ describe("state database permission hardening without chmod support", () => {
     expect(database.db.isOpen).toBe(true);
     // Hardening ran and failed; the failure must stay non-fatal.
     expect(chmodFailHook.calls).toBeGreaterThan(0);
+  });
+
+  it("opens the state database when chmodSync throws EPERM", () => {
+    // NFS with root_squash and Azure Files surface chmod failures as EPERM.
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    chmodFailHook.error = chmodError("EPERM");
+
+    const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+
+    expect(database.db.isOpen).toBe(true);
+    expect(chmodFailHook.calls).toBeGreaterThan(0);
+  });
+
+  it("rethrows unexpected chmod errors at open", () => {
+    // EACCES is not in CHMOD_UNSUPPORTED_CODES: a real permission fault on a
+    // POSIX filesystem must keep the credentials-adjacent hardening fatal.
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    chmodFailHook.error = chmodError("EACCES");
+
+    expect(() => openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } })).toThrow(
+      /EACCES/,
+    );
   });
 
   it("repairs the schema when chmodSync throws ENOTSUP", () => {

--- a/src/state/openclaw-state-db.permissions.test.ts
+++ b/src/state/openclaw-state-db.permissions.test.ts
@@ -12,13 +12,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const chmodFailHook = vi.hoisted(() => ({
   error: undefined as Error | undefined,
   calls: 0,
+  failProbe: true,
 }));
 
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   const chmodSync: typeof actual.chmodSync = ((target: unknown, mode: unknown) => {
     chmodFailHook.calls += 1;
-    if (chmodFailHook.error) {
+    const isProbe = String(target).includes(".openclaw-chmod-probe-");
+    if (chmodFailHook.error && (chmodFailHook.failProbe || !isProbe)) {
       throw chmodFailHook.error;
     }
     return (actual.chmodSync as (...args: unknown[]) => unknown)(target, mode);
@@ -50,6 +52,7 @@ describe("state database permission hardening without chmod support", () => {
   afterEach(() => {
     chmodFailHook.error = undefined;
     chmodFailHook.calls = 0;
+    chmodFailHook.failProbe = true;
     closeOpenClawStateDatabaseForTest();
     if (stateDir) {
       fs.rmSync(stateDir, { recursive: true, force: true });
@@ -68,15 +71,36 @@ describe("state database permission hardening without chmod support", () => {
     expect(chmodFailHook.calls).toBeGreaterThan(0);
   });
 
-  it("opens the state database when chmodSync throws EPERM", () => {
-    // NFS with root_squash and Azure Files surface chmod failures as EPERM.
+  it("rethrows EPERM when existing permissions are too broad", () => {
     stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    fs.chmodSync(stateDir, 0o755);
+    chmodFailHook.error = chmodError("EPERM");
+    chmodFailHook.failProbe = false;
+
+    expect(() => openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } })).toThrow(
+      /EPERM/,
+    );
+  });
+
+  it("opens when EPERM leaves existing permissions restrictive", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+    closeOpenClawStateDatabaseForTest();
     chmodFailHook.error = chmodError("EPERM");
 
     const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
 
     expect(database.db.isOpen).toBe(true);
-    expect(chmodFailHook.calls).toBeGreaterThan(0);
+  });
+
+  it("opens when the filesystem probe also rejects chmod with EPERM", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    fs.chmodSync(stateDir, 0o755);
+    chmodFailHook.error = chmodError("EPERM");
+
+    const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+
+    expect(database.db.isOpen).toBe(true);
   });
 
   it("rethrows unexpected chmod errors at open", () => {

--- a/src/state/openclaw-state-db.permissions.test.ts
+++ b/src/state/openclaw-state-db.permissions.test.ts
@@ -1,0 +1,91 @@
+// State database permission hardening tests cover best-effort chmod on
+// filesystems without POSIX permission support (Azure Files, NFS, certain
+// Docker volume drivers).
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// openclaw-state-db.ts hardens permissions via the named import `chmodSync`
+// from node:fs. A namespace `vi.spyOn(fs, ...)` cannot rebind an
+// already-captured named import, so we mock node:fs and route chmodSync
+// (named + default) through a single controllable failure hook.
+const chmodFailHook = vi.hoisted(() => ({
+  error: undefined as Error | undefined,
+  calls: 0,
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const chmodSync: typeof actual.chmodSync = ((target: unknown, mode: unknown) => {
+    chmodFailHook.calls += 1;
+    if (chmodFailHook.error) {
+      throw chmodFailHook.error;
+    }
+    return (actual.chmodSync as (...args: unknown[]) => unknown)(target, mode);
+  }) as typeof actual.chmodSync;
+  return { ...actual, chmodSync, default: { ...actual, chmodSync } };
+});
+
+const fs = await import("node:fs");
+const {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  repairOpenClawStateDatabaseSchema,
+  runOpenClawStateWriteTransaction,
+} = await import("./openclaw-state-db.js");
+
+function enotsupError(): Error {
+  const err = new Error("ENOTSUP: operation not supported, chmod") as NodeJS.ErrnoException;
+  err.code = "ENOTSUP";
+  return err;
+}
+
+describe("state database permission hardening without chmod support", () => {
+  let stateDir: string | undefined;
+
+  afterEach(() => {
+    chmodFailHook.error = undefined;
+    chmodFailHook.calls = 0;
+    closeOpenClawStateDatabaseForTest();
+    if (stateDir) {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+      stateDir = undefined;
+    }
+  });
+
+  it("opens the state database when chmodSync throws ENOTSUP", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    chmodFailHook.error = enotsupError();
+
+    const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+
+    expect(database.db.isOpen).toBe(true);
+    // Hardening ran and failed; the failure must stay non-fatal.
+    expect(chmodFailHook.calls).toBeGreaterThan(0);
+  });
+
+  it("repairs the schema when chmodSync throws ENOTSUP", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+    closeOpenClawStateDatabaseForTest();
+
+    chmodFailHook.error = enotsupError();
+
+    expect(() =>
+      repairOpenClawStateDatabaseSchema({ env: { OPENCLAW_STATE_DIR: stateDir } }),
+    ).not.toThrow();
+  });
+
+  it("commits write transactions when chmodSync throws ENOTSUP", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    chmodFailHook.error = enotsupError();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+
+    const result = runOpenClawStateWriteTransaction((database) => {
+      expect(database.db.isOpen).toBe(true);
+      return "committed";
+    }, options);
+
+    expect(result).toBe("committed");
+  });
+});

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -116,14 +116,25 @@ const stateDbLog = createSubsystemLogger("state/db");
 /** Targets already warned about, so chmod-less filesystems warn once per path. */
 const chmodWarnedTargets = new Set<string>();
 
-// Permission hardening is best-effort: some filesystems (Azure Files, NFS,
-// certain Docker volume drivers) reject chmod, and the database stays usable
-// without it. This mirrors the policy already documented in
-// runOpenClawStateWriteTransaction, so a chmod failure never aborts startup.
+// Errno codes raised when the filesystem cannot enforce POSIX modes: ENOTSUP/
+// EOPNOTSUPP (Docker volume drivers, FUSE), EINVAL (some SMB mounts), EPERM
+// (Azure Files, NFS with root_squash). EPERM also covers local not-the-owner
+// failures; the warn log keeps that case observable. Anything else (EACCES,
+// EIO, ...) is a real fault and stays fatal.
+const CHMOD_UNSUPPORTED_CODES = new Set(["ENOTSUP", "EOPNOTSUPP", "EINVAL", "EPERM"]);
+
+// Permission hardening is best-effort only on filesystems that cannot apply
+// it: the database stays usable without the chmod, and crashing at open would
+// take the gateway down on Azure Files/NFS/Docker volumes (#91919). Unexpected
+// chmod failures still throw so credentials-adjacent hardening stays loud.
 function bestEffortChmodSync(target: string, mode: number): void {
   try {
     chmodSync(target, mode);
   } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (!code || !CHMOD_UNSUPPORTED_CODES.has(code)) {
+      throw err;
+    }
     if (chmodWarnedTargets.has(target)) {
       return;
     }

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -1,6 +1,6 @@
 // OpenClaw state database manages shared persisted state and migrations.
 import { randomUUID } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import {
@@ -116,12 +116,51 @@ const stateDbLog = createSubsystemLogger("state/db");
 /** Targets already warned about, so chmod-less filesystems warn once per path. */
 const chmodWarnedTargets = new Set<string>();
 
-// Errno codes raised when the filesystem cannot enforce POSIX modes: ENOTSUP/
-// EOPNOTSUPP (Docker volume drivers, FUSE), EINVAL (some SMB mounts), EPERM
-// (Azure Files, NFS with root_squash). EPERM also covers local not-the-owner
-// failures; the warn log keeps that case observable. Anything else (EACCES,
-// EIO, ...) is a real fault and stays fatal.
-const CHMOD_UNSUPPORTED_CODES = new Set(["ENOTSUP", "EOPNOTSUPP", "EINVAL", "EPERM"]);
+// Unambiguous errno codes raised when the filesystem cannot enforce POSIX modes.
+const CHMOD_UNSUPPORTED_CODES = new Set(["ENOTSUP", "EOPNOTSUPP", "EINVAL"]);
+
+function hasRestrictivePermissions(target: string): boolean {
+  try {
+    return (statSync(target).mode & 0o077) === 0;
+  } catch {
+    return false;
+  }
+}
+
+function filesystemRejectsChmod(target: string): boolean {
+  let probePath: string;
+  try {
+    const probeDir = statSync(target).isDirectory() ? target : path.dirname(target);
+    probePath = path.join(probeDir, `.openclaw-chmod-probe-${randomUUID()}`);
+    writeFileSync(probePath, "", { flag: "wx", mode: OPENCLAW_STATE_FILE_MODE });
+  } catch {
+    return false;
+  }
+  try {
+    chmodSync(probePath, OPENCLAW_STATE_FILE_MODE);
+    return false;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  } finally {
+    try {
+      unlinkSync(probePath);
+    } catch {
+      // The probe is best-effort cleanup after a failed capability check.
+    }
+  }
+}
+
+function canIgnoreChmodError(target: string, code: string | undefined): boolean {
+  if (code && CHMOD_UNSUPPORTED_CODES.has(code)) {
+    return true;
+  }
+  if (code !== "EPERM") {
+    return false;
+  }
+  // EPERM is ambiguous: keep restrictive targets usable, otherwise prove the
+  // containing filesystem also rejects chmod before weakening fail-closed behavior.
+  return hasRestrictivePermissions(target) || filesystemRejectsChmod(target);
+}
 
 // Permission hardening is best-effort only on filesystems that cannot apply
 // it: the database stays usable without the chmod, and crashing at open would
@@ -132,7 +171,7 @@ function bestEffortChmodSync(target: string, mode: number): void {
     chmodSync(target, mode);
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
-    if (!code || !CHMOD_UNSUPPORTED_CODES.has(code)) {
+    if (!canIgnoreChmodError(target, code)) {
       throw err;
     }
     if (chmodWarnedTargets.has(target)) {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -11,6 +11,7 @@ import {
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
 import { configureSqliteWalMaintenance, type SqliteWalMaintenance } from "../infra/sqlite-wal.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
   resolveOpenClawStateSqliteDir,
@@ -110,6 +111,27 @@ function assertSupportedSchemaVersion(db: DatabaseSync, pathname: string): void 
   }
 }
 
+const stateDbLog = createSubsystemLogger("state/db");
+
+/** Targets already warned about, so chmod-less filesystems warn once per path. */
+const chmodWarnedTargets = new Set<string>();
+
+// Permission hardening is best-effort: some filesystems (Azure Files, NFS,
+// certain Docker volume drivers) reject chmod, and the database stays usable
+// without it. This mirrors the policy already documented in
+// runOpenClawStateWriteTransaction, so a chmod failure never aborts startup.
+function bestEffortChmodSync(target: string, mode: number): void {
+  try {
+    chmodSync(target, mode);
+  } catch (err) {
+    if (chmodWarnedTargets.has(target)) {
+      return;
+    }
+    chmodWarnedTargets.add(target);
+    stateDbLog.warn(`skipped permission hardening for ${target}: ${String(err)}`);
+  }
+}
+
 function ensureOpenClawStatePermissions(pathname: string, env: NodeJS.ProcessEnv): void {
   const dir = path.dirname(pathname);
   const defaultDir = resolveOpenClawStateSqliteDir(env);
@@ -122,12 +144,12 @@ function ensureOpenClawStatePermissions(pathname: string, env: NodeJS.ProcessEnv
   mkdirSync(dir, { recursive: true, mode: OPENCLAW_STATE_DIR_MODE });
   // Default state contains credentials-adjacent metadata; custom existing dirs keep caller modes.
   if (isDefaultStateDatabase || !dirExisted) {
-    chmodSync(dir, OPENCLAW_STATE_DIR_MODE);
+    bestEffortChmodSync(dir, OPENCLAW_STATE_DIR_MODE);
   }
   for (const suffix of OPENCLAW_STATE_SIDECAR_SUFFIXES) {
     const candidate = `${pathname}${suffix}`;
     if (existsSync(candidate)) {
-      chmodSync(candidate, OPENCLAW_STATE_FILE_MODE);
+      bestEffortChmodSync(candidate, OPENCLAW_STATE_FILE_MODE);
     }
   }
 }


### PR DESCRIPTION
Fixes #91919

`ensureOpenClawStatePermissions` called `chmodSync` unguarded, so any filesystem that rejects chmod (Azure Files, NFS, certain Docker volume drivers) crashed the gateway at startup, before serving any requests. The write-transaction path already documents permission hardening as best-effort; this PR applies the same policy at the open and repair paths.

The fix sits one layer below the call sites suggested in the issue: only the `chmodSync` operations inside `ensureOpenClawStatePermissions` become best-effort, via a small `bestEffortChmodSync` helper. That keeps two things intact that wrapping the call sites would have lost:

1. The path-traversal guard (`state database path resolved outside its state dir`) still throws. The hardening exception is scoped to chmod only, so this does not broaden it the way the earlier attempt on #91925 did.
2. `repairOpenClawStateDatabaseSchema` calls the same function before opening, so the repair path is fixed too, not just `openOpenClawStateDatabase`.

Each skipped target logs one `[state/db] skipped permission hardening for ...` warning (deduped per path), so the degraded mode is visible in logs rather than silent.

The tolerated failures are narrow, not a blanket catch: `ENOTSUP`/`EOPNOTSUPP` and `EINVAL` remain non-fatal. Because `EPERM` is ambiguous, it is tolerated only when the existing mode is already private or a disposable same-directory probe confirms that the filesystem itself rejects `chmod`; ordinary ownership failures stay fatal.

Tests: new `src/state/openclaw-state-db.permissions.test.ts` (house fs-mock shape from `auth-storage.test.ts`) covers open, repair, and write-transaction under a `chmodSync` that throws ENOTSUP, plus the EPERM policy at open: restrictive targets and chmod-less filesystems remain usable, while broad ownership failures and EACCES rethrow. Stash-bisect confirms the ENOTSUP cases fail without the fix. Full `src/state/` lane is green, `tsgo:core` and oxlint pass.

This PR was AI-assisted (written by an autonomous agent; persistent identity at github.com/truffle-dev). The proof below was produced by running the commands in this environment.

## Real behavior proof

- Behavior or issue addressed: gateway crash at startup when the state directory lives on a filesystem that rejects `chmodSync` (#91919).
- Real environment tested: Linux 6.8 Docker container, Node 22, repo at this branch. A real NFS or Azure Files mount cannot be provisioned in this environment, so the chmod failure was injected with a small CJS preload that makes `fs.chmodSync` throw ENOTSUP (the same errno those filesystems return), loaded via `node --require` so it takes effect before any module captures the binding.
- Exact steps or command run after this patch: `node --require /tmp/chmod-repro/enotsup-shim.cjs --import tsx /tmp/chmod-repro/open-state-db.mts` where `open-state-db.mts` imports `openOpenClawStateDatabase` from this branch and opens the database under `OPENCLAW_STATE_DIR=/tmp/chmod-repro/state-dir`.
- Evidence after fix: terminal capture before the patch (same command against the parent commit):

  ```
  Error: ENOTSUP: operation not supported on socket, chmod '/tmp/chmod-repro/state-dir/state'
      at chmodSyncEnotsup (/tmp/chmod-repro/enotsup-shim.cjs:6:15)
      at ensureOpenClawStatePermissions (/app/repos/openclaw/src/state/openclaw-state-db.ts:125:5)
      at openOpenClawStateDatabase (/app/repos/openclaw/src/state/openclaw-state-db.ts:843:3)
  ```

  and after the patch:

  ```
  [state/db] skipped permission hardening for /tmp/chmod-repro/state-dir/state: Error: ENOTSUP: operation not supported on socket, chmod '/tmp/chmod-repro/state-dir/state'
  [state/db] skipped permission hardening for /tmp/chmod-repro/state-dir/state/openclaw.sqlite: Error: ENOTSUP: operation not supported on socket, chmod '/tmp/chmod-repro/state-dir/state/openclaw.sqlite'
  [state/db] skipped permission hardening for /tmp/chmod-repro/state-dir/state/openclaw.sqlite-shm: Error: ENOTSUP: operation not supported on socket, chmod '/tmp/chmod-repro/state-dir/state/openclaw.sqlite-shm'
  [state/db] skipped permission hardening for /tmp/chmod-repro/state-dir/state/openclaw.sqlite-wal: Error: ENOTSUP: operation not supported on socket, chmod '/tmp/chmod-repro/state-dir/state/openclaw.sqlite-wal'
  state db open: true
  state db path: /tmp/chmod-repro/state-dir/state/openclaw.sqlite
  ```

- Observed result after fix: the database opens and is usable, each skipped target warns exactly once, and the process exits cleanly instead of crashing in `ensureOpenClawStatePermissions`.
- What was not tested: a real NFS or Azure Files mount (the ENOTSUP failure was injected via the preload shim described above), and Windows.


