### PR TITLE
fix(memory): report indexed vector store in status

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -421,6 +421,14 @@ describe("memory index", () => {
     return result.manager as unknown as MemoryIndexManager;
   }
 
+  function readIndexMeta(manager: MemoryIndexManager): MemoryIndexMeta | null {
+    return (
+      manager as unknown as {
+        readMeta(): MemoryIndexMeta | null;
+      }
+    ).readMeta();
+  }
+
   async function getPersistentManager(cfg: TestCfg): Promise<MemoryIndexManager> {
     const result = await getMemorySearchManager({ cfg, agentId: "main" });
     const manager = requireManager(result);
@@ -1688,12 +1696,88 @@ describe("memory index", () => {
     const statusManager = await getFreshManager(cfg, "status");
     try {
       const status = statusManager.status();
+      const meta = readIndexMeta(statusManager);
 
       expect(providerCalls).toStrictEqual([]);
       expect(status.vector?.enabled).toBe(true);
       expect(status.vector?.storeAvailable).toBe(true);
       expect(status.vector?.semanticAvailable).toBeUndefined();
       expect(status.vector?.available).toBeUndefined();
+      expect(meta?.vectorDims).toBe(4);
+    } finally {
+      await statusManager.close?.();
+    }
+  });
+
+  it("does not report chunks-only indexes as vector-store ready from plain status", async () => {
+    const dbPath = path.join(workspaceDir, "index-vector-status-fts-only.sqlite");
+    const ftsOnlyCfg = createCfg({
+      storePath: dbPath,
+      provider: "gemini",
+      vectorEnabled: false,
+    });
+    const ftsOnlyManager = await getFreshManager(ftsOnlyCfg);
+    try {
+      await ftsOnlyManager.sync({ reason: "test", force: true });
+      expect(ftsOnlyManager.status().chunks).toBeGreaterThan(0);
+    } finally {
+      await ftsOnlyManager.close?.();
+    }
+
+    providerCalls = [];
+    forceNoProvider = true;
+    const statusCfg = createCfg({
+      storePath: dbPath,
+      provider: "gemini",
+      vectorEnabled: true,
+    });
+    const statusManager = await getFreshManager(statusCfg, "status");
+    try {
+      const status = statusManager.status();
+      const meta = readIndexMeta(statusManager);
+
+      expect(providerCalls).toStrictEqual([]);
+      expect(status.vector?.enabled).toBe(true);
+      expect(status.vector?.storeAvailable).toBeUndefined();
+      expect(status.vector?.semanticAvailable).toBeUndefined();
+      expect(status.vector?.available).toBeUndefined();
+      expect(status.chunks).toBeGreaterThan(0);
+      expect(meta?.vectorDims).toBeUndefined();
+    } finally {
+      await statusManager.close?.();
+    }
+  });
+
+  it("does not report old vector metadata as store-ready when vectors are disabled", async () => {
+    const dbPath = path.join(workspaceDir, "index-vector-status-disabled.sqlite");
+    const vectorCfg = createCfg({
+      storePath: dbPath,
+      vectorEnabled: true,
+    });
+    const indexManager = await getFreshManager(vectorCfg);
+    try {
+      await indexManager.sync({ reason: "test", force: true });
+    } finally {
+      await indexManager.close?.();
+    }
+
+    providerCalls = [];
+    forceNoProvider = true;
+    const disabledCfg = createCfg({
+      storePath: dbPath,
+      vectorEnabled: false,
+    });
+    const statusManager = await getFreshManager(disabledCfg, "status");
+    try {
+      const status = statusManager.status();
+      const meta = readIndexMeta(statusManager);
+
+      expect(providerCalls).toStrictEqual([]);
+      expect(status.vector?.enabled).toBe(false);
+      expect(status.vector?.storeAvailable).toBeUndefined();
+      expect(status.vector?.semanticAvailable).toBeUndefined();
+      expect(status.vector?.available).toBeUndefined();
+      expect(meta?.vectorDims).toBe(4);
     } finally {
       await statusManager.close?.();
     }

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1671,6 +1671,34 @@ describe("memory index", () => {
     expect(status.vector?.available).toBeUndefined();
   });
 
+  it("reports an indexed vector store from plain status without probing embeddings", async () => {
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-vector-status-only.sqlite"),
+      vectorEnabled: true,
+    });
+    const indexManager = await getFreshManager(cfg);
+    try {
+      await indexManager.sync({ reason: "test", force: true });
+    } finally {
+      await indexManager.close?.();
+    }
+
+    providerCalls = [];
+    forceNoProvider = true;
+    const statusManager = await getFreshManager(cfg, "status");
+    try {
+      const status = statusManager.status();
+
+      expect(providerCalls).toStrictEqual([]);
+      expect(status.vector?.enabled).toBe(true);
+      expect(status.vector?.storeAvailable).toBe(true);
+      expect(status.vector?.semanticAvailable).toBeUndefined();
+      expect(status.vector?.available).toBeUndefined();
+    } finally {
+      await statusManager.close?.();
+    }
+  });
+
   it("marks older vector indexes dirty after vector store probing", async () => {
     const dbPath = path.join(workspaceDir, "index-vector-missing-dims.sqlite");
     const legacyCfg = createCfg({

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1139,8 +1139,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       requestedProvider: this.requestedProvider,
       configuredModel: this.settings.model || undefined,
     });
+    const meta = this.readMeta();
     const storeAvailable =
-      this.vector.available ?? (this.vector.enabled && this.hasIndexedChunks() ? true : undefined);
+      this.vector.available ??
+      (this.vector.enabled && meta?.vectorDims !== undefined ? true : undefined);
 
     return {
       backend: "builtin",

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1139,6 +1139,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       requestedProvider: this.requestedProvider,
       configuredModel: this.settings.model || undefined,
     });
+    const storeAvailable =
+      this.vector.available ?? (this.vector.enabled && this.hasIndexedChunks() ? true : undefined);
 
     return {
       backend: "builtin",
@@ -1175,7 +1177,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         : undefined,
       vector: {
         enabled: this.vector.enabled,
-        storeAvailable: this.vector.available ?? undefined,
+        storeAvailable,
         semanticAvailable: this.vector.semanticAvailable,
         available: this.vector.semanticAvailable,
         extensionPath: this.vector.extensionPath,


### PR DESCRIPTION
## Summary

- Report the builtin vector store as ready in plain `memory status` only when persisted vector metadata confirms a prior vector index.
- Replace the previous chunks-row fallback with `vectorDims` metadata, gated by `memorySearch.store.vector.enabled`, so FTS-only/chunks-only indexes do not look vector-ready.
- Add regression coverage for indexed vector metadata, chunks-only/degraded index data, and disabled-vector config with existing vector metadata.

Fixes #92102.

## Real behavior proof

Behavior addressed: `openclaw memory status --agent main` could show `Vector store: unknown` on the fast path after a real vector index already existed. The fix now uses persisted `vectorDims` metadata as the status-only readiness signal, while avoiding false positives from plain chunk rows or disabled vector config.

Real environment tested: PR-head checkout `/private/tmp/openclaw-pr92114-real-proof`, head `1f04d402f80`, macOS Darwin arm64, Node via repo `corepack pnpm openclaw`, disposable OpenClaw state/workspace under `/private/tmp/openclaw-pr92114-cli-proof-20260615`, OpenAI embeddings `text-embedding-3-small` used only for the initial synthetic index.

Exact steps or command run after this patch:

```bash
# Create a synthetic memory file in a disposable workspace, then build the real vector index.
HOME=/private/tmp/openclaw-pr92114-cli-proof-20260615/home \
OPENCLAW_STATE_DIR=/private/tmp/openclaw-pr92114-cli-proof-20260615/state \
OPENCLAW_CONFIG_PATH=/private/tmp/openclaw-pr92114-cli-proof-20260615/config.json \
NO_COLOR=1 CI=1 \
corepack pnpm openclaw memory status --index --agent main

# Fresh process, no embedding key injected, same previously indexed setup.
env -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_API_BASE \
HOME=/private/tmp/openclaw-pr92114-cli-proof-20260615/home \
OPENCLAW_STATE_DIR=/private/tmp/openclaw-pr92114-cli-proof-20260615/state \
OPENCLAW_CONFIG_PATH=/private/tmp/openclaw-pr92114-cli-proof-20260615/config.json \
NO_COLOR=1 CI=1 \
corepack pnpm openclaw memory status --agent main
```

Evidence after fix:

```text
Memory Search (main)
Provider: openai (requested: openai)
Model: text-embedding-3-small
Sources: memory
Indexed: 1/1 files · 1 chunks
Dirty: no
Store: /private/tmp/openclaw-pr92114-cli-proof-20260615/state/memory/main.sqlite
Workspace: /private/tmp/openclaw-pr92114-cli-proof-20260615/workspace
Dreaming: off
By source:
  memory · 1/1 files · 1 chunks
Vector store: ready
Vector dims: 1536
FTS: ready
Embedding cache: enabled (1 entries)
Batch: disabled (failures 0/2)
Recall store: 0 entries · 0 promoted · 0 concept-tagged · 0 spaced
```

Observed result after fix: A real previously indexed builtin memory DB re-opened by a fresh status-only CLI process reports `Vector store: ready` from persisted vector metadata without injecting an embedding key. Focused regressions also confirm chunks-only indexes keep `storeAvailable` undefined and disabled-vector configs do not report old vector metadata as store-ready.

What was not tested: I did not run this against Andy's production memory directory; the real CLI proof used a synthetic disposable memory file to keep PR evidence redacted. Broad full-repo CI remains GitHub-owned after push.

## Verification

```bash
node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts -t "reports an indexed vector store|chunks-only indexes|old vector metadata" --reporter dot
node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts --reporter dot
node scripts/run-vitest.mjs extensions/memory-core/src/cli.test.ts -t "Vector store|plain status" --reporter dot
corepack pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/index.test.ts
node scripts/run-oxlint.mjs extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/index.test.ts
git diff --check
env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed
```
