### PR TITLE
fix(telegram): survive getUpdates conflicts in isolated polling ingress

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -104,6 +104,7 @@ type WorkerPollSuccessListener = (message: {
 type WorkerPollErrorListener = (message: {
   type: "poll-error";
   message: string;
+  errorCode?: number;
   finishedAt: number;
 }) => void;
 type WorkerMessageListener = (message: TelegramIngressWorkerMessage) => void;
@@ -2356,6 +2357,89 @@ describe("TelegramPollingSession", () => {
     }
   });
 
+  it("restarts isolated ingress on a getUpdates conflict instead of crashing the account", async () => {
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const log = vi.fn();
+    const setStatus = vi.fn();
+    // 409 conflicts are not "recoverable network errors"; the conflict branch
+    // must restart the cycle before that classifier is consulted.
+    isRecoverableTelegramNetworkErrorMock.mockReturnValue(false);
+    const deleteWebhook = vi.fn(async () => true);
+    createTelegramBotMock.mockImplementation(() => ({
+      api: {
+        deleteWebhook,
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+    }));
+    const transport1 = makeTelegramTransport();
+    const transport2 = makeTelegramTransport();
+    const createTelegramTransport = vi
+      .fn<() => ReturnType<typeof makeTelegramTransport>>()
+      .mockReturnValueOnce(transport2);
+
+    let workerCycle = 0;
+    let listener: WorkerPollErrorListener | undefined;
+    const createWorker = vi.fn(() => ({
+      onMessage: vi.fn((next: WorkerPollErrorListener) => {
+        listener = next;
+        return () => undefined;
+      }),
+      stop: vi.fn(async () => undefined),
+      task: vi.fn(async () => {
+        workerCycle += 1;
+        if (workerCycle === 1) {
+          listener?.({
+            type: "poll-error",
+            message: "Conflict: terminated by other getUpdates request",
+            errorCode: 409,
+            finishedAt: Date.now(),
+          });
+          throw new Error("Telegram ingress worker exited with code 1");
+        }
+        abort.abort();
+      }),
+    }));
+
+    try {
+      const session = createPollingSession({
+        abortSignal: abort.signal,
+        log,
+        setStatus,
+        telegramTransport: transport1,
+        createTelegramTransport,
+        isolatedIngress: {
+          enabled: true,
+          spoolDir: tempDir,
+          createWorker,
+          drainIntervalMs: 100,
+        },
+      });
+
+      await session.runUntilAbort();
+
+      expect(createWorker).toHaveBeenCalledTimes(2);
+      // The conflict resets webhook cleanup so the next cycle re-runs deleteWebhook.
+      expect(deleteWebhook).toHaveBeenCalledTimes(2);
+      // The conflict marks the transport dirty so the next cycle gets a fresh socket.
+      expect(createTelegramTransport).toHaveBeenCalledTimes(1);
+      expectLogIncludes(log, "Another OpenClaw gateway, script, or Telegram poller");
+      expect(
+        statusPatches(setStatus).some(
+          (patch) =>
+            patch.connected === false &&
+            String(patch.lastError).includes("Another OpenClaw gateway"),
+        ),
+      ).toBe(true);
+    } finally {
+      abort.abort();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps active spooled lanes blocked across account restarts", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const firstAbort = new AbortController();
@@ -3533,9 +3617,11 @@ describe("TelegramPollingSession", () => {
     const watchdogHarness = installPollingStallWatchdogHarness();
 
     const log = vi.fn();
+    const setStatus = vi.fn();
     const session = createPollingSession({
       abortSignal: abort.signal,
       log,
+      setStatus,
     });
 
     try {
@@ -3567,6 +3653,14 @@ describe("TelegramPollingSession", () => {
       abort.abort();
       resolveFirstTask();
       await runPromise;
+
+      // The stall must reach channel status, not just the gateway log.
+      expect(
+        statusPatches(setStatus).some(
+          (patch) =>
+            patch.connected === false && String(patch.lastError).includes("Polling stall detected"),
+        ),
+      ).toBe(true);
     } finally {
       watchdogHarness.restore();
     }
@@ -3614,6 +3708,7 @@ describe("TelegramPollingSession", () => {
   it("logs an actionable duplicate-poller hint for getUpdates conflicts", async () => {
     const abort = new AbortController();
     const log = vi.fn();
+    const setStatus = vi.fn();
     const conflictError = Object.assign(
       new Error("Conflict: terminated by other getUpdates request"),
       {
@@ -3628,11 +3723,19 @@ describe("TelegramPollingSession", () => {
     const session = createPollingSession({
       abortSignal: abort.signal,
       log,
+      setStatus,
     });
 
     await session.runUntilAbort();
 
     expectLogIncludes(log, "Another OpenClaw gateway, script, or Telegram poller");
+    // The hint must reach channel status, not just the gateway log.
+    expect(
+      statusPatches(setStatus).some(
+        (patch) =>
+          patch.connected === false && String(patch.lastError).includes("Another OpenClaw gateway"),
+      ),
+    ).toBe(true);
   });
 
   it("logs polling cycle start after a transport rebuild", async () => {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -110,6 +110,11 @@ function resolveTelegramRestartDelayMs(
   return { delayMs, stopTimeoutSuffix };
 }
 
+// Surfaced in logs and channel status when getUpdates returns 409; the only
+// user-fixable causes are a second poller on the same token or a stale webhook.
+const TELEGRAM_GET_UPDATES_CONFLICT_HINT =
+  " Another OpenClaw gateway, script, or Telegram poller may be using this bot token; stop the duplicate poller or switch this account to webhook mode.";
+
 const DEFAULT_POLL_STALL_THRESHOLD_MS = 120_000;
 const MIN_POLL_STALL_THRESHOLD_MS = 30_000;
 const MAX_POLL_STALL_THRESHOLD_MS = 600_000;
@@ -813,10 +818,12 @@ export class TelegramPollingSession {
       offset: number | null;
       outcome: string;
       error?: string;
+      errorCode: number | null;
     } = {
       startedAt: null,
       offset: null,
       outcome: "not-started",
+      errorCode: null,
     };
     const liveness = new TelegramPollingLivenessTracker();
     let consecutiveDrainFailures = 0;
@@ -853,6 +860,7 @@ export class TelegramPollingSession {
         pollState.offset = message.offset;
         pollState.outcome = "started";
         delete pollState.error;
+        pollState.errorCode = null;
         return;
       }
       if (message.type === "poll-success") {
@@ -871,6 +879,7 @@ export class TelegramPollingSession {
         liveness.noteGetUpdatesFinished();
         pollState.outcome = "error";
         pollState.error = message.message;
+        pollState.errorCode = message.errorCode ?? null;
         return;
       }
       if (message.type === "update") {
@@ -1002,14 +1011,24 @@ export class TelegramPollingSession {
         if (this.opts.abortSignal?.aborted) {
           return "exit";
         }
-        if (
+        // The worker only issues getUpdates, so a 409 is always a duplicate
+        // poller (or stale webhook) conflict. Mirror the classic polling
+        // cycle: re-clear the webhook, rotate the transport (#69787), and
+        // restart with backoff instead of crashing the whole account.
+        const isConflict = pollState.errorCode === 409;
+        if (isConflict) {
+          this.#webhookCleared = false;
+          this.#transportState.markDirty();
+        } else if (
           pollState.error &&
           !isRecoverableTelegramNetworkError(new Error(pollState.error), { context: "polling" })
         ) {
           this.#status.notePollingError(pollState.error);
           throw new Error(pollState.error, { cause: err });
         }
-        const message = formatErrorMessage(err);
+        const message = isConflict
+          ? `Telegram getUpdates conflict: ${pollState.error}.${TELEGRAM_GET_UPDATES_CONFLICT_HINT}`
+          : formatErrorMessage(err);
         this.opts.log(`[telegram][diag] isolated polling ingress failed: ${message}`);
         this.#status.notePollingError(message);
         clearForceCycleTimer();
@@ -1162,6 +1181,7 @@ export class TelegramPollingSession {
         this.#transportState.markDirty();
         stalledRestart = true;
         this.opts.log(`[telegram] ${stall.message}`);
+        this.#status.notePollingError(stall.message);
         requestStopForRestart();
       }
     }, POLL_WATCHDOG_INTERVAL_MS);
@@ -1210,12 +1230,16 @@ export class TelegramPollingSession {
       }
       const reason = isConflict ? "getUpdates conflict" : "network error";
       const errMsg = formatErrorMessage(err);
-      const conflictHint = isConflict
-        ? " Another OpenClaw gateway, script, or Telegram poller may be using this bot token; stop the duplicate poller or switch this account to webhook mode."
-        : "";
+      const conflictHint = isConflict ? TELEGRAM_GET_UPDATES_CONFLICT_HINT : "";
       this.opts.log(
         `[telegram][diag] polling cycle error reason=${reason} ${liveness.formatDiagnosticFields("lastGetUpdatesError")} err=${errMsg}${conflictHint}`,
       );
+      // Conflicts carry a user-fixable diagnosis, so surface them in channel
+      // status. Recoverable network blips stay log-only; the stall watchdog
+      // owns status for extended outages (see detectStall above).
+      if (isConflict) {
+        this.#status.notePollingError(`Telegram ${reason}: ${errMsg}.${conflictHint}`);
+      }
       clearForceCycleTimer();
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram ${reason}: ${errMsg};${conflictHint} retrying in ${delay}.`,

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.ts
@@ -51,6 +51,26 @@ function formatErrorMessage(err: unknown): string {
   return String(err);
 }
 
+function readTelegramErrorCode(err: unknown): number | undefined {
+  if (err && typeof err === "object" && "error_code" in err) {
+    const code = (err as { error_code: unknown }).error_code;
+    if (typeof code === "number") {
+      return code;
+    }
+  }
+  return undefined;
+}
+
+function postPollError(err: unknown): void {
+  const errorCode = readTelegramErrorCode(err);
+  post({
+    type: "poll-error",
+    message: formatErrorMessage(err),
+    ...(errorCode === undefined ? {} : { errorCode }),
+    finishedAt: Date.now(),
+  });
+}
+
 function resolveBackoff(attempt: number): number {
   return Math.min(retryMaxMs, retryInitialMs * 2 ** Math.max(0, attempt - 1));
 }
@@ -122,15 +142,21 @@ async function fetchJson(params: {
     });
     const json = (await response.json()) as {
       ok?: unknown;
+      error_code?: unknown;
       result?: unknown;
       description?: unknown;
     };
     if (!response.ok || json.ok !== true) {
-      throw new Error(
+      const message =
         typeof json.description === "string"
           ? json.description
-          : `Telegram getUpdates failed with HTTP ${response.status}`,
-      );
+          : `Telegram getUpdates failed with HTTP ${response.status}`;
+      // Preserve the Bot API error_code across the worker boundary so the
+      // parent session can distinguish getUpdates conflicts (409) from fatal
+      // errors (401) without parsing description strings.
+      throw typeof json.error_code === "number"
+        ? Object.assign(new Error(message), { error_code: json.error_code })
+        : new Error(message);
     }
     return json.result;
   } finally {
@@ -195,11 +221,7 @@ async function main(): Promise<void> {
           break;
         }
         failures += 1;
-        post({
-          type: "poll-error",
-          message: formatErrorMessage(err),
-          finishedAt: Date.now(),
-        });
+        postPollError(err);
         if (!isRecoverableTelegramNetworkError(err, { context: "polling" })) {
           throw err;
         }
@@ -216,7 +238,7 @@ main()
     parentPort?.close();
   })
   .catch((err: unknown) => {
-    post({ type: "poll-error", message: formatErrorMessage(err), finishedAt: Date.now() });
+    postPollError(err);
     parentPort?.close();
     process.exitCode = stopped ? 0 : 1;
   });

--- a/extensions/telegram/src/telegram-ingress-worker.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.ts
@@ -17,6 +17,8 @@ export type TelegramIngressWorkerMessage =
   | {
       type: "poll-error";
       message: string;
+      /** Telegram Bot API error_code (e.g. 409 for getUpdates conflicts). */
+      errorCode?: number;
       finishedAt: number;
     }
   | {


### PR DESCRIPTION
## Summary

A getUpdates `409 Conflict` (second poller on the same bot token, or a stale webhook) kills the whole Telegram account in isolated ingress mode — the default. The ingress worker flattens Bot API errors into a message string, so the parent session cannot tell a conflict apart from a fatal `401` and rethrows out of `runUntilAbort` (`extensions/telegram/src/polling-session.ts`). The core supervisor then burns one of `MAX_RESTART_ATTEMPTS = 10` (preserved across auto-restarts, `src/gateway/server-channels.ts`) and eventually gives up permanently — while the classic polling cycle has always handled the same 409 in-session with webhook re-clear, transport rotation (#69787), and a duplicate-poller hint.

Changes:
- The ingress worker preserves the Bot API `error_code` on getUpdates failures and posts it in `poll-error` messages (typed worker contract).
- The isolated cycle treats 409 like the classic path: re-clear webhook, rotate transport, restart with backoff + the duplicate-poller hint, instead of crashing the account. Fatal errors (e.g. 401) still propagate.
- The conflict hint and stall detection now reach channel status (`lastError`/`connected`), not just the gateway log. Previously a classic-path conflict loop showed `connected: true` with no error for up to 30 minutes, and the actionable diagnosis never reached `openclaw channels status`.

## Verification

- `node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts` — 54 passed.
- Regression proof (prod files swapped to `origin/main`, new tests kept): `restarts isolated ingress on a getUpdates conflict instead of crashing the account` fails with the account-crash (`runUntilAbort` rejects with `Conflict: terminated by other getUpdates request`); the status assertions in the classic conflict and stall tests fail with no patch published. All pass with this branch's code.
- Testbox `check:changed` green (`tbx_01ktsa6ds3121d18zk2mq7470k`): typecheck extensions + extension tests, oxlint, import cycles, guards.
- Not tested: live two-poller 409 against the real Bot API; the worker runtime file itself has no direct test (boots as a worker thread; covered via the typed message contract and session-level tests).
