### PR TITLE
fix(tools): surface unsupported-signal in anyOf availability

### DIFF
--- a/src/tools/availability.test.ts
+++ b/src/tools/availability.test.ts
@@ -235,4 +235,24 @@ describe("evaluateToolAvailability", () => {
       }).map((entry) => entry.reason),
     ).toEqual(["auth-missing", "env-missing", "config-missing", "plugin-disabled"]);
   });
+
+  it("surfaces an unsupported-signal sibling even when another anyOf branch is available", () => {
+    const descriptor: ToolDescriptor = {
+      ...baseDescriptor,
+      availability: {
+        anyOf: [
+          { kind: "auth", providerId: "openai" },
+          // Empty allOf is a malformed descriptor; its unsupported-signal must not be masked.
+          { allOf: [] },
+        ],
+      },
+    };
+
+    expect(
+      evaluateToolAvailability({
+        descriptor,
+        context: { authProviderIds: new Set(["openai"]) },
+      }).map((entry) => entry.reason),
+    ).toEqual(["unsupported-signal"]);
+  });
 });

--- a/src/tools/availability.ts
+++ b/src/tools/availability.ts
@@ -150,8 +150,13 @@ function evaluateExpression(
       ];
     }
     const diagnostics = expression.anyOf.map((entry) => evaluateExpression(entry, context));
-    // anyOf is available when at least one branch has no diagnostics; otherwise preserve all reasons.
-    return diagnostics.some((entries) => entries.length === 0) ? [] : diagnostics.flat();
+    // "unsupported-signal" marks a malformed descriptor, not a runtime condition, so it must surface
+    // even when a sibling branch is available; otherwise an available branch masks an authoring error.
+    const unsupported = diagnostics.flat().filter((entry) => entry.reason === "unsupported-signal");
+    if (diagnostics.some((entries) => entries.length === 0)) {
+      return unsupported;
+    }
+    return diagnostics.flat();
   }
   return [
     {


### PR DESCRIPTION
## Summary

An `anyOf` availability group swallowed a nested `unsupported-signal` authoring diagnostic when any sibling branch parsed as available, hiding a malformed tool descriptor. Propagate `unsupported-signal` diagnostics regardless of sibling availability.

- Files: src/tools/availability.ts
- No `CHANGELOG.md` edit (release-only per `AGENTS.md`).

## Why core (not ClawHub)
Core correctness fix touching `src/tools/availability.ts` — per `AGENTS.md` these stay in core (security/core hardening, bundled regressions, missing core APIs), not optional skill bundles routed to ClawHub.

## Verification

- `node scripts/run-vitest.mjs run src/tools/availability.test.ts` => **9 passed**
- `pnpm tsgo:core` (tsconfig.core.json) => clean
- `oxfmt --check` + `oxlint` on touched files => clean

## Real behavior proof

- **Behavior addressed:** A malformed-descriptor `unsupported-signal` inside an `anyOf` is now surfaced even when a sibling branch is available.
- **Real environment tested:** macOS (Darwin 25.3.0); OpenClaw at base 2accfeedc7; Node 22; Vitest via scripts/run-vitest.mjs.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run src/tools/availability.test.ts`
- **Evidence after fix:** 9 tests pass, incl. a new case: an anyOf with one available branch plus a malformed empty allOf sibling still surfaces `unsupported-signal`.
- **Observed result after fix:** Genuine anyOf availability semantics preserved (no regression in the planner, its sole consumer); only the authoring-error signal is no longer masked.
- **What was not tested:** Full Crabbox/E2E; Linux CI.. Independently reviewed by a separate agent before commit; not yet run through Crabbox/$autoreview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)