### PR TITLE
#92169: Embedded runtime: don't terminate turn after interstitial message sends

### DIFF
--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
@@ -160,7 +160,7 @@ describe("message-tool-only terminal sends", () => {
     ).toBe(false);
   });
 
-  it("preserves existing after-tool-call output while adding the terminal hint", async () => {
+  it("preserves existing after-tool-call output and records delivery without terminating the turn", async () => {
     const previousAfterToolCall = vi.fn(async () => ({
       content: [{ type: "text" as const, text: "rewritten" }],
       details: { rewritten: true },
@@ -183,7 +183,6 @@ describe("message-tool-only terminal sends", () => {
     ).resolves.toEqual({
       content: [{ type: "text", text: "rewritten" }],
       details: { rewritten: true },
-      terminate: true,
     });
     expect(previousAfterToolCall).toHaveBeenCalledTimes(1);
     expect(onDeliveredSourceReply).toHaveBeenCalledTimes(1);

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
@@ -1,5 +1,9 @@
 /**
- * Detects message-tool-only sends that should terminate an agent turn.
+ * Detects message-tool-only sends that should record delivery evidence.
+ *
+ * Previously used to terminate the agent turn after a qualifying message send;
+ * now only signals delivery so the model can continue working after sending
+ * an interstitial/progress update. (#92169)
  */
 import type { SourceReplyDeliveryMode } from "../../../auto-reply/get-reply-options.types.js";
 import { isMessageToolSendActionName } from "../../embedded-agent-messaging.js";
@@ -191,7 +195,16 @@ export function shouldTerminateAfterMessageToolOnlySend(params: {
   return true;
 }
 
-/** Installs an after-tool hook that terminates the turn after a qualifying message send. */
+/** Installs an after-tool hook that records delivery but does not terminate the turn.
+ *
+ * Previously the hook returned `terminate: true` after a qualifying message send,
+ * which caused the agent loop to end immediately. This prevented the model from
+ * continuing planned work after sending an interstitial/progress update message
+ * (e.g. "checking the codebase, one moment"). The model's natural stopReason
+ * (end_turn/stop) determines when the turn ends — re-invoking the model after
+ * the tool result lets it continue if it was a progress message, or naturally
+ * end with stopReason: stop if it was the final answer. (#92169)
+ */
 export function installMessageToolOnlyTerminalHook(params: {
   agent: Agent;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
@@ -211,7 +224,6 @@ export function installMessageToolOnlyTerminalHook(params: {
       })
     ) {
       params.onDeliveredSourceReply?.();
-      return { ...hookResult, terminate: true };
     }
     return hookResult;
   };


### PR DESCRIPTION
## Summary

Remove `terminate: true` from the message-tool-only afterToolCall hook so that the embedded agent runtime does not erroneously end the turn after every successful interstitial/progress message send. The model can now continue planned tool work after sending a visible progress update (e.g. "checking the codebase, one moment") instead of terminating the turn prematurely.

## Root Cause

In `message_tool_only` delivery mode, `installMessageToolOnlyTerminalHook` in `src/agents/embedded-agent-runner/run/message-tool-terminal.ts` returned `terminate: true` after every successful implicit-route `message.send`. This caused `shouldTerminateToolBatch` to stop the agent loop immediately, preventing the model from re-engaging after the tool result to perform the promised work.

The agent's `stopReason` was `toolUse` (the model expected tool results and planned to continue), but the hook's `terminate: true` skipped the re-invoke step entirely. A 45-day audit across 3 agents showed the follow-through-failure rate doubled on 2026.6.1: 73.3% of promised turns failed to deliver vs 36.2% pre-6.1.

## Real behavior proof

**Behavior addressed:** Remove `terminate: true` from the message-tool-only afterToolCall hook return value while keeping the `onDeliveredSourceReply` delivery tracking callback intact.

**Real environment tested:** Debian GNU/Linux 12 (bookworm), kernel 6.12 x86_64. Standalone Node.js script that simulates the agent loop to demonstrate the before/after behavior difference.

**Exact steps or command run after this patch:**
```console
node /tmp/repro-92169.mjs
```

**Evidence:**
```
======================================================================
Issue #92169 — Before vs After Fix Comparison
======================================================================

【BEFORE FIX】: terminate: true after message.send

  Turns executed: 1
  Tools executed: 1
  Tool #1: terminate=true | text="Message sent successfully"

  ✗ BUG: After message.send("checking the codebase..."), turn ended.
  ✗ Model never got to call "read" or deliver the actual answer.


【AFTER FIX】: no terminate after message.send (model continues naturally)

  Turns executed: 4
  Tools executed: 3
  Tool #1: terminate=false | text="Message sent successfully"
  Tool #2: terminate=undefined | text="read result data"
  Tool #3: terminate=false | text="Message sent successfully"

  ✓ Model sent progress message → continue working → delivered final answer
  ✓ All 3 tools executed in sequence as intended
```

**Observed result after fix:** The agent loop continues after a message.send in `message_tool_only` mode. With the fix, the model sees "Message sent successfully" and continues to subsequent tool calls (read, search) for actual work. The model's natural `stopReason` (end_turn/stop) determines when the turn ends, so progress-update messages do not erroneously terminate the agent loop. In the simulation, 3 tools now execute in sequence (message send → read → message send) across 4 turns, with the model naturally stopping at end_turn.

```diff
diff --git a/src/agents/embedded-agent-runner/run/message-tool-terminal.ts b/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
index 2deaf33d3b..1384f99b89 100644
--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
@@ -191,7 +191,16 @@ export function shouldTerminateAfterMessageToolOnlySend(params: {
   return true;
 }
 
-/** Installs an after-tool hook that terminates the turn after a qualifying message send. */
+/** Installs an after-tool hook that records delivery but does not terminate the turn.
+ *
+ * Previously the hook returned `terminate: true` after a qualifying message send,
+ * which caused the agent loop to end immediately. This prevented the model from
+ * continuing planned work after sending an interstitial/progress update message
+ * (e.g. "checking the codebase, one moment"). The model's natural stopReason
+ * (end_turn/stop) determines when the turn ends — re-invoking the model after
+ * the tool result lets it continue if it was a progress message, or naturally
+ * end with stopReason: stop if it was the final answer. (#92169)
+ */
 export function installMessageToolOnlyTerminalHook(params: {
   agent: Agent;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
@@ -211,7 +220,6 @@ export function installMessageToolOnlyTerminalHook(params: {
       })
     ) {
       params.onDeliveredSourceReply?.();
-      return { ...hookResult, terminate: true };
     }
     return hookResult;
   };
```

**What was not tested:** Full integration test with actual Anthropic API / Slack channel agent. The change is purely a logic fix in the agent runtime hook — no external dependency changes.

## Regression Test Plan

- [x] `pnpm test -- --run src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts` passes (updated test expectations)
- [ ] Change is minimal and targeted — only the `installMessageToolOnlyTerminalHook` function is modified; the `shouldTerminateAfterMessageToolOnlySend` predicate is kept for delivery detection but no longer used for termination.

---

*AI-assisted: built with Claude Code*