### PR TITLE
fix(cron): report canonical SQLite path in cron status (fixes #91766)

### DIFF
--- a/src/cron/service.read-ops-nonblocking.test.ts
+++ b/src/cron/service.read-ops-nonblocking.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { CronService } from "./service.js";
 import { writeCronStoreSnapshot } from "./service.test-harness.js";
 
@@ -79,10 +80,10 @@ function createDeferredIsolatedRun() {
 
 function expectCronStatus(
   status: Awaited<ReturnType<CronService["status"]>>,
-  params: { storePath: string; jobs: number },
+  params: { jobs: number },
 ) {
   expect(status.enabled).toBe(true);
-  expect(status.storePath).toBe(params.storePath);
+  expect(status.storePath).toBe(resolveOpenClawStateSqlitePath());
   expect(status.jobs).toBe(params.jobs);
   if (status.nextWakeAtMs !== null) {
     expect(status.nextWakeAtMs).toBeTypeOf("number");
@@ -142,7 +143,7 @@ describe("CronService read ops while job is running", () => {
       expect(isolatedRun.runIsolatedAgentJob).toHaveBeenCalledTimes(1);
 
       await expect(cron.list({ includeDisabled: true })).resolves.toHaveLength(1);
-      expectCronStatus(await cron.status(), { storePath: store.storePath, jobs: 1 });
+      expectCronStatus(await cron.status(), { jobs: 1 });
 
       const running = await cron.list({ includeDisabled: true });
       expect(running[0]?.state.runningAtMs).toBeTypeOf("number");
@@ -212,7 +213,6 @@ describe("CronService read ops while job is running", () => {
         withTimeout(cron.list({ includeDisabled: true }), 300, "cron.list during cron.run"),
       ).resolves.toHaveLength(1);
       expectCronStatus(await withTimeout(cron.status(), 300, "cron.status during cron.run"), {
-        storePath: store.storePath,
         jobs: 1,
       });
 
@@ -274,7 +274,6 @@ describe("CronService read ops while job is running", () => {
         withTimeout(cron.list({ includeDisabled: true }), 300, "cron.list during startup"),
       ).resolves.toHaveLength(1);
       expectCronStatus(await withTimeout(cron.status(), 300, "cron.status during startup"), {
-        storePath: store.storePath,
         jobs: 1,
       });
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import {
   completeTaskRunByRunId,
   createRunningTaskRun,
@@ -253,7 +254,7 @@ export async function status(state: CronServiceState) {
     await ensureLoadedForRead(state);
     return {
       enabled: state.deps.cronEnabled,
-      storePath: state.deps.storePath,
+      storePath: resolveOpenClawStateSqlitePath(),
       jobs: state.store?.jobs.length ?? 0,
       nextWakeAtMs: state.deps.cronEnabled ? (nextWakeAtMs(state) ?? null) : null,
     };

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -1179,7 +1179,7 @@ describe("gateway server cron", () => {
         | undefined;
       expect(statusPayload?.enabled).toBe(true);
       const storePath = typeof statusPayload?.storePath === "string" ? statusPayload.storePath : "";
-      expect(storePath).toContain("jobs.json");
+      expect(storePath).toContain("openclaw.sqlite");
 
       const autoRes = await directCronReq(cronState, "cron.add", {
         name: "auto run test",


### PR DESCRIPTION
### Summary

- **Problem**: `openclaw cron status` reports the legacy JSON store path (`~/.openclaw/cron/jobs.json`) even though cron storage was migrated to the shared SQLite state database. This confuses users and agents into thinking the legacy JSON file is still authoritative.
- **Root Cause**: `cron.status()` in `src/cron/service/ops.ts` returns `storePath: state.deps.storePath`, which resolves to the legacy JSON path via `resolveCronJobsStorePath()`. The actual cron rows are stored in SQLite (`openOpenClawStateDatabase().db`) using the legacy path only as a logical partition key.
- **Fix**: Changed `cron.status()` to report the canonical SQLite database path via `resolveOpenClawStateSqlitePath()` instead of the legacy JSON store path.
- **What changed**:
  - `src/cron/service/ops.ts` — import `resolveOpenClawStateSqlitePath` and use it for the status `storePath` field
  - `src/cron/service.read-ops-nonblocking.test.ts` — update `expectCronStatus` to assert SQLite path pattern
  - `src/gateway/server.cron.test.ts` — update assertion to expect `openclaw.sqlite` instead of `jobs.json`
- **What did NOT change (scope boundary)**:
  - The logical `state.deps.storePath` key used internally for SQLite partition lookups is untouched
  - No changes to cron storage, loading, or persistence — storage was already SQLite-backed
  - No changes to the `CronStatusSummary` type shape — only the runtime value of `storePath` changed

### Reproduction

1. Run `openclaw cron status` on 2026.6.1+
2. **Before this PR**: `storePath` field shows `/home/<user>/.openclaw/cron/jobs.json` (legacy JSON path)
3. **After this PR**: `storePath` field shows `/home/<user>/.openclaw/state/openclaw.sqlite` (canonical SQLite path)

### Real behavior proof

**Behavior or issue addressed (91766)**: The `cron status` output now reflects the actual SQLite-backed storage location instead of the legacy JSON path. The status function resolves the canonical SQLite database path at runtime rather than returning the legacy store key used internally for partition lookups.

**Real environment tested**: Linux, Node 22 — test infrastructure with fake timers against `CronService.status()`, cron read-ops, CLI cron commands, and gateway cron server methods

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/cron/service.read-ops-nonblocking.test.ts src/cli/cron-cli.test.ts src/cron/cron-protocol-conformance.test.ts src/gateway/server.cron.test.ts`

**Evidence after fix**:
```text
 ✓ |cron| src/cron/service.read-ops-nonblocking.test.ts > CronService read ops while job is running > keeps list and status responsive during a long isolated run
 ✓ |cron| src/cron/service.read-ops-nonblocking.test.ts > CronService read ops while job is running > keeps list and status responsive during manual cron.run execution
 ✓ |cron| src/cron/service.read-ops-nonblocking.test.ts > CronService read ops while job is running > keeps list and status responsive after startup defers catch-up runs
 ✓ |cron| src/cron/cron-protocol-conformance.test.ts 
 ✓ |cli| src/cli/cron-cli.test.ts 
 ✓ |gateway| src/gateway/server.cron.test.ts 

 Test Files  5 passed
      Tests  132 passed
```

**Observed result after fix**: The `expectCronStatus` helper no longer accepts a `storePath` parameter — it asserts against `resolveOpenClawStateSqlitePath()` directly. The gateway cron test now checks that the status response contains `openclaw.sqlite` instead of `jobs.json`. All 132 tests across the cron, CLI, and gateway test suites continue to pass without regression.

**What was not tested**: A live `openclaw cron status` CLI invocation against a running gateway process was not driven — the fix is validated through the test infrastructure, which exercises the same code path (`cron.status()` → CronStatusSummary) with the same runtime environment (`process.env`) that resolves the state directory.

**Repro confirmation**: Before the patch, `cron.status().storePath` returned the legacy JSON path (e.g. `/tmp/.../cron/jobs.json`). After the patch, the same call returns the SQLite path (e.g. `/tmp/.../state/openclaw.sqlite`). The test that previously asserted `storePath` matched the test fixture's `store.storePath` now asserts it matches `resolveOpenClawStateSqlitePath()`, confirming the fix transforms the output without changing the internal storage key.

### Risk / Mitigation

- **Risk**: External scripts that parse `cron status` output may depend on `storePath` containing a `.json` extension
  **Mitigation**: The SQLite path ends in `.sqlite`, which is as distinctive as `.json`. Any script updating from the legacy path format would need to update regardless — the previous value pointed to an outdated file that no longer contained authoritative cron data.
- **Risk**: Changing a gateway JSON response field value could surprise API consumers
  **Mitigation**: The `storePath` field is documented as the storage location. Reporting the actual storage location corrects a bug rather than introducing a behavioral change. The field type (`string`) and name are unchanged.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] cron service
- [x] CLI commands
- [x] gateway server methods

### Regression Test Plan

- `node scripts/run-vitest.mjs src/cron/service.read-ops-nonblocking.test.ts`
- `node scripts/run-vitest.mjs src/cli/cron-cli.test.ts`
- `node scripts/run-vitest.mjs src/cron/cron-protocol-conformance.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server.cron.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #91766
