### PR TITLE
fix(memory-core): score CJK keyword search instead of textScore=0 with trigram FTS5

### DIFF
--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -222,6 +222,103 @@ describe("searchKeyword trigram fallback", () => {
 
     expect(repeated[0]?.score).toBe(unique[0]?.score);
   });
+
+  // ===== CJK FTS textScore regression coverage (issue #92061) =====
+  //
+  // A multi-character CJK query used to be emitted as a single quoted trigram
+  // MATCH phrase (e.g. MATCH "飞书插件配置"), which only matches the exact
+  // contiguous substring. Real documents rarely contain that verbatim run, so
+  // MATCH returned zero rows, no LIKE fallback fired, and every hybrid result
+  // collapsed to textScore=0. The fix decomposes CJK tokens into per-character
+  // LIKE terms and adds a LIKE fallback when MATCH returns zero rows.
+
+  itWithTrigramFts(
+    "scores a multi-character CJK query with textScore=1 instead of 0 (issue #92061)",
+    async () => {
+      // The query characters are all present, but never as the contiguous
+      // substring "飞书插件配置" — the doc has "...配置飞书插件". Pre-fix this
+      // produced an empty keyword result (textScore=0); post-fix it matches.
+      const results = await runSearch({
+        rows: [{ id: "feishu", path: "memory/zh.md", text: "如何配置飞书插件" }],
+        query: "飞书插件配置",
+      });
+      expect(results.map((row) => row.id)).toEqual(["feishu"]);
+      expect(results[0]?.textScore).toBe(1);
+      expect(results[0]?.textScore).toBeGreaterThan(0);
+    },
+  );
+
+  itWithTrigramFts("requires every CJK character of the query to be present", async () => {
+    const results = await runSearch({
+      rows: [
+        { id: "full", path: "memory/full.md", text: "如何配置飞书插件" },
+        // Contains 飞书 but not 插件配置 — must be excluded by the per-character
+        // AND semantics rather than matched on a partial overlap.
+        { id: "partial", path: "memory/partial.md", text: "飞书云文档简介" },
+      ],
+      query: "飞书插件配置",
+    });
+    expect(results.map((row) => row.id)).toEqual(["full"]);
+  });
+
+  itWithTrigramFts(
+    "covers Japanese kanji queries that are not a contiguous substring",
+    async () => {
+      const results = await runSearch({
+        rows: [{ id: "jp", path: "memory/jp.md", text: "東京の駅の周辺を歩く" }],
+        query: "東京駅周辺",
+      });
+      expect(results.map((row) => row.id)).toEqual(["jp"]);
+      expect(results[0]?.textScore).toBe(1);
+    },
+  );
+
+  itWithTrigramFts(
+    "falls back to LIKE when a trigram MATCH returns zero rows without throwing",
+    async () => {
+      // "id" is a sub-trigram (<3 chars) Latin token, so MATCH "id" returns
+      // zero rows (without throwing) under the trigram tokenizer, while the CJK
+      // token splits into substring terms. Pre-fix the empty MATCH short-
+      // circuited to no results because the LIKE fallback only ran on
+      // exceptions; post-fix the zero-row MATCH triggers the LIKE fallback.
+      const results = await runSearch({
+        rows: [{ id: "doc", path: "memory/mixed.md", text: "id配置文档说明" }],
+        query: "id 配置",
+      });
+      expect(results.map((row) => row.id)).toEqual(["doc"]);
+      expect(results[0]?.textScore).toBe(1);
+    },
+  );
+
+  itWithTrigramFts("keeps non-CJK runs whole when splitting a mixed CJK token", async () => {
+    const results = await runSearch({
+      rows: [
+        // Contains the substring "API" and the characters 飞书 (not contiguous).
+        { id: "hit", path: "memory/api.md", text: "查看API文档和飞书设置" },
+        // Has 飞书 and scattered letters but no "API" substring — must be
+        // excluded, proving the ASCII run is matched whole rather than as the
+        // individual letters A, P, I.
+        { id: "miss", path: "memory/apple.md", text: "苹果Apple的飞书通知" },
+      ],
+      query: "API飞书",
+    });
+    expect(results.map((row) => row.id)).toEqual(["hit"]);
+  });
+
+  itWithTrigramFts(
+    "still BM25-scores a mixed Latin+CJK query through MATCH (no regression)",
+    async () => {
+      // The Latin term is trigram-eligible and present, so MATCH succeeds and
+      // the keyword score stays a real BM25 value rather than the LIKE default.
+      const results = await runSearch({
+        rows: [{ id: "doc", path: "memory/mixed.md", text: "feishu 配置文档说明" }],
+        query: "feishu 配置",
+      });
+      expect(results.map((row) => row.id)).toEqual(["doc"]);
+      expect(results[0]?.textScore).toBeGreaterThan(0);
+      expect(results[0]?.textScore).toBeLessThan(1);
+    },
+  );
 });
 
 describe("searchKeyword FTS MATCH fallback", () => {

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -94,28 +94,61 @@ function readCount(row: { count?: number | bigint } | undefined): number {
   return 0;
 }
 
+// Decompose a token that contains CJK characters into LIKE substring terms.
+// Each CJK character becomes its own term while contiguous non-CJK runs (e.g.
+// the "API" in "API配置") are kept whole, so a doc only has to contain each
+// character/run somewhere — not the exact concatenation — to match.
+function splitCjkToken(token: string): string[] {
+  const terms: string[] = [];
+  let asciiRun = "";
+  for (const char of Array.from(token)) {
+    if (SHORT_CJK_TRIGRAM_RE.test(char)) {
+      if (asciiRun) {
+        terms.push(asciiRun);
+        asciiRun = "";
+      }
+      terms.push(char);
+    } else {
+      asciiRun += char;
+    }
+  }
+  if (asciiRun) {
+    terms.push(asciiRun);
+  }
+  return terms;
+}
+
 function planKeywordSearch(params: {
   query: string;
   ftsTokenizer?: "unicode61" | "trigram";
   buildFtsQuery: (raw: string) => string | null;
-}): { matchQuery: string | null; substringTerms: string[] } {
+}): { matchQuery: string | null; substringTerms: string[]; fallbackLikeTerms: string[] } {
   if (params.ftsTokenizer !== "trigram") {
+    const tokens = normalizeStringEntries(params.query.match(FTS_QUERY_TOKEN_RE) ?? []);
     return {
       matchQuery: params.buildFtsQuery(params.query),
       substringTerms: [],
+      fallbackLikeTerms: uniqueStrings(tokens),
     };
   }
 
   const tokens = normalizeStringEntries(params.query.match(FTS_QUERY_TOKEN_RE) ?? []);
   if (tokens.length === 0) {
-    return { matchQuery: null, substringTerms: [] };
+    return { matchQuery: null, substringTerms: [], fallbackLikeTerms: [] };
   }
 
   const matchTerms: string[] = [];
   const substringTerms: string[] = [];
   for (const token of tokens) {
-    if (SHORT_CJK_TRIGRAM_RE.test(token) && Array.from(token).length < 3) {
-      substringTerms.push(token);
+    // The trigram tokenizer turns a multi-character CJK token into a quoted
+    // MATCH phrase that only matches the exact contiguous substring, which
+    // rarely exists verbatim in documents — so every CJK query scored
+    // textScore=0 (issue #92061). Route any CJK-bearing token through per-
+    // character LIKE terms instead, which reliably match regardless of where
+    // the characters appear. Single/double CJK characters already needed this
+    // because trigram requires >=3 characters to form a searchable token.
+    if (SHORT_CJK_TRIGRAM_RE.test(token)) {
+      substringTerms.push(...splitCjkToken(token));
       continue;
     }
     matchTerms.push(token);
@@ -124,6 +157,7 @@ function planKeywordSearch(params: {
   return {
     matchQuery: buildMatchQueryFromTerms(matchTerms),
     substringTerms,
+    fallbackLikeTerms: uniqueStrings([...matchTerms, ...substringTerms]),
   };
 }
 
@@ -346,6 +380,29 @@ export async function searchKeyword(params: {
   }>;
   let usedMatch = false;
 
+  // Per-term LIKE substring search used whenever MATCH is unusable: either it
+  // threw, or it succeeded but returned no rows for a query whose CJK tokens
+  // were decomposed into substring terms (issue #92061).
+  const runLikeFallback = (): typeof rows => {
+    const fallbackLikeClause = plan.fallbackLikeTerms
+      .map(() => " AND text LIKE ? ESCAPE '\\'")
+      .join("");
+    const fallbackLikeParams = plan.fallbackLikeTerms.map((term) => `%${escapeLikePattern(term)}%`);
+    return params.db
+      .prepare(
+        `SELECT id, path, source, start_line, end_line, text,\n` +
+          `       0 AS rank\n` +
+          `  FROM ${params.ftsTable}\n` +
+          ` WHERE 1=1${fallbackLikeClause}${liveChunkClause}${params.sourceFilter.sql}\n` +
+          ` LIMIT ?`,
+      )
+      .all(
+        ...fallbackLikeParams,
+        ...params.sourceFilter.params,
+        params.limit,
+      ) as typeof rows;
+  };
+
   if (plan.matchQuery) {
     try {
       rows = params.db
@@ -364,29 +421,22 @@ export async function searchKeyword(params: {
           params.limit,
         ) as typeof rows;
       usedMatch = true;
+      // A successful MATCH that returns nothing is the CJK failure mode: the
+      // quoted trigram phrase had no exact substring hit. Retry with LIKE on
+      // the decomposed per-character terms so the keyword component still
+      // contributes instead of collapsing every hybrid result to textScore=0.
+      if (rows.length === 0 && plan.substringTerms.length > 0) {
+        rows = runLikeFallback();
+        usedMatch = false;
+      }
     } catch (matchErr) {
       // FTS5 MATCH can fail on certain token patterns depending on the
       // Node.js sqlite runtime and tokenizer (e.g. unicode61 vs trigram).
       // Log the root cause, then fall back to per-token LIKE-based substring
       // search so results are still returned instead of being silently dropped.
       console.warn(`memory search: FTS5 MATCH failed, falling back to LIKE: ${String(matchErr)}`);
-      const queryTokens = normalizeStringEntries(params.query.match(FTS_QUERY_TOKEN_RE) ?? []);
-      const allTerms = uniqueStrings([...queryTokens, ...plan.substringTerms]);
-      const fallbackLikeClause = allTerms.map(() => " AND text LIKE ? ESCAPE '\\'").join("");
-      const fallbackLikeParams = allTerms.map((term) => `%${escapeLikePattern(term)}%`);
-      rows = params.db
-        .prepare(
-          `SELECT id, path, source, start_line, end_line, text,\n` +
-            `       0 AS rank\n` +
-            `  FROM ${params.ftsTable}\n` +
-            ` WHERE 1=1${fallbackLikeClause}${liveChunkClause}${params.sourceFilter.sql}\n` +
-            ` LIMIT ?`,
-        )
-        .all(
-          ...fallbackLikeParams,
-          ...params.sourceFilter.params,
-          params.limit,
-        ) as typeof rows;
+      rows = runLikeFallback();
+      usedMatch = false;
     }
   } else {
     rows = params.db


### PR DESCRIPTION
## Summary

Hybrid memory search scored **every** Chinese/Japanese/Korean (CJK) query at `textScore: 0` when the FTS5 store uses the `trigram` tokenizer. Vector search still returned correct matches, but the BM25/full-text component contributed nothing, dragging down the final hybrid score for all CJK queries. English queries were unaffected.

This fixes the two root causes pinpointed in #92061, both in `extensions/memory-core` (`planKeywordSearch` / `searchKeyword`).

Fixes #92061

## Root cause

`planKeywordSearch` tokenizes the query with `/[\p{L}\p{N}_]+/gu`, which collapses a run of CJK characters into a **single** token (e.g. `飞书插件配置` → one 6-char token). The previous code only diverted CJK to the LIKE path when the token was shorter than 3 characters:

```js
if (SHORT_CJK_TRIGRAM_RE.test(token) && Array.from(token).length < 3) {
  substringTerms.push(token);   // LIKE path
  continue;
}
matchTerms.push(token);          // MATCH path
```

So any CJK token of 3+ characters became a **quoted trigram phrase**, e.g. `MATCH "飞书插件配置"`. A quoted phrase only matches the exact *contiguous* substring, which rarely exists verbatim in documents — so MATCH returned **0 rows**.

The LIKE fallback that could have rescued this only fired inside the `catch` block, i.e. when MATCH **threw**. An empty-but-successful MATCH skipped it entirely, leaving the keyword result set empty → `textScore = 0` for the whole hybrid result.

I verified the mechanism directly against the real `node:sqlite` FTS5 trigram engine (no mocks):

```
phrase 飞书插件配置 (not contiguous in doc): OK rows=0   ← silent empty, no throw
phrase feishu (>=3 latin):                  OK rows=1
```

## Fix

1. **Bug 1 — split CJK tokens for substring matching.** Any token containing CJK is decomposed into per-character LIKE terms (`splitCjkToken`). Contiguous non-CJK runs are kept whole, so `API配置` → `["API", "配", "置"]` rather than letter-by-letter, preserving precision for embedded ASCII.
2. **Bug 2 — fall back to LIKE on an empty MATCH.** When MATCH succeeds but returns 0 rows and the plan has substring terms, retry with the per-term LIKE search instead of returning empty. The exception-path fallback is refactored into a shared `runLikeFallback` helper so both paths use the same correctly-decomposed term set (this also drops the old over-strict whole-CJK-token LIKE term from the exception path).

CJK keyword hits now surface through the LIKE path with `textScore = 1` (no BM25 rank available), exactly like the pre-existing short-CJK and MATCH-exception fallbacks.

## Before / After

| Query (`trigram` tokenizer) | Doc | Before | After |
| --- | --- | --- | --- |
| `飞书插件配置` | `如何配置飞书插件` | ∅ → `textScore 0` | hit → `textScore 1` |
| `東京駅周辺` | `東京の駅の周辺を歩く` | ∅ → `textScore 0` | hit → `textScore 1` |
| `id 配置` (sub-trigram latin + CJK) | `id配置文档说明` | ∅ (empty MATCH, no fallback) | hit → `textScore 1` |
| `API飞书` | `查看API文档和飞书设置` | ∅ → `textScore 0` | hit → `textScore 1` |
| `feishu 配置` (latin ≥3 + CJK) | `feishu 配置文档说明` | BM25 hit | BM25 hit (unchanged) |

## Minimal reproduction

```
agents.defaults.memorySearch.store.fts.tokenizer: "trigram"
```
1. Index a memory file containing `如何配置飞书插件`.
2. `memory_search` with query `飞书插件配置`.
3. Before: all results `textScore: 0`. After: keyword component contributes `textScore: 1`.

## Tests

Added a `CJK FTS textScore regression coverage (issue #92061)` block to `manager-search.test.ts` (runs under the existing `itWithTrigramFts` guard, skipped where trigram FTS5 is unavailable):

- multi-character CJK query scores `textScore = 1` instead of `0` (core repro)
- every CJK character of the query must be present (per-character AND semantics)
- Japanese kanji query that is not a contiguous substring
- empty-MATCH → LIKE fallback (sub-trigram latin `id` + CJK), isolating Bug 2
- non-CJK runs kept whole when splitting a mixed token (`API飞书`)
- mixed latin+CJK still BM25-scored through MATCH (no regression)

The first five **fail against `main`** (empty result set / `textScore 0`) and pass with the fix; I confirmed both directions by replaying the exact regex/SQL logic against `node:sqlite` FTS5 trigram.

## Architecture note

`memory-core` runs lexical (FTS5) and vector (sqlite-vec) search independently and blends them in the hybrid scorer. The trigram tokenizer is the recommended option for CJK precisely because `unicode61` word-segmentation does not apply to scriptio-continua languages — but trigram needs ≥3 characters to form a token and a quoted phrase demands contiguity. The robust lexical primitive for CJK is therefore **per-character substring (LIKE) matching**, which this change makes the consistent path for all CJK tokens while keeping BM25-ranked MATCH for trigram-eligible Latin/numeric terms. The empty-MATCH fallback closes the remaining gap for mixed queries so the keyword channel never silently collapses to zero.

## Real behavior proof

This change is in a path that requires a live OpenClaw instance with an embedding provider (the issue used Ollama `qwen3-embedding:4b`) plus a populated CJK memory index to exercise end-to-end. That hardware/provider setup is **not available in my environment**, so I proved the actual failing mechanism at the layer where the bug lives — the real SQLite FTS5 trigram engine that `memory-core` drives:

```
$ node (real node:sqlite, FTS5 trigram)
doc indexed: "如何配置飞书插件"
MATCH "飞书插件配置"  → rows=0   (silent empty: reproduces textScore=0)
per-char LIKE %飞%..%置% → rows=1 (the fix's path)
```

I also replayed `planKeywordSearch` + `searchKeyword`'s exact SQL/regex against `node:sqlite` for all six test scenarios: the five regression cases return **empty** under `main` and the **correct hit** under the patch.

Since a full hybrid `memory_search` live run with an embedding provider is not reproducible here, I'm requesting maintainers apply **`proof: override`** for the live-instance portion of the proof gate. Happy to run any additional maintainer-specified validation. The branch is pushed to a maintainer-pushable branch with edits enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
