### PR TITLE
fix(whatsapp): confirm auth persistence before login success

### DIFF
--- a/extensions/whatsapp/src/connection-controller.test.ts
+++ b/extensions/whatsapp/src/connection-controller.test.ts
@@ -9,7 +9,7 @@ import {
   WhatsAppConnectionController,
 } from "./connection-controller.js";
 import { createAcceptedWhatsAppSendResult } from "./inbound/send-result.test-helper.js";
-import { createWaSocket, waitForWaConnection } from "./session.js";
+import { createWaSocket, readWebAuthExistsForDecision, waitForWaConnection } from "./session.js";
 import { DEFAULT_WHATSAPP_SOCKET_TIMING } from "./socket-timing.js";
 
 vi.mock("./session.js", async () => {
@@ -17,11 +17,13 @@ vi.mock("./session.js", async () => {
   return {
     ...actual,
     createWaSocket: vi.fn(),
+    readWebAuthExistsForDecision: vi.fn(),
     waitForWaConnection: vi.fn(),
   };
 });
 
 const createWaSocketMock = vi.mocked(createWaSocket);
+const readWebAuthExistsForDecisionMock = vi.mocked(readWebAuthExistsForDecision);
 const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
 
 function createListenerStub(messageId = "ok") {
@@ -47,6 +49,10 @@ describe("WhatsAppConnectionController", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    readWebAuthExistsForDecisionMock.mockResolvedValue({
+      outcome: "stable",
+      exists: true,
+    });
     controller = new WhatsAppConnectionController({
       accountId: "work",
       authDir: "/tmp/wa-auth",
@@ -178,6 +184,51 @@ describe("WhatsAppConnectionController", () => {
     expect(onSocketReplaced).toHaveBeenCalledWith(replacementSock);
     expect(waitForConnection).toHaveBeenNthCalledWith(1, initialSock, { timeout: "none" });
     expect(waitForConnection).toHaveBeenNthCalledWith(2, replacementSock, { timeout: "none" });
+  });
+
+  it("does not report login success before linked auth is stable on disk", async () => {
+    const sock = createSocketWithTransportEmitter();
+    const waitForConnection = vi.fn().mockResolvedValueOnce(undefined);
+    readWebAuthExistsForDecisionMock.mockResolvedValueOnce({ outcome: "unstable" });
+
+    const result = await waitForWhatsAppLoginResult({
+      sock: sock as never,
+      authDir: "/tmp/wa-auth",
+      isLegacyAuthDir: false,
+      verbose: false,
+      runtime: { log: vi.fn() } as never,
+      waitForConnection: waitForConnection as never,
+    });
+
+    expect(result).toMatchObject({
+      outcome: "failed",
+      message: "WhatsApp auth state is still stabilizing. Retry login in a moment.",
+    });
+    expect(readWebAuthExistsForDecisionMock).toHaveBeenCalledWith("/tmp/wa-auth");
+  });
+
+  it("does not report login success when socket opens before linked auth reaches disk", async () => {
+    const sock = createSocketWithTransportEmitter();
+    const waitForConnection = vi.fn().mockResolvedValueOnce(undefined);
+    readWebAuthExistsForDecisionMock.mockResolvedValueOnce({
+      outcome: "stable",
+      exists: false,
+    });
+
+    const result = await waitForWhatsAppLoginResult({
+      sock: sock as never,
+      authDir: "/tmp/wa-auth",
+      isLegacyAuthDir: false,
+      verbose: false,
+      runtime: { log: vi.fn() } as never,
+      waitForConnection: waitForConnection as never,
+    });
+
+    expect(result).toMatchObject({
+      outcome: "failed",
+      message:
+        "WhatsApp connected, but linked auth was not persisted yet. Retry login in a moment.",
+    });
   });
 
   it("still honors the post-pairing 515 restart after a status 408 recovery", async () => {

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -13,6 +13,7 @@ import {
   createWaSocket,
   formatError,
   getStatusCode,
+  readWebAuthExistsForDecision,
   logoutWeb,
   waitForWaConnection,
 } from "./session.js";
@@ -234,6 +235,22 @@ export async function waitForWhatsAppLoginResult(params: {
   while (true) {
     try {
       await wait(currentSock, { timeout: "none" });
+      const auth = await readWebAuthExistsForDecision(params.authDir);
+      if (auth.outcome === "unstable") {
+        return {
+          outcome: "failed",
+          message: "WhatsApp auth state is still stabilizing. Retry login in a moment.",
+          error: new Error("WhatsApp auth state is still stabilizing after socket opened."),
+        };
+      }
+      if (!auth.exists) {
+        return {
+          outcome: "failed",
+          message:
+            "WhatsApp connected, but linked auth was not persisted yet. Retry login in a moment.",
+          error: new Error("WhatsApp linked auth was not persisted after socket opened."),
+        };
+      }
       return {
         outcome: "connected",
         restarted: postPairingRestarted || timeoutRestarted,

--- a/extensions/whatsapp/src/login-qr.test.ts
+++ b/extensions/whatsapp/src/login-qr.test.ts
@@ -110,6 +110,9 @@ describe("login-qr", () => {
   });
 
   it("restarts login once on status 515 and completes", async () => {
+    readWebAuthExistsForDecisionMock
+      .mockResolvedValueOnce({ outcome: "stable", exists: false })
+      .mockResolvedValueOnce({ outcome: "stable", exists: true });
     waitForWaConnectionMock
       // Baileys v7 wraps the error: { error: BoomError(515) }
       .mockRejectedValueOnce({ error: { output: { statusCode: 515 } } })
@@ -243,6 +246,9 @@ describe("login-qr", () => {
   });
 
   it("reports a recovered linked session when socket bootstrap restores auth without a QR", async () => {
+    readWebAuthExistsForDecisionMock
+      .mockResolvedValueOnce({ outcome: "stable", exists: false })
+      .mockResolvedValueOnce({ outcome: "stable", exists: true });
     createWaSocketMock.mockImplementationOnce(
       async (
         _printQr: boolean,
@@ -304,6 +310,9 @@ describe("login-qr", () => {
 
   it("does not short-circuit on an existing QR when the waiter has no current QR image", async () => {
     const accountId = "wait-without-current-qr";
+    readWebAuthExistsForDecisionMock
+      .mockResolvedValueOnce({ outcome: "stable", exists: false })
+      .mockResolvedValueOnce({ outcome: "stable", exists: true });
     waitForWaConnectionMock.mockImplementationOnce(
       () =>
         new Promise((resolve) => {
@@ -330,6 +339,9 @@ describe("login-qr", () => {
 
   it("returns a terminal login result before a stale QR refresh", async () => {
     const accountId = "connected-before-refresh";
+    readWebAuthExistsForDecisionMock
+      .mockResolvedValueOnce({ outcome: "stable", exists: false })
+      .mockResolvedValueOnce({ outcome: "stable", exists: true });
     let resolveLogin: () => void = () => {
       throw new Error("Expected login wait to be pending");
     };

--- a/extensions/whatsapp/src/login.coverage.test.ts
+++ b/extensions/whatsapp/src/login.coverage.test.ts
@@ -56,6 +56,10 @@ vi.mock("./session.js", async () => {
   return {
     ...actual,
     createWaSocket: createWaSocketLocal,
+    readWebAuthExistsForDecision: vi.fn(async () => ({
+      outcome: "stable",
+      exists: true,
+    })),
     waitForWaConnection: waitForWaConnectionLocal,
     formatError: formatErrorLocal,
     getStatusCode,

--- a/extensions/whatsapp/src/login.test.ts
+++ b/extensions/whatsapp/src/login.test.ts
@@ -16,6 +16,10 @@ vi.mock("./session.js", async () => {
   return {
     ...actual,
     createWaSocket: vi.fn().mockResolvedValue(sock),
+    readWebAuthExistsForDecision: vi.fn().mockResolvedValue({
+      outcome: "stable",
+      exists: true,
+    }),
     waitForWaConnection: vi.fn().mockResolvedValue(undefined),
   };
 });


### PR DESCRIPTION
## Summary

- Wait for the selected WhatsApp auth directory to settle after the socket reports connected.
- Re-read the persisted auth state before returning login success.
- Return a retryable failure when auth is still stabilizing or the linked creds are not on disk yet.
- Keep the change inside the shared login waiter so QR login and recovered-session login use the same success boundary.

## Linked context

Closes #92039

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: WhatsApp login could report success as soon as Baileys opened the socket, before queued credential persistence was confirmed on disk.
- Real environment tested: local checkout on macOS with the WhatsApp extension test shard.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/whatsapp/src/connection-controller.test.ts extensions/whatsapp/src/login-qr.test.ts extensions/whatsapp/src/auth-store.test.ts`
- Evidence after fix: the focused command passed with 3 files and 42 tests.
- Observed result after fix: the shared login waiter now returns failure for both unstable auth and missing persisted linked auth after socket-open; existing QR login success tests now have to prove the auth state becomes linked.
- What was not tested: I did not run a real WhatsApp QR login or Docker rebuild/restart cycle.
- Proof limitations or environment constraints: this environment does not have a disposable WhatsApp account available for a live relink/restart proof.
- Before evidence: the old `waitForWhatsAppLoginResult` returned `connected` immediately after `waitForWaConnection` resolved.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/whatsapp/src/connection-controller.test.ts extensions/whatsapp/src/login-qr.test.ts extensions/whatsapp/src/auth-store.test.ts`
- `git diff --check`

Updated coverage in `connection-controller.test.ts` for the two race cases: queued auth still unstable, and socket-open before linked auth is visible on disk. Updated QR login tests so successful paths model auth becoming linked after the connection opens.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `Yes`

Highest-risk area: WhatsApp login may now ask the user to retry instead of reporting success when persistence is delayed or missing.

Mitigation: the check uses the existing `readWebAuthExistsForDecision` helper, which already waits on the per-auth-dir credential save queue and classifies timeout as unstable.

## Current review state

Ready for review. A maintainer with a disposable WhatsApp setup should still run the Docker/restart proof from #92039 before treating this as fully verified in the reported deployment shape.
