### PR TITLE
docs(providers): add LLMBase setup guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1434,6 +1434,7 @@
                   "providers/inworld",
                   "providers/kilocode",
                   "providers/litellm",
+                  "providers/llmbase",
                   "providers/lmstudio",
                   "providers/minimax",
                   "providers/mistral",

--- a/docs/providers/llmbase.md
+++ b/docs/providers/llmbase.md
@@ -1,0 +1,208 @@
+---
+summary: "Configure LLMBase's OpenAI-compatible agent API in OpenClaw"
+title: "LLMBase"
+read_when:
+  - You want to use LLMBase with OpenClaw
+  - You need the LLMBase agent API base URL or key type
+  - You want a sovereign open-source model platform for agent workflows
+---
+
+[LLMBase](https://llmbase.ai) is a privacy-focused, sovereign AI platform for
+hosted open-source models. Its OpenAI-compatible agent API lets OpenClaw use
+LLMBase models without running your own inference stack.
+
+Use LLMBase when you want OpenClaw backed by curated open-source models,
+managed routing, and subscription-backed agent access for coding agents,
+research assistants, local developer tools, or self-hosted assistants.
+
+| Property                | Value                                    |
+| ----------------------- | ---------------------------------------- |
+| Provider id             | `llmbase`                                |
+| API                     | OpenAI-compatible (`openai-completions`) |
+| Agent base URL          | `https://llmbase.ai/api/v1/agents`       |
+| Agent key env var       | `LLMBASE_CHAT_AGENT_KEY`                 |
+| Agent key prefix        | `llmbase_chat_...`                       |
+| Suggested default model | `llmbase/deepseek/deepseek-v4-flash`     |
+| Direct inference API    | `https://api.llmbase.ai/v1`              |
+| Direct API key prefix   | `llmbase_...`                            |
+
+## Why LLMBase in OpenClaw
+
+- Sovereign AI platform built for privacy-conscious workflows.
+- Hosted open-source models without maintaining vLLM, SGLang, Ollama, or LM
+  Studio.
+- OpenAI-compatible chat, streaming, tool calling, structured outputs, and
+  model discovery.
+- Managed model routing behind stable LLMBase model IDs.
+- Agent access on the LLMBase Pro plan, currently $19/month.
+
+LLMBase separates chat-agent subscription access from direct inference billing.
+Use a `llmbase_chat_...` key with OpenClaw. Use a `llmbase_...` inference key
+only for backend services, batch jobs, or product integrations that need direct
+token-based billing.
+
+## Getting started
+
+<Steps>
+  <Step title="Create a chat agent key">
+    1. Open [llmbase.ai](https://llmbase.ai).
+    2. Go to Dashboard -> API Keys.
+    3. Create a key under **Chat agent keys**.
+    4. Copy the `llmbase_chat_...` key immediately.
+
+    Free and Starter accounts cannot create or use chat agent keys. Agent
+    access requires the LLMBase Pro plan.
+
+  </Step>
+  <Step title="Configure LLMBase as a custom provider">
+    Add LLMBase under `models.providers` and set your primary model to the
+    matching `llmbase/...` model ref:
+
+```json5
+{
+  models: {
+    mode: "merge",
+    providers: {
+      llmbase: {
+        baseUrl: "https://llmbase.ai/api/v1/agents",
+        apiKey: "${LLMBASE_CHAT_AGENT_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "deepseek/deepseek-v4-flash",
+            name: "DeepSeek V4 Flash",
+            reasoning: true,
+            input: ["text"],
+            contextWindow: 1048576,
+            maxTokens: 32768,
+          },
+        ],
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      model: { primary: "llmbase/deepseek/deepseek-v4-flash" },
+    },
+  },
+}
+```
+
+    `apiKey: "${LLMBASE_CHAT_AGENT_KEY}"` tells OpenClaw to read the key from
+    the Gateway process environment. Keep the real `llmbase_chat_...` value out
+    of committed config.
+
+  </Step>
+  <Step title="Verify the model is available">
+    ```bash
+    openclaw models list --provider llmbase
+    ```
+
+    You can also verify the live LLMBase agent model endpoint directly:
+
+    ```bash
+    curl https://llmbase.ai/api/v1/agents/models \
+      -H "Authorization: Bearer $LLMBASE_CHAT_AGENT_KEY"
+    ```
+
+  </Step>
+</Steps>
+
+## Model references
+
+OpenClaw model refs use the `llmbase/` provider prefix followed by the stable
+LLMBase model ID:
+
+| Model ref                            | Best fit                              |
+| ------------------------------------ | ------------------------------------- |
+| `llmbase/deepseek/deepseek-v4-flash` | Default agent model                   |
+| `llmbase/z-ai/glm-5.1`               | Coding and agent orchestration        |
+| `llmbase/qwen/qwen3-coder`           | Repository work and structured coding |
+| `llmbase/deepseek/deepseek-v3.2`     | Reasoning-heavy workflows             |
+| `llmbase/deepseek/deepseek-v4-pro`   | Long-context flagship tasks           |
+| `llmbase/openai/gpt-oss-120b`        | Open-weight reasoning                 |
+
+For most OpenClaw users, start with `llmbase/deepseek/deepseek-v4-flash`.
+Switch to `llmbase/z-ai/glm-5.1` or `llmbase/qwen/qwen3-coder` for code-heavy
+workflows, and reserve larger models for difficult long-context tasks.
+
+Add any additional model returned by LLMBase to `models.providers.llmbase.models`
+with its provider-local `id`. Do not include the `llmbase/` prefix inside the
+model entry itself.
+
+<AccordionGroup>
+  <Accordion title="How model id prefixing works">
+    Every LLMBase model ref in OpenClaw starts with `llmbase/`. OpenClaw uses
+    the prefix to select the configured custom provider, then sends the
+    remaining model ID to the LLMBase OpenAI-compatible API.
+
+    For example:
+
+    - OpenClaw model ref: `llmbase/deepseek/deepseek-v4-flash`
+    - LLMBase API model field: `deepseek/deepseek-v4-flash`
+
+    Agents do not configure upstream provider routes or fallback graphs.
+    LLMBase handles eligible routing internally while preserving the public
+    model ID in OpenClaw config.
+
+  </Accordion>
+  <Accordion title="Agent plan and quotas">
+    LLMBase agent access is available on the LLMBase Pro plan, currently
+    $19/month. Agent requests consume the same included chat usage pool as
+    normal LLMBase Chat requests, with fair-use windows by model class.
+
+    Optional prepaid overflow can continue agent traffic after a Pro quota
+    window is exhausted. Production jobs, unattended background workers, and
+    customer-facing API products should use the direct inference API instead.
+
+  </Accordion>
+  <Accordion title="Environment availability for the daemon">
+    If the Gateway runs as a managed service through launchd, systemd, Docker,
+    or a remote host, `LLMBASE_CHAT_AGENT_KEY` must be visible to that process.
+
+    <Warning>
+      A key exported only in an interactive shell will not help a launchd or
+      systemd daemon unless that environment is imported there too. Set the key
+      in `~/.openclaw/.env` or via `env.shellEnv` to make it readable from the
+      Gateway process.
+    </Warning>
+
+    On macOS, `openclaw gateway install` wires `~/.openclaw/.env` into the
+    LaunchAgent environment file. Re-run install or `openclaw doctor --fix`
+    after rotating the key.
+
+  </Accordion>
+</AccordionGroup>
+
+## Troubleshooting
+
+- `401 invalid_api_key`: use a `llmbase_chat_...` chat agent key, not an
+  inference key, OpenAI key, or another provider key.
+- `403 chat_pro_required`: upgrade to LLMBase Pro before creating or using chat
+  agent keys.
+- `402 quota_exceeded`: the Pro agent quota window is exhausted. Wait for the
+  reset, switch to a smaller eligible model, or enable prepaid overflow in
+  LLMBase.
+- Unknown model errors: list models from
+  `https://llmbase.ai/api/v1/agents/models` and add the provider-local model ID
+  under `models.providers.llmbase.models`.
+- Direct inference key confusion: `llmbase_...` keys belong to
+  `https://api.llmbase.ai/v1`; OpenClaw agent access uses `llmbase_chat_...`
+  keys with `https://llmbase.ai/api/v1/agents`.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="LLMBase" href="https://llmbase.ai" icon="external-link">
+    Privacy-focused sovereign AI platform for hosted open-source models.
+  </Card>
+  <Card title="LLMBase agent integrations" href="https://llmbase.ai/docs/agents/" icon="bot">
+    LLMBase setup details for OpenClaw, Hermes, and other agents.
+  </Card>
+  <Card title="Custom providers" href="/gateway/config-tools#custom-providers-and-base-urls" icon="settings">
+    OpenClaw config reference for custom OpenAI-compatible providers.
+  </Card>
+  <Card title="Model providers" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Adds a provider-directory page for configuring LLMBase as a custom OpenAI-compatible provider in OpenClaw.
- Documents the LLMBase agent API base URL, chat-agent key type, Pro plan requirement, $19/month price, model-ref prefixing, daemon environment setup, and troubleshooting.
- Adds `providers/llmbase` to the Mintlify provider navigation.
- Intentionally does not claim LLMBase is a bundled OpenClaw provider or add a new onboarding flag; the documented path uses the existing `models.providers` custom-provider config surface.

Reviewers should focus on whether a custom-provider page belongs in the provider directory and whether the LLMBase wording is clear enough without implying bundled provider support.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

No maintainer request. This is a contributor docs addition for an OpenAI-compatible provider configuration path.

## Real behavior proof (required for external PRs)

- Behavior addressed: OpenClaw docs did not have an LLMBase provider setup page, even though LLMBase can be configured through OpenClaw's custom OpenAI-compatible provider support.
- Real environment tested: Local OpenClaw source checkout on macOS, Node `v24.14.0`, pnpm `11.2.2` via Corepack.
- Exact steps or command run after this patch: Ran `corepack pnpm docs:list | rg 'providers/llmbase|LLMBase'`, `corepack pnpm format:docs:check`, `corepack pnpm dlx --config.resolution-mode=highest markdownlint-cli2 --config config/markdownlint-cli2.jsonc`, `corepack pnpm docs:check-mdx`, `corepack pnpm docs:check-i18n-glossary`, `corepack pnpm docs:check-links`, `git diff --check`, and a `node -e` JSON parse of `docs/docs.json`.
- Evidence after fix: `docs:list` reports `providers/llmbase.md - Configure LLMBase's OpenAI-compatible agent API in OpenClaw`; markdownlint reports `Summary: 0 error(s)`; docs MDX check reports `Docs MDX check passed (678 files, 7346ms)`; link audit reports `checked_internal_links=4453` and `broken_links=0`.
- Observed result after fix: The new page is discoverable by the docs list, the provider nav JSON parses, and the docs checks run directly through Corepack pass.
- What was not tested: A live OpenClaw Gateway call to LLMBase with a real `llmbase_chat_...` key was not run from this environment.
- Proof limitations or environment constraints: `corepack pnpm check:docs` could not be used as a single wrapper because that package script shells out to `pnpm`, and this machine has Corepack but no plain `pnpm` executable on PATH. I ran the same constituent docs checks through `corepack pnpm` instead.
- Before evidence (optional but encouraged): Before this patch, `docs/providers/llmbase.md` did not exist and `docs/docs.json` had no `providers/llmbase` navigation entry.

## Tests and validation

Which commands did you run?

- `corepack pnpm docs:list | rg 'providers/llmbase|LLMBase'`
- `corepack pnpm format:docs:check`
- `corepack pnpm dlx --config.resolution-mode=highest markdownlint-cli2 --config config/markdownlint-cli2.jsonc`
- `corepack pnpm docs:check-mdx`
- `corepack pnpm docs:check-i18n-glossary`
- `corepack pnpm docs:check-links`
- `git diff --check`
- `node -e 'JSON.parse(require("fs").readFileSync("docs/docs.json", "utf8")); console.log("docs/docs.json valid JSON")'`

What regression coverage was added or updated?

No automated tests were added. This is a docs-only change covered by the repository docs formatter, markdown lint, MDX check, i18n glossary check, link audit, JSON parse, and whitespace check.

What failed before this fix, if known?

The docs page and nav entry were absent before this change.

If no test was added, why not?

The change is documentation-only and does not alter runtime code. The docs validation commands cover the changed surfaces.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, docs navigation and provider documentation now include LLMBase.

Did config, environment, or migration behavior change? (`Yes/No`)

No runtime behavior changed. The page documents existing custom-provider config.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The main risk is wording that could imply LLMBase is a bundled OpenClaw provider.

How is that risk mitigated?

The page explicitly says to configure LLMBase under `models.providers`, uses the existing custom-provider config shape, and does not document an onboarding flag or bundled plugin.

## Current review state

What is the next action?

Await maintainer review on provider-directory fit and LLMBase wording.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer review are pending. Live LLMBase Gateway proof was not run in this environment.

Which bot or reviewer comments were addressed?

Initial PR; no review comments yet.

AI-assisted: yes. I reviewed the changed docs and ran the validation commands listed above.
