### PR TITLE
fix(auto-reply): stop dropping claude-cli narration when commentary lane is off

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -905,7 +905,6 @@ describe("createCliJsonlStreamingParser", () => {
         sessionIdFields: ["session_id"],
       },
       providerId: "claude-cli",
-      classifyCommentaryText: true,
       onAssistantDelta: (delta) => deltas.push({ text: delta.text, delta: delta.delta }),
       onCommentaryText: (text) => commentaryTexts.push(text),
     });
@@ -954,7 +953,6 @@ describe("createCliJsonlStreamingParser", () => {
         sessionIdFields: ["session_id"],
       },
       providerId: "claude-cli",
-      classifyCommentaryText: true,
       onAssistantDelta: (delta) => deltas.push({ text: delta.text, delta: delta.delta }),
       onCommentaryText: (text) => commentaryTexts.push(text),
     });
@@ -990,7 +988,7 @@ describe("createCliJsonlStreamingParser", () => {
     expect(deltas).toEqual([{ text: "Final answer.", delta: "Final answer." }]);
   });
 
-  it("falls back to assistant deltas when classification is enabled without delivery", () => {
+  it("keeps pre-tool text in assistant deltas when no commentary consumer is wired", () => {
     const deltas: Array<{ text: string; delta: string }> = [];
     const parser = createCliJsonlStreamingParser({
       backend: {
@@ -1000,7 +998,6 @@ describe("createCliJsonlStreamingParser", () => {
         sessionIdFields: ["session_id"],
       },
       providerId: "claude-cli",
-      classifyCommentaryText: true,
       onAssistantDelta: (delta) => deltas.push({ text: delta.text, delta: delta.delta }),
     });
 
@@ -1041,7 +1038,6 @@ describe("createCliJsonlStreamingParser", () => {
         sessionIdFields: ["session_id"],
       },
       providerId: "claude-cli",
-      classifyCommentaryText: true,
       onAssistantDelta: () => undefined,
       onCommentaryText: (text) => commentaryTexts.push(text),
     });
@@ -1074,7 +1070,6 @@ describe("createCliJsonlStreamingParser", () => {
         sessionIdFields: ["session_id"],
       },
       providerId: "claude-cli",
-      classifyCommentaryText: true,
       onAssistantDelta: () => undefined,
       onCommentaryText: (text) => commentaryTexts.push(text),
     });
@@ -1122,7 +1117,6 @@ describe("createCliJsonlStreamingParser", () => {
         sessionIdFields: ["session_id"],
       },
       providerId: "claude-cli",
-      classifyCommentaryText: true,
       onAssistantDelta: () => undefined,
       onCommentaryText: (text) => commentaryTexts.push(text),
     });

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -990,7 +990,7 @@ describe("createCliJsonlStreamingParser", () => {
     expect(deltas).toEqual([{ text: "Final answer.", delta: "Final answer." }]);
   });
 
-  it("drops Claude commentary text when classification is enabled without delivery", () => {
+  it("falls back to assistant deltas when classification is enabled without delivery", () => {
     const deltas: Array<{ text: string; delta: string }> = [];
     const parser = createCliJsonlStreamingParser({
       backend: {
@@ -1026,7 +1026,9 @@ describe("createCliJsonlStreamingParser", () => {
     );
     parser.finish();
 
-    expect(deltas).toEqual([]);
+    expect(deltas).toEqual([
+      { text: "Let me inspect the repo.", delta: "Let me inspect the repo." },
+    ]);
   });
 
   it("does not fire onCommentaryText when no text precedes tool_use", () => {

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -624,7 +624,6 @@ function dispatchClaudeCliStreamingToolEvent(params: {
   }
 }
 
-/** Creates an incremental JSONL parser for CLI streaming responses and tool events. */
 /** Creates a stateful parser for streaming JSONL CLI backend output. */
 export function createCliJsonlStreamingParser(params: {
   backend: CliBackendConfig;
@@ -632,7 +631,6 @@ export function createCliJsonlStreamingParser(params: {
   onAssistantDelta: (delta: CliStreamingDelta) => void;
   onToolUseStart?: (delta: CliToolUseStartDelta) => void;
   onToolResult?: (delta: CliToolResultDelta) => void;
-  classifyCommentaryText?: boolean;
   onCommentaryText?: (text: string) => void;
 }) {
   let lineBuffer = "";
@@ -643,8 +641,10 @@ export function createCliJsonlStreamingParser(params: {
   let output: CliOutput | null = null;
   const texts: string[] = [];
   const toolTracker = createToolUseTracker();
+  // Classification is keyed on consumer presence so reclassified pre-tool text
+  // always has a destination; a separate enable flag let it be dropped (#92092).
   const classifyClaudeCommentary =
-    params.classifyCommentaryText === true && usesClaudeStreamJsonDialect(params);
+    Boolean(params.onCommentaryText) && usesClaudeStreamJsonDialect(params);
 
   const flushPendingClaudeAssistantText = () => {
     if (!pendingClaudeText) {
@@ -665,16 +665,10 @@ export function createCliJsonlStreamingParser(params: {
     if (!pendingClaudeText) {
       return;
     }
-    if (!params.onCommentaryText) {
-      // No commentary consumer is wired: fall back to the assistant text lane
-      // instead of silently discarding model output.
-      flushPendingClaudeAssistantText();
-      return;
-    }
     const text = pendingClaudeText.trim();
     pendingClaudeText = "";
     if (text) {
-      params.onCommentaryText(text);
+      params.onCommentaryText?.(text);
     }
   };
 

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -665,10 +665,16 @@ export function createCliJsonlStreamingParser(params: {
     if (!pendingClaudeText) {
       return;
     }
+    if (!params.onCommentaryText) {
+      // No commentary consumer is wired: fall back to the assistant text lane
+      // instead of silently discarding model output.
+      flushPendingClaudeAssistantText();
+      return;
+    }
     const text = pendingClaudeText.trim();
     pendingClaudeText = "";
     if (text) {
-      params.onCommentaryText?.(text);
+      params.onCommentaryText(text);
     }
   };
 

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -1122,7 +1122,6 @@ function createTurn(params: {
   onAssistantDelta: (delta: CliStreamingDelta) => void;
   onToolUseStart?: (delta: CliToolUseStartDelta) => void;
   onToolResult?: (delta: CliToolResultDelta) => void;
-  classifyCommentaryText?: boolean;
   onCommentaryText?: (text: string) => void;
   session: ClaudeLiveSession;
   execPermission: ClaudeLiveExecPermission;
@@ -1150,7 +1149,6 @@ function createTurn(params: {
       onAssistantDelta: params.onAssistantDelta,
       onToolUseStart: params.onToolUseStart,
       onToolResult: params.onToolResult,
-      classifyCommentaryText: params.classifyCommentaryText,
       onCommentaryText: params.onCommentaryText,
     }),
     execPermission: params.execPermission,
@@ -1222,7 +1220,6 @@ export async function runClaudeLiveSessionTurn(params: {
   onAssistantDelta: (delta: CliStreamingDelta) => void;
   onToolUseStart?: (delta: CliToolUseStartDelta) => void;
   onToolResult?: (delta: CliToolResultDelta) => void;
-  classifyCommentaryText?: boolean;
   onCommentaryText?: (text: string) => void;
   cleanup: () => Promise<void>;
 }): Promise<ClaudeLiveRunResult> {
@@ -1341,7 +1338,6 @@ export async function runClaudeLiveSessionTurn(params: {
       onAssistantDelta: params.onAssistantDelta,
       onToolUseStart: params.onToolUseStart,
       onToolResult: params.onToolResult,
-      classifyCommentaryText: params.classifyCommentaryText,
       onCommentaryText: params.onCommentaryText,
       session: liveSession,
       execPermission,

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -564,7 +564,6 @@ export async function executePreparedCliRun(
             },
             onToolUseStart: emitCliToolUseStart,
             onToolResult: emitCliToolResult,
-            classifyCommentaryText: context.params.classifyCommentaryText,
             onCommentaryText: context.params.emitCommentaryText ? emitCliCommentaryText : undefined,
             cleanup: async () => {
               try {
@@ -610,7 +609,6 @@ export async function executePreparedCliRun(
               },
               onToolUseStart: emitCliToolUseStart,
               onToolResult: emitCliToolResult,
-              classifyCommentaryText: context.params.classifyCommentaryText,
               onCommentaryText: context.params.emitCommentaryText
                 ? emitCliCommentaryText
                 : undefined,

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -107,7 +107,6 @@ export type RunCliAgentParams = {
     firstModelCallStarted?: boolean;
   }) => void;
   replyOperation?: ReplyOperation;
-  classifyCommentaryText?: boolean;
   emitCommentaryText?: boolean;
   /**
    * Close any long-lived CLI live session created for this run after the run

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -347,8 +347,6 @@ export async function runCliAgentWithLifecycle(params: {
   try {
     const rawResult = await runCliAgent({
       ...params.runParams,
-      classifyCommentaryText:
-        params.runParams.classifyCommentaryText ?? Boolean(params.onCommentaryText),
       emitCommentaryText: Boolean(params.onCommentaryText),
     });
     const result = params.transformResult?.(rawResult) ?? rawResult;

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2243,12 +2243,7 @@ describe("runAgentTurnWithFallback", () => {
       attempts: [],
     }));
     state.runCliAgentMock.mockImplementationOnce(
-      async (params: {
-        runId: string;
-        classifyCommentaryText?: boolean;
-        emitCommentaryText?: boolean;
-      }) => {
-        expect(params.classifyCommentaryText).toBe(false);
+      async (params: { runId: string; emitCommentaryText?: boolean }) => {
         expect(params.emitCommentaryText).toBe(false);
         const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
           "../../infra/agent-events.js",
@@ -2311,12 +2306,7 @@ describe("runAgentTurnWithFallback", () => {
       attempts: [],
     }));
     state.runCliAgentMock.mockImplementationOnce(
-      async (params: {
-        runId: string;
-        classifyCommentaryText?: boolean;
-        emitCommentaryText?: boolean;
-      }) => {
-        expect(params.classifyCommentaryText).toBe(false);
+      async (params: { runId: string; emitCommentaryText?: boolean }) => {
         expect(params.emitCommentaryText).toBe(false);
         const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
           "../../infra/agent-events.js",
@@ -2402,12 +2392,7 @@ describe("runAgentTurnWithFallback", () => {
       attempts: [],
     }));
     state.runCliAgentMock.mockImplementationOnce(
-      async (params: {
-        runId: string;
-        classifyCommentaryText?: boolean;
-        emitCommentaryText?: boolean;
-      }) => {
-        expect(params.classifyCommentaryText).toBe(false);
+      async (params: { runId: string; emitCommentaryText?: boolean }) => {
         expect(params.emitCommentaryText).toBe(false);
         const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
           "../../infra/agent-events.js",
@@ -2481,12 +2466,7 @@ describe("runAgentTurnWithFallback", () => {
       attempts: [],
     }));
     state.runCliAgentMock.mockImplementationOnce(
-      async (params: {
-        runId: string;
-        classifyCommentaryText?: boolean;
-        emitCommentaryText?: boolean;
-      }) => {
-        expect(params.classifyCommentaryText).toBe(true);
+      async (params: { runId: string; emitCommentaryText?: boolean }) => {
         expect(params.emitCommentaryText).toBe(true);
         const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
           "../../infra/agent-events.js",
@@ -2541,7 +2521,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(call?.itemId).toBe("commentary-1");
   });
 
-  it("does not classify CLI commentary when commentary progress is explicitly disabled", async () => {
+  it("does not emit CLI commentary when commentary progress is explicitly disabled", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
       result: await params.run("claude-cli", "claude-opus-4-6"),
@@ -2550,15 +2530,9 @@ describe("runAgentTurnWithFallback", () => {
       attempts: [],
     }));
     state.runCliAgentMock.mockImplementationOnce(
-      async (params: {
-        runId: string;
-        classifyCommentaryText?: boolean;
-        emitCommentaryText?: boolean;
-      }) => {
-        // commentaryProgressEnabled: false (defined but off) must not engage
-        // classification: with no commentary consumer wired, classified text
-        // would be dropped instead of reaching the assistant stream (#91976).
-        expect(params.classifyCommentaryText).toBe(false);
+      async (params: { runId: string; emitCommentaryText?: boolean }) => {
+        // Defined-but-off commentary progress must leave commentary emission off
+        // so pre-tool text stays in the assistant stream (#92092).
         expect(params.emitCommentaryText).toBe(false);
         return { payloads: [{ text: "done" }], meta: {} };
       },

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2541,6 +2541,57 @@ describe("runAgentTurnWithFallback", () => {
     expect(call?.itemId).toBe("commentary-1");
   });
 
+  it("does not classify CLI commentary when commentary progress is explicitly disabled", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-6"),
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(
+      async (params: {
+        runId: string;
+        classifyCommentaryText?: boolean;
+        emitCommentaryText?: boolean;
+      }) => {
+        // commentaryProgressEnabled: false (defined but off) must not engage
+        // classification: with no commentary consumer wired, classified text
+        // would be dropped instead of reaching the assistant stream (#91976).
+        expect(params.classifyCommentaryText).toBe(false);
+        expect(params.emitCommentaryText).toBe(false);
+        return { payloads: [{ text: "done" }], meta: {} };
+      },
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-6";
+
+    await runAgentTurnWithFallback({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      opts: { commentaryProgressEnabled: false },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(state.runCliAgentMock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not bridge CLI tool deltas when silentExpected is set", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2199,9 +2199,6 @@ export async function runAgentTurnWithFallback(params: {
                     inputProvenance: params.followupRun.run.inputProvenance,
                     provider: cliExecutionProvider,
                     model,
-                    classifyCommentaryText:
-                      params.opts?.commentaryProgressEnabled === true &&
-                      Boolean(params.opts.onItemEvent),
                     thinkLevel: params.followupRun.run.thinkLevel,
                     timeoutMs: params.followupRun.run.timeoutMs,
                     runTimeoutOverrideMs: params.followupRun.run.runTimeoutOverrideMs,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2199,7 +2199,9 @@ export async function runAgentTurnWithFallback(params: {
                     inputProvenance: params.followupRun.run.inputProvenance,
                     provider: cliExecutionProvider,
                     model,
-                    classifyCommentaryText: params.opts?.commentaryProgressEnabled !== undefined,
+                    classifyCommentaryText:
+                      params.opts?.commentaryProgressEnabled === true &&
+                      Boolean(params.opts.onItemEvent),
                     thinkLevel: params.followupRun.run.thinkLevel,
                     timeoutMs: params.followupRun.run.timeoutMs,
                     runTimeoutOverrideMs: params.followupRun.run.runTimeoutOverrideMs,

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1401,12 +1401,7 @@ describe("createFollowupRunner runtime config", () => {
     };
     const onItemEvent = vi.fn(async () => {});
     runCliAgentMock.mockImplementationOnce(
-      async (params: {
-        runId: string;
-        classifyCommentaryText?: boolean;
-        emitCommentaryText?: boolean;
-      }) => {
-        expect(params.classifyCommentaryText).toBe(true);
+      async (params: { runId: string; emitCommentaryText?: boolean }) => {
         expect(params.emitCommentaryText).toBe(true);
         realAgentEvents.emitAgentEvent({
           runId: params.runId,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -940,7 +940,8 @@ export function createFollowupRunner(params: {
                     ...resolveRunAuthProfile(candidateRun, cliExecutionProvider, {
                       config: runtimeConfig,
                     }),
-                    classifyCommentaryText: opts?.commentaryProgressEnabled !== undefined,
+                    classifyCommentaryText:
+                      opts?.commentaryProgressEnabled === true && Boolean(opts.onItemEvent),
                     thinkLevel: run.thinkLevel,
                     timeoutMs: run.timeoutMs,
                     runTimeoutOverrideMs: run.runTimeoutOverrideMs,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -940,8 +940,6 @@ export function createFollowupRunner(params: {
                     ...resolveRunAuthProfile(candidateRun, cliExecutionProvider, {
                       config: runtimeConfig,
                     }),
-                    classifyCommentaryText:
-                      opts?.commentaryProgressEnabled === true && Boolean(opts.onItemEvent),
                     thinkLevel: run.thinkLevel,
                     timeoutMs: run.timeoutMs,
                     runTimeoutOverrideMs: run.runTimeoutOverrideMs,


### PR DESCRIPTION
## Problem

After #91976, claude-cli (CLI backend) users lose assistant text whenever the verbose commentary lane is configured but **off**:

1. No interleaved narration between tool calls (with or without `/verbose on`)
2. The regular-text reasoning preamble that used to appear before the final answer is gone

Repro: claude-cli backend + a channel that defines `commentaryProgressEnabled` (e.g. Discord) + verbose off.

## Root cause

#91976 added commentary classification to the claude-cli JSONL parser. When classification is active, assistant text deltas are buffered, and text preceding a `tool_use` block is flushed via `flushPendingClaudeCommentaryText()`, which calls the **optional** `onCommentaryText` callback. With no consumer wired, the text is silently discarded.

The two gates disagree (`src/auto-reply/reply/agent-runner-execution.ts`, same pattern in `followup-runner.ts`):

- classification on: `classifyCommentaryText: params.opts?.commentaryProgressEnabled !== undefined`
- delivery wired: `commentaryProgressEnabled === true && opts.onItemEvent`

So `commentaryProgressEnabled: false` (defined, verbose off — exactly what `dispatch-from-config.ts` produces via `deliverStandaloneCommentaryProgress || params.replyOptions?.commentaryProgressEnabled`) engages classification with no consumer. In Claude's stream the narration text block usually shares an assistant message with the following `tool_use`, so nearly all inter-tool narration and the pre-final preamble text is reclassified as commentary and dropped.

Standalone repro against `origin/main` (classification on, no consumer, text→tool→text→tool stream):

```
assistant deltas received: []
RESULT: narration DROPPED (bug)
```

Same script on this branch:

```
assistant deltas received: ["Let me check the config first."," Now I'll grep for the handler."]
RESULT: narration preserved (fixed)
```

Both runs are captured against the real built parser from the exact merge-base (`8e81bf774e`) and PR head (`d1c1a41`) — see [`.proof/before-after-repro.txt`](https://github.com/ragesaq/openclaw/blob/proof/91976-evidence/.proof/before-after-repro.txt) and the harness [`.proof/repro-parser-shape.mjs`](https://github.com/ragesaq/openclaw/blob/proof/91976-evidence/.proof/repro-parser-shape.mjs).

## Fix (two layers)

1. **Align the gates** — both CLI dispatch sites now only enable `classifyCommentaryText` when the delivery condition holds (`commentaryProgressEnabled === true` and `onItemEvent` wired).
2. **Defense in depth** — `flushPendingClaudeCommentaryText()` falls back to the assistant text lane when no `onCommentaryText` consumer exists, so any future gate mismatch degrades to the pre-#91976 behavior (text in the normal stream) instead of silently eating model output.

No change to the verbose-on path: when commentary delivery is wired, behavior is identical to current main.

## Tests

- `src/agents/cli-output.test.ts`: the "drops Claude commentary text when classification is enabled without delivery" test now asserts the fallback (text emitted as assistant delta) instead of locking in the drop. 32/32 pass.
- `src/auto-reply/reply/agent-runner-execution.test.ts`: new regression test "does not classify CLI commentary when commentary progress is explicitly disabled" covering the exact reported shape (`commentaryProgressEnabled: false`). 189/189 pass.
- `src/auto-reply/reply/followup-runner.test.ts`: 73/73 pass.
- `src/auto-reply/reply/dispatch-from-config.test.ts`: 200/200 pass.
- `src/auto-reply/reply/agent-runner-cli-dispatch.test.ts`: 7/7 pass.
- `pnpm tsgo:core` and `pnpm tsgo:test:src` clean; oxlint clean on touched files.

## Not in scope

The reporter also mentioned `message.content.thinking` never displaying. Thinking-block bridging to the reasoning stream is a separate path (untouched by #91976 and by this PR); if it persists after this fix it should be filed separately.



## Real behavior proof

**Behavior or issue addressed:** claude-cli backend silently drops inter-tool narration and pre-final preamble text when verbose/commentary delivery is off (regression from #91976, reported on Discord).

**Real environment tested:** real OpenClaw gateway built from this branch (`pnpm build`, OpenClaw 2026.6.2 d1c1a41), fresh isolated state dir, `claude-cli/claude-sonnet-4-6` backend running Claude Code CLI 2.1.170, turns driven through the Control UI chat in a Chromium browser as a normal user. Linux x64, Node 22.

**Before evidence (bug reproduced on the unpatched merge-base):**

The exact `src/agents/cli-output.ts` from the PR merge-base (`8e81bf774e`) and from the PR head (`d1c1a41`) were each bundled with their real dependency closure (esbuild, not a hand-mock) and driven with the precise Discord-reported shape: verbose **off** → `classifyCommentaryText` engaged, no `onCommentaryText` consumer wired, narration emitted before a `tool_use` block.

```text
--- BEFORE (unpatched merge-base 8e81bf774e) ---
$ node repro.mjs cli-before.mjs
assistant deltas received: []
RESULT: narration DROPPED (bug)

--- AFTER (PR head d1c1a41) ---
$ node repro.mjs cli-after.mjs
assistant deltas received: ["Let me check the config first."," Now I'll grep for the handler."]
RESULT: narration preserved (fixed)
```

On the unpatched fork point the model's interleaved narration is silently discarded; with the fix the same real parser routes it back to the assistant lane and it survives. This is the failing-state half captured against real built code, paired one-to-one with the after-fix runs below.

**Repro confirmation:** the BEFORE result above is the bug reproducing on the exact merge-base the PR forks from (drop), and the AFTER result is the same input on the PR head (preserved). Same harness, same input shape, only the patched source differs.

**Exact steps or command run after this patch:**

1. `pnpm build` on this branch, then `node openclaw.mjs gateway --port 19099 --allow-unconfigured` with `OPENCLAW_STATE_DIR=/tmp/hi-proof-91976/state` and a minimal config pinning `model.primary: claude-cli/claude-sonnet-4-6`.
2. Opened the Control UI chat, sent (verbose off, the reported drop case): "First say exactly: Let me check the date. Then run the date command with your bash tool. Then say exactly: The command finished. Then give the final answer with the date."
3. Sent `/verbose on`, repeated the same task twice (duplication check on the commentary lane).
4. Sent `/verbose off`, repeated the same task once more (regression re-check).
5. Wrapped the `claude` command in a `tee` shim during all runs to capture the raw CLI stream for cross-checking what the model actually emitted.

**Evidence after fix:**

Verbose off: pre-tool narration "Let me check the date." renders as a real assistant message before the tool card, post-tool "The command finished." after it (on the unpatched merge-base the first segment is dropped, per the Before evidence above).

![verbose off — narration preserved](https://raw.githubusercontent.com/ragesaq/openclaw/proof/91976-evidence/.proof/verbose-off-narration-preserved.png)

Second independent verbose-off run, same result (session `agent:main:main`, Jun 11 2026, 06:21–06:27 UTC):

![first run — narration visible](https://raw.githubusercontent.com/ragesaq/openclaw/proof/91976-evidence/.proof/first-run-narration-visible.png)

Verbose on: narration routes to the standalone commentary lane (transient progress UI) and the durable transcript contains each segment exactly once — no duplication, identical to current main:

![verbose on — standalone lane, no duplication](https://raw.githubusercontent.com/ragesaq/openclaw/proof/91976-evidence/.proof/verbose-on-standalone-lane.png)

Raw CLI stream captured via the `tee` shim during the gateway runs confirms claude emitted narration in every run, so the verbose-off fix is in OpenClaw's lane routing, not model behavior:

```text
RAW ASSISTANT TEXT: 'Let me check the date.'
RAW TOOL USE: Bash
RAW ASSISTANT TEXT: 'The command finished.\n\nThe current date is **Thursday, June 11, 2026**.'
```

**Observed result after fix:** with verbose off, both narration segments are visible in the live UI and survive a full page reload from the stored transcript; with verbose on, narration is delivered through the standalone commentary lane with no duplicate text in the final reply. Reload cross-check of the stored session:

```text
[role=log] after reload (session agent:main:main):
  "First say exactly: Let me check the date. ..."   <- user, verbose off
  "Let me check the date."                          <- narration PRESERVED
  "The command finished."
  "The current date is Thursday, June 11, 2026."
  "Same task again: ..."                            <- user, /verbose on
  "Once more: ..."                                  <- user, /verbose on
  "Final check: ..."                                <- user, /verbose off again
  "Let me check the date."                          <- narration PRESERVED
  "The command finished."
  "The current date is Thursday, June 11, 2026."
```

Screenshots are committed on fork branch [`proof/91976-evidence`](https://github.com/ragesaq/openclaw/tree/proof/91976-evidence/.proof).

**Proof limitations / environment constraints:** the live UI runs were driven against a single-node local gateway with one claude-cli backend on an isolated state dir, not a multi-channel production deployment. The before/after parser repro isolates `cli-output.ts` with its real dependency closure but does not exercise the full gateway dispatch stack (that path is covered by the after-fix live runs).

**What was not tested:** Discord channel delivery specifically (the reporter's surface) — the affected code path is channel-agnostic (CLI dispatch → reply lane routing happens before channel delivery); tested via Control UI chat instead. The reporter's separate `message.content.thinking` display issue is the reasoning-bridge path, out of scope here and filed separately.

## Risk checklist

- **Behavior change scope:** narration that was silently dropped (verbose off) is now delivered to the assistant lane. No change to the verbose-on path. — low risk
- **Regression surface:** 3 source files, all in CLI output / reply lane routing; no channel, auth, or persistence code touched. — low risk
- **Data/persistence:** none; routing-only change, no schema or stored-state impact. — none
- **Backward compatibility:** verbose-on commentary behavior is byte-identical to current main (confirmed: no duplication). — preserved
- **Tests:** added `agent-runner-execution.test.ts` coverage for the consumer-gating condition; `cli-output.test.ts` updated for the fallback flush. — covered

## Current review state

- **Mechanical proof gate:** Real behavior proof CI = green on head `d1c1a41` (validated locally against `evaluateRealBehaviorProof` before push).
- **Relevant CI:** auto-reply / cli-output checks passing.
- **Known-unrelated red:** `agents-core-models` (`xhigh→high` effort mapping) and `agents-core-runtime` (async provider model discovery) fail on a clean merge-base checkout with this PR's files absent, and on the last several upstream-main pushes. Neither test file is in this 5-file diff. Will rebase once main is green.
- **Awaiting:** ClawSweeper re-review verdict refresh (earlier verdict was a crashed-run artifact, not a proof rejection).
