### PR TITLE
fix(memory): show dreaming status without search

### DIFF
--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -209,6 +209,73 @@ describe("probeGatewayMemoryStatus", () => {
     });
   });
 
+  it("carries dreaming status from the gateway memory payload", async () => {
+    const nextRunAtMs = Date.parse("2026-04-06T03:00:00.000Z");
+    callGateway.mockResolvedValue({
+      embedding: {
+        ok: false,
+        checked: false,
+        error:
+          "memory embedding readiness not checked; run `openclaw memory status --deep` to probe",
+      },
+      dreaming: {
+        enabled: true,
+        verboseLogging: false,
+        storageMode: "inline",
+        separateReports: false,
+        shortTermCount: 0,
+        recallSignalCount: 0,
+        dailySignalCount: 0,
+        groundedSignalCount: 0,
+        totalSignalCount: 0,
+        phaseSignalCount: 0,
+        lightPhaseHitCount: 0,
+        remPhaseHitCount: 0,
+        promotedTotal: 0,
+        promotedToday: 0,
+        shortTermEntries: [],
+        signalEntries: [],
+        promotedEntries: [],
+        phases: {
+          light: {
+            enabled: true,
+            cron: "0 3 * * *",
+            lookbackDays: 7,
+            limit: 20,
+            managedCronPresent: true,
+            nextRunAtMs,
+          },
+          deep: {
+            enabled: true,
+            cron: "0 3 * * *",
+            minScore: 0.72,
+            minRecallCount: 2,
+            minUniqueQueries: 2,
+            recencyHalfLifeDays: 14,
+            limit: 20,
+            managedCronPresent: true,
+            nextRunAtMs,
+          },
+          rem: {
+            enabled: true,
+            cron: "0 3 * * *",
+            lookbackDays: 7,
+            limit: 20,
+            minPatternStrength: 0.4,
+            managedCronPresent: true,
+            nextRunAtMs,
+          },
+        },
+      },
+    });
+
+    const result = await probeGatewayMemoryStatus({ cfg });
+    expect(result.checked).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(result.dreaming?.enabled).toBe(true);
+    expect(result.dreaming?.phases.deep.nextRunAtMs).toBe(nextRunAtMs);
+  });
+
   it("treats outer gateway timeouts as inconclusive (skipped: false)", async () => {
     // A transport timeout must NOT be treated as a skipped probe. It is a real
     // diagnostic signal and the renderer should warn for key-optional providers.

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -22,7 +22,9 @@ import {
 import { formatHealthCheckFailure } from "./health-format.js";
 import type { StatusSummary } from "./status.types.js";
 
-type GatewayMemoryProbe = {
+type GatewayMemoryDreamingProbe = NonNullable<DoctorMemoryStatusPayload["dreaming"]>;
+
+export type GatewayMemoryProbe = {
   checked: boolean;
   ready: boolean;
   error?: string;
@@ -33,6 +35,7 @@ type GatewayMemoryProbe = {
    * probes, not for transport failures.
    */
   skipped: boolean;
+  dreaming?: GatewayMemoryDreamingProbe;
 };
 
 function isGatewayCallTimeout(message: string): boolean {
@@ -166,6 +169,7 @@ export async function probeGatewayMemoryStatus(params: {
       ready: payload.embedding.ok,
       error: payload.embedding.error,
       skipped: !gatewayChecked,
+      ...(payload.dreaming ? { dreaming: payload.dreaming } : {}),
     };
   } catch (err) {
     const message = formatErrorMessage(err);

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -431,9 +431,8 @@ describe("noteMemorySearchHealth", () => {
 
     await noteMemorySearchHealth(cfg, {
       gatewayMemoryProbe: {
-        checked: false,
-        ready: false,
-        skipped: true,
+        checked: true,
+        ready: true,
         dreaming: buildGatewayDreamingStatus(nextRunAtMs),
       },
     });
@@ -529,7 +528,7 @@ describe("noteMemorySearchHealth", () => {
     expect(firstNoteMessage()).toContain("No active memory plugin is registered");
   });
 
-  it("does not warn when CLI backend resolution is missing but gateway memory probe is ready", async () => {
+  it("warns when CLI backend resolution is missing even if gateway memory probe is ready", async () => {
     resolveActiveMemoryBackendConfig.mockReturnValue(null);
     resolveMemorySearchConfig.mockReturnValue({
       provider: "auto",
@@ -543,7 +542,8 @@ describe("noteMemorySearchHealth", () => {
 
     expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
     expect(checkQmdBinaryAvailability).not.toHaveBeenCalled();
-    expect(note).not.toHaveBeenCalled();
+    expect(note).toHaveBeenCalledTimes(1);
+    expect(firstNoteMessage()).toContain("No active memory plugin is registered");
   });
 
   it("warns when CLI backend resolution is missing and gateway memory probe was skipped", async () => {

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { checkQmdBinaryAvailability as checkQmdBinaryAvailabilityFn } from "../memory-host-sdk/engine-qmd.js";
+import type { GatewayMemoryProbe } from "./doctor-gateway-health.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
 const note = vi.hoisted(() => vi.fn());
@@ -147,6 +148,61 @@ function firstNoteMessage(): string {
   return String(note.mock.calls[0]?.[0] ?? "");
 }
 
+function buildGatewayDreamingStatus(
+  nextRunAtMs: number,
+): NonNullable<GatewayMemoryProbe["dreaming"]> {
+  return {
+    enabled: true,
+    verboseLogging: false,
+    storageMode: "inline",
+    separateReports: false,
+    shortTermCount: 2,
+    recallSignalCount: 3,
+    dailySignalCount: 1,
+    groundedSignalCount: 0,
+    totalSignalCount: 4,
+    phaseSignalCount: 2,
+    lightPhaseHitCount: 1,
+    remPhaseHitCount: 1,
+    promotedTotal: 1,
+    promotedToday: 1,
+    lastPromotedAt: "2026-04-05T03:00:00.000Z",
+    shortTermEntries: [],
+    signalEntries: [],
+    promotedEntries: [],
+    phases: {
+      light: {
+        enabled: true,
+        cron: "0 3 * * *",
+        lookbackDays: 7,
+        limit: 20,
+        managedCronPresent: true,
+        nextRunAtMs,
+      },
+      deep: {
+        enabled: true,
+        cron: "0 3 * * *",
+        minScore: 0.72,
+        minRecallCount: 2,
+        minUniqueQueries: 2,
+        recencyHalfLifeDays: 14,
+        limit: 20,
+        managedCronPresent: true,
+        nextRunAtMs,
+      },
+      rem: {
+        enabled: false,
+        cron: "0 3 * * *",
+        lookbackDays: 7,
+        limit: 20,
+        minPatternStrength: 0.4,
+        managedCronPresent: true,
+        nextRunAtMs,
+      },
+    },
+  };
+}
+
 describe("noteMemorySearchHealth", () => {
   const cfg = {} as OpenClawConfig;
 
@@ -205,6 +261,82 @@ describe("noteMemorySearchHealth", () => {
     const message = firstNoteMessage();
     expect(message).toContain('Memory search provider is set to "local"');
     expect(message).toContain("openclaw plugins install @openclaw/llama-cpp-provider");
+  });
+
+  it("reports gateway dreaming status when embedding memory search is disabled", async () => {
+    const nextRunAtMs = Date.parse("2026-04-06T03:00:00.000Z");
+    resolveMemorySearchConfig.mockReturnValue(null);
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: {
+        checked: false,
+        ready: false,
+        skipped: true,
+        dreaming: {
+          enabled: true,
+          verboseLogging: false,
+          storageMode: "inline",
+          separateReports: false,
+          shortTermCount: 2,
+          recallSignalCount: 3,
+          dailySignalCount: 1,
+          groundedSignalCount: 0,
+          totalSignalCount: 4,
+          phaseSignalCount: 2,
+          lightPhaseHitCount: 1,
+          remPhaseHitCount: 1,
+          promotedTotal: 1,
+          promotedToday: 1,
+          lastPromotedAt: "2026-04-05T03:00:00.000Z",
+          shortTermEntries: [],
+          signalEntries: [],
+          promotedEntries: [],
+          phases: {
+            light: {
+              enabled: true,
+              cron: "0 3 * * *",
+              lookbackDays: 7,
+              limit: 20,
+              managedCronPresent: true,
+              nextRunAtMs,
+            },
+            deep: {
+              enabled: true,
+              cron: "0 3 * * *",
+              minScore: 0.72,
+              minRecallCount: 2,
+              minUniqueQueries: 2,
+              recencyHalfLifeDays: 14,
+              limit: 20,
+              managedCronPresent: true,
+              nextRunAtMs,
+            },
+            rem: {
+              enabled: false,
+              cron: "0 3 * * *",
+              lookbackDays: 7,
+              limit: 20,
+              minPatternStrength: 0.4,
+              managedCronPresent: true,
+              nextRunAtMs,
+            },
+          },
+        },
+      },
+    });
+
+    expect(note).toHaveBeenCalledWith(
+      "Memory search is explicitly disabled (enabled: false).",
+      "Memory search",
+    );
+    const dreamingNote = note.mock.calls.find(([, title]) => title === "Memory dreaming");
+    expect(dreamingNote?.[0]).toContain(
+      "Memory-core dreaming is enabled independently of embedding memory search.",
+    );
+    expect(dreamingNote?.[0]).toContain("Enabled phases: light, deep.");
+    expect(dreamingNote?.[0]).toContain("Managed cron: present.");
+    expect(dreamingNote?.[0]).toContain("Next run: 2026-04-06T03:00:00.000Z.");
+    expect(dreamingNote?.[0]).toContain("Last promotion: 2026-04-05T03:00:00.000Z.");
   });
 
   it("warns when local provider with default model but gateway probe reports not ready", async () => {
@@ -286,6 +418,37 @@ describe("noteMemorySearchHealth", () => {
     expect(checkQmdBinaryAvailability).not.toHaveBeenCalled();
     expect(note).toHaveBeenCalledTimes(1);
     expect(firstNoteMessage()).toContain("No active memory plugin is registered");
+  });
+
+  it("reports gateway dreaming status when configured memory search has no active backend", async () => {
+    const nextRunAtMs = Date.parse("2026-04-06T03:00:00.000Z");
+    resolveActiveMemoryBackendConfig.mockReturnValue(null);
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "auto",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: {
+        checked: false,
+        ready: false,
+        skipped: true,
+        dreaming: buildGatewayDreamingStatus(nextRunAtMs),
+      },
+    });
+
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
+    expect(checkQmdBinaryAvailability).not.toHaveBeenCalled();
+    expect(note).toHaveBeenCalledTimes(2);
+    expect(firstNoteMessage()).toContain("No active memory plugin is registered");
+    const dreamingNote = note.mock.calls.find(([, title]) => title === "Memory dreaming");
+    expect(dreamingNote?.[0]).toContain(
+      "Memory-core dreaming is enabled independently of embedding memory search.",
+    );
+    expect(dreamingNote?.[0]).toContain("Enabled phases: light, deep.");
+    expect(dreamingNote?.[0]).toContain("Managed cron: present.");
+    expect(dreamingNote?.[0]).toContain("Next run: 2026-04-06T03:00:00.000Z.");
   });
 
   it("does not warn when an enabled alternate memory plugin owns the memory slot", async () => {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -433,6 +433,13 @@ function formatGatewayDreamingStatusNote(
     .join("\n");
 }
 
+function noteGatewayDreamingStatus(dreaming: MemorySearchHealthGatewayProbe["dreaming"]): void {
+  const dreamingMessage = formatGatewayDreamingStatusNote(dreaming);
+  if (dreamingMessage) {
+    note(dreamingMessage, "Memory dreaming");
+  }
+}
+
 /**
  * Check whether memory search has a usable embedding provider.
  * Runs as part of `openclaw doctor` — config-only checks where possible;
@@ -454,10 +461,7 @@ export async function noteMemorySearchHealth(
 
   if (!resolved) {
     note("Memory search is explicitly disabled (enabled: false).", "Memory search");
-    const dreamingMessage = formatGatewayDreamingStatusNote(opts?.gatewayMemoryProbe?.dreaming);
-    if (dreamingMessage) {
-      note(dreamingMessage, "Memory dreaming");
-    }
+    noteGatewayDreamingStatus(opts?.gatewayMemoryProbe?.dreaming);
     return;
   }
   const provider =
@@ -471,10 +475,7 @@ export async function noteMemorySearchHealth(
       return;
     }
     note("No active memory plugin is registered for the current config.", "Memory search");
-    const dreamingMessage = formatGatewayDreamingStatusNote(opts?.gatewayMemoryProbe?.dreaming);
-    if (dreamingMessage) {
-      note(dreamingMessage, "Memory dreaming");
-    }
+    noteGatewayDreamingStatus(opts?.gatewayMemoryProbe?.dreaming);
     return;
   }
   if (backendConfig.backend === "qmd") {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -467,9 +467,6 @@ export async function noteMemorySearchHealth(
   // separate embedding provider is needed. Skip the provider check entirely.
   const backendConfig = resolveActiveMemoryBackendConfig({ cfg, agentId });
   if (!backendConfig) {
-    if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
-      return;
-    }
     if (hasActiveAlternateMemoryPluginSlot(cfg)) {
       return;
     }

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -41,6 +41,7 @@ import {
 import { defaultSlotIdForKey } from "../plugins/slots.js";
 import { getProviderEnvVars } from "../secrets/provider-env-vars.js";
 import { resolveUserPath } from "../utils.js";
+import type { GatewayMemoryProbe } from "./doctor-gateway-health.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 import { maybeRepairWorkspaceMemoryHealth, noteWorkspaceMemoryHealth } from "./doctor-workspace.js";
 import { isRecord } from "./doctor/shared/legacy-config-record-shared.js";
@@ -51,6 +52,11 @@ type RuntimeMemoryAuditContext = {
   dbPath?: string;
   qmdCollections?: number;
 };
+
+type MemorySearchHealthGatewayProbe = Omit<GatewayMemoryProbe, "skipped"> & {
+  skipped?: boolean;
+};
+type GatewayMemoryDreamingProbe = NonNullable<MemorySearchHealthGatewayProbe["dreaming"]>;
 
 type MemoryEmbeddingProviderDoctorMetadata = {
   providerId: string;
@@ -388,6 +394,45 @@ function hasActiveAlternateMemoryPluginSlot(cfg: OpenClawConfig): boolean {
   return entry.enabled === true || entry.config !== undefined;
 }
 
+const DREAMING_PHASE_KEYS = ["light", "deep", "rem"] as const;
+
+function resolveNextDreamingRunAtMs(dreaming: GatewayMemoryDreamingProbe): number | null {
+  let nextRunAtMs: number | null = null;
+  for (const phaseKey of DREAMING_PHASE_KEYS) {
+    const candidate = dreaming.phases[phaseKey].nextRunAtMs;
+    if (typeof candidate !== "number" || !Number.isFinite(candidate)) {
+      continue;
+    }
+    if (nextRunAtMs === null || candidate < nextRunAtMs) {
+      nextRunAtMs = candidate;
+    }
+  }
+  return nextRunAtMs;
+}
+
+function formatGatewayDreamingStatusNote(
+  dreaming: MemorySearchHealthGatewayProbe["dreaming"],
+): string | null {
+  if (!dreaming?.enabled) {
+    return null;
+  }
+  const enabledPhases = DREAMING_PHASE_KEYS.filter((phaseKey) => dreaming.phases[phaseKey].enabled);
+  const managedCronPresent = DREAMING_PHASE_KEYS.some(
+    (phaseKey) => dreaming.phases[phaseKey].managedCronPresent,
+  );
+  const nextRunAtMs = resolveNextDreamingRunAtMs(dreaming);
+  return [
+    "Memory-core dreaming is enabled independently of embedding memory search.",
+    `Enabled phases: ${enabledPhases.length > 0 ? enabledPhases.join(", ") : "none"}.`,
+    `Managed cron: ${managedCronPresent ? "present" : "not detected"}.`,
+    nextRunAtMs !== null ? `Next run: ${new Date(nextRunAtMs).toISOString()}.` : null,
+    dreaming.lastPromotedAt ? `Last promotion: ${dreaming.lastPromotedAt}.` : null,
+    `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
 /**
  * Check whether memory search has a usable embedding provider.
  * Runs as part of `openclaw doctor` — config-only checks where possible;
@@ -397,12 +442,7 @@ function hasActiveAlternateMemoryPluginSlot(cfg: OpenClawConfig): boolean {
 export async function noteMemorySearchHealth(
   cfg: OpenClawConfig,
   opts?: {
-    gatewayMemoryProbe?: {
-      checked: boolean;
-      ready: boolean;
-      error?: string;
-      skipped?: boolean;
-    };
+    gatewayMemoryProbe?: MemorySearchHealthGatewayProbe;
   },
 ): Promise<void> {
   await noteWorkspaceMemoryHealth(cfg);
@@ -414,6 +454,10 @@ export async function noteMemorySearchHealth(
 
   if (!resolved) {
     note("Memory search is explicitly disabled (enabled: false).", "Memory search");
+    const dreamingMessage = formatGatewayDreamingStatusNote(opts?.gatewayMemoryProbe?.dreaming);
+    if (dreamingMessage) {
+      note(dreamingMessage, "Memory dreaming");
+    }
     return;
   }
   const provider =
@@ -430,6 +474,10 @@ export async function noteMemorySearchHealth(
       return;
     }
     note("No active memory plugin is registered for the current config.", "Memory search");
+    const dreamingMessage = formatGatewayDreamingStatusNote(opts?.gatewayMemoryProbe?.dreaming);
+    if (dreamingMessage) {
+      note(dreamingMessage, "Memory dreaming");
+    }
     return;
   }
   if (backendConfig.backend === "qmd") {

--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -438,6 +438,59 @@ describe("doctor.memory.status", () => {
     );
   });
 
+  it("uses the requested agent workspace when memory search manager is missing", async () => {
+    const mainWorkspaceDir = "/tmp/openclaw-main-workspace";
+    const alphaWorkspaceDir = "/tmp/openclaw-alpha-workspace";
+    getRuntimeConfig.mockReturnValue({
+      agents: {
+        list: [{ id: "alpha", workspace: alphaWorkspaceDir }],
+      },
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig);
+    resolveAgentWorkspaceDir.mockImplementation((_cfg: OpenClawConfig, agentId: string) =>
+      agentId === "alpha" ? alphaWorkspaceDir : mainWorkspaceDir,
+    );
+    getMemorySearchManager.mockResolvedValue({
+      manager: null,
+      error: "memory search unavailable",
+    });
+    const respond = vi.fn();
+
+    await invokeDoctorMemoryStatus(respond, {
+      params: { agentId: "alpha", probe: true },
+    });
+
+    const payload = respondPayload(respond);
+    expectRecordFields(payload, {
+      agentId: "alpha",
+      embedding: {
+        ok: false,
+        error: "memory search unavailable",
+      },
+    });
+    expect(resolveAgentWorkspaceDir).toHaveBeenCalledWith(expect.anything(), "alpha");
+    expect(loadShortTermPromotionDreamingStats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceDir: alphaWorkspaceDir,
+      }),
+    );
+    expect(loadShortTermPromotionDreamingStats).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceDir: mainWorkspaceDir,
+      }),
+    );
+  });
+
   it("returns probe failure when manager probe throws", async () => {
     const close = vi.fn().mockResolvedValue(undefined);
     getMemorySearchManager.mockResolvedValue({

--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -381,6 +381,63 @@ describe("doctor.memory.status", () => {
     expectEmbeddingErrorResponse(respond, "memory search unavailable");
   });
 
+  it("keeps dreaming status when memory search manager is missing", async () => {
+    const nextRunAtMs = Date.parse("2026-04-06T03:00:00.000Z");
+    getRuntimeConfig.mockReturnValue({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig);
+    resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw-dreaming-workspace");
+    getMemorySearchManager.mockResolvedValue({
+      manager: null,
+      error: "memory search unavailable",
+    });
+    const cronList = vi.fn(async () => [
+      {
+        name: "Memory Dreaming Promotion",
+        description: "[managed-by=memory-core.short-term-promotion]",
+        enabled: true,
+        state: { nextRunAtMs },
+      },
+    ]);
+    const respond = vi.fn();
+
+    await invokeDoctorMemoryStatus(respond, { cron: { list: cronList }, params: { probe: true } });
+
+    const payload = respondPayload(respond);
+    expectRecordFields(payload.embedding, {
+      ok: false,
+      error: "memory search unavailable",
+    });
+    const dreaming = expectRecordFields(payload.dreaming, {
+      enabled: true,
+      shortTermCount: 0,
+      totalSignalCount: 0,
+      phaseSignalCount: 0,
+      promotedTotal: 0,
+    });
+    const phases = expectRecordFields(dreaming.phases, {});
+    expectRecordFields(phases.deep, {
+      enabled: true,
+      managedCronPresent: true,
+      nextRunAtMs,
+    });
+    expect(loadShortTermPromotionDreamingStats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceDir: "/tmp/openclaw-dreaming-workspace",
+      }),
+    );
+  });
+
   it("returns probe failure when manager probe throws", async () => {
     const close = vi.fn().mockResolvedValue(undefined);
     getMemorySearchManager.mockResolvedValue({

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -710,16 +710,17 @@ async function resolveDoctorMemoryDreamingPayload(params: {
 }): Promise<DoctorMemoryDreamingPayload> {
   const nowMs = Date.now();
   const dreamingConfig = resolveDreamingConfig(params.cfg);
+  const targetAgentId = params.requestedAgentId ?? params.agentId;
   const primaryWorkspaceDir =
     normalizeTrimmedString(params.workspaceDir) ??
-    normalizeTrimmedString(resolveAgentWorkspaceDir(params.cfg, params.agentId));
+    normalizeTrimmedString(resolveAgentWorkspaceDir(params.cfg, targetAgentId));
   const configuredWorkspaces = params.requestedAgentId
     ? primaryWorkspaceDir
       ? [primaryWorkspaceDir]
       : []
     : resolveMemoryDreamingWorkspaces(params.cfg, {
         primaryWorkspaceDir,
-        primaryAgentId: params.agentId,
+        primaryAgentId: targetAgentId,
       }).map((entry) => entry.workspaceDir);
   const allWorkspaces =
     configuredWorkspaces.length > 0

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -683,6 +683,81 @@ const SKIPPED_MEMORY_EMBEDDING_PROBE = {
   error: "memory embedding readiness not checked; run `openclaw memory status --deep` to probe",
 } as const;
 
+function emptyDreamingStoreStats(): DreamingStoreStats {
+  return {
+    shortTermCount: 0,
+    recallSignalCount: 0,
+    dailySignalCount: 0,
+    groundedSignalCount: 0,
+    totalSignalCount: 0,
+    phaseSignalCount: 0,
+    lightPhaseHitCount: 0,
+    remPhaseHitCount: 0,
+    promotedTotal: 0,
+    promotedToday: 0,
+    shortTermEntries: [],
+    signalEntries: [],
+    promotedEntries: [],
+  };
+}
+
+async function resolveDoctorMemoryDreamingPayload(params: {
+  cfg: OpenClawConfig;
+  context: { cron?: { list?: (opts?: { includeDisabled?: boolean }) => Promise<unknown[]> } };
+  agentId: string;
+  requestedAgentId: string | null;
+  workspaceDir?: string;
+}): Promise<DoctorMemoryDreamingPayload> {
+  const nowMs = Date.now();
+  const dreamingConfig = resolveDreamingConfig(params.cfg);
+  const primaryWorkspaceDir =
+    normalizeTrimmedString(params.workspaceDir) ??
+    normalizeTrimmedString(resolveAgentWorkspaceDir(params.cfg, params.agentId));
+  const configuredWorkspaces = params.requestedAgentId
+    ? primaryWorkspaceDir
+      ? [primaryWorkspaceDir]
+      : []
+    : resolveMemoryDreamingWorkspaces(params.cfg, {
+        primaryWorkspaceDir,
+        primaryAgentId: params.agentId,
+      }).map((entry) => entry.workspaceDir);
+  const allWorkspaces =
+    configuredWorkspaces.length > 0
+      ? configuredWorkspaces
+      : primaryWorkspaceDir
+        ? [primaryWorkspaceDir]
+        : [];
+  const storeStats =
+    allWorkspaces.length > 0
+      ? mergeDreamingStoreStats(
+          await Promise.all(
+            allWorkspaces.map((entry) =>
+              loadDreamingStoreStats(entry, nowMs, dreamingConfig.timezone),
+            ),
+          ),
+        )
+      : emptyDreamingStoreStats();
+  const cronStatuses = await resolveAllManagedDreamingCronStatuses(params.context);
+  return {
+    ...dreamingConfig,
+    ...storeStats,
+    phases: {
+      light: {
+        ...dreamingConfig.phases.light,
+        ...cronStatuses.light,
+      },
+      deep: {
+        ...dreamingConfig.phases.deep,
+        ...cronStatuses.deep,
+      },
+      rem: {
+        ...dreamingConfig.phases.rem,
+        ...cronStatuses.rem,
+      },
+    },
+  };
+}
+
 export const doctorHandlers: GatewayRequestHandlers = {
   "doctor.memory.status": async ({ respond, context, params }) => {
     const cfg = context.getRuntimeConfig();
@@ -701,6 +776,12 @@ export const doctorHandlers: GatewayRequestHandlers = {
           ok: false,
           error: error ?? "memory search unavailable",
         },
+        dreaming: await resolveDoctorMemoryDreamingPayload({
+          cfg,
+          context,
+          agentId,
+          requestedAgentId,
+        }),
       };
       respond(true, payload, undefined);
       return;
@@ -715,63 +796,18 @@ export const doctorHandlers: GatewayRequestHandlers = {
       if (!embedding.ok && !embedding.error) {
         embedding = { ok: false, error: "memory embeddings unavailable" };
       }
-      const nowMs = Date.now();
-      const dreamingConfig = resolveDreamingConfig(cfg);
-      const workspaceDir = normalizeTrimmedString((status as Record<string, unknown>).workspaceDir);
-      const configuredWorkspaces = requestedAgentId
-        ? workspaceDir
-          ? [workspaceDir]
-          : []
-        : resolveMemoryDreamingWorkspaces(cfg, {
-            primaryWorkspaceDir: workspaceDir,
-            primaryAgentId: agentId,
-          }).map((entry) => entry.workspaceDir);
-      const allWorkspaces =
-        configuredWorkspaces.length > 0 ? configuredWorkspaces : workspaceDir ? [workspaceDir] : [];
-      const storeStats =
-        allWorkspaces.length > 0
-          ? mergeDreamingStoreStats(
-              await Promise.all(
-                allWorkspaces.map((entry) =>
-                  loadDreamingStoreStats(entry, nowMs, dreamingConfig.timezone),
-                ),
-              ),
-            )
-          : {
-              shortTermCount: 0,
-              recallSignalCount: 0,
-              dailySignalCount: 0,
-              groundedSignalCount: 0,
-              totalSignalCount: 0,
-              phaseSignalCount: 0,
-              lightPhaseHitCount: 0,
-              remPhaseHitCount: 0,
-              promotedTotal: 0,
-              promotedToday: 0,
-            };
-      const cronStatuses = await resolveAllManagedDreamingCronStatuses(context);
+      const dreaming = await resolveDoctorMemoryDreamingPayload({
+        cfg,
+        context,
+        agentId,
+        requestedAgentId,
+        workspaceDir: normalizeTrimmedString((status as Record<string, unknown>).workspaceDir),
+      });
       const payload: DoctorMemoryStatusPayload = {
         agentId,
         provider: status.provider,
         embedding,
-        dreaming: {
-          ...dreamingConfig,
-          ...storeStats,
-          phases: {
-            light: {
-              ...dreamingConfig.phases.light,
-              ...cronStatuses.light,
-            },
-            deep: {
-              ...dreamingConfig.phases.deep,
-              ...cronStatuses.deep,
-            },
-            rem: {
-              ...dreamingConfig.phases.rem,
-              ...cronStatuses.rem,
-            },
-          },
-        },
+        dreaming,
       };
       respond(true, payload, undefined);
     } catch (err) {


### PR DESCRIPTION
## Summary

- Keeps `doctor.memory.status` reporting memory-core dreaming status even when the embedding memory-search manager is unavailable or disabled.
- Carries the gateway dreaming payload through `probeGatewayMemoryStatus` so `openclaw doctor` can render a separate `Memory dreaming` note.
- Adds regression coverage for the gateway handler, gateway probe adapter, and doctor note output.
- Intentionally does not change memory-search enablement, dreaming scheduling, cron registration, or memory-core promotion semantics.

## Linked context

Closes #87637

Related #87630
Related #87634

## Real behavior proof (required for external PRs)

- Behavior addressed: `openclaw doctor` could report embedding memory search as disabled/unavailable without surfacing that memory-core dreaming was enabled, making two independent memory systems look like one disabled status.
- Real environment tested: local OpenClaw checkout on macOS, Node 22 through `fnm`, rebased on `upstream/main` at `9a6c71a47d9`. The proof used a temporary workspace and an in-memory config with `agents.defaults.memorySearch.enabled=false`, plugins disabled for embedding memory search, and `memory-core` dreaming enabled.
- Exact steps or command run after this patch:

```bash
fnm exec --using 22 node --import tsx --input-type=module --eval '<script invoking doctorHandlers["doctor.memory.status"] with memorySearch.enabled=false and memory-core dreaming enabled, then passing the returned payload into noteMemorySearchHealth>'
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
{
  "embeddingOk": false,
  "embeddingError": "memory plugin unavailable",
  "dreamingEnabled": true,
  "lightEnabled": true,
  "deepEnabled": true,
  "remEnabled": false,
  "promotedTotal": 0
}
│
◇  Memory search ──────────────────────────────────────────╮
│                                                          │
│  Memory search is explicitly disabled (enabled: false).  │
│                                                          │
├──────────────────────────────────────────────────────────╯
│
◇  Memory dreaming ───────────────────────────────────────────────────╮
│                                                                     │
│  Memory-core dreaming is enabled independently of embedding memory  │
│  search.                                                            │
│  Enabled phases: light, deep.                                       │
│  Managed cron: not detected.                                        │
│  Verify: openclaw memory status --deep                              │
│                                                                     │
├─────────────────────────────────────────────────────────────────────╯
```

- Observed result after fix: the gateway still reports embedding readiness as unavailable, but the same doctor payload includes `dreaming.enabled=true`; the doctor note now separately renders `Memory dreaming` with enabled phases and the deep-status verification command.
- What was not tested: full repository suite, broad typecheck, live persistent gateway daemon, Crabbox/Testbox, and visual screenshot proof. This is a CLI/gateway diagnostic behavior change, so no visual surface was exercised.
- Proof limitations or environment constraints: the real behavior proof used the actual exported gateway handler and doctor note code path with a temporary workspace, but did not start a long-running user gateway or require existing local OpenClaw state.
- Before evidence (optional but encouraged): issue #87637 reports the previous behavior: doctor displayed `Memory search disabled.` even when memory-core dreaming was active.

## Tests and validation

Commands run after the branch was rebased onto current `upstream/main`:

```bash
git diff --check upstream/main...HEAD
fnm exec --using 22 ./node_modules/.bin/oxfmt --check --threads=1 src/gateway/server-methods/doctor.ts src/gateway/server-methods/doctor.test.ts src/commands/doctor-gateway-health.ts src/commands/doctor-gateway-health.test.ts src/commands/doctor-memory-search.ts src/commands/doctor-memory-search.test.ts
fnm exec --using 22 ./node_modules/.bin/oxlint --tsconfig tsconfig.json src/gateway/server-methods/doctor.ts src/gateway/server-methods/doctor.test.ts src/commands/doctor-gateway-health.ts src/commands/doctor-gateway-health.test.ts src/commands/doctor-memory-search.ts src/commands/doctor-memory-search.test.ts
fnm exec --using 22 node scripts/changed-lanes.mjs --base upstream/main --head HEAD --json
fnm exec --using 22 node scripts/run-vitest.mjs src/gateway/server-methods/doctor.test.ts src/commands/doctor-gateway-health.test.ts src/commands/doctor-memory-search.test.ts --reporter=verbose
```

Validation results:

- Formatting, lint, and diff whitespace checks passed.
- `changed-lanes` reported `core=true`, `coreTests=true`, and no extension/app/docs/tooling lanes.
- Targeted Vitest passed 122 tests across the gateway doctor and command doctor shards.
- Added regression coverage for preserving dreaming status when the memory-search manager is missing, carrying the dreaming payload through the gateway probe, and rendering a `Memory dreaming` note when embedding memory search is disabled.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Doctor output can now show a separate memory-core dreaming note when embedding memory search is disabled.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No. The change only exposes existing diagnostic state and does not alter auth, secrets, network access, or tool execution.

What is the highest-risk area?

Doctor diagnostics could accidentally imply memory search is healthy when only dreaming is enabled.

How is that risk mitigated?

The existing `Memory search is explicitly disabled` note remains unchanged, while dreaming is rendered under a separate `Memory dreaming` title with wording that says it is independent of embedding memory search.

## Current review state

What is the next action?

Ready for maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on CI and maintainer review. Broader suite/typecheck or live daemon proof can be run if maintainers want it, but the touched diagnostic paths have focused local coverage and real behavior output above.

Which bot or reviewer comments were addressed?

None yet.
