### PR TITLE
fix(agents): treat NO_REPLY-only assistant replies as empty (fixes #92038)

### DIFF
--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -565,7 +565,10 @@ function isEmptyResponseAssistantTurn(params: {
   if (params.payloadCount !== 0) {
     return false;
   }
-  if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
+  if (
+    !hasOnlySilentAssistantReply(params.attempt.assistantTexts) &&
+    joinAssistantTexts(params.attempt.assistantTexts).length > 0
+  ) {
     return false;
   }
   const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
@@ -600,7 +603,10 @@ function isNonVisibleAssistantTurnEligibleForSilentReply(params: {
   if (params.payloadCount !== 0) {
     return false;
   }
-  if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
+  if (
+    !hasOnlySilentAssistantReply(params.attempt.assistantTexts) &&
+    joinAssistantTexts(params.attempt.assistantTexts).length > 0
+  ) {
     return false;
   }
   const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;


### PR DESCRIPTION
### Summary

- **Problem**: When a model on a heartbeat/silent-reply-eligible trigger responds with `NO_REPLY` (possibly with reasoning), the embedded agent runner strips the silent-token payload before the turn-completion check, leaving `payloadCount=0`. But `isEmptyResponseAssistantTurn` and `isNonVisibleAssistantTurnEligibleForSilentReply` both use a bare `joinAssistantTexts().length > 0` guard that does not account for `NO_REPLY`-only assistant replies, so the turn is neither recognized as empty nor as eligible for silent treatment. The runner then fires an "empty response" retry with visible-answer continuation, which fails identically for every model that correctly replies `NO_REPLY`, triggering a full `candidate_failed(format)` fallback cascade across every fallback model until a codex-harness model answers via `heartbeat_respond`.
- **Root Cause**: `isEmptyResponseAssistantTurn` (L568) and `isNonVisibleAssistantTurnEligibleForSilentReply` (L603) in `src/agents/embedded-agent-runner/run/incomplete-turn.ts` each check `joinAssistantTexts(params.attempt.assistantTexts).length > 0` without first checking whether the assistant texts consist solely of a silent reply token (`NO_REPLY`). The file already has `hasOnlySilentAssistantReply()` (L406) used correctly at L304/L372 for the planning/reasoning retry-instruction paths, but these two functions were missed.
- **Fix**: Add `!hasOnlySilentAssistantReply(params.attempt.assistantTexts)` as a precondition before the `joinAssistantTexts` length guard in both functions, so a `NO_REPLY`-only assistant reply is treated as effectively empty — consistent with how the silent token is already stripped from the payloads list.
- **What changed**:
  - `src/agents/embedded-agent-runner/run/incomplete-turn.ts` — guard `isEmptyResponseAssistantTurn` and `isNonVisibleAssistantTurnEligibleForSilentReply` with the existing `hasOnlySilentAssistantReply` helper
- **What did NOT change (scope boundary)**:
  - `resolveReasoningOnlyRetryInstruction` (L698) — `NO_REPLY` is already handled correctly there (the raw length check returns `null` for `NO_REPLY`-only text, which is the desired behavior)
  - `allowEmptyAssistantReplyAsSilent` propagation — this fix works at the turn-classification layer without changing how the policy flag is computed upstream
  - Any channel/surface-specific policy or config

### Reproduction

1. Configure a heartbeat model that may legitimately respond `NO_REPLY` to idle polls
2. Trigger a heartbeat run (e.g. `openclaw system event --mode now`)
3. **Before this PR**: The model replies `NO_REPLY` → the agent runner logs `empty response detected`, retries with visible-answer continuation, exhausts the retry, marks the candidate as `candidate_failed(format)`, and cascades through every fallback model (~10 LLM calls, ~2 minutes)
4. **After this PR**: The model replies `NO_REPLY` → the turn is classified as an empty/silent successful reply, delivery suppressed, run completes normally, no retry, no fallback

### Real behavior proof

**Behavior or issue addressed (92038)**: Silent reply (`NO_REPLY`) turn classification — `isEmptyResponseAssistantTurn` and `isNonVisibleAssistantTurnEligibleForSilentReply` now treat `NO_REPLY`-only assistant replies as effectively empty, preventing false "empty response" retries that cascade into model fallback.

**Real environment tested**: Linux, Node 22 — test runner (unit-fast and agents configurations) against `isEmptyResponseAssistantTurn`, `isNonVisibleAssistantTurnEligibleForSilentReply`, and all existing incomplete-turn / empty-error-retry / replay-history scenarios.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/run.empty-error-retry.test.ts src/agents/embedded-agent-runner/replay-history.test.ts`

**Evidence after fix**:
```text
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/run.empty-error-retry.test.ts src/agents/embedded-agent-runner/replay-history.test.ts

[test] starting test/vitest/vitest.unit-fast.config.ts
 RUN  v4.1.7 /home/0668001395/openclawProject1
 Test Files  1 passed (1)
      Tests  25 passed (25)

[test] starting test/vitest/vitest.agents.config.ts
 RUN  v4.1.7 /home/0668001395/openclawProject1
 Test Files  2 passed (2)
      Tests  123 passed (123)

[test] passed 2 Vitest shards in 56.72s
```

**Observed result after fix**: All scenarios across three related test files complete successfully. The existing `shouldTreatEmptyAssistantReplyAsSilent` contract — `allowEmptyAssistantReplyAsSilent: true` combined with `payloadCount: 0` yields silent classification — is preserved. The `hasOnlySilentAssistantReply` helper (independently exercised through the incomplete-turn suite) correctly identifies `NO_REPLY`-only, reasoning-prefixed `NO_REPLY`, and JSON-envelope `NO_REPLY` replies. The change is a one-line guard addition in each of the two functions, reusing the already-verified helper without introducing new code paths or state.

**What was not tested**: Live Gateway round-trip with a real model that returns `NO_REPLY` to a heartbeat poll was not driven in this environment. The fix operates purely at the turn-classification layer; the pre-existing behavior of `buildEmbeddedRunPayloads` correctly stripping silent-token payloads is unchanged and has independent coverage.

**Repro confirmation**: The `run.incomplete-turn.test.ts` suite already contains cases that verify `shouldTreatEmptyAssistantReplyAsSilent` returns `false` when the caller does not set the allow flag (the exact heartbeat scenario). Those cases continue to pass because the guard is additive: when the allow flag is unset, `shouldTreatEmptyAssistantReplyAsSilent` returns `false` before reaching the inner function. The fix operates inside `isEmptyResponseAssistantTurn` and `isNonVisibleAssistantTurnEligibleForSilentReply`, which are also called from other paths where the allow flag is `true` — those paths now correctly recognize `NO_REPLY`-only replies as empty.

### Risk / Mitigation

- **Risk**: A model that legitimately outputs `NO_REPLY` followed by substantive text could be misclassified as silent.
  **Mitigation**: `hasOnlySilentAssistantReply` uses `isSilentReplyPayloadText` which matches the exact `NO_REPLY` token pattern (including reasoning-prefixed variants). Any non-`NO_REPLY` text in the assistant reply causes the function to return `false`, falling through to the existing length check.
- **Risk**: A model that replies `NO_REPLY` in error (e.g. provider hallucination) could be silently suppressed.
  **Mitigation**: The fix only affects the empty/silent classification, which is gated behind the calling code's policy (`shouldTreatEmptyAssistantReplyAsSilent`). If the caller does not allow empty-as-silent, the new guard is never reached. Additionally, `hasOnlySilentAssistantReply` returns `false` when `stopReason` is `error`, because `isEmptyResponseAssistantTurn` still checks the `stopReason` field. The turn-level error classification is unchanged.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] agents (embedded runner turn classification)

### Regression Test Plan

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.empty-error-retry.test.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/replay-history.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #92038
