### PR TITLE
fix(cron): expose real SQLite database path in status output

### DIFF
--- a/src/cron/service.read-ops-nonblocking.test.ts
+++ b/src/cron/service.read-ops-nonblocking.test.ts
@@ -84,6 +84,8 @@ function expectCronStatus(
   expect(status.enabled).toBe(true);
   expect(status.storePath).toBe(params.storePath);
   expect(status.jobs).toBe(params.jobs);
+  expect(status.databasePath).toBeTypeOf("string");
+  expect(status.databasePath).toContain(".sqlite");
   if (status.nextWakeAtMs !== null) {
     expect(status.nextWakeAtMs).toBeTypeOf("number");
   }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import {
   completeTaskRunByRunId,
   createRunningTaskRun,
@@ -254,6 +255,7 @@ export async function status(state: CronServiceState) {
     return {
       enabled: state.deps.cronEnabled,
       storePath: state.deps.storePath,
+      databasePath: resolveOpenClawStateSqlitePath(),
       jobs: state.store?.jobs.length ?? 0,
       nextWakeAtMs: state.deps.cronEnabled ? (nextWakeAtMs(state) ?? null) : null,
     };

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -219,6 +219,7 @@ export type CronWakeMode = "now" | "next-heartbeat";
 export type CronStatusSummary = {
   enabled: boolean;
   storePath: string;
+  databasePath: string;
   jobs: number;
   nextWakeAtMs: number | null;
 };

--- a/src/plugins/contracts/scheduled-turns.contract.test.ts
+++ b/src/plugins/contracts/scheduled-turns.contract.test.ts
@@ -92,6 +92,7 @@ function createMockCronService(): CronServiceContract {
     status: vi.fn(async () => ({
       enabled: true,
       storePath: "/tmp/openclaw-test-cron.json",
+      databasePath: "/tmp/openclaw-test-state.sqlite",
       jobs: 0,
       nextWakeAtMs: null,
     })),


### PR DESCRIPTION
## Summary

Since OpenClaw 2026.6.1, cron jobs are stored in the shared state SQLite database (`~/.openclaw/state/openclaw.sqlite`), but the `openclaw cron status` command still reports the legacy JSON `storePath` (`~/.openclaw/cron/jobs.json`). This confuses users and agents into thinking the old JSON file is still the authoritative storage location.

## Changes

- **`src/cron/service/state.ts`**: Add `databasePath: string` field to `CronStatusSummary` type.
- **`src/cron/service/ops.ts`**: Import `resolveOpenClawStateSqlitePath()` and populate `databasePath` in the `status()` response.
- **`src/plugins/contracts/scheduled-turns.contract.test.ts`**: Add `databasePath` to the mock CronServiceContract status response.
- **`src/cron/service.read-ops-nonblocking.test.ts`**: Add assertions that `status.databasePath` is a string containing `.sqlite`.

4 files, +6 lines. The existing `storePath` field is preserved as the logical partition key within SQLite.

Fixes #91766

## Real behavior proof

**Behavior addressed:** `openclaw cron status` reports the legacy JSON file path (`~/.openclaw/cron/jobs.json`) as `storePath`, but since 2026.6.1 cron jobs are stored in the shared state SQLite database. The fix adds a `databasePath` field that reports the real SQLite database location.

**Real environment tested:** Node v22.22.0, Linux 4.19.112-2.el8.x86_64, openclaw commit `3f856ee9b1`.

**Exact steps or command run after this patch:**

1. Created a proof script that imports `CronService` from the real production module at `src/cron/service.js`
2. Started a cron service instance and called `cron.status()`
3. Validated the response contains `databasePath` pointing to the real SQLite database
4. Confirmed `storePath` is preserved as the legacy partition key
5. Ran regression tests asserting `databasePath` is present in status output

**Evidence after fix (terminal capture):**

$ npx tsx cron-status-proof.mjs
cron.status() response:
{
  "enabled": true,
  "storePath": "/tmp/openclaw-proof-cron-8Ihu1H/cron/jobs.json",
  "databasePath": "/home/0668000959/.openclaw/state/openclaw.sqlite",
  "jobs": 0,
  "nextWakeAtMs": null
}

--- Validation ---
databasePath exists: true
databasePath type: string
Contains 'state': true
Ends with '.sqlite': true
NOT 'jobs.json': true
storePath preserved: true

PASS: cron.status() returns real SQLite databasePath
exit code: 0

**Test regression assertion (terminal capture):**

The `expectCronStatus` helper in `src/cron/service.read-ops-nonblocking.test.ts` now asserts:
- `expect(status.databasePath).toBeTypeOf("string")`
- `expect(status.databasePath).toContain(".sqlite")`

This pins the new output contract so the `databasePath` field cannot be silently dropped.

**Observed result after fix:** The patched `CronService.status()` returns `databasePath: "/home/0668000959/.openclaw/state/openclaw.sqlite"` — the real shared state SQLite database path, while `storePath` continues to serve as the logical partition key. The proof imports the real `CronService` production module (not copied logic) and exercises the actual status() code path. Regression tests assert the `databasePath` field is present.

**What was not tested:** Full end-to-end `openclaw cron status` CLI command with a running gateway (requires gateway setup not available in test environment). The cron service status path tested here is the same code path the CLI uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)