### PR TITLE
build: add tsdown DTS diagnostics controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1675,6 +1675,7 @@
     "test:auth:compat": "node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server.auth.compat-baseline.test.ts src/gateway/client.test.ts src/gateway/reconnect-gating.test.ts && node scripts/run-vitest.mjs run packages/gateway-protocol/src/connect-error-details.test.ts",
     "test:build:singleton": "node scripts/test-built-plugin-singleton.mjs",
     "test:build:status-message-runtime": "node scripts/test-built-status-message-runtime.mjs",
+    "test:build:tsdown-diagnostics": "node scripts/test-tsdown-build-diagnostics.mjs",
     "test:bundled": "node scripts/run-vitest.mjs run --config test/vitest/vitest.bundled.config.ts",
     "test:changed": "node scripts/test-projects.mjs --changed origin/main",
     "test:changed:max": "node scripts/test-projects-max.mjs --changed origin/main",

--- a/scripts/test-tsdown-build-diagnostics.mjs
+++ b/scripts/test-tsdown-build-diagnostics.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+// Fast diagnostics gate for tsdown-build wrapper-only contracts.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  createTsdownConfigIndexFile,
+  parseTsdownBuildArgs,
+  tsdownBuildUsage,
+} from "./tsdown-build.mjs";
+
+assert.deepEqual(parseTsdownBuildArgs(["--help"]), {
+  forwardedArgs: [],
+  help: true,
+  configIndex: null,
+  allowIneffectiveDynamicImport: false,
+});
+assert.deepEqual(parseTsdownBuildArgs(["--format", "esm"]), {
+  forwardedArgs: ["--format", "esm"],
+  help: false,
+  configIndex: null,
+  allowIneffectiveDynamicImport: false,
+});
+assert.deepEqual(parseTsdownBuildArgs(["--config-index", "16", "--logLevel", "info"]), {
+  forwardedArgs: ["--logLevel", "info"],
+  help: false,
+  configIndex: 16,
+  allowIneffectiveDynamicImport: false,
+});
+assert.deepEqual(
+  parseTsdownBuildArgs([
+    "--config-index",
+    "16",
+    "--allow-ineffective-dynamic-import",
+    "--logLevel",
+    "info",
+  ]),
+  {
+    forwardedArgs: ["--logLevel", "info"],
+    help: false,
+    configIndex: 16,
+    allowIneffectiveDynamicImport: true,
+  },
+);
+assert.throws(
+  () => parseTsdownBuildArgs(["--config-index"]),
+  /--config-index requires a non-negative integer value/u,
+);
+assert.throws(
+  () => parseTsdownBuildArgs(["--config-index", "1", "--config-index", "2"]),
+  /--config-index can only be passed once/u,
+);
+
+const usage = tsdownBuildUsage();
+assert.match(usage, /--config-index <number>/u);
+assert.match(usage, /--allow-ineffective-dynamic-import/u);
+
+const helpResult = spawnSync(process.execPath, ["scripts/tsdown-build.mjs", "--help"], {
+  cwd: process.cwd(),
+  encoding: "utf8",
+});
+assert.equal(helpResult.status, 0);
+assert.match(helpResult.stdout, /--config-index <number>/u);
+assert.equal(helpResult.stderr, "");
+
+const invalidArgResult = spawnSync(
+  process.execPath,
+  ["scripts/tsdown-build.mjs", "--config-index"],
+  {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  },
+);
+assert.equal(invalidArgResult.status, 2);
+assert.match(invalidArgResult.stderr, /--config-index requires a non-negative integer value/u);
+assert.match(invalidArgResult.stderr, /Other arguments are forwarded to tsdown/u);
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-tsdown-config-index-"));
+try {
+  const fileName = createTsdownConfigIndexFile({ cwd: tempDir, configIndex: 16 });
+  assert.match(fileName, /^\.openclaw-tsdown-config-16-\d+-\d+\.ts$/u);
+  assert.equal(
+    fs.readFileSync(path.join(tempDir, fileName), "utf8"),
+    'import configs from "./tsdown.config.ts";\nexport default configs[16];\n',
+  );
+} finally {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+}
+
+const configText = fs.readFileSync("tsdown.config.ts", "utf8");
+assert.match(configText, /OPENCLAW_RUN_ROOT_UNIFIED_DTS_BUILD/u);
+assert.match(
+  configText,
+  /dts: RUN_NODE_SKIP_DTS_BUILD \|\| !RUN_ROOT_UNIFIED_DTS_BUILD \? false : undefined/u,
+);
+
+console.log("tsdown-build diagnostics: PASS");

--- a/scripts/tsdown-build.mjs
+++ b/scripts/tsdown-build.mjs
@@ -39,6 +39,8 @@ const GENERATED_SOURCE_DECLARATION_PATHSPEC = ":(glob)extensions/**/*.d.ts";
 const DECLARATION_EXTENSIONS = [".d.ts", ".d.mts", ".d.cts"];
 const SOURCE_DECLARATION_SOURCE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".js", ".mjs", ".cjs"];
 const RUN_NODE_SKIP_DTS_BUILD_ENV = "OPENCLAW_RUN_NODE_SKIP_DTS_BUILD";
+const CONFIG_INDEX_ARG = "--config-index";
+const ALLOW_INEFFECTIVE_DYNAMIC_IMPORT_ARG = "--allow-ineffective-dynamic-import";
 
 function removeDistPluginNodeModulesSymlinks(rootDir) {
   const extensionsDir = path.join(rootDir, "extensions");
@@ -487,7 +489,9 @@ export function tsdownBuildUsage() {
     "Builds OpenClaw with tsdown and validates emitted import diagnostics.",
     "",
     "Options:",
-    "  -h, --help  Show this help without starting tsdown.",
+    "  -h, --help                         Show this help without starting tsdown.",
+    "  --config-index <number>            Run one config from tsdown.config.ts via a temporary local config.",
+    "  --allow-ineffective-dynamic-import  Let diagnostic shard runs exit with tsdown's status when this warning appears.",
     "",
     "Other arguments are forwarded to tsdown.",
   ].join("\n");
@@ -498,12 +502,59 @@ export function parseTsdownBuildArgs(argv) {
     return {
       forwardedArgs: [],
       help: true,
+      configIndex: null,
+      allowIneffectiveDynamicImport: false,
     };
   }
+
+  const forwardedArgs = [];
+  let configIndex = null;
+  let allowIneffectiveDynamicImport = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === ALLOW_INEFFECTIVE_DYNAMIC_IMPORT_ARG) {
+      allowIneffectiveDynamicImport = true;
+      continue;
+    }
+    if (arg !== CONFIG_INDEX_ARG) {
+      forwardedArgs.push(arg);
+      continue;
+    }
+
+    if (configIndex !== null) {
+      throw new Error(`${CONFIG_INDEX_ARG} can only be passed once`);
+    }
+    const value = argv[index + 1];
+    const parsed = parseNonNegativeIntegerEnv(value, CONFIG_INDEX_ARG);
+    if (parsed === null) {
+      throw new Error(`${CONFIG_INDEX_ARG} requires a non-negative integer value`);
+    }
+    configIndex = parsed;
+    index += 1;
+  }
+
   return {
-    forwardedArgs: argv,
+    forwardedArgs,
     help: false,
+    configIndex,
+    allowIneffectiveDynamicImport,
   };
+}
+
+export function createTsdownConfigIndexFile(params = {}) {
+  const cwd = params.cwd ?? process.cwd();
+  const configIndex = params.configIndex;
+  if (!Number.isSafeInteger(configIndex) || configIndex < 0) {
+    throw new Error("configIndex must be a non-negative safe integer");
+  }
+  const fileName = `.openclaw-tsdown-config-${configIndex}-${process.pid}-${Date.now()}.ts`;
+  const filePath = path.join(cwd, fileName);
+  const fsImpl = params.fs ?? fs;
+  fsImpl.writeFileSync(
+    filePath,
+    `import configs from "./tsdown.config.ts";\nexport default configs[${configIndex}];\n`,
+  );
+  return fileName;
 }
 
 export function createTsdownOutputScanner(params = {}) {
@@ -697,39 +748,59 @@ function isMainModule() {
 }
 
 if (isMainModule()) {
-  const args = parseTsdownBuildArgs(process.argv.slice(2));
+  let args;
+  try {
+    args = parseTsdownBuildArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    console.error(tsdownBuildUsage());
+    process.exit(2);
+  }
   if (args.help) {
     console.log(tsdownBuildUsage());
     process.exit(0);
   }
-  pruneSourceCheckoutBundledPluginNodeModules();
-  pruneUntrackedGeneratedSourceDeclarations();
-  pruneStaleRuntimeSymlinks();
-  cleanTsdownOutputRoots();
-  const invocation = resolveTsdownBuildInvocation({ args: args.forwardedArgs });
-  const result = await runTsdownBuildInvocation(invocation);
+  let temporaryConfigPath = null;
+  try {
+    if (args.configIndex !== null) {
+      temporaryConfigPath = createTsdownConfigIndexFile({ configIndex: args.configIndex });
+      args.forwardedArgs = ["--config", temporaryConfigPath, ...args.forwardedArgs];
+    }
+    pruneSourceCheckoutBundledPluginNodeModules();
+    pruneUntrackedGeneratedSourceDeclarations();
+    pruneStaleRuntimeSymlinks();
+    cleanTsdownOutputRoots();
+    const invocation = resolveTsdownBuildInvocation({ args: args.forwardedArgs });
+    const result = await runTsdownBuildInvocation(invocation);
 
-  if (result.status === 0 && result.hasIneffectiveDynamicImport) {
-    console.error(
-      "Build emitted [INEFFECTIVE_DYNAMIC_IMPORT]. Replace transparent runtime re-export facades with real runtime boundaries.",
-    );
-    process.exit(1);
+    if (
+      result.status === 0 &&
+      result.hasIneffectiveDynamicImport &&
+      !args.allowIneffectiveDynamicImport
+    ) {
+      console.error(
+        "Build emitted [INEFFECTIVE_DYNAMIC_IMPORT]. Replace transparent runtime re-export facades with real runtime boundaries.",
+      );
+      process.exitCode = 1;
+    } else if (result.status === 0 && result.fatalUnresolvedImport) {
+      console.error(
+        `Build emitted [UNRESOLVED_IMPORT] outside extensions: ${result.fatalUnresolvedImport}`,
+      );
+      process.exitCode = 1;
+    } else if (result.timedOut) {
+      process.exitCode = 124;
+    } else if (typeof result.status === "number") {
+      process.exitCode = result.status;
+    } else {
+      process.exitCode = 1;
+    }
+  } finally {
+    if (temporaryConfigPath) {
+      try {
+        fs.rmSync(path.join(process.cwd(), temporaryConfigPath), { force: true });
+      } catch {
+        // Best-effort cleanup for diagnostic config files.
+      }
+    }
   }
-
-  if (result.status === 0 && result.fatalUnresolvedImport) {
-    console.error(
-      `Build emitted [UNRESOLVED_IMPORT] outside extensions: ${result.fatalUnresolvedImport}`,
-    );
-    process.exit(1);
-  }
-
-  if (result.timedOut) {
-    process.exit(124);
-  }
-
-  if (typeof result.status === "number") {
-    process.exit(result.status);
-  }
-
-  process.exit(1);
 }

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -8,7 +8,6 @@ import {
   cleanTsdownOutputRoots,
   createTsdownOutputScanner,
   listTsdownOutputRoots,
-  parseTsdownBuildArgs,
   pruneSourceCheckoutBundledPluginNodeModules,
   pruneStaleRootChunkFiles,
   pruneUntrackedGeneratedSourceDeclarations,
@@ -38,14 +37,6 @@ async function expectPathMissing(targetPath: string) {
 }
 
 describe("resolveTsdownBuildInvocation", () => {
-  it("parses wrapper help before any tsdown work", () => {
-    expect(parseTsdownBuildArgs(["--help"])).toEqual({ forwardedArgs: [], help: true });
-    expect(parseTsdownBuildArgs(["--format", "esm"])).toEqual({
-      forwardedArgs: ["--format", "esm"],
-      help: false,
-    });
-  });
-
   it("prints wrapper help without invoking pnpm or tsdown", () => {
     const result = spawnSync(process.execPath, ["scripts/tsdown-build.mjs", "--help"], {
       cwd: process.cwd(),

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -40,6 +40,7 @@ const env = {
 };
 const OUTPUT_SOURCE_MAPS = process.env.OUTPUT_SOURCE_MAPS === "1";
 const RUN_NODE_SKIP_DTS_BUILD = process.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD === "1";
+const RUN_ROOT_UNIFIED_DTS_BUILD = process.env.OPENCLAW_RUN_ROOT_UNIFIED_DTS_BUILD === "1";
 
 const SUPPRESSED_EVAL_WARNING_PATHS = [
   "@protobufjs/inquire/index.js",
@@ -798,8 +799,13 @@ export default defineConfig([
   nodeBuildConfig({
     // Build core entrypoints, plugin-sdk subpaths, bundled plugin entrypoints,
     // and bundled hooks in one graph so runtime singletons are emitted once.
+    // The package-level configs above remain responsible for declaration output.
+    // Keep the unified runtime graph JS-only by default: the bundled-plugin DTS
+    // graph is large enough to hit rolldown-plugin-dts timeout/resource limits
+    // in constrained environments. Set OPENCLAW_RUN_ROOT_UNIFIED_DTS_BUILD=1
+    // only for focused declaration-regression diagnostics.
     clean: true,
-    dts: RUN_NODE_SKIP_DTS_BUILD ? false : undefined,
+    dts: RUN_NODE_SKIP_DTS_BUILD || !RUN_ROOT_UNIFIED_DTS_BUILD ? false : undefined,
     entry: buildUnifiedDistEntries(),
     deps: {
       alwaysBundle: shouldAlwaysBundleDependency,


### PR DESCRIPTION
## Summary

- add tsdown wrapper diagnostics for selecting a single config shard with `--config-index <number>`
- add a diagnostics-only `--allow-ineffective-dynamic-import` escape hatch for known tsdown warning behavior
- keep the root unified DTS graph opt-in while preserving package-level declaration builds
- add a fast `test:build:tsdown-diagnostics` gate for wrapper/config behavior

## Why

The root unified tsdown config can pull a large runtime graph when DTS is enabled. This makes declaration diagnostics expensive and noisy. The change keeps default root unified DTS disabled unless `OPENCLAW_RUN_ROOT_UNIFIED_DTS_BUILD=1` is explicitly set, while preserving package-level DTS generation paths.

The wrapper diagnostics make it easier to validate individual tsdown config shards and known warning behavior without turning those diagnostics into the default build path.

## Verification

Validated locally in a clean replay worktree from base `029f11d3`:

- `git apply --check`
- exact dirty set check
- `node scripts/test-tsdown-build-diagnostics.mjs`
- `pnpm test:build:tsdown-diagnostics`
- `node scripts/run-vitest.mjs run test/scripts/tsdown-build.test.ts` — 25 tests passed
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json parse: PASS')"`
- `git diff --check`
- no `.openclaw-tsdown-config-*` leftovers

Post-commit smoke:

- `node scripts/test-tsdown-build-diagnostics.mjs`
- `git diff --check HEAD~1..HEAD`

## Risk / reviewer notes

- `--allow-ineffective-dynamic-import` is intended only for diagnostic shard runs; it should not become a normal release/build flag.
- `OPENCLAW_RUN_ROOT_UNIFIED_DTS_BUILD=1` re-enables the expensive root unified DTS path and should remain opt-in.
- Parser-focused assertions moved from the Vitest shard into `scripts/test-tsdown-build-diagnostics.mjs`, so this new diagnostics gate should be included in targeted landing checks.

## Commit

`33e1bee04adcbd5179baa021427aec72cb1a101f` — `build: add tsdown DTS diagnostics controls`
