### PR TITLE
fix(gateway): sign custom node ids

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -53,6 +53,7 @@ public struct ConnectParams: Codable, Sendable {
     public let caps: [String]?
     public let commands: [String]?
     public let permissions: [String: AnyCodable]?
+    public let nodeid: String?
     public let pathenv: String?
     public let role: String?
     public let scopes: [String]?
@@ -68,6 +69,7 @@ public struct ConnectParams: Codable, Sendable {
         caps: [String]?,
         commands: [String]?,
         permissions: [String: AnyCodable]?,
+        nodeid: String?,
         pathenv: String?,
         role: String?,
         scopes: [String]?,
@@ -82,6 +84,7 @@ public struct ConnectParams: Codable, Sendable {
         self.caps = caps
         self.commands = commands
         self.permissions = permissions
+        self.nodeid = nodeid
         self.pathenv = pathenv
         self.role = role
         self.scopes = scopes
@@ -98,6 +101,7 @@ public struct ConnectParams: Codable, Sendable {
         case caps
         case commands
         case permissions
+        case nodeid = "nodeId"
         case pathenv = "pathEnv"
         case role
         case scopes

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -25,7 +25,7 @@ import { resolveGatewayStartupRetryAfterMs } from "@openclaw/gateway-protocol/st
 import { MIN_CLIENT_PROTOCOL_VERSION, PROTOCOL_VERSION } from "@openclaw/gateway-protocol/version";
 import ipaddr from "ipaddr.js";
 import { WebSocket, type ClientOptions, type CertMeta } from "ws";
-import { buildDeviceAuthPayloadV3 } from "./device-auth.js";
+import { buildDeviceAuthPayloadV3, buildDeviceAuthPayloadV4 } from "./device-auth.js";
 import { resolveConnectChallengeTimeoutMs, resolveSafeTimeoutDelayMs } from "./timeouts.js";
 
 export type DeviceIdentity = {
@@ -417,6 +417,7 @@ export type GatewayClientOptions = {
   password?: string;
   approvalRuntimeToken?: string;
   instanceId?: string;
+  nodeId?: string;
   clientName?: GatewayClientName;
   clientDisplayName?: string;
   clientVersion?: string;
@@ -522,6 +523,8 @@ export class GatewayClient {
   private deviceTokenRetryBudgetUsed = false;
   private approvalRuntimeTokenCompatibilityDisabled = false;
   private approvalRuntimeTokenRetryBudgetUsed = false;
+  private nodeIdCompatibilityDisabled = false;
+  private nodeIdCompatibilityRetryBudgetUsed = false;
   private pendingStartupReconnectDelayMs: number | null = null;
   private pendingConnectErrorDetailCode: string | null = null;
   private pendingConnectErrorDetails: unknown = null;
@@ -937,6 +940,19 @@ export class GatewayClient {
           this.ws?.close(1008, "connect retry");
           return;
         }
+        if (
+          this.shouldRetryWithoutNodeId({
+            error: err,
+            nodeId: assembled.params.nodeId,
+          })
+        ) {
+          this.nodeIdCompatibilityDisabled = true;
+          this.nodeIdCompatibilityRetryBudgetUsed = true;
+          this.backoffMs = Math.min(this.backoffMs, 250);
+          this.logDebug("gateway rejected nodeId connect field; retrying without it");
+          this.ws?.close(1008, "connect retry");
+          return;
+        }
         this.notifyConnectError(err instanceof Error ? err : new Error(String(err)));
         const msg = `gateway connect failed: ${formatGatewayClientErrorForLog(err)}`;
         if (this.opts.mode === GATEWAY_CLIENT_MODES.PROBE || isGatewayClientStoppedError(err)) {
@@ -991,6 +1007,9 @@ export class GatewayClient {
     });
     const platform = this.opts.platform ?? process.platform;
 
+    const nodeId = this.nodeIdCompatibilityDisabled
+      ? undefined
+      : normalizeOptionalString(this.opts.nodeId);
     return {
       params: {
         minProtocol: this.opts.minProtocol ?? MIN_CLIENT_PROTOCOL_VERSION,
@@ -1010,6 +1029,7 @@ export class GatewayClient {
           this.opts.permissions && typeof this.opts.permissions === "object"
             ? this.opts.permissions
             : undefined,
+        nodeId,
         pathEnv: this.opts.pathEnv,
         auth,
         role,
@@ -1021,6 +1041,7 @@ export class GatewayClient {
           signatureToken,
           signedAtMs,
           platform,
+          nodeId,
         }),
       },
       authApprovalRuntimeToken,
@@ -1037,14 +1058,15 @@ export class GatewayClient {
     signatureToken: string | undefined;
     signedAtMs: number;
     platform: string;
+    nodeId?: string;
   }): ConnectParams["device"] {
     if (!this.opts.deviceIdentity) {
       return undefined;
     }
-    const { nonce, role, scopes, signatureToken, signedAtMs, platform } = params;
+    const { nonce, role, scopes, signatureToken, signedAtMs, platform, nodeId } = params;
     // The signed payload mirrors server verification exactly; keep metadata
     // normalized here so different hosts sign the same logical device facts.
-    const payload = buildDeviceAuthPayloadV3({
+    const payloadParams = {
       deviceId: this.opts.deviceIdentity.deviceId,
       clientId: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
       clientMode: this.opts.mode ?? GATEWAY_CLIENT_MODES.BACKEND,
@@ -1055,7 +1077,10 @@ export class GatewayClient {
       nonce,
       platform,
       deviceFamily: this.opts.deviceFamily,
-    });
+    };
+    const payload = nodeId
+      ? buildDeviceAuthPayloadV4({ ...payloadParams, nodeId })
+      : buildDeviceAuthPayloadV3(payloadParams);
     const signature = this.deps.signDevicePayload(this.opts.deviceIdentity.privateKeyPem, payload);
     return {
       id: this.opts.deviceIdentity.deviceId,
@@ -1215,6 +1240,23 @@ export class GatewayClient {
     }
     const message = normalizeLowercaseStringOrEmpty(params.error.message);
     return message.includes("invalid connect params") && message.includes("approvalruntimetoken");
+  }
+
+  private shouldRetryWithoutNodeId(params: { error: unknown; nodeId?: string }): boolean {
+    if (this.nodeIdCompatibilityRetryBudgetUsed) {
+      return false;
+    }
+    if (!params.nodeId) {
+      return false;
+    }
+    if (!(params.error instanceof GatewayClientRequestError)) {
+      return false;
+    }
+    if (params.error.gatewayCode !== "INVALID_REQUEST") {
+      return false;
+    }
+    const message = normalizeLowercaseStringOrEmpty(params.error.message);
+    return message.includes("invalid connect params") && message.includes("nodeid");
   }
 
   private isTrustedDeviceRetryEndpoint(): boolean {

--- a/packages/gateway-client/src/device-auth.ts
+++ b/packages/gateway-client/src/device-auth.ts
@@ -26,6 +26,10 @@ type DeviceAuthPayloadV3Params = DeviceAuthPayloadParams & {
   deviceFamily?: string | null;
 };
 
+type DeviceAuthPayloadV4Params = DeviceAuthPayloadV3Params & {
+  nodeId?: string | null;
+};
+
 export function buildDeviceAuthPayload(params: DeviceAuthPayloadParams): string {
   const scopes = params.scopes.join(",");
   const token = params.token ?? "";
@@ -61,5 +65,27 @@ export function buildDeviceAuthPayloadV3(params: DeviceAuthPayloadV3Params): str
     params.nonce,
     platform,
     deviceFamily,
+  ].join("|");
+}
+
+export function buildDeviceAuthPayloadV4(params: DeviceAuthPayloadV4Params): string {
+  const scopes = params.scopes.join(",");
+  const token = params.token ?? "";
+  const platform = normalizeDeviceMetadataForAuth(params.platform);
+  const deviceFamily = normalizeDeviceMetadataForAuth(params.deviceFamily);
+  const nodeId = params.nodeId?.trim() ?? "";
+  return [
+    "v4",
+    params.deviceId,
+    params.clientId,
+    params.clientMode,
+    params.role,
+    scopes,
+    String(params.signedAtMs),
+    token,
+    params.nonce,
+    platform,
+    deviceFamily,
+    nodeId,
   ].join("|");
 }

--- a/packages/gateway-protocol/src/index.test.ts
+++ b/packages/gateway-protocol/src/index.test.ts
@@ -80,6 +80,7 @@ describe("lazy protocol validators", () => {
           platform: "test",
           mode: "test",
         },
+        nodeId: "my-mac-node",
       }),
     ).toBe(true);
     expect(validateConnectParams.errors).toBeNull();

--- a/packages/gateway-protocol/src/schema/frames.ts
+++ b/packages/gateway-protocol/src/schema/frames.ts
@@ -47,6 +47,7 @@ export const ConnectParamsSchema = Type.Object(
     caps: Type.Optional(Type.Array(NonEmptyString, { default: [] })),
     commands: Type.Optional(Type.Array(NonEmptyString)),
     permissions: Type.Optional(Type.Record(NonEmptyString, Type.Boolean())),
+    nodeId: Type.Optional(NonEmptyString),
     pathEnv: Type.Optional(Type.String()),
     role: Type.Optional(NonEmptyString),
     scopes: Type.Optional(Type.Array(NonEmptyString)),

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -4,6 +4,10 @@ import { Buffer } from "node:buffer";
 import { generateKeyPairSync } from "node:crypto";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../packages/gateway-protocol/src/client-info.js";
+import {
   MIN_CLIENT_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
 } from "../../packages/gateway-protocol/src/index.js";
@@ -948,7 +952,11 @@ describe("GatewayClient connect auth payload", () => {
     params?: {
       minProtocol?: number;
       maxProtocol?: number;
+      nodeId?: string;
       scopes?: string[];
+      client?: {
+        instanceId?: string;
+      };
       auth?: {
         token?: string;
         bootstrapToken?: string;
@@ -1131,6 +1139,16 @@ describe("GatewayClient connect auth payload", () => {
     failureDetails: Record<string, unknown>;
     failureMessage?: string;
   }) {
+    const request = await expectRetriedConnectRequest(params);
+    return request.params?.auth ?? {};
+  }
+
+  async function expectRetriedConnectRequest(params: {
+    firstWs: MockWebSocket;
+    connectId: string | undefined;
+    failureDetails: Record<string, unknown>;
+    failureMessage?: string;
+  }) {
     emitConnectFailure(
       params.firstWs,
       params.connectId,
@@ -1141,7 +1159,7 @@ describe("GatewayClient connect auth payload", () => {
     const ws = getLatestWs();
     ws.emitOpen();
     emitConnectChallenge(ws, "nonce-2");
-    return connectFrameFrom(ws);
+    return connectRequestFrom(ws);
   }
 
   async function expectNoReconnectAfterConnectFailure(params: {
@@ -1219,6 +1237,34 @@ describe("GatewayClient connect auth payload", () => {
       "retried connect auth",
     );
     expect(retriedAuth.approvalRuntimeToken).toBeUndefined();
+    client.stop();
+  });
+
+  it("retries without node id when an older gateway rejects the connect field", async () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-token",
+      instanceId: "my-mac-node",
+      nodeId: "my-mac-node",
+      clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
+      mode: GATEWAY_CLIENT_MODES.NODE,
+      role: "node",
+      scopes: [],
+      deviceIdentity: null,
+    });
+
+    const { ws: ws1, connect: firstConnect } = startClientAndConnect({ client });
+    expect(firstConnect.params?.nodeId).toBe("my-mac-node");
+
+    const retried = await expectRetriedConnectRequest({
+      firstWs: ws1,
+      connectId: firstConnect.id,
+      failureDetails: {},
+      failureMessage: "invalid connect params: at root: unexpected property 'nodeId'",
+    });
+
+    expect(retried.params?.nodeId).toBeUndefined();
+    expect(retried.params?.client?.instanceId).toBe("my-mac-node");
     client.stop();
   });
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -125,6 +125,7 @@ export type GatewayClientOptions = {
   password?: string;
   approvalRuntimeToken?: string;
   instanceId?: string;
+  nodeId?: string;
   clientName?: GatewayClientName;
   clientDisplayName?: string;
   clientVersion?: string;

--- a/src/gateway/device-auth.test.ts
+++ b/src/gateway/device-auth.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildDeviceAuthPayload,
   buildDeviceAuthPayloadV3,
+  buildDeviceAuthPayloadV4,
   normalizeDeviceMetadataForAuth,
 } from "./device-auth.js";
 
@@ -57,6 +58,25 @@ describe("device-auth payload vectors", () => {
           nonce: "nonce-def",
         }),
       expected: "v3|dev-2|openclaw-ios|ui|operator|operator.read|1700000000001||nonce-def||",
+    },
+    {
+      name: "builds canonical v4 payloads with signed node ids",
+      build: () =>
+        buildDeviceAuthPayloadV4({
+          deviceId: "dev-3",
+          clientId: "node-host",
+          clientMode: "node",
+          role: "node",
+          scopes: [],
+          signedAtMs: 1_700_000_000_002,
+          token: "tok-456",
+          nonce: "nonce-ghi",
+          platform: "  MACOS  ",
+          deviceFamily: "  Mac  ",
+          nodeId: "  my-mac-node  ",
+        }),
+      expected:
+        "v4|dev-3|node-host|node|node||1700000000002|tok-456|nonce-ghi|macos|mac|my-mac-node",
     },
   ])("$name", ({ build, expected }) => {
     expect(build()).toBe(expected);

--- a/src/gateway/device-auth.ts
+++ b/src/gateway/device-auth.ts
@@ -3,5 +3,6 @@
 export {
   buildDeviceAuthPayload,
   buildDeviceAuthPayloadV3,
+  buildDeviceAuthPayloadV4,
   normalizeDeviceMetadataForAuth,
 } from "../../packages/gateway-client/src/device-auth.js";

--- a/src/gateway/node-catalog.test.ts
+++ b/src/gateway/node-catalog.test.ts
@@ -141,6 +141,50 @@ describe("gateway/node-catalog", () => {
     expect(node?.connected).toBe(true);
   });
 
+  it("uses the custom node id as the catalog row for one authenticated device", () => {
+    const catalog = createKnownNodeCatalog({
+      pairedDevices: [
+        pairedDevice({
+          deviceId: "device-fingerprint",
+          displayName: "Mac",
+          approvedAtMs: 99,
+        }),
+      ],
+      pairedNodes: [
+        pairedNode({
+          nodeId: "my-mac-node",
+          deviceId: "device-fingerprint",
+          displayName: "Mac",
+          approvedAtMs: 100,
+        }),
+      ],
+      connectedNodes: [
+        {
+          nodeId: "my-mac-node",
+          deviceId: "device-fingerprint",
+          connId: "conn-1",
+          client: {} as never,
+          clientId: "openclaw-macos",
+          clientMode: "node",
+          displayName: "Mac",
+          platform: "macos",
+          declaredCaps: ["camera"],
+          caps: ["camera"],
+          declaredCommands: ["system.run"],
+          commands: ["system.run"],
+          connectedAtMs: 123,
+        } as unknown as CatalogInput["connectedNodes"][number],
+      ],
+    });
+
+    expect(listKnownNodes(catalog).map((node) => node.nodeId)).toEqual(["my-mac-node"]);
+    const node = getKnownNode(catalog, "my-mac-node");
+    expect(node?.paired).toBe(true);
+    expect(node?.connected).toBe(true);
+    expect(node?.approvedAtMs).toBe(100);
+    expect(getKnownNode(catalog, "device-fingerprint")).toBeNull();
+  });
+
   it("surfaces node-pair metadata even when the node is offline", () => {
     const catalog = createKnownNodeCatalog({
       pairedDevices: [pairedDevice()],

--- a/src/gateway/node-catalog.ts
+++ b/src/gateway/node-catalog.ts
@@ -9,6 +9,7 @@ import type { NodeSession } from "./node-registry.js";
 
 type KnownNodeDevicePairingSource = {
   nodeId: string;
+  deviceId: string;
   displayName?: string;
   platform?: string;
   clientId?: string;
@@ -21,6 +22,7 @@ type KnownNodeDevicePairingSource = {
 
 type KnownNodeApprovedSource = {
   nodeId: string;
+  deviceId?: string;
   displayName?: string;
   platform?: string;
   version?: string;
@@ -57,6 +59,7 @@ function uniqueSortedStrings(...items: Array<readonly unknown[] | undefined>): s
 function buildDevicePairingSource(entry: PairedDevice): KnownNodeDevicePairingSource {
   return {
     nodeId: entry.deviceId,
+    deviceId: entry.deviceId,
     displayName: entry.displayName,
     platform: entry.platform,
     clientId: entry.clientId,
@@ -71,6 +74,7 @@ function buildDevicePairingSource(entry: PairedDevice): KnownNodeDevicePairingSo
 function buildApprovedNodeSource(entry: NodePairingPairedNode): KnownNodeApprovedSource {
   return {
     nodeId: entry.nodeId,
+    deviceId: entry.deviceId,
     displayName: entry.displayName,
     platform: entry.platform,
     version: entry.version,
@@ -173,21 +177,82 @@ function compareKnownNodes(left: NodeListNode, right: NodeListNode): number {
   return left.nodeId.localeCompare(right.nodeId);
 }
 
+function normalizeOptionalNodeId(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function addDeviceNodeAlias(
+  aliases: Map<string, string>,
+  params: { deviceId?: string; nodeId: string; overwrite: boolean },
+): void {
+  const deviceId = normalizeOptionalNodeId(params.deviceId);
+  const nodeId = normalizeOptionalNodeId(params.nodeId);
+  if (!deviceId || !nodeId || deviceId === nodeId || (!params.overwrite && aliases.has(deviceId))) {
+    return;
+  }
+  aliases.set(deviceId, nodeId);
+}
+
+function buildDeviceNodeAliases(params: {
+  pairedNodes: readonly NodePairingPairedNode[];
+  connectedNodes: readonly NodeSession[];
+}): Map<string, string> {
+  const aliases = new Map<string, string>();
+  for (const entry of params.connectedNodes) {
+    addDeviceNodeAlias(aliases, {
+      deviceId: entry.deviceId,
+      nodeId: entry.nodeId,
+      overwrite: false,
+    });
+  }
+  for (const entry of params.pairedNodes) {
+    addDeviceNodeAlias(aliases, {
+      deviceId: entry.deviceId,
+      nodeId: entry.nodeId,
+      overwrite: true,
+    });
+  }
+  return aliases;
+}
+
+function isStaleLiveDeviceAlias(
+  entry: NodeSession,
+  aliasesByDeviceId: ReadonlyMap<string, string>,
+): boolean {
+  const deviceId = normalizeOptionalNodeId(entry.deviceId);
+  return Boolean(deviceId && entry.nodeId === deviceId && aliasesByDeviceId.has(deviceId));
+}
+
 /** Builds a node catalog keyed by node id from pairing stores and live sessions. */
 export function createKnownNodeCatalog(params: {
   pairedDevices: readonly PairedDevice[];
   pairedNodes?: readonly NodePairingPairedNode[];
   connectedNodes: readonly NodeSession[];
 }): KnownNodeCatalog {
-  const devicePairingById = new Map(
-    params.pairedDevices
-      .filter((entry) => hasEffectivePairedDeviceRole(entry, "node"))
-      .map((entry) => [entry.deviceId, buildDevicePairingSource(entry)]),
-  );
+  const pairedNodes = params.pairedNodes ?? [];
+  const aliasesByDeviceId = buildDeviceNodeAliases({
+    pairedNodes,
+    connectedNodes: params.connectedNodes,
+  });
+  const devicePairingById = new Map<string, KnownNodeDevicePairingSource>();
+  for (const entry of params.pairedDevices) {
+    if (!hasEffectivePairedDeviceRole(entry, "node")) {
+      continue;
+    }
+    devicePairingById.set(
+      aliasesByDeviceId.get(entry.deviceId) ?? entry.deviceId,
+      buildDevicePairingSource(entry),
+    );
+  }
   const nodePairingById = new Map(
-    (params.pairedNodes ?? []).map((entry) => [entry.nodeId, buildApprovedNodeSource(entry)]),
+    pairedNodes.map((entry) => [entry.nodeId, buildApprovedNodeSource(entry)]),
   );
-  const liveById = new Map(params.connectedNodes.map((entry) => [entry.nodeId, entry]));
+  const liveById = new Map(
+    params.connectedNodes
+      .filter((entry) => !isStaleLiveDeviceAlias(entry, aliasesByDeviceId))
+      .map((entry) => [entry.nodeId, entry]),
+  );
   const nodeIds = new Set<string>([
     ...devicePairingById.keys(),
     ...nodePairingById.keys(),

--- a/src/gateway/node-connect-reconcile.test.ts
+++ b/src/gateway/node-connect-reconcile.test.ts
@@ -8,7 +8,10 @@ import {
 } from "../../packages/gateway-protocol/src/client-info.js";
 import type { ConnectParams } from "../../packages/gateway-protocol/src/index.js";
 import type { NodePairingPairedNode, NodePairingRequestInput } from "../infra/node-pairing.js";
-import { reconcileNodePairingOnConnect } from "./node-connect-reconcile.js";
+import {
+  NodePairingDeviceMismatchError,
+  reconcileNodePairingOnConnect,
+} from "./node-connect-reconcile.js";
 
 function makeNodeConnectParams(overrides?: Partial<ConnectParams>): ConnectParams {
   return {
@@ -49,6 +52,7 @@ function expectNodePairingRequest(
 ) {
   expect(requestPairing).toHaveBeenCalledWith({
     nodeId: "openclaw-ios",
+    deviceId: undefined,
     clientId: undefined,
     clientMode: undefined,
     displayName: undefined,
@@ -116,6 +120,134 @@ describe("reconcileNodePairingOnConnect", () => {
         permissions: { camera: true },
       }),
     );
+  });
+
+  it("uses explicit node-host node ids for pending pairing requests", async () => {
+    const requestPairing = makePendingPairingRequest("req-custom-node");
+
+    const result = await reconcileNodePairingOnConnect({
+      cfg: {} as never,
+      connectParams: makeNodeConnectParams({
+        nodeId: "my-mac-node",
+        device: {
+          id: "device-fingerprint",
+          publicKey: "public-key",
+          signature: "signature",
+          signedAt: 1,
+          nonce: "nonce",
+        },
+        client: {
+          id: GATEWAY_CLIENT_IDS.NODE_HOST,
+          version: "test",
+          platform: "macos",
+          deviceFamily: "Mac",
+          mode: GATEWAY_CLIENT_MODES.NODE,
+        },
+      }),
+      pairedNode: null,
+      requestPairing,
+    });
+
+    expect(result.nodeId).toBe("my-mac-node");
+    expectNodePairingRequest(requestPairing, {
+      nodeId: "my-mac-node",
+      deviceId: "device-fingerprint",
+      platform: "macos",
+      deviceFamily: "Mac",
+    });
+  });
+
+  it("ignores explicit node ids from non-node-host clients", async () => {
+    const requestPairing = makePendingPairingRequest("req-non-host-node-id");
+
+    const result = await reconcileNodePairingOnConnect({
+      cfg: {} as never,
+      connectParams: makeNodeConnectParams({
+        nodeId: "spoofed-node-id",
+        device: {
+          id: "device-fingerprint",
+          publicKey: "public-key",
+          signature: "signature",
+          signedAt: 1,
+          nonce: "nonce",
+        },
+      }),
+      pairedNode: null,
+      requestPairing,
+    });
+
+    expect(result.nodeId).toBe("device-fingerprint");
+    expectNodePairingRequest(requestPairing, {
+      nodeId: "device-fingerprint",
+      deviceId: "device-fingerprint",
+    });
+  });
+
+  it("rejects approved custom node ids bound to a different device", async () => {
+    const requestPairing = makePendingPairingRequest("req-device-mismatch");
+
+    await expect(
+      reconcileNodePairingOnConnect({
+        cfg: {} as never,
+        connectParams: makeNodeConnectParams({
+          nodeId: "my-mac-node",
+          device: {
+            id: "other-device",
+            publicKey: "public-key",
+            signature: "signature",
+            signedAt: 1,
+            nonce: "nonce",
+          },
+          client: {
+            id: GATEWAY_CLIENT_IDS.NODE_HOST,
+            version: "test",
+            platform: "macos",
+            deviceFamily: "Mac",
+            mode: GATEWAY_CLIENT_MODES.NODE,
+          },
+        }),
+        pairedNode: makePairedNode({
+          nodeId: "my-mac-node",
+          deviceId: "original-device",
+        }),
+        requestPairing,
+      }),
+    ).rejects.toBeInstanceOf(NodePairingDeviceMismatchError);
+    expect(requestPairing).not.toHaveBeenCalled();
+  });
+
+  it("allows legacy paired nodes without stored device ids when node id matches device id", async () => {
+    const requestPairing = makePendingPairingRequest("req-legacy-device-id");
+
+    const result = await reconcileNodePairingOnConnect({
+      cfg: {} as never,
+      connectParams: makeNodeConnectParams({
+        commands: [],
+        device: {
+          id: "legacy-device-id",
+          publicKey: "public-key",
+          signature: "signature",
+          signedAt: 1,
+          nonce: "nonce",
+        },
+        client: {
+          id: GATEWAY_CLIENT_IDS.NODE_HOST,
+          version: "test",
+          platform: "macos",
+          deviceFamily: "Mac",
+          mode: GATEWAY_CLIENT_MODES.NODE,
+        },
+      }),
+      pairedNode: makePairedNode({
+        nodeId: "legacy-device-id",
+        deviceId: undefined,
+        commands: [],
+      }),
+      requestPairing,
+    });
+
+    expect(result.nodeId).toBe("legacy-device-id");
+    expect(requestPairing).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/gateway/node-connect-reconcile.ts
+++ b/src/gateway/node-connect-reconcile.ts
@@ -17,6 +17,11 @@ import {
   resolveNodeCommandAllowlist,
   resolveNodePairingCommandAllowlist,
 } from "./node-command-policy.js";
+import {
+  nodePairingMatchesConnectDevice,
+  resolveNodeConnectDeviceId,
+  resolveNodeConnectId,
+} from "./node-id.js";
 
 // Node connect reconciliation turns declared caps/commands/permissions into the
 // effective runtime surface. New or upgraded surfaces create a pending pairing
@@ -31,6 +36,18 @@ export type NodeConnectPairingReconcileResult = {
   effectivePermissions?: Record<string, boolean>;
   pendingPairing?: RequestNodePairingResult;
 };
+
+export class NodePairingDeviceMismatchError extends Error {
+  readonly nodeId: string;
+  readonly deviceId: string | null;
+
+  constructor(params: { nodeId: string; deviceId: string | null }) {
+    super("node pairing device mismatch");
+    this.name = "NodePairingDeviceMismatchError";
+    this.nodeId = params.nodeId;
+    this.deviceId = params.deviceId;
+  }
+}
 
 function resolveApprovedReconnectCommands(params: {
   pairedCommands: readonly string[] | undefined;
@@ -96,6 +113,7 @@ function buildNodePairingRequestInput(params: {
 }): NodePairingRequestInput {
   return {
     nodeId: params.nodeId,
+    deviceId: params.connectParams.device?.id,
     displayName: params.connectParams.client.displayName,
     platform: params.connectParams.client.platform,
     version: params.connectParams.client.version,
@@ -116,7 +134,16 @@ export async function reconcileNodePairingOnConnect(params: {
   reportedClientIp?: string;
   requestPairing: (input: NodePairingRequestInput) => Promise<RequestNodePairingResult | null>;
 }): Promise<NodeConnectPairingReconcileResult> {
-  const nodeId = params.connectParams.device?.id ?? params.connectParams.client.id;
+  const nodeId = resolveNodeConnectId(params.connectParams);
+  if (
+    params.pairedNode &&
+    !nodePairingMatchesConnectDevice(params.pairedNode, params.connectParams)
+  ) {
+    throw new NodePairingDeviceMismatchError({
+      nodeId,
+      deviceId: resolveNodeConnectDeviceId(params.connectParams),
+    });
+  }
   const policyNode = {
     platform: params.connectParams.client.platform,
     deviceFamily: params.connectParams.client.deviceFamily,

--- a/src/gateway/node-id.ts
+++ b/src/gateway/node-id.ts
@@ -1,0 +1,49 @@
+// Gateway node id resolution keeps the user-visible node-host id separate from
+// the cryptographic device id that authenticates the connecting process.
+import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../../packages/gateway-protocol/src/client-info.js";
+import type { ConnectParams } from "../../packages/gateway-protocol/src/index.js";
+
+function normalizeNodeId(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function isNodeHostConnect(connect: Pick<ConnectParams, "client">): boolean {
+  return (
+    connect.client.id === GATEWAY_CLIENT_IDS.NODE_HOST &&
+    connect.client.mode === GATEWAY_CLIENT_MODES.NODE
+  );
+}
+
+export function resolveNodeConnectId(connect: ConnectParams): string {
+  const explicitNodeId = normalizeNodeId(connect.nodeId);
+  if (explicitNodeId && isNodeHostConnect(connect) && resolveNodeConnectDeviceId(connect)) {
+    return explicitNodeId;
+  }
+  return normalizeNodeId(connect.device?.id) ?? connect.client.id;
+}
+
+export function resolveNodeConnectDeviceId(connect: ConnectParams): string | null {
+  return normalizeNodeId(connect.device?.id) ?? null;
+}
+
+export function nodePairingMatchesConnectDevice(
+  pairedNode: { nodeId: string; deviceId?: string },
+  connect: ConnectParams,
+): boolean {
+  const deviceId = resolveNodeConnectDeviceId(connect);
+  const pairedDeviceId = normalizeNodeId(pairedNode.deviceId);
+  if (!deviceId) {
+    return !pairedDeviceId && pairedNode.nodeId === resolveNodeConnectId(connect);
+  }
+  return pairedDeviceId ? pairedDeviceId === deviceId : pairedNode.nodeId === deviceId;
+}
+
+export function resolveClientNodeId(
+  client: { connect?: ConnectParams } | null | undefined,
+): string | null {
+  return client?.connect ? resolveNodeConnectId(client.connect) : null;
+}

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -23,6 +23,7 @@ function makeClient(
     caps?: string[];
     commands?: string[];
     permissions?: Record<string, boolean>;
+    deviceId?: string;
     declaredCaps?: string[];
     declaredCommands?: string[];
     declaredPermissions?: Record<string, boolean>;
@@ -50,8 +51,9 @@ function makeClient(
         platform: opts.platform ?? "darwin",
         mode: "node",
       },
+      ...(opts.deviceId ? { nodeId } : {}),
       device: {
-        id: nodeId,
+        id: opts.deviceId ?? nodeId,
         publicKey: "public-key",
         signature: "signature",
         signedAt: 1,
@@ -180,7 +182,11 @@ describe("gateway/node-registry", () => {
         ok: true,
       }),
     ).toBe(false);
-    expect(registry.unregister("conn-old")).toBeNull();
+    expect(registry.unregister("conn-old")).toEqual({
+      nodeId: "node-1",
+      nodeDisconnected: false,
+      presenceDisconnected: false,
+    });
     expect(registry.get("node-1")).toBe(newSession);
     await expect(oldDisconnected).resolves.toBeInstanceOf(Error);
   });
@@ -598,6 +604,181 @@ describe("gateway/node-registry", () => {
     expect(updated?.permissions).toEqual({ microphone: true, camera: false });
     expect(client.connect.caps).toEqual(["talk"]);
     expect((client.connect as { commands?: string[] }).commands).toEqual(["talk.ptt.start"]);
+  });
+
+  it("replaces stale same-device sessions when a custom node id connects", () => {
+    const registry = new NodeRegistry();
+    registry.register(
+      makeClient("conn-1", "device-fingerprint", ["screen.snapshot"], {
+        clientId: "node-host",
+        commands: ["screen.snapshot"],
+        deviceId: "device-fingerprint",
+      }),
+      {},
+    );
+
+    const custom = registry.register(
+      makeClient("conn-2", "my-mac-node", ["system.run"], {
+        clientId: "node-host",
+        commands: ["system.run"],
+        deviceId: "device-fingerprint",
+      }),
+      {},
+    );
+
+    expect(custom.nodeId).toBe("my-mac-node");
+    expect(custom.deviceId).toBe("device-fingerprint");
+    expect(registry.get("device-fingerprint")).toBeUndefined();
+    expect(registry.get("my-mac-node")?.connId).toBe("conn-2");
+    expect(registry.listConnected().map((node) => node.nodeId)).toEqual(["my-mac-node"]);
+  });
+
+  it("promotes the approved device instead of updating another device with the same node id", () => {
+    const registry = new NodeRegistry();
+    const deviceBClient = makeClient("conn-b", "shared-custom-node", [], {
+      clientId: "node-host",
+      commands: [],
+      deviceId: "device-b",
+    });
+    registry.register(
+      makeClient("conn-a", "shared-custom-node", [], {
+        clientId: "node-host",
+        commands: [],
+        declaredCommands: ["system.run"],
+        deviceId: "device-a",
+      }),
+      {},
+    );
+    registry.register(deviceBClient, {});
+
+    const updated = registry.updateSurface(
+      "shared-custom-node",
+      {
+        caps: ["camera"],
+        commands: ["system.run"],
+        permissions: undefined,
+      },
+      { deviceId: "device-a" },
+    );
+
+    expect(updated?.deviceId).toBe("device-a");
+    expect(updated?.commands).toEqual(["system.run"]);
+    expect(registry.get("shared-custom-node")?.connId).toBe("conn-a");
+    expect((deviceBClient.connect as { commands?: string[] }).commands).toEqual([]);
+  });
+
+  it("evicts superseded same-node sessions when the approved device is already current", () => {
+    const registry = new NodeRegistry();
+    const staleSocket = { send: vi.fn(), close: vi.fn() };
+    const approvedSocket = { send: vi.fn(), close: vi.fn() };
+    const approvedClient = makeClient("conn-a", "shared-custom-node", [], {
+      clientId: "node-host",
+      commands: [],
+      declaredCommands: ["system.run"],
+      deviceId: "device-a",
+      socket: approvedSocket as unknown as GatewayWsClient["socket"],
+    });
+
+    registry.register(
+      makeClient("conn-b", "shared-custom-node", [], {
+        clientId: "node-host",
+        commands: [],
+        declaredCommands: ["system.run"],
+        deviceId: "device-b",
+        socket: staleSocket as unknown as GatewayWsClient["socket"],
+      }),
+      {},
+    );
+    registry.register(approvedClient, {});
+
+    const updated = registry.updateSurface(
+      "shared-custom-node",
+      {
+        caps: [],
+        commands: ["system.run"],
+        permissions: undefined,
+      },
+      { deviceId: "device-a" },
+    );
+
+    expect(updated?.connId).toBe("conn-a");
+    expect(updated?.commands).toEqual(["system.run"]);
+    expect(staleSocket.close).toHaveBeenCalledWith(4001, "node pairing superseded");
+    expect(approvedSocket.close).not.toHaveBeenCalled();
+    expect(registry.unregister("conn-a")).toEqual({
+      nodeId: "shared-custom-node",
+      nodeDisconnected: true,
+      presenceDisconnected: false,
+    });
+    expect(registry.get("shared-custom-node")).toBeUndefined();
+  });
+
+  it("evicts older same-device reconnects so stale approvals cannot be promoted", () => {
+    const registry = new NodeRegistry();
+    const oldSocket = { send: vi.fn(), close: vi.fn() };
+    registry.register(
+      makeClient("conn-old", "shared-custom-node", [], {
+        clientId: "node-host",
+        commands: ["system.run"],
+        declaredCommands: ["system.run"],
+        deviceId: "device-a",
+        socket: oldSocket as unknown as GatewayWsClient["socket"],
+      }),
+      {},
+    );
+
+    registry.register(
+      makeClient("conn-new", "shared-custom-node", [], {
+        clientId: "node-host",
+        commands: [],
+        declaredCommands: ["system.run"],
+        deviceId: "device-a",
+      }),
+      {},
+    );
+
+    expect(oldSocket.close).toHaveBeenCalledWith(4001, "node connection superseded");
+    expect(registry.unregister("conn-old")).toEqual({
+      nodeId: "shared-custom-node",
+      nodeDisconnected: false,
+      presenceDisconnected: false,
+    });
+    expect(registry.unregister("conn-new")).toEqual({
+      nodeId: "shared-custom-node",
+      nodeDisconnected: true,
+      presenceDisconnected: false,
+    });
+    expect(registry.get("shared-custom-node")).toBeUndefined();
+  });
+
+  it("returns old-node cleanup for same-device reconnects under a new node id", () => {
+    const registry = new NodeRegistry();
+    const oldSocket = { send: vi.fn(), close: vi.fn() };
+    registry.register(
+      makeClient("conn-old", "device-fingerprint", [], {
+        clientId: "node-host",
+        deviceId: "device-fingerprint",
+        socket: oldSocket as unknown as GatewayWsClient["socket"],
+      }),
+      {},
+    );
+
+    registry.register(
+      makeClient("conn-new", "my-mac-node", [], {
+        clientId: "node-host",
+        deviceId: "device-fingerprint",
+      }),
+      {},
+    );
+
+    expect(oldSocket.close).toHaveBeenCalledWith(4001, "node connection superseded");
+    expect(registry.unregister("conn-old")).toEqual({
+      nodeId: "device-fingerprint",
+      nodeDisconnected: true,
+      presenceDisconnected: false,
+    });
+    expect(registry.get("device-fingerprint")).toBeUndefined();
+    expect(registry.get("my-mac-node")?.connId).toBe("conn-new");
   });
 
   it("clears effective permissions when explicitly removed", () => {

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -8,12 +8,14 @@ import {
   resolveTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
 import { logRejectedLargePayload } from "../logging/diagnostic-payload.js";
+import { resolveNodeConnectDeviceId, resolveNodeConnectId } from "./node-id.js";
 import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 
 /** Connected node session advertised over Gateway websocket. */
 export type NodeSession = {
   nodeId: string;
+  deviceId?: string;
   connId: string;
   client: GatewayWsClient;
   clientId?: string;
@@ -34,6 +36,12 @@ export type NodeSession = {
   permissions?: Record<string, boolean>;
   pathEnv?: string;
   connectedAtMs: number;
+};
+
+export type NodeUnregisterResult = {
+  nodeId: string;
+  nodeDisconnected: boolean;
+  presenceDisconnected: boolean;
 };
 
 /** Pending invoke awaiting a node.invoke.response. */
@@ -175,13 +183,18 @@ function withSystemRunEventRunId(params: { command: string; params?: unknown }):
 export class NodeRegistry {
   private nodesById = new Map<string, NodeSession>();
   private nodesByConn = new Map<string, string>();
+  private sessionsByConn = new Map<string, NodeSession>();
+  // Internal closes unregister immediately; the WS close event consumes this once
+  // so presence/node cleanup still runs in the transport owner.
+  private preclosedUnregisterResults = new Map<string, NodeUnregisterResult>();
   private pendingInvokes = new Map<string, PendingInvoke>();
   private authorizedSystemRunEvents = new Map<string, AuthorizedSystemRunEvent>();
 
   /** Register a websocket client as the current connection for its node id. */
   register(client: GatewayWsClient, opts: { remoteIp?: string | undefined }) {
     const connect = client.connect;
-    const nodeId = connect.device?.id ?? connect.client.id;
+    const nodeId = resolveNodeConnectId(connect);
+    const deviceId = resolveNodeConnectDeviceId(connect) ?? undefined;
     const caps = Array.isArray(connect.caps) ? connect.caps : [];
     const declaredCaps = Array.isArray((connect as { declaredCaps?: string[] }).declaredCaps)
       ? ((connect as { declaredCaps?: string[] }).declaredCaps ?? [])
@@ -210,6 +223,7 @@ export class NodeRegistry {
         : undefined;
     const session: NodeSession = {
       nodeId,
+      deviceId,
       connId: client.connId,
       client,
       clientId: connect.client.id,
@@ -233,19 +247,38 @@ export class NodeRegistry {
     };
     this.nodesById.set(nodeId, session);
     this.nodesByConn.set(client.connId, nodeId);
+    this.sessionsByConn.set(client.connId, session);
+    if (deviceId) {
+      this.disconnectSessionsForSameDevice(deviceId, client.connId);
+    }
     return session;
   }
 
   /** Unregister one connection and reject invokes tied to that connection. */
-  unregister(connId: string): string | null {
-    const nodeId = this.nodesByConn.get(connId);
+  unregister(connId: string): NodeUnregisterResult | null {
+    const preclosed = this.preclosedUnregisterResults.get(connId);
+    if (preclosed) {
+      this.preclosedUnregisterResults.delete(connId);
+      return preclosed;
+    }
+    const session = this.sessionsByConn.get(connId);
+    const nodeId = session?.nodeId ?? this.nodesByConn.get(connId);
     if (!nodeId) {
       return null;
     }
     this.nodesByConn.delete(connId);
+    this.sessionsByConn.delete(connId);
     const unregistersCurrentNode = this.nodesById.get(nodeId)?.connId === connId;
+    let replacement: NodeSession | undefined;
     if (unregistersCurrentNode) {
-      this.nodesById.delete(nodeId);
+      replacement = this.findLatestSessionForNode(nodeId) ?? undefined;
+      if (replacement) {
+        this.nodesById.set(nodeId, replacement);
+      } else {
+        this.nodesById.delete(nodeId);
+      }
+    } else {
+      replacement = this.nodesById.get(nodeId);
     }
     for (const [id, pending] of this.pendingInvokes.entries()) {
       if (pending.connId !== connId) {
@@ -260,7 +293,11 @@ export class NodeRegistry {
         this.authorizedSystemRunEvents.delete(key);
       }
     }
-    return unregistersCurrentNode ? nodeId : null;
+    return {
+      nodeId,
+      nodeDisconnected: unregistersCurrentNode && !replacement,
+      presenceDisconnected: this.shouldMarkPresenceDisconnected(session),
+    };
   }
 
   /** List connected node sessions. */
@@ -271,6 +308,15 @@ export class NodeRegistry {
   /** Return a connected node session by node id. */
   get(nodeId: string): NodeSession | undefined {
     return this.nodesById.get(nodeId);
+  }
+
+  hasLivePresenceKey(presenceKey: string): boolean {
+    for (const session of this.sessionsByConn.values()) {
+      if (session.client.presenceKey === presenceKey) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** Probe websocket liveness with ping/pong when the socket supports it. */
@@ -373,10 +419,21 @@ export class NodeRegistry {
       commands: readonly string[];
       permissions?: Record<string, boolean> | undefined;
     },
+    opts: { deviceId?: string | undefined } = {},
   ): NodeSession | null {
-    const node = this.nodesById.get(nodeId);
+    let node = this.nodesById.get(nodeId);
     if (!node) {
       return null;
+    }
+    const expectedDeviceId = normalizeString(opts.deviceId);
+    if (expectedDeviceId) {
+      this.disconnectSessionsForOtherDevices(nodeId, expectedDeviceId);
+      const replacement = this.findLatestSessionForNode(nodeId, expectedDeviceId);
+      if (!replacement) {
+        return null;
+      }
+      this.nodesById.set(nodeId, replacement);
+      node = replacement;
     }
 
     // Runtime approvals can only narrow capabilities/commands/permissions declared at connect.
@@ -396,28 +453,29 @@ export class NodeRegistry {
       if (surface.permissions === undefined) {
         node.permissions = undefined;
         (node.client.connect as { permissions?: Record<string, boolean> }).permissions = undefined;
-        return node;
+      } else {
+        const declared = node.declaredPermissions ?? {};
+        const nextEntries: Array<[string, boolean]> = [];
+        for (const [key, declaredValue] of Object.entries(declared)) {
+          if (!declaredValue) {
+            nextEntries.push([key, false]);
+            continue;
+          }
+          const approvedValue = surface.permissions?.[key];
+          if (approvedValue) {
+            nextEntries.push([key, true]);
+            continue;
+          }
+          if (approvedValue !== undefined) {
+            nextEntries.push([key, false]);
+          }
+        }
+        const nextPermissions =
+          nextEntries.length > 0 ? Object.fromEntries(nextEntries) : undefined;
+        node.permissions = nextPermissions;
+        (node.client.connect as { permissions?: Record<string, boolean> }).permissions =
+          nextPermissions;
       }
-      const declared = node.declaredPermissions ?? {};
-      const nextEntries: Array<[string, boolean]> = [];
-      for (const [key, declaredValue] of Object.entries(declared)) {
-        if (!declaredValue) {
-          nextEntries.push([key, false]);
-          continue;
-        }
-        const approvedValue = surface.permissions?.[key];
-        if (approvedValue) {
-          nextEntries.push([key, true]);
-          continue;
-        }
-        if (approvedValue !== undefined) {
-          nextEntries.push([key, false]);
-        }
-      }
-      const nextPermissions = nextEntries.length > 0 ? Object.fromEntries(nextEntries) : undefined;
-      node.permissions = nextPermissions;
-      (node.client.connect as { permissions?: Record<string, boolean> }).permissions =
-        nextPermissions;
     }
 
     return node;
@@ -637,6 +695,60 @@ export class NodeRegistry {
     sessionKey?: string;
   }): string {
     return `${params.nodeId}\0${params.connId}\0${params.sessionKey ?? ""}\0${params.runId}`;
+  }
+
+  private findLatestSessionForNode(nodeId: string, deviceId?: string): NodeSession | null {
+    let match: NodeSession | null = null;
+    for (const session of this.sessionsByConn.values()) {
+      if (session.nodeId !== nodeId) {
+        continue;
+      }
+      if (deviceId && session.deviceId !== deviceId) {
+        continue;
+      }
+      match = session;
+    }
+    return match;
+  }
+
+  private disconnectSessionsForOtherDevices(nodeId: string, deviceId: string): void {
+    // Approval closes stale same-node owners while unregister mutates the session map.
+    // Snapshot first so no superseded connection can survive and later be promoted.
+    for (const session of Array.from(this.sessionsByConn.values())) {
+      if (session.nodeId === nodeId && session.deviceId !== deviceId) {
+        this.disconnectSession(session, 4001, "node pairing superseded");
+      }
+    }
+  }
+
+  private disconnectSessionsForSameDevice(deviceId: string, exceptConnId: string): void {
+    // Reconnects from one authenticated device replace older sockets for that device.
+    // Leaving them promotable can resurrect stale command approvals after removal.
+    for (const session of Array.from(this.sessionsByConn.values())) {
+      if (session.connId !== exceptConnId && session.deviceId === deviceId) {
+        this.disconnectSession(session, 4001, "node connection superseded");
+      }
+    }
+  }
+
+  private disconnectSession(session: NodeSession, code: number, reason: string): void {
+    const unregisterResult = this.unregister(session.connId);
+    if (unregisterResult) {
+      this.preclosedUnregisterResults.set(session.connId, unregisterResult);
+    }
+    try {
+      session.client.socket.close(code, reason);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private shouldMarkPresenceDisconnected(session: NodeSession | undefined): boolean {
+    const presenceKey = session?.client.presenceKey;
+    if (!presenceKey) {
+      return false;
+    }
+    return !this.hasLivePresenceKey(presenceKey);
   }
 
   handleInvokeResult(params: {

--- a/src/gateway/server-methods/nodes-pending.ts
+++ b/src/gateway/server-methods/nodes-pending.ts
@@ -6,6 +6,7 @@ import {
   validateNodePendingDrainParams,
   validateNodePendingEnqueueParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveClientNodeId } from "../node-id.js";
 import {
   drainNodePendingWork,
   enqueueNodePendingWork,
@@ -21,14 +22,6 @@ import {
   waitForNodeReconnect,
 } from "./nodes.js";
 import type { GatewayRequestHandlers } from "./types.js";
-
-function resolveClientNodeId(
-  client: { connect?: { device?: { id?: string }; client?: { id?: string } } } | null,
-): string | null {
-  const nodeId = client?.connect?.device?.id ?? client?.connect?.client?.id ?? "";
-  const trimmed = nodeId.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
 
 /** Gateway handlers for queueing work until a paired node reconnects. */
 export const nodePendingHandlers: GatewayRequestHandlers = {

--- a/src/gateway/server-methods/nodes.handlers.invoke-result.ts
+++ b/src/gateway/server-methods/nodes.handlers.invoke-result.ts
@@ -4,6 +4,7 @@ import {
   errorShape,
   validateNodeInvokeResultParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveClientNodeId } from "../node-id.js";
 import { respondInvalidParams } from "./nodes.helpers.js";
 import type { GatewayRequestHandler } from "./types.js";
 
@@ -51,7 +52,7 @@ export const handleNodeInvokeResult: GatewayRequestHandler = async ({
     payloadJSON?: string | null;
     error?: { code?: string; message?: string } | null;
   };
-  const callerNodeId = client?.connect?.device?.id ?? client?.connect?.client?.id;
+  const callerNodeId = resolveClientNodeId(client);
   if (callerNodeId && callerNodeId !== p.nodeId) {
     respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "nodeId mismatch"));
     return;

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -58,6 +58,7 @@ import {
   normalizeDeclaredNodeCommands,
   resolveNodeCommandAllowlist,
 } from "../node-command-policy.js";
+import { resolveClientNodeId } from "../node-id.js";
 import { applyPluginNodeInvokePolicy } from "../node-invoke-plugin-policy.js";
 import { sanitizeNodeInvokeParamsForForwarding } from "../node-invoke-sanitize.js";
 import type { NodeSession } from "../node-registry.js";
@@ -801,13 +802,32 @@ export const nodeHandlers: GatewayRequestHandlers = {
         declaredCommands: approvedNode.commands ?? [],
         allowlist: currentAllowlist,
       });
-      const updatedNode = context.nodeRegistry.updateSurface(approvedNode.nodeId, {
-        caps: approvedNode.caps ?? [],
-        commands: currentAllowedCommands,
-        permissions: approvedNode.permissions,
-      });
+      const updatedNode = context.nodeRegistry.updateSurface(
+        approvedNode.nodeId,
+        {
+          caps: approvedNode.caps ?? [],
+          commands: currentAllowedCommands,
+          permissions: approvedNode.permissions,
+        },
+        {
+          deviceId: approvedNode.deviceId,
+        },
+      );
       if (updatedNode) {
         refreshConnectedNodeSurfaceCaches({ context, nodeSession: updatedNode, cfg });
+      }
+      const resolvedAt = Date.now();
+      for (const superseded of approved.superseded ?? []) {
+        context.broadcast(
+          "node.pair.resolved",
+          {
+            requestId: superseded.requestId,
+            nodeId: superseded.nodeId,
+            decision: "rejected",
+            ts: resolvedAt,
+          },
+          { dropIfSlow: true },
+        );
       }
       context.broadcast(
         "node.pair.resolved",
@@ -815,7 +835,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
           requestId,
           nodeId: approvedNode.nodeId,
           decision: "approved",
-          ts: Date.now(),
+          ts: resolvedAt,
         },
         { dropIfSlow: true },
       );
@@ -1009,8 +1029,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
       });
       return;
     }
-    const nodeId = client?.connect?.device?.id ?? client?.connect?.client?.id;
-    const trimmedNodeId = normalizeOptionalString(nodeId) ?? "";
+    const trimmedNodeId = resolveClientNodeId(client) ?? "";
     if (!trimmedNodeId) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "nodeId required"));
       return;
@@ -1044,8 +1063,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
       });
       return;
     }
-    const nodeId = client?.connect?.device?.id ?? client?.connect?.client?.id;
-    const trimmedNodeId = normalizeOptionalString(nodeId) ?? "";
+    const trimmedNodeId = resolveClientNodeId(client) ?? "";
     if (!trimmedNodeId) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "nodeId required"));
       return;
@@ -1384,7 +1402,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
           : null;
     await respondUnavailableOnThrow(respond, async () => {
       const { handleNodeEvent } = await import("../server-node-events.js");
-      const nodeId = client?.connect?.device?.id ?? client?.connect?.client?.id ?? "node";
+      const nodeId = resolveClientNodeId(client) ?? "node";
       const nodeContext: NodeEventContext = {
         deps: context.deps,
         broadcast: context.broadcast,

--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -17,8 +17,10 @@ import {
 } from "./device-authz.test-helpers.js";
 import { connectGatewayClient } from "./test-helpers.e2e.js";
 import {
+  connectReq,
   connectOk,
   installGatewayTestHooks,
+  onceMessage,
   rpcReq,
   startServerWithClient,
 } from "./test-helpers.js";
@@ -44,6 +46,7 @@ async function connectNodeClient(params: {
   port: number;
   deviceIdentity: ReturnType<typeof loadDeviceIdentity>["identity"];
   commands: string[];
+  nodeId?: string;
 }) {
   return await connectGatewayClient({
     url: `ws://127.0.0.1:${params.port}`,
@@ -57,6 +60,7 @@ async function connectNodeClient(params: {
     mode: GATEWAY_CLIENT_MODES.NODE,
     scopes: [],
     commands: params.commands,
+    nodeId: params.nodeId,
     deviceIdentity: params.deviceIdentity,
     timeoutMessage: "timeout waiting for paired node to connect",
   });
@@ -293,6 +297,56 @@ describe("gateway node pairing authorization", () => {
   });
 
   describeWithGatewayServer("rpc approval scopes", (getStarted) => {
+    test("broadcasts rejected resolutions for conflicting pending custom node ids", async () => {
+      const started = getStarted();
+      const ws = await openTrackedWs(started.port);
+      try {
+        await connectOk(ws, {
+          token: "secret",
+          scopes: ["operator.pairing"],
+          deviceIdentityPath: `${await makeNodePairingStateDir()}/operator-conflict.json`,
+        });
+        const first = await requestNodePairing({
+          nodeId: "custom-conflict-node",
+          deviceId: "device-a",
+          platform: "macos",
+        });
+        const second = await requestNodePairing({
+          nodeId: "custom-conflict-node",
+          deviceId: "device-b",
+          platform: "macos",
+        });
+        const rejectedResolution = onceMessage<{
+          type?: string;
+          event?: string;
+          payload?: { requestId?: string; nodeId?: string; decision?: string };
+        }>(
+          ws,
+          (obj) =>
+            obj.type === "event" &&
+            obj.event === "node.pair.resolved" &&
+            obj.payload?.requestId === second.request.requestId,
+        );
+
+        const approve = await rpcReq(ws, "node.pair.approve", {
+          requestId: first.request.requestId,
+        });
+        expect(approve.ok).toBe(true);
+
+        await expect(rejectedResolution).resolves.toMatchObject({
+          type: "event",
+          event: "node.pair.resolved",
+          payload: {
+            requestId: second.request.requestId,
+            nodeId: "custom-conflict-node",
+            decision: "rejected",
+          },
+        });
+      } finally {
+        ws.close();
+      }
+    });
+
     test("rejects system.run node pairing approval without admin scope through rpc", async () => {
       await expectRpcNodePairingApprovalRejected({
         started: getStarted(),
@@ -315,6 +369,96 @@ describe("gateway node pairing authorization", () => {
   });
 
   describeWithGatewayServer("paired node reconnects", (getStarted) => {
+    test("rejects node-host node ids that were not covered by device auth", async () => {
+      const started = getStarted();
+      const pairedNode = await pairDeviceIdentity({
+        name: "unsigned-custom-node-id",
+        role: "node",
+        scopes: [],
+        clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+        clientMode: GATEWAY_CLIENT_MODES.NODE,
+      });
+      const ws = await openTrackedWs(started.port);
+      try {
+        const res = await connectReq(ws, {
+          token: "secret",
+          role: "node",
+          client: {
+            id: GATEWAY_CLIENT_NAMES.NODE_HOST,
+            displayName: "unsigned-node-id",
+            version: "1.0.0",
+            platform: "macos",
+            deviceFamily: "Mac",
+            mode: GATEWAY_CLIENT_MODES.NODE,
+          },
+          scopes: [],
+          commands: [],
+          nodeId: "my-mac-node",
+          deviceIdentityPath: pairedNode.identityPath,
+        });
+
+        expect(res.ok).toBe(false);
+        expect(res.error?.details).toMatchObject({
+          reason: "node-id-signature",
+        });
+      } finally {
+        ws.close();
+      }
+    });
+
+    test("uses an explicit node-host node id for catalog and describe", async () => {
+      const started = getStarted();
+      const customNodeId = "my-mac-node";
+      const pairedNode = await pairDeviceIdentity({
+        name: "custom-node-host",
+        role: "node",
+        scopes: [],
+        clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+        clientMode: GATEWAY_CLIENT_MODES.NODE,
+      });
+
+      let controlWs: WebSocket | undefined;
+      let nodeClient: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+      try {
+        controlWs = await openTrackedWs(started.port);
+        await connectOk(controlWs, { token: "secret" });
+        nodeClient = await connectNodeClient({
+          port: started.port,
+          deviceIdentity: pairedNode.identity,
+          commands: [],
+          nodeId: customNodeId,
+        });
+
+        const connectedControlWs = controlWs;
+        await vi.waitFor(async () => {
+          const list = await rpcReq<{
+            nodes?: Array<{ nodeId: string; connected?: boolean; displayName?: string }>;
+          }>(connectedControlWs, "node.list", {});
+          const node = (list.payload?.nodes ?? []).find((entry) => entry.nodeId === customNodeId);
+          if (node?.connected) {
+            return;
+          }
+          throw new Error(`custom node id not visible yet: ${JSON.stringify(list.payload)}`);
+        });
+
+        const describeResult = await rpcReq<{ nodeId?: string; connected?: boolean }>(
+          connectedControlWs,
+          "node.describe",
+          { nodeId: customNodeId },
+        );
+        expect(describeResult.ok).toBe(true);
+        expect(describeResult.payload?.nodeId).toBe(customNodeId);
+        expect(describeResult.payload?.connected).toBe(true);
+
+        const pairing = await listNodePairing();
+        const pending = pairing.pending?.find((entry) => entry.nodeId === customNodeId);
+        expect(pending?.nodeId).toBe(customNodeId);
+      } finally {
+        controlWs?.close();
+        await nodeClient?.stopAndWait();
+      }
+    });
+
     test("requests re-pairing when a paired node reconnects with upgraded commands", async () => {
       await expectRePairingRequest({
         started: getStarted(),

--- a/src/gateway/server/ws-connection.test-helpers.ts
+++ b/src/gateway/server/ws-connection.test-helpers.ts
@@ -41,12 +41,18 @@ export function createResolvedGatewayTokenAuth(token: string): ResolvedGatewayAu
 
 export function createGatewayWsTestRequestContext(
   overrides: {
-    nodeRegistry?: { unregister: ReturnType<typeof vi.fn> };
+    nodeRegistry?: {
+      unregister: ReturnType<typeof vi.fn>;
+      hasLivePresenceKey?: ReturnType<typeof vi.fn>;
+    };
   } = {},
 ) {
   return {
     unsubscribeAllSessionEvents: vi.fn(),
-    nodeRegistry: overrides.nodeRegistry ?? { unregister: vi.fn() },
+    nodeRegistry: overrides.nodeRegistry ?? {
+      unregister: vi.fn(),
+      hasLivePresenceKey: vi.fn(() => false),
+    },
     nodeUnsubscribeAll: vi.fn(),
   };
 }

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -199,12 +199,15 @@ describe("attachGatewayWsConnectionHandler", () => {
 
   it("skips node presence disconnects for stale reconnected sockets", async () => {
     const unregister = vi.fn(() => null);
+    const hasLivePresenceKey = vi.fn(() => true);
     const { socket } = attachGatewayWsForTest({
       attach: attachGatewayWsConnectionHandler,
       options: {
         refreshHealthSnapshot: vi.fn(),
         buildRequestContext: () =>
-          createGatewayWsTestRequestContext({ nodeRegistry: { unregister } }) as never,
+          createGatewayWsTestRequestContext({
+            nodeRegistry: { unregister, hasLivePresenceKey },
+          }) as never,
       },
     });
     await waitForLazyMessageHandler();
@@ -229,7 +232,51 @@ describe("attachGatewayWsConnectionHandler", () => {
     socket.emit("close", 1000, Buffer.from("stale"));
 
     expect(unregister).toHaveBeenCalledTimes(1);
+    expect(hasLivePresenceKey).toHaveBeenCalledWith("node-1");
     expect(upsertPresenceMock).not.toHaveBeenCalled();
     expect(broadcastPresenceSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("marks replaced node device presence disconnected without clearing active node state", async () => {
+    const unregister = vi.fn(() => ({
+      nodeId: "shared-custom-node",
+      nodeDisconnected: false,
+      presenceDisconnected: true,
+    }));
+    const context = createGatewayWsTestRequestContext({
+      nodeRegistry: { unregister, hasLivePresenceKey: vi.fn(() => false) },
+    });
+    const { socket } = attachGatewayWsForTest({
+      attach: attachGatewayWsConnectionHandler,
+      options: {
+        refreshHealthSnapshot: vi.fn(),
+        buildRequestContext: () => context as never,
+      },
+    });
+    await waitForLazyMessageHandler();
+
+    const passed = firstAttachedHandlerParams() as {
+      setClient: (client: unknown) => boolean;
+    };
+    expect(
+      passed.setClient({
+        socket,
+        connect: {
+          role: "node",
+          client: { id: "openclaw-macos", mode: "node" },
+          nodeId: "shared-custom-node",
+          device: { id: "device-b" },
+        },
+        connId: "conn-b",
+        presenceKey: "device-b",
+        usesSharedGatewayAuth: false,
+      }),
+    ).toBe(true);
+
+    socket.emit("close", 4001, Buffer.from("node pairing superseded"));
+
+    expect(upsertPresenceMock).toHaveBeenCalledWith("device-b", { reason: "disconnect" });
+    expect(broadcastPresenceSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(context.nodeUnsubscribeAll).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -476,21 +476,27 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       }
       const context = buildRequestContext();
       context.unsubscribeAllSessionEvents(connId);
-      let currentDisconnectedNodeId: string | null = null;
+      let disconnectedNodeId: string | null = null;
+      let shouldMarkPresenceDisconnected = client?.connect?.role !== "node";
       if (client?.connect?.role === "node") {
-        currentDisconnectedNodeId = context.nodeRegistry.unregister(connId);
+        const unregisterResult = context.nodeRegistry.unregister(connId);
+        if (unregisterResult) {
+          shouldMarkPresenceDisconnected = unregisterResult.presenceDisconnected;
+          disconnectedNodeId = unregisterResult.nodeDisconnected ? unregisterResult.nodeId : null;
+        } else {
+          shouldMarkPresenceDisconnected = client.presenceKey
+            ? !context.nodeRegistry.hasLivePresenceKey(client.presenceKey)
+            : false;
+        }
       }
-      if (
-        client?.presenceKey &&
-        (client.connect.role !== "node" || currentDisconnectedNodeId !== null)
-      ) {
+      if (client?.presenceKey && shouldMarkPresenceDisconnected) {
         upsertPresence(client.presenceKey, { reason: "disconnect" });
         broadcastPresenceSnapshot({ broadcast, incrementPresenceVersion, getHealthVersion });
       }
-      if (currentDisconnectedNodeId) {
-        removeRemoteNodeInfo(currentDisconnectedNodeId);
-        context.nodeUnsubscribeAll(currentDisconnectedNodeId);
-        clearNodeWakeState(currentDisconnectedNodeId);
+      if (disconnectedNodeId) {
+        removeRemoteNodeInfo(disconnectedNodeId);
+        context.nodeUnsubscribeAll(disconnectedNodeId);
+        clearNodeWakeState(disconnectedNodeId);
       }
       logWs("out", "close", {
         connId,

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -8,7 +8,11 @@ import type { ConnectParams } from "../../../../packages/gateway-protocol/src/in
 import { verifyDeviceSignature } from "../../../infra/device-identity.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult } from "../../auth.js";
-import { buildDeviceAuthPayload, buildDeviceAuthPayloadV3 } from "../../device-auth.js";
+import {
+  buildDeviceAuthPayload,
+  buildDeviceAuthPayloadV3,
+  buildDeviceAuthPayloadV4,
+} from "../../device-auth.js";
 import {
   isLoopbackAddress,
   isLoopbackHost,
@@ -319,7 +323,7 @@ export function resolveDeviceSignaturePayloadVersion(params: {
   scopes: string[];
   signedAtMs: number;
   nonce: string;
-}): "v3" | "v2" | null {
+}): "v4" | "v3" | "v2" | null {
   const signatureToken = resolveSignatureToken(params.connectParams);
   const basePayload = {
     deviceId: params.device.id,
@@ -331,6 +335,16 @@ export function resolveDeviceSignaturePayloadVersion(params: {
     token: signatureToken,
     nonce: params.nonce,
   };
+  const payloadV4 = buildDeviceAuthPayloadV4({
+    ...basePayload,
+    platform: params.connectParams.client.platform,
+    deviceFamily: params.connectParams.client.deviceFamily,
+    nodeId: params.connectParams.nodeId,
+  });
+  if (verifyDeviceSignature(params.device.publicKey, payloadV4, params.device.signature)) {
+    return "v4";
+  }
+
   const payloadV3 = buildDeviceAuthPayloadV3({
     ...basePayload,
     platform: params.connectParams.client.platform,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -105,7 +105,11 @@ import {
   isTrustedProxyAddress,
   resolveClientIp,
 } from "../../net.js";
-import { reconcileNodePairingOnConnect } from "../../node-connect-reconcile.js";
+import {
+  NodePairingDeviceMismatchError,
+  reconcileNodePairingOnConnect,
+} from "../../node-connect-reconcile.js";
+import { resolveNodeConnectId } from "../../node-id.js";
 import {
   resolveNodePairingClientIpSource,
   shouldAutoApproveNodePairingFromTrustedCidrs,
@@ -752,7 +756,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
 
         const deviceRaw = connectParams.device;
         let devicePublicKey: string | null = null;
-        let deviceAuthPayloadVersion: "v2" | "v3" | null = null;
+        let deviceAuthPayloadVersion: "v2" | "v3" | "v4" | null = null;
         const hasTokenAuth = Boolean(connectParams.auth?.token);
         const hasPasswordAuth = Boolean(connectParams.auth?.password);
         const hasSharedAuth = hasTokenAuth || hasPasswordAuth;
@@ -1000,6 +1004,26 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             rejectDeviceAuthInvalid("device-public-key", "device public key invalid");
             return;
           }
+        }
+        if (
+          typeof connectParams.nodeId === "string" &&
+          connectParams.nodeId.trim().length > 0 &&
+          deviceAuthPayloadVersion !== "v4"
+        ) {
+          setHandshakeState("failed");
+          setCloseCause("device-auth-invalid", {
+            reason: "node-id-signature",
+            client: connectParams.client.id,
+            deviceId: device?.id,
+          });
+          sendHandshakeErrorResponse(ErrorCodes.INVALID_REQUEST, "node id signature required", {
+            details: {
+              code: ConnectErrorDetailCodes.DEVICE_AUTH_SIGNATURE_INVALID,
+              reason: "node-id-signature",
+            },
+          });
+          close(1008, "node id signature required");
+          return;
         }
 
         const authDecision = await resolveConnectAuthDecision({
@@ -1615,9 +1639,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         }
         if (role === "node") {
           let reconciliation: Awaited<ReturnType<typeof reconcileNodePairingOnConnect>>;
-          const pairedNode = await getPairedNode(
-            connectParams.device?.id ?? connectParams.client.id,
-          );
+          const pairedNode = await getPairedNode(resolveNodeConnectId(connectParams));
           try {
             reconciliation = await reconcileNodePairingOnConnect({
               cfg: getRuntimeConfig(),
@@ -1642,6 +1664,22 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               },
             });
           } catch (error) {
+            if (error instanceof NodePairingDeviceMismatchError) {
+              markHandshakeFailure("node-pairing-device-mismatch", {
+                nodeId: error.nodeId,
+                deviceId: error.deviceId ?? undefined,
+              });
+              sendHandshakeErrorResponse(ErrorCodes.NOT_PAIRED, "node pairing required", {
+                details: {
+                  code: ConnectErrorDetailCodes.PAIRING_REQUIRED,
+                  reason: "node-device-mismatch",
+                  nodeId: error.nodeId,
+                  deviceId: error.deviceId,
+                },
+              });
+              close(1008, "node pairing required");
+              return;
+            }
             if (error instanceof NodePairingRateLimitError) {
               rejectUnauthorized({
                 ok: false,

--- a/src/gateway/test-helpers.e2e.ts
+++ b/src/gateway/test-helpers.e2e.ts
@@ -47,6 +47,7 @@ export async function connectGatewayClient(params: {
   caps?: string[];
   commands?: string[];
   instanceId?: string;
+  nodeId?: string;
   deviceIdentity?: DeviceIdentity;
   onEvent?: (evt: { event?: string; payload?: unknown }) => void;
   connectChallengeTimeoutMs?: number;
@@ -109,6 +110,7 @@ export async function connectGatewayClient(params: {
       caps: params.caps,
       commands: params.commands,
       instanceId: params.instanceId,
+      nodeId: params.nodeId,
       deviceIdentity,
       onEvent: params.onEvent,
       onHelloOk: () => stop(undefined, client),

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -877,6 +877,7 @@ type ConnectReqOptions = {
   scopes?: string[];
   caps?: string[];
   commands?: string[];
+  nodeId?: string;
   permissions?: Record<string, boolean>;
   device?: ConnectReqDevice | null;
   deviceIdentityPath?: string;
@@ -1075,6 +1076,7 @@ export async function connectReq(
         client,
         caps: opts?.caps ?? [],
         commands: opts?.commands ?? [],
+        nodeId: opts?.nodeId,
         permissions: opts?.permissions ?? undefined,
         role,
         scopes: requestedScopes,

--- a/src/infra/node-pairing.test.ts
+++ b/src/infra/node-pairing.test.ts
@@ -153,6 +153,265 @@ describe("node pairing tokens", () => {
     });
   });
 
+  test("persists node-host device binding through approval", async () => {
+    await withNodePairingDir(async (baseDir) => {
+      const request = await requestNodePairing(
+        {
+          nodeId: "my-mac-node",
+          deviceId: "device-fingerprint",
+          platform: "macos",
+        },
+        baseDir,
+      );
+
+      expect(request.request.deviceId).toBe("device-fingerprint");
+
+      await approveNodePairing(
+        request.request.requestId,
+        { callerScopes: ["operator.pairing"] },
+        baseDir,
+      );
+
+      const paired = await getPairedNode("my-mac-node", baseDir);
+      expect(paired?.deviceId).toBe("device-fingerprint");
+    });
+  });
+
+  test("rekeys stale same-device approvals to the approved custom node id", async () => {
+    await withNodePairingDir(async (baseDir) => {
+      const deviceRequest = await requestNodePairing(
+        {
+          nodeId: "device-fingerprint",
+          deviceId: "device-fingerprint",
+          platform: "macos",
+          commands: ["screen.snapshot"],
+        },
+        baseDir,
+      );
+      const deviceApproval = await approveNodePairing(
+        deviceRequest.request.requestId,
+        { callerScopes: ["operator.pairing", "operator.write"] },
+        baseDir,
+      );
+      const deviceRecord = requireRecord(deviceApproval);
+      const deviceNode = requireRecord(deviceRecord.node);
+
+      const customRequest = await requestNodePairing(
+        {
+          nodeId: "my-mac-node",
+          deviceId: "device-fingerprint",
+          platform: "macos",
+          commands: ["screen.snapshot", "system.run"],
+        },
+        baseDir,
+      );
+      const customApproval = await approveNodePairing(
+        customRequest.request.requestId,
+        { callerScopes: ["operator.pairing", "operator.write", "operator.admin"] },
+        baseDir,
+      );
+      const customRecord = requireRecord(customApproval);
+      const customNode = requireRecord(customRecord.node);
+
+      await expect(getPairedNode("device-fingerprint", baseDir)).resolves.toBeNull();
+      const paired = await getPairedNode("my-mac-node", baseDir);
+      expect(paired?.deviceId).toBe("device-fingerprint");
+      expect(customNode.createdAtMs).toBe(deviceNode.createdAtMs);
+
+      const pairing = await listNodePairing(baseDir);
+      expect(pairing.paired.map((entry) => entry.nodeId)).toEqual(["my-mac-node"]);
+    });
+  });
+
+  test("supersedes same-device pending requests when the visible node id changes", async () => {
+    await withNodePairingDir(async (baseDir) => {
+      const deviceRequest = await requestNodePairing(
+        {
+          nodeId: "device-fingerprint",
+          deviceId: "device-fingerprint",
+          platform: "macos",
+          commands: ["screen.snapshot"],
+        },
+        baseDir,
+      );
+
+      const customRequest = await requestNodePairing(
+        {
+          nodeId: "my-mac-node",
+          deviceId: "device-fingerprint",
+          platform: "macos",
+          commands: ["screen.snapshot"],
+        },
+        baseDir,
+      );
+
+      expect(customRequest.created).toBe(true);
+      expect(customRequest.request.nodeId).toBe("my-mac-node");
+      expect(customRequest.superseded).toEqual([
+        { requestId: deviceRequest.request.requestId, nodeId: "device-fingerprint" },
+      ]);
+
+      const pairing = await listNodePairing(baseDir);
+      expect(pairing.pending.map((entry) => entry.requestId)).toEqual([
+        customRequest.request.requestId,
+      ]);
+      await expect(
+        approveNodePairing(
+          deviceRequest.request.requestId,
+          { callerScopes: ["operator.pairing", "operator.write"] },
+          baseDir,
+        ),
+      ).resolves.toBeNull();
+
+      await approveNodePairing(
+        customRequest.request.requestId,
+        { callerScopes: ["operator.pairing", "operator.write"] },
+        baseDir,
+      );
+      await expect(getPairedNode("device-fingerprint", baseDir)).resolves.toBeNull();
+      expect((await getPairedNode("my-mac-node", baseDir))?.deviceId).toBe("device-fingerprint");
+    });
+  });
+
+  test("keeps unrelated legacy pending requests when approving without a device id", async () => {
+    await withNodePairingDir(async (baseDir) => {
+      const first = await requestNodePairing(
+        {
+          nodeId: "legacy-node-a",
+          platform: "darwin",
+        },
+        baseDir,
+      );
+      const second = await requestNodePairing(
+        {
+          nodeId: "legacy-node-b",
+          platform: "darwin",
+        },
+        baseDir,
+      );
+
+      await approveNodePairing(
+        first.request.requestId,
+        { callerScopes: ["operator.pairing"] },
+        baseDir,
+      );
+
+      const pairing = await listNodePairing(baseDir);
+      expect(pairing.pending.map((entry) => entry.requestId)).toEqual([second.request.requestId]);
+      expect(pairing.paired.map((entry) => entry.nodeId)).toEqual(["legacy-node-a"]);
+    });
+  });
+
+  test("preserves an existing device binding when approving an unbound same-node request", async () => {
+    await withNodePairingDir(async (baseDir) => {
+      const initial = await requestNodePairing(
+        {
+          nodeId: "my-mac-node",
+          deviceId: "device-fingerprint",
+          platform: "macos",
+          commands: ["screen.snapshot"],
+        },
+        baseDir,
+      );
+      await approveNodePairing(
+        initial.request.requestId,
+        { callerScopes: ["operator.pairing", "operator.write"] },
+        baseDir,
+      );
+
+      const upgrade = await requestNodePairing(
+        {
+          nodeId: "my-mac-node",
+          platform: "macos",
+          commands: ["screen.snapshot", "system.run"],
+        },
+        baseDir,
+      );
+      await approveNodePairing(
+        upgrade.request.requestId,
+        { callerScopes: ["operator.pairing", "operator.write", "operator.admin"] },
+        baseDir,
+      );
+
+      const paired = await getPairedNode("my-mac-node", baseDir);
+      expect(paired?.deviceId).toBe("device-fingerprint");
+      expect(paired?.commands).toEqual(["screen.snapshot", "system.run"]);
+    });
+  });
+
+  test("keeps conflicting pending device bindings separate until approval", async () => {
+    await withNodePairingDir(async (baseDir) => {
+      const first = await requestNodePairing(
+        {
+          nodeId: "shared-custom-node",
+          deviceId: "device-a",
+          platform: "macos",
+        },
+        baseDir,
+      );
+      const second = await requestNodePairing(
+        {
+          nodeId: "shared-custom-node",
+          deviceId: "device-b",
+          platform: "macos",
+        },
+        baseDir,
+      );
+
+      expect(second.created).toBe(true);
+      expect(second.request.requestId).not.toBe(first.request.requestId);
+
+      let pairing = await listNodePairing(baseDir);
+      expect(pairing.pending.filter((entry) => entry.nodeId === "shared-custom-node")).toHaveLength(
+        2,
+      );
+
+      await approveNodePairing(
+        first.request.requestId,
+        { callerScopes: ["operator.pairing"] },
+        baseDir,
+      );
+
+      pairing = await listNodePairing(baseDir);
+      expect(pairing.pending.filter((entry) => entry.nodeId === "shared-custom-node")).toHaveLength(
+        0,
+      );
+      expect((await getPairedNode("shared-custom-node", baseDir))?.deviceId).toBe("device-a");
+    });
+  });
+
+  test("returns superseded pending requests when one conflicting device is approved", async () => {
+    await withNodePairingDir(async (baseDir) => {
+      const first = await requestNodePairing(
+        {
+          nodeId: "shared-custom-node",
+          deviceId: "device-a",
+          platform: "macos",
+        },
+        baseDir,
+      );
+      const second = await requestNodePairing(
+        {
+          nodeId: "shared-custom-node",
+          deviceId: "device-b",
+          platform: "macos",
+        },
+        baseDir,
+      );
+
+      await expect(
+        approveNodePairing(
+          first.request.requestId,
+          { callerScopes: ["operator.pairing"] },
+          baseDir,
+        ),
+      ).resolves.toMatchObject({
+        requestId: first.request.requestId,
+        superseded: [{ requestId: second.request.requestId, nodeId: "shared-custom-node" }],
+      });
+    });
+  });
+
   test("supersedes pending requests when the approval surface changes", async () => {
     await withNodePairingDir(async (baseDir) => {
       const first = await requestNodePairing(

--- a/src/infra/node-pairing.ts
+++ b/src/infra/node-pairing.ts
@@ -18,6 +18,7 @@ import { generatePairingToken, verifyPairingToken } from "./pairing-token.js";
 
 type NodeDeclaredSurface = {
   nodeId: string;
+  deviceId?: string;
   clientId?: string;
   clientMode?: string;
   displayName?: string;
@@ -95,6 +96,7 @@ function buildPendingNodePairingRequest(params: {
   return {
     requestId: params.requestId ?? randomUUID(),
     nodeId: params.req.nodeId,
+    deviceId: params.req.deviceId,
     clientId: params.req.clientId,
     clientMode: params.req.clientMode,
     displayName: params.req.displayName,
@@ -121,6 +123,7 @@ function refreshPendingNodePairingRequest(
     ...existing,
     clientId: incoming.clientId ?? existing.clientId,
     clientMode: incoming.clientMode ?? existing.clientMode,
+    deviceId: incoming.deviceId ?? existing.deviceId,
     displayName: incoming.displayName ?? existing.displayName,
     platform: incoming.platform ?? existing.platform,
     version: incoming.version ?? existing.version,
@@ -161,6 +164,7 @@ function mergeNodePairingReplacementInput(params: {
   const latest = params.existing[0];
   return {
     nodeId: params.incoming.nodeId,
+    deviceId: params.incoming.deviceId ?? latest?.deviceId,
     clientId: params.incoming.clientId ?? latest?.clientId,
     clientMode: params.incoming.clientMode ?? latest?.clientMode,
     displayName: params.incoming.displayName ?? latest?.displayName,
@@ -194,7 +198,11 @@ function toPendingNodePairingEntry(pending: NodePairingPendingRequest): NodePair
   };
 }
 
-type ApprovedNodePairingResult = { requestId: string; node: NodePairingPairedNode };
+type ApprovedNodePairingResult = {
+  requestId: string;
+  node: NodePairingPairedNode;
+  superseded?: NodePairingSupersededRequest[];
+};
 type ForbiddenNodePairingResult = { status: "forbidden"; missingScope: string };
 type ApproveNodePairingResult = ApprovedNodePairingResult | ForbiddenNodePairingResult | null;
 
@@ -222,6 +230,97 @@ async function persistState(state: NodePairingStateFile, baseDir?: string) {
 
 function normalizeNodeId(nodeId: string) {
   return nodeId.trim();
+}
+
+function normalizeOptionalNodeId(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function samePendingNodeIdentity(
+  existing: NodePairingPendingRequest,
+  incoming: NodePairingRequestInput,
+): boolean {
+  const existingDeviceId = normalizeOptionalNodeId(existing.deviceId);
+  const incomingDeviceId = normalizeOptionalNodeId(incoming.deviceId);
+  if (existingDeviceId || incomingDeviceId) {
+    return existingDeviceId === incomingDeviceId;
+  }
+  return true;
+}
+
+function samePendingDeviceIdentity(
+  existing: NodePairingPendingRequest,
+  pending: NodePairingPendingRequest,
+): boolean {
+  const pendingDeviceId = normalizeOptionalNodeId(pending.deviceId);
+  if (!pendingDeviceId) {
+    return false;
+  }
+  return (
+    normalizeOptionalNodeId(existing.deviceId) === pendingDeviceId ||
+    existing.nodeId === pendingDeviceId
+  );
+}
+
+function sameIncomingDeviceIdentity(
+  existing: NodePairingPendingRequest,
+  incoming: Pick<NodePairingRequestInput, "deviceId">,
+): boolean {
+  const incomingDeviceId = normalizeOptionalNodeId(incoming.deviceId);
+  if (!incomingDeviceId) {
+    return false;
+  }
+  return (
+    normalizeOptionalNodeId(existing.deviceId) === incomingDeviceId ||
+    existing.nodeId === incomingDeviceId
+  );
+}
+
+function matchesPendingNodeReplacement(
+  existing: NodePairingPendingRequest,
+  incoming: NodePairingRequestInput,
+): boolean {
+  return (
+    (existing.nodeId === incoming.nodeId && samePendingNodeIdentity(existing, incoming)) ||
+    sameIncomingDeviceIdentity(existing, incoming)
+  );
+}
+
+function sameDeviceBoundNode(params: {
+  nodeId: string;
+  deviceId?: string;
+  pending: Pick<NodePairingPendingRequest, "deviceId">;
+}): boolean {
+  const pendingDeviceId = normalizeOptionalNodeId(params.pending.deviceId);
+  if (!pendingDeviceId) {
+    return false;
+  }
+  return (
+    normalizeOptionalNodeId(params.deviceId) === pendingDeviceId ||
+    params.nodeId === pendingDeviceId
+  );
+}
+
+function findExistingPairedNodeForApproval(
+  state: NodePairingStateFile,
+  pending: NodePairingPendingRequest,
+): NodePairingPairedNode | undefined {
+  const sameNode = state.pairedByNodeId[pending.nodeId];
+  if (sameNode) {
+    return sameNode;
+  }
+  const sameDeviceNodes = Object.entries(state.pairedByNodeId)
+    .filter(([nodeId, node]) =>
+      sameDeviceBoundNode({
+        nodeId,
+        deviceId: node.deviceId,
+        pending,
+      }),
+    )
+    .map(([, node]) => node)
+    .toSorted((left, right) => left.createdAtMs - right.createdAtMs);
+  return sameDeviceNodes[0];
 }
 
 function newToken() {
@@ -259,21 +358,25 @@ export async function requestNodePairing(
     if (!nodeId) {
       throw new Error("nodeId required");
     }
+    const incoming = {
+      ...req,
+      nodeId,
+    };
     const pendingForNode = Object.values(state.pendingById)
-      .filter((pending) => pending.nodeId === nodeId)
+      .filter((pending) => matchesPendingNodeReplacement(pending, incoming))
       .toSorted((left, right) => right.ts - left.ts);
     const result = await reconcilePendingPairingRequests({
       pendingById: state.pendingById,
       existing: pendingForNode,
-      incoming: {
-        ...req,
-        nodeId,
-      },
-      canRefreshSingle: (existing, incoming) => samePendingApprovalSurface(existing, incoming),
-      refreshSingle: (existing, incoming) => refreshPendingNodePairingRequest(existing, incoming),
-      buildReplacement: ({ existing, incoming }) =>
+      incoming,
+      canRefreshSingle: (existing, incomingRequest) =>
+        existing.nodeId === incomingRequest.nodeId &&
+        samePendingApprovalSurface(existing, incomingRequest),
+      refreshSingle: (existing, incomingRequest) =>
+        refreshPendingNodePairingRequest(existing, incomingRequest),
+      buildReplacement: ({ existing, incoming: incomingRequest }) =>
         buildPendingNodePairingRequest({
-          req: mergeNodePairingReplacementInput({ existing, incoming }),
+          req: mergeNodePairingReplacementInput({ existing, incoming: incomingRequest }),
         }),
       persist: async () => await persistState(state, baseDir),
     });
@@ -309,9 +412,10 @@ export async function approveNodePairing(
     }
 
     const now = Date.now();
-    const existing = state.pairedByNodeId[pending.nodeId];
+    const existing = findExistingPairedNodeForApproval(state, pending);
     const node: NodePairingPairedNode = {
       nodeId: pending.nodeId,
+      deviceId: pending.deviceId ?? existing?.deviceId,
       token: newToken(),
       clientId: pending.clientId,
       clientMode: pending.clientMode,
@@ -330,10 +434,32 @@ export async function approveNodePairing(
       approvedAtMs: now,
     };
 
-    delete state.pendingById[requestId];
+    const superseded: NodePairingSupersededRequest[] = [];
+    for (const [pendingId, otherPending] of Object.entries(state.pendingById)) {
+      const sameNode = otherPending.nodeId === pending.nodeId;
+      const sameDevice = samePendingDeviceIdentity(otherPending, pending);
+      if (pendingId !== requestId && (sameNode || sameDevice)) {
+        superseded.push({ requestId: pendingId, nodeId: otherPending.nodeId });
+      }
+      if (pendingId === requestId || sameNode || sameDevice) {
+        delete state.pendingById[pendingId];
+      }
+    }
+    for (const [nodeId, paired] of Object.entries(state.pairedByNodeId)) {
+      if (
+        nodeId !== pending.nodeId &&
+        sameDeviceBoundNode({
+          nodeId,
+          deviceId: paired.deviceId,
+          pending,
+        })
+      ) {
+        delete state.pairedByNodeId[nodeId];
+      }
+    }
     state.pairedByNodeId[pending.nodeId] = node;
     await persistState(state, baseDir);
-    return { requestId, node };
+    return superseded.length > 0 ? { requestId, node, superseded } : { requestId, node };
   });
 }
 

--- a/src/node-host/config.test.ts
+++ b/src/node-host/config.test.ts
@@ -1,0 +1,38 @@
+/** Tests persistent node-host config normalization. */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { ensureNodeHostConfig } from "./config.js";
+
+describe("ensureNodeHostConfig", () => {
+  it("keeps legacy node ids generated until the user sets --node-id again", async () => {
+    await withStateDirEnv("openclaw-node-host-config-user-", async ({ stateDir }) => {
+      await fs.writeFile(
+        path.join(stateDir, "node.json"),
+        JSON.stringify({ version: 1, nodeId: "my-mac-node" }),
+        "utf8",
+      );
+
+      const config = await ensureNodeHostConfig();
+
+      expect(config.nodeId).toBe("my-mac-node");
+      expect(config.nodeIdSource).toBe("generated");
+    });
+  });
+
+  it("keeps legacy uuid node ids generated", async () => {
+    await withStateDirEnv("openclaw-node-host-config-generated-", async ({ stateDir }) => {
+      await fs.writeFile(
+        path.join(stateDir, "node.json"),
+        JSON.stringify({ version: 1, nodeId: "11111111-1111-4111-8111-111111111111" }),
+        "utf8",
+      );
+
+      const config = await ensureNodeHostConfig();
+
+      expect(config.nodeId).toBe("11111111-1111-4111-8111-111111111111");
+      expect(config.nodeIdSource).toBe("generated");
+    });
+  });
+});

--- a/src/node-host/config.ts
+++ b/src/node-host/config.ts
@@ -22,6 +22,7 @@ export type NodeHostGatewayConfig = {
 type NodeHostConfig = {
   version: 1;
   nodeId: string;
+  nodeIdSource?: "generated" | "user";
   token?: string;
   displayName?: string;
   gateway?: NodeHostGatewayConfig;
@@ -37,6 +38,7 @@ function normalizeConfig(config: Partial<NodeHostConfig> | null): NodeHostConfig
   const base: NodeHostConfig = {
     version: 1,
     nodeId: "",
+    nodeIdSource: config?.nodeIdSource,
     token: config?.token,
     displayName: config?.displayName,
     gateway: config?.gateway,
@@ -46,6 +48,9 @@ function normalizeConfig(config: Partial<NodeHostConfig> | null): NodeHostConfig
   }
   if (!base.nodeId) {
     base.nodeId = crypto.randomUUID();
+    base.nodeIdSource = "generated";
+  } else if (base.nodeIdSource !== "generated" && base.nodeIdSource !== "user") {
+    base.nodeIdSource = "generated";
   }
   return base;
 }

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -1,5 +1,5 @@
 /** Tests node-host runner command parsing, timeout, and plugin dispatch behavior. */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayClientOptions } from "../gateway/client.js";
 import {
   resolveNodeHostGatewayDeviceFamily,
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   ensureNodeHostConfig: vi.fn(async () => ({
     version: 1,
     nodeId: "node-test",
+    nodeIdSource: "generated" as "generated" | "user",
   })),
   saveNodeHostConfig: vi.fn(async () => undefined),
   getRuntimeConfig: vi.fn(() => ({
@@ -74,6 +75,16 @@ vi.mock("./plugin-node-host.js", () => ({
 }));
 
 describe("runNodeHost", () => {
+  beforeEach(() => {
+    mocks.capturedGatewayClientOptions.length = 0;
+    mocks.ensureNodeHostConfig.mockResolvedValue({
+      version: 1,
+      nodeId: "node-test",
+      nodeIdSource: "generated",
+    });
+    mocks.saveNodeHostConfig.mockClear();
+  });
+
   it("maps runtime platforms to gateway platform ids", () => {
     expect(resolveNodeHostGatewayPlatform("darwin")).toBe("macos");
     expect(resolveNodeHostGatewayPlatform("win32")).toBe("windows");
@@ -101,5 +112,44 @@ describe("runNodeHost", () => {
     expect(mocks.capturedGatewayClientOptions[0]?.deviceFamily).toBe(
       resolveNodeHostGatewayDeviceFamily(process.platform),
     );
+    expect(mocks.capturedGatewayClientOptions[0]?.instanceId).toBe("node-test");
+    expect(mocks.capturedGatewayClientOptions[0]?.nodeId).toBeUndefined();
+  });
+
+  it("passes an explicit node id as the user-visible gateway node id", async () => {
+    await expect(
+      runNodeHost({
+        gatewayHost: "127.0.0.1",
+        gatewayPort: 18789,
+        nodeId: "my-mac-node",
+      }),
+    ).rejects.toThrow("event loop readiness timeout");
+
+    expect(mocks.capturedGatewayClientOptions[0]?.instanceId).toBe("my-mac-node");
+    expect(mocks.capturedGatewayClientOptions[0]?.nodeId).toBe("my-mac-node");
+    expect(mocks.saveNodeHostConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: "my-mac-node",
+        nodeIdSource: "user",
+      }),
+    );
+  });
+
+  it("keeps a persisted user node id visible on reconnect", async () => {
+    mocks.ensureNodeHostConfig.mockResolvedValue({
+      version: 1,
+      nodeId: "my-mac-node",
+      nodeIdSource: "user",
+    });
+
+    await expect(
+      runNodeHost({
+        gatewayHost: "127.0.0.1",
+        gatewayPort: 18789,
+      }),
+    ).rejects.toThrow("event loop readiness timeout");
+
+    expect(mocks.capturedGatewayClientOptions[0]?.instanceId).toBe("my-mac-node");
+    expect(mocks.capturedGatewayClientOptions[0]?.nodeId).toBe("my-mac-node");
   });
 });

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -233,9 +233,13 @@ function buildNodeHostLocalAuthConfig(config: OpenClawConfig): OpenClawConfig {
 
 export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const config = await ensureNodeHostConfig();
-  const nodeId = opts.nodeId?.trim() || config.nodeId;
+  const overrideNodeId = opts.nodeId?.trim();
+  const nodeId = overrideNodeId || config.nodeId;
   if (nodeId !== config.nodeId) {
     config.nodeId = nodeId;
+  }
+  if (overrideNodeId) {
+    config.nodeIdSource = "user";
   }
   const displayName =
     opts.displayName?.trim() || config.displayName || (await getMachineDisplayName());
@@ -270,6 +274,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     password: password || undefined,
     preauthHandshakeTimeoutMs: cfg.gateway?.handshakeTimeoutMs,
     instanceId: nodeId,
+    nodeId: config.nodeIdSource === "user" ? nodeId : undefined,
     clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
     clientDisplayName: displayName,
     clientVersion: VERSION,


### PR DESCRIPTION
## Summary

- Replaces the unsigned `client.instanceId` custom-node-id approach from #88374 with an explicit top-level `ConnectParams.nodeId` that is covered by device-auth v4 signatures.
- Keeps generated node-host device IDs on the existing compatibility path, while honoring user-provided `openclaw node run --node-id ...` values only when the authenticated node-host signs the requested node ID.
- Binds approved custom node IDs to the authenticated `device.id`, resolves/supersedes stale pending requests, and prevents same-node or same-device registry sessions from resurrecting stale command approvals.
- Refreshes the shared Swift gateway protocol model for the new `nodeId` connect field.

## Linked context

Closes #61569.

Related #88374. This is a maintainer-side replacement for the old PR shape because the older branch trusted `client.instanceId` without signing the requested node ID.

Was this requested by a maintainer or owner?

Maintainer-side follow-up after review feedback on #88374 and local autoreview findings.

## Real behavior proof (required for external PRs)

Behavior addressed: `openclaw node run --node-id <custom>` can be represented as the user-visible Gateway node ID without letting another authenticated device claim that ID or reuse stale approvals.

Real environment tested: local source checkout on Windows/PowerShell. A packaged CLI gateway/node-host smoke was not rerun in this shell because `pnpm` and `corepack` are not available on PATH; #88374 already contains contributor CLI smoke evidence for the original user-visible symptom, and this replacement adds source-level security/protocol coverage for the signed-node-id design.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs packages/gateway-protocol/src/index.test.ts src/gateway/client.test.ts src/gateway/device-auth.test.ts src/gateway/node-catalog.test.ts src/gateway/node-connect-reconcile.test.ts src/gateway/node-registry.test.ts src/gateway/server/ws-connection.test.ts src/gateway/server-methods/nodes-pending.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts src/gateway/server.node-pairing-authz.test.ts src/infra/node-pairing.test.ts src/node-host/runner.test.ts src/node-host/config.test.ts`; `node --import tsx scripts/protocol-gen.ts`; `node --import tsx scripts/protocol-gen-swift.ts`; `git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`; `git diff --check origin/main`; `node_modules/.bin/oxfmt.cmd --check <changed files>`; `node scripts/run-oxlint.mjs <changed files>`; `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`; `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix: focused Vitest passed across 3 shards (`50 + 455 + 15` tests). Protocol regeneration plus tracked-output diff passed. `git diff --check`, oxfmt, oxlint, and both tsgo lanes passed. Local autoreview reported no accepted/actionable findings and `overall: patch is correct`.

Observed result after fix: explicit custom node IDs are signed in the connect auth payload, unsigned top-level node IDs are rejected, old gateways get a one-shot client retry without `nodeId`, approved custom IDs remain pinned to the authenticated device, stale same-device pending requests are superseded, and registry replacement cleanup avoids stale command/presence resurrection.

What was not tested: packaged CLI end-to-end smoke in this shell, because package-manager entrypoints were unavailable (`pnpm` and `corepack` not found). Live Crabbox/Testbox proof was not run.

Proof limitations or environment constraints: source-level and protocol-drift proof is strong for the touched contracts, but a maintainer with package-manager access should run one packaged upgrade smoke if they want real CLI evidence for the new signed protocol shape.

Before evidence (optional but encouraged): PR #88374 and issue #61569 document the original failure mode where a custom node-host ID is not honored by Gateway pairing/listing paths.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs packages/gateway-protocol/src/index.test.ts src/gateway/client.test.ts src/gateway/device-auth.test.ts src/gateway/node-catalog.test.ts src/gateway/node-connect-reconcile.test.ts src/gateway/node-registry.test.ts src/gateway/server/ws-connection.test.ts src/gateway/server-methods/nodes-pending.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts src/gateway/server.node-pairing-authz.test.ts src/infra/node-pairing.test.ts src/node-host/runner.test.ts src/node-host/config.test.ts`
- `node --import tsx scripts/protocol-gen.ts`
- `node --import tsx scripts/protocol-gen-swift.ts`
- `git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`
- `git diff --check origin/main`
- `node_modules/.bin/oxfmt.cmd --check <changed files>`
- `node scripts/run-oxlint.mjs <changed files>`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

What regression coverage was added or updated?

- Device-auth v4 payload/signature coverage for top-level `nodeId`.
- Gateway connect rejection for unsigned `nodeId` and old-gateway client fallback.
- Node pairing pending/approval supersession for same node and same authenticated device.
- Registry lifecycle tests for same-node/same-device replacement, stale command-surface prevention, presence cleanup, and internal close handoff.
- Catalog and reconnect tests proving custom node aliases remain device-bound.
- Node-host config/runner tests proving only user-provided node IDs send the explicit signed field.
- Protocol test and generated Swift model update for `ConnectParams.nodeId`.

What failed before this fix, if known?

The original #88374 review surfaced a security-boundary risk: the requested custom node ID was treated as authenticated via `client.instanceId` but was not signed by the device-auth payload. Local autoreview then found stale approval, registry replacement, pending-request, and generated-protocol gaps that are covered in this branch.

If no test was added, why not?

Focused tests were added for the changed protocol/auth/pairing/registry/node-host surfaces.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. User-provided node-host IDs are now honored as Gateway node IDs when signed by the authenticated node-host.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes. Existing node pairing state can be rekeyed/superseded around the authenticated device binding when a custom node ID is approved.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. The connect auth payload gains v4 signing for top-level `nodeId`, and Gateway rejects unsigned explicit custom node IDs.

What is the highest-risk area?

Gateway node identity and pairing ownership, especially upgrade behavior for existing device-ID node approvals moving to user-visible custom node IDs.

How is that risk mitigated?

The runtime separates user-visible `nodeId` from cryptographic `device.id`, accepts explicit custom IDs only when signed in v4 device auth, pins approved records to the authenticated device, supersedes stale pending records, and evicts/reports replaced live sessions so stale command approval cannot be promoted later.

## Current review state

What is the next action?

Gateway/security owner review, plus optional packaged CLI upgrade smoke if maintainers want real environment proof for the new signed protocol shape.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer review. Full packaged CLI smoke was not run locally because package-manager tooling was unavailable in this shell.

Which bot or reviewer comments were addressed?

Addressed the #88374 ClawSweeper merge-risk feedback by replacing unsigned `client.instanceId` trust with a signed top-level `nodeId` protocol/auth contract, adding generated protocol output, and iterating local autoreview until no accepted/actionable findings remained.