### PR TITLE
fix: handle explicit silent assistant replies

### DIFF
--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -75,6 +75,23 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     expect(result).toBeNull();
   });
 
+  it("does not fallback on deliberate silent terminal replies after payload filtering", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "openai",
+      model: "gpt-5.5",
+      result: {
+        payloads: [],
+        meta: {
+          durationMs: 42,
+          finalAssistantRawText: "NO_REPLY",
+          finalAssistantVisibleText: "NO_REPLY",
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("uses provider-scoped failover matching for business-denial payloads", () => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "openrouter",

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2706,6 +2706,62 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(false);
   });
 
+  it("treats exact NO_REPLY assistant turns as silent only when the caller allows it", () => {
+    const attempt = makeAttemptResult({
+      assistantTexts: ["NO_REPLY"],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [{ type: "text", text: "NO_REPLY" }],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    });
+
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: true,
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBe(true);
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: false,
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats post-tool exact NO_REPLY assistant turns as intentional silence", () => {
+    const attempt = makeAttemptResult({
+      assistantTexts: ["NO_REPLY"],
+      toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [{ type: "text", text: "NO_REPLY" }],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    });
+
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: true,
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBe(true);
+  });
+
   it("does not treat error or side-effect empty turns as silent", () => {
     const errorAttempt = makeAttemptResult({
       assistantTexts: [],
@@ -2715,6 +2771,16 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         provider: "openai",
         model: "gpt-5.5",
         content: [],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    });
+    const silentErrorAttempt = makeAttemptResult({
+      assistantTexts: ["NO_REPLY"],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "error",
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [{ type: "text", text: "NO_REPLY" }],
       } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
     });
     const sideEffectAttempt = makeAttemptResult({
@@ -2749,6 +2815,15 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         aborted: false,
         timedOut: false,
         attempt: errorAttempt,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: true,
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt: silentErrorAttempt,
       }),
     ).toBe(false);
     expect(
@@ -2798,6 +2873,47 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     const onlyCall = runAttemptCall(0);
     expect(onlyCall.prompt).not.toContain(REASONING_ONLY_RETRY_INSTRUCTION);
     expect(onlyCall.prompt).not.toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+    expect(result.payloads).toEqual([{ text: "NO_REPLY" }]);
+    expect(result.meta.terminalReplyKind).toBe("silent-empty");
+    expect(result.meta.livenessState).toBe("working");
+  });
+
+  it("returns NO_REPLY without retrying exact silent assistant replies when silence is allowed", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({
+        assistantTexts: ["NO_REPLY"],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [
+            {
+              type: "thinking",
+              thinking: "internal reasoning",
+              thinkingSignature: JSON.stringify({ id: "rs_exact_silent", type: "reasoning" }),
+            },
+            { type: "text", text: "NO_REPLY" },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      allowEmptyAssistantReplyAsSilent: true,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-exact-silent-assistant-reply",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    const onlyCall = runAttemptCall(0);
+    expect(onlyCall.prompt).not.toContain(REASONING_ONLY_RETRY_INSTRUCTION);
+    expect(onlyCall.prompt).not.toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+    expectNoWarnMessageWith("empty response detected");
+    expectNoWarnMessageWith("incomplete turn detected");
     expect(result.payloads).toEqual([{ text: "NO_REPLY" }]);
     expect(result.meta.terminalReplyKind).toBe("silent-empty");
     expect(result.meta.livenessState).toBe("working");
@@ -2860,6 +2976,54 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.meta.terminalReplyKind).toBeUndefined();
     expect(result.meta.finalAssistantVisibleText).toBe("Visible StepFun answer.");
     expectWarnMessageWith("empty response detected");
+  });
+
+  it("returns NO_REPLY without retrying post-tool exact silent assistant replies", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedResolveModelAsync.mockResolvedValue({
+      model: {
+        id: "step-router-v1",
+        provider: "stepfun",
+        contextWindow: 200000,
+        api: "openai-completions",
+      },
+      error: null,
+      authStorage: {
+        setRuntimeApiKey: vi.fn(),
+      },
+      modelRegistry: {},
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["NO_REPLY"],
+        toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
+        lastAssistant: {
+          role: "assistant",
+          api: "openai-completions",
+          stopReason: "stop",
+          provider: "stepfun",
+          model: "step-router-v1",
+          content: [{ type: "text", text: "NO_REPLY" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      allowEmptyAssistantReplyAsSilent: true,
+      provider: "stepfun",
+      model: "step-router-v1",
+      runId: "run-post-tool-exact-silent-retry",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    const onlyCall = runAttemptCall(0);
+    expect(onlyCall.prompt).not.toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+    expectNoWarnMessageWith("empty response detected");
+    expectNoWarnMessageWith("incomplete turn detected");
+    expect(result.payloads).toEqual([{ text: "NO_REPLY" }]);
+    expect(result.meta.terminalReplyKind).toBe("silent-empty");
+    expect(result.meta.livenessState).toBe("working");
   });
 
   it("keeps retrying and surfacing clean empty assistant turns without the silence flag", async () => {

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -635,7 +635,7 @@ function shouldSkipPlanningOnlyRetry(params: {
   );
 }
 
-/** Allows configured silent handling for replay-safe empty or reasoning-only assistant turns. */
+/** Allows configured silent handling for replay-safe empty, reasoning-only, or explicit silent turns. */
 export function shouldTreatEmptyAssistantReplyAsSilent(params: {
   allowEmptyAssistantReplyAsSilent?: boolean;
   payloadCount: number;
@@ -648,6 +648,14 @@ export function shouldTreatEmptyAssistantReplyAsSilent(params: {
   }
   if (hasCommittedMessagingToolDeliveryEvidence(params.attempt)) {
     return false;
+  }
+  const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
+  if (
+    params.payloadCount === 0 &&
+    assistant?.stopReason !== "error" &&
+    hasOnlySilentAssistantReply(params.attempt.assistantTexts)
+  ) {
+    return true;
   }
   // Post-tool empty stops are ambiguous provider failures, not intentional silence.
   // Let the retry/incomplete-turn paths decide whether replay is safe.


### PR DESCRIPTION
## Summary

- Treat explicit terminal `NO_REPLY` assistant text as the existing successful `silent-empty` outcome when silent replies are allowed.
- Preserve existing safeguards for errored assistant turns, committed delivery, side effects, and genuinely empty post-tool stops.
- Add regression coverage for exact `NO_REPLY` runner behavior, tool-assisted exact `NO_REPLY`, post-tool empty retry behavior, and fallback classification.
- Intentionally out of scope: live Zai/provider credential testing and changing the payload filter itself.

## Linked context

Closes #92038

Related #80535, #71516, #60607, #74034

Requested by maintainer discussion on #92038.

## Real behavior proof (required for external PRs)

Behavior addressed: Exact terminal `NO_REPLY` assistant replies in silent-reply-allowed turns complete as successful silent turns instead of being dropped to an empty terminal result that can trigger retry/fallback handling.

Real environment tested: Local source checkout at `86d3aa2`, isolated temp `OPENCLAW_HOME`/state/config, live OpenAI Responses API, model `openai/gpt-5.5`. Supporting regression proof also ran on Blacksmith Testbox through Crabbox, `provider=blacksmith-testbox`, `id=tbx_01ktterzcbks896dbt2rpg4cv2`, Actions run https://github.com/openclaw/openclaw/actions/runs/27323698215.

Exact steps or command run after this patch: Ran a one-off live embedded-agent turn from this checkout with `runEmbeddedAgent`, `provider: "openai"`, `model: "gpt-5.5"`, `chatType: "group"`, `messageProvider: "discord"`, `allowEmptyAssistantReplyAsSilent: true`, `disableTools: true`, and group/channel silent-reply instructions requiring the final answer to be exactly `NO_REPLY`. The first sandboxed live attempt reached the OpenAI endpoint but failed with `stream disconnected before completion`; rerunning the same isolated proof with approved network escalation succeeded. Supporting Testbox command:

```bash
node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- corepack pnpm exec vitest run src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/result-fallback-classifier.test.ts --testNamePattern "exact NO_REPLY|exact silent assistant replies|post-tool exact silent|post-tool openai-compatible empty stop|error or side-effect empty turns|deliberate silent terminal replies" --reporter dot
```

Evidence after fix: Live provider output from the isolated run:

```json
{
  "provider": "openai",
  "model": "gpt-5.5",
  "payloads": [
    {
      "text": "NO_REPLY"
    }
  ],
  "meta": {
    "terminalReplyKind": "silent-empty",
    "livenessState": "working",
    "finalAssistantRawText": "NO_REPLY",
    "finalAssistantVisibleText": "NO_REPLY",
    "finalPromptTextIncludesEmptyRetry": false
  },
  "logSignals": {
    "emptyResponseDetected": false,
    "incompleteTurnDetected": false,
    "candidateFailedFormat": false,
    "fallback": false
  }
}
```

Observed result after fix: A real provider response containing exact `NO_REPLY` completed as `terminalReplyKind: "silent-empty"` without retrying, without `empty response detected`, without `candidate_failed(format)`, and without fallback. The Testbox run also reported `Test Files 3 passed (3)`, `Tests 17 passed | 232 skipped (249)`, `exitCode=0`, covering exact `NO_REPLY`, tool-assisted exact `NO_REPLY`, post-tool empty retry behavior, errored assistant guard behavior, and fallback classification.

What was not tested: Same-provider Zai/GLM credentials and a real scheduled heartbeat cadence were not exercised. Local env did not have `ZAI_API_KEY`; the live proof exercises the fixed runner path with OpenAI.

Before evidence (optional but encouraged): Before the fix, the exact `NO_REPLY` full-runner regression failed with `expected undefined to deeply equal [ { text: 'NO_REPLY' } ]` because the explicit silent payload was filtered away without setting `terminalReplyKind: "silent-empty"`.

## Tests and validation

- `./node_modules/.bin/vitest run src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/result-fallback-classifier.test.ts --testNamePattern "exact NO_REPLY|exact silent assistant replies|post-tool exact silent|post-tool openai-compatible empty stop|error or side-effect empty turns|deliberate silent terminal replies" --reporter dot` - `3 passed`, `17 passed | 232 skipped`.
- `./node_modules/.bin/vitest run src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/result-fallback-classifier.test.ts --reporter dot` - `3 passed`, `249 passed`.
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean on rerun, no accepted/actionable findings.
- Testbox-through-Crabbox command listed in Real behavior proof.
- One-off live OpenAI embedded-agent proof listed in Real behavior proof.

Regression coverage added:
- helper-level exact `NO_REPLY` silent eligibility
- full-runner exact `NO_REPLY` silent terminal outcome
- tool-assisted exact `NO_REPLY` remains intentional silence
- post-tool empty stop still uses retry behavior
- errored assistant text guard for `NO_REPLY`
- fallback classifier guard for filtered deliberate silence

## Risk checklist

Did user-visible behavior change? (`Yes/No`) Yes

Did config, environment, or migration behavior change? (`Yes/No`) No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) No

What is the highest-risk area? Agent terminal outcome classification for silent replies.

How is that risk mitigated? The change is gated by `allowEmptyAssistantReplyAsSilent`, keeps the existing side-effect/delivery/error safeguards, preserves post-tool empty-stop retry behavior, and covers the regression plus guard paths in tests.

## Current review state

What is the next action? Maintainer review, CI, and ClawSweeper re-review.

What is still waiting on author, maintainer, CI, or external proof? Same-provider Zai/GLM proof was not run; live provider proof for the fixed runner path is included above.

Which bot or reviewer comments were addressed? Local autoreview initially caught an errored `NO_REPLY` guard gap; fixed and reran clean. ClawSweeper's post-tool empty-stop concern was evaluated against the source/docs contract: broad post-tool retry would break legitimate heartbeat/tool-assisted exact `NO_REPLY`, so the PR instead adds proof that exact post-tool `NO_REPLY` remains quiet while genuinely empty post-tool stops still retry.