### PR TITLE
feat(diagnostics): chain gateway traces into runs

### DIFF
--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -1255,6 +1255,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         string,
         { span: ReturnType<typeof tracer.startSpan>; spanId: string; owner: TrustedSpanAliasOwner }
       >();
+      const activeRunInvocationSpanIds = new Set<string>();
       const retainedTrustedSpanContexts = new Map<
         string,
         { spanContext: SpanContext; token: symbol; owner?: TrustedSpanAliasOwner }
@@ -1275,6 +1276,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         }
         activeTrustedSpans.clear();
         activeTrustedSpanAliases.clear();
+        activeRunInvocationSpanIds.clear();
       };
 
       const tokensCounter = meter.createCounter("openclaw.tokens", {
@@ -2350,6 +2352,60 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         }
       };
 
+      const recordRunInvocation = (
+        evt: Extract<DiagnosticEventPayload, { type: "run.invocation" }>,
+        metadata: DiagnosticEventMetadata,
+      ) => {
+        if (!tracesEnabled || !metadata.trusted) {
+          return;
+        }
+        const traceContext = trustedTraceContext(evt, metadata);
+        if (!traceContext?.spanId) {
+          return;
+        }
+        const spanAttrs: Record<string, string | number | boolean> = {};
+        addRunAttrs(spanAttrs, evt);
+        const span = trackTrustedSpan(
+          evt,
+          metadata,
+          spanWithDuration("openclaw.run.invocation", spanAttrs, undefined, {
+            parentContext:
+              activeTrustedParentContext(evt, metadata) ??
+              internalOrTrustedExplicitParentContext(evt, metadata),
+            startTimeMs: evt.ts,
+          }),
+        );
+        setSpanAttrs(span, spanAttrs);
+        activeRunInvocationSpanIds.add(traceContext.spanId);
+      };
+
+      const recordRunInvocationCompleted = (
+        evt: Extract<DiagnosticEventPayload, { type: "run.invocation.completed" }>,
+        metadata: DiagnosticEventMetadata,
+      ) => {
+        if (!tracesEnabled || !metadata.trusted) {
+          return;
+        }
+        const traceContext = trustedTraceContext(evt, metadata);
+        const span = traceContext?.spanId ? activeTrustedSpans.get(traceContext.spanId) : undefined;
+        if (
+          !traceContext?.spanId ||
+          !span ||
+          !activeRunInvocationSpanIds.delete(traceContext.spanId)
+        ) {
+          return;
+        }
+        const spanAttrs: Record<string, string | number | boolean> = {
+          "openclaw.outcome": evt.outcome,
+        };
+        addRunAttrs(spanAttrs, evt);
+        setSpanAttrs(span, spanAttrs);
+        if (evt.outcome === "error") {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: "error" });
+        }
+        completeTrackedLifecycleSpan(traceContext.spanId, span, evt.ts);
+      };
+
       const recordLaneEnqueue = (
         evt: Extract<DiagnosticEventPayload, { type: "queue.lane.enqueue" }>,
       ) => {
@@ -3378,6 +3434,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               return;
             case "session.recovery.completed":
               recordSessionRecoveryCompleted(evt);
+              return;
+            case "run.invocation":
+              recordRunInvocation(evt, metadata);
+              return;
+            case "run.invocation.completed":
+              recordRunInvocationCompleted(evt, metadata);
               return;
             case "run.attempt":
               recordRunAttempt(evt);

--- a/src/agents/embedded-agent-runner/run.diagnostic-trace-chain.test.ts
+++ b/src/agents/embedded-agent-runner/run.diagnostic-trace-chain.test.ts
@@ -1,0 +1,116 @@
+import type { IncomingMessage } from "node:http";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createGatewayRequestDiagnosticTrace } from "../../gateway/request-diagnostic-trace.js";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedClassifyFailoverReason,
+  mockedGlobalHookRunner,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
+} from "./run.overflow-compaction.harness.js";
+
+let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
+let traceContext: typeof import("../../infra/diagnostic-trace-context.js");
+
+function requestWithTraceparent(traceparent: string): IncomingMessage {
+  return { headers: { traceparent } } as IncomingMessage;
+}
+
+describe("runEmbeddedAgent diagnostic trace chain", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedAgent } = await loadRunOverflowCompactionHarness());
+    traceContext = await import("../../infra/diagnostic-trace-context.js");
+  });
+
+  beforeEach(() => {
+    resetRunOverflowCompactionHarnessMocks();
+    mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
+    mockedClassifyFailoverReason.mockReturnValue(null);
+  });
+
+  it("passes a gateway trace into attempt diagnostics", async () => {
+    const inboundTrace = traceContext.createDiagnosticTraceContext({
+      traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+      spanId: "00f067aa0ba902b7",
+    });
+    let activeAttemptTrace: ReturnType<typeof traceContext.getActiveDiagnosticTraceContext>;
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async () => {
+      activeAttemptTrace = traceContext.getActiveDiagnosticTraceContext();
+      return makeAttemptResult();
+    });
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-trace-chain",
+      sessionId: "session-trace-chain",
+      sessionKey: "agent:main:trace-chain",
+      provider: "anthropic",
+      model: "claude-sonnet-4.6",
+      messageChannel: "gateway-test",
+      diagnosticTrace: inboundTrace,
+    });
+
+    expect(activeAttemptTrace?.traceId).toBe(inboundTrace.traceId);
+    expect(activeAttemptTrace?.parentSpanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(activeAttemptTrace?.parentSpanId).not.toBe(inboundTrace.spanId);
+    expect(activeAttemptTrace?.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(activeAttemptTrace?.spanId).not.toBe(inboundTrace.spanId);
+  });
+
+  it("creates a root invocation trace for non-gateway embedded runs", async () => {
+    let activeAttemptTrace: ReturnType<typeof traceContext.getActiveDiagnosticTraceContext>;
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async () => {
+      activeAttemptTrace = traceContext.getActiveDiagnosticTraceContext();
+      return makeAttemptResult();
+    });
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-local-trace-chain",
+      sessionId: "session-local-trace-chain",
+      sessionKey: "agent:main:local-trace-chain",
+      provider: "anthropic",
+      model: "claude-sonnet-4.6",
+    });
+
+    expect(activeAttemptTrace?.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(activeAttemptTrace?.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(activeAttemptTrace?.parentSpanId).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("captures the active gateway request trace for embedded runs", async () => {
+    const parentTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+    const parentSpanId = "00f067aa0ba902b7";
+    const requestTrace = createGatewayRequestDiagnosticTrace(
+      requestWithTraceparent(`00-${parentTraceId}-${parentSpanId}-01`),
+      { honorTraceparent: true },
+    );
+    let activeAttemptTrace: ReturnType<typeof traceContext.getActiveDiagnosticTraceContext>;
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async () => {
+      activeAttemptTrace = traceContext.getActiveDiagnosticTraceContext();
+      return makeAttemptResult();
+    });
+
+    await traceContext.runWithDiagnosticTraceContext(requestTrace, () =>
+      runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        runId: "run-active-gateway-trace",
+        sessionId: "session-active-gateway-trace",
+        sessionKey: "agent:main:active-gateway-trace",
+        provider: "anthropic",
+        model: "claude-sonnet-4.6",
+        messageChannel: "gateway-test",
+      }),
+    );
+
+    expect(requestTrace.traceId).toBe(parentTraceId);
+    expect(requestTrace.parentSpanId).toBe(parentSpanId);
+    expect(activeAttemptTrace?.traceId).toBe(parentTraceId);
+    expect(activeAttemptTrace?.parentSpanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(activeAttemptTrace?.parentSpanId).not.toBe(requestTrace.spanId);
+    expect(activeAttemptTrace?.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(activeAttemptTrace?.spanId).not.toBe(requestTrace.spanId);
+  });
+});

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -16,7 +16,14 @@ import {
 } from "../../context-engine/registry.js";
 import { emitAgentPlanEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
-import { freezeDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
+import { emitTrustedDiagnosticEvent } from "../../infra/diagnostic-events.js";
+import {
+  createChildDiagnosticTraceContext,
+  createDiagnosticTraceContext,
+  freezeDiagnosticTraceContext,
+  getActiveDiagnosticTraceContext,
+  runWithDiagnosticTraceContext,
+} from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -500,6 +507,7 @@ export async function runEmbeddedAgent(
   paramsInput: RunEmbeddedAgentParams,
 ): Promise<EmbeddedAgentRunResult> {
   let params = paramsInput;
+  const parentDiagnosticTrace = params.diagnosticTrace ?? getActiveDiagnosticTraceContext();
   // Resolve sessionKey early so all downstream consumers (hooks, LCM, compaction)
   // receive a non-null key even when callers omit it. See #60552.
   const effectiveSessionKey = backfillSessionKey({
@@ -1622,148 +1630,200 @@ export async function runEmbeddedAgent(
           } else {
             parentAbortSignal?.addEventListener("abort", relayParentAbort, { once: true });
           }
-          const rawAttempt = await runEmbeddedAttemptWithBackend({
-            sessionId: activeSessionId,
-            sessionKey: resolvedSessionKey,
-            promptCacheKey: params.promptCacheKey,
-            sandboxSessionKey: params.sandboxSessionKey,
-            trigger: params.trigger,
-            memoryFlushWritePath: params.memoryFlushWritePath,
-            messageChannel: params.messageChannel,
-            messageProvider: params.messageProvider,
-            chatType: params.chatType,
-            agentAccountId: params.agentAccountId,
-            messageTo: params.messageTo,
-            messageThreadId: params.messageThreadId,
-            groupId: params.groupId,
-            groupChannel: params.groupChannel,
-            groupSpace: params.groupSpace,
-            memberRoleIds: params.memberRoleIds,
-            spawnedBy: params.spawnedBy,
-            isCanonicalWorkspace,
-            senderId: params.senderId,
-            senderName: params.senderName,
-            senderUsername: params.senderUsername,
-            senderE164: params.senderE164,
-            currentChannelId: params.currentChannelId,
-            currentThreadTs: params.currentThreadTs,
-            currentMessageId: params.currentMessageId,
-            currentInboundAudio: params.currentInboundAudio,
-            replyToMode: params.replyToMode,
-            hasRepliedRef: params.hasRepliedRef,
-            sessionFile: activeSessionFile,
-            workspaceDir: resolvedWorkspace,
-            cwd: params.cwd,
-            agentDir,
-            config: params.config,
-            allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-            contextEngine,
-            contextTokenBudget: ctxInfo.tokens,
-            contextWindowInfo: ctxInfo,
-            skillsSnapshot: params.skillsSnapshot,
-            prompt,
-            transcriptPrompt: params.transcriptPrompt,
-            userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
-            currentInboundEventKind: params.currentInboundEventKind,
-            currentInboundContext: params.currentInboundContext,
-            images: params.images,
-            imageOrder: params.imageOrder,
-            clientTools: params.clientTools,
-            disableTools: params.disableTools,
-            provider,
-            modelId,
-            // Use the harness selected before model/auth setup for the actual
-            // attempt too. Otherwise plugin-owned transports can skip OpenClaw auth
-            // bootstrap but drift back to OpenClaw when the attempt is created.
-            agentHarnessId: agentHarness.id,
-            ...(params.sessionKey
-              ? {
-                  agentHarnessTaskRuntimeScope: createAgentHarnessTaskRuntimeScope({
-                    requesterSessionKey: params.sessionKey,
-                  }),
-                }
-              : {}),
-            runtimePlan,
-            model: applyAuthHeaderOverride(
-              applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
-              // When runtime auth exchange produced a different credential
-              // (runtimeAuthState is set), the exchanged token lives in
-              // authStorage and the SDK will pick it up automatically.
-              // Skip header injection to avoid leaking the pre-exchange key.
-              runtimeAuthState ? null : apiKeyInfo,
-              params.config,
-            ),
-            resolvedApiKey: resolvedStreamApiKey,
-            authProfileId: lastProfileId,
-            authProfileIdSource: lockedProfileId ? "user" : "auto",
-            initialReplayState: accumulatedReplayState,
-            authStorage,
-            authProfileStore: runAttemptAuthProfileStore,
-            // These harnesses build OpenClaw tools internally. Keep transport auth
-            // scoped while letting tool construction see plugin/provider creds.
-            toolAuthProfileStore: harnessBuildsOpenClawTools ? attemptAuthProfileStore : undefined,
-            modelRegistry,
-            agentId: workspaceResolution.agentId,
-            beforeAgentStartResult,
-            thinkLevel,
-            onToolOutcome: observePostCompactionToolOutcome,
-            onRunProgress: notifyRunProgress,
-            fastMode: params.fastMode,
-            verboseLevel: params.verboseLevel,
-            reasoningLevel: params.reasoningLevel,
-            toolResultFormat: resolvedToolResultFormat,
-            toolProgressDetail: params.toolProgressDetail,
-            execOverrides: params.execOverrides,
-            bashElevated: params.bashElevated,
-            timeoutMs: params.timeoutMs,
-            runTimeoutOverrideMs: params.runTimeoutOverrideMs,
+          const invocationTrace = freezeDiagnosticTraceContext(
+            parentDiagnosticTrace
+              ? createChildDiagnosticTraceContext(parentDiagnosticTrace)
+              : createDiagnosticTraceContext(),
+          );
+          const invocationBase = {
             runId: params.runId,
-            abortSignal: attemptAbortController.signal,
-            replyOperation: params.replyOperation,
-            shouldEmitToolResult: params.shouldEmitToolResult,
-            shouldEmitToolOutput: params.shouldEmitToolOutput,
-            onPartialReply: params.onPartialReply,
-            onAssistantMessageStart: params.onAssistantMessageStart,
-            onBlockReply: params.onBlockReply,
-            onBlockReplyFlush: params.onBlockReplyFlush,
-            blockReplyBreak: params.blockReplyBreak,
-            blockReplyChunking: params.blockReplyChunking,
-            onReasoningStream: params.onReasoningStream,
-            onReasoningEnd: params.onReasoningEnd,
-            onToolResult: params.onToolResult,
-            onAgentEvent: params.onAgentEvent,
-            onExecutionPhase: params.onExecutionPhase,
-            extraSystemPrompt: params.extraSystemPrompt,
-            sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-            inputProvenance: params.inputProvenance,
-            streamParams: params.streamParams,
-            modelRun: params.modelRun,
-            promptMode: params.promptMode,
-            ownerNumbers: params.ownerNumbers,
-            enforceFinalTag: params.enforceFinalTag,
-            silentExpected: params.silentExpected,
-            bootstrapContextMode: params.bootstrapContextMode,
-            bootstrapContextRunKind: params.bootstrapContextRunKind,
-            jobId: params.jobId,
-            toolsAllow: params.toolsAllow,
-            disableMessageTool: params.disableMessageTool,
-            forceMessageTool: params.forceMessageTool,
-            enableHeartbeatTool: params.enableHeartbeatTool,
-            forceHeartbeatTool: params.forceHeartbeatTool,
-            requireExplicitMessageTarget: params.requireExplicitMessageTarget,
-            internalEvents: params.internalEvents,
-            bootstrapPromptWarningSignaturesSeen,
-            bootstrapPromptWarningSignature:
-              bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
-            suppressNextUserMessagePersistence,
-            beforeAgentFinalizeRevisionAttempts,
-            maxBeforeAgentFinalizeRevisions: MAX_BEFORE_AGENT_FINALIZE_REVISIONS,
-            suppressTranscriptOnlyAssistantPersistence:
-              params.suppressTranscriptOnlyAssistantPersistence,
-            suppressAssistantErrorPersistence: params.suppressAssistantErrorPersistence,
-            onUserMessagePersisted,
-            onAssistantErrorMessagePersisted: params.onAssistantErrorMessagePersisted,
-          })
+            ...(resolvedSessionKey && { sessionKey: resolvedSessionKey }),
+            ...(activeSessionId && { sessionId: activeSessionId }),
+            provider,
+            model: modelId,
+            ...(params.trigger && { trigger: params.trigger }),
+            ...((params.messageChannel ?? params.messageProvider)
+              ? { channel: params.messageChannel ?? params.messageProvider }
+              : {}),
+            trace: invocationTrace,
+          };
+          const invocationStartedAt = Date.now();
+          emitTrustedDiagnosticEvent({
+            type: "run.invocation",
+            ...invocationBase,
+          });
+          const runAttempt = () =>
+            runEmbeddedAttemptWithBackend({
+              sessionId: activeSessionId,
+              sessionKey: resolvedSessionKey,
+              promptCacheKey: params.promptCacheKey,
+              sandboxSessionKey: params.sandboxSessionKey,
+              trigger: params.trigger,
+              memoryFlushWritePath: params.memoryFlushWritePath,
+              messageChannel: params.messageChannel,
+              messageProvider: params.messageProvider,
+              chatType: params.chatType,
+              agentAccountId: params.agentAccountId,
+              messageTo: params.messageTo,
+              messageThreadId: params.messageThreadId,
+              groupId: params.groupId,
+              groupChannel: params.groupChannel,
+              groupSpace: params.groupSpace,
+              memberRoleIds: params.memberRoleIds,
+              spawnedBy: params.spawnedBy,
+              isCanonicalWorkspace,
+              senderId: params.senderId,
+              senderName: params.senderName,
+              senderUsername: params.senderUsername,
+              senderE164: params.senderE164,
+              currentChannelId: params.currentChannelId,
+              currentThreadTs: params.currentThreadTs,
+              currentMessageId: params.currentMessageId,
+              currentInboundAudio: params.currentInboundAudio,
+              replyToMode: params.replyToMode,
+              hasRepliedRef: params.hasRepliedRef,
+              sessionFile: activeSessionFile,
+              workspaceDir: resolvedWorkspace,
+              cwd: params.cwd,
+              agentDir,
+              config: params.config,
+              allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+              contextEngine,
+              contextTokenBudget: ctxInfo.tokens,
+              contextWindowInfo: ctxInfo,
+              skillsSnapshot: params.skillsSnapshot,
+              prompt,
+              transcriptPrompt: params.transcriptPrompt,
+              userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
+              currentInboundEventKind: params.currentInboundEventKind,
+              currentInboundContext: params.currentInboundContext,
+              images: params.images,
+              imageOrder: params.imageOrder,
+              clientTools: params.clientTools,
+              disableTools: params.disableTools,
+              provider,
+              modelId,
+              // Use the harness selected before model/auth setup for the actual
+              // attempt too. Otherwise plugin-owned transports can skip OpenClaw auth
+              // bootstrap but drift back to OpenClaw when the attempt is created.
+              agentHarnessId: agentHarness.id,
+              ...(params.sessionKey
+                ? {
+                    agentHarnessTaskRuntimeScope: createAgentHarnessTaskRuntimeScope({
+                      requesterSessionKey: params.sessionKey,
+                    }),
+                  }
+                : {}),
+              runtimePlan,
+              model: applyAuthHeaderOverride(
+                applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
+                // When runtime auth exchange produced a different credential
+                // (runtimeAuthState is set), the exchanged token lives in
+                // authStorage and the SDK will pick it up automatically.
+                // Skip header injection to avoid leaking the pre-exchange key.
+                runtimeAuthState ? null : apiKeyInfo,
+                params.config,
+              ),
+              resolvedApiKey: resolvedStreamApiKey,
+              authProfileId: lastProfileId,
+              authProfileIdSource: lockedProfileId ? "user" : "auto",
+              initialReplayState: accumulatedReplayState,
+              authStorage,
+              authProfileStore: runAttemptAuthProfileStore,
+              // These harnesses build OpenClaw tools internally. Keep transport auth
+              // scoped while letting tool construction see plugin/provider creds.
+              toolAuthProfileStore: harnessBuildsOpenClawTools
+                ? attemptAuthProfileStore
+                : undefined,
+              modelRegistry,
+              agentId: workspaceResolution.agentId,
+              beforeAgentStartResult,
+              thinkLevel,
+              onToolOutcome: observePostCompactionToolOutcome,
+              onRunProgress: notifyRunProgress,
+              fastMode: params.fastMode,
+              verboseLevel: params.verboseLevel,
+              reasoningLevel: params.reasoningLevel,
+              toolResultFormat: resolvedToolResultFormat,
+              toolProgressDetail: params.toolProgressDetail,
+              execOverrides: params.execOverrides,
+              bashElevated: params.bashElevated,
+              timeoutMs: params.timeoutMs,
+              runTimeoutOverrideMs: params.runTimeoutOverrideMs,
+              runId: params.runId,
+              abortSignal: attemptAbortController.signal,
+              replyOperation: params.replyOperation,
+              shouldEmitToolResult: params.shouldEmitToolResult,
+              shouldEmitToolOutput: params.shouldEmitToolOutput,
+              onPartialReply: params.onPartialReply,
+              onAssistantMessageStart: params.onAssistantMessageStart,
+              onBlockReply: params.onBlockReply,
+              onBlockReplyFlush: params.onBlockReplyFlush,
+              blockReplyBreak: params.blockReplyBreak,
+              blockReplyChunking: params.blockReplyChunking,
+              onReasoningStream: params.onReasoningStream,
+              onReasoningEnd: params.onReasoningEnd,
+              onToolResult: params.onToolResult,
+              onAgentEvent: params.onAgentEvent,
+              onExecutionPhase: params.onExecutionPhase,
+              extraSystemPrompt: params.extraSystemPrompt,
+              sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+              inputProvenance: params.inputProvenance,
+              streamParams: params.streamParams,
+              modelRun: params.modelRun,
+              promptMode: params.promptMode,
+              ownerNumbers: params.ownerNumbers,
+              enforceFinalTag: params.enforceFinalTag,
+              silentExpected: params.silentExpected,
+              bootstrapContextMode: params.bootstrapContextMode,
+              bootstrapContextRunKind: params.bootstrapContextRunKind,
+              jobId: params.jobId,
+              toolsAllow: params.toolsAllow,
+              disableMessageTool: params.disableMessageTool,
+              forceMessageTool: params.forceMessageTool,
+              enableHeartbeatTool: params.enableHeartbeatTool,
+              forceHeartbeatTool: params.forceHeartbeatTool,
+              requireExplicitMessageTarget: params.requireExplicitMessageTarget,
+              internalEvents: params.internalEvents,
+              bootstrapPromptWarningSignaturesSeen,
+              bootstrapPromptWarningSignature:
+                bootstrapPromptWarningSignaturesSeen[
+                  bootstrapPromptWarningSignaturesSeen.length - 1
+                ],
+              suppressNextUserMessagePersistence,
+              beforeAgentFinalizeRevisionAttempts,
+              maxBeforeAgentFinalizeRevisions: MAX_BEFORE_AGENT_FINALIZE_REVISIONS,
+              suppressTranscriptOnlyAssistantPersistence:
+                params.suppressTranscriptOnlyAssistantPersistence,
+              suppressAssistantErrorPersistence: params.suppressAssistantErrorPersistence,
+              onUserMessagePersisted,
+              onAssistantErrorMessagePersisted: params.onAssistantErrorMessagePersisted,
+            });
+          const rawAttempt = await (
+            invocationTrace
+              ? runWithDiagnosticTraceContext(invocationTrace, runAttempt)
+              : runAttempt()
+          )
+            .then(
+              (result) => {
+                emitTrustedDiagnosticEvent({
+                  type: "run.invocation.completed",
+                  ...invocationBase,
+                  durationMs: Date.now() - invocationStartedAt,
+                  outcome: "completed",
+                });
+                return result;
+              },
+              (err: unknown): never => {
+                emitTrustedDiagnosticEvent({
+                  type: "run.invocation.completed",
+                  ...invocationBase,
+                  durationMs: Date.now() - invocationStartedAt,
+                  outcome: "error",
+                });
+                throw err;
+              },
+            )
             .catch((err: unknown): never => {
               throw postCompactionAbortError ?? err;
             })

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1103,7 +1103,7 @@ export async function runEmbeddedAttempt(
       resolveContextEngineOwnerPluginId(activeContextEngine);
     const agentDir = params.agentDir ?? resolveAgentDir(params.config ?? {}, sessionAgentId);
     const diagnosticTrace = freezeDiagnosticTraceContext(
-      getActiveDiagnosticTraceContext() ?? createDiagnosticTraceContext(),
+      params.diagnosticTrace ?? getActiveDiagnosticTraceContext() ?? createDiagnosticTraceContext(),
     );
     const runTrace = freezeDiagnosticTraceContext(
       createChildDiagnosticTraceContext(diagnosticTrace),

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -11,6 +11,7 @@ import type { ReasoningLevel, ThinkLevel, VerboseLevel } from "../../../auto-rep
 import type { ChatType } from "../../../channels/chat-type.js";
 import type { InboundEventKind } from "../../../channels/inbound-event/kind.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { DiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
 import type { ImageContent } from "../../../llm/types.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import type { CommandQueueEnqueueFn } from "../../../process/command-queue.types.js";
@@ -172,6 +173,8 @@ export type RunEmbeddedAgentParams = {
    */
   runTimeoutOverrideMs?: number;
   runId: string;
+  /** Parent diagnostic trace for this run, usually captured from the inbound gateway scope. */
+  diagnosticTrace?: DiagnosticTraceContext;
   abortSignal?: AbortSignal;
   onExecutionStarted?: () => void;
   onExecutionPhase?: (info: {

--- a/src/gateway/request-diagnostic-trace.test.ts
+++ b/src/gateway/request-diagnostic-trace.test.ts
@@ -1,0 +1,48 @@
+import type { IncomingMessage } from "node:http";
+import { describe, expect, it } from "vitest";
+import {
+  createGatewayMessageDiagnosticTrace,
+  createGatewayRequestDiagnosticTrace,
+} from "./request-diagnostic-trace.js";
+
+function requestWithTraceparent(traceparent?: string): IncomingMessage {
+  return { headers: traceparent ? { traceparent } : {} } as IncomingMessage;
+}
+
+describe("gateway request diagnostic trace", () => {
+  it("ignores inbound traceparent unless the caller trusts the boundary", () => {
+    const traceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+    const spanId = "00f067aa0ba902b7";
+    const requestTrace = createGatewayRequestDiagnosticTrace(
+      requestWithTraceparent(`00-${traceId}-${spanId}-01`),
+    );
+
+    expect(requestTrace.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(requestTrace.traceId).not.toBe(traceId);
+    expect(requestTrace.parentSpanId).toBeUndefined();
+  });
+
+  it("creates a server child span from trusted inbound traceparent", () => {
+    const traceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+    const spanId = "00f067aa0ba902b7";
+    const requestTrace = createGatewayRequestDiagnosticTrace(
+      requestWithTraceparent(`00-${traceId}-${spanId}-01`),
+      { honorTraceparent: true },
+    );
+
+    expect(requestTrace.traceId).toBe(traceId);
+    expect(requestTrace.parentSpanId).toBe(spanId);
+    expect(requestTrace.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(requestTrace.spanId).not.toBe(spanId);
+  });
+
+  it("creates message spans under the request span", () => {
+    const requestTrace = createGatewayRequestDiagnosticTrace(requestWithTraceparent());
+    const messageTrace = createGatewayMessageDiagnosticTrace(requestTrace);
+
+    expect(messageTrace.traceId).toBe(requestTrace.traceId);
+    expect(messageTrace.parentSpanId).toBe(requestTrace.spanId);
+    expect(messageTrace.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(messageTrace.spanId).not.toBe(requestTrace.spanId);
+  });
+});

--- a/src/gateway/request-diagnostic-trace.ts
+++ b/src/gateway/request-diagnostic-trace.ts
@@ -1,0 +1,32 @@
+import type { IncomingMessage } from "node:http";
+import {
+  createChildDiagnosticTraceContext,
+  createDiagnosticTraceContext,
+  parseDiagnosticTraceparent,
+  type DiagnosticTraceContext,
+} from "../infra/diagnostic-trace-context.js";
+
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  return value?.find((entry) => entry.trim().length > 0);
+}
+
+export function createGatewayRequestDiagnosticTrace(
+  req: IncomingMessage,
+  options: { honorTraceparent?: boolean } = {},
+): DiagnosticTraceContext {
+  const parentTrace = options.honorTraceparent
+    ? parseDiagnosticTraceparent(firstHeaderValue(req.headers.traceparent))
+    : undefined;
+  return parentTrace
+    ? createChildDiagnosticTraceContext(parentTrace)
+    : createDiagnosticTraceContext();
+}
+
+export function createGatewayMessageDiagnosticTrace(
+  requestTrace: DiagnosticTraceContext,
+): DiagnosticTraceContext {
+  return createChildDiagnosticTraceContext(requestTrace);
+}

--- a/src/gateway/server-http.request-trace.test.ts
+++ b/src/gateway/server-http.request-trace.test.ts
@@ -101,4 +101,51 @@ describe("gateway HTTP request trace scope", () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("inherits inbound traceparent as the request trace parent", async () => {
+    const events: Array<{ trace?: DiagnosticTraceContext; type: string }> = [];
+    const stop = onDiagnosticEvent((event) => {
+      events.push({ trace: event.trace, type: event.type });
+    });
+    let activeTraceInHandler: DiagnosticTraceContext | undefined;
+    const parentTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+    const parentSpanId = "00f067aa0ba902b7";
+
+    await withTempConfig({
+      cfg: { gateway: { auth: { mode: "none" } } },
+      run: async () => {
+        const httpServer = createGatewayHttpServer({
+          clients: new Set(),
+          controlUiEnabled: false,
+          controlUiBasePath: "/__control__",
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest: async (_req, res) => {
+            activeTraceInHandler = getActiveDiagnosticTraceContext();
+            emitDiagnosticEvent({ type: "message.queued", source: "gateway-test" });
+            res.statusCode = 204;
+            res.end();
+            return true;
+          },
+          resolvedAuth,
+        });
+        const port = await listen(httpServer);
+        try {
+          const response = await fetch(`http://127.0.0.1:${port}/hook`, {
+            headers: { traceparent: `00-${parentTraceId}-${parentSpanId}-01` },
+          });
+          expect(response.status).toBe(204);
+        } finally {
+          await closeServer(httpServer);
+        }
+      },
+    });
+
+    stop();
+    expect(activeTraceInHandler?.traceId).toBe(parentTraceId);
+    expect(activeTraceInHandler?.parentSpanId).toBe(parentSpanId);
+    expect(activeTraceInHandler?.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(activeTraceInHandler?.spanId).not.toBe(parentSpanId);
+    expect(events).toEqual([{ trace: activeTraceInHandler, type: "message.queued" }]);
+  });
 });

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -12,10 +12,7 @@ import type { WebSocketServer } from "ws";
 import { resolveBundledChannelGatewayAuthBypassPaths } from "../channels/plugins/gateway-auth-bypass.js";
 import { getRuntimeConfig } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  createDiagnosticTraceContext,
-  runWithDiagnosticTraceContext,
-} from "../infra/diagnostic-trace-context.js";
+import { runWithDiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
 import { resolveAssistantIdentity } from "./assistant-identity.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import {
@@ -32,6 +29,7 @@ import {
   normalizePluginNodeCapabilityScopedUrl,
   type PluginNodeCapabilitySurface,
 } from "./plugin-node-capability.js";
+import { createGatewayRequestDiagnosticTrace } from "./request-diagnostic-trace.js";
 import type { HooksRequestHandler } from "./server/hooks-request-handler.js";
 import {
   isProtectedPluginRoutePathFromContext,
@@ -533,8 +531,9 @@ export function createGatewayHttpServer(opts: {
       });
 
   function handleRequestWithTrace(req: IncomingMessage, res: ServerResponse) {
-    return runWithDiagnosticTraceContext(createDiagnosticTraceContext(), () =>
-      handleRequest(req, res),
+    return runWithDiagnosticTraceContext(
+      createGatewayRequestDiagnosticTrace(req, { honorTraceparent: isLocalDirectRequest(req) }),
+      () => handleRequest(req, res),
     );
   }
 
@@ -854,137 +853,143 @@ export function attachGatewayUpgradeHandler(opts: {
   } = opts;
   const getResolvedAuth = opts.getResolvedAuth ?? (() => resolvedAuth);
   httpServer.on("upgrade", (req, socket, head) => {
-    void runWithDiagnosticTraceContext(createDiagnosticTraceContext(), async () => {
-      const configSnapshot = getRuntimeConfig();
-      const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
-      const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
-      const scopedNodeCapability = normalizePluginNodeCapabilityScopedUrl(req.url ?? "/");
-      if (scopedNodeCapability.malformedScopedPath) {
-        writeUpgradeAuthFailure(socket, { ok: false, reason: "unauthorized" });
-        socket.destroy();
-        return;
-      }
-      if (scopedNodeCapability.rewrittenUrl) {
-        req.url = scopedNodeCapability.rewrittenUrl;
-      }
-      const resolvedAuthLocal = getResolvedAuth();
-      const requestPath = scopedNodeCapability.pathname;
-      const pathContext = resolvePluginRoutePathContext(requestPath);
-      const nodeCapability = resolvePluginNodeCapabilityRoute?.(pathContext);
-      if (nodeCapability) {
-        // Node-capability WebSocket upgrades authenticate before plugin upgrade dispatch so
-        // plugin handlers never receive unauthorized scoped capability sockets.
-        const { authorizePluginNodeCapabilityRequest } = await getPluginNodeCapabilityAuthModule();
-        const ok = await authorizePluginNodeCapabilityRequest({
-          req,
-          auth: resolvedAuthLocal,
-          trustedProxies,
-          allowRealIpFallback,
-          clients,
-          nodeCapability,
-          capability: scopedNodeCapability.capability,
-          malformedScopedPath: scopedNodeCapability.malformedScopedPath,
-          rateLimiter,
-        });
-        if (!ok.ok) {
-          writeUpgradeAuthFailure(socket, ok);
+    void runWithDiagnosticTraceContext(
+      createGatewayRequestDiagnosticTrace(req, {
+        honorTraceparent: isLocalDirectRequest(req),
+      }),
+      async () => {
+        const configSnapshot = getRuntimeConfig();
+        const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
+        const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
+        const scopedNodeCapability = normalizePluginNodeCapabilityScopedUrl(req.url ?? "/");
+        if (scopedNodeCapability.malformedScopedPath) {
+          writeUpgradeAuthFailure(socket, { ok: false, reason: "unauthorized" });
           socket.destroy();
           return;
         }
-      }
-      if (handlePluginUpgrade) {
-        let pluginGatewayAuthSatisfied = false;
-        let pluginGatewayRequestAuth: AuthorizedGatewayHttpRequest | undefined;
-        let pluginGatewayRequestOperatorScopes: string[] | undefined;
-        const enforcePluginGatewayAuth = (
-          shouldEnforcePluginGatewayAuth ?? shouldEnforceDefaultPluginGatewayAuth
-        )(pathContext);
-        if (
-          enforcePluginGatewayAuth &&
-          !(await getCachedPluginGatewayAuthBypassPaths(configSnapshot)).has(requestPath)
-        ) {
-          const { checkGatewayHttpRequestAuth } = await getHttpAuthUtilsModule();
-          const authCheck = await checkGatewayHttpRequestAuth({
+        if (scopedNodeCapability.rewrittenUrl) {
+          req.url = scopedNodeCapability.rewrittenUrl;
+        }
+        const resolvedAuthLocal = getResolvedAuth();
+        const requestPath = scopedNodeCapability.pathname;
+        const pathContext = resolvePluginRoutePathContext(requestPath);
+        const nodeCapability = resolvePluginNodeCapabilityRoute?.(pathContext);
+        if (nodeCapability) {
+          // Node-capability WebSocket upgrades authenticate before plugin upgrade dispatch so
+          // plugin handlers never receive unauthorized scoped capability sockets.
+          const { authorizePluginNodeCapabilityRequest } =
+            await getPluginNodeCapabilityAuthModule();
+          const ok = await authorizePluginNodeCapabilityRequest({
             req,
             auth: resolvedAuthLocal,
             trustedProxies,
             allowRealIpFallback,
+            clients,
+            nodeCapability,
+            capability: scopedNodeCapability.capability,
+            malformedScopedPath: scopedNodeCapability.malformedScopedPath,
             rateLimiter,
-            cfg: configSnapshot,
           });
-          if (!authCheck.ok) {
-            writeUpgradeAuthFailure(socket, authCheck.authResult);
+          if (!ok.ok) {
+            writeUpgradeAuthFailure(socket, ok);
             socket.destroy();
             return;
           }
-          pluginGatewayAuthSatisfied = true;
-          pluginGatewayRequestAuth = authCheck.requestAuth;
-          const { resolvePluginRouteRuntimeOperatorScopes } =
-            await getPluginRouteRuntimeScopesModule();
-          pluginGatewayRequestOperatorScopes = resolvePluginRouteRuntimeOperatorScopes(
-            req,
-            authCheck.requestAuth,
-          );
         }
-        if (
-          await handlePluginUpgrade(req, socket, head, pathContext, {
-            gatewayAuthSatisfied: pluginGatewayAuthSatisfied,
-            gatewayRequestAuth: pluginGatewayRequestAuth,
-            gatewayRequestOperatorScopes: pluginGatewayRequestOperatorScopes,
-          })
-        ) {
-          return;
-        }
-      }
-      const preauthBudgetKey = resolveRequestClientIp(req, trustedProxies, allowRealIpFallback);
-      if (wss.listenerCount("connection") === 0) {
-        writeUpgradeServiceUnavailable(socket, "Gateway websocket handlers unavailable");
-        socket.destroy();
-        return;
-      }
-      if (!preauthConnectionBudget.acquire(preauthBudgetKey)) {
-        writeUpgradeServiceUnavailable(socket, "Too many unauthenticated sockets");
-        socket.destroy();
-        return;
-      }
-      let budgetTransferred = false;
-      // The socket owns the preauth budget until the WebSocket connection handler claims it;
-      // close/error paths release here to avoid leaking unauthenticated connection slots.
-      const releaseUpgradeBudget = () => {
-        if (budgetTransferred) {
-          return;
-        }
-        budgetTransferred = true;
-        preauthConnectionBudget.release(preauthBudgetKey);
-      };
-      socket.once("close", releaseUpgradeBudget);
-      try {
-        wss.handleUpgrade(req, socket, head, (ws) => {
-          (
-            ws as unknown as import("ws").WebSocket & {
-              __openclawPreauthBudgetClaimed?: boolean;
-              __openclawPreauthBudgetKey?: string;
+        if (handlePluginUpgrade) {
+          let pluginGatewayAuthSatisfied = false;
+          let pluginGatewayRequestAuth: AuthorizedGatewayHttpRequest | undefined;
+          let pluginGatewayRequestOperatorScopes: string[] | undefined;
+          const enforcePluginGatewayAuth = (
+            shouldEnforcePluginGatewayAuth ?? shouldEnforceDefaultPluginGatewayAuth
+          )(pathContext);
+          if (
+            enforcePluginGatewayAuth &&
+            !(await getCachedPluginGatewayAuthBypassPaths(configSnapshot)).has(requestPath)
+          ) {
+            const { checkGatewayHttpRequestAuth } = await getHttpAuthUtilsModule();
+            const authCheck = await checkGatewayHttpRequestAuth({
+              req,
+              auth: resolvedAuthLocal,
+              trustedProxies,
+              allowRealIpFallback,
+              rateLimiter,
+              cfg: configSnapshot,
+            });
+            if (!authCheck.ok) {
+              writeUpgradeAuthFailure(socket, authCheck.authResult);
+              socket.destroy();
+              return;
             }
-          )["__openclawPreauthBudgetKey"] = preauthBudgetKey;
-          wss.emit("connection", ws, req);
-          const budgetClaimed = Boolean(
+            pluginGatewayAuthSatisfied = true;
+            pluginGatewayRequestAuth = authCheck.requestAuth;
+            const { resolvePluginRouteRuntimeOperatorScopes } =
+              await getPluginRouteRuntimeScopesModule();
+            pluginGatewayRequestOperatorScopes = resolvePluginRouteRuntimeOperatorScopes(
+              req,
+              authCheck.requestAuth,
+            );
+          }
+          if (
+            await handlePluginUpgrade(req, socket, head, pathContext, {
+              gatewayAuthSatisfied: pluginGatewayAuthSatisfied,
+              gatewayRequestAuth: pluginGatewayRequestAuth,
+              gatewayRequestOperatorScopes: pluginGatewayRequestOperatorScopes,
+            })
+          ) {
+            return;
+          }
+        }
+        const preauthBudgetKey = resolveRequestClientIp(req, trustedProxies, allowRealIpFallback);
+        if (wss.listenerCount("connection") === 0) {
+          writeUpgradeServiceUnavailable(socket, "Gateway websocket handlers unavailable");
+          socket.destroy();
+          return;
+        }
+        if (!preauthConnectionBudget.acquire(preauthBudgetKey)) {
+          writeUpgradeServiceUnavailable(socket, "Too many unauthenticated sockets");
+          socket.destroy();
+          return;
+        }
+        let budgetTransferred = false;
+        // The socket owns the preauth budget until the WebSocket connection handler claims it;
+        // close/error paths release here to avoid leaking unauthenticated connection slots.
+        const releaseUpgradeBudget = () => {
+          if (budgetTransferred) {
+            return;
+          }
+          budgetTransferred = true;
+          preauthConnectionBudget.release(preauthBudgetKey);
+        };
+        socket.once("close", releaseUpgradeBudget);
+        try {
+          wss.handleUpgrade(req, socket, head, (ws) => {
             (
               ws as unknown as import("ws").WebSocket & {
                 __openclawPreauthBudgetClaimed?: boolean;
+                __openclawPreauthBudgetKey?: string;
               }
-            )["__openclawPreauthBudgetClaimed"],
-          );
-          if (budgetClaimed) {
-            budgetTransferred = true;
-            socket.off("close", releaseUpgradeBudget);
-          }
-        });
-      } catch {
-        socket.off("close", releaseUpgradeBudget);
-        releaseUpgradeBudget();
-        throw new Error("gateway websocket upgrade failed");
-      }
-    }).catch((err: unknown) => {
+            )["__openclawPreauthBudgetKey"] = preauthBudgetKey;
+            wss.emit("connection", ws, req);
+            const budgetClaimed = Boolean(
+              (
+                ws as unknown as import("ws").WebSocket & {
+                  __openclawPreauthBudgetClaimed?: boolean;
+                }
+              )["__openclawPreauthBudgetClaimed"],
+            );
+            if (budgetClaimed) {
+              budgetTransferred = true;
+              socket.off("close", releaseUpgradeBudget);
+            }
+          });
+        } catch {
+          socket.off("close", releaseUpgradeBudget);
+          releaseUpgradeBudget();
+          throw new Error("gateway websocket upgrade failed");
+        }
+      },
+    ).catch((err: unknown) => {
       const remoteAddress = (socket as { remoteAddress?: string }).remoteAddress ?? "unknown";
       const errorMessage = err instanceof Error ? err.message : String(err);
       log?.warn(`ws upgrade error from ${remoteAddress}: ${errorMessage}`);

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -63,10 +63,7 @@ import {
   updatePairedDeviceMetadata,
   verifyDeviceToken,
 } from "../../../infra/device-pairing.js";
-import {
-  createDiagnosticTraceContext,
-  runWithDiagnosticTraceContext,
-} from "../../../infra/diagnostic-trace-context.js";
+import { runWithDiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
 import {
   getPairedNode,
   requestNodePairing,
@@ -121,6 +118,10 @@ import {
   setClientPluginNodeCapability,
 } from "../../plugin-node-capability.js";
 import { withSerializedRateLimitAttempt } from "../../rate-limit-attempt-serialization.js";
+import {
+  createGatewayMessageDiagnosticTrace,
+  createGatewayRequestDiagnosticTrace,
+} from "../../request-diagnostic-trace.js";
 import { parseGatewayRole } from "../../role-policy.js";
 import {
   MAX_BUFFERED_BYTES,
@@ -427,6 +428,12 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     logHealth,
     logWsControl,
   } = params;
+  // A WebSocket connection is the stable request root; individual JSON-RPC
+  // frames are siblings because separate client calls on one socket are not
+  // causally ordered by transport arrival.
+  const requestTrace = createGatewayRequestDiagnosticTrace(upgradeReq, {
+    honorTraceparent: isLocalDirectRequest(upgradeReq),
+  });
 
   const sendFrame = async (obj: unknown): Promise<void> =>
     await new Promise<void>((resolve, reject) => {
@@ -2116,7 +2123,9 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
   };
 
   socket.on("message", (data) => {
-    void runWithDiagnosticTraceContext(createDiagnosticTraceContext(), () => handleMessage(data));
+    void runWithDiagnosticTraceContext(createGatewayMessageDiagnosticTrace(requestTrace), () =>
+      handleMessage(data),
+    );
   });
 }
 

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -296,6 +296,30 @@ export type DiagnosticRunProgressEvent = DiagnosticBaseEvent & {
   reason: string;
 };
 
+export type DiagnosticRunInvocationEvent = DiagnosticBaseEvent & {
+  type: "run.invocation";
+  runId: string;
+  sessionKey?: string;
+  sessionId?: string;
+  provider?: string;
+  model?: string;
+  trigger?: string;
+  channel?: string;
+};
+
+export type DiagnosticRunInvocationCompletedEvent = DiagnosticBaseEvent & {
+  type: "run.invocation.completed";
+  runId: string;
+  sessionKey?: string;
+  sessionId?: string;
+  provider?: string;
+  model?: string;
+  trigger?: string;
+  channel?: string;
+  durationMs: number;
+  outcome: "completed" | "error";
+};
+
 export type DiagnosticHeartbeatEvent = DiagnosticBaseEvent & {
   type: "diagnostic.heartbeat";
   webhooks: {
@@ -667,6 +691,8 @@ export type DiagnosticEventPayload =
   | DiagnosticSessionTurnCreatedEvent
   | DiagnosticLaneEnqueueEvent
   | DiagnosticLaneDequeueEvent
+  | DiagnosticRunInvocationEvent
+  | DiagnosticRunInvocationCompletedEvent
   | DiagnosticRunAttemptEvent
   | DiagnosticRunProgressEvent
   | DiagnosticHeartbeatEvent


### PR DESCRIPTION
## Summary

- Chain gateway diagnostic traces into embedded agent runs using the existing `DiagnosticTraceContext` instead of adding a second run/request scope.
- Add trusted-boundary-aware gateway request/message trace helpers, plus `run.invocation` / `run.invocation.completed` diagnostic events.
- Record invocation lifecycle spans in diagnostics-otel so request -> invocation -> harness -> run/model/tool spans stay connected and close on success or pre-lifecycle failures.
- Add focused tests for trusted/untrusted gateway traceparent handling and gateway-to-run trace propagation.

## Verification

- `node scripts/run-vitest.mjs src/gateway/request-diagnostic-trace.test.ts src/gateway/server-http.request-trace.test.ts src/agents/embedded-agent-runner/run.diagnostic-trace-chain.test.ts`
- `git diff --check`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo` *(blocked after rebase by existing upstream `src/agents/sessions/sdk.ts:279` TS2322, not touched by this branch)*
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` *(blocked after rebase by existing upstream `src/agents/sessions/sdk.ts:279` TS2322, not touched by this branch)*
- `.agents/skills/autoreview/scripts/autoreview --mode local` *(clean before final rebase; reruns after rebase drove the fixes in this branch, latest focused tests remain green; current core/extension tsgo is blocked by the upstream type drift above)*

## Notes

The gateway helper intentionally ignores inbound `traceparent` by default and only honors it for local-direct gateway boundaries, so public unauthenticated requests cannot spoof trusted telemetry trace IDs.
