### PR TITLE
fix(gateway): notify parent session on sub-agent run timeout

### DIFF
--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -471,7 +471,12 @@ export async function waitForAgentJob(params: {
 
     const timer = setSafeTimeout(() => {
       const pendingError = getPendingAgentRunError(runId);
-      finish(pendingError ? createPendingErrorTimeoutSnapshot(pendingError.snapshot) : null);
+      if (pendingError) {
+        finish(createPendingErrorTimeoutSnapshot(pendingError.snapshot));
+        return;
+      }
+      const pendingTimeout = getPendingAgentRunTimeout(runId);
+      finish(pendingTimeout ? pendingTimeout.snapshot : null);
     }, timeoutMs);
     const onAbort: (() => void) | undefined = () => finish(null);
     signal?.addEventListener("abort", onAbort, { once: true });


### PR DESCRIPTION
## Summary

Fixes #89095. When a sub-agent run is force-killed by its `runTimeoutSeconds`, the parent session receives **no completion/timeout event** and waits indefinitely. The root cause is an asymmetric check in the wait-timer fallback of `waitForAgentJob`: it consults `getPendingAgentRunError` but ignores `getPendingAgentRunTimeout`.

## Change

In `src/gateway/server-methods/agent-job.ts`, the wait-timer fallback now checks both pending error and pending timeout:

```typescript
// Before:
const timer = setSafeTimeout(() => {
  const pendingError = getPendingAgentRunError(runId);
  finish(pendingError ? createPendingErrorTimeoutSnapshot(pendingError.snapshot) : null);
}, timeoutMs);

// After:
const timer = setSafeTimeout(() => {
  const pendingError = getPendingAgentRunError(runId);
  if (pendingError) {
    finish(createPendingErrorTimeoutSnapshot(pendingError.snapshot));
    return;
  }
  const pendingTimeout = getPendingAgentRunTimeout(runId);
  finish(pendingTimeout ? pendingTimeout.snapshot : null);
}, timeoutMs);
```

`getPendingAgentRunTimeout` already exists with a matching signature. This preserves error precedence and ensures the timeout snapshot's `endedAt`/`stopReason` are retained, making `isTerminalWaitTimeout` true downstream so the parent receives the timeout completion event.

## Real behavior proof

**Behavior or issue addressed**: Sub-agent run timeout force-kills the child but parent session never gets a completion event, waiting indefinitely.

**Real environment tested**: Linux (WSL2), Node v24.16.0, OpenClaw 2026.6.5.

**Exact steps or command run after this patch**:
- Spawn a sub-agent with `runTimeoutSeconds: 5` and a task that runs `sleep 600`
- Wait for the timeout to fire
- Check if parent session receives a completion event

**Evidence after fix**:
```
Before: parent waits indefinitely, subagents(action=list) shows status: "timeout" with endedAt set, but no event arrives
After: parent receives timeout completion event with endedAt and stopReason, allowing proper cleanup
```

**Observed result after fix**: Parent session is properly notified when sub-agent times out. Normal completion behavior is unchanged.

**What was not tested**: Interaction with the secondary `hasFailedSubagentNoOutputCompletion` path; multi-agent concurrent timeouts; very short timeout values (< 1s).