### PR TITLE
fix(channels): make timer-fired progress-draft start errors observable

### DIFF
--- a/src/channels/streaming.test.ts
+++ b/src/channels/streaming.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests that the progress-draft gate routes timer-fired startup rejections to
+ * onStartError instead of silently dropping them.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createChannelProgressDraftGate } from "./streaming.js";
+
+describe("createChannelProgressDraftGate timer startup errors", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports a timer-fired onStart rejection to onStartError", async () => {
+    vi.useFakeTimers();
+    const error = new Error("draft unavailable");
+    const onStart = vi.fn<() => Promise<void>>().mockRejectedValueOnce(error);
+    const onStartError = vi.fn();
+    const gate = createChannelProgressDraftGate({ onStart, onStartError });
+
+    await expect(gate.noteWork()).resolves.toBe(false);
+    expect(onStartError).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(gate.hasStarted).toBe(false);
+    expect(onStartError).toHaveBeenCalledTimes(1);
+    expect(onStartError).toHaveBeenCalledWith(error);
+  });
+
+  it("does not invoke onStartError when the timer start resolves", async () => {
+    vi.useFakeTimers();
+    const onStart = vi.fn(async () => {});
+    const onStartError = vi.fn();
+    const gate = createChannelProgressDraftGate({ onStart, onStartError });
+
+    await expect(gate.noteWork()).resolves.toBe(false);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(gate.hasStarted).toBe(true);
+    expect(onStartError).not.toHaveBeenCalled();
+  });
+});

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -553,6 +553,12 @@ export function createChannelProgressDraftGate(params: {
   onStart: () => void | Promise<void>;
   /** Delay before first work event starts a draft; second work event starts immediately. */
   initialDelayMs?: number;
+  /**
+   * Observes a timer-fired startup rejection. The explicit start/noteWork/startNow
+   * paths re-throw to their awaiting caller, but the timer path has no awaiter, so
+   * without this the failure would be silently dropped.
+   */
+  onStartError?: (error: unknown) => void;
   /** Timer implementation, injectable for tests. */
   setTimeoutFn?: typeof setTimeout;
   /** Timer clearer, injectable for tests. */
@@ -612,7 +618,11 @@ export function createChannelProgressDraftGate(params: {
     }
     timer = setTimeoutFn(() => {
       timer = undefined;
-      void start().catch(() => {});
+      // Timer start has no awaiter; route the rejection to onStartError so it is
+      // observed rather than silently dropped.
+      void start().catch((error: unknown) => {
+        params.onStartError?.(error);
+      });
     }, initialDelayMs);
   };
 


### PR DESCRIPTION
## Summary

A timer-fired progress-draft start failure was swallowed via `void start().catch(() => {})`. Add an optional `onStartError` hook (matching the sibling `typing.ts`) and route the timer-path rejection through it, since that path has no awaiter.

- Files: src/channels/streaming.ts
- No `CHANGELOG.md` edit (release-only per `AGENTS.md`).

## Why core (not ClawHub)
Core correctness fix touching `src/channels/streaming.ts` — per `AGENTS.md` these stay in core (security/core hardening, bundled regressions, missing core APIs), not optional skill bundles routed to ClawHub.

## Verification

- `node scripts/run-vitest.mjs run src/channels/streaming.test.ts` => **2 passed**
- `pnpm tsgo:core` (tsconfig.core.json) => clean
- `oxfmt --check` + `oxlint` on touched files => clean

## Real behavior proof

- **Behavior addressed:** Timer-fired progress-draft start rejections are now observable via `onStartError` instead of being silently discarded.
- **Real environment tested:** macOS (Darwin 25.3.0); OpenClaw at base 2accfeedc7; Node 22; Vitest via scripts/run-vitest.mjs.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run src/channels/streaming.test.ts`
- **Evidence after fix:** 2 tests pass: a rejected timer-path onStart is observed via onStartError; a resolving start does not call it.
- **Observed result after fix:** `onStartError` is optional, so omitting it preserves prior behavior; mirrors the existing `typing-start-guard.ts` shape.
- **What was not tested:** The sole production caller (progress-draft-compositor) does not yet pass `onStartError` — wiring it through channels is a disclosed follow-up; full Crabbox; Linux CI.. Independently reviewed by a separate agent before commit; not yet run through Crabbox/$autoreview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)