### PR TITLE
fix(ios): preserve glass surface identity

### DIFF
--- a/apps/ios/Sources/Design/OpenClawProComponents.swift
+++ b/apps/ios/Sources/Design/OpenClawProComponents.swift
@@ -116,21 +116,24 @@ private struct ProPanelBackground: View {
     }
 }
 
-private struct ProLightGlassModifier: ViewModifier {
+private struct ProGlassEffectLayer<Surface: View>: View {
     @Environment(\.colorScheme) private var colorScheme
     let radius: CGFloat
+    var interactive = false
+    @ViewBuilder let surface: Surface
 
-    func body(content: Content) -> some View {
+    var body: some View {
         if #available(iOS 26.0, *), self.colorScheme == .light {
-            content.glassEffect(.regular, in: .rect(cornerRadius: self.radius))
+            self.surface.glassEffect(
+                self.interactive ? .regular.interactive() : .regular,
+                in: .rect(cornerRadius: self.radius))
         } else {
-            content
+            self.surface
         }
     }
 }
 
 private struct ProGlassSurfaceModifier: ViewModifier {
-    @Environment(\.colorScheme) private var colorScheme
     let fill: Color
     let stroke: Color
     let radius: CGFloat
@@ -139,20 +142,17 @@ private struct ProGlassSurfaceModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         let shape = RoundedRectangle(cornerRadius: self.radius, style: .continuous)
-        let surfaced = content.background {
-            shape
-                .fill(self.fill)
-                .overlay {
-                    shape.strokeBorder(self.stroke, lineWidth: self.isProminent ? 1.2 : 1)
-                }
-        }
-
-        if #available(iOS 26.0, *), self.colorScheme == .light {
-            surfaced.glassEffect(
-                self.interactive ? .regular.interactive() : .regular,
-                in: .rect(cornerRadius: self.radius))
-        } else {
-            surfaced
+        content.background {
+            ProGlassEffectLayer(
+                radius: self.radius,
+                interactive: self.interactive)
+            {
+                shape
+                    .fill(self.fill)
+                    .overlay {
+                        shape.strokeBorder(self.stroke, lineWidth: self.isProminent ? 1.2 : 1)
+                    }
+            }
         }
     }
 }
@@ -194,12 +194,13 @@ private struct ProPanelSurfaceModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .background {
-                ProPanelBackground(
-                    radius: self.radius,
-                    tint: self.tint,
-                    isProminent: self.isProminent)
+                ProGlassEffectLayer(radius: self.radius) {
+                    ProPanelBackground(
+                        radius: self.radius,
+                        tint: self.tint,
+                        isProminent: self.isProminent)
+                }
             }
-            .modifier(ProLightGlassModifier(radius: self.radius))
             .shadow(
                 color: self.colorScheme == .dark ? .black.opacity(0.22) : .black.opacity(0.028),
                 radius: self.isProminent ? 9 : 4,


### PR DESCRIPTION
## Summary

- Move the iOS 26 light-mode `glassEffect` availability/color check into the background surface layer.
- Keep card and control content on the same SwiftUI structural path across light/dark and OS versions.

## Why

The previous modifier wrapped the whole surfaced content in an availability/color conditional. On iOS 26 light mode that changes the view shape for the content itself, which can cause unnecessary SwiftUI structural identity churn for cards, controls, and rows that use the shared pro surface helpers.

This keeps the content stable and limits the conditional glass behavior to the stateless background layer.

## Real behavior proof

- Behavior or issue addressed: Preserve SwiftUI structural identity for iOS pro glass surfaces by keeping card/control content on the same view path while limiting conditional Liquid Glass rendering to the background layer.
- Real environment tested: iOS Simulator, iPhone 17 Pro, iOS 26.5, Xcode 26.5 (17F42), OpenClaw iOS app at `6b8186890c2c`, Settings > Gateway screen, light and dark appearance.
- Exact steps or command run after this patch: Regenerated `apps/ios/OpenClaw.xcodeproj` with `pnpm ios:gen`; built with `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' CODE_SIGNING_ALLOWED=NO build`; installed the app on the iOS 26.5 simulator; opened Settings > Gateway with manual gateway state seeded; recorded `xcrun simctl ui` switching light -> dark -> light.
- Evidence after fix: Appearance-transition state proof recording: https://github.com/user-attachments/assets/26b67bc7-698b-47bf-803d-ab8b1bf992de. Existing static screenshots remain available: light-mode before/after https://github.com/user-attachments/assets/84fbd958-c17c-4582-8339-162df1eff015, dark-mode before/after https://github.com/user-attachments/assets/cee9fd8e-1b46-4214-b5a5-145677171094.

  <img width="240" alt="Settings Gateway appearance state proof" src="https://github.com/user-attachments/assets/26b67bc7-698b-47bf-803d-ab8b1bf992de" />

  ![Light mode before/after Settings Gateway screenshot](https://github.com/user-attachments/assets/84fbd958-c17c-4582-8339-162df1eff015)

  ![Dark mode before/after Settings Gateway screenshot](https://github.com/user-attachments/assets/cee9fd8e-1b46-4214-b5a5-145677171094)

  Diagnostic output from the same simulator run:

  ```text
  device: iPhone 17 Pro (D04BEDB8-F524-46C2-BEDB-495735602536), iOS 26.5
  xcode: Xcode 26.5 Build version 17F42
  head: 6b8186890c2c
  appearance-before: light
  host-before-toggle: state-retention.example.test
  appearance-after-dark: dark
  host-after-dark-toggle: state-retention.example.test
  appearance-after-light: light
  host-after-light-toggle: state-retention.example.test
  ```
- Observed result after fix: Settings > Gateway stayed on the same interactive pro surface while the simulator switched light -> dark -> light, and the manual Host field retained `state-retention.example.test` across both appearance transitions.
- What was not tested: Physical device rendering was not tested; simulator proof covered the iOS 26.5 light/dark glass path.

## Verification

- `pnpm ios:gen`
- `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' CODE_SIGNING_ALLOWED=NO build`
- iOS 26.5 Simulator recording of Settings > Gateway switching light -> dark -> light while retaining manual Host field state.
