### PR TITLE
fix #92039: [Bug]: WhatsApp login reports success before auth is durably persisted, so Docker rebuilds/upgrades can force relink

### DIFF
--- a/extensions/whatsapp/src/connection-controller.test.ts
+++ b/extensions/whatsapp/src/connection-controller.test.ts
@@ -1,5 +1,8 @@
 // Whatsapp tests cover connection controller plugin behavior.
 import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { DisconnectReason } from "baileys";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getRegisteredWhatsAppConnectionController } from "./connection-controller-registry.js";
@@ -8,8 +11,9 @@ import {
   waitForWhatsAppLoginResult,
   WhatsAppConnectionController,
 } from "./connection-controller.js";
+import { enqueueCredsSave, writeCredsJsonAtomically } from "./creds-persistence.js";
 import { createAcceptedWhatsAppSendResult } from "./inbound/send-result.test-helper.js";
-import { createWaSocket, waitForWaConnection } from "./session.js";
+import { createWaSocket, readWebAuthExistsForDecision, waitForWaConnection } from "./session.js";
 import { DEFAULT_WHATSAPP_SOCKET_TIMING } from "./socket-timing.js";
 
 vi.mock("./session.js", async () => {
@@ -18,11 +22,13 @@ vi.mock("./session.js", async () => {
     ...actual,
     createWaSocket: vi.fn(),
     waitForWaConnection: vi.fn(),
+    readWebAuthExistsForDecision: vi.fn(async () => ({ outcome: "stable" as const, exists: true })),
   };
 });
 
 const createWaSocketMock = vi.mocked(createWaSocket);
 const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
+const readWebAuthExistsForDecisionMock = vi.mocked(readWebAuthExistsForDecision);
 
 function createListenerStub(messageId = "ok") {
   return {
@@ -47,6 +53,9 @@ describe("WhatsAppConnectionController", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    readWebAuthExistsForDecisionMock
+      .mockReset()
+      .mockResolvedValue({ outcome: "stable", exists: true });
     controller = new WhatsAppConnectionController({
       accountId: "work",
       authDir: "/tmp/wa-auth",
@@ -247,6 +256,102 @@ describe("WhatsAppConnectionController", () => {
     });
     expect(createSocket).toHaveBeenCalledOnce();
     expect(waitForConnection).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a retryable failure when the socket opens before auth persistence settles", async () => {
+    readWebAuthExistsForDecisionMock.mockResolvedValue({ outcome: "unstable" });
+    const waitForConnection = vi.fn().mockResolvedValueOnce(undefined);
+
+    const result = await waitForWhatsAppLoginResult({
+      sock: createSocketWithTransportEmitter() as never,
+      authDir: "/tmp/wa-auth",
+      isLegacyAuthDir: false,
+      verbose: false,
+      runtime: { log: vi.fn() } as never,
+      waitForConnection: waitForConnection as never,
+    });
+
+    expect(result.outcome).toBe("failed");
+    if (result.outcome === "failed") {
+      expect(result.message).toMatch(/retry/i);
+      expect((result.error as { code?: string })?.code).toBe("whatsapp-auth-unstable");
+    }
+  });
+
+  it("returns a retryable failure when auth is not linked on disk after the socket opens", async () => {
+    readWebAuthExistsForDecisionMock.mockResolvedValue({ outcome: "stable", exists: false });
+    const waitForConnection = vi.fn().mockResolvedValueOnce(undefined);
+
+    const result = await waitForWhatsAppLoginResult({
+      sock: createSocketWithTransportEmitter() as never,
+      authDir: "/tmp/wa-auth",
+      isLegacyAuthDir: false,
+      verbose: false,
+      runtime: { log: vi.fn() } as never,
+      waitForConnection: waitForConnection as never,
+    });
+
+    expect(result.outcome).toBe("failed");
+    if (result.outcome === "failed") {
+      expect(result.message).toMatch(/retry/i);
+      expect((result.error as { code?: string })?.code).toBe("whatsapp-auth-unstable");
+    }
+  });
+
+  it("returns connected only after auth is confirmed durable on disk", async () => {
+    readWebAuthExistsForDecisionMock.mockResolvedValue({ outcome: "stable", exists: true });
+    const waitForConnection = vi.fn().mockResolvedValueOnce(undefined);
+    const sock = createSocketWithTransportEmitter();
+
+    const result = await waitForWhatsAppLoginResult({
+      sock: sock as never,
+      authDir: "/tmp/wa-auth",
+      isLegacyAuthDir: false,
+      verbose: false,
+      runtime: { log: vi.fn() } as never,
+      waitForConnection: waitForConnection as never,
+    });
+
+    expect(result).toEqual({ outcome: "connected", restarted: false, sock });
+    expect(readWebAuthExistsForDecisionMock).toHaveBeenCalledWith("/tmp/wa-auth");
+  });
+
+  it("waits for queued creds persistence so linked auth survives an auth-dir reuse", async () => {
+    const actualSession = await vi.importActual<typeof import("./session.js")>("./session.js");
+    const authDir = await fs.mkdtemp(path.join(os.tmpdir(), "wa-auth-durability-"));
+    try {
+      readWebAuthExistsForDecisionMock.mockImplementation(
+        actualSession.readWebAuthExistsForDecision,
+      );
+      let credsSaved = false;
+      enqueueCredsSave(
+        authDir,
+        async () => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 50);
+          });
+          await writeCredsJsonAtomically(authDir, { me: { id: "123@s.whatsapp.net" } });
+          credsSaved = true;
+        },
+        () => {},
+      );
+
+      const result = await waitForWhatsAppLoginResult({
+        sock: createSocketWithTransportEmitter() as never,
+        authDir,
+        isLegacyAuthDir: false,
+        verbose: false,
+        runtime: { log: vi.fn() } as never,
+        waitForConnection: vi.fn().mockResolvedValueOnce(undefined) as never,
+      });
+
+      expect(credsSaved).toBe(true);
+      expect(result.outcome).toBe("connected");
+      // A fresh read of the same auth dir is what a restarted/rebuilt container does.
+      await expect(actualSession.webAuthExists(authDir)).resolves.toBe(true);
+    } finally {
+      await fs.rm(authDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps the previous registered controller until a replacement listener is ready", async () => {

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -14,7 +14,9 @@ import {
   formatError,
   getStatusCode,
   logoutWeb,
+  readWebAuthExistsForDecision,
   waitForWaConnection,
+  WhatsAppAuthUnstableError,
 } from "./session.js";
 import {
   DEFAULT_WHATSAPP_SOCKET_TIMING,
@@ -30,6 +32,10 @@ const WHATSAPP_LOGIN_TIMEOUT_RESTART_MESSAGE =
   "WhatsApp connection timed out before login; retrying with a fresh socket…";
 const WHATSAPP_LOGGED_OUT_RELINK_MESSAGE =
   "WhatsApp reported the session is logged out. Cleared cached web session; please rerun openclaw channels login and scan the QR again.";
+const WHATSAPP_LOGIN_AUTH_UNSTABLE_MESSAGE =
+  "WhatsApp connected, but saving the linked credentials has not settled on disk yet. Retry login in a moment.";
+const WHATSAPP_LOGIN_AUTH_NOT_PERSISTED_MESSAGE =
+  "WhatsApp connected, but the linked credentials were not found on disk. Retry login in a moment.";
 export const WHATSAPP_LOGGED_OUT_QR_MESSAGE =
   "WhatsApp reported the session is logged out. Cleared cached web session; please scan a new QR.";
 export const WHATSAPP_WATCHDOG_TIMEOUT_ERROR = "watchdog-timeout";
@@ -234,6 +240,22 @@ export async function waitForWhatsAppLoginResult(params: {
   while (true) {
     try {
       await wait(currentSock, { timeout: "none" });
+      // Socket open only proves in-memory auth; require persisted creds before success.
+      const persistedAuth = await readWebAuthExistsForDecision(params.authDir);
+      if (persistedAuth.outcome === "unstable") {
+        return {
+          outcome: "failed",
+          message: WHATSAPP_LOGIN_AUTH_UNSTABLE_MESSAGE,
+          error: new WhatsAppAuthUnstableError(WHATSAPP_LOGIN_AUTH_UNSTABLE_MESSAGE),
+        };
+      }
+      if (!persistedAuth.exists) {
+        return {
+          outcome: "failed",
+          message: WHATSAPP_LOGIN_AUTH_NOT_PERSISTED_MESSAGE,
+          error: new WhatsAppAuthUnstableError(WHATSAPP_LOGIN_AUTH_NOT_PERSISTED_MESSAGE),
+        };
+      }
       return {
         outcome: "connected",
         restarted: postPairingRestarted || timeoutRestarted,

--- a/extensions/whatsapp/src/login-qr.test.ts
+++ b/extensions/whatsapp/src/login-qr.test.ts
@@ -114,6 +114,9 @@ describe("login-qr", () => {
       // Baileys v7 wraps the error: { error: BoomError(515) }
       .mockRejectedValueOnce({ error: { output: { statusCode: 515 } } })
       .mockResolvedValueOnce(undefined);
+    readWebAuthExistsForDecisionMock
+      .mockResolvedValueOnce({ outcome: "stable", exists: false })
+      .mockResolvedValue({ outcome: "stable", exists: true });
 
     const start = await startWebLoginWithQr({
       timeoutMs: 5000,
@@ -242,6 +245,34 @@ describe("login-qr", () => {
     expect(createWaSocketMock).not.toHaveBeenCalled();
   });
 
+  it("does not report linked success when the socket opens before creds persistence stabilizes", async () => {
+    const accountId = "socket-open-before-persistence";
+    waitForWaConnectionMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(undefined), 20);
+        }),
+    );
+    readWebAuthExistsForDecisionMock
+      .mockResolvedValueOnce({ outcome: "stable", exists: false })
+      .mockResolvedValue({ outcome: "unstable" });
+
+    const start = await startWebLoginWithQr({
+      timeoutMs: 5000,
+      accountId,
+    });
+    expect(start.qrDataUrl).toBe("data:image/png;base64,encoded:qr-data");
+
+    const result = await waitForWebLogin({
+      timeoutMs: 5000,
+      currentQrDataUrl: start.qrDataUrl,
+      accountId,
+    });
+
+    expect(result.connected).toBe(false);
+    expect(result.message).toMatch(/retry/i);
+  });
+
   it("reports a recovered linked session when socket bootstrap restores auth without a QR", async () => {
     createWaSocketMock.mockImplementationOnce(
       async (
@@ -255,6 +286,9 @@ describe("login-qr", () => {
     );
     waitForWaConnectionMock.mockResolvedValueOnce(undefined);
     readWebSelfIdMock.mockReturnValueOnce({ e164: "+5511977000000", jid: null, lid: null });
+    readWebAuthExistsForDecisionMock
+      .mockResolvedValueOnce({ outcome: "stable", exists: false })
+      .mockResolvedValue({ outcome: "stable", exists: true });
 
     const result = await startWebLoginWithQr({ timeoutMs: 5000 });
 
@@ -310,6 +344,9 @@ describe("login-qr", () => {
           setTimeout(() => resolve(undefined), 20);
         }),
     );
+    readWebAuthExistsForDecisionMock
+      .mockResolvedValueOnce({ outcome: "stable", exists: false })
+      .mockResolvedValue({ outcome: "stable", exists: true });
 
     const start = await startWebLoginWithQr({
       timeoutMs: 5000,
@@ -351,6 +388,9 @@ describe("login-qr", () => {
           resolveLogin = resolve;
         }),
     );
+    readWebAuthExistsForDecisionMock
+      .mockResolvedValueOnce({ outcome: "stable", exists: false })
+      .mockResolvedValue({ outcome: "stable", exists: true });
 
     const start = await startWebLoginWithQr({
       timeoutMs: 5000,

--- a/extensions/whatsapp/src/login.coverage.test.ts
+++ b/extensions/whatsapp/src/login.coverage.test.ts
@@ -59,6 +59,10 @@ vi.mock("./session.js", async () => {
     waitForWaConnection: waitForWaConnectionLocal,
     formatError: formatErrorLocal,
     getStatusCode,
+    readWebAuthExistsForDecision: vi.fn(async () => ({
+      outcome: "stable" as const,
+      exists: true,
+    })),
     logoutWeb: vi.fn(async (params: { authDir?: string }) => {
       await fs.rm(params.authDir ?? authDir, {
         recursive: true,

--- a/extensions/whatsapp/src/login.test.ts
+++ b/extensions/whatsapp/src/login.test.ts
@@ -17,6 +17,10 @@ vi.mock("./session.js", async () => {
     ...actual,
     createWaSocket: vi.fn().mockResolvedValue(sock),
     waitForWaConnection: vi.fn().mockResolvedValue(undefined),
+    readWebAuthExistsForDecision: vi.fn(async () => ({
+      outcome: "stable" as const,
+      exists: true,
+    })),
   };
 });
 


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- WhatsApp login could report `connected` immediately after the Baileys socket opened even when the linked web credentials had not been durably persisted to the auth directory.

Why does this matter now?

- This is a P1 regression for Docker rebuilds/upgrades: a user can see a successful login, restart with the same state mount, and still be forced to relink because the creds never reached disk.

What is the intended outcome?

- Fix classification: canonical root-cause fix.
- Root cause: `waitForWhatsAppLoginResult` treated socket-open as the success boundary, but socket-open only proves the in-memory session works.
- The login success boundary now reuses the existing `readWebAuthExistsForDecision` source-of-truth auth decision before returning `connected`.
- If the auth read is unstable or the linked creds are missing on disk, login returns a retryable `whatsapp-auth-unstable` failure instead of a false success.

What is intentionally out of scope?

- Credential format, auth directory layout, schema, public config, QR rendering, socket creation, and reconnect policy remain unchanged.
- No compatibility or migration behavior change; existing persisted creds remain valid.
- This PR does not decide maintainer ownership of duplicate fixes. #92108 is also open for #92039, so maintainers should choose one canonical landing path rather than merge both.

What does success look like?

- A login result can say `connected` only after the queued creds save has completed and the same auth dir can be read as linked by a fresh auth check.
- Slow/failed persistence surfaces as a retryable login message so the user can retry instead of trusting a non-durable login success.

What should reviewers focus on?

- The source-of-truth boundary: `waitForWhatsAppLoginResult` now calls `readWebAuthExistsForDecision` after `waitForWaConnection` succeeds and before returning `connected`.
- The retry behavior: unstable or missing disk auth uses the existing `WhatsAppAuthUnstableError` code path rather than introducing a terminal logout/relink state.
- The regression tests for unstable auth, missing-on-disk auth, and delayed queued creds persistence.

## Linked context

Which issue does this close?

Closes #92039

Which issues, PRs, or discussions are related?

Related #92039, #92108

Was this requested by a maintainer or owner?

- The linked issue is labeled as a P1 regression with a clear fix shape.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: WhatsApp login no longer reports `connected` until linked credentials have reached the auth directory that a restarted/rebuilt container would reuse.
- Real environment tested: local OpenClaw WhatsApp extension runtime path using the real creds persistence queue and real auth-dir read path on the rebased PR head. No live WhatsApp QR scan was performed.
- Exact steps or command run after this patch:
  - `node --import tsx --input-type=module -e '<script queues a delayed WhatsApp creds save, calls waitForWhatsAppLoginResult with a simulated socket-open, then verifies the same auth dir with webAuthExists>'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied console output from current-head validation `rebased-whatsapp-auth-durability-runtime-proof`:

  ```text
  queued creds save completed before login success=true
  login outcome=connected
  auth dir reusable after simulated restart=true
  ```

- Observed result after fix: login returned `connected` only after the delayed queued creds save finished, and a fresh read of the same auth dir confirmed the linked auth exists for restart/rebuild reuse.
- What was not tested: live WhatsApp QR pairing against the external WhatsApp service and a full Docker image rebuild with a real WhatsApp account.
- Proof limitations or environment constraints: the proof uses the real OpenClaw persistence/auth read path but a simulated socket-open event, so it validates the issue's local durability boundary without depending on a live WhatsApp account or QR scan.
- Before evidence (optional but encouraged): the new regression coverage failed before the production change because the login path treated socket-open as sufficient proof of successful, reusable auth.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-whatsapp.config.ts extensions/whatsapp/src/connection-controller.test.ts extensions/whatsapp/src/login-qr.test.ts extensions/whatsapp/src/login.test.ts extensions/whatsapp/src/login.coverage.test.ts`

  ```text
  Test Files  4 passed (4)
       Tests  35 passed (35)
  ```

- Current-head runtime proof described above:

  ```text
  queued creds save completed before login success=true
  login outcome=connected
  auth dir reusable after simulated restart=true
  ```

What regression coverage was added or updated?

- Added `waitForWhatsAppLoginResult` coverage for unstable auth, missing-on-disk auth, and connected-only-after-durable-auth cases.
- Added a runtime-style regression that queues a delayed creds save and proves the login result waits until the auth dir survives a fresh read.
- Added QR login coverage proving `waitForWebLogin` does not report linked success when the socket opens before creds persistence stabilizes.
- Updated existing login mocks so pre-login auth checks and post-pairing durability checks model separate reads.

What failed before this fix, if known?

- The new regression coverage failed before the production change because the login path treated socket-open as sufficient proof of successful, reusable auth.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

- Yes. WhatsApp login can now ask the user to retry instead of reporting false success when credentials are not durably available yet.

Did config, environment, or migration behavior change? (`Yes/No`)

- No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

- Yes. This tightens the WhatsApp auth success condition, but does not change credential contents, storage format, or secret handling.

What is the highest-risk area?

- Availability/user-flow risk: a slow or failed creds flush may now surface as a retryable login failure instead of success.

How is that risk mitigated?

- The retryable failure is the intentional availability tradeoff from RF-001: retrying is safer than reporting a non-durable login as ready and then losing the linked session after restart/rebuild.
- The new retry messages are not masking symptoms; they enforce the real durability invariant when the source-of-truth auth check is unstable or missing creds.
- Architecture / source-of-truth check: the gate reuses the existing `readWebAuthExistsForDecision` source-of-truth path, including its bounded persistence barrier and unstable-auth classification.
- Failures use the existing retryable `whatsapp-auth-unstable` error code rather than becoming a terminal relink/logout condition.
- The change is limited to the login success boundary and leaves socket creation/restart behavior unchanged.

## Current review state

What is the next action?

- Rebased onto current `main`; wait for remote CI and maintainer review after PR update.
- Maintainers should also choose the canonical landing path for #92039 because #92108 is open for the same linked issue.

What is still waiting on author, maintainer, CI, or external proof?

- Author: merge conflict resolved and current-head focused validation refreshed.
- Maintainer: RF-001 is an intentional availability tradeoff; RF-002 remains a maintainer decision because #92095 and #92108 are both open for #92039.
- CI: remote checks need to run on the updated branch after submit.
- External proof: live QR pairing and Docker rebuild with a real WhatsApp account remain out of scope for this local proof.

Which bot or reviewer comments were addressed?

- RF-001: Addressed in this PR body and current-head proof as an intentional retryable availability tradeoff.
- RF-002: Disclosed as maintainer canonical-path advisory because #92108 is still open for the same linked issue.
