### PR TITLE
feat(auto-reply): durable inter-tool commentary via verbose standalone progress (supersedes #89850/#89890)

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -148,6 +148,7 @@ type DispatchInboundParams = {
       title?: string;
       name?: string;
     }) => Promise<void> | void;
+    onVerboseProgressVisibility?: (isActive: () => boolean) => void;
     onPlanUpdate?: (payload: {
       phase?: string;
       explanation?: string;

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2782,6 +2782,50 @@ describe("processDiscordMessage draft streaming", () => {
     expect(updates).not.toContain("NO_REPLY");
   });
 
+  it.each([
+    ["active", true],
+    ["inactive", false],
+  ])(
+    "renders Discord commentary in the draft exactly when durable verbose progress is %s",
+    async (_label, durableLaneActive) => {
+      const draftStream = createMockDraftStreamForTest();
+
+      dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+        params?.replyOptions?.onVerboseProgressVisibility?.(() => durableLaneActive);
+        await params?.replyOptions?.onItemEvent?.({
+          itemId: "preamble-1",
+          kind: "preamble",
+          progressText: "Checking the current weather source before summarizing.",
+        });
+        return createNoQueuedDispatchResult();
+      });
+
+      const ctx = await createAutomaticSourceDeliveryContext({
+        discordConfig: {
+          streaming: {
+            mode: "progress",
+            progress: {
+              label: false,
+              toolProgress: false,
+              commentary: true,
+            },
+          },
+        },
+      });
+
+      await runProcessDiscordMessage(ctx);
+
+      const updates = draftStream.update.mock.calls.map((call) => call[0]).join("\n");
+      if (durableLaneActive) {
+        // The durable verbose lane owns commentary: the ephemeral draft must
+        // not render it a second time.
+        expect(updates).toBe("");
+      } else {
+        expect(updates).toContain("Checking the current weather source");
+      }
+    },
+  );
+
   it("keeps Discord progress drafts usable after the last commentary line becomes silent", async () => {
     const draftStream = createMockDraftStreamForTest();
 

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -1038,8 +1038,6 @@ async function processDiscordMessageInner(
         },
         onItemEvent: async (payload) => {
           if (payload.kind === "preamble") {
-            // While the durable verbose commentary lane is active, the ephemeral
-            // draft yields its commentary lines so commentary renders once.
             if (verboseProgressActive()) {
               return;
             }

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -557,6 +557,10 @@ async function processDiscordMessageInner(
     chunkMode,
     log: logVerbose,
   });
+  // While the durable verbose commentary lane is active (dispatch reports it
+  // via onVerboseProgressVisibility), the ephemeral draft yields its commentary
+  // lines so commentary is not rendered in both lanes.
+  let verboseProgressActive: () => boolean = () => false;
   const finalPreviewFlags =
     (discordConfig?.suppressEmbeds ?? true) ? MessageFlags.SuppressEmbeds : undefined;
   let finalReplyStartNotified = false;
@@ -1003,6 +1007,9 @@ async function processDiscordMessageInner(
         commentaryProgressEnabled: draftPreview.isProgressMode
           ? draftPreview.commentaryProgressEnabled
           : undefined,
+        onVerboseProgressVisibility: (isActive) => {
+          verboseProgressActive = isActive;
+        },
         onReasoningStream: async (payload) => {
           await statusReactions.setThinking();
           await draftPreview.pushReasoningProgress(payload?.text, {
@@ -1031,6 +1038,11 @@ async function processDiscordMessageInner(
         },
         onItemEvent: async (payload) => {
           if (payload.kind === "preamble") {
+            // While the durable verbose commentary lane is active, the ephemeral
+            // draft yields its commentary lines so commentary renders once.
+            if (verboseProgressActive()) {
+              return;
+            }
             if (draftPreview.commentaryProgressEnabled && payload.progressText) {
               await draftPreview.pushCommentaryProgress(payload.progressText, {
                 itemId: payload.itemId,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1028,10 +1028,9 @@ export const dispatchTelegramMessage = async ({
   });
   let finalAnswerDeliveryStarted = false;
   let finalAnswerDelivered = false;
-  // While the durable verbose commentary lane is active, the ephemeral draft
-  // yields its commentary lines so commentary is not rendered in both lanes.
-  // Tool/plan lines keep the draft: they have no durable counterpart in
-  // streamed runs, so yielding them would lose information.
+  // While the durable verbose lane is active, the ephemeral draft yields its
+  // commentary lines so they render once. Tool/plan status lines keep the
+  // draft: they have no durable counterpart in streamed runs.
   let verboseProgressActive: () => boolean = () => false;
   const pushStreamToolProgress = async (
     line?: string | ChannelProgressDraftLine,
@@ -2041,10 +2040,8 @@ export const dispatchTelegramMessage = async ({
                       }
                       if (segment.lane === "answer" && info.kind === "tool") {
                         if (verboseProgressActive()) {
-                          // The durable verbose progress lane owns tool/commentary
-                          // payloads for this run: deliver as a real standalone
-                          // message instead of diverting into the streaming draft,
-                          // which is ephemeral and discarded at final.
+                          // Durable lane owns tool payloads: send standalone instead
+                          // of diverting into the draft, which is discarded at final.
                           if (
                             await sendPayload(
                               applyTextToPayload(effectivePayload, segment.update.text),

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1028,6 +1028,11 @@ export const dispatchTelegramMessage = async ({
   });
   let finalAnswerDeliveryStarted = false;
   let finalAnswerDelivered = false;
+  // While the durable verbose commentary lane is active, the ephemeral draft
+  // yields its commentary lines so commentary is not rendered in both lanes.
+  // Tool/plan lines keep the draft: they have no durable counterpart in
+  // streamed runs, so yielding them would lose information.
+  let verboseProgressActive: () => boolean = () => false;
   const pushStreamToolProgress = async (
     line?: string | ChannelProgressDraftLine,
     options?: { toolName?: string; startImmediately?: boolean },
@@ -2035,6 +2040,20 @@ export const dispatchTelegramMessage = async ({
                         reasoningStepState.noteReasoningHint();
                       }
                       if (segment.lane === "answer" && info.kind === "tool") {
+                        if (verboseProgressActive()) {
+                          // The durable verbose progress lane owns tool/commentary
+                          // payloads for this run: deliver as a real standalone
+                          // message instead of diverting into the streaming draft,
+                          // which is ephemeral and discarded at final.
+                          if (
+                            await sendPayload(
+                              applyTextToPayload(effectivePayload, segment.update.text),
+                            )
+                          ) {
+                            blockDelivered = true;
+                          }
+                          continue;
+                        }
                         const canRepresentAsTransientProgress = canUseNativeToolProgressDraft({
                           payload: effectivePayload,
                           reply,
@@ -2325,6 +2344,9 @@ export const dispatchTelegramMessage = async ({
                     !streamDeliveryEnabled || Boolean(answerLane.stream),
                   allowProgressCallbacksWhenSourceDeliverySuppressed:
                     !isRoomEvent && Boolean(answerLane.stream),
+                  onVerboseProgressVisibility: (isActive) => {
+                    verboseProgressActive = isActive;
+                  },
                   commentaryProgressEnabled:
                     streamMode === "progress" ? progressDraft.commentaryProgressEnabled : undefined,
                   onToolStart: async (payload) => {
@@ -2349,6 +2371,9 @@ export const dispatchTelegramMessage = async ({
                   },
                   onItemEvent: async (payload) => {
                     if (payload.kind === "preamble") {
+                      if (verboseProgressActive()) {
+                        return;
+                      }
                       await progressDraft.pushCommentaryProgress(payload.progressText, {
                         itemId: payload.itemId,
                       });

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -102,6 +102,14 @@ export type GetReplyOptions = {
    * channel to surface progress via its own streaming/edit UX.
    */
   suppressDefaultToolProgressMessages?: boolean;
+  /**
+   * Called before dispatch with a live getter for whether verbose standalone
+   * progress messages are active for this run. Channels that render tool or
+   * commentary progress inside an ephemeral streaming draft should yield those
+   * draft lines while the getter returns true, so progress is not rendered in
+   * both lanes at once.
+   */
+  onVerboseProgressVisibility?: (isActive: () => boolean) => void;
   onPartialReply?: (payload: PartialReplyPayload) => Promise<void> | void;
   onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when a thinking/reasoning block ends. */

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -1,7 +1,10 @@
 // Tests CLI dispatch arguments and runtime selection for agent runner turns.
 import { describe, expect, it, vi } from "vitest";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
-import { keepCliSessionBindingOnlyWhenReused } from "./agent-runner-cli-dispatch.js";
+import {
+  createCliToolSummaryTracker,
+  keepCliSessionBindingOnlyWhenReused,
+} from "./agent-runner-cli-dispatch.js";
 
 describe("keepCliSessionBindingOnlyWhenReused", () => {
   it("keeps the first room-event CLI binding when no binding exists yet", () => {
@@ -49,5 +52,88 @@ describe("keepCliSessionBindingOnlyWhenReused", () => {
     expect(onDroppedReplacement).toHaveBeenCalledOnce();
     expect(result.meta.agentMeta?.sessionId).toBe("");
     expect(result.meta.agentMeta?.cliSessionBinding).toBeUndefined();
+  });
+});
+
+describe("createCliToolSummaryTracker", () => {
+  const startEvent = {
+    name: "exec",
+    phase: "start" as const,
+    args: { command: "date -u" },
+    toolCallId: "tool-1",
+  };
+  const resultEvent = {
+    name: "exec",
+    phase: "result" as const,
+    args: undefined,
+    toolCallId: "tool-1",
+    isError: false,
+    result: { content: [{ type: "text", text: "Wed Jun 10 2026" }] },
+  };
+
+  it("delivers a tool summary for a result using meta captured at start", async () => {
+    const deliver = vi.fn();
+    const tracker = createCliToolSummaryTracker({
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      deliver,
+    });
+    await tracker.noteToolEvent(startEvent);
+    await tracker.noteToolEvent(resultEvent);
+    expect(deliver).toHaveBeenCalledTimes(1);
+    const payload = deliver.mock.calls[0]?.[0] as { text: string; isError?: boolean };
+    expect(payload.text).toContain("date -u");
+    expect(payload.text).not.toContain("Wed Jun 10 2026");
+    expect(payload.isError).toBeUndefined();
+  });
+
+  it("appends the tool output block when full verbose output is enabled", async () => {
+    const deliver = vi.fn();
+    const tracker = createCliToolSummaryTracker({
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => true,
+      deliver,
+    });
+    await tracker.noteToolEvent(startEvent);
+    await tracker.noteToolEvent(resultEvent);
+    const payload = deliver.mock.calls[0]?.[0] as { text: string };
+    expect(payload.text).toContain("```txt");
+    expect(payload.text).toContain("Wed Jun 10 2026");
+  });
+
+  it("emits nothing while tool summaries are disabled", async () => {
+    const deliver = vi.fn();
+    const tracker = createCliToolSummaryTracker({
+      shouldEmitToolResult: () => false,
+      shouldEmitToolOutput: () => false,
+      deliver,
+    });
+    await tracker.noteToolEvent(startEvent);
+    await tracker.noteToolEvent(resultEvent);
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("propagates tool errors on the summary payload", async () => {
+    const deliver = vi.fn();
+    const tracker = createCliToolSummaryTracker({
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      deliver,
+    });
+    await tracker.noteToolEvent(startEvent);
+    await tracker.noteToolEvent({ ...resultEvent, isError: true });
+    const payload = deliver.mock.calls[0]?.[0] as { isError?: boolean };
+    expect(payload.isError).toBe(true);
+  });
+
+  it("summarizes results without a tracked start event", async () => {
+    const deliver = vi.fn();
+    const tracker = createCliToolSummaryTracker({
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      deliver,
+    });
+    await tracker.noteToolEvent({ ...resultEvent, toolCallId: "unseen" });
+    expect(deliver).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -7,10 +7,13 @@ import {
 import { runCliAgent } from "../../agents/cli-runner.js";
 import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
 import { clearCliSession } from "../../agents/cli-session.js";
+import { extractToolResultText } from "../../agents/embedded-agent-subscribe.tools.js";
+import { inferToolMetaFromArgs } from "../../agents/embedded-agent-utils.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent.js";
 import { updateSessionStore, type SessionEntry } from "../../config/sessions.js";
 import type { AgentEventPayload } from "../../infra/agent-events.js";
 import { emitAgentEvent, onAgentEvent } from "../../infra/agent-events.js";
+import { formatToolAggregate } from "../tool-meta.js";
 
 function isClaudeCliProvider(provider: string): boolean {
   return normalizeLowercaseStringOrEmpty(provider) === "claude-cli";
@@ -118,8 +121,11 @@ function readCommentaryTextPayload(evt: AgentEventPayload): CommentaryTextPayloa
 
 export type CliToolEventPayload = {
   name: string | undefined;
-  phase: "start" | "update";
+  phase: "start" | "update" | "result";
   args: Record<string, unknown> | undefined;
+  toolCallId?: string;
+  isError?: boolean;
+  result?: unknown;
 };
 
 export function keepCliSessionBindingOnlyWhenReused(params: {
@@ -194,17 +200,81 @@ function createToolEventBridge(params: {
         return undefined;
       }
       const phaseValue = evt.data.phase;
-      if (phaseValue !== "start" && phaseValue !== "update") {
+      if (phaseValue !== "start" && phaseValue !== "update" && phaseValue !== "result") {
         return undefined;
       }
-      const phase: CliToolEventPayload["phase"] = phaseValue === "start" ? "start" : "update";
+      const phase: CliToolEventPayload["phase"] =
+        phaseValue === "start" ? "start" : phaseValue === "update" ? "update" : "result";
       return {
         name: typeof evt.data.name === "string" ? evt.data.name : undefined,
         phase,
         args: isRecord(evt.data.args) ? evt.data.args : undefined,
+        toolCallId: typeof evt.data.toolCallId === "string" ? evt.data.toolCallId : undefined,
+        ...(phase === "result"
+          ? {
+              isError: evt.data.isError === true,
+              result: evt.data.result,
+            }
+          : {}),
       };
     },
   });
+}
+
+/**
+ * Tracks CLI tool start/result events and renders the same durable tool
+ * summaries the embedded runner emits: a formatToolAggregate line per result
+ * (with args-derived meta captured at start), plus the tool output block when
+ * full verbose output is enabled. The CLI parser emits tool result events, but
+ * until now they were dropped at the bridge, so CLI-backed runs had no durable
+ * tool record under verbose while embedded runs did.
+ */
+export function createCliToolSummaryTracker(params: {
+  detailMode?: "explain" | "raw";
+  shouldEmitToolResult: () => boolean;
+  shouldEmitToolOutput: () => boolean;
+  deliver: (payload: { text: string; isError?: boolean }) => Promise<void> | void;
+}) {
+  const metaByCallId = new Map<string, string | undefined>();
+  return {
+    noteToolEvent: async (payload: CliToolEventPayload): Promise<void> => {
+      if (payload.phase === "start") {
+        if (payload.toolCallId && payload.name) {
+          metaByCallId.set(
+            payload.toolCallId,
+            inferToolMetaFromArgs(payload.name, payload.args, {
+              detailMode: params.detailMode ?? "explain",
+            }),
+          );
+        }
+        return;
+      }
+      if (payload.phase !== "result") {
+        return;
+      }
+      const meta = payload.toolCallId ? metaByCallId.get(payload.toolCallId) : undefined;
+      if (payload.toolCallId) {
+        metaByCallId.delete(payload.toolCallId);
+      }
+      if (!params.shouldEmitToolResult()) {
+        return;
+      }
+      const aggregate = formatToolAggregate(payload.name, meta ? [meta] : undefined, {
+        markdown: true,
+      });
+      let text = aggregate;
+      if (params.shouldEmitToolOutput()) {
+        const output = extractToolResultText(payload.result)?.trim();
+        if (output) {
+          text = `${aggregate}\n\`\`\`txt\n${output}\n\`\`\``;
+        }
+      }
+      if (!text.trim()) {
+        return;
+      }
+      await params.deliver({ text, ...(payload.isError === true ? { isError: true } : {}) });
+    },
+  };
 }
 
 function createCommentaryEventBridge(params: {

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -224,10 +224,8 @@ function createToolEventBridge(params: {
 /**
  * Tracks CLI tool start/result events and renders the same durable tool
  * summaries the embedded runner emits: a formatToolAggregate line per result
- * (with args-derived meta captured at start), plus the tool output block when
- * full verbose output is enabled. The CLI parser emits tool result events, but
- * until now they were dropped at the bridge, so CLI-backed runs had no durable
- * tool record under verbose while embedded runs did.
+ * (args-derived meta captured at start), plus the output block under full
+ * verbose. Keeps CLI runs at tool-summary parity with embedded runs.
  */
 export function createCliToolSummaryTracker(params: {
   detailMode?: "explain" | "raw";

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -93,6 +93,7 @@ import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
 import {
   clearDroppedCliSessionBinding,
+  createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
   runCliAgentWithLifecycle,
 } from "./agent-runner-cli-dispatch.js";
@@ -2105,6 +2106,14 @@ export async function runAgentTurnWithFallback(params: {
               const cliCurrentMessageId = isRestartSentinelContinuation
                 ? params.sessionCtx.ReplyToId
                 : (params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid);
+              const cliToolSummaryTracker = createCliToolSummaryTracker({
+                detailMode: params.toolProgressDetail,
+                shouldEmitToolResult: params.shouldEmitToolResult,
+                shouldEmitToolOutput: params.shouldEmitToolOutput,
+                deliver: async (payload) => {
+                  await params.opts?.onToolResult?.(payload);
+                },
+              });
               const result = await agentTurnTiming.measure("cli_run", () =>
                 runCliAgentWithLifecycle({
                   runId,
@@ -2121,7 +2130,12 @@ export async function runAgentTurnWithFallback(params: {
                   onReasoningText: async (text) => {
                     await params.opts?.onReasoningStream?.({ text });
                   },
-                  onToolEvent: async ({ name, phase, args }) => {
+                  onToolEvent: async (payload) => {
+                    await cliToolSummaryTracker.noteToolEvent(payload);
+                    if (payload.phase === "result") {
+                      return;
+                    }
+                    const { name, phase, args } = payload;
                     await Promise.all([
                       params.typingSignals.signalToolStart(),
                       params.opts?.onToolStart?.({

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2312,6 +2312,311 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
+  it("delivers verbose inter-tool commentary as standalone progress messages before the tool summary", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "on",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:123@g.us",
+      SessionKey: "agent:main:whatsapp:group:123@g.us",
+    });
+
+    let commentaryEnabled: boolean | undefined;
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      commentaryEnabled = opts?.commentaryProgressEnabled;
+      await opts?.onItemEvent?.({
+        itemId: "c1",
+        kind: "preamble",
+        progressText: "checking the config first",
+      });
+      const onToolResult = requireToolResultHandler(opts?.onToolResult);
+      await onToolResult({ text: "🔧 exec: ls" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(commentaryEnabled).toBe(true);
+    const sendToolResult = dispatcher.sendToolResult as ReturnType<typeof vi.fn>;
+    expect(sendToolResult).toHaveBeenCalledTimes(2);
+    expect((sendToolResult.mock.calls[0]?.[0] as ReplyPayload | undefined)?.text).toBe(
+      "💬 checking the config first",
+    );
+    expect((sendToolResult.mock.calls[1]?.[0] as ReplyPayload | undefined)?.text).toBe(
+      "🔧 exec: ls",
+    );
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes trailing verbose commentary before the final reply", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "on",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:123@g.us",
+      SessionKey: "agent:main:whatsapp:group:123@g.us",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onItemEvent?.({
+        itemId: "c1",
+        kind: "preamble",
+        progressText: "wrapping up",
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    const sendToolResult = dispatcher.sendToolResult as ReturnType<typeof vi.fn>;
+    const sendFinalReply = dispatcher.sendFinalReply as ReturnType<typeof vi.fn>;
+    expect(sendToolResult).toHaveBeenCalledTimes(1);
+    expect((sendToolResult.mock.calls[0]?.[0] as ReplyPayload | undefined)?.text).toBe(
+      "💬 wrapping up",
+    );
+    expect(sendFinalReply).toHaveBeenCalledTimes(1);
+    expect(sendToolResult.mock.invocationCallOrder[0]).toBeLessThan(
+      sendFinalReply.mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY,
+    );
+  });
+
+  it("collapses snapshot updates for one commentary item into a single message", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "on",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:123@g.us",
+      SessionKey: "agent:main:whatsapp:group:123@g.us",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onItemEvent?.({ itemId: "c1", kind: "preamble", progressText: "drafting" });
+      await opts?.onItemEvent?.({
+        itemId: "c1",
+        kind: "preamble",
+        progressText: "drafting a refined plan",
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    const sendToolResult = dispatcher.sendToolResult as ReturnType<typeof vi.fn>;
+    expect(sendToolResult).toHaveBeenCalledTimes(1);
+    expect((sendToolResult.mock.calls[0]?.[0] as ReplyPayload | undefined)?.text).toBe(
+      "💬 drafting a refined plan",
+    );
+  });
+
+  it("flushes the previous commentary block when a new item starts", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "on",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:123@g.us",
+      SessionKey: "agent:main:whatsapp:group:123@g.us",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onItemEvent?.({ itemId: "c1", kind: "preamble", progressText: "first block" });
+      await opts?.onItemEvent?.({ itemId: "c2", kind: "preamble", progressText: "second block" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    const sendToolResult = dispatcher.sendToolResult as ReturnType<typeof vi.fn>;
+    expect(sendToolResult).toHaveBeenCalledTimes(2);
+    expect((sendToolResult.mock.calls[0]?.[0] as ReplyPayload | undefined)?.text).toBe(
+      "💬 first block",
+    );
+    expect((sendToolResult.mock.calls[1]?.[0] as ReplyPayload | undefined)?.text).toBe(
+      "💬 second block",
+    );
+  });
+
+  it("drops retracted commentary that has not been delivered", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "on",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:123@g.us",
+      SessionKey: "agent:main:whatsapp:group:123@g.us",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onItemEvent?.({ itemId: "c1", kind: "preamble", progressText: "scratch that" });
+      await opts?.onItemEvent?.({ itemId: "c1", kind: "preamble", progressText: "" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps commentary out of standalone progress while verbose is off", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "off",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "group",
+      From: "telegram:group:-100123",
+      SessionKey: "agent:main:telegram:group:-100123",
+    });
+    const onItemEvent = vi.fn();
+
+    let commentaryEnabled: boolean | undefined = false;
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      commentaryEnabled = opts?.commentaryProgressEnabled;
+      await opts?.onItemEvent?.({
+        itemId: "c1",
+        kind: "preamble",
+        progressText: "quiet thought",
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { suppressDefaultToolProgressMessages: true, onItemEvent },
+    });
+
+    expect(commentaryEnabled).toBeUndefined();
+    expect(onItemEvent).toHaveBeenCalledWith({
+      itemId: "c1",
+      kind: "preamble",
+      progressText: "quiet thought",
+    });
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+  });
+
+  it("reports verbose progress visibility to the channel", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "on",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:123@g.us",
+      SessionKey: "agent:main:whatsapp:group:123@g.us",
+    });
+
+    let isActive: (() => boolean) | undefined;
+    let activeDuringRun: boolean | undefined;
+    const replyResolver = async (
+      _ctx: MsgContext,
+      _opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      activeDuringRun = isActive?.();
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        onVerboseProgressVisibility: (getter) => {
+          isActive = getter;
+        },
+      },
+    });
+
+    expect(activeDuringRun).toBe(true);
+
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "off",
+    };
+    let isActiveOff: (() => boolean) | undefined;
+    let activeDuringOffRun: boolean | undefined;
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver: async () => {
+        activeDuringOffRun = isActiveOff?.();
+        return { text: "done" } satisfies ReplyPayload;
+      },
+      replyOptions: {
+        onVerboseProgressVisibility: (getter) => {
+          isActiveOff = getter;
+        },
+      },
+    });
+
+    expect(activeDuringOffRun).toBe(false);
+  });
+
   it("forwards channel-owned group progress callbacks while source delivery is suppressed", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2143,13 +2143,9 @@ export async function dispatchReplyFromConfig(
       return !reply.hasMedia && !hasExecApprovalPayload(payload);
     };
     // Durable inter-tool commentary lane: with verbose progress on, preamble
-    // items become standalone progress messages (like tool summaries) instead of
-    // living only in ephemeral channel drafts. The latest text per item id is
-    // buffered so producers that re-emit snapshots for the same item send one
-    // message; the buffer flushes when the producer moves on (a different item,
-    // a tool event, a block reply, or the final reply). The delivery helpers
-    // reference gates declared later in this scope; they only run once the
-    // resolver is executing, well after scope initialization completes.
+    // items become standalone progress messages like tool summaries. The latest
+    // text per item id is buffered (snapshot producers re-emit the same item)
+    // and flushed when the producer moves on, always before the final reply.
     let pendingCommentaryProgress: { itemId?: string; text: string } | null = null;
     const deliverCommentaryProgressMessage = async (text: string) => {
       if (!shouldSendToolSummaries() || shouldSuppressProgressDelivery()) {
@@ -2217,8 +2213,7 @@ export async function dispatchReplyFromConfig(
         }
       };
       throwIfFinalDeliveryAborted();
-      // Drain any trailing commentary before the final reply so the durable
-      // progress lane completes ahead of the answer.
+      // Trailing commentary must land ahead of the final answer.
       await flushPendingCommentaryProgress();
       throwIfFinalDeliveryAborted();
       const sourceReplyTranscriptMirror =
@@ -2663,31 +2658,34 @@ export async function dispatchReplyFromConfig(
     // classification in the CLI runners is wired once at run start, so a
     // mid-run verbose toggle cannot move inter-tool commentary between lanes.
     const deliverStandaloneCommentaryProgress = shouldEmitVerboseProgress();
-    const coreOwnedOnItemEvent = (() => {
-      const forwardItemEvent = wrapProgressCallback(params.replyOptions?.onItemEvent, {
-        forwardWhenSourceDeliverySuppressed: true,
-        requiresToolSummaryVisibility: true,
-        waitForDirectBlockReplyDelivery: true,
-        onForward: (payload) => {
-          if (hasFailedProgressStatus(payload)) {
-            markVisibleToolErrorProgress();
+    const forwardItemEvent = wrapProgressCallback(params.replyOptions?.onItemEvent, {
+      forwardWhenSourceDeliverySuppressed: true,
+      requiresToolSummaryVisibility: true,
+      waitForDirectBlockReplyDelivery: true,
+      onForward: (payload) => {
+        if (hasFailedProgressStatus(payload)) {
+          markVisibleToolErrorProgress();
+        }
+      },
+    });
+    // Item-event presence gates CLI commentary classification downstream, so
+    // the handler exists exactly when verbose buffers it or a channel consumes it.
+    const onItemEvent =
+      deliverStandaloneCommentaryProgress || forwardItemEvent
+        ? async (payload: Parameters<NonNullable<GetReplyOptions["onItemEvent"]>>[0]) => {
+            if (isDispatchOperationAborted()) {
+              return;
+            }
+            if (!forwardItemEvent) {
+              // The wrapped forwarder marks progress itself when present.
+              markProgress();
+            }
+            if (deliverStandaloneCommentaryProgress && payload.kind === "preamble") {
+              await noteCommentaryProgress(payload);
+            }
+            await forwardItemEvent?.(payload);
           }
-        },
-      });
-      return async (payload: Parameters<NonNullable<GetReplyOptions["onItemEvent"]>>[0]) => {
-        if (isDispatchOperationAborted()) {
-          return;
-        }
-        if (!forwardItemEvent) {
-          // The wrapped forwarder marks progress itself when present.
-          markProgress();
-        }
-        if (payload.kind === "preamble") {
-          await noteCommentaryProgress(payload);
-        }
-        await forwardItemEvent?.(payload);
-      };
-    })();
+        : undefined;
     // Let draft-rendering channels yield their ephemeral commentary lines while
     // the durable verbose commentary lane is delivering the same content.
     params.replyOptions?.onVerboseProgressVisibility?.(
@@ -2732,26 +2730,13 @@ export async function dispatchReplyFromConfig(
               requiresToolSummaryVisibility: true,
               waitForDirectBlockReplyDelivery: true,
               onForward: async () => {
-                // A tool is starting: the preceding commentary block is final, so
-                // flush it ahead of the tool's own progress rendering.
+                // Commentary precedes the tool that follows it.
                 await flushPendingCommentaryProgress();
               },
             }),
-            onItemEvent: deliverStandaloneCommentaryProgress
-              ? coreOwnedOnItemEvent
-              : wrapProgressCallback(params.replyOptions?.onItemEvent, {
-                  forwardWhenSourceDeliverySuppressed: true,
-                  requiresToolSummaryVisibility: true,
-                  waitForDirectBlockReplyDelivery: true,
-                  onForward: (payload) => {
-                    if (hasFailedProgressStatus(payload)) {
-                      markVisibleToolErrorProgress();
-                    }
-                  },
-                }),
-            commentaryProgressEnabled: deliverStandaloneCommentaryProgress
-              ? true
-              : params.replyOptions?.commentaryProgressEnabled,
+            onItemEvent,
+            commentaryProgressEnabled:
+              deliverStandaloneCommentaryProgress || params.replyOptions?.commentaryProgressEnabled,
             onCommandOutput: wrapProgressCallback(params.replyOptions?.onCommandOutput, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
@@ -2783,8 +2768,7 @@ export async function dispatchReplyFromConfig(
                   return;
                 }
                 markInboundDedupeReplayUnsafe();
-                // The tool finished: any buffered commentary preceded this tool
-                // call, so it must land before the tool summary.
+                // Buffered commentary preceded this tool; land it before the summary.
                 await flushPendingCommentaryProgress();
                 if (!suppressAutomaticSourceDelivery && shouldSendToolSummaries()) {
                   await onToolResultFromReplyOptions?.(payload);
@@ -2943,8 +2927,7 @@ export async function dispatchReplyFromConfig(
                 ) {
                   markInboundDedupeReplayUnsafe();
                 }
-                // Assistant text is moving on: buffered commentary preceded this
-                // block, so deliver it first to keep the lanes in order.
+                // Buffered commentary preceded this block; deliver it first.
                 await flushPendingCommentaryProgress();
                 if (suppressDelivery) {
                   return;
@@ -3097,8 +3080,8 @@ export async function dispatchReplyFromConfig(
     }
 
     const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
-    // Backstop: a run can end without a visible final reply (silent or
-    // streaming-delivered turns); trailing commentary must still land.
+    // Backstop: silent/streaming-delivered turns end without a visible final
+    // reply; trailing commentary must still land.
     await flushPendingCommentaryProgress();
     const beforeAgentRunBlocked = replies.some(
       (reply) => getReplyPayloadMetadata(reply)?.beforeAgentRunBlocked === true,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -107,7 +107,7 @@ import {
   normalizeCommandBody,
   resolveTextCommand,
 } from "../commands-registry.js";
-import type { BlockReplyContext } from "../get-reply-options.types.js";
+import type { BlockReplyContext, GetReplyOptions } from "../get-reply-options.types.js";
 import {
   copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
@@ -2142,6 +2142,59 @@ export async function dispatchReplyFromConfig(
       const reply = resolveSendableOutboundReplyParts(payload);
       return !reply.hasMedia && !hasExecApprovalPayload(payload);
     };
+    // Durable inter-tool commentary lane: with verbose progress on, preamble
+    // items become standalone progress messages (like tool summaries) instead of
+    // living only in ephemeral channel drafts. The latest text per item id is
+    // buffered so producers that re-emit snapshots for the same item send one
+    // message; the buffer flushes when the producer moves on (a different item,
+    // a tool event, a block reply, or the final reply). The delivery helpers
+    // reference gates declared later in this scope; they only run once the
+    // resolver is executing, well after scope initialization completes.
+    let pendingCommentaryProgress: { itemId?: string; text: string } | null = null;
+    const deliverCommentaryProgressMessage = async (text: string) => {
+      if (!shouldSendToolSummaries() || shouldSuppressProgressDelivery()) {
+        return;
+      }
+      const payload: ReplyPayload = { text: `💬 ${text}` };
+      if (shouldSuppressLateTextOnlyToolProgress(payload)) {
+        return;
+      }
+      if (shouldRouteToOriginating) {
+        await sendPayloadAsync(payload, undefined, false);
+      } else {
+        markInboundDedupeReplayUnsafe();
+        dispatcher.sendToolResult(payload);
+      }
+    };
+    const flushPendingCommentaryProgress = async () => {
+      const pending = pendingCommentaryProgress;
+      pendingCommentaryProgress = null;
+      const text = pending?.text.trim();
+      if (!text) {
+        return;
+      }
+      await deliverCommentaryProgressMessage(text);
+    };
+    const noteCommentaryProgress = async (payload: { itemId?: string; progressText?: string }) => {
+      const itemId = payload.itemId?.trim() || undefined;
+      const text = payload.progressText ?? "";
+      const updatesBufferedItem =
+        pendingCommentaryProgress !== null &&
+        pendingCommentaryProgress.itemId !== undefined &&
+        pendingCommentaryProgress.itemId === itemId;
+      if (!text.trim()) {
+        // Empty commentary with an item id means the producer retracted that
+        // item; drop it if it has not been sent yet.
+        if (updatesBufferedItem) {
+          pendingCommentaryProgress = null;
+        }
+        return;
+      }
+      if (pendingCommentaryProgress && !updatesBufferedItem) {
+        await flushPendingCommentaryProgress();
+      }
+      pendingCommentaryProgress = { itemId, text };
+    };
     const shouldSuppressMessageToolOnlyTextErrorProgress = (payload: ReplyPayload) => {
       if (
         sourceReplyDeliveryMode !== "message_tool_only" ||
@@ -2163,6 +2216,10 @@ export async function dispatchReplyFromConfig(
           throw new DispatchReplyOperationAbortedError();
         }
       };
+      throwIfFinalDeliveryAborted();
+      // Drain any trailing commentary before the final reply so the durable
+      // progress lane completes ahead of the answer.
+      await flushPendingCommentaryProgress();
       throwIfFinalDeliveryAborted();
       const sourceReplyTranscriptMirror =
         getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror;
@@ -2577,7 +2634,7 @@ export async function dispatchReplyFromConfig(
       options?: {
         forwardWhenSourceDeliverySuppressed?: boolean;
         requiresToolSummaryVisibility?: boolean;
-        onForward?: (...args: Args) => void;
+        onForward?: (...args: Args) => Promise<void> | void;
         waitForDirectBlockReplyDelivery?: boolean;
       },
     ): ((...args: Args) => Promise<void>) | undefined => {
@@ -2596,11 +2653,49 @@ export async function dispatchReplyFromConfig(
           }
         }
         if (shouldForwardProgressCallback(options)) {
-          options?.onForward?.(...args);
+          await options?.onForward?.(...args);
           await callback?.(...args);
         }
       };
     };
+
+    // Snapshot verbose progress visibility for this run: commentary
+    // classification in the CLI runners is wired once at run start, so a
+    // mid-run verbose toggle cannot move inter-tool commentary between lanes.
+    const deliverStandaloneCommentaryProgress = shouldEmitVerboseProgress();
+    const coreOwnedOnItemEvent = (() => {
+      const forwardItemEvent = wrapProgressCallback(params.replyOptions?.onItemEvent, {
+        forwardWhenSourceDeliverySuppressed: true,
+        requiresToolSummaryVisibility: true,
+        waitForDirectBlockReplyDelivery: true,
+        onForward: (payload) => {
+          if (hasFailedProgressStatus(payload)) {
+            markVisibleToolErrorProgress();
+          }
+        },
+      });
+      return async (payload: Parameters<NonNullable<GetReplyOptions["onItemEvent"]>>[0]) => {
+        if (isDispatchOperationAborted()) {
+          return;
+        }
+        if (!forwardItemEvent) {
+          // The wrapped forwarder marks progress itself when present.
+          markProgress();
+        }
+        if (payload.kind === "preamble") {
+          await noteCommentaryProgress(payload);
+        }
+        await forwardItemEvent?.(payload);
+      };
+    })();
+    // Let draft-rendering channels yield their ephemeral commentary lines while
+    // the durable verbose commentary lane is delivering the same content.
+    params.replyOptions?.onVerboseProgressVisibility?.(
+      () =>
+        deliverStandaloneCommentaryProgress &&
+        shouldSendVerboseProgressMessages() &&
+        !shouldSuppressProgressDelivery(),
+    );
 
     const replyResolver =
       params.replyResolver ??
@@ -2636,17 +2731,27 @@ export async function dispatchReplyFromConfig(
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
               waitForDirectBlockReplyDelivery: true,
-            }),
-            onItemEvent: wrapProgressCallback(params.replyOptions?.onItemEvent, {
-              forwardWhenSourceDeliverySuppressed: true,
-              requiresToolSummaryVisibility: true,
-              waitForDirectBlockReplyDelivery: true,
-              onForward: (payload) => {
-                if (hasFailedProgressStatus(payload)) {
-                  markVisibleToolErrorProgress();
-                }
+              onForward: async () => {
+                // A tool is starting: the preceding commentary block is final, so
+                // flush it ahead of the tool's own progress rendering.
+                await flushPendingCommentaryProgress();
               },
             }),
+            onItemEvent: deliverStandaloneCommentaryProgress
+              ? coreOwnedOnItemEvent
+              : wrapProgressCallback(params.replyOptions?.onItemEvent, {
+                  forwardWhenSourceDeliverySuppressed: true,
+                  requiresToolSummaryVisibility: true,
+                  waitForDirectBlockReplyDelivery: true,
+                  onForward: (payload) => {
+                    if (hasFailedProgressStatus(payload)) {
+                      markVisibleToolErrorProgress();
+                    }
+                  },
+                }),
+            commentaryProgressEnabled: deliverStandaloneCommentaryProgress
+              ? true
+              : params.replyOptions?.commentaryProgressEnabled,
             onCommandOutput: wrapProgressCallback(params.replyOptions?.onCommandOutput, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
@@ -2678,6 +2783,9 @@ export async function dispatchReplyFromConfig(
                   return;
                 }
                 markInboundDedupeReplayUnsafe();
+                // The tool finished: any buffered commentary preceded this tool
+                // call, so it must land before the tool summary.
+                await flushPendingCommentaryProgress();
                 if (!suppressAutomaticSourceDelivery && shouldSendToolSummaries()) {
                   await onToolResultFromReplyOptions?.(payload);
                 }
@@ -2835,6 +2943,9 @@ export async function dispatchReplyFromConfig(
                 ) {
                   markInboundDedupeReplayUnsafe();
                 }
+                // Assistant text is moving on: buffered commentary preceded this
+                // block, so deliver it first to keep the lanes in order.
+                await flushPendingCommentaryProgress();
                 if (suppressDelivery) {
                   return;
                 }
@@ -2986,6 +3097,9 @@ export async function dispatchReplyFromConfig(
     }
 
     const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
+    // Backstop: a run can end without a visible final reply (silent or
+    // streaming-delivered turns); trailing commentary must still land.
+    await flushPendingCommentaryProgress();
     const beforeAgentRunBlocked = replies.some(
       (reply) => getReplyPayloadMetadata(reply)?.beforeAgentRunBlocked === true,
     );

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -827,6 +827,29 @@ export function createFollowupRunner(params: {
             const notifyUserMessagePersisted = () => {
               queuedUserMessagePersistedAcrossFallback = true;
             };
+            // Shared by the embedded onToolResult callback and the CLI tool
+            // summary tracker so both runners deliver identical durable summaries.
+            const deliverFollowupToolSummary = (payload: ReplyPayload) =>
+              enqueueProgressDelivery(async () => {
+                if (
+                  run.sourceReplyDeliveryMode === "message_tool_only" &&
+                  !shouldEmitToolResultProgress()
+                ) {
+                  return;
+                }
+                await sendFollowupPayloads(
+                  [payload],
+                  effectiveQueued,
+                  {
+                    provider,
+                    modelId: model,
+                  },
+                  { kind: "tool", mirror: false, runId },
+                );
+                if (payload.isError === true) {
+                  markVisibleToolErrorProgress();
+                }
+              });
             try {
               if (isCliProvider(cliExecutionProvider, runtimeConfig)) {
                 const cliSessionBinding = getCliSessionBinding(
@@ -845,27 +868,7 @@ export function createFollowupRunner(params: {
                   detailMode: toolProgressDetail,
                   shouldEmitToolResult: shouldEmitToolResultProgress,
                   shouldEmitToolOutput: shouldEmitToolOutputProgress,
-                  deliver: (payload) =>
-                    enqueueProgressDelivery(async () => {
-                      if (
-                        run.sourceReplyDeliveryMode === "message_tool_only" &&
-                        !shouldEmitToolResultProgress()
-                      ) {
-                        return;
-                      }
-                      await sendFollowupPayloads(
-                        [payload],
-                        effectiveQueued,
-                        {
-                          provider,
-                          modelId: model,
-                        },
-                        { kind: "tool", mirror: false, runId },
-                      );
-                      if (payload.isError === true) {
-                        markVisibleToolErrorProgress();
-                      }
-                    }),
+                  deliver: deliverFollowupToolSummary,
                 });
                 const result = await runCliAgentWithLifecycle({
                   runId,
@@ -1068,27 +1071,7 @@ export function createFollowupRunner(params: {
                 toolProgressDetail,
                 shouldEmitToolResult: shouldEmitToolResultProgress,
                 shouldEmitToolOutput: shouldEmitToolOutputProgress,
-                onToolResult: (payload) =>
-                  enqueueProgressDelivery(async () => {
-                    if (
-                      run.sourceReplyDeliveryMode === "message_tool_only" &&
-                      !shouldEmitToolResultProgress()
-                    ) {
-                      return;
-                    }
-                    await sendFollowupPayloads(
-                      [payload],
-                      effectiveQueued,
-                      {
-                        provider,
-                        modelId: model,
-                      },
-                      { kind: "tool", mirror: false, runId },
-                    );
-                    if (payload.isError === true) {
-                      markVisibleToolErrorProgress();
-                    }
-                  }),
+                onToolResult: deliverFollowupToolSummary,
                 onAgentEvent: (evt) =>
                   enqueueProgressDelivery(async () => {
                     await forwardFollowupProgressEvent({

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -33,6 +33,7 @@ import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.j
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   clearDroppedCliSessionBinding,
+  createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
   runCliAgentWithLifecycle,
 } from "./agent-runner-cli-dispatch.js";
@@ -840,6 +841,32 @@ export function createFollowupRunner(params: {
                   startedAt: cliLifecycleStartedAt,
                 };
                 const followupCurrentMessageId = resolveFollowupCurrentMessageId();
+                const cliToolSummaryTracker = createCliToolSummaryTracker({
+                  detailMode: toolProgressDetail,
+                  shouldEmitToolResult: shouldEmitToolResultProgress,
+                  shouldEmitToolOutput: shouldEmitToolOutputProgress,
+                  deliver: (payload) =>
+                    enqueueProgressDelivery(async () => {
+                      if (
+                        run.sourceReplyDeliveryMode === "message_tool_only" &&
+                        !shouldEmitToolResultProgress()
+                      ) {
+                        return;
+                      }
+                      await sendFollowupPayloads(
+                        [payload],
+                        effectiveQueued,
+                        {
+                          provider,
+                          modelId: model,
+                        },
+                        { kind: "tool", mirror: false, runId },
+                      );
+                      if (payload.isError === true) {
+                        markVisibleToolErrorProgress();
+                      }
+                    }),
+                });
                 const result = await runCliAgentWithLifecycle({
                   runId,
                   provider: cliExecutionProvider,
@@ -847,11 +874,15 @@ export function createFollowupRunner(params: {
                   emitLifecycleTerminal: false,
                   onAgentRunStart: () => opts?.onAgentRunStart?.(runId),
                   suppressAssistantBridge: run.silentExpected,
-                  onToolEvent: async ({ name, phase, args }) => {
+                  onToolEvent: async (payload) => {
+                    await cliToolSummaryTracker.noteToolEvent(payload);
+                    if (payload.phase === "result") {
+                      return;
+                    }
                     await forwardFollowupProgressEvent({
                       evt: {
                         stream: "tool",
-                        data: { name, phase, args },
+                        data: { name: payload.name, phase: payload.phase, args: payload.args },
                       },
                       opts,
                       detailMode: toolProgressDetail,


### PR DESCRIPTION
Supersedes #89850 and #89890, reshaped per @obviyus's guidance there: instead of persisting the ephemeral streaming draft (new `persistProgress` config key, Telegram-only), this adds a **second consumer for inter-tool commentary in core's verbose standalone-progress path** — the same place tool summaries become durable messages in `dispatch-from-config` — gated by the existing `/verbose on`. No new config key, and it works on every channel that uses the generic dispatch path.

It also closes the backend gap that made "verbose already does tool summaries" untrue for CLI runs: the CLI runner now emits the same durable tool summaries the embedded runner does, so `/verbose on` yields the full interleaved record (`💬` commentary + `🛠️` tool summaries) on both backends and in both streaming modes.

## What it does

**Commit 1 — core (`dispatch-from-config`):**
- With verbose progress on, `kind:"preamble"` item events (inter-tool commentary — emitted by the Claude CLI parser since #89834, and natively by codex) are delivered as standalone `💬` progress messages through the same delivery/guard chain as tool summaries (`shouldSendToolSummaries`, progress-delivery suppression, late-text drop, route-to-originating vs dispatcher).
- The latest text per `itemId` is buffered so snapshot-style producers send **one message per commentary block**; the buffer flushes when the producer moves on (next item, tool start/result, block reply, final reply) and always drains **before the final answer**. Retractions (empty text for a buffered item) drop unsent blocks.
- Verbose runs force commentary classification on (`commentaryProgressEnabled: true`), so inter-tool narration routes to the commentary lane instead of being folded into the final answer text — the answer message stays purely the final answer.
- New `onVerboseProgressVisibility` reply option: dispatch hands the channel a live getter for whether the durable verbose lane is active.

**Commit 2 — telegram:**
- With streaming on, the dispatcher used to divert tool-kind payloads (which would include the new commentary messages) into the ephemeral progress draft, where they were discarded at final — so verbose runs lost their progress record whenever streaming was enabled. While the durable lane is active, tool payloads are now sent as real standalone messages, and the draft yields its commentary lines (tool/plan status lines keep the draft for liveness). Reasoning lane and tool status reactions unchanged.

**Commit 3 — CLI tool summaries:**
- The CLI parser already emits tool result events (name, toolCallId, isError, sanitized result), but the runner bridge dropped them — so CLI-backed runs had no durable tool record under verbose while embedded runs did. The bridge now forwards result events, and both runners render the same `formatToolAggregate` summaries the embedded runner emits (args-derived meta captured at tool start; output block under `/verbose full`), delivered through each runner's existing tool-result route.

**Commit 4 — discord (review finding):**
- Discord consumes the same dispatch visibility getter as Telegram: while the durable lane is delivering commentary standalone, its progress draft skips preamble lines, so commentary renders exactly once. Covered by an active/inactive regression pair.

## Result (with `/verbose on`)

| streaming | before | after |
|---|---|---|
| `off` | answer only (claude-cli emitted no tool summaries; commentary folded into the answer) | interleaved `💬` commentary + `🛠️` tool messages in real time, clean answer last |
| `progress` | progress only in the ephemeral draft, vanishes at final | same durable `💬` + `🛠️` record; draft keeps live tool status; answer last |

## Real behavior proof

- **Behavior or issue addressed**: Inter-tool commentary (assistant narration between tool calls) was only visible inside the ephemeral Telegram streaming draft — or folded into the final answer with streaming off — and was lost the moment the final answer arrived. `/verbose on` had no durable commentary record. After this PR, commentary lands as standalone durable `💬` progress messages in both streaming modes.
- **Real environment tested**: real OpenClaw gateway built from this branch (`pnpm openclaw gateway`) in a Linux container with a desktop; real Telegram bot + real Telegram account on Telegram Desktop; real `claude-cli/claude-opus-4-8` backend (live Anthropic API); tdlib user-driver sending real DMs. The baseline build (merge-base `050c0813b39`) ran in the identical setup for before/after.
- **Exact steps or command run after this patch**: started the gateway from the built branch; sent `/new`, then a DM asking the agent to run `date -u` and `uname -a` via exec, narrating before each command; repeated with `streaming.mode: "off"` and `streaming.mode: "progress"` (`agents.defaults.verboseDefault: "on"` in both); screen-recorded Telegram Desktop throughout. This recreates the Mantis telegram-desktop proof flow locally (same mechanism: telegram-desktop + user-driver + screen capture).
- **Evidence after fix**: screenshots and screen recordings below (PR vs baseline, both streaming modes). Gateway runtime log excerpt for the streamed PR run shows the durable sends landing ahead of the final: `[telegram] sendMessage ok chat=… message=425`, `message=426` (commentary), then `outbound send ok … messageId=427` (final answer).
- **Observed result after fix**: with verbose on, each inter-tool commentary block arrived as its own Telegram message in real time, in both streaming modes; the streaming draft still rendered live tool status and was discarded at final as before; the final answer contained no interleaved narration. Baseline runs show no commentary anywhere.
- **What was not tested**: other channels' draft renderers (Discord/Slack) live — they take the unchanged generic dispatch path, covered by the unit tests; codex-native preamble producers live (same item-event shape, covered by the snapshot-collapse tests).

| | streaming off | streaming on (`progress`) |
|---|---|---|
| **baseline** | ![before-stream-off](https://raw.githubusercontent.com/anagnorisis2peripeteia/openclaw/proof-assets-verbose-commentary/before-stream-off.png) | ![before-stream-on](https://raw.githubusercontent.com/anagnorisis2peripeteia/openclaw/proof-assets-verbose-commentary/before-stream-on.png) |
| **PR** | ![after-stream-off](https://raw.githubusercontent.com/anagnorisis2peripeteia/openclaw/proof-assets-verbose-commentary/after-stream-off.png) | ![after-stream-on](https://raw.githubusercontent.com/anagnorisis2peripeteia/openclaw/proof-assets-verbose-commentary/after-stream-on.png) |

Baseline runs answer with **no visible commentary or tool record** in both modes. PR runs show the full interleaved durable record — `💬 "I'll run these one at a time…"` → `🛠️ date -u` → `💬 "Got the time. Next: uname -a…"` → `🛠️ uname -a` — landing in real time before the clean final answer, in both streaming modes.

Motion captures (drafts building, messages landing live):
[after-stream-off](https://raw.githubusercontent.com/anagnorisis2peripeteia/openclaw/proof-assets-verbose-commentary/after-stream-off-motion.gif) · [after-stream-on](https://raw.githubusercontent.com/anagnorisis2peripeteia/openclaw/proof-assets-verbose-commentary/after-stream-on-motion.gif) · [before-stream-off](https://raw.githubusercontent.com/anagnorisis2peripeteia/openclaw/proof-assets-verbose-commentary/before-stream-off-motion.gif) · [before-stream-on](https://raw.githubusercontent.com/anagnorisis2peripeteia/openclaw/proof-assets-verbose-commentary/before-stream-on-motion.gif)

## Tests

- 7 new `dispatch-from-config` cases: ordering (commentary before its tool summary; trailing commentary before final), snapshot collapse per itemId, item-transition flush, retraction drop, verbose-off passthrough (channel callback still forwarded, nothing standalone, no classification forced), visibility getter on/off.
- 5 new CLI tool-summary tracker cases (meta from start args, output block under full verbose, disabled gate, error propagation, untracked result) and a Discord active/inactive regression pair proving commentary renders exactly once.
- `tsgo` clean; `dispatch-from-config` (200) + `followup-runner`/`agent-runner-execution`/`agent-runner-cli-dispatch` + discord `message-handler.process` — 572 tests green on Windows and the dispatch suite in-box on Linux. The one telegram-suite failure on Windows ("records streamed final replies into the prompt context cache") is byte-identical on pristine upstream/main (pre-existing environment issue).
