### PR TITLE
fix(gateway): mirror hidden commentary-phase assistant events

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -3022,6 +3022,160 @@ describe("agent event handler", () => {
     );
   });
 
+  it("mirrors commentary-phase assistant events only to exact session message subscribers", () => {
+    const {
+      broadcast,
+      broadcastToConnIds,
+      nodeSendToSession,
+      sessionMessageSubscribers,
+      handler,
+      nowSpy,
+    } = createHarness({
+      now: 1_000,
+      resolveSessionKeyForRun: () => "session-hidden",
+    });
+    sessionMessageSubscribers.subscribe("conn-selected", "session-hidden");
+    sessionMessageSubscribers.subscribe("conn-other", "session-other");
+    registerAgentRunContext("run-hidden-commentary", {
+      sessionKey: "session-hidden",
+      isControlUiVisible: false,
+      verboseLevel: "off",
+    });
+
+    handler({
+      runId: "run-hidden-commentary",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: {
+        text: "I will inspect the files first.",
+        delta: "I will inspect the files first.",
+        phase: "commentary",
+      },
+    });
+    handler({
+      runId: "run-hidden-commentary",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: {
+        text: "Untagged text frame must not mirror.",
+        delta: "Untagged text frame must not mirror.",
+      },
+    });
+    handler({
+      runId: "run-hidden-commentary",
+      seq: 3,
+      stream: "assistant",
+      ts: Date.now(),
+      data: {
+        delta: "Untagged delta-only stream must not mirror.",
+      },
+    });
+    handler({
+      runId: "run-hidden-commentary",
+      seq: 4,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Terminal echo without delta" },
+    });
+    handler({
+      runId: "run-hidden-commentary",
+      seq: 5,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Final answer", delta: "Final answer", phase: "final_answer" },
+    });
+    handler({
+      runId: "run-hidden-commentary",
+      seq: 6,
+      stream: "assistant",
+      ts: Date.now(),
+      data: {
+        delta: "Streaming commentary delta.",
+        phase: "commentary",
+      },
+    });
+
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
+    expect(agentBroadcastCalls(broadcast)).toHaveLength(0);
+    expect(nodeSendToSession).not.toHaveBeenCalled();
+
+    const agentCalls = broadcastToConnIds.mock.calls.filter(([event]) => event === "agent");
+    expect(agentCalls).toHaveLength(2);
+    expect(agentCalls[0]?.[2]).toEqual(new Set(["conn-selected"]));
+    expect(agentCalls[1]?.[2]).toEqual(new Set(["conn-selected"]));
+    expectPayloadFields(agentCalls[0]?.[1], {
+      runId: "run-hidden-commentary",
+      sessionKey: "session-hidden",
+      stream: "assistant",
+    });
+    expectPayloadFields(agentCalls[1]?.[1], {
+      runId: "run-hidden-commentary",
+      sessionKey: "session-hidden",
+      stream: "assistant",
+    });
+    expectPayloadDataFields(agentCalls[0]?.[1], {
+      text: "I will inspect the files first.",
+      delta: "I will inspect the files first.",
+      phase: "commentary",
+    });
+    expectPayloadDataFields(agentCalls[1]?.[1], {
+      delta: "Streaming commentary delta.",
+      phase: "commentary",
+    });
+
+    const chatCalls = broadcastToConnIds.mock.calls.filter(([event]) => event === "chat");
+    expect(chatCalls).toHaveLength(1);
+    expect(chatCalls[0]?.[2]).toEqual(new Set(["conn-selected"]));
+    expectPayloadFields(chatCalls[0]?.[1], {
+      runId: "run-hidden-commentary",
+      sessionKey: "session-hidden",
+      state: "delta",
+    });
+    nowSpy?.mockRestore();
+  });
+
+  it("does not mirror aborted non-control-UI-visible assistant commentary", () => {
+    const {
+      broadcast,
+      broadcastToConnIds,
+      chatRunState,
+      nodeSendToSession,
+      sessionMessageSubscribers,
+      handler,
+      nowSpy,
+    } = createHarness({
+      now: 1_000,
+      resolveSessionKeyForRun: () => "session-hidden-aborted",
+    });
+    sessionMessageSubscribers.subscribe("conn-selected", "session-hidden-aborted");
+    registerAgentRunContext("run-hidden-commentary-aborted", {
+      sessionKey: "session-hidden-aborted",
+      isControlUiVisible: false,
+      verboseLevel: "off",
+    });
+    chatRunState.abortedRuns.set("run-hidden-commentary-aborted", 1_000);
+
+    handler({
+      runId: "run-hidden-commentary-aborted",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: {
+        text: "This aborted commentary must not be mirrored.",
+        delta: "This aborted commentary must not be mirrored.",
+        phase: "commentary",
+      },
+    });
+
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
+    expect(agentBroadcastCalls(broadcast)).toHaveLength(0);
+    expect(broadcastToConnIds).not.toHaveBeenCalled();
+    expect(nodeSendToSession).not.toHaveBeenCalled();
+    nowSpy?.mockRestore();
+  });
+
   it("uses agent event sessionKey when run-context lookup cannot resolve", () => {
     const { broadcast, handler } = createHarness({
       resolveSessionKeyForRun: () => undefined,

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -10,6 +10,7 @@ import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-event
 import { detectErrorKind, type ErrorKind } from "../infra/errors.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
 import { isAcpSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
+import { resolveAssistantEventPhase } from "../shared/chat-message-content.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
 import {
   normalizeLiveAssistantEventText,
@@ -132,6 +133,19 @@ function shouldHideHeartbeatChatOutput(runId: string, sourceRunId?: string): boo
 
 function shouldSuppressHeartbeatToolEvents(runId: string, sourceRunId?: string): boolean {
   return Boolean(resolveHeartbeatContext(runId, sourceRunId)?.isHeartbeat);
+}
+
+function shouldMirrorAssistantEventToHiddenSessionMessages(data: unknown): boolean {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+  const record = data as { text?: unknown; delta?: unknown };
+  const hasText = typeof record.text === "string" && record.text.length > 0;
+  const hasDelta = typeof record.delta === "string" && record.delta.length > 0;
+  if (!hasText && !hasDelta) {
+    return false;
+  }
+  return resolveAssistantEventPhase(data) === "commentary";
 }
 
 function normalizeHeartbeatChatFinalText(params: {
@@ -1187,6 +1201,18 @@ export function createAgentEventHandler({
             );
           }
         }
+      } else if (
+        !isAborted &&
+        sessionKey &&
+        hasSessionMessageSubscribers &&
+        evt.stream === "assistant" &&
+        shouldMirrorAssistantEventToHiddenSessionMessages(evt.data)
+      ) {
+        sendAgentPayload(
+          sessionKey,
+          { ...agentPayload, ...buildSessionEventSnapshot(sessionKey, undefined, sessionAgentId) },
+          { agentId: sessionAgentId, controlUiVisible: false, dropIfSlow: true },
+        );
       }
     }
 


### PR DESCRIPTION
## Problem

Hidden channel-session subscribers can receive live tool events without the Control UI being visible, but they were not receiving assistant events that had already been normalized as commentary.

That made channel surfaces asymmetric:

- tool activity could reach the channel-side preamble/progress UI
- commentary-phase assistant events did not reach the same exact hidden session subscribers
- final delivery still worked, so the failure looked like missing preamble rather than a broken turn

This PR is separate from #92092. #92092 fixed claude-cli narration being dropped before gateway fanout. This PR only fixes gateway fanout for commentary events that already exist.

## Root cause

`createAgentEventHandler()` already had a hidden-session path for tool events when `isControlUiVisible` is false. There was no matching hidden-session mirror for assistant events whose phase resolves to `commentary`.

The result: hidden channel subscribers could see tools, but not commentary, even when the provider/runtime had already emitted the commentary event.

## Fix

Add a narrow hidden-session mirror for commentary-phase assistant events:

- runs only when `isControlUiVisible` is false
- requires a resolved session key and exact session-message subscribers
- mirrors only assistant frames whose resolved phase is `commentary`
- accepts text or delta content only when phase is commentary
- excludes untagged assistant frames and `final_answer` frames
- preserves aborted-run suppression
- reuses the existing hidden `sendAgentPayload(..., { controlUiVisible: false, dropIfSlow: true })` path

## Deliberately not in scope

This PR does not define the broader channel transaction contract. It does not make `room_event + message_tool_only` produce commentary, does not change model prompting, does not alter provider phase normalization, and does not change ClickClack rendering.

The next channel-progress fix should be a separate PR: a first-class progress/preamble lane for channel turns where final answers remain `message(action=send)` owned, while interim commentary can flow as commentary/progress.

## Tests

Focused gateway regression coverage in `src/gateway/server-chat.agent-events.test.ts`:

- mirrors `phase: "commentary"` assistant text to exact hidden session subscribers
- mirrors `phase: "commentary"` delta-only assistant frames
- does not mirror untagged text frames
- does not mirror untagged delta-only frames
- does not mirror terminal text without delta
- does not mirror `phase: "final_answer"`
- does not globally broadcast hidden commentary or send it through `nodeSendToSession`
- does not send to other session subscribers
- does not mirror aborted hidden runs

Validation previously run on this branch:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-chat.agent-events.test.ts --maxWorkers=1
Test Files  1 passed (1)
Tests       87 passed (87)

pnpm tsgo:core
# clean

pnpm tsgo:test:src
# clean

git diff --check
# clean
```

## Real behavior proof

- Behavior addressed: hidden/channel session subscribers received tool events but not commentary-phase assistant events, preventing ClickClack from building a commentary preamble when those commentary events existed.

- Real environment tested: OpenClaw gateway built from this patch and restarted on `2026-06-11T15:31Z`; ClickClack bridge subscribed to the real channel session `agent:chisel:clickclack:channel:channel:chn_01ktq4zg9bga4dqrycqz67jts6`; real ClickClack `#test` and `#general` turns driven by ragesaq through the deployed bridge.

- Exact steps or command run after this patch:

  1. Built the OpenClaw gateway from branch `fix/channel-hidden-commentary`.
  2. Restarted `openclaw-gateway.service` and `clickclack-bridge.service`.
  3. Drove channel-originated ClickClack turns from ragesaq in `#test` and `#general`.
  4. Confirmed ClickClack persisted `agent_commentary` rows alongside `agent_tool` rows after deploy.
  5. Captured before/after ClickClack screenshots from the real user-facing channel UI.

- Evidence after fix:

Before this patch, ragesaq's channel-originated ClickClack turn reached the final answer, but no commentary/tool preamble rendered for the long-running turn:

![before: final answer without commentary preamble](https://raw.githubusercontent.com/ragesaq/openclaw/proof/channel-hidden-commentary-evidence/.proof/channel-hidden-commentary/before-real-user-channel-proof.png)

After this patch, ragesaq's channel-originated ClickClack turn rendered an expanded preamble with assistant commentary interleaved with tool-call rows:

![after: expanded preamble with commentary and tool calls](https://raw.githubusercontent.com/ragesaq/openclaw/proof/channel-hidden-commentary-evidence/.proof/channel-hidden-commentary/after-real-user-channel-proof.png)

ClickClack also persisted real `agent_commentary` rows in the channel alongside `agent_tool` rows. Example rows from the ClickClack DB after deploy:

```text
2026-06-11T15:55:29.371130227Z  agent_commentary  Pushed (`6055c05`). Posting the summary to the channel.
2026-06-11T15:55:21.602563769Z  agent_tool        **exec**
2026-06-11T15:55:41.92467386Z   agent_tool        **message**
```

Additional proof artifacts:

- expanded preamble, commentary interleaved with tool-call rows: https://raw.githubusercontent.com/ragesaq/openclaw/proof/channel-hidden-commentary-evidence/.proof/channel-hidden-commentary/preamble-expanded-commentary-tools.png
- collapsed preamble with final answer still visible: https://raw.githubusercontent.com/ragesaq/openclaw/proof/channel-hidden-commentary-evidence/.proof/channel-hidden-commentary/preamble-collapsed-final-visible.png
- proof note: https://raw.githubusercontent.com/ragesaq/openclaw/proof/channel-hidden-commentary-evidence/.proof/channel-hidden-commentary/real-behavior-proof.md

Observed result after fix: ClickClack can receive hidden commentary-phase assistant frames for the exact channel session, persist them as durable `agent_commentary` messages, and render them in the preamble while final answer delivery remains separate.

What was not tested: upstream-maintainer-hosted deployment; provider/runtime generation of commentary under every model and delivery mode; the future `room_event + message_tool_only` progress-lane contract.

## Risk checklist

- **Behavior change scope:** hidden/channel session-message subscribers now receive commentary-phase assistant events they were already subscribed to but missing. Control-UI-visible behavior is untouched.
- **Final-answer duplication:** guarded by requiring resolved phase `commentary`; `final_answer` and untagged frames are not mirrored.
- **Session isolation:** uses the existing exact session-message subscriber registry and tests assert only the selected session receives events.
- **Abort behavior:** preserved and covered by regression test.
- **Persistence/schema:** no schema or storage changes.
- **Backpressure:** uses the existing hidden subscriber `dropIfSlow: true` behavior.

## AI assistance

AI-assisted. Authored under ragesaq's OpenClaw contributor identity with Forge and Chisel assistance. ragesaq supplied the real before/after ClickClack screenshots and directed the proof update; Chisel prepared this narrowed PR body revision with `openai/gpt-5.5`.
