### PR TITLE
fix(update): restart managed gateway when update handoff fails after stop

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -3813,10 +3813,6 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
       result: resultWithPostUpdate,
       jsonMode: Boolean(opts.json),
     });
-    await maybeRestartServiceAfterFailedMutableUpdate({
-      preManagedServiceStop,
-      jsonMode: Boolean(opts.json),
-    });
     if (opts.json) {
       defaultRuntime.writeJson(resultWithPostUpdate);
     } else {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -3813,6 +3813,10 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
       result: resultWithPostUpdate,
       jsonMode: Boolean(opts.json),
     });
+    await maybeRestartServiceAfterFailedMutableUpdate({
+      preManagedServiceStop,
+      jsonMode: Boolean(opts.json),
+    });
     if (opts.json) {
       defaultRuntime.writeJson(resultWithPostUpdate);
     } else {

--- a/src/infra/update-managed-service-handoff.test.ts
+++ b/src/infra/update-managed-service-handoff.test.ts
@@ -116,6 +116,92 @@ async function runHelperWithExistingSentinel(params: {
   return { result, sentinelPath };
 }
 
+async function spawnExitedPid(): Promise<number> {
+  const { spawn } =
+    await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return await new Promise<number>((resolve) => {
+    const child = spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+    const pid = child.pid ?? 0;
+    child.once("exit", () => resolve(pid));
+  });
+}
+
+async function runHelperWithCommand(params: {
+  commandArgv: string[];
+  serviceRecovery?: Record<string, unknown>;
+  pathPrepend?: string;
+}): Promise<{ code: number }> {
+  const { execFile } =
+    await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  const { startManagedServiceUpdateHandoff } = await import("./update-managed-service-handoff.js");
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-handoff-recovery-test-"));
+  tempDirs.add(tmpDir);
+
+  await startManagedServiceUpdateHandoff({
+    root: tmpDir,
+    timeoutMs: 1_800_000,
+    restartDelayMs: 0,
+    parentPid: process.pid,
+    execPath: "/usr/local/bin/node",
+    argv1: "/opt/openclaw/openclaw.mjs",
+    env: {},
+    meta: { sessionKey: "agent:test:webchat:dm:user-123" },
+  });
+
+  const [, args] = spawnMock.mock.calls.at(-1) as unknown as [string, string[]];
+  const helperScriptPath = args[0] ?? "";
+  tempDirs.add(path.dirname(helperScriptPath));
+  const baseParams = JSON.parse(await fs.readFile(args[1] ?? "", "utf-8")) as Record<
+    string,
+    unknown
+  >;
+
+  const helperParamsPath = path.join(tmpDir, "helper-params.json");
+  await fs.writeFile(
+    helperParamsPath,
+    `${JSON.stringify(
+      {
+        ...baseParams,
+        parentPid: await spawnExitedPid(),
+        parentExitTimeoutMs: 5000,
+        cwd: tmpDir,
+        commandArgv: params.commandArgv,
+        sentinelPath: path.join(tmpDir, "restart-sentinel.json"),
+        logPath: path.join(tmpDir, "handoff.log"),
+        sensitivePaths: [],
+        ...(params.serviceRecovery ? { serviceRecovery: params.serviceRecovery } : {}),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const childEnv = {
+    ...process.env,
+    ...(params.pathPrepend
+      ? { PATH: `${params.pathPrepend}${path.delimiter}${process.env.PATH ?? ""}` }
+      : {}),
+  };
+  return await new Promise<{ code: number }>((resolve) => {
+    execFile(process.execPath, [helperScriptPath, helperParamsPath], { env: childEnv }, (err) => {
+      const childError = err as NodeJS.ErrnoException | null;
+      resolve({ code: typeof childError?.code === "number" ? childError.code : 0 });
+    });
+  });
+}
+
+async function writeFakeSystemctl(): Promise<{ binDir: string; recordPath: string }> {
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-recovery-bin-"));
+  tempDirs.add(binDir);
+  const recordPath = path.join(binDir, "systemctl-calls.log");
+  await fs.writeFile(
+    path.join(binDir, "systemctl"),
+    `#!/bin/sh\necho "$@" >> '${recordPath}'\nexit 0\n`,
+    { mode: 0o755 },
+  );
+  return { binDir, recordPath };
+}
+
 describe("managed service update handoff", () => {
   it("strips process supervisor hints while preserving service identity for the CLI handoff", async () => {
     const { startManagedServiceUpdateHandoff, stripSupervisorHintEnv } =
@@ -244,7 +330,12 @@ describe("managed service update handoff", () => {
     const helperParams = JSON.parse(await fs.readFile(args[6] ?? "", "utf-8")) as {
       commandArgv?: string[];
       handoffId?: string;
+      serviceRecovery?: unknown;
     };
+    expect(helperParams.serviceRecovery).toEqual({
+      kind: "systemd",
+      unit: "openclaw-gateway.service",
+    });
     expect(helperParams.commandArgv).toEqual([
       "/usr/local/bin/node",
       "/opt/openclaw/openclaw.mjs",
@@ -262,6 +353,75 @@ describe("managed service update handoff", () => {
     expect(options.env.INVOCATION_ID).toBeUndefined();
     expect(options.env.KEEP_ME).toBe("1");
     expect(options.env.OPENCLAW_UPDATE_RUN_HANDOFF).toBe("1");
+  });
+
+  it("starts the managed gateway service when the update command fails after handoff", async () => {
+    const { binDir, recordPath } = await writeFakeSystemctl();
+    const result = await runHelperWithCommand({
+      commandArgv: [process.execPath, "-e", "process.exit(7)"],
+      serviceRecovery: { kind: "systemd", unit: "openclaw-gateway.service" },
+      pathPrepend: binDir,
+    });
+
+    expect(result.code).toBe(7);
+    await expect(fs.readFile(recordPath, "utf-8")).resolves.toBe(
+      "--user start openclaw-gateway.service\n",
+    );
+  });
+
+  it("leaves the gateway service alone when the update command succeeds", async () => {
+    const { binDir, recordPath } = await writeFakeSystemctl();
+    const result = await runHelperWithCommand({
+      commandArgv: [process.execPath, "-e", "process.exit(0)"],
+      serviceRecovery: { kind: "systemd", unit: "openclaw-gateway.service" },
+      pathPrepend: binDir,
+    });
+
+    expect(result.code).toBe(0);
+    await expect(pathExists(recordPath)).resolves.toBe(false);
+  });
+
+  it("passes a gateway service recovery descriptor for each supervisor", async () => {
+    const { startManagedServiceUpdateHandoff } =
+      await import("./update-managed-service-handoff.js");
+    const cases = [
+      {
+        supervisor: "launchd" as const,
+        env: { OPENCLAW_LAUNCHD_LABEL: "com.example.openclaw.test", HOME: "/Users/test" },
+        expected: {
+          kind: "launchd",
+          uid: typeof process.getuid === "function" ? process.getuid() : 501,
+          label: "com.example.openclaw.test",
+          plistPath: "/Users/test/Library/LaunchAgents/com.example.openclaw.test.plist",
+        },
+      },
+      {
+        supervisor: "schtasks" as const,
+        env: { OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Test Gateway" },
+        expected: { kind: "schtasks", taskName: "OpenClaw Test Gateway" },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const result = await startManagedServiceUpdateHandoff({
+        root: "/tmp/openclaw",
+        timeoutMs: 1_800_000,
+        restartDelayMs: 500,
+        parentPid: 12345,
+        execPath: "/usr/local/bin/node",
+        argv1: "/opt/openclaw/openclaw.mjs",
+        supervisor: testCase.supervisor,
+        env: testCase.env,
+        meta: { sessionKey: "agent:test:webchat:dm:user-123" },
+      });
+      expect(result.status).toBe("started");
+      const [, args] = spawnMock.mock.calls.at(-1) as unknown as [string, string[]];
+      tempDirs.add(path.dirname(args[0] ?? ""));
+      const helperParams = JSON.parse(await fs.readFile(args[1] ?? "", "utf-8")) as {
+        serviceRecovery?: unknown;
+      };
+      expect(helperParams.serviceRecovery).toEqual(testCase.expected);
+    }
   });
 
   it("does not overwrite a restart sentinel owned by another startup task", async () => {

--- a/src/infra/update-managed-service-handoff.test.ts
+++ b/src/infra/update-managed-service-handoff.test.ts
@@ -202,6 +202,34 @@ async function writeFakeSystemctl(): Promise<{ binDir: string; recordPath: strin
   return { binDir, recordPath };
 }
 
+async function writeFakeLaunchctl(): Promise<{ binDir: string; recordPath: string }> {
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-launchctl-bin-"));
+  tempDirs.add(binDir);
+  const recordPath = path.join(binDir, "launchctl-calls.log");
+  const countPath = path.join(binDir, "launchctl-kickstart-count");
+  await fs.writeFile(
+    path.join(binDir, "launchctl"),
+    `#!/bin/sh
+echo "$@" >> '${recordPath}'
+if [ "$1" = "kickstart" ]; then
+  count=0
+  if [ -f '${countPath}' ]; then
+    count=$(cat '${countPath}')
+  fi
+  count=$((count + 1))
+  echo "$count" > '${countPath}'
+  [ "$count" -gt 1 ]
+  exit $?
+fi
+[ "$1" = "enable" ] && exit 0
+[ "$1" = "bootstrap" ] && exit 1
+exit 1
+`,
+    { mode: 0o755 },
+  );
+  return { binDir, recordPath };
+}
+
 describe("managed service update handoff", () => {
   it("strips process supervisor hints while preserving service identity for the CLI handoff", async () => {
     const { startManagedServiceUpdateHandoff, stripSupervisorHintEnv } =
@@ -379,6 +407,31 @@ describe("managed service update handoff", () => {
 
     expect(result.code).toBe(0);
     await expect(pathExists(recordPath)).resolves.toBe(false);
+  });
+
+  it("retries launchd start when bootstrap reports an already-loaded label", async () => {
+    const { binDir, recordPath } = await writeFakeLaunchctl();
+    const result = await runHelperWithCommand({
+      commandArgv: [process.execPath, "-e", "process.exit(7)"],
+      serviceRecovery: {
+        kind: "launchd",
+        uid: 501,
+        label: "com.example.openclaw",
+        plistPath: "/Users/test/Library/LaunchAgents/com.example.openclaw.plist",
+      },
+      pathPrepend: binDir,
+    });
+
+    expect(result.code).toBe(7);
+    await expect(fs.readFile(recordPath, "utf-8")).resolves.toBe(
+      [
+        "kickstart gui/501/com.example.openclaw",
+        "enable gui/501/com.example.openclaw",
+        "bootstrap gui/501 /Users/test/Library/LaunchAgents/com.example.openclaw.plist",
+        "kickstart gui/501/com.example.openclaw",
+        "",
+      ].join("\n"),
+    );
   });
 
   it("passes a gateway service recovery descriptor for each supervisor", async () => {

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -4,6 +4,11 @@ import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import {
+  resolveGatewayLaunchAgentLabel,
+  resolveGatewaySystemdServiceName,
+  resolveGatewayWindowsTaskName,
+} from "../daemon/constants.js";
 import { resolveRestartSentinelPath } from "./restart-sentinel.js";
 import { SUPERVISOR_HINT_ENV_VARS, type RespawnSupervisor } from "./supervisor-markers.js";
 import {
@@ -22,7 +27,7 @@ const SERVICE_IDENTITY_ENV_VARS = new Set<string>([
 ] as const);
 
 const HANDOFF_SCRIPT = String.raw`
-const { spawn } = require("node:child_process");
+const { spawn, spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -174,6 +179,51 @@ function markUpdateSentinelFailureIfPending(reason) {
   writeJsonFile(params.sentinelPath, { version: 1, payload });
 }
 
+function runServiceCommand(command, args) {
+  try {
+    const result = spawnSync(command, args, { stdio: "ignore", timeout: 30000 });
+    return typeof result.status === "number" ? result.status : 1;
+  } catch {
+    return 1;
+  }
+}
+
+function startGatewayServiceBestEffort() {
+  const recovery = params.serviceRecovery;
+  if (!recovery || typeof recovery !== "object" || !recovery.kind) {
+    return;
+  }
+  let target = "";
+  let status = 1;
+  if (recovery.kind === "systemd") {
+    target = recovery.unit;
+    status = runServiceCommand("systemctl", ["--user", "start", recovery.unit]);
+  } else if (recovery.kind === "launchd") {
+    target = recovery.label;
+    const serviceTarget = "gui/" + recovery.uid + "/" + recovery.label;
+    status = runServiceCommand("launchctl", ["kickstart", serviceTarget]);
+    if (status !== 0) {
+      runServiceCommand("launchctl", ["enable", serviceTarget]);
+      status = runServiceCommand("launchctl", [
+        "bootstrap",
+        "gui/" + recovery.uid,
+        recovery.plistPath,
+      ]);
+    }
+  } else if (recovery.kind === "schtasks") {
+    target = recovery.taskName;
+    status = runServiceCommand("schtasks.exe", ["/Run", "/TN", recovery.taskName]);
+  } else {
+    return;
+  }
+  appendLog(
+    "gateway service recovery " +
+      (status === 0 ? "succeeded" : "failed status=" + status) +
+      " target=" +
+      target,
+  );
+}
+
 (async () => {
   const deadline = Date.now() + params.parentExitTimeoutMs;
   while (isPidAlive(params.parentPid) && Date.now() < deadline) {
@@ -215,6 +265,7 @@ function markUpdateSentinelFailureIfPending(reason) {
     if (exit && exit.error) {
       appendLog("managed update command failed to start: " + (exit.error && exit.error.stack ? exit.error.stack : String(exit.error)));
       markUpdateSentinelFailureIfPending("managed-service-handoff-spawn-failed");
+      startGatewayServiceBestEffort();
       process.exitCode = 1;
       return;
     }
@@ -226,9 +277,11 @@ function markUpdateSentinelFailureIfPending(reason) {
     );
     if (exit && typeof exit.code === "number" && exit.code !== 0) {
       markUpdateSentinelFailureIfPending("managed-service-handoff-failed");
+      startGatewayServiceBestEffort();
       process.exitCode = exit.code;
     } else if (exit && exit.signal) {
       markUpdateSentinelFailureIfPending("managed-service-handoff-failed");
+      startGatewayServiceBestEffort();
       process.exitCode = 1;
     }
   } finally {
@@ -244,6 +297,7 @@ function markUpdateSentinelFailureIfPending(reason) {
 })().catch((err) => {
   appendLog("handoff failed: " + (err && err.stack ? err.stack : String(err)));
   markUpdateSentinelFailureIfPending("managed-service-handoff-helper-failed");
+  startGatewayServiceBestEffort();
   cleanupSensitiveFiles();
   process.exitCode = 1;
 });
@@ -301,6 +355,44 @@ export function formatManagedServiceUpdateCommand(params?: {
     args.push("--timeout", String(Math.max(1, Math.ceil(params.timeoutMs / 1000))));
   }
   return args.join(" ");
+}
+
+type GatewayServiceRecovery =
+  | { kind: "systemd"; unit: string }
+  | { kind: "launchd"; uid: number; label: string; plistPath: string }
+  | { kind: "schtasks"; taskName: string };
+
+function resolveGatewayServiceRecovery(
+  supervisor: RespawnSupervisor | null | undefined,
+  env: NodeJS.ProcessEnv,
+): GatewayServiceRecovery | undefined {
+  if (supervisor === "systemd") {
+    const override = env.OPENCLAW_SYSTEMD_UNIT?.trim();
+    const unit = override
+      ? override.endsWith(".service")
+        ? override
+        : `${override}.service`
+      : `${resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE)}.service`;
+    return { kind: "systemd", unit };
+  }
+  if (supervisor === "launchd") {
+    const label =
+      env.OPENCLAW_LAUNCHD_LABEL?.trim() || resolveGatewayLaunchAgentLabel(env.OPENCLAW_PROFILE);
+    const uid = typeof process.getuid === "function" ? process.getuid() : 501;
+    const home = env.HOME?.trim() || os.homedir();
+    return {
+      kind: "launchd",
+      uid,
+      label,
+      plistPath: path.join(home, "Library", "LaunchAgents", `${label}.plist`),
+    };
+  }
+  if (supervisor === "schtasks") {
+    const taskName =
+      env.OPENCLAW_WINDOWS_TASK_NAME?.trim() || resolveGatewayWindowsTaskName(env.OPENCLAW_PROFILE);
+    return { kind: "schtasks", taskName };
+  }
+  return undefined;
 }
 
 export function stripSupervisorHintEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
@@ -458,6 +550,7 @@ export async function startManagedServiceUpdateHandoff(params: {
     metaPath,
     sentinelPath: resolveRestartSentinelPath(),
     sensitivePaths: [scriptPath, paramsPath, metaPath],
+    serviceRecovery: resolveGatewayServiceRecovery(params.supervisor, params.env ?? process.env),
   };
 
   await fs.writeFile(scriptPath, `${HANDOFF_SCRIPT}\n`, { mode: 0o700 });

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -209,6 +209,11 @@ function startGatewayServiceBestEffort() {
         "gui/" + recovery.uid,
         recovery.plistPath,
       ]);
+      if (status !== 0) {
+        // Bootstrap can fail when the label is already loaded. Retry start-only
+        // so recovery does not bounce a gateway that is already running.
+        status = runServiceCommand("launchctl", ["kickstart", serviceTarget]);
+      }
     }
   } else if (recovery.kind === "schtasks") {
     target = recovery.taskName;


### PR DESCRIPTION
## Summary

Fixes #92088. When a managed-service update handoff fails after the update command has already stopped `openclaw-gateway.service`, nothing restarted the gateway, leaving the host with no live gateway until manual recovery (`loaded inactive dead`, reported on Ubuntu systemd user services).

The detached handoff helper is the only process that survives the update command, so it now performs a best-effort gateway service start whenever the managed update command fails to spawn, exits nonzero, or dies on a signal (covers OOM kills and `exit 127` style wrapper failures that bypass the CLI's own restore path):

- systemd: `systemctl --user start <unit>` (a no-op when the unit is already active, so failures that happen before the stop, or after the CLI already restored the gateway, do not bounce a healthy gateway)
- launchd: `launchctl kickstart`, falling back to `enable` plus `bootstrap` with the agent plist (the CLI stop path uses `bootout`)
- Windows: `schtasks /Run` on the gateway task

The service identity (unit/label/task name) is resolved at handoff start from the same env vars and `daemon/constants.js` resolvers the rest of the daemon code uses, and passed to the helper via its params file as a `serviceRecovery` descriptor.

Also closes the one CLI failure path that exited without restoring a gateway it had stopped: the plugin post-update sync error branch in `src/cli/update-cli/update-command.ts` now calls `maybeRestartServiceAfterFailedMutableUpdate` like the sibling error/skipped branches.

The issue's stale `update-restart-pending` sentinel note is already handled on main: the helper marks the pending sentinel as `error` via `markUpdateSentinelFailureIfPending` on the same failure paths.

## Real behavior proof

Behavior addressed: a failed managed update handoff left `openclaw-gateway.service` stopped (`loaded inactive dead`, gateway HTTP unreachable) with no automatic recovery.

Real environment tested: Ubuntu Linux (kernel 6.8), systemd user manager, real `openclaw-gateway.service` installed by `openclaw gateway install` from this checkout's dist build, gateway serving HTTP 200 on port 18789. The real generated `handoff.cjs` ran inside a real `systemd-run --user --scope` transient unit via `startManagedServiceUpdateHandoff`, with the managed update command replaced by a stub that reproduces the reported timeline: stop `openclaw-gateway.service`, then exit 127.

Exact steps or command run after this patch: `systemctl --user start openclaw-gateway.service`, confirm `active` and HTTP 200, then run a driver that calls `startManagedServiceUpdateHandoff({ supervisor: "systemd", env: { ...process.env, OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service" }, ... })` against the patched module with the failing update stub, wait for the handoff to finish, then check `systemctl --user is-active openclaw-gateway.service`, the unit list, HTTP on 18789, and the handoff log.

Evidence after fix:

```text
=== AFTER fix, after failed update:
unit: active
  openclaw-gateway.service loaded active running OpenClaw Gateway (v2026.6.2)
HTTP: 200
=== handoff.log:
[2026-06-11T07:28:36.078Z] starting managed update command: openclaw update --yes
[2026-06-11T07:28:36.086Z] managed update command pid=46776
[2026-06-11T07:28:36.132Z] Stopping openclaw-gateway...
[2026-06-11T07:28:37.081Z] Running openclaw update...
[2026-06-11T07:28:37.086Z] managed update command exited code=127 signal=null
[2026-06-11T07:28:37.108Z] gateway service recovery succeeded target=openclaw-gateway.service
```

Same scenario on unpatched main (418d7e1e83c) for contrast:

```text
=== BEFORE fix, after failed update:
unit: inactive
  openclaw-gateway.service loaded inactive dead OpenClaw Gateway (v2026.6.2)
HTTP: 000
=== handoff.log:
[2026-06-11T07:27:53.379Z] starting managed update command: openclaw update --yes
[2026-06-11T07:27:53.385Z] managed update command pid=46685
[2026-06-11T07:27:53.434Z] Stopping openclaw-gateway...
[2026-06-11T07:27:57.154Z] Running openclaw update...
[2026-06-11T07:27:57.161Z] managed update command exited code=127 signal=null
```

No-bounce check on the patched build: an update command that fails with exit 1 before stopping the gateway leaves the running gateway untouched, `MainPID before=46787 after=46787 unit=active`, and the helper logs `gateway service recovery succeeded` from the idempotent `systemctl --user start`.

Observed result after fix: the gateway service is automatically started again within about 20 ms of the failed update command exiting; the host keeps a live gateway instead of a full outage, and successful updates and pre-stop failures see no extra restart.

What was not tested: launchd and schtasks recovery commands were not executed against real macOS/Windows service managers (covered by unit tests asserting the descriptor and the command wiring; the command sequences mirror `src/cli/update-cli/restart-helper.ts`); the plugin post-update sync error branch in `update-command.ts` has no existing test harness and was verified by code reading against the sibling error/skipped branches.

## Maintainer follow-up

Autoreview found one launchd edge case after the contributor proof: `bootstrap` can report an already-loaded/in-progress label while the service still needs a start. The final commit retries start-only `kickstart` after that failure, preserving the no-bounce policy and adding a regression test for the full `kickstart` → `enable` → failed `bootstrap` → `kickstart` sequence.

## Verification

- `node scripts/run-vitest.mjs src/infra/update-managed-service-handoff.test.ts` passes (9 tests); the contributor's 3 core regression tests fail on unpatched main and pass with this change
- `pnpm tsgo:core` and `pnpm tsgo:core:test` clean
- `node scripts/run-oxlint.mjs` and `oxfmt --check` clean on the touched files
- `pnpm check:changed` passes in Testbox `tbx_01kv78qyb9v89ffrtesqekjdgb` ([run](https://github.com/openclaw/openclaw/actions/runs/27592801280))
- Fresh exact-head Crabbox systemd proof passes on Ubuntu/Node 24: the real installed gateway stops inside the failing detached update, exits 127, recovers through `systemctl --user start`, and returns active with HTTP 200 ([run](https://crabbox.openclaw.ai/portal/runs/run_98bf7b1d0a71))
- Live systemd before/after repro above

Reported by @ofan.
