### PR TITLE
feat(status): surface plugin health

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -231,7 +231,8 @@ plugins.
     | `/help` | Show the short help summary |
     | `/commands` | Show the generated command catalog |
     | `/tools [compact\|verbose]` | Show what the current agent can use right now |
-    | `/status` | Show execution/runtime status, Gateway and system uptime, plus provider usage/quota |
+    | `/status` | Show execution/runtime status, Gateway and system uptime, plugin health, plus provider usage/quota |
+    | `/status plugins` | Show detailed plugin health: load errors, quarantines, channel failures, dependency issues, compatibility notices |
     | `/goal [status\|start\|pause\|resume\|complete\|block\|clear] ...` | Manage the current session's durable [goal](/tools/goal) |
     | `/diagnostics [note]` | Owner-only support-report flow. Asks for exec approval every time |
     | `/crestodian <request>` | Run the Crestodian setup and repair helper from an owner DM |

--- a/src/agents/runtime-plan/tools.ts
+++ b/src/agents/runtime-plan/tools.ts
@@ -34,6 +34,10 @@ type AgentRuntimeToolPolicyParams<TSchemaType extends TSchema = TSchema, TResult
   model?: ProviderRuntimeModel;
   runtimeHandle?: ProviderRuntimePluginHandle;
   allowProviderRuntimePluginLoad?: boolean;
+  /**
+   * Invoked on every normalization, including with an empty list, so
+   * consumers can observe the all-clear and retire stale quarantine state.
+   */
   onPreNormalizationSchemaDiagnostics?: (
     diagnostics: readonly RuntimeToolSchemaDiagnostic[],
     tools: readonly AgentTool<TSchemaType, TResult>[],
@@ -102,12 +106,10 @@ export function normalizeAgentRuntimeTools<
 >(params: AgentRuntimeToolPolicyParams<TSchemaType, TResult>): AgentTool<TSchemaType, TResult>[] {
   const planContext = runtimePlanToolContext(params);
   const normalizableToolProjection = filterProviderNormalizableTools(params.tools);
-  if (normalizableToolProjection.diagnostics.length > 0) {
-    params.onPreNormalizationSchemaDiagnostics?.(
-      normalizableToolProjection.diagnostics,
-      params.tools,
-    );
-  }
+  params.onPreNormalizationSchemaDiagnostics?.(
+    normalizableToolProjection.diagnostics,
+    params.tools,
+  );
   const normalizableTools = [...normalizableToolProjection.tools] as AgentTool<
     TSchemaType,
     TResult

--- a/src/agents/tool-schema-quarantine-health.ts
+++ b/src/agents/tool-schema-quarantine-health.ts
@@ -1,0 +1,161 @@
+// Persists runtime tool-schema quarantines in the shared SQLite-backed core
+// plugin-state store so sibling runtime processes can surface health failures.
+import { createCorePluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.js";
+
+const TOOL_SCHEMA_QUARANTINE_OWNER_ID = "core:runtime-tool-quarantine-health";
+const TOOL_SCHEMA_QUARANTINE_NAMESPACE = "schema-quarantines";
+const MAX_TOOL_SCHEMA_QUARANTINE_RECORDS = 128;
+const DEFAULT_TOOL_SCHEMA_QUARANTINE_TTL_MS = 24 * 60 * 60 * 1_000;
+
+export type RuntimeToolSchemaQuarantine = {
+  toolName: string;
+  owner?: string;
+  reason: string;
+  failedAt: Date;
+  runId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+};
+
+type PersistedRuntimeToolSchemaQuarantineRecord = {
+  toolName: string;
+  owner?: string;
+  reason: string;
+  failedAtMs: number;
+  processId: number;
+  recordedAtMs: number;
+  runId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+};
+
+function openQuarantineStore() {
+  return createCorePluginStateSyncKeyedStore<PersistedRuntimeToolSchemaQuarantineRecord>({
+    ownerId: TOOL_SCHEMA_QUARANTINE_OWNER_ID,
+    namespace: TOOL_SCHEMA_QUARANTINE_NAMESPACE,
+    maxEntries: MAX_TOOL_SCHEMA_QUARANTINE_RECORDS,
+    defaultTtlMs: DEFAULT_TOOL_SCHEMA_QUARANTINE_TTL_MS,
+  });
+}
+
+function recordKey(
+  record: Pick<PersistedRuntimeToolSchemaQuarantineRecord, "owner" | "toolName" | "processId">,
+): string {
+  return JSON.stringify([record.owner ?? "", record.toolName, record.processId]);
+}
+
+function isPersistedRecord(value: unknown): value is PersistedRuntimeToolSchemaQuarantineRecord {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Partial<PersistedRuntimeToolSchemaQuarantineRecord>;
+  return (
+    typeof record.toolName === "string" &&
+    record.toolName.trim().length > 0 &&
+    typeof record.reason === "string" &&
+    record.reason.trim().length > 0 &&
+    typeof record.failedAtMs === "number" &&
+    Number.isFinite(record.failedAtMs) &&
+    typeof record.processId === "number" &&
+    Number.isInteger(record.processId) &&
+    record.processId > 0 &&
+    typeof record.recordedAtMs === "number" &&
+    Number.isFinite(record.recordedAtMs)
+  );
+}
+
+function normalizeRecord(value: unknown): PersistedRuntimeToolSchemaQuarantineRecord | undefined {
+  if (!isPersistedRecord(value)) {
+    return undefined;
+  }
+  return {
+    toolName: value.toolName,
+    reason: value.reason,
+    failedAtMs: value.failedAtMs,
+    processId: value.processId,
+    recordedAtMs: value.recordedAtMs,
+    ...(typeof value.owner === "string" && value.owner.trim() ? { owner: value.owner } : {}),
+    ...(typeof value.runId === "string" && value.runId.trim() ? { runId: value.runId } : {}),
+    ...(typeof value.sessionKey === "string" && value.sessionKey.trim()
+      ? { sessionKey: value.sessionKey }
+      : {}),
+    ...(typeof value.sessionId === "string" && value.sessionId.trim()
+      ? { sessionId: value.sessionId }
+      : {}),
+  };
+}
+
+function listPersistedRecords(): PersistedRuntimeToolSchemaQuarantineRecord[] {
+  try {
+    return openQuarantineStore()
+      .entries()
+      .map((entry) => normalizeRecord(entry.value))
+      .filter((record): record is PersistedRuntimeToolSchemaQuarantineRecord => Boolean(record));
+  } catch {
+    return [];
+  }
+}
+
+export function recordPersistedRuntimeToolSchemaQuarantine(
+  quarantine: RuntimeToolSchemaQuarantine,
+): void {
+  const record: PersistedRuntimeToolSchemaQuarantineRecord = {
+    toolName: quarantine.toolName,
+    reason: quarantine.reason,
+    failedAtMs: quarantine.failedAt.getTime(),
+    processId: process.pid,
+    recordedAtMs: Date.now(),
+    ...(quarantine.owner ? { owner: quarantine.owner } : {}),
+    ...(quarantine.runId ? { runId: quarantine.runId } : {}),
+    ...(quarantine.sessionKey ? { sessionKey: quarantine.sessionKey } : {}),
+    ...(quarantine.sessionId ? { sessionId: quarantine.sessionId } : {}),
+  };
+  openQuarantineStore().register(recordKey(record), record);
+}
+
+export function listPersistedRuntimeToolSchemaQuarantines(): RuntimeToolSchemaQuarantine[] {
+  const byTool = new Map<string, PersistedRuntimeToolSchemaQuarantineRecord>();
+  for (const record of listPersistedRecords()) {
+    const key = `${record.owner ?? ""}\0${record.toolName}`;
+    const existing = byTool.get(key);
+    if (!existing || record.failedAtMs > existing.failedAtMs) {
+      byTool.set(key, record);
+    }
+  }
+  return [...byTool.values()].map((record) => {
+    const quarantine: RuntimeToolSchemaQuarantine = {
+      toolName: record.toolName,
+      reason: record.reason,
+      failedAt: new Date(record.failedAtMs),
+    };
+    if (record.owner) {
+      quarantine.owner = record.owner;
+    }
+    if (record.runId) {
+      quarantine.runId = record.runId;
+    }
+    if (record.sessionKey) {
+      quarantine.sessionKey = record.sessionKey;
+    }
+    if (record.sessionId) {
+      quarantine.sessionId = record.sessionId;
+    }
+    return quarantine;
+  });
+}
+
+export function clearPersistedRuntimeToolSchemaQuarantinesForProcess(
+  processId = process.pid,
+): void {
+  try {
+    const store = openQuarantineStore();
+    for (const entry of store.entries()) {
+      const record = normalizeRecord(entry.value);
+      if (record?.processId === processId) {
+        store.delete(entry.key);
+      }
+    }
+  } catch {
+    // Best-effort cleanup for tests and process lifecycle.
+  }
+}

--- a/src/agents/tool-schema-quarantine-health.ts
+++ b/src/agents/tool-schema-quarantine-health.ts
@@ -40,6 +40,7 @@ const quarantineStore = createRuntimeHealthStore<PersistedRuntimeToolSchemaQuara
       reason: value.reason,
       failedAtMs: value.failedAtMs,
       processId: value.processId,
+      processToken: value.processToken,
       processStartTime: value.processStartTime,
       ...(isNonEmptyString(value.owner) ? { owner: value.owner } : {}),
     };

--- a/src/agents/tool-schema-quarantine-health.ts
+++ b/src/agents/tool-schema-quarantine-health.ts
@@ -1,99 +1,56 @@
 // Persists runtime tool-schema quarantines in the shared SQLite-backed core
-// plugin-state store so sibling runtime processes can surface health failures.
-import { createCorePluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.js";
-
-const TOOL_SCHEMA_QUARANTINE_OWNER_ID = "core:runtime-tool-quarantine-health";
-const TOOL_SCHEMA_QUARANTINE_NAMESPACE = "schema-quarantines";
-const MAX_TOOL_SCHEMA_QUARANTINE_RECORDS = 128;
-const DEFAULT_TOOL_SCHEMA_QUARANTINE_TTL_MS = 24 * 60 * 60 * 1_000;
+// plugin-state store so health surfaces can see failures from any live
+// runtime process.
+import {
+  createRuntimeHealthStore,
+  type RuntimeHealthRecordEnvelope,
+} from "../plugin-state/runtime-health-store.js";
 
 export type RuntimeToolSchemaQuarantine = {
   toolName: string;
   owner?: string;
   reason: string;
   failedAt: Date;
-  runId?: string;
-  sessionKey?: string;
-  sessionId?: string;
 };
 
-type PersistedRuntimeToolSchemaQuarantineRecord = {
+type PersistedRuntimeToolSchemaQuarantineRecord = RuntimeHealthRecordEnvelope & {
   toolName: string;
   owner?: string;
   reason: string;
-  failedAtMs: number;
-  processId: number;
-  recordedAtMs: number;
-  runId?: string;
-  sessionKey?: string;
-  sessionId?: string;
 };
 
-function openQuarantineStore() {
-  return createCorePluginStateSyncKeyedStore<PersistedRuntimeToolSchemaQuarantineRecord>({
-    ownerId: TOOL_SCHEMA_QUARANTINE_OWNER_ID,
-    namespace: TOOL_SCHEMA_QUARANTINE_NAMESPACE,
-    maxEntries: MAX_TOOL_SCHEMA_QUARANTINE_RECORDS,
-    defaultTtlMs: DEFAULT_TOOL_SCHEMA_QUARANTINE_TTL_MS,
-  });
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
 }
+
+const quarantineStore = createRuntimeHealthStore<PersistedRuntimeToolSchemaQuarantineRecord>({
+  ownerId: "core:runtime-tool-quarantine-health",
+  namespace: "schema-quarantines",
+  maxEntries: 128,
+  // Failing runs re-register their quarantine and refresh this TTL, so it only
+  // expires records that stop recurring (e.g. a schema fixed without restart).
+  ttlMs: 24 * 60 * 60 * 1_000,
+  normalizeRecord: (value) => {
+    if (!isNonEmptyString(value.toolName) || !isNonEmptyString(value.reason)) {
+      return undefined;
+    }
+    return {
+      toolName: value.toolName,
+      reason: value.reason,
+      failedAtMs: value.failedAtMs,
+      processId: value.processId,
+      ...(isNonEmptyString(value.owner) ? { owner: value.owner } : {}),
+    };
+  },
+  displayKey: (record) => JSON.stringify([record.owner ?? "", record.toolName]),
+  // Latest wins: the most recent violation message is the actionable one.
+  pick: "latest",
+});
 
 function recordKey(
   record: Pick<PersistedRuntimeToolSchemaQuarantineRecord, "owner" | "toolName" | "processId">,
 ): string {
   return JSON.stringify([record.owner ?? "", record.toolName, record.processId]);
-}
-
-function isPersistedRecord(value: unknown): value is PersistedRuntimeToolSchemaQuarantineRecord {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const record = value as Partial<PersistedRuntimeToolSchemaQuarantineRecord>;
-  return (
-    typeof record.toolName === "string" &&
-    record.toolName.trim().length > 0 &&
-    typeof record.reason === "string" &&
-    record.reason.trim().length > 0 &&
-    typeof record.failedAtMs === "number" &&
-    Number.isFinite(record.failedAtMs) &&
-    typeof record.processId === "number" &&
-    Number.isInteger(record.processId) &&
-    record.processId > 0 &&
-    typeof record.recordedAtMs === "number" &&
-    Number.isFinite(record.recordedAtMs)
-  );
-}
-
-function normalizeRecord(value: unknown): PersistedRuntimeToolSchemaQuarantineRecord | undefined {
-  if (!isPersistedRecord(value)) {
-    return undefined;
-  }
-  return {
-    toolName: value.toolName,
-    reason: value.reason,
-    failedAtMs: value.failedAtMs,
-    processId: value.processId,
-    recordedAtMs: value.recordedAtMs,
-    ...(typeof value.owner === "string" && value.owner.trim() ? { owner: value.owner } : {}),
-    ...(typeof value.runId === "string" && value.runId.trim() ? { runId: value.runId } : {}),
-    ...(typeof value.sessionKey === "string" && value.sessionKey.trim()
-      ? { sessionKey: value.sessionKey }
-      : {}),
-    ...(typeof value.sessionId === "string" && value.sessionId.trim()
-      ? { sessionId: value.sessionId }
-      : {}),
-  };
-}
-
-function listPersistedRecords(): PersistedRuntimeToolSchemaQuarantineRecord[] {
-  try {
-    return openQuarantineStore()
-      .entries()
-      .map((entry) => normalizeRecord(entry.value))
-      .filter((record): record is PersistedRuntimeToolSchemaQuarantineRecord => Boolean(record));
-  } catch {
-    return [];
-  }
 }
 
 export function recordPersistedRuntimeToolSchemaQuarantine(
@@ -104,25 +61,13 @@ export function recordPersistedRuntimeToolSchemaQuarantine(
     reason: quarantine.reason,
     failedAtMs: quarantine.failedAt.getTime(),
     processId: process.pid,
-    recordedAtMs: Date.now(),
     ...(quarantine.owner ? { owner: quarantine.owner } : {}),
-    ...(quarantine.runId ? { runId: quarantine.runId } : {}),
-    ...(quarantine.sessionKey ? { sessionKey: quarantine.sessionKey } : {}),
-    ...(quarantine.sessionId ? { sessionId: quarantine.sessionId } : {}),
   };
-  openQuarantineStore().register(recordKey(record), record);
+  quarantineStore.register(recordKey(record), record);
 }
 
 export function listPersistedRuntimeToolSchemaQuarantines(): RuntimeToolSchemaQuarantine[] {
-  const byTool = new Map<string, PersistedRuntimeToolSchemaQuarantineRecord>();
-  for (const record of listPersistedRecords()) {
-    const key = `${record.owner ?? ""}\0${record.toolName}`;
-    const existing = byTool.get(key);
-    if (!existing || record.failedAtMs > existing.failedAtMs) {
-      byTool.set(key, record);
-    }
-  }
-  return [...byTool.values()].map((record) => {
+  return quarantineStore.list().map((record) => {
     const quarantine: RuntimeToolSchemaQuarantine = {
       toolName: record.toolName,
       reason: record.reason,
@@ -131,31 +76,6 @@ export function listPersistedRuntimeToolSchemaQuarantines(): RuntimeToolSchemaQu
     if (record.owner) {
       quarantine.owner = record.owner;
     }
-    if (record.runId) {
-      quarantine.runId = record.runId;
-    }
-    if (record.sessionKey) {
-      quarantine.sessionKey = record.sessionKey;
-    }
-    if (record.sessionId) {
-      quarantine.sessionId = record.sessionId;
-    }
     return quarantine;
   });
-}
-
-export function clearPersistedRuntimeToolSchemaQuarantinesForProcess(
-  processId = process.pid,
-): void {
-  try {
-    const store = openQuarantineStore();
-    for (const entry of store.entries()) {
-      const record = normalizeRecord(entry.value);
-      if (record?.processId === processId) {
-        store.delete(entry.key);
-      }
-    }
-  } catch {
-    // Best-effort cleanup for tests and process lifecycle.
-  }
 }

--- a/src/agents/tool-schema-quarantine-health.ts
+++ b/src/agents/tool-schema-quarantine-health.ts
@@ -55,6 +55,20 @@ function recordKey(
   return JSON.stringify([record.owner ?? "", record.toolName, record.processId]);
 }
 
+export type RuntimeToolSchemaQuarantineIdentity = {
+  toolName: string;
+  owner?: string;
+};
+
+function identityKey(identity: RuntimeToolSchemaQuarantineIdentity): string {
+  return JSON.stringify([identity.owner ?? "", identity.toolName]);
+}
+
+// Keys this process has persisted. Recovery clearing checks this set first so
+// the per-run path does zero store IO unless this process actually recorded a
+// quarantine that may have recovered.
+const locallyPersistedKeys = new Set<string>();
+
 export function recordPersistedRuntimeToolSchemaQuarantine(
   quarantine: RuntimeToolSchemaQuarantine,
 ): void {
@@ -65,18 +79,32 @@ export function recordPersistedRuntimeToolSchemaQuarantine(
     ...(quarantine.owner ? { owner: quarantine.owner } : {}),
   };
   quarantineStore.register(recordKey(record), record);
+  locallyPersistedKeys.add(identityKey(record));
 }
 
-export function clearPersistedRuntimeToolSchemaQuarantine(params: {
-  toolName: string;
-  owner?: string;
-}): void {
-  quarantineStore.clearForProcess(
-    process.pid,
-    (record) =>
-      record.toolName === params.toolName &&
-      (record.owner ?? undefined) === (params.owner ?? undefined),
+/**
+ * Removes this process's persisted quarantines for tools that now validate
+ * cleanly. `listHealthyTools` is only invoked when this process has persisted
+ * quarantines, keeping the common per-run path free of work.
+ */
+export function clearRecoveredPersistedRuntimeToolSchemaQuarantines(
+  listHealthyTools: () => readonly RuntimeToolSchemaQuarantineIdentity[],
+): void {
+  if (locallyPersistedKeys.size === 0) {
+    return;
+  }
+  const recoveredKeys = new Set(
+    listHealthyTools()
+      .map(identityKey)
+      .filter((key) => locallyPersistedKeys.has(key)),
   );
+  if (recoveredKeys.size === 0) {
+    return;
+  }
+  quarantineStore.clearForProcess(process.pid, (record) => recoveredKeys.has(identityKey(record)));
+  for (const key of recoveredKeys) {
+    locallyPersistedKeys.delete(key);
+  }
 }
 
 export function listPersistedRuntimeToolSchemaQuarantines(): RuntimeToolSchemaQuarantine[] {

--- a/src/agents/tool-schema-quarantine-health.ts
+++ b/src/agents/tool-schema-quarantine-health.ts
@@ -2,6 +2,7 @@
 // plugin-state store so health surfaces can see failures from any live
 // runtime process.
 import {
+  createRuntimeHealthRecordEnvelope,
   createRuntimeHealthStore,
   type RuntimeHealthRecordEnvelope,
 } from "../plugin-state/runtime-health-store.js";
@@ -39,6 +40,7 @@ const quarantineStore = createRuntimeHealthStore<PersistedRuntimeToolSchemaQuara
       reason: value.reason,
       failedAtMs: value.failedAtMs,
       processId: value.processId,
+      processStartTime: value.processStartTime,
       ...(isNonEmptyString(value.owner) ? { owner: value.owner } : {}),
     };
   },
@@ -59,11 +61,22 @@ export function recordPersistedRuntimeToolSchemaQuarantine(
   const record: PersistedRuntimeToolSchemaQuarantineRecord = {
     toolName: quarantine.toolName,
     reason: quarantine.reason,
-    failedAtMs: quarantine.failedAt.getTime(),
-    processId: process.pid,
+    ...createRuntimeHealthRecordEnvelope(quarantine.failedAt),
     ...(quarantine.owner ? { owner: quarantine.owner } : {}),
   };
   quarantineStore.register(recordKey(record), record);
+}
+
+export function clearPersistedRuntimeToolSchemaQuarantine(params: {
+  toolName: string;
+  owner?: string;
+}): void {
+  quarantineStore.clearForProcess(
+    process.pid,
+    (record) =>
+      record.toolName === params.toolName &&
+      (record.owner ?? undefined) === (params.owner ?? undefined),
+  );
 }
 
 export function listPersistedRuntimeToolSchemaQuarantines(): RuntimeToolSchemaQuarantine[] {

--- a/src/agents/tool-schema-quarantine.test.ts
+++ b/src/agents/tool-schema-quarantine.test.ts
@@ -1,8 +1,18 @@
 // Tool schema quarantine tests cover diagnostic logging for unreadable runtime
 // tool entries without touching the broken tool object again.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import {
+  listPersistedRuntimeToolSchemaQuarantines,
+  recordPersistedRuntimeToolSchemaQuarantine,
+} from "./tool-schema-quarantine-health.js";
 import { logRuntimeToolSchemaQuarantine } from "./tool-schema-quarantine.js";
 import type { AnyAgentTool } from "./tools/common.js";
+
+afterEach(() => {
+  resetPluginStateStoreForTests();
+});
 
 describe("runtime tool schema quarantine logging", () => {
   it("does not re-read unreadable tool entries while logging diagnostics", () => {
@@ -28,5 +38,31 @@ describe("runtime tool schema quarantine logging", () => {
         runId: "run-fuzzplugin-unreadable-tool",
       }),
     ).not.toThrow();
+  });
+
+  it("clears this process's persisted quarantine after the tool schema recovers", async () => {
+    await withStateDirEnv("openclaw-tool-schema-quarantine-recovery-", async () => {
+      recordPersistedRuntimeToolSchemaQuarantine({
+        toolName: "recovered_tool",
+        reason: 'recovered_tool.parameters.type must be "object"',
+        failedAt: new Date(123),
+      });
+
+      logRuntimeToolSchemaQuarantine({
+        diagnostics: [],
+        tools: [
+          {
+            name: "recovered_tool",
+            label: "Recovered tool",
+            description: "Recovered tool",
+            parameters: { type: "object", properties: {} },
+            execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+          },
+        ],
+        runId: "run-recovered-tool",
+      });
+
+      expect(listPersistedRuntimeToolSchemaQuarantines()).toEqual([]);
+    });
   });
 });

--- a/src/agents/tool-schema-quarantine.ts
+++ b/src/agents/tool-schema-quarantine.ts
@@ -8,6 +8,7 @@ import { emitTrustedDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import type { RuntimeToolSchemaDiagnostic } from "./tool-schema-projection.js";
+import { recordPersistedRuntimeToolSchemaQuarantine } from "./tool-schema-quarantine-health.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 const log = createSubsystemLogger("agents/tools");
@@ -52,6 +53,19 @@ export function logRuntimeToolSchemaQuarantine(params: {
         deniedReason: "unsupported_tool_schema",
         reason: diagnostic.violations.join(", "),
       });
+      try {
+        recordPersistedRuntimeToolSchemaQuarantine({
+          toolName: diagnostic.toolName,
+          ...(pluginId ? { owner: `plugin:${pluginId}` } : {}),
+          reason: diagnostic.violations.join(", "),
+          failedAt: new Date(),
+          runId: params.runId,
+          ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+          ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+        });
+      } catch {
+        // Diagnostic event/log output still carries the failure if persistence is unavailable.
+      }
       return `${diagnostic.toolName}${owner}: ${diagnostic.violations.join(", ")}`;
     })
     .join("; ");

--- a/src/agents/tool-schema-quarantine.ts
+++ b/src/agents/tool-schema-quarantine.ts
@@ -9,8 +9,9 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import type { RuntimeToolSchemaDiagnostic } from "./tool-schema-projection.js";
 import {
-  clearPersistedRuntimeToolSchemaQuarantine,
+  clearRecoveredPersistedRuntimeToolSchemaQuarantines,
   recordPersistedRuntimeToolSchemaQuarantine,
+  type RuntimeToolSchemaQuarantineIdentity,
 } from "./tool-schema-quarantine-health.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -32,11 +33,11 @@ function pluginOwner(pluginId: string | undefined): string | undefined {
   return pluginId ? `plugin:${pluginId}` : undefined;
 }
 
-function toolQuarantineKey(params: { owner?: string; toolName: string }): string {
+function toolQuarantineKey(params: RuntimeToolSchemaQuarantineIdentity): string {
   return JSON.stringify([params.owner ?? "", params.toolName]);
 }
 
-function readToolIdentity(tool: AnyAgentTool): { owner?: string; toolName: string } | undefined {
+function readToolIdentity(tool: AnyAgentTool): RuntimeToolSchemaQuarantineIdentity | undefined {
   try {
     if (typeof tool.name !== "string" || tool.name.length === 0) {
       return undefined;
@@ -48,10 +49,12 @@ function readToolIdentity(tool: AnyAgentTool): { owner?: string; toolName: strin
   }
 }
 
-function clearRecoveredRuntimeToolSchemaQuarantines(params: {
+// Tools that validated cleanly this run; identities behind a thunk so the
+// common no-quarantine path does not even walk the tool list.
+function listHealthyToolIdentities(params: {
   diagnostics: readonly RuntimeToolSchemaDiagnostic[];
   tools: readonly AnyAgentTool[];
-}): void {
+}): RuntimeToolSchemaQuarantineIdentity[] {
   const failingKeys = new Set(
     params.diagnostics.map((diagnostic) =>
       toolQuarantineKey({
@@ -60,13 +63,14 @@ function clearRecoveredRuntimeToolSchemaQuarantines(params: {
       }),
     ),
   );
+  const healthy: RuntimeToolSchemaQuarantineIdentity[] = [];
   for (const tool of params.tools) {
     const identity = readToolIdentity(tool);
-    if (!identity || failingKeys.has(toolQuarantineKey(identity))) {
-      continue;
+    if (identity && !failingKeys.has(toolQuarantineKey(identity))) {
+      healthy.push(identity);
     }
-    clearPersistedRuntimeToolSchemaQuarantine(identity);
   }
+  return healthy;
 }
 
 /** Emits diagnostics and logs for tools removed from runtime schema projection. */
@@ -77,10 +81,9 @@ export function logRuntimeToolSchemaQuarantine(params: {
   sessionKey?: string;
   sessionId?: string;
 }): void {
-  clearRecoveredRuntimeToolSchemaQuarantines({
-    diagnostics: params.diagnostics,
-    tools: params.tools,
-  });
+  clearRecoveredPersistedRuntimeToolSchemaQuarantines(() =>
+    listHealthyToolIdentities({ diagnostics: params.diagnostics, tools: params.tools }),
+  );
   if (params.diagnostics.length === 0) {
     return;
   }

--- a/src/agents/tool-schema-quarantine.ts
+++ b/src/agents/tool-schema-quarantine.ts
@@ -8,7 +8,10 @@ import { emitTrustedDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import type { RuntimeToolSchemaDiagnostic } from "./tool-schema-projection.js";
-import { recordPersistedRuntimeToolSchemaQuarantine } from "./tool-schema-quarantine-health.js";
+import {
+  clearPersistedRuntimeToolSchemaQuarantine,
+  recordPersistedRuntimeToolSchemaQuarantine,
+} from "./tool-schema-quarantine-health.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 const log = createSubsystemLogger("agents/tools");
@@ -25,6 +28,47 @@ function readDiagnosticPluginId(params: {
   }
 }
 
+function pluginOwner(pluginId: string | undefined): string | undefined {
+  return pluginId ? `plugin:${pluginId}` : undefined;
+}
+
+function toolQuarantineKey(params: { owner?: string; toolName: string }): string {
+  return JSON.stringify([params.owner ?? "", params.toolName]);
+}
+
+function readToolIdentity(tool: AnyAgentTool): { owner?: string; toolName: string } | undefined {
+  try {
+    if (typeof tool.name !== "string" || tool.name.length === 0) {
+      return undefined;
+    }
+    const owner = pluginOwner(getPluginToolMeta(tool)?.pluginId);
+    return owner ? { owner, toolName: tool.name } : { toolName: tool.name };
+  } catch {
+    return undefined;
+  }
+}
+
+function clearRecoveredRuntimeToolSchemaQuarantines(params: {
+  diagnostics: readonly RuntimeToolSchemaDiagnostic[];
+  tools: readonly AnyAgentTool[];
+}): void {
+  const failingKeys = new Set(
+    params.diagnostics.map((diagnostic) =>
+      toolQuarantineKey({
+        owner: pluginOwner(readDiagnosticPluginId({ tools: params.tools, diagnostic })),
+        toolName: diagnostic.toolName,
+      }),
+    ),
+  );
+  for (const tool of params.tools) {
+    const identity = readToolIdentity(tool);
+    if (!identity || failingKeys.has(toolQuarantineKey(identity))) {
+      continue;
+    }
+    clearPersistedRuntimeToolSchemaQuarantine(identity);
+  }
+}
+
 /** Emits diagnostics and logs for tools removed from runtime schema projection. */
 export function logRuntimeToolSchemaQuarantine(params: {
   diagnostics: readonly RuntimeToolSchemaDiagnostic[];
@@ -33,6 +77,10 @@ export function logRuntimeToolSchemaQuarantine(params: {
   sessionKey?: string;
   sessionId?: string;
 }): void {
+  clearRecoveredRuntimeToolSchemaQuarantines({
+    diagnostics: params.diagnostics,
+    tools: params.tools,
+  });
   if (params.diagnostics.length === 0) {
     return;
   }
@@ -54,9 +102,10 @@ export function logRuntimeToolSchemaQuarantine(params: {
         reason: diagnostic.violations.join(", "),
       });
       try {
+        const persistedOwner = pluginOwner(pluginId);
         recordPersistedRuntimeToolSchemaQuarantine({
           toolName: diagnostic.toolName,
-          ...(pluginId ? { owner: `plugin:${pluginId}` } : {}),
+          ...(persistedOwner ? { owner: persistedOwner } : {}),
           reason: diagnostic.violations.join(", "),
           failedAt: new Date(),
         });

--- a/src/agents/tool-schema-quarantine.ts
+++ b/src/agents/tool-schema-quarantine.ts
@@ -59,9 +59,6 @@ export function logRuntimeToolSchemaQuarantine(params: {
           ...(pluginId ? { owner: `plugin:${pluginId}` } : {}),
           reason: diagnostic.violations.join(", "),
           failedAt: new Date(),
-          runId: params.runId,
-          ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-          ...(params.sessionId ? { sessionId: params.sessionId } : {}),
         });
       } catch {
         // Diagnostic event/log output still carries the failure if persistence is unavailable.

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -1111,6 +1111,8 @@ describe("control command parsing", () => {
     expect(hasControlCommand("/status")).toBe(true);
     expect(hasControlCommand("/STATUS")).toBe(true);
     expect(hasControlCommand("/status:")).toBe(true);
+    expect(hasControlCommand("/status plugins")).toBe(true);
+    expect(hasControlCommand("/STATUS plugins")).toBe(true);
     expect(hasControlCommand("status")).toBe(false);
     expect(hasControlCommand("usage")).toBe(false);
 
@@ -1134,7 +1136,7 @@ describe("control command parsing", () => {
 
   it("requires commands to be the full message", () => {
     expect(hasControlCommand("hello /status")).toBe(false);
-    expect(hasControlCommand("/status please")).toBe(false);
+    expect(hasControlCommand("/status please")).toBe(true);
     expect(hasControlCommand("prefix /send on")).toBe(false);
     expect(hasControlCommand("/send on")).toBe(true);
   });

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -223,6 +223,7 @@ export function buildBuiltinChatCommands(
       textAlias: "/status",
       category: "status",
       tier: "essential",
+      acceptsArgs: true,
     }),
     defineChatCommand({
       key: "goal",

--- a/src/auto-reply/reply/commands-info.test.ts
+++ b/src/auto-reply/reply/commands-info.test.ts
@@ -9,7 +9,7 @@ import {
   handleSkillCommandUsage,
   handleStatusCommand,
 } from "./commands-info.js";
-import { buildStatusReply } from "./commands-status.js";
+import { buildStatusPluginsReply, buildStatusReply } from "./commands-status.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 import { handleWhoamiCommand } from "./commands-whoami.js";
 
@@ -31,6 +31,7 @@ vi.mock("./commands-export-trajectory.js", () => ({
 }));
 
 vi.mock("./commands-status.js", () => ({
+  buildStatusPluginsReply: vi.fn(async () => ({ text: "plugins status reply" })),
   buildStatusReply: vi.fn(async () => ({ text: "status reply" })),
 }));
 
@@ -403,6 +404,26 @@ describe("info command handlers", () => {
       "buildStatusReply",
     ) as Parameters<typeof buildStatusReply>[0];
     expect(statusReplyParams.resolvedFastMode).toBe(true);
+  });
+
+  it("routes /status plugins to the plugin health summary", async () => {
+    const params = buildInfoParams("/status plugins", {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+
+    const statusResult = await handleStatusCommand(params, true);
+
+    expect(statusResult).toEqual({
+      shouldContinue: false,
+      reply: { text: "plugins status reply" },
+    });
+    expect(buildStatusPluginsReply).toHaveBeenCalledWith({
+      cfg: params.cfg,
+      command: params.command,
+      workspaceDir: params.workspaceDir,
+    });
+    expect(buildStatusReply).not.toHaveBeenCalled();
   });
 
   it("uses the canonical target session agent when listing /commands", async () => {

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -18,7 +18,7 @@ import { resolveChannelAccountId } from "./channel-context.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
 import { buildExportSessionReply } from "./commands-export-session.js";
 import { buildExportTrajectoryCommandReply } from "./commands-export-trajectory.js";
-import { buildStatusReply } from "./commands-status.js";
+import { buildStatusPluginsReply, buildStatusReply } from "./commands-status.js";
 import type { CommandHandler, HandleCommandsParams } from "./commands-types.js";
 import { extractExplicitGroupId } from "./group-id.js";
 import { resolveReplyToMode } from "./reply-threading.js";
@@ -253,8 +253,11 @@ export const handleStatusCommand: CommandHandler = async (params, allowTextComma
   if (!allowTextCommands) {
     return null;
   }
+  const normalizedStatusCommand = params.command.commandBodyNormalized.trim();
   const statusRequested =
-    params.directives.hasStatusDirective || params.command.commandBodyNormalized === "/status";
+    params.directives.hasStatusDirective ||
+    normalizedStatusCommand === "/status" ||
+    normalizedStatusCommand.startsWith("/status ");
   if (!statusRequested) {
     return null;
   }
@@ -263,6 +266,20 @@ export const handleStatusCommand: CommandHandler = async (params, allowTextComma
       `Ignoring /status from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
     );
     return { shouldContinue: false };
+  }
+  if (normalizedStatusCommand === "/status plugins") {
+    const reply = await buildStatusPluginsReply({
+      cfg: params.cfg,
+      command: params.command,
+      workspaceDir: params.workspaceDir,
+    });
+    return { shouldContinue: false, reply };
+  }
+  if (normalizedStatusCommand.startsWith("/status ")) {
+    return {
+      shouldContinue: false,
+      reply: { text: "⚠️ Unknown /status subcommand. Try /status or /status plugins." },
+    };
   }
   const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
   const reply = await buildStatusReply({

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -38,14 +38,19 @@ const providerUsageMock = vi.hoisted(() => ({
     providers: [],
   })),
 }));
+type StatusPluginHealthSnapshot =
+  import("../../status/status-plugin-health.js").StatusPluginHealthSnapshot;
+
 const pluginHealthRuntimeMock = vi.hoisted(() => ({
-  collectRuntimePluginHealthSnapshot: vi.fn(() => ({
-    plugins: [],
-    diagnostics: [],
-    contextEngineQuarantines: [],
-    runtimeToolQuarantines: [],
-    channelPluginFailures: [],
-  })),
+  collectRuntimePluginHealthSnapshot: vi.fn(
+    (): StatusPluginHealthSnapshot => ({
+      plugins: [],
+      diagnostics: [],
+      contextEngineQuarantines: [],
+      runtimeToolQuarantines: [],
+      channelPluginFailures: [],
+    }),
+  ),
 }));
 
 vi.mock("../../infra/provider-usage.js", async (importOriginal) => {

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -38,6 +38,15 @@ const providerUsageMock = vi.hoisted(() => ({
     providers: [],
   })),
 }));
+const pluginHealthRuntimeMock = vi.hoisted(() => ({
+  collectRuntimePluginHealthSnapshot: vi.fn(() => ({
+    plugins: [],
+    diagnostics: [],
+    contextEngineQuarantines: [],
+    runtimeToolQuarantines: [],
+    channelPluginFailures: [],
+  })),
+}));
 
 vi.mock("../../infra/provider-usage.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../infra/provider-usage.js")>();
@@ -46,6 +55,8 @@ vi.mock("../../infra/provider-usage.js", async (importOriginal) => {
     loadProviderUsageSummary: providerUsageMock.loadProviderUsageSummary,
   };
 });
+
+vi.mock("../../status/status-plugin-health.runtime.js", () => pluginHealthRuntimeMock);
 
 vi.mock("../../agents/harness/builtin-openclaw.js", () => ({
   createOpenClawAgentHarness: () => ({
@@ -171,6 +182,14 @@ afterEach(() => {
   providerUsageMock.loadProviderUsageSummary.mockResolvedValue({
     updatedAt: Date.now(),
     providers: [],
+  });
+  pluginHealthRuntimeMock.collectRuntimePluginHealthSnapshot.mockReset();
+  pluginHealthRuntimeMock.collectRuntimePluginHealthSnapshot.mockReturnValue({
+    plugins: [],
+    diagnostics: [],
+    contextEngineQuarantines: [],
+    runtimeToolQuarantines: [],
+    channelPluginFailures: [],
   });
 });
 
@@ -698,6 +717,58 @@ describe("buildStatusReply subagent summary", () => {
     });
 
     expect(normalizeTestText(text)).toContain("Uptime: gateway 2h 5m · system 4d 3h");
+  });
+
+  it("passes config and workspace into compact plugin health", async () => {
+    const cfg = {
+      ...baseCfg,
+      channels: {
+        broken: { enabled: true },
+      },
+    };
+    pluginHealthRuntimeMock.collectRuntimePluginHealthSnapshot.mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+      contextEngineQuarantines: [],
+      runtimeToolQuarantines: [],
+      channelPluginFailures: [
+        {
+          channelId: "broken",
+          message: "configured channel plugin is missing or unavailable",
+        },
+      ],
+    });
+
+    const text = await buildStatusText({
+      cfg,
+      sessionEntry: {
+        sessionId: "sess-status-plugin-health",
+        updatedAt: 0,
+        contextTokens: 32_000,
+      },
+      sessionKey: "agent:main:main",
+      parentSessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      statusChannel: "mobilechat",
+      workspaceDir: "/tmp/status-plugin-health-workspace",
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      contextTokens: 32_000,
+      resolvedFastMode: false,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      modelAuthOverride: "api-key",
+      activeModelAuthOverride: "api-key",
+    });
+
+    expect(pluginHealthRuntimeMock.collectRuntimePluginHealthSnapshot).toHaveBeenCalledWith({
+      config: cfg,
+      workspaceDir: "/tmp/status-plugin-health-workspace",
+    });
+    expect(normalizeTestText(text)).toContain("Plugins: 1 channel plugin failure");
   });
 
   it("shows the effective non-OpenClaw embedded harness in /status", async () => {

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -22,7 +22,7 @@ import {
 } from "../../tasks/task-executor.js";
 import { resetTaskRegistryForTests } from "../../tasks/task-registry.js";
 import { withEnvAsync } from "../../test-utils/env.js";
-import { buildStatusReply, buildStatusText } from "./commands-status.js";
+import { buildStatusPluginsReply, buildStatusReply, buildStatusText } from "./commands-status.js";
 import {
   baseCommandTestConfig,
   buildCommandTestParams,
@@ -42,6 +42,15 @@ type StatusPluginHealthSnapshot =
   import("../../status/status-plugin-health.js").StatusPluginHealthSnapshot;
 
 const pluginHealthRuntimeMock = vi.hoisted(() => ({
+  collectInstalledPluginHealthSnapshot: vi.fn(
+    async (): Promise<StatusPluginHealthSnapshot> => ({
+      plugins: [],
+      diagnostics: [],
+      contextEngineQuarantines: [],
+      runtimeToolQuarantines: [],
+      channelPluginFailures: [],
+    }),
+  ),
   collectRuntimePluginHealthSnapshot: vi.fn(
     (): StatusPluginHealthSnapshot => ({
       plugins: [],
@@ -187,6 +196,14 @@ afterEach(() => {
   providerUsageMock.loadProviderUsageSummary.mockResolvedValue({
     updatedAt: Date.now(),
     providers: [],
+  });
+  pluginHealthRuntimeMock.collectInstalledPluginHealthSnapshot.mockReset();
+  pluginHealthRuntimeMock.collectInstalledPluginHealthSnapshot.mockResolvedValue({
+    plugins: [],
+    diagnostics: [],
+    contextEngineQuarantines: [],
+    runtimeToolQuarantines: [],
+    channelPluginFailures: [],
   });
   pluginHealthRuntimeMock.collectRuntimePluginHealthSnapshot.mockReset();
   pluginHealthRuntimeMock.collectRuntimePluginHealthSnapshot.mockReturnValue({
@@ -768,6 +785,24 @@ describe("buildStatusReply subagent summary", () => {
     // channel inspection happens on this path.
     expect(pluginHealthRuntimeMock.collectRuntimePluginHealthSnapshot).toHaveBeenCalledWith();
     expect(normalizeTestText(text)).toContain("Plugins: 1 channel plugin failure");
+  });
+
+  it("gates /status plugins behind the plugin command flag", async () => {
+    const commandParams = buildCommandTestParams("/status plugins", {
+      ...baseCfg,
+      commands: { text: true, plugins: false },
+    });
+
+    const reply = await buildStatusPluginsReply({
+      cfg: commandParams.cfg,
+      command: commandParams.command,
+      workspaceDir: commandParams.workspaceDir,
+    });
+
+    expect(reply?.text).toBe(
+      "⚠️ /status plugins is disabled. Set commands.plugins=true to enable.",
+    );
+    expect(pluginHealthRuntimeMock.collectInstalledPluginHealthSnapshot).not.toHaveBeenCalled();
   });
 
   it("shows the effective non-OpenClaw embedded harness in /status", async () => {

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -724,13 +724,7 @@ describe("buildStatusReply subagent summary", () => {
     expect(normalizeTestText(text)).toContain("Uptime: gateway 2h 5m · system 4d 3h");
   });
 
-  it("passes config and workspace into compact plugin health", async () => {
-    const cfg = {
-      ...baseCfg,
-      channels: {
-        broken: { enabled: true },
-      },
-    };
+  it("renders compact plugin health from the runtime snapshot", async () => {
     pluginHealthRuntimeMock.collectRuntimePluginHealthSnapshot.mockReturnValue({
       plugins: [],
       diagnostics: [],
@@ -739,13 +733,14 @@ describe("buildStatusReply subagent summary", () => {
       channelPluginFailures: [
         {
           channelId: "broken",
-          message: "configured channel plugin is missing or unavailable",
+          message: "failed to load setup entry: boom",
+          source: "diagnostic",
         },
       ],
     });
 
     const text = await buildStatusText({
-      cfg,
+      cfg: baseCfg,
       sessionEntry: {
         sessionId: "sess-status-plugin-health",
         updatedAt: 0,
@@ -769,10 +764,9 @@ describe("buildStatusReply subagent summary", () => {
       activeModelAuthOverride: "api-key",
     });
 
-    expect(pluginHealthRuntimeMock.collectRuntimePluginHealthSnapshot).toHaveBeenCalledWith({
-      config: cfg,
-      workspaceDir: "/tmp/status-plugin-health-workspace",
-    });
+    // Compact status reads only the runtime snapshot; no config-driven
+    // channel inspection happens on this path.
+    expect(pluginHealthRuntimeMock.collectRuntimePluginHealthSnapshot).toHaveBeenCalledWith();
     expect(normalizeTestText(text)).toContain("Plugins: 1 channel plugin failure");
   });
 

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -1,5 +1,6 @@
 /** Builds /status replies using the command's authorized channel context. */
 import { logVerbose } from "../../globals.js";
+import { formatDetailedPluginHealth } from "../../status/status-plugin-health.js";
 import { buildStatusText } from "../../status/status-text.js";
 import type { BuildStatusTextParams } from "../../status/status-text.types.js";
 import type { ReplyPayload } from "../types.js";
@@ -26,4 +27,30 @@ export async function buildStatusReply(
       statusChannel: command.channel,
     }),
   };
+}
+
+export async function buildStatusPluginsReply(
+  params: Pick<BuildStatusReplyParams, "cfg" | "command" | "workspaceDir">,
+): Promise<ReplyPayload | undefined> {
+  const { command } = params;
+  if (!command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /status plugins from unauthorized sender: ${command.senderId || "<unknown>"}`,
+    );
+    return undefined;
+  }
+
+  try {
+    const { collectInstalledPluginHealthSnapshot } =
+      await import("../../status/status-plugin-health.runtime.js");
+    const snapshot = await collectInstalledPluginHealthSnapshot({
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+    });
+    return { text: formatDetailedPluginHealth(snapshot) };
+  } catch (error) {
+    return {
+      text: `⚠️ Plugins: health unavailable (${error instanceof Error ? error.message : String(error)})`,
+    };
+  }
 }

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -4,6 +4,7 @@ import { formatDetailedPluginHealth } from "../../status/status-plugin-health.js
 import { buildStatusText } from "../../status/status-text.js";
 import type { BuildStatusTextParams } from "../../status/status-text.types.js";
 import type { ReplyPayload } from "../types.js";
+import { requireCommandFlagEnabled } from "./command-gates.js";
 import type { CommandContext } from "./commands-types.js";
 export { buildStatusText } from "../../status/status-text.js";
 
@@ -38,6 +39,13 @@ export async function buildStatusPluginsReply(
       `Ignoring /status plugins from unauthorized sender: ${command.senderId || "<unknown>"}`,
     );
     return undefined;
+  }
+  const disabled = requireCommandFlagEnabled(params.cfg, {
+    label: "/status plugins",
+    configKey: "plugins",
+  });
+  if (disabled) {
+    return disabled.reply;
   }
 
   try {

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
@@ -74,6 +74,18 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
   });
 
+  it("returns true for local status plugin commands", () => {
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      CommandBody: "/STATUS plugins",
+      BodyForCommands: "/STATUS plugins",
+      BodyForAgent: "/STATUS plugins",
+    });
+
+    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
+  });
+
   it("returns true for registry-backed local help commands", () => {
     const ctx = buildTestCtx({
       Provider: "whatsapp",

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -124,6 +124,7 @@ describe("buildStatusMessage", () => {
       resolvedVerbose: "off",
       resolvedHarness: "openclaw",
       queue: { mode: "collect", depth: 0 },
+      pluginHealthLine: "🔌 Plugins: OK",
       modelAuth: "api-key",
       subagentsLine: "🤖 Subagents: 1\n- active run",
       now: 10 * 60_000, // 10 minutes later
@@ -133,6 +134,7 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("OpenClaw");
     expect(normalized).toContain("Model: anthropic/test:opus");
     expect(normalized).toContain("api-key");
+    expect(normalized).toContain("Plugins: OK");
     expect(normalized).toContain("Tokens: 1.2k in / 800 out");
     expect(normalized).toContain("Cost: $0.0020");
     expect(normalized).toContain("Context: 16k/32k (50%)");

--- a/src/channels/inbound-debounce-policy.test.ts
+++ b/src/channels/inbound-debounce-policy.test.ts
@@ -12,6 +12,7 @@ describe("shouldDebounceTextInbound", () => {
     expect(shouldDebounceTextInbound({ text: "   ", cfg })).toBe(false);
     expect(shouldDebounceTextInbound({ text: "hello", cfg, hasMedia: true })).toBe(false);
     expect(shouldDebounceTextInbound({ text: "/status", cfg })).toBe(false);
+    expect(shouldDebounceTextInbound({ text: "/status plugins", cfg })).toBe(false);
     expect(shouldDebounceTextInbound({ text: "stop", cfg })).toBe(false);
     expect(shouldDebounceTextInbound({ text: "abort", cfg })).toBe(false);
     expect(shouldDebounceTextInbound({ text: "wait", cfg })).toBe(false);

--- a/src/context-engine/quarantine-health.test.ts
+++ b/src/context-engine/quarantine-health.test.ts
@@ -1,0 +1,30 @@
+// Context-engine quarantine health tests cover cross-process status visibility.
+import { describe, expect, it } from "vitest";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { recordPersistedContextEngineQuarantine } from "./quarantine-health.js";
+import { clearContextEngineRuntimeQuarantine, listContextEngineQuarantines } from "./registry.js";
+
+describe("context engine quarantine health", () => {
+  it("lists persisted runtime quarantines when local process state is empty", async () => {
+    await withStateDirEnv("openclaw-context-engine-quarantine-", async () => {
+      clearContextEngineRuntimeQuarantine();
+      recordPersistedContextEngineQuarantine({
+        engineId: "lossless-claw",
+        owner: "plugin:lossless-claw",
+        operation: "bootstrap",
+        reason: "intentional bootstrap failure",
+        failedAt: new Date(123),
+      });
+
+      expect(listContextEngineQuarantines()).toEqual([
+        {
+          engineId: "lossless-claw",
+          owner: "plugin:lossless-claw",
+          operation: "bootstrap",
+          reason: "intentional bootstrap failure",
+          failedAt: new Date(123),
+        },
+      ]);
+    });
+  });
+});

--- a/src/context-engine/quarantine-health.test.ts
+++ b/src/context-engine/quarantine-health.test.ts
@@ -99,4 +99,63 @@ describe("context engine quarantine health", () => {
       });
     });
   });
+
+  it("clears all current process records while preserving live sibling quarantines", async () => {
+    await withStateDirEnv("openclaw-context-engine-quarantine-", async ({ stateDir }) => {
+      await withLiveSiblingProcess(async (siblingProcessId) => {
+        const filePath = path.join(stateDir, "context-engine", "runtime-quarantines.json");
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.writeFile(
+          filePath,
+          `${JSON.stringify(
+            {
+              schemaVersion: 1,
+              records: [
+                {
+                  engineId: "local-a",
+                  operation: "bootstrap",
+                  reason: "current process failure a",
+                  failedAtMs: 123,
+                  processId: process.pid,
+                  recordedAtMs: 456,
+                },
+                {
+                  engineId: "local-b",
+                  operation: "assemble",
+                  reason: "current process failure b",
+                  failedAtMs: 234,
+                  processId: process.pid,
+                  recordedAtMs: 567,
+                },
+                {
+                  engineId: "lossless-claw",
+                  owner: "plugin:lossless-claw",
+                  operation: "bootstrap",
+                  reason: "sibling process failure",
+                  failedAtMs: 789,
+                  processId: siblingProcessId,
+                  recordedAtMs: 1_000,
+                },
+              ],
+            },
+            null,
+            2,
+          )}\n`,
+          "utf8",
+        );
+
+        clearContextEngineRuntimeQuarantine();
+
+        expect(listContextEngineQuarantines()).toEqual([
+          {
+            engineId: "lossless-claw",
+            owner: "plugin:lossless-claw",
+            operation: "bootstrap",
+            reason: "sibling process failure",
+            failedAt: new Date(789),
+          },
+        ]);
+      });
+    });
+  });
 });

--- a/src/context-engine/quarantine-health.test.ts
+++ b/src/context-engine/quarantine-health.test.ts
@@ -1,14 +1,29 @@
 // Context-engine quarantine health tests cover cross-process status visibility.
 import { spawn } from "node:child_process";
-import fs from "node:fs/promises";
-import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createCorePluginStateSyncKeyedStore,
+  resetPluginStateStoreForTests,
+} from "../plugin-state/plugin-state-store.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import {
   clearPersistedContextEngineQuarantineForProcess,
   recordPersistedContextEngineQuarantine,
 } from "./quarantine-health.js";
 import { clearContextEngineRuntimeQuarantine, listContextEngineQuarantines } from "./registry.js";
+
+const CONTEXT_ENGINE_QUARANTINE_OWNER_ID = "core:context-engine-quarantine-health";
+const CONTEXT_ENGINE_QUARANTINE_NAMESPACE = "runtime-quarantines";
+
+type ContextEngineQuarantineTestRecord = {
+  engineId: string;
+  owner?: string;
+  operation: string;
+  reason: string;
+  failedAtMs: number;
+  processId: number;
+  recordedAtMs: number;
+};
 
 async function withLiveSiblingProcess<T>(fn: (pid: number) => Promise<T>): Promise<T> {
   const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30_000)"], {
@@ -23,6 +38,20 @@ async function withLiveSiblingProcess<T>(fn: (pid: number) => Promise<T>): Promi
     child.kill();
   }
 }
+
+function seedPersistedContextEngineQuarantineForTest(
+  record: ContextEngineQuarantineTestRecord,
+): void {
+  createCorePluginStateSyncKeyedStore<ContextEngineQuarantineTestRecord>({
+    ownerId: CONTEXT_ENGINE_QUARANTINE_OWNER_ID,
+    namespace: CONTEXT_ENGINE_QUARANTINE_NAMESPACE,
+    maxEntries: 64,
+  }).register(JSON.stringify([record.engineId, record.processId]), record);
+}
+
+afterEach(() => {
+  resetPluginStateStoreForTests();
+});
 
 describe("context engine quarantine health", () => {
   it("lists persisted runtime quarantines when local process state is empty", async () => {
@@ -49,41 +78,26 @@ describe("context engine quarantine health", () => {
   });
 
   it("clears only the current process record while preserving live sibling quarantines", async () => {
-    await withStateDirEnv("openclaw-context-engine-quarantine-", async ({ stateDir }) => {
+    await withStateDirEnv("openclaw-context-engine-quarantine-", async () => {
       await withLiveSiblingProcess(async (siblingProcessId) => {
-        const filePath = path.join(stateDir, "context-engine", "runtime-quarantines.json");
-        await fs.mkdir(path.dirname(filePath), { recursive: true });
-        await fs.writeFile(
-          filePath,
-          `${JSON.stringify(
-            {
-              schemaVersion: 1,
-              records: [
-                {
-                  engineId: "lossless-claw",
-                  owner: "plugin:lossless-claw",
-                  operation: "bootstrap",
-                  reason: "current process failure",
-                  failedAtMs: 123,
-                  processId: process.pid,
-                  recordedAtMs: 456,
-                },
-                {
-                  engineId: "lossless-claw",
-                  owner: "plugin:lossless-claw",
-                  operation: "bootstrap",
-                  reason: "sibling process failure",
-                  failedAtMs: 789,
-                  processId: siblingProcessId,
-                  recordedAtMs: 1_000,
-                },
-              ],
-            },
-            null,
-            2,
-          )}\n`,
-          "utf8",
-        );
+        seedPersistedContextEngineQuarantineForTest({
+          engineId: "lossless-claw",
+          owner: "plugin:lossless-claw",
+          operation: "bootstrap",
+          reason: "current process failure",
+          failedAtMs: 123,
+          processId: process.pid,
+          recordedAtMs: 456,
+        });
+        seedPersistedContextEngineQuarantineForTest({
+          engineId: "lossless-claw",
+          owner: "plugin:lossless-claw",
+          operation: "bootstrap",
+          reason: "sibling process failure",
+          failedAtMs: 789,
+          processId: siblingProcessId,
+          recordedAtMs: 1_000,
+        });
 
         clearPersistedContextEngineQuarantineForProcess("lossless-claw", process.pid);
 
@@ -101,48 +115,33 @@ describe("context engine quarantine health", () => {
   });
 
   it("clears all current process records while preserving live sibling quarantines", async () => {
-    await withStateDirEnv("openclaw-context-engine-quarantine-", async ({ stateDir }) => {
+    await withStateDirEnv("openclaw-context-engine-quarantine-", async () => {
       await withLiveSiblingProcess(async (siblingProcessId) => {
-        const filePath = path.join(stateDir, "context-engine", "runtime-quarantines.json");
-        await fs.mkdir(path.dirname(filePath), { recursive: true });
-        await fs.writeFile(
-          filePath,
-          `${JSON.stringify(
-            {
-              schemaVersion: 1,
-              records: [
-                {
-                  engineId: "local-a",
-                  operation: "bootstrap",
-                  reason: "current process failure a",
-                  failedAtMs: 123,
-                  processId: process.pid,
-                  recordedAtMs: 456,
-                },
-                {
-                  engineId: "local-b",
-                  operation: "assemble",
-                  reason: "current process failure b",
-                  failedAtMs: 234,
-                  processId: process.pid,
-                  recordedAtMs: 567,
-                },
-                {
-                  engineId: "lossless-claw",
-                  owner: "plugin:lossless-claw",
-                  operation: "bootstrap",
-                  reason: "sibling process failure",
-                  failedAtMs: 789,
-                  processId: siblingProcessId,
-                  recordedAtMs: 1_000,
-                },
-              ],
-            },
-            null,
-            2,
-          )}\n`,
-          "utf8",
-        );
+        seedPersistedContextEngineQuarantineForTest({
+          engineId: "local-a",
+          operation: "bootstrap",
+          reason: "current process failure a",
+          failedAtMs: 123,
+          processId: process.pid,
+          recordedAtMs: 456,
+        });
+        seedPersistedContextEngineQuarantineForTest({
+          engineId: "local-b",
+          operation: "assemble",
+          reason: "current process failure b",
+          failedAtMs: 234,
+          processId: process.pid,
+          recordedAtMs: 567,
+        });
+        seedPersistedContextEngineQuarantineForTest({
+          engineId: "lossless-claw",
+          owner: "plugin:lossless-claw",
+          operation: "bootstrap",
+          reason: "sibling process failure",
+          failedAtMs: 789,
+          processId: siblingProcessId,
+          recordedAtMs: 1_000,
+        });
 
         clearContextEngineRuntimeQuarantine();
 

--- a/src/context-engine/quarantine-health.test.ts
+++ b/src/context-engine/quarantine-health.test.ts
@@ -27,7 +27,6 @@ type ContextEngineQuarantineTestRecord = {
   reason: string;
   failedAtMs: number;
   processId: number;
-  recordedAtMs: number;
 };
 
 async function withLiveSiblingProcess<T>(fn: (pid: number) => Promise<T>): Promise<T> {
@@ -92,7 +91,6 @@ describe("context engine quarantine health", () => {
           reason: "current process failure",
           failedAtMs: 123,
           processId: process.pid,
-          recordedAtMs: 456,
         });
         seedPersistedContextEngineQuarantineForTest({
           engineId: "lossless-claw",
@@ -101,7 +99,6 @@ describe("context engine quarantine health", () => {
           reason: "sibling process failure",
           failedAtMs: 789,
           processId: siblingProcessId,
-          recordedAtMs: 1_000,
         });
 
         clearPersistedContextEngineQuarantineForProcess("lossless-claw", process.pid);
@@ -128,7 +125,6 @@ describe("context engine quarantine health", () => {
           reason: "current process failure a",
           failedAtMs: 123,
           processId: process.pid,
-          recordedAtMs: 456,
         });
         seedPersistedContextEngineQuarantineForTest({
           engineId: "local-b",
@@ -136,7 +132,6 @@ describe("context engine quarantine health", () => {
           reason: "current process failure b",
           failedAtMs: 234,
           processId: process.pid,
-          recordedAtMs: 567,
         });
         seedPersistedContextEngineQuarantineForTest({
           engineId: "lossless-claw",
@@ -145,7 +140,6 @@ describe("context engine quarantine health", () => {
           reason: "sibling process failure",
           failedAtMs: 789,
           processId: siblingProcessId,
-          recordedAtMs: 1_000,
         });
 
         clearContextEngineRuntimeQuarantine();

--- a/src/context-engine/quarantine-health.test.ts
+++ b/src/context-engine/quarantine-health.test.ts
@@ -10,7 +10,12 @@ import {
   clearPersistedContextEngineQuarantineForProcess,
   recordPersistedContextEngineQuarantine,
 } from "./quarantine-health.js";
-import { clearContextEngineRuntimeQuarantine, listContextEngineQuarantines } from "./registry.js";
+import {
+  clearContextEngineRuntimeQuarantine,
+  clearContextEnginesForOwner,
+  listContextEngineQuarantines,
+  registerContextEngineForOwner,
+} from "./registry.js";
 
 const CONTEXT_ENGINE_QUARANTINE_OWNER_ID = "core:context-engine-quarantine-health";
 const CONTEXT_ENGINE_QUARANTINE_NAMESPACE = "runtime-quarantines";
@@ -155,6 +160,39 @@ describe("context engine quarantine health", () => {
           },
         ]);
       });
+    });
+  });
+
+  it("clears persisted quarantine records when owner engines unload", async () => {
+    await withStateDirEnv("openclaw-context-engine-quarantine-owner-", async () => {
+      const owner = "plugin:lossless-claw";
+      registerContextEngineForOwner(
+        "lossless-claw",
+        () => ({
+          info: { id: "lossless-claw", name: "Lossless Claw", version: "1" },
+          async ingest() {
+            return { ingested: true };
+          },
+          async assemble({ messages }) {
+            return { messages, estimatedTokens: 0 };
+          },
+          async compact() {
+            return { ok: true, compacted: false };
+          },
+        }),
+        owner,
+      );
+      recordPersistedContextEngineQuarantine({
+        engineId: "lossless-claw",
+        owner,
+        operation: "bootstrap",
+        reason: "plugin disabled",
+        failedAt: new Date(123),
+      });
+
+      clearContextEnginesForOwner(owner);
+
+      expect(listContextEngineQuarantines()).toEqual([]);
     });
   });
 });

--- a/src/context-engine/quarantine-health.test.ts
+++ b/src/context-engine/quarantine-health.test.ts
@@ -1,8 +1,28 @@
 // Context-engine quarantine health tests cover cross-process status visibility.
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
-import { recordPersistedContextEngineQuarantine } from "./quarantine-health.js";
+import {
+  clearPersistedContextEngineQuarantineForProcess,
+  recordPersistedContextEngineQuarantine,
+} from "./quarantine-health.js";
 import { clearContextEngineRuntimeQuarantine, listContextEngineQuarantines } from "./registry.js";
+
+async function withLiveSiblingProcess<T>(fn: (pid: number) => Promise<T>): Promise<T> {
+  const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30_000)"], {
+    stdio: "ignore",
+  });
+  if (!child.pid) {
+    throw new Error("failed to start live sibling process");
+  }
+  try {
+    return await fn(child.pid);
+  } finally {
+    child.kill();
+  }
+}
 
 describe("context engine quarantine health", () => {
   it("lists persisted runtime quarantines when local process state is empty", async () => {
@@ -25,6 +45,58 @@ describe("context engine quarantine health", () => {
           failedAt: new Date(123),
         },
       ]);
+    });
+  });
+
+  it("clears only the current process record while preserving live sibling quarantines", async () => {
+    await withStateDirEnv("openclaw-context-engine-quarantine-", async ({ stateDir }) => {
+      await withLiveSiblingProcess(async (siblingProcessId) => {
+        const filePath = path.join(stateDir, "context-engine", "runtime-quarantines.json");
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.writeFile(
+          filePath,
+          `${JSON.stringify(
+            {
+              schemaVersion: 1,
+              records: [
+                {
+                  engineId: "lossless-claw",
+                  owner: "plugin:lossless-claw",
+                  operation: "bootstrap",
+                  reason: "current process failure",
+                  failedAtMs: 123,
+                  processId: process.pid,
+                  recordedAtMs: 456,
+                },
+                {
+                  engineId: "lossless-claw",
+                  owner: "plugin:lossless-claw",
+                  operation: "bootstrap",
+                  reason: "sibling process failure",
+                  failedAtMs: 789,
+                  processId: siblingProcessId,
+                  recordedAtMs: 1_000,
+                },
+              ],
+            },
+            null,
+            2,
+          )}\n`,
+          "utf8",
+        );
+
+        clearPersistedContextEngineQuarantineForProcess("lossless-claw", process.pid);
+
+        expect(listContextEngineQuarantines()).toEqual([
+          {
+            engineId: "lossless-claw",
+            owner: "plugin:lossless-claw",
+            operation: "bootstrap",
+            reason: "sibling process failure",
+            failedAt: new Date(789),
+          },
+        ]);
+      });
     });
   });
 });

--- a/src/context-engine/quarantine-health.test.ts
+++ b/src/context-engine/quarantine-health.test.ts
@@ -5,6 +5,7 @@ import {
   createCorePluginStateSyncKeyedStore,
   resetPluginStateStoreForTests,
 } from "../plugin-state/plugin-state-store.js";
+import { getProcessStartTime } from "../shared/pid-alive.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import {
   clearPersistedContextEngineQuarantineForProcess,
@@ -27,6 +28,7 @@ type ContextEngineQuarantineTestRecord = {
   reason: string;
   failedAtMs: number;
   processId: number;
+  processStartTime: number | null;
 };
 
 async function withLiveSiblingProcess<T>(fn: (pid: number) => Promise<T>): Promise<T> {
@@ -91,6 +93,7 @@ describe("context engine quarantine health", () => {
           reason: "current process failure",
           failedAtMs: 123,
           processId: process.pid,
+          processStartTime: getProcessStartTime(process.pid),
         });
         seedPersistedContextEngineQuarantineForTest({
           engineId: "lossless-claw",
@@ -99,6 +102,7 @@ describe("context engine quarantine health", () => {
           reason: "sibling process failure",
           failedAtMs: 789,
           processId: siblingProcessId,
+          processStartTime: getProcessStartTime(siblingProcessId),
         });
 
         clearPersistedContextEngineQuarantineForProcess("lossless-claw", process.pid);
@@ -125,6 +129,7 @@ describe("context engine quarantine health", () => {
           reason: "current process failure a",
           failedAtMs: 123,
           processId: process.pid,
+          processStartTime: getProcessStartTime(process.pid),
         });
         seedPersistedContextEngineQuarantineForTest({
           engineId: "local-b",
@@ -132,6 +137,7 @@ describe("context engine quarantine health", () => {
           reason: "current process failure b",
           failedAtMs: 234,
           processId: process.pid,
+          processStartTime: getProcessStartTime(process.pid),
         });
         seedPersistedContextEngineQuarantineForTest({
           engineId: "lossless-claw",
@@ -140,6 +146,7 @@ describe("context engine quarantine health", () => {
           reason: "sibling process failure",
           failedAtMs: 789,
           processId: siblingProcessId,
+          processStartTime: getProcessStartTime(siblingProcessId),
         });
 
         clearContextEngineRuntimeQuarantine();
@@ -154,6 +161,27 @@ describe("context engine quarantine health", () => {
           },
         ]);
       });
+    });
+  });
+
+  it("drops persisted quarantine records when a PID has been reused", async () => {
+    const currentStartTime = getProcessStartTime(process.pid);
+    if (currentStartTime === null) {
+      return;
+    }
+    await withStateDirEnv("openclaw-context-engine-quarantine-pid-reuse-", async () => {
+      clearContextEngineRuntimeQuarantine();
+      seedPersistedContextEngineQuarantineForTest({
+        engineId: "lossless-claw",
+        owner: "plugin:lossless-claw",
+        operation: "bootstrap",
+        reason: "stale process failure",
+        failedAtMs: 123,
+        processId: process.pid,
+        processStartTime: currentStartTime + 1,
+      });
+
+      expect(listContextEngineQuarantines()).toEqual([]);
     });
   });
 

--- a/src/context-engine/quarantine-health.test.ts
+++ b/src/context-engine/quarantine-health.test.ts
@@ -5,6 +5,7 @@ import {
   createCorePluginStateSyncKeyedStore,
   resetPluginStateStoreForTests,
 } from "../plugin-state/plugin-state-store.js";
+import { createRuntimeHealthRecordEnvelope } from "../plugin-state/runtime-health-store.js";
 import { getProcessStartTime } from "../shared/pid-alive.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import {
@@ -21,6 +22,10 @@ import {
 const CONTEXT_ENGINE_QUARANTINE_OWNER_ID = "core:context-engine-quarantine-health";
 const CONTEXT_ENGINE_QUARANTINE_NAMESPACE = "runtime-quarantines";
 
+// Sibling records need a verifiable /proc starttime, so sibling-visibility
+// coverage only runs where that identity source exists.
+const hasProcessStartTimes = process.platform === "linux";
+
 type ContextEngineQuarantineTestRecord = {
   engineId: string;
   owner?: string;
@@ -28,6 +33,7 @@ type ContextEngineQuarantineTestRecord = {
   reason: string;
   failedAtMs: number;
   processId: number;
+  processToken: string;
   processStartTime: number | null;
 };
 
@@ -53,6 +59,21 @@ function seedPersistedContextEngineQuarantineForTest(
     namespace: CONTEXT_ENGINE_QUARANTINE_NAMESPACE,
     maxEntries: 64,
   }).register(JSON.stringify([record.engineId, record.processId]), record);
+}
+
+function seedSiblingQuarantineForTest(params: {
+  engineId: string;
+  owner?: string;
+  operation: string;
+  reason: string;
+  failedAtMs: number;
+  processId: number;
+  processStartTime: number | null;
+}): void {
+  seedPersistedContextEngineQuarantineForTest({
+    ...params,
+    processToken: "sibling-process-token",
+  });
 }
 
 afterEach(() => {
@@ -83,105 +104,144 @@ describe("context engine quarantine health", () => {
     });
   });
 
-  it("clears only the current process record while preserving live sibling quarantines", async () => {
-    await withStateDirEnv("openclaw-context-engine-quarantine-", async () => {
-      await withLiveSiblingProcess(async (siblingProcessId) => {
-        seedPersistedContextEngineQuarantineForTest({
-          engineId: "lossless-claw",
-          owner: "plugin:lossless-claw",
-          operation: "bootstrap",
-          reason: "current process failure",
-          failedAtMs: 123,
-          processId: process.pid,
-          processStartTime: getProcessStartTime(process.pid),
-        });
-        seedPersistedContextEngineQuarantineForTest({
-          engineId: "lossless-claw",
-          owner: "plugin:lossless-claw",
-          operation: "bootstrap",
-          reason: "sibling process failure",
-          failedAtMs: 789,
-          processId: siblingProcessId,
-          processStartTime: getProcessStartTime(siblingProcessId),
-        });
-
-        clearPersistedContextEngineQuarantineForProcess("lossless-claw", process.pid);
-
-        expect(listContextEngineQuarantines()).toEqual([
-          {
+  it.runIf(hasProcessStartTimes)(
+    "clears only the current process record while preserving live sibling quarantines",
+    async () => {
+      await withStateDirEnv("openclaw-context-engine-quarantine-", async () => {
+        await withLiveSiblingProcess(async (siblingProcessId) => {
+          seedPersistedContextEngineQuarantineForTest({
+            engineId: "lossless-claw",
+            owner: "plugin:lossless-claw",
+            operation: "bootstrap",
+            reason: "current process failure",
+            ...createRuntimeHealthRecordEnvelope(new Date(123)),
+          });
+          seedSiblingQuarantineForTest({
             engineId: "lossless-claw",
             owner: "plugin:lossless-claw",
             operation: "bootstrap",
             reason: "sibling process failure",
-            failedAt: new Date(789),
-          },
-        ]);
+            failedAtMs: 789,
+            processId: siblingProcessId,
+            processStartTime: getProcessStartTime(siblingProcessId),
+          });
+
+          clearPersistedContextEngineQuarantineForProcess("lossless-claw", process.pid);
+
+          expect(listContextEngineQuarantines()).toEqual([
+            {
+              engineId: "lossless-claw",
+              owner: "plugin:lossless-claw",
+              operation: "bootstrap",
+              reason: "sibling process failure",
+              failedAt: new Date(789),
+            },
+          ]);
+        });
       });
-    });
-  });
+    },
+  );
 
-  it("clears all current process records while preserving live sibling quarantines", async () => {
-    await withStateDirEnv("openclaw-context-engine-quarantine-", async () => {
-      await withLiveSiblingProcess(async (siblingProcessId) => {
-        seedPersistedContextEngineQuarantineForTest({
-          engineId: "local-a",
-          operation: "bootstrap",
-          reason: "current process failure a",
-          failedAtMs: 123,
-          processId: process.pid,
-          processStartTime: getProcessStartTime(process.pid),
-        });
-        seedPersistedContextEngineQuarantineForTest({
-          engineId: "local-b",
-          operation: "assemble",
-          reason: "current process failure b",
-          failedAtMs: 234,
-          processId: process.pid,
-          processStartTime: getProcessStartTime(process.pid),
-        });
-        seedPersistedContextEngineQuarantineForTest({
-          engineId: "lossless-claw",
-          owner: "plugin:lossless-claw",
-          operation: "bootstrap",
-          reason: "sibling process failure",
-          failedAtMs: 789,
-          processId: siblingProcessId,
-          processStartTime: getProcessStartTime(siblingProcessId),
-        });
-
-        clearContextEngineRuntimeQuarantine();
-
-        expect(listContextEngineQuarantines()).toEqual([
-          {
+  it.runIf(hasProcessStartTimes)(
+    "clears all current process records while preserving live sibling quarantines",
+    async () => {
+      await withStateDirEnv("openclaw-context-engine-quarantine-", async () => {
+        await withLiveSiblingProcess(async (siblingProcessId) => {
+          seedPersistedContextEngineQuarantineForTest({
+            engineId: "local-a",
+            operation: "bootstrap",
+            reason: "current process failure a",
+            ...createRuntimeHealthRecordEnvelope(new Date(123)),
+          });
+          seedPersistedContextEngineQuarantineForTest({
+            engineId: "local-b",
+            operation: "assemble",
+            reason: "current process failure b",
+            ...createRuntimeHealthRecordEnvelope(new Date(234)),
+          });
+          seedSiblingQuarantineForTest({
             engineId: "lossless-claw",
             owner: "plugin:lossless-claw",
             operation: "bootstrap",
             reason: "sibling process failure",
-            failedAt: new Date(789),
-          },
-        ]);
-      });
-    });
-  });
+            failedAtMs: 789,
+            processId: siblingProcessId,
+            processStartTime: getProcessStartTime(siblingProcessId),
+          });
 
-  it("drops persisted quarantine records when a PID has been reused", async () => {
-    const currentStartTime = getProcessStartTime(process.pid);
-    if (currentStartTime === null) {
-      return;
-    }
-    await withStateDirEnv("openclaw-context-engine-quarantine-pid-reuse-", async () => {
+          clearContextEngineRuntimeQuarantine();
+
+          expect(listContextEngineQuarantines()).toEqual([
+            {
+              engineId: "lossless-claw",
+              owner: "plugin:lossless-claw",
+              operation: "bootstrap",
+              reason: "sibling process failure",
+              failedAt: new Date(789),
+            },
+          ]);
+        });
+      });
+    },
+  );
+
+  it("drops records from a previous incarnation of this PID", async () => {
+    await withStateDirEnv("openclaw-context-engine-quarantine-incarnation-", async () => {
       clearContextEngineRuntimeQuarantine();
       seedPersistedContextEngineQuarantineForTest({
         engineId: "lossless-claw",
         owner: "plugin:lossless-claw",
         operation: "bootstrap",
-        reason: "stale process failure",
-        failedAtMs: 123,
-        processId: process.pid,
-        processStartTime: currentStartTime + 1,
+        reason: "stale pre-restart failure",
+        ...createRuntimeHealthRecordEnvelope(new Date(123)),
+        processToken: "stale-incarnation-token",
       });
 
       expect(listContextEngineQuarantines()).toEqual([]);
+    });
+  });
+
+  it.runIf(hasProcessStartTimes)(
+    "drops persisted quarantine records when a sibling PID has been reused",
+    async () => {
+      await withStateDirEnv("openclaw-context-engine-quarantine-pid-reuse-", async () => {
+        await withLiveSiblingProcess(async (siblingProcessId) => {
+          clearContextEngineRuntimeQuarantine();
+          const siblingStartTime = getProcessStartTime(siblingProcessId);
+          seedSiblingQuarantineForTest({
+            engineId: "lossless-claw",
+            owner: "plugin:lossless-claw",
+            operation: "bootstrap",
+            reason: "stale process failure",
+            failedAtMs: 123,
+            processId: siblingProcessId,
+            processStartTime: siblingStartTime === null ? 1 : siblingStartTime + 1,
+          });
+
+          expect(listContextEngineQuarantines()).toEqual([]);
+        });
+      });
+    },
+  );
+
+  it("drops sibling records whose process identity cannot be verified", async () => {
+    await withStateDirEnv("openclaw-context-engine-quarantine-unverified-", async () => {
+      await withLiveSiblingProcess(async (siblingProcessId) => {
+        clearContextEngineRuntimeQuarantine();
+        // A null recorded start time (non-Linux recorder or /proc read failure)
+        // must fail closed instead of trusting bare PID liveness.
+        seedSiblingQuarantineForTest({
+          engineId: "lossless-claw",
+          owner: "plugin:lossless-claw",
+          operation: "bootstrap",
+          reason: "unverifiable recorder identity",
+          failedAtMs: 123,
+          processId: siblingProcessId,
+          processStartTime: null,
+        });
+
+        expect(listContextEngineQuarantines()).toEqual([]);
+      });
     });
   });
 

--- a/src/context-engine/quarantine-health.ts
+++ b/src/context-engine/quarantine-health.ts
@@ -160,32 +160,26 @@ export function listPersistedContextEngineQuarantines(): ContextEngineRuntimeQua
   }));
 }
 
-export function clearPersistedContextEngineQuarantine(engineId?: string): void {
-  if (engineId === undefined) {
-    try {
-      fs.rmSync(quarantineHealthPath(), { force: true });
-    } catch {
-      // Best-effort cleanup; callers still clear in-memory state.
-    }
-    return;
+function removePersistedContextEngineQuarantineFile(): void {
+  try {
+    fs.rmSync(quarantineHealthPath(), { force: true });
+  } catch {
+    // Best-effort cleanup; callers still clear in-memory state.
   }
-  const records = readPersistedRecords().filter((record) => record.engineId !== engineId);
-  if (records.length === 0) {
-    clearPersistedContextEngineQuarantine();
-    return;
-  }
-  writePersistedRecords(records);
 }
 
 export function clearPersistedContextEngineQuarantineForProcess(
-  engineId: string,
+  engineId: string | undefined,
   processId: number,
 ): void {
-  const records = readPersistedRecords().filter(
-    (record) => record.engineId !== engineId || record.processId !== processId,
-  );
+  const records = readPersistedRecords().filter((record) => {
+    if (record.processId !== processId) {
+      return true;
+    }
+    return engineId !== undefined && record.engineId !== engineId;
+  });
   if (records.length === 0) {
-    clearPersistedContextEngineQuarantine();
+    removePersistedContextEngineQuarantineFile();
     return;
   }
   writePersistedRecords(records);

--- a/src/context-engine/quarantine-health.ts
+++ b/src/context-engine/quarantine-health.ts
@@ -1,10 +1,9 @@
 // Persists context-engine runtime quarantines so health surfaces can see
 // failures recorded in sibling runtime processes.
-import fs from "node:fs";
-import path from "node:path";
-import { resolveStateDir } from "../config/paths.js";
+import { createCorePluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.js";
 
-const QUARANTINE_HEALTH_SCHEMA_VERSION = 1;
+const CONTEXT_ENGINE_QUARANTINE_OWNER_ID = "core:context-engine-quarantine-health";
+const CONTEXT_ENGINE_QUARANTINE_NAMESPACE = "runtime-quarantines";
 const MAX_QUARANTINE_RECORDS = 64;
 
 export type PersistedContextEngineRuntimeQuarantine = {
@@ -25,13 +24,12 @@ type PersistedContextEngineQuarantineRecord = {
   recordedAtMs: number;
 };
 
-type ContextEngineQuarantineHealthFile = {
-  schemaVersion: typeof QUARANTINE_HEALTH_SCHEMA_VERSION;
-  records: PersistedContextEngineQuarantineRecord[];
-};
-
-function quarantineHealthPath(): string {
-  return path.join(resolveStateDir(), "context-engine", "runtime-quarantines.json");
+function openQuarantineStore() {
+  return createCorePluginStateSyncKeyedStore<PersistedContextEngineQuarantineRecord>({
+    ownerId: CONTEXT_ENGINE_QUARANTINE_OWNER_ID,
+    namespace: CONTEXT_ENGINE_QUARANTINE_NAMESPACE,
+    maxEntries: MAX_QUARANTINE_RECORDS,
+  });
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -80,65 +78,26 @@ function processLooksLive(processId: number): boolean {
   }
 }
 
-function readPersistedRecords(): PersistedContextEngineQuarantineRecord[] {
-  let raw: string;
+function listPersistedRecords(): PersistedContextEngineQuarantineRecord[] {
   try {
-    raw = fs.readFileSync(quarantineHealthPath(), "utf8");
+    return openQuarantineStore()
+      .entries()
+      .map((entry) => normalizeRecord(entry.value))
+      .filter((record): record is PersistedContextEngineQuarantineRecord => Boolean(record))
+      .filter((record) => processLooksLive(record.processId));
   } catch {
     return [];
   }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return [];
-  }
-
-  if (
-    !parsed ||
-    typeof parsed !== "object" ||
-    (parsed as Partial<ContextEngineQuarantineHealthFile>).schemaVersion !==
-      QUARANTINE_HEALTH_SCHEMA_VERSION ||
-    !Array.isArray((parsed as Partial<ContextEngineQuarantineHealthFile>).records)
-  ) {
-    return [];
-  }
-
-  return (parsed as ContextEngineQuarantineHealthFile).records
-    .map(normalizeRecord)
-    .filter((record): record is PersistedContextEngineQuarantineRecord => Boolean(record))
-    .filter((record) => processLooksLive(record.processId));
-}
-
-function writePersistedRecords(records: PersistedContextEngineQuarantineRecord[]): void {
-  const filePath = quarantineHealthPath();
-  const dir = path.dirname(filePath);
-  fs.mkdirSync(dir, { recursive: true });
-  const payload: ContextEngineQuarantineHealthFile = {
-    schemaVersion: QUARANTINE_HEALTH_SCHEMA_VERSION,
-    records: records
-      .toSorted((left, right) => left.recordedAtMs - right.recordedAtMs)
-      .slice(-MAX_QUARANTINE_RECORDS),
-  };
-  const tempPath = `${filePath}.${process.pid}.tmp`;
-  fs.writeFileSync(tempPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
-  fs.renameSync(tempPath, filePath);
 }
 
 function recordKey(record: Pick<PersistedContextEngineQuarantineRecord, "engineId" | "processId">) {
-  return `${record.engineId}\0${record.processId}`;
+  return JSON.stringify([record.engineId, record.processId]);
 }
 
 export function recordPersistedContextEngineQuarantine(
   quarantine: PersistedContextEngineRuntimeQuarantine,
 ): void {
-  const records = readPersistedRecords();
-  const key = recordKey({ engineId: quarantine.engineId, processId: process.pid });
-  if (records.some((record) => recordKey(record) === key)) {
-    return;
-  }
-  records.push({
+  const record: PersistedContextEngineQuarantineRecord = {
     engineId: quarantine.engineId,
     operation: quarantine.operation,
     reason: quarantine.reason,
@@ -146,13 +105,13 @@ export function recordPersistedContextEngineQuarantine(
     processId: process.pid,
     recordedAtMs: Date.now(),
     ...(quarantine.owner ? { owner: quarantine.owner } : {}),
-  });
-  writePersistedRecords(records);
+  };
+  openQuarantineStore().registerIfAbsent(recordKey(record), record);
 }
 
 export function listPersistedContextEngineQuarantines(): PersistedContextEngineRuntimeQuarantine[] {
   const byEngineId = new Map<string, PersistedContextEngineQuarantineRecord>();
-  for (const record of readPersistedRecords()) {
+  for (const record of listPersistedRecords()) {
     const existing = byEngineId.get(record.engineId);
     if (!existing || record.failedAtMs < existing.failedAtMs) {
       byEngineId.set(record.engineId, record);
@@ -172,27 +131,22 @@ export function listPersistedContextEngineQuarantines(): PersistedContextEngineR
   });
 }
 
-function removePersistedContextEngineQuarantineFile(): void {
-  try {
-    fs.rmSync(quarantineHealthPath(), { force: true });
-  } catch {
-    // Best-effort cleanup; callers still clear in-memory state.
-  }
-}
-
 export function clearPersistedContextEngineQuarantineForProcess(
   engineId: string | undefined,
   processId: number,
 ): void {
-  const records = readPersistedRecords().filter((record) => {
-    if (record.processId !== processId) {
-      return true;
+  try {
+    const store = openQuarantineStore();
+    for (const entry of store.entries()) {
+      const record = normalizeRecord(entry.value);
+      if (
+        record?.processId === processId &&
+        (engineId === undefined || record.engineId === engineId)
+      ) {
+        store.delete(entry.key);
+      }
     }
-    return engineId !== undefined && record.engineId !== engineId;
-  });
-  if (records.length === 0) {
-    removePersistedContextEngineQuarantineFile();
-    return;
+  } catch {
+    // Best-effort cleanup; callers still clear in-memory state.
   }
-  writePersistedRecords(records);
 }

--- a/src/context-engine/quarantine-health.ts
+++ b/src/context-engine/quarantine-health.ts
@@ -3,10 +3,17 @@
 import fs from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
-import type { ContextEngineRuntimeQuarantine } from "./registry.js";
 
 const QUARANTINE_HEALTH_SCHEMA_VERSION = 1;
 const MAX_QUARANTINE_RECORDS = 64;
+
+export type PersistedContextEngineRuntimeQuarantine = {
+  engineId: string;
+  owner?: string;
+  operation: string;
+  reason: string;
+  failedAt: Date;
+};
 
 type PersistedContextEngineQuarantineRecord = {
   engineId: string;
@@ -124,7 +131,7 @@ function recordKey(record: Pick<PersistedContextEngineQuarantineRecord, "engineI
 }
 
 export function recordPersistedContextEngineQuarantine(
-  quarantine: ContextEngineRuntimeQuarantine,
+  quarantine: PersistedContextEngineRuntimeQuarantine,
 ): void {
   const records = readPersistedRecords();
   const key = recordKey({ engineId: quarantine.engineId, processId: process.pid });
@@ -143,7 +150,7 @@ export function recordPersistedContextEngineQuarantine(
   writePersistedRecords(records);
 }
 
-export function listPersistedContextEngineQuarantines(): ContextEngineRuntimeQuarantine[] {
+export function listPersistedContextEngineQuarantines(): PersistedContextEngineRuntimeQuarantine[] {
   const byEngineId = new Map<string, PersistedContextEngineQuarantineRecord>();
   for (const record of readPersistedRecords()) {
     const existing = byEngineId.get(record.engineId);
@@ -151,13 +158,18 @@ export function listPersistedContextEngineQuarantines(): ContextEngineRuntimeQua
       byEngineId.set(record.engineId, record);
     }
   }
-  return [...byEngineId.values()].map((record) => ({
-    engineId: record.engineId,
-    operation: record.operation,
-    reason: record.reason,
-    failedAt: new Date(record.failedAtMs),
-    ...(record.owner ? { owner: record.owner } : {}),
-  }));
+  return [...byEngineId.values()].map((record) => {
+    const quarantine: PersistedContextEngineRuntimeQuarantine = {
+      engineId: record.engineId,
+      operation: record.operation,
+      reason: record.reason,
+      failedAt: new Date(record.failedAtMs),
+    };
+    if (record.owner) {
+      quarantine.owner = record.owner;
+    }
+    return quarantine;
+  });
 }
 
 function removePersistedContextEngineQuarantineFile(): void {

--- a/src/context-engine/quarantine-health.ts
+++ b/src/context-engine/quarantine-health.ts
@@ -1,0 +1,178 @@
+// Persists context-engine runtime quarantines so health surfaces can see
+// failures recorded in sibling runtime processes.
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import type { ContextEngineRuntimeQuarantine } from "./registry.js";
+
+const QUARANTINE_HEALTH_SCHEMA_VERSION = 1;
+const MAX_QUARANTINE_RECORDS = 64;
+
+type PersistedContextEngineQuarantineRecord = {
+  engineId: string;
+  owner?: string;
+  operation: string;
+  reason: string;
+  failedAtMs: number;
+  processId: number;
+  recordedAtMs: number;
+};
+
+type ContextEngineQuarantineHealthFile = {
+  schemaVersion: typeof QUARANTINE_HEALTH_SCHEMA_VERSION;
+  records: PersistedContextEngineQuarantineRecord[];
+};
+
+function quarantineHealthPath(): string {
+  return path.join(resolveStateDir(), "context-engine", "runtime-quarantines.json");
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function normalizeRecord(value: unknown): PersistedContextEngineQuarantineRecord | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Partial<PersistedContextEngineQuarantineRecord>;
+  if (
+    !isNonEmptyString(record.engineId) ||
+    !isNonEmptyString(record.operation) ||
+    !isNonEmptyString(record.reason) ||
+    typeof record.failedAtMs !== "number" ||
+    !Number.isFinite(record.failedAtMs) ||
+    typeof record.processId !== "number" ||
+    !Number.isInteger(record.processId) ||
+    record.processId <= 0 ||
+    typeof record.recordedAtMs !== "number" ||
+    !Number.isFinite(record.recordedAtMs)
+  ) {
+    return undefined;
+  }
+  return {
+    engineId: record.engineId,
+    operation: record.operation,
+    reason: record.reason,
+    failedAtMs: record.failedAtMs,
+    processId: record.processId,
+    recordedAtMs: record.recordedAtMs,
+    ...(isNonEmptyString(record.owner) ? { owner: record.owner } : {}),
+  };
+}
+
+function processLooksLive(processId: number): boolean {
+  if (processId === process.pid) {
+    return true;
+  }
+  try {
+    process.kill(processId, 0);
+    return true;
+  } catch (error) {
+    return error instanceof Error && "code" in error && error.code === "EPERM";
+  }
+}
+
+function readPersistedRecords(): PersistedContextEngineQuarantineRecord[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(quarantineHealthPath(), "utf8");
+  } catch {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    (parsed as Partial<ContextEngineQuarantineHealthFile>).schemaVersion !==
+      QUARANTINE_HEALTH_SCHEMA_VERSION ||
+    !Array.isArray((parsed as Partial<ContextEngineQuarantineHealthFile>).records)
+  ) {
+    return [];
+  }
+
+  return (parsed as ContextEngineQuarantineHealthFile).records
+    .map(normalizeRecord)
+    .filter((record): record is PersistedContextEngineQuarantineRecord => Boolean(record))
+    .filter((record) => processLooksLive(record.processId));
+}
+
+function writePersistedRecords(records: PersistedContextEngineQuarantineRecord[]): void {
+  const filePath = quarantineHealthPath();
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+  const payload: ContextEngineQuarantineHealthFile = {
+    schemaVersion: QUARANTINE_HEALTH_SCHEMA_VERSION,
+    records: records
+      .toSorted((left, right) => left.recordedAtMs - right.recordedAtMs)
+      .slice(-MAX_QUARANTINE_RECORDS),
+  };
+  const tempPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tempPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  fs.renameSync(tempPath, filePath);
+}
+
+function recordKey(record: Pick<PersistedContextEngineQuarantineRecord, "engineId" | "processId">) {
+  return `${record.engineId}\0${record.processId}`;
+}
+
+export function recordPersistedContextEngineQuarantine(
+  quarantine: ContextEngineRuntimeQuarantine,
+): void {
+  const records = readPersistedRecords();
+  const key = recordKey({ engineId: quarantine.engineId, processId: process.pid });
+  if (records.some((record) => recordKey(record) === key)) {
+    return;
+  }
+  records.push({
+    engineId: quarantine.engineId,
+    operation: quarantine.operation,
+    reason: quarantine.reason,
+    failedAtMs: quarantine.failedAt.getTime(),
+    processId: process.pid,
+    recordedAtMs: Date.now(),
+    ...(quarantine.owner ? { owner: quarantine.owner } : {}),
+  });
+  writePersistedRecords(records);
+}
+
+export function listPersistedContextEngineQuarantines(): ContextEngineRuntimeQuarantine[] {
+  const byEngineId = new Map<string, PersistedContextEngineQuarantineRecord>();
+  for (const record of readPersistedRecords()) {
+    const existing = byEngineId.get(record.engineId);
+    if (!existing || record.failedAtMs < existing.failedAtMs) {
+      byEngineId.set(record.engineId, record);
+    }
+  }
+  return [...byEngineId.values()].map((record) => ({
+    engineId: record.engineId,
+    operation: record.operation,
+    reason: record.reason,
+    failedAt: new Date(record.failedAtMs),
+    ...(record.owner ? { owner: record.owner } : {}),
+  }));
+}
+
+export function clearPersistedContextEngineQuarantine(engineId?: string): void {
+  if (engineId === undefined) {
+    try {
+      fs.rmSync(quarantineHealthPath(), { force: true });
+    } catch {
+      // Best-effort cleanup; callers still clear in-memory state.
+    }
+    return;
+  }
+  const records = readPersistedRecords().filter((record) => record.engineId !== engineId);
+  if (records.length === 0) {
+    clearPersistedContextEngineQuarantine();
+    return;
+  }
+  writePersistedRecords(records);
+}

--- a/src/context-engine/quarantine-health.ts
+++ b/src/context-engine/quarantine-health.ts
@@ -1,6 +1,7 @@
 // Persists context-engine runtime quarantines so health surfaces can see
 // failures recorded in sibling runtime processes.
 import {
+  createRuntimeHealthRecordEnvelope,
   createRuntimeHealthStore,
   type RuntimeHealthRecordEnvelope,
 } from "../plugin-state/runtime-health-store.js";
@@ -44,6 +45,7 @@ const quarantineStore = createRuntimeHealthStore<PersistedContextEngineQuarantin
       reason: value.reason,
       failedAtMs: value.failedAtMs,
       processId: value.processId,
+      processStartTime: value.processStartTime,
       ...(isNonEmptyString(value.owner) ? { owner: value.owner } : {}),
     };
   },
@@ -64,8 +66,7 @@ export function recordPersistedContextEngineQuarantine(
     engineId: quarantine.engineId,
     operation: quarantine.operation,
     reason: quarantine.reason,
-    failedAtMs: quarantine.failedAt.getTime(),
-    processId: process.pid,
+    ...createRuntimeHealthRecordEnvelope(quarantine.failedAt),
     ...(quarantine.owner ? { owner: quarantine.owner } : {}),
   };
   // The in-memory registry only records the first quarantine per engine, so

--- a/src/context-engine/quarantine-health.ts
+++ b/src/context-engine/quarantine-health.ts
@@ -45,6 +45,7 @@ const quarantineStore = createRuntimeHealthStore<PersistedContextEngineQuarantin
       reason: value.reason,
       failedAtMs: value.failedAtMs,
       processId: value.processId,
+      processToken: value.processToken,
       processStartTime: value.processStartTime,
       ...(isNonEmptyString(value.owner) ? { owner: value.owner } : {}),
     };

--- a/src/context-engine/quarantine-health.ts
+++ b/src/context-engine/quarantine-health.ts
@@ -176,3 +176,17 @@ export function clearPersistedContextEngineQuarantine(engineId?: string): void {
   }
   writePersistedRecords(records);
 }
+
+export function clearPersistedContextEngineQuarantineForProcess(
+  engineId: string,
+  processId: number,
+): void {
+  const records = readPersistedRecords().filter(
+    (record) => record.engineId !== engineId || record.processId !== processId,
+  );
+  if (records.length === 0) {
+    clearPersistedContextEngineQuarantine();
+    return;
+  }
+  writePersistedRecords(records);
+}

--- a/src/context-engine/quarantine-health.ts
+++ b/src/context-engine/quarantine-health.ts
@@ -1,10 +1,9 @@
 // Persists context-engine runtime quarantines so health surfaces can see
 // failures recorded in sibling runtime processes.
-import { createCorePluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.js";
-
-const CONTEXT_ENGINE_QUARANTINE_OWNER_ID = "core:context-engine-quarantine-health";
-const CONTEXT_ENGINE_QUARANTINE_NAMESPACE = "runtime-quarantines";
-const MAX_QUARANTINE_RECORDS = 64;
+import {
+  createRuntimeHealthStore,
+  type RuntimeHealthRecordEnvelope,
+} from "../plugin-state/runtime-health-store.js";
 
 export type PersistedContextEngineRuntimeQuarantine = {
   engineId: string;
@@ -14,81 +13,45 @@ export type PersistedContextEngineRuntimeQuarantine = {
   failedAt: Date;
 };
 
-type PersistedContextEngineQuarantineRecord = {
+type PersistedContextEngineQuarantineRecord = RuntimeHealthRecordEnvelope & {
   engineId: string;
   owner?: string;
   operation: string;
   reason: string;
-  failedAtMs: number;
-  processId: number;
-  recordedAtMs: number;
 };
-
-function openQuarantineStore() {
-  return createCorePluginStateSyncKeyedStore<PersistedContextEngineQuarantineRecord>({
-    ownerId: CONTEXT_ENGINE_QUARANTINE_OWNER_ID,
-    namespace: CONTEXT_ENGINE_QUARANTINE_NAMESPACE,
-    maxEntries: MAX_QUARANTINE_RECORDS,
-  });
-}
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function normalizeRecord(value: unknown): PersistedContextEngineQuarantineRecord | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  const record = value as Partial<PersistedContextEngineQuarantineRecord>;
-  if (
-    !isNonEmptyString(record.engineId) ||
-    !isNonEmptyString(record.operation) ||
-    !isNonEmptyString(record.reason) ||
-    typeof record.failedAtMs !== "number" ||
-    !Number.isFinite(record.failedAtMs) ||
-    typeof record.processId !== "number" ||
-    !Number.isInteger(record.processId) ||
-    record.processId <= 0 ||
-    typeof record.recordedAtMs !== "number" ||
-    !Number.isFinite(record.recordedAtMs)
-  ) {
-    return undefined;
-  }
-  return {
-    engineId: record.engineId,
-    operation: record.operation,
-    reason: record.reason,
-    failedAtMs: record.failedAtMs,
-    processId: record.processId,
-    recordedAtMs: record.recordedAtMs,
-    ...(isNonEmptyString(record.owner) ? { owner: record.owner } : {}),
-  };
-}
-
-function processLooksLive(processId: number): boolean {
-  if (processId === process.pid) {
-    return true;
-  }
-  try {
-    process.kill(processId, 0);
-    return true;
-  } catch (error) {
-    return error instanceof Error && "code" in error && error.code === "EPERM";
-  }
-}
-
-function listPersistedRecords(): PersistedContextEngineQuarantineRecord[] {
-  try {
-    return openQuarantineStore()
-      .entries()
-      .map((entry) => normalizeRecord(entry.value))
-      .filter((record): record is PersistedContextEngineQuarantineRecord => Boolean(record))
-      .filter((record) => processLooksLive(record.processId));
-  } catch {
-    return [];
-  }
-}
+// No TTL: a quarantine is recorded once per failure and stays valid for the
+// recorder's lifetime, so process liveness alone owns expiry here.
+const quarantineStore = createRuntimeHealthStore<PersistedContextEngineQuarantineRecord>({
+  ownerId: "core:context-engine-quarantine-health",
+  namespace: "runtime-quarantines",
+  maxEntries: 64,
+  normalizeRecord: (value) => {
+    if (
+      !isNonEmptyString(value.engineId) ||
+      !isNonEmptyString(value.operation) ||
+      !isNonEmptyString(value.reason)
+    ) {
+      return undefined;
+    }
+    return {
+      engineId: value.engineId,
+      operation: value.operation,
+      reason: value.reason,
+      failedAtMs: value.failedAtMs,
+      processId: value.processId,
+      ...(isNonEmptyString(value.owner) ? { owner: value.owner } : {}),
+    };
+  },
+  displayKey: (record) => record.engineId,
+  // Earliest wins, matching the in-memory registry's first-failure-wins rule
+  // so health output points at the root cause, not follow-on failures.
+  pick: "earliest",
+});
 
 function recordKey(record: Pick<PersistedContextEngineQuarantineRecord, "engineId" | "processId">) {
   return JSON.stringify([record.engineId, record.processId]);
@@ -103,21 +66,15 @@ export function recordPersistedContextEngineQuarantine(
     reason: quarantine.reason,
     failedAtMs: quarantine.failedAt.getTime(),
     processId: process.pid,
-    recordedAtMs: Date.now(),
     ...(quarantine.owner ? { owner: quarantine.owner } : {}),
   };
-  openQuarantineStore().registerIfAbsent(recordKey(record), record);
+  // The in-memory registry only records the first quarantine per engine, so
+  // this is called at most once per (engine, process) and overwrite is safe.
+  quarantineStore.register(recordKey(record), record);
 }
 
 export function listPersistedContextEngineQuarantines(): PersistedContextEngineRuntimeQuarantine[] {
-  const byEngineId = new Map<string, PersistedContextEngineQuarantineRecord>();
-  for (const record of listPersistedRecords()) {
-    const existing = byEngineId.get(record.engineId);
-    if (!existing || record.failedAtMs < existing.failedAtMs) {
-      byEngineId.set(record.engineId, record);
-    }
-  }
-  return [...byEngineId.values()].map((record) => {
+  return quarantineStore.list().map((record) => {
     const quarantine: PersistedContextEngineRuntimeQuarantine = {
       engineId: record.engineId,
       operation: record.operation,
@@ -135,18 +92,8 @@ export function clearPersistedContextEngineQuarantineForProcess(
   engineId: string | undefined,
   processId: number,
 ): void {
-  try {
-    const store = openQuarantineStore();
-    for (const entry of store.entries()) {
-      const record = normalizeRecord(entry.value);
-      if (
-        record?.processId === processId &&
-        (engineId === undefined || record.engineId === engineId)
-      ) {
-        store.delete(entry.key);
-      }
-    }
-  } catch {
-    // Best-effort cleanup; callers still clear in-memory state.
-  }
+  quarantineStore.clearForProcess(
+    processId,
+    engineId === undefined ? undefined : (record) => record.engineId === engineId,
+  );
 }

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -3,6 +3,11 @@ import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { defaultSlotIdForKey } from "../plugins/slots.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import {
+  clearPersistedContextEngineQuarantine,
+  listPersistedContextEngineQuarantines,
+  recordPersistedContextEngineQuarantine,
+} from "./quarantine-health.js";
 import type {
   AssembleResult,
   BootstrapResult,
@@ -445,6 +450,11 @@ function recordContextEngineQuarantine(params: {
     ...(params.owner ? { owner: params.owner } : {}),
   };
   registryState.quarantinedEngines.set(params.engineId, quarantine);
+  try {
+    recordPersistedContextEngineQuarantine(quarantine);
+  } catch {
+    // Quarantine behavior must not depend on the best-effort health mirror.
+  }
   const ownerSuffix = params.owner ? ` owner=${sanitizeForLog(params.owner)}` : "";
   console.error(
     `[context-engine] Context engine "${sanitizeForLog(params.engineId)}"${ownerSuffix} failed during ${sanitizeForLog(params.operation)}: ` +
@@ -471,6 +481,14 @@ export function listContextEngineQuarantines(): ContextEngineRuntimeQuarantine[]
     }
     quarantines.push(quarantine);
   }
+  const seenEngineIds = new Set(quarantines.map((entry) => entry.engineId));
+  for (const entry of listPersistedContextEngineQuarantines()) {
+    if (seenEngineIds.has(entry.engineId)) {
+      continue;
+    }
+    quarantines.push(entry);
+    seenEngineIds.add(entry.engineId);
+  }
   return quarantines;
 }
 
@@ -478,9 +496,11 @@ export function clearContextEngineRuntimeQuarantine(engineId?: string): void {
   const quarantinedEngines = getContextEngineRegistryState().quarantinedEngines;
   if (engineId === undefined) {
     quarantinedEngines.clear();
+    clearPersistedContextEngineQuarantine();
     return;
   }
   quarantinedEngines.delete(engineId);
+  clearPersistedContextEngineQuarantine(engineId);
 }
 
 /**

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -4,7 +4,6 @@ import type { OpenClawConfig } from "../config/types.js";
 import { defaultSlotIdForKey } from "../plugins/slots.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import {
-  clearPersistedContextEngineQuarantine,
   clearPersistedContextEngineQuarantineForProcess,
   listPersistedContextEngineQuarantines,
   recordPersistedContextEngineQuarantine,
@@ -497,11 +496,11 @@ export function clearContextEngineRuntimeQuarantine(engineId?: string): void {
   const quarantinedEngines = getContextEngineRegistryState().quarantinedEngines;
   if (engineId === undefined) {
     quarantinedEngines.clear();
-    clearPersistedContextEngineQuarantine();
+    clearPersistedContextEngineQuarantineForProcess(undefined, process.pid);
     return;
   }
   quarantinedEngines.delete(engineId);
-  clearPersistedContextEngineQuarantine(engineId);
+  clearPersistedContextEngineQuarantineForProcess(engineId, process.pid);
 }
 
 /**

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -570,6 +570,7 @@ export function clearContextEnginesForOwner(owner: string): void {
     if (entry.owner === normalizedOwner) {
       registry.delete(id);
       registryState.quarantinedEngines.delete(id);
+      clearPersistedContextEngineQuarantineForProcess(id, process.pid);
     }
   }
 }

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -529,8 +529,7 @@ export function registerContextEngineForOwner(
     return { ok: false, existingOwner: existing.owner };
   }
   registry.set(id, { factory, owner: normalizedOwner });
-  getContextEngineRegistryState().quarantinedEngines.delete(id);
-  clearPersistedContextEngineQuarantineForProcess(id, process.pid);
+  clearContextEngineRuntimeQuarantine(id);
   return { ok: true };
 }
 
@@ -564,13 +563,11 @@ export function listContextEngineIds(): string[] {
 
 export function clearContextEnginesForOwner(owner: string): void {
   const normalizedOwner = requireContextEngineOwner(owner);
-  const registryState = getContextEngineRegistryState();
-  const registry = registryState.engines;
+  const registry = getContextEngineRegistryState().engines;
   for (const [id, entry] of registry.entries()) {
     if (entry.owner === normalizedOwner) {
       registry.delete(id);
-      registryState.quarantinedEngines.delete(id);
-      clearPersistedContextEngineQuarantineForProcess(id, process.pid);
+      clearContextEngineRuntimeQuarantine(id);
     }
   }
 }

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -5,6 +5,7 @@ import { defaultSlotIdForKey } from "../plugins/slots.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import {
   clearPersistedContextEngineQuarantine,
+  clearPersistedContextEngineQuarantineForProcess,
   listPersistedContextEngineQuarantines,
   recordPersistedContextEngineQuarantine,
 } from "./quarantine-health.js";
@@ -529,7 +530,8 @@ export function registerContextEngineForOwner(
     return { ok: false, existingOwner: existing.owner };
   }
   registry.set(id, { factory, owner: normalizedOwner });
-  clearContextEngineRuntimeQuarantine(id);
+  getContextEngineRegistryState().quarantinedEngines.delete(id);
+  clearPersistedContextEngineQuarantineForProcess(id, process.pid);
   return { ok: true };
 }
 

--- a/src/plugin-state/runtime-health-store.ts
+++ b/src/plugin-state/runtime-health-store.ts
@@ -1,15 +1,23 @@
 // Shared mechanics for cross-process runtime health records persisted in the
 // core plugin-state store: envelope validation, process-liveness hygiene, and
 // per-process cleanup. Domain modules own record fields and display keys.
+import { randomUUID } from "node:crypto";
 import { getProcessStartTime } from "../shared/pid-alive.js";
 import { createCorePluginStateSyncKeyedStore } from "./plugin-state-store.js";
 
 /** Envelope persisted with every cross-process runtime health record. */
 export type RuntimeHealthRecordEnvelope = {
   processId: number;
+  /** Random per-process identity; proves incarnation for own-PID records. */
+  processToken: string;
+  /** Linux /proc starttime for sibling verification; null when unavailable. */
   processStartTime: number | null;
   failedAtMs: number;
 };
+
+// One token per process lifetime: a restarted process (even with a recycled
+// PID) can never match records written by its predecessor.
+const currentProcessToken = randomUUID();
 
 export type RuntimeHealthStoreOptions<T extends RuntimeHealthRecordEnvelope> = {
   ownerId: `core:${string}`;
@@ -45,6 +53,8 @@ function hasValidEnvelope(
     typeof record.processId === "number" &&
     Number.isInteger(record.processId) &&
     record.processId > 0 &&
+    typeof record.processToken === "string" &&
+    record.processToken.length > 0 &&
     (record.processStartTime === null ||
       (typeof record.processStartTime === "number" &&
         Number.isFinite(record.processStartTime) &&
@@ -58,35 +68,24 @@ function hasValidEnvelope(
 export function createRuntimeHealthRecordEnvelope(failedAt: Date): RuntimeHealthRecordEnvelope {
   return {
     processId: process.pid,
+    processToken: currentProcessToken,
     processStartTime: getProcessStartTime(process.pid),
     failedAtMs: failedAt.getTime(),
   };
 }
 
-function processIdentityMatches(record: RuntimeHealthRecordEnvelope): boolean {
-  if (record.processStartTime === null) {
-    return true;
-  }
-  const currentStartTime = getProcessStartTime(record.processId);
-  return currentStartTime === null || currentStartTime === record.processStartTime;
-}
-
-// Liveness keeps health output actionable across restarts: a dead recorder's
-// failures disappear instead of lingering as stale state, and start-time identity
-// prevents a recycled PID from keeping old failures alive.
+// Records surface only with a positive incarnation match; unverifiable
+// identity fails closed so a recycled PID can never keep stale failures alive.
+// Own PID: the per-process token proves incarnation on every platform.
+// Sibling PIDs: the Linux /proc starttime must match; where it is unavailable
+// (non-Linux, /proc read failure) sibling visibility is sacrificed instead of
+// trusting a bare kill(0) liveness probe.
 function processLooksLive(record: RuntimeHealthRecordEnvelope): boolean {
   if (record.processId === process.pid) {
-    return processIdentityMatches(record);
+    return record.processToken === currentProcessToken;
   }
-  if (!processIdentityMatches(record)) {
-    return false;
-  }
-  try {
-    process.kill(record.processId, 0);
-    return true;
-  } catch (error) {
-    return error instanceof Error && "code" in error && error.code === "EPERM";
-  }
+  const currentStartTime = getProcessStartTime(record.processId);
+  return currentStartTime !== null && currentStartTime === record.processStartTime;
 }
 
 /** Opens a SQLite-backed health record namespace shared across runtime processes. */

--- a/src/plugin-state/runtime-health-store.ts
+++ b/src/plugin-state/runtime-health-store.ts
@@ -1,7 +1,7 @@
-import { getProcessStartTime } from "../shared/pid-alive.js";
 // Shared mechanics for cross-process runtime health records persisted in the
 // core plugin-state store: envelope validation, process-liveness hygiene, and
 // per-process cleanup. Domain modules own record fields and display keys.
+import { getProcessStartTime } from "../shared/pid-alive.js";
 import { createCorePluginStateSyncKeyedStore } from "./plugin-state-store.js";
 
 /** Envelope persisted with every cross-process runtime health record. */

--- a/src/plugin-state/runtime-health-store.ts
+++ b/src/plugin-state/runtime-health-store.ts
@@ -1,0 +1,125 @@
+// Shared mechanics for cross-process runtime health records persisted in the
+// core plugin-state store: envelope validation, process-liveness hygiene, and
+// per-process cleanup. Domain modules own record fields and display keys.
+import { createCorePluginStateSyncKeyedStore } from "./plugin-state-store.js";
+
+/** Envelope persisted with every cross-process runtime health record. */
+export type RuntimeHealthRecordEnvelope = {
+  processId: number;
+  failedAtMs: number;
+};
+
+export type RuntimeHealthStoreOptions<T extends RuntimeHealthRecordEnvelope> = {
+  ownerId: `core:${string}`;
+  namespace: string;
+  maxEntries: number;
+  /** Optional expiry backstop on top of liveness filtering. */
+  ttlMs?: number;
+  /** Validates domain fields and strips unknown ones; envelope is pre-validated. */
+  normalizeRecord: (value: Record<string, unknown> & RuntimeHealthRecordEnvelope) => T | undefined;
+  /** Groups records for display dedupe across recorder processes. */
+  displayKey: (record: T) => string;
+  /** Which failedAtMs wins per display group: root cause vs most recent reason. */
+  pick: "earliest" | "latest";
+};
+
+export type RuntimeHealthStore<T extends RuntimeHealthRecordEnvelope> = {
+  /** Persists a record under the key, overwriting any prior value. */
+  register(key: string, record: T): void;
+  /** One record per display group, restricted to live recorder processes. */
+  list(): T[];
+  /** Removes records recorded by the process, optionally narrowed by predicate. */
+  clearForProcess(processId: number, matches?: (record: T) => boolean): void;
+};
+
+function hasValidEnvelope(
+  value: unknown,
+): value is Record<string, unknown> & RuntimeHealthRecordEnvelope {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Partial<RuntimeHealthRecordEnvelope>;
+  return (
+    typeof record.processId === "number" &&
+    Number.isInteger(record.processId) &&
+    record.processId > 0 &&
+    typeof record.failedAtMs === "number" &&
+    Number.isFinite(record.failedAtMs)
+  );
+}
+
+// Liveness keeps health output actionable across restarts: a dead recorder's
+// failures disappear instead of lingering as stale state. PID reuse can keep a
+// stale record alive briefly; per-store TTLs bound that window.
+function processLooksLive(processId: number): boolean {
+  if (processId === process.pid) {
+    return true;
+  }
+  try {
+    process.kill(processId, 0);
+    return true;
+  } catch (error) {
+    return error instanceof Error && "code" in error && error.code === "EPERM";
+  }
+}
+
+/** Opens a SQLite-backed health record namespace shared across runtime processes. */
+export function createRuntimeHealthStore<T extends RuntimeHealthRecordEnvelope>(
+  options: RuntimeHealthStoreOptions<T>,
+): RuntimeHealthStore<T> {
+  // The keyed store is opened per operation so records follow the state dir
+  // active at call time (tests and embedded runtimes swap OPENCLAW_STATE_DIR).
+  const openStore = () =>
+    createCorePluginStateSyncKeyedStore<T>({
+      ownerId: options.ownerId,
+      namespace: options.namespace,
+      maxEntries: options.maxEntries,
+      ...(options.ttlMs != null ? { defaultTtlMs: options.ttlMs } : {}),
+    });
+
+  const normalize = (value: unknown): T | undefined =>
+    hasValidEnvelope(value) ? options.normalizeRecord(value) : undefined;
+
+  return {
+    register(key, record) {
+      openStore().register(key, record);
+    },
+    list() {
+      try {
+        const byGroup = new Map<string, T>();
+        for (const entry of openStore().entries()) {
+          const record = normalize(entry.value);
+          if (!record || !processLooksLive(record.processId)) {
+            continue;
+          }
+          const groupKey = options.displayKey(record);
+          const existing = byGroup.get(groupKey);
+          const wins =
+            !existing ||
+            (options.pick === "latest"
+              ? record.failedAtMs > existing.failedAtMs
+              : record.failedAtMs < existing.failedAtMs);
+          if (wins) {
+            byGroup.set(groupKey, record);
+          }
+        }
+        return [...byGroup.values()];
+      } catch {
+        return [];
+      }
+    },
+    clearForProcess(processId, matches) {
+      try {
+        const store = openStore();
+        for (const entry of store.entries()) {
+          const record = normalize(entry.value);
+          if (record?.processId === processId && (!matches || matches(record))) {
+            store.delete(entry.key);
+          }
+        }
+      } catch {
+        // Best-effort cleanup; callers also clear their in-memory state.
+      }
+    },
+  };
+}

--- a/src/plugin-state/runtime-health-store.ts
+++ b/src/plugin-state/runtime-health-store.ts
@@ -1,3 +1,4 @@
+import { getProcessStartTime } from "../shared/pid-alive.js";
 // Shared mechanics for cross-process runtime health records persisted in the
 // core plugin-state store: envelope validation, process-liveness hygiene, and
 // per-process cleanup. Domain modules own record fields and display keys.
@@ -6,6 +7,7 @@ import { createCorePluginStateSyncKeyedStore } from "./plugin-state-store.js";
 /** Envelope persisted with every cross-process runtime health record. */
 export type RuntimeHealthRecordEnvelope = {
   processId: number;
+  processStartTime: number | null;
   failedAtMs: number;
 };
 
@@ -43,20 +45,44 @@ function hasValidEnvelope(
     typeof record.processId === "number" &&
     Number.isInteger(record.processId) &&
     record.processId > 0 &&
+    (record.processStartTime === null ||
+      (typeof record.processStartTime === "number" &&
+        Number.isFinite(record.processStartTime) &&
+        record.processStartTime >= 0)) &&
     typeof record.failedAtMs === "number" &&
     Number.isFinite(record.failedAtMs)
   );
 }
 
-// Liveness keeps health output actionable across restarts: a dead recorder's
-// failures disappear instead of lingering as stale state. PID reuse can keep a
-// stale record alive briefly; per-store TTLs bound that window.
-function processLooksLive(processId: number): boolean {
-  if (processId === process.pid) {
+/** Builds the common health envelope for records owned by this process. */
+export function createRuntimeHealthRecordEnvelope(failedAt: Date): RuntimeHealthRecordEnvelope {
+  return {
+    processId: process.pid,
+    processStartTime: getProcessStartTime(process.pid),
+    failedAtMs: failedAt.getTime(),
+  };
+}
+
+function processIdentityMatches(record: RuntimeHealthRecordEnvelope): boolean {
+  if (record.processStartTime === null) {
     return true;
   }
+  const currentStartTime = getProcessStartTime(record.processId);
+  return currentStartTime === null || currentStartTime === record.processStartTime;
+}
+
+// Liveness keeps health output actionable across restarts: a dead recorder's
+// failures disappear instead of lingering as stale state, and start-time identity
+// prevents a recycled PID from keeping old failures alive.
+function processLooksLive(record: RuntimeHealthRecordEnvelope): boolean {
+  if (record.processId === process.pid) {
+    return processIdentityMatches(record);
+  }
+  if (!processIdentityMatches(record)) {
+    return false;
+  }
   try {
-    process.kill(processId, 0);
+    process.kill(record.processId, 0);
     return true;
   } catch (error) {
     return error instanceof Error && "code" in error && error.code === "EPERM";
@@ -89,7 +115,7 @@ export function createRuntimeHealthStore<T extends RuntimeHealthRecordEnvelope>(
         const byGroup = new Map<string, T>();
         for (const entry of openStore().entries()) {
           const record = normalize(entry.value);
-          if (!record || !processLooksLive(record.processId)) {
+          if (!record || !processLooksLive(record)) {
             continue;
           }
           const groupKey = options.displayKey(record);

--- a/src/plugins/loader-records.ts
+++ b/src/plugins/loader-records.ts
@@ -2,7 +2,7 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { PluginCompatCode } from "./compat/registry.js";
 import type { PluginActivationState } from "./config-state.js";
-import type { PluginBundleFormat, PluginFormat } from "./manifest-types.js";
+import type { PluginBundleFormat, PluginDiagnosticCode, PluginFormat } from "./manifest-types.js";
 import type { PluginManifestContracts } from "./manifest.js";
 import type { PluginRecord, PluginRegistry } from "./registry.js";
 import type { PluginLogger } from "./types.js";
@@ -116,6 +116,7 @@ export function recordPluginError(params: {
   error: unknown;
   logPrefix: string;
   diagnosticMessagePrefix: string;
+  diagnosticCode?: PluginDiagnosticCode;
 }) {
   const errorText =
     process.env.OPENCLAW_PLUGIN_LOADER_DEBUG_STACKS === "1" &&
@@ -141,6 +142,7 @@ export function recordPluginError(params: {
     pluginId: params.record.id,
     source: params.record.source,
     message: `${params.diagnosticMessagePrefix}${displayError}`,
+    ...(params.diagnosticCode ? { code: params.diagnosticCode } : {}),
   });
 }
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2397,6 +2397,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
             error: setupRegistration.loadError,
             logPrefix: `[plugins] ${record.id} failed to load setup entry from ${record.source}: `,
             diagnosticMessagePrefix: "failed to load setup entry: ",
+            diagnosticCode: "channel-setup-failure",
           });
           continue;
         }
@@ -2472,6 +2473,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
                 error: err,
                 logPrefix: `[plugins] ${record.id} failed to load setup-runtime entry from ${record.source}: `,
                 diagnosticMessagePrefix: "failed to load setup-runtime entry: ",
+                diagnosticCode: "channel-setup-failure",
               });
               continue;
             }
@@ -2498,6 +2500,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
                   error: err,
                   logPrefix: `[plugins] ${record.id} failed to apply setup-runtime channel runtime from ${record.source}: `,
                   diagnosticMessagePrefix: "failed to apply setup-runtime channel runtime: ",
+                  diagnosticCode: "channel-setup-failure",
                 });
                 continue;
               }
@@ -2517,6 +2520,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
                 error: runtimePluginRegistration.loadError,
                 logPrefix: `[plugins] ${record.id} failed to load setup-runtime channel entry from ${record.source}: `,
                 diagnosticMessagePrefix: "failed to load setup-runtime channel entry: ",
+                diagnosticCode: "channel-setup-failure",
               });
               continue;
             }
@@ -2572,6 +2576,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
                 error: err,
                 logPrefix: `[plugins] ${record.id} failed to apply setup channel runtime from ${record.source}: `,
                 diagnosticMessagePrefix: "failed to apply setup channel runtime: ",
+                diagnosticCode: "channel-setup-failure",
               });
               continue;
             }
@@ -2599,6 +2604,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
                   logPrefix: `[plugins] ${record.id} failed to register setup-runtime channel side effects from ${record.source}: `,
                   diagnosticMessagePrefix:
                     "failed to register setup-runtime channel side effects: ",
+                  diagnosticCode: "channel-setup-failure",
                 });
                 continue;
               }
@@ -2618,6 +2624,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
               error: err,
               logPrefix: `[plugins] ${record.id} failed to register setup channel from ${record.source}: `,
               diagnosticMessagePrefix: "failed to register setup channel: ",
+              diagnosticCode: "channel-setup-failure",
             });
             continue;
           }

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -14,10 +14,17 @@ export type PluginFormat = "openclaw" | "bundle";
 /** Supported external bundle manifest formats. */
 export type PluginBundleFormat = "codex" | "claude" | "cursor";
 
+/**
+ * Closed classification codes for plugin diagnostics. Health surfaces branch
+ * on these instead of matching freeform diagnostic message text.
+ */
+export type PluginDiagnosticCode = "channel-setup-failure";
+
 /** Diagnostic emitted while discovering or validating plugins. */
 export type PluginDiagnostic = {
   level: "warn" | "error";
   message: string;
   pluginId?: string;
   source?: string;
+  code?: PluginDiagnosticCode;
 };

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -108,6 +108,7 @@ export type StatusArgs = {
   mediaDecisions?: ReadonlyArray<MediaUnderstandingDecision>;
   subagentsLine?: string;
   taskLine?: string;
+  pluginHealthLine?: string;
   includeTranscriptUsage?: boolean;
   now?: number;
 };
@@ -1086,6 +1087,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     args.subagentsLine,
     args.taskLine,
     `⚙️ ${optionsLine}`,
+    args.pluginHealthLine,
     pluginStatusLine ? `🧩 ${pluginStatusLine}` : null,
     voiceLine,
     activationLine,

--- a/src/status/status-plugin-health.runtime.test.ts
+++ b/src/status/status-plugin-health.runtime.test.ts
@@ -1,9 +1,10 @@
 // Runtime plugin health tests cover state shared across runtime processes.
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearPersistedRuntimeToolSchemaQuarantinesForProcess,
   recordPersistedRuntimeToolSchemaQuarantine,
 } from "../agents/tool-schema-quarantine-health.js";
+import { resolveReadOnlyChannelPluginsForConfig } from "../channels/plugins/read-only.js";
 import { recordPersistedContextEngineQuarantine } from "../context-engine/quarantine-health.js";
 import { clearContextEngineRuntimeQuarantine } from "../context-engine/registry.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
@@ -11,7 +12,16 @@ import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plug
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { collectRuntimePluginHealthSnapshot } from "./status-plugin-health.runtime.js";
 
+vi.mock("../channels/plugins/read-only.js", () => ({
+  resolveReadOnlyChannelPluginsForConfig: vi.fn(),
+}));
+
+const resolveReadOnlyChannelPluginsForConfigMock = vi.mocked(
+  resolveReadOnlyChannelPluginsForConfig,
+);
+
 afterEach(() => {
+  resolveReadOnlyChannelPluginsForConfigMock.mockReset();
   resetPluginRuntimeStateForTest();
 });
 
@@ -142,6 +152,36 @@ describe("runtime plugin health snapshot", () => {
         pluginId: "broken-channel",
         message: "failed to load setup entry: boom",
         source: "diagnostic",
+      },
+    ]);
+  });
+
+  it("does not add a generic missing-channel failure when setup load already failed", () => {
+    resolveReadOnlyChannelPluginsForConfigMock.mockReturnValue({
+      plugins: [],
+      configuredChannelIds: ["broken-channel"],
+      missingConfiguredChannelIds: ["broken-channel"],
+      loadFailures: [
+        {
+          channelId: "broken-channel",
+          pluginId: "broken-channel",
+          message: "failed to load setup entry: boom",
+          source: "setup",
+        },
+      ],
+    });
+
+    const snapshot = collectRuntimePluginHealthSnapshot({
+      config: { channels: {} } as never,
+      workspaceDir: "/tmp/ws",
+    });
+
+    expect(snapshot.channelPluginFailures).toEqual([
+      {
+        channelId: "broken-channel",
+        pluginId: "broken-channel",
+        message: "failed to load setup entry: boom",
+        source: "setup",
       },
     ]);
   });

--- a/src/status/status-plugin-health.runtime.test.ts
+++ b/src/status/status-plugin-health.runtime.test.ts
@@ -157,6 +157,13 @@ describe("runtime plugin health snapshot", () => {
   });
 
   it("does not add a generic missing-channel failure when setup load already failed", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.diagnostics.push({
+      level: "error",
+      pluginId: "broken-channel",
+      message: "failed to load setup entry: boom",
+    } as never);
+    setActivePluginRegistry(registry, "broken-channel", "default", "/tmp/ws");
     resolveReadOnlyChannelPluginsForConfigMock.mockReturnValue({
       plugins: [],
       configuredChannelIds: ["broken-channel"],
@@ -181,7 +188,7 @@ describe("runtime plugin health snapshot", () => {
         channelId: "broken-channel",
         pluginId: "broken-channel",
         message: "failed to load setup entry: boom",
-        source: "setup",
+        source: "diagnostic",
       },
     ]);
   });

--- a/src/status/status-plugin-health.runtime.test.ts
+++ b/src/status/status-plugin-health.runtime.test.ts
@@ -1,0 +1,31 @@
+// Runtime plugin health tests cover state shared across runtime processes.
+import { describe, expect, it } from "vitest";
+import { recordPersistedContextEngineQuarantine } from "../context-engine/quarantine-health.js";
+import { clearContextEngineRuntimeQuarantine } from "../context-engine/registry.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { collectRuntimePluginHealthSnapshot } from "./status-plugin-health.runtime.js";
+
+describe("runtime plugin health snapshot", () => {
+  it("includes persisted context-engine quarantines", async () => {
+    await withStateDirEnv("openclaw-status-plugin-health-", async () => {
+      clearContextEngineRuntimeQuarantine();
+      recordPersistedContextEngineQuarantine({
+        engineId: "lossless-claw",
+        owner: "plugin:lossless-claw",
+        operation: "bootstrap",
+        reason: "intentional bootstrap failure",
+        failedAt: new Date(123),
+      });
+
+      expect(collectRuntimePluginHealthSnapshot().contextEngineQuarantines).toEqual([
+        {
+          engineId: "lossless-claw",
+          owner: "plugin:lossless-claw",
+          operation: "bootstrap",
+          reason: "intentional bootstrap failure",
+          failedAt: new Date(123),
+        },
+      ]);
+    });
+  });
+});

--- a/src/status/status-plugin-health.runtime.test.ts
+++ b/src/status/status-plugin-health.runtime.test.ts
@@ -1,9 +1,19 @@
 // Runtime plugin health tests cover state shared across runtime processes.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearPersistedRuntimeToolSchemaQuarantinesForProcess,
+  recordPersistedRuntimeToolSchemaQuarantine,
+} from "../agents/tool-schema-quarantine-health.js";
 import { recordPersistedContextEngineQuarantine } from "../context-engine/quarantine-health.js";
 import { clearContextEngineRuntimeQuarantine } from "../context-engine/registry.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { collectRuntimePluginHealthSnapshot } from "./status-plugin-health.runtime.js";
+
+afterEach(() => {
+  resetPluginRuntimeStateForTest();
+});
 
 describe("runtime plugin health snapshot", () => {
   it("includes persisted context-engine quarantines", async () => {
@@ -27,5 +37,112 @@ describe("runtime plugin health snapshot", () => {
         },
       ]);
     });
+  });
+
+  it("includes persisted runtime tool-schema quarantines", async () => {
+    await withStateDirEnv("openclaw-status-tool-quarantine-", async () => {
+      clearPersistedRuntimeToolSchemaQuarantinesForProcess();
+      const registry = createEmptyPluginRegistry();
+      registry.plugins.push({
+        id: "bad-tools",
+        status: "loaded",
+        enabled: true,
+      } as never);
+      setActivePluginRegistry(registry, "bad-tools", "default", "/tmp/ws");
+      recordPersistedRuntimeToolSchemaQuarantine({
+        toolName: "bad_tool",
+        owner: "plugin:bad-tools",
+        reason: "unsupported anyOf",
+        failedAt: new Date(456),
+        runId: "run-test",
+      });
+
+      expect(collectRuntimePluginHealthSnapshot().runtimeToolQuarantines).toEqual([
+        {
+          toolName: "bad_tool",
+          owner: "plugin:bad-tools",
+          reason: "unsupported anyOf",
+          failedAt: new Date(456),
+          runId: "run-test",
+        },
+      ]);
+    });
+  });
+
+  it("keeps runtime tool-schema quarantine records independent of source process liveness", async () => {
+    await withStateDirEnv("openclaw-status-tool-quarantine-core-", async () => {
+      clearPersistedRuntimeToolSchemaQuarantinesForProcess();
+      setActivePluginRegistry(createEmptyPluginRegistry(), "empty", "default", "/tmp/ws");
+      recordPersistedRuntimeToolSchemaQuarantine({
+        toolName: "core_bad_tool",
+        reason: "unsupported schema",
+        failedAt: new Date(789),
+        runId: "run-core-test",
+      });
+
+      expect(collectRuntimePluginHealthSnapshot().runtimeToolQuarantines).toEqual([
+        {
+          toolName: "core_bad_tool",
+          reason: "unsupported schema",
+          failedAt: new Date(789),
+          runId: "run-core-test",
+        },
+      ]);
+    });
+  });
+
+  it("suppresses persisted plugin-owned runtime tool quarantines after the owner plugin is gone", async () => {
+    await withStateDirEnv("openclaw-status-tool-quarantine-owner-", async () => {
+      clearPersistedRuntimeToolSchemaQuarantinesForProcess();
+      recordPersistedRuntimeToolSchemaQuarantine({
+        toolName: "bad_tool",
+        owner: "plugin:bad-tools",
+        reason: "unsupported anyOf",
+        failedAt: new Date(456),
+        runId: "run-plugin-test",
+      });
+
+      setActivePluginRegistry(createEmptyPluginRegistry(), "empty", "default", "/tmp/ws");
+      expect(collectRuntimePluginHealthSnapshot().runtimeToolQuarantines).toEqual([]);
+
+      const registry = createEmptyPluginRegistry();
+      registry.plugins.push({
+        id: "bad-tools",
+        status: "loaded",
+        enabled: true,
+      } as never);
+      setActivePluginRegistry(registry, "bad-tools", "default", "/tmp/ws");
+
+      expect(collectRuntimePluginHealthSnapshot().runtimeToolQuarantines).toEqual([
+        {
+          toolName: "bad_tool",
+          owner: "plugin:bad-tools",
+          reason: "unsupported anyOf",
+          failedAt: new Date(456),
+          runId: "run-plugin-test",
+        },
+      ]);
+    });
+  });
+
+  it("classifies setup-channel diagnostics as channel plugin failures", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.diagnostics.push({
+      level: "error",
+      pluginId: "broken-channel",
+      message: "failed to load setup entry: boom",
+    } as never);
+    setActivePluginRegistry(registry, "broken-channel", "default", "/tmp/ws");
+
+    const snapshot = collectRuntimePluginHealthSnapshot();
+
+    expect(snapshot.channelPluginFailures).toEqual([
+      {
+        channelId: "broken-channel",
+        pluginId: "broken-channel",
+        message: "failed to load setup entry: boom",
+        source: "diagnostic",
+      },
+    ]);
   });
 });

--- a/src/status/status-plugin-health.runtime.test.ts
+++ b/src/status/status-plugin-health.runtime.test.ts
@@ -9,9 +9,9 @@ import {
   createCorePluginStateSyncKeyedStore,
   resetPluginStateStoreForTests,
 } from "../plugin-state/plugin-state-store.js";
+import { createRuntimeHealthRecordEnvelope } from "../plugin-state/runtime-health-store.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
-import { getProcessStartTime } from "../shared/pid-alive.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { collectRuntimePluginHealthSnapshot } from "./status-plugin-health.runtime.js";
 
@@ -47,6 +47,7 @@ function seedPersistedToolQuarantineForTest(record: {
   reason: string;
   failedAtMs: number;
   processId: number;
+  processToken: string;
   processStartTime: number | null;
 }): void {
   createCorePluginStateSyncKeyedStore<typeof record>({
@@ -127,22 +128,22 @@ describe("runtime plugin health snapshot", () => {
     });
   });
 
-  it("drops runtime tool quarantines recorded by dead processes", async () => {
+  it("drops runtime tool quarantines from dead or unverifiable recorder processes", async () => {
     await withStateDirEnv("openclaw-status-tool-quarantine-liveness-", async () => {
       setActivePluginRegistry(createEmptyPluginRegistry(), "empty", "default", "/tmp/ws");
+      // Dead sibling: no current start time exists, so the record fails closed.
       seedPersistedToolQuarantineForTest({
         toolName: "stale_tool",
         reason: "unsupported schema",
         failedAtMs: 123,
         processId: await deadProcessId(),
+        processToken: "dead-process-token",
         processStartTime: null,
       });
       seedPersistedToolQuarantineForTest({
         toolName: "live_tool",
         reason: "unsupported schema",
-        failedAtMs: 456,
-        processId: process.pid,
-        processStartTime: getProcessStartTime(process.pid),
+        ...createRuntimeHealthRecordEnvelope(new Date(456)),
       });
 
       expect(collectRuntimePluginHealthSnapshot().runtimeToolQuarantines).toEqual([
@@ -155,19 +156,14 @@ describe("runtime plugin health snapshot", () => {
     });
   });
 
-  it("drops runtime tool quarantines recorded by a reused PID", async () => {
-    const currentStartTime = getProcessStartTime(process.pid);
-    if (currentStartTime === null) {
-      return;
-    }
+  it("drops runtime tool quarantines from a previous incarnation of this PID", async () => {
     await withStateDirEnv("openclaw-status-tool-quarantine-pid-reuse-", async () => {
       setActivePluginRegistry(createEmptyPluginRegistry(), "empty", "default", "/tmp/ws");
       seedPersistedToolQuarantineForTest({
         toolName: "reused_pid_tool",
         reason: "unsupported schema",
-        failedAtMs: 123,
-        processId: process.pid,
-        processStartTime: currentStartTime + 1,
+        ...createRuntimeHealthRecordEnvelope(new Date(123)),
+        processToken: "stale-incarnation-token",
       });
 
       expect(collectRuntimePluginHealthSnapshot().runtimeToolQuarantines).toEqual([]);

--- a/src/status/status-plugin-health.runtime.test.ts
+++ b/src/status/status-plugin-health.runtime.test.ts
@@ -1,12 +1,14 @@
 // Runtime plugin health tests cover state shared across runtime processes.
+import { spawn } from "node:child_process";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  clearPersistedRuntimeToolSchemaQuarantinesForProcess,
-  recordPersistedRuntimeToolSchemaQuarantine,
-} from "../agents/tool-schema-quarantine-health.js";
+import { recordPersistedRuntimeToolSchemaQuarantine } from "../agents/tool-schema-quarantine-health.js";
 import { resolveReadOnlyChannelPluginsForConfig } from "../channels/plugins/read-only.js";
 import { recordPersistedContextEngineQuarantine } from "../context-engine/quarantine-health.js";
 import { clearContextEngineRuntimeQuarantine } from "../context-engine/registry.js";
+import {
+  createCorePluginStateSyncKeyedStore,
+  resetPluginStateStoreForTests,
+} from "../plugin-state/plugin-state-store.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
@@ -23,7 +25,35 @@ const resolveReadOnlyChannelPluginsForConfigMock = vi.mocked(
 afterEach(() => {
   resolveReadOnlyChannelPluginsForConfigMock.mockReset();
   resetPluginRuntimeStateForTest();
+  resetPluginStateStoreForTests();
 });
+
+async function deadProcessId(): Promise<number> {
+  const child = spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+  const pid = child.pid;
+  if (!pid) {
+    throw new Error("failed to spawn short-lived process");
+  }
+  await new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
+  });
+  return pid;
+}
+
+function seedPersistedToolQuarantineForTest(record: {
+  toolName: string;
+  owner?: string;
+  reason: string;
+  failedAtMs: number;
+  processId: number;
+}): void {
+  createCorePluginStateSyncKeyedStore<typeof record>({
+    ownerId: "core:runtime-tool-quarantine-health",
+    namespace: "schema-quarantines",
+    maxEntries: 128,
+    defaultTtlMs: 24 * 60 * 60 * 1_000,
+  }).register(JSON.stringify([record.owner ?? "", record.toolName, record.processId]), record);
+}
 
 describe("runtime plugin health snapshot", () => {
   it("includes persisted context-engine quarantines", async () => {
@@ -51,7 +81,6 @@ describe("runtime plugin health snapshot", () => {
 
   it("includes persisted runtime tool-schema quarantines", async () => {
     await withStateDirEnv("openclaw-status-tool-quarantine-", async () => {
-      clearPersistedRuntimeToolSchemaQuarantinesForProcess();
       const registry = createEmptyPluginRegistry();
       registry.plugins.push({
         id: "bad-tools",
@@ -64,7 +93,6 @@ describe("runtime plugin health snapshot", () => {
         owner: "plugin:bad-tools",
         reason: "unsupported anyOf",
         failedAt: new Date(456),
-        runId: "run-test",
       });
 
       expect(collectRuntimePluginHealthSnapshot().runtimeToolQuarantines).toEqual([
@@ -73,21 +101,18 @@ describe("runtime plugin health snapshot", () => {
           owner: "plugin:bad-tools",
           reason: "unsupported anyOf",
           failedAt: new Date(456),
-          runId: "run-test",
         },
       ]);
     });
   });
 
-  it("keeps runtime tool-schema quarantine records independent of source process liveness", async () => {
+  it("includes core-owned runtime tool quarantines from this process", async () => {
     await withStateDirEnv("openclaw-status-tool-quarantine-core-", async () => {
-      clearPersistedRuntimeToolSchemaQuarantinesForProcess();
       setActivePluginRegistry(createEmptyPluginRegistry(), "empty", "default", "/tmp/ws");
       recordPersistedRuntimeToolSchemaQuarantine({
         toolName: "core_bad_tool",
         reason: "unsupported schema",
         failedAt: new Date(789),
-        runId: "run-core-test",
       });
 
       expect(collectRuntimePluginHealthSnapshot().runtimeToolQuarantines).toEqual([
@@ -95,7 +120,32 @@ describe("runtime plugin health snapshot", () => {
           toolName: "core_bad_tool",
           reason: "unsupported schema",
           failedAt: new Date(789),
-          runId: "run-core-test",
+        },
+      ]);
+    });
+  });
+
+  it("drops runtime tool quarantines recorded by dead processes", async () => {
+    await withStateDirEnv("openclaw-status-tool-quarantine-liveness-", async () => {
+      setActivePluginRegistry(createEmptyPluginRegistry(), "empty", "default", "/tmp/ws");
+      seedPersistedToolQuarantineForTest({
+        toolName: "stale_tool",
+        reason: "unsupported schema",
+        failedAtMs: 123,
+        processId: await deadProcessId(),
+      });
+      seedPersistedToolQuarantineForTest({
+        toolName: "live_tool",
+        reason: "unsupported schema",
+        failedAtMs: 456,
+        processId: process.pid,
+      });
+
+      expect(collectRuntimePluginHealthSnapshot().runtimeToolQuarantines).toEqual([
+        {
+          toolName: "live_tool",
+          reason: "unsupported schema",
+          failedAt: new Date(456),
         },
       ]);
     });
@@ -103,13 +153,11 @@ describe("runtime plugin health snapshot", () => {
 
   it("suppresses persisted plugin-owned runtime tool quarantines after the owner plugin is gone", async () => {
     await withStateDirEnv("openclaw-status-tool-quarantine-owner-", async () => {
-      clearPersistedRuntimeToolSchemaQuarantinesForProcess();
       recordPersistedRuntimeToolSchemaQuarantine({
         toolName: "bad_tool",
         owner: "plugin:bad-tools",
         reason: "unsupported anyOf",
         failedAt: new Date(456),
-        runId: "run-plugin-test",
       });
 
       setActivePluginRegistry(createEmptyPluginRegistry(), "empty", "default", "/tmp/ws");
@@ -129,19 +177,19 @@ describe("runtime plugin health snapshot", () => {
           owner: "plugin:bad-tools",
           reason: "unsupported anyOf",
           failedAt: new Date(456),
-          runId: "run-plugin-test",
         },
       ]);
     });
   });
 
-  it("classifies setup-channel diagnostics as channel plugin failures", () => {
+  it("classifies channel-setup diagnostics as channel plugin failures", () => {
     const registry = createEmptyPluginRegistry();
     registry.diagnostics.push({
       level: "error",
       pluginId: "broken-channel",
+      code: "channel-setup-failure",
       message: "failed to load setup entry: boom",
-    } as never);
+    });
     setActivePluginRegistry(registry, "broken-channel", "default", "/tmp/ws");
 
     const snapshot = collectRuntimePluginHealthSnapshot();
@@ -161,8 +209,9 @@ describe("runtime plugin health snapshot", () => {
     registry.diagnostics.push({
       level: "error",
       pluginId: "broken-channel",
+      code: "channel-setup-failure",
       message: "failed to load setup entry: boom",
-    } as never);
+    });
     setActivePluginRegistry(registry, "broken-channel", "default", "/tmp/ws");
     resolveReadOnlyChannelPluginsForConfigMock.mockReturnValue({
       plugins: [],

--- a/src/status/status-plugin-health.runtime.test.ts
+++ b/src/status/status-plugin-health.runtime.test.ts
@@ -236,24 +236,8 @@ describe("runtime plugin health snapshot", () => {
       message: "failed to load setup entry: boom",
     });
     setActivePluginRegistry(registry, "broken-channel", "default", "/tmp/ws");
-    resolveReadOnlyChannelPluginsForConfigMock.mockReturnValue({
-      plugins: [],
-      configuredChannelIds: ["broken-channel"],
-      missingConfiguredChannelIds: ["broken-channel"],
-      loadFailures: [
-        {
-          channelId: "broken-channel",
-          pluginId: "broken-channel",
-          message: "failed to load setup entry: boom",
-          source: "setup",
-        },
-      ],
-    });
 
-    const snapshot = collectRuntimePluginHealthSnapshot({
-      config: { channels: {} } as never,
-      workspaceDir: "/tmp/ws",
-    });
+    const snapshot = collectRuntimePluginHealthSnapshot();
 
     expect(snapshot.channelPluginFailures).toEqual([
       {

--- a/src/status/status-plugin-health.runtime.test.ts
+++ b/src/status/status-plugin-health.runtime.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../plugin-state/plugin-state-store.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { getProcessStartTime } from "../shared/pid-alive.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { collectRuntimePluginHealthSnapshot } from "./status-plugin-health.runtime.js";
 
@@ -46,6 +47,7 @@ function seedPersistedToolQuarantineForTest(record: {
   reason: string;
   failedAtMs: number;
   processId: number;
+  processStartTime: number | null;
 }): void {
   createCorePluginStateSyncKeyedStore<typeof record>({
     ownerId: "core:runtime-tool-quarantine-health",
@@ -133,12 +135,14 @@ describe("runtime plugin health snapshot", () => {
         reason: "unsupported schema",
         failedAtMs: 123,
         processId: await deadProcessId(),
+        processStartTime: null,
       });
       seedPersistedToolQuarantineForTest({
         toolName: "live_tool",
         reason: "unsupported schema",
         failedAtMs: 456,
         processId: process.pid,
+        processStartTime: getProcessStartTime(process.pid),
       });
 
       expect(collectRuntimePluginHealthSnapshot().runtimeToolQuarantines).toEqual([
@@ -148,6 +152,25 @@ describe("runtime plugin health snapshot", () => {
           failedAt: new Date(456),
         },
       ]);
+    });
+  });
+
+  it("drops runtime tool quarantines recorded by a reused PID", async () => {
+    const currentStartTime = getProcessStartTime(process.pid);
+    if (currentStartTime === null) {
+      return;
+    }
+    await withStateDirEnv("openclaw-status-tool-quarantine-pid-reuse-", async () => {
+      setActivePluginRegistry(createEmptyPluginRegistry(), "empty", "default", "/tmp/ws");
+      seedPersistedToolQuarantineForTest({
+        toolName: "reused_pid_tool",
+        reason: "unsupported schema",
+        failedAtMs: 123,
+        processId: process.pid,
+        processStartTime: currentStartTime + 1,
+      });
+
+      expect(collectRuntimePluginHealthSnapshot().runtimeToolQuarantines).toEqual([]);
     });
   });
 
@@ -204,7 +227,7 @@ describe("runtime plugin health snapshot", () => {
     ]);
   });
 
-  it("does not add a generic missing-channel failure when setup load already failed", () => {
+  it("does not inspect configured channel plugins for compact runtime health", () => {
     const registry = createEmptyPluginRegistry();
     registry.diagnostics.push({
       level: "error",
@@ -240,5 +263,6 @@ describe("runtime plugin health snapshot", () => {
         source: "diagnostic",
       },
     ]);
+    expect(resolveReadOnlyChannelPluginsForConfigMock).not.toHaveBeenCalled();
   });
 });

--- a/src/status/status-plugin-health.runtime.ts
+++ b/src/status/status-plugin-health.runtime.ts
@@ -1,0 +1,69 @@
+// Runtime plugin health collection is isolated from pure status formatting so
+// ordinary status tests do not eagerly load plugin registry internals.
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { listContextEngineQuarantines } from "../context-engine/registry.js";
+import { getActiveRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
+import type {
+  PluginDiagnosticRecord,
+  PluginHealthRecord,
+  StatusPluginHealthSnapshot,
+} from "./status-plugin-health.js";
+
+function normalizeSnapshotPlugin(plugin: PluginHealthRecord): PluginHealthRecord {
+  const normalized: PluginHealthRecord = { id: plugin.id };
+  if (plugin.status !== undefined) {
+    normalized.status = plugin.status;
+  }
+  if (plugin.enabled !== undefined) {
+    normalized.enabled = plugin.enabled;
+  }
+  if (plugin.error !== undefined) {
+    normalized.error = plugin.error;
+  }
+  if (plugin.dependencyStatus !== undefined) {
+    normalized.dependencyStatus = plugin.dependencyStatus;
+  }
+  if (plugin.failurePhase !== undefined) {
+    normalized.failurePhase = plugin.failurePhase;
+  }
+  return normalized;
+}
+
+function normalizeDiagnostic(diagnostic: PluginDiagnosticRecord): PluginDiagnosticRecord {
+  const normalized: PluginDiagnosticRecord = {
+    level: diagnostic.level,
+    message: diagnostic.message,
+  };
+  if (diagnostic.pluginId) {
+    normalized.pluginId = diagnostic.pluginId;
+  }
+  return normalized;
+}
+
+export function collectRuntimePluginHealthSnapshot(): StatusPluginHealthSnapshot {
+  const registry = getActiveRuntimePluginRegistry();
+  return {
+    plugins: (registry?.plugins ?? []).map(normalizeSnapshotPlugin),
+    diagnostics: (registry?.diagnostics ?? []).map(normalizeDiagnostic),
+    contextEngineQuarantines: listContextEngineQuarantines(),
+  };
+}
+
+export async function collectInstalledPluginHealthSnapshot(params: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+}): Promise<StatusPluginHealthSnapshot> {
+  const [{ buildPluginSnapshotReport }, runtime] = await Promise.all([
+    import("../plugins/status.js"),
+    Promise.resolve(collectRuntimePluginHealthSnapshot()),
+  ]);
+  const report = buildPluginSnapshotReport({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+  });
+  return {
+    plugins: report.plugins.map(normalizeSnapshotPlugin),
+    diagnostics: report.diagnostics.map(normalizeDiagnostic),
+    contextEngineQuarantines: runtime.contextEngineQuarantines,
+  };
+}

--- a/src/status/status-plugin-health.runtime.ts
+++ b/src/status/status-plugin-health.runtime.ts
@@ -93,8 +93,20 @@ function collectChannelPluginFailures(params: {
       }
       return failure;
     });
+  const dedupeConcreteFailures = (
+    failures: readonly ChannelPluginFailureRecord[],
+  ): ChannelPluginFailureRecord[] => {
+    const byFailure = new Map<string, ChannelPluginFailureRecord>();
+    for (const failure of failures) {
+      const key = JSON.stringify([failure.channelId, failure.pluginId ?? "", failure.message]);
+      if (!byFailure.has(key)) {
+        byFailure.set(key, failure);
+      }
+    }
+    return [...byFailure.values()];
+  };
   if (!params.config) {
-    return diagnosticFailures;
+    return dedupeConcreteFailures(diagnosticFailures);
   }
   try {
     const resolution = resolveReadOnlyChannelPluginsForConfig(params.config, {
@@ -109,12 +121,10 @@ function collectChannelPluginFailures(params: {
       message: failure.message,
       ...(failure.source ? { source: failure.source } : {}),
     }));
-    const failedChannelIds = new Set(
-      [...diagnosticFailures, ...loadFailures].map((failure) => failure.channelId),
-    );
+    const concreteFailures = dedupeConcreteFailures([...diagnosticFailures, ...loadFailures]);
+    const failedChannelIds = new Set(concreteFailures.map((failure) => failure.channelId));
     return [
-      ...diagnosticFailures,
-      ...loadFailures,
+      ...concreteFailures,
       ...resolution.missingConfiguredChannelIds
         .filter((channelId) => !failedChannelIds.has(channelId))
         .map((channelId) => ({

--- a/src/status/status-plugin-health.runtime.ts
+++ b/src/status/status-plugin-health.runtime.ts
@@ -103,18 +103,24 @@ function collectChannelPluginFailures(params: {
       includePersistedAuthState: false,
       includeSetupFallbackPlugins: params.includeSetupFallbackPlugins === true,
     });
+    const loadFailures = resolution.loadFailures.map((failure) => ({
+      channelId: failure.channelId,
+      pluginId: failure.pluginId,
+      message: failure.message,
+      ...(failure.source ? { source: failure.source } : {}),
+    }));
+    const failedChannelIds = new Set(
+      [...diagnosticFailures, ...loadFailures].map((failure) => failure.channelId),
+    );
     return [
       ...diagnosticFailures,
-      ...resolution.loadFailures.map((failure) => ({
-        channelId: failure.channelId,
-        pluginId: failure.pluginId,
-        message: failure.message,
-        ...(failure.source ? { source: failure.source } : {}),
-      })),
-      ...resolution.missingConfiguredChannelIds.map((channelId) => ({
-        channelId,
-        message: "configured channel plugin is missing or unavailable",
-      })),
+      ...loadFailures,
+      ...resolution.missingConfiguredChannelIds
+        .filter((channelId) => !failedChannelIds.has(channelId))
+        .map((channelId) => ({
+          channelId,
+          message: "configured channel plugin is missing or unavailable",
+        })),
     ];
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/status/status-plugin-health.runtime.ts
+++ b/src/status/status-plugin-health.runtime.ts
@@ -1,11 +1,20 @@
+import { listPersistedRuntimeToolSchemaQuarantines } from "../agents/tool-schema-quarantine-health.js";
+import { resolveReadOnlyChannelPluginsForConfig } from "../channels/plugins/read-only.js";
 // Runtime plugin health collection is isolated from pure status formatting so
 // ordinary status tests do not eagerly load plugin registry internals.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { listContextEngineQuarantines } from "../context-engine/registry.js";
 import { getActiveRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
+import {
+  isChannelPluginFailureDiagnostic,
+  mergeStatusPluginHealthSnapshots,
+} from "./status-plugin-health.js";
 import type {
+  ChannelPluginFailureRecord,
+  PluginCompatibilityHealthNotice,
   PluginDiagnosticRecord,
   PluginHealthRecord,
+  RuntimeToolQuarantineRecord,
   StatusPluginHealthSnapshot,
 } from "./status-plugin-health.js";
 
@@ -40,12 +49,131 @@ function normalizeDiagnostic(diagnostic: PluginDiagnosticRecord): PluginDiagnost
   return normalized;
 }
 
-export function collectRuntimePluginHealthSnapshot(): StatusPluginHealthSnapshot {
-  const registry = getActiveRuntimePluginRegistry();
+function normalizeCompatibilityNotice(
+  notice: PluginCompatibilityHealthNotice,
+): PluginCompatibilityHealthNotice {
   return {
-    plugins: (registry?.plugins ?? []).map(normalizeSnapshotPlugin),
-    diagnostics: (registry?.diagnostics ?? []).map(normalizeDiagnostic),
+    pluginId: notice.pluginId,
+    severity: notice.severity,
+    message: notice.message,
+    ...(notice.code ? { code: notice.code } : {}),
+  };
+}
+
+function mergeDiagnostics(
+  left: readonly PluginDiagnosticRecord[],
+  right: readonly PluginDiagnosticRecord[],
+): PluginDiagnosticRecord[] {
+  const merged = new Map<string, PluginDiagnosticRecord>();
+  for (const diagnostic of [...left, ...right]) {
+    merged.set(
+      JSON.stringify([diagnostic.level, diagnostic.pluginId ?? "", diagnostic.message]),
+      diagnostic,
+    );
+  }
+  return [...merged.values()];
+}
+
+function collectChannelPluginFailures(params: {
+  config?: OpenClawConfig;
+  diagnostics?: readonly PluginDiagnosticRecord[];
+  workspaceDir?: string;
+  includeSetupFallbackPlugins?: boolean;
+}): ChannelPluginFailureRecord[] {
+  const diagnosticFailures = (params.diagnostics ?? [])
+    .filter(isChannelPluginFailureDiagnostic)
+    .map((diagnostic) => {
+      const failure: ChannelPluginFailureRecord = {
+        channelId: diagnostic.pluginId ?? "unknown",
+        message: diagnostic.message,
+        source: "diagnostic",
+      };
+      if (diagnostic.pluginId) {
+        failure.pluginId = diagnostic.pluginId;
+      }
+      return failure;
+    });
+  if (!params.config) {
+    return diagnosticFailures;
+  }
+  try {
+    const resolution = resolveReadOnlyChannelPluginsForConfig(params.config, {
+      workspaceDir: params.workspaceDir,
+      activationSourceConfig: params.config,
+      includePersistedAuthState: false,
+      includeSetupFallbackPlugins: params.includeSetupFallbackPlugins === true,
+    });
+    return [
+      ...diagnosticFailures,
+      ...resolution.loadFailures.map((failure) => ({
+        channelId: failure.channelId,
+        pluginId: failure.pluginId,
+        message: failure.message,
+        ...(failure.source ? { source: failure.source } : {}),
+      })),
+      ...resolution.missingConfiguredChannelIds.map((channelId) => ({
+        channelId,
+        message: "configured channel plugin is missing or unavailable",
+      })),
+    ];
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return [
+      ...diagnosticFailures,
+      {
+        channelId: "unknown",
+        message: `failed to inspect configured channel plugins: ${message}`,
+      },
+    ];
+  }
+}
+
+function parsePluginOwner(owner: string | undefined): string | undefined {
+  const prefix = "plugin:";
+  if (!owner?.startsWith(prefix)) {
+    return undefined;
+  }
+  const pluginId = owner.slice(prefix.length).trim();
+  return pluginId.length > 0 ? pluginId : undefined;
+}
+
+function filterRuntimeToolQuarantinesForRegistry(params: {
+  quarantines: readonly RuntimeToolQuarantineRecord[];
+  plugins: readonly PluginHealthRecord[];
+}): RuntimeToolQuarantineRecord[] {
+  const loadedPluginIds = new Set(
+    params.plugins
+      .filter((plugin) => plugin.enabled !== false && plugin.status !== "disabled")
+      .map((plugin) => plugin.id),
+  );
+  return params.quarantines.filter((quarantine) => {
+    const pluginId = parsePluginOwner(quarantine.owner);
+    return !pluginId || loadedPluginIds.has(pluginId);
+  });
+}
+
+export function collectRuntimePluginHealthSnapshot(
+  params: {
+    config?: OpenClawConfig;
+    workspaceDir?: string;
+  } = {},
+): StatusPluginHealthSnapshot {
+  const registry = getActiveRuntimePluginRegistry();
+  const diagnostics = (registry?.diagnostics ?? []).map(normalizeDiagnostic);
+  const plugins = (registry?.plugins ?? []).map(normalizeSnapshotPlugin);
+  return {
+    plugins,
+    diagnostics,
     contextEngineQuarantines: listContextEngineQuarantines(),
+    runtimeToolQuarantines: filterRuntimeToolQuarantinesForRegistry({
+      quarantines: listPersistedRuntimeToolSchemaQuarantines(),
+      plugins,
+    }),
+    channelPluginFailures: collectChannelPluginFailures({
+      ...params,
+      diagnostics,
+      includeSetupFallbackPlugins: true,
+    }),
   };
 }
 
@@ -53,17 +181,51 @@ export async function collectInstalledPluginHealthSnapshot(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
 }): Promise<StatusPluginHealthSnapshot> {
-  const [{ buildPluginSnapshotReport }, runtime] = await Promise.all([
-    import("../plugins/status.js"),
-    Promise.resolve(collectRuntimePluginHealthSnapshot()),
-  ]);
+  const runtimeRegistry = getActiveRuntimePluginRegistry();
+  const [{ buildPluginCompatibilityNotices, buildPluginSnapshotReport }, runtime] =
+    await Promise.all([
+      import("../plugins/status.js"),
+      Promise.resolve(collectRuntimePluginHealthSnapshot()),
+    ]);
   const report = buildPluginSnapshotReport({
     config: params.config,
     workspaceDir: params.workspaceDir,
   });
-  return {
-    plugins: report.plugins.map(normalizeSnapshotPlugin),
-    diagnostics: report.diagnostics.map(normalizeDiagnostic),
-    contextEngineQuarantines: runtime.contextEngineQuarantines,
-  };
+  const installedDiagnostics = report.diagnostics.map(normalizeDiagnostic);
+  const runtimeDiagnostics = (runtimeRegistry?.diagnostics ?? []).map(normalizeDiagnostic);
+  const diagnostics = mergeDiagnostics(installedDiagnostics, runtimeDiagnostics);
+  const installedChannelPluginFailures = collectChannelPluginFailures({
+    config: params.config,
+    diagnostics,
+    workspaceDir: params.workspaceDir,
+    includeSetupFallbackPlugins: true,
+  });
+  const runtimeCompatibilityNotices = runtimeRegistry
+    ? buildPluginCompatibilityNotices({
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+        report: runtimeRegistry,
+      }).map(normalizeCompatibilityNotice)
+    : [];
+  return mergeStatusPluginHealthSnapshots(
+    {
+      plugins: report.plugins.map(normalizeSnapshotPlugin),
+      diagnostics: installedDiagnostics,
+      contextEngineQuarantines: [],
+      channelPluginFailures: installedChannelPluginFailures,
+      compatibilityNotices: buildPluginCompatibilityNotices({
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+        report,
+      }).map(normalizeCompatibilityNotice),
+    },
+    {
+      plugins: (runtimeRegistry?.plugins ?? []).map(normalizeSnapshotPlugin),
+      diagnostics: runtimeDiagnostics,
+      contextEngineQuarantines: runtime.contextEngineQuarantines,
+      runtimeToolQuarantines: runtime.runtimeToolQuarantines,
+      channelPluginFailures: runtime.channelPluginFailures,
+      compatibilityNotices: runtimeCompatibilityNotices,
+    },
+  );
 }

--- a/src/status/status-plugin-health.runtime.ts
+++ b/src/status/status-plugin-health.runtime.ts
@@ -6,6 +6,8 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { listContextEngineQuarantines } from "../context-engine/registry.js";
 import { getActiveRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
 import {
+  dedupeChannelPluginFailures,
+  dedupePluginDiagnostics,
   isChannelPluginFailureDiagnostic,
   mergeStatusPluginHealthSnapshots,
 } from "./status-plugin-health.js";
@@ -18,6 +20,9 @@ import type {
   StatusPluginHealthSnapshot,
 } from "./status-plugin-health.js";
 
+// The normalize* helpers project registry records onto the snapshot types while
+// omitting absent fields entirely, so snapshot merges never see explicitly
+// undefined values and test fixtures stay minimal.
 function normalizeSnapshotPlugin(plugin: PluginHealthRecord): PluginHealthRecord {
   const normalized: PluginHealthRecord = { id: plugin.id };
   if (plugin.status !== undefined) {
@@ -46,6 +51,9 @@ function normalizeDiagnostic(diagnostic: PluginDiagnosticRecord): PluginDiagnost
   if (diagnostic.pluginId) {
     normalized.pluginId = diagnostic.pluginId;
   }
+  if (diagnostic.code) {
+    normalized.code = diagnostic.code;
+  }
   return normalized;
 }
 
@@ -58,20 +66,6 @@ function normalizeCompatibilityNotice(
     message: notice.message,
     ...(notice.code ? { code: notice.code } : {}),
   };
-}
-
-function mergeDiagnostics(
-  left: readonly PluginDiagnosticRecord[],
-  right: readonly PluginDiagnosticRecord[],
-): PluginDiagnosticRecord[] {
-  const merged = new Map<string, PluginDiagnosticRecord>();
-  for (const diagnostic of [...left, ...right]) {
-    merged.set(
-      JSON.stringify([diagnostic.level, diagnostic.pluginId ?? "", diagnostic.message]),
-      diagnostic,
-    );
-  }
-  return [...merged.values()];
 }
 
 function collectChannelPluginFailures(params: {
@@ -93,20 +87,8 @@ function collectChannelPluginFailures(params: {
       }
       return failure;
     });
-  const dedupeConcreteFailures = (
-    failures: readonly ChannelPluginFailureRecord[],
-  ): ChannelPluginFailureRecord[] => {
-    const byFailure = new Map<string, ChannelPluginFailureRecord>();
-    for (const failure of failures) {
-      const key = JSON.stringify([failure.channelId, failure.pluginId ?? "", failure.message]);
-      if (!byFailure.has(key)) {
-        byFailure.set(key, failure);
-      }
-    }
-    return [...byFailure.values()];
-  };
   if (!params.config) {
-    return dedupeConcreteFailures(diagnosticFailures);
+    return dedupeChannelPluginFailures(diagnosticFailures);
   }
   try {
     const resolution = resolveReadOnlyChannelPluginsForConfig(params.config, {
@@ -121,7 +103,7 @@ function collectChannelPluginFailures(params: {
       message: failure.message,
       ...(failure.source ? { source: failure.source } : {}),
     }));
-    const concreteFailures = dedupeConcreteFailures([...diagnosticFailures, ...loadFailures]);
+    const concreteFailures = dedupeChannelPluginFailures([...diagnosticFailures, ...loadFailures]);
     const failedChannelIds = new Set(concreteFailures.map((failure) => failure.channelId));
     return [
       ...concreteFailures,
@@ -197,25 +179,24 @@ export async function collectInstalledPluginHealthSnapshot(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
 }): Promise<StatusPluginHealthSnapshot> {
-  const runtimeRegistry = getActiveRuntimePluginRegistry();
-  const [{ buildPluginCompatibilityNotices, buildPluginSnapshotReport }, runtime] =
-    await Promise.all([
-      import("../plugins/status.js"),
-      Promise.resolve(collectRuntimePluginHealthSnapshot()),
-    ]);
+  const { buildPluginCompatibilityNotices, buildPluginSnapshotReport } =
+    await import("../plugins/status.js");
+  const runtime = collectRuntimePluginHealthSnapshot();
   const report = buildPluginSnapshotReport({
     config: params.config,
     workspaceDir: params.workspaceDir,
   });
   const installedDiagnostics = report.diagnostics.map(normalizeDiagnostic);
-  const runtimeDiagnostics = (runtimeRegistry?.diagnostics ?? []).map(normalizeDiagnostic);
-  const diagnostics = mergeDiagnostics(installedDiagnostics, runtimeDiagnostics);
-  const installedChannelPluginFailures = collectChannelPluginFailures({
+  // Channel failures resolve once against the union of installed and runtime
+  // diagnostics so missing-channel entries cannot duplicate concrete failures
+  // that only one side observed.
+  const channelPluginFailures = collectChannelPluginFailures({
     config: params.config,
-    diagnostics,
+    diagnostics: dedupePluginDiagnostics([...installedDiagnostics, ...runtime.diagnostics]),
     workspaceDir: params.workspaceDir,
     includeSetupFallbackPlugins: true,
   });
+  const runtimeRegistry = getActiveRuntimePluginRegistry();
   const runtimeCompatibilityNotices = runtimeRegistry
     ? buildPluginCompatibilityNotices({
         config: params.config,
@@ -228,20 +209,13 @@ export async function collectInstalledPluginHealthSnapshot(params: {
       plugins: report.plugins.map(normalizeSnapshotPlugin),
       diagnostics: installedDiagnostics,
       contextEngineQuarantines: [],
-      channelPluginFailures: installedChannelPluginFailures,
+      channelPluginFailures,
       compatibilityNotices: buildPluginCompatibilityNotices({
         config: params.config,
         workspaceDir: params.workspaceDir,
         report,
       }).map(normalizeCompatibilityNotice),
     },
-    {
-      plugins: (runtimeRegistry?.plugins ?? []).map(normalizeSnapshotPlugin),
-      diagnostics: runtimeDiagnostics,
-      contextEngineQuarantines: runtime.contextEngineQuarantines,
-      runtimeToolQuarantines: runtime.runtimeToolQuarantines,
-      channelPluginFailures: runtime.channelPluginFailures,
-      compatibilityNotices: runtimeCompatibilityNotices,
-    },
+    { ...runtime, compatibilityNotices: runtimeCompatibilityNotices },
   );
 }

--- a/src/status/status-plugin-health.runtime.ts
+++ b/src/status/status-plugin-health.runtime.ts
@@ -72,7 +72,6 @@ function collectChannelPluginFailures(params: {
   config?: OpenClawConfig;
   diagnostics?: readonly PluginDiagnosticRecord[];
   workspaceDir?: string;
-  includeSetupFallbackPlugins?: boolean;
 }): ChannelPluginFailureRecord[] {
   const diagnosticFailures = (params.diagnostics ?? [])
     .filter(isChannelPluginFailureDiagnostic)
@@ -95,7 +94,9 @@ function collectChannelPluginFailures(params: {
       workspaceDir: params.workspaceDir,
       activationSourceConfig: params.config,
       includePersistedAuthState: false,
-      includeSetupFallbackPlugins: params.includeSetupFallbackPlugins === true,
+      // Detailed status inspects the full surface, including setup-fallback
+      // plugins, so missing-channel detection matches what setup would load.
+      includeSetupFallbackPlugins: true,
     });
     const loadFailures = resolution.loadFailures.map((failure) => ({
       channelId: failure.channelId,
@@ -150,12 +151,9 @@ function filterRuntimeToolQuarantinesForRegistry(params: {
   });
 }
 
-export function collectRuntimePluginHealthSnapshot(
-  _params: {
-    config?: OpenClawConfig;
-    workspaceDir?: string;
-  } = {},
-): StatusPluginHealthSnapshot {
+// Compact status reads only the active registry and persisted health stores;
+// full config-driven channel inspection is reserved for the installed path.
+export function collectRuntimePluginHealthSnapshot(): StatusPluginHealthSnapshot {
   const registry = getActiveRuntimePluginRegistry();
   const diagnostics = (registry?.diagnostics ?? []).map(normalizeDiagnostic);
   const plugins = (registry?.plugins ?? []).map(normalizeSnapshotPlugin);
@@ -192,7 +190,6 @@ export async function collectInstalledPluginHealthSnapshot(params: {
     config: params.config,
     diagnostics: dedupePluginDiagnostics([...installedDiagnostics, ...runtime.diagnostics]),
     workspaceDir: params.workspaceDir,
-    includeSetupFallbackPlugins: true,
   });
   const runtimeRegistry = getActiveRuntimePluginRegistry();
   const runtimeCompatibilityNotices = runtimeRegistry

--- a/src/status/status-plugin-health.runtime.ts
+++ b/src/status/status-plugin-health.runtime.ts
@@ -151,7 +151,7 @@ function filterRuntimeToolQuarantinesForRegistry(params: {
 }
 
 export function collectRuntimePluginHealthSnapshot(
-  params: {
+  _params: {
     config?: OpenClawConfig;
     workspaceDir?: string;
   } = {},
@@ -168,9 +168,7 @@ export function collectRuntimePluginHealthSnapshot(
       plugins,
     }),
     channelPluginFailures: collectChannelPluginFailures({
-      ...params,
       diagnostics,
-      includeSetupFallbackPlugins: true,
     }),
   };
 }

--- a/src/status/status-plugin-health.test.ts
+++ b/src/status/status-plugin-health.test.ts
@@ -1,0 +1,69 @@
+// Plugin health status tests cover compact and detailed chat formatting.
+import { describe, expect, it } from "vitest";
+import {
+  formatCompactPluginHealthLine,
+  formatDetailedPluginHealth,
+  type StatusPluginHealthSnapshot,
+} from "./status-plugin-health.js";
+
+const emptySnapshot: StatusPluginHealthSnapshot = {
+  plugins: [],
+  diagnostics: [],
+  contextEngineQuarantines: [],
+};
+
+describe("plugin health status formatting", () => {
+  it("shows a tiny OK line when there are no plugin health problems", () => {
+    expect(formatCompactPluginHealthLine(emptySnapshot)).toBe("🔌 Plugins: OK");
+  });
+
+  it("summarizes plugin errors and context engine quarantines in the compact line", () => {
+    expect(
+      formatCompactPluginHealthLine({
+        plugins: [
+          {
+            id: "broken-plugin",
+            status: "error",
+            enabled: true,
+            error: "boom",
+          },
+        ],
+        diagnostics: [],
+        contextEngineQuarantines: [
+          {
+            engineId: "lossless-claw",
+            owner: "plugin:lossless-claw",
+            operation: "bootstrap",
+            reason: "replay guard tripped",
+            failedAt: new Date(0),
+          },
+        ],
+      }),
+    ).toBe("⚠️ Plugins: 1 plugin error · 1 context engine quarantine");
+  });
+
+  it("includes detailed plugin state without dumping the full plugin registry", () => {
+    const text = formatDetailedPluginHealth({
+      plugins: [
+        { id: "ok-plugin", status: "loaded", enabled: true },
+        { id: "disabled-plugin", status: "disabled", enabled: false },
+        {
+          id: "bad-plugin",
+          status: "error",
+          enabled: true,
+          failurePhase: "load",
+          error: "module failed",
+        },
+      ],
+      diagnostics: [{ level: "warn", pluginId: "bad-plugin", message: "deprecated hook" }],
+      contextEngineQuarantines: [],
+    });
+
+    expect(text).toContain("⚠️ Plugins: 1 plugin error");
+    expect(text).toContain("Loaded: 1 (ok-plugin)");
+    expect(text).toContain("Disabled: 1");
+    expect(text).toContain("- bad-plugin [load]: module failed");
+    expect(text).toContain("Diagnostics: 0 errors · 1 warnings");
+    expect(text).toContain("Full inventory: /plugins list");
+  });
+});

--- a/src/status/status-plugin-health.test.ts
+++ b/src/status/status-plugin-health.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatCompactPluginHealthLine,
   formatDetailedPluginHealth,
+  mergeStatusPluginHealthSnapshots,
   type StatusPluginHealthSnapshot,
 } from "./status-plugin-health.js";
 
@@ -42,6 +43,157 @@ describe("plugin health status formatting", () => {
     ).toBe("⚠️ Plugins: 1 plugin error · 1 context engine quarantine");
   });
 
+  it("counts runtime tool quarantines and channel plugin failures as compact problems", () => {
+    expect(
+      formatCompactPluginHealthLine({
+        ...emptySnapshot,
+        runtimeToolQuarantines: [
+          {
+            toolName: "bad_tool",
+            owner: "plugin:bad-tools",
+            reason: "unsupported anyOf",
+            failedAt: new Date(0),
+          },
+        ],
+        channelPluginFailures: [
+          {
+            channelId: "sms",
+            pluginId: "sms-plugin",
+            message: "setup failed",
+          },
+        ],
+      }),
+    ).toBe("⚠️ Plugins: 1 runtime tool quarantine · 1 channel plugin failure");
+  });
+
+  it("does not double-count diagnostics classified as channel plugin failures", () => {
+    expect(
+      formatCompactPluginHealthLine({
+        ...emptySnapshot,
+        diagnostics: [
+          {
+            level: "error",
+            pluginId: "broken-channel",
+            message: "failed to load setup entry: boom",
+          },
+        ],
+        channelPluginFailures: [
+          {
+            channelId: "broken-channel",
+            pluginId: "broken-channel",
+            message: "failed to load setup entry: boom",
+            source: "diagnostic",
+          },
+        ],
+      }),
+    ).toBe("⚠️ Plugins: 1 channel plugin failure");
+  });
+
+  it("counts channel setup diagnostics when no channel failure record is present", () => {
+    expect(
+      formatCompactPluginHealthLine({
+        ...emptySnapshot,
+        diagnostics: [
+          {
+            level: "error",
+            pluginId: "broken-channel",
+            message: "failed to load setup entry: boom",
+          },
+        ],
+      }),
+    ).toBe("⚠️ Plugins: 1 diagnostic error");
+  });
+
+  it("keeps compatibility notices out of the compact problem line", () => {
+    expect(
+      formatCompactPluginHealthLine({
+        ...emptySnapshot,
+        compatibilityNotices: [
+          {
+            pluginId: "legacy-plugin",
+            severity: "warn",
+            code: "hook-only",
+            message: "uses a compatibility shim",
+          },
+        ],
+      }),
+    ).toBe("🔌 Plugins: OK");
+  });
+
+  it("merges runtime health into installed plugin snapshots for detailed status", () => {
+    const snapshot = mergeStatusPluginHealthSnapshots(
+      {
+        plugins: [{ id: "installed-ok", status: "loaded", enabled: true }],
+        diagnostics: [],
+        contextEngineQuarantines: [],
+        compatibilityNotices: [
+          {
+            pluginId: "compat-only",
+            severity: "warn",
+            code: "legacy-before-agent-start",
+            message: "still uses legacy before_agent_start",
+          },
+        ],
+      },
+      {
+        plugins: [
+          {
+            id: "runtime-broken",
+            status: "error",
+            enabled: true,
+            failurePhase: "load",
+            error: "runtime load failed",
+          },
+        ],
+        diagnostics: [
+          {
+            level: "error",
+            pluginId: "runtime-broken",
+            message: "failed to load setup entry: runtime load failed",
+          },
+        ],
+        contextEngineQuarantines: [],
+        runtimeToolQuarantines: [
+          {
+            toolName: "bad_tool",
+            owner: "plugin:bad-tools",
+            reason: "unsupported schema",
+            failedAt: new Date(789),
+          },
+        ],
+        channelPluginFailures: [
+          {
+            channelId: "runtime-broken",
+            pluginId: "runtime-broken",
+            message: "failed to load setup entry: runtime load failed",
+            source: "diagnostic",
+          },
+        ],
+      },
+    );
+
+    expect(snapshot.plugins).toContainEqual({
+      id: "runtime-broken",
+      status: "error",
+      enabled: true,
+      failurePhase: "load",
+      error: "runtime load failed",
+    });
+    expect(snapshot.runtimeToolQuarantines).toHaveLength(1);
+    expect(snapshot.channelPluginFailures).toContainEqual({
+      channelId: "runtime-broken",
+      pluginId: "runtime-broken",
+      message: "failed to load setup entry: runtime load failed",
+      source: "diagnostic",
+    });
+    expect(snapshot.compatibilityNotices).toContainEqual({
+      pluginId: "compat-only",
+      severity: "warn",
+      code: "legacy-before-agent-start",
+      message: "still uses legacy before_agent_start",
+    });
+  });
+
   it("includes detailed plugin state without dumping the full plugin registry", () => {
     const text = formatDetailedPluginHealth({
       plugins: [
@@ -57,13 +209,42 @@ describe("plugin health status formatting", () => {
       ],
       diagnostics: [{ level: "warn", pluginId: "bad-plugin", message: "deprecated hook" }],
       contextEngineQuarantines: [],
+      runtimeToolQuarantines: [
+        {
+          toolName: "bad_tool",
+          owner: "plugin:bad-tools",
+          reason: "unsupported anyOf",
+          failedAt: new Date(0),
+        },
+      ],
+      channelPluginFailures: [
+        {
+          channelId: "sms",
+          pluginId: "sms-plugin",
+          message: "setup failed",
+          source: "setup",
+        },
+      ],
+      compatibilityNotices: [
+        {
+          pluginId: "legacy-plugin",
+          severity: "warn",
+          code: "hook-only",
+          message: "uses a compatibility shim",
+        },
+      ],
     });
 
-    expect(text).toContain("⚠️ Plugins: 1 plugin error");
+    expect(text).toContain(
+      "⚠️ Plugins: 1 plugin error · 1 runtime tool quarantine · 1 channel plugin failure",
+    );
     expect(text).toContain("Loaded: 1 (ok-plugin)");
     expect(text).toContain("Disabled: 1");
     expect(text).toContain("- bad-plugin [load]: module failed");
+    expect(text).toContain("- bad_tool owner=plugin:bad-tools: unsupported anyOf");
+    expect(text).toContain("- sms plugin=sms-plugin [setup]: setup failed");
     expect(text).toContain("Diagnostics: 0 errors · 1 warnings");
+    expect(text).toContain("- WARN legacy-plugin [hook-only]: uses a compatibility shim");
     expect(text).toContain("Full inventory: /plugins list");
   });
 });

--- a/src/status/status-plugin-health.test.ts
+++ b/src/status/status-plugin-health.test.ts
@@ -74,6 +74,7 @@ describe("plugin health status formatting", () => {
           {
             level: "error",
             pluginId: "broken-channel",
+            code: "channel-setup-failure",
             message: "failed to load setup entry: boom",
           },
         ],
@@ -97,6 +98,7 @@ describe("plugin health status formatting", () => {
           {
             level: "error",
             pluginId: "broken-channel",
+            code: "channel-setup-failure",
             message: "failed to load setup entry: boom",
           },
         ],
@@ -149,6 +151,7 @@ describe("plugin health status formatting", () => {
           {
             level: "error",
             pluginId: "runtime-broken",
+            code: "channel-setup-failure",
             message: "failed to load setup entry: runtime load failed",
           },
         ],

--- a/src/status/status-plugin-health.ts
+++ b/src/status/status-plugin-health.ts
@@ -29,11 +29,132 @@ export type ContextEngineQuarantineRecord = {
   failedAt: Date | number;
 };
 
+export type RuntimeToolQuarantineRecord = {
+  toolName: string;
+  owner?: string;
+  reason: string;
+  failedAt: Date | number;
+};
+
+export type PluginCompatibilityHealthNotice = {
+  pluginId: string;
+  severity: "warn" | "info";
+  message: string;
+  code?: string;
+};
+
+export type ChannelPluginFailureRecord = {
+  channelId: string;
+  pluginId?: string;
+  message: string;
+  source?: string;
+};
+
 export type StatusPluginHealthSnapshot = {
   plugins: PluginHealthRecord[];
   diagnostics: PluginDiagnosticRecord[];
   contextEngineQuarantines: ContextEngineQuarantineRecord[];
+  runtimeToolQuarantines?: RuntimeToolQuarantineRecord[];
+  compatibilityNotices?: PluginCompatibilityHealthNotice[];
+  channelPluginFailures?: ChannelPluginFailureRecord[];
 };
+
+function diagnosticKey(diagnostic: PluginDiagnosticRecord): string {
+  return JSON.stringify([diagnostic.level, diagnostic.pluginId ?? "", diagnostic.message]);
+}
+
+function channelFailureKey(failure: ChannelPluginFailureRecord): string {
+  return JSON.stringify([
+    failure.channelId,
+    failure.pluginId ?? "",
+    failure.source ?? "",
+    failure.message,
+  ]);
+}
+
+function compatibilityNoticeKey(notice: PluginCompatibilityHealthNotice): string {
+  return JSON.stringify([notice.pluginId, notice.severity, notice.code ?? "", notice.message]);
+}
+
+function mergeDiagnostics(
+  left: readonly PluginDiagnosticRecord[],
+  right: readonly PluginDiagnosticRecord[],
+): PluginDiagnosticRecord[] {
+  const merged = new Map<string, PluginDiagnosticRecord>();
+  for (const diagnostic of [...left, ...right]) {
+    merged.set(diagnosticKey(diagnostic), diagnostic);
+  }
+  return [...merged.values()];
+}
+
+function mergeChannelFailures(
+  left: readonly ChannelPluginFailureRecord[],
+  right: readonly ChannelPluginFailureRecord[],
+): ChannelPluginFailureRecord[] {
+  const merged = new Map<string, ChannelPluginFailureRecord>();
+  for (const failure of [...left, ...right]) {
+    merged.set(channelFailureKey(failure), failure);
+  }
+  return [...merged.values()];
+}
+
+function mergeCompatibilityNotices(
+  left: readonly PluginCompatibilityHealthNotice[],
+  right: readonly PluginCompatibilityHealthNotice[],
+): PluginCompatibilityHealthNotice[] {
+  const merged = new Map<string, PluginCompatibilityHealthNotice>();
+  for (const notice of [...left, ...right]) {
+    merged.set(compatibilityNoticeKey(notice), notice);
+  }
+  return [...merged.values()];
+}
+
+function mergePluginRecords(
+  installed: readonly PluginHealthRecord[],
+  runtime: readonly PluginHealthRecord[],
+): PluginHealthRecord[] {
+  const merged = new Map<string, PluginHealthRecord>();
+  for (const plugin of installed) {
+    merged.set(plugin.id, plugin);
+  }
+  for (const plugin of runtime) {
+    const existing = merged.get(plugin.id);
+    merged.set(plugin.id, {
+      ...existing,
+      ...plugin,
+      ...(existing?.dependencyStatus && !plugin.dependencyStatus
+        ? { dependencyStatus: existing.dependencyStatus }
+        : {}),
+    });
+  }
+  return [...merged.values()];
+}
+
+export function mergeStatusPluginHealthSnapshots(
+  installed: StatusPluginHealthSnapshot,
+  runtime: StatusPluginHealthSnapshot,
+): StatusPluginHealthSnapshot {
+  return {
+    plugins: mergePluginRecords(installed.plugins, runtime.plugins),
+    diagnostics: mergeDiagnostics(installed.diagnostics, runtime.diagnostics),
+    contextEngineQuarantines: [
+      ...installed.contextEngineQuarantines,
+      ...runtime.contextEngineQuarantines,
+    ],
+    runtimeToolQuarantines: [
+      ...(installed.runtimeToolQuarantines ?? []),
+      ...(runtime.runtimeToolQuarantines ?? []),
+    ],
+    channelPluginFailures: mergeChannelFailures(
+      installed.channelPluginFailures ?? [],
+      runtime.channelPluginFailures ?? [],
+    ),
+    compatibilityNotices: mergeCompatibilityNotices(
+      installed.compatibilityNotices ?? [],
+      runtime.compatibilityNotices ?? [],
+    ),
+  };
+}
 
 function countEnabledDependencyIssues(plugins: readonly PluginHealthRecord[]): number {
   return plugins.filter(
@@ -42,6 +163,29 @@ function countEnabledDependencyIssues(plugins: readonly PluginHealthRecord[]): n
       plugin.dependencyStatus?.hasDependencies === true &&
       plugin.dependencyStatus.requiredInstalled === false,
   ).length;
+}
+
+function shouldSuppressChannelPluginDiagnostic(
+  diagnostic: PluginDiagnosticRecord,
+  channelPluginFailures: readonly ChannelPluginFailureRecord[],
+): boolean {
+  if (!isChannelPluginFailureDiagnostic(diagnostic)) {
+    return false;
+  }
+  return channelPluginFailures.some(
+    (failure) =>
+      failure.message === diagnostic.message &&
+      (failure.pluginId == null ||
+        diagnostic.pluginId == null ||
+        failure.pluginId === diagnostic.pluginId),
+  );
+}
+
+function getReportableDiagnostics(snapshot: StatusPluginHealthSnapshot): PluginDiagnosticRecord[] {
+  const channelPluginFailures = snapshot.channelPluginFailures ?? [];
+  return snapshot.diagnostics.filter(
+    (entry) => !shouldSuppressChannelPluginDiagnostic(entry, channelPluginFailures),
+  );
 }
 
 function countProblemDiagnostics(diagnostics: readonly PluginDiagnosticRecord[]): {
@@ -54,12 +198,30 @@ function countProblemDiagnostics(diagnostics: readonly PluginDiagnosticRecord[])
   };
 }
 
+export function isChannelPluginFailureDiagnostic(diagnostic: PluginDiagnosticRecord): boolean {
+  if (diagnostic.level !== "error") {
+    return false;
+  }
+  return /failed to (?:apply setup(?:-runtime)? channel runtime|load setup(?:-runtime)? channel entry|load setup entry|register setup(?:-runtime)? channel)/iu.test(
+    diagnostic.message,
+  );
+}
+
 export function formatCompactPluginHealthLine(snapshot: StatusPluginHealthSnapshot): string {
   const loadErrors = snapshot.plugins.filter((plugin) => plugin.status === "error").length;
   const dependencyIssues = countEnabledDependencyIssues(snapshot.plugins);
-  const diagnosticCounts = countProblemDiagnostics(snapshot.diagnostics);
+  const diagnostics = getReportableDiagnostics(snapshot);
+  const diagnosticCounts = countProblemDiagnostics(diagnostics);
   const quarantines = snapshot.contextEngineQuarantines.length;
-  const problems = loadErrors + dependencyIssues + diagnosticCounts.errors + quarantines;
+  const runtimeToolQuarantines = snapshot.runtimeToolQuarantines?.length ?? 0;
+  const channelPluginFailures = snapshot.channelPluginFailures?.length ?? 0;
+  const problems =
+    loadErrors +
+    dependencyIssues +
+    diagnosticCounts.errors +
+    quarantines +
+    runtimeToolQuarantines +
+    channelPluginFailures;
 
   if (problems === 0) {
     return "🔌 Plugins: OK";
@@ -69,6 +231,14 @@ export function formatCompactPluginHealthLine(snapshot: StatusPluginHealthSnapsh
     loadErrors > 0 ? `${loadErrors} plugin error${loadErrors === 1 ? "" : "s"}` : null,
     quarantines > 0
       ? `${quarantines} context engine quarantine${quarantines === 1 ? "" : "s"}`
+      : null,
+    runtimeToolQuarantines > 0
+      ? `${runtimeToolQuarantines} runtime tool quarantine${
+          runtimeToolQuarantines === 1 ? "" : "s"
+        }`
+      : null,
+    channelPluginFailures > 0
+      ? `${channelPluginFailures} channel plugin failure${channelPluginFailures === 1 ? "" : "s"}`
       : null,
     dependencyIssues > 0
       ? `${dependencyIssues} dependency issue${dependencyIssues === 1 ? "" : "s"}`
@@ -106,7 +276,11 @@ export function formatDetailedPluginHealth(snapshot: StatusPluginHealthSnapshot)
         plugin.dependencyStatus.requiredInstalled === false,
     )
     .toSorted((left, right) => left.id.localeCompare(right.id));
-  const diagnosticCounts = countProblemDiagnostics(snapshot.diagnostics);
+  const diagnostics = getReportableDiagnostics(snapshot);
+  const diagnosticCounts = countProblemDiagnostics(diagnostics);
+  const runtimeToolQuarantines = snapshot.runtimeToolQuarantines ?? [];
+  const compatibilityNotices = snapshot.compatibilityNotices ?? [];
+  const channelPluginFailures = snapshot.channelPluginFailures ?? [];
   const header = formatCompactPluginHealthLine(snapshot);
   const lines = [
     header,
@@ -134,6 +308,27 @@ export function formatDetailedPluginHealth(snapshot: StatusPluginHealthSnapshot)
     );
   }
 
+  if (runtimeToolQuarantines.length > 0) {
+    lines.push(
+      `Runtime tool quarantines: ${runtimeToolQuarantines.length}`,
+      ...runtimeToolQuarantines.slice(0, 8).map((entry) => {
+        const owner = entry.owner ? ` owner=${entry.owner}` : "";
+        return `- ${entry.toolName}${owner}: ${entry.reason}`;
+      }),
+    );
+  }
+
+  if (channelPluginFailures.length > 0) {
+    lines.push(
+      `Channel plugin failures: ${channelPluginFailures.length}`,
+      ...channelPluginFailures.slice(0, 8).map((entry) => {
+        const plugin = entry.pluginId ? ` plugin=${entry.pluginId}` : "";
+        const source = entry.source ? ` [${entry.source}]` : "";
+        return `- ${entry.channelId}${plugin}${source}: ${entry.message}`;
+      }),
+    );
+  }
+
   if (dependencyIssues.length > 0) {
     lines.push(
       `Dependency issues: ${dependencyIssues.length}`,
@@ -148,10 +343,20 @@ export function formatDetailedPluginHealth(snapshot: StatusPluginHealthSnapshot)
     lines.push(
       `Diagnostics: ${diagnosticCounts.errors} errors · ${diagnosticCounts.warnings} warnings`,
     );
-    for (const diagnostic of snapshot.diagnostics.slice(0, 8)) {
+    for (const diagnostic of diagnostics.slice(0, 8)) {
       const target = diagnostic.pluginId ? `${diagnostic.pluginId}: ` : "";
       lines.push(`- ${diagnostic.level.toUpperCase()} ${target}${diagnostic.message}`);
     }
+  }
+
+  if (compatibilityNotices.length > 0) {
+    lines.push(
+      `Compatibility notices: ${compatibilityNotices.length}`,
+      ...compatibilityNotices.slice(0, 8).map((notice) => {
+        const code = notice.code ? ` [${notice.code}]` : "";
+        return `- ${notice.severity.toUpperCase()} ${notice.pluginId}${code}: ${notice.message}`;
+      }),
+    );
   }
 
   lines.push("Full inventory: /plugins list");

--- a/src/status/status-plugin-health.ts
+++ b/src/status/status-plugin-health.ts
@@ -1,0 +1,159 @@
+// Builds compact plugin health summaries for chat status surfaces.
+
+export type StatusPluginDependencyStatus = {
+  hasDependencies?: boolean;
+  requiredInstalled?: boolean;
+  missing?: string[];
+};
+
+export type PluginHealthRecord = {
+  id: string;
+  status?: "loaded" | "disabled" | "error";
+  enabled?: boolean;
+  error?: string;
+  dependencyStatus?: StatusPluginDependencyStatus;
+  failurePhase?: string;
+};
+
+export type PluginDiagnosticRecord = {
+  level: "warn" | "error";
+  message: string;
+  pluginId?: string;
+};
+
+export type ContextEngineQuarantineRecord = {
+  engineId: string;
+  owner?: string;
+  operation: string;
+  reason: string;
+  failedAt: Date | number;
+};
+
+export type StatusPluginHealthSnapshot = {
+  plugins: PluginHealthRecord[];
+  diagnostics: PluginDiagnosticRecord[];
+  contextEngineQuarantines: ContextEngineQuarantineRecord[];
+};
+
+function countEnabledDependencyIssues(plugins: readonly PluginHealthRecord[]): number {
+  return plugins.filter(
+    (plugin) =>
+      plugin.enabled !== false &&
+      plugin.dependencyStatus?.hasDependencies === true &&
+      plugin.dependencyStatus.requiredInstalled === false,
+  ).length;
+}
+
+function countProblemDiagnostics(diagnostics: readonly PluginDiagnosticRecord[]): {
+  errors: number;
+  warnings: number;
+} {
+  return {
+    errors: diagnostics.filter((entry) => entry.level === "error").length,
+    warnings: diagnostics.filter((entry) => entry.level === "warn").length,
+  };
+}
+
+export function formatCompactPluginHealthLine(snapshot: StatusPluginHealthSnapshot): string {
+  const loadErrors = snapshot.plugins.filter((plugin) => plugin.status === "error").length;
+  const dependencyIssues = countEnabledDependencyIssues(snapshot.plugins);
+  const diagnosticCounts = countProblemDiagnostics(snapshot.diagnostics);
+  const quarantines = snapshot.contextEngineQuarantines.length;
+  const problems = loadErrors + dependencyIssues + diagnosticCounts.errors + quarantines;
+
+  if (problems === 0) {
+    return "🔌 Plugins: OK";
+  }
+
+  const parts = [
+    loadErrors > 0 ? `${loadErrors} plugin error${loadErrors === 1 ? "" : "s"}` : null,
+    quarantines > 0
+      ? `${quarantines} context engine quarantine${quarantines === 1 ? "" : "s"}`
+      : null,
+    dependencyIssues > 0
+      ? `${dependencyIssues} dependency issue${dependencyIssues === 1 ? "" : "s"}`
+      : null,
+    diagnosticCounts.errors > 0
+      ? `${diagnosticCounts.errors} diagnostic error${diagnosticCounts.errors === 1 ? "" : "s"}`
+      : null,
+  ].filter((part): part is string => Boolean(part));
+
+  return `⚠️ Plugins: ${parts.join(" · ")}`;
+}
+
+function formatPluginList(ids: readonly string[], limit: number): string {
+  if (ids.length === 0) {
+    return "none";
+  }
+  const visible = ids.slice(0, limit).join(", ");
+  return ids.length > limit ? `${visible}, +${ids.length - limit} more` : visible;
+}
+
+export function formatDetailedPluginHealth(snapshot: StatusPluginHealthSnapshot): string {
+  const loaded = snapshot.plugins
+    .filter((plugin) => plugin.status === "loaded")
+    .map((plugin) => plugin.id)
+    .toSorted((left, right) => left.localeCompare(right));
+  const disabled = snapshot.plugins.filter((plugin) => plugin.status === "disabled").length;
+  const errors = snapshot.plugins
+    .filter((plugin) => plugin.status === "error")
+    .toSorted((left, right) => left.id.localeCompare(right.id));
+  const dependencyIssues = snapshot.plugins
+    .filter(
+      (plugin) =>
+        plugin.enabled !== false &&
+        plugin.dependencyStatus?.hasDependencies === true &&
+        plugin.dependencyStatus.requiredInstalled === false,
+    )
+    .toSorted((left, right) => left.id.localeCompare(right.id));
+  const diagnosticCounts = countProblemDiagnostics(snapshot.diagnostics);
+  const header = formatCompactPluginHealthLine(snapshot);
+  const lines = [
+    header,
+    `Loaded: ${loaded.length}${loaded.length > 0 ? ` (${formatPluginList(loaded, 8)})` : ""}`,
+    `Disabled: ${disabled}`,
+  ];
+
+  if (errors.length > 0) {
+    lines.push(
+      `Errors: ${errors.length}`,
+      ...errors.slice(0, 8).map((plugin) => {
+        const phase = plugin.failurePhase ? ` [${plugin.failurePhase}]` : "";
+        return `- ${plugin.id}${phase}: ${plugin.error ?? "failed to load"}`;
+      }),
+    );
+  }
+
+  if (snapshot.contextEngineQuarantines.length > 0) {
+    lines.push(
+      `Context engine quarantines: ${snapshot.contextEngineQuarantines.length}`,
+      ...snapshot.contextEngineQuarantines.slice(0, 8).map((entry) => {
+        const owner = entry.owner ? ` owner=${entry.owner}` : "";
+        return `- ${entry.engineId}${owner} during ${entry.operation}: ${entry.reason}`;
+      }),
+    );
+  }
+
+  if (dependencyIssues.length > 0) {
+    lines.push(
+      `Dependency issues: ${dependencyIssues.length}`,
+      ...dependencyIssues.slice(0, 8).map((plugin) => {
+        const missing = plugin.dependencyStatus?.missing ?? [];
+        return `- ${plugin.id}: missing ${missing.join(", ") || "required dependencies"}`;
+      }),
+    );
+  }
+
+  if (diagnosticCounts.errors > 0 || diagnosticCounts.warnings > 0) {
+    lines.push(
+      `Diagnostics: ${diagnosticCounts.errors} errors · ${diagnosticCounts.warnings} warnings`,
+    );
+    for (const diagnostic of snapshot.diagnostics.slice(0, 8)) {
+      const target = diagnostic.pluginId ? `${diagnostic.pluginId}: ` : "";
+      lines.push(`- ${diagnostic.level.toUpperCase()} ${target}${diagnostic.message}`);
+    }
+  }
+
+  lines.push("Full inventory: /plugins list");
+  return lines.join("\n");
+}

--- a/src/status/status-plugin-health.ts
+++ b/src/status/status-plugin-health.ts
@@ -1,4 +1,5 @@
 // Builds compact plugin health summaries for chat status surfaces.
+import type { PluginDiagnosticCode } from "../plugins/manifest-types.js";
 
 export type StatusPluginDependencyStatus = {
   hasDependencies?: boolean;
@@ -19,6 +20,7 @@ export type PluginDiagnosticRecord = {
   level: "warn" | "error";
   message: string;
   pluginId?: string;
+  code?: PluginDiagnosticCode;
 };
 
 export type ContextEngineQuarantineRecord = {
@@ -59,54 +61,42 @@ export type StatusPluginHealthSnapshot = {
   channelPluginFailures?: ChannelPluginFailureRecord[];
 };
 
-function diagnosticKey(diagnostic: PluginDiagnosticRecord): string {
-  return JSON.stringify([diagnostic.level, diagnostic.pluginId ?? "", diagnostic.message]);
+/** Keeps the first record per key; later duplicates are dropped. */
+function dedupeBy<T>(items: readonly T[], keyOf: (item: T) => string): T[] {
+  const seen = new Map<string, T>();
+  for (const item of items) {
+    const key = keyOf(item);
+    if (!seen.has(key)) {
+      seen.set(key, item);
+    }
+  }
+  return [...seen.values()];
 }
 
-function channelFailureKey(failure: ChannelPluginFailureRecord): string {
-  return JSON.stringify([
-    failure.channelId,
-    failure.pluginId ?? "",
-    failure.source ?? "",
-    failure.message,
-  ]);
-}
-
-function compatibilityNoticeKey(notice: PluginCompatibilityHealthNotice): string {
-  return JSON.stringify([notice.pluginId, notice.severity, notice.code ?? "", notice.message]);
-}
-
-function mergeDiagnostics(
-  left: readonly PluginDiagnosticRecord[],
-  right: readonly PluginDiagnosticRecord[],
+export function dedupePluginDiagnostics(
+  diagnostics: readonly PluginDiagnosticRecord[],
 ): PluginDiagnosticRecord[] {
-  const merged = new Map<string, PluginDiagnosticRecord>();
-  for (const diagnostic of [...left, ...right]) {
-    merged.set(diagnosticKey(diagnostic), diagnostic);
-  }
-  return [...merged.values()];
+  return dedupeBy(diagnostics, (entry) =>
+    JSON.stringify([entry.level, entry.pluginId ?? "", entry.code ?? "", entry.message]),
+  );
 }
 
-function mergeChannelFailures(
-  left: readonly ChannelPluginFailureRecord[],
-  right: readonly ChannelPluginFailureRecord[],
+// The key ignores `source` so the same failure surfaced via loader diagnostics
+// and via channel resolution dedupes; callers list the preferred record first.
+export function dedupeChannelPluginFailures(
+  failures: readonly ChannelPluginFailureRecord[],
 ): ChannelPluginFailureRecord[] {
-  const merged = new Map<string, ChannelPluginFailureRecord>();
-  for (const failure of [...left, ...right]) {
-    merged.set(channelFailureKey(failure), failure);
-  }
-  return [...merged.values()];
+  return dedupeBy(failures, (entry) =>
+    JSON.stringify([entry.channelId, entry.pluginId ?? "", entry.message]),
+  );
 }
 
-function mergeCompatibilityNotices(
-  left: readonly PluginCompatibilityHealthNotice[],
-  right: readonly PluginCompatibilityHealthNotice[],
+function dedupeCompatibilityNotices(
+  notices: readonly PluginCompatibilityHealthNotice[],
 ): PluginCompatibilityHealthNotice[] {
-  const merged = new Map<string, PluginCompatibilityHealthNotice>();
-  for (const notice of [...left, ...right]) {
-    merged.set(compatibilityNoticeKey(notice), notice);
-  }
-  return [...merged.values()];
+  return dedupeBy(notices, (entry) =>
+    JSON.stringify([entry.pluginId, entry.severity, entry.code ?? "", entry.message]),
+  );
 }
 
 function mergePluginRecords(
@@ -119,12 +109,15 @@ function mergePluginRecords(
   }
   for (const plugin of runtime) {
     const existing = merged.get(plugin.id);
+    // Field-wise merge: runtime facts win, but a runtime record missing a
+    // field never erases what the installed scan knew.
     merged.set(plugin.id, {
-      ...existing,
-      ...plugin,
-      ...(existing?.dependencyStatus && !plugin.dependencyStatus
-        ? { dependencyStatus: existing.dependencyStatus }
-        : {}),
+      id: plugin.id,
+      status: plugin.status ?? existing?.status,
+      enabled: plugin.enabled ?? existing?.enabled,
+      error: plugin.error ?? existing?.error,
+      dependencyStatus: plugin.dependencyStatus ?? existing?.dependencyStatus,
+      failurePhase: plugin.failurePhase ?? existing?.failurePhase,
     });
   }
   return [...merged.values()];
@@ -136,7 +129,7 @@ export function mergeStatusPluginHealthSnapshots(
 ): StatusPluginHealthSnapshot {
   return {
     plugins: mergePluginRecords(installed.plugins, runtime.plugins),
-    diagnostics: mergeDiagnostics(installed.diagnostics, runtime.diagnostics),
+    diagnostics: dedupePluginDiagnostics([...installed.diagnostics, ...runtime.diagnostics]),
     contextEngineQuarantines: [
       ...installed.contextEngineQuarantines,
       ...runtime.contextEngineQuarantines,
@@ -145,24 +138,23 @@ export function mergeStatusPluginHealthSnapshots(
       ...(installed.runtimeToolQuarantines ?? []),
       ...(runtime.runtimeToolQuarantines ?? []),
     ],
-    channelPluginFailures: mergeChannelFailures(
-      installed.channelPluginFailures ?? [],
-      runtime.channelPluginFailures ?? [],
-    ),
-    compatibilityNotices: mergeCompatibilityNotices(
-      installed.compatibilityNotices ?? [],
-      runtime.compatibilityNotices ?? [],
-    ),
+    channelPluginFailures: dedupeChannelPluginFailures([
+      ...(installed.channelPluginFailures ?? []),
+      ...(runtime.channelPluginFailures ?? []),
+    ]),
+    compatibilityNotices: dedupeCompatibilityNotices([
+      ...(installed.compatibilityNotices ?? []),
+      ...(runtime.compatibilityNotices ?? []),
+    ]),
   };
 }
 
-function countEnabledDependencyIssues(plugins: readonly PluginHealthRecord[]): number {
-  return plugins.filter(
-    (plugin) =>
-      plugin.enabled !== false &&
-      plugin.dependencyStatus?.hasDependencies === true &&
-      plugin.dependencyStatus.requiredInstalled === false,
-  ).length;
+function hasDependencyIssue(plugin: PluginHealthRecord): boolean {
+  return (
+    plugin.enabled !== false &&
+    plugin.dependencyStatus?.hasDependencies === true &&
+    plugin.dependencyStatus.requiredInstalled === false
+  );
 }
 
 function shouldSuppressChannelPluginDiagnostic(
@@ -172,6 +164,8 @@ function shouldSuppressChannelPluginDiagnostic(
   if (!isChannelPluginFailureDiagnostic(diagnostic)) {
     return false;
   }
+  // Only suppress when the failure is actually reported in the channel
+  // section; otherwise the diagnostic must still count as a problem.
   return channelPluginFailures.some(
     (failure) =>
       failure.message === diagnostic.message &&
@@ -199,56 +193,33 @@ function countProblemDiagnostics(diagnostics: readonly PluginDiagnosticRecord[])
 }
 
 export function isChannelPluginFailureDiagnostic(diagnostic: PluginDiagnosticRecord): boolean {
-  if (diagnostic.level !== "error") {
-    return false;
-  }
-  return /failed to (?:apply setup(?:-runtime)? channel runtime|load setup(?:-runtime)? channel entry|load setup entry|register setup(?:-runtime)? channel)/iu.test(
-    diagnostic.message,
-  );
+  return diagnostic.level === "error" && diagnostic.code === "channel-setup-failure";
+}
+
+function formatCount(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }
 
 export function formatCompactPluginHealthLine(snapshot: StatusPluginHealthSnapshot): string {
   const loadErrors = snapshot.plugins.filter((plugin) => plugin.status === "error").length;
-  const dependencyIssues = countEnabledDependencyIssues(snapshot.plugins);
-  const diagnostics = getReportableDiagnostics(snapshot);
-  const diagnosticCounts = countProblemDiagnostics(diagnostics);
+  const dependencyIssues = snapshot.plugins.filter(hasDependencyIssue).length;
+  const diagnosticErrors = countProblemDiagnostics(getReportableDiagnostics(snapshot)).errors;
   const quarantines = snapshot.contextEngineQuarantines.length;
   const runtimeToolQuarantines = snapshot.runtimeToolQuarantines?.length ?? 0;
   const channelPluginFailures = snapshot.channelPluginFailures?.length ?? 0;
-  const problems =
-    loadErrors +
-    dependencyIssues +
-    diagnosticCounts.errors +
-    quarantines +
-    runtimeToolQuarantines +
-    channelPluginFailures;
-
-  if (problems === 0) {
-    return "🔌 Plugins: OK";
-  }
 
   const parts = [
-    loadErrors > 0 ? `${loadErrors} plugin error${loadErrors === 1 ? "" : "s"}` : null,
-    quarantines > 0
-      ? `${quarantines} context engine quarantine${quarantines === 1 ? "" : "s"}`
-      : null,
+    loadErrors > 0 ? formatCount(loadErrors, "plugin error") : null,
+    quarantines > 0 ? formatCount(quarantines, "context engine quarantine") : null,
     runtimeToolQuarantines > 0
-      ? `${runtimeToolQuarantines} runtime tool quarantine${
-          runtimeToolQuarantines === 1 ? "" : "s"
-        }`
+      ? formatCount(runtimeToolQuarantines, "runtime tool quarantine")
       : null,
-    channelPluginFailures > 0
-      ? `${channelPluginFailures} channel plugin failure${channelPluginFailures === 1 ? "" : "s"}`
-      : null,
-    dependencyIssues > 0
-      ? `${dependencyIssues} dependency issue${dependencyIssues === 1 ? "" : "s"}`
-      : null,
-    diagnosticCounts.errors > 0
-      ? `${diagnosticCounts.errors} diagnostic error${diagnosticCounts.errors === 1 ? "" : "s"}`
-      : null,
+    channelPluginFailures > 0 ? formatCount(channelPluginFailures, "channel plugin failure") : null,
+    dependencyIssues > 0 ? formatCount(dependencyIssues, "dependency issue") : null,
+    diagnosticErrors > 0 ? formatCount(diagnosticErrors, "diagnostic error") : null,
   ].filter((part): part is string => Boolean(part));
 
-  return `⚠️ Plugins: ${parts.join(" · ")}`;
+  return parts.length === 0 ? "🔌 Plugins: OK" : `⚠️ Plugins: ${parts.join(" · ")}`;
 }
 
 function formatPluginList(ids: readonly string[], limit: number): string {
@@ -259,31 +230,38 @@ function formatPluginList(ids: readonly string[], limit: number): string {
   return ids.length > limit ? `${visible}, +${ids.length - limit} more` : visible;
 }
 
+function byLocale(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
 export function formatDetailedPluginHealth(snapshot: StatusPluginHealthSnapshot): string {
   const loaded = snapshot.plugins
     .filter((plugin) => plugin.status === "loaded")
     .map((plugin) => plugin.id)
-    .toSorted((left, right) => left.localeCompare(right));
+    .toSorted(byLocale);
   const disabled = snapshot.plugins.filter((plugin) => plugin.status === "disabled").length;
   const errors = snapshot.plugins
     .filter((plugin) => plugin.status === "error")
-    .toSorted((left, right) => left.id.localeCompare(right.id));
+    .toSorted((left, right) => byLocale(left.id, right.id));
   const dependencyIssues = snapshot.plugins
-    .filter(
-      (plugin) =>
-        plugin.enabled !== false &&
-        plugin.dependencyStatus?.hasDependencies === true &&
-        plugin.dependencyStatus.requiredInstalled === false,
-    )
-    .toSorted((left, right) => left.id.localeCompare(right.id));
+    .filter(hasDependencyIssue)
+    .toSorted((left, right) => byLocale(left.id, right.id));
   const diagnostics = getReportableDiagnostics(snapshot);
   const diagnosticCounts = countProblemDiagnostics(diagnostics);
-  const runtimeToolQuarantines = snapshot.runtimeToolQuarantines ?? [];
-  const compatibilityNotices = snapshot.compatibilityNotices ?? [];
-  const channelPluginFailures = snapshot.channelPluginFailures ?? [];
-  const header = formatCompactPluginHealthLine(snapshot);
+  const contextEngineQuarantines = snapshot.contextEngineQuarantines.toSorted((left, right) =>
+    byLocale(left.engineId, right.engineId),
+  );
+  const runtimeToolQuarantines = (snapshot.runtimeToolQuarantines ?? []).toSorted((left, right) =>
+    byLocale(left.toolName, right.toolName),
+  );
+  const compatibilityNotices = (snapshot.compatibilityNotices ?? []).toSorted((left, right) =>
+    byLocale(left.pluginId, right.pluginId),
+  );
+  const channelPluginFailures = (snapshot.channelPluginFailures ?? []).toSorted((left, right) =>
+    byLocale(left.channelId, right.channelId),
+  );
   const lines = [
-    header,
+    formatCompactPluginHealthLine(snapshot),
     `Loaded: ${loaded.length}${loaded.length > 0 ? ` (${formatPluginList(loaded, 8)})` : ""}`,
     `Disabled: ${disabled}`,
   ];
@@ -298,10 +276,10 @@ export function formatDetailedPluginHealth(snapshot: StatusPluginHealthSnapshot)
     );
   }
 
-  if (snapshot.contextEngineQuarantines.length > 0) {
+  if (contextEngineQuarantines.length > 0) {
     lines.push(
-      `Context engine quarantines: ${snapshot.contextEngineQuarantines.length}`,
-      ...snapshot.contextEngineQuarantines.slice(0, 8).map((entry) => {
+      `Context engine quarantines: ${contextEngineQuarantines.length}`,
+      ...contextEngineQuarantines.slice(0, 8).map((entry) => {
         const owner = entry.owner ? ` owner=${entry.owner}` : "";
         return `- ${entry.engineId}${owner} during ${entry.operation}: ${entry.reason}`;
       }),

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -47,6 +47,7 @@ import {
   formatTaskStatusDetail,
   formatTaskStatusTitle,
 } from "../tasks/task-status.js";
+import { formatCompactPluginHealthLine } from "./status-plugin-health.js";
 import type { BuildStatusTextParams } from "./status-text.types.js";
 export type { BuildStatusTextParams } from "./status-text.types.js";
 
@@ -67,6 +68,9 @@ let agentHarnessSelectionRuntimePromise: Promise<
 let statusQueueRuntimePromise: Promise<typeof import("./status-queue.runtime.js")> | null = null;
 let statusSubagentsRuntimePromise: Promise<typeof import("./status-subagents.runtime.js")> | null =
   null;
+let statusPluginHealthRuntimePromise: Promise<
+  typeof import("./status-plugin-health.runtime.js")
+> | null = null;
 
 function loadStatusMessageRuntime(): Promise<typeof import("../auto-reply/status.runtime.js")> {
   const runtimePromise = (statusMessageRuntimePromise ??=
@@ -92,6 +96,14 @@ function loadStatusSubagentsRuntime(): Promise<typeof import("./status-subagents
 
 function loadStatusQueueRuntime(): Promise<typeof import("./status-queue.runtime.js")> {
   const runtimePromise = (statusQueueRuntimePromise ??= import("./status-queue.runtime.js"));
+  return runtimePromise;
+}
+
+function loadStatusPluginHealthRuntime(): Promise<
+  typeof import("./status-plugin-health.runtime.js")
+> {
+  const runtimePromise = (statusPluginHealthRuntimePromise ??=
+    import("./status-plugin-health.runtime.js"));
   return runtimePromise;
 }
 
@@ -266,6 +278,15 @@ export function buildStatusUptimeLine(): string {
   const gatewayUptimeMs = Math.max(0, Math.round(process.uptime() * 1000));
   const systemUptimeMs = Math.max(0, Math.round(os.uptime() * 1000));
   return `⏱️ Uptime: gateway ${formatStatusUptimeDuration(gatewayUptimeMs)} · system ${formatStatusUptimeDuration(systemUptimeMs)}`;
+}
+
+async function resolveRuntimePluginHealthLine(): Promise<string> {
+  try {
+    const { collectRuntimePluginHealthSnapshot } = await loadStatusPluginHealthRuntime();
+    return formatCompactPluginHealthLine(collectRuntimePluginHealthSnapshot());
+  } catch {
+    return "⚠️ Plugins: health unavailable";
+  }
 }
 
 // Public status text builder for CLI/chat status commands. It resolves dynamic
@@ -510,6 +531,9 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     allowPluginNormalization: false,
   });
   const configuredDefaultModelLabel = `${configuredDefaultRef.provider}/${configuredDefaultRef.model}`;
+  const pluginHealthLine = Object.hasOwn(params, "pluginHealthLineOverride")
+    ? params.pluginHealthLineOverride
+    : await resolveRuntimePluginHealthLine();
   const { buildStatusMessage } = await loadStatusMessageRuntime();
   const explicitThinkingDefault =
     (agentConfig?.thinkingDefault as ThinkLevel | undefined) ??
@@ -595,6 +619,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     },
     subagentsLine,
     taskLine,
+    pluginHealthLine,
     mediaDecisions: params.mediaDecisions,
     includeTranscriptUsage: params.includeTranscriptUsage ?? true,
   });

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -280,18 +280,10 @@ export function buildStatusUptimeLine(): string {
   return `⏱️ Uptime: gateway ${formatStatusUptimeDuration(gatewayUptimeMs)} · system ${formatStatusUptimeDuration(systemUptimeMs)}`;
 }
 
-async function resolveRuntimePluginHealthLine(params: {
-  cfg: OpenClawConfig;
-  workspaceDir: string;
-}): Promise<string> {
+async function resolveRuntimePluginHealthLine(): Promise<string> {
   try {
     const { collectRuntimePluginHealthSnapshot } = await loadStatusPluginHealthRuntime();
-    return formatCompactPluginHealthLine(
-      collectRuntimePluginHealthSnapshot({
-        config: params.cfg,
-        workspaceDir: params.workspaceDir,
-      }),
-    );
+    return formatCompactPluginHealthLine(collectRuntimePluginHealthSnapshot());
   } catch {
     return "⚠️ Plugins: health unavailable";
   }
@@ -541,7 +533,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
   const configuredDefaultModelLabel = `${configuredDefaultRef.provider}/${configuredDefaultRef.model}`;
   const pluginHealthLine = Object.hasOwn(params, "pluginHealthLineOverride")
     ? params.pluginHealthLineOverride
-    : await resolveRuntimePluginHealthLine({ cfg, workspaceDir: statusWorkspaceDir });
+    : await resolveRuntimePluginHealthLine();
   const { buildStatusMessage } = await loadStatusMessageRuntime();
   const explicitThinkingDefault =
     (agentConfig?.thinkingDefault as ThinkLevel | undefined) ??

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -280,10 +280,18 @@ export function buildStatusUptimeLine(): string {
   return `⏱️ Uptime: gateway ${formatStatusUptimeDuration(gatewayUptimeMs)} · system ${formatStatusUptimeDuration(systemUptimeMs)}`;
 }
 
-async function resolveRuntimePluginHealthLine(): Promise<string> {
+async function resolveRuntimePluginHealthLine(params: {
+  cfg: OpenClawConfig;
+  workspaceDir: string;
+}): Promise<string> {
   try {
     const { collectRuntimePluginHealthSnapshot } = await loadStatusPluginHealthRuntime();
-    return formatCompactPluginHealthLine(collectRuntimePluginHealthSnapshot());
+    return formatCompactPluginHealthLine(
+      collectRuntimePluginHealthSnapshot({
+        config: params.cfg,
+        workspaceDir: params.workspaceDir,
+      }),
+    );
   } catch {
     return "⚠️ Plugins: health unavailable";
   }
@@ -533,7 +541,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
   const configuredDefaultModelLabel = `${configuredDefaultRef.provider}/${configuredDefaultRef.model}`;
   const pluginHealthLine = Object.hasOwn(params, "pluginHealthLineOverride")
     ? params.pluginHealthLineOverride
-    : await resolveRuntimePluginHealthLine();
+    : await resolveRuntimePluginHealthLine({ cfg, workspaceDir: statusWorkspaceDir });
   const { buildStatusMessage } = await loadStatusMessageRuntime();
   const explicitThinkingDefault =
     (agentConfig?.thinkingDefault as ThinkLevel | undefined) ??

--- a/src/status/status-text.types.ts
+++ b/src/status/status-text.types.ts
@@ -34,6 +34,7 @@ export type BuildStatusTextParams = {
   defaultGroupActivation: () => "always" | "mention";
   mediaDecisions?: MediaUnderstandingDecision[];
   taskLineOverride?: string;
+  pluginHealthLineOverride?: string;
   skipDefaultTaskLookup?: boolean;
   primaryModelLabelOverride?: string;
   modelAuthOverride?: string;


### PR DESCRIPTION
## Summary
- add compact plugin health to `/status` and detailed `/status plugins`
- surface plugin load errors, enabled dependency failures, diagnostic errors, context-engine quarantines, channel setup failures, and runtime tool-schema quarantines
- keep compatibility notices detail-only so they do not flip compact `Plugins: OK`

## Behavior notes
- `/status` now accepts arguments (`acceptsArgs: true`), so any message starting with `/status ` is handled as a command. Unknown subcommands (e.g. `/status please`) get a short error reply instead of falling through to the agent. This is an intentional, maintainer-approved contract change matching the other arg-accepting commands (`/goal`, `/fast`, `/model`).
- Compact `/status` reads only the active plugin registry and the persisted health stores. Config-driven channel inspection (including "configured channel plugin is missing or unavailable" detection) runs only in `/status plugins`, keeping the chat-command path free of disk/discovery work.
- Persisted quarantine records surface only with a positive process-incarnation match and otherwise fail closed: own-PID records must match a per-process random token (works on every platform), and sibling-PID records must match the recorder's Linux /proc start time. Where sibling identity cannot be verified (non-Linux hosts, /proc read failures, recycled PIDs), the record is hidden rather than trusted. Tool-schema quarantine records additionally carry a 24h TTL refreshed by recurring failures.
- Tool-schema quarantines self-clear on recovery: the schema-diagnostics callback fires on every normalization (including the all-clear), and the recorder keeps a process-local set of persisted keys so the per-run path does zero store IO unless this process actually has a quarantine that may have recovered.

## Design
- Channel-setup failures are classified by a closed `code: "channel-setup-failure"` on `PluginDiagnostic`, attached at the loader's `recordPluginError` sites — no freeform message matching.
- Cross-process quarantine persistence (context-engine + tool-schema) shares one SQLite-backed helper, `src/plugin-state/runtime-health-store.ts`, with per-store semantics documented at the option sites (earliest-wins root cause for context engines, latest-wins + TTL for tool schemas).

## Live proof
Captured on a live gateway running `OpenClaw 2026.6.2 (7cf15e2)` with special-purpose proof fixtures.

Evidence file on the proof host:
`/var/lib/openclaw/runtime-source/openclaw-main/.local/plugin-health-live-after-fixture-restart.md`

Observed compact `/status`:
```text
⚠️ Plugins: 1 plugin error · 1 runtime tool quarantine · 1 channel plugin failure
```

Observed detailed `/status plugins` included:
```text
Runtime tool quarantines: 1
- plugin_health_bad_schema owner=plugin:plugin-health-bad-tool-proof: plugin_health_bad_schema.parameters.type must be "object"

Channel plugin failures: 1
- plugin-health-channel-fail-proof plugin=plugin-health-channel-fail-proof [diagnostic]: failed to load setup entry: Error: plugin health matrix setup failure

Compatibility notices: 2
- WARN plugin-health-compat-proof [legacy-before-agent-start]: still uses legacy before_agent_start; keep regression coverage on this plugin, and prefer before_model_resolve/before_prompt_build for new work.
- INFO plugin-health-compat-proof [hook-only]: is hook-only. This remains a supported compatibility path, but it has not migrated to explicit capability registration yet.
```

SQLite persistence was also confirmed in `plugin_state_entries` under `core:runtime-tool-quarantine-health` for `plugin_health_bad_schema`.

After restoring normal plugin config, Josh confirmed restored status was back to OK.

## Validation
- `pnpm tsgo:core`, `pnpm check:test-types`
- `pnpm test` over status, context-engine, tool-schema-quarantine, runtime-plan tools, plugin loader, doctor tool-schema warnings/core-checks, command-control, commands-status/info, read-only channel plugins, plugins status — all passing (sibling-visibility cases are Linux-gated and run on CI)
- `pnpm build` (no `[INEFFECTIVE_DYNAMIC_IMPORT]`), `pnpm check:import-cycles`, oxlint on touched files, `git diff --check`
- live proof above covered the runtime behavior on the original revision; follow-up refactors are covered by the unit/runtime suites
