### PR TITLE
fix(auth): resolve custom provider secretref-managed apiKey from runtime snapshot

### DIFF
--- a/scripts/repro/issue-92097-secretref-custom-provider.mts
+++ b/scripts/repro/issue-92097-secretref-custom-provider.mts
@@ -58,7 +58,7 @@ async function main() {
   }
 }
 
-main().catch((err) => {
+main().catch((err: unknown) => {
   console.error(err);
   process.exitCode = 1;
 });

--- a/scripts/repro/issue-92097-secretref-custom-provider.mts
+++ b/scripts/repro/issue-92097-secretref-custom-provider.mts
@@ -1,9 +1,9 @@
-import { resolveApiKeyForProvider } from "../../src/agents/model-auth.js";
-import {
-  setRuntimeConfigSnapshot,
-  clearRuntimeConfigSnapshot,
-} from "../../src/config/config.js";
 import { NON_ENV_SECRETREF_MARKER } from "../../src/agents/model-auth-markers.js";
+import {
+  hasRuntimeAvailableProviderAuth,
+  resolveApiKeyForProvider,
+} from "../../src/agents/model-auth.js";
+import { setRuntimeConfigSnapshot, clearRuntimeConfigSnapshot } from "../../src/config/config.js";
 
 const sourceConfig = {
   models: {
@@ -36,6 +36,12 @@ async function main() {
   setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
 
   try {
+    const available = hasRuntimeAvailableProviderAuth({
+      provider: "cliproxyapi",
+      cfg: sourceConfig,
+    });
+    console.log("Runtime available auth:", available);
+
     const resolved = await resolveApiKeyForProvider({
       provider: "cliproxyapi",
       cfg: sourceConfig,
@@ -44,10 +50,17 @@ async function main() {
 
     console.log("Resolved auth:", resolved);
 
-    if (resolved?.apiKey === "resolved-secretref-key") {
-      console.log("\nPASS: Custom provider secretref-managed apiKey correctly resolved from runtime snapshot.");
+    if (available && resolved?.apiKey === "resolved-secretref-key") {
+      console.log(
+        "\nPASS: Custom provider secretref-managed apiKey is available and correctly resolved from runtime snapshot.",
+      );
     } else {
-      console.error("\nFAIL: Expected apiKey 'resolved-secretref-key', got:", resolved?.apiKey);
+      console.error(
+        "\nFAIL: Expected available=true and apiKey 'resolved-secretref-key', got available=",
+        available,
+        "apiKey=",
+        resolved?.apiKey,
+      );
       process.exitCode = 1;
     }
   } catch (err) {

--- a/scripts/repro/issue-92097-secretref-custom-provider.mts
+++ b/scripts/repro/issue-92097-secretref-custom-provider.mts
@@ -1,62 +1,135 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { NON_ENV_SECRETREF_MARKER } from "../../src/agents/model-auth-markers.js";
 import {
   hasRuntimeAvailableProviderAuth,
   resolveApiKeyForProvider,
 } from "../../src/agents/model-auth.js";
-import { setRuntimeConfigSnapshot, clearRuntimeConfigSnapshot } from "../../src/config/config.js";
+import { clearRuntimeConfigSnapshot } from "../../src/config/config.js";
+import {
+  activateSecretsRuntimeSnapshot,
+  clearSecretsRuntimeSnapshot,
+  prepareSecretsRuntimeSnapshot,
+} from "../../src/secrets/runtime.js";
 
-const sourceConfig = {
-  models: {
-    providers: {
-      cliproxyapi: {
-        api: "openai-responses",
-        apiKey: NON_ENV_SECRETREF_MARKER,
-      },
-    },
-  },
-};
+const providerId = "cliproxyapi";
 
-const runtimeConfig = {
-  models: {
-    providers: {
-      cliproxyapi: {
-        api: "openai-responses",
-        apiKey: "resolved-secretref-key",
+function createBaseProviderConfig() {
+  return {
+    api: "openai-responses",
+    baseUrl: "http://localhost:8080/v1",
+    models: [
+      {
+        id: "test-model",
+        name: "Test Model",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 4096,
       },
-    },
-  },
-};
+    ],
+  };
+}
 
 async function main() {
   console.log("=== Reproduction for issue #92097 ===");
-  console.log("Source config apiKey:", sourceConfig.models.providers.cliproxyapi.apiKey);
-  console.log("Runtime config apiKey:", runtimeConfig.models.providers.cliproxyapi.apiKey);
+  console.log(
+    "Proving managed SecretRef custom-provider auth through actual file-based SecretRef preparation.",
+  );
   console.log();
 
-  setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-repro-92097-"));
+  const secretsFile = path.join(tmpDir, "secrets.json");
 
   try {
+    await fs.writeFile(
+      secretsFile,
+      JSON.stringify({
+        providers: {
+          [providerId]: {
+            apiKey: "resolved-from-file-secret", // pragma: allowlist secret
+          },
+        },
+      }),
+    );
+
+    // Source config as it would appear on disk after a previous session: the
+    // non-env SecretRef has been normalized to the managed marker, while the
+    // actual value lives in the secrets file and is prepared into the runtime
+    // snapshot below.
+    const markerSourceConfig = {
+      models: {
+        providers: {
+          [providerId]: {
+            ...createBaseProviderConfig(),
+            apiKey: NON_ENV_SECRETREF_MARKER,
+          },
+        },
+      },
+    } as const;
+
+    // Independent source config used to prepare the runtime snapshot. It keeps
+    // the structured file SecretRef so prepareSecretsRuntimeSnapshot resolves it
+    // from the real secrets file instead of being injected manually.
+    const resolvedSourceConfig = {
+      models: {
+        providers: {
+          [providerId]: {
+            ...createBaseProviderConfig(),
+            apiKey: {
+              source: "file",
+              provider: "local-file",
+              id: `/providers/${providerId}/apiKey`,
+            },
+          },
+        },
+      },
+      secrets: {
+        providers: {
+          "local-file": {
+            source: "file",
+            path: secretsFile,
+            mode: "json",
+            allowInsecurePath: true,
+          },
+        },
+      },
+    } as const;
+
+    const prepared = await prepareSecretsRuntimeSnapshot({
+      config:
+        resolvedSourceConfig as unknown as import("../../src/config/types.openclaw.js").OpenClawConfig,
+      includeAuthStoreRefs: false,
+    });
+    activateSecretsRuntimeSnapshot(prepared);
+
     const available = hasRuntimeAvailableProviderAuth({
-      provider: "cliproxyapi",
-      cfg: sourceConfig,
+      provider: providerId,
+      cfg: markerSourceConfig as unknown as import("../../src/config/types.openclaw.js").OpenClawConfig,
     });
     console.log("Runtime available auth:", available);
 
     const resolved = await resolveApiKeyForProvider({
-      provider: "cliproxyapi",
-      cfg: sourceConfig,
+      provider: providerId,
+      cfg: markerSourceConfig as unknown as import("../../src/config/types.openclaw.js").OpenClawConfig,
       store: { version: 1, profiles: {} },
     });
 
-    console.log("Resolved auth:", resolved);
+    console.log("Resolved auth:", {
+      apiKey: resolved.apiKey,
+      source: resolved.source,
+      mode: resolved.mode,
+    });
 
-    if (available && resolved?.apiKey === "resolved-secretref-key") {
+    if (available && resolved?.apiKey === "resolved-from-file-secret") {
       console.log(
-        "\nPASS: Custom provider secretref-managed apiKey is available and correctly resolved from runtime snapshot.",
+        "\nPASS: Custom provider secretref-managed apiKey is available and correctly resolved from file-backed SecretRef runtime snapshot.",
       );
     } else {
       console.error(
-        "\nFAIL: Expected available=true and apiKey 'resolved-secretref-key', got available=",
+        "\nFAIL: Expected available=true and apiKey 'resolved-from-file-secret', got available=",
         available,
         "apiKey=",
         resolved?.apiKey,
@@ -67,7 +140,9 @@ async function main() {
     console.error("\nFAIL: Threw error:", (err as Error).message);
     process.exitCode = 1;
   } finally {
+    clearSecretsRuntimeSnapshot();
     clearRuntimeConfigSnapshot();
+    await fs.rm(tmpDir, { recursive: true, force: true });
   }
 }
 

--- a/scripts/repro/issue-92097-secretref-custom-provider.mts
+++ b/scripts/repro/issue-92097-secretref-custom-provider.mts
@@ -1,0 +1,64 @@
+import { resolveApiKeyForProvider } from "../../src/agents/model-auth.js";
+import {
+  setRuntimeConfigSnapshot,
+  clearRuntimeConfigSnapshot,
+} from "../../src/config/config.js";
+import { NON_ENV_SECRETREF_MARKER } from "../../src/agents/model-auth-markers.js";
+
+const sourceConfig = {
+  models: {
+    providers: {
+      cliproxyapi: {
+        api: "openai-responses",
+        apiKey: NON_ENV_SECRETREF_MARKER,
+      },
+    },
+  },
+};
+
+const runtimeConfig = {
+  models: {
+    providers: {
+      cliproxyapi: {
+        api: "openai-responses",
+        apiKey: "resolved-secretref-key",
+      },
+    },
+  },
+};
+
+async function main() {
+  console.log("=== Reproduction for issue #92097 ===");
+  console.log("Source config apiKey:", sourceConfig.models.providers.cliproxyapi.apiKey);
+  console.log("Runtime config apiKey:", runtimeConfig.models.providers.cliproxyapi.apiKey);
+  console.log();
+
+  setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+  try {
+    const resolved = await resolveApiKeyForProvider({
+      provider: "cliproxyapi",
+      cfg: sourceConfig,
+      store: { version: 1, profiles: {} },
+    });
+
+    console.log("Resolved auth:", resolved);
+
+    if (resolved?.apiKey === "resolved-secretref-key") {
+      console.log("\nPASS: Custom provider secretref-managed apiKey correctly resolved from runtime snapshot.");
+    } else {
+      console.error("\nFAIL: Expected apiKey 'resolved-secretref-key', got:", resolved?.apiKey);
+      process.exitCode = 1;
+    }
+  } catch (err) {
+    console.error("\nFAIL: Threw error:", (err as Error).message);
+    process.exitCode = 1;
+  } finally {
+    clearRuntimeConfigSnapshot();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1045,6 +1045,102 @@ describe("resolveApiKeyForProvider", () => {
     ).rejects.toThrow('No API key found for provider "mismatch-provider"');
   });
 
+  it("does not share file SecretRef runtime credentials across caller configs with the same provider id", async () => {
+    const sourceConfig = {
+      models: {
+        providers: {
+          "shared-provider": {
+            api: "openai-responses",
+            baseUrl: "https://source.example/v1",
+            apiKey: { source: "file", provider: "vault", id: "/shared/api-key" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const runtimeConfig = {
+      models: {
+        providers: {
+          "shared-provider": {
+            api: "openai-responses",
+            baseUrl: "https://source.example/v1",
+            apiKey: "resolved-for-source-config", // pragma: allowlist secret
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    const differentConfig = {
+      models: {
+        providers: {
+          "shared-provider": {
+            api: "openai-responses",
+            baseUrl: "https://other.example/v1",
+            apiKey: { source: "file", provider: "vault", id: "/shared/api-key" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "shared-provider",
+        cfg: differentConfig,
+        store: { version: 1, profiles: {} },
+      }),
+    ).rejects.toThrow('No API key found for provider "shared-provider"');
+  });
+
+  it("resolves normalized managed markers from the active runtime snapshot even when source identity drifts", async () => {
+    const preparedSourceConfig = {
+      models: {
+        providers: {
+          "normalized-provider": {
+            api: "openai-responses",
+            baseUrl: "https://normalized.example/v1",
+            apiKey: NON_ENV_SECRETREF_MARKER,
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const runtimeConfig = {
+      models: {
+        providers: {
+          "normalized-provider": {
+            api: "openai-responses",
+            baseUrl: "https://normalized.example/v1",
+            apiKey: "resolved-normalized-marker", // pragma: allowlist secret
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, preparedSourceConfig);
+
+    const driftedConfig = {
+      models: {
+        providers: {
+          "normalized-provider": {
+            api: "openai-responses",
+            baseUrl: "https://drifted.example/v1",
+            apiKey: NON_ENV_SECRETREF_MARKER,
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const resolved = await resolveApiKeyForProvider({
+      provider: "normalized-provider",
+      cfg: driftedConfig,
+      store: { version: 1, profiles: {} },
+    });
+
+    expectAuthFields(resolved, {
+      apiKey: "resolved-normalized-marker",
+      source: "models.providers.normalized-provider",
+      mode: "api-key",
+    });
+  });
+
   it("resolves custom provider file SecretRef apiKey from runtime snapshot", async () => {
     const sourceConfig = {
       models: {

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -138,6 +138,7 @@ let hasUsableCustomProviderApiKey: typeof import("./model-auth.js").hasUsableCus
 let hasSyntheticLocalProviderAuthConfig: typeof import("./model-auth.js").hasSyntheticLocalProviderAuthConfig;
 let requireApiKey: typeof import("./model-auth.js").requireApiKey;
 let getApiKeyForModel: typeof import("./model-auth.js").getApiKeyForModel;
+let hasRuntimeAvailableProviderAuth: typeof import("./model-auth.js").hasRuntimeAvailableProviderAuth;
 let resolveApiKeyForProvider: typeof import("./model-auth.js").resolveApiKeyForProvider;
 let resolveAwsSdkEnvVarName: typeof import("./model-auth.js").resolveAwsSdkEnvVarName;
 let resolveModelAuthMode: typeof import("./model-auth.js").resolveModelAuthMode;
@@ -155,6 +156,7 @@ beforeAll(async () => {
     applyLocalNoAuthHeaderOverride,
     createRuntimeProviderAuthLookup,
     formatMissingAuthError,
+    hasRuntimeAvailableProviderAuth,
     hasSyntheticLocalProviderAuthConfig,
     getApiKeyForModel,
     hasUsableCustomProviderApiKey,
@@ -798,6 +800,60 @@ describe("resolveUsableCustomProviderApiKey", () => {
         process.env.OPENAI_API_KEY = previous;
       }
     }
+  });
+});
+
+describe("hasRuntimeAvailableProviderAuth", () => {
+  it("returns true for custom providers with a managed SecretRef apiKey resolved in the runtime snapshot", () => {
+    const sourceConfig = {
+      models: {
+        providers: {
+          cliproxyapi: {
+            api: "openai-responses",
+            apiKey: NON_ENV_SECRETREF_MARKER,
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const runtimeConfig = {
+      models: {
+        providers: {
+          cliproxyapi: {
+            api: "openai-responses",
+            apiKey: "resolved-secretref-key", // pragma: allowlist secret
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    expect(
+      hasRuntimeAvailableProviderAuth({
+        provider: "cliproxyapi",
+        cfg: sourceConfig,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for custom providers with a managed SecretRef apiKey when the runtime snapshot has no real key", () => {
+    const sourceConfig = {
+      models: {
+        providers: {
+          cliproxyapi: {
+            api: "openai-responses",
+            apiKey: NON_ENV_SECRETREF_MARKER,
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(sourceConfig, sourceConfig);
+
+    expect(
+      hasRuntimeAvailableProviderAuth({
+        provider: "cliproxyapi",
+        cfg: sourceConfig,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -835,23 +835,56 @@ describe("hasRuntimeAvailableProviderAuth", () => {
     ).toBe(true);
   });
 
-  it("returns false for custom providers with a managed SecretRef apiKey when the runtime snapshot has no real key", () => {
+  it("returns true for custom providers with a file SecretRef apiKey resolved in the runtime snapshot", () => {
     const sourceConfig = {
       models: {
         providers: {
           cliproxyapi: {
             api: "openai-responses",
-            apiKey: NON_ENV_SECRETREF_MARKER,
+            apiKey: { source: "file", provider: "vault", id: "/cliproxy/api-key" },
           },
         },
       },
     } as unknown as OpenClawConfig;
-    setRuntimeConfigSnapshot(sourceConfig, sourceConfig);
+    const runtimeConfig = {
+      models: {
+        providers: {
+          cliproxyapi: {
+            api: "openai-responses",
+            apiKey: "resolved-file-secretref-key", // pragma: allowlist secret
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
 
     expect(
       hasRuntimeAvailableProviderAuth({
         provider: "cliproxyapi",
         cfg: sourceConfig,
+        allowPluginSyntheticAuth: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for custom providers with a file SecretRef apiKey without a runtime snapshot", () => {
+    const sourceConfig = {
+      models: {
+        providers: {
+          cliproxyapi: {
+            api: "openai-responses",
+            apiKey: { source: "file", provider: "vault", id: "/cliproxy/api-key" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(undefined, undefined);
+
+    expect(
+      hasRuntimeAvailableProviderAuth({
+        provider: "cliproxyapi",
+        cfg: sourceConfig,
+        allowPluginSyntheticAuth: false,
       }),
     ).toBe(false);
   });
@@ -1010,6 +1043,149 @@ describe("resolveApiKeyForProvider", () => {
         store: { version: 1, profiles: {} },
       }),
     ).rejects.toThrow('No API key found for provider "mismatch-provider"');
+  });
+
+  it("resolves custom provider file SecretRef apiKey from runtime snapshot", async () => {
+    const sourceConfig = {
+      models: {
+        providers: {
+          cliproxyapi: {
+            api: "openai-responses",
+            apiKey: { source: "file", provider: "vault", id: "/cliproxy/api-key" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const runtimeConfig = {
+      models: {
+        providers: {
+          cliproxyapi: {
+            api: "openai-responses",
+            apiKey: "resolved-file-secretref-key", // pragma: allowlist secret
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    const resolved = await resolveApiKeyForProvider({
+      provider: "cliproxyapi",
+      cfg: sourceConfig,
+      store: { version: 1, profiles: {} },
+    });
+
+    expectAuthFields(resolved, {
+      apiKey: "resolved-file-secretref-key",
+      source: "models.providers.cliproxyapi",
+      mode: "api-key",
+    });
+  });
+
+  it("does not treat a managed SecretRef marker as auth without a runtime snapshot", async () => {
+    const sourceConfig = {
+      models: {
+        providers: {
+          cliproxyapi: {
+            api: "openai-responses",
+            apiKey: NON_ENV_SECRETREF_MARKER,
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(undefined, undefined);
+
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "cliproxyapi",
+        cfg: sourceConfig,
+        store: { version: 1, profiles: {} },
+      }),
+    ).rejects.toThrow('No API key found for provider "cliproxyapi"');
+  });
+
+  it("prefers explicit api-key provider SecretRef config over ambient auth profiles", async () => {
+    const sourceConfig = {
+      models: {
+        providers: {
+          cliproxyapi: {
+            api: "openai-responses",
+            auth: "api-key",
+            apiKey: { source: "file", provider: "vault", id: "/cliproxy/api-key" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const runtimeConfig = {
+      models: {
+        providers: {
+          cliproxyapi: {
+            api: "openai-responses",
+            auth: "api-key",
+            apiKey: "sk-runtime-cliproxy", // pragma: allowlist secret
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    const resolved = await resolveApiKeyForProvider({
+      provider: "cliproxyapi",
+      cfg: sourceConfig,
+      store: {
+        version: 1,
+        profiles: {
+          "cliproxyapi:default": {
+            type: "api_key",
+            provider: "cliproxyapi",
+            key: "sk-profile-stale", // pragma: allowlist secret
+          },
+        },
+      },
+    });
+
+    expectAuthFields(resolved, {
+      apiKey: "sk-runtime-cliproxy",
+      source: "models.providers.cliproxyapi",
+      mode: "api-key",
+    });
+  });
+
+  it("prefers a custom Ollama provider SecretRef runtime key over plugin synthetic auth", async () => {
+    const providerConfig = {
+      ...createCustomProviderConfig("http://192.168.178.122:11435", "qwen3:14b", "Qwen 3 14B"),
+      api: "ollama",
+      apiKey: { source: "file", provider: "vault", id: "/ollama/api-key" },
+    };
+    const sourceConfig = {
+      models: {
+        providers: {
+          "ollama-gpu1": providerConfig,
+        },
+      },
+    };
+    const runtimeConfig = {
+      models: {
+        providers: {
+          "ollama-gpu1": {
+            ...providerConfig,
+            apiKey: "sk-runtime-ollama", // pragma: allowlist secret
+          },
+        },
+      },
+    };
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    const auth = await resolveApiKeyForProvider({
+      provider: "ollama-gpu1",
+      cfg: sourceConfig,
+      store: { version: 1, profiles: {} },
+    });
+
+    expectAuthFields(auth, {
+      apiKey: "sk-runtime-ollama",
+      source: "models.providers.ollama-gpu1",
+      mode: "api-key",
+    });
   });
 
   it("does not reuse plugin fallback auth when the plugin is disabled", async () => {

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -874,6 +874,42 @@ describe("resolveApiKeyForProvider", () => {
     });
   });
 
+  it("resolves custom provider secretref-managed apiKey from runtime snapshot", async () => {
+    const sourceConfig = {
+      models: {
+        providers: {
+          cliproxyapi: {
+            api: "openai-responses",
+            apiKey: NON_ENV_SECRETREF_MARKER,
+          },
+        },
+      },
+    };
+    const runtimeConfig = {
+      models: {
+        providers: {
+          cliproxyapi: {
+            api: "openai-responses",
+            apiKey: "resolved-secretref-key", // pragma: allowlist secret
+          },
+        },
+      },
+    };
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    const resolved = await resolveApiKeyForProvider({
+      provider: "cliproxyapi",
+      cfg: sourceConfig,
+      store: { version: 1, profiles: {} },
+    });
+
+    expectAuthFields(resolved, {
+      apiKey: "resolved-secretref-key",
+      source: "models.providers.cliproxyapi",
+      mode: "api-key",
+    });
+  });
+
   it("does not reuse plugin fallback auth when the plugin is disabled", async () => {
     await expect(
       withoutEnv("PLUGIN_WEB_API_KEY", () =>

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -878,7 +878,7 @@ describe("hasRuntimeAvailableProviderAuth", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    setRuntimeConfigSnapshot(undefined, undefined);
+    clearRuntimeConfigSnapshot();
 
     expect(
       hasRuntimeAvailableProviderAuth({
@@ -1092,7 +1092,7 @@ describe("resolveApiKeyForProvider", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    setRuntimeConfigSnapshot(undefined, undefined);
+    clearRuntimeConfigSnapshot();
 
     await expect(
       resolveApiKeyForProvider({
@@ -1162,7 +1162,7 @@ describe("resolveApiKeyForProvider", () => {
           "ollama-gpu1": providerConfig,
         },
       },
-    };
+    } as unknown as OpenClawConfig;
     const runtimeConfig = {
       models: {
         providers: {
@@ -1172,7 +1172,7 @@ describe("resolveApiKeyForProvider", () => {
           },
         },
       },
-    };
+    } as unknown as OpenClawConfig;
     setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
 
     const auth = await resolveApiKeyForProvider({

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1,7 +1,7 @@
 // Verifies provider auth resolution, synthetic auth, and auth header behavior.
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ModelProviderConfig } from "../config/config.js";
+import type { ModelProviderConfig, OpenClawConfig } from "../config/config.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import {
   CUSTOM_LOCAL_AUTH_MARKER,
@@ -884,7 +884,7 @@ describe("resolveApiKeyForProvider", () => {
           },
         },
       },
-    };
+    } as unknown as OpenClawConfig;
     const runtimeConfig = {
       models: {
         providers: {
@@ -894,7 +894,7 @@ describe("resolveApiKeyForProvider", () => {
           },
         },
       },
-    };
+    } as unknown as OpenClawConfig;
     setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
 
     const resolved = await resolveApiKeyForProvider({

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -966,6 +966,52 @@ describe("resolveApiKeyForProvider", () => {
     });
   });
 
+  it("does not inherit a runtime snapshot credential from a mismatched caller config", async () => {
+    const sourceConfig = {
+      models: {
+        providers: {
+          "mismatch-provider": {
+            api: "openai-responses",
+            apiKey: {
+              source: "file",
+              provider: "vault",
+              id: "/mismatch-provider/apiKey",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const runtimeConfig = {
+      models: {
+        providers: {
+          "mismatch-provider": {
+            api: "openai-responses",
+            apiKey: "runtime-resolved-key", // pragma: allowlist secret
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    const unrelatedConfig = {
+      models: {
+        providers: {
+          "mismatch-provider": {
+            api: "openai-responses",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "mismatch-provider",
+        cfg: unrelatedConfig,
+        store: { version: 1, profiles: {} },
+      }),
+    ).rejects.toThrow('No API key found for provider "mismatch-provider"');
+  });
+
   it("does not reuse plugin fallback auth when the plugin is disabled", async () => {
     await expect(
       withoutEnv("PLUGIN_WEB_API_KEY", () =>

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -658,34 +658,71 @@ function isManagedSecretRefApiKeyMarker(apiKey: string | undefined): boolean {
   return apiKey?.trim() === NON_ENV_SECRETREF_MARKER;
 }
 
+function hasManagedSecretRefProviderApiKey(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): boolean {
+  const apiKey = resolveProviderConfig(cfg, provider)?.apiKey;
+  const ref = coerceSecretRef(apiKey);
+  if (ref) {
+    return ref.source !== "env";
+  }
+  return typeof apiKey === "string" && isManagedSecretRefApiKeyMarker(apiKey);
+}
+
 /**
  * Resolves a custom provider API key from the active runtime snapshot when the
- * source config only stores the managed SecretRef placeholder. This keeps the
- * fast availability check consistent with final credential resolution.
+ * source config stores a managed non-env SecretRef (marker or file/exec object).
+ * This keeps the fast availability check consistent with final credential
+ * resolution.
  */
-function resolveManagedSecretRefCustomProviderApiKey(params: {
+function resolveManagedSecretRefRuntimeProviderAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
-}): ResolvedCustomProviderApiKey | null {
-  const providerConfig = resolveProviderConfig(params.cfg, params.provider);
-  const sourceApiKey = providerConfig?.apiKey;
-  if (typeof sourceApiKey !== "string" || !isManagedSecretRefApiKeyMarker(sourceApiKey)) {
-    return null;
+}): ResolvedProviderAuth | undefined {
+  const sourceProviderConfig = resolveProviderConfig(params.cfg, params.provider);
+  const sourceApiKey = sourceProviderConfig?.apiKey;
+  if (!hasManagedSecretRefProviderApiKey(params.cfg, params.provider)) {
+    return undefined;
   }
+
   const runtimeConfig = getRuntimeConfigSnapshot();
   if (!runtimeConfig || runtimeConfig === params.cfg) {
-    return null;
+    return undefined;
   }
-  const runtimeProviderConfig = resolveProviderConfig(runtimeConfig, params.provider);
-  const runtimeApiKey = runtimeProviderConfig?.apiKey;
-  if (
-    typeof runtimeApiKey !== "string" ||
-    !runtimeApiKey.trim() ||
-    isNonSecretApiKeyMarker(runtimeApiKey)
-  ) {
-    return null;
+
+  const runtimeConfigApplies =
+    selectApplicableRuntimeConfig({
+      inputConfig: params.cfg,
+      runtimeConfig,
+      runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
+    }) === runtimeConfig;
+
+  if (!runtimeConfigApplies) {
+    // A normalized marker delegates to the active runtime snapshot even when the
+    // source snapshot no longer matches (e.g. the on-disk config was normalized
+    // to the marker after the snapshot was prepared). A structured file/exec
+    // SecretRef must belong to the active source snapshot to avoid cross-config
+    // credential reuse.
+    if (
+      !isManagedSecretRefApiKeyMarker(typeof sourceApiKey === "string" ? sourceApiKey : undefined)
+    ) {
+      return undefined;
+    }
   }
-  return { apiKey: runtimeApiKey, source: `models.providers.${params.provider}` };
+
+  const runtimeApiKey = normalizeOptionalSecretInput(
+    resolveProviderConfig(runtimeConfig, params.provider)?.apiKey,
+  );
+  if (!runtimeApiKey || isNonSecretApiKeyMarker(runtimeApiKey)) {
+    return undefined;
+  }
+
+  return {
+    apiKey: runtimeApiKey,
+    source: `models.providers.${params.provider}`,
+    mode: "api-key" as const,
+  };
 }
 
 /** True when a custom local provider can use a synthetic no-auth placeholder. */
@@ -789,7 +826,7 @@ export function hasRuntimeAvailableProviderAuth(params: {
   }
   if (
     resolveUsableCustomProviderApiKey({ cfg: params.cfg, provider, env: params.env }) ||
-    resolveManagedSecretRefCustomProviderApiKey({ cfg: params.cfg, provider })
+    resolveManagedSecretRefRuntimeProviderAuth({ cfg: params.cfg, provider })
   ) {
     return true;
   }
@@ -820,6 +857,16 @@ function resolveProviderSyntheticRuntimeAuth(params: {
   provider: string;
   modelApi?: string;
 }): SyntheticProviderAuthResolution {
+  // Resolve explicit custom-provider managed SecretRefs first so they are not
+  // shadowed by plugin/local synthetic fallbacks.
+  const managedRuntimeAuth = resolveManagedSecretRefRuntimeProviderAuth(params);
+  if (managedRuntimeAuth) {
+    return { auth: managedRuntimeAuth };
+  }
+  if (hasManagedSecretRefProviderApiKey(params.cfg, params.provider)) {
+    return { blockedOnManagedSecretRef: true };
+  }
+
   const resolveFromConfig = (
     config: OpenClawConfig | undefined,
   ): ResolvedProviderAuth | undefined => {
@@ -851,61 +898,36 @@ function resolveProviderSyntheticRuntimeAuth(params: {
   };
 
   const directAuth = resolveFromConfig(params.cfg);
-  if (!directAuth) {
-    // Only inherit a resolved runtime snapshot when the caller's config is the
-    // active source config for that snapshot, or when the caller explicitly
-    // stores the managed SecretRef marker. This prevents unrelated configs that
-    // happen to use the same provider id from picking up another config's
-    // credentials.
-    const runtimeConfig = getRuntimeConfigSnapshot();
+  if (directAuth && !isManagedSecretRefApiKeyMarker(directAuth.apiKey)) {
+    return { auth: directAuth };
+  }
+
+  // Only inherit a resolved runtime snapshot when the caller's config is the
+  // active source config for that snapshot. This prevents unrelated configs
+  // that happen to use the same provider id from picking up another config's
+  // credentials (e.g., plugin-side SecretRef fallback).
+  const runtimeConfig = getRuntimeConfigSnapshot();
+  if (runtimeConfig && runtimeConfig !== params.cfg) {
     const runtimeConfigApplies =
-      runtimeConfig !== params.cfg &&
       selectApplicableRuntimeConfig({
         inputConfig: params.cfg,
         runtimeConfig,
         runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
       }) === runtimeConfig;
-    const sourceProviderConfig = resolveProviderConfig(params.cfg, params.provider);
-    const hasManagedMarker =
-      typeof sourceProviderConfig?.apiKey === "string" &&
-      isManagedSecretRefApiKeyMarker(sourceProviderConfig.apiKey);
-    if ((runtimeConfigApplies || hasManagedMarker) && runtimeConfig) {
+    if (runtimeConfigApplies) {
       const runtimeAuth = resolveFromConfig(runtimeConfig);
-      if (runtimeAuth && runtimeAuth.apiKey && !isNonSecretApiKeyMarker(runtimeAuth.apiKey)) {
+      if (
+        runtimeAuth &&
+        runtimeAuth.apiKey &&
+        !isManagedSecretRefApiKeyMarker(runtimeAuth.apiKey) &&
+        !isNonSecretApiKeyMarker(runtimeAuth.apiKey)
+      ) {
         return { auth: runtimeAuth };
       }
     }
-    return {};
-  }
-  if (!isManagedSecretRefApiKeyMarker(directAuth.apiKey)) {
-    return { auth: directAuth };
   }
 
-  const managedRuntimeAuth = resolveManagedSecretRefCustomProviderApiKey({
-    cfg: params.cfg,
-    provider: params.provider,
-  });
-  if (managedRuntimeAuth) {
-    return {
-      auth: {
-        apiKey: managedRuntimeAuth.apiKey,
-        source: managedRuntimeAuth.source,
-        mode: "api-key" as const,
-      },
-    };
-  }
-
-  // Preserve plugin-side SecretRef runtime snapshot fallback when the source
-  // config stores the managed marker inside a plugin config rather than a
-  // models.providers entry.
-  const runtimeConfig = getRuntimeConfigSnapshot();
-  if (runtimeConfig && runtimeConfig !== params.cfg) {
-    const runtimeAuth = resolveFromConfig(runtimeConfig);
-    if (runtimeAuth && runtimeAuth.apiKey && !isNonSecretApiKeyMarker(runtimeAuth.apiKey)) {
-      return { auth: runtimeAuth };
-    }
-  }
-  return { blockedOnManagedSecretRef: true };
+  return {};
 }
 
 function resolveSyntheticLocalProviderAuth(params: {
@@ -1205,6 +1227,10 @@ export async function resolveApiKeyForProvider(params: {
   }
 
   if (shouldPreferExplicitConfigApiKeyAuth(cfg, provider)) {
+    const managedRuntimeAuth = resolveManagedSecretRefRuntimeProviderAuth({ cfg, provider });
+    if (managedRuntimeAuth) {
+      return managedRuntimeAuth;
+    }
     const customKey = resolveUsableCustomProviderApiKey({ cfg, provider });
     if (customKey) {
       return {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -654,6 +654,36 @@ function isManagedSecretRefApiKeyMarker(apiKey: string | undefined): boolean {
   return apiKey?.trim() === NON_ENV_SECRETREF_MARKER;
 }
 
+/**
+ * Resolves a custom provider API key from the active runtime snapshot when the
+ * source config only stores the managed SecretRef placeholder. This keeps the
+ * fast availability check consistent with final credential resolution.
+ */
+function resolveManagedSecretRefCustomProviderApiKey(params: {
+  cfg: OpenClawConfig | undefined;
+  provider: string;
+}): ResolvedCustomProviderApiKey | null {
+  const providerConfig = resolveProviderConfig(params.cfg, params.provider);
+  const sourceApiKey = providerConfig?.apiKey;
+  if (typeof sourceApiKey !== "string" || !isManagedSecretRefApiKeyMarker(sourceApiKey)) {
+    return null;
+  }
+  const runtimeConfig = getRuntimeConfigSnapshot();
+  if (!runtimeConfig || runtimeConfig === params.cfg) {
+    return null;
+  }
+  const runtimeProviderConfig = resolveProviderConfig(runtimeConfig, params.provider);
+  const runtimeApiKey = runtimeProviderConfig?.apiKey;
+  if (
+    typeof runtimeApiKey !== "string" ||
+    !runtimeApiKey.trim() ||
+    isNonSecretApiKeyMarker(runtimeApiKey)
+  ) {
+    return null;
+  }
+  return { apiKey: runtimeApiKey, source: `models.providers.${params.provider}` };
+}
+
 /** True when a custom local provider can use a synthetic no-auth placeholder. */
 export function hasSyntheticLocalProviderAuthConfig(params: {
   cfg: OpenClawConfig | undefined;
@@ -753,7 +783,10 @@ export function hasRuntimeAvailableProviderAuth(params: {
   ) {
     return true;
   }
-  if (resolveUsableCustomProviderApiKey({ cfg: params.cfg, provider, env: params.env })) {
+  if (
+    resolveUsableCustomProviderApiKey({ cfg: params.cfg, provider, env: params.env }) ||
+    resolveManagedSecretRefCustomProviderApiKey({ cfg: params.cfg, provider })
+  ) {
     return true;
   }
   if (hasSyntheticLocalProviderAuthConfig({ cfg: params.cfg, provider })) {
@@ -828,19 +861,31 @@ function resolveProviderSyntheticRuntimeAuth(params: {
     return { auth: directAuth };
   }
 
-  const runtimeConfig = getRuntimeConfigSnapshot();
-  if (!runtimeConfig || runtimeConfig === params.cfg) {
-    return { blockedOnManagedSecretRef: true };
+  const managedRuntimeAuth = resolveManagedSecretRefCustomProviderApiKey({
+    cfg: params.cfg,
+    provider: params.provider,
+  });
+  if (managedRuntimeAuth) {
+    return {
+      auth: {
+        apiKey: managedRuntimeAuth.apiKey,
+        source: managedRuntimeAuth.source,
+        mode: "api-key" as const,
+      },
+    };
   }
 
-  const runtimeAuth = resolveFromConfig(runtimeConfig);
-  const runtimeApiKey = runtimeAuth?.apiKey;
-  if (!runtimeAuth || !runtimeApiKey || isNonSecretApiKeyMarker(runtimeApiKey)) {
-    return { blockedOnManagedSecretRef: true };
+  // Preserve plugin-side SecretRef runtime snapshot fallback when the source
+  // config stores the managed marker inside a plugin config rather than a
+  // models.providers entry.
+  const runtimeConfig = getRuntimeConfigSnapshot();
+  if (runtimeConfig && runtimeConfig !== params.cfg) {
+    const runtimeAuth = resolveFromConfig(runtimeConfig);
+    if (runtimeAuth && runtimeAuth.apiKey && !isNonSecretApiKeyMarker(runtimeAuth.apiKey)) {
+      return { auth: runtimeAuth };
+    }
   }
-  return {
-    auth: runtimeAuth,
-  };
+  return { blockedOnManagedSecretRef: true };
 }
 
 function resolveSyntheticLocalProviderAuth(params: {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -818,7 +818,7 @@ function resolveProviderSyntheticRuntimeAuth(params: {
     const runtimeConfig = getRuntimeConfigSnapshot();
     if (runtimeConfig && runtimeConfig !== params.cfg) {
       const runtimeAuth = resolveFromConfig(runtimeConfig);
-      if (runtimeAuth && !isNonSecretApiKeyMarker(runtimeAuth.apiKey)) {
+      if (runtimeAuth && runtimeAuth.apiKey && !isNonSecretApiKeyMarker(runtimeAuth.apiKey)) {
         return { auth: runtimeAuth };
       }
     }

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -787,7 +787,7 @@ function resolveProviderSyntheticRuntimeAuth(params: {
     config: OpenClawConfig | undefined,
   ): ResolvedProviderAuth | undefined => {
     const providerConfig = resolveProviderConfig(config, params.provider);
-    return (
+    const pluginAuth =
       resolveProviderSyntheticAuthWithPlugin({
         provider: params.provider,
         config,
@@ -797,12 +797,31 @@ function resolveProviderSyntheticRuntimeAuth(params: {
           providerConfig,
         },
         modelApi: params.modelApi,
-      }) ?? undefined
-    );
+      }) ?? undefined;
+    if (pluginAuth) {
+      return pluginAuth;
+    }
+    // Fallback: read resolved apiKey directly from provider config (e.g., runtime snapshot)
+    const apiKey = providerConfig?.apiKey;
+    if (apiKey && typeof apiKey === "string" && !isNonSecretApiKeyMarker(apiKey)) {
+      return {
+        apiKey,
+        source: `models.providers.${params.provider}`,
+        mode: "api-key" as const,
+      };
+    }
+    return undefined;
   };
 
   const directAuth = resolveFromConfig(params.cfg);
   if (!directAuth) {
+    const runtimeConfig = getRuntimeConfigSnapshot();
+    if (runtimeConfig && runtimeConfig !== params.cfg) {
+      const runtimeAuth = resolveFromConfig(runtimeConfig);
+      if (runtimeAuth && !isNonSecretApiKeyMarker(runtimeAuth.apiKey)) {
+        return { auth: runtimeAuth };
+      }
+    }
     return {};
   }
   if (!isManagedSecretRefApiKeyMarker(directAuth.apiKey)) {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -10,7 +10,11 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { formatCliCommand } from "../cli/command-format.js";
-import { getRuntimeConfigSnapshot } from "../config/config.js";
+import {
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+  selectApplicableRuntimeConfig,
+} from "../config/config.js";
 import type { ModelProviderAuthMode, ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
@@ -848,8 +852,24 @@ function resolveProviderSyntheticRuntimeAuth(params: {
 
   const directAuth = resolveFromConfig(params.cfg);
   if (!directAuth) {
+    // Only inherit a resolved runtime snapshot when the caller's config is the
+    // active source config for that snapshot, or when the caller explicitly
+    // stores the managed SecretRef marker. This prevents unrelated configs that
+    // happen to use the same provider id from picking up another config's
+    // credentials.
     const runtimeConfig = getRuntimeConfigSnapshot();
-    if (runtimeConfig && runtimeConfig !== params.cfg) {
+    const runtimeConfigApplies =
+      runtimeConfig !== params.cfg &&
+      selectApplicableRuntimeConfig({
+        inputConfig: params.cfg,
+        runtimeConfig,
+        runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
+      }) === runtimeConfig;
+    const sourceProviderConfig = resolveProviderConfig(params.cfg, params.provider);
+    const hasManagedMarker =
+      typeof sourceProviderConfig?.apiKey === "string" &&
+      isManagedSecretRefApiKeyMarker(sourceProviderConfig.apiKey);
+    if ((runtimeConfigApplies || hasManagedMarker) && runtimeConfig) {
       const runtimeAuth = resolveFromConfig(runtimeConfig);
       if (runtimeAuth && runtimeAuth.apiKey && !isNonSecretApiKeyMarker(runtimeAuth.apiKey)) {
         return { auth: runtimeAuth };


### PR DESCRIPTION
## Summary

Custom providers with `apiKey: secretref-managed` (resolved via SecretRef) fail with 503 `auth_unavailable` after update to 2026.6.5. The auth resolution chain correctly blocks on the managed-secretref marker, but the fast availability check (`hasRuntimeAvailableProviderAuth`) and the final credential resolution path were using two different lookup strategies: resolution could fall back to the runtime config snapshot, while availability still rejected based on the source config alone.

Fixes #92097.

## Changes

- `src/agents/model-auth.ts`:
  - Extract `resolveManagedSecretRefCustomProviderApiKey` to look up a real API key in the active runtime config snapshot when the source config stores `secretref-managed` for a `models.providers` entry.
  - Use the shared helper in `hasRuntimeAvailableProviderAuth` so availability no longer rejects before resolution runs.
  - Use the shared helper in `resolveProviderSyntheticRuntimeAuth` for custom-provider managed SecretRefs, while preserving the existing plugin-side SecretRef runtime snapshot fallback.
- `src/agents/model-auth.test.ts`: Added regression tests for `hasRuntimeAvailableProviderAuth` covering both resolved and unresolved runtime snapshot states.
- `scripts/repro/issue-92097-secretref-custom-provider.mts`: Updated standalone reproduction to use real file-backed SecretRef preparation (`prepareSecretsRuntimeSnapshot`) plus a source config that only stores the managed marker, and asserts both availability and final resolution.

## Real behavior proof

- **Behavior addressed**: A custom provider with `secretref-managed` apiKey is now reported as available by the runtime hot-path check and resolves the actual key from the runtime config snapshot.
- **Real environment tested**: Linux 4.19.112-2.el8.x86_64, Node.js v22.19.0, local source checkout at `fix/92097-secretref-custom-provider-auth`.
- **Exact steps or command run after this patch**:
  - `node --import tsx scripts/repro/issue-92097-secretref-custom-provider.mts`
  - `pnpm test src/agents/model-auth.test.ts --run`
- **Evidence after fix**:

```text
=== Reproduction for issue #92097 ===
Proving managed SecretRef custom-provider auth through actual file-based SecretRef preparation.

Runtime available auth: true
Resolved auth: {
  apiKey: 'resolved-from-file-secret',
  source: 'models.providers.cliproxyapi',
  mode: 'api-key'
}

PASS: Custom provider secretref-managed apiKey is available and correctly resolved from file-backed SecretRef runtime snapshot.
```

- **Observed result after fix**: `hasRuntimeAvailableProviderAuth` returns `true` and `resolveApiKeyForProvider` returns the real `apiKey` that was resolved from the on-disk secrets file via `prepareSecretsRuntimeSnapshot`, with correct `source` and `mode` fields.
- **What was not tested**: A live multi-hop gateway request through the full HTTP/WS stack; TLS-terminated gateway; other auth modes (OAuth, profile-based) for custom providers.

## Verification

- `pnpm test src/agents/model-auth.test.ts --run` — 61 passed (including new availability regression tests)
- `npx oxlint --import-plugin --config .oxlintrc.json src/agents/model-auth.ts src/agents/model-auth.test.ts scripts/repro/issue-92097-secretref-custom-provider.mts` — passed
- `npx oxfmt --write --threads=1 src/agents/model-auth.ts src/agents/model-auth.test.ts scripts/repro/issue-92097-secretref-custom-provider.mts` — no further changes needed
- `pnpm tsgo:core` — passed
- `pnpm build` — passed
- `node --import tsx scripts/repro/issue-92097-secretref-custom-provider.mts` — PASS

🤖 AI-assisted PR