### PR TITLE
fix(logging): prune non-idle stale diagnostic session states (fixes #91697)

### DIFF
--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -55,8 +55,13 @@ export function pruneDiagnosticSessionStates(now = Date.now(), force = false): v
 
   for (const [key, state] of diagnosticSessionStates.entries()) {
     const ageMs = now - state.lastActivity;
+    if (ageMs <= SESSION_STATE_TTL_MS) continue;
     const isIdle = state.state === "idle";
-    if (isIdle && state.queueDepth <= 0 && ageMs > SESSION_STATE_TTL_MS) {
+    if (isIdle && state.queueDepth <= 0) {
+      diagnosticSessionStates.delete(key);
+    } else if (!isIdle) {
+      // Clean up non-idle ghost entries that survived a failed recovery and
+      // never transitioned back to idle (e.g. recovery outcome was "failed").
       diagnosticSessionStates.delete(key);
     }
   }

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -168,6 +168,26 @@ describe("diagnostic session state pruning", () => {
     expect(getDiagnosticSessionStateCountForTest()).toBe(1);
   });
 
+  it("evicts stale non-idle session states (ghost entries after failed recovery)", () => {
+    // Simulate a non-idle ghost entry that survived a failed recovery
+    const now = Date.now();
+    diagnosticSessionStates.set("ghost-session", {
+      sessionId: "ghost-session",
+      lastActivity: now - 31 * 60 * 1000,
+      generation: 1,
+      state: "processing",
+      queueDepth: 1,
+    });
+    expect(getDiagnosticSessionStateCountForTest()).toBe(1);
+
+    // Trigger prune via a fresh getDiagnosticSessionState call
+    getDiagnosticSessionState({ sessionId: "fresh-1" });
+
+    // Non-idle ghost older than TTL should be cleaned up
+    expect(getDiagnosticSessionStateCountForTest()).toBe(1);
+    expect(diagnosticSessionStates.has("ghost-session")).toBe(false);
+  });
+
   it("caps tracked session states to a bounded max", () => {
     const now = Date.now();
     for (let i = 0; i < 2001; i += 1) {


### PR DESCRIPTION
### Summary

- **Problem**: `pruneDiagnosticSessionStates()` only cleans up diagnostic entries where `state === "idle"` AND `queueDepth <= 0`. Entries that never transition back to "idle" — for example after a failed stuck-session recovery — accumulate in the process-local Map indefinitely, holding activity snapshots, tool call history, and queue metadata in V8 heap until the 2000-entry FIFO cap is reached.
- **Root Cause**: When `requestStuckSessionRecovery()` fails (e.g. stale generation check, already-closed session), `recoveryOutcomeMutatesSessionState()` returns `false` for `status: "failed"` outcomes, so `applyRecoveryOutcomeToDiagnosticState()` never sets the diagnostic state back to "idle". The prune guard `isIdle && queueDepth <= 0 && ageMs > TTL` then skips these orphaned non-idle entries forever.
- **Fix**: Add a fallback deletion branch in `pruneDiagnosticSessionStates()` that removes any non-idle entry older than `SESSION_STATE_TTL_MS` (30 min), regardless of state. The existing idle+empty-queue path is unchanged; the new `else if (!isIdle)` branch catches ghost entries that survived failed recovery.
- **What changed**:
  - `src/logging/diagnostic-session-state.ts` — added early `continue` for entries within TTL, then `else if (!isIdle)` fallback delete in the prune loop
- **What did NOT change (scope boundary)**:
  - `recoveryOutcomeMutatesSessionState()` — not changed; recovery coordinator behavior is left alone to avoid side effects
  - The `SESSION_STATE_MAX_ENTRIES` FIFO cap — remains as a hard upper bound (2000 entries)

### Reproduction

1. Gateway with `diagnostics.stuckSessionAbortMs` configured (e.g. 300000)
2. A session stalls → `stuckSessionAbortMs` fires → recovery attempts
3. Recovery fails (e.g. stale generation check `isDiagnosticSessionStateCurrent` returns false)
4. Outcome `{ status: "failed", action: "none" }` skips the idle transition
5. **Before this PR**: entry stays in "processing" state in the Map forever (up to the 2000-entry cap), never pruned by the 30-min TTL sweep
6. **After this PR**: entry is removed once its `lastActivity` age exceeds `SESSION_STATE_TTL_MS` (30 min)

### Real behavior proof

**Behavior or issue addressed (91697)**: The diagnostic session state Map accumulates non-idle ghost entries indefinitely after failed stuck-session recoveries. After the fix, any non-idle entry older than the 30-minute TTL is cleaned up on the next prune sweep, preventing unbounded heap growth from orphaned diagnostic state.

**Real environment tested**: Linux, Node 22 — Vitest with fake timers against `pruneDiagnosticSessionStates` and `getDiagnosticSessionState`

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts`

**Evidence after fix**:
```text
 RUN  v4.1.7 /home/0668001395/openclawProject1

 Test Files  1 passed (1)
      Tests  69 passed (69)
   Start at  22:18:16
   Duration  2.40s (transform 982ms, setup 243ms, import 1.77s, tests 209ms, environment 0ms)
```

**Observed result after fix**: All 69 diagnostic tests pass, including the new "evicts stale non-idle session states (ghost entries after failed recovery)" test. The test creates a non-idle ("processing") entry with a 31-minute-old `lastActivity` timestamp and a non-zero `queueDepth`, then triggers a prune via `getDiagnosticSessionState`. After the prune sweep, the ghost entry is deleted and only the fresh entry remains. The existing "evicts stale idle session states" test continues to pass unchanged, confirming the idle-path behavior is preserved.

**What was not tested**: Live Gateway integration was not driven — the test uses Vitest fake timers to simulate the TTL window and does not exercise the full stuck-session recovery→failed→prune pipeline end-to-end with a real Gateway process.

**Repro confirmation**: The new test case fails on origin/main before the patch — non-idle stale entries survive the prune sweep — and passes after the fix, confirming the ghost entry is cleaned up once it exceeds the TTL regardless of state.

### Risk / Mitigation

- **Risk**: A genuinely long-running session that stays "processing" for >30 minutes could be incorrectly pruned.
  **Mitigation**: The `lastActivity` field is updated on every diagnostic heartbeat (not wall-clock time since state transition). A genuinely active processing session refreshes `lastActivity` continually, so `ageMs` stays well under 30 minutes. Only entries with no activity for >30 minutes are evicted.
- **Risk**: The fallback branch could mask a recovery coordinator bug by silently cleaning up entries that recovery should have handled.
  **Mitigation**: The prune sweep is a garbage-collection concern, not an error-handling concern. Recovery coordinator bugs should be fixed separately; this change only ensures memory doesn't grow unbounded when they occur.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] agents (diagnostic session state tracking)
- [x] logging

### Regression Test Plan

- `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts` — covers prune behavior for idle and non-idle stale entries
- `node scripts/run-vitest.mjs src/logging/diagnostic-stability-bundle.test.ts` — covers downstream diagnostic stability snapshot consumers

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #91697
