### PR TITLE
fix(sessions): derive channel from direct-chat session keys in send-policy

### DIFF
--- a/src/sessions/send-policy.test.ts
+++ b/src/sessions/send-policy.test.ts
@@ -67,6 +67,12 @@ describe("resolveSendPolicy", () => {
       sessionKey: "agent:main:other-channel:group:dev",
       expected: "allow",
     },
+    {
+      name: "channel-scoped deny fires for direct session key without explicit channel field",
+      cfg: cfgWithRules([{ action: "deny", match: { channel: "demo-channel" } }]),
+      sessionKey: "demo-channel:direct:user-1",
+      expected: "deny",
+    },
   ])("$name", ({ cfg, entry, sessionKey, expected }) => {
     expect(resolveSendPolicy({ cfg, entry, sessionKey })).toBe(expected);
   });

--- a/src/sessions/send-policy.ts
+++ b/src/sessions/send-policy.ts
@@ -46,7 +46,12 @@ function deriveChannelFromKey(key?: string) {
     return undefined;
   }
   const parts = normalizedKey.split(":").filter(Boolean);
-  if (parts.length >= 3 && (parts[1] === "group" || parts[1] === "channel")) {
+  // Canonical key layout is <channel>:<peerKind>:<peerId>; parts[0] is the channel
+  // for direct/dm peers too, so channel-scoped rules also fire for direct chats.
+  if (
+    parts.length >= 3 &&
+    (parts[1] === "group" || parts[1] === "channel" || parts[1] === "direct" || parts[1] === "dm")
+  ) {
     return normalizeMatchValue(parts[0]);
   }
   return undefined;


### PR DESCRIPTION
## Summary

`deriveChannelFromKey` returned undefined for `direct`/`dm` session keys, so channel-scoped send rules silently never fired for direct chats. Treat `parts[0]` as the channel for direct/dm keys too (canonical `<channel>:<peerKind>:<peerId>`), matching the sibling `deriveChatTypeFromKey`.

- Files: src/sessions/send-policy.ts
- No `CHANGELOG.md` edit (release-only per `AGENTS.md`).

## Why core (not ClawHub)
Core correctness fix touching `src/sessions/send-policy.ts` — per `AGENTS.md` these stay in core (security/core hardening, bundled regressions, missing core APIs), not optional skill bundles routed to ClawHub.

## Verification

- `node scripts/run-vitest.mjs run src/sessions/send-policy.test.ts` => **7 passed**
- `pnpm tsgo:core` (tsconfig.core.json) => clean
- `oxfmt --check` + `oxlint` on touched files => clean

## Real behavior proof

- **Behavior addressed:** Channel-scoped send-policy rules now apply to direct/dm sessions, not just group/channel sessions.
- **Real environment tested:** macOS (Darwin 25.3.0); OpenClaw at base 2accfeedc7; Node 22; Vitest via scripts/run-vitest.mjs.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run src/sessions/send-policy.test.ts`
- **Evidence after fix:** 7 tests pass, incl. a new regression: a channel-scoped deny rule fires for a direct session key with no explicit channel field.
- **Observed result after fix:** A direct key `demo-channel:direct:user-1` resolves channel `demo-channel`; 2-token keys still fall through to prefix matching (unchanged).
- **What was not tested:** Full Crabbox/live E2E across real channels; Linux CI; cross-OS.. Independently reviewed by a separate agent before commit; not yet run through Crabbox/$autoreview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)