### PR TITLE
fix(gateway): recover config hot-reload after watcher errors

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1574,6 +1574,93 @@ describe("startGatewayConfigReloader", () => {
   });
 });
 
+describe("startGatewayConfigReloader watcher error recovery", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function startReloaderWithWatchers(watchers: ReturnType<typeof createWatcherMock>[]) {
+    const watchSpy = vi.spyOn(chokidar, "watch");
+    for (const watcher of watchers) {
+      watchSpy.mockReturnValueOnce(watcher as unknown as never);
+    }
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const reloader = startGatewayConfigReloader({
+      initialConfig: { gateway: { reload: { debounceMs: 0 } } },
+      readSnapshot: vi.fn(async () => makeSnapshot()),
+      initialPluginInstallRecords: {},
+      readPluginInstallRecords: async () => ({}),
+      onHotReload: vi.fn(async () => {}),
+      onRestart: vi.fn(),
+      log,
+      watchPath: "/tmp/openclaw.json",
+    });
+    return { watchSpy, log, reloader };
+  }
+
+  it("re-creates the watcher with backoff after a transient error", async () => {
+    const first = createWatcherMock();
+    const second = createWatcherMock();
+    const { watchSpy, log, reloader } = startReloaderWithWatchers([first, second]);
+
+    expect(watchSpy).toHaveBeenCalledTimes(1);
+
+    first.emit("error");
+    expect(reloader.hotReloadStatus()).toBe("active");
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("re-creating watcher (attempt 1/3 in 500ms)"),
+    );
+    expect(first.close).toHaveBeenCalledTimes(1);
+
+    // Watcher is only re-created once the backoff timer fires.
+    expect(watchSpy).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(watchSpy).toHaveBeenCalledTimes(2);
+    expect(reloader.hotReloadStatus()).toBe("active");
+    expect(log.error).not.toHaveBeenCalled();
+
+    await reloader.stop();
+  });
+
+  it("disables hot-reload and logs at error level after the retry budget is exhausted", async () => {
+    const watchers = [
+      createWatcherMock(),
+      createWatcherMock(),
+      createWatcherMock(),
+      createWatcherMock(),
+    ];
+    const { watchSpy, log, reloader } = startReloaderWithWatchers(watchers);
+
+    // Three errors consume the retry budget; the fourth error escalates.
+    watchers[0]?.emit("error");
+    await vi.advanceTimersByTimeAsync(500);
+    watchers[1]?.emit("error");
+    await vi.advanceTimersByTimeAsync(2000);
+    watchers[2]?.emit("error");
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(watchSpy).toHaveBeenCalledTimes(4);
+    expect(reloader.hotReloadStatus()).toBe("active");
+
+    watchers[3]?.emit("error");
+    expect(reloader.hotReloadStatus()).toBe("disabled");
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "config hot-reload disabled: watcher failed after 3 re-create attempts",
+      ),
+    );
+    // No further watcher is created once disabled.
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(watchSpy).toHaveBeenCalledTimes(4);
+
+    await reloader.stop();
+  });
+});
+
 describe("shouldInvalidateSkillsSnapshotForPaths", () => {
   it.each([
     "skills",

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -33,6 +33,13 @@ export type { ChannelKind, GatewayReloadPlan } from "./config-reload-plan.js";
 const MISSING_CONFIG_RETRY_DELAY_MS = 150;
 const MISSING_CONFIG_MAX_RETRIES = 2;
 
+// Watcher 'error' events (for example EMFILE/ENOSPC inotify exhaustion) close
+// the chokidar watcher. Re-create it with bounded backoff so a transient fault
+// does not permanently kill config hot-reload, but escalate to error + a
+// persistent disabled status once the retry budget is exhausted.
+const WATCHER_RECREATE_MAX_RETRIES = 3;
+const WATCHER_RECREATE_BACKOFF_MS = [500, 2000, 5000] as const;
+
 /**
  * Paths under `skills.*` always change the snapshot that sessions cache in
  * sessions.json. Any prefix match here (for example `skills.allowBundled`,
@@ -71,8 +78,14 @@ function isNoopReloadPlan(plan: GatewayReloadPlan): boolean {
   );
 }
 
+// Hot-reload stays "active" while a watcher is live. It flips to "disabled" only
+// after watcher re-creation fails past the retry budget, so operators/callers
+// can detect silent degradation instead of assuming reloads still fire.
+export type GatewayHotReloadStatus = "active" | "disabled";
+
 type GatewayConfigReloader = {
   stop: () => Promise<void>;
+  hotReloadStatus: () => GatewayHotReloadStatus;
 };
 
 type PluginInstallRecords = Record<string, PluginInstallRecord>;
@@ -371,12 +384,6 @@ export function startGatewayConfigReloader(opts: {
     }
   };
 
-  const watcher = chokidar.watch(opts.watchPath, {
-    ignoreInitial: true,
-    awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
-    usePolling: Boolean(process.env.VITEST),
-  });
-
   const scheduleFromWatcher = () => {
     schedule();
   };
@@ -396,18 +403,59 @@ export function startGatewayConfigReloader(opts: {
       scheduleAfter(0);
     }) ?? (() => {});
 
-  watcher.on("add", scheduleFromWatcher);
-  watcher.on("change", scheduleFromWatcher);
-  watcher.on("unlink", scheduleFromWatcher);
-  let watcherClosed = false;
-  watcher.on("error", (err) => {
-    if (watcherClosed) {
+  let watcher: ReturnType<typeof chokidar.watch> | null = null;
+  let watcherRecreateRetries = 0;
+  let watcherRecreateTimer: ReturnType<typeof setTimeout> | null = null;
+  let hotReloadStatus: GatewayHotReloadStatus = "active";
+
+  const createWatcher = () => {
+    if (stopped) {
       return;
     }
-    watcherClosed = true;
-    opts.log.warn(`config watcher error: ${String(err)}`);
-    void watcher.close().catch(() => {});
-  });
+    const next = chokidar.watch(opts.watchPath, {
+      ignoreInitial: true,
+      awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
+      usePolling: Boolean(process.env.VITEST),
+    });
+    next.on("add", scheduleFromWatcher);
+    next.on("change", scheduleFromWatcher);
+    next.on("unlink", scheduleFromWatcher);
+    next.on("error", (err) => {
+      handleWatcherError(next, err);
+    });
+    watcher = next;
+    hotReloadStatus = "active";
+  };
+
+  const handleWatcherError = (source: typeof watcher, err: unknown) => {
+    // Ignore stale errors from a watcher we already replaced or stopped.
+    if (stopped || source !== watcher) {
+      return;
+    }
+    watcher = null;
+    void source?.close().catch(() => {});
+    if (watcherRecreateRetries >= WATCHER_RECREATE_MAX_RETRIES) {
+      hotReloadStatus = "disabled";
+      opts.log.error(
+        `config hot-reload disabled: watcher failed after ${WATCHER_RECREATE_MAX_RETRIES} re-create attempts: ${String(err)}`,
+      );
+      return;
+    }
+    const backoff =
+      WATCHER_RECREATE_BACKOFF_MS[watcherRecreateRetries] ??
+      WATCHER_RECREATE_BACKOFF_MS[WATCHER_RECREATE_BACKOFF_MS.length - 1] ??
+      0;
+    watcherRecreateRetries += 1;
+    opts.log.warn(
+      `config watcher error; re-creating watcher (attempt ${watcherRecreateRetries}/${WATCHER_RECREATE_MAX_RETRIES} in ${backoff}ms): ${String(err)}`,
+    );
+    watcherRecreateTimer = setTimeout(() => {
+      watcherRecreateTimer = null;
+      createWatcher();
+    }, backoff);
+  };
+
+  createWatcher();
 
   return {
     stop: async () => {
@@ -416,9 +464,15 @@ export function startGatewayConfigReloader(opts: {
         clearTimeout(debounceTimer);
       }
       debounceTimer = null;
-      watcherClosed = true;
+      if (watcherRecreateTimer) {
+        clearTimeout(watcherRecreateTimer);
+        watcherRecreateTimer = null;
+      }
       unsubscribeFromWrites();
-      await watcher.close().catch(() => {});
+      const active = watcher;
+      watcher = null;
+      await active?.close().catch(() => {});
     },
+    hotReloadStatus: () => hotReloadStatus,
   };
 }


### PR DESCRIPTION
## Summary

A chokidar watcher `error` permanently disabled config hot-reload with only a single warn. Re-create the watcher with bounded backoff (500ms/2s/5s, 3 retries); on exhausted budget escalate to `log.error` and flip a persistent `hotReloadStatus` to `disabled`. `stop()` clears any pending re-create timer.

- Files: src/gateway/config-reload.ts
- No `CHANGELOG.md` edit (release-only per `AGENTS.md`).

## Why core (not ClawHub)
Core stability fix touching `src/gateway/config-reload.ts` — per `AGENTS.md` these stay in core (security/core hardening, bundled regressions, missing core APIs), not optional skill bundles routed to ClawHub.

## Verification

- `node scripts/run-vitest.mjs run src/gateway/config-reload.test.ts` => **328 passed**
- `pnpm tsgo:core` (tsconfig.core.json) => clean
- `oxfmt --check` + `oxlint` on touched files => clean

## Real behavior proof

- **Behavior addressed:** A transient config-watcher error now recovers hot-reload via bounded backoff instead of silently disabling it forever; permanent failure is escalated and exposed via status.
- **Real environment tested:** macOS (Darwin 25.3.0); OpenClaw at base 2accfeedc7; Node 22; Vitest via scripts/run-vitest.mjs.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run src/gateway/config-reload.test.ts`
- **Evidence after fix:** 328 tests pass, incl. two new cases: re-create fires only after the backoff timer (status stays active); a 4th error past the retry budget flips status to disabled and logs at error level.
- **Observed result after fix:** Stale-source guard prevents double-consuming the retry budget; existing `{ stop }` consumers unaffected (extra `hotReloadStatus` is structurally compatible).
- **What was not tested:** Retry budget does not reset after a successful recovery (intentional, bounded); status not yet wired into an operator endpoint; full Crabbox; Linux CI.. Independently reviewed by a separate agent before commit; not yet run through Crabbox/$autoreview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)