### PR TITLE
fix(model-auth): resolve secretref-managed apiKey from runtime config snapshot (#92097)

### DIFF
--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -799,6 +799,127 @@ describe("resolveUsableCustomProviderApiKey", () => {
       }
     }
   });
+
+  describe("runtime snapshot secretref fallback", () => {
+    it("resolves file-backed SecretRef apiKey from matched runtime config snapshot", () => {
+      const sourceConfig = {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://api.example.com/v1",
+              apiKey: NON_ENV_SECRETREF_MARKER,
+              models: [],
+            },
+          },
+        },
+      };
+      const runtimeConfig = {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://api.example.com/v1",
+              apiKey: "sk-resolved-from-snapshot", // pragma: allowlist secret
+              models: [],
+            },
+          },
+        },
+      };
+      setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+      const resolved = resolveUsableCustomProviderApiKey({
+        cfg: sourceConfig,
+        provider: "custom",
+      });
+      expect(resolved).toEqual({
+        apiKey: "sk-resolved-from-snapshot",
+        source: "runtime config snapshot (secretref)",
+      });
+    });
+
+    it("does not resolve when runtime snapshot exists but source config mismatches", () => {
+      const sourceConfig = {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://api.example.com/v1",
+              apiKey: NON_ENV_SECRETREF_MARKER,
+              models: [],
+            },
+          },
+        },
+      };
+      const mismatchedSourceConfig = {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://different.example.com/v1",
+              apiKey: NON_ENV_SECRETREF_MARKER,
+              models: [],
+            },
+          },
+        },
+      };
+      const runtimeConfig = {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://api.example.com/v1",
+              apiKey: "sk-should-not-leak", // pragma: allowlist secret
+              models: [],
+            },
+          },
+        },
+      };
+      setRuntimeConfigSnapshot(runtimeConfig, mismatchedSourceConfig);
+
+      const resolved = resolveUsableCustomProviderApiKey({
+        cfg: sourceConfig,
+        provider: "custom",
+      });
+      expect(resolved).toBeNull();
+    });
+
+    it("returns null when no runtime snapshot is available (graceful fallback)", () => {
+      // clearRuntimeConfigSnapshot already called in beforeEach
+      const resolved = resolveUsableCustomProviderApiKey({
+        cfg: {
+          models: {
+            providers: {
+              custom: {
+                baseUrl: "https://api.example.com/v1",
+                apiKey: NON_ENV_SECRETREF_MARKER,
+                models: [],
+              },
+            },
+          },
+        },
+        provider: "custom",
+      });
+      expect(resolved).toBeNull();
+    });
+
+    it("does not resolve when applicable config equals input config (same object)", () => {
+      const cfg = {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://api.example.com/v1",
+              apiKey: NON_ENV_SECRETREF_MARKER,
+              models: [],
+            },
+          },
+        },
+      };
+      // set snapshot with the same config as both runtime and source
+      setRuntimeConfigSnapshot(cfg, cfg);
+
+      const resolved = resolveUsableCustomProviderApiKey({
+        cfg,
+        provider: "custom",
+      });
+      expect(resolved).toBeNull();
+    });
+  });
 });
 
 describe("resolveApiKeyForProvider", () => {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -336,6 +336,19 @@ export function resolveUsableCustomProviderApiKey(params: {
       source: "models.json (local marker)",
     };
   }
+  if (customKey === NON_ENV_SECRETREF_MARKER) {
+    const runtimeConfig = getRuntimeConfigSnapshot();
+    if (runtimeConfig && runtimeConfig !== params.cfg) {
+      const runtimeProviderConfig = resolveProviderConfig(runtimeConfig, params.provider);
+      const runtimeApiKey = normalizeOptionalSecretInput(runtimeProviderConfig?.apiKey);
+      if (runtimeApiKey && !isNonSecretApiKeyMarker(runtimeApiKey)) {
+        return {
+          apiKey: runtimeApiKey,
+          source: "runtime config snapshot (secretref)",
+        };
+      }
+    }
+  }
   return null;
 }
 

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -10,7 +10,11 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { formatCliCommand } from "../cli/command-format.js";
-import { getRuntimeConfigSnapshot } from "../config/config.js";
+import {
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+  selectApplicableRuntimeConfig,
+} from "../config/config.js";
 import type { ModelProviderAuthMode, ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
@@ -337,9 +341,13 @@ export function resolveUsableCustomProviderApiKey(params: {
     };
   }
   if (customKey === NON_ENV_SECRETREF_MARKER) {
-    const runtimeConfig = getRuntimeConfigSnapshot();
-    if (runtimeConfig && runtimeConfig !== params.cfg) {
-      const runtimeProviderConfig = resolveProviderConfig(runtimeConfig, params.provider);
+    const applicableConfig = selectApplicableRuntimeConfig({
+      inputConfig: params.cfg,
+      runtimeConfig: getRuntimeConfigSnapshot(),
+      runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
+    });
+    if (applicableConfig && applicableConfig !== params.cfg) {
+      const runtimeProviderConfig = resolveProviderConfig(applicableConfig, params.provider);
       const runtimeApiKey = normalizeOptionalSecretInput(runtimeProviderConfig?.apiKey);
       if (runtimeApiKey && !isNonSecretApiKeyMarker(runtimeApiKey)) {
         return {


### PR DESCRIPTION
## Summary

Fix auth resolution gap where custom providers using `apiKey: "secretref-managed"`
(file-backed SecretRef) fail with `503 auth_unavailable`. The secrets runtime
correctly resolves file-backed SecretRefs at startup via
`prepareSecretsRuntimeSnapshot()` and stores actual values in the runtime config
snapshot — the auth chain just never consulted it.

## Root Cause

`resolveUsableCustomProviderApiKey()` in `src/agents/model-auth.ts` returns `null`
for `secretref-managed` markers because `isNonSecretApiKeyMarker()` returns `true`,
but the function never falls back to `getRuntimeConfigSnapshot()` where the
actual resolved API key lives. Env-based SecretRefs (`apiKey: "MY_VAR"`) work
because they resolve via `process.env` directly.

## Real behavior proof

### behavior

Add `selectApplicableRuntimeConfig()` fallback in `resolveUsableCustomProviderApiKey()`
for non-env `secretref-managed` apiKey markers. When a runtime config snapshot
exists and its source matches the caller's config (preventing cross-config
secret leakage via `configSnapshotsMatch()`), the resolved API key is returned.

### environment

- OS: Linux 4.19.112-2.el8.x86_64
- Runtime: Node.js v26.2.0
- Setup: openclaw workspace at `/home/0668001050/workspace/openclaw`, PR branch `fix/issue-92097-secretref-auth-snapshot`

### steps

1. Configure a custom provider with `apiKey: "secretref-managed"` (the `NON_ENV_SECRETREF_MARKER`)
2. Set up a matching runtime config snapshot with the resolved API key (simulating what `prepareSecretsRuntimeSnapshot()` does at startup)
3. Call `resolveUsableCustomProviderApiKey()` — the same function the gateway uses for auth resolution
4. Verify: matched snapshot → returns resolved key; mismatched snapshot → returns null; no snapshot → returns null

### observedResult

**Reproduction script (`scripts/repro-92097.mjs`) — calls ACTUAL production code via tsx:**

```
============================================================
Issue #92097 Fix Verification — Real Auth Resolution Test
============================================================
Module: src/agents/model-auth.js
Function: resolveUsableCustomProviderApiKey()
Runtime: Node.js v26.2.0

Scenario 1: File-backed SecretRef with MATCHED runtime snapshot
----------------------------------------
  apiKey marker in source config: secretref-managed
  runtime snapshot available:      YES (source-matched)
  resolved result: {"apiKey":"sk-proj-abc123redacted","source":"runtime config snapshot (secretref)"}
  auth resolved:                    SUCCESS

Scenario 2: File-backed SecretRef WITHOUT runtime snapshot (pre-fix behavior)
----------------------------------------
  apiKey marker in source config: secretref-managed
  runtime snapshot available:      NO
  resolved result: null
  auth resolved:                    FAILED (would produce 503 auth_unavailable at gateway)

Scenario 3: Source config MISMATCH (cross-config leakage prevention)
----------------------------------------
  input config != runtime source:  YES (different baseUrl)
  resolved result: null
  cross-config leakage prevented:   YES (returns null)

Scenario 4: Direct apiKey string — regression check (env-based SecretRef)
----------------------------------------
  apiKey: OPENAI_API_KEY (env ref)
  resolved result: {"apiKey":"sk-env-resolved-key","source":"env: OPENAI_API_KEY (models.json marker)"}
  regression preserved:             YES

============================================================
Verification complete.

Before fix (no snapshot fallback):  secretref-managed -> null -> 503 auth_unavailable
After fix (snapshot fallback):      secretref-managed -> resolved key -> request proceeds
Security boundary:                  source config mismatch -> null -> no cross-config leak
============================================================
```

**Test suite (`pnpm test -- --run src/agents/model-auth.test.ts`):**

```
 Test Files  1 passed (1)
      Tests  62 passed (62)
   Start at  19:03:28
   Duration  5.58s
```

Includes 4 new regression tests for the snapshot fallback path:
- matched runtime snapshot → resolves API key correctly
- mismatched source config → returns null (no cross-config leakage)
- no runtime snapshot → returns null (graceful fallback)
- same-object input/runtime config → returns null (no infinite loop)

**Production change (`src/agents/model-auth.ts` +17 lines):**

```typescript
if (customKey === NON_ENV_SECRETREF_MARKER) {
    const applicableConfig = selectApplicableRuntimeConfig({
      inputConfig: params.cfg,
      runtimeConfig: getRuntimeConfigSnapshot(),
      runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
    });
    if (applicableConfig && applicableConfig !== params.cfg) {
      const runtimeProviderConfig = resolveProviderConfig(applicableConfig, params.provider);
      const runtimeApiKey = normalizeOptionalSecretInput(runtimeProviderConfig?.apiKey);
      if (runtimeApiKey && !isNonSecretApiKeyMarker(runtimeApiKey)) {
        return {
          apiKey: runtimeApiKey,
          source: "runtime config snapshot (secretref)",
        };
      }
    }
  }
```

## Regression Test Plan

- [x] `pnpm test -- --run src/agents/model-auth.test.ts` — 62 passed (includes 4 new snapshot fallback tests)
- [x] Matched runtime snapshot → API key resolved correctly
- [x] Mismatched source config → null returned (no cross-config leakage)
- [x] No runtime snapshot → null returned (graceful fallback)
- [x] Env-based SecretRef regression preserved
- [x] Direct apiKey string regression preserved
- [ ] Change is minimal (+17 lines, 1 file) and targeted

---

*AI-assisted: built with Claude Code*
