### PR TITLE
Fix diagnostics OTEL runtime install trust

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -699,6 +699,38 @@ describe("loadPluginManifestRegistry", () => {
     expect(registry.plugins[0]?.trustedOfficialInstall).toBe(true);
   });
 
+  it("marks official diagnostics-otel config paths trusted when the install record matches", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "diagnostics-otel", configSchema: { type: "object" } });
+
+    const registry = loadPluginManifestRegistry({
+      installRecords: {
+        "diagnostics-otel": {
+          source: "npm",
+          spec: "@openclaw/diagnostics-otel",
+          installPath: dir,
+          resolvedName: "@openclaw/diagnostics-otel",
+          resolvedVersion: "2026.5.18",
+          resolvedSpec: "@openclaw/diagnostics-otel@2026.5.18",
+        },
+      },
+      candidates: [
+        createPluginCandidate({
+          idHint: "diagnostics-otel",
+          rootDir: dir,
+          packageName: "@openclaw/diagnostics-otel",
+          origin: "config",
+        }),
+      ],
+    });
+
+    expect(registry.plugins).toHaveLength(1);
+    expectRecordFields(registry.plugins[0], "plugin", {
+      origin: "config",
+      trustedOfficialInstall: true,
+    });
+  });
+
   it("preserves trusted official installs when a config path selects the installed package", () => {
     const dir = makeTempDir();
     writeManifest(dir, { id: "diagnostics-prometheus", configSchema: { type: "object" } });

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -369,6 +369,23 @@ describe("startPluginServices", () => {
     expect(prometheusContexts[0]?.internalDiagnostics?.onEvent).toBeTypeOf("function");
     expect(prometheusContexts[0]?.internalDiagnostics?.emit).toBeTypeOf("function");
 
+    const officialDiagnosticsOtelContexts: OpenClawPluginServiceContext[] = [];
+    const officialDiagnosticsOtelService = createTrackingService("diagnostics-otel", {
+      contexts: officialDiagnosticsOtelContexts,
+    });
+    await startPluginServices({
+      registry: createRegistry(
+        [officialDiagnosticsOtelService],
+        "diagnostics-otel",
+        "config",
+        true,
+      ),
+      config: createServiceConfig(),
+    });
+
+    expect(officialDiagnosticsOtelContexts[0]?.internalDiagnostics?.onEvent).toBeTypeOf("function");
+    expect(officialDiagnosticsOtelContexts[0]?.internalDiagnostics?.emit).toBeTypeOf("function");
+
     const officialInstallContexts: OpenClawPluginServiceContext[] = [];
     const officialInstallService = createTrackingService("diagnostics-prometheus", {
       contexts: officialInstallContexts,


### PR DESCRIPTION
## Summary

Fixes the Gateway diagnostics OTEL trust path for runtime-managed plugin installs.

Lobster/OpenClaw FRE showed `diagnostics-otel` loading from the configured package path but still logging:

```text
diagnostics-otel: internal diagnostics capability unavailable
```

RCA: Gateway runtime load context retained `plugins.installs` for discovery, but did not pass those runtime install records into the plugin metadata snapshot. The lower-level loader correctly kept raw config-authored install records untrusted, so the diagnostics plugin could load but never receive `internalDiagnostics` and therefore never forward Gateway OTEL batches.

This PR now:

- threads runtime config install records into `resolvePluginMetadataSnapshot` from `resolvePluginRuntimeLoadContext`
- preserves the existing safety boundary: direct user-authored config install records remain untrusted unless they are in the trusted installed-index/runtime context
- adds Gateway-effective trust coverage proving persisted/runtime records make `diagnostics-otel` trusted before services start
- keeps spoofed/wrong-path/non-official install records untrusted
- keeps service-context coverage for `internalDiagnostics` grants to trusted diagnostics exporters

## Verification

RED/GREEN:

- RED: `node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/runtime/load-context.test.ts -t "passes runtime config install records into the metadata snapshot"`
  - failed because `installRecords` was not passed to `resolvePluginMetadataSnapshot`
- GREEN: same command passed after the fix

Focused validation:

```bash
git diff --check
pnpm exec oxfmt --check --threads=1 \
  src/plugins/loader.test.ts \
  src/plugins/loader.ts \
  src/plugins/manifest-registry-installed.test.ts \
  src/plugins/manifest-registry.test.ts \
  src/plugins/manifest-registry.ts \
  src/plugins/runtime/load-context.test.ts \
  src/plugins/runtime/load-context.ts \
  src/plugins/gateway-effective-trust.test.ts

node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts \
  src/plugins/runtime/load-context.test.ts \
  src/plugins/gateway-effective-trust.test.ts

node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts \
  src/plugins/manifest-registry.test.ts \
  -t "diagnostics-otel|trusted official|user-authored"

node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts \
  src/plugins/manifest-registry-installed.test.ts \
  -t "diagnostics-otel|official|untrusted"

node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts \
  src/plugins/services.test.ts \
  -t "grants internal diagnostics only to trusted diagnostics exporter services"

OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-vitest-include-loader.json \
  node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts \
  -t "keeps user-authored diagnostics-otel config install records untrusted during plugin load"
```

All commands above passed after the fix. A full `loader.test.ts` run was attempted, but the repo wrapper terminated it after 120s of no output; the targeted security regression from that file passed.

## Deployed evidence driving this PR

Lobster PR #2858 fixed the baked install-record/package version drift and deployed to FRE301 in OpenClaw builds `26.162.04`, `26.162.05`, and `26.162.06`. Kusto still showed fresh Gateway startups with:

- `diagnostics-otel` plugin loaded
- Gateway ready
- zero `OpenClaw Gateway OTEL batch forwarded` rows
- persistent `diagnostics-otel: internal diagnostics capability unavailable`

This PR addresses the remaining OpenClaw runtime trust propagation gap.
