### PR TITLE
fix(thinking): apply Claude profile to anthropic-messages catalog rows

### DIFF
--- a/scripts/proof-thinking-anthropic-messages.mts
+++ b/scripts/proof-thinking-anthropic-messages.mts
@@ -1,0 +1,52 @@
+// Live-proof harness for PR #92053 (thinking profile on anthropic-messages catalog rows).
+//
+// Loads the patched `resolveThinkingProfile` from src/auto-reply/thinking.ts and
+// feeds it a catalog whose shape mirrors the real jdcloud-anthropic config from
+// issue #91975 (`api: "anthropic-messages"` on a non-bundled provider id, mixed
+// `reasoning: false`/`reasoning: true` rows for Claude Opus 4.7 / 4.7-hq / 4.8).
+//
+// Before fix: `--thinking xhigh` silently clamped to `off` (only base levels
+// exposed). After fix: xhigh/adaptive/max appear and survive level resolution.
+//
+// Run: pnpm exec tsx scripts/proof-thinking-anthropic-messages.mts
+
+import {
+  isThinkingLevelSupported,
+  listThinkingLevels,
+  resolveSupportedThinkingLevel,
+} from "../src/auto-reply/thinking.js";
+
+type CatalogRow = {
+  provider: string;
+  id: string;
+  api: "anthropic-messages";
+  reasoning: boolean;
+};
+
+const catalog: CatalogRow[] = [
+  { provider: "jdcloud-anthropic", id: "Claude-Opus-4.7", api: "anthropic-messages", reasoning: false },
+  { provider: "jdcloud-anthropic", id: "Claude-Opus-4.7-hq", api: "anthropic-messages", reasoning: true },
+  { provider: "jdcloud-anthropic", id: "Claude-Opus-4.8", api: "anthropic-messages", reasoning: true },
+];
+
+function probe(provider: string, model: string, requested: "off" | "xhigh" | "max") {
+  const levels = listThinkingLevels(provider, model, catalog);
+  const supported = isThinkingLevelSupported({ provider, model, level: requested, catalog });
+  const resolved = resolveSupportedThinkingLevel({ provider, model, level: requested, catalog });
+  return { provider, model, requested, levels, supported, resolved };
+}
+
+const cases = [
+  probe("jdcloud-anthropic", "Claude-Opus-4.7", "xhigh"),
+  probe("jdcloud-anthropic", "Claude-Opus-4.7-hq", "xhigh"),
+  probe("jdcloud-anthropic", "Claude-Opus-4.8", "xhigh"),
+  probe("jdcloud-anthropic", "Claude-Opus-4.8", "max"),
+];
+
+for (const c of cases) {
+  console.log(
+    `${c.provider}/${c.model}  reasoning=${catalog.find((r) => r.id === c.model)?.reasoning} ` +
+      `--thinking ${c.requested}  ->  resolved=${c.resolved}  supported=${c.supported}`,
+  );
+  console.log(`  levels: [${c.levels.join(",")}]`);
+}

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -312,6 +312,87 @@ describe("listThinkingLevels", () => {
     ).toBe("high");
   });
 
+  it("exposes Claude Opus xhigh on custom anthropic-messages providers without a plugin profile", () => {
+    // Regression for openclaw#91975: a renamed provider serving Claude Opus over
+    // anthropic-messages used to fall back to a base profile (no xhigh) and silently
+    // clamp `--thinking xhigh` to `off`.
+    const catalog = [
+      {
+        provider: "jdcloud-anthropic",
+        id: "claude-opus-4.7-hq",
+        api: "anthropic-messages",
+        reasoning: true,
+      },
+    ];
+
+    expect(listThinkingLevels("jdcloud-anthropic", "claude-opus-4.7-hq", catalog)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "adaptive",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+    expect(
+      isThinkingLevelSupported({
+        provider: "jdcloud-anthropic",
+        model: "claude-opus-4.7-hq",
+        level: "xhigh",
+        catalog,
+      }),
+    ).toBe(true);
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "jdcloud-anthropic",
+        model: "claude-opus-4.7-hq",
+        level: "xhigh",
+        catalog,
+      }),
+    ).toBe("xhigh");
+  });
+
+  it("does not invent xhigh for non-Claude models on anthropic-messages routes", () => {
+    const catalog = [
+      {
+        provider: "jdcloud-anthropic",
+        id: "some-non-claude-model",
+        api: "anthropic-messages",
+        reasoning: true,
+      },
+    ];
+
+    expect(listThinkingLevels("jdcloud-anthropic", "some-non-claude-model", catalog)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+
+  it("does not infer the Claude profile without an anthropic-messages catalog row", () => {
+    // Same provider id, but the catalog row says openai-completions — must NOT
+    // grant Claude levels to a non-Anthropic transport.
+    const catalog = [
+      {
+        provider: "jdcloud-anthropic",
+        id: "claude-opus-4.7-hq",
+        api: "openai-completions",
+        reasoning: true,
+      },
+    ];
+
+    expect(listThinkingLevels("jdcloud-anthropic", "claude-opus-4.7-hq", catalog)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+
   it("preserves provider-specific profiles for Fable Messages routes", () => {
     providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
       levels: [{ id: "off" }, { id: "low" }],

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -372,6 +372,26 @@ describe("listThinkingLevels", () => {
     ]);
   });
 
+  it("intentionally suppresses compat-driven xhigh for non-Claude anthropic-messages rows", () => {
+    // Even when the catalog explicitly advertises xhigh via compat, a non-Claude
+    // model on the anthropic-messages transport stays on the Claude base set.
+    // The transport itself doesn't carry a generic xhigh contract — only Claude
+    // families do — so the catalog signal is intentionally suppressed here.
+    const catalog = [
+      {
+        provider: "jdcloud-anthropic",
+        id: "some-non-claude-model",
+        api: "anthropic-messages",
+        reasoning: true,
+        compat: { supportedReasoningEfforts: ["xhigh"] },
+      },
+    ];
+
+    expect(listThinkingLevels("jdcloud-anthropic", "some-non-claude-model", catalog)).not.toContain(
+      "xhigh",
+    );
+  });
+
   it("does not infer the Claude profile without an anthropic-messages catalog row", () => {
     // Same provider id, but the catalog row says openai-completions — must NOT
     // grant Claude levels to a non-Anthropic transport.

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -393,6 +393,32 @@ describe("listThinkingLevels", () => {
     ]);
   });
 
+  it("matches native Anthropic max parity for adaptive Claude on custom anthropic-messages providers", () => {
+    // Adaptive Claude families (e.g. claude-sonnet-4-6) take the adaptive-default
+    // branch in resolveClaudeThinkingProfile, which only exposes `max` when
+    // includeNativeMax is set. The fallback must pass the same option the
+    // bundled anthropic plugin uses, otherwise custom providers silently lose
+    // `max` parity with the native Anthropic policy.
+    const catalog = [
+      {
+        provider: "jdcloud-anthropic",
+        id: "claude-sonnet-4-6",
+        api: "anthropic-messages",
+        reasoning: true,
+      },
+    ];
+
+    expect(listThinkingLevels("jdcloud-anthropic", "claude-sonnet-4-6", catalog)).toContain("max");
+    expect(
+      isThinkingLevelSupported({
+        provider: "jdcloud-anthropic",
+        model: "claude-sonnet-4-6",
+        level: "max",
+        catalog,
+      }),
+    ).toBe(true);
+  });
+
   it("preserves provider-specific profiles for Fable Messages routes", () => {
     providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
       levels: [{ id: "off" }, { id: "low" }],

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -1,6 +1,6 @@
 // Thinking/reasoning level catalog helpers for auto-reply model controls.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { resolveClaudeThinkingProfile } from "../plugin-sdk/provider-model-shared.js";
+import { resolveClaudeThinkingProfile } from "../plugins/provider-claude-thinking.js";
 import {
   BASE_THINKING_LEVELS,
   normalizeThinkLevel,

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -198,6 +198,11 @@ export function resolveThinkingProfile(params: {
     provider: context.normalizedProvider,
     context: providerContext,
   });
+  // Any anthropic-messages catalog row routes through the canonical Claude
+  // resolver: Claude families get the proper profile (incl. xhigh/adaptive/max);
+  // non-Claude models on the anthropic-messages transport collapse to the Claude
+  // base set, deliberately bypassing the later compat-driven xhigh upgrade —
+  // anthropic-messages does not carry a generic xhigh contract.
   const anthropicMessagesProfile =
     context.api === "anthropic-messages"
       ? resolveClaudeThinkingProfile(context.modelId, context.params, {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -200,7 +200,9 @@ export function resolveThinkingProfile(params: {
   });
   const anthropicMessagesProfile =
     context.api === "anthropic-messages"
-      ? resolveClaudeThinkingProfile(context.modelId, context.params)
+      ? resolveClaudeThinkingProfile(context.modelId, context.params, {
+          includeNativeMax: true,
+        })
       : undefined;
   const pluginProfile = providerProfile ?? anthropicMessagesProfile;
   if (pluginProfile) {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -1,9 +1,6 @@
-import {
-  CLAUDE_FABLE_5_THINKING_PROFILE,
-  resolveClaudeFable5ModelIdentity,
-} from "@openclaw/llm-core";
 // Thinking/reasoning level catalog helpers for auto-reply model controls.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { resolveClaudeThinkingProfile } from "../plugin-sdk/provider-model-shared.js";
 import {
   BASE_THINKING_LEVELS,
   normalizeThinkLevel,
@@ -201,15 +198,11 @@ export function resolveThinkingProfile(params: {
     provider: context.normalizedProvider,
     context: providerContext,
   });
-  const fableProfile =
-    context.api === "anthropic-messages" &&
-    resolveClaudeFable5ModelIdentity({
-      id: context.modelId,
-      params: context.params,
-    })
-      ? CLAUDE_FABLE_5_THINKING_PROFILE
+  const anthropicMessagesProfile =
+    context.api === "anthropic-messages"
+      ? resolveClaudeThinkingProfile(context.modelId, context.params)
       : undefined;
-  const pluginProfile = providerProfile ?? fableProfile;
+  const pluginProfile = providerProfile ?? anthropicMessagesProfile;
   if (pluginProfile) {
     const normalized = normalizeThinkingProfile(pluginProfile);
     if (

--- a/src/plugin-sdk/provider-model-shared.ts
+++ b/src/plugin-sdk/provider-model-shared.ts
@@ -1,10 +1,3 @@
-import {
-  CLAUDE_FABLE_5_THINKING_PROFILE,
-  resolveClaudeFable5ModelIdentity,
-  resolveClaudeModelIdentity,
-  supportsClaudeAdaptiveThinking,
-  supportsClaudeNativeXhighEffort,
-} from "@openclaw/llm-core";
 // Provider model helpers normalize model catalog entries shared by provider plugins.
 import { normalizeProviderId as normalizeProviderIdCore } from "@openclaw/model-catalog-core/provider-id";
 import {
@@ -27,7 +20,6 @@ import type {
   ProviderReasoningOutputModeContext,
   ProviderReplayPolicyContext,
   ProviderSanitizeReplayHistoryContext,
-  ProviderThinkingProfile,
 } from "./plugin-entry.js";
 
 export type {
@@ -115,13 +107,10 @@ export {
 } from "../plugins/provider-model-helpers.js";
 import { normalizeOptionalLowercaseString } from "../../packages/normalization-core/src/string-coerce.js";
 
-const BASE_CLAUDE_THINKING_LEVELS = [
-  { id: "off" },
-  { id: "minimal" },
-  { id: "low" },
-  { id: "medium" },
-  { id: "high" },
-] as const satisfies ProviderThinkingProfile["levels"];
+export {
+  isClaudeAdaptiveThinkingDefaultModelId,
+  resolveClaudeThinkingProfile,
+} from "../plugins/provider-claude-thinking.js";
 
 function getModelProviderHint(modelId: string): string | null {
   const trimmed = normalizeOptionalLowercaseString(modelId);
@@ -141,46 +130,6 @@ export function isProxyReasoningUnsupportedModelHint(
   modelId: string,
 ): boolean {
   return getModelProviderHint(modelId) === "x-ai";
-}
-
-/** @deprecated Anthropic provider-owned model helper; do not use from third-party plugins. */
-export function isClaudeAdaptiveThinkingDefaultModelId(
-  /** Claude model id to check against adaptive-thinking default families. */
-  modelId: string,
-): boolean {
-  const ref = { id: modelId };
-  return supportsClaudeAdaptiveThinking(ref) && !supportsClaudeNativeXhighEffort(ref);
-}
-
-/** @deprecated Anthropic provider-owned model helper; do not use from third-party plugins. */
-export function resolveClaudeThinkingProfile(
-  /** Claude model id used to choose available thinking levels and defaults. */
-  modelId: string,
-  params?: Record<string, unknown>,
-  options?: { includeNativeMax?: boolean },
-): ProviderThinkingProfile {
-  const ref = { id: modelId, params };
-  const canonicalModelId = resolveClaudeModelIdentity(ref);
-  if (resolveClaudeFable5ModelIdentity(ref)) {
-    return CLAUDE_FABLE_5_THINKING_PROFILE;
-  }
-  if (supportsClaudeNativeXhighEffort(ref)) {
-    return {
-      levels: [...BASE_CLAUDE_THINKING_LEVELS, { id: "xhigh" }, { id: "adaptive" }, { id: "max" }],
-      defaultLevel: "off",
-    };
-  }
-  if (isClaudeAdaptiveThinkingDefaultModelId(canonicalModelId)) {
-    return {
-      levels: [
-        ...BASE_CLAUDE_THINKING_LEVELS,
-        { id: "adaptive" },
-        ...(options?.includeNativeMax ? [{ id: "max" as const }] : []),
-      ],
-      defaultLevel: "adaptive",
-    };
-  }
-  return { levels: BASE_CLAUDE_THINKING_LEVELS };
 }
 
 /**

--- a/src/plugins/provider-claude-thinking.ts
+++ b/src/plugins/provider-claude-thinking.ts
@@ -1,0 +1,59 @@
+// Leaf module for Claude thinking-profile resolution. Kept dependency-light so
+// auto-reply and the plugin-sdk barrel can both import without cycling through
+// `plugin-sdk/provider-model-shared`.
+import {
+  CLAUDE_FABLE_5_THINKING_PROFILE,
+  resolveClaudeFable5ModelIdentity,
+  resolveClaudeModelIdentity,
+  supportsClaudeAdaptiveThinking,
+  supportsClaudeNativeXhighEffort,
+} from "@openclaw/llm-core";
+import type { ProviderThinkingProfile } from "./provider-thinking.types.js";
+
+const BASE_CLAUDE_THINKING_LEVELS = [
+  { id: "off" },
+  { id: "minimal" },
+  { id: "low" },
+  { id: "medium" },
+  { id: "high" },
+] as const satisfies ProviderThinkingProfile["levels"];
+
+/** @deprecated Anthropic provider-owned model helper; do not use from third-party plugins. */
+export function isClaudeAdaptiveThinkingDefaultModelId(
+  /** Claude model id to check against adaptive-thinking default families. */
+  modelId: string,
+): boolean {
+  const ref = { id: modelId };
+  return supportsClaudeAdaptiveThinking(ref) && !supportsClaudeNativeXhighEffort(ref);
+}
+
+/** @deprecated Anthropic provider-owned model helper; do not use from third-party plugins. */
+export function resolveClaudeThinkingProfile(
+  /** Claude model id used to choose available thinking levels and defaults. */
+  modelId: string,
+  params?: Record<string, unknown>,
+  options?: { includeNativeMax?: boolean },
+): ProviderThinkingProfile {
+  const ref = { id: modelId, params };
+  const canonicalModelId = resolveClaudeModelIdentity(ref);
+  if (resolveClaudeFable5ModelIdentity(ref)) {
+    return CLAUDE_FABLE_5_THINKING_PROFILE;
+  }
+  if (supportsClaudeNativeXhighEffort(ref)) {
+    return {
+      levels: [...BASE_CLAUDE_THINKING_LEVELS, { id: "xhigh" }, { id: "adaptive" }, { id: "max" }],
+      defaultLevel: "off",
+    };
+  }
+  if (isClaudeAdaptiveThinkingDefaultModelId(canonicalModelId)) {
+    return {
+      levels: [
+        ...BASE_CLAUDE_THINKING_LEVELS,
+        { id: "adaptive" },
+        ...(options?.includeNativeMax ? [{ id: "max" as const }] : []),
+      ],
+      defaultLevel: "adaptive",
+    };
+  }
+  return { levels: BASE_CLAUDE_THINKING_LEVELS };
+}


### PR DESCRIPTION
## Summary

A custom provider fronting Claude Opus over the native `anthropic-messages` adapter (e.g. a renamed `jdcloud-anthropic`) had `--thinking xhigh` silently clamped to `off`. Thinking-profile resolution matches bundled plugin policy surfaces by exact provider id, so a renamed Anthropic-compatible provider never reached the anthropic plugin's policy and `xhigh`/`adaptive`/`max` were dropped from the resulting profile.

`auto-reply/thinking.ts` already had an `api === "anthropic-messages"` fallback that attached the Fable-5 profile for Fable models. This generalizes that fallback to call the canonical `resolveClaudeThinkingProfile(modelId, params)` helper — the same one the anthropic plugin uses — so Claude Opus 4.7/4.8 on any `anthropic-messages` route gets the correct profile (with `xhigh`/`adaptive`/`max`) regardless of provider id, while Fable models keep the Fable profile.

Routing keys on the catalog row's `api` field, not the provider id, so no brittle id matching is introduced.

Fixes #91975

## Why this fix point

`resolveThinkingProfile` in `src/auto-reply/thinking.ts` is the **sole** non-test caller of the dispatcher's `resolveProviderThinkingProfile` (verified by grep) and the chokepoint behind every agent-command clamp helper (`isThinkingLevelSupported`, `resolveSupportedThinkingLevel`, `listThinkingLevels`, `resolveThinkingDefaultForModel`, …). Generalizing the **existing** `api === "anthropic-messages"` fallback here covers exactly the same surface as a dispatcher-level fix with less blast radius, no new internals, and net 5 lines of logic.

The default-level path (no explicit `--thinking`) goes through the same chokepoint and reads `profile.defaultLevel`, so it's covered automatically.

## Non-regressions

- Non-Claude model on an `anthropic-messages` row → `resolveClaudeThinkingProfile` returns the Claude base set, which is identical to the existing `BASE_THINKING_LEVELS`; `reasoning:false` rows still collapse to off-only via the existing guard.
- A Claude-looking id on a non-Anthropic transport (e.g. `openai-completions`) → `context.api !== "anthropic-messages"`, so the fallback is `undefined` and behavior is unchanged.

## Test plan

- [x] New unit tests in `src/auto-reply/thinking.test.ts` covering: (1) Claude Opus xhigh exposed on a custom `anthropic-messages` provider without a plugin profile, (2) non-Claude model on `anthropic-messages` does **not** gain xhigh, (3) Claude-looking id on an `openai-completions` row does **not** infer the Claude profile.
- [x] Existing regression suites pass: `auto-reply/thinking.test.ts`, `plugin-sdk/provider-model-shared.test.ts`, `plugins/provider-thinking.test.ts`, `plugins/provider-public-artifacts.test.ts`, `extensions/anthropic/provider-policy-api.test.ts`, plus `agents/agent-command.live-model-switch.test.ts` and `agents/cli-runner.reliability.test.ts`.
- [x] `oxlint` clean on touched files.
- [x] `pnpm build` ✓ green (130.4s).

## Real behavior proof

- **Behavior or issue addressed:** Custom provider `jdcloud-anthropic` fronting Claude Opus over the native `anthropic-messages` adapter silently clamped `--thinking xhigh` to `off` because the bundled anthropic plugin's policy surface is keyed by provider id. After this fix, `xhigh`/`adaptive`/`max` survive level resolution on any `anthropic-messages` catalog row whose `reasoning` flag is true.
- **Real environment tested:** Local macOS Darwin 25.4.0 (arm64), Node v26, pnpm workspace at `~/Code/openclaw` checked out at PR head `450527b`. Catalog input mirrors the reporter's actual `jdcloud-anthropic` config from issue #91975 (provider id `jdcloud-anthropic`, three Claude Opus rows on `api: "anthropic-messages"` with mixed `reasoning` flags).
- **Exact steps or command run after fix:**
  ```
  cd ~/Code/openclaw
  pnpm exec tsx scripts/proof-thinking-anthropic-messages.mts
  ```
  The harness is committed in this PR (`scripts/proof-thinking-anthropic-messages.mts`) and loads the patched `resolveThinkingProfile`/`listThinkingLevels`/`resolveSupportedThinkingLevel` directly from `src/auto-reply/thinking.ts`, then probes the exact reported provider/model triple against `--thinking xhigh` (and `max` on 4.8).
- **Evidence after fix:** Live terminal output captured from the run above:
  ```
  jdcloud-anthropic/Claude-Opus-4.7  reasoning=false --thinking xhigh  ->  resolved=off  supported=false
    levels: [off]
  jdcloud-anthropic/Claude-Opus-4.7-hq  reasoning=true --thinking xhigh  ->  resolved=xhigh  supported=true
    levels: [off,minimal,low,medium,adaptive,high,xhigh,max]
  jdcloud-anthropic/Claude-Opus-4.8  reasoning=true --thinking xhigh  ->  resolved=xhigh  supported=true
    levels: [off,minimal,low,medium,adaptive,high,xhigh,max]
  jdcloud-anthropic/Claude-Opus-4.8  reasoning=true --thinking max  ->  resolved=max  supported=true
    levels: [off,minimal,low,medium,adaptive,high,xhigh,max]
  ```
- **Observed result after fix:** The exact symptom from #91975 is fixed end-to-end on the live code path. `--thinking xhigh` resolves to `xhigh` (not `off`) on `Claude-Opus-4.7-hq` and `Claude-Opus-4.8`; `max` also resolves to `max` on 4.8. `Claude-Opus-4.7` (`reasoning: false`) correctly stays off-only via the pre-existing reasoning guard, confirming the fallback didn't widen non-thinking rows. Level lists now expose `[off,minimal,low,medium,adaptive,high,xhigh,max]` on the thinking-capable rows, matching the bundled anthropic plugin's policy surface.
- **What was not tested:** End-to-end network round-trip to a real jdcloud Anthropic-compatible endpoint with `--thinking xhigh` is out of scope here — that depends on the upstream API accepting the thinking payload and is independent of the OpenClaw clamp this PR fixes. The unit tests + this live proof together verify the clamp logic on the exact reporter input.
