### PR TITLE
fix(cron): keep main-session one-shot result ok when immediate heartbeat is skipped

### DIFF
--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -449,6 +449,39 @@ describe("CronService", () => {
     await stopCronAndCleanup(cron, store);
   });
 
+  it("wakeMode now records ok and queues fallback heartbeat when immediate heartbeat is disabled (#91775)", async () => {
+    // Regression: when heartbeats are disabled globally or for the agent,
+    // runHeartbeatOnce returns { status: "skipped", reason: "disabled" }. The
+    // main-session systemEvent has already been enqueued at this point, so the
+    // cron run must NOT be reported as skipped — otherwise applyJobResult
+    // disables the one-shot at-job instead of deleting it, leaving a zombie
+    // disabled row in cron_jobs.
+    const runHeartbeatOnce = vi.fn(async () => ({
+      status: "skipped" as const,
+      reason: "disabled",
+    }));
+
+    const { store, cron, requestHeartbeat } = await createWakeModeNowMainHarness({
+      runHeartbeatOnce,
+    });
+
+    const sessionKey = "agent:main:discord:channel:ops";
+    const job = await addWakeModeNowMainSystemEventJob(cron, {
+      name: "wakeMode now disabled-heartbeat fallback",
+      sessionKey,
+    });
+
+    await cron.run(job.id, "force");
+
+    expect(runHeartbeatOnce).toHaveBeenCalledTimes(1);
+    expectQueuedCronHeartbeat(requestHeartbeat, { jobId: job.id });
+    expect(job.state.lastStatus).toBe("ok");
+    expect(job.state.lastError).toBeUndefined();
+
+    await cron.list({ includeDisabled: true });
+    await stopCronAndCleanup(cron, store);
+  });
+
   it("runs an isolated job without posting a fallback summary to main", async () => {
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
     const { store, cron, enqueueSystemEvent, requestHeartbeat, events } =

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1517,12 +1517,21 @@ async function executeMainSessionCronJob(
       return { status: "ok", summary: text, sessionKey: cronRunSessionKey };
     }
     if (heartbeatResult.status === "skipped") {
-      return {
-        status: "skipped",
-        error: heartbeatResult.reason,
-        summary: text,
+      // The main-session system event has already been enqueued above. A skipped
+      // immediate heartbeat (for example because heartbeats are globally disabled)
+      // must not flip the cron run to "skipped": doing so causes one-shot at-jobs
+      // to be disabled instead of deleted by applyJobResult and leaves zombie
+      // disabled rows in cron_jobs (#91775). Fall back to a queued heartbeat so
+      // the wake is still requested via the event lane.
+      state.deps.requestHeartbeat({
+        source: "cron",
+        intent: "immediate",
+        reason,
+        agentId: job.agentId,
         sessionKey: cronRunSessionKey,
-      };
+        heartbeat: { target: "last" },
+      });
+      return { status: "ok", summary: text, sessionKey: cronRunSessionKey };
     }
     return {
       status: "error",


### PR DESCRIPTION
Closes #91775.

## Summary

When a `sessionTarget: "main"` one-shot `at` cron job runs with default `wakeMode: "now"`, `executeMainSessionCronJob` first enqueues the system event (success), then calls `runHeartbeatOnce` for the immediate wake. If heartbeats are globally disabled, disabled for the agent, or have no interval, `runHeartbeatOnce` returns `{ status: "skipped", reason: "disabled" }` (`src/infra/heartbeat-runner.ts:1320-1326`). The previous main-session executor then returned `{ status: "skipped", error: "disabled" }`, even though the system event had already been delivered. `applyJobResult` (`src/cron/service/timer.ts:533-544`) then **disables** the `at` job and clears `nextRunAtMs` instead of deleting it, because `deleteAfterRun` only deletes on `result.status === "ok"`. Result: every affected one-shot job is recorded as `skipped/disabled` and persists in the table forever.

This fix mirrors the existing `HEARTBEAT_SKIP_CRON_IN_PROGRESS` branch in the same function: when the immediate heartbeat is skipped after a successful systemEvent enqueue, request a queued heartbeat via `requestHeartbeat({ intent: "immediate", ... })` so the wake is still delivered through the event lane, and report the cron run as `ok`. The existing retry loop already only breaks out for non-retryable skip reasons (e.g. `disabled`), so retry semantics for busy/lane-blocked cases are unchanged.

Tight-loop protection from #11452 is preserved: one-shot `at` jobs are still treated terminally by `applyJobResult` — successful runs are deleted via `deleteAfterRun`, errors follow the existing retry/disable path.

## Real behavior proof

**Behavior or issue addressed**: One-shot `at` cron jobs with `sessionTarget: "main"` and `payload.kind: "systemEvent"` were being recorded as `skipped` with `error: "disabled"` whenever the immediate heartbeat was skipped, even though the system event had already been delivered. The result was a zombie `enabled: false` row in `cron_jobs` per fire, and `deleteAfterRun` never triggered.

**Real environment tested**: macOS 25.5.0 (arm64), Node v22.22.0. Bug reproduced against the released OpenClaw 2026.6.1 LaunchAgent gateway on this machine. The fix was developed in a source checkout of `openclaw/openclaw` at upstream/main `e24c3df27d2` (branch `fix/cron-one-shot-disable-before-run`). SQLite state inspected at `~/.openclaw/state/openclaw.sqlite`.

**Exact steps or command run after this patch**:

Before-fix repro against released 2026.6.1 gateway (proves the bug exists):
```
openclaw cron add 91775-main-bug --agent main --session main \
  --system-event "regression #91775 bug repro" --at +25s --delete-after-run
sleep 35
sqlite3 -header -column ~/.openclaw/state/openclaw.sqlite \
  "SELECT enabled, last_run_status, last_error, schedule_kind
     FROM cron_jobs WHERE name='91775-main-bug';"
```

After-fix verification (source tree on this branch, run from `~/.openclaw/workspace/openclaw`):
```
node scripts/run-vitest.mjs run src/cron/service.runs-one-shot-main-job-disables-it.test.ts
node scripts/run-vitest.mjs run src/cron/service/timer.regression.test.ts
node scripts/run-vitest.mjs run src/cron/normalize.test.ts
npx oxfmt --write src/cron/service/timer.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts
npx oxlint  src/cron/service/timer.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts
# Drift proof: stash the timer.ts change and re-run only the new regression test.
git stash push -- src/cron/service/timer.ts
node scripts/run-vitest.mjs run src/cron/service.runs-one-shot-main-job-disables-it.test.ts -t "disabled"
git stash pop
```

**Evidence after fix**:

Live `openclaw cron` + `sqlite3` terminal capture against released 2026.6.1 (released bug, no patch applied yet):
```
$ openclaw cron add 91775-main-bug --agent main --session main \
    --system-event "regression #91775 bug repro" --at +25s --delete-after-run
{
  "id": "951a4087-b6e3-418d-a7e7-5bdafd9bb59f",
  "name": "91775-main-bug",
  "enabled": true,
  "deleteAfterRun": true,
  "schedule": { "kind": "at", "at": "2026-06-10T15:39:31.196Z" },
  "sessionTarget": "main",
  "wakeMode": "now",
  "payload": { "kind": "systemEvent", "text": "regression #91775 bug repro" },
  "state": { "nextRunAtMs": 1781105971196 }
}

$ sleep 35 && sqlite3 -header -column ~/.openclaw/state/openclaw.sqlite \
    "SELECT enabled, last_run_status, last_error, schedule_kind
       FROM cron_jobs WHERE name='91775-main-bug';"
enabled  last_run_status  last_error  schedule_kind
-------  ---------------  ----------  -------------
0        skipped          disabled    at
```
Released gateway confirms the exact symptom from the issue body: `enabled=0`, `last_run_status=skipped`, `last_error="disabled"`, row not deleted despite `deleteAfterRun: true`. (Repro job removed via `openclaw cron rm` after capture.)

Source tree after applying this patch:
```
$ node scripts/run-vitest.mjs run src/cron/service.runs-one-shot-main-job-disables-it.test.ts
 ✓ cron  src/cron/service.runs-one-shot-main-job-disables-it.test.ts (13 tests) 86ms
 Test Files  1 passed (1)
      Tests  13 passed (13)
[test] passed 1 Vitest shard in 4.60s

$ node scripts/run-vitest.mjs run src/cron/service/timer.regression.test.ts src/cron/normalize.test.ts
 ✓ cron  src/cron/service/timer.regression.test.ts (47 tests) 285ms
 ✓ cron  src/cron/normalize.test.ts            (51 tests) 17ms
 Test Files  2 passed (2)
      Tests  98 passed (98)
[test] passed 1 Vitest shard in 3.42s

$ npx oxlint src/cron/service/timer.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts
Found 0 warnings and 0 errors.
Finished in 19ms on 2 files with 208 rules using 10 threads.
```

Drift proof — without the timer.ts fix, the new regression test fails on the released-bug assertion:
```
$ git stash push -- src/cron/service/timer.ts
Saved working directory and index state WIP on fix/cron-one-shot-disable-before-run

$ node scripts/run-vitest.mjs run src/cron/service.runs-one-shot-main-job-disables-it.test.ts -t "disabled"
 ⨯ wakeMode now records ok and queues fallback heartbeat when immediate heartbeat is disabled (#91775)
   AssertionError: expected undefined to match object { source: 'cron', intent: 'immediate', ... }
   ❯ expectQueuedCronHeartbeat src/cron/service.runs-one-shot-main-job-disables-it.test.ts:229:19
 Test Files  1 failed (1)
      Tests  1 failed | 12 skipped (13)

$ git stash pop
# all 13 tests pass again
```

**Observed result after fix**: With the patch applied (verified via the regression test above against the actual `CronService` + `CronStore` harness), main-session one-shot `at` jobs whose immediate heartbeat is skipped now record `lastStatus: "ok"` with no `lastError`, `applyJobResult` deletes the job via the existing `deleteAfterRun` path, and the system event continues to be delivered (it was already enqueued before the heartbeat call). A fallback queued heartbeat is also requested through the event lane via `requestHeartbeat`, matching the existing `HEARTBEAT_SKIP_CRON_IN_PROGRESS` recovery shape. Recurring (`cron`, `every`) jobs do not go through this main-session wake path and are unaffected.

**What was not tested**: A live source-tree gateway repro (releasing the patched build and re-running the same released-version sqlite check). The released 2026.6.1 binary still ships the bug, so the after-fix sqlite output cannot be captured without first publishing a build with this patch. Other cron payload kinds for `sessionTarget: "main"` were not exercised because `executeMainSessionCronJob` rejects non-systemEvent payloads up front (`'main job requires payload.kind="systemEvent"'`), so they cannot reach the heartbeat skip path being fixed. The repro job above was created with the existing released gateway only to confirm the bug shape; the patched behavior is verified via the harness regression test.
