### PR TITLE
fix(ui): collapse duplicate assistant groups during segmented streaming

### DIFF
--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -6,7 +6,7 @@ import type { MessageGroup } from "../types/chat-types.ts";
 import {
   formatChatTimestampForDisplay,
   renderMessageGroup,
-  renderStreamingGroup,
+  renderStreamGroup,
   resetAssistantAttachmentAvailabilityCacheForTest,
 } from "./grouped-render.ts";
 import { normalizeMessage } from "./message-normalizer.ts";
@@ -880,7 +880,18 @@ describe("grouped chat rendering", () => {
     expect(time?.textContent?.trim()).toBe(display.label);
     expect(time?.getAttribute("title")).toBe(display.title);
 
-    render(renderStreamingGroup("Working", timestamp), container);
+    render(
+      renderStreamGroup([
+        {
+          kind: "stream",
+          key: `stream:${timestamp}`,
+          text: "Working",
+          startedAt: timestamp,
+          isStreaming: true,
+        },
+      ]),
+      container,
+    );
 
     const streamingTime = container.querySelector<HTMLTimeElement>(".chat-group-timestamp");
     expect(streamingTime?.textContent?.trim()).toBe(display.label);
@@ -889,7 +900,18 @@ describe("grouped chat rendering", () => {
   it("omits streaming bubble class for completed stream segments", () => {
     const container = document.createElement("div");
 
-    render(renderStreamingGroup("Completed segment", 1, false), container);
+    render(
+      renderStreamGroup([
+        {
+          kind: "stream",
+          key: "stream:1",
+          text: "Completed segment",
+          startedAt: 1,
+          isStreaming: false,
+        },
+      ]),
+      container,
+    );
 
     const bubble = container.querySelector(".chat-bubble");
     expect(bubble?.classList.contains("streaming")).toBe(false);
@@ -901,13 +923,65 @@ describe("grouped chat rendering", () => {
     streamingMarkdownRenderMock.mockClear();
     streamingTextRenderMock.mockClear();
 
-    render(renderStreamingGroup("**live**\nreply", 1), container);
+    render(
+      renderStreamGroup([
+        {
+          kind: "stream",
+          key: "stream:1",
+          text: "**live**\nreply",
+          startedAt: 1,
+          isStreaming: true,
+        },
+      ]),
+      container,
+    );
 
     expect(markdownRenderMock).not.toHaveBeenCalled();
     expect(streamingTextRenderMock).not.toHaveBeenCalled();
     expect(streamingMarkdownRenderMock).toHaveBeenCalledWith("**live**\nreply", undefined);
     const text = container.querySelector(".streaming-markdown");
     expect(text?.textContent).toBe("**live**\nreply");
+  });
+
+  it("renders a multi-segment stream run as one group with one avatar/footer", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderStreamGroup([
+        { kind: "stream", key: "stream-seg:s:0", text: "first", startedAt: 20, isStreaming: false },
+        {
+          kind: "stream",
+          key: "stream-seg:s:1",
+          text: "second",
+          startedAt: 10,
+          isStreaming: false,
+        },
+        { kind: "stream", key: "stream:s:live", text: "third", startedAt: 30, isStreaming: true },
+      ]),
+      container,
+    );
+
+    expect(container.querySelectorAll(".chat-group.assistant")).toHaveLength(1);
+    expect(container.querySelectorAll(".chat-avatar.assistant")).toHaveLength(1);
+    expect(container.querySelectorAll(".chat-group-footer")).toHaveLength(1);
+    // One bubble per segment, all under the single group.
+    expect(container.querySelectorAll(".chat-bubble")).toHaveLength(3);
+    // Footer time anchors to the earliest segment start, not render order.
+    const display = formatChatTimestampForDisplay(10);
+    expect(container.querySelector(".chat-group-timestamp")?.textContent?.trim()).toBe(
+      display.label,
+    );
+  });
+
+  it("renders a reading-indicator-only run as one group with no footer", () => {
+    const container = document.createElement("div");
+
+    render(renderStreamGroup([{ kind: "reading-indicator", key: "reading" }]), container);
+
+    expect(container.querySelectorAll(".chat-group.assistant")).toHaveLength(1);
+    expect(container.querySelectorAll(".chat-avatar.assistant")).toHaveLength(1);
+    expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
+    expect(container.querySelector(".chat-group-footer")).toBeNull();
   });
 
   it("renders configured local user names", () => {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -12,6 +12,7 @@ import type { SidebarContent } from "../sidebar-content.ts";
 import { detectTextDirection } from "../text-direction.ts";
 import { resolveToolDisplay } from "../tool-display.ts";
 import type {
+  ChatItem,
   MessageContentItem,
   MessageGroup,
   NormalizedMessage,
@@ -351,54 +352,61 @@ function extractTranscriptAttachments(message: unknown): AttachmentItem[] {
   return attachments;
 }
 
-export function renderReadingIndicatorGroup(
-  assistant?: AssistantIdentity,
-  basePath?: string,
-  authToken?: string | null,
-) {
+/** A contiguous run of in-flight streaming items rendered under one assistant group. */
+export type StreamGroupPart = Extract<ChatItem, { kind: "stream" } | { kind: "reading-indicator" }>;
+
+type StreamGroupOptions = {
+  onOpenSidebar?: (content: SidebarContent) => void;
+  assistant?: AssistantIdentity;
+  basePath?: string;
+  authToken?: string | null;
+};
+
+function renderReadingIndicatorBubble() {
   return html`
-    <div class="chat-group assistant">
-      ${renderChatAvatar("assistant", assistant, undefined, basePath, authToken)}
-      <div class="chat-group-messages">
-        <div class="chat-bubble chat-reading-indicator" aria-hidden="true">
-          <span class="chat-reading-indicator__dots">
-            <span></span><span></span><span></span>
-          </span>
-        </div>
-      </div>
+    <div class="chat-bubble chat-reading-indicator" aria-hidden="true">
+      <span class="chat-reading-indicator__dots"> <span></span><span></span><span></span> </span>
     </div>
   `;
 }
 
-export function renderStreamingGroup(
-  text: string,
-  startedAt: number,
-  isStreaming = true,
-  onOpenSidebar?: (content: SidebarContent) => void,
-  assistant?: AssistantIdentity,
-  basePath?: string,
-  authToken?: string | null,
-) {
+// One assistant group per contiguous run of streaming items: a reply that
+// arrives as several stream segments renders under a single avatar/footer
+// instead of flashing a separate avatar+bubble per segment (#63956).
+export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOptions = {}) {
+  const { onOpenSidebar, assistant, basePath, authToken } = opts;
   const name = assistant?.name ?? "Assistant";
+  // Footer (sender + time) anchors to the earliest streamed segment; a run that
+  // is only the reading indicator has no timestamp and therefore no footer.
+  const streamStarts = parts.flatMap((part) => (part.kind === "stream" ? [part.startedAt] : []));
+  const footerStartedAt = streamStarts.length > 0 ? Math.min(...streamStarts) : null;
 
   return html`
     <div class="chat-group assistant">
       ${renderChatAvatar("assistant", assistant, undefined, basePath, authToken)}
       <div class="chat-group-messages">
-        ${renderGroupedMessage(
-          {
-            role: "assistant",
-            content: [{ type: "text", text }],
-            timestamp: startedAt,
-          },
-          `stream:${startedAt}`,
-          { isStreaming, showReasoning: false },
-          onOpenSidebar,
+        ${parts.map((part) =>
+          part.kind === "reading-indicator"
+            ? renderReadingIndicatorBubble()
+            : renderGroupedMessage(
+                {
+                  role: "assistant",
+                  content: [{ type: "text", text: part.text }],
+                  timestamp: part.startedAt,
+                },
+                part.key,
+                { isStreaming: part.isStreaming, showReasoning: false },
+                onOpenSidebar,
+              ),
         )}
-        <div class="chat-group-footer">
-          <span class="chat-sender-name">${name}</span>
-          ${renderChatTimestamp(startedAt)}
-        </div>
+        ${footerStartedAt !== null
+          ? html`
+              <div class="chat-group-footer">
+                <span class="chat-sender-name">${name}</span>
+                ${renderChatTimestamp(footerStartedAt)}
+              </div>
+            `
+          : nothing}
       </div>
     </div>
   `;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -20,6 +20,7 @@ import { renderWelcomeState } from "../chat/chat-welcome.ts";
 import { renderChatSessionSelect } from "../chat/session-controls.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type { GatewaySessionRow, ModelCatalogEntry, SessionsListResult } from "../types.ts";
+import type { ChatItem, MessageGroup } from "../types/chat-types.ts";
 import type { ChatAttachment, ChatQueueItem } from "../ui-types.ts";
 import { renderChat, resetChatViewState } from "./chat.ts";
 
@@ -146,16 +147,20 @@ vi.mock("../chat/build-chat-items.ts", () => ({
 vi.mock("../chat/grouped-render.ts", () => ({
   getAssistantAttachmentAvailabilityRenderVersion: () => assistantAttachmentRenderVersionMock.value,
   renderMessageGroup: renderMessageGroupMock,
-  renderReadingIndicatorGroup: () => {
-    const element = document.createElement("div");
-    element.className = "chat-reading-indicator";
-    return element;
-  },
-  renderStreamingGroup: (text: string) => {
-    const element = document.createElement("div");
-    element.className = "chat-stream";
-    element.textContent = text;
-    return element;
+  renderStreamGroup: (parts: Array<{ kind: string; text?: string }>) => {
+    const group = document.createElement("div");
+    group.className = "chat-stream-run";
+    for (const part of parts) {
+      const bubble = document.createElement("div");
+      if (part.kind === "reading-indicator") {
+        bubble.className = "chat-reading-indicator";
+      } else {
+        bubble.className = "chat-stream";
+        bubble.textContent = part.text ?? "";
+      }
+      group.appendChild(bubble);
+    }
+    return group;
   },
 }));
 
@@ -1182,6 +1187,46 @@ describe("chat loading skeleton", () => {
 
     expect(container.querySelector(".chat-loading-skeleton")).toBeNull();
     expect(container.querySelectorAll(".chat-reading-indicator")).toHaveLength(1);
+  });
+
+  it("folds adjacent streaming items into one group and lets a message group break the run (#63956)", () => {
+    const items: Array<ChatItem | MessageGroup> = [
+      {
+        kind: "stream",
+        key: "stream-seg:main:0",
+        text: "alpha",
+        startedAt: 10,
+        isStreaming: false,
+      },
+      { kind: "stream", key: "stream-seg:main:1", text: "beta", startedAt: 20, isStreaming: false },
+      { kind: "reading-indicator", key: "reading:main" },
+      {
+        kind: "group",
+        key: "group:assistant:test",
+        role: "assistant",
+        messages: [{ key: "m0", message: { content: "tool break" } }],
+        timestamp: 25,
+        isStreaming: false,
+      },
+      { kind: "stream", key: "stream:main:live", text: "gamma", startedAt: 30, isStreaming: true },
+    ];
+    buildChatItemsMock.mockReturnValueOnce(
+      items as unknown as ReturnType<typeof buildChatItemsMock>,
+    );
+
+    const container = renderChatView({ stream: "gamma", streamStartedAt: 30 });
+
+    // Two contiguous streaming runs, split by the message group between them.
+    const runs = container.querySelectorAll(".chat-stream-run");
+    expect(runs).toHaveLength(2);
+    // First run folds both committed segments plus the trailing reading indicator.
+    expect(runs[0]?.querySelectorAll(".chat-stream")).toHaveLength(2);
+    expect(runs[0]?.querySelectorAll(".chat-reading-indicator")).toHaveLength(1);
+    // The message group stays its own group and breaks the run.
+    expect(container.querySelectorAll(".chat-group")).toHaveLength(1);
+    // The live segment after the group forms the second run.
+    expect(runs[1]?.querySelectorAll(".chat-stream")).toHaveLength(1);
+    expect(container.querySelectorAll(".chat-stream")).toHaveLength(3);
   });
 
   it("shows prompt-bar progress while the current session send is awaiting acknowledgement", () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -25,8 +25,8 @@ import { exportChatMarkdown } from "../chat/export.ts";
 import {
   getAssistantAttachmentAvailabilityRenderVersion,
   renderMessageGroup,
-  renderReadingIndicatorGroup,
-  renderStreamingGroup,
+  renderStreamGroup,
+  type StreamGroupPart,
 } from "../chat/grouped-render.ts";
 import { CHAT_HISTORY_RENDER_LIMIT } from "../chat/history-limits.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "../chat/input-history.ts";
@@ -582,6 +582,37 @@ function buildCachedChatItems(input: BuildChatItemsProps): ReturnType<typeof bui
   cached.input = input;
   cached.items = items;
   return items;
+}
+
+type RenderChatItem = ReturnType<typeof buildChatItems>[number];
+type StreamRunRenderItem = { kind: "stream-run"; key: string; parts: StreamGroupPart[] };
+
+// Fold each contiguous run of in-flight stream/reading-indicator items into a
+// single group so segmented replies render under one assistant avatar instead
+// of one bubble per segment (#63956). Any message/group/divider breaks the run,
+// so interleaved tool calls keep their own groups.
+function coalesceStreamRuns(
+  items: ReturnType<typeof buildChatItems>,
+): Array<RenderChatItem | StreamRunRenderItem> {
+  const result: Array<RenderChatItem | StreamRunRenderItem> = [];
+  let run: StreamGroupPart[] = [];
+  const flush = () => {
+    const [first] = run;
+    if (first) {
+      result.push({ kind: "stream-run", key: `stream-run:${first.key}`, parts: run });
+      run = [];
+    }
+  };
+  for (const item of items) {
+    if (item.kind === "stream" || item.kind === "reading-indicator") {
+      run.push(item);
+      continue;
+    }
+    flush();
+    result.push(item);
+  }
+  flush();
+  return result;
 }
 
 function deletedChatItemsSignature(
@@ -1750,7 +1781,7 @@ export function renderChat(props: ChatProps) {
           ],
           () =>
             repeat(
-              chatItems,
+              coalesceStreamRuns(chatItems),
               (item) => item.key,
               (item) => {
                 if (item.kind === "divider") {
@@ -1787,23 +1818,13 @@ export function renderChat(props: ChatProps) {
                     </div>
                   `;
                 }
-                if (item.kind === "reading-indicator") {
-                  return renderReadingIndicatorGroup(
-                    assistantIdentity,
-                    props.basePath,
-                    props.assistantAttachmentAuthToken ?? null,
-                  );
-                }
-                if (item.kind === "stream") {
-                  return renderStreamingGroup(
-                    item.text,
-                    item.startedAt,
-                    item.isStreaming,
-                    props.onOpenSidebar,
-                    assistantIdentity,
-                    props.basePath,
-                    props.assistantAttachmentAuthToken ?? null,
-                  );
+                if (item.kind === "stream-run") {
+                  return renderStreamGroup(item.parts, {
+                    onOpenSidebar: props.onOpenSidebar,
+                    assistant: assistantIdentity,
+                    basePath: props.basePath,
+                    authToken: props.assistantAttachmentAuthToken ?? null,
+                  });
                 }
                 if (item.kind === "group") {
                   if (deleted.has(item.key)) {


### PR DESCRIPTION
## Summary

- During a streaming reply, Control UI rendered each in-flight stream segment as its
  own top-level assistant group, so a segmented reply flashed a separate avatar +
  footer per segment and collapsed into one group on completion (#63956). Segments
  arise around tool-call boundaries / stream reconciliation
  (`ui/src/ui/app-tool-stream.ts`, `ui/src/ui/chat/stream-reconciliation.ts`), not
  ordinary token chunks.
- This folds a contiguous run of in-flight `stream` / `reading-indicator` items into a
  single assistant group — one avatar, one footer, segments stacked as bubbles inside.
- Scope: this removes the repeated assistant groups/avatars/footers. It does **not**
  merge the per-segment bubbles into a single bubble — segments remain distinct bubbles
  within the one group (as multi-part turns already render). Render-layer only: the
  shared `ChatItem` types and `build-chat-items.ts` are untouched, and a
  `message`/`group`/`divider` breaks the run so interleaved tool calls keep their own
  groups.
- What success looks like: streaming a multi-segment reply shows one assistant avatar
  updating in place, not a new avatar per segment.

## Linked context

Closes #63956

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Control UI streaming reply showed multiple assistant
  avatars/footers (one per stream segment) that collapse into one group on completion.
- Real environment tested: the Control UI render path (`renderChat` → `renderStreamGroup`)
  rendered with a multi-segment streaming reply, in jsdom and in a headless Chromium
  against the production components and production `ui/src/styles.css`.
- Exact steps or command run after this patch: rendered a 3-segment streaming reply
  through the production render path and counted the resulting assistant groups/avatars,
  before vs after the change.
- Evidence after fix (copied runtime DOM output from the production render path):
  ```
  BEFORE (3 assistant groups):
    group#1: avatars=1 footers=1 bubbles=["Sure — here's the plan."]
    group#2: avatars=1 footers=1 bubbles=["First we group the streamed segments together."]
    group#3: avatars=1 footers=1 bubbles=["Then they all render inside one assistant bubble…"]
  AFTER (1 assistant groups):
    group#1: avatars=1 footers=1 bubbles=["Sure — here's the plan.","First we group the streamed segments together.","Then they all render inside one assistant bubble…"]
  ```
  A rendered before/after screenshot (real components + CSS) is available on request.
- Observed result after fix: the segments render in a single assistant group with one
  avatar and one footer instead of a separate avatar+footer per segment; the live
  segment updates in place. Each segment remains its own bubble within the group — this
  fixes the duplicated avatars/groups, not the per-segment bubble count.
- What was not tested: a live gateway streaming from a real model (e.g. the reporter's
  minimax/openrouter chain).
- Proof limitations or environment constraints: no streaming-model credentials in this
  environment, so the multi-segment stream was reproduced by driving the production
  render components directly (jsdom + headless Chromium) rather than via a live
  end-to-end send.
- Before evidence: see the BEFORE block above (3 separate assistant groups, 3 avatars).

## Tests and validation

- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts ui/src/ui/chat/grouped-render.test.ts ui/src/ui/chat/build-chat-items.test.ts` → 195 passed
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json` and `-p tsconfig.core.json` → clean
- `node scripts/run-oxlint.mjs` (changed files) → clean; `oxfmt --check` → clean
- Added regression coverage: `chat.test.ts` asserts adjacent stream items fold into one
  group and a `message` group breaks the run; `grouped-render.test.ts` asserts the
  helper emits one `.chat-group.assistant` / avatar / footer with N bubbles, and a
  reading-indicator-only run has no footer.
- Before this fix, the render loop mapped each `stream` item to its own
  `renderStreamingGroup`, producing N top-level assistant groups.

## Risk checklist

- Did user-visible behavior change? Yes — segmented streaming replies render as one
  grouped assistant block (one avatar/footer) instead of one group per segment.
- Did config, environment, or migration behavior change? No.
- Did security, auth, secrets, network, or tool execution behavior change? No.
- Highest-risk area: the run-grouping boundary in `coalesceStreamRuns`.
- How is that risk mitigated? Only adjacent `stream`/`reading-indicator` items fold;
  any `message`/`group`/`divider` breaks the run (covered by the `chat.test.ts`
  regression that interleaves a group between segments).

## Current review state

- Next action: maintainer review.
- Waiting on: nothing from author; CI + review.
- A pre-merge cross-agent review (Codex) found no code blockers and confirmed segments
  are tool-boundary/reconciliation artifacts, so the render-layer fold is the
  appropriately-scoped fix.

<sub>AI-assisted.</sub>
