### PR TITLE
fix(gateway): log swallowed background-task finalization errors

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -4413,6 +4413,54 @@ describe("gateway agent handler", () => {
     });
   });
 
+  it("logs a swallowed finalize error without blocking the background run", async () => {
+    await withTempDir({ prefix: "openclaw-gateway-agent-finalize-throw-" }, async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      primeMainAgentRun();
+
+      const defaultRuntime = getDetachedTaskLifecycleRuntime();
+      const finalizeError = new Error("finalize boom");
+      const finalizeTaskRunByRunIdSpy = vi.fn(() => {
+        throw finalizeError;
+      });
+      setDetachedTaskLifecycleRuntime({
+        ...defaultRuntime,
+        finalizeTaskRunByRunId: finalizeTaskRunByRunIdSpy,
+      });
+
+      const context = makeContext();
+      const respond = vi.fn();
+
+      await invokeAgent(
+        {
+          message: "finalize throw seam task",
+          sessionKey: "agent:main:main",
+          idempotencyKey: "task-registry-finalize-throw",
+        },
+        { context, respond, reqId: "task-registry-finalize-throw" },
+      );
+
+      // Finalize threw, but the run must still complete (second res frame with ok status).
+      expect(finalizeTaskRunByRunIdSpy).toHaveBeenCalledTimes(1);
+      const completed = respond.mock.calls.some(([ok, payload]) => {
+        return ok === true && (payload as { status?: string } | undefined)?.status === "ok";
+      });
+      expect(completed).toBe(true);
+
+      // The swallowed finalize error stays observable via a warn log.
+      const warnMock = context.logGateway.warn as ReturnType<typeof vi.fn>;
+      const loggedFinalizeError = warnMock.mock.calls.some(([message]) => {
+        return (
+          typeof message === "string" &&
+          message.includes("failed to finalize tracked agent task") &&
+          message.includes("finalize boom")
+        );
+      });
+      expect(loggedFinalizeError).toBe(true);
+    });
+  });
+
   it("routes voice wake trigger to configured session target", async () => {
     mocks.loadVoiceWakeRoutingConfig.mockResolvedValue({
       version: 1,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -681,6 +681,7 @@ function tryFinalizeTrackedAgentTask(params: {
   status: GatewayAgentTaskTerminalStatus;
   error?: string;
   terminalSummary?: string;
+  log: Pick<GatewayRequestContext["logGateway"], "warn">;
 }): void {
   try {
     finalizeTaskRunByRunId({
@@ -691,8 +692,10 @@ function tryFinalizeTrackedAgentTask(params: {
       ...(params.error !== undefined ? { error: params.error } : {}),
       ...(params.terminalSummary !== undefined ? { terminalSummary: params.terminalSummary } : {}),
     });
-  } catch {
+  } catch (err) {
     // Best-effort only: background task tracking must not block agent runs.
+    // Still surface the swallowed error so non-transient finalize failures stay observable.
+    params.log.warn(`failed to finalize tracked agent task ${params.runId}: ${formatForLog(err)}`);
   }
 }
 
@@ -907,8 +910,12 @@ function dispatchAgentRunFromGateway(params: {
           startedAt: Date.now(),
         }),
       );
-    } catch {
+    } catch (err) {
       // Best-effort only: background task tracking must not block agent runs.
+      // Still surface the swallowed error so non-transient tracking failures stay observable.
+      params.context.logGateway.warn(
+        `failed to start tracked agent task ${params.runId}: ${formatForLog(err)}`,
+      );
     }
   }
   void agentCommandFromIngress(params.ingressOpts, defaultRuntime, params.context.deps)
@@ -920,6 +927,7 @@ function dispatchAgentRunFromGateway(params: {
           runId: params.runId,
           status: aborted ? "timed_out" : "succeeded",
           terminalSummary: aborted ? "aborted" : "completed",
+          log: params.context.logGateway,
         });
       }
       const payload = {
@@ -957,6 +965,7 @@ function dispatchAgentRunFromGateway(params: {
           status: aborted ? "timed_out" : resolveFailedTrackedAgentTaskStatus(err),
           error: renderedErr,
           terminalSummary: renderedErr,
+          log: params.context.logGateway,
         });
       }
       const error = errorShape(ErrorCodes.UNAVAILABLE, renderedErr);


### PR DESCRIPTION
## Summary

Background-task finalization swallowed all errors, including non-transient ones. Log the swallowed error via `formatForLog` at warn so failures are observable, while staying non-blocking.

- Files: src/gateway/server-methods/agent.ts
- No `CHANGELOG.md` edit (release-only per `AGENTS.md`).

## Why core (not ClawHub)
Core correctness fix touching `src/gateway/server-methods/agent.ts` — per `AGENTS.md` these stay in core (security/core hardening, bundled regressions, missing core APIs), not optional skill bundles routed to ClawHub.

## Verification

- `node scripts/run-vitest.mjs run src/gateway/server-methods/agent.test.ts` => **302 passed**
- `pnpm tsgo:core` (tsconfig.core.json) => clean
- `oxfmt --check` + `oxlint` on touched files => clean

## Real behavior proof

- **Behavior addressed:** Non-transient background-task finalization failures are now logged (redacted via formatForLog) instead of silently dropped; the run still completes.
- **Real environment tested:** macOS (Darwin 25.3.0); OpenClaw at base 2accfeedc7; Node 22; Vitest via scripts/run-vitest.mjs.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run src/gateway/server-methods/agent.test.ts`
- **Evidence after fix:** 302 tests pass, incl. a new case: a thrown finalize error is logged at warn without blocking the run.
- **Observed result after fix:** Both finalize/start catch sites covered; logging is non-blocking; uses the already-imported `formatForLog` (redaction applied once).
- **What was not tested:** Full Crabbox/live gateway E2E; Linux CI.. Independently reviewed by a separate agent before commit; not yet run through Crabbox/$autoreview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)