### PR TITLE
fix(fal): preserve raw video queue results

### DIFF
--- a/extensions/fal/video-generation-provider.test.ts
+++ b/extensions/fal/video-generation-provider.test.ts
@@ -61,6 +61,7 @@ describe("fal video generation provider", () => {
     videoUrl: string;
     bytes: string;
     contentType?: string;
+    resultPayload?: Record<string, unknown>;
     responseExtras?: Record<string, unknown>;
   }) {
     fetchGuardMock
@@ -73,13 +74,15 @@ describe("fal video generation provider", () => {
       )
       .mockResolvedValueOnce(releasedJson({ status: "COMPLETED" }))
       .mockResolvedValueOnce(
-        releasedJson({
-          status: "COMPLETED",
-          response: {
-            video: { url: params.videoUrl },
-            ...params.responseExtras,
+        releasedJson(
+          params.resultPayload ?? {
+            status: "COMPLETED",
+            response: {
+              video: { url: params.videoUrl },
+              ...params.responseExtras,
+            },
           },
-        }),
+        ),
       )
       .mockResolvedValueOnce(
         releasedVideo({ contentType: params.contentType ?? "video/mp4", bytes: params.bytes }),
@@ -169,6 +172,37 @@ describe("fal video generation provider", () => {
     expect(result.videos[0]?.url).toBe("https://fal.run/files/video.mp4");
     expect(result.metadata).toEqual({
       requestId: "req-123",
+    });
+  });
+
+  it("preserves raw fal video results fetched from the queue response URL", async () => {
+    mockFalProviderRuntime();
+    mockCompletedFalVideoJob({
+      requestId: "req-raw",
+      statusUrl: "https://queue.fal.run/fal-ai/minimax/requests/req-raw/status",
+      responseUrl: "https://queue.fal.run/fal-ai/minimax/requests/req-raw",
+      videoUrl: "https://fal.run/files/raw-video.mp4",
+      bytes: "raw-mp4-bytes",
+      resultPayload: {
+        video: { url: "https://fal.run/files/raw-video.mp4" },
+        prompt: "A raw queue result",
+        seed: 443600358,
+      },
+    });
+
+    const provider = buildFalVideoGenerationProvider();
+    const result = await provider.generateVideo({
+      provider: "fal",
+      model: "fal-ai/minimax/video-01-live",
+      prompt: "A raw queue result",
+      cfg: {},
+    });
+
+    expect(result.videos[0]?.url).toBe("https://fal.run/files/raw-video.mp4");
+    expect(result.metadata).toEqual({
+      requestId: "req-raw",
+      prompt: "A raw queue result",
+      seed: 443600358,
     });
   });
 

--- a/extensions/fal/video-generation-provider.ts
+++ b/extensions/fal/video-generation-provider.ts
@@ -166,6 +166,17 @@ function readFalQueueResponse(payload: unknown): FalQueueResponse {
   };
 }
 
+function readFalQueueResultResponse(payload: unknown): FalQueueResponse {
+  const queueResponse = readFalQueueResponse(payload);
+  if (queueResponse.response || !isRecord(payload)) {
+    return queueResponse;
+  }
+  if (payload.video !== undefined || payload.videos !== undefined) {
+    return { ...queueResponse, response: readFalVideoPayload(payload) };
+  }
+  return queueResponse;
+}
+
 function toDataUrl(buffer: Buffer, mimeType: string): string {
   return `data:${mimeType};base64,${buffer.toString("base64")}`;
 }
@@ -509,7 +520,7 @@ async function waitForFalQueueResult(params: {
     }
     lastStatus = status;
     if (status === "COMPLETED") {
-      return readFalQueueResponse(
+      return readFalQueueResultResponse(
         await fetchFalJson({
           url: params.responseUrl,
           init: {


### PR DESCRIPTION
## Summary

- Preserve raw fal video result payloads returned from the queue `response_url` instead of dropping top-level `video` / `videos` fields.
- Keep the existing wrapped `response` parsing path intact for deployments that return an envelope-like result.
- Add focused regression coverage for the raw result shape reported in #91989.
- Out of scope: the separate uppercase resolution observation from the issue.

Reviewers should focus on the completed queue result boundary in `extensions/fal/video-generation-provider.ts`.

## Linked context

Closes #91989

Related: the issue includes direct fal queue curl evidence showing `response_url` returning a raw model output with top-level `video.url`.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: fal video jobs that complete successfully can return a raw result payload from `response_url`; OpenClaw previously parsed that payload as a queue envelope and dropped `video.url`, causing `fal video generation response missing output URL`.
- Real environment tested: Local OpenClaw source checkout on macOS, Node 24, with the fal video provider runtime loaded from this branch and executed through a local queue-result replay. No fal secret or live paid fal job was available in this environment.
- Exact steps or command run after this patch:
  ```bash
  FAL_KEY=redacted-local-proof node --import tsx /tmp/fal-raw-result-proof.mjs
  ```
- Evidence after fix:
  ```text
  $ FAL_KEY=redacted-local-proof node --import tsx /tmp/fal-raw-result-proof.mjs
  [fal-proof] submit URL: https://queue.fal.run/fal-ai/minimax/video-01-live
  [fal-proof] status URL: https://queue.fal.run/fal-ai/minimax/requests/req-local-raw-result/status
  [fal-proof] result URL: https://queue.fal.run/fal-ai/minimax/requests/req-local-raw-result
  [fal-proof] returned URL prefix: data:video/mp4;base64
  [fal-proof] returned bytes: 17
  [fal-proof] metadata: {"requestId":"req-local-raw-result","prompt":"raw result local replay","seed":443600358}
  [fal-proof] PASS raw result video URL preserved
  ```
- Observed result after fix: `generateVideo` fetched the completed queue result URL, accepted the raw top-level `video.url`, returned the generated video data URL, and preserved `prompt` plus `seed` metadata instead of throwing `missing output URL`.
- What was not tested: A live fal paid video generation job was not run because this environment does not expose a fal credential.
- Proof limitations or environment constraints: The local replay avoids spending a live fal job, but it drives the same completed queue result parser used by the runtime. The issue also includes direct fal curl evidence for the upstream raw result shape.
- Before evidence (optional but encouraged): The issue's source-level analysis shows `readFalQueueResponse` previously whitelisted queue fields and stripped top-level `video` / `videos` from the fetched result body.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/fal/video-generation-provider.test.ts`
- `pnpm format:check extensions/fal/video-generation-provider.ts extensions/fal/video-generation-provider.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/fal/video-generation-provider.ts extensions/fal/video-generation-provider.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Regression coverage added: `preserves raw fal video results fetched from the queue response URL`.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) Yes

Did config, environment, or migration behavior change? (`Yes/No`) No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) No

What is the highest-risk area? fal queue result payload parsing.

How is that risk mitigated? The change is limited to the completed result fetch path, preserves the existing envelope `response` path, and adds focused coverage for the raw result shape.

## Current review state

What is the next action? Waiting for maintainer and ClawSweeper review.

What is still waiting on author, maintainer, CI, or external proof? Author-side focused tests, format, lint, whitespace check, and autoreview are complete. CI and maintainer review are pending after PR creation.

Which bot or reviewer comments were addressed? None yet.
