### PR TITLE
fix(plugins): rescan storm in "/models" call (regression shipped since v2026.5.18)

### DIFF
--- a/src/plugins/plugin-metadata-snapshot.memo.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.memo.test.ts
@@ -562,6 +562,30 @@ describe("loadPluginMetadataSnapshot process memo", () => {
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledOnce();
   });
 
+  it("memoizes derived snapshots across alternating call shapes", () => {
+    const stateDir = tempStateDir();
+    touchPersistedIndex(stateDir);
+    const workspaceDir = path.join(stateDir, "workspace");
+    // Two call shapes share a persisted index but derive different snapshot
+    // indexes, like the model-catalog build alternating workspace-scoped and
+    // global lookups. Store keys re-derived from snapshot.index never match the
+    // next lookup, so every alternation re-ran the full manifest scan.
+    loadPluginRegistrySnapshotWithMetadata.mockImplementation(
+      (params: { workspaceDir?: string }) => ({
+        source: "derived",
+        snapshot: makeIndex(params.workspaceDir ? "alpha" : "beta"),
+        diagnostics: [],
+      }),
+    );
+
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, workspaceDir });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, workspaceDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps process-stable derived snapshots when derived plugin files change", () => {
     const stateDir = tempStateDir();
     touchPersistedIndex(stateDir);

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -246,7 +246,6 @@ function resolvePersistedRegistryMemoLookupContextHash(params: {
 
 function resolvePersistedRegistryMemoState(params: {
   env: NodeJS.ProcessEnv;
-  index?: InstalledPluginIndex;
   preferPersisted?: boolean;
   stateDir?: string;
 }): PersistedRegistryMemoState {
@@ -263,12 +262,10 @@ function resolvePersistedRegistryMemoState(params: {
       fingerprint: fastFingerprint,
     };
   }
-  const index =
-    params.index ??
-    readPersistedInstalledPluginIndexSync({
-      env: params.env,
-      ...(params.stateDir ? { stateDir: params.stateDir } : {}),
-    });
+  const index = readPersistedInstalledPluginIndexSync({
+    env: params.env,
+    ...(params.stateDir ? { stateDir: params.stateDir } : {}),
+  });
   return {
     contextHash,
     fastHash,
@@ -617,19 +614,11 @@ export function loadPluginMetadataSnapshot(
   );
   const snapshot = freezePluginMetadataSnapshot(result.snapshot);
   if (canMemoizePluginMetadataSnapshotResult(result)) {
-    const cachedRegistryState =
-      result.registrySource === "derived"
-        ? resolvePersistedRegistryMemoState({
-            env,
-            index: snapshot.index,
-            ...(params.stateDir ? { stateDir: resolveUserPath(params.stateDir, env) } : {}),
-            ...(params.preferPersisted !== undefined
-              ? { preferPersisted: params.preferPersisted }
-              : {}),
-          })
-        : registryState;
+    // Store under the exact key this call looked up by. Derived registries used
+    // to re-key off the freshly built snapshot.index, so the store key never
+    // matched the next lookup and every call re-ran the full manifest scan.
     rememberPluginMetadataSnapshotMemo({
-      key: computePluginMetadataSnapshotMemoKey({ params, registryState: cachedRegistryState }),
+      key: memoKey,
       lookupContextHash: resolvePersistedRegistryMemoLookupContextHash({
         env,
         ...(params.stateDir ? { stateDir: resolveUserPath(params.stateDir, env) } : {}),
@@ -637,7 +626,7 @@ export function loadPluginMetadataSnapshot(
           ? { preferPersisted: params.preferPersisted }
           : {}),
       }),
-      registryState: cachedRegistryState,
+      registryState,
       snapshot,
     });
   }


### PR DESCRIPTION
TL;DR: same box, same Telegram `/model` workflow as #90747, the other half of the stall: with the catalog forced into full discovery, every `/models` step re-ran the full plugin manifest scan several times over because the snapshot memo stored under one key and looked up under another. The memo has been dead on arrival for "derived" registries since v2026.5.18 — every call paid the scan, plus all the downstream caches keyed on snapshot identity.

## Summary

What problem does this PR solve?

- A shipped regression that defeats the plugin metadata snapshot memo for every "derived" registry. Since `5734193fdf` ("fix(plugins): keep metadata snapshot memo fresh", 2026-05-15, first shipped in v2026.5.18), `loadPluginMetadataSnapshot` stores derived-registry results under a key recomputed from the freshly built `snapshot.index`, while lookups key off the persisted-index registry state. The two keys never match. Worse, the lookup-side adoption loop returns the most recently stored `registryState` for the context, so two alternating call shapes — exactly what the model-catalog build does, mixing workspace-scoped and global lookups — each adopt the other shape's state, compute a key that was never stored, and re-run the full plugin manifest scan — on every call, forever. Each miss also mints a new snapshot identity, invalidating every downstream cache keyed on it.

Why does this matter now?

- This is current-stable behavior: every install ≥ v2026.5.18 has it. It hits whenever the registry resolves as "derived" — persisted plugin index absent or not covering the running checkout (source checkouts, version changes) — and the chat `/models` full-discovery path (provider wildcards in `agents.defaults.models`, or `view=all`) then pays multiple full manifest scans plus the downstream invalidation per step: list → pick provider → pick model, every step, every time, in every chat channel. Measured below: ~6.5s of pinned CPU per catalog build that should take ~0.26s.

What is the intended outcome?

- The memo stores under the exact `memoKey`/`registryState` the call looked up by. Repeat lookups — including alternating call shapes — hit the memo; the full manifest scan runs once per lifecycle, as designed. Output is identical; only the recomputation goes away.

What is intentionally out of scope?

- No config, schema, or default changes; no change to what gets memoized or when the memo is cleared. The per-model setup-registry rebuild on the same `/models` path is the sibling fix #90747.

What does success look like?

- `/models` full-discovery catalog builds reuse the snapshot memo; repeated builds drop from seconds of rescanning to milliseconds, with identical catalog output.

What should reviewers focus on?

- Freshness semantics are unchanged: invalidation is still owned by the lookup context hash and the plugin-metadata lifecycle clears (`registerPluginMetadataProcessMemoLifecycleClear` — install/reload/doctor). The existing process-stable tests ("keeps process-stable derived snapshots when derived plugin files change", "keeps persisted registry snapshots process-stable until lifecycle clear") pass unchanged.
- The removed `index` parameter of `resolvePersistedRegistryMemoState`: its single remaining caller never passed `index`, so the removed branch was dead after this fix.

## Linked context

Which issue does this close?

- None — no tracking issue; found, profiled, and fixed while dogfooding a live install (same diagnosis session as #90747).

Which issues, PRs, or discussions are related?

- `5734193fdf` introduced the store/lookup divergence (re-keying the derived store side off `snapshot.index`); first release tag carrying it: v2026.5.18. The 8-slot restructure `4314674054` (#85843) preserved it.
- #90747 is the sibling fix for the same `/models` workflow (per-model setup-registry rebuild); its description names this model-catalog snapshot cost as out of scope — this PR is that follow-up.
- #86555 (closed) made derived results memoizable at the `canMemoize` gate; it was superseded by the memo path on `main`. This PR fixes the remaining defect in that path: derived results were "memoized" but stored under a key no lookup ever computes.
- #85345 (open) threads prepared snapshots through gateway startup/provider-auth prewarm — complementary; it does not touch the memo keying.

Was this requested by a maintainer or owner?

- No; self-found while dogfooding. Instrumenting the memo on the live box showed every store on the derived path logging a key that differed from its own lookup key, and the catalog build rescanning on every call.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: the shipped derived-registry memo regression above (since v2026.5.18, introduced by `5734193fdf`) — the `/models` full-discovery catalog build no longer re-runs the full plugin manifest scan on every call; repeat snapshot lookups are memo hits with identical output.
- Real environment tested: my live OpenClaw dogfood install — Oracle Linux Server 10.1 aarch64, Node v26.0.0, gateway running from source as a systemd user service with two Telegram bot providers; same box and diagnosis session as #90747. The gateway has been running this exact patch serving real Telegram traffic.
- Exact steps or command run after this patch: `bash run-proof.sh` (first comment below). It checks out the PR base (`418d7e1e83`, current `main`) and the fix into two throwaway git worktrees and runs the same sha256-pinned measurement file against each. It imports the production modules straight from `src/` and times the catalog build behind chat `/models` (`loadModelCatalog({readOnly:false})`) and the snapshot lookup it issues (`loadPluginMetadataSnapshot`, alternating the two call shapes the catalog path actually uses). The plugin discovery underneath is the real loader scanning this checkout's real plugin set; the same catalog comes back on both sides (263 entries; see limitations).

  _Both harness files and the full copyable terminal output are in the first comment below (sha256-pinned in the run)._

- Evidence after fix: the four `MEASURED` lines below are the result (warmup excluded, labeled in the run):

  ```
  [418d7e1e83] MEASURED /models full-discovery catalog build — loadModelCatalog(readOnly:false): 6461.6ms (entries=263)
  [418d7e1e83] MEASURED snapshot lookups x20 (alternating call shapes): total=875.5ms perCall=43.777ms
  
  [897e67b5d6] MEASURED /models full-discovery catalog build — loadModelCatalog(readOnly:false): 256.1ms (entries=260)
  [897e67b5d6] MEASURED snapshot lookups x20 (alternating call shapes): total=2.1ms perCall=0.103ms
  ```

  | timed production call | base `418d7e1e83` | this fix | speedup |
  |---|---:|---:|---:|
  | `loadModelCatalog({readOnly:false})` — the `/models` full-discovery build | 6,462 ms | 256 ms | ~25× |
  | `loadPluginMetadataSnapshot` ×20 alternating shapes | 43.8 ms/call | 0.10 ms/call | ~425× |

  Screenshot of the full terminal run:

<img width="1051" height="1336" alt="image" src="https://github.com/user-attachments/assets/76847432-4bb2-4b6a-b19c-5f0a7266b07a" />

- Observed result after fix: the repeated `/models` full-discovery catalog build dropped from ~6.5s of pinned CPU to ~0.26s; alternating snapshot lookups from ~44ms/call (a full manifest scan each) to ~0.10ms/call, even though the fixed side warms only two calls and the broken side keeps rescanning regardless of warmup. The live gateway on this box runs this exact change.
- What was not tested: other chat channels were not exercised live — the catalog build is channel-agnostic; the desktop/web model picker was not exercised. The measurement file passes a minimal config object; the cost it measures (snapshot memo miss → manifest rescan) does not depend on config contents, and the alternating call shapes mirror the production catalog path (verified by instrumenting the memo during diagnosis).
- Proof limitations or environment constraints: numbers are from a shared-tenancy ARM VM; relative improvement is the meaningful part. The catalog includes rows from live provider discovery; across cold-process runs the entry count wobbled between 260 and 263 once on each side, independent of the patch (repeated builds inside one process return a stable 263 on both). The regression needs a "derived" registry resolution (persisted index absent or not covering the checkout) — installs where every lookup is served by the persisted index or the gateway's current-snapshot fast path don't pay this cost, which is why it survived unnoticed since v2026.5.18.
- Before evidence (optional but encouraged): the base-side `MEASURED` lines above; during diagnosis the instrumented memo on the base code logged `divergedFromLookup=true` on every derived store, with the same two lookup keys missing on every consecutive catalog build.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/plugins/plugin-metadata-snapshot.memo.test.ts` — 32 passed (includes the new regression test)
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` — clean
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json` — clean
- `oxfmt` on the touched files
- Structured review #1: `autoreview --mode commit --commit HEAD --engine claude --model claude=claude-fable-5 --thinking claude=high` → `autoreview clean: no accepted/actionable findings reported`, overall `patch is correct (0.92)`
- Structured review #2: `autoreview --mode commit --commit HEAD --engine codex --model codex=gpt-5.5 --thinking codex=medium` → `autoreview clean: no accepted/actionable findings reported`, overall `patch is correct (0.84)`

What regression coverage was added or updated?

- New: "memoizes derived snapshots across alternating call shapes" — two call shapes sharing a persisted index but deriving different snapshot indexes (the production catalog-build pattern); asserts the manifest scan runs exactly twice across four calls. Red on `main` (4 scans), green here (2).
- Existing derived/persisted memo tests pass unchanged, including the process-stable and lifecycle-clear contracts.

What failed before this fix, if known?

- The regression above, shipped since v2026.5.18: output stayed correct, but the derived-path memo never produced a hit under the production call mix, so every snapshot lookup re-ran the full plugin manifest scan and invalidated every downstream cache keyed on snapshot identity.

If no test was added, why not?

- n/a — test added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

- No. Output is identical; only latency/CPU improve.

Did config, environment, or migration behavior change? (`Yes/No`)

- No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

- No.

What is the highest-risk area?

- A stale metadata snapshot inside a long-lived process (memo returning pre-reload state after plugin changes), now that derived-path lookups actually hit the memo.

How is that risk mitigated?

- This fix changes which key the result is stored under, not when it is invalidated. The memo was already designed to serve derived results (the `canMemoize` gate admits them; the adoption loop's process-stable comments document the contract); freshness is owned by the lookup context hash plus the plugin-metadata lifecycle clears (`registerPluginMetadataProcessMemoLifecycleClear` — install/reload/doctor), identical before and after. The existing process-stable and lifecycle-clear tests pass unchanged, and the persisted-registry path is untouched.

## Current review state

What is the next action?

- Maintainer review; CI + ClawSweeper on the head.

What is still waiting on author, maintainer, CI, or external proof?

- Nothing from the author; CI on the pushed head.

Which bot or reviewer comments were addressed?

- Pre-push structured reviews only (Claude clean at 0.92, Codex clean at 0.84); no human review comments yet.

