### PR TITLE
#92067: fix(telegram): honor ingest config before unaddressed-group-media skip

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -800,6 +800,10 @@ export const registerTelegramHandlers = ({
         commandAuthorized: commandGate.authorized,
       },
     });
+    // If ingest is explicitly enabled, break out of media download skip
+    if ((topicConfig?.ingest ?? groupConfig?.ingest) === true) {
+      return false;
+    }
     if (mentionDecision.shouldSkip) {
       logger.info({ chatId, reason: "no-mention" }, "skipping group media before download");
       return true;


### PR DESCRIPTION
## Summary

Honor group/topic `ingest` config before the unaddressed-group-media skip check, so plugins with `ingest: true` receive media-bearing messages in addition to text messages.

## Root Cause

`shouldSkipMediaDownloadForUnaddressedMentionGroup` returned `true` for un-addressed group/topic media **before** the `message:received` ingest hook fired. A plugin with `channels.telegram.groups[<id>].ingest: true` therefore received text messages but never media-bearing ones — the skip won before ingest was consulted.

## Changes

- `extensions/telegram/src/bot-handlers.runtime.ts`: Added ingest config check before the mention-skip decision. When `topicConfig?.ingest` or `groupConfig?.ingest` is `true`, the media skip is bypassed, allowing the ingest hook to fire.

## Real behavior proof

**Behavior or issue addressed:** Honor group/topic `ingest` config before the unaddressed-group-media skip, so explicitly ingest-enabled groups/topics receive media-bearing messages.

**Real environment tested:**
- OS: Linux 4.19.112-2.el8.x86_64
- Runtime: Node.js v22.19.0
- Setup: Local source checkout at `main`

**Exact steps or command run after this patch:**
```
node /tmp/repro-92067.mjs
pnpm test -- --run extensions/telegram/src/bot-handlers.runtime.test.ts
```

**Evidence after fix:**
```
$ node /tmp/repro-92067.mjs
=== Issue #92067: Honor ingest config before unaddressed-group-media skip ===

Test: Group with ingest=true, no mention
  Before fix -> skipMedia=true (media silently dropped)
  After fix  -> skipMedia=false (kept)
  FIX CHANGED BEHAVIOR

Test: Topic with ingest=true, group with ingest=false, no mention
  Before fix -> skipMedia=true (media silently dropped)
  After fix  -> skipMedia=false (kept)
  FIX CHANGED BEHAVIOR

Test: Group without ingest, no mention (default behavior unchanged)
  Before fix -> skipMedia=true (media silently dropped)
  After fix  -> skipMedia=true (media dropped)
  Behavior unchanged (expected)

Test: Group with ingest=false, no mention
  Before fix -> skipMedia=true (media silently dropped)
  After fix  -> skipMedia=true (media dropped)
  Behavior unchanged (expected)

Test: Group with ingest=true, has mention (mention check also passes)
  Before fix -> skipMedia=false (kept)
  After fix  -> skipMedia=false (kept)
  Behavior unchanged (expected)
```

**Observed result after fix:** The repro script confirms ingest-enabled groups/topics no longer have their media silently dropped. Groups without ingest config behave identically to before the fix. All 4 existing tests pass.

**What was not tested:** End-to-end Telegram bot connectivity (requires actual bot token); other group types beyond the forum supergroup scenario described in the issue.

## Regression Test Plan

- [x] `pnpm test -- --run extensions/telegram/src/bot-handlers.runtime.test.ts` passes (4/4)
- [x] Change is minimal (4 lines added) and targeted
- [x] Default behavior is unchanged when `ingest` is not configured

---

*AI-assisted: built with Claude Code*