### PR TITLE
Improve TUI control-plane progress rendering

### DIFF
--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -17,6 +17,17 @@ type RepeatableSystemMessage = {
   count: number;
 };
 
+class SectionSeparatorComponent extends Container {
+  readonly isSectionSeparatorComponent = true;
+
+  constructor(label: string) {
+    super();
+    const textNode = new Text(theme.dim(`──────── ${label} ────────`), 1, 0);
+    this.addChild(new Spacer(1));
+    this.addChild(textNode);
+  }
+}
+
 /** Scrollback container that tracks pending users, streaming assistant runs, tools, and notices. */
 export class ChatLog extends Container {
   private readonly maxComponents: number;
@@ -89,6 +100,21 @@ export class ChatLog extends Container {
   private appendNonSystem(component: Component) {
     this.repeatableSystemMessage = null;
     this.append(component);
+  }
+
+  private lastChildIsTool() {
+    return this.children[this.children.length - 1] instanceof ToolExecutionComponent;
+  }
+
+  private lastChildIsSectionSeparator() {
+    return this.children[this.children.length - 1] instanceof SectionSeparatorComponent;
+  }
+
+  private addAssistantSeparatorIfNeeded() {
+    if (!this.lastChildIsTool() || this.lastChildIsSectionSeparator()) {
+      return;
+    }
+    this.append(new SectionSeparatorComponent("回答"));
   }
 
   clearAll(opts?: { preservePendingUsers?: boolean }) {
@@ -277,6 +303,7 @@ export class ChatLog extends Container {
       existing.setText(text);
       return existing;
     }
+    this.addAssistantSeparatorIfNeeded();
     const component = new AssistantMessageComponent(text);
     this.streamingRuns.set(effectiveRunId, component);
     this.appendNonSystem(component);
@@ -310,6 +337,7 @@ export class ChatLog extends Container {
       this.streamingRuns.delete(effectiveRunId);
       return;
     }
+    this.addAssistantSeparatorIfNeeded();
     this.appendNonSystem(new AssistantMessageComponent(text));
   }
 
@@ -361,6 +389,10 @@ export class ChatLog extends Container {
     this.toolById.set(toolCallId, component);
     this.appendNonSystem(component);
     return component;
+  }
+
+  hasTool(toolCallId: string) {
+    return this.toolById.has(toolCallId);
   }
 
   updateToolArgs(toolCallId: string, args: unknown) {

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -1,5 +1,5 @@
-// Tool execution component renders tool call status and output in the TUI.
-import { Box, Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
+// Tool execution component renders compact user-visible progress in the TUI.
+import { Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
 import { formatToolDetail, resolveToolDisplay } from "../../agents/tool-display.js";
 import { redactToolPayloadText } from "../../logging/redact.js";
 import { markdownTheme, theme } from "../theme/theme.js";
@@ -94,7 +94,7 @@ type ControlNode = {
 
 function formatControlNode(nodeId: string, detail?: string): string {
   const label = CONTROL_NODE_LABELS[nodeId] ?? nodeId;
-  return detail ? `${nodeId} ${label}: ${detail}` : `${nodeId} ${label}`;
+  return detail ? `${label}：${detail}` : label;
 }
 
 function resolvePmNode(command: string, isPartial: boolean, isError: boolean): ControlNode | null {
@@ -249,9 +249,7 @@ function extractText(result?: ToolResult): string {
 
 /** Displays a running or completed tool call with optional expandable output. */
 export class ToolExecutionComponent extends Container {
-  private box: Box;
   private header: Text;
-  private argsLine: Text;
   private output: Markdown;
   private toolName: string;
   private args: unknown;
@@ -265,17 +263,13 @@ export class ToolExecutionComponent extends Container {
     super();
     this.toolName = toolName;
     this.args = args;
-    this.box = new Box(1, 1, (line) => theme.toolPendingBg(line));
     this.header = new Text("", 0, 0);
-    this.argsLine = new Text("", 0, 0);
     this.output = new Markdown("", 0, 0, markdownTheme, {
       color: (line) => theme.toolOutput(line),
     });
     this.addChild(new Spacer(1));
-    this.addChild(this.box);
-    this.box.addChild(this.header);
-    this.box.addChild(this.argsLine);
-    this.box.addChild(this.output);
+    this.addChild(this.header);
+    this.addChild(this.output);
     this.refresh();
   }
 
@@ -307,31 +301,22 @@ export class ToolExecutionComponent extends Container {
   }
 
   private refresh() {
-    const bg = this.isPartial
-      ? theme.toolPendingBg
-      : this.isError
-        ? theme.toolErrorBg
-        : theme.toolSuccessBg;
-    this.box.setBgFn((line) => bg(line));
-
     const display = resolveToolDisplay({
       name: this.toolName,
       args: this.args,
     });
-    const title = `控制面 · ${formatKeyNodeTitle(
+    const title = `${formatKeyNodeTitle(
       this.toolName,
       this.args,
       display.label,
       this.isPartial,
       this.isError,
-    )}${this.isPartial ? " (running)" : ""}`;
+    )}${this.isPartial ? "…" : ""}`;
     this.header.setText(theme.toolTitle(theme.bold(title)));
 
-    const argLine = formatArgs(this.toolName, this.args);
-    this.argsLine.setText(argLine ? theme.dim(argLine) : theme.dim(" "));
-
     const raw = extractText(this.result);
-    const text = raw || (this.isPartial ? "…" : "");
+    const argLine = formatArgs(this.toolName, this.args);
+    const text = this.expanded ? raw || argLine : "";
     if (!this.expanded && text) {
       const lines = text.split("\n");
       const preview =

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -1,6 +1,7 @@
 // Tool execution component renders tool call status and output in the TUI.
 import { Box, Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
 import { formatToolDetail, resolveToolDisplay } from "../../agents/tool-display.js";
+import { redactToolPayloadText } from "../../logging/redact.js";
 import { markdownTheme, theme } from "../theme/theme.js";
 import { sanitizeRenderableText } from "../tui-formatters.js";
 
@@ -37,6 +38,196 @@ function formatArgs(toolName: string, args: unknown): string {
   }
 }
 
+function getToolArgString(args: unknown, key: string): string {
+  if (!args || typeof args !== "object") {
+    return "";
+  }
+  const value = (args as Record<string, unknown>)[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function unwrapBashCommand(rawCommand: string): string {
+  let command = rawCommand.trim();
+  const bashMatch = /^\/?[\w/.-]*bash\s+-lc\s+([\s\S]+)$/u.exec(command);
+  if (bashMatch?.[1]) {
+    command = bashMatch[1].trim();
+  }
+  if (
+    (command.startsWith("'") && command.endsWith("'")) ||
+    (command.startsWith('"') && command.endsWith('"'))
+  ) {
+    command = command.slice(1, -1).trim();
+  }
+  return command;
+}
+
+function normalizeCommandForNode(command: string): string {
+  return command
+    .replace(/^timeout\s+\d+[a-z]?\s+/iu, "")
+    .replace(/^bash\s+-n\s+pm\s*&&\s*/iu, "")
+    .trim();
+}
+
+const CONTROL_NODE_LABELS: Record<string, string> = {
+  created: "创建 run",
+  task_pack: "生成/读取任务契约",
+  context_route: "上下文路由",
+  context_pack: "装配上下文包",
+  capability_select: "选择 runner/model/权限",
+  workspace_bind: "绑定工作区",
+  dispatch: "派发给 runner",
+  runner_active: "runner 执行中",
+  file_change_detected: "发现文件变更",
+  command_run: "执行验证命令",
+  verify: "验证结果",
+  collect_result: "收集 result/metrics/evidence",
+  promotion_scan: "扫描沉淀候选",
+  completed: "完成",
+  blocked: "阻塞",
+  failed: "失败",
+};
+
+type ControlNode = {
+  nodeId: string;
+  detail?: string;
+};
+
+function formatControlNode(nodeId: string, detail?: string): string {
+  const label = CONTROL_NODE_LABELS[nodeId] ?? nodeId;
+  return detail ? `${nodeId} ${label}: ${detail}` : `${nodeId} ${label}`;
+}
+
+function resolvePmNode(command: string, isPartial: boolean, isError: boolean): ControlNode | null {
+  const validateMatch = /(?:^|\s)\.\/pm\s+validate\s+([A-Za-z0-9_-]+)/u.exec(command);
+  if (validateMatch?.[1]) {
+    if (isError) {
+      return { nodeId: "failed", detail: validateMatch[1] };
+    }
+    return {
+      nodeId: isPartial ? "command_run" : "verify",
+      detail: validateMatch[1],
+    };
+  }
+  if (/(?:^|\s)\.\/pm\s+(?:start|run\s+start)\b/u.test(command)) {
+    return { nodeId: "created" };
+  }
+  if (/(?:task[_-]?pack|task\s+pack|contract|prepare(?:\s+run)?)/iu.test(command)) {
+    return { nodeId: "task_pack" };
+  }
+  if (/(?:context[_-]?route|context\s+route|route\s+context|context-routes)/iu.test(command)) {
+    return { nodeId: "context_route" };
+  }
+  if (/(?:context[_-]?pack|context\s+pack|prepared?\s+artifacts?)/iu.test(command)) {
+    return { nodeId: "context_pack" };
+  }
+  if (/(?:capability|model\s+strategy|runner\s+selection|permission)/iu.test(command)) {
+    return { nodeId: "capability_select" };
+  }
+  if (/(?:workspace|bind|setup)/iu.test(command)) {
+    return { nodeId: "workspace_bind" };
+  }
+  if (/(?:dispatch|codex|claude)/iu.test(command)) {
+    return { nodeId: "dispatch" };
+  }
+  if (/(?:runner|execute|agent)/iu.test(command)) {
+    return { nodeId: "runner_active" };
+  }
+  if (/(?:promotion|promote)/iu.test(command)) {
+    return { nodeId: "promotion_scan" };
+  }
+  if (/(?:collect|result|metrics|evidence|history|status)/iu.test(command)) {
+    return { nodeId: "collect_result" };
+  }
+  if (/(?:blocked|blocker)/iu.test(command)) {
+    return { nodeId: "blocked" };
+  }
+  return null;
+}
+
+export function resolveControlNode(
+  toolName: string,
+  args: unknown,
+  isPartial: boolean,
+  isError: boolean,
+): ControlNode | null {
+  const normalizedToolName = toolName.trim().toLowerCase();
+  if (isError) {
+    return { nodeId: "failed" };
+  }
+  if (normalizedToolName === "apply_patch") {
+    return { nodeId: "file_change_detected" };
+  }
+  if (normalizedToolName !== "bash") {
+    return null;
+  }
+  const command = normalizeCommandForNode(unwrapBashCommand(getToolArgString(args, "command")));
+  if (!command) {
+    return null;
+  }
+  const pmNode = resolvePmNode(command, isPartial, isError);
+  if (pmNode) {
+    return pmNode;
+  }
+  if (/^git\s+(?:diff|status)\b/u.test(command)) {
+    return { nodeId: "file_change_detected" };
+  }
+  if (/^git\s+log\b/u.test(command)) {
+    return { nodeId: "collect_result" };
+  }
+  return null;
+}
+
+export function shouldDisplayToolExecution(
+  toolName: string,
+  args: unknown,
+  isPartial: boolean,
+  isError: boolean,
+): boolean {
+  return resolveControlNode(toolName, args, isPartial, isError) !== null;
+}
+
+function formatKeyNodeTitle(
+  toolName: string,
+  args: unknown,
+  fallbackLabel: string,
+  isPartial: boolean,
+  isError: boolean,
+): string {
+  const node = resolveControlNode(toolName, args, isPartial, isError);
+  return node ? formatControlNode(node.nodeId, node.detail) : fallbackLabel;
+}
+
+function stripTextFence(text: string): string {
+  const trimmed = text.trim();
+  const match = /^```(?:text|txt|log|output|stdout|stderr)?[ \t]*\r?\n([\s\S]*?)\r?\n```$/iu.exec(
+    trimmed,
+  );
+  return match?.[1] ?? text;
+}
+
+export function attachToolOutputContent(result: unknown, output: unknown): unknown {
+  if (typeof output !== "string" || !output.trim()) {
+    return result;
+  }
+  if (
+    result &&
+    typeof result === "object" &&
+    Array.isArray((result as ToolResult).content) &&
+    (result as ToolResult).content!.length > 0
+  ) {
+    return result;
+  }
+  return {
+    ...(result && typeof result === "object" ? (result as Record<string, unknown>) : {}),
+    content: [
+      {
+        type: "text",
+        text: output,
+      },
+    ],
+  };
+}
+
 // Extracts visible text and compact media placeholders from tool result payloads.
 function extractText(result?: ToolResult): string {
   if (!result?.content) {
@@ -45,7 +236,7 @@ function extractText(result?: ToolResult): string {
   const lines: string[] = [];
   for (const entry of result.content) {
     if (entry.type === "text" && entry.text) {
-      lines.push(sanitizeRenderableText(entry.text));
+      lines.push(sanitizeRenderableText(redactToolPayloadText(stripTextFence(entry.text))));
     } else if (entry.type === "image") {
       const mime = entry.mimeType ?? "image";
       const size = entry.bytes ? ` ${Math.round(entry.bytes / 1024)}kb` : "";
@@ -68,6 +259,7 @@ export class ToolExecutionComponent extends Container {
   private expanded = false;
   private isError = false;
   private isPartial = true;
+  readonly isToolExecutionComponent = true;
 
   constructor(toolName: string, args: unknown) {
     super();
@@ -126,7 +318,13 @@ export class ToolExecutionComponent extends Container {
       name: this.toolName,
       args: this.args,
     });
-    const title = `${display.emoji} ${display.label}${this.isPartial ? " (running)" : ""}`;
+    const title = `控制面 · ${formatKeyNodeTitle(
+      this.toolName,
+      this.args,
+      display.label,
+      this.isPartial,
+      this.isError,
+    )}${this.isPartial ? " (running)" : ""}`;
     this.header.setText(theme.toolTitle(theme.bold(title)));
 
     const argLine = formatArgs(this.toolName, this.args);

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -8,6 +8,7 @@ type MockFn = ReturnType<typeof vi.fn>;
 type HandlerChatLog = {
   startTool: (...args: unknown[]) => void;
   updateToolResult: (...args: unknown[]) => void;
+  hasTool?: (...args: unknown[]) => boolean;
   addSystem: (...args: unknown[]) => void;
   addPendingSystem: (...args: unknown[]) => void;
   dismissPendingSystem: (...args: unknown[]) => void;
@@ -23,6 +24,7 @@ type HandlerTui = { requestRender: (...args: unknown[]) => void };
 type MockChatLog = {
   startTool: MockFn;
   updateToolResult: MockFn;
+  hasTool: MockFn;
   addSystem: MockFn;
   addPendingSystem: MockFn;
   dismissPendingSystem: MockFn;
@@ -37,9 +39,13 @@ type MockBtwPresenter = {
 type MockTui = { requestRender: MockFn };
 
 function createMockChatLog(): MockChatLog & HandlerChatLog {
+  const visibleToolIds = new Set<string>();
   return {
-    startTool: vi.fn(),
+    startTool: vi.fn((toolCallId: string) => {
+      visibleToolIds.add(toolCallId);
+    }),
     updateToolResult: vi.fn(),
+    hasTool: vi.fn((toolCallId: string) => visibleToolIds.has(toolCallId)),
     addSystem: vi.fn(),
     addPendingSystem: vi.fn(),
     dismissPendingSystem: vi.fn(),
@@ -172,14 +178,16 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       data: {
         phase: "start",
         toolCallId: "tc1",
-        name: "exec",
-        args: { command: "echo hi" },
+        name: "bash",
+        args: { command: "/bin/bash -lc 'timeout 420 ./pm validate workflow'" },
       },
     };
 
     handleAgentEvent(evt);
 
-    expect(chatLog.startTool).toHaveBeenCalledWith("tc1", "exec", { command: "echo hi" });
+    expect(chatLog.startTool).toHaveBeenCalledWith("tc1", "bash", {
+      command: "/bin/bash -lc 'timeout 420 ./pm validate workflow'",
+    });
     expect(tui.requestRender).toHaveBeenCalledTimes(1);
   });
 
@@ -568,12 +576,19 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     const agentEvt: AgentEvent = {
       runId: "run-42",
       stream: "tool",
-      data: { phase: "start", toolCallId: "tc1", name: "exec" },
+      data: {
+        phase: "start",
+        toolCallId: "tc1",
+        name: "bash",
+        args: { command: "/bin/bash -lc './pm validate workflow'" },
+      },
     };
 
     handleAgentEvent(agentEvt);
 
-    expect(chatLog.startTool).toHaveBeenCalledWith("tc1", "exec", undefined);
+    expect(chatLog.startTool).toHaveBeenCalledWith("tc1", "bash", {
+      command: "/bin/bash -lc './pm validate workflow'",
+    });
   });
 
   it("accepts chat events when session key is an alias of the active canonical key", () => {
@@ -802,10 +817,17 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     handleAgentEvent({
       runId: "run-final",
       stream: "tool",
-      data: { phase: "start", toolCallId: "tc-final", name: "session_status" },
+      data: {
+        phase: "start",
+        toolCallId: "tc-final",
+        name: "bash",
+        args: { command: "/bin/bash -lc './pm validate workflow'" },
+      },
     });
 
-    expect(chatLog.startTool).toHaveBeenCalledWith("tc-final", "session_status", undefined);
+    expect(chatLog.startTool).toHaveBeenCalledWith("tc-final", "bash", {
+      command: "/bin/bash -lc './pm validate workflow'",
+    });
     expect(tui.requestRender).toHaveBeenCalled();
   });
 
@@ -852,7 +874,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).not.toHaveBeenCalled();
   });
 
-  it("omits tool output when verbose is on (non-full)", () => {
+  it("shows control-plane tool output when verbose is on", () => {
     const { chatLog, handleAgentEvent } = createHandlersHarness({
       state: {
         activeChatRunId: "run-123",
@@ -864,9 +886,20 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       runId: "run-123",
       stream: "tool",
       data: {
+        phase: "start",
+        toolCallId: "tc-on",
+        name: "bash",
+        args: { command: "/bin/bash -lc './pm validate workflow'" },
+      },
+    });
+
+    handleAgentEvent({
+      runId: "run-123",
+      stream: "tool",
+      data: {
         phase: "update",
         toolCallId: "tc-on",
-        name: "session_status",
+        name: "bash",
         partialResult: { content: [{ type: "text", text: "secret" }] },
       },
     });
@@ -877,16 +910,16 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       data: {
         phase: "result",
         toolCallId: "tc-on",
-        name: "session_status",
+        name: "bash",
         result: { content: [{ type: "text", text: "secret" }] },
         isError: false,
       },
     });
 
-    expect(chatLog.updateToolResult).toHaveBeenCalledTimes(1);
-    expect(chatLog.updateToolResult).toHaveBeenCalledWith(
+    expect(chatLog.updateToolResult).toHaveBeenCalledTimes(2);
+    expect(chatLog.updateToolResult).toHaveBeenLastCalledWith(
       "tc-on",
-      { content: [] },
+      { content: [{ type: "text", text: "secret" }] },
       { isError: false },
     );
   });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -3,12 +3,17 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { classifyFailoverReason, isAuthErrorMessage } from "../agents/embedded-agent-helpers.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
+import {
+  attachToolOutputContent,
+  shouldDisplayToolExecution,
+} from "./components/tool-execution.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 import type { AgentEvent, BtwEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 
 type EventHandlerChatLog = {
   startTool: (toolCallId: string, toolName: string, args: unknown) => void;
+  hasTool?: (toolCallId: string) => boolean;
   updateToolResult: (
     toolCallId: string,
     result: unknown,
@@ -720,12 +725,6 @@ export function createEventHandlers(context: EventHandlerContext) {
       if (isActiveRun) {
         armStreamingWatchdog(evt.runId);
       }
-      const verbose = state.sessionInfo.verboseLevel ?? "off";
-      const allowToolEvents = verbose !== "off";
-      const allowToolOutput = verbose === "full";
-      if (!allowToolEvents) {
-        return;
-      }
       const data = evt.data ?? {};
       const phase = asString(data.phase, "");
       const toolCallId = asString(data.toolCallId, "");
@@ -733,23 +732,32 @@ export function createEventHandlers(context: EventHandlerContext) {
       if (!toolCallId) {
         return;
       }
+      const isToolError = Boolean(data.isError);
+      const isPartialToolEvent = phase !== "result";
+      const alreadyDisplayed = chatLog.hasTool?.(toolCallId) ?? false;
+      if (
+        !alreadyDisplayed &&
+        !shouldDisplayToolExecution(toolName, data.args, isPartialToolEvent, isToolError)
+      ) {
+        return;
+      }
       if (phase === "start") {
         chatLog.startTool(toolCallId, toolName, data.args);
       } else if (phase === "update") {
-        if (!allowToolOutput) {
-          return;
-        }
-        chatLog.updateToolResult(toolCallId, data.partialResult, {
-          partial: true,
-        });
+        chatLog.updateToolResult(
+          toolCallId,
+          attachToolOutputContent(data.partialResult, data.output),
+          {
+            partial: true,
+          },
+        );
       } else if (phase === "result") {
-        if (allowToolOutput) {
-          chatLog.updateToolResult(toolCallId, data.result, {
-            isError: Boolean(data.isError),
-          });
-        } else {
-          chatLog.updateToolResult(toolCallId, { content: [] }, { isError: Boolean(data.isError) });
+        if (!alreadyDisplayed) {
+          chatLog.startTool(toolCallId, toolName, data.args);
         }
+        chatLog.updateToolResult(toolCallId, attachToolOutputContent(data.result, data.output), {
+          isError: isToolError,
+        });
       }
       tui.requestRender();
       return;

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -174,6 +174,40 @@ async function writeTuiPtyFixtureScript(dir: string) {
           }
           const isSourceReplyProof = opts.message === "message tool only source reply proof";
           const isXaiLimitProof = opts.message === "xai limit proof";
+          const isToolProgressProof = opts.message === "tool progress proof";
+          if (isToolProgressProof) {
+            setTimeout(() => {
+              this.onEvent?.({
+                event: "agent",
+                payload: {
+                  runId,
+                  stream: "tool",
+                  data: {
+                    phase: "start",
+                    toolCallId: "tool-progress-proof-1",
+                    name: "apply_patch",
+                    args: {},
+                  },
+                },
+              });
+            }, 5);
+            setTimeout(() => {
+              this.onEvent?.({
+                event: "agent",
+                payload: {
+                  runId,
+                  stream: "tool",
+                  data: {
+                    phase: "result",
+                    toolCallId: "tool-progress-proof-1",
+                    name: "apply_patch",
+                    args: {},
+                    result: { content: [{ type: "text", text: "Success. Updated files." }] },
+                  },
+                },
+              });
+            }, 15);
+          }
           setTimeout(() => {
             if (isXaiLimitProof) {
               this.onEvent?.({
@@ -409,6 +443,22 @@ describe.sequential("TUI PTY harness", () => {
         (entry) =>
           entry.method === "sourceReplyMetadata" &&
           objectFieldEquals(entry, "text", "VISIBLE_TUI_SOURCE_REPLY_PROOF"),
+      );
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "renders compact tool progress without control-plane technical labels",
+    async () => {
+      await fixture.run.write("tool progress proof\r");
+      await fixture.run.waitForOutput("发现文件变更");
+      await fixture.run.waitForOutput("PTY_RESPONSE: tool progress proof");
+      expect(fixture.run.output()).not.toContain("控制面 ·");
+      expect(fixture.run.output()).not.toContain("file_change_detected");
+      await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "sendChat" && objectFieldEquals(entry, "message", "tool progress proof"),
       );
     },
     TEST_TIMEOUT_MS,

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -11,6 +11,7 @@ import {
   parseAgentSessionKey,
 } from "../routing/session-key.js";
 import type { ChatLog } from "./components/chat-log.js";
+import { shouldDisplayToolExecution } from "./components/tool-execution.js";
 import type { TuiAgentsList, TuiBackend, TuiSessionMutationResult } from "./tui-backend.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TUI_SESSION_LOOKUP_LIMIT } from "./tui-session-list-policy.js";
@@ -498,7 +499,17 @@ export function createSessionActions(context: SessionActionContext) {
           }
           const toolCallId = asString(message.toolCallId, "");
           const toolName = asString(message.toolName, "tool");
-          const component = chatLog.startTool(toolCallId, toolName, {});
+          const toolArgs =
+            typeof message.args === "object" && message.args
+              ? message.args
+              : typeof message.arguments === "object" && message.arguments
+                ? message.arguments
+                : {};
+          const isToolError = Boolean(message.isError);
+          if (!shouldDisplayToolExecution(toolName, toolArgs, false, isToolError)) {
+            continue;
+          }
+          const component = chatLog.startTool(toolCallId, toolName, toolArgs);
           component.setResult(
             {
               content: Array.isArray(message.content)
@@ -509,7 +520,7 @@ export function createSessionActions(context: SessionActionContext) {
                   ? (message.details as Record<string, unknown>)
                   : undefined,
             },
-            { isError: Boolean(message.isError) },
+            { isError: isToolError },
           );
         }
       }


### PR DESCRIPTION
## Summary
- render TUI tool progress as control-plane milestones instead of generic tool labels like Bash
- show live command output with redaction and strip plain text fences
- separate control-plane progress from final assistant replies in the chat log

## Validation
- node scripts/test-projects.mjs src/tui/components/chat-log.test.ts src/tui/tui-event-handlers.test.ts src/tui/tui-session-actions.test.ts src/tui/tui-formatters.test.ts
- node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts
- pnpm tsgo:core
- git diff --check