### PR TITLE
test(secrets,routing): cover sensitive-header, exec-ref, and binding-scope policies

### DIFF
--- a/src/routing/binding-scope.test.ts
+++ b/src/routing/binding-scope.test.ts
@@ -1,0 +1,91 @@
+// Binding scope tests cover route binding scope matching and match resolution.
+import { describe, expect, it } from "vitest";
+import type { AgentRouteBinding } from "../config/types.agents.js";
+import { resolveNormalizedRouteBindingMatch, routeBindingScopeMatches } from "./binding-scope.js";
+
+describe("routeBindingScopeMatches", () => {
+  it("passes when the constraint has no guild/team/role limits", () => {
+    expect(routeBindingScopeMatches({}, { guildId: "g1", teamId: "t1" })).toBe(true);
+  });
+
+  it("matches an exact guild id constraint", () => {
+    expect(routeBindingScopeMatches({ guildId: "g1" }, { guildId: "g1" })).toBe(true);
+  });
+
+  it("matches an exact team id constraint", () => {
+    expect(routeBindingScopeMatches({ teamId: "t1" }, { teamId: "t1" })).toBe(true);
+  });
+
+  it("falls back to the group space when guild/team ids are absent", () => {
+    expect(routeBindingScopeMatches({ guildId: "space-1" }, { groupSpace: "space-1" })).toBe(true);
+    expect(routeBindingScopeMatches({ teamId: "space-1" }, { groupSpace: "space-1" })).toBe(true);
+  });
+
+  it("fails when the guild id constraint does not match", () => {
+    expect(routeBindingScopeMatches({ guildId: "g1" }, { guildId: "g2" })).toBe(false);
+  });
+
+  it("fails when the team id constraint does not match", () => {
+    expect(routeBindingScopeMatches({ teamId: "t1" }, { teamId: "t2" })).toBe(false);
+  });
+});
+
+describe("routeBindingScopeMatches role intersection", () => {
+  it("accepts a Set of member role ids", () => {
+    expect(
+      routeBindingScopeMatches(
+        { roles: ["admin"] },
+        { memberRoleIds: new Set(["member", "admin"]) },
+      ),
+    ).toBe(true);
+    expect(
+      routeBindingScopeMatches({ roles: ["admin"] }, { memberRoleIds: new Set(["member"]) }),
+    ).toBe(false);
+  });
+
+  it("accepts an iterable of member role ids", () => {
+    expect(
+      routeBindingScopeMatches({ roles: ["admin"] }, { memberRoleIds: ["member", "admin"] }),
+    ).toBe(true);
+    expect(routeBindingScopeMatches({ roles: ["admin"] }, { memberRoleIds: ["member"] })).toBe(
+      false,
+    );
+  });
+
+  it("fails role-constrained bindings when no member role ids are provided", () => {
+    expect(routeBindingScopeMatches({ roles: ["admin"] }, {})).toBe(false);
+  });
+
+  it("ignores empty role lists as unconstrained", () => {
+    expect(routeBindingScopeMatches({ roles: [] }, {})).toBe(true);
+  });
+});
+
+describe("resolveNormalizedRouteBindingMatch", () => {
+  function bindingWith(accountId: string | undefined, channel: string): AgentRouteBinding {
+    return {
+      agentId: "Main",
+      match: { channel, accountId },
+    };
+  }
+
+  it("resolves a concrete account binding into canonical ids", () => {
+    expect(resolveNormalizedRouteBindingMatch(bindingWith("Bot-Alpha", "discord"))).toEqual({
+      agentId: "main",
+      accountId: "bot-alpha",
+      channelId: "discord",
+    });
+  });
+
+  it("rejects wildcard account matches", () => {
+    expect(resolveNormalizedRouteBindingMatch(bindingWith("*", "discord"))).toBeNull();
+  });
+
+  it("rejects empty account matches", () => {
+    expect(resolveNormalizedRouteBindingMatch(bindingWith("   ", "discord"))).toBeNull();
+  });
+
+  it("rejects blank channel matches", () => {
+    expect(resolveNormalizedRouteBindingMatch(bindingWith("bot-alpha", "   "))).toBeNull();
+  });
+});

--- a/src/secrets/exec-resolution-policy.test.ts
+++ b/src/secrets/exec-resolution-policy.test.ts
@@ -1,0 +1,99 @@
+/** Tests exec-ref resolution policy splitting and skipped-ref static validation. */
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SecretRef } from "../config/types.secrets.js";
+import { getSkippedExecRefStaticError, selectRefsForExecPolicy } from "./exec-resolution-policy.js";
+import { formatExecSecretRefIdValidationMessage } from "./ref-contract.js";
+
+const envRef: SecretRef = { source: "env", provider: "default", id: "OPENAI_API_KEY" };
+const fileRef: SecretRef = { source: "file", provider: "mounted-json", id: "/providers/openai" };
+const execRef: SecretRef = { source: "exec", provider: "vault", id: "openai/api-key" };
+
+function configWithProvider(provider: string, source: string): OpenClawConfig {
+  return {
+    secrets: { providers: { [provider]: { source } } },
+  } as unknown as OpenClawConfig;
+}
+
+describe("selectRefsForExecPolicy", () => {
+  it("skips exec refs but keeps non-exec refs when allowExec is false", () => {
+    const { refsToResolve, skippedExecRefs } = selectRefsForExecPolicy({
+      refs: [envRef, fileRef, execRef],
+      allowExec: false,
+    });
+
+    expect(refsToResolve).toEqual([envRef, fileRef]);
+    expect(skippedExecRefs).toEqual([execRef]);
+  });
+
+  it("resolves exec refs when allowExec is true", () => {
+    const { refsToResolve, skippedExecRefs } = selectRefsForExecPolicy({
+      refs: [envRef, execRef],
+      allowExec: true,
+    });
+
+    expect(refsToResolve).toEqual([envRef, execRef]);
+    expect(skippedExecRefs).toEqual([]);
+  });
+
+  it("returns empty splits for empty input", () => {
+    const { refsToResolve, skippedExecRefs } = selectRefsForExecPolicy({
+      refs: [],
+      allowExec: false,
+    });
+
+    expect(refsToResolve).toEqual([]);
+    expect(skippedExecRefs).toEqual([]);
+  });
+});
+
+describe("getSkippedExecRefStaticError", () => {
+  it("reports an empty id error when the ref id is blank", () => {
+    const error = getSkippedExecRefStaticError({
+      ref: { source: "exec", provider: "vault", id: "   " },
+      config: configWithProvider("vault", "exec"),
+    });
+
+    expect(error).toBe("Error: Secret reference id is empty.");
+  });
+
+  it("reports a grammar validation error for invalid exec ids", () => {
+    const error = getSkippedExecRefStaticError({
+      ref: { source: "exec", provider: "vault", id: "../escape" },
+      config: configWithProvider("vault", "exec"),
+    });
+
+    expect(error).toBe(
+      `Error: ${formatExecSecretRefIdValidationMessage()} (ref: exec:vault:../escape).`,
+    );
+  });
+
+  it("reports an unconfigured provider error", () => {
+    const error = getSkippedExecRefStaticError({
+      ref: execRef,
+      config: { secrets: { providers: {} } } as unknown as OpenClawConfig,
+    });
+
+    expect(error).toBe(
+      'Error: Secret provider "vault" is not configured (ref: exec:vault:openai/api-key).',
+    );
+  });
+
+  it("reports a source mismatch error when provider source differs", () => {
+    const error = getSkippedExecRefStaticError({
+      ref: execRef,
+      config: configWithProvider("vault", "env"),
+    });
+
+    expect(error).toBe('Error: Secret provider "vault" has source "env" but ref requests "exec".');
+  });
+
+  it("returns null when the skipped exec ref is statically valid", () => {
+    const error = getSkippedExecRefStaticError({
+      ref: execRef,
+      config: configWithProvider("vault", "exec"),
+    });
+
+    expect(error).toBeNull();
+  });
+});

--- a/src/secrets/model-provider-header-policy.test.ts
+++ b/src/secrets/model-provider-header-policy.test.ts
@@ -1,0 +1,53 @@
+/** Tests the model-provider sensitive-header classifier. */
+import { describe, expect, it } from "vitest";
+import { isLikelySensitiveModelProviderHeaderName } from "./model-provider-header-policy.js";
+
+describe("isLikelySensitiveModelProviderHeaderName", () => {
+  const alwaysSensitive = [
+    "authorization",
+    "proxy-authorization",
+    "x-api-key",
+    "api-key",
+    "apikey",
+    "x-auth-token",
+    "auth-token",
+    "x-access-token",
+    "access-token",
+    "x-secret-key",
+    "secret-key",
+  ];
+
+  it.each(alwaysSensitive)("treats always-sensitive header %s as secret", (name) => {
+    expect(isLikelySensitiveModelProviderHeaderName(name)).toBe(true);
+  });
+
+  it.each([
+    ["Authorization", true],
+    ["X-API-KEY", true],
+    ["APIKEY", true],
+    ["Secret-Key", true],
+  ] as const)("matches case-insensitively for %s", (name, expected) => {
+    expect(isLikelySensitiveModelProviderHeaderName(name)).toBe(expected);
+  });
+
+  it.each([
+    ["x-my-token", true],
+    ["X-API-KEY-V2", true],
+    ["authorization", true],
+    ["x-provider-secret", true],
+    ["x-vault-password", true],
+    ["x-service-credential", true],
+  ] as const)("flags fragment/substring match %s", (name, expected) => {
+    expect(isLikelySensitiveModelProviderHeaderName(name)).toBe(expected);
+  });
+
+  it.each([
+    ["content-type", false],
+    ["accept", false],
+    ["user-agent", false],
+    ["", false],
+    ["   ", false],
+  ] as const)("does not flag benign or empty input %j", (name, expected) => {
+    expect(isLikelySensitiveModelProviderHeaderName(name)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit coverage for three security-sensitive policy modules that lacked direct tests: sensitive model-provider header classification (credential-leak guard), exec secret-ref resolution gating (dry-run execution gate), and route binding-scope + role matching. Test-only; no production change.

- Files: src/secrets/model-provider-header-policy.test.ts, src/secrets/exec-resolution-policy.test.ts, src/routing/binding-scope.test.ts
- No `CHANGELOG.md` edit (release-only per `AGENTS.md`).

## Why core (not ClawHub)
Core test coverage touching `src/secrets/model-provider-header-policy.test.ts` — per `AGENTS.md` these stay in core (security/core hardening, bundled regressions, missing core APIs), not optional skill bundles routed to ClawHub.

## Verification

- `node scripts/run-vitest.mjs run src/secrets/model-provider-header-policy.test.ts src/secrets/exec-resolution-policy.test.ts --config test/vitest/vitest.secrets.config.ts ; node scripts/run-vitest.mjs run src/routing/binding-scope.test.ts` => **34 + 14 passed**
- `pnpm tsgo:core` (tsconfig.core.json) => clean
- `oxfmt --check` + `oxlint` on touched files => clean

## Real behavior proof

- **Behavior addressed:** New regression coverage for sensitive-header classification, exec secret-ref gating, and binding-scope/role matching.
- **Real environment tested:** macOS (Darwin 25.3.0); OpenClaw at base 2accfeedc7; Node 22; Vitest via scripts/run-vitest.mjs.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run src/secrets/model-provider-header-policy.test.ts src/secrets/exec-resolution-policy.test.ts --config test/vitest/vitest.secrets.config.ts ; node scripts/run-vitest.mjs run src/routing/binding-scope.test.ts`
- **Evidence after fix:** 34 secrets tests + 14 routing tests pass; tables cover ALWAYS_SENSITIVE names, case/fragment matches, all exec-skip error branches, and binding-scope guild/team/role gating.
- **Observed result after fix:** Classifier, exec-resolution policy, and binding-scope behavior is pinned by assertions against the real exports.
- **What was not tested:** These are unit tests only — no runtime/E2E behavior changed.. Independently reviewed by a separate agent before commit; not yet run through Crabbox/$autoreview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)