### PR TITLE
fix(telegram): rethrow dispatch errors so spooled updates are not silently deleted

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -475,6 +475,7 @@ export const registerTelegramHandlers = ({
   const inboundDebouncer = createInboundDebouncer<TelegramDebounceEntry>({
     debounceMs,
     serializeImmediate: true,
+    rethrowOnFlushError: true,
     resolveDebounceMs: (entry) =>
       entry.debounceLane === "forward" ? FORWARD_BURST_DEBOUNCE_MS : debounceMs,
     buildKey: (entry) => entry.debounceKey,

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -243,7 +243,7 @@ describe("telegram bot message processor", () => {
     expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("sends user-visible fallback when dispatch throws", async () => {
+  it("sends user-visible fallback and rethrows when dispatch throws", async () => {
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const { processMessage, runtimeError } = createDispatchFailureHarness(
       {
@@ -253,7 +253,7 @@ describe("telegram bot message processor", () => {
       },
       sendMessage,
     );
-    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
+    await expect(processSampleMessage(processMessage)).rejects.toThrow("dispatch exploded");
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,
@@ -275,7 +275,7 @@ describe("telegram bot message processor", () => {
       },
       sendMessage,
     );
-    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
+    await expect(processSampleMessage(processMessage)).rejects.toThrow("dispatch exploded");
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,
@@ -284,7 +284,7 @@ describe("telegram bot message processor", () => {
     );
   });
 
-  it("swallows fallback delivery failures after dispatch throws", async () => {
+  it("rethrows after sending fallback even when fallback delivery fails", async () => {
     const sendMessage = vi.fn().mockRejectedValue(new Error("blocked by user"));
     const { processMessage, runtimeError } = createDispatchFailureHarness(
       {
@@ -293,7 +293,7 @@ describe("telegram bot message processor", () => {
       },
       sendMessage,
     );
-    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
+    await expect(processSampleMessage(processMessage)).rejects.toThrow("dispatch exploded");
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -209,6 +209,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
           buildTelegramThreadParams(context.threadSpec),
         );
       } catch {}
+      throw err;
     }
     return true;
   };

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -94,7 +94,9 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     // Rethrow so the enqueue caller can propagate the failure (e.g. to
     // reject bot.handleUpdate() and keep spooled update claims for retry).
     if (flushError !== undefined && params.rethrowOnFlushError) {
-      throw flushError;
+      throw flushError instanceof Error
+        ? flushError
+        : new Error(typeof flushError === "string" ? flushError : "unknown flush error");
     }
   };
 

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -54,6 +54,10 @@ export type InboundDebounceCreateParams<T> = {
   shouldDebounce?: (item: T) => boolean;
   resolveDebounceMs?: (item: T) => number | undefined;
   serializeImmediate?: boolean;
+  /** When true, flush errors rethrow after calling onError so the enqueue
+   *  caller can propagate the failure (e.g. to reject bot.handleUpdate()
+   *  and keep spooled update claims for retry). */
+  rethrowOnFlushError?: boolean;
   onFlush: (items: T[]) => Promise<void>;
   onError?: (err: unknown, items: T[]) => void;
   onCancel?: (items: T[]) => void;
@@ -75,15 +79,22 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
   };
 
   const runFlush = async (items: T[]) => {
+    let flushError: unknown;
     try {
       await params.onFlush(items);
     } catch (err) {
+      flushError = err;
       try {
         params.onError?.(err, items);
       } catch {
         // Flush failures are reported via onError, but this helper stays
         // non-throwing so keyed chains can continue processing later items.
       }
+    }
+    // Rethrow so the enqueue caller can propagate the failure (e.g. to
+    // reject bot.handleUpdate() and keep spooled update claims for retry).
+    if (flushError !== undefined && params.rethrowOnFlushError) {
+      throw flushError;
     }
   };
 

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -682,6 +682,22 @@ describe("createInboundDebouncer", () => {
     expect(calls).toEqual(["1", "2"]);
   });
 
+  it("rethrows flush errors when rethrowOnFlushError is set", async () => {
+    const onError = vi.fn();
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 0,
+      buildKey: (item) => item.key,
+      rethrowOnFlushError: true,
+      onFlush: async () => {
+        throw new Error("flush failed");
+      },
+      onError,
+    });
+
+    await expect(debouncer.enqueue({ key: "a", id: "1" })).rejects.toThrow("flush failed");
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), expect.any(Array));
+  });
+
   it("does not leak unhandled rejections when a keyed flush failure is awaited", async () => {
     const debouncer = createInboundDebouncer<{ key: string; id: string }>({
       debounceMs: 0,


### PR DESCRIPTION
## Summary

Fix Telegram spooled update message loss by propagating dispatch errors through the handler chain and debouncer, so `bot.handleUpdate()` rejects when the message processor fails and the spooled update consumer releases the claim for retry instead of deleting it.

## Root cause

When `dispatchTelegramMessage` throws inside `processMessage`, the error was caught and swallowed at two levels:

1. **`processMessage`** (`extensions/telegram/src/bot-message.ts`): The catch block sent a user-visible fallback but did not rethrow, so the caller saw success.
2. **`createInboundDebouncer`** (`src/auto-reply/inbound-debounce.ts`): Even when the handler does throw, `runFlush` catches all `onFlush` errors and routes them to `onError` without rethrowing, so `bot.handleUpdate()` always resolves — causing `#handleClaimedSpooledUpdate` to delete the claimed update instead of releasing it for retry.

## Fix

### 1. Rethrow in `processMessage`

After sending the user-visible fallback message, rethrow the dispatch error so callers can distinguish success from failure.

### 2. Add `rethrowOnFlushError` to the inbound debouncer

Add an opt-in `rethrowOnFlushError` option to `createInboundDebouncer`. When enabled, `runFlush` rethrows the error after calling `onError`, propagating the failure through `enqueue()` → middleware → `bot.handleUpdate()` → spooled update consumer.

Enabled this option in the Telegram handler debouncer.

**Other debouncer users are unaffected** — the option defaults to `false`.

### 3. Fix oxlint `only-throw-error` lint

Wrap the `unknown`-typed `flushError` with `instanceof Error` before rethrowing to satisfy the oxlint `typescript(only-throw-error)` rule.

## Tests and validation

### Unit tests for `processMessage` error rethrow

All 3 dispatch-failure tests now assert rejection instead of resolution:

- `"sends user-visible fallback and rethrows when dispatch throws"` — `processMessage` rejects after fallback
- `"omits message_thread_id for General-topic fallback replies"` — thread param omitted for General topic
- `"rethrows after sending fallback even when fallback delivery fails"` — rethrow wins even if fallback send also fails

### Unit tests for debouncer rethrow

- `"rethrows flush errors when rethrowOnFlushError is set"` — new test asserting error propagation

### Test output

```text
node scripts/run-vitest.mjs extensions/telegram/src/bot-message.test.ts
# 10 passed — 3 dispatch-failure tests now assert rejection

node scripts/run-vitest.mjs src/auto-reply/inbound.test.ts
# 62 passed — includes new rethrow test, existing tests unchanged
```

## CI status

- `check-lint` — ✅ Fixed (wrapped unknown flushError with instanceof Error)
- `checks-node-agentic-gateway-methods` — ❌ Pre-existing flaky test (sessionStartedAt timing), unrelated to this PR
- `Real behavior proof` — ❌ No real Telegram bot available for live testing; unit tests cover the deterministic error propagation paths completely

## Real behavior proof

- Behavior addressed: Spooled Telegram updates are silently deleted on dispatch failure instead of being released for retry.
- Real environment tested: Linux (RHEL), Node.js 22.x, local checkout on branch `fix/issue-92129-telegram-spooled-message-loss`, commit `994878d`.
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs extensions/telegram/src/bot-message.test.ts
```

- Evidence after fix:

```text
[test] starting test/vitest/vitest.extension-telegram.config.ts

 RUN  v4.1.7

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  17:27:24
   Duration  39.11s (transform 31.46s, setup 960ms, import 38ms, tests 37.74s, environment 0ms)
```

The 3 dispatch-failure tests assert rejection instead of resolution:
- `sends user-visible fallback and rethrows when dispatch throws`
- `omits message_thread_id for General-topic fallback replies`
- `rethrows after sending fallback even when fallback delivery fails`

- Observed result after fix:

```text
[test] starting test/vitest/vitest.auto-reply.config.ts

 RUN  v4.1.7

 Test Files  1 passed (1)
      Tests  62 passed (62)
   Start at  17:28:15
   Duration  15.85s (transform 11.84s, setup 1.21s, import 13.62s, tests 580ms, environment 0ms)
```

Dispatch errors now propagate through both `processMessage` (rejects after fallback instead of resolving) and the debouncer with `rethrowOnFlushError: true`. The 62 inbound tests include the new `rethrows flush errors when rethrowOnFlushError is set` test, and all existing debouncer tests pass unchanged with the default `rethrowOnFlushError: false`.

- What was not tested: Live Telegram dispatch with a real bot (no Telegram bot token available). This fix changes deterministic error propagation paths only — the `throw err` in `processMessage` and the `rethrowOnFlushError` branch in the debouncer. The unit tests directly assert the contract change. These are async/await control-flow assertions, not integration-dependent behavior.

## Risk

Low. The `throw err` in `processMessage` is an additive change on an existing error path — the fallback is still sent. The `rethrowOnFlushError` option defaults to `false` and is only enabled for Telegram. Other debouncer users (Discord, WhatsApp, Feishu, MS Teams, Mattermost) are unaffected.

## Verification

- `pnpm test:changed` — all changed files pass
- Unit tests confirm:
  - Dispatch failure → processMessage rejects instead of resolving
  - Fallback message is still sent before rethrow
  - Fallback delivery failure does not prevent rethrow
  - Debouncer with `rethrowOnFlushError: false` (default) still swallows errors (backward compat)
  - Debouncer with `rethrowOnFlushError: true` propagates flush errors up to the caller
- `oxlint` — clean
- Import cycles — clean