### PR TITLE
fix(workboard): let gateway resolve dispatch scopes

### DIFF
--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -143,6 +143,24 @@ describe("registerWorkboardCli", () => {
     expect(after?.metadata?.automation?.dispatchCount).toBeUndefined();
   });
 
+  it("lets gateway runtime choose dispatch scopes", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const program = createProgram(store);
+    gatewayRuntime.callGatewayFromCli.mockResolvedValueOnce({
+      started: [],
+      startFailures: [],
+    });
+
+    await program.parseAsync(["workboard", "dispatch"], { from: "user" });
+
+    expect(gatewayRuntime.callGatewayFromCli).toHaveBeenCalledWith(
+      "workboard.cards.dispatch",
+      expect.objectContaining({ json: false }),
+      { boardId: undefined },
+      { mode: "cli" },
+    );
+  });
+
   it("rejects ambiguous card id prefixes", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const prefix = await createAmbiguousPrefix(store);

--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -88,7 +88,6 @@ async function callWorkboardGateway(
 ): Promise<unknown> {
   return await callGatewayFromCli(method, options, params, {
     mode: "cli",
-    scopes: ["operator.write", "operator.read"],
   });
 }
 


### PR DESCRIPTION
## Summary\n- stop hardcoding workboard dispatch CLI scopes to write/read\n- let the gateway CLI runtime choose scopes for plugin methods it cannot classify locally\n- add coverage that dispatch forwards scope selection to the gateway runtime\n\n## Testing\n- node scripts/run-vitest.mjs extensions/workboard/src/cli.test.ts\n\nFixes #92044