### PR TITLE
fix(cron): expose real SQLite database path in status output

### DIFF
--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import {
   completeTaskRunByRunId,
   createRunningTaskRun,
@@ -254,6 +255,7 @@ export async function status(state: CronServiceState) {
     return {
       enabled: state.deps.cronEnabled,
       storePath: state.deps.storePath,
+      databasePath: resolveOpenClawStateSqlitePath(),
       jobs: state.store?.jobs.length ?? 0,
       nextWakeAtMs: state.deps.cronEnabled ? (nextWakeAtMs(state) ?? null) : null,
     };

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -219,6 +219,7 @@ export type CronWakeMode = "now" | "next-heartbeat";
 export type CronStatusSummary = {
   enabled: boolean;
   storePath: string;
+  databasePath: string;
   jobs: number;
   nextWakeAtMs: number | null;
 };


### PR DESCRIPTION
## Summary

Since OpenClaw 2026.6.1, cron jobs are stored in the shared state SQLite database (`~/.openclaw/state/openclaw.sqlite`), but the `openclaw cron status` command still reports the legacy JSON `storePath` (`~/.openclaw/cron/jobs.json`). This confuses users and agents into thinking the old JSON file is still the authoritative storage location.

## Changes

- **`src/cron/service/state.ts`**: Add `databasePath: string` field to `CronStatusSummary` type.
- **`src/cron/service/ops.ts`**: Import `resolveOpenClawStateSqlitePath()` and populate `databasePath` in the `status()` response.

2 files, +3 lines. The existing `storePath` field is preserved as the logical partition key within SQLite.

Fixes #91766

## Real behavior proof

**Behavior addressed:** `openclaw cron status` reports the legacy JSON file path (`~/.openclaw/cron/jobs.json`) as `storePath`, but since 2026.6.1 cron jobs are stored in the shared state SQLite database. The fix adds a `databasePath` field that reports the real SQLite database location.

**Real environment tested:** Node v22.22.0, Linux 4.19.112-2.el8.x86_64, openclaw commit 8d1adc70.

**Exact steps or command run after this patch:**

1. Created proof script importing `resolveOpenClawStateSqlitePath` from the real production module at `src/state/openclaw-state-db.paths.js`
2. Script calls `resolveOpenClawStateSqlitePath()` to get the actual database path
3. Validates that the path is a `.sqlite` file under the `state` directory (not the legacy `cron/jobs.json`)
4. Confirms the `CronStatusSummary` type now includes the `databasePath` field
5. Ran `npx tsx scripts/proof-92115.mjs`

**Evidence after fix (terminal capture):**

$ npx tsx scripts/proof-92115.mjs
================================================================
openclaw — cron status databasePath proof
================================================================
Module: src/state/openclaw-state-db.paths.js (real import)
PR: https://github.com/openclaw/openclaw/pull/92115

--- Real SQLite database path ---
  resolveOpenClawStateSqlitePath() = /home/0668000959/.openclaw/state/openclaw.sqlite

--- Validation ---
  Ends with .sqlite: true
  Contains 'state':   true
  NOT jobs.json:      true

--- Code change verification ---
  src/cron/service/state.ts — CronStatusSummary now includes:
    databasePath: string  (NEW — real SQLite DB location)
    storePath: string     (existing — legacy JSON partition key)

  src/cron/service/ops.ts — status() now returns:
    databasePath: resolveOpenClawStateSqlitePath()  (NEW)
    storePath: state.deps.storePath                 (existing)

--- Result ---
  All checks: PASS
  databasePath resolves to the real SQLite database,
  not the legacy ~/.openclaw/cron/jobs.json path.
exit code: 0

**Observed result after fix:** `resolveOpenClawStateSqlitePath()` (imported from real production module, not copied logic) returns `/home/0668000959/.openclaw/state/openclaw.sqlite` — the real SQLite database path, not the legacy `cron/jobs.json`. The proof validates that the path ends with `.sqlite`, contains `state`, and does NOT reference `jobs.json`. The `CronStatusSummary` type now includes both `databasePath` (real DB location) and `storePath` (legacy partition key for backwards compatibility).

**What was not tested:** Full gateway with cron service running and `openclaw cron status` CLI output showing the new `databasePath` field in JSON response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
