### PR TITLE
feat(plugins): add iFlow Search external provider

### DIFF
--- a/docs/tools/iflow-search.md
+++ b/docs/tools/iflow-search.md
@@ -1,0 +1,264 @@
+---
+summary: "iFlow Search API setup for web_search, image search, and web fetch"
+read_when:
+  - You want to use iFlow Search (心流搜索) for web_search
+  - You need IFLOW_API_KEY or Chinese-first search results
+  - You want image search via iflow_image_search
+title: "iFlow search"
+---
+
+OpenClaw supports [iFlow Search (心流搜索)](https://platform.iflow.cn) as a `web_search` provider, plus
+three explicit agent tools for web search, image search, and clean web-page extraction.
+iFlow's results are Chinese-first but cover the global web.
+
+| Property      | Value                                                       |
+| ------------- | ----------------------------------------------------------- |
+| Plugin id     | `iflow`                                                     |
+| Auth          | `IFLOW_API_KEY` or config `apiKey`                          |
+| Base URL      | `https://platform.iflow.cn` (default)                       |
+| Bundled tools | `iflow_web_search`, `iflow_image_search`, `iflow_web_fetch` |
+
+## Getting started
+
+<Steps>
+  <Step title="Get an API key">
+    Create an account at the [iFlow Open Platform](https://platform.iflow.cn)
+    and generate an API key in the dashboard.
+  </Step>
+  <Step title="Configure the plugin and provider">
+    ```json5
+    {
+      plugins: {
+        entries: {
+          iflow: {
+            enabled: true,
+            config: {
+              webSearch: {
+                apiKey: "your-key-here", // optional if IFLOW_API_KEY is set
+              },
+            },
+          },
+        },
+      },
+      tools: {
+        web: {
+          search: {
+            provider: "iflow",
+          },
+        },
+        // Enable iFlow explicit tools alongside the coding profile
+        alsoAllow: [
+          "iflow_web_search",
+          "iflow_image_search",
+          "iflow_web_fetch"
+        ],
+      },
+    }
+    ```
+  </Step>
+  <Step title="Verify search runs">
+    Trigger a `web_search` from any agent, or call `iflow_web_search` directly.
+  </Step>
+</Steps>
+
+<Tip>
+Choosing iFlow in onboarding or `openclaw configure --section web` enables the
+bundled iFlow plugin automatically.
+</Tip>
+
+## Install
+
+The plugin is published on npm as
+[`@iflow-ai/iflow-plugin`](https://www.npmjs.com/package/@iflow-ai/iflow-plugin).
+After choosing iFlow in `openclaw onboard` or `openclaw configure --section web`,
+OpenClaw installs it on demand. To install manually:
+
+```bash
+openclaw plugins install @iflow-ai/iflow-plugin@0.1.6
+openclaw gateway restart
+openclaw plugins inspect iflow --runtime --json
+```
+
+## Provider vs explicit tools
+
+The iFlow plugin exposes two capability layers:
+
+### Web Search Provider
+
+When configured as `tools.web.search.provider = "iflow"`, iFlow powers the
+built-in **`web_search`** tool. This tool is always visible in the `coding`
+profile — no extra configuration needed.
+
+### Explicit Tools
+
+The plugin also registers three explicit tools with additional capabilities:
+
+| Tool                 | Purpose                                           | Why use it                                     |
+| -------------------- | ------------------------------------------------- | ---------------------------------------------- |
+| `iflow_web_search`   | Web search with iFlow-specific controls           | Direct access, independent of provider routing |
+| `iflow_image_search` | **Image search** — not available via `web_search` | The only way to search images through iFlow    |
+| `iflow_web_fetch`    | Fetch web page content                            | Direct access, independent of provider routing |
+
+<Note>
+`iflow_image_search` is **not** the OpenClaw built-in `image` tool (which is for
+image understanding/vision). It is a dedicated image search tool that returns
+image URLs, titles, and source pages.
+</Note>
+
+### Tool visibility and profiles
+
+OpenClaw's `tools.profile` controls which tools are available to the agent:
+
+| Profile                | `web_search` (provider) | Explicit tools (`iflow_*`) |
+| ---------------------- | ----------------------- | -------------------------- |
+| `coding` (default)     | ✅ Always visible       | ❌ Hidden by default       |
+| `full`                 | ✅ Always visible       | ✅ Visible                 |
+| `coding` + `alsoAllow` | ✅ Always visible       | ✅ Visible                 |
+
+To enable explicit tools with the `coding` profile, add `alsoAllow`:
+
+```json5
+{
+  tools: {
+    profile: "coding",
+    alsoAllow: ["iflow_web_search", "iflow_image_search", "iflow_web_fetch"],
+  },
+}
+```
+
+<Note>
+This is standard OpenClaw behavior — all plugin explicit tools (including
+Tavily's `tavily_search` and `tavily_extract`) follow the same profile rules.
+</Note>
+
+## Tool reference
+
+### `iflow_web_search`
+
+Search the public web via iFlow Search. Returns titles, URLs, snippets,
+position, and (when available) publish date. Chinese-language results are
+first-class.
+
+<ParamField path="query" type="string" required>
+Search query. Forwarded to iFlow as `keywords`.
+</ParamField>
+
+<ParamField path="count" type="number" default="10">
+Number of results to return (1–10). Forwarded to iFlow as `num`.
+</ParamField>
+
+Returns `{ query, provider:"iflow", count, tookMs, results: [{ title, url, snippet, position, date }] }`.
+
+### `iflow_image_search`
+
+Search the public web for images via iFlow Search. Returns image URLs, titles,
+and source page URLs.
+
+<ParamField path="query" type="string" required>
+Image search query. Forwarded to iFlow as `keywords`.
+</ParamField>
+
+<ParamField path="count" type="number" default="10">
+Number of images to return (1–20). Forwarded to iFlow as `num`.
+</ParamField>
+
+Returns `{ query, provider:"iflow", count, tookMs, images: [{ url, title, sourceUrl }] }`.
+
+### `iflow_web_fetch`
+
+Fetch the readable content of a single web page via iFlow Search. Returns
+title, plain-text/markdown content, and a cache hint.
+
+<ParamField path="url" type="string" required>
+HTTP(S) URL to fetch.
+</ParamField>
+
+Returns `{ title, url, content, fromCache, provider:"iflow", tookMs }`.
+
+## Choosing the right tool
+
+| Need                                     | Tool                 |
+| ---------------------------------------- | -------------------- |
+| Quick web search, no special options     | `web_search`         |
+| iFlow-specific search with count control | `iflow_web_search`   |
+| Image search                             | `iflow_image_search` |
+| Extract content from a specific URL      | `iflow_web_fetch`    |
+
+<Note>
+The generic `web_search` tool with iFlow as provider supports `query` and
+`count` (up to 10 results). For image search or web content extraction, use the
+explicit tools.
+</Note>
+
+## Advanced configuration
+
+<AccordionGroup>
+  <Accordion title="API key resolution order">
+    The iFlow client looks up its API key in this order:
+
+    1. `plugins.entries.iflow.config.webSearch.apiKey` (resolved through SecretRefs).
+    2. `IFLOW_API_KEY` from the gateway environment.
+
+    All tools raise a setup error if neither is present.
+
+  </Accordion>
+
+  <Accordion title="Custom base URL">
+    Override `plugins.entries.iflow.config.webSearch.baseUrl` if you front iFlow
+    through a proxy. The default is `https://platform.iflow.cn`.
+  </Accordion>
+
+  <Accordion title="Cache">
+    Results are cached in-memory for 15 minutes by default (configurable via
+    `cacheTtlMinutes`; set `0` to disable). The cache key includes the iFlow
+    base URL, so proxy-specific responses do not collide.
+  </Accordion>
+</AccordionGroup>
+
+| Option                      | Default                     | Description                                       |
+| --------------------------- | --------------------------- | ------------------------------------------------- |
+| `webSearch.apiKey`          | `IFLOW_API_KEY` env var     | API key (string or SecretRef).                    |
+| `webSearch.baseUrl`         | `https://platform.iflow.cn` | API endpoint override.                            |
+| `webSearch.timeoutSeconds`  | `30`                        | HTTP timeout per request in seconds.              |
+| `webSearch.cacheTtlMinutes` | `15`                        | In-memory cache TTL in minutes. Set 0 to disable. |
+
+## Error codes
+
+| Code                 | Meaning                                            |
+| -------------------- | -------------------------------------------------- |
+| `missing_api_key`    | No API key found in config or environment.         |
+| `missing_param`      | A required parameter was not provided.             |
+| `invalid_param`      | A parameter value is invalid (e.g., non-HTTP URL). |
+| `network_timeout`    | Request to iFlow timed out.                        |
+| `network_error`      | Network failure talking to iFlow.                  |
+| `api_error`          | iFlow returned a non-2xx HTTP status.              |
+| `api_business_error` | iFlow returned `success: false`.                   |
+
+## Attribution headers
+
+The iFlow plugin sends non-sensitive attribution headers so iFlow can identify
+requests coming from the OpenClaw plugin integration. No API key, user query,
+URL, search keywords, or user content is added to these headers.
+
+```http
+IFlow-Source: openclaw
+IFlow-Integration: @iflow-ai/iflow-plugin
+IFlow-Integration-Version: <plugin version>
+```
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Web Search overview" href="/tools/web" icon="magnifying-glass">
+    All providers and auto-detection rules.
+  </Card>
+  <Card title="Tavily" href="/tools/tavily" icon="globe">
+    Tavily search and extract tools.
+  </Card>
+  <Card title="Brave Search" href="/tools/brave-search" icon="shield">
+    Brave Search with snippets and filters.
+  </Card>
+  <Card title="Configuration" href="/gateway/configuration" icon="gear">
+    Full config schema for plugin entries and tool routing.
+  </Card>
+</CardGroup>

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -75,6 +75,9 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
   <Card title="Grok" icon="zap" href="/tools/grok-search">
     AI-synthesized answers with citations via xAI web grounding.
   </Card>
+  <Card title="iFlow Search" icon="globe" href="/tools/iflow-search">
+    Chinese-first structured results plus image search and clean-content web fetch via the iFlow Open Platform.
+  </Card>
   <Card title="Kimi" icon="moon" href="/tools/kimi-search">
     AI-synthesized answers with citations via Moonshot web search; ungrounded chat fallbacks fail explicitly.
   </Card>
@@ -111,6 +114,7 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 | [Firecrawl](/tools/firecrawl)                    | Structured snippets                                            | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                                                                     |
 | [Gemini](/tools/gemini-search)                   | AI-synthesized + citations                                     | --                                               | `GEMINI_API_KEY`                                                                        |
 | [Grok](/tools/grok-search)                       | AI-synthesized + citations                                     | --                                               | xAI OAuth, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey`              |
+| [iFlow Search](/tools/iflow-search)              | Structured snippets (Chinese-first)                            | Via `iflow_image_search` and `iflow_web_fetch`   | `IFLOW_API_KEY`                                                                         |
 | [Kimi](/tools/kimi-search)                       | AI-synthesized + citations; fails on ungrounded chat fallbacks | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`                                                     |
 | [MiniMax Search](/tools/minimax-search)          | Structured snippets                                            | Region (`global` / `cn`)                         | `MINIMAX_CODE_PLAN_KEY` / `MINIMAX_CODING_API_KEY` / `MINIMAX_OAUTH_TOKEN`              |
 | [Ollama Web Search](/tools/ollama-search)        | Structured snippets                                            | --                                               | None for signed-in local hosts; `OLLAMA_API_KEY` for direct `https://ollama.com` search |
@@ -193,13 +197,14 @@ API-backed providers first:
 8. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`; optional `plugins.entries.exa.config.webSearch.baseUrl` overrides the Exa endpoint (order 65)
 9. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
 10. **Parallel** -- paid Parallel Search API via `PARALLEL_API_KEY` or `plugins.entries.parallel.config.webSearch.apiKey`; optional `plugins.entries.parallel.config.webSearch.baseUrl` overrides the endpoint (order 75)
+11. **iFlow Search** -- `IFLOW_API_KEY` or `plugins.entries.iflow.config.webSearch.apiKey` (order 80, external plugin)
 
 Key-free fallbacks after that:
 
-11. **Parallel Search (Free)** -- the zero-config default: works with no account or API key via Parallel's free hosted [Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) (order 76)
-12. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
-13. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
-14. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
+12. **Parallel Search (Free)** -- the zero-config default: works with no account or API key via Parallel's free hosted [Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) (order 76)
+13. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
+14. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
+15. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
 
 When no API-backed provider is configured, OpenClaw defaults to **Parallel
 Search (Free)**, so `web_search` works without an API key.
@@ -213,7 +218,7 @@ to route them through the managed path.
   All provider key fields support SecretRef objects. Plugin-scoped SecretRefs
   under `plugins.entries.<plugin>.config.webSearch.apiKey` are resolved for the
   bundled API-backed web search providers, including Brave, Exa, Firecrawl,
-  Gemini, Grok, Kimi, MiniMax, Parallel, Perplexity, and Tavily,
+  Gemini, Grok, iFlow, Kimi, MiniMax, Parallel, Perplexity, and Tavily,
   whether the provider is picked explicitly via `tools.web.search.provider` or
   selected through auto-detect. In auto-detect mode, OpenClaw resolves only the
   selected provider key -- non-selected SecretRefs stay inactive, so you can

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -140,6 +140,38 @@
       }
     },
     {
+      "name": "@iflow-ai/iflow-plugin",
+      "description": "iFlow Search (心流搜索) — Chinese-first web search, image search, and web content fetch.",
+      "source": "external",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "iflow",
+          "label": "iFlow Search"
+        },
+        "webSearchProviders": [
+          {
+            "id": "iflow",
+            "label": "iFlow Search",
+            "hint": "Connect Your AI Agent to the Real World",
+            "onboardingScopes": ["text-inference"],
+            "credentialLabel": "iFlow API key",
+            "envVars": ["IFLOW_API_KEY"],
+            "placeholder": "Enter iFlow API key",
+            "signupUrl": "https://platform.iflow.cn",
+            "docsUrl": "https://docs.openclaw.ai/tools/iflow-search",
+            "credentialPath": "plugins.entries.iflow.config.webSearch.apiKey",
+            "autoDetectOrder": 80
+          }
+        ],
+        "install": {
+          "npmSpec": "@iflow-ai/iflow-plugin@0.1.6",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.5.7"
+        }
+      }
+    },
+    {
       "name": "@openclaw/google-meet",
       "description": "OpenClaw Google Meet participant plugin",
       "source": "official",

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -70,6 +70,33 @@ describe("official external plugin catalog", () => {
     });
   });
 
+  it("lists iFlow as an external web search provider plugin with correct install spec", () => {
+    const entry = expectCatalogEntry("iflow");
+    expect(resolveOfficialExternalPluginId(entry)).toBe("iflow");
+    const install = resolveOfficialExternalPluginInstall(entry);
+    expect(install?.npmSpec).toBe("@iflow-ai/iflow-plugin@0.1.6");
+    expect(install?.defaultChoice).toBe("npm");
+    expect(install?.minHostVersion).toBe(">=2026.5.7");
+  });
+
+  it("exposes iFlow web search provider metadata for onboarding", () => {
+    const entry = expectCatalogEntry("iflow");
+    const manifest = entry.openclaw;
+    const providers = manifest?.webSearchProviders ?? [];
+    expect(providers.length).toBe(1);
+
+    const provider = providers[0];
+    expect(provider.id).toBe("iflow");
+    expect(provider.label).toBe("iFlow Search");
+    expect(provider.credentialLabel).toBe("iFlow API key");
+    expect(provider.envVars).toEqual(["IFLOW_API_KEY"]);
+    expect(provider.credentialPath).toBe("plugins.entries.iflow.config.webSearch.apiKey");
+    expect(provider.autoDetectOrder).toBe(80);
+    expect(provider.signupUrl).toBe("https://platform.iflow.cn");
+    expect(provider.docsUrl).toBe("https://docs.openclaw.ai/tools/iflow-search");
+    expect(provider.placeholder).not.toContain("sk-");
+  });
+
   it("lists Matrix as an official external ClawHub channel after cutover", () => {
     const ids = new Set<string>();
     for (const entry of listOfficialExternalPluginCatalogEntries()) {


### PR DESCRIPTION
## Summary

Add [iFlow Search (心流搜索)](https://platform.iflow.cn) as an external Web Search provider in the official plugin catalog, so users can select it during `openclaw onboard` or `openclaw configure --section web`.

This integration uses the published external plugin:

- **npm:** `@iflow-ai/iflow-plugin@0.1.6`
- **Provider id:** `iflow`
- **Auth:** `IFLOW_API_KEY` or `plugins.entries.iflow.config.webSearch.apiKey`

## Changes

- Add `@iflow-ai/iflow-plugin@0.1.6` to `scripts/lib/official-external-plugin-catalog.json`
- Add `docs/tools/iflow-search.md` with provider setup, explicit tools reference, tool visibility profiles, and `alsoAllow` configuration
- Update `docs/tools/web.md` with:
  - iFlow provider card
  - comparison table row
  - auto-detect entry (order 80)
  - SecretRef / API key guidance
- Add catalog tests for install spec and provider onboarding metadata

## Plugin summary

| Property | Value |
|----------|-------|
| Plugin id | `iflow` |
| npm | `@iflow-ai/iflow-plugin@0.1.6` |
| ClawHub | `@iflow-ai/iflow-plugin@0.1.6` |
| Auth | `IFLOW_API_KEY` or `plugins.entries.iflow.config.webSearch.apiKey` |
| Auto-detect order | 80 |
| Source | https://github.com/zhengyanglsun/openclaw-iflow-plugin |
| Source commit | `974be86b104d8ab58d8361cdf1eeb04fb70bba08` |

## Capabilities

- **Web Search provider:** registers `iflow` as a `web_search` provider via `api.registerWebSearchProvider`
- **Explicit plugin tools:**
  - `iflow_web_search`
  - `iflow_image_search`
  - `iflow_web_fetch`

The explicit tools follow OpenClaw's normal `tools.profile` / `tools.alsoAllow` policy. In the default `coding` profile, users can enable them with:

```json5
{
  "tools": {
    "profile": "coding",
    "alsoAllow": [
      "iflow_web_search",
      "iflow_image_search",
      "iflow_web_fetch"
    ]
  }
}
```

This is the same profile behavior used for other external plugin tools such as Tavily's explicit tools.

## Files changed

| File | Change |
|------|--------|
| `scripts/lib/official-external-plugin-catalog.json` | Add iFlow external plugin entry with `webSearchProviders` and pinned install spec |
| `docs/tools/iflow-search.md` | New iFlow provider and explicit tools documentation |
| `docs/tools/web.md` | Add iFlow provider card, comparison row, auto-detect entry, and SecretRef guidance |
| `src/plugins/official-external-plugin-catalog.test.ts` | Add tests for install spec and provider metadata |

## Real behavior proof

- **Behavior addressed:** iFlow Search plugin should install without errors, register as the `web_search` provider, expose three explicit tools (`iflow_web_search`, `iflow_image_search`, `iflow_web_fetch`), and appear as a selectable provider in `openclaw configure --section web`.

- **Real environment tested:** OpenClaw built from this branch on Windows 11 with Node.js 22 and pnpm. Plugin `@iflow-ai/iflow-plugin@0.1.6` installed from npm.

- **Exact steps or command run after this patch:**

```bash
git clone --branch feat/add-iflow-search-provider https://github.com/zhengyanglsun/openclaw.git
cd openclaw
pnpm install && pnpm build
pnpm openclaw plugins install @iflow-ai/iflow-plugin@0.1.6
pnpm openclaw plugins inspect iflow --runtime --json
pnpm openclaw configure --section web
```

- **Evidence after fix:**

Plugin install — terminal output:

```
$ pnpm openclaw plugins install @iflow-ai/iflow-plugin@0.1.6
Extracting iflow-ai-iflow-plugin-0.1.6.tgz…
Plugin manifest id "iflow" differs from npm package name "@iflow-ai/iflow-plugin"; using manifest id as the config key.
Installing to ~/.openclaw/extensions/iflow…
Installing plugin dependencies…
[plugins] iflow: initialized (baseUrl=https://platform.iflow.cn, timeout=30s, cacheTtl=15min, iFlow API key configured)
[plugins] iflow: registered as web_search provider (best-effort)
Installed plugin: iflow
Restart the gateway to load plugins.
```

Runtime inspect — terminal output:

```
$ pnpm openclaw plugins inspect iflow --runtime --json
{
  "plugin": {
    "id": "iflow",
    "version": "0.1.6",
    "status": "loaded",
    "toolNames": ["iflow_web_search", "iflow_image_search", "iflow_web_fetch"],
    "webSearchProviderIds": ["iflow"],
    "contracts": {
      "webSearchProviders": ["iflow"],
      "tools": ["iflow_web_search", "iflow_image_search", "iflow_web_fetch"]
    }
  },
  "diagnostics": []
}
```

Onboard wizard — `pnpm openclaw configure --section web` shows iFlow Search in the provider selection list. Screenshots attached in comments below.

- **Observed result after fix:** Plugin installs cleanly, registers as `web_search` provider, exposes three explicit tools in runtime inspect, and iFlow Search appears as a selectable provider in the onboard/configure web search wizard.

- **What was not tested:** Live API search call was not included in the terminal output above. The plugin's search functionality has been verified separately on macOS with a real IFLOW_API_KEY configured and returns normal results (~1.5s response time).
