### PR TITLE
fix(doctor): survive throwing plugin hooks and warn on build-version skew

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1002,26 +1002,6 @@ vi.mock("./doctor/shared/channel-doctor.js", () => {
     return changed;
   }
 
-  function collectCompatibilityMutations(cfg: { channels?: Record<string, unknown> }) {
-    const next = structuredClone(cfg);
-    const changes: string[] = [];
-    const telegram = asRecord(next.channels?.telegram);
-    if (telegram && "groupMentionsOnly" in telegram) {
-      const groups = asRecord(telegram.groups) ?? {};
-      const defaultGroup = asRecord(groups["*"]) ?? {};
-      if (defaultGroup.requireMention === undefined) {
-        defaultGroup.requireMention = telegram.groupMentionsOnly;
-      }
-      groups["*"] = defaultGroup;
-      telegram.groups = groups;
-      delete telegram.groupMentionsOnly;
-      changes.push(
-        'Moved channels.telegram.groupMentionsOnly → channels.telegram.groups."*".requireMention.',
-      );
-    }
-    return changes.length > 0 ? [{ config: next, changes }] : [];
-  }
-
   function collectInactiveTelegramWarnings(cfg: { channels?: Record<string, unknown> }): string[] {
     const telegram = asRecord(cfg.channels?.telegram);
     if (!telegram) {
@@ -1088,7 +1068,6 @@ vi.mock("./doctor/shared/channel-doctor.js", () => {
   }
 
   return {
-    collectChannelDoctorCompatibilityMutations: vi.fn(collectCompatibilityMutations),
     collectChannelDoctorEmptyAllowlistExtraWarnings: vi.fn(collectTelegramFirstTimeExtraWarnings),
     collectChannelDoctorMutableAllowlistWarnings: vi.fn(
       ({ cfg }: { cfg: { channels?: Record<string, unknown> } }) => {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -276,6 +276,10 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       candidate,
       { env: process.env },
     )) {
+      // Warning-only mutations carry adapter failures (e.g. version-skewed plugins).
+      if (staleCleanup.warnings?.length) {
+        emitDoctorNotes({ note, warningNotes: staleCleanup.warnings });
+      }
       if (staleCleanup.changes.length === 0) {
         continue;
       }

--- a/src/commands/doctor/shared/channel-doctor.test.ts
+++ b/src/commands/doctor/shared/channel-doctor.test.ts
@@ -2,12 +2,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeResolvedSecretInputString } from "../../../config/types.secrets.js";
 import {
-  collectChannelDoctorCompatibilityMutations,
   collectChannelDoctorEmptyAllowlistExtraWarnings,
   collectChannelDoctorMutableAllowlistWarnings,
   collectChannelDoctorPreviewWarnings,
+  collectChannelDoctorRepairMutations,
   collectChannelDoctorStaleConfigMutations,
   createChannelDoctorEmptyAllowlistPolicyHooks,
+  runChannelDoctorConfigSequences,
+  shouldSkipChannelDoctorDefaultEmptyGroupAllowlistWarning,
 } from "./channel-doctor.js";
 
 const mocks = vi.hoisted(() => ({
@@ -50,7 +52,7 @@ function createMatrixEnabledConfig() {
   };
 }
 
-function createNormalizeCompatibilityConfig(change = "matrix") {
+function createCleanStaleConfig(change = "matrix") {
   return vi.fn(({ cfg }: { cfg: unknown }) => ({
     config: cfg,
     changes: [change],
@@ -104,18 +106,20 @@ function expectMatrixDoctorLookupCalls(cfg?: unknown) {
 
 async function expectRuntimeWarningFallback(params: {
   cfg: unknown;
-  normalizeCompatibilityConfig: ReturnType<typeof vi.fn>;
+  cleanStaleConfig: ReturnType<typeof vi.fn>;
   collectMutableAllowlistWarnings: ReturnType<typeof vi.fn>;
 }) {
-  expect(collectChannelDoctorCompatibilityMutations(params.cfg as never)).toHaveLength(1);
+  await expect(collectChannelDoctorStaleConfigMutations(params.cfg as never)).resolves.toHaveLength(
+    1,
+  );
   await expect(
     collectChannelDoctorMutableAllowlistWarnings({ cfg: params.cfg as never }),
   ).resolves.toEqual(["runtime warning"]);
-  expect(params.normalizeCompatibilityConfig).toHaveBeenCalledTimes(1);
+  expect(params.cleanStaleConfig).toHaveBeenCalledTimes(1);
   expect(params.collectMutableAllowlistWarnings).toHaveBeenCalledTimes(1);
 }
 
-describe("channel doctor compatibility mutations", () => {
+describe("channel doctor stale config mutations", () => {
   beforeEach(() => {
     mocks.getLoadedChannelPlugin.mockReset();
     mocks.getBundledChannelPlugin.mockReset();
@@ -127,8 +131,8 @@ describe("channel doctor compatibility mutations", () => {
     mocks.resolveReadOnlyChannelPluginsForConfig.mockReturnValue({ plugins: [] });
   });
 
-  it("skips plugin discovery when no channels are configured", () => {
-    const result = collectChannelDoctorCompatibilityMutations({} as never);
+  it("skips plugin discovery when no channels are configured", async () => {
+    const result = await collectChannelDoctorStaleConfigMutations({} as never);
 
     expect(result).toStrictEqual([]);
     expect(mocks.resolveReadOnlyChannelPluginsForConfig).not.toHaveBeenCalled();
@@ -181,8 +185,8 @@ describe("channel doctor compatibility mutations", () => {
     expect(discordCleanup).not.toHaveBeenCalled();
   });
 
-  it("skips plugin discovery for explicitly disabled channels", () => {
-    const result = collectChannelDoctorCompatibilityMutations({
+  it("skips plugin discovery for explicitly disabled channels", async () => {
+    const result = await collectChannelDoctorStaleConfigMutations({
       channels: {
         mattermost: {
           enabled: false,
@@ -197,15 +201,15 @@ describe("channel doctor compatibility mutations", () => {
     expect(mocks.getBundledChannelPlugin).not.toHaveBeenCalled();
   });
 
-  it("uses read-only doctor adapters for configured channel ids", () => {
-    const normalizeCompatibilityConfig = createNormalizeCompatibilityConfig();
-    mockReadOnlyMatrixPlugin({ normalizeCompatibilityConfig });
+  it("uses read-only doctor adapters for configured channel ids", async () => {
+    const cleanStaleConfig = createCleanStaleConfig();
+    mockReadOnlyMatrixPlugin({ cleanStaleConfig });
     const cfg = createMatrixEnabledConfig();
 
-    const result = collectChannelDoctorCompatibilityMutations(cfg as never);
+    const result = await collectChannelDoctorStaleConfigMutations(cfg as never);
 
     expect(result).toHaveLength(1);
-    expect(normalizeCompatibilityConfig).toHaveBeenCalledTimes(1);
+    expect(cleanStaleConfig).toHaveBeenCalledTimes(1);
     expectMatrixDoctorLookupCalls(cfg);
     expect(mocks.getBundledChannelSetupPlugin).not.toHaveBeenCalledWith("discord");
   });
@@ -233,70 +237,70 @@ describe("channel doctor compatibility mutations", () => {
   });
 
   it("merges partial doctor adapters instead of masking runtime-only hooks", async () => {
-    const normalizeCompatibilityConfig = createNormalizeCompatibilityConfig();
+    const cleanStaleConfig = createCleanStaleConfig();
     const collectMutableAllowlistWarnings = vi.fn(() => ["runtime warning"]);
-    mockReadOnlyMatrixPlugin({ normalizeCompatibilityConfig });
+    mockReadOnlyMatrixPlugin({ cleanStaleConfig });
     mockBundledMatrixRuntimePlugin({ collectMutableAllowlistWarnings });
     const cfg = createMatrixEnabledConfig();
 
     await expectRuntimeWarningFallback({
       cfg,
-      normalizeCompatibilityConfig,
+      cleanStaleConfig,
       collectMutableAllowlistWarnings,
     });
   });
 
   it("ignores malformed doctor adapter values so valid fallbacks still run", async () => {
-    const normalizeCompatibilityConfig = createNormalizeCompatibilityConfig("setup");
+    const cleanStaleConfig = createCleanStaleConfig("setup");
     const collectMutableAllowlistWarnings = vi.fn(() => ["runtime warning"]);
     mockReadOnlyMatrixPlugin({
-      normalizeCompatibilityConfig: null,
+      cleanStaleConfig: null,
       collectMutableAllowlistWarnings: "not-a-function",
       warnOnEmptyGroupSenderAllowlist: "yes",
     });
-    mockBundledMatrixSetupPlugin({ normalizeCompatibilityConfig });
+    mockBundledMatrixSetupPlugin({ cleanStaleConfig });
     mockBundledMatrixRuntimePlugin({ collectMutableAllowlistWarnings });
     const cfg = createMatrixEnabledConfig();
 
     await expectRuntimeWarningFallback({
       cfg,
-      normalizeCompatibilityConfig,
+      cleanStaleConfig,
       collectMutableAllowlistWarnings,
     });
   });
 
-  it("falls back to setup doctor adapters when read-only plugins lack doctor hooks", () => {
-    const normalizeCompatibilityConfig = createNormalizeCompatibilityConfig();
+  it("falls back to setup doctor adapters when read-only plugins lack doctor hooks", async () => {
+    const cleanStaleConfig = createCleanStaleConfig();
     mockReadOnlyMatrixPlugin();
-    mockBundledMatrixSetupPlugin({ normalizeCompatibilityConfig });
+    mockBundledMatrixSetupPlugin({ cleanStaleConfig });
     const cfg = createMatrixEnabledConfig();
 
-    const result = collectChannelDoctorCompatibilityMutations(cfg as never);
+    const result = await collectChannelDoctorStaleConfigMutations(cfg as never);
 
     expect(result).toHaveLength(1);
-    expect(normalizeCompatibilityConfig).toHaveBeenCalledTimes(1);
+    expect(cleanStaleConfig).toHaveBeenCalledTimes(1);
     expectMatrixDoctorLookupCalls(cfg);
   });
 
-  it("falls back to bundled runtime doctor adapters when setup adapters lack doctor hooks", () => {
-    const normalizeCompatibilityConfig = createNormalizeCompatibilityConfig();
+  it("falls back to bundled runtime doctor adapters when setup adapters lack doctor hooks", async () => {
+    const cleanStaleConfig = createCleanStaleConfig();
     mockReadOnlyMatrixPlugin();
     mockBundledMatrixSetupPlugin();
-    mockBundledMatrixRuntimePlugin({ normalizeCompatibilityConfig });
+    mockBundledMatrixRuntimePlugin({ cleanStaleConfig });
     const cfg = createMatrixEnabledConfig();
 
-    const result = collectChannelDoctorCompatibilityMutations(cfg as never);
+    const result = await collectChannelDoctorStaleConfigMutations(cfg as never);
 
     expect(result).toHaveLength(1);
-    expect(normalizeCompatibilityConfig).toHaveBeenCalledTimes(1);
+    expect(cleanStaleConfig).toHaveBeenCalledTimes(1);
     expectMatrixDoctorLookupCalls();
   });
 
-  it("passes explicit env into read-only channel plugin discovery", () => {
+  it("passes explicit env into read-only channel plugin discovery", async () => {
     const cfg = createMatrixEnabledConfig();
     const env = { OPENCLAW_HOME: "/tmp/openclaw-test-home" };
 
-    collectChannelDoctorCompatibilityMutations(cfg as never, { env });
+    await collectChannelDoctorStaleConfigMutations(cfg as never, { env });
 
     expect(mocks.resolveReadOnlyChannelPluginsForConfig).toHaveBeenCalledWith(cfg, {
       env,
@@ -304,7 +308,7 @@ describe("channel doctor compatibility mutations", () => {
     });
   });
 
-  it("keeps configured channel doctor lookup non-fatal when setup loading fails", () => {
+  it("keeps configured channel doctor lookup non-fatal when setup loading fails", async () => {
     mocks.resolveReadOnlyChannelPluginsForConfig.mockImplementation(() => {
       throw new Error("missing runtime dep");
     });
@@ -315,7 +319,7 @@ describe("channel doctor compatibility mutations", () => {
       return undefined;
     });
 
-    const result = collectChannelDoctorCompatibilityMutations({
+    const result = await collectChannelDoctorStaleConfigMutations({
       channels: {
         discord: {
           enabled: true,
@@ -441,5 +445,171 @@ describe("channel doctor compatibility mutations", () => {
     });
     expect(collectEmptyAllowlistExtraWarnings).toHaveBeenCalledTimes(3);
     expect(shouldSkipDefaultEmptyGroupAllowlistWarning).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("channel doctor adapter fail-soft", () => {
+  beforeEach(() => {
+    mocks.getLoadedChannelPlugin.mockReset();
+    mocks.getBundledChannelPlugin.mockReset();
+    mocks.getBundledChannelSetupPlugin.mockReset();
+    mocks.resolveReadOnlyChannelPluginsForConfig.mockReset();
+    mocks.getLoadedChannelPlugin.mockReturnValue(undefined);
+    mocks.getBundledChannelPlugin.mockReturnValue(undefined);
+    mocks.getBundledChannelSetupPlugin.mockReturnValue(undefined);
+    mocks.resolveReadOnlyChannelPluginsForConfig.mockReturnValue({ plugins: [] });
+  });
+
+  function mockReadOnlyPlugins(plugins: Array<{ id: string; doctor: Record<string, unknown> }>) {
+    mocks.resolveReadOnlyChannelPluginsForConfig.mockReturnValue({ plugins });
+  }
+
+  function createTwoChannelConfig() {
+    return {
+      channels: {
+        matrix: { enabled: true },
+        slack: { enabled: true },
+      },
+    };
+  }
+
+  it("keeps running config sequences when one channel adapter throws", async () => {
+    mockReadOnlyPlugins([
+      {
+        id: "matrix",
+        doctor: {
+          runConfigSequence: vi.fn(() => {
+            throw new TypeError("resolveSessionStoreTargets is not a function");
+          }),
+        },
+      },
+      {
+        id: "slack",
+        doctor: {
+          runConfigSequence: vi.fn(() => ({ changeNotes: ["slack change"], warningNotes: [] })),
+        },
+      },
+    ]);
+
+    const result = await runChannelDoctorConfigSequences({
+      cfg: createTwoChannelConfig() as never,
+      env: {},
+      shouldRepair: false,
+    });
+
+    expect(result.changeNotes).toEqual(["slack change"]);
+    expect(result.warningNotes).toHaveLength(1);
+    expect(result.warningNotes[0]).toContain("matrix channel doctor runConfigSequence failed");
+    expect(result.warningNotes[0]).toContain("openclaw plugins update matrix");
+  });
+
+  it("reports stale-config adapter throws as warning-only mutations and keeps the config chain", async () => {
+    const baseCfg = createTwoChannelConfig();
+    const slackCleanStaleConfig = vi.fn(({ cfg }: { cfg: unknown }) => ({
+      config: cfg,
+      changes: ["slack cleanup"],
+    }));
+    mockReadOnlyPlugins([
+      {
+        id: "matrix",
+        doctor: {
+          cleanStaleConfig: vi.fn(() => {
+            throw new Error("skewed plugin");
+          }),
+        },
+      },
+      { id: "slack", doctor: { cleanStaleConfig: slackCleanStaleConfig } },
+    ]);
+
+    const mutations = await collectChannelDoctorStaleConfigMutations(baseCfg as never);
+
+    expect(mutations).toHaveLength(2);
+    expect(mutations[0]?.changes).toEqual([]);
+    expect(mutations[0]?.config).toBe(baseCfg);
+    expect(mutations[0]?.warnings?.[0]).toContain("matrix channel doctor cleanStaleConfig failed");
+    expect(mutations[1]?.changes).toEqual(["slack cleanup"]);
+    expect(slackCleanStaleConfig).toHaveBeenCalledWith({ cfg: baseCfg });
+  });
+
+  it("converts mutable allowlist adapter throws into warnings", async () => {
+    mockReadOnlyPlugins([
+      {
+        id: "matrix",
+        doctor: {
+          collectMutableAllowlistWarnings: vi.fn(() => {
+            throw new Error("boom");
+          }),
+        },
+      },
+      {
+        id: "slack",
+        doctor: { collectMutableAllowlistWarnings: vi.fn(() => ["slack warning"]) },
+      },
+    ]);
+
+    const warnings = await collectChannelDoctorMutableAllowlistWarnings({
+      cfg: createTwoChannelConfig() as never,
+    });
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain("matrix channel doctor collectMutableAllowlistWarnings failed");
+    expect(warnings[0]).toContain("openclaw plugins update matrix");
+    expect(warnings[1]).toBe("slack warning");
+  });
+
+  it("converts repair adapter throws into warning-only mutations", async () => {
+    mockReadOnlyPlugins([
+      {
+        id: "matrix",
+        doctor: {
+          repairConfig: vi.fn(() => {
+            throw new Error("boom");
+          }),
+        },
+      },
+    ]);
+
+    const mutations = await collectChannelDoctorRepairMutations({
+      cfg: { channels: { matrix: { enabled: true } } } as never,
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(mutations).toHaveLength(1);
+    expect(mutations[0]?.changes).toEqual([]);
+    expect(mutations[0]?.warnings?.[0]).toContain("matrix channel doctor repairConfig failed");
+  });
+
+  it("skips throwing empty-allowlist hooks without failing the lookup", () => {
+    mockReadOnlyPlugins([
+      {
+        id: "matrix",
+        doctor: {
+          collectEmptyAllowlistExtraWarnings: vi.fn(() => {
+            throw new Error("boom");
+          }),
+          shouldSkipDefaultEmptyGroupAllowlistWarning: vi.fn(() => {
+            throw new Error("boom");
+          }),
+        },
+      },
+    ]);
+    const cfg = { channels: { matrix: { enabled: true } } };
+
+    expect(
+      collectChannelDoctorEmptyAllowlistExtraWarnings({
+        account: {},
+        channelName: "matrix",
+        cfg: cfg as never,
+        prefix: "channels.matrix",
+      }),
+    ).toEqual([]);
+    expect(
+      shouldSkipChannelDoctorDefaultEmptyGroupAllowlistWarning({
+        account: {},
+        channelName: "matrix",
+        cfg: cfg as never,
+        prefix: "channels.matrix",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/commands/doctor/shared/channel-doctor.ts
+++ b/src/commands/doctor/shared/channel-doctor.ts
@@ -14,11 +14,20 @@ import type {
 } from "../../../channels/plugins/types.adapters.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { isUnresolvedSecretInputError } from "../../../config/types.secrets.js";
+import { formatErrorMessage } from "../../../infra/errors.js";
 
 type ChannelDoctorEntry = {
   id: string;
   doctor: ChannelDoctorAdapter;
 };
+
+// Installed plugins can throw from doctor hooks when their build no longer matches this
+// host (for example SDK imports that stopped resolving after a core upgrade). Doctor is
+// the repair tool, so one broken adapter must degrade to a warning instead of aborting
+// the run and blocking every other repair.
+function channelDoctorAdapterFailureWarning(id: string, hook: string, err: unknown): string {
+  return `${id} channel doctor ${hook} failed (${formatErrorMessage(err)}); skipped it. If the ${id} plugin was built for another OpenClaw release, run \`openclaw plugins update ${id}\`.`;
+}
 
 type ChannelDoctorPluginCandidate = {
   id: string;
@@ -35,7 +44,6 @@ type ChannelDoctorEmptyAllowlistLookupParams = ChannelDoctorEmptyAllowlistAccoun
 };
 
 const channelDoctorFunctionKeys = new Set<keyof ChannelDoctorAdapter>([
-  "normalizeCompatibilityConfig",
   "collectPreviewWarnings",
   "collectMutableAllowlistWarnings",
   "repairConfig",
@@ -248,7 +256,14 @@ function collectEmptyAllowlistExtraWarningsForEntries(
   const warnings: string[] = [];
   const pluginParams = toPluginEmptyAllowlistContext(params);
   for (const entry of entries) {
-    const lines = entry.doctor.collectEmptyAllowlistExtraWarnings?.(pluginParams);
+    // Called per account: skip throwing adapters quietly here; the per-run collectors
+    // below already surface the adapter failure once with the update hint.
+    let lines: string[] | undefined;
+    try {
+      lines = entry.doctor.collectEmptyAllowlistExtraWarnings?.(pluginParams);
+    } catch {
+      continue;
+    }
     if (lines?.length) {
       warnings.push(...lines);
     }
@@ -261,9 +276,13 @@ function shouldSkipDefaultEmptyGroupAllowlistWarningForEntries(
   params: ChannelDoctorEmptyAllowlistLookupParams,
 ): boolean {
   const pluginParams = toPluginEmptyAllowlistContext(params);
-  return entries.some(
-    (entry) => entry.doctor.shouldSkipDefaultEmptyGroupAllowlistWarning?.(pluginParams) === true,
-  );
+  return entries.some((entry) => {
+    try {
+      return entry.doctor.shouldSkipDefaultEmptyGroupAllowlistWarning?.(pluginParams) === true;
+    } catch {
+      return false;
+    }
+  });
 }
 
 /** Build cached empty-allowlist hooks backed by channel doctor adapters. */
@@ -304,7 +323,13 @@ export async function runChannelDoctorConfigSequences(params: {
     cfg: params.cfg,
     env: params.env,
   })) {
-    const result = await entry.doctor.runConfigSequence?.(params);
+    let result: ChannelDoctorSequenceResult | undefined;
+    try {
+      result = await entry.doctor.runConfigSequence?.(params);
+    } catch (err) {
+      warningNotes.push(channelDoctorAdapterFailureWarning(entry.id, "runConfigSequence", err));
+      continue;
+    }
     if (!result) {
       continue;
     }
@@ -312,28 +337,6 @@ export async function runChannelDoctorConfigSequences(params: {
     warningNotes.push(...result.warningNotes);
   }
   return { changeNotes, warningNotes };
-}
-
-/** Collect compatibility migrations from configured channel doctor adapters in order. */
-export function collectChannelDoctorCompatibilityMutations(
-  cfg: OpenClawConfig,
-  options: { env?: NodeJS.ProcessEnv } = {},
-): ChannelDoctorConfigMutation[] {
-  const channelIds = collectConfiguredChannelIds(cfg);
-  if (channelIds.length === 0) {
-    return [];
-  }
-  const mutations: ChannelDoctorConfigMutation[] = [];
-  let nextCfg = cfg;
-  for (const entry of listChannelDoctorEntries(channelIds, { cfg, env: options.env })) {
-    const mutation = entry.doctor.normalizeCompatibilityConfig?.({ cfg: nextCfg });
-    if (!mutation || mutation.changes.length === 0) {
-      continue;
-    }
-    mutations.push(mutation);
-    nextCfg = mutation.config;
-  }
-  return mutations;
 }
 
 /** Collect stale channel config cleanup mutations from configured channel doctor adapters. */
@@ -348,7 +351,17 @@ export async function collectChannelDoctorStaleConfigMutations(
     cfg,
     env: options.env,
   })) {
-    const mutation = await entry.doctor.cleanStaleConfig?.({ cfg: nextCfg });
+    let mutation: ChannelDoctorConfigMutation | undefined;
+    try {
+      mutation = await entry.doctor.cleanStaleConfig?.({ cfg: nextCfg });
+    } catch (err) {
+      mutations.push({
+        config: nextCfg,
+        changes: [],
+        warnings: [channelDoctorAdapterFailureWarning(entry.id, "cleanStaleConfig", err)],
+      });
+      continue;
+    }
     if (!mutation || mutation.changes.length === 0) {
       continue;
     }
@@ -372,13 +385,14 @@ export async function collectChannelDoctorPreviewWarnings(params: {
     let lines: string[] | undefined;
     try {
       lines = await entry.doctor.collectPreviewWarnings?.(params);
-    } catch (error) {
-      if (!isUnresolvedSecretInputError(error)) {
-        throw error;
+    } catch (err) {
+      if (isUnresolvedSecretInputError(err)) {
+        warnings.push(
+          `- channels.${entry.id}: configured SecretRef at ${err.path} is unavailable in doctor preview; skipping secret-backed channel preview checks.`,
+        );
+      } else {
+        warnings.push(channelDoctorAdapterFailureWarning(entry.id, "collectPreviewWarnings", err));
       }
-      warnings.push(
-        `- channels.${entry.id}: configured SecretRef at ${error.path} is unavailable in doctor preview; skipping secret-backed channel preview checks.`,
-      );
       continue;
     }
     if (lines?.length) {
@@ -398,7 +412,15 @@ export async function collectChannelDoctorMutableAllowlistWarnings(params: {
     cfg: params.cfg,
     env: params.env,
   })) {
-    const lines = await entry.doctor.collectMutableAllowlistWarnings?.(params);
+    let lines: string[] | undefined;
+    try {
+      lines = await entry.doctor.collectMutableAllowlistWarnings?.(params);
+    } catch (err) {
+      warnings.push(
+        channelDoctorAdapterFailureWarning(entry.id, "collectMutableAllowlistWarnings", err),
+      );
+      continue;
+    }
     if (lines?.length) {
       warnings.push(...lines);
     }
@@ -418,11 +440,21 @@ export async function collectChannelDoctorRepairMutations(params: {
     cfg: params.cfg,
     env: params.env,
   })) {
-    const mutation = await entry.doctor.repairConfig?.({
-      cfg: nextCfg,
-      doctorFixCommand: params.doctorFixCommand,
-      ...(params.env ? { env: params.env } : {}),
-    });
+    let mutation: ChannelDoctorConfigMutation | undefined;
+    try {
+      mutation = await entry.doctor.repairConfig?.({
+        cfg: nextCfg,
+        doctorFixCommand: params.doctorFixCommand,
+        ...(params.env ? { env: params.env } : {}),
+      });
+    } catch (err) {
+      mutations.push({
+        config: nextCfg,
+        changes: [],
+        warnings: [channelDoctorAdapterFailureWarning(entry.id, "repairConfig", err)],
+      });
+      continue;
+    }
     if (!mutation || mutation.changes.length === 0) {
       if (mutation?.warnings?.length) {
         mutations.push({ config: nextCfg, changes: [], warnings: mutation.warnings });

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -2745,19 +2745,27 @@ async function collectPluginDoctorStateMigrationPlans(params: {
     config: params.cfg,
     env: params.env,
   })) {
-    const detected = await entry.migration.detectLegacyState({
-      config: params.cfg,
-      env: params.env,
-      stateDir: params.stateDir,
-      oauthDir: params.oauthDir,
-      context: createPluginDoctorStateMigrationContext(entry.pluginId, params.env),
-    });
-    if (detected?.preview.length) {
-      plans.push({
-        pluginId: entry.pluginId,
-        migration: entry.migration,
-        preview: detected.preview,
+    // Detection runs plugin-shipped code: a version-skewed install can throw at call
+    // time, and one broken plugin must not abort migration detection for the rest.
+    // The migrate phase below degrades the same way; manifest-registry's build-version
+    // diagnostic owns the user-facing warning.
+    try {
+      const detected = await entry.migration.detectLegacyState({
+        config: params.cfg,
+        env: params.env,
+        stateDir: params.stateDir,
+        oauthDir: params.oauthDir,
+        context: createPluginDoctorStateMigrationContext(entry.pluginId, params.env),
       });
+      if (detected?.preview.length) {
+        plans.push({
+          pluginId: entry.pluginId,
+          migration: entry.migration,
+          preview: detected.preview,
+        });
+      }
+    } catch {
+      continue;
     }
   }
   return plans;

--- a/src/plugins/build-version-skew.test.ts
+++ b/src/plugins/build-version-skew.test.ts
@@ -1,0 +1,85 @@
+// Build-version skew tests lock the warn matrix for plugin artifacts vs the running host.
+import { describe, expect, it } from "vitest";
+import { checkPluginBuildVersionSkew } from "./build-version-skew.js";
+
+describe("checkPluginBuildVersionSkew", () => {
+  const cases: Array<{
+    name: string;
+    build: unknown;
+    current: string | undefined;
+    skew: boolean;
+  }> = [
+    { name: "missing build metadata", build: undefined, current: "2026.6.5", skew: false },
+    { name: "blank build metadata", build: "  ", current: "2026.6.5", skew: false },
+    { name: "non-string build metadata", build: 42, current: "2026.6.5", skew: false },
+    { name: "unknown host version", build: "2026.6.5", current: undefined, skew: false },
+    { name: "unparseable build version", build: "next", current: "2026.6.5", skew: false },
+    { name: "exact match", build: "2026.6.5", current: "2026.6.5", skew: false },
+    {
+      name: "exact prerelease match",
+      build: "2026.6.5-beta.5",
+      current: "2026.6.5-beta.5",
+      skew: false,
+    },
+    {
+      name: "older stable build on newer host",
+      build: "2026.6.4",
+      current: "2026.6.5",
+      skew: false,
+    },
+    {
+      name: "older stable build on newer prerelease host",
+      build: "2026.6.4",
+      current: "2026.6.5-beta.2",
+      skew: false,
+    },
+    {
+      name: "build metadata suffix treated as stable",
+      build: "2026.6.4+sha.abc",
+      current: "2026.6.5",
+      skew: false,
+    },
+    {
+      name: "prerelease build on same-train stable host",
+      build: "2026.6.5-beta.5",
+      current: "2026.6.5",
+      skew: true,
+    },
+    {
+      name: "prerelease build on different prerelease host",
+      build: "2026.6.5-beta.5",
+      current: "2026.6.5-beta.6",
+      skew: true,
+    },
+    {
+      name: "prerelease build on older host",
+      build: "2026.6.5-beta.5",
+      current: "2026.6.4",
+      skew: true,
+    },
+    { name: "stable build on older host", build: "2026.6.6", current: "2026.6.5", skew: true },
+    {
+      name: "stable build on same-train prerelease host",
+      build: "2026.6.5",
+      current: "2026.6.5-beta.6",
+      skew: true,
+    },
+  ];
+
+  for (const testCase of cases) {
+    it(testCase.name, () => {
+      const result = checkPluginBuildVersionSkew({
+        currentVersion: testCase.current,
+        buildOpenclawVersion: testCase.build,
+      });
+      if (testCase.skew) {
+        expect(result).toEqual({
+          buildVersion: testCase.build,
+          currentVersion: testCase.current,
+        });
+      } else {
+        expect(result).toBeNull();
+      }
+    });
+  }
+});

--- a/src/plugins/build-version-skew.ts
+++ b/src/plugins/build-version-skew.ts
@@ -1,0 +1,42 @@
+// Detects installed plugin artifacts built against a different OpenClaw release than this host.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { compareComparableSemver, parseComparableSemver } from "../infra/semver-compare.js";
+
+/** Build/host version pair for a plugin whose recorded build host does not match this host. */
+export type PluginBuildVersionSkew = {
+  buildVersion: string;
+  currentVersion: string;
+};
+
+/**
+ * Checks a plugin's recorded `openclaw.build.openclawVersion` against the running host.
+ *
+ * Stable-built plugins rely on additive SDK evolution, so older stable builds stay quiet.
+ * Prerelease builds only match the exact host they were built for: prerelease SDK surface
+ * can be withdrawn before the train ships (a beta-built plugin importing a barrel export
+ * the stable release dropped fails as a call-time TypeError under the jiti loader).
+ */
+export function checkPluginBuildVersionSkew(params: {
+  currentVersion: string | undefined;
+  buildOpenclawVersion: unknown;
+}): PluginBuildVersionSkew | null {
+  const buildVersion = normalizeOptionalString(params.buildOpenclawVersion);
+  const currentVersion = normalizeOptionalString(params.currentVersion);
+  // Missing build metadata (dev/local/git installs) is not skew; only release artifacts carry it.
+  if (!buildVersion || !currentVersion || buildVersion === currentVersion) {
+    return null;
+  }
+  const buildSemver = parseComparableSemver(buildVersion);
+  const currentSemver = parseComparableSemver(currentVersion);
+  if (!buildSemver || !currentSemver) {
+    return null;
+  }
+  const skew = { buildVersion, currentVersion };
+  if (buildSemver.prerelease) {
+    return skew;
+  }
+  // Stable builds are safe on hosts at or past their release; prerelease hosts of the same
+  // triple order below the stable build, so this also catches hosts that predate it.
+  const comparison = compareComparableSemver(currentSemver, buildSemver);
+  return comparison !== null && comparison < 0 ? skew : null;
+}

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -215,6 +215,33 @@ describe("doctor-contract-registry module loader", () => {
     ]);
   });
 
+  it("skips compatibility hooks that throw without aborting other plugin migrations", () => {
+    const throwingRoot = makeTempDir();
+    fs.writeFileSync(
+      path.join(throwingRoot, "doctor-contract-api.cjs"),
+      "module.exports = { normalizeCompatibilityConfig: () => { throw new TypeError('stale sdk import'); } };\n",
+      "utf-8",
+    );
+    const healthyRoot = makeTempDir();
+    fs.writeFileSync(
+      path.join(healthyRoot, "doctor-contract-api.cjs"),
+      "module.exports = { normalizeCompatibilityConfig: ({ cfg }) => ({ config: { ...cfg, repaired: true }, changes: ['healthy change'] }) };\n",
+      "utf-8",
+    );
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        { id: "broken-plugin", rootDir: throwingRoot },
+        { id: "healthy-plugin", rootDir: healthyRoot },
+      ],
+      diagnostics: [],
+    });
+
+    const result = applyPluginDoctorCompatibilityMigrations({} as never, { env: {} });
+
+    expect(result.changes).toEqual(["healthy change"]);
+    expect((result.config as { repaired?: boolean }).repaired).toBe(true);
+  });
+
   it("loads multiple bundled CLI route-state owners from doctor contract modules", () => {
     const anthropicRoot = makeTempDir();
     const googleRoot = makeTempDir();

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -460,12 +460,19 @@ export function applyPluginDoctorCompatibilityMigrations(
   let nextCfg = cfg;
   const changes: string[] = [];
   for (const entry of resolvePluginDoctorContracts(params)) {
-    const mutation = entry.normalizeCompatibilityConfig?.({ cfg: nextCfg });
-    if (!mutation || mutation.changes.length === 0) {
+    // Contract hooks run plugin-shipped code: a version-skewed install can throw at
+    // call time even when the module loaded. Skip like failed contract module loads;
+    // the manifest-registry build-version diagnostic owns the user-facing warning.
+    try {
+      const mutation = entry.normalizeCompatibilityConfig?.({ cfg: nextCfg });
+      if (!mutation || mutation.changes.length === 0) {
+        continue;
+      }
+      nextCfg = mutation.config;
+      changes.push(...mutation.changes);
+    } catch {
       continue;
     }
-    nextCfg = mutation.config;
-    changes.push(...mutation.changes);
   }
   return { config: nextCfg, changes };
 }

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -296,6 +296,34 @@ function loadRegistryForPluginApiCase(params: {
   });
 }
 
+function loadRegistryForBuildVersionCase(params: {
+  rootDir: string;
+  buildOpenclawVersion: string;
+  env: NodeJS.ProcessEnv;
+  origin?: "bundled" | "global";
+  idHint?: string;
+}) {
+  return loadPluginManifestRegistry({
+    env: params.env,
+    candidates: [
+      createPluginCandidate({
+        idHint: params.idHint ?? "synology-chat",
+        rootDir: params.rootDir,
+        packageDir: params.rootDir,
+        origin: params.origin ?? "global",
+        packageManifest: {
+          install: {
+            npmSpec: "@openclaw/synology-chat",
+          },
+          build: {
+            openclawVersion: params.buildOpenclawVersion,
+          },
+        },
+      }),
+    ],
+  });
+}
+
 function hasUnsafeManifestDiagnostic(registry: ReturnType<typeof loadPluginManifestRegistry>) {
   return registry.diagnostics.some((diag) => diag.message.includes("unsafe plugin manifest path"));
 }
@@ -2462,6 +2490,55 @@ describe("loadPluginManifestRegistry", () => {
 
     expect(registry.plugins.map((plugin) => plugin.id)).toContain("codex");
     expectNoRegistryDiagnosticContains(registry, "requires plugin API");
+  });
+
+  it("warns without skipping load when a prerelease-built plugin runs on the train's stable host", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "synology-chat", configSchema: { type: "object" } });
+
+    const registry = loadRegistryForBuildVersionCase({
+      rootDir: dir,
+      buildOpenclawVersion: "2026.6.5-beta.5",
+      env: { OPENCLAW_VERSION: "2026.6.5" } as NodeJS.ProcessEnv,
+    });
+
+    expect(registry.plugins.map((plugin) => plugin.id)).toEqual(["synology-chat"]);
+    expectRegistryDiagnosticContains(
+      registry,
+      "plugin was built for OpenClaw 2026.6.5-beta.5, but this host is 2026.6.5",
+    );
+    expectRegistryDiagnosticContains(registry, "openclaw plugins update synology-chat");
+    expect(registry.diagnostics.map((diag) => diag.level)).toContain("warn");
+  });
+
+  it("stays quiet for older stable plugin builds on a newer host", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "synology-chat", configSchema: { type: "object" } });
+
+    const registry = loadRegistryForBuildVersionCase({
+      rootDir: dir,
+      buildOpenclawVersion: "2026.6.4",
+      env: { OPENCLAW_VERSION: "2026.6.5" } as NodeJS.ProcessEnv,
+    });
+
+    expect(registry.plugins.map((plugin) => plugin.id)).toEqual(["synology-chat"]);
+    expectNoRegistryDiagnosticContains(registry, "was built for OpenClaw");
+  });
+
+  it("does not build-version-gate bundled source plugins", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "codex", configSchema: { type: "object" } });
+
+    const registry = loadRegistryForBuildVersionCase({
+      rootDir: dir,
+      buildOpenclawVersion: "2026.6.5-beta.5",
+      env: { OPENCLAW_VERSION: "2026.6.5" } as NodeJS.ProcessEnv,
+      origin: "bundled",
+      idHint: "codex",
+    });
+
+    expect(registry.plugins.map((plugin) => plugin.id)).toContain("codex");
+    expectNoRegistryDiagnosticContains(registry, "was built for OpenClaw");
   });
 
   it.each([

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -13,6 +13,7 @@ import { satisfiesPluginApiRange } from "../infra/clawhub.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
+import { checkPluginBuildVersionSkew } from "./build-version-skew.js";
 import { loadBundleManifest } from "./bundle-manifest.js";
 import { normalizePluginsConfigWithResolver } from "./config-policy.js";
 import { isBundledPluginInsideDevSourceRoot } from "./dev-source-root.js";
@@ -1083,6 +1084,20 @@ export function loadPluginManifestRegistry(
           message: `plugin requires plugin API ${packagePluginApiRange}, but this host is ${currentHostVersion}; skipping load`,
         });
         continue;
+      }
+      const buildVersionSkew = checkPluginBuildVersionSkew({
+        currentVersion: currentHostVersion,
+        buildOpenclawVersion: candidate.packageManifest?.build?.openclawVersion,
+      });
+      if (buildVersionSkew) {
+        // Warn-only: the plugin still loads, but a skewed build can reference SDK surface
+        // this host does not export, which the loader surfaces as call-time TypeErrors.
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: packageManifestSource,
+          message: `plugin was built for OpenClaw ${buildVersionSkew.buildVersion}, but this host is ${buildVersionSkew.currentVersion}; its SDK imports may not match. Run \`openclaw plugins update ${manifest.id}\` to install a matching build.`,
+        });
       }
     }
 

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -1977,6 +1977,11 @@ export type OpenClawPackageCompat = {
   pluginApi?: string;
 };
 
+export type OpenClawPackageBuild = {
+  /** Exact OpenClaw release this plugin artifact was built and published with. */
+  openclawVersion?: string;
+};
+
 export type OpenClawPackageManifest = {
   extensions?: string[];
   runtimeExtensions?: string[];
@@ -1989,6 +1994,7 @@ export type OpenClawPackageManifest = {
   };
   channel?: PluginPackageChannel;
   compat?: OpenClawPackageCompat;
+  build?: OpenClawPackageBuild;
   install?: PluginPackageInstall;
   startup?: OpenClawPackageStartup;
 };


### PR DESCRIPTION
## Summary

Hardens `openclaw doctor` and plugin loading against installed plugins built for a different OpenClaw release, the failure class behind #91991 (reported by @cn1313113): `@openclaw/feishu@2026.6.5-beta.5` imports an SDK export that `openclaw@2026.6.5` stable no longer ships (the #91322 release-line revert removed it), and the jiti loader turns the missing named export into a call-time `TypeError` that aborted the whole doctor run.

Two pieces:

**1. Plugin doctor hooks are now fail-soft (`fix(doctor)`)**
- `src/commands/doctor/shared/channel-doctor.ts`: every channel doctor adapter hook invocation (`runConfigSequence`, `cleanStaleConfig`, `collectPreviewWarnings`, `collectMutableAllowlistWarnings`, `repairConfig`, empty-allowlist hooks) catches per entry. One broken plugin degrades to a doctor warning naming the channel and suggesting `openclaw plugins update <id>` instead of aborting every other repair. Entries carry the channel id to make the warning actionable. The production-uncalled `collectChannelDoctorCompatibilityMutations` collector is deleted (tests re-pointed at the equivalent `cleanStaleConfig` probe).
- `src/commands/doctor-config-flow.ts`: warning-only stale mutations now surface as doctor warnings instead of being silently dropped.
- Same class, sibling surfaces found during review and fixed with per-entry catches mirroring the module's existing silent-skip policy for failed contract module loads: `applyPluginDoctorCompatibilityMigrations` (`src/plugins/doctor-contract-registry.ts`) and the `detectLegacyState` phase (`src/infra/state-migrations.ts`, whose migrate phase was already wrapped).

**2. Build-version skew warning (`feat(plugins)`)**
- New `src/plugins/build-version-skew.ts` checks the `openclaw.build.openclawVersion` every published plugin artifact already records against the running host, reusing `src/infra/semver-compare.ts`. Rule: prerelease builds only match the exact host they were built for (prerelease SDK surface can be withdrawn before the train ships — exactly the beta.5 incident); stable builds are quiet on any host at or past their release; missing build metadata (dev/local/git installs) stays silent.
- `src/plugins/manifest-registry.ts` emits a warn-only diagnostic for skewed non-bundled plugins (plugin still loads): `plugin was built for OpenClaw 2026.6.5-beta.5, but this host is 2026.6.5; its SDK imports may not match. Run 'openclaw plugins update <id>' to install a matching build.` The diagnostic surfaces in both gateway load logs and doctor's "Plugin diagnostics" panel from one implementation point.

With both pieces, the #91991 scenario (stale beta plugin + stable core) no longer crashes doctor: the run completes, and the user gets a named warning with the `plugins update` remedy.

Scope notes:
- `channel-legacy-config-migrate.ts` stays unwrapped on purpose: it only invokes bundled channel contracts, which ship inside the core dist and cannot version-skew.
- The `detectLegacyState` catch has no dedicated test; it is the same three-line pattern as the adjacent, already-shipped migrate-phase catch. The thrown-hook behavior class is covered by the channel-doctor and contract-registry tests.

## Verification

- `node scripts/run-vitest.mjs src/plugins/build-version-skew.test.ts src/plugins/doctor-contract-registry.test.ts src/plugins/manifest-registry.test.ts src/commands/doctor/shared/channel-doctor.test.ts src/commands/doctor-config-flow.test.ts src/infra/state-migrations.test.ts` — all shards pass, including new coverage: 15-case skew matrix, throwing adapters for sequence/stale/mutable/repair/empty-allowlist hooks (healthy siblings keep running, config chain preserved), a real throwing `.cjs` doctor-contract fixture, and 3 manifest-registry skew cases (warn fires, plugin still loads, bundled origin exempt).
- `pnpm tsgo` + `pnpm check:test-types` clean; `node scripts/run-oxlint.mjs` on touched files clean; `oxfmt` applied via `pnpm format:diff`.
- `pnpm build` clean after the manifest-registry import change (plugin-sdk export checks and dynamic-import checks pass).
- Maintainer note: skipping the parsed `Real behavior proof` block per write-access policy; behavior is locked by the unit/integration tests above, which reproduce the #91991 failure shape (a hook throwing `TypeError` mid-doctor).

Related: #91991, #91322.
