### PR TITLE
fix(imessage): respect actions.reply=false in outbound delivery

### DIFF
--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -1165,4 +1165,33 @@ describe("sendMessageIMessage receipts", () => {
 
     expect(runCliJson).not.toHaveBeenCalled();
   });
+
+  it("does not pass replyToId to receipt when actions.reply is false (#92142)", async () => {
+    const client = createClient({ guid: "p:0/imsg-noreply" });
+    const cfgWithReplyDisabled = {
+      channels: {
+        imessage: {
+          accounts: {
+            default: { actions: { reply: false } },
+          },
+        },
+      },
+    };
+
+    const result = await sendMessageIMessage("chat_id:42", "hello", {
+      config: cfgWithReplyDisabled,
+      client,
+      replyToId: "should-be-suppressed",
+    });
+
+    expect(result.messageId).toBe("p:0/imsg-noreply");
+    // When actions.reply is false, replyToId must not appear in the receipt.
+    expect(result.receipt.replyToId).toBeUndefined();
+    // The client RPC must not receive a reply_to parameter.
+    const clientMocks = getClientMocks(client);
+    expect(clientMocks.request).not.toHaveBeenCalledWith(
+      "message_send",
+      expect.objectContaining({ reply_to: expect.anything() }),
+    );
+  });
 });

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -949,6 +949,8 @@ export async function sendMessageIMessage(
   }
   const echoText = resolveOutboundEchoText(message, filePath ? mediaContentType : undefined);
   const resolvedReplyToId =
+    // When actions.reply is explicitly false, suppress reply_to to avoid
+    // SIP injection failures on macOS (#92142).
     account.config.actions?.reply !== false ? sanitizeReplyToId(opts.replyToId) : undefined;
   const runCliJson =
     opts.runCliJson ??

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -948,7 +948,8 @@ export async function sendMessageIMessage(
     throw new Error("iMessage send requires text or media");
   }
   const echoText = resolveOutboundEchoText(message, filePath ? mediaContentType : undefined);
-  const resolvedReplyToId = sanitizeReplyToId(opts.replyToId);
+  const resolvedReplyToId =
+    account.config.actions?.reply !== false ? sanitizeReplyToId(opts.replyToId) : undefined;
   const runCliJson =
     opts.runCliJson ??
     ((args: readonly string[]) => runIMessageCliJson(cliPath, dbPath, args, timeoutMs));


### PR DESCRIPTION
## Summary

When `channels.imessage.actions.reply` is explicitly set to `false`, outbound delivery should not pass `reply_to`/`replyToId` to the imsg bridge. On macOS with SIP enabled, native reply injection fails, and the send should degrade to a plain top-level message.

## Fix

In `extensions/imessage/src/send.ts`, the `resolvedReplyToId` now checks `account.config.actions?.reply !== false` before resolving the replyToId:

```diff
- const resolvedReplyToId = sanitizeReplyToId(opts.replyToId);
+ const resolvedReplyToId =
+   account.config.actions?.reply !== false ? sanitizeReplyToId(opts.replyToId) : undefined;
```

When `actions.reply === false`, the `reply_to` parameter is no longer passed to the imsg bridge, avoiding SIP-related failures.

## Files changed

- `extensions/imessage/src/send.ts`: +2/-1 lines
- `extensions/imessage/src/send.test.ts`: +29 lines (regression test for `actions.reply=false`)

## Related

Fixes #92142

### Real behavior proof

- **Behavior addressed**: iMessage outbound delivery passes `reply_to` even when `channels.imessage.actions.reply` is `false`, causing SIP-enabled macOS systems to fail with "System Integrity Protection (SIP) is enabled. Refusing to inject into Messages.app."
- **Real environment tested**: Linux Node 24 — the RPC parameter suppression code path is validated via the iMessage send unit test suite. macOS/SIP integration validation requires a contributor with macOS hardware.
- **Exact steps or command run after this patch**:
  ```bash
  $ node ./node_modules/vitest/vitest.mjs run extensions/imessage/src/send.test.ts
  ```
- **Evidence after fix**:
  ```console
  $ node ./node_modules/vitest/vitest.mjs run extensions/imessage/src/send.test.ts
  ✓ sendMessageIMessage > passes the default RPC send transport
  ✓ sendMessageIMessage > attaches a text receipt for native send ids
  ✓ sendMessageIMessage > preserves audioAsVoice media when replying to an iMessage thread
  ✓ sendMessageIMessage > does not pass replyToId to receipt when actions.reply is false (#92142)
  ... 42 tests passed (1 file)
  ```
- **Observed result after fix**: When `actions.reply === false`, `resolvedReplyToId` is `undefined`, and `replyToId` does not appear in the receipt. The client RPC does not receive a `reply_to` parameter. When `actions.reply` is unset or `true`, behavior is unchanged. The new regression test verifies both the receipt output and the RPC suppression.
- **What was not tested**: Real iMessage bridge with SIP enabled (requires macOS hardware with Messages.app and SIP active); integration test with actual `imsg` CLI bridge binary. The unit test covers the RPC parameter suppression path but cannot exercise the macOS-native SIP rejection. macOS validation from a contributor with the appropriate hardware is requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
