### PR TITLE
fix(cron): preserve yielded media completions

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts
@@ -7,6 +7,7 @@ import {
 import { resetTaskRegistryForTests, type TaskRecord } from "../../../tasks/runtime-internal.js";
 import {
   requiresCompletionRequiredAsyncTaskWait,
+  shouldWaitForCompletionRequiredAsyncTasks,
   waitForCompletionRequiredAsyncTasks,
   type AsyncStartedToolMeta,
 } from "./attempt.async-tasks.js";
@@ -93,6 +94,46 @@ describe("waitForCompletionRequiredAsyncTasks", () => {
       requiresCompletionRequiredAsyncTaskWait({
         sessionKey,
         toolMetas: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("skips media task waiting after sessions_yield pauses the attempt", () => {
+    resetTaskRegistryForTests();
+    const sessionKey = "agent:main:cron:daily-media:run:run-123";
+    createRunningTaskRun({
+      runtime: "cli",
+      taskKind: "image_generation",
+      sourceId: "image_generate:openai",
+      requesterSessionKey: sessionKey,
+      ownerKey: sessionKey,
+      scopeKind: "session",
+      runId: "tool:image_generate:run-123",
+      task: "daily image",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      startedAt: 1,
+      lastEventAt: 1,
+    });
+
+    expect(
+      shouldWaitForCompletionRequiredAsyncTasks({
+        sessionKey,
+        toolMetas: [
+          {
+            toolName: "image_generate",
+            asyncStarted: true,
+            asyncTaskRunId: "tool:image_generate:run-123",
+          },
+        ],
+        yieldDetected: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldWaitForCompletionRequiredAsyncTasks({
+        sessionKey,
+        toolMetas: [],
+        yieldDetected: false,
       }),
     ).toBe(true);
   });

--- a/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
@@ -160,6 +160,23 @@ export function requiresCompletionRequiredAsyncTaskWait(params: {
   );
 }
 
+/** Returns whether the current attempt should synchronously wait for media tasks. */
+export function shouldWaitForCompletionRequiredAsyncTasks(params: {
+  sessionKey: string | undefined;
+  toolMetas: readonly AsyncStartedToolMeta[];
+  yieldDetected?: boolean;
+}): boolean {
+  if (params.yieldDetected === true) {
+    // sessions_yield pauses the turn so the completion event can wake it later;
+    // waiting here would reuse the internal abort signal and turn the pause into AbortError.
+    return false;
+  }
+  return requiresCompletionRequiredAsyncTaskWait({
+    sessionKey: params.sessionKey,
+    toolMetas: params.toolMetas,
+  });
+}
+
 /**
  * Polls completion-required async tasks until they reach terminal state, time
  * out at the run deadline, or abort. Newly discovered task run ids are folded

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -315,7 +315,7 @@ import {
   resolveTerminalAssistantTexts,
 } from "./attempt-trajectory-status.js";
 import {
-  requiresCompletionRequiredAsyncTaskWait,
+  shouldWaitForCompletionRequiredAsyncTasks,
   waitForCompletionRequiredAsyncTasks,
   type AsyncStartedToolMeta,
   type CompletionRequiredAsyncTaskWaitResult,
@@ -4571,9 +4571,10 @@ export async function runEmbeddedAttempt(
         await sessionLockController.releaseForPrompt();
 
         if (
-          requiresCompletionRequiredAsyncTaskWait({
+          shouldWaitForCompletionRequiredAsyncTasks({
             sessionKey: params.sessionKey,
             toolMetas,
+            yieldDetected: yieldAborted,
           })
         ) {
           const getAsyncStartedToolMetas = () =>

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -315,6 +315,7 @@ import {
   resolveTerminalAssistantTexts,
 } from "./attempt-trajectory-status.js";
 import {
+  requiresCompletionRequiredAsyncTaskWait,
   shouldWaitForCompletionRequiredAsyncTasks,
   waitForCompletionRequiredAsyncTasks,
   type AsyncStartedToolMeta,

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -345,6 +345,8 @@ async function deliverSlackChannelAnnouncement(params: {
   queueEmbeddedAgentMessageWithOutcome?: QueueEmbeddedAgentMessageWithOutcome;
   sendMessage?: typeof runtimeSendMessage;
   internalEvents?: AgentInternalEvent[];
+  sourceSessionKey?: string;
+  sourceChannel?: string;
   sourceTool?: string;
   runtimeConfig?: Record<string, unknown>;
 }) {
@@ -381,6 +383,8 @@ async function deliverSlackChannelAnnouncement(params: {
     bestEffortDeliver: true,
     directIdempotencyKey: params.directIdempotencyKey,
     internalEvents: params.internalEvents,
+    sourceSessionKey: params.sourceSessionKey,
+    sourceChannel: params.sourceChannel,
     sourceTool: params.sourceTool,
   });
 }
@@ -4015,8 +4019,21 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("directly delivers stale isolated cron run media completions", async () => {
-    const callGateway = createGatewayMock();
+  it("runs inactive isolated cron media completions through the requester agent first", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [{ text: "queued the generated image confirmation" }],
+        messagingToolSentTargets: [
+          {
+            tool: "sessions_send",
+            provider: "slack",
+            to: "channel:C123",
+            text: "The daily media workflow continued after the image callback.",
+            mediaUrls: ["/tmp/generated-daily.png"],
+          },
+        ],
+      },
+    });
     const sendMessage = createSendMessageMock();
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
     const result = await deliverSlackChannelAnnouncement({
@@ -4044,6 +4061,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
           replyInstruction: "Deliver the generated image through the requester run.",
         },
       ],
+      sourceSessionKey: "image_generate:task-123",
+      sourceChannel: "internal",
     });
 
     expectRecordFields(result, {
@@ -4051,7 +4070,71 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       path: "direct",
     });
     expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
-    expect(callGateway).not.toHaveBeenCalled();
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    const params = expectGatewayAgentParams(callGateway, {
+      sessionKey: "agent:main:cron:daily-media:run:run-123",
+      deliver: true,
+      channel: "slack",
+      accountId: "acct-1",
+      to: "channel:C123",
+      idempotencyKey: "announce-stale-cron-media",
+    });
+    expectRecordFields(params.inputProvenance, {
+      kind: "inter_session",
+      sourceSessionKey: "image_generate:task-123",
+      sourceChannel: "internal",
+      sourceTool: "image_generate",
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("directly delivers inactive isolated cron media only after requester-agent fallback misses media", async () => {
+    const callGateway = createGatewayMock();
+    const sendMessage = createSendMessageMock();
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      queueEmbeddedAgentMessageWithOutcome,
+      sessionId: "stale-cron-run-session",
+      isActive: false,
+      requesterSessionKey: "agent:main:cron:daily-media:run:run-123",
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-stale-cron-media-fallback",
+      sourceTool: "image_generate",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "image_generation",
+          childSessionKey: "image_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "image generation task",
+          taskLabel: "daily media",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated 1 image.\nMEDIA:/tmp/generated-daily.png",
+          mediaUrls: ["/tmp/generated-daily.png"],
+          replyInstruction: "Deliver the generated image through the requester run.",
+        },
+      ],
+      sourceSessionKey: "image_generate:task-123",
+      sourceChannel: "internal",
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expectGatewayAgentParams(callGateway, {
+      sessionKey: "agent:main:cron:daily-media:run:run-123",
+      deliver: true,
+      channel: "slack",
+      accountId: "acct-1",
+      to: "channel:C123",
+      idempotencyKey: "announce-stale-cron-media-fallback",
+    });
     expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "slack",
@@ -4059,7 +4142,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         to: "channel:C123",
         content: "The generated image is ready.",
         mediaUrls: ["/tmp/generated-daily.png"],
-        idempotencyKey: "announce-stale-cron-media:generated-media-direct",
+        idempotencyKey: "announce-stale-cron-media-fallback:generated-media-direct",
       }),
     );
   });

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1387,7 +1387,8 @@ async function sendSubagentAnnounceDirectly(params: {
     if (
       params.expectsCompletionMessage &&
       isCronRunSessionKey(canonicalRequesterSessionKey) &&
-      !resolveRequesterSessionActivity(canonicalRequesterSessionKey).isActive
+      !resolveRequesterSessionActivity(canonicalRequesterSessionKey).isActive &&
+      !agentMediatedCompletion
     ) {
       const generatedMediaDelivery = await tryGeneratedMediaDirectDelivery();
       if (generatedMediaDelivery) {


### PR DESCRIPTION
## Summary

- Problem: Isolated cron media runs can call `image_generate`, then correctly call `sessions_yield`, but the attempt still enters the completion-required media wait with the already-aborted internal `sessions_yield` signal and turns the intentional pause into `AbortError: aborted`. The generated-media callback path could also bypass the requester-agent continuation for inactive isolated cron run sessions.
- Solution: Skip the synchronous completion-required media wait only after the attempt has positively detected the intentional `sessions_yield` abort, and keep agent-mediated generated-media completions routed through the requester-agent before any direct media fallback.
- What changed: Added `shouldWaitForCompletionRequiredAsyncTasks`, wired it into embedded attempt finalization, and tightened inactive isolated cron generated-media delivery so `image_generate` completions run the same cron run session first. Regression coverage now proves the wait policy, the clean yield pause, the completion callback, the same-session requester-agent handoff, a `sessions_send` follow-up action with generated media, and the fallback path when requester-agent media evidence is missing.
- What did NOT change (scope boundary): No provider, channel plugin, config shape, task-registry, dependency, lockfile, migration, auth, or storage behavior changed. Direct generated-media delivery remains as a fallback when the requester-agent does not prove media delivery.

## Motivation

Isolated cron workflows that generate media as an intermediate step should remain resumable after `sessions_yield`. The media callback path already exists; this patch prevents the paused attempt from immediately reusing its own `sessions_yield` abort signal and prevents inactive isolated cron media callbacks from skipping the requester-agent continuation step.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #92120
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A cron-run `sessions_yield` pause with an active generated-media task no longer enters the completion-required media wait using the already-aborted `sessions_yield` signal. The generated-media callback now enters the same inactive isolated cron run via the requester-agent first, where a follow-up `sessions_send` action can deliver the generated media. Normal non-yield cron media waits and direct generated-media fallback behavior remain covered.
- Real environment tested: Fresh disposable Linux OpenClaw checkouts; before/after diagnostic base `main` at `c692fabeba`; final pushed PR branch commit `5857bb7f3ae6fee4843b327bbf8833e475287e80`; Node `v24.16.0`, pnpm `11.2.2`.
- Exact steps or command run after this patch:

```bash
pnpm install --frozen-lockfile
pnpm tsgo:core
node --import tsx tmp-92120-real-image-proof.ts
OPENCLAW_PROOF_ARTIFACT_DIR=/tmp/openclaw-92120-proof-artifacts node --import tsx tmp/proof-92120-cron-media.ts
OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts -t "inactive isolated cron media"
OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts
OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts src/agents/agent-run-terminal-outcome.test.ts
OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs src/agents/tools/image-generate-background.test.ts -t "queues a completion event through the shared generated-media wake path"
git diff --check
pnpm exec oxfmt --check src/agents/embedded-agent-runner/run/attempt.async-tasks.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts src/agents/subagent-announce-delivery.ts src/agents/subagent-announce-delivery.test.ts
```

- Evidence after fix:

```text
final pushed PR branch commit=5857bb7f3ae6fee4843b327bbf8833e475287e80
PROOF_REQUIRES_WITHOUT_YIELD=true
PROOF_HAS_YIELD_POLICY=true
PROOF_SHOULD_WAIT_AFTER_YIELD=false
PROOF_OUTCOME=patched_paused_no_wait

REAL_IMAGE_PROOF=PASS
IMAGE_FILE=generated-daily.png
IMAGE_EXISTS=true
IMAGE_BYTES=225
IMAGE_SHA256=3a23e2ad20572f384a5e7028862556e8c2f70c2a98a57ccefff83a4cb43565c1
CRON_RUN_SESSION=agent:main:cron:daily-media:run:run-real-image-proof
CALLBACK_SOURCE_TOOL=image_generate
CALLBACK_SOURCE_SESSION=image_generate:task-real-image-proof
REQUESTER_AGENT_CALLS=1
REQUESTER_AGENT_SESSION_KEY=agent:main:cron:daily-media:run:run-real-image-proof
FOLLOWUP_TOOL=sessions_send
FOLLOWUP_MEDIA_MATCH=true
DIRECT_FALLBACK_SENDS=0
DELIVERY_RESULT=delivered:true,path:direct
EXTERNAL_PROVIDER_USED=false

ACTUAL_GATEWAY_CRON_RUN=PASS
CRON_RPC_RUN_FORCE=PASS
JOB_SESSION_TARGET=isolated
MODEL_TOOL_SEQUENCE=image_generate,sessions_yield,sessions_send,final,final
IMAGE_PROVIDER_REQUESTS=1
CALLBACK_RESUME_SEEN=true
CALLBACK_INPUT_HAS_SOURCE_TOOL_IMAGE_GENERATE=true
SESSIONS_SEND_CALLED=true
NESTED_MAIN_FINAL_SEEN=true
DIRECT_FALLBACK_IMAGE_EVENTS=0
OPENCLAW_SAVED_IMAGE_BYTES=702
OPENCLAW_SAVED_IMAGE_SHA256=94eff542b057e38dada70a97fe6a1eb5d1737318a519eb545da0ed6a2eb4ce85

pnpm tsgo:core PASS
inactive isolated cron media focused callback/follow-up test: 4/4 PASS, 192 skipped
subagent-announce-delivery.test.ts: 98/98 PASS
attempt.async-tasks.test.ts: 8/8 PASS
agent-run-terminal-outcome.test.ts: 12/12 PASS
sessions-yield.orchestration.test.ts: 4/4 PASS
image-generate-background focused wake-path test: 2/2 PASS, 6 skipped
git diff --check PASS
oxfmt changed files PASS on 5 files
```

- Observed result after fix: The paused attempt no longer waits on a `sessions_yield`-aborted signal. The yielded run exits as clean `end_turn` and is no longer active. The real image proof created an actual PNG (`generated-daily.png`, 225 bytes, SHA-256 `3a23e2ad20572f384a5e7028862556e8c2f70c2a98a57ccefff83a4cb43565c1`) and passed that media artifact through the inactive isolated cron `image_generate` completion callback into the same requester-agent run session. The requester-agent then emitted `sessions_send` with matching media evidence, and direct fallback sends stayed at `0`. A separate real Gateway/Cron proof started OpenClaw's Gateway server, added and force-ran an isolated cron job through `GatewayClient`, invoked `image_generate`, paused with `sessions_yield`, resumed from the generated-media callback with `sourceTool=image_generate`, called `sessions_send`, reached the main session follow-up, saved the generated PNG through OpenClaw media storage, and recorded `DIRECT_FALLBACK_IMAGE_EVENTS=0`.
- What was not tested: No live external image provider credential, real Google/OpenAI image generation call, full repository-wide suite, browser/UI path, production channel delivery, or real user account behavior was used. The image proof used deterministic/local provider-controlled PNG artifacts so the runner/session/media-delivery layer could be verified without provider flake.
- Before evidence:

```text
unpatched main commit=c692fabeba
PROOF_REQUIRES_WITHOUT_YIELD=true
PROOF_HAS_YIELD_POLICY=false
PROOF_SHOULD_WAIT_AFTER_YIELD=true
PROOF_OUTCOME=base_abort_error
PROOF_ERROR_NAME=AbortError
PROOF_ERROR_MESSAGE=aborted
PROOF_ERROR_CAUSE=sessions_yield
```

## Root Cause (if applicable)

- Root cause: `sessions_yield` intentionally aborts the internal attempt controller with reason `sessions_yield`, but the post-prompt completion-required media wait still ran after that pause and reused the already-aborted signal. Separately, inactive cron generated-media completions had a stale-run shortcut that could direct-deliver media before the requester-agent continuation ran.
- Missing detection / guardrail: The completion-required media wait policy did not distinguish a clean yield pause from an ordinary cron run that must synchronously wait for active generated-media tasks before finalizing. The inactive isolated cron delivery path also did not distinguish generated-media tools that require agent-mediated continuation from non-agent-mediated stale cron completions.
- Contributing context (if known): Prior cron media work correctly waits for generated-media tasks when no yield path is used. The missing guard was at the handoff between intentional yield cleanup, cron media waiting, and generated-media callback delivery for inactive cron run sessions.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts`, `src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts`, `src/agents/agent-run-terminal-outcome.test.ts`, `src/agents/tools/image-generate-background.test.ts`, and `src/agents/subagent-announce-delivery.test.ts`.
- Scenario the test should lock in: A cron run with an active completion-required generated-media task still waits when no yield happened, skips that synchronous wait after a confirmed `sessions_yield` pause, then handles the generated-media completion through the same inactive isolated cron run session before falling back to direct media delivery only if the requester-agent did not deliver the media.
- Why this is the smallest reliable guardrail: The bug crosses two local OpenClaw boundaries: the post-yield wait decision and the generated-media completion delivery decision. Testing those boundaries directly avoids provider flake while still proving the requested follow-up action (`sessions_send`) runs from the same cron run session.
- Existing test that already covers this (if any): Existing tests covered clean yield exit, generated-media wake events, active requester media completion delivery, and normal cron media wait behavior, but not inactive isolated cron media callback continuation after `sessions_yield`.
- If no new test is added, why not: New regression tests are added.

## User-visible / Behavior Changes

Isolated cron workflows that intentionally yield while waiting for generated-media completion should stay in the resumable completion-event path instead of reporting `AbortError: aborted` immediately after the yield. When the media callback arrives after the cron run is inactive, OpenClaw now gives the same isolated cron run session the first chance to continue and send the follow-up message/action.

## Diagram

```text
image_generate starts generated-media task
  -> sessions_yield intentionally pauses the attempt
  -> post-prompt cron media wait sees yieldDetected=true and does not wait on the aborted signal
  -> generated-media completion callback arrives for image_generate:task-123
  -> inactive isolated cron run is not steered because it is no longer active
  -> requester-agent runs with sessionKey=agent:main:cron:daily-media:run:run-123
  -> requester-agent performs sessions_send follow-up with generated media
  -> direct generated-media fallback remains available only when requester-agent media evidence is missing
```

## Security Impact (required)

- New permissions/capabilities? No.
- Secrets/tokens handling changed? No.
- New/changed network calls? No.
- Command/tool execution surface changed? No.
- Data access scope changed? No.
- If any `Yes`, explain risk + mitigation: Not applicable.

## Repro + Verification

### Environment

- OS: Linux disposable test checkout.
- Runtime/container: Node `v24.16.0`, pnpm `11.2.2`.
- Model/provider: No external provider call; deterministic OpenClaw source/runtime harnesses.
- Integration/channel (if any): Embedded runner cron media wait, sessions-yield orchestration, generated-media completion wake, inactive isolated cron requester-agent delivery, `sessions_send` follow-up evidence, and direct generated-media fallback.
- Relevant config (redacted): `OPENCLAW_TEST_FAST=1` for focused Vitest runs.

### Steps

1. Reproduce the old decision path on unpatched `main` with an active cron-owned `image_generation` task and `sessions_yield` abort reason.
2. Apply this patch and confirm the same active task still requires a wait without yield but does not require a wait after `yieldDetected=true`.
3. Generate a real local PNG artifact and pass it through the inactive isolated cron `image_generate` completion callback.
4. Prove the callback calls the requester-agent on the same cron run session.
5. Prove the requester-agent follow-up contains `sessions_send` delivery evidence with the generated media.
6. Prove direct generated-media fallback remains only when requester-agent media evidence is missing.
7. Start a real OpenClaw Gateway server, create an isolated cron job through the Gateway RPC client, force-run it, let the model-provider double emit `image_generate`, `sessions_yield`, and `sessions_send`, then verify the generated-media callback resume and saved image artifact.
8. Run focused and adjacent source tests for wait policy, clean yield exit, terminal outcome, image completion wake, inactive cron callback continuation, full announcement delivery, typecheck, whitespace, and formatting.

### Expected

- Non-yield cron media runs keep the synchronous generated-media wait.
- Yielded cron media runs do not reuse the `sessions_yield`-aborted signal for the synchronous wait.
- Yielded sessions still exit as clean `end_turn` runs and are no longer active.
- Generated-media completions for inactive isolated cron runs route through the requester-agent on the same cron run session before direct fallback.
- The requester-agent follow-up can send the generated media through `sessions_send`.
- Direct generated-media fallback stays available when the requester-agent misses media delivery evidence.

### Actual

- Unpatched `main`: the simulated post-yield wait decision entered the wait and threw `AbortError` with cause `sessions_yield`.
- Patched branch: the post-yield wait decision returned false while the non-yield media wait decision still returned true. The inactive isolated cron media callback called the requester-agent on the same cron run session and accepted `sessions_send` media delivery evidence for the generated PNG artifact; the fallback-only test still delivered generated media directly after requester-agent media evidence was missing.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
Before:
PROOF_OUTCOME=base_abort_error
PROOF_ERROR_NAME=AbortError
PROOF_ERROR_CAUSE=sessions_yield

After:
PROOF_OUTCOME=patched_paused_no_wait
REAL_IMAGE_PROOF=PASS
IMAGE_FILE=generated-daily.png
IMAGE_EXISTS=true
IMAGE_BYTES=225
IMAGE_SHA256=3a23e2ad20572f384a5e7028862556e8c2f70c2a98a57ccefff83a4cb43565c1
ACTUAL_GATEWAY_CRON_RUN=PASS
CRON_RPC_RUN_FORCE=PASS
JOB_SESSION_TARGET=isolated
MODEL_TOOL_SEQUENCE=image_generate,sessions_yield,sessions_send,final,final
IMAGE_PROVIDER_REQUESTS=1
CALLBACK_RESUME_SEEN=true
CALLBACK_INPUT_HAS_SOURCE_TOOL_IMAGE_GENERATE=true
SESSIONS_SEND_CALLED=true
NESTED_MAIN_FINAL_SEEN=true
DIRECT_FALLBACK_IMAGE_EVENTS=0
OPENCLAW_SAVED_IMAGE_BYTES=702
OPENCLAW_SAVED_IMAGE_SHA256=94eff542b057e38dada70a97fe6a1eb5d1737318a519eb545da0ed6a2eb4ce85
FOLLOWUP_TOOL=sessions_send
FOLLOWUP_MEDIA_MATCH=true
DIRECT_FALLBACK_SENDS=0
DELIVERY_RESULT=delivered:true,path:direct
pnpm tsgo:core PASS
inactive isolated cron media focused callback/follow-up test: 4/4 PASS, 192 skipped
subagent-announce-delivery.test.ts: 98/98 PASS
attempt.async-tasks.test.ts: 8/8 PASS
agent-run-terminal-outcome.test.ts: 12/12 PASS
sessions-yield.orchestration.test.ts: 4/4 PASS
image-generate-background focused wake-path test: 2/2 PASS, 6 skipped
git diff --check PASS
oxfmt changed files PASS on 5 files

Callback/follow-up proof details:
- actual Gateway cron run passed through Gateway RPC add/run
- isolated cron job target was preserved
- model tool sequence was image_generate -> sessions_yield -> sessions_send
- generated-media callback resume included sourceTool=image_generate
- requester agent called once
- sessionKey=agent:main:cron:daily-media:run:run-real-image-proof
- sourceTool=image_generate
- sourceSessionKey=image_generate:task-real-image-proof
- delivery evidence tool=sessions_send
- delivery evidence media matches generated-daily.png
- direct fallback sendMessage was not called when requester-agent media evidence existed
- direct fallback sendMessage was called when requester-agent media evidence was missing
```

## Human Verification (required)

- Verified scenarios: Base-vs-patched wait decision, non-yield generated-media wait preservation, clean sessions-yield `end_turn` behavior, terminal-outcome coverage, image completion wake path, real generated PNG artifact, real Gateway RPC cron add/run, isolated cron target, `image_generate -> sessions_yield -> callback resume -> sessions_send` model sequence, OpenClaw-saved generated image artifact, inactive isolated cron callback continuation through the same requester-agent session, `sessions_send` follow-up with matching generated media, direct fallback after missing media evidence, full announcement delivery suite, core typecheck, formatting, and whitespace.
- Edge cases checked: `yieldDetected=true` only skips the synchronous wait after the attempt has confirmed the `sessions_yield` abort; ordinary cron media waits still return true for active image-generation tasks; generated-media callbacks use the requester-agent path before direct fallback; non-agent-mediated stale cron completion behavior is left on the existing direct/no-op path.
- What you did **not** verify: Live external image provider generation, production channel delivery, full repository-wide suite, browser/UI behavior, or real user account behavior.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

The latest ClawSweeper review found a missing import and requested a stronger real image continuation proof. The import is fixed in `5857bb7f3ae6fee4843b327bbf8833e475287e80`, and the real Gateway/Cron/PNG continuation proof is included above. No review conversation was resolved by this PR body update.

## Compatibility / Migration

- Backward compatible? Yes.
- Config/env changes? No.
- Migration needed? No.
- If yes, exact upgrade steps: Not applicable.

## Risks and Mitigations

- Risk: The completion-required media wait could be skipped too broadly.
  - Mitigation: The helper skips only when the attempt has already positively classified the abort as `sessions_yield`; the regression test asserts non-yield cron media tasks still require the wait.
- Risk: Inactive isolated cron completions could skip the requester-agent continuation.
  - Mitigation: Agent-mediated generated-media completions no longer use the stale cron direct shortcut first; the new test proves same-session requester-agent continuation and `sessions_send` delivery evidence.
- Risk: Removing the old direct shortcut for generated-media cron completions could drop media delivery if the requester-agent misses the media.
  - Mitigation: A paired regression test proves direct generated-media fallback still fires after requester-agent media delivery evidence is missing.
- Risk: Live provider behavior could differ from the deterministic source harness.
  - Mitigation: The bug is in local runner/session/delivery control flow after `sessions_yield`; the proof isolates that path without relying on provider availability. No external provider success is claimed.