### PR TITLE
feat(plugins): add iFlow Search external provider

### DIFF
--- a/docs/tools/iflow-search.md
+++ b/docs/tools/iflow-search.md
@@ -1,0 +1,268 @@
+---
+summary: "iFlow Search API setup for web_search, image search, and web fetch"
+read_when:
+  - You want to use iFlow Search (心流搜索) for web_search
+  - You need IFLOW_API_KEY or Chinese-first search results
+  - You want image search via iflow_image_search
+title: "iFlow search"
+---
+
+OpenClaw supports [iFlow Search (心流搜索)](https://platform.iflow.cn) as a `web_search` provider, plus
+three explicit agent tools for web search, image search, and clean web-page extraction.
+iFlow's results are Chinese-first but cover the global web.
+
+| Property      | Value                               |
+| ------------- | ----------------------------------- |
+| Plugin id     | `iflow`                             |
+| Auth          | `IFLOW_API_KEY` or config `apiKey`  |
+| Base URL      | `https://platform.iflow.cn` (default) |
+| Bundled tools | `iflow_web_search`, `iflow_image_search`, `iflow_web_fetch` |
+
+## Getting started
+
+<Steps>
+  <Step title="Get an API key">
+    Create an account at the [iFlow Open Platform](https://platform.iflow.cn)
+    and generate an API key in the dashboard.
+  </Step>
+  <Step title="Configure the plugin and provider">
+    ```json5
+    {
+      plugins: {
+        entries: {
+          iflow: {
+            enabled: true,
+            config: {
+              webSearch: {
+                apiKey: "your-key-here", // optional if IFLOW_API_KEY is set
+              },
+            },
+          },
+        },
+      },
+      tools: {
+        web: {
+          search: {
+            provider: "iflow",
+          },
+        },
+        // Enable iFlow explicit tools alongside the coding profile
+        alsoAllow: [
+          "iflow_web_search",
+          "iflow_image_search",
+          "iflow_web_fetch"
+        ],
+      },
+    }
+    ```
+  </Step>
+  <Step title="Verify search runs">
+    Trigger a `web_search` from any agent, or call `iflow_web_search` directly.
+  </Step>
+</Steps>
+
+<Tip>
+Choosing iFlow in onboarding or `openclaw configure --section web` enables the
+bundled iFlow plugin automatically.
+</Tip>
+
+## Install
+
+The plugin is published on npm as
+[`@iflow-ai/iflow-plugin`](https://www.npmjs.com/package/@iflow-ai/iflow-plugin).
+After choosing iFlow in `openclaw onboard` or `openclaw configure --section web`,
+OpenClaw installs it on demand. To install manually:
+
+```bash
+openclaw plugins install @iflow-ai/iflow-plugin@0.1.6
+openclaw gateway restart
+openclaw plugins inspect iflow --runtime --json
+```
+
+## Provider vs explicit tools
+
+The iFlow plugin exposes two capability layers:
+
+### Web Search Provider
+
+When configured as `tools.web.search.provider = "iflow"`, iFlow powers the
+built-in **`web_search`** tool. This tool is always visible in the `coding`
+profile — no extra configuration needed.
+
+### Explicit Tools
+
+The plugin also registers three explicit tools with additional capabilities:
+
+| Tool | Purpose | Why use it |
+|------|---------|-----------|
+| `iflow_web_search` | Web search with iFlow-specific controls | Direct access, independent of provider routing |
+| `iflow_image_search` | **Image search** — not available via `web_search` | The only way to search images through iFlow |
+| `iflow_web_fetch` | Fetch web page content | Direct access, independent of provider routing |
+
+<Note>
+`iflow_image_search` is **not** the OpenClaw built-in `image` tool (which is for
+image understanding/vision). It is a dedicated image search tool that returns
+image URLs, titles, and source pages.
+</Note>
+
+### Tool visibility and profiles
+
+OpenClaw's `tools.profile` controls which tools are available to the agent:
+
+| Profile | `web_search` (provider) | Explicit tools (`iflow_*`) |
+|---------|------------------------|---------------------------|
+| `coding` (default) | ✅ Always visible | ❌ Hidden by default |
+| `full` | ✅ Always visible | ✅ Visible |
+| `coding` + `alsoAllow` | ✅ Always visible | ✅ Visible |
+
+To enable explicit tools with the `coding` profile, add `alsoAllow`:
+
+```json5
+{
+  tools: {
+    profile: "coding",
+    alsoAllow: [
+      "iflow_web_search",
+      "iflow_image_search",
+      "iflow_web_fetch"
+    ],
+  },
+}
+```
+
+<Note>
+This is standard OpenClaw behavior — all plugin explicit tools (including
+Tavily's `tavily_search` and `tavily_extract`) follow the same profile rules.
+</Note>
+
+## Tool reference
+
+### `iflow_web_search`
+
+Search the public web via iFlow Search. Returns titles, URLs, snippets,
+position, and (when available) publish date. Chinese-language results are
+first-class.
+
+<ParamField path="query" type="string" required>
+Search query. Forwarded to iFlow as `keywords`.
+</ParamField>
+
+<ParamField path="count" type="number" default="10">
+Number of results to return (1–10). Forwarded to iFlow as `num`.
+</ParamField>
+
+Returns `{ query, provider:"iflow", count, tookMs, results: [{ title, url, snippet, position, date }] }`.
+
+### `iflow_image_search`
+
+Search the public web for images via iFlow Search. Returns image URLs, titles,
+and source page URLs.
+
+<ParamField path="query" type="string" required>
+Image search query. Forwarded to iFlow as `keywords`.
+</ParamField>
+
+<ParamField path="count" type="number" default="10">
+Number of images to return (1–20). Forwarded to iFlow as `num`.
+</ParamField>
+
+Returns `{ query, provider:"iflow", count, tookMs, images: [{ url, title, sourceUrl }] }`.
+
+### `iflow_web_fetch`
+
+Fetch the readable content of a single web page via iFlow Search. Returns
+title, plain-text/markdown content, and a cache hint.
+
+<ParamField path="url" type="string" required>
+HTTP(S) URL to fetch.
+</ParamField>
+
+Returns `{ title, url, content, fromCache, provider:"iflow", tookMs }`.
+
+## Choosing the right tool
+
+| Need                                     | Tool                |
+| ---------------------------------------- | ------------------- |
+| Quick web search, no special options     | `web_search`        |
+| iFlow-specific search with count control | `iflow_web_search`  |
+| Image search                             | `iflow_image_search`|
+| Extract content from a specific URL      | `iflow_web_fetch`   |
+
+<Note>
+The generic `web_search` tool with iFlow as provider supports `query` and
+`count` (up to 10 results). For image search or web content extraction, use the
+explicit tools.
+</Note>
+
+## Advanced configuration
+
+<AccordionGroup>
+  <Accordion title="API key resolution order">
+    The iFlow client looks up its API key in this order:
+
+    1. `plugins.entries.iflow.config.webSearch.apiKey` (resolved through SecretRefs).
+    2. `IFLOW_API_KEY` from the gateway environment.
+
+    All tools raise a setup error if neither is present.
+
+  </Accordion>
+
+  <Accordion title="Custom base URL">
+    Override `plugins.entries.iflow.config.webSearch.baseUrl` if you front iFlow
+    through a proxy. The default is `https://platform.iflow.cn`.
+  </Accordion>
+
+  <Accordion title="Cache">
+    Results are cached in-memory for 15 minutes by default (configurable via
+    `cacheTtlMinutes`; set `0` to disable). The cache key includes the iFlow
+    base URL, so proxy-specific responses do not collide.
+  </Accordion>
+</AccordionGroup>
+
+| Option                    | Default                      | Description                                  |
+| ------------------------- | ---------------------------- | -------------------------------------------- |
+| `webSearch.apiKey`        | `IFLOW_API_KEY` env var      | API key (string or SecretRef).               |
+| `webSearch.baseUrl`       | `https://platform.iflow.cn`  | API endpoint override.                       |
+| `webSearch.timeoutSeconds`| `30`                         | HTTP timeout per request in seconds.         |
+| `webSearch.cacheTtlMinutes`| `15`                        | In-memory cache TTL in minutes. Set 0 to disable. |
+
+## Error codes
+
+| Code | Meaning |
+|------|---------|
+| `missing_api_key` | No API key found in config or environment. |
+| `missing_param` | A required parameter was not provided. |
+| `invalid_param` | A parameter value is invalid (e.g., non-HTTP URL). |
+| `network_timeout` | Request to iFlow timed out. |
+| `network_error` | Network failure talking to iFlow. |
+| `api_error` | iFlow returned a non-2xx HTTP status. |
+| `api_business_error` | iFlow returned `success: false`. |
+
+## Attribution headers
+
+The iFlow plugin sends non-sensitive attribution headers so iFlow can identify
+requests coming from the OpenClaw plugin integration. No API key, user query,
+URL, search keywords, or user content is added to these headers.
+
+```http
+IFlow-Source: openclaw
+IFlow-Integration: @iflow-ai/iflow-plugin
+IFlow-Integration-Version: <plugin version>
+```
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Web Search overview" href="/tools/web" icon="magnifying-glass">
+    All providers and auto-detection rules.
+  </Card>
+  <Card title="Tavily" href="/tools/tavily" icon="globe">
+    Tavily search and extract tools.
+  </Card>
+  <Card title="Brave Search" href="/tools/brave-search" icon="shield">
+    Brave Search with snippets and filters.
+  </Card>
+  <Card title="Configuration" href="/gateway/configuration" icon="gear">
+    Full config schema for plugin entries and tool routing.
+  </Card>
+</CardGroup>

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -75,6 +75,9 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
   <Card title="Grok" icon="zap" href="/tools/grok-search">
     AI-synthesized answers with citations via xAI web grounding.
   </Card>
+  <Card title="iFlow Search" icon="globe" href="/tools/iflow-search">
+    Chinese-first structured results plus image search and clean-content web fetch via the iFlow Open Platform.
+  </Card>
   <Card title="Kimi" icon="moon" href="/tools/kimi-search">
     AI-synthesized answers with citations via Moonshot web search; ungrounded chat fallbacks fail explicitly.
   </Card>
@@ -83,6 +86,12 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
   </Card>
   <Card title="Ollama Web Search" icon="globe" href="/tools/ollama-search">
     Search via a signed-in local Ollama host or the hosted Ollama API.
+  </Card>
+  <Card title="Parallel" icon="layer-group" href="/tools/parallel-search">
+    Paid Parallel Search API (`PARALLEL_API_KEY`); higher rate limits and objective tuning.
+  </Card>
+  <Card title="Parallel Search (Free)" icon="layer-group" href="/tools/parallel-search">
+    Zero-config default. Parallel's free Search MCP, with LLM-optimized dense excerpts and no API key.
   </Card>
   <Card title="Perplexity" icon="search" href="/tools/perplexity-search">
     Structured results with content extraction controls and domain filtering.
@@ -97,20 +106,23 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 
 ### Provider comparison
 
-| Provider                                  | Result style                                                   | Filters                                          | API key                                                                                 |
-| ----------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------- |
-| [Brave](/tools/brave-search)              | Structured snippets                                            | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                                                                         |
-| [DuckDuckGo](/tools/duckduckgo-search)    | Structured snippets                                            | --                                               | None (key-free)                                                                         |
-| [Exa](/tools/exa-search)                  | Structured + extracted                                         | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                                                                           |
-| [Firecrawl](/tools/firecrawl)             | Structured snippets                                            | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                                                                     |
-| [Gemini](/tools/gemini-search)            | AI-synthesized + citations                                     | --                                               | `GEMINI_API_KEY`                                                                        |
-| [Grok](/tools/grok-search)                | AI-synthesized + citations                                     | --                                               | `XAI_API_KEY`                                                                           |
-| [Kimi](/tools/kimi-search)                | AI-synthesized + citations; fails on ungrounded chat fallbacks | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`                                                     |
-| [MiniMax Search](/tools/minimax-search)   | Structured snippets                                            | Region (`global` / `cn`)                         | `MINIMAX_CODE_PLAN_KEY` / `MINIMAX_CODING_API_KEY` / `MINIMAX_OAUTH_TOKEN`              |
-| [Ollama Web Search](/tools/ollama-search) | Structured snippets                                            | --                                               | None for signed-in local hosts; `OLLAMA_API_KEY` for direct `https://ollama.com` search |
-| [Perplexity](/tools/perplexity-search)    | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY`                                             |
-| [SearXNG](/tools/searxng-search)          | Structured snippets                                            | Categories, language                             | None (self-hosted)                                                                      |
-| [Tavily](/tools/tavily)                   | Structured snippets                                            | Via `tavily_search` tool                         | `TAVILY_API_KEY`                                                                        |
+| Provider                                         | Result style                                                   | Filters                                          | API key                                                                                 |
+| ------------------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| [Brave](/tools/brave-search)                     | Structured snippets                                            | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                                                                         |
+| [DuckDuckGo](/tools/duckduckgo-search)           | Structured snippets                                            | --                                               | None (key-free)                                                                         |
+| [Exa](/tools/exa-search)                         | Structured + extracted                                         | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                                                                           |
+| [Firecrawl](/tools/firecrawl)                    | Structured snippets                                            | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                                                                     |
+| [Gemini](/tools/gemini-search)                   | AI-synthesized + citations                                     | --                                               | `GEMINI_API_KEY`                                                                        |
+| [Grok](/tools/grok-search)                       | AI-synthesized + citations                                     | --                                               | xAI OAuth, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey`              |
+| [iFlow Search](/tools/iflow-search)              | Structured snippets (Chinese-first)                            | Via `iflow_image_search` and `iflow_web_fetch`   | `IFLOW_API_KEY`                                                                         |
+| [Kimi](/tools/kimi-search)                       | AI-synthesized + citations; fails on ungrounded chat fallbacks | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`                                                     |
+| [MiniMax Search](/tools/minimax-search)          | Structured snippets                                            | Region (`global` / `cn`)                         | `MINIMAX_CODE_PLAN_KEY` / `MINIMAX_CODING_API_KEY` / `MINIMAX_OAUTH_TOKEN`              |
+| [Ollama Web Search](/tools/ollama-search)        | Structured snippets                                            | --                                               | None for signed-in local hosts; `OLLAMA_API_KEY` for direct `https://ollama.com` search |
+| [Parallel](/tools/parallel-search)               | Dense excerpts ranked for LLM context                          | --                                               | `PARALLEL_API_KEY` (paid)                                                               |
+| [Parallel Search (Free)](/tools/parallel-search) | Dense excerpts ranked for LLM context                          | --                                               | None (free Search MCP)                                                                  |
+| [Perplexity](/tools/perplexity-search)           | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY`                                             |
+| [SearXNG](/tools/searxng-search)                 | Structured snippets                                            | Categories, language                             | None (self-hosted)                                                                      |
+| [Tavily](/tools/tavily)                          | Structured snippets                                            | Via `tavily_search` tool                         | `TAVILY_API_KEY`                                                                        |
 
 ## Auto-detection
 
@@ -123,7 +135,7 @@ Direct OpenAI Responses models use OpenAI's hosted `web_search` tool automatical
 Codex-capable models can optionally use the provider-native Responses `web_search` tool instead of OpenClaw's managed `web_search` function.
 
 - Configure it under `tools.web.search.openaiCodex`
-- It only activates for Codex-capable models (`openai-codex/*` or providers using `api: "openai-codex-responses"`)
+- It only activates for Codex-capable OpenAI models (`openai/*` models using `api: "openai-chatgpt-responses"`)
 - Managed `web_search` still applies to non-Codex models
 - `mode: "cached"` is the default and recommended setting
 - `tools.web.search.enabled: false` disables both managed and native search
@@ -178,27 +190,35 @@ API-backed providers first:
 1. **Brave** -- `BRAVE_API_KEY` or `plugins.entries.brave.config.webSearch.apiKey` (order 10)
 2. **MiniMax Search** -- `MINIMAX_CODE_PLAN_KEY` / `MINIMAX_CODING_API_KEY` / `MINIMAX_OAUTH_TOKEN` / `MINIMAX_API_KEY` or `plugins.entries.minimax.config.webSearch.apiKey` (order 15)
 3. **Gemini** -- `plugins.entries.google.config.webSearch.apiKey`, `GEMINI_API_KEY`, or `models.providers.google.apiKey` (order 20)
-4. **Grok** -- `XAI_API_KEY` or `plugins.entries.xai.config.webSearch.apiKey` (order 30)
+4. **Grok** -- xAI OAuth, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey` (order 30)
 5. **Kimi** -- `KIMI_API_KEY` / `MOONSHOT_API_KEY` or `plugins.entries.moonshot.config.webSearch.apiKey` (order 40)
 6. **Perplexity** -- `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey` (order 50)
 7. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey` (order 60)
 8. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`; optional `plugins.entries.exa.config.webSearch.baseUrl` overrides the Exa endpoint (order 65)
 9. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
+10. **Parallel** -- paid Parallel Search API via `PARALLEL_API_KEY` or `plugins.entries.parallel.config.webSearch.apiKey`; optional `plugins.entries.parallel.config.webSearch.baseUrl` overrides the endpoint (order 75)
+11. **iFlow Search** -- `IFLOW_API_KEY` or `plugins.entries.iflow.config.webSearch.apiKey` (order 80, external plugin)
 
 Key-free fallbacks after that:
 
-10. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
-11. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
-12. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
+12. **Parallel Search (Free)** -- the zero-config default: works with no account or API key via Parallel's free hosted [Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) (order 76)
+13. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
+14. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
+15. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
 
-If no provider is detected, it falls back to Brave (you will get a missing-key
-error prompting you to configure one).
+When no API-backed provider is configured, OpenClaw defaults to **Parallel
+Search (Free)**, so `web_search` works without an API key.
+
+OpenAI Responses models are an exception: while `tools.web.search.provider` is
+unset, they use OpenAI's native web search instead of the managed providers
+above. Set `tools.web.search.provider` to `parallel-free` (or another provider)
+to route them through the managed path.
 
 <Note>
   All provider key fields support SecretRef objects. Plugin-scoped SecretRefs
   under `plugins.entries.<plugin>.config.webSearch.apiKey` are resolved for the
   bundled API-backed web search providers, including Brave, Exa, Firecrawl,
-  Gemini, Grok, Kimi, MiniMax, Perplexity, and Tavily,
+  Gemini, Grok, iFlow, Kimi, MiniMax, Parallel, Perplexity, and Tavily,
   whether the provider is picked explicitly via `tools.web.search.provider` or
   selected through auto-detect. In auto-detect mode, OpenClaw resolves only the
   selected provider key -- non-selected SecretRefs stay inactive, so you can
@@ -229,6 +249,8 @@ Provider-specific config (API keys, base URLs, modes) lives under
 `models.providers.google.apiKey` and `models.providers.google.baseUrl` as lower-priority
 fallbacks after its dedicated web-search config and `GEMINI_API_KEY`. See the
 provider pages for examples.
+Grok can also reuse an xAI OAuth auth profile from `openclaw models auth login
+--provider xai --method oauth`; API-key config remains the fallback.
 
 `tools.web.search.provider` is validated against the web-search provider ids
 declared by bundled and installed plugin manifests. A typo such as `"brvae"`
@@ -259,7 +281,7 @@ same xAI auth profile as chat, or the `XAI_API_KEY` / plugin web-search
 credential used by Grok web search.
 Legacy `tools.web.x_search.*` config is auto-migrated by `openclaw doctor --fix`.
 When you choose Grok during `openclaw onboard` or `openclaw configure --section web`,
-OpenClaw can also offer optional `x_search` setup with the same key.
+OpenClaw can also offer optional `x_search` setup with the same credential.
 This is a separate follow-up step inside the Grok path, not a separate top-level
 web-search provider choice. If you pick another provider, OpenClaw does not
 show the `x_search` prompt.

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -51,6 +51,24 @@
       }
     },
     {
+      "name": "@openclaw/copilot",
+      "description": "OpenClaw GitHub Copilot agent runtime plugin",
+      "source": "official",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "copilot",
+          "label": "GitHub Copilot agent runtime"
+        },
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/copilot",
+          "npmSpec": "@openclaw/copilot",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.5.28"
+        }
+      }
+    },
+    {
       "name": "@openclaw/diagnostics-otel",
       "description": "OpenClaw diagnostics OpenTelemetry exporter",
       "source": "official",
@@ -104,6 +122,56 @@
       }
     },
     {
+      "name": "@openclaw/diffs-language-pack",
+      "description": "OpenClaw diffs viewer syntax highlighting language pack",
+      "source": "official",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "diffs-language-pack",
+          "label": "Diff Viewer Language Pack"
+        },
+        "install": {
+          "npmSpec": "@openclaw/diffs-language-pack",
+          "clawhubSpec": "clawhub:@openclaw/diffs-language-pack",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.5.27"
+        }
+      }
+    },
+    {
+      "name": "@iflow-ai/iflow-plugin",
+      "description": "iFlow Search (心流搜索) — Chinese-first web search, image search, and web content fetch.",
+      "source": "external",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "iflow",
+          "label": "iFlow Search"
+        },
+        "webSearchProviders": [
+          {
+            "id": "iflow",
+            "label": "iFlow Search",
+            "hint": "Connect Your AI Agent to the Real World",
+            "onboardingScopes": ["text-inference"],
+            "credentialLabel": "iFlow API key",
+            "envVars": ["IFLOW_API_KEY"],
+            "placeholder": "Enter iFlow API key",
+            "signupUrl": "https://platform.iflow.cn",
+            "docsUrl": "https://docs.openclaw.ai/tools/iflow-search",
+            "credentialPath": "plugins.entries.iflow.config.webSearch.apiKey",
+            "autoDetectOrder": 80
+          }
+        ],
+        "install": {
+          "npmSpec": "@iflow-ai/iflow-plugin@0.1.6",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.5.7"
+        }
+      }
+    },
+    {
       "name": "@openclaw/google-meet",
       "description": "OpenClaw Google Meet participant plugin",
       "source": "official",
@@ -150,7 +218,27 @@
         "install": {
           "npmSpec": "@openclaw/memory-lancedb",
           "defaultChoice": "npm",
-          "minHostVersion": ">=2026.4.10"
+          "minHostVersion": ">=2026.5.31"
+        }
+      }
+    },
+    {
+      "name": "@openclaw/llama-cpp-provider",
+      "description": "OpenClaw llama.cpp embedding provider plugin",
+      "source": "official",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "llama-cpp",
+          "label": "llama.cpp Provider"
+        },
+        "contracts": {
+          "embeddingProviders": ["local"]
+        },
+        "install": {
+          "npmSpec": "@openclaw/llama-cpp-provider",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.6.2"
         }
       }
     },
@@ -168,6 +256,42 @@
           "npmSpec": "@openclaw/openshell-sandbox",
           "defaultChoice": "npm",
           "minHostVersion": ">=2026.5.12-beta.1"
+        }
+      }
+    },
+    {
+      "name": "@openclaw/pixverse-provider",
+      "description": "OpenClaw PixVerse video generation provider plugin",
+      "source": "official",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "pixverse",
+          "label": "PixVerse"
+        },
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/pixverse-provider",
+          "npmSpec": "@openclaw/pixverse-provider",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.5.26"
+        }
+      }
+    },
+    {
+      "name": "@openclaw/tokenjuice",
+      "description": "OpenClaw tokenjuice exec output compaction plugin",
+      "source": "official",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "tokenjuice",
+          "label": "Tokenjuice"
+        },
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/tokenjuice",
+          "npmSpec": "@openclaw/tokenjuice",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.5.28"
         }
       }
     },

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -42,6 +42,17 @@ describe("official external plugin catalog", () => {
     expect(resolveOfficialExternalPluginInstall(expectCatalogEntry("line"))?.npmSpec).toBe(
       "@openclaw/line",
     );
+    expect(resolveOfficialExternalPluginInstall(expectCatalogEntry("diffs-language-pack"))).toEqual(
+      {
+        npmSpec: "@openclaw/diffs-language-pack",
+        clawhubSpec: "clawhub:@openclaw/diffs-language-pack",
+        defaultChoice: "npm",
+        minHostVersion: ">=2026.5.27",
+      },
+    );
+    expect(resolveOfficialExternalPluginInstall(expectCatalogEntry("llama-cpp"))?.npmSpec).toBe(
+      "@openclaw/llama-cpp-provider",
+    );
   });
 
   it("allows invalid-config recovery for externalized stock plugins", () => {
@@ -57,6 +68,33 @@ describe("official external plugin catalog", () => {
       npmSpec: "@openclaw/discord",
       allowInvalidConfigRecovery: true,
     });
+  });
+
+  it("lists iFlow as an external web search provider plugin with correct install spec", () => {
+    const entry = expectCatalogEntry("iflow");
+    expect(resolveOfficialExternalPluginId(entry)).toBe("iflow");
+    const install = resolveOfficialExternalPluginInstall(entry);
+    expect(install?.npmSpec).toBe("@iflow-ai/iflow-plugin@0.1.6");
+    expect(install?.defaultChoice).toBe("npm");
+    expect(install?.minHostVersion).toBe(">=2026.5.7");
+  });
+
+  it("exposes iFlow web search provider metadata for onboarding", () => {
+    const entry = expectCatalogEntry("iflow");
+    const manifest = entry.openclaw;
+    const providers = manifest?.webSearchProviders ?? [];
+    expect(providers.length).toBe(1);
+
+    const provider = providers[0]!;
+    expect(provider.id).toBe("iflow");
+    expect(provider.label).toBe("iFlow Search");
+    expect(provider.credentialLabel).toBe("iFlow API key");
+    expect(provider.envVars).toEqual(["IFLOW_API_KEY"]);
+    expect(provider.credentialPath).toBe("plugins.entries.iflow.config.webSearch.apiKey");
+    expect(provider.autoDetectOrder).toBe(80);
+    expect(provider.signupUrl).toBe("https://platform.iflow.cn");
+    expect(provider.docsUrl).toBe("https://docs.openclaw.ai/tools/iflow-search");
+    expect(provider.placeholder).not.toContain("sk-");
   });
 
   it("lists Matrix as an official external ClawHub channel after cutover", () => {


### PR DESCRIPTION
## Summary

Add [iFlow Search (心流搜索)](https://platform.iflow.cn) as an external Web Search provider in the official plugin catalog, so users can select it during `openclaw onboard` or `openclaw configure --section web`.

This integration uses the published external plugin:

- **npm:** `@iflow-ai/iflow-plugin@0.1.6`
- **Provider id:** `iflow`
- **Auth:** `IFLOW_API_KEY` or `plugins.entries.iflow.config.webSearch.apiKey`

## Changes

- Add `@iflow-ai/iflow-plugin@0.1.6` to `scripts/lib/official-external-plugin-catalog.json`
- Add `docs/tools/iflow-search.md` with provider setup, explicit tools reference, tool visibility profiles, and `alsoAllow` configuration
- Update `docs/tools/web.md` with:
  - iFlow provider card
  - comparison table row
  - auto-detect entry
  - SecretRef / API key guidance
- Add catalog tests for install spec and provider onboarding metadata

## Plugin summary

| Property | Value |
|----------|-------|
| Plugin id | `iflow` |
| npm | `@iflow-ai/iflow-plugin@0.1.6` |
| ClawHub | `@iflow-ai/iflow-plugin@0.1.6` |
| Auth | `IFLOW_API_KEY` or `plugins.entries.iflow.config.webSearch.apiKey` |
| Auto-detect order | 80 |
| Source | https://github.com/zhengyanglsun/openclaw-iflow-plugin |
| Source commit | `974be86b104d8ab58d8361cdf1eeb04fb70bba08` |

## Capabilities

- **Web Search provider:** registers `iflow` as a `web_search` provider via `api.registerWebSearchProvider`
- **Explicit plugin tools:**
  - `iflow_web_search`
  - `iflow_image_search`
  - `iflow_web_fetch`

The explicit tools follow OpenClaw's normal `tools.profile` / `tools.alsoAllow` policy. In the default `coding` profile, users can enable them with:

```json5
{
  "tools": {
    "profile": "coding",
    "alsoAllow": [
      "iflow_web_search",
      "iflow_image_search",
      "iflow_web_fetch"
    ]
  }
}
```

This is the same profile behavior used for other external plugin tools such as Tavily's explicit tools.

## Files changed

| File | Change |
|------|--------|
| `scripts/lib/official-external-plugin-catalog.json` | Add iFlow external plugin entry with `webSearchProviders` and pinned install spec |
| `docs/tools/iflow-search.md` | New iFlow provider and explicit tools documentation |
| `docs/tools/web.md` | Add iFlow provider card, comparison row, auto-detect entry, and SecretRef guidance |
| `src/plugins/official-external-plugin-catalog.test.ts` | Add tests for install spec and provider metadata |

## Real behavior proof

- **Behavior or issue addressed:** iFlow Search plugin should appear as a selectable web search provider during onboarding, install without errors, register as the `web_search` provider, and expose three explicit tools (`iflow_web_search`, `iflow_image_search`, `iflow_web_fetch`).

- **Real environment tested:** OpenClaw Enterprise v0.1.7, CLI v2026.5.18, macOS, Node.js v22.22.3, with `@iflow-ai/iflow-plugin@0.1.6` installed from ClawHub and npm.

- **Exact steps or command run after the patch:**

```bash
# 1. Install plugin from ClawHub
openclaw plugins install clawhub:@iflow-ai/iflow-plugin --pin --force

# 2. Inspect runtime registration
openclaw plugins inspect iflow --runtime --json

# 3. Test web_search with iFlow provider (tools.web.search.provider = "iflow")
openclaw agent --agent main --local --message "搜索杭州天气"

# 4. Test explicit tools visibility under full profile
# Set tools.profile = "full" in openclaw.json, then:
openclaw agent --agent main --local --message "列出你所有可用的工具名称" --json

# 5. Test explicit tools visibility under coding + alsoAllow
# Set tools.profile = "coding", tools.alsoAllow = ["iflow_web_search","iflow_image_search","iflow_web_fetch"]
openclaw agent --agent main --local --message "列出你所有可用的工具名称" --json

# 6. Confirm coding profile without alsoAllow hides explicit tools
# Set tools.profile = "coding", remove alsoAllow
openclaw agent --agent main --local --message "列出你所有可用的工具名称" --json
```

- **Evidence after fix:**

Plugin install output:
```
[plugins] iflow: initialized (baseUrl=https://platform.iflow.cn, timeout=30s, cacheTtl=15min, iFlow API key configured)
[plugins] iflow: registered as web_search provider (best-effort)
Installed plugin: iflow
```

Runtime inspect output:
```
version: 0.1.6
status: loaded
toolNames: ['iflow_web_search', 'iflow_image_search', 'iflow_web_fetch']
webSearchProviderIds: ['iflow']
diagnostics: []
install.source: clawhub
install.version: 0.1.6
```

Agent tool list under `full` profile (28 tools total, including):
```
iflow_web_search  — summaryChars: 165, schemaChars: 292, propertiesCount: 2
iflow_image_search — summaryChars: 100, schemaChars: 297, propertiesCount: 2
iflow_web_fetch   — summaryChars: 127, schemaChars: 127, propertiesCount: 1
```

Agent tool list under `coding` + `alsoAllow` (22 tools — 19 core + 3 iflow).

Agent tool list under default `coding` profile (19 tools, no `iflow_*` tools — correct behavior, same as Tavily explicit tools).

- **Observed result after fix:** Plugin installs cleanly from both npm and ClawHub, registers as `web_search` provider, exposes three explicit tools under `full` or `coding` + `alsoAllow` profiles, hides them under default `coding` profile (matching Tavily behavior), `web_search` with iFlow provider returns results normally (~1.5s).

- **What was not tested:** `openclaw onboard` flow with iFlow appearing in the provider selection list (requires this catalog change to be merged and released in a new OpenClaw version). The plugin runtime behavior has been verified through `openclaw plugins install` and `openclaw plugins inspect --runtime`.
