### PR TITLE
fix(release): gate beta publish on plugin verification

### DIFF
--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -317,6 +317,23 @@ pnpm release:check
 pnpm test:install:smoke
 ```
 
+- Before tagging, diff publishable plugin package manifests against the last
+  reachable stable/beta release tag. For every newly publishable package
+  (`openclaw.release.publishToNpm: true` or `publishToClawHub: true`) whose
+  package name did not exist in the base tag, verify the target registry package
+  already exists in npm/ClawHub or stop and help the owner mint/prepublish the
+  package first. Do not hide or disable release surfaces just to unblock a
+  train unless the owner explicitly decides the plugin should not ship in that
+  release; first-package registry ownership is release prep, not product
+  rollback. The mint/prepublish path must either be the real release publish
+  path for the auto-bumped beta version, or a deliberately non-consuming
+  registry-prep step that cannot occupy the next beta version/tag. Confirm
+  registry owner, npm scope/package-creation permission, provenance path, and
+  first-package publish plan before the full release publish continues. Useful
+  npm probe:
+  `npm view <package-name> version dist-tags --json --prefer-online`; a 404 for
+  a package newly added to the release is a release-prep blocker, not something
+  to discover from the publish job.
 - Use `pnpm qa:otel:smoke` when release validation needs telemetry coverage.
   It starts a local OTLP/HTTP trace receiver, runs QA-lab's
   `otel-trace-smoke`, and checks span names plus content/identifier redaction
@@ -562,7 +579,11 @@ node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version>
 - Use `NPM_TOKEN` only for explicit npm dist-tag management modes, because npm
   does not support trusted publishing for `npm dist-tag add`.
 - `@openclaw/*` plugin publishes use a separate maintainer-only flow.
-- Only publish plugins that already exist on npm; bundled disk-tree-only plugins stay unpublished.
+- Publishable plugins that are new to npm require owner-led first-package
+  minting before the full release publish. Do not consume the next beta version
+  with an ad-hoc manual package publish; use the release-owned auto-bumped
+  version path, or a non-consuming registry setup/preflight step. Bundled
+  disk-tree-only plugins stay unpublished.
 
 ## Fallback local mac publish
 
@@ -619,7 +640,9 @@ node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version>
     mac app, signing, notarization, and appcast path.
 12. Confirm the target npm version is not already published.
 13. Create and push the git tag from the release branch.
-14. Create or refresh the matching GitHub release.
+14. Do not create or publish the matching GitHub release page yet. The real
+    publish workflow creates or undrafts it only after postpublish verification
+    and release evidence upload pass.
 15. Dispatch Actions > `QA-Lab - All Lanes` against the release tag and wait
     for the mock parity, live Matrix, and live Telegram credentialed-channel
     lanes to pass.
@@ -642,20 +665,29 @@ node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version>
     with `preflight_only=true` and wait for it to pass. Save that run id because
     the real publish requires it to reuse the notarized mac artifacts.
 21. If any preflight or validation run fails, fix the issue on a new commit,
-    delete the tag and matching GitHub release, recreate them from the fixed
-    commit, and rerun all relevant preflights from scratch before continuing.
-    Never reuse old preflight results after the commit changes. For pushed or
-    published beta tags, do not delete/recreate; increment to the next beta tag.
-    For preflight-only failures where npm did not publish the beta version,
-    delete/recreate the same beta tag and prerelease at the fixed commit instead
-    of skipping a prerelease number.
+    delete the tag and any accidental draft/incomplete GitHub release, recreate
+    the tag from the fixed commit, and rerun all relevant preflights from
+    scratch before continuing. Never reuse old preflight results after the
+    commit changes. Once the npm version exists, do not rerun the publish
+    workflow for that same version; finalize the existing draft/evidence state
+    manually or cut a correction tag. For pushed or published beta tags, do not
+    delete/recreate; increment to the next beta tag. For preflight-only failures
+    where npm did not publish the beta version, delete/recreate the same beta
+    tag and any accidental draft/incomplete prerelease at the fixed commit
+    instead of skipping a prerelease number.
 22. Start `.github/workflows/openclaw-npm-release.yml` from the same branch with
     the same tag for the real publish, choose `npm_dist_tag` (`beta` default,
     `latest` only when you intentionally want direct stable publish), keep it
     the same as the preflight run, and pass the successful npm
     `preflight_run_id`.
 23. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
-24. Run postpublish verification:
+24. Wait for the real publish workflow to run postpublish verification,
+    create or update the GitHub release as a draft, upload dependency evidence,
+    append release verification proof, and only then undraft/publish it. If a
+    waited plugin publish fails after OpenClaw npm succeeds, the workflow keeps
+    the release draft with OpenClaw npm evidence and exits red; do not undraft
+    until the plugin publish gap is repaired. The standalone verifier command
+    remains the recovery probe:
     `node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version>`.
 25. Run the post-published beta verification roster. First scan current `main`
     for critical fixes that landed after the release branch cut; backport only

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -653,6 +653,63 @@ jobs:
             done
           }
 
+          guard_existing_public_release() {
+            local release_version asset_name release_json is_draft has_sha has_proof has_asset release_url
+
+            if [[ "${PUBLISH_OPENCLAW_NPM}" != "true" ]]; then
+              return 0
+            fi
+
+            if ! release_json="$(gh release view "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" --json isDraft,assets,body,url 2>/dev/null)"; then
+              return 0
+            fi
+
+            is_draft="$(printf '%s' "${release_json}" | jq -r '.isDraft')"
+            if [[ "${is_draft}" == "true" ]]; then
+              return 0
+            fi
+
+            release_version="${RELEASE_TAG#v}"
+            asset_name="openclaw-${release_version}-dependency-evidence.zip"
+            has_sha="$(printf '%s' "${release_json}" | jq --arg sha "${TARGET_SHA}" -r '.body | contains($sha)')"
+            has_proof="$(printf '%s' "${release_json}" | jq -r '.body | contains("### Release verification")')"
+            has_asset="$(printf '%s' "${release_json}" | jq --arg name "${asset_name}" -r 'any(.assets[]?; .name == $name)')"
+            release_url="$(printf '%s' "${release_json}" | jq -r '.url')"
+
+            if [[ "${has_sha}" == "true" && "${has_proof}" == "true" && "${has_asset}" == "true" ]]; then
+              return 0
+            fi
+
+            {
+              echo "Release ${RELEASE_TAG} already has a public GitHub release page without complete postpublish evidence for ${TARGET_SHA}."
+              echo "Refusing to reuse a public prerelease tag after publication started: ${release_url}"
+              echo "Create a new beta tag or delete/draft the incomplete public release before retrying."
+            } >&2
+            exit 1
+          }
+
+          guard_openclaw_npm_not_already_published() {
+            local release_version release_url
+
+            if [[ "${PUBLISH_OPENCLAW_NPM}" != "true" ]]; then
+              return 0
+            fi
+
+            release_version="${RELEASE_TAG#v}"
+            if ! npm view "openclaw@${release_version}" version >/dev/null 2>&1; then
+              return 0
+            fi
+
+            release_url="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
+            {
+              echo "openclaw@${release_version} is already published on npm."
+              echo "Refusing to dispatch publish child workflows for an already-published version."
+              echo "If this is recovery from a failed postpublish evidence or draft-release step, repair/finalize the existing draft or create a correction tag; do not rerun the publish workflow for the same npm version."
+              echo "Release page, if present: ${release_url}"
+            } >&2
+            exit 1
+          }
+
           create_or_update_github_release() {
             local release_version notes_version title notes_file changelog_file latest_arg prerelease_args
             release_version="${RELEASE_TAG#v}"
@@ -698,11 +755,17 @@ jobs:
             else
               gh release create "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" \
                 --verify-tag \
+                --draft \
                 --title "${title}" \
                 --notes-file "${notes_file}" \
                 "${prerelease_args[@]}" \
                 "${latest_arg}"
             fi
+            echo "- GitHub release draft: https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}" >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          publish_github_release() {
+            gh release edit "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" --draft=false
             echo "- GitHub release: https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}" >> "$GITHUB_STEP_SUMMARY"
           }
 
@@ -735,8 +798,10 @@ jobs:
           }
 
           verify_published_release() {
-            local release_version evidence_path
+            local release_version evidence_path skip_clawhub
             local -a verify_args
+
+            skip_clawhub="${1:-false}"
 
             release_version="${RELEASE_TAG#v}"
             evidence_path="${POSTPUBLISH_EVIDENCE_DIR}/release-postpublish-evidence.json"
@@ -754,11 +819,12 @@ jobs:
               --plugin-npm-run "${plugin_npm_run_id}"
               --openclaw-npm-run "${openclaw_npm_run_id}"
               --evidence-out "${evidence_path}"
+              --skip-github-release
             )
-            if [[ "${WAIT_FOR_CLAWHUB}" == "true" ]]; then
-              verify_args+=(--plugin-clawhub-run "${plugin_clawhub_run_id}")
-            else
+            if [[ "${skip_clawhub}" == "true" || "${WAIT_FOR_CLAWHUB}" != "true" ]]; then
               verify_args+=(--skip-clawhub)
+            else
+              verify_args+=(--plugin-clawhub-run "${plugin_clawhub_run_id}")
             fi
             if [[ -n "${PLUGINS// }" ]]; then
               verify_args+=(--plugins "${PLUGINS}")
@@ -799,6 +865,7 @@ jobs:
               RELEASE_NOTES_FILE="${notes_file}" \
               RELEASE_VERSION="${release_version}" \
               RELEASE_TAG="${RELEASE_TAG}" \
+              RELEASE_SHA="${TARGET_SHA}" \
               RELEASE_REPO="${GITHUB_REPOSITORY}" \
               RELEASE_TARBALL="${tarball}" \
               RELEASE_INTEGRITY="${integrity}" \
@@ -825,6 +892,7 @@ jobs:
             `- npm package: https://www.npmjs.com/package/openclaw/v/${process.env.RELEASE_VERSION}`,
             `- registry tarball: ${process.env.RELEASE_TARBALL}`,
             `- integrity: \`${process.env.RELEASE_INTEGRITY}\``,
+            `- release SHA: \`${process.env.RELEASE_SHA}\``,
             `- full release CI report: https://github.com/openclaw/releases/blob/main/evidence/${process.env.RELEASE_VERSION}/release-evidence.md`,
             `- release publish: https://github.com/${process.env.RELEASE_REPO}/actions/runs/${process.env.RELEASE_PUBLISH_RUN_ID}`,
             `- npm preflight: https://github.com/${process.env.RELEASE_REPO}/actions/runs/${process.env.PREFLIGHT_RUN_ID}`,
@@ -862,6 +930,9 @@ jobs:
               echo "- Workflow completion does not wait for ClawHub; monitor the dispatched ClawHub run separately"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+          guard_existing_public_release
+          guard_openclaw_npm_not_already_published
 
           npm_args=(-f publish_scope="${PLUGIN_PUBLISH_SCOPE}" -f ref="${TARGET_SHA}" -f release_publish_run_id="${GITHUB_RUN_ID}")
           clawhub_args=(-f publish_scope="${PLUGIN_PUBLISH_SCOPE}" -f ref="${TARGET_SHA}" -f release_publish_run_id="${GITHUB_RUN_ID}")
@@ -934,11 +1005,6 @@ jobs:
             openclaw_failed=1
           fi
 
-          if [[ -n "${openclaw_npm_run_id}" && "${openclaw_failed}" == "0" ]]; then
-            create_or_update_github_release
-            upload_dependency_evidence_release_asset
-          fi
-
           if [[ -n "${clawhub_pid}" ]] && ! wait "${clawhub_pid}"; then
             failed=1
           fi
@@ -946,9 +1012,20 @@ jobs:
             failed=1
           fi
 
-          if [[ "${failed}" == "0" && -n "${openclaw_npm_run_id}" ]]; then
-            verify_published_release
+          if [[ -n "${openclaw_npm_run_id}" && "${openclaw_failed}" == "0" ]]; then
+            if [[ "${failed}" == "0" ]]; then
+              verify_published_release
+            else
+              verify_published_release true
+            fi
+            create_or_update_github_release
+            upload_dependency_evidence_release_asset
             append_release_proof_to_github_release
+            if [[ "${failed}" == "0" ]]; then
+              publish_github_release
+            else
+              echo "- GitHub release: left as draft because a required publish child failed" >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi
           if [[ "${failed}" != "0" ]]; then
             exit 1

--- a/scripts/lib/release-beta-verifier.ts
+++ b/scripts/lib/release-beta-verifier.ts
@@ -21,6 +21,7 @@ export type ReleaseVerifyBetaArgs = {
   pluginSelection: string[];
   evidenceOut?: string;
   skipPostpublish: boolean;
+  skipGitHubRelease: boolean;
   skipClawHub: boolean;
   rerunFailedClawHub: boolean;
   workflowRuns: {
@@ -118,7 +119,7 @@ export function parseReleaseVerifyBetaArgs(argv: string[]): ReleaseVerifyBetaArg
   const version = values.shift();
   if (!version || version.startsWith("-")) {
     throw new Error(
-      "Usage: pnpm release:verify-beta -- <version> [--workflow-ref REF] [--full-release-validation-run ID] [--openclaw-npm-run ID] [--plugin-npm-run ID] [--plugin-clawhub-run ID] [--npm-telegram-run ID] [--skip-clawhub]",
+      "Usage: pnpm release:verify-beta -- <version> [--workflow-ref REF] [--full-release-validation-run ID] [--openclaw-npm-run ID] [--plugin-npm-run ID] [--plugin-clawhub-run ID] [--npm-telegram-run ID] [--skip-github-release] [--skip-clawhub]",
     );
   }
 
@@ -132,6 +133,7 @@ export function parseReleaseVerifyBetaArgs(argv: string[]): ReleaseVerifyBetaArg
     pluginSelection: [],
     evidenceOut: undefined,
     skipPostpublish: false,
+    skipGitHubRelease: false,
     skipClawHub: false,
     rerunFailedClawHub: false,
     workflowRuns: {},
@@ -190,6 +192,9 @@ export function parseReleaseVerifyBetaArgs(argv: string[]): ReleaseVerifyBetaArg
         break;
       case "--skip-postpublish":
         parsed.skipPostpublish = true;
+        break;
+      case "--skip-github-release":
+        parsed.skipGitHubRelease = true;
         break;
       case "--skip-clawhub":
         parsed.skipClawHub = true;
@@ -479,8 +484,12 @@ export async function verifyBetaRelease(
   }
 
   const lines: string[] = [];
-  const releaseUrl = verifyGitHubRelease(args);
-  lines.push(`GitHub release OK: ${releaseUrl}`);
+  const releaseUrl = args.skipGitHubRelease ? undefined : verifyGitHubRelease(args);
+  if (releaseUrl === undefined) {
+    lines.push("GitHub release skipped: final release page is created after verification");
+  } else {
+    lines.push(`GitHub release OK: ${releaseUrl}`);
+  }
 
   const openclawNpm = verifyNpmPackage("openclaw", args.version, args.distTag);
   lines.push(`openclaw npm OK: ${args.version} (${args.distTag})`);
@@ -612,7 +621,7 @@ export async function verifyBetaRelease(
           npmDistTag: args.distTag,
           pluginSelection: args.pluginSelection,
           openclawNpmIntegrity: openclawNpm.integrity,
-          githubReleaseUrl: releaseUrl,
+          githubReleaseUrl: releaseUrl ?? null,
           pluginNpmPackageCount: npmPlugins.length,
           clawHubPackageCount: clawHubPlugins.length,
           workflowRuns,

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1603,7 +1603,12 @@ describe("package artifact reuse", () => {
     expect(releaseWorkflow).toContain("npm_telegram_run_id");
     expect(releaseWorkflow).toContain('release_publish_run_id="${GITHUB_RUN_ID}"');
     expect(releaseWorkflow).toContain("append_release_proof_to_github_release");
+    expect(releaseWorkflow).toContain("guard_existing_public_release");
+    expect(releaseWorkflow).toContain(
+      "already has a public GitHub release page without complete postpublish evidence",
+    );
     expect(releaseWorkflow).toContain("registry tarball");
+    expect(releaseWorkflow).toContain("release SHA");
     expect(releaseWorkflow).toContain("not awaited by this proof");
     expect(releaseWorkflow).toContain("wait_for_job_success");
     expect(releaseWorkflow).toContain("Validate release publish approval");
@@ -1612,6 +1617,7 @@ describe("package artifact reuse", () => {
     expect(releaseWorkflow).toContain("Approve child release gate after parent release approval");
     expect(releaseWorkflow).toContain("release:verify-beta");
     expect(releaseWorkflow).toContain('--workflow-ref "${CHILD_WORKFLOW_REF}"');
+    expect(releaseWorkflow).toContain("--skip-github-release");
     expect(releaseWorkflow).toContain('verify_args+=(--plugins "${PLUGINS}")');
     expect(releaseWorkflow).toContain("openclaw-release-postpublish-evidence");
     expect(releaseWorkflow).toContain("Failed child job summary");
@@ -1654,8 +1660,11 @@ describe("package artifact reuse", () => {
     expect(releaseWorkflow).toContain(
       "has failed jobs before the workflow completed: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}",
     );
+    expect(releaseWorkflow.lastIndexOf("verify_published_release")).toBeLessThan(
+      releaseWorkflow.lastIndexOf("create_or_update_github_release"),
+    );
     expect(releaseWorkflow.lastIndexOf("create_or_update_github_release")).toBeLessThan(
-      releaseWorkflow.indexOf('if [[ -n "${clawhub_pid}" ]] && ! wait "${clawhub_pid}"'),
+      releaseWorkflow.lastIndexOf("append_release_proof_to_github_release"),
     );
     expect(releaseWorkflow).toContain("finished with ${conclusion} in ${duration_label}");
   });

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -18,6 +18,7 @@ describe("parseReleaseVerifyBetaArgs", () => {
       pluginSelection: [],
       evidenceOut: undefined,
       skipPostpublish: false,
+      skipGitHubRelease: false,
       skipClawHub: false,
       rerunFailedClawHub: false,
       workflowRuns: {},
@@ -46,6 +47,7 @@ describe("parseReleaseVerifyBetaArgs", () => {
         "--evidence-out",
         ".artifacts/release-evidence.json",
         "--skip-postpublish",
+        "--skip-github-release",
         "--skip-clawhub",
         "--rerun-failed-clawhub",
       ]),
@@ -59,6 +61,7 @@ describe("parseReleaseVerifyBetaArgs", () => {
       pluginSelection: ["@openclaw/plugin-a", "@openclaw/plugin-b"],
       evidenceOut: ".artifacts/release-evidence.json",
       skipPostpublish: true,
+      skipGitHubRelease: true,
       skipClawHub: true,
       rerunFailedClawHub: true,
       workflowRuns: {


### PR DESCRIPTION
## Summary
- gate `openclaw-release-publish.yml` so GitHub release publication happens only after OpenClaw npm postpublish verification, dependency evidence upload, release-proof append, and required plugin publish completion
- keep the GitHub release as a draft while evidence is being attached; leave it draft-only if a waited plugin publish fails after OpenClaw npm succeeds
- add guards for already-public incomplete releases and already-published OpenClaw npm versions before dispatching publish children
- teach the beta verifier to skip GitHub release checks during the intentional pre-release-page verification phase
- update the release skill so newly publishable plugins, including `@openclaw/llama-cpp-provider`, are treated as first-package mint/prepublish work instead of being hidden from install surfaces; the mint path must not consume the next auto-bumped beta version unless it is the real release publish

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/openclaw-release-publish.yml"); puts "workflow yaml ok"'`
- `node scripts/generate-plugin-inventory-doc.mjs --check`
- `node scripts/run-vitest.mjs test/scripts/release-beta-verifier.test.ts test/scripts/package-acceptance-workflow.test.ts test/plugin-npm-release.test.ts test/plugin-clawhub-release.test.ts src/plugins/official-external-plugin-catalog.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/release/2026.6.6` clean
- `node scripts/crabbox-wrapper.mjs run -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` passed on Crabbox `cbx_84b72c81d586` / `quick-lobster`

## Notes
- `@openclaw/llama-cpp-provider` currently returns npm 404, so the next release prep should mint/prepublish the package through the owner-approved plugin flow before the full beta publish.
- The private npm dist-tag sync attempt for moving beta to latest failed with npm auth (`E401`); this PR does not change dist-tag credentials.
