### PR TITLE
test(agents): align agentic CI expectations

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -2122,7 +2122,7 @@ describe("anthropic transport stream", () => {
     const payload = latestAnthropicRequest().payload;
     expect(payload.thinking).toEqual({ type: "adaptive" });
     expect(payload.output_config).toEqual({ effort: "high" });
-    expect(payload.tool_choice).toEqual({ type: "auto" });
+    expect(payload.tool_choice).toBeUndefined();
   });
 
   it("does not infer adaptive thinking from forward-compatible effort maps", async () => {

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -476,6 +476,17 @@ describe("prepareSimpleCompletionModel", () => {
   });
 
   it("can preserve asynchronous provider model discovery", async () => {
+    hoisted.resolveModelAsyncMock.mockResolvedValueOnce({
+      model: {
+        provider: "anthropic",
+        id: "claude-opus-4-6",
+      },
+      authStorage: {
+        setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
+      },
+      modelRegistry: {},
+    });
+
     const result = await prepareSimpleCompletionModel({
       cfg: undefined,
       provider: "anthropic",


### PR DESCRIPTION
## Summary

- Fixes two current `main` agentic CI failures by aligning the tests with the current narrowed contracts.
- `anthropic-transport-stream.test.ts`: Claude 4.6 adaptive thinking without an explicit `toolChoice` should not assert an implicit `tool_choice` payload field. Existing Fable/explicit-tool-choice coverage still asserts unsafe tool choice is downgraded to `auto`.
- `simple-completion-runtime.test.ts`: the async discovery test now provides an async resolver fixture that does not delegate through the sync resolver mock, so the assertion actually verifies the async path.

## Change Type

- [x] Test / CI unblocker
- [ ] Runtime behavior change
- [ ] Docs

## Real behavior proof

- **Behavior or issue addressed**: current `openclaw/openclaw:main` has red `checks-node-agentic-agents-core-models` and `checks-node-agentic-agents-core-runtime` shards. The failing tests are `src/agents/anthropic-transport-stream.test.ts > maps unsupported xhigh to high effort for Claude 4.6 transport runs` and `src/agents/simple-completion-runtime.test.ts > can preserve asynchronous provider model discovery`.
- **Real environment tested**: Windows host, latest `upstream/main` at `bd96e4d22dafe64f558fb7f3ba5977aa3a93aee6`, Node/Vitest from the repo install.
- **Exact steps or command run after this patch**:

```powershell
node node_modules/vitest/vitest.mjs run src/agents/anthropic-transport-stream.test.ts src/agents/simple-completion-runtime.test.ts --config test/vitest/vitest.agents-core.config.ts --reporter verbose --pool forks --maxWorkers=1 --fileParallelism=false --testNamePattern "maps unsupported xhigh|can preserve asynchronous provider model discovery" --testTimeout=10000 --hookTimeout=10000

node node_modules/vitest/vitest.mjs run src/agents/anthropic-transport-stream.test.ts src/agents/simple-completion-runtime.test.ts --config test/vitest/vitest.agents-core.config.ts --reporter verbose --pool forks --maxWorkers=1 --fileParallelism=false --testTimeout=10000 --hookTimeout=10000

node_modules\.bin\oxfmt --check --threads=1 src/agents/anthropic-transport-stream.test.ts src/agents/simple-completion-runtime.test.ts
node_modules\.bin\oxlint src/agents/anthropic-transport-stream.test.ts src/agents/simple-completion-runtime.test.ts
```

- **Evidence after fix**: copied terminal output from the same checkout after applying this patch:

```text
Focused failure reproduction after patch:
Test Files  2 passed (2)
Tests  2 passed | 83 skipped (85)

Full affected files after patch:
Test Files  2 passed (2)
Tests  85 passed (85)

oxfmt --check:
All matched files use the correct format.

oxlint:
exited successfully for both changed files.
```

- **Observed result after fix**: the two previously failing assertions pass, and the full affected test files pass 85/85 locally.
- **What was not tested**: full repository CI matrix was left to GitHub Actions; this PR only targets the two red agentic shards that are blocking unrelated PRs.