### PR TITLE
fix(logging): prune stale non-idle diagnostic session entries after TTL (fixes #91697)

### DIFF
--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -45,7 +45,7 @@ const SESSION_STATE_MAX_ENTRIES = 2000;
 
 let lastSessionPruneAt = 0;
 
-/** Prunes stale idle session states and caps the process-local state map. */
+/** Prunes stale session states with no active work and caps the process-local state map. */
 export function pruneDiagnosticSessionStates(now = Date.now(), force = false): void {
   const shouldPruneForSize = diagnosticSessionStates.size > SESSION_STATE_MAX_ENTRIES;
   if (!force && !shouldPruneForSize && now - lastSessionPruneAt < SESSION_STATE_PRUNE_INTERVAL_MS) {
@@ -55,10 +55,7 @@ export function pruneDiagnosticSessionStates(now = Date.now(), force = false): v
 
   for (const [key, state] of diagnosticSessionStates.entries()) {
     const ageMs = now - state.lastActivity;
-    const isIdle = state.state === "idle";
-    if (isIdle && state.queueDepth <= 0 && ageMs > SESSION_STATE_TTL_MS) {
-      diagnosticSessionStates.delete(key);
-    } else if (ageMs > SESSION_STATE_TTL_MS) {
+    if (state.queueDepth <= 0 && ageMs > SESSION_STATE_TTL_MS) {
       diagnosticSessionStates.delete(key);
     }
   }

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -58,6 +58,8 @@ export function pruneDiagnosticSessionStates(now = Date.now(), force = false): v
     const isIdle = state.state === "idle";
     if (isIdle && state.queueDepth <= 0 && ageMs > SESSION_STATE_TTL_MS) {
       diagnosticSessionStates.delete(key);
+    } else if (ageMs > SESSION_STATE_TTL_MS) {
+      diagnosticSessionStates.delete(key);
     }
   }
 

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -168,17 +168,17 @@ describe("diagnostic session state pruning", () => {
     expect(getDiagnosticSessionStateCountForTest()).toBe(1);
   });
 
-  it("evicts stale non-idle session states after TTL", () => {
+  it("evicts stale non-idle session states after TTL when no active work is queued", () => {
     const now = Date.now();
-    // Insert a non-idle ("processing") entry with lastActivity well past TTL
-    diagnosticSessionStates.set("stale-processing", {
-      sessionId: "stale-processing",
+    // Ghost entry from failed recovery: non-idle, no active work, past TTL
+    diagnosticSessionStates.set("stale-processing-ghost", {
+      sessionId: "stale-processing-ghost",
       lastActivity: now - 31 * 60 * 1000,
       generation: 0,
       state: "processing",
-      queueDepth: 1,
+      queueDepth: 0,
     });
-    // Insert a fresh idle entry (should survive)
+    // Fresh idle entry (should survive)
     diagnosticSessionStates.set("fresh-idle", {
       sessionId: "fresh-idle",
       lastActivity: now,
@@ -190,9 +190,37 @@ describe("diagnostic session state pruning", () => {
 
     pruneDiagnosticSessionStates(now, true);
 
-    // stale processing entry pruned; fresh idle entry survives
+    // stale processing ghost pruned; fresh idle entry survives
     expect(getDiagnosticSessionStateCountForTest()).toBe(1);
-    expect(diagnosticSessionStates.has("stale-processing")).toBe(false);
+    expect(diagnosticSessionStates.has("stale-processing-ghost")).toBe(false);
+    expect(diagnosticSessionStates.has("fresh-idle")).toBe(true);
+  });
+
+  it("preserves non-idle entries with active work even past TTL", () => {
+    const now = Date.now();
+    // Active processing entry: has queued work, should NOT be pruned
+    diagnosticSessionStates.set("active-processing", {
+      sessionId: "active-processing",
+      lastActivity: now - 31 * 60 * 1000,
+      generation: 0,
+      state: "processing",
+      queueDepth: 2,
+    });
+    // Fresh idle entry
+    diagnosticSessionStates.set("fresh-idle", {
+      sessionId: "fresh-idle",
+      lastActivity: now,
+      generation: 0,
+      state: "idle",
+      queueDepth: 0,
+    });
+    expect(getDiagnosticSessionStateCountForTest()).toBe(2);
+
+    pruneDiagnosticSessionStates(now, true);
+
+    // active processing survives (has queued work); fresh idle survives
+    expect(getDiagnosticSessionStateCountForTest()).toBe(2);
+    expect(diagnosticSessionStates.has("active-processing")).toBe(true);
     expect(diagnosticSessionStates.has("fresh-idle")).toBe(true);
   });
 

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -168,6 +168,34 @@ describe("diagnostic session state pruning", () => {
     expect(getDiagnosticSessionStateCountForTest()).toBe(1);
   });
 
+  it("evicts stale non-idle session states after TTL", () => {
+    const now = Date.now();
+    // Insert a non-idle ("processing") entry with lastActivity well past TTL
+    diagnosticSessionStates.set("stale-processing", {
+      sessionId: "stale-processing",
+      lastActivity: now - 31 * 60 * 1000,
+      generation: 0,
+      state: "processing",
+      queueDepth: 1,
+    });
+    // Insert a fresh idle entry (should survive)
+    diagnosticSessionStates.set("fresh-idle", {
+      sessionId: "fresh-idle",
+      lastActivity: now,
+      generation: 0,
+      state: "idle",
+      queueDepth: 0,
+    });
+    expect(getDiagnosticSessionStateCountForTest()).toBe(2);
+
+    pruneDiagnosticSessionStates(now, true);
+
+    // stale processing entry pruned; fresh idle entry survives
+    expect(getDiagnosticSessionStateCountForTest()).toBe(1);
+    expect(diagnosticSessionStates.has("stale-processing")).toBe(false);
+    expect(diagnosticSessionStates.has("fresh-idle")).toBe(true);
+  });
+
   it("caps tracked session states to a bounded max", () => {
     const now = Date.now();
     for (let i = 0; i < 2001; i += 1) {
@@ -213,13 +241,14 @@ describe("diagnostic session state pruning", () => {
 
   it("merges split sessionId and sessionKey state without leaving stale queued work", () => {
     const sessionKey = "agent:main:demo-channel:channel:c1";
+    const now = Date.now();
     const keyed = getDiagnosticSessionState({ sessionKey });
     keyed.queueDepth = 1;
-    keyed.lastActivity = 1;
+    keyed.lastActivity = now - 1;
     const bySessionId = getDiagnosticSessionState({ sessionId: "s1" });
     bySessionId.queueDepth = 1;
     bySessionId.state = "processing";
-    bySessionId.lastActivity = 2;
+    bySessionId.lastActivity = now;
 
     const merged = getDiagnosticSessionState({ sessionId: "s1", sessionKey });
 


### PR DESCRIPTION
### Summary

- **Problem**: `pruneDiagnosticSessionStates()` only deletes entries where `state === "idle"` AND `queueDepth <= 0` AND `age > TTL`. Entries that never transition back to `"idle"` (e.g. after a failed stuck-session recovery) and have no active work accumulate in the `diagnosticSessionStates` Map indefinitely.
- **Root Cause**: The prune loop uses `isIdle` as a gate, so non-idle entries (including ghosts from failed recovery with `queueDepth === 0`) are never cleaned up.
- **Fix**: Remove the `isIdle` guard and rely on `queueDepth <= 0` as the orphan signal for all entries. Entries with active work (`queueDepth > 0`) are preserved regardless of age; entries with no active work are cleaned up after TTL regardless of state.
- **What changed**:
  - `src/logging/diagnostic-session-state.ts` — simplify prune condition from `isIdle && queueDepth <= 0 && age > TTL` to `queueDepth <= 0 && age > TTL` (-3/+1 lines)
  - `src/logging/diagnostic.test.ts` — add regression test for non-idle ghost eviction; add test verifying active non-idle entries survive past TTL; fix merge test timestamps
- **What did NOT change (scope boundary)**:
  - No change to `SESSION_STATE_TTL_MS` (30 min) or `SESSION_STATE_PRUNE_INTERVAL_MS` (1 min)
  - No change to the FIFO cap eviction path (still oldest-first by `lastActivity`)
  - No change to stuck-session recovery logic or state mutation
  - No change to `getDiagnosticSessionState` merge/alias behavior

### Reproduction

1. Gateway with `diagnostics.stuckSessionAbortMs` configured
2. A cron session stalls → `stuckSessionAbortMs` fires
3. Recovery fails → outcome `{ status: "failed" }` skips state mutation
4. State remains `"processing"` with `queueDepth === 0` (no active work)
5. Entry lives in Map permanently because the old prune loop only cleans `idle` entries

### Real behavior proof

**Behavior or issue addressed (91697)**: `pruneDiagnosticSessionStates()` now cleans up stale diagnostic entries that have no active work (`queueDepth <= 0`) after TTL, regardless of state. Ghost entries from failed recovery (non-idle, no queued work) are pruned; active processing entries with queued work survive even past TTL.

**Real environment tested**: Linux, Node 22 — fake-timer test harness against `pruneDiagnosticSessionStates`

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts`

**Evidence after fix**:
```text
[test] starting test/vitest/vitest.logging.config.ts

 RUN  v4.1.7 /home/0668001395/openclawProject1


 Test Files  1 passed (1)
      Tests  70 passed (70)
   Start at  01:36:01
   Duration  3.65s (transform 1.79s, setup 383ms, import 2.74s, tests 285ms, environment 0ms)

[test] passed 1 Vitest shard in 13.05s
```

**Observed result after fix**: A non-idle ghost entry ("processing", `queueDepth=0`, 31 min old) is pruned. An active non-idle entry ("processing", `queueDepth=2`, 31 min old) is preserved — its queued work signals legitimate activity. A fresh idle entry survives as before. All 68 pre-existing diagnostic tests continue to pass alongside the 2 new regression cases.

**What was not tested**: Live Gateway round-trip with real stuck-session recovery failure and subsequent prune cycle was not driven; the fix was validated via the colocated diagnostic test suite with fake timers covering both the ghost-eviction and active-preservation scenarios.

**Repro confirmation**: The new test "evicts stale non-idle session states after TTL when no active work is queued" fails on origin/main before the patch (stale non-idle ghost survives with `queueDepth=0`) and passes after (stale ghost is deleted). The companion test "preserves non-idle entries with active work even past TTL" passes on both branches, confirming the `queueDepth` gate protects live processing sessions.

### Risk / Mitigation

- **Risk**: The simplified condition removes the explicit `isIdle` guard, relying solely on `queueDepth <= 0` as the safety signal.
  **Mitigation**: `queueDepth` tracks queued work items (turns, commands, tool calls). Any genuinely active session has `queueDepth > 0`. The TTL is 30 minutes — a session with no queued work for >30 minutes is genuinely stale. The new test "preserves non-idle entries with active work even past TTL" explicitly verifies this boundary.
- **Risk**: The merge test timestamp change (from hardcoded `1`/`2` to `Date.now()`-relative values) could mask a timing issue.
  **Mitigation**: The merge test tests alias resolution, not pruning. The timestamp change only prevents the new prune logic from interfering during merge tests; the actual merge logic is unchanged.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] logging/diagnostics
- [x] session-state

### Regression Test Plan

- `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts`

### Review Findings Addressed

- **[P1] Do not evict live non-idle state before progress lookup** — addressed by gating non-idle eviction on `queueDepth <= 0` (no active work). Active processing entries with `queueDepth > 0` are preserved even past TTL. Verified by new test "preserves non-idle entries with active work even past TTL".

### Linked Issue/PR

Fixes #91697
