### PR TITLE
fix(agents): drop body/method on cross-origin MCP HTTP redirects

### DIFF
--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -177,6 +177,66 @@ describe("MCP HTTP fetch helpers", () => {
     expect(getDispatcher(fetchCalls[1]?.init)).toBeInstanceOf(TestEnvHttpProxyAgent);
   });
 
+  it("drops the POST body on a cross-origin 307 redirect", async () => {
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async (url: string | URL | Request, init?: unknown) => {
+        fetchCalls.push({ url, init });
+        return fetchCalls.length === 1
+          ? redirectResponse("https://attacker.example.com/token", 307)
+          : new Response("ok");
+      },
+    };
+    const fetch = buildMcpHttpFetch({
+      resourceUrl: "https://mcp.example.com/mcp",
+    });
+
+    await fetch("https://mcp.example.com/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ secret: "value" }),
+    });
+
+    const firstInit = fetchCalls[0]?.init as RequestInit | undefined;
+    expect(firstInit?.method).toBe("POST");
+    expect(firstInit?.body).toBeDefined();
+
+    // Secure default: the original body and content-type must not replay across
+    // the cross-origin redirect even though 307 otherwise preserves the method.
+    const replayedInit = fetchCalls[1]?.init as RequestInit | undefined;
+    expect(replayedInit?.body ?? undefined).toBeUndefined();
+    expect(new Headers(replayedInit?.headers).get("content-type")).toBeNull();
+  });
+
+  it("switches a cross-origin 302 POST redirect to GET and drops the body", async () => {
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async (url: string | URL | Request, init?: unknown) => {
+        fetchCalls.push({ url, init });
+        return fetchCalls.length === 1
+          ? redirectResponse("https://attacker.example.com/token", 302)
+          : new Response("ok");
+      },
+    };
+    const fetch = buildMcpHttpFetch({
+      resourceUrl: "https://mcp.example.com/mcp",
+    });
+
+    await fetch("https://mcp.example.com/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ secret: "value" }),
+    });
+
+    const replayedInit = fetchCalls[1]?.init as RequestInit | undefined;
+    expect(replayedInit?.method).toBe("GET");
+    expect(replayedInit?.body ?? undefined).toBeUndefined();
+  });
+
   it("removes static Authorization headers for OAuth-backed runtime requests", () => {
     expect(
       withoutMcpAuthorizationHeader({

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -169,7 +169,9 @@ export function buildMcpHttpFetch(params: {
       init: request.init,
       fetchImpl: fetchWithUndiciGuard,
       maxRedirects: MCP_HTTP_MAX_REDIRECTS,
-      allowCrossOriginUnsafeRedirectReplay: true,
+      // MCP transport keeps the secure default: a cross-origin 30x redirect must
+      // not replay the original POST body/method, so the fetch-guard strips both.
+      allowCrossOriginUnsafeRedirectReplay: false,
       auditContext: "mcp-http",
       useEnvProxyForEligibleUrls: true,
       ...(policy ? { policy } : {}),


### PR DESCRIPTION
## Summary

The MCP HTTP transport passed `allowCrossOriginUnsafeRedirectReplay: true`, so a cross-origin 30x redirect replayed the original POST body/method — an SSRF / credential-exfil vector. Set it to `false` to match the secure default already used by `provider-transport-fetch.ts`, letting the fetch-guard strip body+method on cross-origin redirects.

- Files: src/agents/mcp-http-fetch.ts
- No `CHANGELOG.md` edit (release-only per `AGENTS.md`).

## Why core (not ClawHub)
Core security hardening touching `src/agents/mcp-http-fetch.ts` — per `AGENTS.md` these stay in core (security/core hardening, bundled regressions, missing core APIs), not optional skill bundles routed to ClawHub.

## Verification

- `node scripts/run-vitest.mjs run src/agents/mcp-http-fetch.test.ts --config test/vitest/vitest.agents-core.config.ts` => **8 passed**
- `pnpm tsgo:core` (tsconfig.core.json) => clean
- `oxfmt --check` + `oxlint` on touched files => clean

## Real behavior proof

- **Behavior addressed:** MCP HTTP transport no longer replays the request body/method across a cross-origin redirect.
- **Real environment tested:** macOS (Darwin 25.3.0); OpenClaw at base 2accfeedc7; Node 22; Vitest via scripts/run-vitest.mjs.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run src/agents/mcp-http-fetch.test.ts --config test/vitest/vitest.agents-core.config.ts`
- **Evidence after fix:** 8 tests pass, incl. new cases: a cross-origin 307 POST redirect drops body + content-type, and a 302 POST redirect switches to GET and drops the body.
- **Observed result after fix:** Cross-origin redirect on a POST is stripped to a bodyless GET by the SSRF guard; same-origin behavior unchanged.
- **What was not tested:** Full Crabbox/live E2E against a real MCP server over a redirecting proxy; Linux CI; cross-OS.. Independently reviewed by a separate agent before commit; not yet run through Crabbox/$autoreview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)