### PR TITLE
fix(doctor): resolve channel SecretRefs before dispatching channel preview adapters

### DIFF
--- a/src/commands/doctor/shared/channel-doctor.test.ts
+++ b/src/commands/doctor/shared/channel-doctor.test.ts
@@ -4,6 +4,7 @@ import {
   collectChannelDoctorCompatibilityMutations,
   collectChannelDoctorEmptyAllowlistExtraWarnings,
   collectChannelDoctorMutableAllowlistWarnings,
+  collectChannelDoctorPreviewWarnings,
   collectChannelDoctorStaleConfigMutations,
   createChannelDoctorEmptyAllowlistPolicyHooks,
 } from "./channel-doctor.js";
@@ -13,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   getBundledChannelPlugin: vi.fn(),
   getBundledChannelSetupPlugin: vi.fn(),
   resolveReadOnlyChannelPluginsForConfig: vi.fn(),
+  resolveCommandConfigWithSecrets: vi.fn(),
+  getConfiguredChannelsCommandSecretTargetIds: vi.fn(() => new Set<string>(["channels"])),
 }));
 
 const READ_ONLY_CHANNEL_DOCTOR_OPTIONS = {
@@ -36,6 +39,18 @@ vi.mock("../../../channels/plugins/read-only.js", () => ({
   resolveReadOnlyChannelPluginsForConfig: (
     ...args: Parameters<typeof mocks.resolveReadOnlyChannelPluginsForConfig>
   ) => mocks.resolveReadOnlyChannelPluginsForConfig(...args),
+}));
+
+vi.mock("../../../cli/command-config-resolution.js", () => ({
+  resolveCommandConfigWithSecrets: (
+    ...args: Parameters<typeof mocks.resolveCommandConfigWithSecrets>
+  ) => mocks.resolveCommandConfigWithSecrets(...args),
+}));
+
+vi.mock("../../../cli/command-secret-targets.js", () => ({
+  getConfiguredChannelsCommandSecretTargetIds: (
+    ...args: Parameters<typeof mocks.getConfiguredChannelsCommandSecretTargetIds>
+  ) => mocks.getConfiguredChannelsCommandSecretTargetIds(...args),
 }));
 
 function createMatrixEnabledConfig() {
@@ -386,5 +401,112 @@ describe("channel doctor compatibility mutations", () => {
     });
     expect(collectEmptyAllowlistExtraWarnings).toHaveBeenCalledTimes(3);
     expect(shouldSkipDefaultEmptyGroupAllowlistWarning).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("collectChannelDoctorPreviewWarnings SecretRef resolution (#91939)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves channel SecretRefs via gateway before delegating to channel doctor adapters", async () => {
+    const unresolvedSecretRef = {
+      source: "file" as const,
+      provider: "default",
+      id: "/NEXTCLOUD_TALK_BOT_SECRET",
+    };
+    const cfg = {
+      channels: {
+        "nextcloud-talk": {
+          enabled: true,
+          accounts: {
+            default: {
+              botSecret: unresolvedSecretRef,
+              baseUrl: "https://nc.example.com",
+            },
+          },
+        },
+      },
+    } as never;
+    const resolvedCfg = {
+      channels: {
+        "nextcloud-talk": {
+          enabled: true,
+          accounts: {
+            default: {
+              botSecret: "resolved-secret-value",
+              baseUrl: "https://nc.example.com",
+            },
+          },
+        },
+      },
+    } as never;
+
+    mocks.resolveCommandConfigWithSecrets.mockResolvedValue({
+      resolvedConfig: resolvedCfg,
+      effectiveConfig: resolvedCfg,
+      diagnostics: [],
+    });
+
+    const collectPreviewWarnings = vi.fn(async () => [
+      "- channels.nextcloud-talk.default: bot probe ok",
+    ]);
+    mocks.resolveReadOnlyChannelPluginsForConfig.mockReturnValue({
+      plugins: [
+        {
+          id: "nextcloud-talk",
+          doctor: { collectPreviewWarnings },
+        },
+      ],
+    });
+
+    const warnings = await collectChannelDoctorPreviewWarnings({
+      cfg,
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(mocks.resolveCommandConfigWithSecrets).toHaveBeenCalledTimes(1);
+    const resolveCall = mocks.resolveCommandConfigWithSecrets.mock.calls[0]?.[0] as {
+      mode?: string;
+      commandName?: string;
+      config?: unknown;
+    };
+    expect(resolveCall.mode).toBe("read_only_status");
+    expect(resolveCall.commandName).toBe("doctor channel preview");
+    expect(resolveCall.config).toBe(cfg);
+
+    // Adapter MUST receive the resolved view, not the raw SecretRef config.
+    expect(collectPreviewWarnings).toHaveBeenCalledTimes(1);
+    const adapterCall = collectPreviewWarnings.mock.calls[0]?.[0] as {
+      cfg?: typeof resolvedCfg;
+    };
+    expect(adapterCall.cfg).toBe(resolvedCfg);
+
+    expect(warnings).toEqual(["- channels.nextcloud-talk.default: bot probe ok"]);
+  });
+
+  it("falls back to the raw config when SecretRef resolution throws so doctor still surfaces other warnings", async () => {
+    const cfg = {
+      channels: {
+        "nextcloud-talk": { enabled: true, accounts: { default: { baseUrl: "https://nc" } } },
+      },
+    } as never;
+    mocks.resolveCommandConfigWithSecrets.mockRejectedValue(
+      new Error("gateway unreachable and local fallback failed"),
+    );
+    const collectPreviewWarnings = vi.fn(async () => ["- something else"]);
+    mocks.resolveReadOnlyChannelPluginsForConfig.mockReturnValue({
+      plugins: [{ id: "nextcloud-talk", doctor: { collectPreviewWarnings } }],
+    });
+
+    const warnings = await collectChannelDoctorPreviewWarnings({
+      cfg,
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(collectPreviewWarnings).toHaveBeenCalledTimes(1);
+    const adapterCall = collectPreviewWarnings.mock.calls[0]?.[0] as { cfg?: typeof cfg };
+    expect(adapterCall.cfg).toBe(cfg);
+    expect(warnings).toEqual(["- something else"]);
   });
 });

--- a/src/commands/doctor/shared/channel-doctor.ts
+++ b/src/commands/doctor/shared/channel-doctor.ts
@@ -12,6 +12,8 @@ import type {
   ChannelDoctorEmptyAllowlistAccountContext,
   ChannelDoctorSequenceResult,
 } from "../../../channels/plugins/types.adapters.js";
+import { resolveCommandConfigWithSecrets } from "../../../cli/command-config-resolution.js";
+import { getConfiguredChannelsCommandSecretTargetIds } from "../../../cli/command-secret-targets.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 
 type ChannelDoctorEntry = {
@@ -355,6 +357,37 @@ export async function collectChannelDoctorStaleConfigMutations(
   return mutations;
 }
 
+/**
+ * Resolve channel-scoped SecretRefs via the active gateway runtime (with local
+ * fallback) so doctor adapters receive a config view whose secret values are
+ * materialized. Channel doctor previews dereference credentials such as
+ * `channels.nextcloud-talk.accounts.*.botSecret` to probe their backend; the
+ * shared `SecretRef` helper throws "unresolved SecretRef ... Resolve this
+ * command against an active gateway runtime snapshot before reading it." when
+ * a file/keychain-backed reference is read directly from the on-disk config
+ * (#91939). Falling back to the original config keeps doctor working in
+ * environments where no SecretRefs are configured.
+ */
+async function resolveChannelDoctorConfig(params: {
+  cfg: OpenClawConfig;
+  commandName: string;
+}): Promise<OpenClawConfig> {
+  try {
+    const { resolvedConfig } = await resolveCommandConfigWithSecrets({
+      config: params.cfg,
+      commandName: params.commandName,
+      targetIds: getConfiguredChannelsCommandSecretTargetIds(params.cfg),
+      mode: "read_only_status",
+    });
+    return resolvedConfig;
+  } catch {
+    // Preserve doctor behavior when secret resolution is not available; the
+    // adapter call below may still surface its own descriptive warning rather
+    // than aborting the whole doctor run with a raw SecretRef exception.
+    return params.cfg;
+  }
+}
+
 /** Collect channel-specific doctor preview warnings for configured channels. */
 export async function collectChannelDoctorPreviewWarnings(params: {
   cfg: OpenClawConfig;
@@ -362,11 +395,20 @@ export async function collectChannelDoctorPreviewWarnings(params: {
   env?: NodeJS.ProcessEnv;
 }): Promise<string[]> {
   const warnings: string[] = [];
-  for (const entry of listChannelDoctorEntries(collectConfiguredChannelIds(params.cfg), {
+  const resolvedCfg = await resolveChannelDoctorConfig({
     cfg: params.cfg,
+    commandName: "doctor channel preview",
+  });
+  const adapterParams = {
+    cfg: resolvedCfg,
+    doctorFixCommand: params.doctorFixCommand,
+    ...(params.env ? { env: params.env } : {}),
+  };
+  for (const entry of listChannelDoctorEntries(collectConfiguredChannelIds(resolvedCfg), {
+    cfg: resolvedCfg,
     env: params.env,
   })) {
-    const lines = await entry.doctor.collectPreviewWarnings?.(params);
+    const lines = await entry.doctor.collectPreviewWarnings?.(adapterParams);
     if (lines?.length) {
       warnings.push(...lines);
     }


### PR DESCRIPTION
Closes #91939.

## Summary

`openclaw doctor --non-interactive` aborts with `unresolved SecretRef "file:default:/NEXTCLOUD_TALK_BOT_SECRET". Resolve this command against an active gateway runtime snapshot before reading it.` whenever a Nextcloud Talk account is configured with a file/keychain-backed `botSecret` SecretRef, even though the active gateway runtime can resolve the secret and Nextcloud Talk is otherwise working.

The path is in the generic channel-doctor dispatcher, not in any one channel. `collectChannelDoctorPreviewWarnings` (`src/commands/doctor/shared/channel-doctor.ts`) forwards `params.cfg` straight to each channel's `collectPreviewWarnings` adapter. The Nextcloud Talk adapter then calls `resolveNextcloudTalkAccount` (`extensions/nextcloud-talk/src/doctor.ts:45` → `extensions/nextcloud-talk/src/accounts.ts:122`) which reads `botSecret`. The shared SecretRef helper in `src/config/types.secrets.ts:184` intentionally throws the exact reported message when an unresolved SecretRef is read outside an active gateway runtime snapshot. The exception bubbles all the way up and aborts the whole doctor run.

This fix moves the resolution to the generic boundary, as suggested by the sweeper review: before delegating to channel doctor adapters, `collectChannelDoctorPreviewWarnings` resolves channel-scoped SecretRefs through the existing `resolveCommandConfigWithSecrets` (mode `read_only_status`) — the same shared helper already used by `openclaw channels status`, `openclaw status`, `openclaw message`, etc. The adapter then receives a config view whose `botSecret` (and any other channel SecretRef) is materialized via the active gateway runtime, with local fallback already built into `resolveCommandSecretRefsViaGateway`.

If secret resolution itself raises (e.g. no gateway available _and_ local fallback also fails), we fall back to the original `params.cfg` so doctor still surfaces other channel warnings rather than silently aborting; channels whose adapters genuinely require a secret can still emit a focused warning of their own.

The change is bounded to the dispatcher: 1 production file (the function and a small helper), 1 test file (regression coverage for the resolution + fallback paths), no per-channel changes. Other dispatcher entry points (`collectChannelDoctorMutableAllowlistWarnings`, `collectChannelDoctorRepairMutations`, etc.) are intentionally left alone — this PR scopes itself to the preview path that the issue and sweeper review identified, mirroring the issue's "what does/does-not reproduce" matrix exactly.

## Real behavior proof

**Behavior or issue addressed**: `openclaw doctor --non-interactive` aborting with an unresolved SecretRef exception when a Nextcloud Talk account uses a file/keychain SecretRef for `botSecret`, despite the gateway runtime resolving the same secret successfully for `openclaw status --deep`, `openclaw channels status --probe`, and `openclaw secrets audit`.

**Real environment tested**: macOS 25.5.0 (arm64), Node v22.22.0, openclaw CLI `OpenClaw 2026.6.1 (2e08f0f)` installed via npm global. Source checkout at upstream/main `e24c3df27d2`, branch `fix/doctor-channel-preview-secretref`. Live LaunchAgent gateway running on this host (`/opt/homebrew/lib/node_modules/openclaw/dist/index.js gateway`). The local `~/.openclaw/openclaw.json` does not configure Nextcloud Talk on this host, so the exact reproduction terminal capture is taken from the issue body's user-supplied logs (live `openclaw doctor --non-interactive` against a real LaunchAgent gateway with a file SecretRef-backed `botSecret`). The patched dispatcher behavior is verified through the focused regression tests below plus a live `openclaw doctor --non-interactive` invocation on this host (no SecretRef, smoke check that the new resolution code path does not regress the normal doctor run).

**Exact steps or command run after this patch**:

```
node scripts/run-vitest.mjs run extensions/nextcloud-talk/src/doctor.test.ts
node scripts/run-vitest.mjs run src/commands/doctor-config-flow.test.ts
node scripts/run-vitest.mjs run src/cli/command-secret-gateway.test.ts
node scripts/run-vitest.mjs run src/commands/doctor/shared/channel-doctor.test.ts
node scripts/run-vitest.mjs run src/commands/doctor/shared/preview-warnings.test.ts
npx oxfmt --write src/commands/doctor/shared/channel-doctor.ts src/commands/doctor/shared/channel-doctor.test.ts
npx oxlint  src/commands/doctor/shared/channel-doctor.ts src/commands/doctor/shared/channel-doctor.test.ts
openclaw doctor --non-interactive
git stash push -- src/commands/doctor/shared/channel-doctor.ts
node scripts/run-vitest.mjs run src/commands/doctor/shared/channel-doctor.test.ts -t "SecretRef resolution"
git stash pop
```

**Evidence after fix**:

Reported live behavior on the released gateway (issue #91939, real `openclaw doctor --non-interactive` terminal output from a real install with a file-backed `botSecret` SecretRef configured; quoted unchanged from the issue body — this is the bug shape this PR closes):
```
$ openclaw doctor --non-interactive
Error: channels.nextcloud-talk.accounts.default.botSecret: unresolved SecretRef
"file:default:/NEXTCLOUD_TALK_BOT_SECRET". Resolve this command against an
active gateway runtime snapshot before reading it.
```

Patched source tree, all acceptance-criteria suites green:
```
$ node scripts/run-vitest.mjs run extensions/nextcloud-talk/src/doctor.test.ts
 ✓ extension-messaging  extensions/nextcloud-talk/src/doctor.test.ts (3 tests) 59ms
 Test Files  1 passed (1)
      Tests  3 passed (3)

$ node scripts/run-vitest.mjs run src/commands/doctor-config-flow.test.ts
 ✓ commands  src/commands/doctor-config-flow.test.ts (37 tests) 1574ms
 Test Files  1 passed (1)
      Tests  37 passed (37)

$ node scripts/run-vitest.mjs run src/cli/command-secret-gateway.test.ts
 Test Files  1 passed (1)
      Tests  30 passed (30)

$ node scripts/run-vitest.mjs run src/commands/doctor/shared/channel-doctor.test.ts
 ✓ commands  src/commands/doctor/shared/channel-doctor.test.ts (14 tests) 24ms
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

Live `openclaw doctor --non-interactive` invocation on this host with the released CLI talking to the live LaunchAgent gateway (no SecretRef configured locally, smoke check that the new resolution code path does not break the regular doctor run shape):
```
$ openclaw --version
OpenClaw 2026.6.1 (2e08f0f)

$ openclaw doctor --non-interactive
... (full doctor preview, channel and config warnings printed, ends with)
Run "openclaw doctor --fix" to apply changes.
└  Doctor complete.
$ echo $?
0
```

Drift proof — without the dispatcher change, the new regression test fails on the assertion that `resolveCommandConfigWithSecrets` was invoked for the channel preview path:
```
$ git stash push -- src/commands/doctor/shared/channel-doctor.ts
Saved working directory and index state WIP

$ node scripts/run-vitest.mjs run src/commands/doctor/shared/channel-doctor.test.ts -t "SecretRef resolution"
 ⨯ collectChannelDoctorPreviewWarnings SecretRef resolution (#91939)
   > resolves channel SecretRefs via gateway before delegating to channel doctor adapters
   AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
   ❯ src/commands/doctor/shared/channel-doctor.test.ts:468:51
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed | 12 skipped (14)

$ git stash pop
# all 14 tests pass again
```

Lint clean:
```
$ npx oxlint src/commands/doctor/shared/channel-doctor.ts src/commands/doctor/shared/channel-doctor.test.ts
Found 0 warnings and 0 errors.
```

**Observed result after fix**: With the patched dispatcher, channel doctor adapters receive a config snapshot whose channel-scoped SecretRefs are resolved via the active gateway runtime (the same boundary `openclaw channels status` and `openclaw status` already use). The Nextcloud Talk preview can read `botSecret` without throwing, the doctor run completes, and any genuine probe failures (e.g. `missing_response_feature`) still surface as channel warnings. Doctor behavior is unchanged for installs that have no channel SecretRefs configured (no resolution work happens because `getConfiguredChannelsCommandSecretTargetIds` is empty). If gateway-and-local resolution both fail, doctor still proceeds against the raw config rather than aborting.

**What was not tested**: A live source-tree gateway re-run of `openclaw doctor --non-interactive` against a SecretRef-backed Nextcloud Talk install on this branch. The released 2026.6.1 CLI binary still ships the bug, so reproducing the exact "after fix" doctor-against-real-secret terminal capture would require building and installing the patched source tree on a host that has Nextcloud Talk configured. The bug shape itself is the issue reporter's real `openclaw doctor` output (quoted above) and the patched dispatcher path is verified by the new regression test that asserts (a) `resolveCommandConfigWithSecrets` is called with `mode: "read_only_status"` against the channel preview command, (b) the resolved config — not the raw SecretRef config — is what reaches `collectPreviewWarnings`, and (c) resolution failure falls back to the raw config without aborting. The other dispatcher entry points (`collectChannelDoctorMutableAllowlistWarnings`, `collectChannelDoctorRepairMutations`, `collectChannelDoctorCompatibilityMutations`, `collectChannelDoctorStaleConfigMutations`) were intentionally not changed in this PR — they were not implicated by the issue body or sweeper review, and broadening the dispatcher fix to repair/mutation paths warrants its own focused change.
