### PR TITLE
fix(exec): preserve approved gateway output

### DIFF
--- a/src/agents/bash-process-registry.test-helpers.ts
+++ b/src/agents/bash-process-registry.test-helpers.ts
@@ -37,6 +37,7 @@ export function createProcessSessionFixture(params: {
     exitCode: undefined,
     exitSignal: undefined,
     truncated: false,
+    aggregateTruncated: false,
     backgrounded: params.backgrounded ?? false,
     cursorKeyMode: params.cursorKeyMode ?? "normal",
   };

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -81,6 +81,7 @@ export interface ProcessSession {
   exitReason?: TerminationReason;
   exited: boolean;
   truncated: boolean;
+  aggregateTruncated: boolean;
   backgrounded: boolean;
   /** PTY cursor key mode: unknown until a PTY reports smkx/rmkx. */
   cursorKeyMode: "unknown" | "normal" | "application";
@@ -165,8 +166,9 @@ export function appendOutput(session: ProcessSession, stream: "stdout" | "stderr
   }
   session.totalOutputChars += chunk.length;
   const aggregated = trimWithCap(session.aggregated + chunk, session.maxOutputChars);
-  session.truncated =
-    session.truncated || aggregated.length < session.aggregated.length + chunk.length;
+  const aggregateTruncated = aggregated.length < session.aggregated.length + chunk.length;
+  session.aggregateTruncated = session.aggregateTruncated || aggregateTruncated;
+  session.truncated = session.truncated || aggregateTruncated;
   session.aggregated = aggregated;
   session.tail = tail(session.aggregated, 2000);
 }

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -48,7 +48,6 @@ import {
   shouldResolveExecApprovalUnavailableInline,
 } from "./bash-tools.exec-host-shared.js";
 import {
-  DEFAULT_NOTIFY_TAIL_CHARS,
   createApprovalSlug,
   normalizeNotifyOutput,
   runExecProcess,
@@ -265,6 +264,18 @@ function formatDiagnosticsExportFailure(params: {
   return lines.join("\n");
 }
 
+function formatApprovalCompletionOutput(outcome: ExecApprovalFollowupOutcome): string {
+  const output = (outcome.aggregated || "").trim();
+  if (!output) {
+    return outcome.truncated
+      ? "[Output truncated by exec capture limit before any text was retained.]"
+      : "";
+  }
+  return outcome.truncated
+    ? `${output}\n\n[Output truncated by exec capture limit before this follow-up was delivered.]`
+    : output;
+}
+
 function buildGatewayExecApprovalFollowupSummary(params: {
   approvalId: string;
   sessionId: string;
@@ -283,9 +294,7 @@ function buildGatewayExecApprovalFollowupSummary(params: {
     return `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})\n${body}`;
   }
 
-  const output = normalizeNotifyOutput(
-    tail(params.outcome.aggregated || "", DEFAULT_NOTIFY_TAIL_CHARS),
-  );
+  const output = formatApprovalCompletionOutput(params.outcome);
   return output
     ? `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})\n${output}`
     : `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})`;

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -799,6 +799,46 @@ describe("runExecProcess POSIX command wrapper", () => {
     expect(supervisorMock.spawn.mock.calls[1]?.[0].timeoutMs).toBe(MAX_SAFE_TIMEOUT_DELAY_MS);
   });
 
+  it("does not mark complete aggregate output truncated when only pending buffers are capped", async () => {
+    const output = "x".repeat(120);
+    supervisorMock.spawn.mockImplementationOnce(
+      async (input: { onStdout?: (chunk: string) => void }) => {
+        input.onStdout?.(output);
+        return {
+          runId: "mock-run",
+          startedAtMs: Date.now(),
+          wait: async () => ({
+            reason: "exit" as const,
+            exitCode: 0,
+            exitSignal: null,
+            durationMs: 0,
+            stdout: "",
+            stderr: "",
+            timedOut: false,
+            noOutputTimedOut: false,
+          }),
+          cancel: vi.fn(),
+        };
+      },
+    );
+
+    const outcome = await runExecProcess({
+      command: "emit pending-capped output",
+      workdir: "/tmp",
+      env: { PATH: "/usr/bin" },
+      pathPrepend: [],
+      usePty: false,
+      warnings: [],
+      maxOutput: 1000,
+      pendingMaxOutput: 50,
+      notifyOnExit: false,
+      timeoutSec: null,
+    });
+
+    expect(outcome.status).toBe("completed");
+    expect(outcome.aggregated).toBe(output);
+    expect(outcome.truncated).toBe(false);
+  });
   it("wraps command with PATH export if OPENCLAW_PREPEND_PATH is present", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -173,6 +173,7 @@ export type ExecProcessOutcome =
       exitSignal: NodeJS.Signals | number | null;
       durationMs: number;
       aggregated: string;
+      truncated: boolean;
       timedOut: false;
     }
   | {
@@ -181,6 +182,7 @@ export type ExecProcessOutcome =
       exitSignal: NodeJS.Signals | number | null;
       durationMs: number;
       aggregated: string;
+      truncated: boolean;
       timedOut: boolean;
       failureKind: ExecProcessFailureKind;
       reason: string;
@@ -563,6 +565,7 @@ export function buildExecExitOutcome(params: {
   aggregated: string;
   durationMs: number;
   timeoutSec: number | null | undefined;
+  truncated?: boolean;
 }): ExecProcessOutcome {
   const exitCode = params.exit.exitCode ?? 0;
   const isNormalExit = params.exit.reason === "exit";
@@ -577,6 +580,7 @@ export function buildExecExitOutcome(params: {
       exitSignal: params.exit.exitSignal,
       durationMs: params.durationMs,
       aggregated: params.aggregated + exitMsg,
+      truncated: params.truncated === true,
       timedOut: false,
     };
   }
@@ -597,6 +601,7 @@ export function buildExecExitOutcome(params: {
     exitSignal: params.exit.exitSignal,
     durationMs: params.durationMs,
     aggregated: params.aggregated,
+    truncated: params.truncated === true,
     timedOut: params.exit.timedOut,
     failureKind,
     reason: joinExecFailureOutput(params.aggregated, reason),
@@ -608,6 +613,7 @@ export function buildExecRuntimeErrorOutcome(params: {
   error: unknown;
   aggregated: string;
   durationMs: number;
+  truncated?: boolean;
 }): ExecProcessOutcome {
   return {
     status: "failed",
@@ -615,6 +621,7 @@ export function buildExecRuntimeErrorOutcome(params: {
     exitSignal: null,
     durationMs: params.durationMs,
     aggregated: params.aggregated,
+    truncated: params.truncated === true,
     timedOut: false,
     failureKind: "runtime-error",
     reason: joinExecFailureOutput(params.aggregated, String(params.error)),
@@ -953,6 +960,7 @@ export async function runExecProcess(opts: {
             error: retryErr,
             aggregated: session.aggregated.trim(),
             durationMs: Date.now() - startedAt,
+            truncated: session.truncated,
           }),
           sessionKey: opts.sessionKey,
           target: diagnosticTarget,
@@ -969,6 +977,7 @@ export async function runExecProcess(opts: {
           error: err,
           aggregated: session.aggregated.trim(),
           durationMs: Date.now() - startedAt,
+          truncated: session.truncated,
         }),
         sessionKey: opts.sessionKey,
         target: diagnosticTarget,
@@ -993,6 +1002,7 @@ export async function runExecProcess(opts: {
         aggregated: session.aggregated.trim(),
         durationMs,
         timeoutSec: opts.timeoutSec,
+        truncated: session.truncated,
       });
 
       markExited(session, exit.exitCode, exit.exitSignal, outcome.status, exit.reason);
@@ -1025,6 +1035,7 @@ export async function runExecProcess(opts: {
         error: err,
         aggregated: session.aggregated.trim(),
         durationMs: Date.now() - startedAt,
+        truncated: session.truncated,
       });
       emitExecProcessCompleted({
         command: opts.command,

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -737,6 +737,7 @@ export async function runExecProcess(opts: {
     exitCode: undefined as number | null | undefined,
     exitSignal: undefined as NodeJS.Signals | number | null | undefined,
     truncated: false,
+    aggregateTruncated: false,
     backgrounded: false,
     cursorKeyMode: opts.usePty ? "unknown" : "normal",
   };
@@ -960,7 +961,7 @@ export async function runExecProcess(opts: {
             error: retryErr,
             aggregated: session.aggregated.trim(),
             durationMs: Date.now() - startedAt,
-            truncated: session.truncated,
+            truncated: session.aggregateTruncated,
           }),
           sessionKey: opts.sessionKey,
           target: diagnosticTarget,
@@ -977,7 +978,7 @@ export async function runExecProcess(opts: {
           error: err,
           aggregated: session.aggregated.trim(),
           durationMs: Date.now() - startedAt,
-          truncated: session.truncated,
+          truncated: session.aggregateTruncated,
         }),
         sessionKey: opts.sessionKey,
         target: diagnosticTarget,
@@ -1002,7 +1003,7 @@ export async function runExecProcess(opts: {
         aggregated: session.aggregated.trim(),
         durationMs,
         timeoutSec: opts.timeoutSec,
-        truncated: session.truncated,
+        truncated: session.aggregateTruncated,
       });
 
       markExited(session, exit.exitCode, exit.exitSignal, outcome.status, exit.reason);
@@ -1035,7 +1036,7 @@ export async function runExecProcess(opts: {
         error: err,
         aggregated: session.aggregated.trim(),
         durationMs: Date.now() - startedAt,
-        truncated: session.truncated,
+        truncated: session.aggregateTruncated,
       });
       emitExecProcessCompleted({
         command: opts.command,

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -83,6 +83,7 @@ export type ExecApprovalFollowupOutcome = {
   exitCode: number | null;
   timedOut: boolean;
   aggregated: string;
+  truncated?: boolean;
   reason?: string;
 };
 

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -1092,9 +1092,7 @@ describe("exec approvals", () => {
       { length: 60 },
       (_, index) => `approval-output-line-${String(index).padStart(2, "0")}`,
     );
-    const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(
-      `process.stdout.write(${JSON.stringify(outputLines.join("\n"))})`,
-    )}`;
+    const command = `printf '%s\\n' ${outputLines.map((line) => JSON.stringify(line)).join(" ")}`;
 
     mockAcceptedApprovalFlow({
       onAgent: (params) => {

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -1086,6 +1086,49 @@ describe("exec approvals", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("preserves multiline approved gateway exec output in async follow-ups", async () => {
+    const agentCalls: Array<Record<string, unknown>> = [];
+    const outputLines = Array.from(
+      { length: 60 },
+      (_, index) => `approval-output-line-${String(index).padStart(2, "0")}`,
+    );
+    const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(
+      `process.stdout.write(${JSON.stringify(outputLines.join("\n"))})`,
+    )}`;
+
+    mockAcceptedApprovalFlow({
+      onAgent: (params) => {
+        agentCalls.push(params);
+      },
+    });
+
+    const tool = createExecTool({
+      host: "gateway",
+      ask: "always",
+      approvalRunningNoticeMs: 0,
+      sessionKey: "agent:main:discord:channel:123",
+      elevated: { enabled: true, allowed: true, defaultLevel: "ask" },
+      messageProvider: "discord",
+      currentChannelId: "123",
+      accountId: "default",
+      currentThreadTs: "456",
+    });
+
+    const result = await tool.execute("call-gw-followup-multiline-output", {
+      command,
+      workdir: process.cwd(),
+    });
+
+    expect(result.details.status).toBe("approval-pending");
+    await expect.poll(() => agentCalls.length, { timeout: 3000, interval: 1 }).toBe(1);
+    const message = String(agentCalls[0]?.message);
+    expect(message).toContain(outputLines[0]);
+    expect(message).toContain(outputLines[outputLines.length - 1]);
+    expect(message).toContain(`${outputLines[0]}\n${outputLines[1]}`);
+    expect(message).not.toContain("Output truncated by exec capture limit");
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("waits for native webchat approval and returns approved gateway output as a foreground result", async () => {
     const agentCalls: Array<Record<string, unknown>> = [];
 

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -121,6 +121,11 @@ vi.mock("../process/supervisor/index.js", () => {
     if (command.includes("printf delayed-ok")) {
       return "delayed-ok";
     }
+    if (command.includes("approval-output-line-00")) {
+      return `${Array.from({ length: 60 }, (_, index) =>
+        `approval-output-line-${String(index).padStart(2, "0")}`,
+      ).join("\n")}\n`;
+    }
     if (command.includes("printf webchat-ok")) {
       return "webchat-ok";
     }

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -654,6 +654,7 @@ const seedFinishedLogSession = (lines: string[]) => {
     tail: "",
     exited: false,
     truncated: false,
+    aggregateTruncated: false,
     backgrounded: false,
     cursorKeyMode: "unknown",
   };


### PR DESCRIPTION
## Summary

- Preserves multiline output for approved async gateway exec follow-ups instead of tailing it to the compact background-notification limit.
- Keeps ordinary background `notifyOnExit` summaries on the existing compact formatter, so this does not expand normal background channel notifications.
- Carries the exec capture `truncated` state into approval follow-up formatting and adds an explicit truncation notice only when the capture cap was actually hit.
- Adds regression coverage for a Discord-routed async approval follow-up with more than 400 characters of multiline output.

## Linked context

Closes #41152

Related #41170

Was this requested by a maintainer or owner?

No direct maintainer request. This follows the source-level diagnosis and patch boundary described in #41152.

## Real behavior proof

- Behavior or issue addressed: async approved gateway exec follow-ups were using the compact background notification formatter, which tailed output to the last 400 characters and normalized whitespace before resuming the agent.
- Real environment tested: local OpenClaw checkout on Windows, executed outside Vitest/CI with `node node_modules/tsx/dist/cli.mjs -e <proof script>`.
- Exact steps or command run after this patch: imported OpenClaw's real `runExecProcess` from `src/agents/bash-tools.exec-runtime.ts`, ran a real child process through that exec runtime with a command emitting 60 newline-separated output lines, built the same approval-completion follow-up shape used by this PR, and compared the result with the old 400-character tail plus whitespace-normalization behavior.
- Evidence after fix: console output from the manual proof run:

```json
{
  "status": "completed",
  "exitCode": 0,
  "truncated": false,
  "outputLength": 1439,
  "lineCount": 60,
  "firstLinePresent": true,
  "lastLinePresent": true,
  "newlinePreserved": true,
  "oldCompactWouldDropFirstLine": true,
  "oldCompactWouldStripNewlines": true,
  "followupPreview": "Exec finished (gateway id=proof-approval, session=amber-falcon, code 0)\napproval-output-line-00\napproval-output-line-01\napproval-output-line-02\napproval-output-line-03\napproval-output-line-04",
  "followupTail": "approval-output-line-56\napproval-output-line-57\napproval-output-line-58\napproval-output-line-59"
}
```

- Observed result after fix: the patched path preserved the first line, final line, and newline boundary for 60 lines / 1439 characters of approved exec output. The old compact formatter would have dropped `approval-output-line-00` and stripped newline boundaries, matching the issue report.
- What was not tested: a live Discord approval round trip with a real Discord account.

## Tests and validation

Which commands did you run?

```bash
git diff --check
node node_modules/oxfmt/bin/oxfmt --check src/agents/bash-tools.exec-host-gateway.ts src/agents/bash-tools.exec-runtime.ts src/agents/bash-tools.exec-types.ts src/agents/bash-tools.exec.approval-id.test.ts
node node_modules/oxlint/bin/oxlint src/agents/bash-tools.exec-host-gateway.ts src/agents/bash-tools.exec-runtime.ts src/agents/bash-tools.exec-types.ts src/agents/bash-tools.exec.approval-id.test.ts
node scripts/run-vitest.mjs src/agents/bash-tools.exec.approval-id.test.ts
```

What regression coverage was added or updated?

Added an async gateway exec approval follow-up test that emits multiline output longer than 400 characters and asserts that the resumed agent message preserves both the beginning of the output and newline separators.

What failed before this fix, if known?

The affected path used the compact notification formatter intended for background notifications: `tail(..., DEFAULT_NOTIFY_TAIL_CHARS)` plus `normalizeNotifyOutput(...)`. That drops the beginning of long output and collapses newlines.

If no test was added, why not?

A regression test was added.

Note: I could not run `pnpm check:changed` because `pnpm` is not installed in this local environment.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Approved async gateway exec follow-up messages can now include more captured output than before, up to the existing exec capture cap.

How is that risk mitigated?

The change is scoped to approval-completion follow-ups that resume the agent. Existing compact background `notifyOnExit` notifications keep their current tailing and whitespace-normalization behavior, and true capture-cap truncation is explicitly marked.

## Current review state

What is the next action?

Ready for ClawSweeper re-review and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

ClawSweeper re-review, CI, and maintainer review.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's `needs real behavior proof before merge` and the required proof fields by using the exact field names from `scripts/github/real-behavior-proof-policy.mjs`.