### PR TITLE
fix(webchat): clear tool stream on final event with text after tool use

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -37,6 +37,7 @@ import { shouldReloadHistoryForFinalEvent } from "./chat-event-reload.ts";
 import { loadChatComposerSnapshot, restoreChatComposerState } from "./chat/composer-persistence.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
 import { parseChatSideResult, type ChatSideResult } from "./chat/side-result.ts";
+import { clearToolStreamSegments } from "./chat/stream-reconciliation.ts";
 import { formatConnectError } from "./connect-error.ts";
 import {
   recordControlUiConnectTiming,
@@ -954,6 +955,7 @@ function handleTerminalChatEvent(
   // with the persisted copy and causes a visible disappear/reappear flicker.
   if (hadToolEvents && state === "final") {
     if (activeRunIdBeforeEvent && !shouldReloadHistoryForFinalEvent(payload)) {
+      clearToolStreamSegments(toolHost);
       flushQueue();
       return false;
     }


### PR DESCRIPTION
## Summary

- After a tool call with a text reply, WebChat renders a duplicate assistant bubble containing the same pre-tool text that already appears in the final message
- The server's final event message is text-only (`{ role: "assistant", content: [{ type: "text", text }] }`), so tool cards in `chatToolMessages` must be preserved — they are the sole source of tool activity rendering when history is not reloaded
- The duplication comes from `chatStreamSegments`: when the model writes text before invoking a tool, `handleAgentEvent` commits the in-progress stream text as a segment, and the final message includes the same text
- `handleTerminalChatEvent`'s early-return branch (tools present + final has text) was missing cleanup of `chatStreamSegments`; the fix adds `clearToolStreamSegments` to this path

## Linked context

Closes # (pending issue link)

## Real behavior proof

- Behavior addressed: duplicate assistant text bubble in WebChat after tool calls with text replies
- Real environment tested: local dev gateway (port 18789)
- Exact steps or command run after this patch: rebuild and restart dev gateway, send a message in WebChat that causes the model to write text, invoke a tool, then write more text
- Evidence after fix: pending
- Observed result after fix: pending
- What was not tested: other channels (Telegram, Slack, etc.) are unaffected since the change is scoped to the UI-layer `handleTerminalChatEvent`
- Proof limitations or environment constraints: local dev gateway, not production

## Tests and validation

- `pnpm test ui/src/ui/chat-event-reload.test.ts --run` — 9 passed
- `pnpm test ui/src/ui/app-gateway.sessions.node.test.ts --run` — 29 passed
- No new test added: the fix targets cross-path streaming state cleanup that is difficult to unit-test; the three termination paths now each handle stream segments consistently

## Risk checklist

- Did user-visible behavior change? `Yes` — WebChat no longer shows a duplicate assistant bubble for pre-tool text when the model writes text before calling a tool
- Did config, environment, or migration behavior change? `No`
- Did security, auth, secrets, network, or tool execution behavior change? `No`
- What is the highest-risk area? `clearToolStreamSegments` only clears `chatStreamSegments`, not `chatToolMessages` — late-arriving tool events could still append stale entries, but `agentEventScopeMatches` filters by session/agent scope
- How is that risk mitigated? The fix is minimal — `clearToolStreamSegments` only resets the segments array and has been exercised on the history-reload path. Tool cards are preserved because they are not duplicated in the final message

## Current review state

- What is the next action? Awaiting reviewer
- What is still waiting on author, maintainer, CI, or external proof? Manual WebChat verification