### PR TITLE
[codex] fix(skill-creator): accept mixed-case resources

### DIFF
--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -208,8 +208,20 @@ def title_case_skill_name(skill_name):
 def parse_resources(raw_resources):
     if not raw_resources:
         return []
-    resources = [item.strip() for item in raw_resources.split(",") if item.strip()]
-    invalid = sorted({item for item in resources if item not in ALLOWED_RESOURCES})
+
+    resources = []
+    invalid = []
+    for item in raw_resources.split(","):
+        original = item.strip()
+        if not original:
+            continue
+        normalized = original.lower()
+        if normalized not in ALLOWED_RESOURCES:
+            invalid.append(original)
+            continue
+        resources.append(normalized)
+
+    invalid = sorted(set(invalid))
     if invalid:
         allowed = ", ".join(sorted(ALLOWED_RESOURCES))
         print(f"[ERROR] Unknown resource type(s): {', '.join(invalid)}")

--- a/skills/skill-creator/scripts/test_init_skill.py
+++ b/skills/skill-creator/scripts/test_init_skill.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Regression tests for skill initialization helpers.
+"""
+
+import sys
+from pathlib import Path
+from unittest import TestCase, main
+from unittest.mock import patch
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from init_skill import parse_resources
+
+
+class TestParseResources(TestCase):
+    def test_accepts_mixed_case_resources(self):
+        resources = parse_resources("Scripts,References,ASSETS")
+
+        self.assertEqual(resources, ["scripts", "references", "assets"])
+
+    def test_dedupes_resources_case_insensitively(self):
+        resources = parse_resources("scripts,Scripts,REFERENCES,references")
+
+        self.assertEqual(resources, ["scripts", "references"])
+
+    def test_ignores_empty_resource_tokens(self):
+        resources = parse_resources(" scripts, , Assets ,")
+
+        self.assertEqual(resources, ["scripts", "assets"])
+
+    def test_reports_invalid_resources_with_original_spelling(self):
+        with patch("builtins.print") as mock_print:
+            with self.assertRaises(SystemExit) as raised:
+                parse_resources("Scripts,BadThing")
+
+        self.assertEqual(raised.exception.code, 1)
+        messages = [call.args[0] for call in mock_print.call_args_list]
+        self.assertEqual(messages[0], "[ERROR] Unknown resource type(s): BadThing")
+        self.assertEqual(messages[1], "   Allowed: assets, references, scripts")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Normalize `init_skill.py --resources` tokens to canonical lowercase before validation.
- Keep invalid resource diagnostics tied to the original user spelling.
- Add focused regression tests for mixed-case input, case-insensitive deduplication, empty tokens, and invalid values.

## Related Issue

- Closes #38076

## Duplicate Check

- Open PR search for `#38076`, `init_skill resources case-insensitive`, `parse_resources`, and `skills/skill-creator/scripts/init_skill.py` returned no open overlap immediately before creating this PR.
- Historical overlapping PRs #38073, #38095, #47316, #47773, and #82693 are all closed and unmerged.

## Real behavior proof

Behavior addressed: `skills/skill-creator/scripts/init_skill.py --resources` now accepts valid resource names regardless of letter case, returns canonical lowercase resource names, and creates the requested resource directories.

Real environment tested: local OpenClaw checkout on macOS using the PR branch `codex/skill-creator-resources-case-insensitive` at commit `2f6d529d7b` with system `python3`.

Exact steps or command run after this patch:

```text
tmpdir=$(mktemp -d)
PYTHONDONTWRITEBYTECODE=1 python3 -B skills/skill-creator/scripts/init_skill.py mixed-case-skill --path "$tmpdir" --resources Scripts,References,ASSETS
find "$tmpdir/mixed-case-skill" -maxdepth 1 -type d -print | sed "s#$tmpdir#<tmp>#"
```

Evidence after fix:

```text
Initializing skill: mixed-case-skill
   Location: /var/folders/1g/vjlcpc414z3fmjw91_3mm9y40000gn/T/tmp.7kSAUxeprL
   Resources: scripts, references, assets

[OK] Created skill directory: /private/var/folders/1g/vjlcpc414z3fmjw91_3mm9y40000gn/T/tmp.7kSAUxeprL/mixed-case-skill
[OK] Created SKILL.md
[OK] Created scripts/
[OK] Created references/
[OK] Created assets/

[OK] Skill 'mixed-case-skill' initialized successfully at /private/var/folders/1g/vjlcpc414z3fmjw91_3mm9y40000gn/T/tmp.7kSAUxeprL/mixed-case-skill

Next steps:
1. Edit SKILL.md to complete the TODO items and update the description
2. Add resources to scripts/, references/, and assets/ as needed
3. Run the validator when ready to check the skill structure
<tmp>/mixed-case-skill
<tmp>/mixed-case-skill/references
<tmp>/mixed-case-skill/scripts
<tmp>/mixed-case-skill/assets
```

Observed result after fix: mixed-case valid resource tokens were accepted, printed as canonical lowercase resources, and created `scripts/`, `references/`, and `assets/` under the generated skill.

What was not tested: a packaged OpenClaw release build was not created; this change is limited to the bundled skill-creator Python helper and was validated through direct script execution plus focused regression tests.

## Verification

```text
PYTHONDONTWRITEBYTECODE=1 python3 -B skills/skill-creator/scripts/test_init_skill.py
PYTHONDONTWRITEBYTECODE=1 python3 -B skills/skill-creator/scripts/test_package_skill.py
PYTHONDONTWRITEBYTECODE=1 python3 -B skills/skill-creator/scripts/test_quick_validate.py
git diff --check
```
