### PR TITLE
fix(mcp): always log channel-bridge notification failures

### DIFF
--- a/src/mcp/channel-bridge.test.ts
+++ b/src/mcp/channel-bridge.test.ts
@@ -26,12 +26,14 @@ type BridgeInternals = {
   }) => Promise<void>;
   listPendingApprovals: () => unknown[];
   close: () => Promise<void>;
+  server: { server: { notification: (n: unknown) => Promise<void> } } | null;
+  sendNotification: (notification: { method: string }) => Promise<void>;
 };
 
-function makeBridge(): BridgeInternals {
+function makeBridge(verbose = false): BridgeInternals {
   return new OpenClawChannelBridge({} as never, {
     claudeChannelMode: "off",
-    verbose: false,
+    verbose,
   }) as unknown as BridgeInternals;
 }
 
@@ -193,6 +195,32 @@ describe("OpenClawChannelBridge — pendingClaudePermissions / pendingApprovals 
     expect(bridge.pendingClaudePermissions.size).toBe(0);
     expect(bridge.pendingApprovals.size).toBe(0);
     expect(bridge.pendingSweepInterval).toBeNull();
+  });
+
+  test("a failed notification still emits exactly one diagnostic record with verbose off", async () => {
+    const bridge = makeBridge(false);
+    const writes: string[] = [];
+    const writeSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        writes.push(String(chunk));
+        return true;
+      });
+    bridge.server = {
+      server: {
+        notification: () => Promise.reject(new Error("transport closed")),
+      },
+    };
+    try {
+      await bridge.sendNotification({ method: "channel/event" });
+
+      expect(writes).toHaveLength(1);
+      expect(writes[0]).toBe("openclaw mcp: notification channel/event failed\n");
+      expect(writes[0]).not.toContain("transport closed");
+    } finally {
+      writeSpy.mockRestore();
+      await bridge.close();
+    }
   });
 
   test("sweeper interval is not started before any pending entry is added", async () => {

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -378,9 +378,15 @@ export class OpenClawChannelBridge {
     try {
       await this.server.server.notification(notification);
     } catch (error) {
-      if (this.verbose && !this.closed) {
+      if (this.closed) {
+        return;
+      }
+      // Always surface a single low-noise record so swallowed delivery failures
+      // remain observable; the spammy error detail stays behind --verbose.
+      process.stderr.write(`openclaw mcp: notification ${notification.method} failed\n`);
+      if (this.verbose) {
         process.stderr.write(
-          `openclaw mcp: notification ${notification.method} failed: ${String(error)}\n`,
+          `openclaw mcp: notification ${notification.method} error: ${String(error)}\n`,
         );
       }
     }


### PR DESCRIPTION
## Summary

MCP channel-bridge notification delivery failures were only logged when verbose, otherwise fully swallowed. Emit one low-noise diagnostic on a non-closed failure always; gate only the error detail behind verbose.

- Files: src/mcp/channel-bridge.ts
- No `CHANGELOG.md` edit (release-only per `AGENTS.md`).

## Why core (not ClawHub)
Core correctness fix touching `src/mcp/channel-bridge.ts` — per `AGENTS.md` these stay in core (security/core hardening, bundled regressions, missing core APIs), not optional skill bundles routed to ClawHub.

## Verification

- `node scripts/run-vitest.mjs run src/mcp/channel-bridge.test.ts` => **10 passed**
- `pnpm tsgo:core` (tsconfig.core.json) => clean
- `oxfmt --check` + `oxlint` on touched files => clean

## Real behavior proof

- **Behavior addressed:** A failed MCP notification now always emits one diagnostic record; verbose adds the error detail.
- **Real environment tested:** macOS (Darwin 25.3.0); OpenClaw at base 2accfeedc7; Node 22; Vitest via scripts/run-vitest.mjs.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run src/mcp/channel-bridge.test.ts`
- **Evidence after fix:** 10 tests pass, incl. a new case: a failed notification with verbose off emits exactly one diagnostic record and does not leak the error string.
- **Observed result after fix:** Preserves prior swallow-on-close behavior (notifications can reject because the transport closed); callers still see void.
- **What was not tested:** Full Crabbox/live MCP E2E; Linux CI.. Independently reviewed by a separate agent before commit; not yet run through Crabbox/$autoreview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)