### PR TITLE
fix(embedded-runner): recheck owned-writes before session takeover (#91236)

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -596,6 +596,43 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(2);
   });
 
+  // #91236 — a concurrent same-process lane (e.g. a cron-nested/main wrapper
+  // lane driving the same session as the session lane) appends to the session
+  // file through the owned-write publication path. That write must NOT be
+  // treated as a foreign session takeover, even when its owned-write record
+  // lands just after the fence first samples the owned-writes map.
+  // NOTE (needs-validation): authored against the harness conventions but not
+  // executed in the author's environment — see PR description.
+  it("does not declare a takeover for a concurrent same-process owned write (#91236)", async () => {
+    const sessionFile = await createTempSessionFile();
+    const releaseA = vi.fn(async () => {});
+    const acquireA = vi.fn(async () => ({ release: releaseA }));
+    const controllerA = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireA,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    // A releases its coarse lock for the prompt/model window.
+    await controllerA.releaseHeldLockForAbort();
+
+    // A same-process peer lane writes the same session file under its own
+    // owned-write lock, recording an owned write in the shared in-process map.
+    const releaseB = vi.fn(async () => {});
+    const acquireB = vi.fn(async () => ({ release: releaseB }));
+    const controllerB = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireB,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    await controllerB.withSessionWriteLock(async () => {
+      await fs.appendFile(sessionFile, '{"type":"tool_call","id":"peer-lane"}\n', "utf8");
+    });
+
+    // A reacquires for cleanup: the peer's append is our own process's write and
+    // must be recognised as benign, not a foreign takeover.
+    await expect(controllerA.withSessionWriteLock(() => "ok")).resolves.toBe("ok");
+    expect(controllerA.hasSessionTakeover()).toBe(false);
+  });
+
   it("runs post-prompt transcript writes under a short reacquired lock", async () => {
     const events: string[] = [];
     const acquireSessionWriteLockLocal14 = vi

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -812,6 +812,33 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       return;
     }
 
+    // #91236 — close a record-after-write race between concurrent *same-process*
+    // lanes (e.g. a `cron-nested`/`main` wrapper lane and the session lane that
+    // both drive one session). The peer lane may have written the session file
+    // but not yet called recordOwnedSessionFileWrite() when we first sampled the
+    // owned-writes map above, so its own append looks foreign. Yield once and
+    // re-sample before declaring a takeover. A foreign / cross-instance writer
+    // never populates this in-process map, so this cannot mask a real takeover —
+    // it only recognises a write made by our own concurrent lane.
+    {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      if (takeoverDetected) {
+        return;
+      }
+      const recheckCurrent = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+      const recheckOwned = ownedSessionFileWrites.get(sessionFileFenceKey);
+      if (
+        recheckOwned &&
+        recheckOwned.generation > fenceGeneration &&
+        sameSessionFileFingerprint(recheckOwned.fingerprint, recheckCurrent)
+      ) {
+        fenceFingerprint = recheckCurrent;
+        fenceSnapshot = { fingerprint: recheckCurrent };
+        fenceGeneration = recheckOwned.generation;
+        return;
+      }
+    }
+
     if (
       await sessionFenceCtimeDriftIsBenign({
         sessionFile: params.lockOptions.sessionFile,


### PR DESCRIPTION
> **Status: DRAFT — proposed fix, needs validation.** The fix and regression test were authored from source analysis against the harness conventions but **have not been executed in my environment** (deps not installed). Please treat this as a starting point for maintainer/CI review, not a verified patch. Refs #91236.

## Problem

Long-running embedded agent turns abort with `EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released`. In production this fires **deterministically** on multi-step runs dispatched through a wrapper lane — daily scheduled (`cron-nested`) jobs and delivery (`main`) turns — across multiple agents:

```
lane=cron-nested durationMs=180340  agents/cashflow/sessions/<sid>.jsonl
lane=cron-nested durationMs=97280   agents/main/sessions/<sid>.jsonl
lane=cron-nested durationMs=82233   agents/collections/sessions/<sid>.jsonl
lane=cron-nested durationMs=54274   agents/credit/sessions/<sid>.jsonl
```

Each failure is logged twice — once for the wrapper lane and once for `session:agent:<id>:…:run:<runId>` — referencing the **same session file** and **same runId**. A *direct* `openclaw agent` run (no wrapper lane) completes; only wrapper-lane runs fail. This is the same symptom as #84460 (closed not-planned).

## Root cause

A single run is driven by two **same-process** lanes (the wrapper lane and the session lane), both appending to one session JSONL. In `assertSessionFileFence()` the fence samples `ownedSessionFileWrites` once. Between a peer lane's `fs` write and its `recordOwnedSessionFileWrite()` call there is a window where the fence reads the new on-disk state but the owned-write record is still stale — so the peer lane's own append fails both the owned-write check and `sessionFenceAdvanceIsBenign()` (the appended tool-call lines aren't `isTranscriptOnlyOpenClawAssistantLine`), and a **takeover is wrongly declared**.

## Fix

Before declaring a takeover, yield once (`setImmediate`) and re-sample `ownedSessionFileWrites` / the current fingerprint. If a same-process owned write now matches, the change is recognised as benign.

**Why this is safe:** `ownedSessionFileWrites` is per-process. A genuine foreign / cross-instance takeover never populates *this* process's map, so the re-check still won't find a matching owned write and the takeover is still raised. The change only affects the case where our *own* concurrent lane made the write — i.e. it narrows a false positive without weakening cross-instance protection. Worst case it adds a single microtask before an error that was about to throw anyway.

## Test

Added `does not declare a takeover for a concurrent same-process owned write (#91236)` — the benign complement of the existing `keeps the session fence active after releasing for sessions_yield abort cleanup` test (which exercises a *foreign* append). **Not executed locally** — needs CI.

## Open questions for maintainers
- Is the cleaner fix at the **dispatch** layer (ensure one run executes in exactly one lane, with the wrapper delegating to/awaiting the session lane) rather than in the fence? That would remove the concurrent-writer condition entirely.
- Should the `setImmediate` re-check be bounded/looped for very tight interleavings, or is a single yield sufficient given the owned-write record is synchronous after the write resolves?
