### PR TITLE
fix(webchat): recover session after stop

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2676,6 +2676,81 @@ describe("agent event handler", () => {
     expect(clearAgentRunContext).not.toHaveBeenCalled();
   });
 
+  it("uses the tracked lifecycle start to reject stale same-session terminal snapshots", async () => {
+    vi.mocked(loadGatewaySessionRow).mockReturnValue({
+      key: "session-race",
+      kind: "direct",
+      sessionId: "same-session",
+      updatedAt: 2_000,
+      status: "running",
+      startedAt: 2_000,
+      endedAt: undefined,
+      runtimeMs: undefined,
+      abortedLastRun: false,
+    });
+    const { broadcastToConnIds, sessionEventSubscribers, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-race",
+    });
+    sessionEventSubscribers.subscribe("conn-session");
+
+    handler({
+      runId: "old-run",
+      seq: 1,
+      stream: "lifecycle",
+      sessionKey: "session-race",
+      sessionId: "same-session",
+      ts: 1_050,
+      data: {
+        phase: "start",
+        startedAt: 1_000,
+      },
+    });
+    handler({
+      runId: "old-run",
+      seq: 2,
+      stream: "lifecycle",
+      sessionKey: "session-race",
+      sessionId: "same-session",
+      ts: 1_500,
+      data: {
+        phase: "end",
+        endedAt: 1_500,
+        aborted: true,
+        stopReason: "rpc",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+      ).toHaveLength(2);
+    });
+    const sessionsChangedCalls = broadcastToConnIds.mock.calls.filter(
+      ([event]) => event === "sessions.changed",
+    );
+    expectPayloadFields(sessionsChangedCalls[1]?.[1], {
+      sessionKey: "session-race",
+      phase: "end",
+      sessionId: "same-session",
+      status: "running",
+      startedAt: 2_000,
+      updatedAt: 2_000,
+      abortedLastRun: false,
+    });
+    const endPersistParams = requireRecord(
+      persistGatewaySessionLifecycleEventMock.mock.calls
+        .map((call) => call[0])
+        .find((params) => {
+          const event = (params as { event?: { data?: { phase?: string } } } | undefined)?.event;
+          return event?.data?.phase === "end";
+        }),
+      "terminal lifecycle persist params",
+    );
+    const persistedEvent = requireRecord(endPersistParams.event, "terminal lifecycle event");
+    expect(requireRecord(persistedEvent.data, "terminal lifecycle data").startedAt).toBe(1_000);
+    resetAgentRunContextForTest();
+  });
+
   it("clears tracked active runs before terminal sessions.changed broadcasts", async () => {
     vi.mocked(loadGatewaySessionRow).mockReturnValue({
       key: "session-finished",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -32,6 +32,7 @@ import { persistGatewaySessionLifecycleEvent } from "./server-chat.persist-sessi
 import {
   deriveGatewaySessionLifecycleProjectionPatch,
   isRestartRecoveryLifecycleEvent,
+  isStaleLifecycleEventForRunGeneration,
   isStaleLifecycleEventForSession,
 } from "./session-lifecycle-state.js";
 import { loadSessionEntry } from "./session-utils.js";
@@ -327,6 +328,7 @@ export function createAgentEventHandler({
   };
 
   const pendingTerminalLifecycleErrors = new Map<string, PendingTerminalLifecycleError>();
+  const lifecycleStartedAtByRunId = new Map<string, number>();
 
   type AgentTextThrottleStream = "assistant" | "thinking";
 
@@ -375,6 +377,34 @@ export function createAgentEventHandler({
     }
   };
 
+  const finiteLifecycleTimestamp = (value: unknown): number | undefined =>
+    typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+
+  const trackLifecycleStart = (evt: AgentEventPayload) => {
+    const startedAt =
+      finiteLifecycleTimestamp(evt.data?.startedAt) ??
+      finiteLifecycleTimestamp(evt.ts) ??
+      Date.now();
+    lifecycleStartedAtByRunId.set(evt.runId, startedAt);
+  };
+
+  const lifecycleEventWithStartedAt = (evt: AgentEventPayload): AgentEventPayload => {
+    if (finiteLifecycleTimestamp(evt.data?.startedAt) !== undefined) {
+      return evt;
+    }
+    const startedAt = lifecycleStartedAtByRunId.get(evt.runId);
+    if (startedAt === undefined) {
+      return evt;
+    }
+    return {
+      ...evt,
+      data: {
+        ...evt.data,
+        startedAt,
+      },
+    };
+  };
+
   // Only subagent/acp keys can carry spawnedBy (mirrors supportsSpawnLineage in
   // sessions-patch.ts). Short-circuit everyone else so high-volume chat streams
   // do not touch the session store. Results are cached per sessionKey because
@@ -412,6 +442,10 @@ export function createAgentEventHandler({
       !isStaleLifecycleEventForSession({
         owningSessionId: evt.sessionId,
         currentSessionId: row?.sessionId,
+      }) &&
+      !isStaleLifecycleEventForRunGeneration({
+        eventStartedAt: evt.data?.startedAt,
+        currentStartedAt: row?.startedAt,
       })
         ? deriveGatewaySessionLifecycleProjectionPatch({
             entry: row
@@ -556,6 +590,8 @@ export function createAgentEventHandler({
     const activeLifecycleGeneration = resolveActiveLifecycleGenerationForRun(evt.runId);
     const currentLifecycleGeneration =
       activeLifecycleGeneration ?? currentRunContext?.lifecycleGeneration;
+    clearPendingTerminalLifecycleError(evt.runId);
+    const lifecycleEvent = lifecycleEventWithStartedAt(evt);
 
     const chatLink = chatRunState.registry.peek(evt.runId);
     const sessionAgentId = chatLink?.agentId ?? evt.agentId;
@@ -663,6 +699,7 @@ export function createAgentEventHandler({
       chatRunState.registry.remove(evt.runId, clientRunId, sessionKey);
     }
     clearAgentRunContext(evt.runId);
+    lifecycleStartedAtByRunId.delete(evt.runId);
     agentRunSeq.delete(evt.runId);
     agentRunSeq.delete(clientRunId);
 
@@ -672,7 +709,7 @@ export function createAgentEventHandler({
         const persistence = persistGatewaySessionLifecycleEvent({
           sessionKey,
           agentId: sessionAgentId,
-          event: evt,
+          event: lifecycleEvent,
         });
         trackTrackedRunTerminalPersistence?.({
           runId: evt.runId,
@@ -719,7 +756,7 @@ export function createAgentEventHandler({
           .catch(() => {
             // Persistence recovery remains tracked by the controller entry, but
             // subscribers still need a terminal projection instead of hanging.
-            broadcastSessionChange(evt);
+            broadcastSessionChange(lifecycleEvent);
           });
       }
     }
@@ -1431,6 +1468,7 @@ export function createAgentEventHandler({
     }
 
     if (sessionKey && lifecyclePhase === "start") {
+      trackLifecycleStart(evt);
       void persistGatewaySessionLifecycleEvent({
         sessionKey,
         agentId: sessionAgentId,

--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -326,6 +326,50 @@ describe("chat abort transcript persistence", () => {
     expect(entry.runtimeMs).toBe((entry.endedAt as number) - startedAt);
   });
 
+  it("does not let stale abort persistence overwrite a newer session run", async () => {
+    const { transcriptPath, sessionId } = await createTranscriptFixture(
+      "openclaw-chat-abort-lifecycle-stale-",
+    );
+    const runId = "idem-abort-lifecycle-stale";
+    const abortedStartedAt = 1_700_000_000_000;
+    const newerStartedAt = abortedStartedAt + 1_000;
+    await writeSessionStoreEntry(transcriptPath, sessionId, {
+      status: "running",
+      startedAt: newerStartedAt,
+      updatedAt: newerStartedAt,
+      endedAt: undefined,
+      runtimeMs: undefined,
+      abortedLastRun: false,
+    });
+    const active = createActiveRun("main", { sessionId });
+    active.startedAtMs = abortedStartedAt;
+    const respond = vi.fn();
+    const context = createChatAbortContext({
+      chatAbortControllers: new Map([[runId, active]]),
+      chatRunBuffers: new Map([[runId, ""]]),
+      chatDeltaSentAt: new Map([[runId, Date.now()]]),
+      logGateway: { warn: vi.fn() },
+    });
+
+    await invokeChatAbortHandler({
+      handler: chatHandlers["chat.abort"],
+      context,
+      request: { sessionKey: "main", runId },
+      respond,
+    });
+
+    const [ok, payload] = requireLastRespondCall(respond);
+    expect(ok).toBe(true);
+    expectAbortPayload(payload, { runIds: [runId] });
+    const entry = await readSessionStoreEntry(transcriptPath);
+    expect(entry.status).toBe("running");
+    expect(entry.abortedLastRun).toBe(false);
+    expect(entry.startedAt).toBe(newerStartedAt);
+    expect(entry.updatedAt).toBe(newerStartedAt);
+    expect(entry.endedAt).toBeUndefined();
+    expect(entry.runtimeMs).toBeUndefined();
+  });
+
   it("does not let non-assistant idempotency collisions suppress abort partial persistence", async () => {
     const { transcriptPath, sessionId } = await createTranscriptFixture(
       "openclaw-chat-abort-idempotency-collision-",

--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -20,7 +20,7 @@ type TranscriptLine = {
 const sessionEntryState = vi.hoisted(() => ({
   transcriptPath: "",
   sessionId: "",
-  hasEntry: true,
+  hasEntry: false,
   canonicalKey: "main",
   cfg: {} as Record<string, unknown>,
   loadCalls: [] as Array<{ sessionKey: string; opts?: { agentId?: string } }>,
@@ -59,6 +59,37 @@ async function writeTranscriptHeader(transcriptPath: string, sessionId: string) 
     cwd: "/tmp",
   };
   await fs.writeFile(transcriptPath, `${JSON.stringify(header)}\n`, "utf-8");
+}
+
+function storePathForTranscript(transcriptPath: string): string {
+  return path.join(path.dirname(transcriptPath), "sessions.json");
+}
+
+async function writeSessionStoreEntry(
+  transcriptPath: string,
+  sessionId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const entry = {
+    sessionId,
+    sessionFile: transcriptPath,
+    updatedAt: 1,
+    status: "running",
+    startedAt: 1,
+    abortedLastRun: false,
+    ...overrides,
+  };
+  await fs.writeFile(
+    storePathForTranscript(transcriptPath),
+    JSON.stringify({ main: entry }, null, 2),
+    "utf-8",
+  );
+}
+
+async function readSessionStoreEntry(transcriptPath: string): Promise<Record<string, unknown>> {
+  const raw = await fs.readFile(storePathForTranscript(transcriptPath), "utf-8");
+  const store = JSON.parse(raw) as Record<string, Record<string, unknown>>;
+  return store.main;
 }
 
 async function readTranscriptLines(transcriptPath: string): Promise<TranscriptLine[]> {
@@ -171,6 +202,7 @@ async function createTranscriptFixture(prefix: string) {
   const sessionId = "sess-main";
   const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
   await writeTranscriptHeader(transcriptPath, sessionId);
+  await writeSessionStoreEntry(transcriptPath, sessionId);
   setMockSessionEntry(transcriptPath, sessionId);
   return { transcriptPath, sessionId };
 }
@@ -190,6 +222,12 @@ afterAll(() => {
 afterEach(() => {
   vi.restoreAllMocks();
   resetAgentEventsForTest();
+  sessionEntryState.transcriptPath = "";
+  sessionEntryState.sessionId = "";
+  sessionEntryState.hasEntry = false;
+  sessionEntryState.canonicalKey = "main";
+  sessionEntryState.cfg = {};
+  sessionEntryState.loadCalls = [];
 });
 
 describe("chat abort transcript persistence", () => {
@@ -245,6 +283,47 @@ describe("chat abort transcript persistence", () => {
       runId,
       stopReason: "stop",
     });
+  });
+
+  it("marks run-scoped rpc aborts as killed before replying", async () => {
+    const { transcriptPath, sessionId } = await createTranscriptFixture(
+      "openclaw-chat-abort-lifecycle-",
+    );
+    const runId = "idem-abort-lifecycle";
+    const startedAt = 1_700_000_000_000;
+    await writeSessionStoreEntry(transcriptPath, sessionId, {
+      status: "running",
+      startedAt,
+      endedAt: undefined,
+      runtimeMs: undefined,
+      abortedLastRun: false,
+    });
+    const active = createActiveRun("main", { sessionId });
+    active.startedAtMs = startedAt;
+    const respond = vi.fn();
+    const context = createChatAbortContext({
+      chatAbortControllers: new Map([[runId, active]]),
+      chatRunBuffers: new Map([[runId, ""]]),
+      chatDeltaSentAt: new Map([[runId, Date.now()]]),
+      logGateway: { warn: vi.fn() },
+    });
+
+    await invokeChatAbortHandler({
+      handler: chatHandlers["chat.abort"],
+      context,
+      request: { sessionKey: "main", runId },
+      respond,
+    });
+
+    const [ok, payload] = requireLastRespondCall(respond);
+    expect(ok).toBe(true);
+    expectAbortPayload(payload, { runIds: [runId] });
+    const entry = await readSessionStoreEntry(transcriptPath);
+    expect(entry.status).toBe("killed");
+    expect(entry.abortedLastRun).toBe(true);
+    expect(entry.startedAt).toBe(startedAt);
+    expect(typeof entry.endedAt).toBe("number");
+    expect(entry.runtimeMs).toBe((entry.endedAt as number) - startedAt);
   });
 
   it("does not let non-assistant idempotency collisions suppress abort partial persistence", async () => {

--- a/src/gateway/server-methods/chat.abort.test-helpers.ts
+++ b/src/gateway/server-methods/chat.abort.test-helpers.ts
@@ -71,6 +71,8 @@ export function createChatAbortContext(
     agentRunSeq: new Map<string, number>(),
     getRuntimeConfig: () => ({}),
     broadcast: vi.fn(),
+    broadcastToConnIds: vi.fn(),
+    getSessionEventSubscriberConnIds: () => new Set<string>(),
     nodeSendToSession: vi.fn(),
     logGateway: { warn: vi.fn() },
     ...overrides,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -60,7 +60,11 @@ import {
   type StageSandboxMediaResult,
 } from "../../auto-reply/reply/stage-sandbox-media.js";
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
-import { resolveSessionFilePath, updateSessionStoreEntry } from "../../config/sessions.js";
+import {
+  resolveSessionFilePath,
+  updateSessionStoreEntry,
+  type SessionEntry,
+} from "../../config/sessions.js";
 import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -218,6 +222,16 @@ type AbortedPartialSnapshot = {
   agentId?: string;
   text: string;
   abortOrigin: AbortOrigin;
+};
+
+type AbortedLifecycleSnapshot = {
+  runId: string;
+  sessionKey: string;
+  sessionId: string;
+  agentId?: string;
+  startedAtMs: number;
+  endedAtMs: number;
+  controlUiVisible?: boolean;
 };
 
 type ChatAbortRequester = {
@@ -2049,6 +2063,103 @@ function collectSessionAbortPartials(params: {
   return out;
 }
 
+function collectSessionAbortLifecycleSnapshots(params: {
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+  runIds: ReadonlySet<string>;
+  endedAtMs: number;
+}): AbortedLifecycleSnapshot[] {
+  const out: AbortedLifecycleSnapshot[] = [];
+  for (const [runId, active] of params.chatAbortControllers) {
+    if (!params.runIds.has(runId)) {
+      continue;
+    }
+    out.push({
+      runId,
+      sessionKey: active.sessionKey,
+      sessionId: active.sessionId,
+      agentId: active.agentId,
+      startedAtMs: active.startedAtMs,
+      endedAtMs: params.endedAtMs,
+      controlUiVisible: active.controlUiVisible,
+    });
+  }
+  return out;
+}
+
+function finitePositiveTimestamp(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function buildAbortedLifecyclePatch(
+  current: SessionEntry,
+  snapshot: AbortedLifecycleSnapshot,
+): Partial<SessionEntry> | null {
+  if (snapshot.sessionId && current.sessionId && current.sessionId !== snapshot.sessionId) {
+    return null;
+  }
+  const endedAt = finitePositiveTimestamp(snapshot.endedAtMs) ?? Date.now();
+  const startedAt = finitePositiveTimestamp(snapshot.startedAtMs) ?? current.startedAt;
+  return {
+    updatedAt: endedAt,
+    status: "killed",
+    startedAt,
+    endedAt,
+    runtimeMs: startedAt !== undefined ? Math.max(0, endedAt - startedAt) : current.runtimeMs,
+    abortedLastRun: true,
+  };
+}
+
+async function persistAbortedSessionLifecycles(params: {
+  context: Pick<
+    GatewayRequestContext,
+    | "chatAbortControllers"
+    | "broadcastToConnIds"
+    | "getRuntimeConfig"
+    | "getSessionEventSubscriberConnIds"
+    | "logGateway"
+  >;
+  snapshots: AbortedLifecycleSnapshot[];
+}): Promise<void> {
+  for (const snapshot of params.snapshots) {
+    if (snapshot.controlUiVisible === false) {
+      continue;
+    }
+    const sessionLoadOptions =
+      snapshot.sessionKey === "global" && snapshot.agentId
+        ? { agentId: snapshot.agentId }
+        : undefined;
+    const { storePath, canonicalKey, entry } = loadSessionEntry(
+      snapshot.sessionKey,
+      sessionLoadOptions,
+    );
+    if (!entry) {
+      continue;
+    }
+    try {
+      const persisted = await updateSessionStoreEntry({
+        storePath,
+        sessionKey: canonicalKey,
+        skipMaintenance: true,
+        takeCacheOwnership: true,
+        update: (current) => buildAbortedLifecyclePatch(current, snapshot),
+      });
+      if (persisted) {
+        emitSessionsChanged(params.context, {
+          sessionKey: canonicalKey,
+          ...(canonicalKey === "global" && snapshot.agentId ? { agentId: snapshot.agentId } : {}),
+          reason: "abort",
+        });
+      }
+    } catch (err) {
+      params.context.logGateway.warn(
+        `chat.abort session lifecycle persistence failed for ${snapshot.runId}: ${formatErrorMessage(
+          err,
+        )}`,
+      );
+    }
+  }
+}
+
 async function persistAbortedPartials(params: {
   context: Pick<GatewayRequestContext, "logGateway">;
   sessionKey: string;
@@ -2467,6 +2578,12 @@ async function abortChatRunsForSessionKeyWithPartials(params: {
     runIds: authorizedRunIdSet,
     abortOrigin: params.abortOrigin,
   });
+  const endedAt = Date.now();
+  const lifecycleSnapshots = collectSessionAbortLifecycleSnapshots({
+    chatAbortControllers: params.context.chatAbortControllers,
+    runIds: authorizedRunIdSet,
+    endedAtMs: endedAt,
+  });
   const runIds: string[] = [];
   for (const { runId, sessionKey } of authorizedRuns) {
     const res = abortChatRunById(params.ops, {
@@ -2478,7 +2595,6 @@ async function abortChatRunsForSessionKeyWithPartials(params: {
       runIds.push(runId);
     }
   }
-  const endedAt = Date.now();
   const stopReason = params.stopReason ?? "rpc";
   for (const { runId, sessionKey, payload } of authorizedPendingAgentRuns) {
     writePreRegisteredAgentAbort({
@@ -2493,6 +2609,10 @@ async function abortChatRunsForSessionKeyWithPartials(params: {
   }
   const res = { aborted: runIds.length > 0, runIds, unauthorized: false };
   if (res.aborted) {
+    await persistAbortedSessionLifecycles({
+      context: params.context,
+      snapshots: lifecycleSnapshots,
+    });
     await persistAbortedPartials({
       context: params.context,
       sessionKey: params.persistSessionKey ?? params.sessionKey,
@@ -3361,6 +3481,22 @@ export const chatHandlers: GatewayRequestHandlers = {
       sessionKey: active.sessionKey,
       stopReason: "rpc",
     });
+    if (res.aborted) {
+      await persistAbortedSessionLifecycles({
+        context,
+        snapshots: [
+          {
+            runId,
+            sessionKey: active.sessionKey,
+            sessionId: active.sessionId,
+            agentId: active.agentId,
+            startedAtMs: active.startedAtMs,
+            endedAtMs: Date.now(),
+            controlUiVisible: active.controlUiVisible,
+          },
+        ],
+      });
+    }
     if (res.aborted && active.controlUiVisible !== false && partialText && partialText.trim()) {
       await persistAbortedPartials({
         context,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2097,8 +2097,17 @@ function buildAbortedLifecyclePatch(
   if (snapshot.sessionId && current.sessionId && current.sessionId !== snapshot.sessionId) {
     return null;
   }
+  const snapshotStartedAt = finitePositiveTimestamp(snapshot.startedAtMs);
+  const currentStartedAt = finitePositiveTimestamp(current.startedAt);
+  if (
+    snapshotStartedAt !== undefined &&
+    currentStartedAt !== undefined &&
+    currentStartedAt > snapshotStartedAt
+  ) {
+    return null;
+  }
   const endedAt = finitePositiveTimestamp(snapshot.endedAtMs) ?? Date.now();
-  const startedAt = finitePositiveTimestamp(snapshot.startedAtMs) ?? current.startedAt;
+  const startedAt = snapshotStartedAt ?? current.startedAt;
   return {
     updatedAt: endedAt,
     status: "killed",

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -162,7 +162,10 @@ import { ADMIN_SCOPE } from "../method-scopes.js";
 import { chatAbortMarkerTimestampMs, type ChatRunTiming } from "../server-chat-state.js";
 import { getMaxChatHistoryMessagesBytes, MAX_PAYLOAD_BYTES } from "../server-constants.js";
 import { resolveSessionHistoryTailReadOptions } from "../session-history-state.js";
-import { persistGatewaySessionLifecycleEvent } from "../session-lifecycle-state.js";
+import {
+  isStaleLifecycleEventForRunGeneration,
+  persistGatewaySessionLifecycleEvent,
+} from "../session-lifecycle-state.js";
 import { readSessionTranscriptIndex } from "../session-transcript-index.fs.js";
 import {
   capArrayByJsonBytes,
@@ -2100,9 +2103,7 @@ function buildAbortedLifecyclePatch(
   const snapshotStartedAt = finitePositiveTimestamp(snapshot.startedAtMs);
   const currentStartedAt = finitePositiveTimestamp(current.startedAt);
   if (
-    snapshotStartedAt !== undefined &&
-    currentStartedAt !== undefined &&
-    currentStartedAt > snapshotStartedAt
+    isStaleLifecycleEventForRunGeneration({ eventStartedAt: snapshotStartedAt, currentStartedAt })
   ) {
     return null;
   }

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   deriveGatewaySessionLifecycleSnapshot,
   derivePersistedSessionLifecyclePatch,
+  isStaleLifecycleEventForRunGeneration,
   isStaleLifecycleEventForSession,
 } from "./session-lifecycle-state.js";
 
@@ -77,6 +78,50 @@ describe("session lifecycle state", () => {
     expect(
       isStaleLifecycleEventForSession({ owningSessionId: undefined, currentSessionId: "new-id" }),
     ).toBe(false);
+  });
+
+  it("treats older lifecycle events as stale once a same-session row has a newer run generation", () => {
+    expect(
+      isStaleLifecycleEventForRunGeneration({
+        eventStartedAt: 1_000,
+        currentStartedAt: 2_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("applies lifecycle events for the same run generation", () => {
+    expect(
+      isStaleLifecycleEventForRunGeneration({
+        eventStartedAt: 2_000,
+        currentStartedAt: 2_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not let an old abort lifecycle event terminalize a newer same-session run", () => {
+    expect(
+      derivePersistedSessionLifecyclePatch({
+        entry: {
+          updatedAt: 2_000,
+          status: "running",
+          startedAt: 2_000,
+          endedAt: undefined,
+          runtimeMs: undefined,
+          abortedLastRun: false,
+        },
+        event: {
+          ts: 1_500,
+          sessionId: "same-session",
+          data: {
+            phase: "end",
+            startedAt: 1_000,
+            endedAt: 1_500,
+            aborted: true,
+            stopReason: "rpc",
+          },
+        },
+      }),
+    ).toBeNull();
   });
 
   it("reactivates completed sessions on lifecycle start", () => {

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -173,9 +173,17 @@ export function deriveGatewaySessionLifecycleSnapshot(params: {
 export function derivePersistedSessionLifecyclePatch(params: {
   entry?: Partial<PersistedLifecycleSessionShape> | null;
   event: LifecycleEventLike;
-}): Partial<PersistedLifecycleSessionShape> {
+}): Partial<PersistedLifecycleSessionShape> | null {
   if (isRestartRecoveryLifecycleEvent(params)) {
     return {};
+  }
+  if (
+    isStaleLifecycleEventForRunGeneration({
+      eventStartedAt: params.event.data?.startedAt,
+      currentStartedAt: params.entry?.startedAt,
+    })
+  ) {
+    return null;
   }
   const snapshot = deriveGatewaySessionLifecycleSnapshot({
     session: params.entry ?? undefined,
@@ -211,8 +219,11 @@ export function deriveGatewaySessionLifecycleProjectionPatch(params: {
   entry?: Partial<PersistedLifecycleSessionShape> | null;
   event: LifecycleEventLike;
 }): GatewaySessionLifecycleSnapshot {
-  const { restartRecoveryRuns: _restartRecoveryRuns, ...patch } =
-    derivePersistedSessionLifecyclePatch(params);
+  const persistedPatch = derivePersistedSessionLifecyclePatch(params);
+  if (!persistedPatch) {
+    return {};
+  }
+  const { restartRecoveryRuns: _restartRecoveryRuns, ...patch } = persistedPatch;
   return patch;
 }
 
@@ -250,6 +261,22 @@ export function isStaleLifecycleEventForSession(params: {
     params.owningSessionId &&
     params.currentSessionId &&
     params.owningSessionId !== params.currentSessionId,
+  );
+}
+
+/**
+ * Consecutive runs reuse a sessionId, so session identity alone cannot reject a
+ * late lifecycle end from the previous run. A row that already has a newer
+ * startedAt owns a newer run generation and must not be terminalized.
+ */
+export function isStaleLifecycleEventForRunGeneration(params: {
+  eventStartedAt?: unknown;
+  currentStartedAt?: unknown;
+}): boolean {
+  return (
+    isFiniteTimestamp(params.eventStartedAt) &&
+    isFiniteTimestamp(params.currentStartedAt) &&
+    params.currentStartedAt > params.eventStartedAt
   );
 }
 
@@ -293,6 +320,9 @@ export async function persistGatewaySessionLifecycleEvent(params: {
         entry,
         event: params.event,
       });
+      if (!patch) {
+        return null;
+      }
       return Object.keys(patch).length > 0 ? patch : null;
     },
   });

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -3225,7 +3225,7 @@ describe("handleAbortChat", () => {
       sessionKey: "agent:main",
     });
     expect(host.chatMessage).toBe("next prompt");
-    expect(host.chatRunId).toBe("run-main");
+    expect(host.chatRunId).toBeNull();
   });
 
   it("clears typed stop commands after aborting the active run", async () => {
@@ -3244,6 +3244,7 @@ describe("handleAbortChat", () => {
       sessionKey: "agent:main",
     });
     expect(host.chatMessage).toBe("");
+    expect(host.chatRunId).toBeNull();
   });
 
   it("queues the active run abort while disconnected", async () => {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -3210,7 +3210,7 @@ describe("handleAbortChat", () => {
   });
 
   it("preserves the draft for connected toolbar aborts", async () => {
-    const request = vi.fn(async () => ({ aborted: true }));
+    const request = vi.fn(async () => ({ aborted: true, runIds: ["run-main"] }));
     const host = makeHost({
       client: { request } as unknown as ChatHost["client"],
       chatRunId: "run-main",
@@ -3229,7 +3229,7 @@ describe("handleAbortChat", () => {
   });
 
   it("clears typed stop commands after aborting the active run", async () => {
-    const request = vi.fn(async () => ({ aborted: true }));
+    const request = vi.fn(async () => ({ aborted: true, runIds: ["run-main"] }));
     const host = makeHost({
       client: { request } as unknown as ChatHost["client"],
       chatRunId: "run-main",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2454,6 +2454,28 @@ describe("sendChatMessage", () => {
 });
 
 describe("abortChatRun", () => {
+  it("locally terminalizes the active run after a successful abort", async () => {
+    const request = vi.fn().mockResolvedValue({ aborted: true, runIds: ["run-1"] });
+    const state = createState({
+      connected: true,
+      chatRunId: "run-1",
+      chatStream: "Partial reply",
+      chatStreamStartedAt: 10,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const result = await abortChatRun(state);
+
+    expect(result).toBe(true);
+    expect(request).toHaveBeenCalledWith("chat.abort", {
+      sessionKey: "main",
+      runId: "run-1",
+    });
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+    expectTextChatMessage(state.chatMessages.at(-1), "assistant", "Partial reply");
+  });
+
   it("formats structured non-auth connect failures for chat abort", async () => {
     // Abort now shares the same structured connect-error formatter as send.
     const request = vi.fn().mockRejectedValue(

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2476,6 +2476,57 @@ describe("abortChatRun", () => {
     expectTextChatMessage(state.chatMessages.at(-1), "assistant", "Partial reply");
   });
 
+  it("does not terminalize when the abort response does not include the active run", async () => {
+    const request = vi.fn().mockResolvedValue({ aborted: false, runIds: [] });
+    const state = createState({
+      connected: true,
+      chatRunId: "run-1",
+      chatStream: "Partial reply",
+      chatStreamStartedAt: 10,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const result = await abortChatRun(state);
+
+    expect(result).toBe(true);
+    expect(request).toHaveBeenCalledWith("chat.abort", {
+      sessionKey: "main",
+      runId: "run-1",
+    });
+    expect(state.chatRunId).toBe("run-1");
+    expect(state.chatStream).toBe("Partial reply");
+    expect(state.chatMessages).toStrictEqual([]);
+  });
+
+  it("does not terminalize a newer run after a stale abort response", async () => {
+    const deferred = createDeferred<{ aborted: boolean; runIds: string[] }>();
+    const request = vi.fn().mockReturnValue(deferred.promise);
+    const state = createState({
+      connected: true,
+      chatRunId: "run-1",
+      chatStream: "Partial reply",
+      chatStreamStartedAt: 10,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const abort = abortChatRun(state);
+    state.chatRunId = "run-2";
+    state.chatStream = "Newer reply";
+    state.chatStreamStartedAt = 20;
+    deferred.resolve({ aborted: true, runIds: ["run-1"] });
+    const result = await abort;
+
+    expect(result).toBe(true);
+    expect(request).toHaveBeenCalledWith("chat.abort", {
+      sessionKey: "main",
+      runId: "run-1",
+    });
+    expect(state.chatRunId).toBe("run-2");
+    expect(state.chatStream).toBe("Newer reply");
+    expect(state.chatStreamStartedAt).toBe(20);
+    expect(state.chatMessages).toStrictEqual([]);
+  });
+
   it("formats structured non-auth connect failures for chat abort", async () => {
     // Abort now shares the same structured connect-error formatter as send.
     const request = vi.fn().mockRejectedValue(

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1288,13 +1288,41 @@ function reconcileSuccessfulLocalAbort(state: ChatState, runId: string | null) {
   });
 }
 
+function abortedRunIdsFromResult(result: unknown): Set<string> {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return new Set();
+  }
+  const runIds = (result as { runIds?: unknown }).runIds;
+  if (!Array.isArray(runIds)) {
+    return new Set();
+  }
+  return new Set(runIds.filter((runId): runId is string => typeof runId === "string"));
+}
+
+function shouldReconcileSuccessfulLocalAbort(
+  state: ChatState,
+  capturedRunId: string | null,
+  result: unknown,
+): boolean {
+  if (state.chatRunId !== capturedRunId) {
+    return false;
+  }
+  if (!capturedRunId || !result || typeof result !== "object" || Array.isArray(result)) {
+    return false;
+  }
+  if ((result as { aborted?: unknown }).aborted !== true) {
+    return false;
+  }
+  return abortedRunIdsFromResult(result).has(capturedRunId);
+}
+
 export async function abortChatRun(state: ChatState): Promise<boolean> {
   if (!state.client || !state.connected) {
     return false;
   }
   const runId = state.chatRunId;
   try {
-    await state.client.request(
+    const result = await state.client.request(
       "chat.abort",
       runId
         ? {
@@ -1313,7 +1341,9 @@ export async function abortChatRun(state: ChatState): Promise<boolean> {
             })(),
           },
     );
-    reconcileSuccessfulLocalAbort(state, runId);
+    if (shouldReconcileSuccessfulLocalAbort(state, runId, result)) {
+      reconcileSuccessfulLocalAbort(state, runId);
+    }
     return true;
   } catch (err) {
     setChatError(state, formatConnectError(err));

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1270,6 +1270,24 @@ export async function sendSteerChatMessage(
   return sendChatMessageWithGeneratedRunId(state, message, attachments);
 }
 
+function reconcileSuccessfulLocalAbort(state: ChatState, runId: string | null) {
+  if (!runId && state.chatStream == null) {
+    return;
+  }
+  state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state);
+  reconcileChatRunLifecycle(state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0], {
+    outcome: "interrupted",
+    sessionStatus: "killed",
+    runId,
+    sessionKey: state.sessionKey,
+    clearLocalRun: true,
+    clearChatStream: true,
+    clearToolStream: true,
+    clearSideResultTerminalRuns: true,
+    armLocalTerminalReconcile: Boolean(runId),
+  });
+}
+
 export async function abortChatRun(state: ChatState): Promise<boolean> {
   if (!state.client || !state.connected) {
     return false;
@@ -1295,6 +1313,7 @@ export async function abortChatRun(state: ChatState): Promise<boolean> {
             })(),
           },
     );
+    reconcileSuccessfulLocalAbort(state, runId);
     return true;
   } catch (err) {
     setChatError(state, formatConnectError(err));

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -661,6 +661,87 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("recovers after stopping a streaming WebChat turn and sends the next turn", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await gateway.deferNext("chat.send");
+
+      const firstPrompt = "start a stoppable streaming response";
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill(firstPrompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+
+      const firstSendRequest = await gateway.waitForRequest("chat.send");
+      const firstParams = requireRecord(firstSendRequest.params);
+      const firstRunId = requireString(firstParams.idempotencyKey, "first run id");
+      expect(firstParams.sessionKey).toBe("main");
+      expect(firstParams.message).toBe(firstPrompt);
+
+      const partialText = "PR92003 first turn is streaming before Stop.";
+      await gateway.emitGatewayEvent("chat", {
+        deltaText: partialText,
+        message: {
+          content: [{ text: partialText, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+        runId: firstRunId,
+        sessionKey: "main",
+        state: "delta",
+      });
+      await page.locator(".chat-thread").getByText(partialText).waitFor({ timeout: 10_000 });
+
+      await gateway.resolveDeferred("chat.send", { runId: firstRunId, status: "started" });
+      const stopButton = page.getByRole("button", { name: "Stop generating" });
+      await stopButton.waitFor({ state: "visible", timeout: 10_000 });
+
+      await gateway.deferNext("chat.abort");
+      await stopButton.click();
+      const abortRequest = await gateway.waitForRequest("chat.abort");
+      const abortParams = requireRecord(abortRequest.params);
+      expect(abortParams.sessionKey).toBe("main");
+      expect(abortParams.runId).toBe(firstRunId);
+
+      await gateway.resolveDeferred("chat.abort", {
+        aborted: true,
+        runIds: [firstRunId],
+        sessionKeys: ["main"],
+      });
+      await page.locator(".chat-thread").getByText(partialText).waitFor({ timeout: 10_000 });
+      await stopButton.waitFor({ state: "detached", timeout: 10_000 });
+
+      const secondPrompt = "PR92003 second turn should complete after Stop";
+      await composer.fill(secondPrompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+
+      const sendRequests = await waitForRequests(gateway, "chat.send", 2);
+      const secondParams = requireRecord(sendRequests[1]?.params);
+      const secondRunId = requireString(secondParams.idempotencyKey, "second run id");
+      expect(secondRunId).not.toBe(firstRunId);
+      expect(secondParams.sessionKey).toBe("main");
+      expect(secondParams.message).toBe(secondPrompt);
+
+      await gateway.emitChatFinal({
+        runId: secondRunId,
+        text: "PR92003 second turn completed after Stop.",
+      });
+      await page
+        .locator(".chat-thread")
+        .getByText("PR92003 second turn completed after Stop.")
+        .waitFor({ timeout: 10_000 });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps chat usable while sessions are still loading", async () => {
     const context = await newBrowserContext({
       locale: "en-US",


### PR DESCRIPTION
Fixes #91987.

## What Problem This Solves

WebChat Stop could leave the selected session stuck as `running` after a confirmed `chat.abort`, especially when the terminal chat event was delayed or lost. That made the same WebChat session unreliable for an immediate follow-up turn without refreshing or using `/reset`.

This PR persists confirmed aborts as terminal `killed` lifecycle state, reconciles the WebChat client only for the captured run id, and guards stale lifecycle/Stop responses so an older abort cannot terminalize a newer same-session run.

## Summary
- Persist successful WebChat `chat.abort` requests as terminal `killed` session lifecycle before the RPC responds, including `abortedLastRun: true`, `endedAt`, and `runtimeMs`.
- Reconcile WebChat locally after a confirmed Stop so the active run id/stream/tool state are cleared even if the terminal chat event is delayed or lost.
- Guard both new abort terminalization paths against stale run races: gateway persistence refuses to overwrite a newer session generation, and the client only reconciles the captured run id when the abort response confirms that run.
- Add focused unit/gateway regressions plus a browser Control UI e2e regression for the visible stream, Stop, second-send recovery path.

## Evidence

### Current-head proof after rebase (2026-07-01)

- Rebased the branch onto current `origin/main` `24d94a54a51625cad7d6f68197de76267c665da6`.
- New PR head is `ba5fcb9e57edfb7c49fe2bddca1f5929e53fc10b`.
- Removed the unrelated `scripts/plugin-sdk-surface-report.mjs` budget bump that ClawSweeper flagged; the PR diff is now limited to WebChat/Gateway stop recovery files.
- Behavior addressed: clicking Stop during an active WebChat run no longer leaves the selected session stuck as `running`; the same WebChat session can immediately send and complete the next turn without refresh or `/reset`. Stale lifecycle/Stop responses are guarded by the current run generation.

### Live browser proof

Ran the rebased PR head through a real Chromium WebChat flow against an isolated temporary Gateway and a local OpenAI-compatible streaming provider. Production gateway/config was not mutated.

Flow observed:
- Opened Control UI/WebChat against the temporary Gateway.
- Sent first prompt: `PR92003 first prompt: start a stoppable streaming response`.
- The local streaming provider began returning visible assistant text: `PR92003 current-head first turn streamed before Stop.`.
- Clicked the visible Stop button while that first provider request was still streaming.
- The first provider request was aborted: `aborted=true`, `completed=false`.
- Sent second prompt in the same WebChat session without refresh or `/reset`: `PR92003 second prompt: second turn should complete after Stop`.
- The second provider request completed: `aborted=false`, `completed=true`.
- Browser showed final marker: `PR92003 current-head second turn completed after Stop.`.

Redacted runtime evidence:

```text
head: ba5fcb9e57edfb7c49fe2bddca1f5929e53fc10b
temporary gateway port: 64643
local provider: proof-local/pr92003-proof-model

provider request 1:
  prompt: PR92003 first prompt: start a stoppable streaming response
  aborted: true
  completed: false

provider request 2:
  prompt: PR92003 second prompt: second turn should complete after Stop
  aborted: false
  completed: true

gateway log excerpt:
  [ws] res chat.send runId=94db07b4-49e7-4269-857f-215a451fd97f
  [model-fetch] response provider=proof-local model=pr92003-proof-model status=200 contentType=text/event-stream
  [ws] res chat.abort 199ms
  [agent/embedded] runId=94db07b4-49e7-4269-857f-215a451fd97f ... rawError=Request was aborted
  [model-fetch] start provider=proof-local model=pr92003-proof-model
  [model-fetch] response provider=proof-local model=pr92003-proof-model status=200 contentType=text/event-stream
```

Browser screenshots were captured locally for the three visible states:
- first stream visible before Stop
- Stop control cleared after abort
- second turn completed in the same session

### Verification

- `node scripts/run-vitest.mjs ui/src/ui/app-chat.test.ts` — 101 passed
- `node scripts/run-vitest.mjs ui/src/ui/controllers/chat.test.ts` — 133 passed
- `node scripts/run-vitest.mjs ui/src/ui/chat/run-lifecycle.test.ts` — 13 passed
- `node scripts/run-vitest.mjs src/gateway/chat-abort.test.ts` — 124 passed
- `node scripts/run-vitest.mjs src/gateway/server-methods/chat.abort-persistence.test.ts` — 56 passed
- `node scripts/run-vitest.mjs ui/src/ui/e2e/chat-flow.e2e.test.ts` — 19 passed
- `pnpm exec oxfmt --check --threads=1 <11 changed files>`
- `pnpm exec oxlint <11 changed files>`
- `git diff --check origin/main...HEAD`
- `pnpm tsgo:prod`

What was not tested: no production gateway restart or production WebChat session was used. The proof used an isolated temporary Gateway plus a local streaming provider so the browser Stop path, Gateway abort RPC, provider abort, and same-session second-send recovery were exercised without touching production.
