### PR TITLE
feat(plugins): include inbound bodies and attachments in before_agent_reply event [AI-assisted]

### DIFF
--- a/src/auto-reply/reply/get-reply.before-agent-reply.test.ts
+++ b/src/auto-reply/reply/get-reply.before-agent-reply.test.ts
@@ -124,6 +124,63 @@ describe("getReplyFromConfig before_agent_reply wiring", () => {
 
     expect(result).toEqual({ text: SILENT_REPLY_TOKEN });
   });
+
+  it("passes inbound bodies and materialized attachments to the hook event", async () => {
+    mocks.runBeforeAgentReply.mockResolvedValue({
+      handled: true,
+      reply: { text: "plugin reply" },
+    });
+
+    await getReplyFromConfig(
+      buildGetReplyGroupCtx({
+        RawBody: "raw hello",
+        BodyForAgent: "agent hello",
+        MediaPaths: ["/tmp/media/inbound/file_1.zip", "/tmp/media/inbound/file_2.pdf"],
+        MediaUrls: ["https://example.com/file_1.zip"],
+        MediaTypes: ["application/zip"],
+        MediaType: "application/pdf",
+      }),
+      undefined,
+      {},
+    );
+
+    expect(mocks.runBeforeAgentReply).toHaveBeenCalledTimes(1);
+    const [[event]] = mocks.runBeforeAgentReply.mock.calls;
+    expect(event.cleanedBody).toBe("hello world");
+    expect(event.body).toBe("raw hello");
+    expect(event.rawBody).toBe("raw hello");
+    expect(event.bodyForAgent).toBe("agent hello");
+    expect(event.content).toBe("agent hello");
+    expect(event.attachments).toEqual([
+      {
+        path: "/tmp/media/inbound/file_1.zip",
+        url: "https://example.com/file_1.zip",
+        mimeType: "application/zip",
+        contentType: "application/zip",
+      },
+      {
+        path: "/tmp/media/inbound/file_2.pdf",
+        url: "/tmp/media/inbound/file_2.pdf",
+        mimeType: "application/pdf",
+        contentType: "application/pdf",
+      },
+    ]);
+    expect(event.media).toEqual(event.attachments);
+  });
+
+  it("omits attachments from the hook event when no media is present", async () => {
+    mocks.runBeforeAgentReply.mockResolvedValue({
+      handled: true,
+      reply: { text: "plugin reply" },
+    });
+
+    await getReplyFromConfig(buildGetReplyGroupCtx(), undefined, {});
+
+    expect(mocks.runBeforeAgentReply).toHaveBeenCalledTimes(1);
+    const [[event]] = mocks.runBeforeAgentReply.mock.calls;
+    expect(event.attachments).toBeUndefined();
+    expect(event.media).toBeUndefined();
+  });
 });
 afterEach(() => {
   vi.unstubAllEnvs();

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -930,9 +930,31 @@ export async function getReplyFromConfig(
         originatingChannel: sessionCtx.OriginatingChannel,
         provider: sessionCtx.Provider,
       });
+      const hookMediaPaths =
+        Array.isArray(ctx.MediaPaths) && ctx.MediaPaths.length > 0
+          ? ctx.MediaPaths
+          : ctx.MediaPath?.trim()
+            ? [ctx.MediaPath.trim()]
+            : [];
+      const hookMediaUrls = Array.isArray(ctx.MediaUrls) ? ctx.MediaUrls : [];
+      const hookMediaTypes = Array.isArray(ctx.MediaTypes) ? ctx.MediaTypes : [];
+      const hookAttachments = hookMediaPaths.map((mediaPath, index) => ({
+        path: mediaPath,
+        url: hookMediaUrls[index] ?? mediaPath,
+        mimeType: hookMediaTypes[index] ?? ctx.MediaType,
+        contentType: hookMediaTypes[index] ?? ctx.MediaType,
+      }));
       const hookResult = await traceGetReplyPhase("reply.before_agent_reply_hooks", () =>
         hookRunner.runBeforeAgentReply(
-          { cleanedBody },
+          {
+            cleanedBody,
+            body: ctx.RawBody ?? ctx.Body ?? cleanedBody,
+            content: ctx.BodyForAgent ?? cleanedBody,
+            rawBody: ctx.RawBody,
+            bodyForAgent: ctx.BodyForAgent,
+            attachments: hookAttachments.length > 0 ? hookAttachments : undefined,
+            media: hookAttachments.length > 0 ? hookAttachments : undefined,
+          },
           {
             agentId,
             sessionKey: agentSessionKey,

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -260,8 +260,29 @@ export type PluginHookContextWindowSource =
   | "agentContextTokens"
   | "default";
 
+export type PluginHookMessageAttachment = {
+  /** Local materialized path of the inbound attachment, when available. */
+  path?: string;
+  /** Source URL of the attachment (falls back to the path). */
+  url?: string;
+  mimeType?: string;
+  contentType?: string;
+};
+
 export type PluginHookBeforeAgentReplyEvent = {
   cleanedBody: string;
+  /** Inbound body before agent-presentation rewrites, when available. */
+  body?: string;
+  /** Body as it will be presented to the agent, when available. */
+  content?: string;
+  /** Raw inbound body, when the channel provides one. */
+  rawBody?: string;
+  /** Channel-provided agent-facing body, when set. */
+  bodyForAgent?: string;
+  /** Materialized inbound attachments for the current message, when present. */
+  attachments?: PluginHookMessageAttachment[];
+  /** Alias of attachments for handlers that inspect media. */
+  media?: PluginHookMessageAttachment[];
 };
 
 export type PluginHookBeforeAgentReplyResult = {


### PR DESCRIPTION
## Summary

- The `before_agent_reply` hook event only carries `cleanedBody`, so plugins that need to gate a reply on the **current message's materialized media** (e.g. refusing to generate a client-facing audit document unless an auditable source attachment is actually present) cannot see inbound attachments at all — even after the channel has already downloaded them.
- This PR extends `PluginHookBeforeAgentReplyEvent` with optional `body`, `content`, `rawBody`, `bodyForAgent`, and `attachments`/`media` (built from the message context `MediaPaths`/`MediaUrls`/`MediaTypes`) and populates them in the reply pipeline.
- All new fields are optional and only set when the data exists, so existing hook handlers are unaffected (`cleanedBody`-only consumers keep working unchanged).
- Out of scope: the agent-runner `before_agent_reply` call sites for cron/CLI prompts (`cli-runner.ts`, `embedded-agent-runner/run.ts`) — those are prompt-based and have no channel media context.
- Reviewers: focus on the event construction in `get-reply.ts` (attachment array built per-index from MediaPaths/MediaUrls/MediaTypes with MediaType fallback).

## Linked context

Maintainer request: none — limitation found while operating a production OpenClaw gateway where a plugin enforces a fail-closed "no audit document without an anchored source attachment" gate on Telegram.

Related #91984 (companion fix that makes local Bot API attachments materialize at all; independent changes).

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: a plugin hook gating document generation could not detect a legitimately attached Telegram document because the hook event had no attachment data; legitimate requests were blocked with "source not materialized".
- Real environment tested: production OpenClaw 2026.6.1 gateway (Node 22.22.2, Ubuntu) with a `before_agent_reply` plugin gate and a local Telegram Bot API server.
- Exact steps or command run after this patch: re-sent the same "generate the audit document from the attached zip" request that previously got blocked.
- Evidence after fix (redacted): the plugin gate classified the request as anchored (attachment visible on the hook event), scheduled the isolated job, and the generated PDF was delivered with an `operation=sendDocument deliveryKind=document` outbound journal entry.
- Observed result after fix: same request that was previously refused with a "missing source" message completed end to end.
- Copied live output (redacted — chat ids, bot token segments, and the client project name masked):

Before fix (2026-06-10 11:52Z) — the inbound zip was already materialized on disk, but the plugin gate blocked because the hook event carried no attachment data (plugin ledger, JSONL):

```
{"id":"<redacted-id>-0f0d40a2cee6","status":"audit_source_anchor_blocked","channel":"telegram","topicId":"4","reason":"temporal_reference_without_source","messageHash":"dbeebd433c52f3d7","bodyPreview":"**Gera o doc de auditoria no nosso padrão atual, do arquivo: <client-project>(1).zip que estou enviando**","ts":"2026-06-10T11:52:27.676Z"}
```

After fix (same request re-sent 2026-06-10 13:45Z) — gate saw the attachment on the hook event and scheduled the isolated job (plugin ledger, JSONL):

```
{"id":"<redacted-id>-0f0d40a2cee6","status":"schedule_attempt","channel":"telegram","to":"telegram:-<redacted-id>","threadId":"4","agentId":"atlas-telegram","reason":"technical_audit_document:4","dedupeKey":"9100f1d3cb35","messageHash":"dbeebd433c52f3d7","bodyPreview":"**Gera o doc de auditoria no nosso padrão atual, do arquivo: <client-project>(1).zip que estou enviando**","ts":"2026-06-10T13:45:41.455Z"}
```

Job final artifact (excerpt of `FINAL_ARTIFACT.json` written by the scheduled job, 13:53Z):

```
"schema": "dizevolv.auditoria.final-artifact.v1",
"created_at": "2026-06-10T13:53:27.776114Z",
"pdf": "tmp/auditoria-<client-project>-20260610T1346Z/auditoria-repositorio-<client-project>.pdf",
"sha256": "c67c13b0430ae75460ba1d2f2359da4e393b7b2385e2fa48719dbcbccbbab2ef",
"size_bytes": 37711,
"validation": { "ok": true, "pages": 9, "page_size": "612 x 792 pts (letter)", "producer": "WeasyPrint 68.1", ... }
```

Gateway outbound journal — the generated PDF delivered as a document (13:53:52Z):

```
Jun 10 13:53:52 srv<redacted> node[1214256]: 2026-06-10T13:53:52.573+00:00 [telegram] outbound send ok accountId=default chatId=-<redacted-id> messageId=11626 operation=sendDocument deliveryKind=document threadId=4
```
- What was not tested: non-Telegram channels (the event fields are channel-agnostic and built from the shared message context, but live proof was Telegram).
- Proof limitations or environment constraints: live validation used this same event enrichment applied as a dist-level hotfix on the running gateway; this PR is the source port plus regression tests.
- Before evidence: plugin ledger recorded the request as blocked (`temporal_reference_without_source`) while the materialized file already existed in `media/inbound`.

## Tests and validation

- `pnpm vitest run src/auto-reply/reply/get-reply.before-agent-reply.test.ts` — 4 passed (2 existing + 2 new: attachments populated; attachments omitted when no media).
- `pnpm test:contracts:plugins` — 43 files / 953 tests passed.
- What failed before this fix: not a crash — hook handlers simply had no way to observe inbound attachments.

## Risk checklist

Did user-visible behavior change? No for users; hook event gains optional fields for plugin authors.
Did config, environment, or migration behavior change? No.
Did security, auth, secrets, network, or tool execution behavior change? No new I/O; the event exposes paths/URLs the pipeline already holds in the message context to in-process plugin hooks that already receive the message body.
What is the highest-risk area? Event payload size/shape changes for existing hook consumers.
How is that risk mitigated? All fields optional and undefined when absent; `cleanedBody` semantics untouched; contracts lane passes.

## Current review state

What is the next action? Maintainer review.
What is still waiting on author, maintainer, CI, or external proof? Nothing on author side.
Which bot or reviewer comments were addressed? The "Real behavior proof" check initially failed because the proof section described the evidence without pasting it; the body was updated on 2026-06-10 with the copied live output above and the check now passes.

---
AI-assisted (Claude Code, reviewed and validated by the operator before submission).

