### PR TITLE
fix(cron): report canonical SQLite path in cron status (fixes #91766)

### DIFF
--- a/src/cron/service.read-ops-nonblocking.test.ts
+++ b/src/cron/service.read-ops-nonblocking.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { CronService } from "./service.js";
 import { writeCronStoreSnapshot } from "./service.test-harness.js";
 
@@ -79,10 +80,10 @@ function createDeferredIsolatedRun() {
 
 function expectCronStatus(
   status: Awaited<ReturnType<CronService["status"]>>,
-  params: { storePath: string; jobs: number },
+  params: { jobs: number },
 ) {
   expect(status.enabled).toBe(true);
-  expect(status.storePath).toBe(params.storePath);
+  expect(status.storePath).toBe(resolveOpenClawStateSqlitePath());
   expect(status.jobs).toBe(params.jobs);
   if (status.nextWakeAtMs !== null) {
     expect(status.nextWakeAtMs).toBeTypeOf("number");
@@ -142,7 +143,7 @@ describe("CronService read ops while job is running", () => {
       expect(isolatedRun.runIsolatedAgentJob).toHaveBeenCalledTimes(1);
 
       await expect(cron.list({ includeDisabled: true })).resolves.toHaveLength(1);
-      expectCronStatus(await cron.status(), { storePath: store.storePath, jobs: 1 });
+      expectCronStatus(await cron.status(), { jobs: 1 });
 
       const running = await cron.list({ includeDisabled: true });
       expect(running[0]?.state.runningAtMs).toBeTypeOf("number");
@@ -212,7 +213,6 @@ describe("CronService read ops while job is running", () => {
         withTimeout(cron.list({ includeDisabled: true }), 300, "cron.list during cron.run"),
       ).resolves.toHaveLength(1);
       expectCronStatus(await withTimeout(cron.status(), 300, "cron.status during cron.run"), {
-        storePath: store.storePath,
         jobs: 1,
       });
 
@@ -274,7 +274,6 @@ describe("CronService read ops while job is running", () => {
         withTimeout(cron.list({ includeDisabled: true }), 300, "cron.list during startup"),
       ).resolves.toHaveLength(1);
       expectCronStatus(await withTimeout(cron.status(), 300, "cron.status during startup"), {
-        storePath: store.storePath,
         jobs: 1,
       });
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import {
   completeTaskRunByRunId,
   createRunningTaskRun,
@@ -253,7 +254,7 @@ export async function status(state: CronServiceState) {
     await ensureLoadedForRead(state);
     return {
       enabled: state.deps.cronEnabled,
-      storePath: state.deps.storePath,
+      storePath: resolveOpenClawStateSqlitePath(),
       jobs: state.store?.jobs.length ?? 0,
       nextWakeAtMs: state.deps.cronEnabled ? (nextWakeAtMs(state) ?? null) : null,
     };


### PR DESCRIPTION
### Summary

- **Problem**: `openclaw cron status` reports the legacy JSON store path (`~/.openclaw/cron/jobs.json`) instead of the canonical SQLite state database path (`~/.openclaw/state/openclaw.sqlite`) where cron jobs are actually persisted since the SQLite migration.
- **Root Cause**: The `status()` function in `src/cron/service/ops.ts` returns `state.deps.storePath` which is the logical store key (resolved from the legacy JSON file path). When cron persistence moved to SQLite, the status reporting was never updated to reflect the canonical storage location.
- **Fix**: Import `resolveOpenClawStateSqlitePath` from `src/state/openclaw-state-db.paths.ts` and use it in the `status()` response instead of the legacy `state.deps.storePath`.
- **What changed**:
  - `src/cron/service/ops.ts` — `status()` now returns `resolveOpenClawStateSqlitePath()` as the `storePath` field
  - `src/cron/service.read-ops-nonblocking.test.ts` — updated `expectCronStatus` helper and call sites to assert the SQLite path
- **What did NOT change (scope boundary)**:
  - Internal uses of `state.deps.storePath` (12 call sites in `store.ts`, `locked.ts`) remain untouched — they use it as a SQLite store key, not for user-facing output
  - `CronStatusSummary` interface shape is unchanged
  - `CronServiceDeps.storePath` semantics are unchanged

### Reproduction

1. Run `openclaw cron status` on a gateway with cron storage migrated to SQLite
2. Observe the `storePath` field in the JSON output
3. **Before this PR**: `storePath` shows the legacy JSON file path (e.g., `/home/node/.openclaw/cron/jobs.json`) — misleading since actual cron data lives in the shared SQLite database
4. **After this PR**: `storePath` shows the canonical SQLite database path (e.g., `~/.openclaw/state/openclaw.sqlite`) — matches the actual storage location

### Real behavior proof

**Behavior or issue addressed (91766)**: `cron.status()` returned the legacy JSON `storePath` which no longer reflects the canonical cron storage. After the fix, `storePath` reports the shared SQLite state database path that cron actually reads from and writes to.

**Real environment tested**: Linux, Node 22 — the cron service test infrastructure exercising `CronService.status()`, `CronService.list()`, and nonblocking read-op behavior during isolated job runs and startup catchup.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/cron/service.read-ops-nonblocking.test.ts src/cron/cron-protocol-conformance.test.ts src/cron/service/ops.regression.test.ts`

**Evidence after fix**:
```text
[test] starting test/vitest/vitest.cron.config.ts

 RUN  v4.1.7 /home/0668001395/openclawProject1


 Test Files  3 passed (3)
      Tests  14 passed (14)
   Start at  20:31:34
   Duration  4.39s (transform 1.76s, setup 314ms, import 3.44s, tests 404ms, environment 0ms)

[test] passed 1 Vitest shard in 13.29s
```

**Observed result after fix**: The three read-ops-nonblocking test scenarios (isolated job run, manual run via `cron.run`, startup catchup) all confirm `status.storePath` resolves to the canonical SQLite database path via `resolveOpenClawStateSqlitePath()`. The `expectCronStatus` helper now validates the SQLite path directly, and status remains responsive (nonblocking) during all three concurrent-operation scenarios.

**What was not tested**: Live gateway round-trip of `openclaw cron status` CLI command was not driven — the coverage exercises `CronService.status()` directly which is the same code path the CLI calls through the gateway RPC layer.

**Repro confirmation**: The `expectCronStatus` helper previously asserted `storePath` against `store.storePath` (the legacy temp JSON path). After the fix, it asserts against `resolveOpenClawStateSqlitePath()`. The same three scenarios that previously validated the legacy path now confirm the SQLite path — the before and after assertions demonstrate the fix directly within the test infrastructure.

### Risk / Mitigation

- **Risk**: Scripts that parse `cron.status` output and read the `storePath` field as a JSON file path will now find a SQLite database file instead.
  **Mitigation**: The reported path is now correct — scripts that were reading the legacy JSON path would already have stale data since cron storage moved to SQLite. The corrected path allows scripts to access the actual canonical data store.
- **Risk**: The `storePath` field name might be considered misleading now that it points to a SQLite file rather than a JSON store.
  **Mitigation**: The field name is preserved for backward compatibility with API consumers. The value change is semantically correct since this IS the path where cron state is stored.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Cron service (src/cron/)
- [x] CLI / commands

### Regression Test Plan

- `node scripts/run-vitest.mjs src/cron/service.read-ops-nonblocking.test.ts`
- `node scripts/run-vitest.mjs src/cron/cron-protocol-conformance.test.ts`
- `node scripts/run-vitest.mjs src/cron/service/ops.regression.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #91766
