### PR TITLE
fix(agents): align /btw model resolution with runtime aliases

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -76,8 +76,8 @@ vi.mock("./model-auth.js", () => ({
   requireApiKey: (...args: unknown[]) => requireApiKeyMock(...args),
 }));
 
-vi.mock("./model-runtime-aliases.js", () => ({
-  resolveCliRuntimeExecutionProvider: ({
+vi.mock("./model-runtime-aliases.js", () => {
+  const resolveConfiguredRuntime = ({
     provider,
     cfg,
     modelId,
@@ -97,8 +97,13 @@ vi.mock("./model-runtime-aliases.js", () => ({
       ? cfg?.agents?.defaults?.models?.[key]?.agentRuntime?.id?.trim()
       : undefined;
     return runtime || undefined;
-  },
-}));
+  };
+  return {
+    resolveCliRuntimeExecutionProvider: resolveConfiguredRuntime,
+    isCliRuntimeAliasForProvider: (params: { runtime?: string; provider?: string }) =>
+      params.runtime === "claude-cli" && params.provider === "anthropic",
+  };
+});
 
 vi.mock("./embedded-agent-runner/runs.js", () => ({
   getActiveEmbeddedRunSnapshot: (...args: unknown[]) => getActiveEmbeddedRunSnapshotMock(...args),
@@ -441,10 +446,14 @@ describe("runBtwSideQuestion", () => {
     buildSessionContextMock.mockImplementation((entries: Array<{ message?: unknown }> = []) => {
       return { messages: entries.flatMap((entry) => (entry.message ? [entry.message] : [])) };
     });
-    resolveModelWithRegistryMock.mockReturnValue({
-      provider: "anthropic",
-      id: "claude-sonnet-4-6",
-      api: "anthropic-messages",
+    resolveModelAsyncMock.mockResolvedValue({
+      model: {
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+        api: "anthropic-messages",
+      },
+      authStorage: { profiles: {} },
+      modelRegistry: { find: () => null },
     });
     ensureAuthProfileStoreMock.mockReturnValue({ version: 1, profiles: {} });
     ensureAuthProfileStoreWithoutExternalProfilesMock.mockReturnValue({ version: 1, profiles: {} });
@@ -549,12 +558,52 @@ describe("runBtwSideQuestion", () => {
     const result = await runSideQuestion();
 
     expect(result).toEqual({ text: "Final answer." });
-    const ensureArgs = mockCall(ensureOpenClawModelsJsonMock);
-    expect(ensureArgs?.[1]).toBe(DEFAULT_AGENT_DIR);
-    expect(ensureArgs?.[2]).toEqual({ workspaceDir: "/tmp/workspace" });
-    expect(discoverModelsMock).toHaveBeenCalledWith(undefined, DEFAULT_AGENT_DIR, {
-      workspaceDir: "/tmp/workspace",
+    const resolveCall = mockCall(resolveModelAsyncMock);
+    expect(resolveCall?.[0]).toBe("anthropic");
+    expect(resolveCall?.[2]).toBe(DEFAULT_AGENT_DIR);
+    const resolveOptions = resolveCall?.[4] as Record<string, unknown> | undefined;
+    expect(resolveOptions?.workspaceDir).toBe("/tmp/workspace");
+    expect(resolveOptions?.skipAgentDiscovery).toBe(true);
+  });
+
+  // Regression: #92168 — when the canonical alias (anthropic/*) is routed via
+  // agentRuntime.id = claude-cli but the agent's models.json has no bare
+  // `anthropic` provider entry, BTW must still resolve the model through the
+  // bundled static catalog instead of the primitive registry-only path.
+  it("allows bundled catalog fallback for CLI-runtime alias models (#92168)", async () => {
+    resolveModelAsyncMock.mockReset();
+    resolveModelAsyncMock.mockResolvedValue({
+      model: {
+        provider: "anthropic",
+        id: "claude-opus-4-7",
+        api: "anthropic-messages",
+      },
+      authStorage: { profiles: {} },
+      modelRegistry: { find: () => null },
     });
+    mockDoneAnswer("Recovered answer.");
+
+    const result = await runSideQuestion({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+            },
+          },
+        },
+      } as never,
+      model: "claude-opus-4-7",
+    });
+
+    expect(result).toEqual({ text: "Recovered answer." });
+    expect(resolveModelAsyncMock).toHaveBeenCalledTimes(1);
+    const resolveOptions = mockCall(resolveModelAsyncMock)[4] as Record<string, unknown>;
+    expect(resolveOptions.allowBundledStaticCatalogFallback).toBe(true);
+    expect(resolveOptions.allowConfiguredMetadataFallback).toBe(true);
+    expect(resolveOptions.preferBundledStaticCatalogTransport).toBe(true);
+    expect(resolveOptions.skipAgentDiscovery).toBe(true);
+    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
   });
 
   it("routes Codex-selected BTW questions through the harness side-question hook", async () => {
@@ -566,10 +615,14 @@ describe("runBtwSideQuestion", () => {
       runAttempt: vi.fn(),
       runSideQuestion: codexSideQuestionMock,
     });
-    resolveModelWithRegistryMock.mockReturnValue({
-      provider: "openai",
-      id: "gpt-5.5",
-      api: "openai-responses",
+    resolveModelAsyncMock.mockResolvedValue({
+      model: {
+        provider: "openai",
+        id: "gpt-5.5",
+        api: "openai-responses",
+      },
+      authStorage: { profiles: {} },
+      modelRegistry: { find: () => null },
     });
     resolveSessionAuthProfileOverrideMock.mockResolvedValue("openai:work");
 
@@ -840,11 +893,15 @@ describe("runBtwSideQuestion", () => {
   });
 
   it("applies provider runtime auth before streaming github-copilot BTW questions", async () => {
-    resolveModelWithRegistryMock.mockReturnValue({
-      provider: "github-copilot",
-      id: "gpt-5.4",
-      api: "openai-responses",
-      baseUrl: "https://api.individual.githubcopilot.com",
+    resolveModelAsyncMock.mockResolvedValue({
+      model: {
+        provider: "github-copilot",
+        id: "gpt-5.4",
+        api: "openai-responses",
+        baseUrl: "https://api.individual.githubcopilot.com",
+      },
+      authStorage: { profiles: {} },
+      modelRegistry: { find: () => null },
     });
     getApiKeyForModelMock.mockResolvedValue({
       apiKey: "github-token",
@@ -891,11 +948,15 @@ describe("runBtwSideQuestion", () => {
     // bypassed the provider's createStreamFn/wrapStreamFn hooks. That caused
     // Ollama Cloud (api: "openai-completions", baseUrl: "https://ollama.com/")
     // to hit the marketing site instead of /v1/chat/completions.
-    resolveModelWithRegistryMock.mockReturnValue({
-      provider: "ollama",
-      id: "glm-5.1",
-      api: "openai-completions",
-      baseUrl: "https://ollama.com/",
+    resolveModelAsyncMock.mockResolvedValue({
+      model: {
+        provider: "ollama",
+        id: "glm-5.1",
+        api: "openai-completions",
+        baseUrl: "https://ollama.com/",
+      },
+      authStorage: { profiles: {} },
+      modelRegistry: { find: () => null },
     });
     const providerStreamFn = vi
       .fn()
@@ -918,12 +979,16 @@ describe("runBtwSideQuestion", () => {
   });
 
   it("routes MiniMax Anthropic fallback streams through the embedded resolver", async () => {
-    resolveModelWithRegistryMock.mockReturnValue({
-      provider: "minimax-portal",
-      id: "MiniMax-M2.7",
-      api: "anthropic-messages",
-      baseUrl: "https://api.minimax.io/anthropic",
-      maxTokens: 196_608,
+    resolveModelAsyncMock.mockResolvedValue({
+      model: {
+        provider: "minimax-portal",
+        id: "MiniMax-M2.7",
+        api: "anthropic-messages",
+        baseUrl: "https://api.minimax.io/anthropic",
+        maxTokens: 196_608,
+      },
+      authStorage: { profiles: {} },
+      modelRegistry: { find: () => null },
     });
     registerProviderStreamForModelMock.mockReturnValue(undefined);
     const resolvedStreamFn = vi
@@ -988,10 +1053,14 @@ describe("runBtwSideQuestion", () => {
   });
 
   it("allows Bedrock /btw runs to proceed without a static api key in aws-sdk mode", async () => {
-    resolveModelWithRegistryMock.mockReturnValue({
-      provider: "amazon-bedrock",
-      id: "us.anthropic.claude-sonnet-4-5-v1:0",
-      api: "anthropic-messages",
+    resolveModelAsyncMock.mockResolvedValue({
+      model: {
+        provider: "amazon-bedrock",
+        id: "us.anthropic.claude-sonnet-4-5-v1:0",
+        api: "anthropic-messages",
+      },
+      authStorage: { profiles: {} },
+      modelRegistry: { find: () => null },
     });
     getApiKeyForModelMock.mockResolvedValue({
       apiKey: undefined,

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -18,16 +18,14 @@ import type {
   TextContent,
 } from "../llm/types.js";
 import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.js";
-import { discoverAuthStorage, discoverModels } from "./agent-model-discovery.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.js";
 import { resolveExternalCliAuthOverlayScopeFromSelection } from "./auth-profiles/external-cli-auth-selection.js";
 import { resolveSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
 import { readBtwTranscriptMessages, resolveBtwSessionTranscriptPath } from "./btw-transcript.js";
 import { EmbeddedBlockChunker, type BlockReplyChunking } from "./embedded-agent-block-chunker.js";
-import { resolveModelWithRegistry } from "./embedded-agent-runner/model.js";
+import { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import { getActiveEmbeddedRunSnapshot } from "./embedded-agent-runner/runs.js";
 import { resolveEmbeddedAgentStreamFn } from "./embedded-agent-runner/stream-resolution.js";
-import { applyPreparedRuntimeAuthToModel } from "./provider-request-config.js";
 import { resolveAvailableAgentHarnessPolicy, selectAgentHarness } from "./harness/selection.js";
 import {
   resolveImageSanitizationLimits,
@@ -39,8 +37,13 @@ import {
   getApiKeyForModel,
   requireApiKey,
 } from "./model-auth.js";
+import { resolveCliRuntimeExecutionProvider } from "./model-runtime-aliases.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
-import { listOpenAIAuthProfileProvidersForAgentRuntime } from "./openai-routing.js";
+import {
+  listOpenAIAuthProfileProvidersForAgentRuntime,
+  resolveSelectedOpenAIRuntimeProvider,
+} from "./openai-routing.js";
+import { applyPreparedRuntimeAuthToModel } from "./provider-request-config.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
 import { stripToolResultDetails } from "./session-transcript-repair.js";
 import { sanitizeImageBlocks } from "./tool-images.js";
@@ -254,32 +257,30 @@ async function resolveRuntimeModel(params: {
   authProfileId?: string;
   authProfileIdSource?: "auto" | "user";
 }> {
-  const modelsOptions = params.workspaceDir ? { workspaceDir: params.workspaceDir } : undefined;
-  await ensureOpenClawModelsJson(params.cfg, params.agentDir, modelsOptions);
-  const authStorage = discoverAuthStorage(params.agentDir);
-  const modelRegistry = discoverModels(authStorage, params.agentDir, modelsOptions);
-  const model = resolveModelWithRegistry({
+  const harness = selectAgentHarness({
     provider: params.provider,
     modelId: params.model,
-    modelRegistry,
-    cfg: params.cfg,
+    config: params.cfg,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
   });
-  if (!model) {
-    throw new Error(`Unknown model: ${params.provider}/${params.model}`);
-  }
-
+  const harnessRuntime =
+    harness.id === "openclaw"
+      ? resolveAvailableAgentHarnessPolicy({
+          provider: params.provider,
+          modelId: params.model,
+          config: params.cfg,
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+        }).runtime
+      : harness.id;
   const authProfileId = await resolveSessionAuthProfileOverride({
     cfg: params.cfg,
     provider: params.provider,
     acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
       provider: params.provider,
-      harnessRuntime: resolveAvailableAgentHarnessPolicy({
-        provider: params.provider,
-        modelId: params.model,
-        config: params.cfg,
-        agentId: params.agentId,
-        sessionKey: params.sessionKey,
-      }).runtime,
+      harnessRuntime,
+      agentHarnessId: harness.id,
       config: params.cfg,
     }),
     agentDir: params.agentDir,
@@ -289,8 +290,88 @@ async function resolveRuntimeModel(params: {
     storePath: params.storePath,
     isNewSession: params.isNewSession,
   });
+
+  const cliRuntimeProvider = resolveCliRuntimeExecutionProvider({
+    provider: params.provider,
+    cfg: params.cfg,
+    agentId: params.agentId,
+    modelId: params.model,
+    authProfileId,
+  });
+  const runtimeOwnsTransport = harness.id !== "openclaw" || Boolean(cliRuntimeProvider);
+  const selectedRuntimeProvider = resolveSelectedOpenAIRuntimeProvider({
+    provider: params.provider,
+    harnessRuntime,
+    agentHarnessId: harness.id,
+    authProfileProvider: authProfileId?.split(":", 1)[0],
+    authProfileId,
+    config: params.cfg,
+    workspaceDir: params.workspaceDir,
+  });
+  const modelResolutionProviders =
+    selectedRuntimeProvider !== params.provider
+      ? [selectedRuntimeProvider, params.provider]
+      : [params.provider];
+  let resolvedModelProvider = params.provider;
+  let firstModelResolution: Awaited<ReturnType<typeof resolveModelAsync>> | undefined;
+  let modelResolution: Awaited<ReturnType<typeof resolveModelAsync>> | undefined;
+
+  for (const candidateProvider of modelResolutionProviders) {
+    const candidateResolution = await resolveModelAsync(
+      candidateProvider,
+      params.model,
+      params.agentDir,
+      params.cfg,
+      {
+        skipAgentDiscovery: true,
+        allowBundledStaticCatalogFallback: runtimeOwnsTransport,
+        allowConfiguredMetadataFallback: runtimeOwnsTransport,
+        preferBundledStaticCatalogTransport: runtimeOwnsTransport,
+        workspaceDir: params.workspaceDir,
+        authProfileId,
+      },
+    );
+    firstModelResolution ??= candidateResolution;
+    if (candidateResolution.model) {
+      resolvedModelProvider = candidateProvider;
+      modelResolution = candidateResolution;
+      break;
+    }
+  }
+
+  if (!modelResolution && !runtimeOwnsTransport) {
+    await ensureOpenClawModelsJson(
+      params.cfg,
+      params.agentDir,
+      params.workspaceDir ? { workspaceDir: params.workspaceDir } : undefined,
+    );
+    for (const candidateProvider of modelResolutionProviders) {
+      const candidateResolution = await resolveModelAsync(
+        candidateProvider,
+        params.model,
+        params.agentDir,
+        params.cfg,
+        {
+          workspaceDir: params.workspaceDir,
+          authProfileId,
+        },
+      );
+      firstModelResolution ??= candidateResolution;
+      if (candidateResolution.model) {
+        resolvedModelProvider = candidateProvider;
+        modelResolution = candidateResolution;
+        break;
+      }
+    }
+  }
+
+  modelResolution ??= firstModelResolution;
+  if (!modelResolution?.model) {
+    throw new Error(modelResolution?.error ?? `Unknown model: ${params.provider}/${params.model}`);
+  }
+
   return {
-    model,
+    model: { ...modelResolution.model, provider: resolvedModelProvider },
     authProfileId,
     authProfileIdSource: resolveReturnedAuthProfileSource(params.sessionEntry, authProfileId),
   };

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2257,6 +2257,40 @@ describe("resolveModel", () => {
     expect(result.model?.input).toEqual(["text"]);
   });
 
+  it("resolves metadata-only CLI-runtime agent models without provider registration", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-custom-private": {
+              agentRuntime: { id: "claude-cli" },
+              contextWindow: 200000,
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await resolveModelAsync(
+      "anthropic",
+      "claude-custom-private",
+      "/tmp/agent",
+      cfg,
+      {
+        runtimeHooks: createRuntimeHooks(),
+        skipAgentDiscovery: true,
+        allowBundledStaticCatalogFallback: true,
+        allowConfiguredMetadataFallback: true,
+        preferBundledStaticCatalogTransport: true,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.model?.provider).toBe("anthropic");
+    expect(result.model?.id).toBe("claude-custom-private");
+    expect(result.model?.contextWindow).toBe(200000);
+  });
+
   it("explains when an agent model entry is missing provider model registration", async () => {
     const cfg = {
       agents: {

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -498,6 +498,50 @@ function hasConfiguredFallbackSurface(params: {
   return Boolean(baseUrl);
 }
 
+function findConfiguredAgentModelMetadata(params: {
+  cfg?: OpenClawConfig;
+  provider: string;
+  modelId: string;
+}): Partial<Model> | undefined {
+  const configuredModels = params.cfg?.agents?.defaults?.models;
+  if (!configuredModels) {
+    return undefined;
+  }
+  const directKeys = [
+    modelKey(params.provider, params.modelId),
+    `${params.provider}/${params.modelId}`,
+  ];
+  for (const key of directKeys) {
+    const entry = configuredModels[key];
+    if (entry && typeof entry === "object") {
+      return entry as Partial<Model>;
+    }
+  }
+
+  const normalizedProvider = normalizeProviderId(params.provider);
+  const normalizedModelId = normalizeStaticProviderModelId(normalizedProvider, params.modelId)
+    .trim()
+    .toLowerCase();
+  for (const [rawKey, entry] of Object.entries(configuredModels)) {
+    const slashIndex = rawKey.indexOf("/");
+    if (slashIndex <= 0) {
+      continue;
+    }
+    const candidateProvider = rawKey.slice(0, slashIndex);
+    const candidateModelId = rawKey.slice(slashIndex + 1);
+    if (
+      normalizeProviderId(candidateProvider) === normalizedProvider &&
+      normalizeStaticProviderModelId(normalizedProvider, candidateModelId).trim().toLowerCase() ===
+        normalizedModelId &&
+      entry &&
+      typeof entry === "object"
+    ) {
+      return entry as Partial<Model>;
+    }
+  }
+  return undefined;
+}
+
 function readModelParams(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
@@ -516,7 +560,7 @@ function findConfiguredAgentModelParams(params: {
   cfg?: OpenClawConfig;
   provider: string;
   modelId: string;
-}): Record<string, unknown> | undefined {
+}): Partial<Model> | undefined {
   const configuredModels = params.cfg?.agents?.defaults?.models;
   if (!configuredModels) {
     return undefined;
@@ -1037,12 +1081,19 @@ function resolveConfiguredFallbackModel(params: {
   agentDir?: string;
   workspaceDir?: string;
   runtimeHooks?: ProviderRuntimeHooks;
+  allowConfiguredMetadataFallback?: boolean;
 }): Model | undefined {
   const { provider, modelId, cfg, agentDir, workspaceDir, runtimeHooks } = params;
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
   const requestTimeoutMs = resolveProviderRequestTimeoutMs(providerConfig?.timeoutSeconds);
   const configuredModel = findConfiguredProviderModel(providerConfig, provider, modelId);
-  if (!hasConfiguredFallbackSurface({ providerConfig, configuredModel, modelId })) {
+  const configuredAgentModel = params.allowConfiguredMetadataFallback
+    ? findConfiguredAgentModelMetadata({ cfg, provider, modelId })
+    : undefined;
+  if (
+    !configuredAgentModel &&
+    !hasConfiguredFallbackSurface({ providerConfig, configuredModel, modelId })
+  ) {
     return undefined;
   }
   const staticCatalogModel = configuredModel
@@ -1054,9 +1105,10 @@ function resolveConfiguredFallbackModel(params: {
         workspaceDir,
         includeRuntimeDiscovery: true,
       }) as StaticCatalogFallbackModel | undefined);
-  const metadataModel = configuredModel ?? staticCatalogModel;
+  const metadataModel = configuredModel ?? staticCatalogModel ?? configuredAgentModel;
   const fallbackCompat = configuredModel?.compat ?? staticCatalogModel?.compat;
   const fallbackMediaInput = configuredModel?.mediaInput ?? staticCatalogModel?.mediaInput;
+  const metadataModelName = typeof metadataModel?.name === "string" ? metadataModel.name : modelId;
   const providerHeaders = sanitizeModelHeaders(providerConfig?.headers, {
     stripSecretRefMarkers: true,
   });
@@ -1115,7 +1167,7 @@ function resolveConfiguredFallbackModel(params: {
       attachModelProviderRequestTransport(
         {
           id: modelId,
-          name: metadataModel?.name ?? modelId,
+          name: metadataModelName,
           api: requestConfig.api ?? "openai-responses",
           provider,
           baseUrl: requestConfig.baseUrl,
@@ -1123,7 +1175,7 @@ function resolveConfiguredFallbackModel(params: {
           input: resolveProviderModelInput({
             provider,
             modelId,
-            modelName: metadataModel?.name ?? modelId,
+            modelName: metadataModelName,
             input: metadataModel?.input,
           }),
           cost: metadataModel?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -1409,6 +1461,7 @@ export async function resolveModelAsync(
     authStorage?: AuthStorage;
     modelRegistry?: ModelRegistry;
     allowBundledStaticCatalogFallback?: boolean;
+    allowConfiguredMetadataFallback?: boolean;
     preferBundledStaticCatalogTransport?: boolean;
     retryTransientProviderRuntimeMiss?: boolean;
     runtimeHooks?: ProviderRuntimeHooks;
@@ -1578,6 +1631,7 @@ export async function resolveModelAsync(
       agentDir: resolvedAgentDir,
       workspaceDir,
       runtimeHooks,
+      allowConfiguredMetadataFallback: options?.allowConfiguredMetadataFallback,
     });
   }
   if (model && options?.allowBundledStaticCatalogFallback) {


### PR DESCRIPTION
## Summary

Fixes #92168.

`/btw` used a registry-only model lookup, while the main agent loop resolves models through `resolveModelAsync` with runtime-aware fallback. That made `/btw` fail for canonical provider aliases such as `anthropic/*` when they are intentionally routed through a CLI runtime via `agentRuntime.id` and no direct provider entry exists in the agent's discovered `models.json`.

This PR aligns `/btw` model resolution with the main agent path by:

- resolving the selected harness/runtime before model lookup
- using `resolveModelAsync` instead of the primitive registry-only resolver
- allowing bundled static catalog fallback when a plugin/CLI runtime owns transport
- allowing metadata-only configured agent models when a plugin/CLI runtime owns transport
- preserving the existing discovered-models retry path for normal OpenClaw-owned transports

## Real behavior proof

- **Behavior or issue addressed:** Native Telegram `/btw` side questions should resolve the selected session model the same way as the main agent turn when the selected model is a canonical provider alias routed through a CLI/plugin runtime. A metadata-only `agents.defaults.models["provider/model"]` entry with `agentRuntime.id` should not fail early with `Unknown model` just because there is no direct `models.providers.<provider>` registration.
- **Real environment tested:** OpenClaw 2026.6.5 local gateway on macOS, Telegram group topic command path, patched local dist built from this PR branch. The concrete custom model id, private provider details, and local account identifiers are intentionally redacted.
- **Exact steps or command run after this patch:**
  1. Configure the primary model as `anthropic/<redacted-custom-cli-model>`.
  2. Configure `agents.defaults.models["anthropic/<redacted-custom-cli-model>"].agentRuntime.id = "claude-cli"`.
  3. Leave `models.providers.anthropic` unregistered, matching the original failing setup.
  4. Trigger native Telegram `/btw what is this repro checking?` in an active session.
  5. Compare the failure layer before and after the resolver change.
- **Evidence after fix:**
  - Before the follow-up fix, native Telegram `/btw` stopped in the resolver with a redacted form of: `Unknown model: anthropic/<redacted-custom-cli-model>. Found agents.defaults.models[...] but no matching models.providers["anthropic"].models[] entry...`.
  - After the code change, the real resolver regression for the same redacted config shape (`skipAgentDiscovery`, no provider registration, metadata-only `agentRuntime.id = "claude-cli"`) returns a resolved model instead of `Unknown model`.
  - Local verification for the patch: `npm test -- --run src/agents/btw.test.ts src/agents/embedded-agent-runner/model.test.ts` passed 142 tests; `npm run tsgo:core:test`, `oxfmt --check`, `oxlint`, and `git diff --check` all passed.
- **Observed result after fix:** The resolver no longer rejects metadata-only CLI-runtime agent models before execution. `/btw` now uses the runtime-aware resolver path and can proceed past model resolution for the original no-`models.providers.anthropic` configuration shape. Any later provider/API/runtime error is outside this resolver bug and no longer appears as the primitive `/btw` `Unknown model` failure.
- **What was not tested:** The PR does not publish the private custom model id, private provider credentials, raw Telegram screenshots, or account-specific runtime logs. It also does not claim that every downstream CLI provider accepts every custom model id; this fix is scoped to `/btw` model resolution consistency before provider execution.

## Tests

- `npm test -- --run src/agents/btw.test.ts src/agents/embedded-agent-runner/model.test.ts`
- `npm run tsgo:core:test`
- `npx oxfmt --check src/agents/btw.ts src/agents/btw.test.ts src/agents/embedded-agent-runner/model.ts src/agents/embedded-agent-runner/model.test.ts`
- `npx oxlint src/agents/btw.ts src/agents/btw.test.ts src/agents/embedded-agent-runner/model.ts src/agents/embedded-agent-runner/model.test.ts`
- `git diff --check`

Note: `npm run check:changed` could not run locally because the configured Blacksmith/crabbox wrapper failed its own binary sanity check before executing repository checks.


