### PR TITLE
fix(media): recognize .m2a files as audio

### DIFF
--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -1011,6 +1011,27 @@ describe("resolveMedia original filename preservation", () => {
     });
   });
 
+  it("classifies an audio document from the saved MIME type", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "documents/recording.m2a" });
+    saveRemoteMedia.mockResolvedValueOnce({
+      path: "/tmp/inbound/recording.m2a",
+      contentType: "audio/mpeg",
+    });
+
+    const result = await resolveMediaWithDefaults(
+      makeCtx("document", getFile, {
+        file_name: "recording.m2a",
+        mime_type: "application/octet-stream",
+      }),
+    );
+
+    expectResolvedMediaFields(result, "MPEG-2 audio document", {
+      path: "/tmp/inbound/recording.m2a",
+      contentType: "audio/mpeg",
+      placeholder: "<media:audio>",
+    });
+  });
+
   it("passes audio.file_name to saveMediaBuffer", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "music/file_99.mp3" });
     readRemoteMediaBuffer.mockResolvedValueOnce({

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -517,6 +517,8 @@ export async function resolveMedia(params: {
     trustedLocalFileRoots,
     dangerouslyAllowPrivateNetwork,
   });
-  const placeholder = resolveTelegramMediaPlaceholder(msg) ?? "<media:document>";
+  const placeholder = saved.contentType?.startsWith("audio/")
+    ? "<media:audio>"
+    : (resolveTelegramMediaPlaceholder(msg) ?? "<media:document>");
   return { path: saved.path, contentType: saved.contentType, placeholder };
 }

--- a/packages/media-core/src/mime.test.ts
+++ b/packages/media-core/src/mime.test.ts
@@ -191,6 +191,8 @@ describe("mimeTypeFromFilePath", () => {
     { filePath: "photo.jpg", expected: "image/jpeg" },
     { filePath: "photo.JPG", expected: "image/jpeg" },
     { filePath: "voice.mp3", expected: "audio/mpeg" },
+    { filePath: "voice.m2a", expected: "audio/mpeg" },
+    { filePath: "voice.oga", expected: "audio/ogg" },
     { filePath: "voice.wav", expected: "audio/wav" },
     { filePath: "clip.avi", expected: "video/x-msvideo" },
     { filePath: "clip.mkv", expected: "video/x-matroska" },
@@ -266,6 +268,9 @@ describe("isAudioFileName", () => {
   it.each([
     { fileName: "voice.mp3", expected: true },
     { fileName: "voice.caf", expected: true },
+    { fileName: "voice.M2A", expected: true },
+    { fileName: "voice.oga", expected: true },
+    { fileName: "voice.webm", expected: false },
     { fileName: "voice.bin", expected: false },
   ] as const)("matches audio extension for $fileName", ({ fileName, expected }) => {
     expectAudioFileNameCase(fileName, expected);

--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -72,7 +72,9 @@ const MIME_BY_EXT: Record<string, string> = {
   ...buildMimeByExt(),
   // Canonical extension mappings for common MIME aliases
   ".jpg": "image/jpeg",
+  ".m2a": "audio/mpeg",
   ".mp3": "audio/mpeg",
+  ".oga": "audio/ogg",
   ".wav": "audio/wav",
   ".webm": "video/webm",
   // Additional extension aliases
@@ -83,18 +85,6 @@ const MIME_BY_EXT: Record<string, string> = {
   ".xml": "text/xml",
   ".yml": "application/yaml",
 };
-
-const AUDIO_FILE_EXTENSIONS = new Set([
-  ".aac",
-  ".caf",
-  ".flac",
-  ".m4a",
-  ".mp3",
-  ".oga",
-  ".ogg",
-  ".opus",
-  ".wav",
-]);
 
 const fileTypeModuleLoader = createLazyImportLoader(() => import("file-type"));
 
@@ -174,11 +164,7 @@ export function mimeTypeFromFilePath(filePath?: string | null): string | undefin
 
 /** Returns true when a filename extension is a supported audio container. */
 export function isAudioFileName(fileName?: string | null): boolean {
-  const ext = getFileExtension(fileName);
-  if (!ext) {
-    return false;
-  }
-  return AUDIO_FILE_EXTENSIONS.has(ext);
+  return mediaKindFromMime(mimeTypeFromFilePath(fileName)) === "audio";
 }
 
 /** Detects the best MIME type from bytes, file path, and header metadata. */

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -124,6 +124,7 @@ describe("memory host SDK package internals", () => {
     fsSync.mkdirSync(extraDir, { recursive: true });
     fsSync.writeFileSync(path.join(extraDir, "note.md"), "# Note");
     fsSync.writeFileSync(path.join(extraDir, "diagram.png"), Buffer.from("png"));
+    fsSync.writeFileSync(path.join(extraDir, "recording.m2a"), Buffer.from("audio"));
     fsSync.writeFileSync(path.join(extraDir, "ignore.txt"), "ignored");
 
     const files = await listMemoryFiles(
@@ -136,6 +137,7 @@ describe("memory host SDK package internals", () => {
       "MEMORY.md",
       path.join("extra", "diagram.png"),
       path.join("extra", "note.md"),
+      path.join("extra", "recording.m2a"),
     ]);
   });
 

--- a/packages/memory-host-sdk/src/host/multimodal.ts
+++ b/packages/memory-host-sdk/src/host/multimodal.ts
@@ -10,7 +10,7 @@ const MEMORY_MULTIMODAL_SPECS = {
   },
   audio: {
     labelPrefix: "Audio file",
-    extensions: [".mp3", ".wav", ".ogg", ".opus", ".m4a", ".aac", ".flac"],
+    extensions: [".mp3", ".wav", ".ogg", ".opus", ".m4a", ".m2a", ".aac", ".flac"],
   },
 } as const;
 

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -317,6 +317,21 @@ describe("buildInboundMediaNote", () => {
     expect(note).toBe("[media attached: /tmp/document.pdf]");
   });
 
+  it("strips transcribed MPEG-2 audio by extension", () => {
+    const note = buildInboundMediaNote({
+      MediaPaths: ["/tmp/recording.m2a", "/tmp/document.pdf"],
+      MediaUnderstanding: [
+        {
+          kind: "audio.transcription",
+          attachmentIndex: 0,
+          text: "Transcribed audio content",
+          provider: "whisper",
+        },
+      ],
+    });
+    expect(note).toBe("[media attached: /tmp/document.pdf]");
+  });
+
   it("keeps audio attachments when no transcription is available", () => {
     const note = buildInboundMediaNote({
       MediaPaths: ["/tmp/voice.ogg"],

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -66,6 +66,7 @@ const AUDIO_EXTENSIONS = new Set([
   ".opus",
   ".mp3",
   ".m4a",
+  ".m2a",
   ".wav",
   ".webm",
   ".flac",

--- a/src/gateway/server-methods/chat-webchat-media.test.ts
+++ b/src/gateway/server-methods/chat-webchat-media.test.ts
@@ -22,9 +22,9 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     tmpDir = undefined;
   });
 
-  function writeAudioFixture(bytes = [0xff, 0xfb, 0x90, 0x00]) {
+  function writeAudioFixture(bytes = [0xff, 0xfb, 0x90, 0x00], extension = ".mp3") {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-webchat-audio-"));
-    const audioPath = path.join(tmpDir, "clip.mp3");
+    const audioPath = path.join(tmpDir, `clip${extension}`);
     fs.writeFileSync(audioPath, Buffer.from(bytes));
     return { audioPath, localRoot: tmpDir };
   }
@@ -48,6 +48,19 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
       kind: "audio",
       label: "clip.mp3",
       mimeType: "audio/mpeg",
+    });
+  });
+
+  it("exposes MPEG-2 audio files with their canonical MIME type", async () => {
+    const { audioPath, localRoot } = writeAudioFixture([0xff, 0xfd, 0x80, 0x00], ".m2a");
+
+    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+      [{ mediaUrl: audioPath, trustedLocalMedia: true }],
+      { localRoots: [localRoot] },
+    );
+
+    expect(blocks[0]).toMatchObject({
+      attachment: { label: "clip.m2a", kind: "audio", mimeType: "audio/mpeg" },
     });
   });
 

--- a/src/gateway/server-methods/chat-webchat-media.ts
+++ b/src/gateway/server-methods/chat-webchat-media.ts
@@ -2,7 +2,7 @@
 // blocks that the control UI can render without unsafe file exposure.
 import path from "node:path";
 import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
-import { isAudioFileName } from "@openclaw/media-core/mime";
+import { isAudioFileName, mimeTypeFromFilePath } from "@openclaw/media-core/mime";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { openLocalFileSafely } from "../../infra/fs-safe.js";
@@ -25,17 +25,6 @@ const ALLOWED_WEBCHAT_DATA_IMAGE_MEDIA_TYPES = new Set([
   "image/png",
   "image/webp",
 ]);
-
-const MIME_BY_EXT: Record<string, string> = {
-  ".aac": "audio/aac",
-  ".m4a": "audio/mp4",
-  ".mp3": "audio/mpeg",
-  ".oga": "audio/ogg",
-  ".ogg": "audio/ogg",
-  ".opus": "audio/opus",
-  ".wav": "audio/wav",
-  ".webm": "audio/webm",
-};
 
 type WebchatAudioEmbeddingOptions = {
   localRoots?: readonly string[];
@@ -152,8 +141,7 @@ async function resolveReplyMediaAudioEmbedding(
 }
 
 function mimeTypeForPath(filePath: string): string {
-  const ext = normalizeLowercaseStringOrEmpty(path.extname(filePath));
-  return MIME_BY_EXT[ext] ?? "audio/mpeg";
+  return mimeTypeFromFilePath(filePath) ?? "audio/mpeg";
 }
 
 function isBase64DataPayload(value: string): boolean {

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -335,6 +335,25 @@ describe("message-normalizer", () => {
       ]);
     });
 
+    it("classifies MPEG-2 audio attachments", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: "MEDIA:https://example.com/recording.m2a",
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "attachment",
+          attachment: {
+            url: "https://example.com/recording.m2a",
+            kind: "audio",
+            label: "recording.m2a",
+            mimeType: "audio/mpeg",
+          },
+        },
+      ]);
+    });
+
     it("keeps valid local MEDIA paths as assistant attachments", () => {
       const result = normalizeMessage({
         role: "assistant",

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -144,6 +144,7 @@ const MIME_BY_EXT: Record<string, string> = {
   aac: "audio/aac",
   opus: "audio/opus",
   m4a: "audio/mp4",
+  m2a: "audio/mpeg",
   mp4: "video/mp4",
   mov: "video/quicktime",
   pdf: "application/pdf",

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -286,7 +286,8 @@ function isAudioTranscriptMediaPath(path: string, mediaType: unknown): boolean {
   }
   const ext = getFileExtension(path);
   return (
-    ext !== undefined && ["aac", "flac", "m4a", "mp3", "oga", "ogg", "opus", "wav"].includes(ext)
+    ext !== undefined &&
+    ["aac", "flac", "m2a", "m4a", "mp3", "oga", "ogg", "opus", "wav"].includes(ext)
   );
 }
 


### PR DESCRIPTION
Fixes #23014.

## What Problem This Solves

`.m2a` is an MPEG-2 Layer II audio filename, but OpenClaw did not map it to `audio/mpeg`. Telegram commonly delivers it as a document, so the saved attachment could retain a document placeholder and miss audio transcription/rendering paths.

## Why This Change Was Made

The original PR added `.m2a` to repeated allowlists, including the channel voice-note allowlist. This maintainer rewrite instead:

- adds `.m2a -> audio/mpeg` to the canonical media MIME map;
- derives generic audio filename classification from that map, with the existing `.oga` alias made explicit;
- reuses the canonical MIME helper in WebChat instead of maintaining a second map;
- adds `.m2a` only to owner-specific prompt, memory, and browser lists that cannot consume the Node MIME module;
- classifies Telegram documents from the saved MIME result so `.m2a` becomes `<media:audio>`;
- deliberately leaves `.m2a` out of voice-note upload formats.

`audio/mpeg` is the registered MPEG audio media type: https://www.iana.org/assignments/media-types/media-types.xhtml

Telegram's documented audio/voice upload formats do not include `.m2a`: https://core.telegram.org/bots/api#sendaudio and https://core.telegram.org/bots/api#sendvoice

## User Impact

Users can send `.m2a` files through Telegram and other media surfaces; OpenClaw recognizes, stores, prompts, indexes, and renders them as ordinary audio without incorrectly forcing the Telegram voice-note path.

## Evidence

- 252 focused media, WebChat, memory, Control UI, and Telegram tests passed across four Vitest shards.
- Full `pnpm check:changed` passed, including core/extension production and test typechecks plus lint.
- Full `pnpm build` passed.
- Generated a real 12,538-byte MP2 stream with FFmpeg on Blacksmith Testbox and verified byte sniffing, extension MIME, and audio filename classification all returned `audio/mpeg` / true.
- Blacksmith Testbox lease: `tbx_01kww1cytcgctj7rzjm3g6rczw`.
- Fresh autoreview reported no actionable findings after restoring the `.oga` alias regression it caught.
- Real-user Telegram Crabbox was attempted but could not start: the approved Convex credential lease file/environment was absent, and 1Password desktop authorization timed out twice. No personal Telegram account was substituted.
