### PR TITLE
test(gateway): widen chat-b fast-wait timeout to 1s

### DIFF
--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -24,7 +24,7 @@ import {
 } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
-const FAST_WAIT_OPTS = { timeout: 250, interval: 2 } as const;
+const FAST_WAIT_OPTS = { timeout: 1_000, interval: 2 } as const;
 type GatewayHarness = Awaited<ReturnType<typeof createGatewaySuiteHarness>>;
 type GatewaySocket = Awaited<ReturnType<GatewayHarness["openWs"]>>;
 let harness: GatewayHarness;


### PR DESCRIPTION
## Summary

- `src/gateway/server.chat.gateway-server-chat-b.test.ts` uses `FAST_WAIT_OPTS = { timeout: 250, interval: 2 }` for all 14 of its `vi.waitFor` assertions. 250ms is too tight for the async hop chain behind `chat.send`: the RPC acks before reply dispatch, which then goes through `loadChatHandlers` lazy handler loading, two `createLazyImportLoader` dynamic imports in `src/auto-reply/reply/dispatch-from-config.ts`, session-store reads, and transcript checks before reaching the mocked `getReplyFromConfig`. On a cold module/transform cache or a loaded CI runner this chain can exceed 250ms, and the wait fails with `expected 0 to be greater than 0`.
- This PR widens the file's shared wait timeout to 1s, matching the same-named constant in `src/gateway/server.roles-allowlist-update.test.ts` (`{ timeout: 1_000, interval: 2 }`). The 2ms poll interval is unchanged, so the happy path resolves just as fast; only the failure deadline moves.
- Out of scope: any production code, other test files, and the per-call wait sites themselves (all 14 usages share the single constant; none asserts "nothing happens within the window", so widening cannot mask a regression — verified by reading each call site, they are all positive waits).
- Success: the agentic-control-plane-agent-chat shard stops failing intermittently on this assertion.

## Linked context

Observed on PR #52664, CI run [27282068799](https://github.com/openclaw/openclaw/actions/runs/27282068799/job/80579129384) (job `checks-node-agentic-control-plane-agent-chat`, head `0b85ff03`):

```
FAIL src/gateway/server.chat.gateway-server-chat-b.test.ts > gateway server chat > chat.send does not force-disable block streaming
AssertionError: expected 0 to be greater than 0
```

That PR touches no gateway code (its get-reply changes sit behind the suite's `get-reply-from-config.runtime.js` mock boundary in `src/gateway/test-helpers.mocks.ts`), and the test passed on the same PR's next run with no relevant change — pointing at test timing, not product behavior.

Related #52664

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: intermittent CI-shard failure of a gateway test; no product behavior changes.
- Real environment tested: local checkout on macOS (Darwin 25.5.0, Node 22, pnpm 11.2.2), plus evidence from real CI runs linked above.
- Exact steps or command run after this patch: `pnpm test src/gateway/server.chat.gateway-server-chat-b.test.ts` — three rounds, the first with `node_modules/.experimental-vitest-cache` removed to reproduce the cold-cache condition under which the flake was observed.
- Evidence after fix: copied live terminal output (console output) from the after-fix run of `node scripts/test-projects.mjs`, invoked via `pnpm test src/gateway/server.chat.gateway-server-chat-b.test.ts`:

```
$ pnpm test src/gateway/server.chat.gateway-server-chat-b.test.ts
[test] starting test/vitest/vitest.gateway.config.ts
 RUN  v4.1.7 /Users/kentpeng/projects/openclaw
 Test Files  2 passed (2)
      Tests  76 passed (76)
   Start at  00:01:46
   Duration  62.42s (transform 48.88s, setup 1.32s, import 13.34s, tests 47.98s, environment 0ms)
[test] passed 1 Vitest shard in 82.28s
```

plus two further full-file rounds, both exit 0.
- Observed result after fix: actual output above shows 76/76 green across both files in the shard, 3/3 rounds locally; this PR's own CI run exercises the change on the real runner fleet (gateway shard green, run 27289215005).
- What was not tested: nothing else — the diff is one test constant.
- Proof limitations or environment constraints: this diff is test-only (one wait-timeout constant inside a Vitest file); there is no production code path to exercise in a live OpenClaw setup, so runtime proof beyond the test runs above cannot exist for this change. The flake itself is load/cold-cache dependent, so local reproduction is probabilistic; before-evidence below quantifies it.
- Before evidence (optional but encouraged): on the pre-fix tree, 22 local rounds of this file/test produced exactly 1 failure — the very first run after a fresh `pnpm install` (fully cold caches), failing with the same `expected 0 to be greater than 0` at the same assertion as CI. 10 warm-cache single-test rounds and 6 cold-transform-cache full-file rounds afterward all passed, consistent with a tight-deadline race that needs cold-start latency to trip.

## Tests and validation

- `pnpm test src/gateway/server.chat.gateway-server-chat-b.test.ts` (3 rounds post-fix, including one cold-cache; all green).
- `pnpm exec oxfmt --check --threads=1 src/gateway/server.chat.gateway-server-chat-b.test.ts` (clean).
- No regression test added: the change is itself a test-stability fix; the regression signal is the disappearance of this shard flake.
- What failed before this fix: the assertion at the `chat.send does not force-disable block streaming` test (CI run linked above; reproduced once locally in 22 rounds, cold-start only).

## Risk checklist

- Did user-visible behavior change? No
- Did config, environment, or migration behavior change? No
- Did security, auth, secrets, network, or tool execution behavior change? No
- Highest-risk area: a longer wait deadline could in principle hide a "must not happen" regression if some wait were a negative assertion.
- Mitigation: audited all 14 `FAST_WAIT_OPTS` call sites in the file — every one waits for something to happen (mock called, run removed, abort observed); none gates on absence. The poll interval is unchanged, so passing tests complete in the same time as before.

## Current review state

- Next action: maintainer review.
- Earlier `Real behavior proof` / `auto-response` / `Security High` failures on this PR coincided with the June 10 GitHub platform auth incident (`401 Requires authentication` in all three job logs; githubstatus.com incident "Authentication issues related to API requests"); evidence formatting was also tightened so the proof gate can parse the copied terminal output.
- Nothing else waiting on author.
- No human reviewer comments yet.
