### PR TITLE
refactor: move workspace skill writes to lifecycle

### DIFF
--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -116,7 +116,8 @@ vi.mock("../config/logging.js", () => ({
   logConfigUpdated: mocks.logConfigUpdated,
 }));
 
-vi.mock("../utils.js", () => ({
+vi.mock("../utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils.js")>()),
   isRecord: mocks.isRecord,
   shortenHomePath: mocks.shortenHomePath,
 }));

--- a/src/skills/lifecycle/workspace-skill-write.ts
+++ b/src/skills/lifecycle/workspace-skill-write.ts
@@ -196,14 +196,14 @@ async function prepareWorkspaceSkillWrite(params: {
       symlinkPolicy: params.symlinkPolicy,
     });
     if (params.mode === "update") {
-      const previousContent = await readWorkspaceSupportFile({
+      const previousSupportContent = await readWorkspaceSupportFile({
         skillDir: params.skillDir,
         relativePath: file.path,
       });
       previousSupportFiles.push(
-        previousContent === null
+        previousSupportContent === null
           ? { path: file.path, existed: false }
-          : { path: file.path, existed: true, previousContent },
+          : { path: file.path, existed: true, previousContent: previousSupportContent },
       );
     }
   }

--- a/src/skills/lifecycle/workspace-skill-write.ts
+++ b/src/skills/lifecycle/workspace-skill-write.ts
@@ -13,10 +13,12 @@ type WorkspaceSkillSymlinkWritePolicy = {
   allowWrites: boolean;
   allowedTargetRealPaths: readonly string[];
 };
+type WorkspaceSkillSupportFileWrite = { path: string; content: string };
 
-type WorkspaceSkillSupportFileWrite = {
-  path: string;
-  content: string;
+type WorkspaceSkillWriteTargetParams = {
+  workspaceDir: string;
+  filePath: string;
+  symlinkPolicy: WorkspaceSkillSymlinkWritePolicy;
 };
 
 type PreviousSupportFile = { path: string; existed: boolean; previousContent?: string };
@@ -96,6 +98,12 @@ export async function readWorkspaceSupportFile(params: {
   return read.buffer.toString("utf8");
 }
 
+export async function assertWorkspaceSkillWriteTarget(
+  params: WorkspaceSkillWriteTargetParams,
+): Promise<void> {
+  await resolveWorkspaceSkillWriteTarget(params);
+}
+
 export async function writeWorkspaceSkill(params: {
   workspaceDir: string;
   skillDir: string;
@@ -106,7 +114,6 @@ export async function writeWorkspaceSkill(params: {
   symlinkPolicy: WorkspaceSkillSymlinkWritePolicy;
 }): Promise<void> {
   assertInsideWorkspace(params.workspaceDir, params.skillDir, "skill directory");
-  assertInsideWorkspace(params.workspaceDir, params.skillFile, "skill file");
   const supportFiles = normalizeSupportFiles(params.supportFiles ?? []);
   const previousSupportFiles = await prepareWorkspaceSkillWrite({
     mode: params.mode,
@@ -188,22 +195,19 @@ async function prepareWorkspaceSkillWrite(params: {
       filePath,
       symlinkPolicy: params.symlinkPolicy,
     });
-    const previousContent = await readWorkspaceSupportFile({
-      skillDir: params.skillDir,
-      relativePath: file.path,
-    });
-    if (params.mode === "create" && previousContent !== null) {
-      throw new Error(
-        `Target support file already exists: ${path.join(params.skillDir, file.path)}`,
+    if (params.mode === "update") {
+      const previousContent = await readWorkspaceSupportFile({
+        skillDir: params.skillDir,
+        relativePath: file.path,
+      });
+      previousSupportFiles.push(
+        previousContent === null
+          ? { path: file.path, existed: false }
+          : { path: file.path, existed: true, previousContent },
       );
     }
-    previousSupportFiles.push(
-      previousContent === null
-        ? { path: file.path, existed: false }
-        : { path: file.path, existed: true, previousContent },
-    );
   }
-  return params.mode === "update" ? previousSupportFiles : [];
+  return previousSupportFiles;
 }
 
 async function writeWorkspaceFile(params: {
@@ -268,11 +272,9 @@ async function restoreSupportFilesAfterFailedWrite(params: {
   );
 }
 
-async function resolveWorkspaceSkillWriteTarget(params: {
-  workspaceDir: string;
-  filePath: string;
-  symlinkPolicy: WorkspaceSkillSymlinkWritePolicy;
-}): Promise<{ rootDir: string; relativePath: string }> {
+async function resolveWorkspaceSkillWriteTarget(
+  params: WorkspaceSkillWriteTargetParams,
+): Promise<{ rootDir: string; relativePath: string }> {
   assertInsideWorkspace(params.workspaceDir, params.filePath, "skill file");
   const workspaceDir = path.resolve(params.workspaceDir);
   const filePath = path.resolve(params.filePath);

--- a/src/skills/lifecycle/workspace-skill-write.ts
+++ b/src/skills/lifecycle/workspace-skill-write.ts
@@ -1,0 +1,347 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathExists, root } from "../../infra/fs-safe.js";
+import { isPathInside } from "../../infra/path-safety.js";
+import { findContainingAllowedSkillSymlinkTarget } from "../loading/symlink-targets.js";
+
+const ALLOWED_SUPPORT_FILE_ROOTS = new Set(
+  "assets examples references scripts templates".split(" "),
+);
+export const MAX_WORKSPACE_SKILL_SUPPORT_FILE_BYTES = 256 * 1024;
+
+type WorkspaceSkillSymlinkWritePolicy = {
+  allowWrites: boolean;
+  allowedTargetRealPaths: readonly string[];
+};
+
+type WorkspaceSkillSupportFileWrite = {
+  path: string;
+  content: string;
+};
+
+type PreviousSupportFile = { path: string; existed: boolean; previousContent?: string };
+
+export function normalizeWorkspaceSkillSupportPath(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("Support file path is required.");
+  }
+  if (trimmed.includes("\\")) {
+    throw new Error("Support file paths must use forward slashes.");
+  }
+  if (path.posix.isAbsolute(trimmed)) {
+    throw new Error("Support file paths must be relative.");
+  }
+  if (
+    trimmed
+      .split("/")
+      .some((part) => !part || part === "." || part === ".." || part.startsWith("."))
+  ) {
+    throw new Error("Support file paths must use plain relative path segments.");
+  }
+  if (!ALLOWED_SUPPORT_FILE_ROOTS.has(trimmed.split("/")[0] ?? "")) {
+    throw new Error(
+      `Support file paths must be under one of: ${[...ALLOWED_SUPPORT_FILE_ROOTS].join(", ")}.`,
+    );
+  }
+  if (trimmed === "PROPOSAL.md" || trimmed === "SKILL.md") {
+    throw new Error("Support files cannot replace the proposal or skill markdown file.");
+  }
+  return trimmed;
+}
+
+export function assertWorkspaceSkillSupportPathSetIsFileOnly(paths: readonly string[]): void {
+  const sorted = paths.toSorted((a, b) => a.localeCompare(b));
+  for (const filePath of sorted) {
+    if (!filePath.includes("/")) {
+      throw new Error("Support file paths must include a file below an allowed support directory.");
+    }
+  }
+  for (let index = 1; index < sorted.length; index += 1) {
+    const previous = sorted[index - 1];
+    const current = sorted[index];
+    if (previous && current?.startsWith(`${previous}/`)) {
+      throw new Error(`Support file paths cannot overlap: ${previous} and ${current}`);
+    }
+  }
+}
+
+export async function readWorkspaceSkillFile(filePath: string): Promise<string | null> {
+  if (!(await pathExists(filePath))) {
+    return null;
+  }
+  const skillRoot = await root(path.dirname(filePath));
+  const read = await skillRoot.read(path.basename(filePath), {
+    hardlinks: "reject",
+    maxBytes: 1024 * 1024,
+    symlinks: "reject",
+  });
+  return read.buffer.toString("utf8");
+}
+
+export async function readWorkspaceSupportFile(params: {
+  skillDir: string;
+  relativePath: string;
+}): Promise<string | null> {
+  const relativePath = normalizeWorkspaceSkillSupportPath(params.relativePath);
+  if (!(await pathExists(path.join(params.skillDir, ...relativePath.split("/"))))) {
+    return null;
+  }
+  const skillRoot = await root(params.skillDir);
+  const read = await skillRoot.read(relativePath, {
+    hardlinks: "reject",
+    maxBytes: MAX_WORKSPACE_SKILL_SUPPORT_FILE_BYTES,
+    symlinks: "reject",
+  });
+  return read.buffer.toString("utf8");
+}
+
+export async function writeWorkspaceSkill(params: {
+  workspaceDir: string;
+  skillDir: string;
+  skillFile: string;
+  content: string;
+  supportFiles?: readonly WorkspaceSkillSupportFileWrite[];
+  mode: "create" | "update";
+  symlinkPolicy: WorkspaceSkillSymlinkWritePolicy;
+}): Promise<void> {
+  assertInsideWorkspace(params.workspaceDir, params.skillDir, "skill directory");
+  assertInsideWorkspace(params.workspaceDir, params.skillFile, "skill file");
+  const supportFiles = normalizeSupportFiles(params.supportFiles ?? []);
+  const previousSupportFiles = await prepareWorkspaceSkillWrite({
+    mode: params.mode,
+    workspaceDir: params.workspaceDir,
+    skillDir: params.skillDir,
+    skillFile: params.skillFile,
+    supportFiles,
+    symlinkPolicy: params.symlinkPolicy,
+  });
+  const writtenSupportPaths: string[] = [];
+  try {
+    for (const file of supportFiles) {
+      await writeWorkspaceFile({
+        workspaceDir: params.workspaceDir,
+        filePath: path.join(params.skillDir, ...file.path.split("/")),
+        content: file.content,
+        overwrite: params.mode === "update",
+        symlinkPolicy: params.symlinkPolicy,
+      });
+      writtenSupportPaths.push(file.path);
+    }
+    await writeWorkspaceFile({
+      workspaceDir: params.workspaceDir,
+      filePath: params.skillFile,
+      content: params.content,
+      overwrite: params.mode === "update",
+      symlinkPolicy: params.symlinkPolicy,
+    });
+  } catch (error) {
+    await restoreSupportFilesAfterFailedWrite({
+      mode: params.mode,
+      workspaceDir: params.workspaceDir,
+      skillDir: params.skillDir,
+      writtenSupportPaths,
+      previousSupportFiles,
+      symlinkPolicy: params.symlinkPolicy,
+    });
+    throw error;
+  }
+}
+
+function normalizeSupportFiles(
+  supportFiles: readonly WorkspaceSkillSupportFileWrite[],
+): WorkspaceSkillSupportFileWrite[] {
+  const normalized = supportFiles.map((file) => ({
+    ...file,
+    path: normalizeWorkspaceSkillSupportPath(file.path),
+  }));
+  assertWorkspaceSkillSupportPathSetIsFileOnly(normalized.map((file) => file.path));
+  return normalized;
+}
+
+async function prepareWorkspaceSkillWrite(params: {
+  mode: "create" | "update";
+  workspaceDir: string;
+  skillDir: string;
+  skillFile: string;
+  supportFiles: readonly WorkspaceSkillSupportFileWrite[];
+  symlinkPolicy: WorkspaceSkillSymlinkWritePolicy;
+}): Promise<PreviousSupportFile[]> {
+  await resolveWorkspaceSkillWriteTarget({
+    workspaceDir: params.workspaceDir,
+    filePath: params.skillFile,
+    symlinkPolicy: params.symlinkPolicy,
+  });
+  const previousContent = await readWorkspaceSkillFile(params.skillFile);
+  if (params.mode === "create" && previousContent !== null) {
+    throw new Error(`Target skill already exists: ${params.skillFile}`);
+  }
+  if (params.mode === "update" && previousContent === null) {
+    throw new Error(`Target skill is missing: ${params.skillFile}`);
+  }
+
+  const previousSupportFiles: PreviousSupportFile[] = [];
+  for (const file of params.supportFiles) {
+    const filePath = path.join(params.skillDir, ...file.path.split("/"));
+    await resolveWorkspaceSkillWriteTarget({
+      workspaceDir: params.workspaceDir,
+      filePath,
+      symlinkPolicy: params.symlinkPolicy,
+    });
+    const previousContent = await readWorkspaceSupportFile({
+      skillDir: params.skillDir,
+      relativePath: file.path,
+    });
+    if (params.mode === "create" && previousContent !== null) {
+      throw new Error(
+        `Target support file already exists: ${path.join(params.skillDir, file.path)}`,
+      );
+    }
+    previousSupportFiles.push(
+      previousContent === null
+        ? { path: file.path, existed: false }
+        : { path: file.path, existed: true, previousContent },
+    );
+  }
+  return params.mode === "update" ? previousSupportFiles : [];
+}
+
+async function writeWorkspaceFile(params: {
+  workspaceDir: string;
+  filePath: string;
+  content: string;
+  overwrite: boolean;
+  symlinkPolicy: WorkspaceSkillSymlinkWritePolicy;
+}): Promise<void> {
+  const target = await resolveWorkspaceSkillWriteTarget(params);
+  const targetRoot = await root(target.rootDir);
+  await targetRoot.write(target.relativePath, params.content, {
+    encoding: "utf8",
+    mkdir: true,
+    overwrite: params.overwrite,
+  });
+}
+
+async function removeWorkspaceFile(params: {
+  workspaceDir: string;
+  filePath: string;
+  symlinkPolicy: WorkspaceSkillSymlinkWritePolicy;
+}): Promise<void> {
+  const target = await resolveWorkspaceSkillWriteTarget(params);
+  const targetRoot = await root(target.rootDir);
+  await targetRoot.remove(target.relativePath).catch((error: unknown) => {
+    if ((error as { code?: string })?.code !== "ENOENT") {
+      throw error;
+    }
+  });
+}
+
+async function restoreSupportFilesAfterFailedWrite(params: {
+  mode: "create" | "update";
+  workspaceDir: string;
+  skillDir: string;
+  writtenSupportPaths: readonly string[];
+  previousSupportFiles: readonly PreviousSupportFile[];
+  symlinkPolicy: WorkspaceSkillSymlinkWritePolicy;
+}): Promise<void> {
+  const previousByPath = new Map(params.previousSupportFiles.map((file) => [file.path, file]));
+  await Promise.allSettled(
+    params.writtenSupportPaths.toReversed().map(async (relativePath) => {
+      const filePath = path.join(params.skillDir, ...relativePath.split("/"));
+      const previous = previousByPath.get(relativePath);
+      if (params.mode === "update" && previous?.existed) {
+        await writeWorkspaceFile({
+          workspaceDir: params.workspaceDir,
+          filePath,
+          content: previous.previousContent ?? "",
+          overwrite: true,
+          symlinkPolicy: params.symlinkPolicy,
+        });
+      } else {
+        await removeWorkspaceFile({
+          workspaceDir: params.workspaceDir,
+          filePath,
+          symlinkPolicy: params.symlinkPolicy,
+        });
+      }
+    }),
+  );
+}
+
+async function resolveWorkspaceSkillWriteTarget(params: {
+  workspaceDir: string;
+  filePath: string;
+  symlinkPolicy: WorkspaceSkillSymlinkWritePolicy;
+}): Promise<{ rootDir: string; relativePath: string }> {
+  assertInsideWorkspace(params.workspaceDir, params.filePath, "skill file");
+  const workspaceDir = path.resolve(params.workspaceDir);
+  const filePath = path.resolve(params.filePath);
+  const aliasTarget = await resolveWorkspaceAliasTarget({ workspaceDir, filePath });
+  if (!aliasTarget) {
+    return { rootDir: workspaceDir, relativePath: path.relative(workspaceDir, filePath) };
+  }
+  const allowedRoot = params.symlinkPolicy.allowWrites
+    ? findContainingAllowedSkillSymlinkTarget(
+        params.symlinkPolicy.allowedTargetRealPaths,
+        aliasTarget.realTarget,
+      )
+    : null;
+  if (!allowedRoot) {
+    throw new Error(
+      `Skill file resolves through an untrusted symlink target: ${params.filePath}. Configure skills.load.allowSymlinkTargets and enable skills.workshop.allowSymlinkTargetWrites for intentional Skill Workshop symlink writes.`,
+    );
+  }
+  return {
+    rootDir: allowedRoot,
+    relativePath: path.relative(allowedRoot, aliasTarget.realTarget),
+  };
+}
+
+async function resolveWorkspaceAliasTarget(params: {
+  workspaceDir: string;
+  filePath: string;
+}): Promise<{ realTarget: string } | null> {
+  const workspaceRealPath = (await tryRealpath(params.workspaceDir)) ?? params.workspaceDir;
+  const realTarget = await resolveRealPathThroughExistingAncestors(
+    params.workspaceDir,
+    params.filePath,
+  );
+  return isPathInside(workspaceRealPath, realTarget) ? null : { realTarget };
+}
+
+async function resolveRealPathThroughExistingAncestors(
+  workspaceDir: string,
+  filePath: string,
+): Promise<string> {
+  const segments = path.relative(workspaceDir, filePath).split(path.sep).filter(Boolean);
+  let lexicalCursor = workspaceDir;
+  let realCursor = (await tryRealpath(workspaceDir)) ?? workspaceDir;
+  for (const segment of segments) {
+    lexicalCursor = path.join(lexicalCursor, segment);
+    realCursor = (await tryRealpath(lexicalCursor)) ?? path.join(realCursor, segment);
+  }
+  return path.resolve(realCursor);
+}
+
+async function tryRealpath(filePath: string): Promise<string | null> {
+  try {
+    return await fs.realpath(filePath);
+  } catch {
+    return null;
+  }
+}
+
+export function assertInsideWorkspace(
+  workspaceDir: string,
+  targetPath: string,
+  label: string,
+): void {
+  const resolvedWorkspaceDir = path.resolve(workspaceDir);
+  const resolvedTarget = path.resolve(targetPath);
+  if (
+    resolvedTarget !== resolvedWorkspaceDir &&
+    !isPathInside(resolvedWorkspaceDir, resolvedTarget)
+  ) {
+    throw new Error(`${label} must stay inside the workspace.`);
+  }
+}

--- a/src/skills/research/autocapture.ts
+++ b/src/skills/research/autocapture.ts
@@ -1,9 +1,10 @@
 // Research autocapture helpers decide when skill research signals should be captured.
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { readWorkspaceSkillFile } from "../lifecycle/workspace-skill-write.js";
 import { resolveSkillWorkshopConfig } from "../workshop/config.js";
 import { listSkillProposals, proposeCreateSkill, proposeUpdateSkill } from "../workshop/service.js";
-import { readWorkspaceSkillFile, resolveSkillProposalTarget } from "../workshop/store.js";
+import { resolveSkillProposalTarget } from "../workshop/store.js";
 import { extractDurableInstructionProposal } from "./signals.js";
 
 type SkillResearchAgentEndEvent = {

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -1,4 +1,3 @@
-// Workshop service orchestrates skill draft creation, validation, and persistence.
 import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -12,6 +11,7 @@ import {
 } from "../discovery/status.js";
 import {
   assertInsideWorkspace,
+  assertWorkspaceSkillWriteTarget,
   MAX_WORKSPACE_SKILL_SUPPORT_FILE_BYTES,
   normalizeWorkspaceSkillSupportPath,
   readWorkspaceSkillFile,
@@ -538,6 +538,11 @@ export async function applySkillProposal(
         ? resolveAllowedSkillSymlinkTargetRealPaths(input.config)
         : [],
     };
+    await assertWorkspaceSkillWriteTarget({
+      workspaceDir: input.workspaceDir,
+      filePath: record.target.skillFile,
+      symlinkPolicy,
+    });
     const targetState = await readApplyTargetState(record, supportFiles);
     const rollback = createSkillProposalRollback({
       proposalId: record.id,

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -10,6 +10,14 @@ import {
   resolveSkillStatusEntry,
   type SkillStatusEntry,
 } from "../discovery/status.js";
+import {
+  assertInsideWorkspace,
+  MAX_WORKSPACE_SKILL_SUPPORT_FILE_BYTES,
+  normalizeWorkspaceSkillSupportPath,
+  readWorkspaceSkillFile,
+  readWorkspaceSupportFile,
+  writeWorkspaceSkill,
+} from "../lifecycle/workspace-skill-write.js";
 import { resolveAllowedSkillSymlinkTargetRealPaths } from "../loading/symlink-targets.js";
 import { bumpSkillsSnapshotVersion } from "../runtime/refresh-state.js";
 import { scanSkillContent, scanSource } from "../security/scanner.js";
@@ -20,30 +28,21 @@ import {
   stripProposalFrontmatterForSkill,
 } from "./frontmatter.js";
 import {
-  assertInsideWorkspace,
-  assertWorkspaceSkillWriteTarget,
   createSkillProposalId,
   createSkillProposalRollback,
   hashSkillProposalContent,
-  MAX_PROPOSAL_SUPPORT_FILE_BYTES,
   MAX_PROPOSAL_SUPPORT_FILES,
-  normalizeSkillProposalSupportPath,
   prepareSkillProposalSupportFiles,
   readProposalSupportFiles,
   readSkillProposal,
   readSkillProposalRecord,
   readSkillProposalManifest,
-  removeWorkspaceSupportFile,
-  readWorkspaceSupportFile,
-  readWorkspaceSkillFile,
   replaceSkillProposalDraft,
   refreshSkillProposalManifest,
   resolveSkillProposalTarget,
   updateSkillProposalRecord,
   writeSkillProposal,
   writeSkillProposalRollback,
-  writeWorkspaceSupportFile,
-  writeWorkspaceSkillFile,
   withSkillProposalTargetLock,
   type PreparedSkillProposalSupportFile,
 } from "./store.js";
@@ -137,14 +136,14 @@ export async function readSkillProposalDraftDirectory(dirPath: string): Promise<
     if (entry.kind !== "file") {
       throw new Error(`Proposal support file must be a regular file: ${relativePath}`);
     }
-    const supportPath = normalizeSkillProposalSupportPath(relativePath);
+    const supportPath = normalizeWorkspaceSkillSupportPath(relativePath);
     const stats = await fs.stat(entry.path);
     if ((stats.mode & 0o111) !== 0) {
       throw new Error(`Proposal support files must not be executable: ${relativePath}`);
     }
     const read = await draftRoot.read(relativePath, {
       hardlinks: "reject",
-      maxBytes: MAX_PROPOSAL_SUPPORT_FILE_BYTES,
+      maxBytes: MAX_WORKSPACE_SKILL_SUPPORT_FILE_BYTES,
       symlinks: "reject",
     });
     supportFiles.push({
@@ -533,14 +532,12 @@ export async function applySkillProposal(
     assertInsideWorkspace(input.workspaceDir, record.target.skillFile, "skill file");
     assertInsideWorkspace(input.workspaceDir, record.target.skillDir, "skill directory");
     const workshopConfig = resolveSkillWorkshopConfig(input.config);
-    const allowedSymlinkTargetRealPaths = workshopConfig.allowSymlinkTargetWrites
-      ? resolveAllowedSkillSymlinkTargetRealPaths(input.config)
-      : [];
-    await assertWorkspaceSkillWriteTarget({
-      workspaceDir: input.workspaceDir,
-      filePath: record.target.skillFile,
-      allowedSymlinkTargetRealPaths,
-    });
+    const symlinkPolicy = {
+      allowWrites: workshopConfig.allowSymlinkTargetWrites,
+      allowedTargetRealPaths: workshopConfig.allowSymlinkTargetWrites
+        ? resolveAllowedSkillSymlinkTargetRealPaths(input.config)
+        : [],
+    };
     const targetState = await readApplyTargetState(record, supportFiles);
     const rollback = createSkillProposalRollback({
       proposalId: record.id,
@@ -559,13 +556,14 @@ export async function applySkillProposal(
     });
 
     const skillContent = stripProposalFrontmatterForSkill(content);
-    await publishProposalTarget({
+    await writeWorkspaceSkill({
       workspaceDir: input.workspaceDir,
-      record,
-      skillContent,
+      skillDir: record.target.skillDir,
+      skillFile: record.target.skillFile,
+      content: skillContent,
       supportFiles,
-      previousSupportFiles: targetState.previousSupportFiles,
-      allowedSymlinkTargetRealPaths,
+      mode: record.kind,
+      symlinkPolicy,
     });
     bumpSkillsSnapshotVersion({
       workspaceDir: input.workspaceDir,
@@ -650,108 +648,6 @@ async function readApplyTargetState(
     }
   }
   return { previousContent, previousSupportFiles };
-}
-
-async function publishProposalTarget(params: {
-  workspaceDir: string;
-  record: SkillProposalRecord;
-  skillContent: string;
-  supportFiles: readonly PreparedSkillProposalSupportFile[];
-  previousSupportFiles: NonNullable<SkillProposalRollback["supportFiles"]>;
-  allowedSymlinkTargetRealPaths: readonly string[];
-}): Promise<void> {
-  const writtenSupportPaths: string[] = [];
-  try {
-    for (const file of params.supportFiles) {
-      await writeWorkspaceSupportFile({
-        workspaceDir: params.workspaceDir,
-        skillDir: params.record.target.skillDir,
-        relativePath: file.path,
-        content: file.content,
-        overwrite: params.record.kind === "update",
-        allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
-      });
-      writtenSupportPaths.push(file.path);
-    }
-    await writeWorkspaceSkillFile({
-      workspaceDir: params.workspaceDir,
-      filePath: params.record.target.skillFile,
-      content: params.skillContent,
-      overwrite: params.record.kind === "update",
-      allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
-    });
-  } catch (error) {
-    if (params.record.kind === "create") {
-      await cleanupCreatedSupportFiles({
-        workspaceDir: params.workspaceDir,
-        record: params.record,
-        writtenSupportPaths,
-        allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
-      });
-    } else {
-      await restoreUpdatedSupportFiles({
-        workspaceDir: params.workspaceDir,
-        record: params.record,
-        writtenSupportPaths,
-        previousSupportFiles: params.previousSupportFiles,
-        allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
-      });
-    }
-    throw error;
-  }
-}
-
-async function cleanupCreatedSupportFiles(params: {
-  workspaceDir: string;
-  record: SkillProposalRecord;
-  writtenSupportPaths: readonly string[];
-  allowedSymlinkTargetRealPaths: readonly string[];
-}): Promise<void> {
-  await Promise.allSettled(
-    params.writtenSupportPaths.toReversed().map(async (relativePath) => {
-      await removeWorkspaceSupportFile({
-        workspaceDir: params.workspaceDir,
-        skillDir: params.record.target.skillDir,
-        relativePath,
-        allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
-      });
-    }),
-  );
-}
-
-async function restoreUpdatedSupportFiles(params: {
-  workspaceDir: string;
-  record: SkillProposalRecord;
-  writtenSupportPaths: readonly string[];
-  previousSupportFiles: NonNullable<SkillProposalRollback["supportFiles"]>;
-  allowedSymlinkTargetRealPaths: readonly string[];
-}): Promise<void> {
-  const previousByPath = new Map(params.previousSupportFiles.map((file) => [file.path, file]));
-  await Promise.allSettled(
-    params.writtenSupportPaths.toReversed().map(async (relativePath) => {
-      const previous = previousByPath.get(relativePath);
-      if (!previous) {
-        return;
-      }
-      if (previous.existed) {
-        await writeWorkspaceSupportFile({
-          workspaceDir: params.workspaceDir,
-          skillDir: params.record.target.skillDir,
-          relativePath,
-          content: previous.previousContent ?? "",
-          overwrite: true,
-          allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
-        });
-      } else {
-        await removeWorkspaceSupportFile({
-          workspaceDir: params.workspaceDir,
-          skillDir: params.record.target.skillDir,
-          relativePath,
-          allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
-        });
-      }
-    }),
-  );
 }
 
 function scanProposalBundle(

--- a/src/skills/workshop/store.ts
+++ b/src/skills/workshop/store.ts
@@ -1,4 +1,3 @@
-// Workshop store persists generated skill drafts and metadata under the workspace.
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -35,7 +34,6 @@ const MANIFEST_LOCK_REL_PATH = path.join(TARGET_LOCKS_REL_DIR, "proposals-manife
 const PROPOSAL_RECORD_FILE = "proposal.json";
 const PROPOSAL_DRAFT_FILE = "PROPOSAL.md";
 const PROPOSAL_ROLLBACK_FILE = "rollback.json";
-/** Maximum bytes accepted for a proposal draft. */
 export const MAX_PROPOSAL_BYTES = 1024 * 1024;
 export const MAX_PROPOSAL_SUPPORT_FILES = 64;
 export const MAX_PROPOSAL_SUPPORT_FILES_TOTAL_BYTES = 2 * 1024 * 1024;

--- a/src/skills/workshop/store.ts
+++ b/src/skills/workshop/store.ts
@@ -5,11 +5,15 @@ import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveStateDir } from "../../config/paths.js";
 import { type FileLockOptions, withFileLock } from "../../infra/file-lock.js";
-import { pathExists, root } from "../../infra/fs-safe.js";
+import { root } from "../../infra/fs-safe.js";
 import { tryReadJson } from "../../infra/json-files.js";
-import { isPathInside } from "../../infra/path-safety.js";
 import { normalizeSkillIndexName } from "../discovery/skill-index.js";
-import { findContainingAllowedSkillSymlinkTarget } from "../loading/symlink-targets.js";
+import {
+  assertInsideWorkspace,
+  assertWorkspaceSkillSupportPathSetIsFileOnly,
+  MAX_WORKSPACE_SKILL_SUPPORT_FILE_BYTES,
+  normalizeWorkspaceSkillSupportPath,
+} from "../lifecycle/workspace-skill-write.js";
 import {
   SKILL_WORKSHOP_MANIFEST_SCHEMA,
   SKILL_WORKSHOP_ROLLBACK_SCHEMA,
@@ -33,16 +37,8 @@ const PROPOSAL_DRAFT_FILE = "PROPOSAL.md";
 const PROPOSAL_ROLLBACK_FILE = "rollback.json";
 /** Maximum bytes accepted for a proposal draft. */
 export const MAX_PROPOSAL_BYTES = 1024 * 1024;
-export const MAX_PROPOSAL_SUPPORT_FILE_BYTES = 256 * 1024;
 export const MAX_PROPOSAL_SUPPORT_FILES = 64;
 export const MAX_PROPOSAL_SUPPORT_FILES_TOTAL_BYTES = 2 * 1024 * 1024;
-const ALLOWED_SUPPORT_FILE_ROOTS = new Set([
-  "assets",
-  "examples",
-  "references",
-  "scripts",
-  "templates",
-]);
 const PROPOSAL_ID_PATTERN = /^[a-z0-9][a-z0-9-]{5,120}$/;
 const SKILL_WORKSHOP_LOCK_OPTIONS: FileLockOptions = {
   retries: {
@@ -118,42 +114,6 @@ export function resolveProposalDraftPath(
   return path.join(resolveProposalDir(proposalId, options), PROPOSAL_DRAFT_FILE);
 }
 
-export function normalizeSkillProposalSupportPath(input: string): string {
-  const trimmed = input.trim();
-  if (!trimmed) {
-    throw new Error("Support file path is required.");
-  }
-  if (trimmed.includes("\\")) {
-    throw new Error("Support file paths must use forward slashes.");
-  }
-  if (path.posix.isAbsolute(trimmed)) {
-    throw new Error("Support file paths must be relative.");
-  }
-  const rawParts = trimmed.split("/");
-  if (rawParts.some((part) => !part || part === "." || part === ".." || part.startsWith("."))) {
-    throw new Error("Support file paths must use plain relative path segments.");
-  }
-  const normalized = path.posix.normalize(trimmed);
-  if (
-    !normalized ||
-    normalized === "." ||
-    normalized.startsWith("../") ||
-    normalized.includes("/../")
-  ) {
-    throw new Error("Support file paths must stay inside the skill directory.");
-  }
-  const parts = normalized.split("/");
-  if (!ALLOWED_SUPPORT_FILE_ROOTS.has(parts[0] ?? "")) {
-    throw new Error(
-      `Support file paths must be under one of: ${[...ALLOWED_SUPPORT_FILE_ROOTS].join(", ")}.`,
-    );
-  }
-  if (normalized === PROPOSAL_DRAFT_FILE || normalized === "SKILL.md") {
-    throw new Error("Support files cannot replace the proposal or skill markdown file.");
-  }
-  return normalized;
-}
-
 export function prepareSkillProposalSupportFiles(
   input: readonly SkillProposalSupportFileInput[] | undefined,
 ): PreparedSkillProposalSupportFile[] {
@@ -167,13 +127,13 @@ export function prepareSkillProposalSupportFiles(
   let totalBytes = 0;
   const files: PreparedSkillProposalSupportFile[] = [];
   for (const file of input) {
-    const filePath = normalizeSkillProposalSupportPath(file.path);
+    const filePath = normalizeWorkspaceSkillSupportPath(file.path);
     if (seen.has(filePath)) {
       throw new Error(`Duplicate support file path: ${filePath}`);
     }
     seen.add(filePath);
     const sizeBytes = contentSizeBytes(file.content);
-    if (sizeBytes > MAX_PROPOSAL_SUPPORT_FILE_BYTES) {
+    if (sizeBytes > MAX_WORKSPACE_SKILL_SUPPORT_FILE_BYTES) {
       throw new Error(`Support file is too large: ${filePath}`);
     }
     if (file.content.includes("\0")) {
@@ -190,24 +150,8 @@ export function prepareSkillProposalSupportFiles(
       content: file.content,
     });
   }
-  assertSupportPathSetIsFileOnly(files.map((file) => file.path));
+  assertWorkspaceSkillSupportPathSetIsFileOnly(files.map((file) => file.path));
   return files;
-}
-
-function assertSupportPathSetIsFileOnly(paths: readonly string[]): void {
-  const sorted = paths.toSorted((a, b) => a.localeCompare(b));
-  for (const filePath of sorted) {
-    if (!filePath.includes("/")) {
-      throw new Error("Support file paths must include a file below an allowed support directory.");
-    }
-  }
-  for (let index = 1; index < sorted.length; index += 1) {
-    const previous = sorted[index - 1];
-    const current = sorted[index];
-    if (previous && current?.startsWith(`${previous}/`)) {
-      throw new Error(`Support file paths cannot overlap: ${previous} and ${current}`);
-    }
-  }
 }
 
 export function resolveSkillProposalTarget(params: { workspaceDir: string; skillName: string }): {
@@ -320,7 +264,7 @@ export async function replaceSkillProposalDraft(params: {
     trailingNewline: true,
   });
   for (const file of params.previousSupportFiles ?? []) {
-    const filePath = normalizeSkillProposalSupportPath(file.path);
+    const filePath = normalizeWorkspaceSkillSupportPath(file.path);
     if (!nextSupportPaths.has(filePath)) {
       await stateRoot.remove(path.join(relativeDir, filePath)).catch(() => undefined);
     }
@@ -454,19 +398,6 @@ async function withSkillWorkshopLock<T>(lockFile: string, fn: () => Promise<T>):
   }
 }
 
-export async function readWorkspaceSkillFile(filePath: string): Promise<string | null> {
-  if (!(await pathExists(filePath))) {
-    return null;
-  }
-  const skillRoot = await root(path.dirname(filePath));
-  const read = await skillRoot.read(path.basename(filePath), {
-    hardlinks: "reject",
-    maxBytes: MAX_PROPOSAL_BYTES,
-    symlinks: "reject",
-  });
-  return read.buffer.toString("utf8");
-}
-
 export async function readProposalSupportFiles(
   record: SkillProposalRecord,
   options: SkillWorkshopStoreOptions = {},
@@ -474,10 +405,10 @@ export async function readProposalSupportFiles(
   const stateRoot = await root(resolveSkillWorkshopStateDir(options));
   const out: PreparedSkillProposalSupportFile[] = [];
   for (const file of record.supportFiles ?? []) {
-    const filePath = normalizeSkillProposalSupportPath(file.path);
+    const filePath = normalizeWorkspaceSkillSupportPath(file.path);
     const read = await stateRoot.read(path.join(proposalRelativeDir(record.id), filePath), {
       hardlinks: "reject",
-      maxBytes: MAX_PROPOSAL_SUPPORT_FILE_BYTES,
+      maxBytes: MAX_WORKSPACE_SKILL_SUPPORT_FILE_BYTES,
       symlinks: "reject",
     });
     const content = read.buffer.toString("utf8");
@@ -488,178 +419,8 @@ export async function readProposalSupportFiles(
     }
     out.push({ path: filePath, sizeBytes, hash, content });
   }
-  assertSupportPathSetIsFileOnly(out.map((file) => file.path));
+  assertWorkspaceSkillSupportPathSetIsFileOnly(out.map((file) => file.path));
   return out;
-}
-
-export async function readWorkspaceSupportFile(params: {
-  skillDir: string;
-  relativePath: string;
-}): Promise<string | null> {
-  const relativePath = normalizeSkillProposalSupportPath(params.relativePath);
-  const absolutePath = path.join(params.skillDir, ...relativePath.split("/"));
-  if (!(await pathExists(absolutePath))) {
-    return null;
-  }
-  const skillRoot = await root(params.skillDir);
-  const read = await skillRoot.read(relativePath, {
-    hardlinks: "reject",
-    maxBytes: MAX_PROPOSAL_SUPPORT_FILE_BYTES,
-    symlinks: "reject",
-  });
-  return read.buffer.toString("utf8");
-}
-
-export async function writeWorkspaceSkillFile(params: {
-  workspaceDir: string;
-  filePath: string;
-  content: string;
-  overwrite?: boolean;
-  allowedSymlinkTargetRealPaths?: readonly string[];
-}): Promise<void> {
-  assertInsideWorkspace(params.workspaceDir, params.filePath, "skill file");
-  const target = await resolveWorkspaceSkillWriteTarget({
-    workspaceDir: params.workspaceDir,
-    filePath: params.filePath,
-    allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
-  });
-  const targetRoot = await root(target.rootDir);
-  await targetRoot.write(target.relativePath, params.content, {
-    encoding: "utf8",
-    mkdir: true,
-    ...(params.overwrite === undefined ? {} : { overwrite: params.overwrite }),
-  });
-}
-
-export async function assertWorkspaceSkillWriteTarget(params: {
-  workspaceDir: string;
-  filePath: string;
-  allowedSymlinkTargetRealPaths?: readonly string[];
-}): Promise<void> {
-  assertInsideWorkspace(params.workspaceDir, params.filePath, "skill file");
-  await resolveWorkspaceSkillWriteTarget(params);
-}
-
-type WorkspaceSkillWriteTarget = {
-  rootDir: string;
-  relativePath: string;
-};
-
-async function resolveWorkspaceSkillWriteTarget(params: {
-  workspaceDir: string;
-  filePath: string;
-  allowedSymlinkTargetRealPaths?: readonly string[];
-}): Promise<WorkspaceSkillWriteTarget> {
-  const workspaceDir = path.resolve(params.workspaceDir);
-  const filePath = path.resolve(params.filePath);
-  const relativePath = path.relative(workspaceDir, filePath);
-  const aliasTarget = await resolveWorkspaceAliasTarget({
-    workspaceDir,
-    filePath,
-  });
-  if (!aliasTarget) {
-    return { rootDir: workspaceDir, relativePath };
-  }
-  const allowedRoot = findContainingAllowedSkillSymlinkTarget(
-    params.allowedSymlinkTargetRealPaths ?? [],
-    aliasTarget.realTarget,
-  );
-  if (!allowedRoot) {
-    throw new Error(
-      `Skill file resolves through an untrusted symlink target: ${params.filePath}. Configure skills.load.allowSymlinkTargets and enable skills.workshop.allowSymlinkTargetWrites for intentional Skill Workshop symlink writes.`,
-    );
-  }
-  return {
-    rootDir: allowedRoot,
-    relativePath: path.relative(allowedRoot, aliasTarget.realTarget),
-  };
-}
-
-async function resolveWorkspaceAliasTarget(params: {
-  workspaceDir: string;
-  filePath: string;
-}): Promise<{ realTarget: string } | null> {
-  const workspaceRealPath = (await tryRealpath(params.workspaceDir)) ?? params.workspaceDir;
-  const realTarget = await resolveRealPathThroughExistingAncestors(
-    params.workspaceDir,
-    params.filePath,
-  );
-  if (isPathInside(workspaceRealPath, realTarget)) {
-    return null;
-  }
-  return { realTarget };
-}
-
-async function resolveRealPathThroughExistingAncestors(
-  workspaceDir: string,
-  filePath: string,
-): Promise<string> {
-  const relativePath = path.relative(workspaceDir, filePath);
-  const segments = relativePath.split(path.sep).filter(Boolean);
-  let lexicalCursor = workspaceDir;
-  let realCursor = (await tryRealpath(workspaceDir)) ?? workspaceDir;
-  for (const segment of segments) {
-    lexicalCursor = path.join(lexicalCursor, segment);
-    const existingRealPath = await tryRealpath(lexicalCursor);
-    realCursor = existingRealPath ?? path.join(realCursor, segment);
-  }
-  return path.resolve(realCursor);
-}
-
-async function tryRealpath(filePath: string): Promise<string | null> {
-  try {
-    return await fs.realpath(filePath);
-  } catch {
-    return null;
-  }
-}
-
-export async function writeWorkspaceSupportFile(params: {
-  workspaceDir?: string;
-  skillDir: string;
-  relativePath: string;
-  content: string;
-  overwrite?: boolean;
-  allowedSymlinkTargetRealPaths?: readonly string[];
-}): Promise<void> {
-  const relativePath = normalizeSkillProposalSupportPath(params.relativePath);
-  const filePath = path.join(params.skillDir, ...relativePath.split("/"));
-  const target = params.workspaceDir
-    ? await resolveWorkspaceSkillWriteTarget({
-        workspaceDir: params.workspaceDir,
-        filePath,
-        allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
-      })
-    : { rootDir: params.skillDir, relativePath };
-  const targetRoot = await root(target.rootDir);
-  await targetRoot.write(target.relativePath, params.content, {
-    encoding: "utf8",
-    mkdir: true,
-    ...(params.overwrite === undefined ? {} : { overwrite: params.overwrite }),
-  });
-}
-
-export async function removeWorkspaceSupportFile(params: {
-  workspaceDir?: string;
-  skillDir: string;
-  relativePath: string;
-  allowedSymlinkTargetRealPaths?: readonly string[];
-}): Promise<void> {
-  const relativePath = normalizeSkillProposalSupportPath(params.relativePath);
-  const filePath = path.join(params.skillDir, ...relativePath.split("/"));
-  const target = params.workspaceDir
-    ? await resolveWorkspaceSkillWriteTarget({
-        workspaceDir: params.workspaceDir,
-        filePath,
-        allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
-      })
-    : { rootDir: params.skillDir, relativePath };
-  const targetRoot = await root(target.rootDir);
-  await targetRoot.remove(target.relativePath).catch((error: unknown) => {
-    if ((error as { code?: string })?.code !== "ENOENT") {
-      throw error;
-    }
-  });
 }
 
 export function createSkillProposalRollback(params: {
@@ -685,17 +446,6 @@ export function createSkillProposalRollback(params: {
       ? { supportFiles: params.supportFiles }
       : {}),
   };
-}
-
-export function assertInsideWorkspace(workspaceDir: string, targetPath: string, label: string) {
-  const resolvedWorkspaceDir = path.resolve(workspaceDir);
-  const resolvedTarget = path.resolve(targetPath);
-  if (
-    resolvedTarget !== resolvedWorkspaceDir &&
-    !isPathInside(resolvedWorkspaceDir, resolvedTarget)
-  ) {
-    throw new Error(`${label} must stay inside the workspace.`);
-  }
 }
 
 export function assertProposalId(proposalId: string): void {
@@ -788,7 +538,7 @@ function isValidSupportFileList(value: unknown): boolean {
       typeof file.sizeBytes !== "number" ||
       !Number.isSafeInteger(file.sizeBytes) ||
       file.sizeBytes < 0 ||
-      file.sizeBytes > MAX_PROPOSAL_SUPPORT_FILE_BYTES ||
+      file.sizeBytes > MAX_WORKSPACE_SKILL_SUPPORT_FILE_BYTES ||
       (file.targetExisted !== undefined && typeof file.targetExisted !== "boolean") ||
       (file.targetContentHash !== undefined &&
         (typeof file.targetContentHash !== "string" ||
@@ -798,7 +548,7 @@ function isValidSupportFileList(value: unknown): boolean {
     }
     let normalized: string;
     try {
-      normalized = normalizeSkillProposalSupportPath(file.path);
+      normalized = normalizeWorkspaceSkillSupportPath(file.path);
     } catch {
       return false;
     }


### PR DESCRIPTION
## Summary

Skill Workshop now publishes approved skill changes through the skills lifecycle writer instead of carrying a parallel write implementation.

This keeps the ownership split tighter:

- `skills/lifecycle` owns the final write contract for workspace skills:
  - workspace containment
  - trusted symlink target enforcement
  - `allowSymlinkTargetWrites`
  - create vs update overwrite rules
  - support-file path validation
  - partial-publish cleanup
- `skills/workshop` still owns Workshop-specific state:
  - proposal storage
  - scan/quarantine handling
  - stale proposal checks
  - rollback metadata
  - apply status updates

The user-facing behavior is intended to stay the same. The refactor preserves the existing create/update paths and the current symlink-write contract while removing duplicated path-resolution/write-policy code from Workshop.

## Verification

- `node scripts/run-vitest.mjs src/skills/workshop/service.test.ts`
- `pnpm tsgo:prod --pretty false`
- `node scripts/run-oxlint.mjs src/skills/lifecycle/workspace-skill-write.ts`
- `node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts src/agents/cli-runner/bundle-mcp.resume.test.ts src/commands/doctor/shared/context-engine-host-compat.test.ts`
- Crabbox AWS `run_7005eb361a54` / `cbx_d728603313a2` / `coral-lobster`:
  - `pnpm check:changed`
  - `pnpm test:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Auto-review reported no accepted/actionable findings.
