### PR TITLE
[codex] fix(agents): detect not supported model errors

### DIFF
--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -44,6 +44,20 @@ describe("live model error helpers", () => {
     expect(
       isModelNotFoundErrorMessage("The deployment does not exist or you do not have access."),
     ).toBe(false);
+    expect(
+      isModelNotFoundErrorMessage(
+        '{"error":{"code":"400","message":"Param Incorrect","param":"Not supported model some-model-id"}}',
+      ),
+    ).toBe(true);
+    expect(isModelNotFoundErrorMessage("The selected model does not support image input.")).toBe(
+      false,
+    );
+    expect(
+      isModelNotFoundErrorMessage("This model is not supported for tool calling on this endpoint."),
+    ).toBe(false);
+    expect(isModelNotFoundErrorMessage("Unsupported reasoning effort for model gpt-5.5.")).toBe(
+      false,
+    );
     expect(isModelNotFoundErrorMessage('{"error":{"message":"Resource missing","code":404}}')).toBe(
       false,
     );

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -37,6 +37,9 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
   if (/model/i.test(msg) && /does not exist/i.test(msg)) {
     return true;
   }
+  if (/\bnot supported model\b/i.test(msg)) {
+    return true;
+  }
   if (/model/i.test(msg) && /deprecated/i.test(msg) && /(upgrade|transition) to/i.test(msg)) {
     return true;
   }


### PR DESCRIPTION
## Summary

- Classifies provider responses like `Not supported model some-model-id` as model-not-found errors instead of schema/tool-payload failures.
- Keeps unrelated capability errors, such as unsupported tool calling or reasoning effort, out of the model-not-found bucket.
- Adds focused coverage in the shared live model error helper test.
- Out of scope: changing provider routing, schema-error handling, or any model catalog data.

## Linked context

Closes #92118

Related #92118

Was this requested by a maintainer or owner?

ClawSweeper marked #92118 as a source-reproduced, queueable fix candidate and named the shared helper/test surface.

## Real behavior proof (required for external PRs)

- Behavior addressed: OpenAI-compatible provider errors containing `Not supported model <model-id>` now match the model-not-found classifier.
- Real environment tested: Local OpenClaw source checkout on the pushed branch with the repo Node toolchain.
- Exact steps or command run after this patch: `node --import tsx -e "const { isModelNotFoundErrorMessage } = await import('./src/agents/live-model-errors.ts'); console.log('not-supported-model=' + isModelNotFoundErrorMessage('{\"error\":{\"code\":\"400\",\"message\":\"Param Incorrect\",\"param\":\"Not supported model some-model-id\"}}')); console.log('capability-error=' + isModelNotFoundErrorMessage('This model is not supported for tool calling on this endpoint.'));"`
- Evidence after fix: Terminal transcript from the local source checkout: `not-supported-model=true` and `capability-error=false`.
- Observed result after fix: The reported provider error phrase is accepted as model-not-found, while a nearby capability-support error remains false.
- What was not tested: A live third-party provider call returning this exact payload was not run.
- Proof limitations or environment constraints: This is a pure classifier change; the proof exercises the shared helper directly rather than making a network request to a private/provider-specific gateway.
- Before evidence: Current main did not contain a `not supported model` match in `src/agents/live-model-errors.ts`, and #92118 includes the source-level reproduction.

## Tests and validation

Which commands did you run?

```text
node scripts/run-vitest.mjs src/agents/live-model-errors.test.ts
node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
git diff --check
```

What regression coverage was added or updated?

`src/agents/live-model-errors.test.ts` now covers the reported JSON error payload and negative cases for model capability/support wording.

What failed before this fix, if known?

The new `Not supported model some-model-id` classifier assertion would fail before the helper learned this phrase.

If no test was added, why not?

A focused regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. The same provider error should now surface as a model configuration/not-found issue instead of a schema/tool-payload issue.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Over-classifying unrelated provider capability errors as model-not-found.

How is that risk mitigated?

The match is limited to the exact `not supported model` word order, and tests keep `model does not support image input`, `model is not supported for tool calling`, and unsupported reasoning-effort messages false.

## Current review state

What is the next action?

Ready for maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on CI and maintainer review.

Which bot or reviewer comments were addressed?

Addresses the ClawSweeper guidance on #92118 to fix the shared helper and include positive plus negative classifier coverage.
