### PR TITLE
fix(cron): retry disabled heartbeat one-shots

### DIFF
--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -74,6 +74,28 @@ describe("CronService restart catch-up", () => {
     };
   }
 
+  function createOverdueDisabledHeartbeatOneShotRetry(id: string, nextRunAtMs: number): CronJob {
+    return {
+      id,
+      name: `disabled-heartbeat-retry-${id}`,
+      enabled: true,
+      createdAtMs: nextRunAtMs - 60_000,
+      updatedAtMs: nextRunAtMs - 30_000,
+      deleteAfterRun: true,
+      schedule: { kind: "at", at: new Date(nextRunAtMs - 30_000).toISOString() },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: `retry-${id}` },
+      state: {
+        nextRunAtMs,
+        lastRunAtMs: nextRunAtMs - 30_000,
+        lastRunStatus: "skipped",
+        lastError: "disabled",
+        consecutiveSkipped: 1,
+      },
+    };
+  }
+
   function expectQueuedSystemEvent(
     enqueueSystemEvent: ReturnType<typeof vi.fn>,
     expectedText: string,
@@ -616,6 +638,45 @@ describe("CronService restart catch-up", () => {
     expect(
       (staggeredJobs[1]?.state.nextRunAtMs ?? 0) - (staggeredJobs[0]?.state.nextRunAtMs ?? 0),
     ).toBe(5_000);
+
+    await store.cleanup();
+  });
+
+  it("stagger-limits overdue disabled-heartbeat one-shot retries after restart", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+
+    await writeStoreJobs(store.storePath, [
+      createOverdueDisabledHeartbeatOneShotRetry("disabled-retry-0", startNow - 60_000),
+      createOverdueDisabledHeartbeatOneShotRetry("disabled-retry-1", startNow - 45_000),
+    ]);
+
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => startNow,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      maxMissedJobsPerRestart: 1,
+      missedJobStaggerMs: 5_000,
+    });
+
+    await runMissedJobs(state);
+
+    expectQueuedSystemEvent(enqueueSystemEvent, "retry-disabled-retry-0");
+    expect(requestHeartbeat).toHaveBeenCalledTimes(1);
+
+    const listedJobs = state.store?.jobs ?? [];
+    expect(listedJobs.find((job) => job.id === "disabled-retry-0")).toBeUndefined();
+    const deferred = listedJobs.find((job) => job.id === "disabled-retry-1");
+    expect(deferred?.enabled).toBe(true);
+    expect(deferred?.state.lastRunStatus).toBe("skipped");
+    expect(deferred?.state.lastError).toBe("disabled");
+    expect(deferred?.state.nextRunAtMs).toBe(startNow + 5_000);
 
     await store.cleanup();
   });

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -60,6 +60,7 @@ type CronHarnessOptions = {
   runIsolatedAgentJob?: CronServiceDeps["runIsolatedAgentJob"];
   runHeartbeatOnce?: NonNullable<CronServiceDeps["runHeartbeatOnce"]>;
   nowMs?: () => number;
+  cronConfig?: CronServiceDeps["cronConfig"];
   wakeNowHeartbeatBusyMaxWaitMs?: number;
   wakeNowHeartbeatBusyRetryDelayMs?: number;
   withEvents?: boolean;
@@ -76,6 +77,7 @@ async function createCronHarness(options: CronHarnessOptions = {}) {
     cronEnabled: true,
     log: noopLogger,
     ...(options.nowMs ? { nowMs: options.nowMs } : {}),
+    ...(options.cronConfig ? { cronConfig: options.cronConfig } : {}),
     ...(options.wakeNowHeartbeatBusyMaxWaitMs !== undefined
       ? { wakeNowHeartbeatBusyMaxWaitMs: options.wakeNowHeartbeatBusyMaxWaitMs }
       : {}),
@@ -321,6 +323,91 @@ describe("CronService", () => {
     expect(jobs.find((j) => j.id === job.id)).toBeUndefined();
     expectMainSystemEventPosted(enqueueSystemEvent, { text: "hello", jobId: job.id });
     expect(requestHeartbeat).toHaveBeenCalled();
+
+    await stopCronAndCleanup(cron, store);
+  });
+
+  it("keeps a one-shot main job retryable when immediate heartbeat is disabled", async () => {
+    const atMs = Date.parse("2025-12-13T00:00:02.000Z");
+    const runHeartbeatOnce = vi.fn(async () => ({
+      status: "skipped" as const,
+      reason: "disabled",
+    }));
+    const { store, cron, enqueueSystemEvent, requestHeartbeat, events } = await createCronHarness({
+      runHeartbeatOnce,
+      nowMs: () => atMs,
+    });
+    if (!events) {
+      throw new Error("missing event harness");
+    }
+    const job = await addMainOneShotHelloJob(cron, {
+      atMs,
+      name: "one-shot heartbeat disabled",
+    });
+
+    vi.setSystemTime(new Date(atMs));
+    await vi.runOnlyPendingTimersAsync();
+    const finished = await events.waitFor(
+      (evt) => evt.jobId === job.id && evt.action === "finished",
+    );
+
+    expect(finished.status).toBe("skipped");
+    expect(finished.error).toBe("disabled");
+    expect(runHeartbeatOnce).toHaveBeenCalledTimes(1);
+    expectMainSystemEventPosted(enqueueSystemEvent, { text: "hello", jobId: job.id });
+    expect(requestHeartbeat).not.toHaveBeenCalled();
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const updated = jobs.find((j) => j.id === job.id);
+    expect(updated).toBeDefined();
+    expect(updated?.enabled).toBe(true);
+    expect(updated?.state.lastStatus).toBe("skipped");
+    expect(updated?.state.lastError).toBe("disabled");
+    expect(updated?.state.consecutiveSkipped).toBe(1);
+    expect(updated?.state.nextRunAtMs).toBe(atMs + 30_000);
+
+    await stopCronAndCleanup(cron, store);
+  });
+
+  it("disables a disabled-heartbeat one-shot when its retry budget is exhausted", async () => {
+    const atMs = Date.parse("2025-12-13T00:00:02.000Z");
+    const runHeartbeatOnce = vi.fn(async () => ({
+      status: "skipped" as const,
+      reason: "disabled",
+    }));
+    const { store, cron, enqueueSystemEvent, requestHeartbeat, events } = await createCronHarness({
+      runHeartbeatOnce,
+      nowMs: () => atMs,
+      cronConfig: { retry: { maxAttempts: 0, backoffMs: [30_000] } },
+    });
+    if (!events) {
+      throw new Error("missing event harness");
+    }
+    const job = await addMainOneShotHelloJob(cron, {
+      atMs,
+      name: "one-shot heartbeat disabled exhausted",
+    });
+
+    vi.setSystemTime(new Date(atMs));
+    await vi.runOnlyPendingTimersAsync();
+    const finished = await events.waitFor(
+      (evt) => evt.jobId === job.id && evt.action === "finished",
+    );
+
+    expect(finished.status).toBe("skipped");
+    expect(finished.error).toBe("disabled");
+    expect(runHeartbeatOnce).toHaveBeenCalledTimes(1);
+    expectMainSystemEventPosted(enqueueSystemEvent, { text: "hello", jobId: job.id });
+    expect(requestHeartbeat).not.toHaveBeenCalled();
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const updated = jobs.find((j) => j.id === job.id);
+    expect(updated).toBeDefined();
+    expect(updated?.enabled).toBe(false);
+    expect(updated?.state.lastStatus).toBe("skipped");
+    expect(updated?.state.lastError).toBe("disabled");
+    expect(updated?.state.consecutiveSkipped).toBe(1);
+    expect(updated?.state.nextRunAtMs).toBeUndefined();
 
     await stopCronAndCleanup(cron, store);
   });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -78,6 +78,7 @@ export { failureNotificationDeliveryFromJobState } from "./failure-alerts.js";
 export { wake } from "./wake.js";
 
 const MAX_TIMER_DELAY_MS = 60_000;
+const HEARTBEAT_SKIP_DISABLED = "disabled";
 
 /**
  * Minimum gap between consecutive fires of the same cron job.  This is a
@@ -275,6 +276,13 @@ type TransientCronRetryDecision = {
   reason: "transient retry" | "max retries exhausted" | "permanent error";
 };
 
+type DisabledHeartbeatOneShotRetryDecision = {
+  retryable: boolean;
+  consecutiveSkipped: number;
+  backoffMs?: number;
+  reason: "disabled heartbeat retry" | "max retries exhausted";
+};
+
 function resolveCronNextRunWithLowerBound(params: {
   state: CronServiceState;
   job: CronJob;
@@ -344,6 +352,27 @@ function resolveTransientCronRetryDecision(params: {
     retryCategory: retryHint.category,
     backoffMs: errorBackoffMs(consecutiveErrors, retryConfig.backoffMs),
     reason: "transient retry",
+  };
+}
+
+function resolveDisabledHeartbeatOneShotRetryDecision(params: {
+  cronConfig?: CronConfig;
+  consecutiveSkipped: number | undefined;
+}): DisabledHeartbeatOneShotRetryDecision {
+  const retryConfig = resolveRetryConfig(params.cronConfig);
+  const consecutiveSkipped = params.consecutiveSkipped ?? 0;
+  if (consecutiveSkipped > retryConfig.maxAttempts) {
+    return {
+      retryable: false,
+      consecutiveSkipped,
+      reason: "max retries exhausted",
+    };
+  }
+  return {
+    retryable: true,
+    consecutiveSkipped,
+    backoffMs: errorBackoffMs(consecutiveSkipped, retryConfig.backoffMs),
+    reason: "disabled heartbeat retry",
   };
 }
 
@@ -423,6 +452,44 @@ function resolveDeliveryState(params: {
     };
   }
   return { status: "unknown", failureNotification: { status: "not-requested" } };
+}
+
+function shouldRetryDisabledHeartbeatOneShot(
+  job: CronJob,
+  result: { status: CronRunStatus; error?: string },
+): boolean {
+  return (
+    job.schedule.kind === "at" &&
+    job.sessionTarget === "main" &&
+    job.wakeMode === "now" &&
+    result.status === "skipped" &&
+    result.error === HEARTBEAT_SKIP_DISABLED
+  );
+}
+
+function isScheduledTerminalOneShotRetry(
+  job: CronJob,
+  lastRunStatus: CronRunStatus,
+  lastRun: unknown,
+  nextRun: unknown,
+): boolean {
+  if (
+    !isJobEnabled(job) ||
+    typeof nextRun !== "number" ||
+    typeof lastRun !== "number" ||
+    nextRun <= lastRun
+  ) {
+    return false;
+  }
+  if (lastRunStatus === "error") {
+    return true;
+  }
+  return (
+    lastRunStatus === "skipped" &&
+    job.sessionTarget === "main" &&
+    job.wakeMode === "now" &&
+    job.state.lastError === HEARTBEAT_SKIP_DISABLED
+  );
 }
 
 /** Applies run outcome state, delivery state, backoff/next-run scheduling, and delete-after-run policy. */
@@ -532,10 +599,42 @@ export function applyJobResult(
 
   const shouldDelete =
     job.schedule.kind === "at" && job.deleteAfterRun === true && result.status === "ok";
+  const retryDisabledHeartbeatOneShot = shouldRetryDisabledHeartbeatOneShot(job, result);
 
   if (!shouldDelete) {
     if (job.schedule.kind === "at") {
-      if (result.status === "ok" || result.status === "skipped") {
+      if (retryDisabledHeartbeatOneShot) {
+        const retryDecision = resolveDisabledHeartbeatOneShotRetryDecision({
+          cronConfig: state.deps.cronConfig,
+          consecutiveSkipped: job.state.consecutiveSkipped,
+        });
+        if (retryDecision.retryable && retryDecision.backoffMs !== undefined) {
+          job.enabled = true;
+          job.state.nextRunAtMs = result.endedAt + retryDecision.backoffMs;
+          state.deps.log.info(
+            {
+              jobId: job.id,
+              jobName: job.name,
+              consecutiveSkipped: retryDecision.consecutiveSkipped,
+              backoffMs: retryDecision.backoffMs,
+              nextRunAtMs: job.state.nextRunAtMs,
+            },
+            "cron: scheduling one-shot retry after disabled heartbeat",
+          );
+        } else {
+          job.enabled = false;
+          job.state.nextRunAtMs = undefined;
+          state.deps.log.warn(
+            {
+              jobId: job.id,
+              jobName: job.name,
+              consecutiveSkipped: retryDecision.consecutiveSkipped,
+              reason: retryDecision.reason,
+            },
+            "cron: disabling one-shot job after disabled heartbeat retries",
+          );
+        }
+      } else if (result.status === "ok" || result.status === "skipped") {
         // One-shot done or skipped: disable to prevent tight-loop (#11452).
         job.enabled = false;
         job.state.nextRunAtMs = undefined;
@@ -1025,16 +1124,14 @@ function isRunnableJob(params: {
   const lastRunStatus = resolveJobLastRunStatus(job);
   if (params.skipAtIfAlreadyRan && job.schedule.kind === "at" && lastRunStatus) {
     // One-shot with terminal status: skip unless it's a transient-error retry.
-    // Retries have nextRunAtMs > lastRunAtMs (scheduled after the failed run) (#24355).
-    // ok/skipped or error-without-retry always skip (#13845).
+    // Retries have nextRunAtMs > lastRunAtMs (scheduled after the failed/skipped run)
+    // and include disabled-heartbeat delivery retries that must survive restart catch-up (#24355, #91775).
+    // ok/skipped-without-retry or error-without-retry always skip (#13845).
     const lastRun = job.state.lastRunAtMs;
     const nextRun = job.state.nextRunAtMs;
     if (
-      lastRunStatus === "error" &&
-      isJobEnabled(job) &&
-      typeof nextRun === "number" &&
-      typeof lastRun === "number" &&
-      nextRun > lastRun
+      isScheduledTerminalOneShotRetry(job, lastRunStatus, lastRun, nextRun) &&
+      typeof nextRun === "number"
     ) {
       return nowMs >= nextRun;
     }


### PR DESCRIPTION
## Summary

- Keep `wakeMode=now` main-session one-shot cron jobs retryable when the immediate heartbeat returns `skipped`/`disabled`, instead of consuming the one-shot before delivery can be confirmed.
- Bound disabled-heartbeat retries with the existing `cron.retry.maxAttempts` and backoff policy so permanent operator-disabled heartbeat states still become terminal skipped runs.
- Include persisted disabled-heartbeat retry one-shots in restart catch-up planning so overdue retries obey `maxMissedJobsPerRestart` and stagger controls.

## Real behavior proof

Behavior addressed: #91775 - default `deleteAfterRun` one-shot `at` cron jobs should not be deleted or permanently disabled when immediate heartbeat delivery is skipped as `disabled` before the queued system event is consumed.
Real environment tested: local OpenClaw worktree at `d20cc849516fecbda845f00961d6f25362f48e6a` on macOS, using real source modules with a temp cron store: `CronService`, `runHeartbeatOnce`, `setHeartbeatsEnabled(false)`, `enqueueSystemEvent`, and `drainSystemEventEntries`.
Exact steps or command run after this patch: `node --import tsx --input-type=module` with an inline runtime proof script that created due main-session `wakeMode=now` one-shot cron jobs, disabled heartbeats through the real heartbeat runtime switch, and inspected persisted cron state plus the real in-memory system-event queue after `cron.run(job.id, "due")`.
Evidence after fix: copied terminal output from that runtime proof:

```json
{
  "head": "d20cc849516fecbda845f00961d6f25362f48e6a",
  "heartbeatsEnabled": false,
  "retry": {
    "name": "default-retry",
    "eventAccepted": true,
    "drainedCount": 1,
    "drainedText": "issue-91775 default-retry payload",
    "jobPresent": true,
    "enabled": true,
    "lastStatus": "skipped",
    "lastError": "disabled",
    "consecutiveSkipped": 1,
    "nextRunDeltaMs": 30000
  },
  "exhausted": {
    "name": "retry-budget-exhausted",
    "eventAccepted": true,
    "drainedCount": 1,
    "drainedText": "issue-91775 retry-budget-exhausted payload",
    "jobPresent": true,
    "enabled": false,
    "lastStatus": "skipped",
    "lastError": "disabled",
    "consecutiveSkipped": 1,
    "nextRunDeltaMs": null
  }
}
```

Observed result after fix: with the default retry budget, the disabled heartbeat result leaves the one-shot present and enabled with `nextRunDeltaMs: 30000` while the system event was accepted and drained from the real queue. With the retry budget exhausted, the same disabled heartbeat result remains a terminal skipped/disabled run and does not schedule another retry.
What was not tested: a full long-running gateway process with live channel connections; this proof used real OpenClaw runtime modules and a temp store for the cron/heartbeat/system-event boundary, and the focused test suite covers restart catch-up throttling for persisted retry state.

## Verification

- `node --import tsx --input-type=module` inline runtime proof described above
- `node scripts/run-vitest.mjs src/cron/service.runs-one-shot-main-job-disables-it.test.ts src/cron/service.restart-catchup.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/cron/service/timer.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts src/cron/service.restart-catchup.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings

Replacement for closed #91794.
Fixes #91775.
