### PR TITLE
#92069: fix(cli): usage errors exit 0

### DIFF
--- a/src/cli/program/action-reparse.test.ts
+++ b/src/cli/program/action-reparse.test.ts
@@ -16,6 +16,10 @@ vi.mock("./helpers.js", () => ({
   resolveCommandOptionArgs: resolveCommandOptionArgsMock,
 }));
 
+function setRawArgs(command: Command, rawArgs: string[]): void {
+  (command as Command & { rawArgs: string[] }).rawArgs = rawArgs;
+}
+
 describe("reparseProgramFromActionArgs", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -26,7 +30,7 @@ describe("reparseProgramFromActionArgs", () => {
 
   it("uses action command name + args as fallback argv", async () => {
     const program = new Command().name("openclaw");
-    program.rawArgs = ["node", "openclaw", "status", "--json"];
+    setRawArgs(program, ["node", "openclaw", "status", "--json"]);
     const parseAsync = vi.spyOn(program, "parseAsync").mockResolvedValue(program);
     const actionCommand = {
       name: () => "status",
@@ -46,7 +50,7 @@ describe("reparseProgramFromActionArgs", () => {
 
   it("falls back to action args without command name when action has no name", async () => {
     const program = new Command().name("openclaw");
-    program.rawArgs = ["node", "openclaw"];
+    setRawArgs(program, ["node", "openclaw"]);
     const parseAsync = vi.spyOn(program, "parseAsync").mockResolvedValue(program);
     const actionCommand = {
       name: () => "",
@@ -87,7 +91,7 @@ describe("reparseProgramFromActionArgs", () => {
 
   it("uses root raw args and reparses the root for nested lazy commands", async () => {
     const root = new Command().name("openclaw");
-    root.rawArgs = ["node", "openclaw", "workspaces", "audit", "export", "--since", "1"];
+    setRawArgs(root, ["node", "openclaw", "workspaces", "audit", "export", "--since", "1"]);
     const workspaces = root.command("workspaces");
     const audit = workspaces.command("audit");
     const exportCommand = audit.command("export");

--- a/src/cli/program/action-reparse.test.ts
+++ b/src/cli/program/action-reparse.test.ts
@@ -85,6 +85,27 @@ describe("reparseProgramFromActionArgs", () => {
     expect(parseAsync).toHaveBeenCalledWith(["node", "openclaw", "status"]);
   });
 
+  it("uses root raw args and reparses the root for nested lazy commands", async () => {
+    const root = new Command().name("openclaw");
+    root.rawArgs = ["node", "openclaw", "workspaces", "audit", "export", "--since", "1"];
+    const workspaces = root.command("workspaces");
+    const audit = workspaces.command("audit");
+    const exportCommand = audit.command("export");
+    const parseAsync = vi.spyOn(root, "parseAsync").mockResolvedValue(root);
+    const auditParseAsync = vi.spyOn(audit, "parseAsync");
+    resolveActionArgsMock.mockReturnValue(["--since", "1"]);
+
+    await reparseProgramFromActionArgs(audit, [exportCommand]);
+
+    expect(buildParseArgvMock).toHaveBeenCalledWith({
+      programName: "openclaw",
+      rawArgs: ["node", "openclaw", "workspaces", "audit", "export", "--since", "1"],
+      fallbackArgv: ["export", "--since", "1"],
+    });
+    expect(parseAsync).toHaveBeenCalledWith(["node", "openclaw", "status"]);
+    expect(auditParseAsync).not.toHaveBeenCalled();
+  });
+
   it("uses program root when action command is missing", async () => {
     const program = new Command().name("openclaw");
     const parseAsync = vi.spyOn(program, "parseAsync").mockResolvedValue(program);

--- a/src/cli/program/action-reparse.test.ts
+++ b/src/cli/program/action-reparse.test.ts
@@ -26,12 +26,11 @@ describe("reparseProgramFromActionArgs", () => {
 
   it("uses action command name + args as fallback argv", async () => {
     const program = new Command().name("openclaw");
+    program.rawArgs = ["node", "openclaw", "status", "--json"];
     const parseAsync = vi.spyOn(program, "parseAsync").mockResolvedValue(program);
     const actionCommand = {
       name: () => "status",
-      parent: {
-        rawArgs: ["node", "openclaw", "status", "--json"],
-      },
+      parent: program,
     } as unknown as Command;
     resolveActionArgsMock.mockReturnValue(["--json"]);
 
@@ -47,10 +46,11 @@ describe("reparseProgramFromActionArgs", () => {
 
   it("falls back to action args without command name when action has no name", async () => {
     const program = new Command().name("openclaw");
+    program.rawArgs = ["node", "openclaw"];
     const parseAsync = vi.spyOn(program, "parseAsync").mockResolvedValue(program);
     const actionCommand = {
       name: () => "",
-      parent: {},
+      parent: program,
     } as unknown as Command;
     resolveActionArgsMock.mockReturnValue(["--json"]);
 
@@ -58,7 +58,7 @@ describe("reparseProgramFromActionArgs", () => {
 
     expect(buildParseArgvMock).toHaveBeenCalledWith({
       programName: "openclaw",
-      rawArgs: undefined,
+      rawArgs: ["node", "openclaw"],
       fallbackArgv: ["--json"],
     });
     expect(parseAsync).toHaveBeenCalledWith(["node", "openclaw", "status"]);

--- a/src/cli/program/action-reparse.ts
+++ b/src/cli/program/action-reparse.ts
@@ -12,19 +12,31 @@ function buildFallbackArgv(program: Command, actionCommand: Command | undefined)
     : [...parentOptionArgs, ...actionArgsList];
 }
 
+function findRootCommand(cmd: Command): Command {
+  let current: Command = cmd;
+  while (current.parent) {
+    current = current.parent;
+  }
+  return current;
+}
+
 /** Rebuild argv from Commander action args and re-run parsing after lazy registration. */
 export async function reparseProgramFromActionArgs(
   program: Command,
   actionArgs: unknown[],
 ): Promise<void> {
   const actionCommand = actionArgs.at(-1) as Command | undefined;
-  const root = actionCommand?.parent ?? program;
-  const rawArgs = (root as Command & { rawArgs?: string[] }).rawArgs;
+  // Use the true root program for argv reconstruction and parsing.
+  // For nested lazy commands (e.g. workspaces → audit), `program` is a sub-command
+  // whose rawArgs is cleared by Commander's restoreStateBeforeParse(). Only the
+  // root program retains the rawArgs set by _prepareUserArgs.
+  const rootProgram = findRootCommand(actionCommand ?? program);
+  const rawArgs = (rootProgram as Command & { rawArgs?: string[] }).rawArgs;
   const fallbackArgv = buildFallbackArgv(program, actionCommand);
   const parseArgv = buildParseArgv({
-    programName: program.name(),
+    programName: rootProgram.name(),
     rawArgs,
     fallbackArgv,
   });
-  await program.parseAsync(parseArgv);
+  await rootProgram.parseAsync(parseArgv);
 }


### PR DESCRIPTION
## Summary

Fix `reparseProgramFromActionArgs` to use the root Commander program for argv reconstruction, so nested lazy commands correctly detect unknown options and preserve non-zero usage-error exits.

## Root Cause

When a nested lazy command group is resolved (for example `workspaces → audit → export`), `reparseProgramFromActionArgs` read `rawArgs` from the parent sub-command. Commander's `restoreStateBeforeParse()` clears intermediate command state, including `rawArgs`, during reparse. That left `rawArgs` empty, so `buildParseArgv` could fall back to the wrong argv and the reparse could miss the unknown-option failure mode.

## Real behavior proof

**Behavior addressed:** CLI usage errors from lazy-command reparsing must exit non-zero instead of looking successful to scripts or CI. The reported issue is an undeclared plugin subcommand option such as `openclaw workspaces audit export --since 1` exiting 0.

**Real environment tested:** Crabbox Azure Linux lease `cbx_c1eeccc9b8ec`; Node.js via repo `tsx` entrypoint; Commander 14.0.3 contract checked locally (`_prepareUserArgs` sets root `rawArgs`, `restoreStateBeforeParse()` clears command `rawArgs`).

**Exact steps or command run after this patch:**
```sh
node --import tsx src/entry.ts nodes list --since 1
printf 'status=%s\n' "$?"
```
Focused regression coverage also exercised the nested lazy-command path directly:
```sh
node scripts/run-vitest.mjs src/cli/program/action-reparse.test.ts src/cli/program/register.subclis.test.ts src/cli/argv.test.ts
```

**Evidence after fix:** Crabbox run `run_5bfc588dcee4` terminal output:
```text
OpenClaw does not recognize option "--since".
Try: openclaw nodes list --help
status=1
```
Crabbox run `run_e35c2276a338` also passed the focused CLI regression files, including the nested lazy-command reparse test added for this PR.

**Observed result after fix:** The real CLI exits with status 1 for an undeclared option, and the nested lazy-command unit regression proves `reparseProgramFromActionArgs` reads `rawArgs` from the Commander root and calls root `parseAsync` instead of reparsing only the intermediate sub-command.

**What was not tested:** No full plugin catalog or unavailable `workspaces audit export` runtime command was tested in this checkout; that path is covered by the focused nested lazy-command regression test because the command is not registered in the current repo setup.

## Regression Test Plan

- [x] Unknown option through the CLI exits non-zero in a real repo setup.
- [x] Nested lazy-command reparse uses root `rawArgs` and root `parseAsync`.
- [x] Existing CLI argv and subcommand registration tests remain covered.
