### PR TITLE
fix(memory): honor configured qmd search timeouts

### DIFF
--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -184,6 +184,76 @@ describe("memory_search unavailable payloads", () => {
     }
   });
 
+  it("honors configured qmd timeout budgets for slow successful searches", async () => {
+    vi.useFakeTimers();
+    try {
+      setMemoryBackend("qmd");
+      setMemorySearchImpl(
+        async () =>
+          await new Promise((resolve) => {
+            setTimeout(
+              () =>
+                resolve([
+                  {
+                    path: "MEMORY.md",
+                    startLine: 1,
+                    endLine: 1,
+                    score: 0.9,
+                    snippet: "Slow QMD hit.",
+                    source: "memory" as const,
+                  },
+                ]),
+              20_000,
+            );
+          }),
+      );
+      const tool = createMemorySearchToolOrThrow({
+        config: asOpenClawConfig({
+          agents: { list: [{ id: "main", default: true }] },
+          memory: { backend: "qmd", qmd: { limits: { timeoutMs: 30_000 } } },
+        }),
+      });
+
+      const resultPromise = tool.execute("slow-qmd-success", { query: "hello" });
+      await vi.advanceTimersByTimeAsync(20_000);
+      const result = await resultPromise;
+
+      expect((result.details as { results?: Array<{ path: string }> }).results?.[0]?.path).toBe(
+        "MEMORY.md",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out qmd searches after the configured timeout plus bounded overhead", async () => {
+    vi.useFakeTimers();
+    try {
+      setMemoryBackend("qmd");
+      setMemorySearchImpl(async () => await new Promise(() => {}));
+      const tool = createMemorySearchToolOrThrow({
+        config: asOpenClawConfig({
+          agents: { list: [{ id: "main", default: true }] },
+          memory: { backend: "qmd", qmd: { limits: { timeoutMs: 30_000 } } },
+        }),
+      });
+
+      const resultPromise = tool.execute("slow-qmd-timeout", { query: "hello" });
+      await vi.advanceTimersByTimeAsync(34_999);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await resultPromise;
+
+      expectUnavailableMemorySearchDetails(result.details, {
+        error: "memory_search timed out after 35s",
+        warning: "Memory search is unavailable due to an embedding/provider error.",
+        action: "Check embedding provider configuration and retry memory_search.",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("re-resolves the manager once when a cached sqlite handle was closed", async () => {
     let searchCalls = 0;
     setMemorySearchImpl(async () => {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -45,6 +45,7 @@ type MemorySearchToolResult =
   | MemoryCorpusSearchResult;
 
 const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 15_000;
+const MEMORY_SEARCH_TOOL_QMD_TIMEOUT_OVERHEAD_MS = 5_000;
 const MEMORY_SEARCH_TOOL_COOLDOWN_MS = 60_000;
 
 const memorySearchToolCooldowns = new Map<string, { until: number; error: string }>();
@@ -80,6 +81,24 @@ export const testing = {
     memorySearchToolCooldowns.clear();
   },
 } as const;
+
+function resolveMemorySearchToolTimeoutMs(params: {
+  backend: string | undefined;
+  qmdTimeoutMs: number | undefined;
+}): number {
+  if (
+    params.backend !== "qmd" ||
+    typeof params.qmdTimeoutMs !== "number" ||
+    !Number.isFinite(params.qmdTimeoutMs) ||
+    params.qmdTimeoutMs <= 0
+  ) {
+    return MEMORY_SEARCH_TOOL_TIMEOUT_MS;
+  }
+  return Math.max(
+    MEMORY_SEARCH_TOOL_TIMEOUT_MS,
+    Math.floor(params.qmdTimeoutMs) + MEMORY_SEARCH_TOOL_QMD_TIMEOUT_OVERHEAD_MS,
+  );
+}
 
 async function runMemorySearchToolWithDeadline<T>(params: {
   timeoutMs: number;
@@ -345,6 +364,8 @@ export function createMemorySearchTool(options: {
     execute:
       ({ cfg, agentId }) =>
       async (_toolCallId, params) => {
+        const { resolveMemoryBackendConfig } = await loadMemoryToolRuntime();
+        const resolvedMemoryBackend = resolveMemoryBackendConfig({ cfg, agentId });
         const rawParams = asToolParamsRecord(params);
         const query = readStringParam(rawParams, "query", { required: true });
         const maxResults = readPositiveIntegerParam(rawParams, "maxResults");
@@ -381,9 +402,11 @@ export function createMemorySearchTool(options: {
         };
 
         const outcome = await runMemorySearchToolWithDeadline({
-          timeoutMs: MEMORY_SEARCH_TOOL_TIMEOUT_MS,
+          timeoutMs: resolveMemorySearchToolTimeoutMs({
+            backend: resolvedMemoryBackend.backend,
+            qmdTimeoutMs: resolvedMemoryBackend.qmd?.limits?.timeoutMs,
+          }),
           run: async () => {
-            const { resolveMemoryBackendConfig } = await loadMemoryToolRuntime();
             const shouldQuerySupplements = requestedCorpus === "wiki" || requestedCorpus === "all";
             const shouldQueryMemory = requestedCorpus !== "wiki" && !cooldown;
             if (cooldown && !shouldQuerySupplements) {
@@ -502,10 +525,12 @@ export function createMemorySearchTool(options: {
                 }
                 const status = activeMemory.manager.status();
                 const decorated = decorateCitations(rawResults, includeCitations);
-                const resolved = resolveMemoryBackendConfig({ cfg, agentId });
                 const memoryResults =
                   status.backend === "qmd"
-                    ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
+                    ? clampResultsByInjectedChars(
+                        decorated,
+                        resolvedMemoryBackend.qmd?.limits?.maxInjectedChars,
+                      )
                     : decorated;
                 surfacedMemoryResults = memoryResults.map((result) => ({
                   ...result,


### PR DESCRIPTION
## Summary\n- derive the memory_search tool deadline from the configured QMD timeout when the qmd backend is active\n- keep a bounded wrapper overhead so hung searches still fail cleanly\n- add regression coverage for slow successful QMD searches and timeout behavior\n\n## Testing\n- node scripts/run-vitest.mjs extensions/memory-core/src/tools.test.ts\n\nFixes #91947