### PR TITLE
fix(agents): retry thinking-only errored turns

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -3131,28 +3131,18 @@ function buildAnthropicMessageResponse(params: {
 }
 
 const QA_ANTHROPIC_THINKING_ERROR_TEXT =
-  "QA replay-safe read completed, but the provider returned only signed thinking before a terminal error.";
+  "QA replay-safe read completed, but the provider stream failed after signed thinking.";
 const QA_ANTHROPIC_THINKING_ERROR_SIGNATURE = "qa_signed_thinking_block_91953";
+const QA_ANTHROPIC_THINKING_ERROR_MESSAGE = "QA injected provider stream failure";
 
 function buildAnthropicThinkingErrorResponse(params: { model: string }): Record<string, unknown> {
   return {
-    id: `msg_mock_${Math.floor(Math.random() * 1_000_000).toString(16)}`,
-    type: "message",
-    role: "assistant",
-    model: params.model || "claude-opus-4-8",
-    content: [
-      {
-        type: "thinking",
-        thinking: QA_ANTHROPIC_THINKING_ERROR_TEXT,
-        signature: QA_ANTHROPIC_THINKING_ERROR_SIGNATURE,
-      },
-    ],
-    stop_reason: "sensitive",
-    stop_sequence: null,
-    usage: {
-      input_tokens: 64,
-      output_tokens: 1120,
+    type: "error",
+    error: {
+      type: "api_error",
+      message: QA_ANTHROPIC_THINKING_ERROR_MESSAGE,
     },
+    model: params.model || "claude-opus-4-8",
   };
 }
 
@@ -3182,7 +3172,23 @@ function buildAnthropicThinkingErrorStreamEvents(params: {
       index: 0,
       content_block: {
         type: "thinking",
+        thinking: "",
+        signature: "",
+      },
+    },
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: {
+        type: "thinking_delta",
         thinking: QA_ANTHROPIC_THINKING_ERROR_TEXT,
+      },
+    },
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: {
+        type: "signature_delta",
         signature: QA_ANTHROPIC_THINKING_ERROR_SIGNATURE,
       },
     },
@@ -3192,16 +3198,18 @@ function buildAnthropicThinkingErrorStreamEvents(params: {
     },
     {
       type: "message_delta",
-      delta: {
-        stop_reason: "sensitive",
-      },
+      delta: {},
       usage: {
         input_tokens: 64,
         output_tokens: 1120,
       },
     },
     {
-      type: "message_stop",
+      type: "error",
+      error: {
+        type: "api_error",
+        message: QA_ANTHROPIC_THINKING_ERROR_MESSAGE,
+      },
     },
   ];
 }

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -149,6 +149,7 @@ const TINY_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0nQAAAAASUVORK5CYII=";
 const QA_REASONING_ONLY_RECOVERY_PROMPT_RE = /reasoning-only continuation qa check/i;
 const QA_REASONING_ONLY_SIDE_EFFECT_PROMPT_RE = /reasoning-only after write safety check/i;
+const QA_ANTHROPIC_THINKING_ERROR_RECOVERY_PROMPT_RE = /anthropic thinking error qa check/i;
 const QA_THINKING_VISIBILITY_OFF_PROMPT_RE = /qa thinking visibility check off/i;
 const QA_THINKING_VISIBILITY_MAX_PROMPT_RE = /qa thinking visibility check max/i;
 const QA_EMPTY_RESPONSE_RECOVERY_PROMPT_RE = /empty response continuation qa check/i;
@@ -189,6 +190,7 @@ const QA_GROUP_AUDIO_MIN_MULTIPART_BODY_CHARS = 48_000;
 const QA_MCP_CODE_MODE_API_FILE_PROMPT_RE = /mcp code mode api file qa check/i;
 
 type MockScenarioState = {
+  anthropicThinkingErrorPhase: number;
   subagentFanoutPhase: number;
   subagentHandoffSpawned: boolean;
 };
@@ -3128,6 +3130,82 @@ function buildAnthropicMessageResponse(params: {
   };
 }
 
+const QA_ANTHROPIC_THINKING_ERROR_TEXT =
+  "QA replay-safe read completed, but the provider returned only signed thinking before a terminal error.";
+const QA_ANTHROPIC_THINKING_ERROR_SIGNATURE = "qa_signed_thinking_block_91953";
+
+function buildAnthropicThinkingErrorResponse(params: { model: string }): Record<string, unknown> {
+  return {
+    id: `msg_mock_${Math.floor(Math.random() * 1_000_000).toString(16)}`,
+    type: "message",
+    role: "assistant",
+    model: params.model || "claude-opus-4-8",
+    content: [
+      {
+        type: "thinking",
+        thinking: QA_ANTHROPIC_THINKING_ERROR_TEXT,
+        signature: QA_ANTHROPIC_THINKING_ERROR_SIGNATURE,
+      },
+    ],
+    stop_reason: "sensitive",
+    stop_sequence: null,
+    usage: {
+      input_tokens: 64,
+      output_tokens: 1120,
+    },
+  };
+}
+
+function buildAnthropicThinkingErrorStreamEvents(params: {
+  model: string;
+}): AnthropicStreamEvent[] {
+  const messageId = `msg_mock_${Math.floor(Math.random() * 1_000_000).toString(16)}`;
+  return [
+    {
+      type: "message_start",
+      message: {
+        id: messageId,
+        type: "message",
+        role: "assistant",
+        model: params.model || "claude-opus-4-8",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 64,
+          output_tokens: 0,
+        },
+      },
+    },
+    {
+      type: "content_block_start",
+      index: 0,
+      content_block: {
+        type: "thinking",
+        thinking: QA_ANTHROPIC_THINKING_ERROR_TEXT,
+        signature: QA_ANTHROPIC_THINKING_ERROR_SIGNATURE,
+      },
+    },
+    {
+      type: "content_block_stop",
+      index: 0,
+    },
+    {
+      type: "message_delta",
+      delta: {
+        stop_reason: "sensitive",
+      },
+      usage: {
+        input_tokens: 64,
+        output_tokens: 1120,
+      },
+    },
+    {
+      type: "message_stop",
+    },
+  ];
+}
+
 function buildAnthropicMessageStreamEvents(params: {
   model: string;
   extracted: ExtractedAssistantOutput;
@@ -3254,6 +3332,35 @@ async function buildMessagesPayload(
     stream: false,
     ...(Array.isArray(body.tools) ? { tools: body.tools } : {}),
   };
+  const allInputText = extractAllRequestTexts(input, dispatchBody);
+  if (QA_ANTHROPIC_THINKING_ERROR_RECOVERY_PROMPT_RE.test(allInputText)) {
+    const toolOutput = extractToolOutput(input);
+    const shouldEmitThinkingError =
+      toolOutput.length > 0 && scenarioState.anthropicThinkingErrorPhase === 0;
+    const events =
+      toolOutput.length === 0
+        ? buildToolCallEventsWithArgs("read", { path: "QA_KICKOFF_TASK.md" })
+        : shouldEmitThinkingError
+          ? (() => {
+              scenarioState.anthropicThinkingErrorPhase = 1;
+              return buildAssistantEvents("");
+            })()
+          : buildAssistantEvents("ANTHROPIC-THINKING-ERROR-RECOVERED-OK");
+    const extracted = extractFinalAssistantOutputFromEvents(events);
+    const responseBody = shouldEmitThinkingError
+      ? buildAnthropicThinkingErrorResponse({ model: normalizedModel })
+      : buildAnthropicMessageResponse({
+          model: normalizedModel,
+          extracted,
+        });
+    const streamEvents = shouldEmitThinkingError
+      ? buildAnthropicThinkingErrorStreamEvents({ model: normalizedModel })
+      : buildAnthropicMessageStreamEvents({
+          model: normalizedModel,
+          extracted,
+        });
+    return { events, input, extracted, responseBody, streamEvents, model: normalizedModel };
+  }
   const events = await buildResponsesPayload(dispatchBody, scenarioState);
   const extracted = extractFinalAssistantOutputFromEvents(events);
   const responseBody = buildAnthropicMessageResponse({
@@ -3270,6 +3377,7 @@ async function buildMessagesPayload(
 export async function startQaMockOpenAiServer(params?: { host?: string; port?: number }) {
   const host = params?.host ?? "127.0.0.1";
   const scenarioState: MockScenarioState = {
+    anthropicThinkingErrorPhase: 0,
     subagentFanoutPhase: 0,
     subagentHandoffSpawned: false,
   };

--- a/qa/scenarios/runtime/anthropic-thinking-error-recovery-replay-safe-read.md
+++ b/qa/scenarios/runtime/anthropic-thinking-error-recovery-replay-safe-read.md
@@ -9,10 +9,10 @@ coverage:
     - runtime.anthropic-thinking-error-recovery
   secondary:
     - runtime.retry-policy
-objective: Verify an Anthropic thinking-only terminal error after a replay-safe read retries the same prompt into a visible answer.
+objective: Verify an Anthropic stream error after signed thinking and a replay-safe read retries the same prompt into a visible answer.
 successCriteria:
   - Scenario is mock-openai only so live lanes do not pick it up implicitly.
-  - The agent performs a replay-safe read before the Anthropic thinking-only terminal error.
+  - The agent performs a replay-safe read before the Anthropic stream error.
   - The runtime retries the same prompt without injecting the visible-answer continuation instruction.
   - The final visible reply contains the exact recovery marker.
 docsRefs:
@@ -22,7 +22,7 @@ codeRefs:
   - src/agents/embedded-agent-runner/run/incomplete-turn.ts
 execution:
   kind: flow
-  summary: Verify Anthropic thinking-only error turns recover after a replay-safe read.
+  summary: Verify Anthropic stream errors after signed thinking recover after a replay-safe read.
   config:
     requiredProvider: mock-openai
     promptSnippet: Anthropic thinking error QA check

--- a/qa/scenarios/runtime/anthropic-thinking-error-recovery-replay-safe-read.md
+++ b/qa/scenarios/runtime/anthropic-thinking-error-recovery-replay-safe-read.md
@@ -1,0 +1,89 @@
+# Anthropic thinking error recovery after replay-safe read
+
+```yaml qa-scenario
+id: anthropic-thinking-error-recovery-replay-safe-read
+title: Anthropic thinking error recovery after replay-safe read
+surface: runtime
+coverage:
+  primary:
+    - runtime.anthropic-thinking-error-recovery
+  secondary:
+    - runtime.retry-policy
+objective: Verify an Anthropic thinking-only terminal error after a replay-safe read retries the same prompt into a visible answer.
+successCriteria:
+  - Scenario is mock-openai only so live lanes do not pick it up implicitly.
+  - The agent performs a replay-safe read before the Anthropic thinking-only terminal error.
+  - The runtime retries the same prompt without injecting the visible-answer continuation instruction.
+  - The final visible reply contains the exact recovery marker.
+docsRefs:
+  - docs/help/testing.md
+codeRefs:
+  - extensions/qa-lab/src/providers/mock-openai/server.ts
+  - src/agents/embedded-agent-runner/run/incomplete-turn.ts
+execution:
+  kind: flow
+  summary: Verify Anthropic thinking-only error turns recover after a replay-safe read.
+  config:
+    requiredProvider: mock-openai
+    promptSnippet: Anthropic thinking error QA check
+    prompt: "Anthropic thinking error QA check: read QA_KICKOFF_TASK.md, then answer with exactly ANTHROPIC-THINKING-ERROR-RECOVERED-OK."
+    expectedReply: ANTHROPIC-THINKING-ERROR-RECOVERED-OK
+    visibleAnswerRetryNeedle: The previous attempt did not produce a user-visible answer.
+```
+
+```yaml qa-flow
+steps:
+  - name: retries a thinking-only Anthropic error after a replay-safe read
+    actions:
+      - assert:
+          expr: "env.providerMode === 'mock-openai'"
+          message: this seeded scenario is mock-openai only
+      - call: waitForGatewayHealthy
+        args:
+          - ref: env
+          - 60000
+      - call: reset
+      - set: requestCountBefore
+        value:
+          expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/requests`)).length : 0"
+      - set: sessionKey
+        value:
+          expr: "`agent:qa:anthropic-thinking-error:${randomUUID().slice(0, 8)}`"
+      - call: runAgentPrompt
+        args:
+          - ref: env
+          - sessionKey:
+              ref: sessionKey
+            message:
+              expr: config.prompt
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 45000)
+      - call: waitForOutboundMessage
+        saveAs: outbound
+        args:
+          - ref: state
+          - lambda:
+              params: [candidate]
+              expr: "candidate.conversation.id === 'qa-operator' && candidate.text.includes(config.expectedReply)"
+          - expr: liveTurnTimeoutMs(env, 30000)
+      - assert:
+          expr: "outbound.text.includes(config.expectedReply)"
+          message:
+            expr: "`missing Anthropic thinking-error recovery marker: ${outbound.text}`"
+      - if:
+          expr: "Boolean(env.mock)"
+          then:
+            - set: scenarioRequests
+              value:
+                expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests`)).slice(requestCountBefore)"
+            - assert:
+                expr: "scenarioRequests.some((request) => String(request.allInputText ?? '').includes(config.promptSnippet) && request.providerVariant === 'anthropic' && request.plannedToolName === 'read')"
+                message: expected replay-safe read request on the Anthropic mock route
+            - assert:
+                expr: "scenarioRequests.filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet) && request.providerVariant === 'anthropic').length >= 3"
+                message: expected initial read, terminal-error attempt, and same-prompt retry
+            - assert:
+                expr: "!scenarioRequests.some((request) => String(request.allInputText ?? '').includes(config.visibleAnswerRetryNeedle))"
+                message: expected same-prompt retry, not visible-answer continuation retry
+    detailsExpr: "env.mock ? `${outbound.text}\\nrequests=${String(scenarioRequests?.length ?? 0)}` : outbound.text"
+```

--- a/qa/scenarios/runtime/anthropic-thinking-error-recovery-replay-safe-read.md
+++ b/qa/scenarios/runtime/anthropic-thinking-error-recovery-replay-safe-read.md
@@ -9,6 +9,12 @@ coverage:
     - runtime.anthropic-thinking-error-recovery
   secondary:
     - runtime.retry-policy
+gatewayConfigPatch:
+  agents:
+    defaults:
+      models:
+        anthropic/claude-opus-4-8:
+          params: {}
 objective: Verify an Anthropic stream error after signed thinking and a replay-safe read retries the same prompt into a visible answer.
 successCriteria:
   - Scenario is mock-openai only so live lanes do not pick it up implicitly.
@@ -24,7 +30,8 @@ execution:
   kind: flow
   summary: Verify Anthropic stream errors after signed thinking recover after a replay-safe read.
   config:
-    requiredProvider: mock-openai
+    requiredProviderMode: mock-openai
+    anthropicModelRef: anthropic/claude-opus-4-8
     promptSnippet: Anthropic thinking error QA check
     prompt: "Anthropic thinking error QA check: read QA_KICKOFF_TASK.md, then answer with exactly ANTHROPIC-THINKING-ERROR-RECOVERED-OK."
     expectedReply: ANTHROPIC-THINKING-ERROR-RECOVERED-OK
@@ -49,6 +56,9 @@ steps:
       - set: sessionKey
         value:
           expr: "`agent:qa:anthropic-thinking-error:${randomUUID().slice(0, 8)}`"
+      - set: modelAck
+        value:
+          expr: "await env.gateway.call('sessions.patch', { key: sessionKey, model: config.anthropicModelRef }, { timeoutMs: liveTurnTimeoutMs(env, 45000) })"
       - call: runAgentPrompt
         args:
           - ref: env

--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -38,6 +38,7 @@ export {
   isLikelyContextOverflowError,
   isFailoverAssistantError,
   isFailoverErrorMessage,
+  isGenericUnknownStreamErrorMessage,
   isImageDimensionErrorMessage,
   isImageSizeError,
   isOverloadedErrorMessage,

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -960,7 +960,7 @@ function isBilling429MessageForProvider(raw: string, provider: string | undefine
 // stream ends with stopReason === "aborted" | "error" without specific info. Treat
 // it as a transient transport failure so the configured fallback chain rotates
 // instead of returning the bare string to the user (#71620).
-function isGenericUnknownStreamError(raw: string): boolean {
+export function isGenericUnknownStreamErrorMessage(raw: string): boolean {
   return /^\s*an unknown error occurred\.?\s*$/i.test(raw);
 }
 
@@ -1064,7 +1064,7 @@ function classifyFailoverClassificationFromMessage(
   if (isAuthErrorMessage(raw)) {
     return toReasonClassification("auth");
   }
-  if (isGenericUnknownStreamError(raw)) {
+  if (isGenericUnknownStreamErrorMessage(raw)) {
     return toReasonClassification("timeout");
   }
   if (isOpenRouterProviderReturnedError(raw, provider)) {

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -102,6 +102,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
   });
 
   it("retries thinking-only unknown provider errors before assistant failover", async () => {
+    mockedClassifyFailoverReason.mockReturnValue("timeout");
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       emptyErrorAttempt(
         "anthropic",
@@ -128,6 +129,34 @@ describe("runEmbeddedAgent silent-error retry", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads).toBeUndefined();
+  });
+
+  it("does not intercept concrete non-transient failover errors", async () => {
+    mockedClassifyFailoverReason.mockReturnValue("model_not_found");
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      emptyErrorAttempt(
+        "anthropic",
+        "missing-model",
+        1120,
+        [
+          {
+            type: "thinking",
+            thinking: "internal reasoning before provider error",
+            thinkingSignature: JSON.stringify({ id: "rs_missing_model", type: "reasoning" }),
+          },
+        ],
+        "model not found",
+      ),
+    );
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "anthropic",
+      model: "missing-model",
+      runId: "run-empty-error-retry-non-transient",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
   });
 
   it("caps retries at MAX_EMPTY_ERROR_RETRIES and surfaces incomplete-turn error", async () => {

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -319,6 +319,14 @@ describe("runEmbeddedAgent silent-error retry", () => {
         },
       },
     ],
+    ["tool media", { toolMediaUrls: ["file:///tmp/render.png"] }],
+    ["voice media", { toolAudioAsVoice: true }],
+    ["trusted local media", { toolTrustedLocalMedia: true }],
+    [
+      "source reply payloads",
+      { messagingToolSourceReplyPayloads: [{ text: "Delivered through the source reply." }] },
+    ],
+    ["delivered source replies", { didDeliverSourceReplyViaMessageTool: true }],
     ["tool errors", { lastToolError: { toolName: "read", error: "read failed" } }],
   ] satisfies Array<[string, Partial<EmbeddedRunAttemptResult>]>)(
     "does not retry after terminal %s",

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
+  mockedClassifyAssistantFailoverReason,
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
@@ -129,6 +130,37 @@ describe("runEmbeddedAgent silent-error retry", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads).toBeUndefined();
+  });
+
+  it.each([
+    ["timeout", "LLM request timed out."],
+    ["server_error", "Internal server error"],
+  ] as const)("does not intercept recognized %s failover errors", async (reason, errorMessage) => {
+    mockedClassifyAssistantFailoverReason.mockReturnValue(reason);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      emptyErrorAttempt(
+        "anthropic",
+        "claude-opus-4-8",
+        1120,
+        [
+          {
+            type: "thinking",
+            thinking: "internal reasoning before provider error",
+            thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
+          },
+        ],
+        errorMessage,
+      ),
+    );
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      runId: `run-empty-error-retry-${reason}`,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
   });
 
   it("does not intercept concrete non-transient failover errors", async () => {

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -301,4 +301,39 @@ describe("runEmbeddedAgent silent-error retry", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads?.[0]?.isError).toBe(true);
   });
+
+  it.each([
+    [
+      "client tool calls",
+      { clientToolCalls: [{ name: "browser", params: { url: "https://example.com" } }] },
+    ],
+    ["yield", { yieldDetected: true }],
+    ["approval prompts", { didSendDeterministicApprovalPrompt: true }],
+    ["tool errors", { lastToolError: { toolName: "read", error: "read failed" } }],
+  ] satisfies Array<[string, Partial<EmbeddedRunAttemptResult>]>)(
+    "does not retry after terminal %s",
+    async (_label, attemptState) => {
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+        makeAttemptResult({
+          ...emptyErrorAttempt("anthropic", "claude-opus-4-8", 1120, [
+            {
+              type: "thinking",
+              thinking: "internal reasoning before provider error",
+              thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
+            },
+          ]),
+          ...attemptState,
+        }),
+      );
+
+      await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+        runId: `run-empty-error-retry-terminal-${_label.replaceAll(" ", "-")}`,
+      });
+
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    },
+  );
 });

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -13,21 +13,27 @@ import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
 
+type AssistantContent = NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>["content"];
+
 function emptyErrorAttempt(
   provider: string,
   model: string,
   outputTokens = 0,
+  content: AssistantContent = [],
+  errorMessage?: string,
 ): EmbeddedRunAttemptResult {
   // Models can report stopReason=error with no output after tool activity; that
   // is replay-safe only when the attempt metadata records no side effects.
   return makeAttemptResult({
     assistantTexts: [],
     lastAssistant: {
+      role: "assistant",
       stopReason: "error",
       provider,
       model,
-      content: [],
+      content,
       usage: { input: 100, output: outputTokens, totalTokens: 100 + outputTokens },
+      ...(errorMessage ? { errorMessage } : {}),
     } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
   });
 }
@@ -36,6 +42,7 @@ function successAttempt(provider: string, model: string): EmbeddedRunAttemptResu
   return makeAttemptResult({
     assistantTexts: ["Done."],
     lastAssistant: {
+      role: "assistant",
       stopReason: "stop",
       provider,
       model,
@@ -65,6 +72,58 @@ describe("runEmbeddedAgent silent-error retry", () => {
       provider: "ollama",
       model: "glm-5.1:cloud",
       runId: "run-empty-error-retry-basic",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toBeUndefined();
+  });
+
+  it("retries when stopReason=error emitted only thinking blocks and output tokens", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      emptyErrorAttempt("anthropic", "claude-opus-4-8", 1120, [
+        {
+          type: "thinking",
+          thinking: "internal reasoning before provider error",
+          thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
+        },
+      ]),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(successAttempt("anthropic", "claude-opus-4-8"));
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      runId: "run-empty-error-retry-thinking-only",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toBeUndefined();
+  });
+
+  it("retries thinking-only unknown provider errors before assistant failover", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      emptyErrorAttempt(
+        "anthropic",
+        "claude-opus-4-8",
+        1120,
+        [
+          {
+            type: "thinking",
+            thinking: "internal reasoning before provider error",
+            thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
+          },
+        ],
+        "An unknown error occurred",
+      ),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(successAttempt("anthropic", "claude-opus-4-8"));
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      runId: "run-empty-error-retry-before-assistant-failover",
     });
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
@@ -113,6 +172,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
       makeAttemptResult({
         assistantTexts: [],
         lastAssistant: {
+          role: "assistant",
           stopReason: "stop",
           provider: "plain-provider",
           model: "plain-model",
@@ -156,6 +216,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
       makeAttemptResult({
         assistantTexts: [],
         lastAssistant: {
+          role: "assistant",
           stopReason: "error",
           provider: "ollama",
           model: "glm-5.1:cloud",

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -309,6 +309,16 @@ describe("runEmbeddedAgent silent-error retry", () => {
     ],
     ["yield", { yieldDetected: true }],
     ["approval prompts", { didSendDeterministicApprovalPrompt: true }],
+    [
+      "heartbeat responses",
+      {
+        heartbeatToolResponse: {
+          outcome: "progress",
+          notify: false,
+          summary: "Still working",
+        },
+      },
+    ],
     ["tool errors", { lastToolError: { toolName: "read", error: "read failed" } }],
   ] satisfies Array<[string, Partial<EmbeddedRunAttemptResult>]>)(
     "does not retry after terminal %s",

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2568,48 +2568,97 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("retries replay-safe errored turns that only emitted thinking blocks", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      content: [
+        {
+          type: "thinking",
+          thinking: "internal reasoning before provider error",
+          thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
+        },
+        { type: "redacted_thinking", data: "opaque" },
+        { type: "text", text: " " },
+      ],
+      usage: { input: 100, output: 1120, totalTokens: 1220 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
     expect(
       shouldRetrySilentErrorAssistantTurn({
-        attempt: makeAttemptResult({
-          assistantTexts: [],
-          lastAssistant: {
-            role: "assistant",
-            stopReason: "error",
-            provider: "anthropic",
-            model: "claude-opus-4-8",
-            content: [
-              {
-                type: "thinking",
-                thinking: "internal reasoning before provider error",
-                thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
-              },
-            ],
-            usage: { input: 100, output: 1120, totalTokens: 1220 },
-          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-        }),
+        attempt: makeAttemptResult({ assistantTexts: [], lastAssistant: assistant }),
+        assistant,
       }),
     ).toBe(true);
   });
 
   it("does not retry errored empty turns when non-zero output may indicate progress", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "ollama",
+      model: "glm-5.1:cloud",
+      content: [],
+      usage: { input: 100, output: 12, totalTokens: 112 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
     expect(
       shouldRetrySilentErrorAssistantTurn({
-        attempt: makeAttemptResult({
-          assistantTexts: [],
-          lastAssistant: {
-            role: "assistant",
-            stopReason: "error",
-            provider: "ollama",
-            model: "glm-5.1:cloud",
-            content: [],
-            usage: { input: 100, output: 12, totalTokens: 112 },
-          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-        }),
+        attempt: makeAttemptResult({ assistantTexts: [], lastAssistant: assistant }),
+        assistant,
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
+    {
+      name: "visible text",
+      content: [
+        { type: "thinking", thinking: "internal", thinkingSignature: "sig" },
+        { type: "text", text: "partial answer" },
+      ],
+    },
+    {
+      name: "tool call",
+      content: [
+        { type: "thinking", thinking: "internal", thinkingSignature: "sig" },
+        { type: "toolCall", id: "call_1", name: "read", arguments: { path: "README.md" } },
+      ],
+    },
+    {
+      name: "unknown block",
+      content: [{ type: "provider_metadata", value: "opaque" }],
+    },
+  ])("does not retry errored turns containing $name", ({ content }) => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      content,
+      usage: { input: 100, output: 1120, totalTokens: 1220 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({ assistantTexts: [], lastAssistant: assistant }),
+        assistant,
       }),
     ).toBe(false);
   });
 
   it("does not retry errored thinking-only turns after side effects", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      content: [
+        {
+          type: "redacted_thinking",
+          data: "opaque",
+        },
+      ],
+      usage: { input: 100, output: 1120, totalTokens: 1220 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
     expect(
       shouldRetrySilentErrorAssistantTurn({
         attempt: makeAttemptResult({
@@ -2618,24 +2667,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             hadPotentialSideEffects: true,
             replaySafe: false,
           },
-          lastAssistant: {
-            role: "assistant",
-            stopReason: "error",
-            provider: "anthropic",
-            model: "claude-opus-4-8",
-            content: [
-              {
-                type: "thinking",
-                thinking: "internal reasoning before provider error",
-                thinkingSignature: JSON.stringify({
-                  id: "rs_error_side_effect",
-                  type: "reasoning",
-                }),
-              },
-            ],
-            usage: { input: 100, output: 1120, totalTokens: 1220 },
-          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+          lastAssistant: assistant,
         }),
+        assistant,
       }),
     ).toBe(false);
   });

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2567,6 +2567,58 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(incompleteTurnText).toContain("couldn't generate a response");
   });
 
+  it.each([
+    [
+      "heartbeat responses",
+      {
+        heartbeatToolResponse: {
+          outcome: "progress" as const,
+          notify: false,
+          summary: "Still working",
+        },
+      },
+    ],
+    ["tool media", { toolMediaUrls: ["file:///tmp/render.png"] }],
+    ["voice media", { toolAudioAsVoice: true }],
+    ["trusted local media", { toolTrustedLocalMedia: true }],
+    [
+      "source reply payloads",
+      { messagingToolSourceReplyPayloads: [{ text: "Delivered through the source reply." }] },
+    ],
+    ["delivered source replies", { didDeliverSourceReplyViaMessageTool: true }],
+  ] satisfies Array<[string, Partial<EmbeddedRunAttemptResult>]>)(
+    "does not replace terminal %s with an incomplete-turn warning",
+    (_label, attemptState) => {
+      const incompleteTurnText = resolveIncompleteTurnPayloadText({
+        payloadCount: 1,
+        aborted: false,
+        timedOut: false,
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          ...attemptState,
+          lastAssistant: {
+            role: "assistant",
+            stopReason: "error",
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal reasoning before provider error",
+                thinkingSignature: JSON.stringify({
+                  id: "rs_terminal_payload",
+                  type: "reasoning",
+                }),
+              },
+            ],
+          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
+      });
+
+      expect(incompleteTurnText).toBeNull();
+    },
+  );
+
   it("retries replay-safe errored turns that only emitted thinking blocks", () => {
     const assistant = {
       role: "assistant",

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -41,6 +41,7 @@ import {
   resolveRunLivenessState,
   resolveSilentToolResultReplyPayload,
   shouldRetryMissingAssistantTurn,
+  shouldRetrySilentErrorAssistantTurn,
   shouldTreatEmptyAssistantReplyAsSilent,
 } from "./run/incomplete-turn.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
@@ -693,7 +694,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.payloads).toBeUndefined();
   });
 
-  it("does not retry reasoning-only turns when the assistant ended in error", async () => {
+  it("retries reasoning-only turns when the assistant ended in error", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
@@ -714,6 +715,18 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
       }),
     );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Recovered."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [{ type: "text", text: "Recovered." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
 
     const result = await runEmbeddedAgent({
       ...overflowBaseRunParams,
@@ -722,9 +735,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       runId: "run-reasoning-only-assistant-error",
     });
 
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-    expect(result.payloads?.[0]?.isError).toBe(true);
-    expect(result.payloads?.[0]?.text).toContain("Please try again");
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toBeUndefined();
   });
 
   it("does not retry reasoning-only turns for non-strict-agentic providers", async () => {
@@ -2527,6 +2539,105 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
 
     expect(retryInstruction).toBeNull();
+  });
+
+  it("surfaces incomplete-turn text for errored signed-thinking-only turns with payloads", () => {
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "error",
+          provider: "anthropic",
+          model: "claude-opus-4-8",
+          content: [
+            {
+              type: "thinking",
+              thinking: "internal reasoning before provider error",
+              thinkingSignature: JSON.stringify({ id: "rs_error_payload", type: "reasoning" }),
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(incompleteTurnText).toContain("couldn't generate a response");
+  });
+
+  it("retries replay-safe errored turns that only emitted thinking blocks", () => {
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: {
+            role: "assistant",
+            stopReason: "error",
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal reasoning before provider error",
+                thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
+              },
+            ],
+            usage: { input: 100, output: 1120, totalTokens: 1220 },
+          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not retry errored empty turns when non-zero output may indicate progress", () => {
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: {
+            role: "assistant",
+            stopReason: "error",
+            provider: "ollama",
+            model: "glm-5.1:cloud",
+            content: [],
+            usage: { input: 100, output: 12, totalTokens: 112 },
+          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not retry errored thinking-only turns after side effects", () => {
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          replayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+          lastAssistant: {
+            role: "assistant",
+            stopReason: "error",
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal reasoning before provider error",
+                thinkingSignature: JSON.stringify({
+                  id: "rs_error_side_effect",
+                  type: "reasoning",
+                }),
+              },
+            ],
+            usage: { input: 100, output: 1120, totalTokens: 1220 },
+          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
+      }),
+    ).toBe(false);
   });
 
   it("detects empty openai-compatible stop turns with non-zero output usage", () => {

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -225,6 +225,9 @@ export const mockedIsBillingAssistantError = vi.fn(() => false);
 export const mockedIsCompactionFailureError = vi.fn(() => false);
 export const mockedIsFailoverAssistantError = vi.fn<MockAssistantErrorProbe>(() => false);
 export const mockedIsFailoverErrorMessage = vi.fn(() => false);
+export const mockedIsGenericUnknownStreamErrorMessage = vi.fn((raw: string) =>
+  /^\s*an unknown error occurred\.?\s*$/i.test(raw),
+);
 export const mockedIsLikelyContextOverflowError = vi.fn((msg?: string) => {
   const lower = normalizeLowercaseStringOrEmpty(msg ?? "");
   return (
@@ -412,6 +415,10 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   mockedIsFailoverAssistantError.mockReturnValue(false);
   mockedIsFailoverErrorMessage.mockReset();
   mockedIsFailoverErrorMessage.mockReturnValue(false);
+  mockedIsGenericUnknownStreamErrorMessage.mockReset();
+  mockedIsGenericUnknownStreamErrorMessage.mockImplementation((raw: string) =>
+    /^\s*an unknown error occurred\.?\s*$/i.test(raw),
+  );
   mockedIsLikelyContextOverflowError.mockReset();
   mockedIsLikelyContextOverflowError.mockImplementation((msg?: string) => {
     const lower = normalizeLowercaseStringOrEmpty(msg ?? "");
@@ -642,6 +649,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     isLikelyContextOverflowError: mockedIsLikelyContextOverflowError,
     isFailoverAssistantError: mockedIsFailoverAssistantError,
     isFailoverErrorMessage: mockedIsFailoverErrorMessage,
+    isGenericUnknownStreamErrorMessage: mockedIsGenericUnknownStreamErrorMessage,
     parseImageSizeError: mockedParseImageSizeError,
     parseImageDimensionError: mockedParseImageDimensionError,
     isRateLimitAssistantError: mockedIsRateLimitAssistantError,

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2937,6 +2937,13 @@ async function runEmbeddedAgentInternal(
           const imageDimensionError = parseImageDimensionError(
             assistantForFailover?.errorMessage ?? "",
           );
+          const silentErrorRetryReason =
+            assistantFailoverReason === null ||
+            assistantFailoverReason === "timeout" ||
+            assistantFailoverReason === "server_error" ||
+            assistantFailoverReason === "no_error_details" ||
+            assistantFailoverReason === "unclassified" ||
+            assistantFailoverReason === "unknown";
           // Retry replay-safe non-visible provider errors before assistant
           // failover surfaces them as terminal provider failures.
           if (
@@ -2948,7 +2955,8 @@ async function runEmbeddedAgentInternal(
             !aborted &&
             !promptError &&
             !timedOut &&
-            shouldRetrySilentErrorAssistantTurn({ attempt }) &&
+            silentErrorRetryReason &&
+            shouldRetrySilentErrorAssistantTurn({ attempt, assistant: assistantForFailover }) &&
             emptyErrorRetries < MAX_EMPTY_ERROR_RETRIES
           ) {
             emptyErrorRetries += 1;

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -195,6 +195,7 @@ import {
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
   shouldRetryMissingAssistantTurn,
+  shouldRetrySilentErrorAssistantTurn,
   shouldTreatEmptyAssistantReplyAsSilent,
 } from "./run/incomplete-turn.js";
 import type { RunEmbeddedAgentParams } from "./run/params.js";
@@ -2936,6 +2937,30 @@ async function runEmbeddedAgentInternal(
           const imageDimensionError = parseImageDimensionError(
             assistantForFailover?.errorMessage ?? "",
           );
+          // Retry replay-safe non-visible provider errors before assistant
+          // failover surfaces them as terminal provider failures.
+          if (
+            !authFailure &&
+            !rateLimitFailure &&
+            !billingFailure &&
+            !cloudCodeAssistFormatError &&
+            !imageDimensionError &&
+            !aborted &&
+            !promptError &&
+            !timedOut &&
+            shouldRetrySilentErrorAssistantTurn({ attempt }) &&
+            emptyErrorRetries < MAX_EMPTY_ERROR_RETRIES
+          ) {
+            emptyErrorRetries += 1;
+            log.warn(
+              `[empty-error-retry] stopReason=error non-visible-output; resubmitting ` +
+                `attempt=${emptyErrorRetries}/${MAX_EMPTY_ERROR_RETRIES} ` +
+                `provider=${assistantForFailover?.provider ?? provider} ` +
+                `model=${assistantForFailover?.model ?? model.id} ` +
+                `sessionKey=${params.sessionKey ?? params.sessionId}`,
+            );
+            continue;
+          }
           // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
           const failedAssistantProfileId = lastProfileId;
           const logAssistantFailoverDecision = createFailoverDecisionLogger({
@@ -3601,47 +3626,6 @@ async function runEmbeddedAgentInternal(
               `empty response retries exhausted: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} attempts=${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} — surfacing incomplete-turn error`,
             );
-          }
-          // ── silent-error retry ────────────────────────────────────────────
-          // Observed with ollama/glm-5.1: a turn can end with stopReason="error"
-          // and zero output tokens AND empty content after a successful
-          // tool-call sequence, producing no user-visible text at all. This
-          // path is narrower than the empty-response continuation retry:
-          // same prompt, same session transcript (tool results already
-          // captured), no instruction injection. Placed before the
-          // incompleteTurnText return so it actually gets a chance to fire.
-          //
-          // Content-empty guard: a reasoning-only error (content has thinking
-          // blocks) is a distinct failure mode handled elsewhere; only retry
-          // when the assistant truly produced nothing.
-          //
-          // Side-effect guard: if the failed attempt already recorded potential
-          // side effects (messaging tool sent, cron add, mutating tool
-          // call that wasn't round-tripped as replay-safe), resubmission can
-          // duplicate those actions. Mirror the gate the other retry resolvers
-          // use (resolveEmptyResponseRetryInstruction, reasoning-only, planning-
-          // only), which short-circuit on attempt.replayMetadata.hadPotentialSideEffects.
-          const silentErrorContent = sessionLastAssistant?.content as Array<unknown> | undefined;
-          if (
-            incompleteTurnText &&
-            !aborted &&
-            !promptError &&
-            !timedOut &&
-            sessionLastAssistant?.stopReason === "error" &&
-            ((sessionLastAssistant?.usage as { output?: number } | undefined)?.output ?? 0) === 0 &&
-            (silentErrorContent?.length ?? 0) === 0 &&
-            (attempt.replayMetadata ? !attempt.replayMetadata.hadPotentialSideEffects : false) &&
-            emptyErrorRetries < MAX_EMPTY_ERROR_RETRIES
-          ) {
-            emptyErrorRetries += 1;
-            log.warn(
-              `[empty-error-retry] stopReason=error output=0; resubmitting ` +
-                `attempt=${emptyErrorRetries}/${MAX_EMPTY_ERROR_RETRIES} ` +
-                `provider=${sessionLastAssistant?.provider ?? provider} ` +
-                `model=${sessionLastAssistant?.model ?? model.id} ` +
-                `sessionKey=${params.sessionKey ?? params.sessionId}`,
-            );
-            continue;
           }
           if (incompleteTurnText) {
             const replayInvalid = resolveReplayInvalidForAttempt(incompleteTurnText);

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -72,6 +72,7 @@ import {
   isCompactionFailureError,
   isFailoverAssistantError,
   isFailoverErrorMessage,
+  isGenericUnknownStreamErrorMessage,
   isLikelyContextOverflowError,
   isRateLimitAssistantError,
   parseImageDimensionError,
@@ -107,6 +108,7 @@ import {
   resolveSelectedOpenAIRuntimeProvider,
 } from "../openai-routing.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
+import { hasOnlyAssistantReasoningContent } from "../replay-turn-classification.js";
 import { runAgentCleanupStep } from "../run-cleanup-timeout.js";
 import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
@@ -2937,10 +2939,15 @@ async function runEmbeddedAgentInternal(
           const imageDimensionError = parseImageDimensionError(
             assistantForFailover?.errorMessage ?? "",
           );
+          // The shared runtime wraps interrupted streams as a timeout. Retry that
+          // wrapper only for reasoning-only output so ordinary timeouts keep failover.
+          const genericUnknownReasoningError =
+            assistantFailoverReason === "timeout" &&
+            isGenericUnknownStreamErrorMessage(assistantForFailover?.errorMessage ?? "") &&
+            Boolean(assistantForFailover && hasOnlyAssistantReasoningContent(assistantForFailover));
           const silentErrorRetryReason =
             assistantFailoverReason === null ||
-            assistantFailoverReason === "timeout" ||
-            assistantFailoverReason === "server_error" ||
+            genericUnknownReasoningError ||
             assistantFailoverReason === "no_error_details" ||
             assistantFailoverReason === "unclassified" ||
             assistantFailoverReason === "unknown";

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -45,6 +45,12 @@ type IncompleteTurnAttempt = Pick<
   | "currentAttemptAssistant"
   | "yieldDetected"
   | "didSendDeterministicApprovalPrompt"
+  | "heartbeatToolResponse"
+  | "toolMediaUrls"
+  | "toolAudioAsVoice"
+  | "toolTrustedLocalMedia"
+  | "didDeliverSourceReplyViaMessageTool"
+  | "messagingToolSourceReplyPayloads"
   | "didSendViaMessagingTool"
   | "messagingToolSentTexts"
   | "messagingToolSentMediaUrls"
@@ -263,6 +269,35 @@ export function resolveAttemptReplayMetadata(attempt: {
   return attempt.replayMetadata ?? REPLAY_UNSAFE_FALLBACK_METADATA;
 }
 
+type TerminalAttemptState = Pick<
+  EmbeddedRunAttemptResult,
+  | "clientToolCalls"
+  | "yieldDetected"
+  | "didSendDeterministicApprovalPrompt"
+  | "heartbeatToolResponse"
+  | "lastToolError"
+  | "toolMediaUrls"
+  | "toolAudioAsVoice"
+  | "toolTrustedLocalMedia"
+  | "didDeliverSourceReplyViaMessageTool"
+  | "messagingToolSourceReplyPayloads"
+>;
+
+function hasAttemptTerminalState(attempt: TerminalAttemptState): boolean {
+  return Boolean(
+    attempt.clientToolCalls ||
+    attempt.yieldDetected ||
+    attempt.didSendDeterministicApprovalPrompt ||
+    attempt.heartbeatToolResponse ||
+    attempt.lastToolError ||
+    attempt.toolMediaUrls?.some((url) => url.trim().length > 0) ||
+    attempt.toolAudioAsVoice ||
+    attempt.toolTrustedLocalMedia ||
+    attempt.didDeliverSourceReplyViaMessageTool ||
+    attempt.messagingToolSourceReplyPayloads?.length,
+  );
+}
+
 /**
  * Builds the user-visible incomplete-turn warning when a terminal attempt did
  * not produce a safe final assistant response and no committed delivery/progress
@@ -288,6 +323,7 @@ export function resolveIncompleteTurnPayloadText(params: {
   const thinkingOnlyTerminal =
     params.payloadCount !== 0 &&
     !joinAssistantTexts(params.attempt.assistantTexts).length &&
+    !hasAttemptTerminalState(params.attempt) &&
     Boolean(assistant && hasOnlyAssistantReasoningContent(assistant));
 
   if (
@@ -565,6 +601,11 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     | "didSendDeterministicApprovalPrompt"
     | "heartbeatToolResponse"
     | "lastToolError"
+    | "toolMediaUrls"
+    | "toolAudioAsVoice"
+    | "toolTrustedLocalMedia"
+    | "didDeliverSourceReplyViaMessageTool"
+    | "messagingToolSourceReplyPayloads"
     | "replayMetadata"
   >;
   assistant: EmbeddedRunAttemptResult["lastAssistant"] | null | undefined;
@@ -572,13 +613,7 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
   if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
     return false;
   }
-  if (
-    params.attempt.clientToolCalls ||
-    params.attempt.yieldDetected ||
-    params.attempt.didSendDeterministicApprovalPrompt ||
-    params.attempt.heartbeatToolResponse ||
-    params.attempt.lastToolError
-  ) {
+  if (hasAttemptTerminalState(params.attempt)) {
     return false;
   }
   if (resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects) {

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -16,6 +16,7 @@ import {
   isStrictAgenticSupportedProviderModel,
   stripProviderPrefix,
 } from "../../execution-contract.js";
+import { hasOnlyAssistantReasoningContent } from "../../replay-turn-classification.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { isLikelyMutatingToolName } from "../../tool-mutation.js";
 import {
@@ -287,7 +288,7 @@ export function resolveIncompleteTurnPayloadText(params: {
   const thinkingOnlyTerminal =
     params.payloadCount !== 0 &&
     !joinAssistantTexts(params.attempt.assistantTexts).length &&
-    (isReasoningOnlyAssistantTurn(assistant) || isUnsignedThinkingOnlyAssistantTurn(assistant));
+    Boolean(assistant && hasOnlyAssistantReasoningContent(assistant));
 
   if (
     (params.payloadCount !== 0 && !toolUseTerminal && !thinkingOnlyTerminal) ||
@@ -556,10 +557,8 @@ function isUnsignedThinkingOnlyAssistantTurn(message: unknown): boolean {
 }
 
 export function shouldRetrySilentErrorAssistantTurn(params: {
-  attempt: Pick<
-    EmbeddedRunAttemptResult,
-    "assistantTexts" | "currentAttemptAssistant" | "lastAssistant" | "replayMetadata"
-  >;
+  attempt: Pick<EmbeddedRunAttemptResult, "assistantTexts" | "replayMetadata">;
+  assistant: EmbeddedRunAttemptResult["lastAssistant"] | null | undefined;
 }): boolean {
   if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
     return false;
@@ -568,7 +567,7 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     return false;
   }
 
-  const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
+  const assistant = params.assistant;
   if (!assistant || assistant.stopReason !== "error") {
     return false;
   }
@@ -581,7 +580,7 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     return !hasPositiveOutputTokenUsage(assistant);
   }
 
-  return isReasoningOnlyAssistantTurn(assistant) || isUnsignedThinkingOnlyAssistantTurn(assistant);
+  return hasOnlyAssistantReasoningContent(assistant);
 }
 
 function isEmptyResponseAssistantTurn(params: {

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -557,10 +557,26 @@ function isUnsignedThinkingOnlyAssistantTurn(message: unknown): boolean {
 }
 
 export function shouldRetrySilentErrorAssistantTurn(params: {
-  attempt: Pick<EmbeddedRunAttemptResult, "assistantTexts" | "replayMetadata">;
+  attempt: Pick<
+    EmbeddedRunAttemptResult,
+    | "assistantTexts"
+    | "clientToolCalls"
+    | "yieldDetected"
+    | "didSendDeterministicApprovalPrompt"
+    | "lastToolError"
+    | "replayMetadata"
+  >;
   assistant: EmbeddedRunAttemptResult["lastAssistant"] | null | undefined;
 }): boolean {
   if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
+    return false;
+  }
+  if (
+    params.attempt.clientToolCalls ||
+    params.attempt.yieldDetected ||
+    params.attempt.didSendDeterministicApprovalPrompt ||
+    params.attempt.lastToolError
+  ) {
     return false;
   }
   if (resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects) {

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -563,6 +563,7 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     | "clientToolCalls"
     | "yieldDetected"
     | "didSendDeterministicApprovalPrompt"
+    | "heartbeatToolResponse"
     | "lastToolError"
     | "replayMetadata"
   >;
@@ -575,6 +576,7 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     params.attempt.clientToolCalls ||
     params.attempt.yieldDetected ||
     params.attempt.didSendDeterministicApprovalPrompt ||
+    params.attempt.heartbeatToolResponse ||
     params.attempt.lastToolError
   ) {
     return false;

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -281,16 +281,16 @@ export function resolveIncompleteTurnPayloadText(params: {
   // produced. (#76477)
   const toolUseTerminal = params.attempt.lastAssistant?.stopReason === "toolUse";
   const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
-  // Unsigned thinking payloads count toward payloadCount but carry no user-visible
-  // content; bypass the visible-text guard when unsigned thinking was the only output
-  // so that incomplete-turn stall detection fires below. (#89787)
-  const unsignedThinkingOnlyTerminal =
+  // Thinking payloads can count toward payloadCount but carry no user-visible
+  // content; bypass the visible-text guard when thinking was the only output
+  // so that incomplete-turn stall detection fires below. (#89787, #91953)
+  const thinkingOnlyTerminal =
     params.payloadCount !== 0 &&
     !joinAssistantTexts(params.attempt.assistantTexts).length &&
-    isUnsignedThinkingOnlyAssistantTurn(assistant);
+    (isReasoningOnlyAssistantTurn(assistant) || isUnsignedThinkingOnlyAssistantTurn(assistant));
 
   if (
-    (params.payloadCount !== 0 && !toolUseTerminal && !unsignedThinkingOnlyTerminal) ||
+    (params.payloadCount !== 0 && !toolUseTerminal && !thinkingOnlyTerminal) ||
     (params.aborted && params.externalAbort) ||
     params.timedOut ||
     params.attempt.clientToolCalls ||
@@ -330,7 +330,7 @@ export function resolveIncompleteTurnPayloadText(params: {
   if (
     !incompleteTerminalAssistant &&
     !reasoningOnlyAssistant &&
-    !unsignedThinkingOnlyTerminal &&
+    !thinkingOnlyTerminal &&
     !emptyResponseAssistant &&
     stopReason !== "error"
   ) {
@@ -553,6 +553,35 @@ function isUnsignedThinkingOnlyAssistantTurn(message: unknown): boolean {
     return false;
   }
   return assessLastAssistantMessage(message as AgentMessage) === "incomplete-thinking";
+}
+
+export function shouldRetrySilentErrorAssistantTurn(params: {
+  attempt: Pick<
+    EmbeddedRunAttemptResult,
+    "assistantTexts" | "currentAttemptAssistant" | "lastAssistant" | "replayMetadata"
+  >;
+}): boolean {
+  if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
+    return false;
+  }
+  if (resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects) {
+    return false;
+  }
+
+  const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
+  if (!assistant || assistant.stopReason !== "error") {
+    return false;
+  }
+
+  const content = (assistant as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  if (content.length === 0) {
+    return !hasPositiveOutputTokenUsage(assistant);
+  }
+
+  return isReasoningOnlyAssistantTurn(assistant) || isUnsignedThinkingOnlyAssistantTurn(assistant);
 }
 
 function isEmptyResponseAssistantTurn(params: {

--- a/src/agents/replay-turn-classification.ts
+++ b/src/agents/replay-turn-classification.ts
@@ -4,9 +4,9 @@ type AssistantTurnLike = {
   content?: unknown;
 };
 
-/** Returns true when a token-limited turn contains only incomplete provider reasoning. */
-export function isReasoningOnlyLengthAssistantTurn(message: AssistantTurnLike): boolean {
-  if (message.role !== "assistant" || message.stopReason !== "length") {
+/** Returns true when an assistant turn contains only provider reasoning and blank text. */
+export function hasOnlyAssistantReasoningContent(message: AssistantTurnLike): boolean {
+  if (message.role !== "assistant") {
     return false;
   }
   const content = Array.isArray(message.content)
@@ -30,4 +30,9 @@ export function isReasoningOnlyLengthAssistantTurn(message: AssistantTurnLike): 
     return false;
   }
   return hasThinking;
+}
+
+/** Returns true when a token-limited turn contains only incomplete provider reasoning. */
+export function isReasoningOnlyLengthAssistantTurn(message: AssistantTurnLike): boolean {
+  return message.stopReason === "length" && hasOnlyAssistantReasoningContent(message);
 }


### PR DESCRIPTION
## Summary

- Fixes #91953.
- Retry replay-safe `stopReason="error"` turns when the assistant emitted only non-visible reasoning before the provider error.
- Run that retry before assistant failover, while preserving existing fallback for classified failures.
- Do not retry after visible output or terminal effects such as tools, approvals, yields, heartbeat outcomes, media/source replies, or delivery.

## Verification

- `pnpm test src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts src/agents/embedded-agent-runner/run.empty-error-retry.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/model-fallback.run-embedded.e2e.test.ts extensions/qa-lab/src/suite-planning.test.ts extensions/qa-lab/src/scenario-catalog.test.ts` (362 tests, 4 shards)
- `pnpm openclaw qa suite --provider-mode mock-openai --scenario anthropic-thinking-error-recovery-replay-safe-read --concurrency 1 --output-dir .artifacts/pr-92191-anthropic-terminal-state-final` (passed; final marker `ANTHROPIC-THINKING-ERROR-RECOVERED-OK`; 4 requests)
- Official live provider probes: OpenAI `gpt-5.5` and Anthropic Claude Sonnet 4.6 tool call, tool result replay, and transport completion (13 tests)
- Testbox `tbx_01kv3drsxppe093zac5y78dngs`: `pnpm check:changed` passed; all agent/model/tool/runtime lanes passed. The later unrelated gateway-server portion stopped producing output for six minutes and the run was terminated rather than treated as proof.
- Fresh autoreview: no actionable findings.
- Rebase onto current `main`: six commits byte-equivalent by `git range-diff`.

## Real behavior proof

Behavior addressed: A replay-safe Anthropic-style turn that ends in a provider error after emitting only signed reasoning is retried instead of surfacing the non-visible failure as terminal. Classified provider failures and turns with visible or terminal outputs retain their existing fallback/terminal ownership.

Real environment tested: Local source checkout on Node 22 and pnpm 11; isolated OpenClaw QA home; real gateway child; Anthropic Messages SSE fault injection; official OpenAI and Anthropic live credentials for no-regression tool-call probes; Linux Blacksmith Testbox for changed checks and broad tests.

Exact steps or command run after this patch: Ran the focused six-file `pnpm test` command above; ran the QA suite command above; ran official live OpenAI and Anthropic tool-call/replay probes; ran `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` and then `corepack pnpm test` in Testbox `tbx_01kv3drsxppe093zac5y78dngs`.

Evidence after fix: The gateway QA scenario performs a replay-safe read, receives signed Anthropic reasoning followed by `event:error`, then succeeds on same-model retry with `ANTHROPIC-THINKING-ERROR-RECOVERED-OK`; 4 requests observed. Focused tests passed 362 assertions. Official OpenAI and Anthropic live tool/replay probes passed 13 tests. Testbox changed checks and all relevant model/tool/runtime suites passed.

Observed result after fix: The runner retries only strict reasoning-only, replay-safe unknown errors before failover. It does not retry after tool execution, client tools, approvals, yields, heartbeat terminal state, media/audio/source replies, delivery, visible assistant text, or concrete classified failures.

What was not tested: The original intermittent Vertex AI/Claude failure was not reproduced against the live Vertex path because it is not deterministically triggerable in the available account. Bedrock was not live-tested because the available AWS credentials are invalid. Both gaps are covered only by deterministic Anthropic protocol/runtime tests, not claimed as live proof.
