### PR TITLE
fix(provider): route thinking profiles by model API

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -661,7 +661,7 @@ API key auth, and dynamic model resolution.
 
       - `normalizeConfig` checks the matched provider first, then other hook-capable provider plugins until one actually changes the config. If no provider hook rewrites a supported Google-family config entry, the bundled Google config normalizer still applies.
       - `resolveConfigApiKey` uses the provider hook when exposed. Amazon Bedrock keeps AWS env-marker resolution in its provider plugin; runtime auth itself still uses the AWS SDK default chain when configured with `auth: "aws-sdk"`.
-      - `resolveThinkingProfile(ctx)` receives the selected `provider`, `modelId`, optional merged `reasoning` catalog hint, and optional merged model `compat` facts. Use `compat` only to select the provider's thinking UI/profile.
+      - `resolveThinkingProfile(ctx)` receives the selected `provider`, `modelId`, optional selected model/provider `api`, optional merged `reasoning` catalog hint, and optional merged model `compat` facts. Use `api` when the provider exposes shared API families such as `anthropic-messages` or `openai-responses`; use `compat` only to select the provider's thinking UI/profile.
       - `resolveSystemPromptContribution` lets a provider inject cache-aware system-prompt guidance for a model family. Prefer it over `before_prompt_build` when the behavior belongs to one provider/model family and should preserve the stable/dynamic cache split.
 
       For detailed descriptions and real-world examples, see [Internals: Provider Runtime Hooks](/plugins/architecture-internals#provider-runtime-hooks).

--- a/extensions/anthropic/provider-policy-api.test.ts
+++ b/extensions/anthropic/provider-policy-api.test.ts
@@ -184,6 +184,18 @@ describe("anthropic provider policy public artifact", () => {
     }
   });
 
+  it("exposes Anthropic thinking profiles for Anthropic Messages custom providers", () => {
+    const profile = resolveThinkingProfile({
+      provider: "jdcloud-anthropic",
+      api: "anthropic-messages",
+      modelId: "claude-opus-4-6",
+    });
+
+    expect(levelIds(profile?.levels)).toContain("adaptive");
+    expect(levelIds(profile?.levels)).toContain("max");
+    expect(profile?.defaultLevel).toBe("adaptive");
+  });
+
   it("does not expose Anthropic thinking profiles for unrelated providers", () => {
     expect(
       resolveThinkingProfile({

--- a/extensions/anthropic/provider-policy-api.ts
+++ b/extensions/anthropic/provider-policy-api.ts
@@ -26,6 +26,7 @@ export function applyConfigDefaults(params: Parameters<typeof applyAnthropicConf
 /** Resolve Claude thinking profile for Anthropic or Claude CLI providers. */
 export function resolveThinkingProfile(params: {
   provider: string;
+  api?: string;
   modelId: string;
   params?: Record<string, unknown>;
 }) {
@@ -33,6 +34,7 @@ export function resolveThinkingProfile(params: {
     id: params.modelId,
     params: params.params,
   });
+  const api = params.api?.trim().toLowerCase();
   switch (params.provider.trim().toLowerCase()) {
     case "anthropic":
       return resolveClaudeThinkingProfile(contractModelId, undefined, {
@@ -46,6 +48,11 @@ export function resolveThinkingProfile(params: {
         includeNativeMax: true,
       });
     default:
+      if (api === "anthropic-messages") {
+        return resolveClaudeThinkingProfile(contractModelId, undefined, {
+          includeNativeMax: true,
+        });
+      }
       return null;
   }
 }

--- a/extensions/openai/provider-policy-api.test.ts
+++ b/extensions/openai/provider-policy-api.test.ts
@@ -21,4 +21,20 @@ describe("OpenAI provider policy artifact", () => {
     expect(openaiProfile?.levels.map((level) => level.id)).not.toContain("xhigh");
     expect(openaiMiniProfile?.levels.map((level) => level.id)).toContain("xhigh");
   });
+
+  it("applies OpenAI thinking policy to custom openai-responses refs", () => {
+    const profile = resolveThinkingProfile({
+      provider: "custom-openai",
+      api: "openai-responses",
+      modelId: "gpt-5.5",
+    });
+    const unrelatedProfile = resolveThinkingProfile({
+      provider: "custom-openai",
+      api: "anthropic-messages",
+      modelId: "gpt-5.5",
+    });
+
+    expect(profile?.levels.map((level) => level.id)).toContain("xhigh");
+    expect(unrelatedProfile).toBeNull();
+  });
 });

--- a/extensions/openai/provider-policy-api.ts
+++ b/extensions/openai/provider-policy-api.ts
@@ -6,11 +6,19 @@ export function normalizeConfig(params: { provider: string; providerConfig: Mode
   return params.providerConfig;
 }
 
-export function resolveThinkingProfile(params: { provider: string; modelId: string }) {
+export function resolveThinkingProfile(params: {
+  provider: string;
+  api?: string;
+  modelId: string;
+}) {
+  const api = params.api?.trim().toLowerCase();
   switch (params.provider.trim().toLowerCase()) {
     case "openai":
       return resolveUnifiedOpenAIThinkingProfile(params.modelId);
     default:
+      if (api === "openai-responses") {
+        return resolveUnifiedOpenAIThinkingProfile(params.modelId);
+      }
       return null;
   }
 }

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -282,6 +282,40 @@ describe("listThinkingLevels", () => {
     ).toBe("low");
   });
 
+  it("passes catalog API into provider thinking profiles", () => {
+    providerRuntimeMocks.resolveProviderThinkingProfile.mockImplementation(({ context }) =>
+      context.api === "anthropic-messages"
+        ? {
+            levels: [{ id: "off" }, { id: "adaptive" }, { id: "max" }],
+            defaultLevel: "adaptive",
+          }
+        : undefined,
+    );
+    const catalog = [
+      {
+        provider: "jdcloud-anthropic",
+        id: "claude-opus-4-6",
+        api: "anthropic-messages",
+        reasoning: true,
+      },
+    ];
+
+    expect(listThinkingLevels("jdcloud-anthropic", "claude-opus-4-6", catalog)).toEqual([
+      "off",
+      "adaptive",
+      "max",
+    ]);
+    expect(providerRuntimeMocks.resolveProviderThinkingProfile).toHaveBeenCalledWith({
+      provider: "jdcloud-anthropic",
+      context: expect.objectContaining({
+        api: "anthropic-messages",
+        modelId: "claude-opus-4-6",
+        provider: "jdcloud-anthropic",
+        reasoning: true,
+      }),
+    });
+  });
+
   it("uses canonical Fable params when no provider thinking profile exists", () => {
     const catalog = [
       {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -190,6 +190,7 @@ export function resolveThinkingProfile(params: {
   const providerContext = {
     provider: context.normalizedProvider,
     modelId: context.modelId,
+    ...(context.api ? { api: context.api } : {}),
     reasoning: context.reasoning,
     ...(context.params ? { params: context.params } : {}),
     compat: context.compat,

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { ModelCatalogApi } from "@openclaw/model-catalog-core/model-catalog-types";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ModelProviderConfig } from "../config/types.models.js";
@@ -348,7 +349,12 @@ describe("provider public artifacts", () => {
     const { resolveBundledProviderPolicySurfaces: resolvePolicySurfaces } = await importFreshModule<
       typeof import("./provider-public-artifacts.js")
     >(import.meta.url, "./provider-public-artifacts.js?scope=shared-provider-api-ref");
-    const plugin = (id: string, provider: string, api: string, modelApis: string[] = []) => ({
+    const plugin = (
+      id: string,
+      provider: string,
+      api: ModelCatalogApi,
+      modelApis: readonly ModelCatalogApi[] = [],
+    ) => ({
       id,
       channels: [],
       cliBackends: [],

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -331,6 +331,89 @@ describe("provider public artifacts", () => {
     });
   });
 
+  it("returns every bundled owner for shared provider API refs", async () => {
+    const loadBundledPluginPublicArtifactModuleSync = vi.fn(({ dirName }: { dirName: string }) => {
+      if (!["anthropic", "github-copilot", "openai"].includes(dirName)) {
+        throw new Error(`Unable to resolve bundled plugin public surface ${dirName}`);
+      }
+      return {
+        resolveThinkingProfile: () => ({ levels: [{ id: dirName }] }),
+      };
+    });
+
+    vi.doMock("./public-surface-loader.js", () => ({
+      loadBundledPluginPublicArtifactModuleSync,
+    }));
+
+    const { resolveBundledProviderPolicySurfaces: resolvePolicySurfaces } = await importFreshModule<
+      typeof import("./provider-public-artifacts.js")
+    >(import.meta.url, "./provider-public-artifacts.js?scope=shared-provider-api-ref");
+    const plugin = (id: string, provider: string, api: string, modelApis: string[] = []) => ({
+      id,
+      channels: [],
+      cliBackends: [],
+      hooks: [],
+      origin: "bundled" as const,
+      manifestPath: `/tmp/${id}/openclaw.plugin.json`,
+      providers: [provider],
+      modelCatalog: {
+        providers: {
+          [provider]: {
+            api,
+            models: modelApis.map((modelApi) => ({
+              id: `${modelApi}-model`,
+              api: modelApi,
+            })),
+          },
+        },
+      },
+      rootDir: `/tmp/${id}`,
+      skills: [],
+      source: `/tmp/${id}/index.js`,
+    });
+    const manifestRegistry = {
+      plugins: [
+        plugin("github-copilot", "github-copilot", "anthropic-messages", ["openai-responses"]),
+        plugin("anthropic", "anthropic", "anthropic-messages"),
+        plugin("openai", "openai", "openai-responses"),
+      ],
+    };
+    const surfaceIds = (
+      surfaces: ReturnType<typeof resolvePolicySurfaces>,
+      api: string,
+      modelId: string,
+    ) =>
+      surfaces.map(
+        (surface) =>
+          surface.resolveThinkingProfile?.({
+            provider: "custom",
+            api,
+            modelId,
+          })?.levels[0]?.id,
+      );
+
+    expect(
+      surfaceIds(
+        resolvePolicySurfaces("custom-anthropic", {
+          providerRefs: ["anthropic-messages"],
+          manifestRegistry,
+        }),
+        "anthropic-messages",
+        "claude-opus-4-6",
+      ),
+    ).toEqual(["anthropic", "github-copilot"]);
+    expect(
+      surfaceIds(
+        resolvePolicySurfaces("custom-openai", {
+          providerRefs: ["openai-responses"],
+          manifestRegistry,
+        }),
+        "openai-responses",
+        "gpt-5.5",
+      ),
+    ).toEqual(["github-copilot", "openai"]);
+  });
+
   it("does not cache manifest-owned provider policy aliases across bundled metadata changes", async () => {
     const bundledPluginsDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "openclaw-provider-policy-refresh-"),

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -270,6 +270,67 @@ describe("provider public artifacts", () => {
     expect(loadPluginManifestRegistry).not.toHaveBeenCalled();
   });
 
+  it("resolves bundled policy artifacts through manifest model catalog API refs", async () => {
+    const loadBundledPluginPublicArtifactModuleSync = vi.fn(({ dirName }: { dirName: string }) => {
+      if (dirName !== "anthropic") {
+        throw new Error(`Unable to resolve bundled plugin public surface ${dirName}`);
+      }
+      return {
+        resolveThinkingProfile: ({ api }: { api?: string }) => ({
+          levels: [{ id: api }],
+        }),
+      };
+    });
+
+    vi.doMock("./public-surface-loader.js", () => ({
+      loadBundledPluginPublicArtifactModuleSync,
+    }));
+
+    const { resolveBundledProviderPolicySurface: resolvePolicySurface } = await importFreshModule<
+      typeof import("./provider-public-artifacts.js")
+    >(import.meta.url, "./provider-public-artifacts.js?scope=provider-api-ref");
+
+    const surface = resolvePolicySurface("jdcloud-anthropic", {
+      providerRefs: ["anthropic-messages"],
+      manifestRegistry: {
+        plugins: [
+          {
+            id: "anthropic",
+            channels: [],
+            cliBackends: [],
+            hooks: [],
+            origin: "bundled",
+            manifestPath: "/tmp/anthropic/openclaw.plugin.json",
+            providers: ["anthropic"],
+            modelCatalog: {
+              providers: {
+                anthropic: {
+                  api: "anthropic-messages",
+                  models: [],
+                },
+              },
+            },
+            rootDir: "/tmp/anthropic",
+            skills: [],
+            source: "/tmp/anthropic/index.js",
+          },
+        ],
+      },
+    });
+
+    expect(
+      surface?.resolveThinkingProfile?.({
+        provider: "jdcloud-anthropic",
+        api: "anthropic-messages",
+        modelId: "claude-opus-4-6",
+      })?.levels,
+    ).toEqual([{ id: "anthropic-messages" }]);
+    expect(loadBundledPluginPublicArtifactModuleSync).toHaveBeenCalledWith({
+      dirName: "anthropic",
+      artifactBasename: "provider-policy-api.js",
+    });
+  });
+
   it("does not cache manifest-owned provider policy aliases across bundled metadata changes", async () => {
     const bundledPluginsDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "openclaw-provider-policy-refresh-"),

--- a/src/plugins/provider-public-artifacts.ts
+++ b/src/plugins/provider-public-artifacts.ts
@@ -101,6 +101,20 @@ function resolveBundledProviderPolicyPluginId(
   return null;
 }
 
+function normalizeProviderPolicyRefs(
+  providerId: string,
+  providerRefs?: readonly string[],
+): string[] {
+  const refs: string[] = [];
+  for (const rawRef of [providerId, ...(providerRefs ?? [])]) {
+    const ref = normalizeProviderId(rawRef);
+    if (ref && !refs.includes(ref)) {
+      refs.push(ref);
+    }
+  }
+  return refs;
+}
+
 function pluginOwnsProviderPolicyRef(
   plugin: PluginManifestRegistry["plugins"][number],
   normalizedProviderId: string,
@@ -122,25 +136,50 @@ function pluginOwnsProviderPolicyRef(
     }
   }
 
+  for (const [rawProvider, catalogProvider] of Object.entries(
+    plugin.modelCatalog?.providers ?? {},
+  )) {
+    const provider = normalizeProviderId(rawProvider);
+    if (!provider || !ownedProviders.has(provider)) {
+      continue;
+    }
+    const providerApi = catalogProvider.api ? normalizeProviderId(catalogProvider.api) : "";
+    if (providerApi === normalizedProviderId) {
+      return true;
+    }
+    if (
+      catalogProvider.models.some(
+        (model) => (model.api ? normalizeProviderId(model.api) : "") === normalizedProviderId,
+      )
+    ) {
+      return true;
+    }
+  }
+
   return false;
 }
 
 /** Resolves provider policy hooks for a bundled provider or its owning plugin. */
 export function resolveBundledProviderPolicySurface(
   providerId: string,
-  options: { manifestRegistry?: Pick<PluginManifestRegistry, "plugins"> } = {},
+  options: {
+    manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
+    providerRefs?: readonly string[];
+  } = {},
 ): BundledProviderPolicySurface | null {
-  const normalizedProviderId = normalizeProviderId(providerId);
-  if (!normalizedProviderId) {
-    return null;
+  for (const providerRef of normalizeProviderPolicyRefs(providerId, options.providerRefs)) {
+    const directSurface = tryLoadBundledProviderPolicySurface(providerRef);
+    if (directSurface) {
+      return directSurface;
+    }
+    const ownerPluginId = resolveBundledProviderPolicyPluginId(providerRef, options);
+    if (!ownerPluginId || ownerPluginId === providerRef) {
+      continue;
+    }
+    const ownerSurface = tryLoadBundledProviderPolicySurface(ownerPluginId);
+    if (ownerSurface) {
+      return ownerSurface;
+    }
   }
-  const directSurface = tryLoadBundledProviderPolicySurface(normalizedProviderId);
-  if (directSurface) {
-    return directSurface;
-  }
-  const ownerPluginId = resolveBundledProviderPolicyPluginId(normalizedProviderId, options);
-  if (!ownerPluginId || ownerPluginId === normalizedProviderId) {
-    return null;
-  }
-  return tryLoadBundledProviderPolicySurface(ownerPluginId);
+  return null;
 }

--- a/src/plugins/provider-public-artifacts.ts
+++ b/src/plugins/provider-public-artifacts.ts
@@ -73,19 +73,20 @@ function tryLoadBundledProviderPolicySurface(
   return null;
 }
 
-function resolveBundledProviderPolicyPluginId(
+function resolveBundledProviderPolicyPluginIds(
   providerId: string,
   options: { manifestRegistry?: Pick<PluginManifestRegistry, "plugins"> } = {},
-): string | null {
+): string[] {
   const normalizedProviderId = normalizeProviderId(providerId);
   if (!normalizedProviderId) {
-    return null;
+    return [];
   }
   const bundledPluginsDir = resolveBundledPluginsDir();
   if (!bundledPluginsDir) {
-    return null;
+    return [];
   }
 
+  const pluginIds: string[] = [];
   const registry = options.manifestRegistry ?? loadPluginManifestRegistry();
   for (const plugin of registry.plugins.toSorted((left, right) =>
     left.id.localeCompare(right.id),
@@ -94,11 +95,11 @@ function resolveBundledProviderPolicyPluginId(
       continue;
     }
     if (pluginOwnsProviderPolicyRef(plugin, normalizedProviderId)) {
-      return plugin.id;
+      pluginIds.push(plugin.id);
     }
   }
 
-  return null;
+  return pluginIds;
 }
 
 function normalizeProviderPolicyRefs(
@@ -160,6 +161,36 @@ function pluginOwnsProviderPolicyRef(
 }
 
 /** Resolves provider policy hooks for a bundled provider or its owning plugin. */
+export function resolveBundledProviderPolicySurfaces(
+  providerId: string,
+  options: {
+    manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
+    providerRefs?: readonly string[];
+  } = {},
+): BundledProviderPolicySurface[] {
+  const surfaces: BundledProviderPolicySurface[] = [];
+  const visitedPluginIds = new Set<string>();
+  const loadSurface = (pluginId: string) => {
+    if (visitedPluginIds.has(pluginId)) {
+      return;
+    }
+    visitedPluginIds.add(pluginId);
+    const surface = tryLoadBundledProviderPolicySurface(pluginId);
+    if (surface) {
+      surfaces.push(surface);
+    }
+  };
+
+  for (const providerRef of normalizeProviderPolicyRefs(providerId, options.providerRefs)) {
+    loadSurface(providerRef);
+    for (const ownerPluginId of resolveBundledProviderPolicyPluginIds(providerRef, options)) {
+      loadSurface(ownerPluginId);
+    }
+  }
+  return surfaces;
+}
+
+/** Resolves provider policy hooks for a bundled provider or its owning plugin. */
 export function resolveBundledProviderPolicySurface(
   providerId: string,
   options: {
@@ -172,8 +203,8 @@ export function resolveBundledProviderPolicySurface(
     if (directSurface) {
       return directSurface;
     }
-    const ownerPluginId = resolveBundledProviderPolicyPluginId(providerRef, options);
-    if (!ownerPluginId || ownerPluginId === providerRef) {
+    const ownerPluginId = resolveBundledProviderPolicyPluginIds(providerRef, options)[0];
+    if (!ownerPluginId) {
       continue;
     }
     const ownerSurface = tryLoadBundledProviderPolicySurface(ownerPluginId);

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -284,8 +284,9 @@ describe("provider-runtime", () => {
   beforeAll(async () => {
     vi.resetModules();
     vi.doMock("./provider-public-artifacts.js", () => ({
-      resolveBundledProviderPolicySurface: (provider: string) =>
-        resolveBundledProviderPolicySurfaceMock(provider),
+      resolveBundledProviderPolicySurface: (
+        ...params: Parameters<ResolveBundledProviderPolicySurface>
+      ) => resolveBundledProviderPolicySurfaceMock(...params),
     }));
     vi.doMock("./providers.js", () => ({
       resolveCatalogHookProviderPluginIds: (params: unknown) =>
@@ -1466,6 +1467,170 @@ describe("provider-runtime", () => {
 
     expect(resolveThinkingProfile).toHaveBeenCalledTimes(1);
     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
+  });
+
+  it("passes custom provider API refs to bundled thinking policy lookup", () => {
+    const resolveThinkingProfile = vi.fn(() => ({
+      levels: [{ id: "adaptive" as const }],
+      defaultLevel: "adaptive" as const,
+    }));
+    resolveBundledProviderPolicySurfaceMock.mockImplementation((_, options) => {
+      return options?.providerRefs?.includes("anthropic-messages")
+        ? { resolveThinkingProfile }
+        : null;
+    });
+
+    expect(
+      resolveProviderThinkingProfile({
+        provider: "jdcloud-anthropic",
+        config: {
+          models: {
+            providers: {
+              "jdcloud-anthropic": {
+                api: "openai-responses",
+                baseUrl: "https://example.com/anthropic",
+                models: [
+                  {
+                    id: "claude-opus-4-6",
+                    name: "Claude Opus 4.6",
+                    api: "anthropic-messages",
+                    reasoning: true,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 200_000,
+                    maxTokens: 64_000,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        context: {
+          provider: "jdcloud-anthropic",
+          modelId: "claude-opus-4-6",
+          reasoning: true,
+        },
+      }),
+    ).toEqual({ levels: [{ id: "adaptive" }], defaultLevel: "adaptive" });
+
+    expect(resolveBundledProviderPolicySurfaceMock).toHaveBeenCalledWith("jdcloud-anthropic", {
+      providerRefs: ["jdcloud-anthropic", "anthropic-messages"],
+    });
+    expect(resolveThinkingProfile).toHaveBeenCalledWith({
+      provider: "jdcloud-anthropic",
+      api: "anthropic-messages",
+      modelId: "claude-opus-4-6",
+      reasoning: true,
+    });
+    expect(resolvePluginProvidersMock).toHaveBeenCalled();
+  });
+
+  it("falls back to runtime plugins when an API-ref bundled thinking policy declines", () => {
+    const resolveBundledThinkingProfile = vi.fn(() => null);
+    resolveBundledProviderPolicySurfaceMock.mockReturnValue({
+      resolveThinkingProfile: resolveBundledThinkingProfile,
+    });
+    const resolveRuntimeThinkingProfile = vi.fn(() => ({
+      levels: [{ id: "max" as const }],
+      defaultLevel: "max" as const,
+    }));
+    resolvePluginProvidersMock.mockReturnValue([
+      {
+        id: "custom-openai",
+        label: "Custom OpenAI",
+        auth: [],
+        resolveThinkingProfile: resolveRuntimeThinkingProfile,
+      },
+    ]);
+
+    expect(
+      resolveProviderThinkingProfile({
+        provider: "custom-openai",
+        config: {
+          models: {
+            providers: {
+              "custom-openai": {
+                api: "openai-responses",
+                baseUrl: "https://api.example.com/v1",
+                models: [],
+              },
+            },
+          },
+        },
+        context: {
+          provider: "custom-openai",
+          modelId: "gpt-5.5",
+          reasoning: true,
+        },
+      }),
+    ).toEqual({ levels: [{ id: "max" }], defaultLevel: "max" });
+
+    expect(resolveBundledThinkingProfile).toHaveBeenCalledWith({
+      provider: "custom-openai",
+      api: "openai-responses",
+      modelId: "gpt-5.5",
+      reasoning: true,
+    });
+    expect(resolveRuntimeThinkingProfile).toHaveBeenCalledWith({
+      provider: "custom-openai",
+      api: "openai-responses",
+      modelId: "gpt-5.5",
+      reasoning: true,
+    });
+  });
+
+  it("keeps runtime thinking hooks ahead of API-ref bundled policy fallback", () => {
+    const resolveThinkingProfile = vi.fn(() => ({
+      levels: [{ id: "adaptive" as const }],
+      defaultLevel: "adaptive" as const,
+    }));
+    resolveBundledProviderPolicySurfaceMock.mockImplementation((_, options) => {
+      return options?.providerRefs?.includes("anthropic-messages")
+        ? { resolveThinkingProfile }
+        : null;
+    });
+    const resolveRuntimeThinkingProfile = vi.fn(() => ({
+      levels: [{ id: "off" as const }, { id: "low" as const }],
+      defaultLevel: "off" as const,
+    }));
+    resolvePluginProvidersMock.mockReturnValue([
+      {
+        id: "custom-anthropic",
+        label: "Custom Anthropic",
+        auth: [],
+        resolveThinkingProfile: resolveRuntimeThinkingProfile,
+      },
+    ]);
+
+    expect(
+      resolveProviderThinkingProfile({
+        provider: "custom-anthropic",
+        config: {
+          models: {
+            providers: {
+              "custom-anthropic": {
+                api: "anthropic-messages",
+                baseUrl: "https://api.example.com/anthropic",
+                models: [],
+              },
+            },
+          },
+        },
+        context: {
+          provider: "custom-anthropic",
+          modelId: "claude-opus-4-6",
+          reasoning: true,
+        },
+      }),
+    ).toEqual({ levels: [{ id: "off" }, { id: "low" }], defaultLevel: "off" });
+
+    expect(resolveRuntimeThinkingProfile).toHaveBeenCalledWith({
+      provider: "custom-anthropic",
+      api: "anthropic-messages",
+      modelId: "claude-opus-4-6",
+      reasoning: true,
+    });
+    expect(resolveThinkingProfile).not.toHaveBeenCalled();
   });
 
   it("resolves provider config defaults through owner plugins", () => {

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -30,6 +30,8 @@ type ResolveOwningPluginIdsForProvider =
   typeof import("./providers.js").resolveOwningPluginIdsForProvider;
 type ResolveBundledProviderPolicySurface =
   typeof import("./provider-public-artifacts.js").resolveBundledProviderPolicySurface;
+type ResolveBundledProviderPolicySurfaces =
+  typeof import("./provider-public-artifacts.js").resolveBundledProviderPolicySurfaces;
 
 const resolvePluginProvidersMock = vi.fn<ResolvePluginProviders>((_) => [] as ProviderPlugin[]);
 const isPluginProvidersLoadInFlightMock = vi.fn<IsPluginProvidersLoadInFlight>((_) => false);
@@ -45,6 +47,9 @@ const resolveOwningPluginIdsForProviderMock = vi.fn<ResolveOwningPluginIdsForPro
 );
 const resolveBundledProviderPolicySurfaceMock = vi.fn<ResolveBundledProviderPolicySurface>(
   (_) => null,
+);
+const resolveBundledProviderPolicySurfacesMock = vi.fn<ResolveBundledProviderPolicySurfaces>(
+  (_) => [],
 );
 const providerRuntimeWarnMock = vi.fn();
 
@@ -287,6 +292,9 @@ describe("provider-runtime", () => {
       resolveBundledProviderPolicySurface: (
         ...params: Parameters<ResolveBundledProviderPolicySurface>
       ) => resolveBundledProviderPolicySurfaceMock(...params),
+      resolveBundledProviderPolicySurfaces: (
+        ...params: Parameters<ResolveBundledProviderPolicySurfaces>
+      ) => resolveBundledProviderPolicySurfacesMock(...params),
     }));
     vi.doMock("./providers.js", () => ({
       resolveCatalogHookProviderPluginIds: (params: unknown) =>
@@ -385,6 +393,8 @@ describe("provider-runtime", () => {
     resolveOwningPluginIdsForProviderMock.mockReturnValue(undefined);
     resolveBundledProviderPolicySurfaceMock.mockReset();
     resolveBundledProviderPolicySurfaceMock.mockReturnValue(null);
+    resolveBundledProviderPolicySurfacesMock.mockReset();
+    resolveBundledProviderPolicySurfacesMock.mockReturnValue([]);
     providerRuntimeWarnMock.mockReset();
   });
 
@@ -1474,11 +1484,7 @@ describe("provider-runtime", () => {
       levels: [{ id: "adaptive" as const }],
       defaultLevel: "adaptive" as const,
     }));
-    resolveBundledProviderPolicySurfaceMock.mockImplementation((_, options) => {
-      return options?.providerRefs?.includes("anthropic-messages")
-        ? { resolveThinkingProfile }
-        : null;
-    });
+    resolveBundledProviderPolicySurfacesMock.mockReturnValue([{ resolveThinkingProfile }]);
 
     expect(
       resolveProviderThinkingProfile({
@@ -1513,7 +1519,7 @@ describe("provider-runtime", () => {
       }),
     ).toEqual({ levels: [{ id: "adaptive" }], defaultLevel: "adaptive" });
 
-    expect(resolveBundledProviderPolicySurfaceMock).toHaveBeenCalledWith("jdcloud-anthropic", {
+    expect(resolveBundledProviderPolicySurfacesMock).toHaveBeenCalledWith("jdcloud-anthropic", {
       providerRefs: ["jdcloud-anthropic", "anthropic-messages"],
     });
     expect(resolveThinkingProfile).toHaveBeenCalledWith({
@@ -1524,6 +1530,70 @@ describe("provider-runtime", () => {
     });
     expect(resolvePluginProvidersMock).toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      api: "anthropic-messages",
+      provider: "jdcloud-anthropic",
+      modelId: "claude-opus-4-6",
+    },
+    {
+      api: "openai-responses",
+      provider: "custom-openai",
+      modelId: "gpt-5.5",
+    },
+  ])(
+    "continues API-ref bundled thinking policy lookup across shared $api owners",
+    ({ api, provider, modelId }) => {
+      const firstOwnerResolveThinkingProfile = vi.fn(() => null);
+      const secondOwnerResolveThinkingProfile = vi.fn(() => ({
+        levels: [{ id: "adaptive" as const }],
+        defaultLevel: "adaptive" as const,
+      }));
+      resolveBundledProviderPolicySurfacesMock.mockReturnValue([
+        { resolveThinkingProfile: firstOwnerResolveThinkingProfile },
+        { resolveThinkingProfile: secondOwnerResolveThinkingProfile },
+      ]);
+
+      expect(
+        resolveProviderThinkingProfile({
+          provider,
+          config: {
+            models: {
+              providers: {
+                [provider]: {
+                  api,
+                  baseUrl: "https://api.example.com/v1",
+                  models: [],
+                },
+              },
+            },
+          },
+          context: {
+            provider,
+            modelId,
+            reasoning: true,
+          },
+        }),
+      ).toEqual({ levels: [{ id: "adaptive" }], defaultLevel: "adaptive" });
+
+      expect(firstOwnerResolveThinkingProfile).toHaveBeenCalledWith({
+        provider,
+        api,
+        modelId,
+        reasoning: true,
+      });
+      expect(secondOwnerResolveThinkingProfile).toHaveBeenCalledWith({
+        provider,
+        api,
+        modelId,
+        reasoning: true,
+      });
+      expect(resolveBundledProviderPolicySurfacesMock).toHaveBeenCalledWith(provider, {
+        providerRefs: [provider, api],
+      });
+    },
+  );
 
   it("falls back to runtime plugins when an API-ref bundled thinking policy declines", () => {
     const resolveBundledThinkingProfile = vi.fn(() => null);

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -32,6 +32,7 @@ type ResolveBundledProviderPolicySurface =
   typeof import("./provider-public-artifacts.js").resolveBundledProviderPolicySurface;
 type ResolveBundledProviderPolicySurfaces =
   typeof import("./provider-public-artifacts.js").resolveBundledProviderPolicySurfaces;
+type ProviderConfigApi = NonNullable<ModelProviderConfig["api"]>;
 
 const resolvePluginProvidersMock = vi.fn<ResolvePluginProviders>((_) => [] as ProviderPlugin[]);
 const isPluginProvidersLoadInFlightMock = vi.fn<IsPluginProvidersLoadInFlight>((_) => false);
@@ -1542,7 +1543,11 @@ describe("provider-runtime", () => {
       provider: "custom-openai",
       modelId: "gpt-5.5",
     },
-  ])(
+  ] satisfies ReadonlyArray<{
+    api: ProviderConfigApi;
+    provider: string;
+    modelId: string;
+  }>)(
     "continues API-ref bundled thinking policy lookup across shared $api owners",
     ({ api, provider, modelId }) => {
       const firstOwnerResolveThinkingProfile = vi.fn(() => null);

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -39,7 +39,10 @@ import {
   type ProviderRuntimePluginHandle,
   wrapProviderStreamFn,
 } from "./provider-hook-runtime.js";
-import { resolveBundledProviderPolicySurface } from "./provider-public-artifacts.js";
+import {
+  resolveBundledProviderPolicySurface,
+  resolveBundledProviderPolicySurfaces,
+} from "./provider-public-artifacts.js";
 import type { ProviderRuntimeModel } from "./provider-runtime-model.types.js";
 import type { ProviderThinkingProfile } from "./provider-thinking.types.js";
 import {
@@ -819,8 +822,18 @@ export function resolveProviderThinkingProfile(params: {
     return runtimeProfile;
   }
   const providerRefs = resolveProviderHookRefs(params.provider, providerConfig, api);
-  const apiFallbackSurface = resolveBundledProviderPolicySurface(params.provider, { providerRefs });
-  return apiFallbackSurface?.resolveThinkingProfile?.(policyContext) ?? undefined;
+  for (const apiFallbackSurface of resolveBundledProviderPolicySurfaces(params.provider, {
+    providerRefs,
+  })) {
+    if (apiFallbackSurface === directSurface || !apiFallbackSurface.resolveThinkingProfile) {
+      continue;
+    }
+    const bundledProfile = apiFallbackSurface.resolveThinkingProfile(policyContext);
+    if (bundledProfile !== null && bundledProfile !== undefined) {
+      return bundledProfile;
+    }
+  }
+  return undefined;
 }
 
 export function resolveProviderDefaultThinkingLevel(params: {

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -123,6 +123,19 @@ function resolveProviderHookRefs(
   return uniqueStrings(refs);
 }
 
+function resolveProviderConfigModelApi(
+  providerConfig: ModelProviderConfig | undefined,
+  modelId: string,
+): string | undefined {
+  const normalizedModelId = normalizeOptionalString(modelId)?.toLowerCase();
+  if (!normalizedModelId) {
+    return undefined;
+  }
+  return providerConfig?.models.find(
+    (model) => normalizeOptionalString(model.id)?.toLowerCase() === normalizedModelId,
+  )?.api;
+}
+
 function matchesAnyProviderPluginRef(provider: ProviderPlugin, providerRefs: readonly string[]) {
   return providerRefs.some((providerRef) => matchesProviderPluginRef(provider, providerRef));
 }
@@ -783,11 +796,31 @@ export function resolveProviderThinkingProfile(params: {
   env?: NodeJS.ProcessEnv;
   context: ProviderDefaultThinkingPolicyContext;
 }): ProviderThinkingProfile | null | undefined {
-  const bundledSurface = resolveBundledProviderPolicySurface(params.provider);
-  if (bundledSurface?.resolveThinkingProfile) {
-    return bundledSurface.resolveThinkingProfile(params.context) ?? undefined;
+  const providerConfig = findNormalizedProviderValue(
+    params.config?.models?.providers,
+    params.provider,
+  );
+  const modelApi = resolveProviderConfigModelApi(providerConfig, params.context.modelId);
+  const api = params.context.api ?? modelApi ?? providerConfig?.api;
+  const policyContext = {
+    ...params.context,
+    ...(api ? { api } : {}),
+  };
+  const directSurface = resolveBundledProviderPolicySurface(params.provider);
+  if (directSurface?.resolveThinkingProfile) {
+    const bundledProfile = directSurface.resolveThinkingProfile(policyContext);
+    if (bundledProfile !== null && bundledProfile !== undefined) {
+      return bundledProfile;
+    }
   }
-  return resolveProviderRuntimePlugin(params)?.resolveThinkingProfile?.(params.context);
+  const runtimeProfile =
+    resolveProviderRuntimePlugin(params)?.resolveThinkingProfile?.(policyContext);
+  if (runtimeProfile !== null && runtimeProfile !== undefined) {
+    return runtimeProfile;
+  }
+  const providerRefs = resolveProviderHookRefs(params.provider, providerConfig, api);
+  const apiFallbackSurface = resolveBundledProviderPolicySurface(params.provider, { providerRefs });
+  return apiFallbackSurface?.resolveThinkingProfile?.(policyContext) ?? undefined;
 }
 
 export function resolveProviderDefaultThinkingLevel(params: {

--- a/src/plugins/provider-thinking.test.ts
+++ b/src/plugins/provider-thinking.test.ts
@@ -1,0 +1,66 @@
+// Verifies provider thinking profile lookup across active and bundled policy surfaces.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type ResolveBundledProviderPolicySurfaces =
+  typeof import("./provider-public-artifacts.js").resolveBundledProviderPolicySurfaces;
+
+const policySurfaceMocks = vi.hoisted(() => ({
+  resolveBundledProviderPolicySurfaces: vi.fn<ResolveBundledProviderPolicySurfaces>(() => []),
+}));
+
+vi.mock("./provider-public-artifacts.js", () => ({
+  resolveBundledProviderPolicySurfaces: policySurfaceMocks.resolveBundledProviderPolicySurfaces,
+}));
+
+const { resolveProviderThinkingProfile } = await import("./provider-thinking.js");
+
+beforeEach(() => {
+  delete (globalThis as typeof globalThis & Record<symbol, unknown>)[
+    Symbol.for("openclaw.pluginRegistryState")
+  ];
+  policySurfaceMocks.resolveBundledProviderPolicySurfaces.mockReset();
+  policySurfaceMocks.resolveBundledProviderPolicySurfaces.mockReturnValue([]);
+});
+
+describe("provider thinking policy", () => {
+  it("continues across API-ref bundled policy surfaces until one returns a profile", () => {
+    const firstResolveThinkingProfile = vi.fn(() => null);
+    const secondResolveThinkingProfile = vi.fn(() => ({
+      levels: [{ id: "xhigh" as const }],
+      defaultLevel: "xhigh" as const,
+    }));
+    policySurfaceMocks.resolveBundledProviderPolicySurfaces.mockReturnValue([
+      { resolveThinkingProfile: firstResolveThinkingProfile },
+      { resolveThinkingProfile: secondResolveThinkingProfile },
+    ]);
+
+    expect(
+      resolveProviderThinkingProfile({
+        provider: "custom-openai",
+        context: {
+          provider: "custom-openai",
+          api: "openai-responses",
+          modelId: "gpt-5.5",
+          reasoning: true,
+        },
+      }),
+    ).toEqual({ levels: [{ id: "xhigh" }], defaultLevel: "xhigh" });
+
+    expect(policySurfaceMocks.resolveBundledProviderPolicySurfaces).toHaveBeenCalledWith(
+      "custom-openai",
+      { providerRefs: ["openai-responses"] },
+    );
+    expect(firstResolveThinkingProfile).toHaveBeenCalledWith({
+      provider: "custom-openai",
+      api: "openai-responses",
+      modelId: "gpt-5.5",
+      reasoning: true,
+    });
+    expect(secondResolveThinkingProfile).toHaveBeenCalledWith({
+      provider: "custom-openai",
+      api: "openai-responses",
+      modelId: "gpt-5.5",
+      reasoning: true,
+    });
+  });
+});

--- a/src/plugins/provider-thinking.ts
+++ b/src/plugins/provider-thinking.ts
@@ -1,6 +1,6 @@
 // Resolves provider thinking-level policy from plugin metadata.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { resolveBundledProviderPolicySurface } from "./provider-public-artifacts.js";
+import { resolveBundledProviderPolicySurfaces } from "./provider-public-artifacts.js";
 import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
@@ -86,10 +86,17 @@ export function resolveProviderThinkingProfile(
   if (activeProfile !== undefined) {
     return activeProfile;
   }
-  return resolveBundledProviderPolicySurface(
+  const surfaces = resolveBundledProviderPolicySurfaces(
     params.provider,
     params.context.api ? { providerRefs: [params.context.api] } : undefined,
-  )?.resolveThinkingProfile?.(params.context);
+  );
+  for (const surface of surfaces) {
+    const profile = surface.resolveThinkingProfile?.(params.context);
+    if (profile !== null && profile !== undefined) {
+      return profile;
+    }
+  }
+  return undefined;
 }
 
 /** Resolves the provider default thinking level from the active plugin registry. */

--- a/src/plugins/provider-thinking.ts
+++ b/src/plugins/provider-thinking.ts
@@ -86,9 +86,10 @@ export function resolveProviderThinkingProfile(
   if (activeProfile !== undefined) {
     return activeProfile;
   }
-  return resolveBundledProviderPolicySurface(params.provider)?.resolveThinkingProfile?.(
-    params.context,
-  );
+  return resolveBundledProviderPolicySurface(
+    params.provider,
+    params.context.api ? { providerRefs: [params.context.api] } : undefined,
+  )?.resolveThinkingProfile?.(params.context);
 }
 
 /** Resolves the provider default thinking level from the active plugin registry. */

--- a/src/plugins/provider-thinking.types.ts
+++ b/src/plugins/provider-thinking.types.ts
@@ -27,6 +27,7 @@ export type ProviderThinkingModelCompat = {
  * profiles only when the configured payload style supports them.
  */
 export type ProviderDefaultThinkingPolicyContext = ProviderThinkingPolicyContext & {
+  api?: string;
   reasoning?: boolean;
   params?: Record<string, unknown>;
   compat?: ProviderThinkingModelCompat | null;


### PR DESCRIPTION
## Summary

- Fixes custom Anthropic-compatible providers whose selected model API is `anthropic-messages` but whose provider id is not literally `anthropic`.
- Carries the selected catalog/config model API into thinking policy resolution so Anthropic Messages routes can expose `adaptive`/`max`/`xhigh` levels according to the Claude model contract.
- Continues bundled API-family policy lookup across all deterministic owners when an earlier shared API owner declines, covering shared refs such as `anthropic-messages` and `openai-responses`.
- Keeps owner precedence intact: direct bundled provider policy still wins, exact runtime provider hooks can override API-family fallback, and API-family bundled policy only runs after provider-owned hooks decline.
- Out of scope: changing provider auth, model catalog contents, config shape, migrations, or transport behavior.

## Linked context

Closes #91975

Related: the issue's ClawSweeper review identified the missing API fact in thinking-policy dispatch and recommended reusing API-owner routing without provider-id substring matching. Follow-up ClawSweeper feedback also identified non-unique API refs, so this revision continues past declining owners instead of stopping at the first API-family match.

## Real behavior proof (required for external PRs)

Behavior addressed: Custom providers with `api: "anthropic-messages"` now route thinking profile lookup through the Anthropic policy fallback after exact provider hooks decline, so supported Claude models no longer reject valid extended thinking controls such as `--thinking xhigh` solely because the provider id is custom.
Real environment tested: Local OpenClaw CLI/source checkout on Node 24, using the PR branch at commit `cde44b2362cb4f184e03c902050e093321f201ae` with dependencies installed.
Exact steps or command run after this patch: Created a temporary `OPENCLAW_CONFIG_PATH` with provider `jdcloud-anthropic`, `api: "anthropic-messages"`, model `claude-opus-4-7`, then ran `pnpm openclaw agent --local --model jdcloud-anthropic/claude-opus-4-7 --message "thinking proof" --session-key agent:main:proof --thinking xhigh --json --timeout 3`. The proof command asserted that output contained the expected missing-auth error and did not contain `Thinking level "xhigh" is not supported`.
Evidence after fix: Redacted terminal capture from the local checkout:

```text
$ OPENCLAW_CONFIG_PATH="$tmpdir/openclaw.json" OPENCLAW_STATE_DIR="$tmpdir/state" \
  pnpm openclaw agent --local --model jdcloud-anthropic/claude-opus-4-7 \
  --message "thinking proof" --session-key agent:main:proof --thinking xhigh --json --timeout 3

[diagnostic] lane task error: lane=main ... error="ProviderAuthError: No API key found for provider "jdcloud-anthropic". Auth store: [tmp-state]/agents/main/agent/openclaw-agent.sqlite ..."
[model-fallback/decision] model fallback decision: decision=candidate_failed requested=jdcloud-anthropic/claude-opus-4-7 candidate=jdcloud-anthropic/claude-opus-4-7 reason=auth next=none detail=No API key found for provider "jdcloud-anthropic" ...
FailoverError: No API key found for provider "jdcloud-anthropic" ...
PROOF_RESULT=passed: status 1 reached expected missing-auth path without unsupported-thinking error
```

Observed result after fix: The real CLI/local-agent entrypoint accepts `--thinking xhigh` for the configured custom `anthropic-messages` Claude Opus 4.7 route and proceeds to the expected auth failure. Before this fix, this path failed earlier with `Thinking level "xhigh" is not supported`.
What was not tested: No live external Anthropic/JDCloud API request was made; this change is local provider thinking-policy/profile resolution, not network transport or auth.
Proof limitations or environment constraints: The proof intentionally uses a temporary config without credentials to avoid external network/API dependency; the expected terminal state is the missing-auth error after thinking validation succeeds.
Before evidence (optional but encouraged): Regression tests added in this PR encode the prior failure mode where the selected model API was available in catalog/config but was not passed through API-owner thinking-policy dispatch, and where the first shared API owner could block later owners.

## Tests and validation

- `pnpm tsgo:core:test`
- `pnpm tsgo:extensions:test`
- `node scripts/run-vitest.mjs src/plugins/provider-thinking.test.ts src/plugins/provider-runtime.test.ts src/plugins/provider-public-artifacts.test.ts src/auto-reply/thinking.test.ts extensions/anthropic/provider-policy-api.test.ts extensions/openai/provider-policy-api.test.ts`
- `pnpm format:check -- src/plugins/provider-public-artifacts.ts src/plugins/provider-runtime.ts src/plugins/provider-thinking.ts src/plugins/provider-runtime.test.ts src/plugins/provider-public-artifacts.test.ts src/plugins/provider-thinking.test.ts extensions/openai/provider-policy-api.ts extensions/openai/provider-policy-api.test.ts`
- `OPENCLAW_OXLINT_SKIP_LOCK=1 OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs src/plugins/provider-thinking.ts src/plugins/provider-thinking.test.ts extensions/openai/provider-policy-api.ts extensions/openai/provider-policy-api.test.ts src/plugins/provider-public-artifacts.ts src/plugins/provider-runtime.ts src/plugins/provider-runtime.test.ts src/plugins/provider-public-artifacts.test.ts`
- `git diff --check`
- `pnpm check:docs` -> format, markdownlint, and MDX passed; `docs:check-i18n-glossary` reported pre-existing unrelated glossary gaps in other docs pages.
- `pnpm build`
- CLI proof command above, with grep assertions for expected auth failure and absence of unsupported-thinking error.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` -> clean: no accepted/actionable findings reported.

Regression coverage added for API propagation, bundled policy lookup by manifest model-catalog API refs, shared API owner traversal for `anthropic-messages` and `openai-responses`, custom OpenAI Responses thinking profile opt-in, model-level API override precedence, runtime hook precedence over API fallback, and UI/autoreply thinking profile lookup through multiple API-ref owners.

## Risk checklist

Did user-visible behavior change? Yes

Did config, environment, or migration behavior change? No

Did security, auth, secrets, network, or tool execution behavior change? No

Highest-risk area: Provider thinking-policy ownership and fallback ordering.

Risk mitigation: Direct bundled policy remains first for literal bundled providers, runtime provider hooks win before API-family fallback, active UI/autoreply provider hooks still win before bundled policy fallback, and common/non-unique API refs that decline no longer block later bundled owner policy surfaces.

## Current review state

Next action: Waiting for fresh CI and ClawSweeper re-review on head `e22ee99a5b96e6dcc19750a691a363aaca515de8`.

Still waiting on: Maintainer review and any broader CI/Testbox signal maintainers want beyond the focused local proof above.

Bot/reviewer comments addressed: Rebased onto current `upstream/main`, dropped the already-merged `cliBackends` ownership overlap from #93261, fixed the two widened API literal test fixture type errors, refreshed current-head CLI proof, documented the new provider thinking-policy `api` context, and reran local autoreview clean.
