### PR TITLE
fix(gateway): use normalizeMessageChannel for send validation to support plugin channels

### DIFF
--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -923,6 +923,37 @@ describe("gateway send mirroring", () => {
     expect(response?.[2]?.message).toContain("Use `chat.send`");
   });
 
+  it("accepts bundled channels before plugin registry normalization for message actions", async () => {
+    const { respond } = await runMessageActionRequest({
+      channel: "TELEGRAM",
+      action: "send",
+      params: { target: "123", message: "hi" },
+      idempotencyKey: "idem-telegram-message-action",
+    });
+
+    const call = lastDispatchChannelMessageActionCall();
+    expect(call?.channel).toBe("telegram");
+    expect(firstRespondCall(respond)[0]).toBe(true);
+  });
+
+  it("rejects unknown send channels without delivering", async () => {
+    mocks.getChannelPlugin.mockReturnValue(undefined);
+
+    const { respond } = await runSend({
+      to: "x",
+      message: "hi",
+      channel: "definitely-not-a-real-channel-xyz",
+      idempotencyKey: "idem-unknown-channel",
+    });
+
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+    const response = firstRespondCall(respond);
+    expect(response?.[0]).toBe(false);
+    expect(response?.[2]?.message).toContain(
+      "unsupported channel: definitely-not-a-real-channel-xyz",
+    );
+  });
+
   it("auto-picks the single configured channel for send", async () => {
     mockDeliverySuccess("m-single-send");
 

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -15,7 +15,6 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { sendDurableMessageBatch } from "../../channels/message/runtime.js";
-import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
 import { createOutboundSendDeps } from "../../cli/deps.js";
 import {
@@ -49,6 +48,7 @@ import {
   normalizeSessionKeyPreservingOpaquePeerIds,
   parseThreadSessionSuffix,
 } from "../../sessions/session-key-utils.js";
+import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
 import { resolveGatewayPluginConfig } from "../runtime-plugin-config.js";
 import { formatForLog } from "../ws-log.js";
@@ -178,16 +178,15 @@ async function resolveRequestedChannel(params: {
 > {
   const channelInput = readStringValue(params.requestChannel);
   const normalizedChannel = channelInput ? normalizeMessageChannel(channelInput) : undefined;
+  if (params.rejectWebchatAsInternalOnly && normalizedChannel === INTERNAL_MESSAGE_CHANNEL) {
+    return {
+      error: errorShape(
+        ErrorCodes.INVALID_REQUEST,
+        "unsupported channel: webchat (internal-only). Use `chat.send` for WebChat UI messages or choose a deliverable channel.",
+      ),
+    };
+  }
   if (channelInput && !normalizedChannel) {
-    const normalizedInput = normalizeOptionalLowercaseString(channelInput) ?? "";
-    if (params.rejectWebchatAsInternalOnly && normalizedInput === "webchat") {
-      return {
-        error: errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          "unsupported channel: webchat (internal-only). Use `chat.send` for WebChat UI messages or choose a deliverable channel.",
-        ),
-      };
-    }
     return {
       error: errorShape(ErrorCodes.INVALID_REQUEST, params.unsupportedMessage(channelInput)),
     };

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { sendDurableMessageBatch } from "../../channels/message/runtime.js";
-import { normalizeChannelId } from "../../channels/plugins/index.js";
+import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
 import { createOutboundSendDeps } from "../../cli/deps.js";
 import {
@@ -177,7 +177,7 @@ async function resolveRequestedChannel(params: {
     }
 > {
   const channelInput = readStringValue(params.requestChannel);
-  const normalizedChannel = channelInput ? normalizeChannelId(channelInput) : null;
+  const normalizedChannel = channelInput ? normalizeMessageChannel(channelInput) : undefined;
   if (channelInput && !normalizedChannel) {
     const normalizedInput = normalizeOptionalLowercaseString(channelInput) ?? "";
     if (params.rejectWebchatAsInternalOnly && normalizedInput === "webchat") {


### PR DESCRIPTION
## Summary

Fixes #92094. The `message` tool `action=send` was returning "unsupported channel: telegram" because the gateway send method was using `normalizeChannelId` which only checks the active plugin registry, causing failures when the registry wasn't fully initialized or when plugin channels weren't yet registered.

## Approach

Changed `src/gateway/server-methods/send.ts:180` to use `normalizeMessageChannel` instead of `normalizeChannelId`. This function:

1. Checks built-in channels first (webchat, etc.)
2. Falls back to plugin registry lookup via `normalizeAnyChannelId`
3. Accepts unknown-but-normalized ids so external plugin channels can route before their full runtime is loaded

This matches the behavior used in `resolveOutboundChannelPlugin` and other outbound resolution paths, allowing Telegram and other plugin channels to be validated and then properly resolved through the existing adapter infrastructure.

## Real behavior proof

**Behavior addressed:** Proactive message sends to Telegram channels were failing with "unsupported channel: telegram" even though the Telegram plugin had a complete outbound adapter and normal inbound/reply flows worked correctly.

**Real environment tested:** Local OpenClaw installation on Ubuntu 24.04 with Node v22.22.3, configured Telegram channel with bot token and dmPolicy: "pairing".

**Exact steps or command run after the patch:**
1. Applied the fix changing `normalizeChannelId` to `normalizeMessageChannel` in `send.ts:180`
2. Configured Telegram channel with valid bot token
3. Ran `openclaw message send --channel telegram --target <id> --message "test"` 
4. Called `message(action=send, channel="telegram", target="<id>", message="test")` via agent tool

**Evidence after fix:** Both CLI and message tool now successfully send messages to Telegram targets without "unsupported channel" errors. The channel passes validation and is then properly resolved through `resolveOutboundChannelPlugin` which finds the existing Telegram outbound adapter.

**What was not tested:** Multi-account Telegram setups, group vs DM differentiation beyond basic targeting, edge cases with malformed channel names.