### PR TITLE
fix(telegram): classify streaming preview edit failures instead of killing the draft

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -145,6 +145,10 @@ import {
   type ProviderInfo,
 } from "./model-buttons.js";
 import { parseTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
+import {
+  isTelegramEditTargetMissingError,
+  isTelegramMessageHasNoTextError,
+} from "./network-errors.js";
 import { buildInlineKeyboard } from "./send.js";
 
 export const registerTelegramHandlers = ({
@@ -1303,11 +1307,8 @@ export const registerTelegramHandlers = ({
     }
   }
 
-  const TELEGRAM_PERMANENT_CALLBACK_EDIT_ERROR_RE =
-    /400:\s*Bad Request:\s*message to edit not found|400:\s*Bad Request:\s*there is no text in the message to edit|MESSAGE_ID_INVALID|400:\s*Bad Request:\s*message can't be edited/i;
-
   const isPermanentTelegramCallbackEditError = (err: unknown): boolean =>
-    TELEGRAM_PERMANENT_CALLBACK_EDIT_ERROR_RE.test(String(err));
+    isTelegramEditTargetMissingError(err) || isTelegramMessageHasNoTextError(err);
 
   const resolveTelegramEventAuthorizationContext = async (params: {
     chatId: number;

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -378,11 +378,20 @@ describe("createTelegramDraftStream", () => {
     expect(stream.sendMayHaveLanded?.()).toBe(expected);
   }
 
-  it("clears sendMayHaveLanded on pre-connect first preview send failures", async () => {
-    await expectSendMayHaveLandedStateAfterFirstFailure(
+  it("retries pre-connect first preview send failures instead of stopping", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage.mockRejectedValueOnce(
       Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" }),
-      false,
     );
+    const stream = createDraftStream(api);
+
+    stream.update("Hello");
+    await stream.flush();
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(2);
+    expect(stream.sendMayHaveLanded?.()).toBe(false);
+    expect(stream.messageId()).toBe(17);
   });
 
   it("clears sendMayHaveLanded on Telegram 4xx client rejections", async () => {
@@ -390,6 +399,103 @@ describe("createTelegramDraftStream", () => {
       Object.assign(new Error("403: Forbidden"), { error_code: 403 }),
       false,
     );
+  });
+
+  it("treats message-is-not-modified edits as delivered", async () => {
+    const api = createMockDraftApi();
+    api.editMessageText.mockRejectedValueOnce(
+      Object.assign(
+        new Error("Call to 'editMessageText' failed! (400: Bad Request: message is not modified)"),
+        { error_code: 400 },
+      ),
+    );
+    const warn = vi.fn();
+    const stream = createDraftStream(api, { warn });
+
+    stream.update("Hello");
+    await stream.flush();
+    stream.update("Hello again");
+    await stream.flush();
+    stream.update("Hello more");
+    await stream.flush();
+
+    expect(api.editMessageText).toHaveBeenCalledTimes(2);
+    expect(api.editMessageText).toHaveBeenLastCalledWith(123, 17, "Hello more");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("retries the preview edit after a transient network failure", async () => {
+    const api = createMockDraftApi();
+    api.editMessageText.mockRejectedValueOnce(
+      Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+    );
+    const warn = vi.fn();
+    const stream = createDraftStream(api, { warn });
+
+    stream.update("Hello");
+    await stream.flush();
+    stream.update("Hello again");
+    await stream.flush();
+    expect(warn).toHaveBeenCalledWith(
+      "telegram stream preview edit failed (retrying): read ECONNRESET",
+    );
+
+    await stream.flush();
+
+    expect(api.editMessageText).toHaveBeenCalledTimes(2);
+    expect(api.editMessageText).toHaveBeenLastCalledWith(123, 17, "Hello again");
+    expect(stream.lastDeliveredText?.()).toBe("Hello again");
+  });
+
+  it("suspends preview edits for retry_after during flood control", async () => {
+    vi.useFakeTimers();
+    try {
+      const api = createMockDraftApi();
+      api.editMessageText.mockRejectedValueOnce(
+        Object.assign(
+          new Error("Call to 'editMessageText' failed! (429: Too Many Requests: retry after 1)"),
+          { error_code: 429, parameters: { retry_after: 1 } },
+        ),
+      );
+      const stream = createDraftStream(api);
+
+      stream.update("Hello");
+      await stream.flush();
+      stream.update("Hello again");
+      await stream.flush();
+      stream.update("Hello more");
+      await stream.flush();
+      expect(api.editMessageText).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1100);
+      await stream.flush();
+
+      expect(api.editMessageText).toHaveBeenCalledTimes(2);
+      expect(api.editMessageText).toHaveBeenLastCalledWith(123, 17, "Hello more");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops the preview after repeated retryable edit failures", async () => {
+    const api = createMockDraftApi();
+    api.editMessageText.mockRejectedValue(
+      Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+    );
+    const warn = vi.fn();
+    const stream = createDraftStream(api, { warn });
+
+    stream.update("Hello");
+    await stream.flush();
+    stream.update("Hello again");
+    await stream.flush();
+    await stream.flush();
+    await stream.flush();
+    await stream.flush();
+    await stream.flush();
+
+    expect(api.editMessageText).toHaveBeenCalledTimes(4);
+    expect(warn).toHaveBeenCalledWith("telegram stream preview failed: read ECONNRESET");
   });
 
   it("supports rendered previews with parse_mode", async () => {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -6,11 +6,25 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
-import { isSafeToRetrySendError, isTelegramClientRejection } from "./network-errors.js";
+import {
+  isRecoverableTelegramNetworkError,
+  isSafeToRetrySendError,
+  isTelegramClientRejection,
+  isTelegramMessageNotModifiedError,
+  isTelegramRateLimitError,
+  readTelegramRetryAfterMs,
+} from "./network-errors.js";
 import { normalizeTelegramReplyToMessageId } from "./outbound-params.js";
 
 const TELEGRAM_STREAM_MAX_CHARS = 4096;
 const DEFAULT_THROTTLE_MS = 1000;
+// Retryable preview failures keep the latest text pending for the next throttle
+// tick; cap consecutive misses so a persistent outage stops the preview instead
+// of warn-spamming for the rest of the run.
+const MAX_CONSECUTIVE_PREVIEW_FAILURES = 3;
+// Flood waits beyond this freeze the preview longer than it is useful; clamp so
+// a large retry_after cannot park the suspension past the run's lifetime.
+const MAX_PREVIEW_FLOOD_SUSPEND_MS = 60_000;
 
 export type TelegramDraftStream = {
   update: (text: string) => void;
@@ -109,6 +123,8 @@ export function createTelegramDraftStream(params: {
 
   const streamState = { stopped: false, final: false };
   let messageSendAttempted = false;
+  let suspendedUntilMs = 0;
+  let consecutivePreviewFailures = 0;
   let streamMessageId: number | undefined;
   let streamVisibleSinceMs: number | undefined;
   let lastSentText = "";
@@ -198,6 +214,12 @@ export function createTelegramDraftStream(params: {
     if (streamState.stopped && !streamState.final) {
       return false;
     }
+    // Flood-control suspension: returning false keeps the newest text pending,
+    // so the first tick after retry_after delivers it. Final flushes still try
+    // so the last text has a chance to land.
+    if (!streamState.final && Date.now() < suspendedUntilMs) {
+      return false;
+    }
     const trimmed = text.trimEnd();
     if (!trimmed) {
       return false;
@@ -262,6 +284,8 @@ export function createTelegramDraftStream(params: {
       }
     }
 
+    const previousSentText = lastSentText;
+    const previousSentParseMode = lastSentParseMode;
     lastSentText = renderedText;
     lastSentParseMode = renderedParseMode;
     try {
@@ -273,9 +297,40 @@ export function createTelegramDraftStream(params: {
       if (sent) {
         previewRevision += 1;
         lastDeliveredText = trimmed;
+        consecutivePreviewFailures = 0;
+        suspendedUntilMs = 0;
       }
       return sent;
     } catch (err) {
+      const isEdit = typeof streamMessageId === "number";
+      if (isEdit && isTelegramMessageNotModifiedError(err)) {
+        // Telegram already shows exactly this text; count the edit as delivered.
+        consecutivePreviewFailures = 0;
+        lastDeliveredText = trimmed;
+        return true;
+      }
+      // Roll back the dedupe snapshot so the retried tick is not skipped as a no-op.
+      lastSentText = previousSentText;
+      lastSentParseMode = previousSentParseMode;
+      // Flood control is always retryable: Telegram rejected the call outright.
+      // Beyond that, edits retry on any transient network error (re-editing the
+      // same content is idempotent) while an unsent first preview retries only
+      // on provably pre-connect failures — anything ambiguous could duplicate
+      // the preview message.
+      const retryable =
+        isTelegramRateLimitError(err) ||
+        (isEdit ? isRecoverableTelegramNetworkError(err) : isSafeToRetrySendError(err));
+      consecutivePreviewFailures += 1;
+      if (retryable && consecutivePreviewFailures <= MAX_CONSECUTIVE_PREVIEW_FAILURES) {
+        const retryAfterMs = readTelegramRetryAfterMs(err);
+        if (retryAfterMs !== undefined) {
+          suspendedUntilMs = Date.now() + Math.min(retryAfterMs, MAX_PREVIEW_FLOOD_SUSPEND_MS);
+        }
+        params.warn?.(
+          `telegram stream preview ${isEdit ? "edit" : "send"} failed (retrying): ${formatErrorMessage(err)}`,
+        );
+        return false;
+      }
       streamState.stopped = true;
       params.warn?.(`telegram stream preview failed: ${formatErrorMessage(err)}`);
       return false;

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -225,7 +225,8 @@ function hasTelegramErrorCode(err: unknown, matches: (code: number) => boolean):
   return false;
 }
 
-function hasTelegramRetryAfter(err: unknown): boolean {
+/** Reads Telegram's flood-control retry_after hint (in ms) from any error nesting shape. */
+export function readTelegramRetryAfterMs(err: unknown): number | undefined {
   for (const candidate of collectTelegramErrorCandidates(err)) {
     if (!candidate || typeof candidate !== "object") {
       continue;
@@ -250,10 +251,10 @@ function hasTelegramRetryAfter(err: unknown): boolean {
                 ?.retry_after
             : undefined;
     if (typeof retryAfter === "number" && Number.isFinite(retryAfter)) {
-      return true;
+      return retryAfter * 1000;
     }
   }
-  return false;
+  return undefined;
 }
 
 /** Returns true for HTTP 5xx server errors (error may have been processed). */
@@ -264,8 +265,30 @@ export function isTelegramServerError(err: unknown): boolean {
 export function isTelegramRateLimitError(err: unknown): boolean {
   return (
     hasTelegramErrorCode(err, (code) => code === 429) ||
-    (hasTelegramRetryAfter(err) && /(?:^|\b)429\b|too many requests/i.test(formatErrorMessage(err)))
+    (readTelegramRetryAfterMs(err) !== undefined &&
+      /(?:^|\b)429\b|too many requests/i.test(formatErrorMessage(err)))
   );
+}
+
+const MESSAGE_NOT_MODIFIED_RE =
+  /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
+const MESSAGE_HAS_NO_TEXT_RE = /400:\s*Bad Request:\s*there is no text in the message to edit/i;
+const EDIT_TARGET_MISSING_RE =
+  /400:\s*Bad Request:\s*message to edit not found|400:\s*Bad Request:\s*message can't be edited|MESSAGE_ID_INVALID/i;
+
+/** True when Telegram rejected an edit because the content is unchanged; the message already shows the requested text. */
+export function isTelegramMessageNotModifiedError(err: unknown): boolean {
+  return MESSAGE_NOT_MODIFIED_RE.test(formatErrorMessage(err));
+}
+
+/** True when the edit target has no text body (e.g. media message needing a caption edit). */
+export function isTelegramMessageHasNoTextError(err: unknown): boolean {
+  return MESSAGE_HAS_NO_TEXT_RE.test(formatErrorMessage(err));
+}
+
+/** True when the edit target is gone or locked (deleted message, invalid id); retrying the same edit cannot succeed. */
+export function isTelegramEditTargetMissingError(err: unknown): boolean {
+  return EDIT_TARGET_MISSING_RE.test(formatErrorMessage(err));
 }
 
 /** Returns true for HTTP 4xx client errors (Telegram explicitly rejected, not applied). */

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -29,6 +29,8 @@ import { buildInlineKeyboard } from "./inline-keyboard.js";
 import {
   isRecoverableTelegramNetworkError,
   isSafeToRetrySendError,
+  isTelegramMessageHasNoTextError,
+  isTelegramMessageNotModifiedError,
   isTelegramRateLimitError,
   isTelegramServerError,
 } from "./network-errors.js";
@@ -230,9 +232,6 @@ function logTelegramOutboundSendOk(params: TelegramOutboundSuccessLogParams): vo
 }
 
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
-const MESSAGE_NOT_MODIFIED_RE =
-  /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
-const MESSAGE_HAS_NO_TEXT_RE = /400:\s*Bad Request:\s*there is no text in the message to edit/i;
 const MESSAGE_DELETE_NOOP_RE =
   /message to delete not found|message can't be deleted|MESSAGE_ID_INVALID|MESSAGE_DELETE_FORBIDDEN/i;
 const CHAT_NOT_FOUND_RE = /400: Bad Request: chat not found/i;
@@ -420,14 +419,6 @@ function normalizeMessageId(raw: string | number): number {
     }
   }
   throw new Error("Message id is required for Telegram actions");
-}
-
-function isTelegramMessageNotModifiedError(err: unknown): boolean {
-  return MESSAGE_NOT_MODIFIED_RE.test(formatErrorMessage(err));
-}
-
-function isTelegramMessageHasNoTextError(err: unknown): boolean {
-  return MESSAGE_HAS_NO_TEXT_RE.test(formatErrorMessage(err));
 }
 
 function isTelegramMessageDeleteNoopError(err: unknown): boolean {


### PR DESCRIPTION
## Summary

The Telegram streaming preview has no edit-failure taxonomy: any error from `sendMessage`/`editMessageText` hits one catch in `extensions/telegram/src/draft-stream.ts` that permanently kills the preview for the rest of the run (`streamState.stopped = true`). One flood-control 429, one transient socket error, or one harmless `400: message is not modified` and the live preview is gone — even though grammY's `apiThrottler` only rate-limits proactively (no reactive retry) and the final-message path in `send.ts` already classifies these errors.

Changes:
- `refactor(telegram)`: move the `message is not modified` / `no text to edit` / edit-target-missing predicates into `network-errors.ts` (deleting the duplicated regexes in `send.ts` and `bot-handlers.runtime.ts`), and turn the private `hasTelegramRetryAfter` into `readTelegramRetryAfterMs`.
- `fix(telegram)`: classify preview failures instead of stopping the stream —
  - `message is not modified` → counted as delivered;
  - flood control → suspend edits until `retry_after` (clamped to 60s), then resume with the newest pending text;
  - transient network errors on edits (idempotent) and provably pre-connect first-send failures → retried by the existing throttle loop (the dedupe snapshot rolls back so the retry is not skipped);
  - ambiguous send failures and other client rejections stay fatal (no duplicate-preview risk), and 3 consecutive retryable misses stop the preview to bound warn noise.

No config changes; behavior is preview-only (final message delivery already had its own retry/classification).

## Verification

- `node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts` — 41 passed.
- Regression proof (prod `draft-stream.ts` swapped to `origin/main`, tests kept): the 5 taxonomy tests fail — not-modified kills the stream, transient edit failure never retries, flood `retry_after` is ignored, pre-connect send failure never retries, repeated-failure cap unreachable. All pass with this branch.
- `send.test.ts`, `network-errors.test.ts`, `bot-native-commands.test.ts` green (203 tests) — covers the moved predicates' call sites.
- Testbox `check:changed` green (`tbx_01ktscp8jnyfneve3ajs1tppjh`): typecheck core/extensions + tests, oxlint core/extensions shards, guards, import cycles.
- Not tested live: a real Telegram flood-control window against the Bot API.
