### PR TITLE
fix(memory): preserve live SQLite index during swaps

### DIFF
--- a/extensions/memory-core/src/memory/manager-atomic-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-atomic-reindex.ts
@@ -51,13 +51,14 @@ async function renameWithRetry(
   source: string,
   target: string,
   options: ResolvedMemoryIndexFileOptions,
+  optional = false,
 ): Promise<void> {
   for (let attempt = 1; attempt <= options.maxRenameAttempts; attempt++) {
     try {
       await options.fileOps.rename(source, target);
       return;
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      if (optional && (err as NodeJS.ErrnoException).code === "ENOENT") {
         return;
       }
       if (!isTransientFileError(err) || attempt === options.maxRenameAttempts) {
@@ -79,7 +80,7 @@ export async function moveMemoryIndexFiles(
   for (const suffix of suffixes) {
     const source = `${sourceBase}${suffix}`;
     const target = `${targetBase}${suffix}`;
-    await renameWithRetry(source, target, resolvedOptions);
+    await renameWithRetry(source, target, resolvedOptions, suffix !== "");
   }
 }
 
@@ -112,6 +113,47 @@ export async function removeMemoryIndexFiles(
   }
 }
 
+async function removeMemoryIndexSidecars(
+  basePath: string,
+  options: ResolvedMemoryIndexFileOptions,
+): Promise<void> {
+  await rmWithRetry(`${basePath}-wal`, options);
+  await rmWithRetry(`${basePath}-shm`, options);
+}
+
+async function moveMemoryIndexSidecars(
+  sourceBase: string,
+  targetBase: string,
+  options: ResolvedMemoryIndexFileOptions,
+): Promise<void> {
+  const suffixes = ["-wal", "-shm"];
+  for (const suffix of suffixes) {
+    await renameWithRetry(`${sourceBase}${suffix}`, `${targetBase}${suffix}`, options, true);
+  }
+}
+
+async function moveMemoryIndexSidecarsWithRollback(
+  sourceBase: string,
+  targetBase: string,
+  options: ResolvedMemoryIndexFileOptions,
+): Promise<void> {
+  try {
+    await moveMemoryIndexSidecars(sourceBase, targetBase, options);
+  } catch (err) {
+    try {
+      await moveMemoryIndexSidecars(targetBase, sourceBase, options);
+    } catch (rollbackErr) {
+      const aggregateErr = new AggregateError(
+        [err, rollbackErr],
+        "memory index sidecar backup failed and rollback failed",
+        { cause: rollbackErr },
+      );
+      throw aggregateErr;
+    }
+    throw err;
+  }
+}
+
 async function swapMemoryIndexFiles(
   targetPath: string,
   tempPath: string,
@@ -122,30 +164,40 @@ async function swapMemoryIndexFiles(
   // publishing the new one. On Windows, rename fails when the target
   // exists, so the three-step backup protocol is retained.
   const resolvedOptions = resolveMemoryIndexFileOptions(options);
+  const backupPath = `${targetPath}.backup-${randomUUID()}`;
+  // The old and temp DBs are checkpointed and closed before swap. Hide target
+  // sidecars before publishing the new main DB, but keep them rollbackable
+  // until the main-file publish succeeds.
+  await moveMemoryIndexSidecarsWithRollback(targetPath, backupPath, resolvedOptions);
   try {
-    await moveMemoryIndexFiles(tempPath, targetPath, options);
+    await renameWithRetry(tempPath, targetPath, resolvedOptions);
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "EPERM" || (err as NodeJS.ErrnoException).code === "EEXIST") {
+    if (
+      (err as NodeJS.ErrnoException).code === "EPERM" ||
+      (err as NodeJS.ErrnoException).code === "EEXIST"
+    ) {
       // Windows: target exists, use three-step backup protocol with rollback.
-      const backupPath = `${targetPath}.backup-${randomUUID()}`;
-      await moveMemoryIndexFiles(targetPath, backupPath, options);
       try {
-        await moveMemoryIndexFiles(tempPath, targetPath, options);
+        await renameWithRetry(targetPath, backupPath, resolvedOptions);
+      } catch (backupErr) {
+        await moveMemoryIndexSidecars(backupPath, targetPath, resolvedOptions);
+        throw backupErr;
+      }
+      try {
+        await renameWithRetry(tempPath, targetPath, resolvedOptions);
       } catch (moveErr) {
         await moveMemoryIndexFiles(backupPath, targetPath, options);
         throw moveErr;
       }
-      await removeMemoryIndexFiles(backupPath, options);
     } else {
+      await moveMemoryIndexSidecars(backupPath, targetPath, resolvedOptions);
       throw err;
     }
   }
-  // Clean up stale WAL/SHM sidecars from the old index that may
-  // linger if the previous index was in WAL mode. rename only
-  // moves the main file; -wal and -shm from the old live DB
-  // can remain at the target path if the old DB had them.
-  await rmWithRetry(`${targetPath}-wal`, resolvedOptions);
-  await rmWithRetry(`${targetPath}-shm`, resolvedOptions);
+  await removeMemoryIndexFiles(backupPath, options);
+  // Closed temp databases should not need sidecars after checkpoint; remove
+  // leftovers at the temp path without touching the published target pair.
+  await removeMemoryIndexSidecars(tempPath, resolvedOptions);
 }
 
 export async function runMemoryAtomicReindex<T>(params: {

--- a/extensions/memory-core/src/memory/manager-atomic-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-atomic-reindex.ts
@@ -112,16 +112,40 @@ export async function removeMemoryIndexFiles(
   }
 }
 
-async function swapMemoryIndexFiles(targetPath: string, tempPath: string): Promise<void> {
-  const backupPath = `${targetPath}.backup-${randomUUID()}`;
-  await moveMemoryIndexFiles(targetPath, backupPath);
+async function swapMemoryIndexFiles(
+  targetPath: string,
+  tempPath: string,
+  options: MemoryIndexFileOptions = {},
+): Promise<void> {
+  // On POSIX (Linux/macOS), rename(2) atomically overwrites the target,
+  // so there is no absent-window between removing the old index and
+  // publishing the new one. On Windows, rename fails when the target
+  // exists, so the three-step backup protocol is retained.
+  const resolvedOptions = resolveMemoryIndexFileOptions(options);
   try {
-    await moveMemoryIndexFiles(tempPath, targetPath);
+    await moveMemoryIndexFiles(tempPath, targetPath, options);
   } catch (err) {
-    await moveMemoryIndexFiles(backupPath, targetPath);
-    throw err;
+    if ((err as NodeJS.ErrnoException).code === "EPERM" || (err as NodeJS.ErrnoException).code === "EEXIST") {
+      // Windows: target exists, use three-step backup protocol with rollback.
+      const backupPath = `${targetPath}.backup-${randomUUID()}`;
+      await moveMemoryIndexFiles(targetPath, backupPath, options);
+      try {
+        await moveMemoryIndexFiles(tempPath, targetPath, options);
+      } catch (moveErr) {
+        await moveMemoryIndexFiles(backupPath, targetPath, options);
+        throw moveErr;
+      }
+      await removeMemoryIndexFiles(backupPath, options);
+    } else {
+      throw err;
+    }
   }
-  await removeMemoryIndexFiles(backupPath);
+  // Clean up stale WAL/SHM sidecars from the old index that may
+  // linger if the previous index was in WAL mode. rename only
+  // moves the main file; -wal and -shm from the old live DB
+  // can remain at the target path if the old DB had them.
+  await rmWithRetry(`${targetPath}-wal`, resolvedOptions);
+  await rmWithRetry(`${targetPath}-shm`, resolvedOptions);
 }
 
 export async function runMemoryAtomicReindex<T>(params: {
@@ -133,7 +157,7 @@ export async function runMemoryAtomicReindex<T>(params: {
 }): Promise<T> {
   try {
     const result = await params.build();
-    await swapMemoryIndexFiles(params.targetPath, params.tempPath);
+    await swapMemoryIndexFiles(params.targetPath, params.tempPath, params.fileOptions);
     return result;
   } catch (err) {
     try {

--- a/extensions/memory-core/src/memory/manager-db-probe.test.ts
+++ b/extensions/memory-core/src/memory/manager-db-probe.test.ts
@@ -44,7 +44,7 @@ describe("openMemoryDatabaseAtPath readOnly probe", () => {
   it("refuses to auto-create an empty database when allowCreate is false", async () => {
     const dbPath = path.join(fixtureRoot, `case-${caseId++}`, "absent-index.sqlite");
 
-    await expect(() => openMemoryDatabaseAtPath(dbPath, false, false)).toThrow(
+    expect(() => openMemoryDatabaseAtPath(dbPath, false, false)).toThrow(
       /Memory database not found.*refusing to auto-create/,
     );
 

--- a/extensions/memory-core/src/memory/manager-db-probe.test.ts
+++ b/extensions/memory-core/src/memory/manager-db-probe.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { openMemoryDatabaseAtPath } from "./manager-db.js";
+
+describe("openMemoryDatabaseAtPath readOnly probe", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-db-probe-"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("allows opening when the database file exists", async () => {
+    const dbPath = path.join(fixtureRoot, `case-${caseId++}`, "index.sqlite");
+    const dir = path.dirname(dbPath);
+    await fs.mkdir(dir, { recursive: true });
+    const seed = new DatabaseSync(dbPath);
+    seed.exec("CREATE TABLE IF NOT EXISTS meta(key TEXT PRIMARY KEY, value TEXT)");
+    seed.close();
+
+    const db = openMemoryDatabaseAtPath(dbPath, false);
+    expect(db).toBeDefined();
+    db.close();
+  });
+
+  it("allows creating a new database when allowCreate is true", async () => {
+    const dbPath = path.join(fixtureRoot, `case-${caseId++}`, "new-index.sqlite");
+
+    const db = openMemoryDatabaseAtPath(dbPath, false, true);
+    expect(db).toBeDefined();
+    db.close();
+
+    const stat = await fs.stat(dbPath);
+    expect(stat.size).toBeGreaterThan(0);
+  });
+
+  it("refuses to auto-create an empty database when allowCreate is false", async () => {
+    const dbPath = path.join(fixtureRoot, `case-${caseId++}`, "absent-index.sqlite");
+
+    await expect(() => openMemoryDatabaseAtPath(dbPath, false, false)).toThrow(
+      /Memory database not found.*refusing to auto-create/,
+    );
+
+    await expect(fs.access(dbPath)).rejects.toThrow("ENOENT");
+  });
+
+  it("allows open with allowCreate=true for temp database creation", async () => {
+    const dbPath = path.join(fixtureRoot, `case-${caseId++}`, "temp-index.sqlite");
+
+    const db = openMemoryDatabaseAtPath(dbPath, false, true);
+    db.exec("CREATE TABLE IF NOT EXISTS meta(key TEXT PRIMARY KEY, value TEXT)");
+    db.close();
+
+    const reopen = openMemoryDatabaseAtPath(dbPath, false, false);
+    expect(reopen).toBeDefined();
+    reopen.close();
+  });
+});

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -8,15 +8,39 @@ import {
   requireNodeSqlite,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 
-export function openMemoryDatabaseAtPath(dbPath: string, allowExtension: boolean): DatabaseSync {
+export function openMemoryDatabaseAtPath(
+  dbPath: string,
+  allowExtension: boolean,
+  allowCreate = true,
+): DatabaseSync {
   const dir = path.dirname(dbPath);
   ensureDir(dir);
   const { DatabaseSync } = requireNodeSqlite();
+  // When allowCreate is false, probe with readOnly first.
+  // DatabaseSync auto-creates the file in read-write mode, which
+  // produces an empty database with schema but no meta row when the
+  // file is momentarily absent during an index swap. readOnly: true
+  // throws SQLITE_CANTOPEN when the file does not exist, preventing
+  // the auto-create race.
+  if (!allowCreate) {
+    try {
+      const probe = new DatabaseSync(dbPath, { readOnly: true });
+      probe.close();
+    } catch (err) {
+      const msg = (err as Error).message ?? "";
+      if (
+        msg.includes("unable to open database file") ||
+        msg.includes("SQLITE_CANTOPEN")
+      ) {
+        throw new Error(
+          `Memory database not found at ${dbPath}; refusing to auto-create an empty database during an index swap window.`,
+          { cause: err },
+        );
+      }
+    }
+  }
   const db = new DatabaseSync(dbPath, { allowExtension });
   configureMemorySqliteWalMaintenance(db);
-  // busy_timeout is per-connection and resets to 0 on restart.
-  // Set it on every open so concurrent processes retry instead of
-  // failing immediately with SQLITE_BUSY.
   db.exec("PRAGMA busy_timeout = 5000");
   return db;
 }

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -2322,7 +2322,7 @@ export abstract class MemoryManagerSyncOps {
 
     const restoreOriginalState = () => {
       if (originalDbClosed) {
-        this.db = openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled);
+        this.db = openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled, false);
       } else {
         this.db = originalDb;
       }
@@ -2434,7 +2434,7 @@ export abstract class MemoryManagerSyncOps {
         },
       });
 
-      this.db = openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled);
+      this.db = openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled, false);
       this.resetVectorState();
       this.ensureSchema();
       this.vector.dims = nextMeta?.vectorDims;

--- a/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
@@ -24,6 +24,15 @@ async function expectRejectCode(promise: Promise<unknown>, code: string): Promis
   throw new Error(`Expected rejection with code ${code}`);
 }
 
+function normalizeBackupName(filePath: string): string {
+  return path
+    .basename(filePath)
+    .replace(
+      /backup-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
+      "backup-<uuid>",
+    );
+}
+
 describe("memory manager atomic reindex", () => {
   let fixtureRoot = "";
   let caseId = 0;
@@ -129,6 +138,25 @@ describe("memory manager atomic reindex", () => {
     });
 
     expect(rename).toHaveBeenCalledTimes(3);
+    expect(wait).not.toHaveBeenCalled();
+  });
+
+  it("requires the main sqlite file during index moves", async () => {
+    const rename = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("missing"), { code: "ENOENT" }));
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expectRejectCode(
+      moveMemoryIndexFiles("index.sqlite.tmp", "index.sqlite", {
+        fileOps: { rename, rm: fs.rm, wait },
+        maxRenameAttempts: 3,
+        renameRetryDelayMs: 10,
+      }),
+      "ENOENT",
+    );
+
+    expect(rename).toHaveBeenCalledTimes(1);
     expect(wait).not.toHaveBeenCalled();
   });
 
@@ -255,7 +283,12 @@ describe("memory manager atomic reindex", () => {
     const existsChecks: boolean[] = [];
     const realRename = fs.rename;
     const rename: typeof fs.rename = vi.fn(async (source, target) => {
-      existsChecks.push(await fs.access(indexPath).then(() => true, () => false));
+      existsChecks.push(
+        await fs.access(indexPath).then(
+          () => true,
+          () => false,
+        ),
+      );
       return realRename(source, target);
     });
 
@@ -273,6 +306,119 @@ describe("memory manager atomic reindex", () => {
     for (const exists of existsChecks) {
       expect(exists).toBe(true);
     }
+  });
+
+  it("backs up stale target sidecars before replacing the main index", async () => {
+    writeChunkMarker(indexPath, "before");
+    writeChunkMarker(tempIndexPath, "after");
+    await fs.writeFile(`${indexPath}-wal`, "stale wal");
+    await fs.writeFile(`${indexPath}-shm`, "stale shm");
+    await fs.writeFile(`${tempIndexPath}-wal`, "closed temp wal");
+    await fs.writeFile(`${tempIndexPath}-shm`, "closed temp shm");
+
+    const events: string[] = [];
+    const realRename = fs.rename;
+    const realRm = fs.rm;
+    const rename: typeof fs.rename = vi.fn(async (source, target) => {
+      events.push(
+        `rename:${normalizeBackupName(String(source))}->${normalizeBackupName(String(target))}`,
+      );
+      await realRename(source, target);
+    });
+    const rm: typeof fs.rm = vi.fn(async (filePath, options) => {
+      events.push(`rm:${normalizeBackupName(String(filePath))}:${readChunkMarker(indexPath)}`);
+      await realRm(filePath, options);
+    });
+
+    await runMemoryAtomicReindex({
+      targetPath: indexPath,
+      tempPath: tempIndexPath,
+      fileOptions: {
+        fileOps: { rename, rm, wait: vi.fn().mockResolvedValue(undefined) },
+      },
+      build: async () => undefined,
+    });
+
+    expect(readChunkMarker(indexPath)).toBe("after");
+    expect(rename).toHaveBeenCalledTimes(3);
+    expect(events).toEqual([
+      "rename:index.sqlite-wal->index.sqlite.backup-<uuid>-wal",
+      "rename:index.sqlite-shm->index.sqlite.backup-<uuid>-shm",
+      "rename:index.sqlite.tmp->index.sqlite",
+      "rm:index.sqlite.backup-<uuid>:after",
+      "rm:index.sqlite.backup-<uuid>-wal:after",
+      "rm:index.sqlite.backup-<uuid>-shm:after",
+      "rm:index.sqlite.tmp-wal:after",
+      "rm:index.sqlite.tmp-shm:after",
+    ]);
+    await expectPathMissing(`${indexPath}-wal`);
+    await expectPathMissing(`${indexPath}-shm`);
+    await expectPathMissing(`${tempIndexPath}-wal`);
+    await expectPathMissing(`${tempIndexPath}-shm`);
+  });
+
+  it("restores backed-up target sidecars when publishing the main index fails", async () => {
+    writeChunkMarker(indexPath, "before");
+    writeChunkMarker(tempIndexPath, "after");
+    await fs.writeFile(`${indexPath}-wal`, "stale wal");
+    await fs.writeFile(`${indexPath}-shm`, "stale shm");
+
+    const realRename = fs.rename;
+    const rename: typeof fs.rename = vi.fn(async (source, target) => {
+      if (String(source) === tempIndexPath && String(target) === indexPath) {
+        throw Object.assign(new Error("locked target"), { code: "EACCES" });
+      }
+      await realRename(source, target);
+    });
+
+    await expectRejectCode(
+      runMemoryAtomicReindex({
+        targetPath: indexPath,
+        tempPath: tempIndexPath,
+        fileOptions: {
+          fileOps: { rename, rm: fs.rm, wait: vi.fn().mockResolvedValue(undefined) },
+        },
+        build: async () => undefined,
+      }),
+      "EACCES",
+    );
+
+    await expect(fs.readFile(`${indexPath}-wal`, "utf8")).resolves.toBe("stale wal");
+    await expect(fs.readFile(`${indexPath}-shm`, "utf8")).resolves.toBe("stale shm");
+    expect(readChunkMarker(indexPath)).toBe("before");
+    await expectPathMissing(tempIndexPath);
+  });
+
+  it("restores target sidecars when sidecar backup partially fails", async () => {
+    writeChunkMarker(indexPath, "before");
+    writeChunkMarker(tempIndexPath, "after");
+    await fs.writeFile(`${indexPath}-wal`, "stale wal");
+    await fs.writeFile(`${indexPath}-shm`, "stale shm");
+
+    const realRename = fs.rename;
+    const rename: typeof fs.rename = vi.fn(async (source, target) => {
+      if (String(source) === `${indexPath}-shm` && String(target).includes(".backup-")) {
+        throw Object.assign(new Error("locked shm"), { code: "EACCES" });
+      }
+      await realRename(source, target);
+    });
+
+    await expectRejectCode(
+      runMemoryAtomicReindex({
+        targetPath: indexPath,
+        tempPath: tempIndexPath,
+        fileOptions: {
+          fileOps: { rename, rm: fs.rm, wait: vi.fn().mockResolvedValue(undefined) },
+        },
+        build: async () => undefined,
+      }),
+      "EACCES",
+    );
+
+    await expect(fs.readFile(`${indexPath}-wal`, "utf8")).resolves.toBe("stale wal");
+    await expect(fs.readFile(`${indexPath}-shm`, "utf8")).resolves.toBe("stale shm");
+    expect(readChunkMarker(indexPath)).toBe("before");
+    await expectPathMissing(tempIndexPath);
   });
 });
 

--- a/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
@@ -247,6 +247,33 @@ describe("memory manager atomic reindex", () => {
       "rm:index.sqlite.tmp-shm:closed",
     ]);
   });
+
+  it("atomic swap on POSIX: target file never goes absent during swap", async () => {
+    writeChunkMarker(indexPath, "before");
+    writeChunkMarker(tempIndexPath, "after");
+
+    const existsChecks: boolean[] = [];
+    const realRename = fs.rename;
+    const rename: typeof fs.rename = vi.fn(async (source, target) => {
+      existsChecks.push(await fs.access(indexPath).then(() => true, () => false));
+      return realRename(source, target);
+    });
+
+    await runMemoryAtomicReindex({
+      targetPath: indexPath,
+      tempPath: tempIndexPath,
+      fileOptions: {
+        fileOps: { rename, rm: fs.rm, wait: vi.fn().mockResolvedValue(undefined) },
+      },
+      build: async () => undefined,
+    });
+
+    expect(readChunkMarker(indexPath)).toBe("after");
+    expect(existsChecks.length).toBeGreaterThan(0);
+    for (const exists of existsChecks) {
+      expect(exists).toBe(true);
+    }
+  });
 });
 
 function writeChunkMarker(dbPath: string, marker: string): void {


### PR DESCRIPTION
## Summary

Fixes #91216 by removing the POSIX `main.sqlite` absent window during memory index swaps and by preventing post-swap recovery paths from silently creating an empty replacement database.

- Problem: the old three-step swap moved the live DB to a backup before publishing the temp DB, so a concurrent opener could see `main.sqlite` missing and `DatabaseSync` would auto-create an empty DB with no memory index metadata.
- Swap fix: on POSIX, publish the temp main DB with an overwrite `rename`, keep stale target WAL/SHM sidecars rollbackable while the publish is in progress, and keep the Windows backup protocol for target-exists failures.
- Open fix: `openMemoryDatabaseAtPath(..., allowCreate=false)` probes with `readOnly: true` before post-swap reopens so recovery paths fail closed instead of creating an empty DB.
- What did not change: config surfaces, CLI commands, default lazy first-run DB creation, provider/model identity logic.

## Change Type

- [x] Bug fix

## Scope

- [x] Memory / storage

## Linked Issue

- Fixes #91216

## Changes

**File**: `extensions/memory-core/src/memory/manager-atomic-reindex.ts`

- Makes the main SQLite file mandatory during index moves; WAL/SHM sidecars remain optional.
- Publishes POSIX swaps with a single main-file overwrite rename so `main.sqlite` never goes absent.
- Moves target WAL/SHM sidecars to a rollbackable backup before publishing the new main file, restores them on pre-publish failures, and removes backup/temp sidecars only after publish succeeds.
- Keeps the Windows target-exists fallback, but avoids treating sidecar moves as an atomic multi-file operation.

**File**: `extensions/memory-core/src/memory/manager-db.ts`

- Adds `allowCreate` with default `true`.
- When `allowCreate=false`, verifies file existence with a read-only `DatabaseSync` probe before opening read-write.

**File**: `extensions/memory-core/src/memory/manager-sync-ops.ts`

- Uses `allowCreate=false` for post-swap reopen and restore paths.
- Leaves temp DB creation and normal lazy open behavior unchanged.

**Tests**

- `extensions/memory-core/src/memory/manager.atomic-reindex.test.ts`: POSIX no-absent-window coverage, required main-file behavior, rollbackable target sidecars, restore on publish failure, restore on partial sidecar-backup failure.
- `extensions/memory-core/src/memory/manager-db-probe.test.ts`: `allowCreate=true` creation, existing DB open, and `allowCreate=false` no-auto-create behavior.

## Real Behavior Proof

- Behavior addressed: Gateway `memory_search` could stay disabled with `index metadata is missing` after `main.sqlite` was momentarily absent during index swap and a concurrent `DatabaseSync` open auto-created an empty DB.
- Real environment tested: macOS local checkout, Node/Vitest via repo `scripts/run-vitest.mjs`, branch `fix/memory-swap-empty-db-91216` at commit `60df2b4178c8e16a301b715c77bc6197aced99d1`.
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.atomic-reindex.test.ts extensions/memory-core/src/memory/manager-db-probe.test.ts extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts extensions/memory-core/src/memory/manager-reindex-state.test.ts extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts extensions/memory-core/src/memory/manager.readonly-recovery.test.ts
git diff --check origin/main...HEAD
node scripts/run-oxlint.mjs extensions/memory-core/src/memory/manager-atomic-reindex.ts extensions/memory-core/src/memory/manager.atomic-reindex.test.ts extensions/memory-core/src/memory/manager-db.ts extensions/memory-core/src/memory/manager-db-probe.test.ts extensions/memory-core/src/memory/manager-sync-ops.ts
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

- Evidence after fix:

```console
Test Files  6 passed (6)
Tests       48 passed (48)

node scripts/run-oxlint.mjs ...
# clean

autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.82)
```

- Observed result after fix: The POSIX swap test verifies `index.sqlite` remains present at every rename step; rollback tests verify target sidecars are restored if publish or sidecar backup fails; the read-only probe test verifies `allowCreate=false` refuses an absent DB instead of creating an empty one.
- What was not tested: Live gateway plus concurrent `openclaw memory index --force` / `memory_search` race, and native Windows filesystem behavior. Windows fallback behavior is covered through unit-level filesystem-operation mocks.

## Risks

- **SQLite sidecars**: WAL/SHM are multi-file SQLite state, so the swap keeps old sidecars rollbackable until the new main DB is published. The new temp DB is closed/checkpointed before swap and leftover temp sidecars are removed only after publish.
- **First-run behavior**: Normal lazy opens still allow creation; only post-swap recovery reopens use `allowCreate=false`.
- **Windows fallback**: Target-exists failures still use the backup protocol. The fix narrows the optimistic path to the main file so sidecar errors cannot trigger fallback after a partial main publish.

## Compatibility / Migration

- [x] Backward compatible? Yes (`allowCreate` defaults `true`)
- [x] Config/env changes? No
- [x] Migration needed? No

Refs #91216
