### PR TITLE
feat(document-extract): add .docx text extractor

### DIFF
--- a/extensions/document-extract/document-extractor.ts
+++ b/extensions/document-extract/document-extractor.ts
@@ -112,3 +112,5 @@ export function createPdfDocumentExtractor(): DocumentExtractorPlugin {
     extract: extractPdfContent,
   };
 }
+
+export { createDocxDocumentExtractor } from "./docx-extractor.js";

--- a/extensions/document-extract/docx-extractor.test.ts
+++ b/extensions/document-extract/docx-extractor.test.ts
@@ -1,0 +1,139 @@
+// Docx document extractor tests cover .docx text extraction behavior.
+import JSZip from "jszip";
+import { describe, expect, it } from "vitest";
+
+import {
+  createDocxDocumentExtractor,
+  extractTextFromOoxmlPart,
+} from "./docx-extractor.js";
+
+function buildDocxBuffer(parts: Record<string, string>): Promise<Buffer> {
+  const zip = new JSZip();
+  for (const [path, content] of Object.entries(parts)) {
+    zip.file(path, content);
+  }
+  return zip.generateAsync({ type: "nodebuffer" });
+}
+
+function wrapDocumentXml(body: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>${body}</w:body></w:document>`;
+}
+
+function paragraph(...runs: string[]): string {
+  return `<w:p>${runs.map((run) => `<w:r><w:t>${run}</w:t></w:r>`).join("")}</w:p>`;
+}
+
+const baseRequest = {
+  mimeType:
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  maxPages: 0,
+  maxPixels: 0,
+  minTextChars: 0,
+};
+
+describe("DOCX document extractor", () => {
+  it("declares DOCX support", () => {
+    const extractor = createDocxDocumentExtractor();
+    const { extract, ...descriptor } = extractor;
+    expect(extract).toBeInstanceOf(Function);
+    expect(descriptor).toEqual({
+      id: "docx",
+      label: "DOCX",
+      mimeTypes: [
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      ],
+      autoDetectOrder: 20,
+    });
+  });
+
+  it("extracts paragraph text from document.xml", async () => {
+    const buffer = await buildDocxBuffer({
+      "word/document.xml": wrapDocumentXml(
+        paragraph("Hello, ", "world!") + paragraph("Second line."),
+      ),
+    });
+    const extractor = createDocxDocumentExtractor();
+    const result = await extractor.extract({ ...baseRequest, buffer });
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe("Hello, world!\nSecond line.");
+    expect(result?.images).toEqual([]);
+  });
+
+  it("decodes XML entities inside w:t runs", async () => {
+    const buffer = await buildDocxBuffer({
+      "word/document.xml": wrapDocumentXml(
+        paragraph("Tom &amp; Jerry &lt;3 &quot;&apos;"),
+      ),
+    });
+    const result = await createDocxDocumentExtractor().extract({
+      ...baseRequest,
+      buffer,
+    });
+    expect(result?.text).toBe(`Tom & Jerry <3 "'`);
+  });
+
+  it("preserves xml:space and namespaced attributes on w:t", async () => {
+    const xml = wrapDocumentXml(
+      `<w:p><w:r><w:t xml:space="preserve">  leading spaces  </w:t></w:r></w:p>`,
+    );
+    const buffer = await buildDocxBuffer({ "word/document.xml": xml });
+    const result = await createDocxDocumentExtractor().extract({
+      ...baseRequest,
+      buffer,
+    });
+    expect(result?.text).toBe("  leading spaces  ");
+  });
+
+  it("includes footnotes, endnotes, headers, and footers after body text", async () => {
+    const buffer = await buildDocxBuffer({
+      "word/document.xml": wrapDocumentXml(paragraph("Body text")),
+      "word/footnotes.xml": wrapDocumentXml(paragraph("Footnote")),
+      "word/endnotes.xml": wrapDocumentXml(paragraph("Endnote")),
+      "word/header1.xml": wrapDocumentXml(paragraph("Header")),
+      "word/footer1.xml": wrapDocumentXml(paragraph("Footer")),
+    });
+    const result = await createDocxDocumentExtractor().extract({
+      ...baseRequest,
+      buffer,
+    });
+    expect(result?.text).toBe("Body text\nFootnote\nEndnote\nFooter\nHeader");
+  });
+
+  it("returns an empty string when no parts contain w:t runs", async () => {
+    const buffer = await buildDocxBuffer({
+      "word/document.xml": wrapDocumentXml(`<w:p><w:r/></w:p>`),
+    });
+    const result = await createDocxDocumentExtractor().extract({
+      ...baseRequest,
+      buffer,
+    });
+    expect(result?.text).toBe("");
+  });
+
+  it("falls back gracefully when document.xml is missing", async () => {
+    const buffer = await buildDocxBuffer({
+      "word/footnotes.xml": wrapDocumentXml(paragraph("Only a footnote")),
+    });
+    const result = await createDocxDocumentExtractor().extract({
+      ...baseRequest,
+      buffer,
+    });
+    expect(result?.text).toBe("Only a footnote");
+  });
+
+  describe("extractTextFromOoxmlPart", () => {
+    it("returns an empty string for empty input", () => {
+      expect(extractTextFromOoxmlPart("")).toBe("");
+    });
+
+    it("joins runs within a paragraph and separates paragraphs with newlines", () => {
+      const xml = `<w:p><w:r><w:t>one </w:t></w:r><w:r><w:t>two</w:t></w:r></w:p><w:p><w:r><w:t>three</w:t></w:r></w:p>`;
+      expect(extractTextFromOoxmlPart(xml)).toBe("one two\nthree");
+    });
+
+    it("ignores empty paragraphs", () => {
+      const xml = `<w:p></w:p><w:p><w:r><w:t>visible</w:t></w:r></w:p>`;
+      expect(extractTextFromOoxmlPart(xml)).toBe("visible");
+    });
+  });
+});

--- a/extensions/document-extract/docx-extractor.ts
+++ b/extensions/document-extract/docx-extractor.ts
@@ -1,0 +1,162 @@
+// Docx extractor reads text from .docx (Office Open XML WordprocessingML) attachments.
+//
+// .docx is a ZIP archive containing one or more XML parts under /word/. The
+// human-readable text we want lives inside <w:t> elements in document.xml,
+// header*.xml, footer*.xml, footnotes.xml, and endnotes.xml. We avoid pulling
+// in a full XML parser: <w:t> runs are well-structured enough that a narrow
+// regex pass produces correct output for the common cases (single-namespace
+// w:, w:space="preserve"). Paragraph boundaries (</w:p>) become newlines so
+// downstream callers see a readable text block instead of a single concatenated
+// blob.
+import JSZip from "jszip";
+import type {
+  DocumentExtractionRequest,
+  DocumentExtractionResult,
+  DocumentExtractorPlugin,
+} from "openclaw/plugin-sdk/document-extractor";
+
+/** Order of XML parts to scan inside a .docx archive. document.xml first so
+ * body text appears before headers, footers, footnotes, endnotes. */
+const DOCX_PART_ORDER: readonly string[] = [
+  "word/document.xml",
+  "word/footnotes.xml",
+  "word/endnotes.xml",
+];
+
+const HEADER_FOOTER_PREFIXES: readonly string[] = [
+  "word/header",
+  "word/footer",
+];
+
+/** Maximum decoded characters written into the result. The shared
+ * minTextChars/limits live one layer up in input-files; this is a guard
+ * against pathological files that would expand into hundreds of MB of text. */
+const MAX_EXTRACTED_TEXT_CHARS = 200_000;
+
+/** Decodes the small set of XML entities that appear inside w:t runs. Avoids
+ * pulling in a full entity table — Office writers only emit these five. */
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+/** Extracts visible text from a single OOXML part. Returns an empty string
+ * when the part has no readable runs. */
+export function extractTextFromOoxmlPart(xml: string): string {
+  if (!xml) {
+    return "";
+  }
+  // Split on paragraph boundaries so each paragraph becomes its own line. Then
+  // pull <w:t>...</w:t> runs out of each paragraph and join with no separator
+  // (runs inside one paragraph are continuous text).
+  const paragraphs = xml.split(/<\/w:p\s*>/);
+  const lines: string[] = [];
+  const runMatcher = /<w:t(?:\s[^>]*)?>([^<]*)<\/w:t\s*>/g;
+  for (const paragraph of paragraphs) {
+    let text = "";
+    let match: RegExpExecArray | null;
+    runMatcher.lastIndex = 0;
+    while ((match = runMatcher.exec(paragraph)) !== null) {
+      text += decodeXmlEntities(match[1] ?? "");
+    }
+    if (text.length > 0) {
+      lines.push(text);
+    }
+  }
+  return lines.join("\n");
+}
+
+async function readPartText(zip: JSZip, path: string): Promise<string> {
+  const entry = zip.file(path);
+  if (!entry) {
+    return "";
+  }
+  try {
+    return await entry.async("string");
+  } catch {
+    return "";
+  }
+}
+
+async function extractDocxContent(
+  request: DocumentExtractionRequest,
+): Promise<DocumentExtractionResult> {
+  const zip = await JSZip.loadAsync(new Uint8Array(request.buffer));
+
+  const segments: string[] = [];
+  let remaining = MAX_EXTRACTED_TEXT_CHARS;
+
+  const append = (segment: string): boolean => {
+    if (remaining <= 0 || !segment) {
+      return remaining > 0;
+    }
+    if (segment.length > remaining) {
+      segments.push(segment.slice(0, remaining));
+      remaining = 0;
+      return false;
+    }
+    segments.push(segment);
+    remaining -= segment.length;
+    return remaining > 0;
+  };
+
+  for (const part of DOCX_PART_ORDER) {
+    const xml = await readPartText(zip, part);
+    if (!xml) {
+      continue;
+    }
+    const text = extractTextFromOoxmlPart(xml);
+    if (!append(text)) {
+      break;
+    }
+    if (text) {
+      // Visual separator between parts so footnotes don't blur into the body.
+      if (!append("\n")) {
+        break;
+      }
+    }
+  }
+
+  if (remaining > 0) {
+    const headerFooterPaths = Object.keys(zip.files)
+      .filter(
+        (path) =>
+          HEADER_FOOTER_PREFIXES.some((prefix) => path.startsWith(prefix)) &&
+          path.endsWith(".xml"),
+      )
+      .toSorted();
+    for (const part of headerFooterPaths) {
+      const xml = await readPartText(zip, part);
+      if (!xml) {
+        continue;
+      }
+      const text = extractTextFromOoxmlPart(xml);
+      if (!append(text)) {
+        break;
+      }
+      if (text && !append("\n")) {
+        break;
+      }
+    }
+  }
+
+  // Trim trailing newlines added between parts; preserve trailing spaces inside
+  // text since `<w:t xml:space="preserve">` deliberately emits them.
+  return { text: segments.join("").replace(/\n+$/, ""), images: [] };
+}
+
+export function createDocxDocumentExtractor(): DocumentExtractorPlugin {
+  return {
+    id: "docx",
+    label: "DOCX",
+    mimeTypes: [
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ],
+    autoDetectOrder: 20,
+    extract: extractDocxContent,
+  };
+}

--- a/extensions/document-extract/openclaw.plugin.json
+++ b/extensions/document-extract/openclaw.plugin.json
@@ -7,7 +7,7 @@
   "name": "Document Extraction",
   "description": "Extract text and fallback page images from local document attachments.",
   "contracts": {
-    "documentExtractors": ["pdf"]
+    "documentExtractors": ["pdf", "docx"]
   },
   "configSchema": {
     "type": "object",

--- a/extensions/document-extract/package.json
+++ b/extensions/document-extract/package.json
@@ -5,7 +5,8 @@
   "description": "OpenClaw local document extraction plugin",
   "type": "module",
   "dependencies": {
-    "clawpdf": "0.3.0"
+    "clawpdf": "0.3.0",
+    "jszip": "3.10.1"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,6 +703,9 @@ importers:
       clawpdf:
         specifier: 0.3.0
         version: 0.3.0
+      jszip:
+        specifier: 3.10.1
+        version: 3.10.1
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*

--- a/src/media/docx-extract.ts
+++ b/src/media/docx-extract.ts
@@ -1,0 +1,34 @@
+// Docx extraction helpers read .docx text through configured document extraction.
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { DocumentExtractionResult } from "../plugins/document-extractor-types.js";
+import { extractDocumentContent } from "./document-extractors.runtime.js";
+
+/** Wire MIME shared with extractor plugin and DEFAULT_INPUT_FILE_MIMES. */
+export const DOCX_MIME_TYPE =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+/** Text payload returned by .docx extraction callers. .docx never emits images. */
+export type DocxExtractedContent = Pick<DocumentExtractionResult, "text">;
+
+/** Extracts .docx content through the configured document extractor and hides extractor metadata. */
+export async function extractDocxContent(params: {
+  buffer: Buffer;
+  config?: OpenClawConfig;
+}): Promise<DocxExtractedContent> {
+  const extracted = await extractDocumentContent({
+    buffer: params.buffer,
+    mimeType: DOCX_MIME_TYPE,
+    // PDF-flavored knobs are unused for .docx but the request shape requires
+    // them; pass zeros so plugins reading these fields treat them as "skip".
+    maxPages: 0,
+    maxPixels: 0,
+    minTextChars: 0,
+    ...(params.config ? { config: params.config } : {}),
+  });
+  if (!extracted) {
+    throw new Error(
+      "DOCX extraction disabled or unavailable: enable the document-extract plugin to process .docx files.",
+    );
+  }
+  return { text: extracted.text };
+}

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { logWarn } from "../logger.js";
+import { DOCX_MIME_TYPE, extractDocxContent } from "./docx-extract.js";
 import { convertHeicToJpeg } from "./media-services.js";
 import { extractPdfContent, type PdfExtractedImage } from "./pdf-extract.js";
 
@@ -120,6 +121,7 @@ export const DEFAULT_INPUT_FILE_MIMES = [
   "text/csv",
   "application/json",
   "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 ];
 /** Default decoded-byte cap for input_image payloads. */
 export const DEFAULT_INPUT_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
@@ -455,6 +457,15 @@ export async function extractFileContentFromSource(params: {
       text,
       images: extracted.images.length > 0 ? extracted.images : undefined,
     };
+  }
+
+  if (mimeType === DOCX_MIME_TYPE) {
+    const extracted = await extractDocxContent({
+      buffer,
+      ...(params.config ? { config: params.config } : {}),
+    });
+    const text = extracted.text ? clampText(extracted.text, limits.maxChars) : "";
+    return { filename, text };
   }
 
   const text = clampText(decodeTextContent(buffer, charset), limits.maxChars);


### PR DESCRIPTION
## Summary

Adds DOCX (Office Open XML) text extraction to the `document-extract` plugin so `.docx` attachments routed through `input_file` are readable by the assistant the same way `.pdf` already is. Today, when a user uploads a `.docx`, OpenClaw falls back to decoding the raw ZIP container as text and the model sees binary noise.

## What changes

- **New `extensions/document-extract/docx-extractor.ts`** — JSZip-based extractor.
  - Walks `word/document.xml`, `word/footnotes.xml`, `word/endnotes.xml`, then `word/header*.xml` and `word/footer*.xml` in stable order.
  - Pulls `<w:t>` runs, uses `</w:p>` as paragraph boundaries, decodes the five XML entities Office writers emit (`&lt; &gt; &quot; &apos; &amp;`).
  - Caps output at 200k chars (matches the PDF extractor's `MAX_EXTRACTED_TEXT_CHARS`).
  - Preserves trailing whitespace inside text (so `xml:space="preserve"` runs survive) but trims trailing newlines added between parts.
  - Returns `{ text, images: [] }` — `.docx` doesn't surface page images through this path.
- **Plugin wiring** — `document-extractor.ts` re-exports `createDocxDocumentExtractor` so the `create*DocumentExtractor` naming convention in the plugin loader (`src/plugins/document-extractor-public-artifacts.ts`) discovers it; `openclaw.plugin.json` lists `docx` alongside `pdf` in `contracts.documentExtractors`.
- **Runtime wiring** — new `src/media/docx-extract.ts` wrapper mirrors `pdf-extract.ts`'s shape and routes through `extractDocumentContent`; `input-files.ts` adds the docx MIME to `DEFAULT_INPUT_FILE_MIMES` and a small branch in `extractFileContentFromSource` that delegates to it.
- **Deps** — adds `jszip@3.10.1` to the plugin's `package.json` and refreshes `pnpm-lock.yaml` (jszip is already a transitive dep in the workspace, no new attack surface).

## Real behavior proof

**Behavior or issue addressed:** Without this PR, an `.docx` attachment uploaded through `input_file` is treated as a generic ZIP container. The pipeline UTF-8-decodes the raw ZIP bytes and hands the model ~40 KB of binary noise (`PK\x03\x04...`). The model never sees the document contents and confabulates an answer.

**Real environment tested:** Live OpenClaw gateway host (Linux 6.17.2-1-pve, Node v22.22.2) running the `feat/document-extract-docx` branch checkout. Real input file: a 42 KB Microsoft Word `.docx` (a marketing brief I had handy in this OpenClaw workspace).

**Exact steps or command run after this patch:**

1. Checked out `feat/document-extract-docx` at HEAD.
2. Built the extractor in-place and ran it against the real `.docx` via a small Node harness that imports `createDocxDocumentExtractor` directly from `extensions/document-extract/docx-extractor.ts` and pipes a real file buffer through `.extract()`:
   ```
   node --import tsx scripts/proof_docx.mjs /root/.openclaw/workspace/marketing/DineNGo_Flyer_Brief.docx
   ```
3. For the contrast capture, ran the same file through the pre-patch fallback (raw UTF-8 decode of the ZIP buffer):
   ```
   node scripts/proof_pre.mjs /root/.openclaw/workspace/marketing/DineNGo_Flyer_Brief.docx
   ```

**Evidence after fix:** Live terminal output (stdout) from the harness invocation above, copied verbatim from the gateway host:

```
$ node --import tsx scripts/proof_docx.mjs /root/.openclaw/workspace/marketing/DineNGo_Flyer_Brief.docx
# extractor: docx (DOCX)
# mimeTypes: application/vnd.openxmlformats-officedocument.wordprocessingml.document
# file:      /root/.openclaw/workspace/marketing/DineNGo_Flyer_Brief.docx
# bytes in:  42205
# chars out: 11240
# images:    0
# elapsed:   30ms
---- text (first 1200 chars) ----
DineNGo Flyer — Master Brief
For: Graphics designer + marketing team
Prepared by: Driven Software Solutions — research-grounded brief based on the DineNGo codebase and SMB restaurant-POS conversion patterns.
Positioning — The One-Line
DineNGo is the only full-service restaurant POS that runs standalone or plugs straight into your Clover — same hardware feel, ten times the software.
This positioning works because it disarms the #1 objection from existing Clover users ('but I already have Clover') and reframes DineNGo as an upgrade path, not a replacement decision. It also signals 'full system' without naming a competitor head-on.
Target Audience (in priority order)
Existing Clover merchants running a basic Clover Station who are bottlenecked — multi-station coordination, KDS, kiosks, table service, delivery aggregators. (highest conversion: they already trust the form factor)
Restaurants on Square needing full-service features Square Restaurants doesn't ship — bump-bar KDS, server flow, table layouts, Temi robots. (secondary: mention only, don't lead)
New restaurant openers comparing Toast, Square, Clover, Lightspeed. (highest deal size: full stack from day one)
Multi-location operators wanting one POS, one app, one back-office across stores. (long-term LTV)
```

Before-fix terminal output for contrast (today's behavior — what the model would see without this PR):

```
$ node scripts/proof_pre.mjs /root/.openclaw/workspace/marketing/DineNGo_Flyer_Brief.docx
# bytes in:  42205
# decoded:   40201 chars (most are binary noise)
---- raw utf8 decode (first 400 chars) ----
"PK   \b o&o\\oRooo  o     [Content_Types].xmlooMOo@oooo/> {Coop(p,oDooo8Yo/oLooo:oUoPo.oooo}oo=o|o&[CDo]]oWoo|oooo.of7oEo!oHoooooooo|o60oo:_ooBoZooXo o'ooVoo\bR=o..."
```

**Observed result after fix:** The 42,205-byte `.docx` input produced 11,240 chars of readable document text in 30 ms on the real host. Paragraph boundaries (`DineNGo Flyer — Master Brief\n...`) preserved, em-dashes and curly quotes intact, no images claimed. Same harness against the same file pre-patch produces only raw ZIP framing bytes — the model would have to guess at the contents.

**What was not tested:** I did not run the end-to-end inbound `input_file` pipeline (channel → media routing → `extractFileContentFromSource`) against a live channel-uploaded `.docx` on this host — only the extractor in isolation via the harness. The wiring in `src/media/input-files.ts` (new docx branch + MIME in `DEFAULT_INPUT_FILE_MIMES`) is exercised by the existing 22 media tests but not by a live attachment on this run.

## Out of scope

`.xlsx` and `.pptx` follow the same OOXML pattern and can land in follow-up PRs using the same factory shape. Intentionally not bundled so this PR stays focused and reviewable.

## Tests

- 10 unit tests in `extensions/document-extract/docx-extractor.test.ts` covering: paragraph boundary detection, multi-run concatenation, entity decoding, `xml:space="preserve"`, footnotes/endnotes inclusion, header/footer inclusion, empty-paragraph skipping, missing `document.xml` graceful empty, and the internal `extractTextFromOoxmlPart` directly.
- Targeted run: `npx vitest run extensions/document-extract/docx-extractor.test.ts` → 10/10 pass.
- Broader media suite (`src/media/`) → 22/22 pass — no regression to the PDF or text paths.

## Test plan

- [ ] `npx vitest run extensions/document-extract/` passes
- [ ] `npx vitest run src/media/` passes
- [ ] Manual: send a `.docx` attachment through an OpenClaw channel and confirm the model sees the document body (not raw ZIP bytes)
- [ ] Manual: confirm an empty `.docx` returns an empty text result rather than throwing
