### PR TITLE
fix(cron): skip async task wait after sessions_yield to prevent AbortError in isolated cron runs

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4540,6 +4540,7 @@ export async function runEmbeddedAttempt(
         await sessionLockController.releaseForPrompt();
 
         if (
+          !yieldAborted &&
           requiresCompletionRequiredAsyncTaskWait({
             sessionKey: params.sessionKey,
             toolMetas,


### PR DESCRIPTION
## Summary

When `sessions_yield` fires in an isolated cron session, the `runAbortController` is aborted with reason `"sessions_yield"`. The subsequent completion-required async task wait block at line ~4542 passes this already-aborted signal to `waitForCompletionRequiredAsyncTasks`, which calls `throwIfAborted()` and throws immediately — converting the intentional yield into a fatal `AbortError`.

This means any isolated cron workflow that uses `image_generate` → `sessions_yield` → more steps will silently fail after the image step, even though the image is generated successfully.

## Fix

Add `!yieldAborted` guard to the async task wait condition. When the run ended due to `sessions_yield`, skip the completion-required wait. The generated media callback will arrive independently and trigger a continuation turn on the yielded session.

## Changes

- `src/agents/embedded-agent-runner/run/attempt.ts`: Add `!yieldAborted &&` guard before `requiresCompletionRequiredAsyncTaskWait()` check.

## Real behavior proof

**Behavior or issue addressed:** In isolated cron sessions, calling `image_generate` followed by `sessions_yield` causes the runner to abort with `AbortError: aborted` instead of cleanly yielding. The media callback arrives after the session is dead, so post-yield steps never execute.

**Real environment tested:** Ubuntu 24.04 (Linux 6.17.0, arm64), OpenClaw 2026.6.5, Node v24.16.0, commit 3d6252a5 (current upstream/main).

**Exact steps or command run after this patch:**
```
OPENCLAW_TEST_FAST=1 npx vitest run --config test/vitest/vitest.unit-fast.config.ts src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts
```

**Evidence after fix:**
```
 ✓ unit-fast src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts (7 tests) 619ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  15:43:56
   Duration  37.43s
```

**Observed result after fix:** All 7 existing async-tasks unit tests pass. The `!yieldAborted` guard ensures `waitForCompletionRequiredAsyncTasks` is not called when the run was intentionally yielded via `sessions_yield`, preventing the spurious `AbortError`. The yield flow continues to its existing cleanup path: strip artifacts, persist yield context, release session lock.

**What was not tested:** Live cron execution with actual `image_generate` → `sessions_yield` → callback continuation was not tested in this environment (requires a running OpenClaw gateway with image generation provider). The orchestration-level integration test (`sessions-yield.orchestration.test.ts`) validates the broader yield flow at the mock level.

**Proof limitations:** This is a source-level fix validated by unit tests. Full end-to-end proof requires a live isolated cron job with a real image generation provider.