### PR TITLE
test(ci): restore upgrade survivor session fixture

### DIFF
--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -23,6 +23,23 @@ function writeMigratedSessionState(stateDir: string): void {
   writeFileSync(mainSessionFile, '{"type":"main"}\n');
   writeFileSync(directSessionFile, '{"type":"direct"}\n');
   writeFileSync(groupSessionFile, '{"type":"group"}\n');
+  writeJson(join(agentSessionsDir, "sessions.json"), {
+    "agent:main:main": {
+      sessionFile: mainSessionFile,
+      sessionId: "upgrade-main-session",
+      skillsSnapshot: {
+        prompt: "legacy prompt survives as metadata",
+      },
+    },
+    "agent:main:+15551234567": {
+      sessionFile: directSessionFile,
+      sessionId: "upgrade-direct-session",
+    },
+    "agent:main:slack:channel:cupgrade": {
+      sessionFile: groupSessionFile,
+      sessionId: "upgrade-group-session",
+    },
+  });
 
   const db = new DatabaseSync(join(agentDbDir, "openclaw-agent.sqlite"));
   try {


### PR DESCRIPTION
## Summary
- add the migrated sessions index to the upgrade-survivor assertion fixture
- keep the configured-plugin assertions focused on plugin path validation instead of failing early on missing session state

## Validation
- node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts test/scripts/upgrade-survivor-assertions.test.ts
- node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json test/scripts/upgrade-survivor-assertions.test.ts
- ./node_modules/.bin/oxfmt --check --threads=1 test/scripts/upgrade-survivor-assertions.test.ts
- git diff --check