### PR TITLE
fix(fal): parse raw completed queue results

### DIFF
--- a/extensions/fal/video-generation-provider.test.ts
+++ b/extensions/fal/video-generation-provider.test.ts
@@ -172,6 +172,42 @@ describe("fal video generation provider", () => {
     });
   });
 
+  it("parses raw fal queue result payloads with top-level video output", async () => {
+    mockFalProviderRuntime();
+    fetchGuardMock
+      .mockResolvedValueOnce(
+        releasedJson({
+          request_id: "req-raw",
+          status_url: "https://queue.fal.run/fal-ai/wan/requests/req-raw/status",
+          response_url: "https://queue.fal.run/fal-ai/wan/requests/req-raw",
+        }),
+      )
+      .mockResolvedValueOnce(releasedJson({ status: "COMPLETED" }))
+      .mockResolvedValueOnce(
+        releasedJson({
+          video: { url: "https://fal.run/files/raw-output.mp4" },
+          prompt: "A calm harbor at sunrise",
+          seed: 443600358,
+        }),
+      )
+      .mockResolvedValueOnce(releasedVideo({ contentType: "video/mp4", bytes: "mp4-bytes" }));
+
+    const provider = buildFalVideoGenerationProvider();
+    const result = await provider.generateVideo({
+      provider: "fal",
+      model: "fal-ai/wan/v2.2-a14b/image-to-video",
+      prompt: "A calm harbor at sunrise",
+      cfg: {},
+    });
+
+    expect(result.videos[0]?.url).toBe("https://fal.run/files/raw-output.mp4");
+    expect(result.metadata).toEqual({
+      requestId: "req-raw",
+      prompt: "A calm harbor at sunrise",
+      seed: 443600358,
+    });
+  });
+
   it("returns URL-only videos when generated video downloads exceed the configured media cap", async () => {
     mockFalProviderRuntime();
     mockCompletedFalVideoJob({

--- a/extensions/fal/video-generation-provider.ts
+++ b/extensions/fal/video-generation-provider.ts
@@ -166,6 +166,21 @@ function readFalQueueResponse(payload: unknown): FalQueueResponse {
   };
 }
 
+function readFalCompletedQueueResult(payload: unknown): FalQueueResponse {
+  if (!isRecord(payload)) {
+    throw new Error(FAL_VIDEO_MALFORMED_RESPONSE);
+  }
+  if (
+    payload.response !== undefined ||
+    (payload.video === undefined && payload.videos === undefined)
+  ) {
+    return readFalQueueResponse(payload);
+  }
+  return {
+    response: readFalVideoPayload(payload),
+  };
+}
+
 function toDataUrl(buffer: Buffer, mimeType: string): string {
   return `data:${mimeType};base64,${buffer.toString("base64")}`;
 }
@@ -509,7 +524,7 @@ async function waitForFalQueueResult(params: {
     }
     lastStatus = status;
     if (status === "COMPLETED") {
-      return readFalQueueResponse(
+      return readFalCompletedQueueResult(
         await fetchFalJson({
           url: params.responseUrl,
           init: {


### PR DESCRIPTION
## Summary

- fal's completed-queue `response_url` can return a **raw** top-level output payload (`{ video: { url }, prompt, seed }`) instead of the wrapper envelope (`{ response: { ... } }`) the provider assumed. The raw shape was parsed as a queue envelope, so the top-level `video`/`videos` keys were dropped and every fal video model failed with "missing output URL."
- This adds a completed-queue parser that accepts **either** wrapper payloads (with `response`) **or** raw payloads (with top-level `video`/`videos`), so the generated video URL, `prompt`, and `seed` survive and the download proceeds.
- Intentionally out of scope: in-progress queue/status parsing and non-video fal providers are unchanged; malformed payloads still reject.
- Success: a fal video request whose COMPLETED `response_url` returns a raw payload yields a downloadable video + metadata instead of "missing output URL."
- Reviewers: confirm the wrapper-vs-raw discrimination is correct and does not accept malformed responses that should stay rejected.

> **AI-assisted:** prepared with AI assistance (Claude) and reviewed by the author; the author understands and owns the diff.

## Linked context

Closes #91989

Related # — none.

Maintainer/owner request: issue is maintainer-triaged (`P1`, `clawsweeper:fix-shape-clear`, `clawsweeper:queueable-fix`, `clawsweeper:source-repro`).

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: fal COMPLETED queue `response_url` returning a raw `{ video: { url }, prompt, seed }` payload was parsed as a queue envelope, stripping `video`/`videos` → "missing output URL" for all fal video models (#91989).
- Real environment tested: local OpenClaw checkout (Node v24.16.0); the fal video-generation provider exercised through its real `generateVideo` code path. **Live fal API not exercised — no fal credentials in this environment** (see limitations).
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/fal/video-generation-provider.test.ts` — including a new case that drives `provider.generateVideo({ provider: "fal", model: "fal-ai/wan/v2.2-a14b/image-to-video", ... })` against the exact raw completed-queue payload `{ video: { url: "https://fal.run/files/raw-output.mp4" }, prompt, seed }` returned on `response_url`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `Test Files 1 passed (1) / Tests 18 passed (18)`. The new case asserts `result.videos[0].url === "https://fal.run/files/raw-output.mp4"` and `result.metadata === { requestId: "req-raw", prompt: "A calm harbor at sunrise", seed: 443600358 }`.
- Observed result after fix: raw completed-queue payloads now extract `video.url` (plus `prompt`/`seed`) and download the video; wrapper payloads and error/`detail` envelopes are unchanged; malformed payloads still throw `FAL_VIDEO_MALFORMED_RESPONSE`.
- What was not tested: an end-to-end run against the **live fal queue API** with real credentials. A maintainer/contributor with fal access should run one real `generateVideo` against a fal video model whose `response_url` returns the raw shape.
- Proof limitations or environment constraints: this environment has no fal API key, so the live network path could not be exercised. Behavior is demonstrated through the real provider code with the network transport mocked at the documented raw-payload shape from the issue.
- Before evidence (optional but encouraged): before this patch the raw payload hit `readFalQueueResponse`, which reads only `payload.response`; with no `response` key the video URL is dropped and the provider reports the missing-output error described in the issue.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/fal/video-generation-provider.test.ts` → 18 passed (adds 1 regression case for the raw completed-queue shape).
- `oxfmt` (pre-commit) clean; `oxlint extensions/fal/video-generation-provider.ts extensions/fal/video-generation-provider.test.ts` clean; `git diff --check` clean.
- Regression coverage added: raw top-level `video` payload preserves `video.url`/`prompt`/`seed` and downloads.
- What failed before: raw completed-queue payloads were parsed as queue envelopes (`response` undefined) → video stripped → "missing output URL."

## Risk checklist

- Did user-visible behavior change? `Yes` — fal video models that previously failed with "missing output URL" on raw completed-queue payloads now return the video.
- Did config, environment, or migration behavior change? `No`.
- Did security, auth, secrets, network, or tool execution behavior change? `No` (same fetch/SSRF path; only the COMPLETED-payload shape interpretation changed).
- Highest-risk area: the wrapper-vs-raw discrimination — wrongly routing a wrapper payload to the raw branch or vice versa.
- How mitigated: the raw branch is taken only when there is no `response` key AND a top-level `video`/`videos` is present; otherwise the existing `readFalQueueResponse` path runs unchanged, preserving status/error/`detail` handling. Malformed payloads still reject via `readFalVideoPayload`. Covered by the regression test.

## Current review state

- Next action: maintainer review + a live fal real-behavior run (author lacks fal credentials).
- Still waiting on: live fal API proof (external); otherwise ready.
- Bot/reviewer comments addressed: none yet (initial draft).
