### PR TITLE
fix(session-lock): remove ctimeNs from fingerprint to avoid Btrfs false takeover

### DIFF
--- a/scripts/repro/issue-92109-btrfs-ctiens-instability.mts
+++ b/scripts/repro/issue-92109-btrfs-ctiens-instability.mts
@@ -1,0 +1,89 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+// Reproduction for issue #92109
+// Demonstrates that ctimeNs-only changes (common on Btrfs due to background
+// maintenance) should not be treated as a session file takeover.
+
+async function main() {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-repro-92109-"));
+  const sessionFile = path.join(tmpDir, "session.jsonl");
+
+  try {
+    await fs.writeFile(sessionFile, '{"type":"session"}\n', "utf8");
+
+    // Read initial fingerprint
+    const before = await fs.stat(sessionFile, { bigint: true });
+    console.log("=== Reproduction for issue #92109 ===");
+    console.log("Session file:", sessionFile);
+    console.log();
+    console.log("Initial fingerprint:");
+    console.log("  dev:", before.dev.toString());
+    console.log("  ino:", before.ino.toString());
+    console.log("  size:", before.size.toString());
+    console.log("  mtimeNs:", before.mtimeNs.toString());
+    console.log("  ctimeNs:", before.ctimeNs.toString());
+
+    // Simulate Btrfs background maintenance: chmod changes ctimeNs without
+    // changing mtimeNs, size, or file content.
+    await fs.chmod(sessionFile, 0o644);
+
+    const after = await fs.stat(sessionFile, { bigint: true });
+    console.log();
+    console.log("After chmod (simulated Btrfs ctime drift):");
+    console.log("  dev:", after.dev.toString());
+    console.log("  ino:", after.ino.toString());
+    console.log("  size:", after.size.toString());
+    console.log("  mtimeNs:", after.mtimeNs.toString());
+    console.log("  ctimeNs:", after.ctimeNs.toString());
+
+    // Verify what changed
+    const devChanged = before.dev !== after.dev;
+    const inoChanged = before.ino !== after.ino;
+    const sizeChanged = before.size !== after.size;
+    const mtimeChanged = before.mtimeNs !== after.mtimeNs;
+    const ctimeChanged = before.ctimeNs !== after.ctimeNs;
+
+    console.log();
+    console.log("Fields changed:");
+    console.log("  dev:", devChanged ? "CHANGED" : "same");
+    console.log("  ino:", inoChanged ? "CHANGED" : "same");
+    console.log("  size:", sizeChanged ? "CHANGED" : "same");
+    console.log("  mtimeNs:", mtimeChanged ? "CHANGED" : "same");
+    console.log("  ctimeNs:", ctimeChanged ? "CHANGED" : "same");
+
+    // Old logic (before fix): ctimeNs included → false on Btrfs
+    const oldFingerprintMatch =
+      !devChanged && !inoChanged && !sizeChanged && !mtimeChanged && !ctimeChanged;
+
+    // New logic (after fix): ctimeNs excluded → true on Btrfs
+    const newFingerprintMatch =
+      !devChanged && !inoChanged && !sizeChanged && !mtimeChanged;
+
+    console.log();
+    console.log("sameSessionFileFingerprint result:");
+    console.log("  Before fix (includes ctimeNs):", oldFingerprintMatch ? "MATCH" : "MISMATCH ← takeover");
+    console.log("  After fix (excludes ctimeNs):", newFingerprintMatch ? "MATCH ← ok" : "MISMATCH");
+
+    if (!ctimeChanged) {
+      console.error("\nFAIL: Expected ctimeNs to change after chmod. This may be a non-Btrfs filesystem.");
+      process.exitCode = 1;
+      return;
+    }
+
+    if (!oldFingerprintMatch && newFingerprintMatch) {
+      console.log("\nPASS: ctimeNs-only change no longer triggers session takeover.");
+    } else {
+      console.error("\nFAIL: Unexpected fingerprint comparison result.");
+      process.exitCode = 1;
+    }
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -671,6 +671,28 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(2);
   });
 
+  it("does not treat ctime-only changes as session takeover (#92109)", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocalBtrfs = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocalBtrfs,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+
+    // Simulate Btrfs background maintenance: chmod changes ctimeNs without
+    // changing mtimeNs, size, or file content. This must not trigger takeover.
+    await fs.chmod(sessionFile, 0o644);
+
+    await expect(controller.withSessionWriteLock(() => "ok")).resolves.toBe("ok");
+    expect(controller.hasSessionTakeover()).toBe(false);
+
+    const cleanupLock = await controller.acquireForCleanup();
+    await cleanupLock.release();
+  });
+
   it("allows delivery mirror appends while the prompt lock is released", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -78,8 +78,7 @@ function sameSessionFileFingerprint(
     left.dev === right.dev &&
     left.ino === right.ino &&
     left.size === right.size &&
-    left.mtimeNs === right.mtimeNs &&
-    left.ctimeNs === right.ctimeNs
+    left.mtimeNs === right.mtimeNs
   );
 }
 


### PR DESCRIPTION
## Summary

On Btrfs filesystems (common on NAS devices like Zspace, Synology, QNAP), background filesystem maintenance tasks (snapshots, scrub, quota recalculation, metadata balancing) spontaneously update file `ctime` without any user-initiated write. This caused `sameSessionFileFingerprint()` to return `false` because it compared `ctimeNs`, triggering `EmbeddedAttemptSessionTakeoverError` on every cron job and subagent spawn that held a session for more than a few seconds.

`dev + ino + size + mtimeNs` is sufficient to detect real external writes — any content-changing write also changes `mtimeNs` and/or `size`. `ctimeNs` adds no meaningful protection against takeovers while creating a false-positive trap on Btrfs.

Fixes #92109.

## Changes

- `src/agents/embedded-agent-runner/run/attempt.session-lock.ts`: Removed `ctimeNs` from `sameSessionFileFingerprint()` comparison (line 82).
- `src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`: Added regression test that simulates Btrfs `ctime` drift via `chmod` and verifies the session lock controller does not treat it as a takeover.
- `scripts/repro/issue-92109-btrfs-ctiens-instability.mts`: Standalone reproduction script.

## Real behavior proof

- **Behavior addressed**: `EmbeddedAttemptSessionTakeoverError` on Btrfs filesystems caused by spontaneous `ctimeNs` changes from background filesystem maintenance.
- **Real environment tested**: Linux 4.19.112-2.el8.x86_64, Node.js v22.19.0, local source checkout at `main`.
- **Exact steps or command run after this patch**:
  - `npx tsx scripts/repro/issue-92109-btrfs-ctiens-instability.mts`
  - `pnpm test src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts --run`
- **Evidence after fix**:

```text
=== Reproduction for issue #92109 ===
Session file: /tmp/openclaw-repro-92109-6x6rrI/session.jsonl

Initial fingerprint:
  dev: 64768
  ino: 4922456
  size: 19
  mtimeNs: 1781165688717211960
  ctimeNs: 1781165688717211960

After chmod (simulated Btrfs ctime drift):
  dev: 64768
  ino: 4922456
  size: 19
  mtimeNs: 1781165688717211960
  ctimeNs: 1781165688721212176

Fields changed:
  dev: same
  ino: same
  size: same
  mtimeNs: same
  ctimeNs: CHANGED

sameSessionFileFingerprint result:
  Before fix (includes ctimeNs): MISMATCH ← takeover
  After fix (excludes ctimeNs): MATCH ← ok

PASS: ctimeNs-only change no longer triggers session takeover.
```

- **Observed result after fix**: The session lock controller correctly ignores `ctimeNs`-only changes and allows post-prompt writes to proceed without throwing `EmbeddedAttemptSessionTakeoverError`.
- **What was not tested**: Actual Btrfs filesystem (repro uses `chmod` which changes `ctime` on all Linux filesystems); live gateway cron/subagent execution on a Btrfs NAS.

## Verification

- `pnpm test src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts --run` — 50 passed (including new regression test)
- `pnpm build` — passed
- `npx oxlint --import-plugin --config .oxlintrc.json src/agents/embedded-agent-runner/run/attempt.session-lock.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts` — passed
- `pnpm format:fix src/agents/embedded-agent-runner/run/attempt.session-lock.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts` — no changes needed