### PR TITLE
#92109: [Bug]: EmbeddedAttemptSessionTakeoverError caused by Btrfs ctimeNs instability

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -834,6 +834,42 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(2);
   });
 
+  it("allows ctime-only fingerprint drift while the prompt lock is released", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocalCtimeDrift = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocalCtimeDrift,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+
+    const stableStat = await fs.stat(sessionFile, { bigint: true });
+    const driftedStat = Object.assign(
+      Object.create(Object.getPrototypeOf(stableStat)),
+      stableStat,
+      {
+        ctimeNs: stableStat.ctimeNs + 1_000_000n,
+      },
+    ) as typeof stableStat;
+    const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (target, options) => {
+      if (target === sessionFile && options?.bigint === true) {
+        return driftedStat;
+      }
+      throw new Error(`unexpected stat call for ${String(target)}`);
+    });
+
+    try {
+      await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
+    } finally {
+      statSpy.mockRestore();
+    }
+    expect(controller.hasSessionTakeover()).toBe(false);
+    expect(acquireSessionWriteLockLocalCtimeDrift).toHaveBeenCalledTimes(2);
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
   it("still rejects external edits after the prompt stream lock is reacquired", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -870,6 +870,45 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(2);
   });
 
+  it("rejects same-size transcript rewrites with restored mtime", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocalSameSizeRewrite = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocalSameSizeRewrite,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+
+    const stableStat = await fs.stat(sessionFile, { bigint: true });
+    await fs.writeFile(sessionFile, '{"type":"sessioN"}\n', "utf8");
+    const driftedStat = Object.assign(
+      Object.create(Object.getPrototypeOf(stableStat)),
+      stableStat,
+      {
+        ctimeNs: stableStat.ctimeNs + 1_000_000n,
+      },
+    ) as typeof stableStat;
+    const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (target, options) => {
+      if (target === sessionFile && options?.bigint === true) {
+        return driftedStat;
+      }
+      throw new Error(`unexpected stat call for ${String(target)}`);
+    });
+
+    try {
+      await expect(controller.withSessionWriteLock(() => "finalize")).rejects.toBeInstanceOf(
+        EmbeddedAttemptSessionTakeoverError,
+      );
+    } finally {
+      statSpy.mockRestore();
+    }
+    expect(controller.hasSessionTakeover()).toBe(true);
+    expect(acquireSessionWriteLockLocalSameSizeRewrite).toHaveBeenCalledTimes(2);
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
   it("still rejects external edits after the prompt stream lock is reacquired", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -56,6 +56,15 @@ async function createTempSessionFile(): Promise<string> {
   return sessionFile;
 }
 
+function cloneBigIntStatWith(
+  stat: Awaited<ReturnType<typeof fs.stat>>,
+  fields: Partial<Awaited<ReturnType<typeof fs.stat>>>,
+): Awaited<ReturnType<typeof fs.stat>> {
+  return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, fields) as Awaited<
+    ReturnType<typeof fs.stat>
+  >;
+}
+
 describe("embedded attempt session lock lifecycle", () => {
   it("serializes embedded attempts that share a session file owner", async () => {
     const sessionFile = await createTempSessionFile();
@@ -846,13 +855,9 @@ describe("embedded attempt session lock lifecycle", () => {
     await controller.releaseForPrompt();
 
     const stableStat = await fs.stat(sessionFile, { bigint: true });
-    const driftedStat = Object.assign(
-      Object.create(Object.getPrototypeOf(stableStat)),
-      stableStat,
-      {
-        ctimeNs: stableStat.ctimeNs + 1_000_000n,
-      },
-    ) as typeof stableStat;
+    const driftedStat = cloneBigIntStatWith(stableStat, {
+      ctimeNs: stableStat.ctimeNs + 1_000_000n,
+    });
     const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (target, options) => {
       if (target === sessionFile && options?.bigint === true) {
         return driftedStat;
@@ -870,6 +875,85 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(2);
   });
 
+  it("trusts owned writes after accepting ctime-only fingerprint drift", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocalOwnedAfterDrift = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocalOwnedAfterDrift,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+
+    const stableStat = await fs.stat(sessionFile, { bigint: true });
+    const driftedStat = cloneBigIntStatWith(stableStat, {
+      ctimeNs: stableStat.ctimeNs + 1_000_000n,
+    });
+    const appendedText = '{"type":"message","id":"owned-after-drift"}\n';
+    const changedStat = cloneBigIntStatWith(stableStat, {
+      ctimeNs: stableStat.ctimeNs + 2_000_000n,
+      mtimeNs: stableStat.mtimeNs + 1_000_000n,
+      size: stableStat.size + BigInt(Buffer.byteLength(appendedText)),
+    });
+    let currentStat = driftedStat;
+    const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (target, options) => {
+      if (target === sessionFile && options?.bigint === true) {
+        return currentStat;
+      }
+      throw new Error(`unexpected stat call for ${String(target)}`);
+    });
+
+    try {
+      await expect(
+        controller.withSessionWriteLock(
+          async () => {
+            currentStat = changedStat;
+            await fs.appendFile(sessionFile, appendedText, "utf8");
+          },
+          { publishOwnedWrite: true },
+        ),
+      ).resolves.toBeUndefined();
+      await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
+    } finally {
+      statSpy.mockRestore();
+    }
+    expect(controller.hasSessionTakeover()).toBe(false);
+    expect(acquireSessionWriteLockLocalOwnedAfterDrift).toHaveBeenCalledTimes(3);
+    expect(release).toHaveBeenCalledTimes(3);
+  });
+
+  it("allows ctime-only fingerprint drift for large transcript snapshots", async () => {
+    const sessionFile = await createTempSessionFile();
+    await fs.writeFile(sessionFile, Buffer.alloc(8 * 1024 * 1024 + 1, "x"));
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocalLargeCtimeDrift = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocalLargeCtimeDrift,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+
+    const stableStat = await fs.stat(sessionFile, { bigint: true });
+    const driftedStat = cloneBigIntStatWith(stableStat, {
+      ctimeNs: stableStat.ctimeNs + 1_000_000n,
+    });
+    const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (target, options) => {
+      if (target === sessionFile && options?.bigint === true) {
+        return driftedStat;
+      }
+      throw new Error(`unexpected stat call for ${String(target)}`);
+    });
+
+    try {
+      await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
+    } finally {
+      statSpy.mockRestore();
+    }
+    expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
   it("rejects same-size transcript rewrites with restored mtime", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});
@@ -883,13 +967,9 @@ describe("embedded attempt session lock lifecycle", () => {
 
     const stableStat = await fs.stat(sessionFile, { bigint: true });
     await fs.writeFile(sessionFile, '{"type":"sessioN"}\n', "utf8");
-    const driftedStat = Object.assign(
-      Object.create(Object.getPrototypeOf(stableStat)),
-      stableStat,
-      {
-        ctimeNs: stableStat.ctimeNs + 1_000_000n,
-      },
-    ) as typeof stableStat;
+    const driftedStat = cloneBigIntStatWith(stableStat, {
+      ctimeNs: stableStat.ctimeNs + 1_000_000n,
+    });
     const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (target, options) => {
       if (target === sessionFile && options?.bigint === true) {
         return driftedStat;

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -74,13 +74,12 @@ function sameSessionFileFingerprint(
   if (!left.exists || !right.exists) {
     return true;
   }
-  // ctimeNs intentionally excluded: unstable on Btrfs (background maintenance
-  // tasks like snapshots/scrub/quota update ctime without any file content change)
   return (
     left.dev === right.dev &&
     left.ino === right.ino &&
     left.size === right.size &&
-    left.mtimeNs === right.mtimeNs
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
   );
 }
 
@@ -89,6 +88,20 @@ function sameSessionFileIdentity(
   right: SessionFileFingerprint,
 ): boolean {
   return Boolean(left?.exists && right.exists && left.dev === right.dev && left.ino === right.ino);
+}
+
+function sameSessionFileContentMetadata(
+  left: SessionFileFingerprint | undefined,
+  right: SessionFileFingerprint,
+): boolean {
+  return Boolean(
+    left?.exists &&
+    right.exists &&
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs,
+  );
 }
 
 function splitSessionFileLines(text: string): string[] {
@@ -258,6 +271,27 @@ async function sessionFenceAdvanceIsBenign(params: {
   }
   const lines = normalizeStringEntries(text.split("\n"));
   return lines.length > 0 && lines.every(isTranscriptOnlyOpenClawAssistantLine);
+}
+
+async function sessionFenceCtimeDriftIsBenign(params: {
+  sessionFile: string;
+  previous: SessionFileFenceSnapshot | undefined;
+  current: SessionFileFingerprint;
+}): Promise<boolean> {
+  if (
+    !sameSessionFileContentMetadata(params.previous?.fingerprint, params.current) ||
+    params.previous?.fingerprint.exists !== true ||
+    !params.current.exists ||
+    params.previous.fingerprint.ctimeNs === params.current.ctimeNs ||
+    params.previous.text === undefined
+  ) {
+    return false;
+  }
+  try {
+    return (await fs.readFile(params.sessionFile, "utf8")) === params.previous.text;
+  } catch {
+    return false;
+  }
 }
 
 async function sessionFenceRewriteIsBenign(params: {
@@ -733,6 +767,11 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
 
     if (
+      (await sessionFenceCtimeDriftIsBenign({
+        sessionFile: params.lockOptions.sessionFile,
+        previous: fenceSnapshot,
+        current,
+      })) ||
       (await sessionFenceAdvanceIsBenign({
         sessionFile: params.lockOptions.sessionFile,
         previous: fenceSnapshot,

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -74,12 +74,13 @@ function sameSessionFileFingerprint(
   if (!left.exists || !right.exists) {
     return true;
   }
+  // ctimeNs intentionally excluded: unstable on Btrfs (background maintenance
+  // tasks like snapshots/scrub/quota update ctime without any file content change)
   return (
     left.dev === right.dev &&
     left.ino === right.ino &&
     left.size === right.size &&
-    left.mtimeNs === right.mtimeNs &&
-    left.ctimeNs === right.ctimeNs
+    left.mtimeNs === right.mtimeNs
   );
 }
 

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -314,6 +314,9 @@ async function sessionFenceCtimeDriftIsBenign(params: {
     return false;
   }
   if (params.previous.text === undefined) {
+    if (params.previous.digest === undefined) {
+      return false;
+    }
     const currentDigest = await readSessionFileDigest(params.sessionFile);
     return currentDigest !== undefined && currentDigest === params.previous.digest;
   }

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -58,6 +58,7 @@ const MAX_BENIGN_SESSION_FENCE_ADVANCE_BYTES = 1024 * 1024;
 const MAX_BENIGN_SESSION_FENCE_REWRITE_BYTES = 8 * 1024 * 1024;
 const MAX_BENIGN_SESSION_FENCE_REWRITE_RESULT_BYTES =
   MAX_BENIGN_SESSION_FENCE_REWRITE_BYTES + MAX_BENIGN_SESSION_FENCE_ADVANCE_BYTES;
+const MAX_BENIGN_SESSION_FENCE_CTIME_DIGEST_BYTES = 32 * 1024 * 1024;
 const MAX_SAFE_FILE_OFFSET = BigInt(Number.MAX_SAFE_INTEGER);
 
 type SessionFileFenceSnapshot = {
@@ -249,6 +250,9 @@ async function readSessionFileFenceSnapshot(
     } catch {
       return { fingerprint };
     }
+  }
+  if (fingerprint.size > BigInt(MAX_BENIGN_SESSION_FENCE_CTIME_DIGEST_BYTES)) {
+    return { fingerprint };
   }
   return {
     fingerprint,

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -2,7 +2,8 @@
  * Coordinates embedded-attempt session ownership, takeover, and prompt locks.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
-import { readFileSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { createReadStream, readFileSync, statSync } from "node:fs";
 import fs from "node:fs/promises";
 import { isDeepStrictEqual } from "node:util";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
@@ -61,6 +62,7 @@ const MAX_SAFE_FILE_OFFSET = BigInt(Number.MAX_SAFE_INTEGER);
 
 type SessionFileFenceSnapshot = {
   fingerprint: SessionFileFingerprint;
+  digest?: string;
   text?: string;
 };
 
@@ -232,21 +234,42 @@ async function readSessionFileFenceSnapshot(
   sessionFile: string,
 ): Promise<SessionFileFenceSnapshot> {
   const fingerprint = await readSessionFileFingerprint(sessionFile);
+  if (!fingerprint.exists) {
+    return { fingerprint };
+  }
   if (
-    !fingerprint.exists ||
-    fingerprint.size > BigInt(MAX_BENIGN_SESSION_FENCE_REWRITE_BYTES) ||
-    fingerprint.size > MAX_SAFE_FILE_OFFSET
+    fingerprint.size <= BigInt(MAX_BENIGN_SESSION_FENCE_REWRITE_BYTES) &&
+    fingerprint.size <= MAX_SAFE_FILE_OFFSET
   ) {
-    return { fingerprint };
+    try {
+      return {
+        fingerprint,
+        text: await fs.readFile(sessionFile, "utf8"),
+      };
+    } catch {
+      return { fingerprint };
+    }
   }
-  try {
-    return {
-      fingerprint,
-      text: await fs.readFile(sessionFile, "utf8"),
-    };
-  } catch {
-    return { fingerprint };
-  }
+  return {
+    fingerprint,
+    digest: await readSessionFileDigest(sessionFile),
+  };
+}
+
+async function readSessionFileDigest(sessionFile: string): Promise<string | undefined> {
+  const hash = createHash("sha256");
+  return await new Promise<string | undefined>((resolve) => {
+    const stream = createReadStream(sessionFile);
+    stream.on("data", (chunk) => {
+      hash.update(chunk);
+    });
+    stream.on("error", () => {
+      resolve(undefined);
+    });
+    stream.on("end", () => {
+      resolve(hash.digest("hex"));
+    });
+  });
 }
 
 async function sessionFenceAdvanceIsBenign(params: {
@@ -282,10 +305,13 @@ async function sessionFenceCtimeDriftIsBenign(params: {
     !sameSessionFileContentMetadata(params.previous?.fingerprint, params.current) ||
     params.previous?.fingerprint.exists !== true ||
     !params.current.exists ||
-    params.previous.fingerprint.ctimeNs === params.current.ctimeNs ||
-    params.previous.text === undefined
+    params.previous.fingerprint.ctimeNs === params.current.ctimeNs
   ) {
     return false;
+  }
+  if (params.previous.text === undefined) {
+    const currentDigest = await readSessionFileDigest(params.sessionFile);
+    return currentDigest !== undefined && currentDigest === params.previous.digest;
   }
   try {
     return (await fs.readFile(params.sessionFile, "utf8")) === params.previous.text;
@@ -535,6 +561,19 @@ function recordOwnedSessionFileWrite(
   return ownedSessionFileWriteGeneration;
 }
 
+function recordTrustedSessionFileState(
+  sessionFileKey: string,
+  fingerprint: SessionFileFingerprint,
+): number {
+  ownedSessionFileWriteGeneration += 1;
+  const state = {
+    generation: ownedSessionFileWriteGeneration,
+    fingerprint,
+  };
+  trustedSessionFileStates.set(sessionFileKey, state);
+  return ownedSessionFileWriteGeneration;
+}
+
 function trustSessionFileState(
   sessionFileKey: string,
   fingerprint: SessionFileFingerprint,
@@ -767,11 +806,19 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
 
     if (
-      (await sessionFenceCtimeDriftIsBenign({
+      await sessionFenceCtimeDriftIsBenign({
         sessionFile: params.lockOptions.sessionFile,
         previous: fenceSnapshot,
         current,
-      })) ||
+      })
+    ) {
+      fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
+      fenceFingerprint = fenceSnapshot.fingerprint;
+      fenceGeneration = recordTrustedSessionFileState(sessionFileFenceKey, current);
+      return;
+    }
+
+    if (
       (await sessionFenceAdvanceIsBenign({
         sessionFile: params.lockOptions.sessionFile,
         previous: fenceSnapshot,


### PR DESCRIPTION
## Summary

Fix the session-file fence so Btrfs `ctimeNs`-only metadata drift does not falsely trip `EmbeddedAttemptSessionTakeoverError` during cron/subagent prompt-lock release.

The maintained branch keeps the normal strict fingerprint, including `ctimeNs`, for takeover detection. It only accepts `ctimeNs` drift after verifying the session file content is unchanged through the existing text snapshot path or a bounded SHA-256 digest path for larger transcripts.

## Root Cause

`attempt.session-lock.ts` treats any session file fingerprint change while the prompt lock is released as a possible external takeover. On Btrfs, filesystem metadata maintenance can update `ctimeNs` without changing file content, `mtimeNs`, `size`, or `ino`, so the old fence could reject the same session file as a takeover.

Dropping `ctimeNs` globally would be too broad because same-size external rewrites can restore `mtimeNs`. This patch narrows the exception to verified `ctimeNs`-only drift and then promotes the verified snapshot into trusted state before future owned writes.

## Real behavior proof

Behavior addressed: Btrfs can change a session file's `ctimeNs` without a content write, which made the embedded attempt fence treat cron/subagent prompt-lock release as a session takeover.

Real environment tested: Reporter tested on OpenClaw 2026.6.5 (`5181e4f`), Node.js v24.14.0, Linux 6.8.1 aarch64, Zspace Z4Pro+ NAS, Btrfs filesystem, Docker deployment with the OpenClaw data directory mounted from the NAS volume. Maintainer proof was run locally in the OpenClaw source checkout on PR head `449043802397556ee3c04ff66f58540fe35d6ec4`.

Exact steps or command run after this patch: Reporter recorded BigInt stat values for a session file on Btrfs, waited 20 seconds with no writes, observed `mtimeNs`, `size`, and `ino` unchanged while `ctimeNs` changed, then applied the `ctimeNs` takeover comparison change and observed the cron task complete on first attempt. Maintainer added focused session-lock regression coverage and ran `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`, `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`, and `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix: Reporter’s before/after terminal evidence says 14+ consecutive cron failures reproduced before the patch and the cron task succeeded on the first attempt after the `ctimeNs` takeover comparison change. Maintainer test output on the patched branch: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts` passed 53 tests, including ctime-only drift, owned writes after accepted drift, digest-backed large snapshots, and same-size rewrites with restored mtime.

Observed result after fix: The patched fence accepts verified `ctimeNs`-only drift instead of throwing `EmbeddedAttemptSessionTakeoverError`; it still rejects same-size transcript rewrites with restored `mtimeNs`. `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts` was clean, and autoreview reported no accepted/actionable findings on `449043802397556ee3c04ff66f58540fe35d6ec4`.

What was not tested: I did not personally run a live Btrfs NAS/Docker cron scenario from this maintainer machine. Focused local tests for unrelated model-runtime CI failures reproduce on exact `origin/main` `f1401b2cac`, so those failures are not caused by this PR. GitHub CI on the pushed SHA remains the broader type/check gate.

## Regression Test Plan

- [x] `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`
- [x] `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`
- [x] `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- [ ] GitHub CI on the pushed PR head

