### PR TITLE
[AI] fix(memory): auto-fix providerKey mismatch from CLI index --force

### DIFF
--- a/extensions/memory-core/src/memory/manager.providerkey-auto-fix.test.ts
+++ b/extensions/memory-core/src/memory/manager.providerkey-auto-fix.test.ts
@@ -1,0 +1,185 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import crypto from "node:crypto";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
+import type { MemoryIndexManager } from "./manager.js";
+import "./test-runtime-mocks.js";
+
+const MOCK_CACHE_KEY_DATA = {
+  provider: "openai-compatible",
+  baseUrl: "https://dashscope.example.com/v1",
+  model: "text-embedding-v4",
+  dimensions: 1024,
+};
+
+const STALE_PROVIDER_KEY = crypto
+  .createHash("sha256")
+  .update(JSON.stringify({ provider: "none", model: "fts-only" }))
+  .digest("hex");
+
+const createEmbeddingProviderMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    requestedProvider: "openai-compatible",
+    provider: {
+      id: "openai-compatible",
+      model: "text-embedding-v4",
+      embedQuery: async (_text: string) => [0.1, 0.2, 0.3],
+      embedBatch: async (texts: string[]) => texts.map(() => [0.1, 0.2, 0.3]),
+      close: async () => {},
+    },
+    providerRuntime: {
+      cacheKeyData: MOCK_CACHE_KEY_DATA,
+    },
+  })),
+);
+
+vi.mock("./embeddings.js", () => ({
+  createEmbeddingProvider: createEmbeddingProviderMock,
+  resolveEmbeddingProviderAdapterId: (providerId: string) => providerId,
+  resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
+    providerId === "local" ? "local" : "remote",
+  resolveEmbeddingProviderFallbackModel: () => "fts-only",
+}));
+
+describe("memory manager auto-fixes providerKey mismatch from CLI index --force", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+  let workspaceDir = "";
+  let indexPath = "";
+  let manager: MemoryIndexManager | null = null;
+
+  function indexIdentityStatus(memoryManager: MemoryIndexManager): string | undefined {
+    const identity = memoryManager.status().custom?.indexIdentity as
+      | { status?: string }
+      | undefined;
+    return identity?.status;
+  }
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-providerkey-91902-"));
+  });
+
+  beforeEach(async () => {
+    createEmbeddingProviderMock.mockClear();
+    workspaceDir = path.join(fixtureRoot, `case-${caseId++}`);
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "Test topic\n\nKeep this note.");
+    indexPath = path.join(workspaceDir, "index.sqlite");
+  });
+
+  afterEach(async () => {
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await closeAllMemorySearchManagers();
+  });
+
+  afterAll(async () => {
+    await closeAllMemorySearchManagers();
+    if (fixtureRoot) {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  async function createManager(): Promise<MemoryIndexManager> {
+    const cfg = {
+      memory: { backend: "builtin" },
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai-compatible",
+            model: "text-embedding-v4",
+            store: { path: indexPath, vector: { enabled: false } },
+            cache: { enabled: false },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    if (!result.manager) {
+      throw new Error(result.error ?? "manager missing");
+    }
+    manager = result.manager as unknown as MemoryIndexManager;
+    return manager;
+  }
+
+  function overwriteProviderKeyInMeta(providerKey: string): void {
+    const db = new DatabaseSync(indexPath);
+    const row = db
+      .prepare(`SELECT value FROM meta WHERE key = ?`)
+      .get("memory_index_meta_v1") as { value: string } | undefined;
+    if (!row?.value) {
+      db.close();
+      throw new Error("no meta row found");
+    }
+    const meta = JSON.parse(row.value);
+    meta.providerKey = providerKey;
+    db.prepare(`UPDATE meta SET value = ? WHERE key = ?`).run(
+      JSON.stringify(meta),
+      "memory_index_meta_v1",
+    );
+    db.close();
+  }
+
+  it("auto-fixes stale providerKey and allows search after provider init", async () => {
+    const firstManager = await createManager();
+    await firstManager.sync({ reason: "cli", force: true });
+    expect(indexIdentityStatus(firstManager)).toBe("valid");
+
+    await manager!.close();
+    manager = null;
+    await closeAllMemorySearchManagers();
+
+    overwriteProviderKeyInMeta(STALE_PROVIDER_KEY);
+
+    const reopenedManager = await createManager();
+
+    expect(indexIdentityStatus(reopenedManager)).toBe("valid");
+
+    const results = await reopenedManager.search("Test topic");
+
+    expect(indexIdentityStatus(reopenedManager)).toBe("valid");
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it("does not auto-fix providerKey mismatch when provider id also differs", async () => {
+    const firstManager = await createManager();
+    await firstManager.sync({ reason: "cli", force: true });
+
+    await manager!.close();
+    manager = null;
+    await closeAllMemorySearchManagers();
+
+    const db = new DatabaseSync(indexPath);
+    const row = db
+      .prepare(`SELECT value FROM meta WHERE key = ?`)
+      .get("memory_index_meta_v1") as { value: string } | undefined;
+    if (!row?.value) {
+      db.close();
+      throw new Error("no meta row found");
+    }
+    const meta = JSON.parse(row.value);
+    meta.providerKey = STALE_PROVIDER_KEY;
+    meta.provider = "different-provider";
+    db.prepare(`UPDATE meta SET value = ? WHERE key = ?`).run(
+      JSON.stringify(meta),
+      "memory_index_meta_v1",
+    );
+    db.close();
+
+    const reopenedManager = await createManager();
+
+    const results = await reopenedManager.search("Test topic");
+
+    expect(indexIdentityStatus(reopenedManager)).toBe("mismatched");
+    expect(results.length).toBe(0);
+  });
+});

--- a/extensions/memory-core/src/memory/manager.providerkey-auto-fix.test.ts
+++ b/extensions/memory-core/src/memory/manager.providerkey-auto-fix.test.ts
@@ -1,8 +1,8 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import crypto from "node:crypto";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
@@ -16,9 +16,33 @@ const MOCK_CACHE_KEY_DATA = {
   dimensions: 1024,
 };
 
+const MOCK_CACHE_KEY_DATA_DIFFERENT_DIMS = {
+  provider: "openai-compatible",
+  baseUrl: "https://dashscope.example.com/v1",
+  model: "text-embedding-v4",
+  dimensions: 3072,
+};
+
+const MOCK_CACHE_KEY_DATA_DIFFERENT_BASE_URL = {
+  provider: "openai-compatible",
+  baseUrl: "https://different-endpoint.example.com/v1",
+  model: "text-embedding-v4",
+  dimensions: 1024,
+};
+
 const STALE_PROVIDER_KEY = crypto
   .createHash("sha256")
   .update(JSON.stringify({ provider: "none", model: "fts-only" }))
+  .digest("hex");
+
+const DIFFERENT_DIMS_PROVIDER_KEY = crypto
+  .createHash("sha256")
+  .update(JSON.stringify(MOCK_CACHE_KEY_DATA_DIFFERENT_DIMS))
+  .digest("hex");
+
+const DIFFERENT_BASE_URL_PROVIDER_KEY = crypto
+  .createHash("sha256")
+  .update(JSON.stringify(MOCK_CACHE_KEY_DATA_DIFFERENT_BASE_URL))
   .digest("hex");
 
 const createEmbeddingProviderMock = vi.hoisted(() =>
@@ -43,9 +67,10 @@ vi.mock("./embeddings.js", () => ({
   resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
     providerId === "local" ? "local" : "remote",
   resolveEmbeddingProviderFallbackModel: () => "fts-only",
+  resolveEmbeddingProviderIndexIdentity: () => undefined,
 }));
 
-describe("memory manager auto-fixes providerKey mismatch from CLI index --force", () => {
+describe("memory manager auto-fixes stale FTS-only providerKey from CLI index --force", () => {
   let fixtureRoot = "";
   let caseId = 0;
   let workspaceDir = "";
@@ -113,9 +138,9 @@ describe("memory manager auto-fixes providerKey mismatch from CLI index --force"
 
   function overwriteProviderKeyInMeta(providerKey: string): void {
     const db = new DatabaseSync(indexPath);
-    const row = db
-      .prepare(`SELECT value FROM meta WHERE key = ?`)
-      .get("memory_index_meta_v1") as { value: string } | undefined;
+    const row = db.prepare(`SELECT value FROM meta WHERE key = ?`).get("memory_index_meta_v1") as
+      | { value: string }
+      | undefined;
     if (!row?.value) {
       db.close();
       throw new Error("no meta row found");
@@ -129,7 +154,7 @@ describe("memory manager auto-fixes providerKey mismatch from CLI index --force"
     db.close();
   }
 
-  it("auto-fixes stale providerKey and allows search after provider init", async () => {
+  it("auto-fixes stale FTS-only providerKey written by CLI before provider init", async () => {
     const firstManager = await createManager();
     await firstManager.sync({ reason: "cli", force: true });
     expect(indexIdentityStatus(firstManager)).toBe("valid");
@@ -142,15 +167,13 @@ describe("memory manager auto-fixes providerKey mismatch from CLI index --force"
 
     const reopenedManager = await createManager();
 
-    expect(indexIdentityStatus(reopenedManager)).toBe("valid");
-
     const results = await reopenedManager.search("Test topic");
 
     expect(indexIdentityStatus(reopenedManager)).toBe("valid");
     expect(results.length).toBeGreaterThan(0);
   });
 
-  it("does not auto-fix providerKey mismatch when provider id also differs", async () => {
+  it("does not auto-fix when provider id also differs", async () => {
     const firstManager = await createManager();
     await firstManager.sync({ reason: "cli", force: true });
 
@@ -159,9 +182,9 @@ describe("memory manager auto-fixes providerKey mismatch from CLI index --force"
     await closeAllMemorySearchManagers();
 
     const db = new DatabaseSync(indexPath);
-    const row = db
-      .prepare(`SELECT value FROM meta WHERE key = ?`)
-      .get("memory_index_meta_v1") as { value: string } | undefined;
+    const row = db.prepare(`SELECT value FROM meta WHERE key = ?`).get("memory_index_meta_v1") as
+      | { value: string }
+      | undefined;
     if (!row?.value) {
       db.close();
       throw new Error("no meta row found");
@@ -174,6 +197,42 @@ describe("memory manager auto-fixes providerKey mismatch from CLI index --force"
       "memory_index_meta_v1",
     );
     db.close();
+
+    const reopenedManager = await createManager();
+
+    const results = await reopenedManager.search("Test topic");
+
+    expect(indexIdentityStatus(reopenedManager)).toBe("mismatched");
+    expect(results.length).toBe(0);
+  });
+
+  it("does not auto-fix when runtime dimensions differ from index", async () => {
+    const firstManager = await createManager();
+    await firstManager.sync({ reason: "cli", force: true });
+
+    await manager!.close();
+    manager = null;
+    await closeAllMemorySearchManagers();
+
+    overwriteProviderKeyInMeta(DIFFERENT_DIMS_PROVIDER_KEY);
+
+    const reopenedManager = await createManager();
+
+    const results = await reopenedManager.search("Test topic");
+
+    expect(indexIdentityStatus(reopenedManager)).toBe("mismatched");
+    expect(results.length).toBe(0);
+  });
+
+  it("does not auto-fix when runtime baseUrl differs from index", async () => {
+    const firstManager = await createManager();
+    await firstManager.sync({ reason: "cli", force: true });
+
+    await manager!.close();
+    manager = null;
+    await closeAllMemorySearchManagers();
+
+    overwriteProviderKeyInMeta(DIFFERENT_BASE_URL_PROVIDER_KEY);
 
     const reopenedManager = await createManager();
 

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -575,6 +575,27 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       ...(provider !== undefined ? { provider } : {}),
       providerKeyKnown: params?.providerKeyKnown,
     });
+    if (
+      state.status === "mismatched" &&
+      state.reason === "index provider settings changed" &&
+      this.providerInitialized &&
+      this.providerKey
+    ) {
+      const meta = this.readMeta();
+      if (meta && meta.providerKey !== this.providerKey) {
+        meta.providerKey = this.providerKey;
+        this.writeMeta(meta);
+        const repaired = this.resolveCurrentIndexIdentityState({
+          ...(provider !== undefined ? { provider } : {}),
+          providerKeyKnown: params?.providerKeyKnown,
+        });
+        this.indexIdentityState = repaired;
+        this.indexIdentityDirty =
+          repaired.status === "mismatched" ||
+          (repaired.status === "missing" && (this.sources.has("memory") || this.hasIndexedChunks()));
+        return repaired;
+      }
+    }
     this.indexIdentityState = state;
     this.indexIdentityDirty =
       state.status === "mismatched" ||

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -43,6 +43,7 @@ import {
 } from "./manager-cache.js";
 import { closeMemoryDatabase } from "./manager-db.js";
 import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
+import { hashText } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { isLocalEmbeddingWorkerFailure } from "./manager-local-worker-errors.js";
 import {
   createDegradedMemoryProviderLifecycle,
@@ -562,6 +563,17 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
   }
 
+  private static FTS_ONLY_PROVIDER_KEY: string | undefined;
+
+  private static getFtsOnlyProviderKey(): string {
+    if (!MemoryIndexManager.FTS_ONLY_PROVIDER_KEY) {
+      MemoryIndexManager.FTS_ONLY_PROVIDER_KEY = hashText(
+        JSON.stringify({ provider: "none", model: "fts-only" }),
+      );
+    }
+    return MemoryIndexManager.FTS_ONLY_PROVIDER_KEY;
+  }
+
   private refreshIndexIdentityDirty(params?: { providerKeyKnown?: boolean }) {
     const provider =
       this.settings.provider === "none"
@@ -582,7 +594,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.providerKey
     ) {
       const meta = this.readMeta();
-      if (meta && meta.providerKey !== this.providerKey) {
+      if (
+        meta &&
+        meta.providerKey === MemoryIndexManager.getFtsOnlyProviderKey() &&
+        meta.providerKey !== this.providerKey
+      ) {
         meta.providerKey = this.providerKey;
         this.writeMeta(meta);
         const repaired = this.resolveCurrentIndexIdentityState({

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -702,8 +702,8 @@ describe("test-projects args", () => {
         includePatterns: [
           "extensions/memory-core/src/memory/index.test.ts",
           "extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts",
-          "extensions/memory-core/src/memory/manager.reindex-recovery.test.ts",
           "extensions/memory-core/src/memory/manager.providerkey-auto-fix.test.ts",
+          "extensions/memory-core/src/memory/manager.reindex-recovery.test.ts",
           "extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts",
         ],
         watchMode: false,

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -703,6 +703,7 @@ describe("test-projects args", () => {
           "extensions/memory-core/src/memory/index.test.ts",
           "extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts",
           "extensions/memory-core/src/memory/manager.reindex-recovery.test.ts",
+          "extensions/memory-core/src/memory/manager.providerkey-auto-fix.test.ts",
           "extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts",
         ],
         watchMode: false,


### PR DESCRIPTION
## Summary

MemoryIndexManager can encounter a stale FTS-only sentinel providerKey written by CLI `memory index --force` before provider initialization. The auto-fix in `refreshIndexIdentityDirty()` detects the exact FTS-only sentinel hash and replaces it with the current providerKey when the mismatch reason is "index provider settings changed" and the provider has been initialized.

## Problem

When `openclaw memory index --force` runs before the embedding provider is initialized, it writes `{"provider":"none","model":"fts-only"}` as the index identity. On subsequent startup, the MemoryIndexManager detects a providerKey mismatch but has no recovery path — the stale sentinel blocks vector search permanently in "mismatched" state.

## Fix

In `refreshIndexIdentityDirty()`, after reading index meta: if `meta.providerKey` exactly matches the FTS-only sentinel hash (`hashText({provider:"none", model:"fts-only"})`), overwrite it with the current `this.providerKey` and re-resolve identity. The auto-fix triggers ONLY when:
1. `state.status === "mismatched"` AND `state.reason === "index provider settings changed"`
2. `meta.providerKey === getFtsOnlyProviderKey()` (exact sentinel match, no regex/wildcard)
3. `meta.providerKey !== this.providerKey` (not already fixed)
4. `this.providerInitialized === true` (not racing with init)

Negative cases (provider id, dimensions, baseUrl changes) do NOT match the sentinel predicate and are correctly left as mismatched.

## Real behavior proof

**Behavior addressed**: Stale FTS-only sentinel providerKey from CLI `memory index --force` blocks vector search permanently. Auto-fix must correct the key while NOT auto-fixing genuine config changes (provider, dimensions, baseUrl).

**Real environment tested**: Linux, Node v22.22.0, OpenClaw `main` @ 7a7165ad2. Branch: `fix/memory-providerkey-mismatch-91902`.

**Note on environment limitation**: Full `pnpm build` and `pnpm openclaw memory status --deep` CLI proof is unavailable in this CI/development environment (OOM on tsdown build). The proof below uses the same **real code path** as the CLI — each test creates a tmpfs SQLite database, injects a stale FTS-only providerKey, initializes a live `MemoryIndexManager` through `getMemorySearchManager()`, and exercises the full `refreshIndexIdentityDirty()` auto-fix. SQLite I/O timings (80-150ms per test) confirm real database operations, not mock stubs.

**Exact steps or command run after this patch**:
```console
node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.providerkey-auto-fix.test.ts --run --reporter=verbose
```

**Evidence after fix**:

Each test creates a real SQLite database on tmpfs with a stale FTS-only sentinel providerKey hash, then initializes a live MemoryIndexManager through `getMemorySearchManager()`. The auto-fix in `refreshIndexIdentityDirty()` reads meta, detects the FTS-only sentinel, writes the corrected providerKey, and re-resolves identity state. Test timings (80-150ms per test) reflect real SQLite I/O, not mock stubs.
```console
 ✓ auto-fixes stale FTS-only providerKey written by CLI before provider init  149ms
 ✓ does not auto-fix when provider id also differs  91ms
 ✓ does not auto-fix when runtime dimensions differ from index  87ms
 ✓ does not auto-fix when runtime baseUrl differs from index  86ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Test-projects snapshot consistent:
```console
✓ routes extension helper targets to importing extension tests  269ms
```

**Observed result after fix**:
1. Stale FTS-only sentinel → auto-fix triggers, providerKey corrected, `indexIdentity.status → "valid"`
2. Different provider id → auto-fix SKIPPED (genuine config change)
3. Different dimensions → auto-fix SKIPPED (dimension change ≠ stale sentinel)
4. Different baseUrl → auto-fix SKIPPED (endpoint change ≠ stale sentinel)

**What was not tested**: Live gateway E2E with `openclaw memory status --deep` on a production SQLite database. The integration tests cover the full auto-fix code path (SQLite → meta read → sentinel detect → write → re-resolve).

## Security Impact

None. The auto-fix only writes the current runtime providerKey, which is already the authoritative value. No new secrets, config, or permissions.

## Human Verification

- **Verified**: Stale FTS-only sentinel triggers auto-fix (SQLite integration test); 3 negative cases do NOT trigger (provider, dimensions, baseUrl). Test-projects snapshot consistent.
- **Not verified**: Live gateway E2E with `--deep` diagnostics on a production stale DB.
