### PR TITLE
feat(skills): add per-section remediation hints to skills check

### DIFF
--- a/src/cli/skills-cli.format.test.ts
+++ b/src/cli/skills-cli.format.test.ts
@@ -1,0 +1,76 @@
+// Formatter tests for `openclaw skills check` remediation hints.
+import { describe, expect, it } from "vitest";
+import type { SkillStatusEntry, SkillStatusReport } from "../skills/discovery/status.js";
+import { createEmptyInstallChecks } from "./requirements-test-fixtures.js";
+import { formatSkillsCheck } from "./skills-cli.format.js";
+
+function createMockSkill(overrides: Partial<SkillStatusEntry> = {}): SkillStatusEntry {
+  const skill: SkillStatusEntry = {
+    name: "test-skill",
+    description: "A test skill",
+    source: "bundled",
+    bundled: false,
+    filePath: "/path/to/SKILL.md",
+    baseDir: "/path/to",
+    skillKey: "test-skill",
+    emoji: "🧪",
+    homepage: "https://example.com",
+    always: false,
+    disabled: false,
+    blockedByAllowlist: false,
+    blockedByAgentFilter: false,
+    eligible: true,
+    modelVisible: true,
+    userInvocable: true,
+    commandVisible: true,
+    ...createEmptyInstallChecks(),
+    ...overrides,
+  };
+  if (overrides.modelVisible === undefined) {
+    skill.modelVisible = skill.eligible && !skill.blockedByAgentFilter;
+  }
+  if (overrides.commandVisible === undefined) {
+    skill.commandVisible = skill.eligible && !skill.blockedByAgentFilter && skill.userInvocable;
+  }
+  return skill;
+}
+
+function createMockReport(skills: SkillStatusEntry[]): SkillStatusReport {
+  return {
+    workspaceDir: "/workspace",
+    managedSkillsDir: "/managed",
+    skills,
+  };
+}
+
+describe("formatSkillsCheck remediation hints", () => {
+  it("tells authors how to fix each problem section", () => {
+    const report = createMockReport([
+      createMockSkill({
+        name: "prompt-hidden",
+        eligible: true,
+        modelVisible: false,
+        commandVisible: true,
+      }),
+      createMockSkill({
+        name: "not-assigned",
+        eligible: true,
+        blockedByAgentFilter: true,
+      }),
+      createMockSkill({
+        name: "missing-reqs",
+        eligible: false,
+        missing: { bins: ["ffmpeg"], anyBins: [], env: [], config: [], os: [] },
+      }),
+    ]);
+
+    const output = formatSkillsCheck(report, {});
+
+    // Hidden from model prompt remediation.
+    expect(output).toContain("disable-model-invocation: false");
+    // Agent allowlist remediation.
+    expect(output).toContain("agents.list[].skills");
+    // Missing requirements remediation.
+    expect(output).toContain("openclaw skills info <name>");
+  });
+});

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -478,7 +478,7 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
       );
     }
     lines.push(
-      `  ${theme.muted("Fix:")} add the skill name to this agent's \`skills\` allowlist (\`agents.list[].skills\` or \`agents.defaults.skills\`).`,
+      `  ${theme.muted("Fix:")} add the skill name to this agent's \`agents.list[].skills\` allowlist (or \`agents.defaults.skills\`, which applies only when the agent sets no explicit list).`,
     );
   }
 

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -463,6 +463,9 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
         `  ${emoji ? `${emoji} ` : ""}${sanitizeForLog(skill.name)} ${theme.muted(`(${reason})`)}`,
       );
     }
+    lines.push(
+      `  ${theme.muted("Fix:")} set frontmatter \`disable-model-invocation: false\` to expose the skill to the model.`,
+    );
   }
 
   if (agentFiltered.length > 0) {
@@ -474,6 +477,9 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
         `  ${emoji ? `${emoji} ` : ""}${sanitizeForLog(skill.name)} ${theme.muted("(loaded, but this agent is not allowed to see/use it)")}`,
       );
     }
+    lines.push(
+      `  ${theme.muted("Fix:")} add the skill name to this agent's \`skills\` allowlist (\`agents.list[].skills\` or \`agents.defaults.skills\`).`,
+    );
   }
 
   if (missingReqs.length > 0) {
@@ -486,6 +492,9 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
         `  ${emoji ? `${emoji} ` : ""}${sanitizeForLog(skill.name)} ${theme.muted(`(${missing})`)}`,
       );
     }
+    lines.push(
+      `  ${theme.muted("Fix:")} run ${formatCliCommand("openclaw skills info <name>")} for install hints.`,
+    );
   }
 
   return appendClawHubHint(lines.join("\n"), opts.json);


### PR DESCRIPTION
## Summary

`skills check` listed hidden / agent-excluded / missing-requirement skills but never told the author how to fix each. Append a per-section `Fix:` hint: hidden -> frontmatter `disable-model-invocation: false`; excluded -> add to the agent's `skills` allowlist (`agents.list[].skills` / `agents.defaults.skills`); missing -> `openclaw skills info <name>`.

- Files: src/cli/skills-cli.format.ts
- No `CHANGELOG.md` edit (release-only per `AGENTS.md`).

## Why core (not ClawHub)
Core first-run/CLI UX fix touching `src/cli/skills-cli.format.ts` — per `AGENTS.md` these stay in core (security/core hardening, bundled regressions, missing core APIs), not optional skill bundles routed to ClawHub.

## Verification

- `node scripts/run-vitest.mjs run src/cli/skills-cli.format.test.ts src/cli/skills-cli.test.ts --config test/vitest/vitest.cli.config.ts` => **26 passed**
- `pnpm tsgo:core` (tsconfig.core.json) => clean
- `oxfmt --check` + `oxlint` on touched files => clean

## Real behavior proof

- **Behavior addressed:** `skills check` output now includes an actionable remediation line under each problem section.
- **Real environment tested:** macOS (Darwin 25.3.0); OpenClaw at base 2accfeedc7; Node 22; Vitest via scripts/run-vitest.mjs.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run src/cli/skills-cli.format.test.ts src/cli/skills-cli.test.ts --config test/vitest/vitest.cli.config.ts`
- **Evidence after fix:** 26 tests pass, incl. a new formatter test asserting the three remediation strings (with the correct `agents.list[].skills` allowlist key) appear.
- **Observed result after fix:** Hints render only when their section renders; allowlist key verified against the real config schema (`agents.list[].skills`).
- **What was not tested:** Full CLI E2E; Linux CI; docs/cli/skills.md not updated in this PR.. Independently reviewed by a separate agent before commit; not yet run through Crabbox/$autoreview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Real behavior proof (updated — real CLI run)

Ran the built `openclaw skills check` from source against a real workspace. The
new per-section remediation hint renders under the affected section:

```
Missing requirements:
  🐻 bear-notes (bins: grizzly)
  ...
  Fix: run openclaw skills info <name> for install hints.
```

The `Fix:` line is appended by `formatSkillsCheck` per problem section
(hidden-from-model → `disable-model-invocation: false`; agent-excluded →
`agents.list[].skills` allowlist; missing-requirements → `openclaw skills info <name>`),
confirming the hints appear in real CLI output, not only in the formatter test.