### PR TITLE
fix(plugins): compose live hook registry view for tool-call hooks

### DIFF
--- a/src/plugins/hook-runner-global.compose.test.ts
+++ b/src/plugins/hook-runner-global.compose.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Composition rules for the global hook runner's live registry view (#91918).
+ * These exercise the ownership/precedence/liveness decisions directly with
+ * mock registries, complementing the real-load kill-chain coverage in
+ * loader.hook-runner-live-view.test.ts.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getGlobalHookRunner,
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "./hook-runner-global.js";
+import { addTestHook, createMockPluginRegistry } from "./hooks.test-helpers.js";
+import type { PluginRegistry } from "./registry.js";
+import {
+  pinActivePluginChannelRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "./runtime.js";
+
+function runner() {
+  const value = getGlobalHookRunner();
+  if (!value) {
+    throw new Error("Expected global hook runner");
+  }
+  return value;
+}
+
+afterEach(() => {
+  resetGlobalHookRunner();
+  resetPluginRuntimeStateForTest();
+});
+
+describe("global hook runner composition (#91918)", () => {
+  it("prefers a loaded registration over a failed scoped reload of the same plugin", () => {
+    const boot = createMockPluginRegistry([
+      { hookName: "before_tool_call", handler: vi.fn(), pluginId: "gate" },
+    ]);
+    // Scoped reload where the gate plugin failed to register: record present,
+    // status not loaded, no hooks.
+    const scopedFailure = createMockPluginRegistry([]);
+    scopedFailure.plugins[0].id = "gate";
+    scopedFailure.plugins[0].status = "error";
+
+    setActivePluginRegistry(boot);
+    pinActivePluginChannelRegistry(boot);
+    initializeGlobalHookRunner(boot);
+    expect(runner().hasHooks("before_tool_call")).toBe(true);
+
+    setActivePluginRegistry(scopedFailure);
+    initializeGlobalHookRunner(scopedFailure);
+    // The pinned boot registry still owns the loaded gate, so the fail-closed
+    // tool-call hook is not shadowed by the errored scoped record.
+    expect(runner().hasHooks("before_tool_call")).toBe(true);
+  });
+
+  it("prefers a loaded source that carries the hook over a loaded-but-hookless record", () => {
+    // Pinned boot registry: plugin C loaded WITH a fail-closed tool-call gate.
+    const boot = createMockPluginRegistry([
+      { hookName: "before_tool_call", handler: vi.fn(), pluginId: "C" },
+    ]);
+    // Scoped reload where C is present and loaded but registered no hooks
+    // (e.g. a setup-runtime channel load registers the channel, not api.on).
+    const scopedHookless = createMockPluginRegistry([]);
+    scopedHookless.plugins[0].id = "C";
+    scopedHookless.plugins[0].status = "loaded";
+
+    pinActivePluginChannelRegistry(boot);
+    setActivePluginRegistry(scopedHookless);
+    initializeGlobalHookRunner(scopedHookless);
+    // The hookless scoped record is highest precedence but must not shadow the
+    // pinned registration that actually carries C's gate.
+    expect(runner().hasHooks("before_tool_call")).toBe(true);
+  });
+
+  it("keeps a pinned registry with zero channels visible to hook dispatch", () => {
+    const hookOnlyPinned = createMockPluginRegistry([
+      { hookName: "subagent_ended", handler: vi.fn(), pluginId: "hooky" },
+    ]);
+    const channelActive = createMockPluginRegistry([
+      { hookName: "message_sent", handler: vi.fn(), pluginId: "chan" },
+    ]);
+    // Give the active registry a channel so the channel-presentation selector
+    // would prefer it and evict the zero-channel pinned registry — the raw
+    // live-registry collector must keep the pinned one regardless.
+    (channelActive.channels as unknown[]).push({});
+
+    setActivePluginRegistry(channelActive);
+    pinActivePluginChannelRegistry(hookOnlyPinned);
+    initializeGlobalHookRunner(channelActive);
+
+    expect(runner().hasHooks("subagent_ended")).toBe(true);
+    expect(runner().hasHooks("message_sent")).toBe(true);
+  });
+
+  it("lets an explicitly initialized registry win ownership over the active registry", () => {
+    const activeRegistry = createMockPluginRegistry([
+      { hookName: "message_received", handler: vi.fn(), pluginId: "foo" },
+    ]);
+    const sdkRegistry = createMockPluginRegistry([
+      { hookName: "message_sent", handler: vi.fn(), pluginId: "foo" },
+    ]);
+
+    setActivePluginRegistry(activeRegistry);
+    initializeGlobalHookRunner(sdkRegistry);
+
+    // Last-initialized highest precedence: the SDK registry owns plugin "foo",
+    // so its hook dispatches and the active registry's "foo" hook is shadowed.
+    expect(runner().hasHooks("message_sent")).toBe(true);
+    expect(runner().hasHooks("message_received")).toBe(false);
+  });
+
+  it("dispatches hooks pushed into a registry after initialization", () => {
+    const registry: PluginRegistry = createMockPluginRegistry([
+      { hookName: "message_received", handler: vi.fn(), pluginId: "p" },
+    ]);
+
+    setActivePluginRegistry(registry);
+    initializeGlobalHookRunner(registry);
+    // Read once so any internal caching would have settled.
+    expect(runner().hasHooks("message_received")).toBe(true);
+    expect(runner().hasHooks("message_sent")).toBe(false);
+
+    addTestHook({ registry, pluginId: "p", hookName: "message_sent", handler: vi.fn() });
+    // Live composition: the late registration is visible without re-init.
+    expect(runner().hasHooks("message_sent")).toBe(true);
+  });
+});

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -3,6 +3,15 @@
  *
  * Singleton hook runner that's initialized when plugins are loaded
  * and can be called from anywhere in the codebase.
+ *
+ * The runner is created once and resolves hooks live on every dispatch from a
+ * composed view of the registries that are currently live: the most recently
+ * initialized registry, the active registry, and the pinned channel/http-route
+ * surfaces. Freezing one registry caused scoped mid-run activations (harness
+ * and memory ensures) to rebind the runner to a narrow registry and silently
+ * drop other plugins' tool-call hooks (#91918). Composing live also preserves
+ * the older contract that hooks pushed into a registry after initialization
+ * (e.g. the SDK `addTestHook` helper) dispatch immediately.
  */
 
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -10,6 +19,9 @@ import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import type { GlobalHookRunnerRegistry } from "./hook-registry.types.js";
 import type { PluginHookGatewayContext, PluginHookGatewayStopEvent } from "./hook-types.js";
 import { createHookRunner, type HookRunner } from "./hooks.js";
+import { isPluginRegistryRetired } from "./registry-lifecycle.js";
+import type { PluginRegistry } from "./registry-types.js";
+import { collectLivePluginRegistries } from "./runtime.js";
 
 type HookRunnerGlobalState = {
   hookRunner: HookRunner | null;
@@ -25,27 +37,153 @@ const getState = () =>
 
 const getLog = () => createSubsystemLogger("plugins");
 
+function collectHookRegistrySources(
+  lastInitialized: GlobalHookRunnerRegistry | null,
+): GlobalHookRunnerRegistry[] {
+  const ordered: GlobalHookRunnerRegistry[] = [];
+  const seen = new Set<GlobalHookRunnerRegistry>();
+  const add = (registry: GlobalHookRunnerRegistry | null) => {
+    if (!registry || seen.has(registry)) {
+      return;
+    }
+    // Retired registries were superseded by a newer activation; dispatching
+    // their hooks would resurrect stale config closures. Only lastInitialized
+    // can be retired here (the live registries below are active/pinned, never
+    // retired); SDK-supplied registries are not PluginRegistry and never match.
+    if (isPluginRegistryRetired(registry as PluginRegistry)) {
+      return;
+    }
+    seen.add(registry);
+    ordered.push(registry);
+  };
+  // Precedence: the explicitly initialized registry wins so an SDK caller that
+  // initializes an isolated registry stays authoritative; in the gateway it is
+  // the same object as the active registry, so this just dedupes.
+  add(lastInitialized);
+  for (const registry of collectLivePluginRegistries()) {
+    add(registry);
+  }
+  return ordered;
+}
+
+function composeLiveHookRegistry(
+  lastInitialized: GlobalHookRunnerRegistry | null,
+): GlobalHookRunnerRegistry {
+  const sources = collectHookRegistrySources(lastInitialized);
+  // One source registry owns a plugin's entire contribution (status + hooks),
+  // so handlers never double-fire across registries and a plugin's hooks stay
+  // paired with the status the inbound-claim path reads.
+  const ownerSourceIndexByPluginId = new Map<string, number>();
+  const claimOwner = (pluginId: string, index: number) => {
+    if (!ownerSourceIndexByPluginId.has(pluginId)) {
+      ownerSourceIndexByPluginId.set(pluginId, index);
+    }
+  };
+  // pluginIds each source actually contributes a hook for, so ownership can
+  // prefer a source that carries the plugin's hooks over a same-plugin record
+  // that loaded without any (e.g. a setup-runtime channel load registers the
+  // channel but not the plugin's api.on(...) hooks).
+  const hookPluginIdsBySource = sources.map((registry) => {
+    const ids = new Set<string>();
+    for (const hook of registry.typedHooks) {
+      ids.add(hook.pluginId);
+    }
+    for (const hook of registry.hooks) {
+      ids.add(hook.pluginId);
+    }
+    return ids;
+  });
+  // Prefer the highest-precedence source where the plugin loaded AND actually
+  // contributes a hook, so a loaded-but-hookless record (failed/disabled scoped
+  // reload, or a setup-runtime channel load) cannot shadow a lower-precedence
+  // registration that still carries a fail-closed tool-call gate.
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      if (plugin.status === "loaded" && hookPluginIdsBySource[index].has(plugin.id)) {
+        claimOwner(plugin.id, index);
+      }
+    }
+  });
+  // Then a loaded record owns the plugin's status when no live source
+  // contributes a hook for it, keeping status paired with a single owner.
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      if (plugin.status === "loaded") {
+        claimOwner(plugin.id, index);
+      }
+    }
+  });
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      claimOwner(plugin.id, index);
+    }
+  });
+  // Defensive: claim any hook whose plugin record is absent from .plugins so a
+  // malformed registry never silently drops a registered hook.
+  sources.forEach((registry, index) => {
+    for (const hook of registry.typedHooks) {
+      claimOwner(hook.pluginId, index);
+    }
+    for (const hook of registry.hooks) {
+      claimOwner(hook.pluginId, index);
+    }
+  });
+  return {
+    hooks: sources.flatMap((registry, index) =>
+      registry.hooks.filter((hook) => ownerSourceIndexByPluginId.get(hook.pluginId) === index),
+    ),
+    typedHooks: sources.flatMap((registry, index) =>
+      registry.typedHooks.filter((hook) => ownerSourceIndexByPluginId.get(hook.pluginId) === index),
+    ),
+    plugins: sources.flatMap((registry, index) =>
+      registry.plugins.filter((plugin) => ownerSourceIndexByPluginId.get(plugin.id) === index),
+    ),
+  };
+}
+
+function createComposedHookRegistryFacade(state: HookRunnerGlobalState): GlobalHookRunnerRegistry {
+  // Live getters: createHookRunner reads these on every hasHooks/getHooksForName
+  // call, so the runner always dispatches the current live registry set rather
+  // than a snapshot captured at initialization. Composition is bounded by the
+  // small live registry set and runs on hook-paced events, not tight loops.
+  return {
+    get hooks() {
+      return composeLiveHookRegistry(state.registry).hooks;
+    },
+    get typedHooks() {
+      return composeLiveHookRegistry(state.registry).typedHooks;
+    },
+    get plugins() {
+      return composeLiveHookRegistry(state.registry).plugins;
+    },
+  };
+}
+
 /**
  * Initialize the global hook runner with a plugin registry.
- * Called once when plugins are loaded during gateway startup.
+ * Called on every plugin registry activation and by SDK consumers. The runner
+ * instance stays stable so references captured mid-run keep seeing current
+ * hooks; the passed registry becomes the highest-precedence composition source.
  */
 export function initializeGlobalHookRunner(registry: GlobalHookRunnerRegistry): void {
   const state = getState();
   const log = getLog();
   state.registry = registry;
-  state.hookRunner = createHookRunner(registry, {
-    logger: {
-      debug: (msg) => log.debug(msg),
-      warn: (msg) => log.warn(msg),
-      error: (msg) => log.error(msg),
-    },
-    catchErrors: true,
-    failurePolicyByHook: {
-      before_agent_run: "fail-closed",
-      before_install: "fail-closed",
-      before_tool_call: "fail-closed",
-    },
-  });
+  if (!state.hookRunner) {
+    state.hookRunner = createHookRunner(createComposedHookRegistryFacade(state), {
+      logger: {
+        debug: (msg) => log.debug(msg),
+        warn: (msg) => log.warn(msg),
+        error: (msg) => log.error(msg),
+      },
+      catchErrors: true,
+      failurePolicyByHook: {
+        before_agent_run: "fail-closed",
+        before_install: "fail-closed",
+        before_tool_call: "fail-closed",
+      },
+    });
+  }
 
   const hookCount = registry.hooks.length;
   if (hookCount > 0) {
@@ -62,8 +200,9 @@ export function getGlobalHookRunner(): HookRunner | null {
 }
 
 /**
- * Get the global plugin registry.
- * Returns null if plugins haven't been loaded yet.
+ * Get the registry from the most recent activation or explicit initialization.
+ * Returns null if plugins haven't been loaded yet. Hook dispatch does not use
+ * this single registry; the runner resolves hooks from the live composed view.
  */
 export function getGlobalPluginRegistry(): GlobalHookRunnerRegistry | null {
   return getState().registry;

--- a/src/plugins/loader.hook-runner-live-view.test.ts
+++ b/src/plugins/loader.hook-runner-live-view.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression coverage for #91918: local-extension before_tool_call /
+ * after_tool_call hooks must stay dispatchable across the gateway run
+ * lifecycle.
+ *
+ * Mirrors the production sequence that killed them on v2026.6.5:
+ *  1. gateway boot: full gateway-bindable load (coreGatewayMethodNames set),
+ *     boot registry pinned to the channel/http surfaces
+ *  2. harness ensure: scoped default-mode activating load (consumed the old
+ *     one-shot preserve gate and flipped active mode to "default")
+ *  3. memory ensure: second scoped default-mode activating load (re-initialized
+ *     the runner from a memory-only registry, silently dropping tool hooks)
+ *
+ * With the live composed view, the pinned boot registry keeps the extension's
+ * hooks dispatchable no matter how many scoped activations follow.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { getGlobalHookRunner, resetGlobalHookRunner } from "./hook-runner-global.js";
+import { loadOpenClawPlugins } from "./loader.js";
+import {
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+import {
+  getActivePluginRegistry,
+  pinActivePluginChannelRegistry,
+  pinActivePluginHttpRouteRegistry,
+} from "./runtime.js";
+
+describe("global hook runner live view (#91918)", () => {
+  afterEach(() => {
+    resetGlobalHookRunner();
+    resetPluginLoaderTestStateForTest();
+  });
+
+  it("keeps local-extension tool-call hooks dispatchable across scoped default-mode activations", async () => {
+    useNoBundledPlugins();
+    const gate = writePlugin({
+      id: "local-gate",
+      filename: "local-gate.cjs",
+      body: `module.exports = { id: "local-gate", register(api) {
+        api.on("before_tool_call", (event) => {
+          if (String(event.params?.command ?? "").includes("curl")) {
+            return { block: true, blockReason: "blocked by gate" };
+          }
+        });
+        api.on("after_tool_call", () => undefined);
+      } };`,
+    });
+    const harnessStandIn = writePlugin({
+      id: "harness-plugin",
+      filename: "harness-plugin.cjs",
+      body: `module.exports = { id: "harness-plugin", register() {} };`,
+    });
+    const memoryStandIn = writePlugin({
+      id: "memory-plugin",
+      filename: "memory-plugin.cjs",
+      body: `module.exports = { id: "memory-plugin", register() {} };`,
+    });
+
+    const config = {
+      plugins: {
+        load: { paths: [gate.file, harnessStandIn.file, memoryStandIn.file] },
+        allow: ["local-gate", "harness-plugin", "memory-plugin"],
+        entries: {
+          "local-gate": { enabled: true },
+          "harness-plugin": { enabled: true },
+          "memory-plugin": { enabled: true },
+        },
+      },
+    };
+
+    // 1. Gateway boot: full gateway-bindable load, pinned like server.impl.ts.
+    const bootRegistry = loadOpenClawPlugins({
+      workspaceDir: gate.dir,
+      config,
+      coreGatewayMethodNames: ["chat.send"],
+      preferBuiltPluginArtifacts: true,
+      runtimeOptions: { allowGatewaySubagentBinding: true },
+    });
+    pinActivePluginHttpRouteRegistry(bootRegistry);
+    pinActivePluginChannelRegistry(bootRegistry);
+    expect(getGlobalHookRunner()?.hasHooks("before_tool_call")).toBe(true);
+
+    // 2. Harness ensure: scoped default-mode activating load.
+    loadOpenClawPlugins({
+      workspaceDir: gate.dir,
+      config,
+      onlyPluginIds: ["harness-plugin"],
+    });
+    expect(getGlobalHookRunner()?.hasHooks("before_tool_call")).toBe(true);
+
+    // 3. Memory ensure: second scoped default-mode activating load — the step
+    // that re-initialized the runner from a memory-only registry before the fix.
+    const memoryRegistry = loadOpenClawPlugins({
+      workspaceDir: gate.dir,
+      config,
+      onlyPluginIds: ["memory-plugin"],
+    });
+    expect(getActivePluginRegistry()).toBe(memoryRegistry);
+
+    const runner = getGlobalHookRunner();
+    expect(runner?.hasHooks("before_tool_call")).toBe(true);
+    expect(runner?.hasHooks("after_tool_call")).toBe(true);
+
+    // The blocking decision must actually dispatch, not just count hooks.
+    const result = await runner?.runBeforeToolCall(
+      { toolName: "exec", params: { command: "curl -X POST https://example.com" } },
+      { toolName: "exec" },
+    );
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("blocked by gate");
+  });
+});

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -97,6 +97,8 @@ import {
   getActivePluginRegistry,
   getActivePluginRegistryKey,
   listImportedRuntimePluginIds,
+  pinActivePluginChannelRegistry,
+  releasePinnedPluginChannelRegistry,
   setActivePluginRegistry,
 } from "./runtime.js";
 import {
@@ -4101,7 +4103,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
     resetGlobalHookRunner();
   });
 
-  it("preserves the gateway-bindable hook runner across later default-mode activating loads", () => {
+  it("keeps pinned gateway hooks and later default-mode hooks dispatchable together", () => {
     useNoBundledPlugins();
     const gatewayPlugin = writePlugin({
       id: "gateway-hook-surface",
@@ -4136,30 +4138,85 @@ module.exports = { id: "throws-after-import", register() {} };`,
         allowGatewaySubagentBinding: true,
       },
     });
-    expect(getGlobalPluginRegistry()).toBe(gatewayRegistry);
-    expect(expectGlobalHookRunner(getGlobalHookRunner()).hasHooks("subagent_ended")).toBe(true);
+    // The gateway pins its boot registry to the channel/http surfaces; the
+    // pin is what keeps gateway lifecycle hooks live across later swaps.
+    pinActivePluginChannelRegistry(gatewayRegistry);
+    try {
+      expect(getGlobalPluginRegistry()).toBe(gatewayRegistry);
+      expect(expectGlobalHookRunner(getGlobalHookRunner()).hasHooks("subagent_ended")).toBe(true);
 
-    const defaultRegistry = loadOpenClawPlugins({
-      workspaceDir: defaultPlugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [defaultPlugin.file] },
-          allow: ["default-hook-surface"],
-          entries: {
-            "default-hook-surface": {
-              enabled: true,
-              hooks: { allowConversationAccess: true },
+      const defaultRegistry = loadOpenClawPlugins({
+        workspaceDir: defaultPlugin.dir,
+        config: {
+          plugins: {
+            load: { paths: [defaultPlugin.file] },
+            allow: ["default-hook-surface"],
+            entries: {
+              "default-hook-surface": {
+                enabled: true,
+                hooks: { allowConversationAccess: true },
+              },
             },
           },
         },
-      },
+      });
+
+      expect(getActivePluginRegistry()).toBe(defaultRegistry);
+      expect(getGlobalPluginRegistry()).toBe(defaultRegistry);
+      // Regression guard for #91918: the runner must see the union of live
+      // registries, not just whichever registry initialized it last.
+      const globalHookRunner = expectGlobalHookRunner(getGlobalHookRunner());
+      expect(globalHookRunner.hasHooks("subagent_ended")).toBe(true);
+      expect(globalHookRunner.hasHooks("message_sent")).toBe(true);
+    } finally {
+      releasePinnedPluginChannelRegistry(gatewayRegistry);
+    }
+  });
+
+  it("drops hooks of replaced unpinned registries from the global runner", () => {
+    useNoBundledPlugins();
+    const firstPlugin = writePlugin({
+      id: "retired-hook-surface",
+      filename: "retired-hook-surface.cjs",
+      body: `module.exports = { id: "retired-hook-surface", register(api) {
+        api.on("subagent_ended", () => undefined);
+      } };`,
+    });
+    const secondPlugin = writePlugin({
+      id: "replacing-hook-surface",
+      filename: "replacing-hook-surface.cjs",
+      body: `module.exports = { id: "replacing-hook-surface", register(api) {
+        api.on("message_sent", () => undefined);
+      } };`,
     });
 
-    expect(getActivePluginRegistry()).toBe(defaultRegistry);
-    expect(getGlobalPluginRegistry()).toBe(gatewayRegistry);
+    loadOpenClawPlugins({
+      workspaceDir: firstPlugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [firstPlugin.file] },
+          allow: ["retired-hook-surface"],
+          entries: { "retired-hook-surface": { enabled: true } },
+        },
+      },
+    });
+    expect(expectGlobalHookRunner(getGlobalHookRunner()).hasHooks("subagent_ended")).toBe(true);
+
+    // A second activation retires the unpinned first registry entirely; its
+    // hooks must drop instead of dispatching stale config closures.
+    loadOpenClawPlugins({
+      workspaceDir: secondPlugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [secondPlugin.file] },
+          allow: ["replacing-hook-surface"],
+          entries: { "replacing-hook-surface": { enabled: true } },
+        },
+      },
+    });
     const globalHookRunner = expectGlobalHookRunner(getGlobalHookRunner());
-    expect(globalHookRunner.hasHooks("subagent_ended")).toBe(true);
-    expect(globalHookRunner.hasHooks("message_sent")).toBe(false);
+    expect(globalHookRunner.hasHooks("message_sent")).toBe(true);
+    expect(globalHookRunner.hasHooks("subagent_ended")).toBe(false);
   });
 
   it.each([

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -65,7 +65,7 @@ import {
   restoreRegisteredEmbeddingProviders,
 } from "./embedding-providers.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
-import { getGlobalHookRunner, initializeGlobalHookRunner } from "./hook-runner-global.js";
+import { initializeGlobalHookRunner } from "./hook-runner-global.js";
 import { toSafeImportPath } from "./import-specifier.js";
 import { collectPluginManifestCompatCodes } from "./installed-plugin-index-record-builder.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
@@ -1709,14 +1709,11 @@ function activatePluginRegistry(
   runtimeSubagentMode: "default" | "explicit" | "gateway-bindable",
   workspaceDir?: string,
 ): void {
-  const preserveGatewayHookRunner =
-    runtimeSubagentMode === "default" &&
-    getActivePluginRuntimeSubagentMode() === "gateway-bindable" &&
-    getGlobalHookRunner() !== null;
+  // Always re-initialize: the global runner resolves hooks from the live
+  // registry set (active + pinned surfaces), so activation order and scope
+  // cannot drop hooks the way the old preserve-one-runner gate did (#91918).
   setActivePluginRegistry(registry, cacheKey, runtimeSubagentMode, workspaceDir);
-  if (!preserveGatewayHookRunner) {
-    initializeGlobalHookRunner(registry);
-  }
+  initializeGlobalHookRunner(registry);
 }
 
 export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegistry {

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -117,7 +117,15 @@ function retirePluginRegistryIfUnused(registry: PluginRegistry | null): boolean 
   return true;
 }
 
-function collectLivePluginAgentEventRegistries(): PluginRegistry[] {
+/**
+ * Returns the distinct live plugin registries in precedence order: the active
+ * registry first, then the pinned http-route and channel surfaces. Uses the
+ * raw pinned registries (not channel-presentation selection) so a pinned
+ * registry stays visible to runtime dispatch even with zero channels. Shared
+ * by the agent-event bridge and the global hook runner so both dispatch
+ * surfaces agree on what "live" means.
+ */
+export function collectLivePluginRegistries(): PluginRegistry[] {
   const registries: PluginRegistry[] = [];
   const seen = new Set<PluginRegistry>();
   const addRegistry = (registry: PluginRegistry | null) => {
@@ -136,11 +144,11 @@ function collectLivePluginAgentEventRegistries(): PluginRegistry[] {
 function syncPluginAgentEventBridge(): void {
   state.agentEventBridgeUnsubscribe?.();
   state.agentEventBridgeUnsubscribe = undefined;
-  if (collectLivePluginAgentEventRegistries().length === 0) {
+  if (collectLivePluginRegistries().length === 0) {
     return;
   }
   state.agentEventBridgeUnsubscribe = onAgentEvent((event) => {
-    for (const registry of collectLivePluginAgentEventRegistries()) {
+    for (const registry of collectLivePluginRegistries()) {
       dispatchPluginAgentEventSubscriptions({ registry, event });
     }
   });


### PR DESCRIPTION
## Summary

Fixes #91918. After upgrading 2026.5.27 → 2026.6.5, `before_tool_call` / `after_tool_call` hooks of local (global-dir) extensions register but never fire during agent runs, silently disabling hook-based safety/observability plugins.

**Root cause.** The global plugin hook runner froze a single registry at initialization. A scoped, mid-run plugin activation — the codex/copilot harness ensure or the memory ensure — re-initialized the runner from a *narrow* registry that excludes a local extension's plugin, so its tool-call hooks stopped dispatching. `before_prompt_build` kept working because it reads a runner captured at run start, while `before_tool_call` does a live `getGlobalHookRunner()` lookup — which is why the breakage looked tool-call-specific. The loader's `preserveGatewayHookRunner` gate absorbed only one such activation and then disarmed (active mode flipped to `default`), so it could not prevent the next scoped load.

**Fix.** The runner is created once and resolves hooks **live on every dispatch** from the composed set of currently-live registries — the most recently initialized registry, the active registry, and the pinned channel/http-route surfaces — instead of binding one registry. This mirrors how the agent-event bridge already composes live registries; both now consume the same `collectLivePluginRegistries()` collector, so the two dispatch surfaces agree on what is "live." The one-shot preserve gate in `activatePluginRegistry` is removed because activation order no longer matters.

Composition details that keep it correct:

- **Per-plugin ownership prefers loaded records**, so a failed or disabled scoped reload cannot shadow a healthy pinned registration — which would otherwise silently drop a fail-closed `before_tool_call` gate.
- The **explicitly initialized registry is highest precedence**, preserving the shipped SDK contract (`initializeGlobalHookRunner` is exported via `openclaw/plugin-sdk/hook-runtime`) that an isolated test registry stays authoritative.
- **Raw** pinned registries are used (not the channel-presentation selector), so a pinned registry with zero channels stays visible to hook dispatch.
- Composition is **live (no memo)**, so hooks pushed into a registry after init (e.g. the `addTestHook` SDK helper) dispatch immediately.

## Files

- `src/plugins/hook-runner-global.ts` — live composed view + ownership/precedence rules.
- `src/plugins/runtime.ts` — expose `collectLivePluginRegistries` (renamed from the private agent-event collector; both consumers now share it).
- `src/plugins/loader.ts` — remove the preserve gate; always re-initialize.
- `src/plugins/loader.test.ts` — flip the assertion that previously enshrined the registry/runner split.
- `src/plugins/loader.hook-runner-live-view.test.ts` (new) — real-load kill chain.
- `src/plugins/hook-runner-global.compose.test.ts` (new) — ownership / precedence / liveness rules.

## Verification

Local (this patch, macOS):

- `node scripts/run-vitest.mjs src/plugins/loader.test.ts` → 156 passed (includes the flipped preserve-gate test).
- `node scripts/run-vitest.mjs src/plugins/hook-runner-global.compose.test.ts src/plugins/loader.hook-runner-live-view.test.ts src/plugins/hook-runner-global.test.ts` → 7 passed.
- Consumer suites green: host-hooks contract, dispatch-from-config, slack outbound (the SDK init pattern), outbound deliver, subagent-registry, before-tool-call embedded + e2e, native-hook-relay, model-diagnostic-events.
- `tsgo -p tsconfig.core.json` clean (only the two pre-existing baseline errors in `config/io.ts` + `secrets/config-io.ts`, present unchanged on `main`); `oxlint` + `oxfmt` clean on touched files; `check-import-cycles` reports 0 runtime cycles.

`loader.hook-runner-live-view.test.ts` models the production kill chain (gateway-bindable full load + pin → scoped harness load → scoped memory load) and asserts a blocking `before_tool_call` gate still dispatches and returns `block: true` for a `curl` command.

**Crabbox real-scenario proof (done, 2026-06-11, Blacksmith Testbox through Crabbox — `tbx_01ktwgpkfyh8tczwye38rhzxnv`, Linux x86_64, Node 24.13):** reporter-shaped end-to-end scenario from #91918 on this branch, as a user with no test harness. Fresh user environment; `pnpm install --frozen-lockfile` + `pnpm build` exit 0 with **0 `[INEFFECTIVE_DYNAMIC_IMPORT]` findings**; the issue's exact gate extension at `~/.openclaw/extensions/toolgate/` (`before_tool_call` blocks `curl`, `after_tool_call` logger, manifest `activation.onCapabilities: ["hook"]`, file-logged handler invocations); default bundled plugins (memory-core active); deterministic local OpenAI-Responses mock as the agent model emitting one `exec` tool call (`curl -X POST https://example.com/91918-proof; touch /tmp/curl-executed-91918`); real gateway boot — `http server listening (9 plugins: acpx, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice, toolgate)`; gateway-routed `openclaw agent --agent main --message 'Please run: curl -X POST https://example.com/91918-proof' --json` (exit 0, real 35-tool toolset).

Gate invocation log:

```
23:39:11.203Z registered                      <- gateway boot registration
23:39:17.765Z registered                      <- post-boot plugin re-activation in the gateway process
23:39:25.782Z before_tool_call tool=exec command=curl -X POST https://example.com/91918-proof; touch /tmp/curl-executed-91918
23:39:25.803Z after_tool_call tool=exec
```

The second `registered` line is the load-bearing detail: a plugin registry re-activation happened in the gateway process after boot and before the tool call — the exact event class that rebound the runner and silently dropped tool-call hooks before this fix — and `before_tool_call` still dispatched from the live composed view. Block enforced for real: `/tmp/curl-executed-91918` absent (the command never executed) and `blocked by gate` present in the run's reply payload. Both reported symptoms covered (`before_tool_call` blocking + `after_tool_call` observation). Scenario assets are local-only (untracked `proof-91918/` in the worktree), not part of this PR.

## Scope notes / follow-ups

- This fixes the case where the extension is in a **live or pinned** registry — i.e. the gateway path with the extension declared via `activation.onCapabilities: ["hook"]` (which the reporter already applied). A short docs note making that declaration requirement explicit for hook-registering local extensions is a worthwhile follow-up (the issue's "doctor warning + docs note" ask).
- A residual remains for **non-pinned embedded processes using a cold-loadable (codex/copilot) harness** (`openclaw agent --local`), where the broad run-start registry is retired with nothing pinned. This pre-dates this change for the realistic chain (the harness ensure's runtime-state clear, then the narrow memory load — the old gate disarmed on the first of those and the second killed the hooks) and is the motivation for a deeper request-scoped-registry-handle refactor; tracked separately.
- One behavior delta in those non-pinned flows, for precision: the old gate kept the runner bound to the **retired** broad registry through one scoped default load, so its hooks kept firing from stale config closures; the live view drops retired registries immediately (the new `loader.test.ts` case "drops hooks of replaced unpinned registries" pins this as the contract). Hooks there can disappear one scoped activation earlier than before — accepted as more correct than dispatching stale closures, and moot wherever a surface is pinned. In practice the slice is thin: the memory ensure early-returns while the broad registry's memory runtime is live (`src/plugins/memory-runtime.ts`), so the narrow killer load needs the cold-harness clear first, which the gate did not survive either.

Reported by @vokaplok.


