### PR TITLE
fix(agents): prevent recursive task execution during model fallback

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1325,6 +1325,25 @@ describe("Codex app-server dynamic tool build", () => {
     expect(toolOptions.exec?.mode).toBeUndefined();
   });
 
+  it("passes the delegation capability into shared OpenClaw tool construction", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.delegationCapability = "report_only";
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    const factoryOptions: unknown[] = [];
+    setOpenClawCodingToolsFactoryForTests((options) => {
+      factoryOptions.push(options);
+      return [];
+    });
+
+    await buildDynamicToolsForTest(params, workspaceDir, { sandbox: null as never });
+
+    expect(factoryOptions).toHaveLength(1);
+    expect(factoryOptions[0]).toMatchObject({ delegationCapability: "report_only" });
+  });
+
   it("uses the tool auth profile store for Codex dynamic tool construction", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -293,6 +293,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
         : undefined,
     modelApi: params.model.api,
     modelContextWindowTokens: params.model.contextWindow,
+    delegationCapability: params.delegationCapability,
     modelAuthMode: resolveModelAuthMode(
       params.model.provider,
       params.config,

--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -350,8 +350,12 @@ export async function startOrResumeThread(
     const startModelProvider = startModelSelection.modelProvider;
     // Capability read failures use managed search for this turn but must not
     // create a binding that later looks like a confirmed provider-policy change.
+    const transientDelegationRestriction = params.params.delegationCapability === "report_only";
     let preserveExistingBinding =
-      !ringZeroActive && params.nativeProviderWebSearchSupport === "unknown" && !binding?.threadId;
+      transientDelegationRestriction ||
+      (!ringZeroActive &&
+        params.nativeProviderWebSearchSupport === "unknown" &&
+        !binding?.threadId);
     let rotatedContextEngineBinding = false;
     let prebuiltPluginThreadConfig: CodexPluginThreadConfig | undefined;
     const webSearchBindingChanged =
@@ -437,6 +441,16 @@ export async function startOrResumeThread(
         },
       );
       preserveExistingBinding = true;
+      binding = undefined;
+    }
+    if (binding?.threadId && transientDelegationRestriction) {
+      assertCodexBindingMayBeReplaced(binding, "starting a delegation-restricted turn");
+      // Loaded Codex threads ignore resume config overrides. Keep the normal
+      // binding intact and start a transient thread with collaboration disabled.
+      embeddedAgentLog.debug(
+        "codex app-server delegation restricted for turn; starting transient thread",
+        { threadId: binding.threadId },
+      );
       binding = undefined;
     }
     if (binding?.threadId && (binding.contextEngine || contextEngineBinding)) {

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -1155,6 +1155,64 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
   });
 
+  it("uses a transient Codex thread for report-only fallback completion", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    const appServer = createThreadLifecycleAppServerOptions();
+    let starts = 0;
+    const request = vi.fn(async (method: string, requestParams?: unknown) => {
+      if (method === "thread/start") {
+        starts += 1;
+        return threadStartResult(`thread-${starts}`);
+      }
+      if (method === "thread/resume") {
+        return threadStartResult((requestParams as { threadId: string }).threadId);
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer,
+    });
+    params.delegationCapability = "report_only";
+    const restrictedBinding = await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer,
+    });
+    const savedAfterRestriction = await readCodexAppServerBinding(sessionFile);
+    params.delegationCapability = "full";
+    const resumedBinding = await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer,
+    });
+
+    expect(restrictedBinding.threadId).toBe("thread-2");
+    expect(savedAfterRestriction?.threadId).toBe("thread-1");
+    expect(resumedBinding.threadId).toBe("thread-1");
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/start",
+      "thread/start",
+      "thread/resume",
+    ]);
+    expect(request.mock.calls[1]?.[1]).toMatchObject({
+      config: {
+        "features.multi_agent": false,
+        "features.multi_agent_v2": false,
+      },
+    });
+  });
+
   it("preserves the native-search binding when provider capability support is unknown", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -84,6 +84,37 @@ describe("Codex ring-zero thread config", () => {
   });
 });
 
+describe("Codex delegation capability", () => {
+  it("disables native delegation on start and resume without disabling other tools", () => {
+    const params = createAttemptParams({ provider: "openai" });
+    params.delegationCapability = "report_only";
+    const appServer = createAppServerOptions() as never;
+    const config = {
+      "features.multi_agent": true,
+      "features.multi_agent_v2": true,
+      "features.goals": true,
+    };
+    const start = buildThreadStartParams(params, {
+      appServer,
+      cwd: "/repo",
+      dynamicTools: [],
+      config,
+    });
+    const resume = buildThreadResumeParams(params, {
+      appServer,
+      dynamicTools: [],
+      threadId: "thread-1",
+      config,
+    });
+
+    for (const request of [start, resume]) {
+      expect(request.config?.["features.multi_agent"]).toBe(false);
+      expect(request.config?.["features.multi_agent_v2"]).toBe(false);
+      expect(request.config?.["features.goals"]).toBe(true);
+    }
+  });
+});
+
 function startOrResumeThread(
   params: Omit<Parameters<typeof startOrResumeThreadImpl>[0], "bindingStore">,
 ) {

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -51,6 +51,11 @@ const CODEX_TOOL_SEARCH_UNSUPPORTED_THREAD_CONFIG: JsonObject = {
   "features.multi_agent": false,
 };
 
+const CODEX_DELEGATION_DISABLED_THREAD_CONFIG: JsonObject = {
+  "features.multi_agent": false,
+  "features.multi_agent_v2": false,
+};
+
 const CODEX_RING_ZERO_THREAD_CONFIG: JsonObject = {
   "features.apps": false,
   "features.current_time_reminder": false,
@@ -361,6 +366,9 @@ export function buildCodexRuntimeThreadConfigForRun(
       options.appServer?.networkProxy?.configPatch,
       shouldDisableCodexToolSearchForModel(params.modelId)
         ? CODEX_TOOL_SEARCH_UNSUPPORTED_THREAD_CONFIG
+        : undefined,
+      params.delegationCapability === "report_only"
+        ? CODEX_DELEGATION_DISABLED_THREAD_CONFIG
         : undefined,
       buildCodexRingZeroThreadConfigPatch(
         params,

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -500,6 +500,7 @@ describe("createCopilotToolBridge", () => {
           forceMessageTool: true,
           enableHeartbeatTool: true,
           forceHeartbeatTool: false,
+          delegationCapability: "report_only",
         } as never,
         createOpenClawCodingTools,
         modelId: "gpt-4o",
@@ -532,6 +533,7 @@ describe("createCopilotToolBridge", () => {
         requireExplicitMessageTarget: true,
         forceMessageTool: true,
         enableHeartbeatTool: true,
+        delegationCapability: "report_only",
       });
     });
 

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -407,6 +407,7 @@ function buildOpenClawCodingToolsOptions(
     modelCompat,
     modelApi: model?.api,
     modelContextWindowTokens: model?.contextWindow,
+    delegationCapability: a.delegationCapability,
     modelAuthMode: resolveModelAuthMode(input.modelProvider, a.config, undefined, {
       workspaceDir,
     }),

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -66,6 +66,7 @@ import {
   type ResolvedConversationCapabilityProfile,
 } from "./conversation-capability-profile.js";
 import type { OpenClawCodingToolConstructionPlan } from "./core-tool-factory-descriptors.js";
+import { applyDelegationCapability, type DelegationCapability } from "./delegation-capability.js";
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
 import { createLazyExecTool, resolveExecToolConfig } from "./lazy-exec-tool.js";
 import {
@@ -342,6 +343,8 @@ type OpenClawCodingToolsOptions = {
   modelId?: string;
   /** Internal review-run restrictions and proposal provenance. */
   skillWorkshop?: SkillWorkshopRunOptions;
+  /** Attempt-local authority to start or redirect delegated work. */
+  delegationCapability?: DelegationCapability;
   /** Model API for the current provider (used for provider-native tool arbitration). */
   modelApi?: string;
   /** Model context window in tokens (used to scale read-tool output budget). */
@@ -1102,7 +1105,10 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   });
   // Host-bound ring-zero tools carry their own authority checks. Agent policy
   // must not deadlock setup, but the tools still receive schema/hook wrappers.
-  const authorizedTools = mergeAgentRingZeroTools(ringZeroTools, subagentFiltered);
+  const authorizedTools = applyDelegationCapability(
+    mergeAgentRingZeroTools(ringZeroTools, subagentFiltered),
+    options?.delegationCapability,
+  );
   if (shouldInheritEffectiveToolAllowlist) {
     replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, authorizedTools);
   }

--- a/src/agents/delegation-capability.test.ts
+++ b/src/agents/delegation-capability.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { applyDelegationCapability, resolveDelegationCapability } from "./delegation-capability.js";
+import type { AnyAgentTool } from "./tools/common.js";
+
+function createTool(
+  name: string,
+  execute = vi.fn(async () => ({ content: [], details: {} })),
+): AnyAgentTool {
+  return {
+    name,
+    label: name,
+    description: name,
+    parameters: {} as never,
+    execute,
+  } as unknown as AnyAgentTool;
+}
+
+describe("delegation capability", () => {
+  it("enters report-only mode only for fallback completion reports", () => {
+    expect(
+      resolveDelegationCapability({
+        fallbackActive: true,
+        inputProvenance: { kind: "inter_session", sourceTool: "subagent_announce" },
+      }),
+    ).toBe("report_only");
+    expect(
+      resolveDelegationCapability({
+        fallbackActive: true,
+        inputProvenance: { kind: "inter_session", sourceTool: "agent_harness_task" },
+      }),
+    ).toBe("report_only");
+    expect(
+      resolveDelegationCapability({
+        fallbackActive: false,
+        inputProvenance: { kind: "inter_session", sourceTool: "subagent_announce" },
+      }),
+    ).toBe("full");
+    expect(
+      resolveDelegationCapability({
+        fallbackActive: true,
+        inputProvenance: { kind: "external_user" },
+      }),
+    ).toBe("full");
+  });
+
+  it("removes delegation tools but retains ordinary reporting tools", () => {
+    const tools = [
+      createTool("sessions_spawn"),
+      createTool("sessions_send"),
+      createTool("openclaw"),
+      createTool("llm-task"),
+      createTool("codex_session_send"),
+      createTool("message"),
+      createTool("gateway"),
+      createTool("sessions_history"),
+    ];
+
+    expect(applyDelegationCapability(tools, "report_only").map((tool) => tool.name)).toEqual([
+      "message",
+      "gateway",
+      "sessions_history",
+    ]);
+    expect(applyDelegationCapability(tools, "full")).toBe(tools);
+  });
+
+  it("keeps status and cleanup actions while rejecting new background work", async () => {
+    const cronExecute = vi.fn(async () => ({ content: [], details: {} }));
+    const imageExecute = vi.fn(async () => ({ content: [], details: {} }));
+    const [cron, image] = applyDelegationCapability(
+      [createTool("cron", cronExecute), createTool("image_generate", imageExecute)],
+      "report_only",
+    );
+
+    await expect(cron?.execute("cron-status", { action: "status" })).resolves.toEqual({
+      content: [],
+      details: {},
+    });
+    await expect(cron?.execute("cron-remove", { action: "remove" })).resolves.toEqual({
+      content: [],
+      details: {},
+    });
+    await expect(cron?.execute("cron-add", { action: "add" })).rejects.toThrow(
+      "New delegation is unavailable",
+    );
+    await expect(image?.execute("image-status", { action: "status" })).resolves.toEqual({
+      content: [],
+      details: {},
+    });
+    await expect(image?.execute("image-generate", {})).rejects.toThrow(
+      "New delegation is unavailable",
+    );
+    expect(cronExecute).toHaveBeenCalledTimes(2);
+    expect(imageExecute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/delegation-capability.ts
+++ b/src/agents/delegation-capability.ts
@@ -1,0 +1,89 @@
+import { isCompletionReportInputProvenance } from "../sessions/input-provenance.js";
+import { normalizeToolName } from "./tool-policy.js";
+import type { AnyAgentTool } from "./tools/common.js";
+import { ToolAuthorizationError } from "./tools/common.js";
+
+export type DelegationCapability = "full" | "report_only";
+
+const NEW_DELEGATION_TOOL_NAMES = new Set([
+  "codex_session_send",
+  "llm-task",
+  "openclaw",
+  "sessions_send",
+  "sessions_spawn",
+]);
+
+const REPORT_ONLY_TOOL_ACTIONS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ["cron", new Set(["get", "list", "remove", "runs", "status"])],
+  ["image_generate", new Set(["list", "status"])],
+  ["music_generate", new Set(["list", "status"])],
+  ["video_generate", new Set(["list", "status"])],
+]);
+
+const REPORT_ONLY_ERROR =
+  "New delegation is unavailable while reporting a completion through a fallback model.";
+
+export function resolveDelegationCapability(params: {
+  fallbackActive: boolean;
+  inputProvenance: unknown;
+}): DelegationCapability {
+  return params.fallbackActive && isCompletionReportInputProvenance(params.inputProvenance)
+    ? "report_only"
+    : "full";
+}
+
+function readToolAction(params: unknown): string {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return "";
+  }
+  const action = (params as { action?: unknown }).action;
+  return typeof action === "string" ? action.trim().toLowerCase() : "";
+}
+
+function wrapReportOnlyTool(tool: AnyAgentTool, allowedActions: ReadonlySet<string>): AnyAgentTool {
+  return new Proxy(tool, {
+    get(target, property, receiver) {
+      if (property !== "execute") {
+        return Reflect.get(target, property, receiver);
+      }
+      return async (
+        toolCallId: string,
+        params: unknown,
+        signal?: AbortSignal,
+        onUpdate?: Parameters<AnyAgentTool["execute"]>[3],
+      ) => {
+        if (!allowedActions.has(readToolAction(params))) {
+          throw new ToolAuthorizationError(REPORT_ONLY_ERROR);
+        }
+        return await Reflect.apply(target.execute, undefined, [
+          toolCallId,
+          params,
+          signal,
+          onUpdate,
+        ]);
+      };
+    },
+  });
+}
+
+/**
+ * Enforces the run's delegation capability after ordinary tool authorization.
+ * Tool names and safe actions here are explicit built-in/plugin contracts: the
+ * gate removes task launchers while retaining status, history, and cleanup.
+ */
+export function applyDelegationCapability(
+  tools: AnyAgentTool[],
+  capability: DelegationCapability | undefined,
+): AnyAgentTool[] {
+  if (capability !== "report_only") {
+    return tools;
+  }
+  return tools.flatMap((tool) => {
+    const name = normalizeToolName(tool.name);
+    if (NEW_DELEGATION_TOOL_NAMES.has(name)) {
+      return [];
+    }
+    const allowedActions = REPORT_ONLY_TOOL_ACTIONS.get(name);
+    return allowedActions ? [wrapReportOnlyTool(tool, allowedActions)] : [tool];
+  });
+}

--- a/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
@@ -258,6 +258,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
           modelCompat: extractModelCompat(attempt.model),
           modelApi: attempt.model.api,
           modelContextWindowTokens: attempt.model.contextWindow,
+          delegationCapability: attempt.delegationCapability,
           modelAuthMode: resolveModelAuthMode(attempt.model.provider, attempt.config, undefined, {
             workspaceDir: params.effectiveWorkspace,
           }),

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -2,6 +2,7 @@ import type { ContextEngineSessionTarget } from "../../../context-engine/types.j
 import { createAgentHarnessTaskRuntimeScope } from "../../../tasks/agent-harness-task-runtime-scope.js";
 import type { ToolOutcomeObserver } from "../../agent-tools.before-tool-call.js";
 import type { AuthProfileStore } from "../../auth-profiles.js";
+import { resolveDelegationCapability } from "../../delegation-capability.js";
 import type { AgentHarnessRuntimeArtifactBinding } from "../../harness/runtime-artifact.types.js";
 import { applyAuthHeaderOverride, applyLocalNoAuthHeaderOverride } from "../../model-auth.js";
 import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
@@ -227,6 +228,10 @@ export async function dispatchEmbeddedRunAttempt(input: {
     requestedModelId: runtime.requestedModelId,
     fallbackActive: runtime.fallbackActive,
     fallbackReason: runtime.fallbackReason,
+    delegationCapability: resolveDelegationCapability({
+      fallbackActive: runtime.fallbackActive,
+      inputProvenance: params.inputProvenance,
+    }),
     isFinalFallbackAttempt: params.isFinalFallbackAttempt,
     agentHarnessId: runtime.agentHarnessId,
     agentHarnessRuntimeOverride: runtime.agentHarnessId,

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -15,6 +15,7 @@ import type { AgentHarnessTaskRuntimeScope } from "../../../tasks/agent-harness-
 import type { AcceptedSessionSpawn } from "../../accepted-session-spawn.js";
 import type { ToolOutcomeObserver } from "../../agent-tools.before-tool-call.js";
 import type { AuthProfileStore } from "../../auth-profiles/types.js";
+import type { DelegationCapability } from "../../delegation-capability.js";
 import type {
   MessagingToolSend,
   MessagingToolSourceReplyPayload,
@@ -113,6 +114,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   fallbackActive?: boolean;
   /** Concrete fallback reason that selected this attempt, when known. */
   fallbackReason?: string | null;
+  /** Whether this attempt may start or redirect work to another agent/task. */
+  delegationCapability?: DelegationCapability;
   /** Concrete degraded-runtime reason for this attempt, when known. */
   degradedReason?: string | null;
   /** Session-pinned embedded harness id. Prevents runtime hot-switching. */

--- a/src/sessions/input-provenance.ts
+++ b/src/sessions/input-provenance.ts
@@ -83,6 +83,15 @@ export function isAgentMediatedCompletionSourceTool(value: unknown): boolean {
   return sourceTool ? AGENT_MEDIATED_COMPLETION_SOURCE_TOOL_SET.has(sourceTool) : false;
 }
 
+export function isCompletionReportInputProvenance(value: unknown): boolean {
+  const provenance = normalizeInputProvenance(value);
+  if (provenance?.kind !== "inter_session") {
+    return false;
+  }
+  const sourceTool = normalizeOptionalString(provenance.sourceTool)?.toLowerCase();
+  return sourceTool === "subagent_announce" || isAgentMediatedCompletionSourceTool(sourceTool);
+}
+
 const USER_FACING_SESSION_STATE_PRESERVING_SOURCE_TOOLS: ReadonlySet<string> = new Set([
   ...AGENT_MEDIATED_COMPLETION_SOURCE_TOOLS,
   "subagent_announce",


### PR DESCRIPTION
Closes #92271

## What Problem This Solves

Fixes an issue where a fallback model handling an internal completion report could interpret that report as fresh work and recursively delegate it again.

## Why This Change Was Made

The run now derives a typed `report_only` delegation capability only when a fallback handles completion provenance. The shared OpenClaw tool boundary removes or action-gates delegation surfaces while preserving reporting, status, history, and cleanup tools. Codex app-server runs additionally disable both native collaboration feature generations on a transient thread, because loaded Codex threads ignore resume-time config overrides. Normal thread bindings remain unchanged.

This replaces the original `sessions_spawn`-only guard and covers `sessions_send`, system-agent delegation, LLM tasks, Codex session steering, cron/media launch actions, the Pi/Copilot/Codex shared tool surfaces, and native Codex collaboration.

## User Impact

Fallback completion reports can summarize and verify completed work without launching or redirecting more work. Normal user turns, non-fallback completion reports, and ordinary verification/reporting tools retain their existing behavior.

## Evidence

- `node scripts/run-vitest.mjs src/agents/delegation-capability.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/copilot/src/tool-bridge.test.ts` — 3 core tests, 223 Codex tests, and 77 Copilot tests passed.
- `node scripts/check-changed.mjs -- <15 touched files>` — Blacksmith Testbox changed gate passed (`tbx_01kxq0tacnrjjj6vpd3h3x22c5`): https://github.com/openclaw/openclaw/actions/runs/29551712547
- Autoreview accepted and fixed the loaded-Codex-thread bypass. Final branch review's only reported concern referenced a nonexistent `subagents.steer` action; current source and schema expose only `list` and `cancel`, so no hypothetical branch was added.

Contributor credit preserved in the rewritten commit. Thanks @MertBasar0.
