### PR TITLE
fix(plugins): keep CLI auth backends out of startup agent harnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Docker: add `OPENCLAW_INSTALL_CLAUDE_CLI` build arg to optionally install the Anthropic Claude Code CLI with a pinned SHA-512 integrity check, enabling the `claude-cli` agent runtime inside the container.
 - CLI progress: emit Claude CLI commentary progress events and bridge inter-tool commentary into channel progress without exposing internal protocol scaffolding. (#89834, #90883) Thanks @anagnorisis2peripeteia.
 - Observability: allow trusted diagnostics channels to capture tool input/output content, add first-assistant-event traces, and warn on slow initial replies. (#91256, #91568, #91583) Thanks @amknight.
 - Plugins/ClawHub: dogfood reusable package publishing, let dry runs skip publish approval, allow declared installed trusted hooks, report managed plugin version drift, and warn instead of failing on retired Skill Workshop configuration. (#91574, #91591, #90004, #90927, #90838) Thanks @Patrick-Erichsen, @brokemac79, and @lonexreb.
@@ -24,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins: stop folding CLI auth backends into `startup.agentHarnesses`, so login backends such as Anthropic's `claude-cli` no longer fail startup harness selection with "Requested agent harness is not registered".
 - Agent/session recovery: drop stale approval follow-ups after session rebind, remove drained reply-queue items by identity, recover stale main and visible replies, preserve Codex context-engine compaction ownership, lower the default compaction timeout to 180 seconds while respecting explicit configuration, and keep provider-failure terminal lifecycle state correct. (#85679, #91450, #91566, #91840, #91590, #91361, #91895) Thanks @openperf, @yetval, @joshavant, @wangmiao0668000666, and @TurboTheTurtle.
 - User-visible content boundaries: suppress Codex/Harmony protocol artifacts, neutralize browser and LanceDB memory media directives, redact transcript images, and preserve native `/compact` replies through source suppression. (#89151, #91422, #91425, #91529, #90212) Thanks @joelnishanth, @pgondhi987, @joshavant, and @snowzlm.
 - Channel delivery: keep WhatsApp captured replies attached to the successor controller after restart, retry Feishu rate limits, preserve Mattermost thread replies, canonicalize LINE webhook paths, restore Discord reply hydration and runtime timeout exports, and show OpenAI Realtime WebRTC assistant transcripts. (#85823, #89659, #91684, #91649, #90263, #91686, #90426) Thanks @itsuzef, @ladygege, @jacobtomlinson, @fuller-stack-dev, and @shushushv.

--- a/Dockerfile
+++ b/Dockerfile
@@ -288,6 +288,37 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
         docker-ce-cli docker-compose-plugin; \
     fi
 
+# Optionally install Anthropic Claude Code CLI for the claude-cli agent runtime
+# (Claude Max/Pro subscription reuse). Build with:
+#   docker build --build-arg OPENCLAW_INSTALL_CLAUDE_CLI=1 ...
+# Override version with --build-arg OPENCLAW_CLAUDE_CLI_VERSION=<semver> and
+# its matching --build-arg OPENCLAW_CLAUDE_CLI_INTEGRITY=sha512-<base64>.
+# Get the integrity for a version with:
+#   npm view @anthropic-ai/claude-code@<semver> dist.integrity
+# Requires `~/.claude` and `~/.claude.json` from the host to be bind-mounted at
+# runtime for credential reuse. Adds ~230MB (bundled native binaries per arch).
+ARG OPENCLAW_INSTALL_CLAUDE_CLI=""
+ARG OPENCLAW_CLAUDE_CLI_VERSION="2.1.154"
+ARG OPENCLAW_CLAUDE_CLI_INTEGRITY="sha512-1LSc7Jtm7Jy/GgqzoC4jDtTeV4GphGdB2+r49QDJnDa4fDsJfxVHR4TQNETeyNtGw/uD1+voo7f2Vhjldyqe8w=="
+RUN --mount=type=cache,id=openclaw-npm-cache,target=/root/.npm,sharing=locked \
+    if [ -n "$OPENCLAW_INSTALL_CLAUDE_CLI" ]; then \
+      set -eu; \
+      tarball="$(npm pack "@anthropic-ai/claude-code@${OPENCLAW_CLAUDE_CLI_VERSION}" --silent)"; \
+      # Verify the downloaded tarball against the pinned subresource integrity
+      # before letting it install. Refuses any registry-served bytes whose
+      # SHA-512 does not match the build-time pin (mirrors the Docker apt key
+      # fingerprint-check pattern above).
+      expected="${OPENCLAW_CLAUDE_CLI_INTEGRITY#sha512-}"; \
+      actual="$(openssl dgst -sha512 -binary "$tarball" | openssl base64 -A)"; \
+      if [ "$actual" != "$expected" ]; then \
+        echo "ERROR: @anthropic-ai/claude-code@${OPENCLAW_CLAUDE_CLI_VERSION} integrity mismatch" >&2; \
+        echo "  expected sha512-$expected" >&2; \
+        echo "  actual   sha512-$actual" >&2; \
+        exit 1; \
+      fi; \
+      npm install -g "./$tarball" && rm -f "$tarball"; \
+    fi
+
 # Expose the CLI binary without requiring npm global writes as non-root.
 RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
  && chmod 755 /app/openclaw.mjs

--- a/src/plugins/installed-plugin-index-record-builder.ts
+++ b/src/plugins/installed-plugin-index-record-builder.ts
@@ -29,10 +29,11 @@ function buildStartupInfo(record: PluginManifestRecord): InstalledPluginStartupI
     memory: hasKind(record.kind, "memory"),
     deferConfiguredChannelFullLoadUntilAfterListen:
       record.startupDeferConfiguredChannelFullLoadUntilAfterListen === true,
-    agentHarnesses: normalizeSortedUniqueStringEntries([
-      ...(record.activation?.onAgentHarnesses ?? []),
-      ...(record.cliBackends ?? []),
-    ]),
+    // Only manifest-declared agent harnesses belong here. CLI backends are auth
+    // backends (e.g. anthropic's `claude-cli`), not agent harness runtimes;
+    // folding them in made startup planning treat a login backend as a required
+    // harness, which then failed harness selection with "not registered".
+    agentHarnesses: normalizeSortedUniqueStringEntries(record.activation?.onAgentHarnesses ?? []),
     configPaths: normalizeSortedUniqueStringEntries(record.activation?.onConfigPaths),
   };
 }

--- a/src/plugins/installed-plugin-index.test.ts
+++ b/src/plugins/installed-plugin-index.test.ts
@@ -250,6 +250,12 @@ describe("installed plugin index", () => {
         "provider-auth-env-vars",
       ],
     });
+    // Startup harness runtimes come only from `activation.onAgentHarnesses`.
+    // CLI backends (e.g. `demo-cli`) are auth backends, not harness runtimes, so
+    // they must not leak into `startup.agentHarnesses` (regression: a folded
+    // `claude-cli` made startup treat a login backend as a required harness and
+    // failed harness selection with "not registered").
+    expect(readRecordField(plugin, "startup", "startup info").agentHarnesses).toEqual(["codex"]);
     expectRecordFields(readRecordField(plugin, "packageInstall", "package install"), {
       defaultChoice: "npm",
       npm: {


### PR DESCRIPTION
## Summary

CLI backends declared in a plugin manifest's `cliBackends` (e.g. Anthropic's `claude-cli`) are **auth backends**, not agent harness runtimes. The installed-plugin-index record builder was folding them into `startup.agentHarnesses`, so startup planning treated a login backend as a required harness and then failed harness selection with:

```
Requested agent harness "claude-cli" is not registered.
```

This PR limits `startup.agentHarnesses` to manifest-declared `activation.onAgentHarnesses` only.

- `src/plugins/installed-plugin-index-record-builder.ts`: stop folding `record.cliBackends` into the startup harness list (keeps the `normalizeSortedUniqueStringEntries` helper and `configPaths` field from current `main`).
- `src/plugins/installed-plugin-index.test.ts`: regression assertion that a CLI backend (`demo-cli`) does not leak into `startup.agentHarnesses`.
- `Dockerfile`: optional `OPENCLAW_INSTALL_CLAUDE_CLI` build arg to install the Claude Code CLI with a pinned SHA-512 integrity check (verified against `npm view dist.integrity` before install), enabling the `claude-cli` agent runtime inside the container.
- `CHANGELOG.md`: Fixes + Changes entries.

## Verification

Local, on this branch rebased onto latest `origin/main`:

```
pnpm test src/plugins/installed-plugin-index.test.ts   # 30/30 passed
pnpm tsgo                                              # exit 0
pnpm check:changed                                     # oxlint clean, 0 runtime import cycles, all guards pass
```

Real after-fix behavior proof (live Docker gateway, 2026-06-12):

- Before: a gateway container running the `anthropic` plugin with `claude-cli` as a CLI auth backend failed startup harness selection with `Requested agent harness "claude-cli" is not registered`.
- After: rebuilt the image from this branch (`docker compose build` with `--build-arg OPENCLAW_INSTALL_CLAUDE_CLI=1`) and recreated the container. Result: container healthy, **zero** `error`/`fail` lines in startup logs, the "not registered" harness error is gone, and `claude --version` inside the container reports `2.1.154 (Claude Code)` — matching the pinned integrity version.
