### PR TITLE
fix(plugin-sdk): re-export resolveAllAgentSessionStoreTargetsSync from session-store-runtime

### DIFF
--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -41,4 +41,5 @@ export {
   resolveThreadFlag,
 } from "../config/sessions/reset.js";
 export { resolveSendPolicy } from "../sessions/send-policy.js";
+export { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targets.js";
 export type { SessionEntry, SessionScope } from "../config/sessions/types.js";


### PR DESCRIPTION
## Summary

`resolveAllAgentSessionStoreTargetsSync` is defined in `src/config/sessions/targets.ts` but was missing from the `plugin-sdk/session-store-runtime` re-export surface. External consumers importing from `openclaw/plugin-sdk/session-store-runtime` get:

```
TypeError: (0, _sessionStoreRuntime.resolveAllAgentSessionStoreTargetsSync) is not a function
```

## Changes

- Add re-export of `resolveAllAgentSessionStoreTargetsSync` from `src/plugin-sdk/session-store-runtime.ts`.
- No runtime logic change; 1 line added.

## Real behavior proof

Behavior or issue addressed: After the fix, importing `resolveAllAgentSessionStoreTargetsSync` from `openclaw/plugin-sdk/session-store-runtime` succeeds and resolves to a function, matching the documented plugin-sdk surface. Before the fix, the import fails with `does not provide an export named`.
Real environment tested: Repository `openclaw/openclaw`, branch `fix/session-store-targets-reexport`, commit `4a6bee7f73`, on latest `origin/main`, via git worktree on Linux x64 with Node.js v24 and tsx.
Exact steps or command run after this patch:
```shell
git diff --check
npx oxlint src/plugin-sdk/session-store-runtime.ts
node --import tsx -e 'import { resolveAllAgentSessionStoreTargetsSync } from "./src/plugin-sdk/session-store-runtime.js"; console.log("OK:", typeof resolveAllAgentSessionStoreTargetsSync)'
```
Evidence after fix:
```
=== diff --check ===
(no output - clean)
=== oxlint ===
Found 0 warnings and 0 errors.
Finished in 33ms on 1 file with 208 rules using 8 threads.
=== runtime import ===
OK: function
```
Observed result after fix: The re-export resolves to `function`, confirming the symbol is accessible from the plugin-sdk entry point. Before the fix (on current main), the same import throws SyntaxError.
What was not tested: Full repository build (dist generation) and end-to-end plugin import in a real downstream project.

## Test Plan

- `npx oxlint src/plugin-sdk/session-store-runtime.ts` — 0 errors.
- `git diff --check` — clean.
- Runtime import check resolves to `function`.

## Risk

Minimal. Adds one re-export line. No behavior change for existing consumers. Does not modify runtime logic, dependencies, or test files.

Closes https://github.com/openclaw/openclaw/issues/91991