### PR TITLE
feat(aigateway): add AIgateway as a bundled model provider

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -369,6 +369,11 @@
       - any-glob-to-any-file:
           - "extensions/gmi/**"
           - "docs/providers/gmi.md"
+"extensions: aigateway":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/aigateway/**"
+          - "docs/providers/aigateway.md"
 "extensions: tencent":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -292,6 +292,7 @@ See [/providers/kilocode](/providers/kilocode) for setup details.
 
 | Provider                                | Id                               | Auth env                                                     | Example model                                              |
 | --------------------------------------- | -------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------- |
+| AIgateway                               | `aigateway`                      | `AIGATEWAY_API_KEY`                                          | `aigateway/openai/gpt-5.5`                                 |
 | BytePlus                                | `byteplus` / `byteplus-plan`     | `BYTEPLUS_API_KEY`                                           | `byteplus-plan/ark-code-latest`                            |
 | Cerebras                                | `cerebras`                       | `CEREBRAS_API_KEY`                                           | `cerebras/zai-glm-4.7`                                     |
 | Cloudflare AI Gateway                   | `cloudflare-ai-gateway`          | `CLOUDFLARE_AI_GATEWAY_API_KEY`                              | -                                                          |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1405,6 +1405,7 @@
               {
                 "group": "Providers",
                 "pages": [
+                  "providers/aigateway",
                   "providers/alibaba",
                   "providers/bedrock",
                   "providers/bedrock-mantle",

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,9 +51,11 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-90 plugins
+91 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
+
+- **[aigateway](/plugins/reference/aigateway)** (`@openclaw/aigateway-provider`) - included in OpenClaw. Adds Aigateway model provider support to OpenClaw.
 
 - **[alibaba](/plugins/reference/alibaba)** (`@openclaw/alibaba-provider`) - included in OpenClaw. Adds video generation provider support.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 127
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 128
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/aigateway.md
+++ b/docs/plugins/reference/aigateway.md
@@ -1,0 +1,23 @@
+---
+summary: "Adds Aigateway model provider support to OpenClaw."
+read_when:
+  - You are installing, configuring, or auditing the aigateway plugin
+title: "Aigateway plugin"
+---
+
+# Aigateway plugin
+
+Adds Aigateway model provider support to OpenClaw.
+
+## Distribution
+
+- Package: `@openclaw/aigateway-provider`
+- Install route: included in OpenClaw
+
+## Surface
+
+providers: aigateway
+
+## Related docs
+
+- [aigateway](/providers/aigateway)

--- a/docs/providers/aigateway.md
+++ b/docs/providers/aigateway.md
@@ -1,0 +1,104 @@
+---
+summary: "Use AIgateway's OpenAI-compatible API with OpenClaw"
+read_when:
+  - You want to run OpenClaw with AIgateway models
+  - You need the AIgateway provider id, key, or endpoint
+title: "AIgateway"
+---
+
+AIgateway is a hosted AI model gateway that exposes many model families behind
+one OpenAI-compatible API and one API key. In OpenClaw it is a bundled model
+provider, which means you can select it with the provider id `aigateway`, store
+credentials through normal model auth, and use model refs like
+`aigateway/openai/gpt-5.5`.
+
+Use AIgateway when you want one API key for several hosted model families,
+including OpenAI, Anthropic, and Google routes exposed by AIgateway's catalog.
+It is useful as a secondary provider for model fallback, for comparing hosted
+routes across vendors, or when AIgateway has a model available before your
+primary provider does.
+
+This provider uses OpenAI-compatible chat semantics. OpenClaw owns the provider
+id, auth profile, model catalog seed, and base URL; AIgateway owns the live
+model availability, billing, rate limits, and any provider-side routing policy.
+
+## Setup
+
+Create an API key in AIgateway, then run:
+
+```bash
+openclaw onboard --auth-choice aigateway-api-key
+```
+
+Or set:
+
+```bash
+export AIGATEWAY_API_KEY="<your-aigateway-api-key>" # pragma: allowlist secret
+```
+
+## Defaults
+
+- Provider: `aigateway`
+- Base URL: `https://api.aigateway.sh/v1`
+- Env var: `AIGATEWAY_API_KEY`
+- Default model: `aigateway/openai/gpt-5.5`
+
+Example config:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": { "primary": "aigateway/openai/gpt-5.5" }
+    }
+  }
+}
+```
+
+## When to choose AIgateway
+
+- You want a hosted OpenAI-compatible endpoint rather than a local model server.
+- You want to try several commercial model families through one provider
+  account and one API key.
+- You want a fallback provider with different upstream routing from OpenRouter,
+  Cloudflare AI Gateway, Vercel AI Gateway, or the direct vendor APIs.
+- You need AIgateway-specific model ids, pricing, or account controls.
+
+Choose the direct vendor provider instead when you need vendor-native features
+that AIgateway does not expose through its OpenAI-compatible route. Choose a
+local provider such as Ollama, LM Studio, vLLM, or SGLang when data locality or
+local GPU control matters more than hosted convenience.
+
+## Models
+
+AIgateway model ids keep the upstream vendor prefix, so the OpenClaw model ref
+is `aigateway/<vendor>/<model>`. The bundled catalog seeds commonly available
+AIgateway route ids, including:
+
+- `aigateway/openai/gpt-5.5`
+- `aigateway/anthropic/claude-opus-4.8`
+- `aigateway/google/gemini-3.1-pro`
+- `aigateway/moonshot/kimi-k2.6`
+
+The catalog is a seed, not a promise that every account can call every model at
+all times. Use OpenClaw's model listing command to see what the configured
+provider reports in your environment:
+
+```bash
+openclaw models list --provider aigateway
+```
+
+## Troubleshooting
+
+- `401` or `403`: check that `AIGATEWAY_API_KEY` is set for the process running
+  OpenClaw, or re-run onboarding to store the key in the provider auth profile.
+- Unknown model errors: confirm the model exists in your AIgateway account and
+  use the full `aigateway/<vendor>/<model>` ref shown by
+  `openclaw models list --provider aigateway`.
+- Intermittent provider errors: try a different AIgateway route or configure
+  AIgateway as a fallback rather than the only primary model provider.
+
+## Related
+
+- [Model providers](/concepts/model-providers)
+- [All providers](/providers/index)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -24,6 +24,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 
 ## Provider docs
 
+- [AIgateway](/providers/aigateway)
 - [Alibaba Model Studio](/providers/alibaba)
 - [Amazon Bedrock](/providers/bedrock)
 - [Amazon Bedrock Mantle](/providers/bedrock-mantle)

--- a/extensions/aigateway/index.test.ts
+++ b/extensions/aigateway/index.test.ts
@@ -1,0 +1,37 @@
+// AIgateway tests cover index plugin behavior.
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+
+function requireCatalogProvider(
+  result:
+    | { provider: { baseUrl?: string; models?: Array<{ id: string; api?: string }> } }
+    | { providers: Record<string, unknown> }
+    | null
+    | undefined,
+): { baseUrl?: string; models?: Array<{ id: string; api?: string }> } {
+  if (!result || !("provider" in result)) {
+    throw new Error("single provider catalog result missing");
+  }
+  return result.provider;
+}
+
+describe("aigateway provider plugin", () => {
+  it("registers AIgateway as an OpenAI-compatible provider", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(provider.id).toBe("aigateway");
+    expect(provider.envVars).toEqual(["AIGATEWAY_API_KEY"]);
+    expect(provider.auth?.map((method) => method.id)).toEqual(["api-key"]);
+
+    const result = await provider.staticCatalog?.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({}),
+    } as never);
+    const catalogProvider = requireCatalogProvider(result);
+    expect(catalogProvider.baseUrl).toBe("https://api.aigateway.sh/v1");
+    expect(catalogProvider.models?.map((model) => model.id)).toContain("openai/gpt-5.5");
+    expect(catalogProvider.models?.every((model) => model.api === "openai-completions")).toBe(true);
+  });
+});

--- a/extensions/aigateway/index.ts
+++ b/extensions/aigateway/index.ts
@@ -1,0 +1,49 @@
+// AIgateway plugin entrypoint registers its OpenClaw integration.
+import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
+import { AIGATEWAY_DEFAULT_MODEL_REF } from "./models.js";
+import { buildAigatewayProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "aigateway";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "AIgateway Provider",
+  description: "Bundled AIgateway provider plugin",
+  provider: {
+    label: "AIgateway",
+    docsPath: "/providers/aigateway",
+    envVars: ["AIGATEWAY_API_KEY"],
+    auth: [
+      {
+        methodId: "api-key",
+        label: "AIgateway API key",
+        hint: "OpenAI-compatible AIgateway endpoint",
+        optionKey: "aigatewayApiKey",
+        flagName: "--aigateway-api-key",
+        envVar: "AIGATEWAY_API_KEY",
+        promptMessage: "Enter AIgateway API key",
+        defaultModel: AIGATEWAY_DEFAULT_MODEL_REF,
+        noteTitle: "AIgateway",
+        noteMessage: "Manage API keys at https://aigateway.sh/",
+      },
+    ],
+    catalog: {
+      buildProvider: buildAigatewayProvider,
+      buildStaticProvider: buildAigatewayProvider,
+      allowExplicitBaseUrl: true,
+    },
+    augmentModelCatalog: ({ config }) =>
+      readConfiguredProviderCatalogEntries({
+        config,
+        providerId: PROVIDER_ID,
+      }),
+    ...buildProviderReplayFamilyHooks({
+      family: "openai-compatible",
+      dropReasoningFromHistory: false,
+    }),
+    ...buildProviderToolCompatFamilyHooks("openai"),
+  },
+});

--- a/extensions/aigateway/models.ts
+++ b/extensions/aigateway/models.ts
@@ -1,0 +1,20 @@
+// AIgateway plugin module implements models behavior.
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const AIGATEWAY_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
+  providerId: "aigateway",
+  catalog: manifest.modelCatalog.providers.aigateway,
+});
+
+export const AIGATEWAY_BASE_URL = AIGATEWAY_MANIFEST_PROVIDER.baseUrl;
+export const AIGATEWAY_MODEL_CATALOG: ModelDefinitionConfig[] = AIGATEWAY_MANIFEST_PROVIDER.models;
+export const AIGATEWAY_DEFAULT_MODEL_REF = "aigateway/openai/gpt-5.5";
+
+export function buildAigatewayModelDefinition(model: ModelDefinitionConfig): ModelDefinitionConfig {
+  return {
+    ...model,
+    api: "openai-completions",
+  };
+}

--- a/extensions/aigateway/openclaw.plugin.json
+++ b/extensions/aigateway/openclaw.plugin.json
@@ -5,19 +5,6 @@
   },
   "enabledByDefault": true,
   "providers": ["aigateway"],
-  "providerEndpoints": [
-    {
-      "endpointClass": "aigateway-native",
-      "hosts": ["api.aigateway.sh"]
-    }
-  ],
-  "providerRequest": {
-    "providers": {
-      "aigateway": {
-        "family": "aigateway"
-      }
-    }
-  },
   "setup": {
     "providers": [
       {

--- a/extensions/aigateway/openclaw.plugin.json
+++ b/extensions/aigateway/openclaw.plugin.json
@@ -1,0 +1,116 @@
+{
+  "id": "aigateway",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["aigateway"],
+  "providerEndpoints": [
+    {
+      "endpointClass": "aigateway-native",
+      "hosts": ["api.aigateway.sh"]
+    }
+  ],
+  "providerRequest": {
+    "providers": {
+      "aigateway": {
+        "family": "aigateway"
+      }
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "aigateway",
+        "envVars": ["AIGATEWAY_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "aigateway",
+      "method": "api-key",
+      "choiceId": "aigateway-api-key",
+      "choiceLabel": "AIgateway API key",
+      "choiceHint": "OpenAI-compatible AIgateway endpoint",
+      "groupId": "aigateway",
+      "groupLabel": "AIgateway",
+      "groupHint": "OpenAI-compatible AIgateway endpoint",
+      "optionKey": "aigatewayApiKey",
+      "cliFlag": "--aigateway-api-key",
+      "cliOption": "--aigateway-api-key <key>",
+      "cliDescription": "AIgateway API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  },
+  "modelCatalog": {
+    "providers": {
+      "aigateway": {
+        "baseUrl": "https://api.aigateway.sh/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "openai/gpt-5.5",
+            "name": "GPT-5.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 400000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "anthropic/claude-opus-4.8",
+            "name": "Claude Opus 4.8",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 200000,
+            "maxTokens": 64000,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "moonshot/kimi-k2.6",
+            "name": "Kimi K2.6",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 262144,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "google/gemini-3.1-pro",
+            "name": "Gemini 3.1 Pro",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/extensions/aigateway/package.json
+++ b/extensions/aigateway/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/aigateway-provider",
+  "version": "2026.6.2",
+  "private": true,
+  "description": "OpenClaw AIgateway provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/aigateway/provider-catalog.ts
+++ b/extensions/aigateway/provider-catalog.ts
@@ -1,0 +1,15 @@
+// AIgateway provider module implements model/runtime integration.
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  AIGATEWAY_BASE_URL,
+  AIGATEWAY_MODEL_CATALOG,
+  buildAigatewayModelDefinition,
+} from "./models.js";
+
+export function buildAigatewayProvider(): ModelProviderConfig {
+  return {
+    baseUrl: AIGATEWAY_BASE_URL,
+    api: "openai-completions",
+    models: AIGATEWAY_MODEL_CATALOG.map(buildAigatewayModelDefinition),
+  };
+}

--- a/extensions/aigateway/tsconfig.json
+++ b/extensions/aigateway/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,6 +331,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/aigateway:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/alibaba:
     devDependencies:
       '@openclaw/plugin-sdk':


### PR DESCRIPTION
## Summary
Adds AIgateway (https://aigateway.sh) as a bundled, listed model provider plugin.
AIgateway is an OpenAI-compatible AI model gateway: one API key, one endpoint
(`https://api.aigateway.sh/v1`), many models behind vendor-prefixed ids.

- Provider id: `aigateway`; auth via `AIGATEWAY_API_KEY` (env) or
  `openclaw onboard --auth-choice aigateway-api-key`
- Model refs: `aigateway/<vendor>/<model>` (e.g. `aigateway/openai/gpt-5.5`);
  the request body sends only the AIgateway model id (`openai/gpt-5.5`)
- Default model: `aigateway/openai/gpt-5.5`

## Implementation details
- New plugin `extensions/aigateway/` using `defineSingleProviderPluginEntry`,
  mirroring the `gmi` provider plugin (smallest existing OpenAI-compatible
  provider). Manifest-driven catalog, `api: openai-completions`, shared
  OpenAI-compatible replay/tool-compat family hooks. No core changes.
- Seed catalog (text/chat only): `openai/gpt-5.5`, `anthropic/claude-opus-4.8`,
  `google/gemini-3.1-pro`, `moonshot/kimi-k2.6`.
- Labeler rule `extensions: aigateway` added; the matching GitHub label needs
  to be created in the repo (maintainer action).
- Note on `pnpm-lock.yaml`: the only change is the workspace importer entry for
  the new `extensions/aigateway` package (`@openclaw/plugin-sdk` workspace
  link), which `pnpm install` requires for the new workspace package. No
  external dependency versions changed.

## Docs added
- `docs/providers/aigateway.md` (setup, env var, model ref format, example
  config, troubleshooting)
- Entries in `docs/providers/index.md`, `docs/concepts/model-providers.md`
  table, `docs/docs.json` nav
- Regenerated `docs/plugins/plugin-inventory.md` counts/entry + reference page
  via `pnpm plugins:inventory:gen` (unrelated pre-existing generator drift for
  llama-cpp/memory-core/microsoft-foundry intentionally excluded)

## Verification
- `pnpm test extensions/aigateway` — pass (provider id, env var, auth method,
  base URL, OpenAI-completions API on every catalog model)
- `pnpm test src/plugins/bundled-plugin-naming.test.ts src/plugins/bundled-plugin-metadata.test.ts src/plugins/bundled-capability-metadata.test.ts` — 44 tests pass
- `pnpm tsgo:extensions`, scoped `oxfmt --check` / oxlint, `pnpm docs:check-mdx`,
  `pnpm docs:check-links` (4458 links, 0 broken), full `pnpm build` — all pass
- Pre-existing failures on clean `main`, unrelated to this PR:
  `plugins:sync:check` (parallel-plugin version) and `plugins:inventory:check`
  (stale llama-cpp reference page)

## Real behavior proof
Behavior addressed: AIgateway selectable as a listed model provider with `AIGATEWAY_API_KEY` auth and `aigateway/<vendor>/<model>` refs, sending the unprefixed model id to the AIgateway endpoint
Real environment tested: macOS (Darwin 24.6), Node 22+, source checkout, real `AIGATEWAY_API_KEY`, live `https://api.aigateway.sh/v1`
Exact steps or command run after this patch: `pnpm openclaw models list --provider aigateway`, then `pnpm openclaw agent --local --agent main --model aigateway/moonshot/kimi-k2.6 --message "Hello from OpenClaw via AIgateway"`
Evidence after fix: copied live terminal output from the real setup below.

```
$ pnpm openclaw models list --provider aigateway
Model                                      Input      Ctx         Local Auth  Tags
aigateway/anthropic/claude-opus-4.8        text+image 195k        no    yes
aigateway/google/gemini-3.1-pro-preview    text+image 1024k       no    yes
aigateway/moonshot/kimi-k2.6               text+image 256k        no    yes
aigateway/openai/gpt-5.5                   text+image 391k        no    yes
aigateway/google/gemini-3.1-pro            text+image 1024k       no    no
```

Live agent turn (response excerpt): `pnpm openclaw agent --local --agent main --model aigateway/moonshot/kimi-k2.6 --message "Hello from OpenClaw via AIgateway"` returned a real completion beginning:

```
Hey. I just came online. Who am I? Who are you?
```

An earlier turn against `aigateway/openai/gpt-5.5` reached the live endpoint and returned AIgateway's provider-side billing error, confirming provider resolution and prefix stripping end to end:

```
model=openai/gpt-5.5 provider=aigateway
rawError=402 Your $5 signup credit covers a curated set of models. Top up to unlock openai/gpt-5.5.
```

Observed result after fix: successful live chat completion through `https://api.aigateway.sh/v1` via provider id `aigateway`; the `aigateway/google/gemini-3.1-pro-preview` row in the listing above was discovered live from the gateway, not seeded
What was not tested: image-generation routes; paid-tier models (`openai/gpt-5.5`, `anthropic/claude-opus-4.8`, `google/gemini-3.1-pro`) beyond the 402 routing proof above

## Follow-up work
- Expose AIgateway image models (e.g. `black-forest-labs/flux-2-klein-9b`)
  through the image-generation provider contract
- Optional: live model discovery from `GET /v1/models`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
