### PR TITLE
fix(btw): resolve agentRuntime alias models in /btw side questions

### DIFF
--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -258,12 +258,25 @@ async function resolveRuntimeModel(params: {
   await ensureOpenClawModelsJson(params.cfg, params.agentDir, modelsOptions);
   const authStorage = discoverAuthStorage(params.agentDir);
   const modelRegistry = discoverModels(authStorage, params.agentDir, modelsOptions);
-  const model = resolveModelWithRegistry({
+  let model = resolveModelWithRegistry({
     provider: params.provider,
     modelId: params.model,
     modelRegistry,
     cfg: params.cfg,
   });
+  if (!model) {
+    // When the agent's primary model is configured as a canonical alias
+    // routed via agentRuntime (e.g. anthropic/claude-opus-4-7 with
+    // agentRuntime.id: claude-cli), the model won't be in the standard
+    // registry.  Synthesize a minimal model so the downstream harness
+    // selection (selectAgentHarness) can route through the configured
+    // runtime (issue #92168).
+    const agentDefaultsModels = params.cfg?.agents?.defaults?.models;
+    const agentModelKey = `${params.provider}/${params.model}`;
+    if (agentDefaultsModels?.[agentModelKey]?.agentRuntime) {
+      model = { id: params.model, provider: params.provider };
+    }
+  }
   if (!model) {
     throw new Error(`Unknown model: ${params.provider}/${params.model}`);
   }


### PR DESCRIPTION
## Summary

Fixes #92168: `/btw` throws `Unknown model` when the agent model is configured as a canonical alias routed via `agentRuntime.id` (e.g. `anthropic/claude-opus-4-7` with `agentRuntime.id: claude-cli`).

**Root cause**: `resolveRuntimeModel` calls `resolveModelWithRegistry` which does a strict registry lookup. When the model is only configured as an `agentRuntime` alias, the lookup fails.

**Fix**: When the registry lookup fails, check `cfg.agents.defaults.models` for a matching `agentRuntime` config. If found, synthesize a minimal model so downstream `selectAgentHarness` can route correctly.

## Real behavior proof

- **Command**: `node scripts/run-vitest.mjs run src/agents/btw.test.ts`
- **Result**: 33/33 passed

Closes #92168.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Code <noreply@anthropic.com>