### PR TITLE
fix(auto-reply): defer foreground fence until delivery

### DIFF
--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -138,6 +138,91 @@ describe("foreground reply freshness", () => {
     expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
   });
 
+  it("keeps fresh settled delivery active when no ordinary delivery creates a foreground fence", async () => {
+    const deliveries: Delivery[] = [];
+    const onFreshSettledDelivery = vi.fn(() => ({ visibleReplySent: true }));
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "no-delivery-message") {
+          return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const result = await dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "no-delivery-message" }),
+      deliveries,
+      { onFreshSettledDelivery },
+    );
+
+    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+    expect(deliveries).toEqual([]);
+    expect(onFreshSettledDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an older foreground final when a newer same-session dispatch is pending before visible delivery", async () => {
+    const deliveries: Delivery[] = [];
+    const beforeDeliverStarted = createDeferred<void>();
+    const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
+    const newerPending = createDeferred<void>();
+    const beforeDeliver = vi.fn(() => {
+      beforeDeliverStarted.resolve();
+      return releaseBeforeDeliver.promise;
+    });
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "old-message") {
+          params.dispatcher.sendFinalReply({ text: "old final" });
+          return queuedFinalResult();
+        }
+        if (params.ctx.MessageSid === "new-message") {
+          await newerPending.promise;
+          params.dispatcher.sendFinalReply({ text: "new final" });
+          return queuedFinalResult();
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const olderDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "old-message" }),
+      deliveries,
+      { beforeDeliver },
+    );
+    await beforeDeliverStarted.promise;
+
+    const newerDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "new-message" }),
+      deliveries,
+    );
+    await Promise.resolve();
+
+    releaseBeforeDeliver.resolve({ text: "old rewritten final" });
+    const olderResult = await olderDispatch;
+
+    expect(beforeDeliver).toHaveBeenCalledTimes(1);
+    expect(olderResult).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(deliveries).toEqual([{ kind: "final", text: "old rewritten final" }]);
+
+    newerPending.resolve();
+    const newerResult = await newerDispatch;
+
+    expect(newerResult).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(deliveries).toEqual([
+      { kind: "final", text: "old rewritten final" },
+      { kind: "final", text: "new final" },
+    ]);
+  });
+
   it("keeps an older foreground final when a newer inbound has no visible delivery while beforeDeliver is pending", async () => {
     const deliveries: Delivery[] = [];
     const beforeDeliverStarted = createDeferred<void>();

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -555,20 +555,22 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
     ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
     : globalBeforeDeliver;
-  const beforeDeliver: ReplyDispatchBeforeDeliver = async (payload, info) => {
-    const fence = getForegroundReplyFence();
-    // Check both before and after hooks because hooks can await while newer replies finish.
-    if (await shouldCancelForegroundReplyDelivery(fence)) {
-      return null;
-    }
-    const deliverPayload = configuredBeforeDeliver
-      ? await configuredBeforeDeliver(payload, info)
-      : payload;
-    if (!deliverPayload || (await shouldCancelForegroundReplyDelivery(fence))) {
-      return null;
-    }
-    return deliverPayload;
-  };
+  const beforeDeliver: ReplyDispatchBeforeDeliver | undefined = configuredBeforeDeliver
+    ? async (payload, info) => {
+        const fence = getForegroundReplyFence();
+        // Check both before and after hooks because hooks can await while newer replies finish.
+        if (await shouldCancelForegroundReplyDelivery(fence)) {
+          return null;
+        }
+        const deliverPayload = configuredBeforeDeliver
+          ? await configuredBeforeDeliver(payload, info)
+          : payload;
+        if (!deliverPayload || (await shouldCancelForegroundReplyDelivery(fence))) {
+          return null;
+        }
+        return deliverPayload;
+      }
+    : undefined;
   const deliver: ReplyDispatcherWithTypingOptions["deliver"] = async (payload, info) => {
     const fence = getForegroundReplyFence();
     try {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -539,7 +539,11 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   onSessionMetadataChanges?: (changes: CommandSessionMetadataChange[]) => void;
 }): Promise<DispatchInboundResult> {
   const finalized = finalizeInboundContext(params.ctx);
-  const foregroundReplyFence = beginForegroundReplyFence(finalized);
+  let foregroundReplyFence: ForegroundReplyFenceSnapshot | undefined;
+  const getForegroundReplyFence = () => {
+    foregroundReplyFence ??= beginForegroundReplyFence(finalized);
+    return foregroundReplyFence;
+  };
   const silentReplyContext = resolveDispatcherSilentReplyContext(finalized, params.cfg);
   const replyPayloadBeforeDeliver = buildReplyPayloadSendingBeforeDeliver(finalized, {
     runId: params.replyOptions?.runId,
@@ -551,33 +555,29 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
     ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
     : globalBeforeDeliver;
-  const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
-    foregroundReplyFence || configuredBeforeDeliver
-      ? async (payload, info) => {
-          // Check both before and after hooks because hooks can await while newer replies finish.
-          if (await shouldCancelForegroundReplyDelivery(foregroundReplyFence)) {
-            return null;
-          }
-          const deliverPayload = configuredBeforeDeliver
-            ? await configuredBeforeDeliver(payload, info)
-            : payload;
-          if (
-            !deliverPayload ||
-            (await shouldCancelForegroundReplyDelivery(foregroundReplyFence))
-          ) {
-            return null;
-          }
-          return deliverPayload;
-        }
-      : undefined;
+  const beforeDeliver: ReplyDispatchBeforeDeliver = async (payload, info) => {
+    const fence = getForegroundReplyFence();
+    // Check both before and after hooks because hooks can await while newer replies finish.
+    if (await shouldCancelForegroundReplyDelivery(fence)) {
+      return null;
+    }
+    const deliverPayload = configuredBeforeDeliver
+      ? await configuredBeforeDeliver(payload, info)
+      : payload;
+    if (!deliverPayload || (await shouldCancelForegroundReplyDelivery(fence))) {
+      return null;
+    }
+    return deliverPayload;
+  };
   const deliver: ReplyDispatcherWithTypingOptions["deliver"] = async (payload, info) => {
+    const fence = getForegroundReplyFence();
     try {
       const result = await params.dispatcherOptions.deliver(payload, info);
-      markForegroundReplyFenceVisibleDelivery(foregroundReplyFence, payload, result);
+      markForegroundReplyFenceVisibleDelivery(fence, payload, result);
       return result;
     } catch (err: unknown) {
       if (isVisiblePartialDeliveryError(err)) {
-        markForegroundReplyFenceVisibleDelivery(foregroundReplyFence, payload, {
+        markForegroundReplyFenceVisibleDelivery(fence, payload, {
           visibleReplySent: true,
         });
       }
@@ -608,7 +608,7 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   } finally {
     try {
       const settledResult = await params.dispatcherOptions.onSettled?.();
-      if (isExplicitlyVisibleDelivery(settledResult)) {
+      if (foregroundReplyFence && isExplicitlyVisibleDelivery(settledResult)) {
         markForegroundReplyFenceVisibleDeliveryGeneration(foregroundReplyFence);
       }
       await runForegroundReplyFenceFreshSettledDelivery(


### PR DESCRIPTION
## Summary

Fixes #91914.

This defers foreground reply fence creation until a buffered dispatch first attempts visible/source delivery, instead of creating the fence as soon as the inbound dispatch enters `dispatchInboundMessageWithBufferedDispatcher()`.

The previous ordering could create a hybrid state for same-session follow-up messages:

- the older turn is still running and has not been aborted;
- the newer turn is queued behind it and has not been admitted to run yet;
- but the newer turn has already advanced the foreground freshness generation;
- the older turn's later source delivery can then be treated as stale before it reaches the originating plugin/channel.

That means an external channel can stop receiving the older response even though the older turn continues in the web/session UI and the newer turn is still waiting.

With this change, queued same-session turns do not advance foreground freshness until they actually attempt visible/source delivery.

## Changes

- Lazily starts `foregroundReplyFence` from `beforeDeliver` / `deliver`.
- Keeps `onSettled`, `onFreshSettledDelivery`, and `endForegroundReplyFence` undefined-safe when no visible/source delivery was attempted.
- Adds a freshness regression test where a newer same-session dispatch remains pending before visible delivery while the older pending source delivery is allowed to complete.

## Validation

- `git diff --check` passed.
- Lightweight marker/sanity check passed locally.
- I also validated the equivalent built-dist patch on a local gateway with a plugin-backed external channel: while an older response was still delivering, a newer same-session inbound no longer cut off the older response's later plugin/channel delivery.

Targeted vitest could not be run in this local checkout because `pnpm exec` triggered dependency installation and the repository lockfile currently hits the active pnpm supply-chain `minimumReleaseAge` policy for recently published optional Codex platform packages. I did not modify the lockfile or relax that policy locally.
