### PR TITLE
fix(telegram): honor ingest config before unaddressed-group-media skip

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -794,6 +794,11 @@ export const registerTelegramHandlers = ({
       },
     });
     if (mentionDecision.shouldSkip) {
+      // #92067: honor ingest config — an explicitly ingest-enabled group/topic
+      // opts out of the media skip so plugins still receive media-bearing updates.
+      if ((topicConfig?.ingest ?? groupConfig?.ingest) === true) {
+        return false;
+      }
       logger.info({ chatId, reason: "no-mention" }, "skipping group media before download");
       return true;
     }


### PR DESCRIPTION
## Summary

Fixes #92067. The `shouldSkipMediaDownloadForUnaddressedMentionGroup` path returns `true` (skip) for un-addressed group/topic media **before** the `message:received` ingest hook fires. A plugin that sets `channels.telegram.groups[<id>].ingest: true` therefore receives text messages but never media-bearing ones — the skip wins before ingest is consulted.

## Change

Insert an ingest check before the skip's `return true` — an explicitly ingest-enabled group/topic opts out of the media skip; default behavior is unchanged for everyone else.

```js
if ((topicConfig?.ingest ?? groupConfig?.ingest) === true) {
  return false;
}
```

## Real behavior proof

**Behavior or issue addressed**: Telegram group/topic media messages are silently skipped when `requireMention` is true but the user does not @mention the bot, even when `ingest: true` is configured. The ingest hook never fires for media-bearing messages.

**Real environment tested**: Linux (WSL2), Node v24.16.0, OpenClaw 2026.6.5 (dist bundle patched), Telegram bot in forum supergroup.

**Exact steps or command run after this patch**:
- Configure `channels.telegram.groups[<chatId>] = { ingest: true, requireMention: true }`
- Register a `message:received` plugin hook
- Send a photo (no text, no @mention) in a group topic
- Observe gateway logs

**Evidence after fix**:
```
Before patch: log shows "skipping group media before download" and the hook never fires
After patch: media download proceeds, hook fires with the media-bearing update, plugin receives the photo
```

**Observed result after fix**: Media-bearing messages in ingest-enabled groups/topics are no longer silently skipped. Text message behavior is unchanged.

**What was not tested**: Multi-account Telegram setups; behavior with `ingest` set at topic level only (not group level); performance impact on high-traffic groups with many media messages.