### PR TITLE
feat(fireworks): catalog DeepSeek V4 Pro, MiniMax M2.7, GLM-5.1, GPT-OSS 120B reasoning models

### DIFF
--- a/docs/providers/fireworks.md
+++ b/docs/providers/fireworks.md
@@ -7,7 +7,7 @@ read_when:
   - You are debugging Kimi thinking-off behavior on Fireworks
 ---
 
-[Fireworks](https://fireworks.ai) exposes open-weight and routed models through an OpenAI-compatible API. OpenClaw includes a bundled Fireworks provider plugin that ships with two pre-cataloged Kimi models and accepts any Fireworks model or router id at runtime.
+[Fireworks](https://fireworks.ai) exposes open-weight and routed models through an OpenAI-compatible API. OpenClaw includes a bundled Fireworks provider plugin that ships with pre-cataloged Kimi, DeepSeek, MiniMax, GLM, and GPT-OSS models and accepts any Fireworks model or router id at runtime.
 
 | Property        | Value                                                  |
 | --------------- | ------------------------------------------------------ |
@@ -51,7 +51,7 @@ export FIREWORKS_API_KEY=fw-...
     openclaw models list --provider fireworks
     ```
 
-    The list should include `Kimi K2.6` and `Kimi K2.5 Turbo (Fire Pass)`. If `FIREWORKS_API_KEY` is unresolved, `openclaw models status --json` reports the missing credential under `auth.unusableProfiles`.
+    The list should include `Kimi K2.6`, `Kimi K2.5 Turbo (Fire Pass)`, `DeepSeek V4 Pro`, `MiniMax M3`, `GLM-5.1`, and `GPT-OSS 120B`. If `FIREWORKS_API_KEY` is unresolved, `openclaw models status --json` reports the missing credential under `auth.unusableProfiles`.
 
   </Step>
 </Steps>
@@ -71,10 +71,14 @@ openclaw onboard --non-interactive \
 
 ## Built-in catalog
 
-| Model ref                                              | Name                        | Input        | Context | Max output | Thinking             |
-| ------------------------------------------------------ | --------------------------- | ------------ | ------- | ---------- | -------------------- |
-| `fireworks/accounts/fireworks/models/kimi-k2p6`        | Kimi K2.6                   | text + image | 262,144 | 262,144    | Forced off           |
-| `fireworks/accounts/fireworks/routers/kimi-k2p5-turbo` | Kimi K2.5 Turbo (Fire Pass) | text + image | 256,000 | 256,000    | Forced off (default) |
+| Model ref                                              | Name                        | Input        | Context   | Max output | Thinking                      |
+| ------------------------------------------------------ | --------------------------- | ------------ | --------- | ---------- | ----------------------------- |
+| `fireworks/accounts/fireworks/models/kimi-k2p6`        | Kimi K2.6                   | text + image | 262,144   | 262,144    | Forced off                    |
+| `fireworks/accounts/fireworks/routers/kimi-k2p5-turbo` | Kimi K2.5 Turbo (Fire Pass) | text + image | 256,000   | 256,000    | Forced off (default)          |
+| `fireworks/accounts/fireworks/models/deepseek-v4-pro`  | DeepSeek V4 Pro             | text         | 1,048,576 | 1,048,576  | off/low/medium/high/xhigh/max |
+| `fireworks/accounts/fireworks/models/minimax-m3`       | MiniMax M3                  | text + image | 524,288   | 64,000     | off/low/medium/high           |
+| `fireworks/accounts/fireworks/models/glm-5p1`          | GLM-5.1                     | text         | 202,752   | 202,752    | off/low/medium/high           |
+| `fireworks/accounts/fireworks/models/gpt-oss-120b`     | GPT-OSS 120B                | text         | 131,072   | 131,072    | low/medium/high               |
 
 <Note>
   OpenClaw pins all Fireworks Kimi models to `thinking: off` because Fireworks rejects Kimi thinking parameters in production. Routing the same model through [Moonshot](/providers/moonshot) directly preserves Kimi reasoning output. See [thinking modes](/tools/thinking) for switching between providers.
@@ -82,7 +86,7 @@ openclaw onboard --non-interactive \
 
 ## Custom Fireworks model ids
 
-OpenClaw accepts any Fireworks model or router id at runtime. Use the exact id shown by Fireworks and prefix it with `fireworks/`. Dynamic resolution clones the Fire Pass template (text + image input, OpenAI-compatible API, default cost zero) and disables thinking automatically when the id matches the Kimi pattern. GLM dynamic ids are marked text-only unless you configure a custom model entry with image input.
+OpenClaw accepts any Fireworks model or router id at runtime. Use the exact id shown by Fireworks and prefix it with `fireworks/`. Dynamic resolution clones the Fire Pass template (text + image input, OpenAI-compatible API, default cost zero) and disables thinking automatically when the id matches the Kimi pattern. GLM dynamic ids are marked text-only unless you configure a custom model entry with image input. The cataloged reasoning models above (DeepSeek V4 Pro, MiniMax M3, GLM-5.1, GPT-OSS 120B) carry their per-model `reasoning_effort` contract in the manifest, and their `/think` menus are derived from each model's `supportedReasoningEfforts`; configure those exact ids to get those menus.
 
 ```json5
 {
@@ -108,7 +112,7 @@ OpenClaw accepts any Fireworks model or router id at runtime. Use the exact id s
   </Accordion>
 
   <Accordion title="Why thinking is forced off for Kimi">
-    Fireworks K2.6 returns a 400 if the request carries `reasoning_*` parameters even though Kimi supports thinking through Moonshot's own API. The bundled policy (`extensions/fireworks/thinking-policy.ts`) advertises only the `off` thinking level for Kimi model ids, so manual `/think` switches and provider-policy surfaces stay aligned with the runtime contract.
+    Fireworks K2.6 returns a 400 if the request carries `reasoning_*` parameters even though Kimi supports thinking through Moonshot's own API. The Kimi catalog rows are marked `reasoning: false` in the manifest, so OpenClaw advertises only the `off` thinking level for them, and the bundled stream wrapper (`extensions/fireworks/stream.ts`) strips any thinking parameters from the request — manual `/think` switches and provider-policy surfaces stay aligned with the runtime contract.
 
     To use Kimi reasoning end-to-end, configure the [Moonshot provider](/providers/moonshot) and route the same model through it.
 

--- a/extensions/fireworks/index.test.ts
+++ b/extensions/fireworks/index.test.ts
@@ -12,12 +12,16 @@ import {
 import fireworksPlugin from "./index.js";
 import {
   FIREWORKS_BASE_URL,
+  FIREWORKS_DEEPSEEK_V4_MODEL_ID,
   FIREWORKS_DEFAULT_CONTEXT_WINDOW,
   FIREWORKS_DEFAULT_MAX_TOKENS,
   FIREWORKS_DEFAULT_MODEL_ID,
+  FIREWORKS_GLM_5_1_MODEL_ID,
+  FIREWORKS_GPT_OSS_120B_MODEL_ID,
   FIREWORKS_K2_6_CONTEXT_WINDOW,
   FIREWORKS_K2_6_MAX_TOKENS,
   FIREWORKS_K2_6_MODEL_ID,
+  FIREWORKS_MINIMAX_M3_MODEL_ID,
 } from "./provider-catalog.js";
 import { resolveThinkingProfile } from "./provider-policy-api.js";
 
@@ -69,6 +73,10 @@ describe("fireworks provider plugin", () => {
     expect(models.map((model) => model.id)).toEqual([
       FIREWORKS_K2_6_MODEL_ID,
       FIREWORKS_DEFAULT_MODEL_ID,
+      FIREWORKS_DEEPSEEK_V4_MODEL_ID,
+      FIREWORKS_MINIMAX_M3_MODEL_ID,
+      FIREWORKS_GLM_5_1_MODEL_ID,
+      FIREWORKS_GPT_OSS_120B_MODEL_ID,
     ]);
     expect(models[0]?.reasoning).toBe(false);
     expect(models[0]?.input).toEqual(["text", "image"]);
@@ -78,6 +86,51 @@ describe("fireworks provider plugin", () => {
     expect(models[1]?.input).toEqual(["text", "image"]);
     expect(models[1]?.contextWindow).toBe(FIREWORKS_DEFAULT_CONTEXT_WINDOW);
     expect(models[1]?.maxTokens).toBe(FIREWORKS_DEFAULT_MAX_TOKENS);
+  });
+
+  it("catalogs reasoning families with reasoning_effort compat from the manifest", async () => {
+    const provider = await registerSingleProviderPlugin(fireworksPlugin);
+    const catalogProvider = await runSingleProviderCatalog(provider);
+    const byId = new Map(catalogProvider.models?.map((model) => [model.id, model]) ?? []);
+
+    const deepseek = byId.get(FIREWORKS_DEEPSEEK_V4_MODEL_ID);
+    expect(deepseek?.reasoning).toBe(true);
+    // thinkingFormat "openai" opts out of core's deepseek-native fallback for
+    // deepseek-v4-* ids; Fireworks 400s on payloads carrying `thinking` next to
+    // `reasoning_effort`.
+    expect(deepseek?.compat).toMatchObject({
+      thinkingFormat: "openai",
+      supportsReasoningEffort: true,
+      supportedReasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
+      reasoningEffortMap: { off: "none", max: "max" },
+    });
+
+    const minimax = byId.get(FIREWORKS_MINIMAX_M3_MODEL_ID);
+    expect(minimax?.reasoning).toBe(true);
+    expect(minimax?.input).toEqual(["text", "image"]);
+    expect(minimax?.compat).toMatchObject({
+      supportsReasoningEffort: true,
+      supportedReasoningEfforts: ["none", "low", "medium", "high"],
+      reasoningEffortMap: { off: "none", max: "high" },
+    });
+
+    const glm = byId.get(FIREWORKS_GLM_5_1_MODEL_ID);
+    expect(glm?.reasoning).toBe(true);
+    expect(glm?.compat).toMatchObject({
+      supportsReasoningEffort: true,
+      supportedReasoningEfforts: ["none", "low", "medium", "high"],
+      reasoningEffortMap: { off: "none", max: "high" },
+    });
+
+    const gptOss = byId.get(FIREWORKS_GPT_OSS_120B_MODEL_ID);
+    expect(gptOss?.reasoning).toBe(true);
+    expect(gptOss?.compat).toMatchObject({
+      supportsReasoningEffort: true,
+      supportedReasoningEfforts: ["low", "medium", "high"],
+      reasoningEffortMap: { max: "high" },
+    });
+    expect(gptOss?.compat?.supportedReasoningEfforts).not.toContain("minimal");
+    expect(gptOss?.compat?.reasoningEffortMap).not.toHaveProperty("off");
   });
 
   it("resolves forward-compat Fireworks model ids from the default template", async () => {
@@ -119,13 +172,13 @@ describe("fireworks provider plugin", () => {
     const resolved = provider.resolveDynamicModel?.(
       createProviderDynamicModelContext({
         provider: "fireworks",
-        modelId: "accounts/fireworks/models/glm-5p1",
+        modelId: "accounts/fireworks/models/glm-4p6",
         models: [createFireworksDefaultRuntimeModel({ reasoning: false })],
       }),
     );
 
     expect(resolved?.provider).toBe("fireworks");
-    expect(resolved?.id).toBe("accounts/fireworks/models/glm-5p1");
+    expect(resolved?.id).toBe("accounts/fireworks/models/glm-4p6");
     expect(resolved?.input).toEqual(["text"]);
   });
 
@@ -159,6 +212,61 @@ describe("fireworks provider plugin", () => {
     }
   });
 
+  it("derives thinking menus from each cataloged model's supportedReasoningEfforts", async () => {
+    const provider = await registerSingleProviderPlugin(fireworksPlugin);
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "fireworks",
+        modelId: FIREWORKS_DEEPSEEK_V4_MODEL_ID,
+      }),
+    ).toEqual({
+      levels: [
+        { id: "off" },
+        { id: "low" },
+        { id: "medium" },
+        { id: "high" },
+        { id: "xhigh" },
+        { id: "max" },
+      ],
+    });
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "fireworks",
+        modelId: FIREWORKS_MINIMAX_M3_MODEL_ID,
+      }),
+    ).toEqual({
+      levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }],
+    });
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "fireworks",
+        modelId: FIREWORKS_GLM_5_1_MODEL_ID,
+      }),
+    ).toEqual({
+      levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }],
+    });
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "fireworks",
+        modelId: FIREWORKS_GPT_OSS_120B_MODEL_ID,
+      }),
+    ).toEqual({
+      levels: [{ id: "low" }, { id: "medium" }, { id: "high" }],
+    });
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "fireworks",
+        modelId: "accounts/fireworks/models/deepseek-v4-flash",
+      }),
+    ).toBeUndefined();
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "fireworks",
+        modelId: "accounts/fireworks/models/glm-5p2",
+      }),
+    ).toBeUndefined();
+  });
+
   it("exposes off-only thinking policy for Fireworks Kimi models", async () => {
     const provider = await registerSingleProviderPlugin(fireworksPlugin);
 
@@ -169,7 +277,6 @@ describe("fireworks provider plugin", () => {
       }),
     ).toEqual({
       levels: [{ id: "off" }],
-      defaultLevel: "off",
     });
     expect(
       provider.resolveThinkingProfile?.({
@@ -178,7 +285,6 @@ describe("fireworks provider plugin", () => {
       }),
     ).toEqual({
       levels: [{ id: "off" }],
-      defaultLevel: "off",
     });
     expect(
       provider.resolveThinkingProfile?.({
@@ -188,7 +294,6 @@ describe("fireworks provider plugin", () => {
     ).toBeUndefined();
     expect(resolveThinkingProfile({ modelId: FIREWORKS_K2_6_MODEL_ID })).toEqual({
       levels: [{ id: "off" }],
-      defaultLevel: "off",
     });
     expect(
       resolveThinkingProfile({

--- a/extensions/fireworks/openclaw.plugin.json
+++ b/extensions/fireworks/openclaw.plugin.json
@@ -64,6 +64,117 @@
               "cacheRead": 0,
               "cacheWrite": 0
             }
+          },
+          {
+            "id": "accounts/fireworks/models/deepseek-v4-pro",
+            "name": "DeepSeek V4 Pro",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 1048576,
+            "compat": {
+              "thinkingFormat": "openai",
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["none", "low", "medium", "high", "xhigh", "max"],
+              "reasoningEffortMap": {
+                "off": "none",
+                "none": "none",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+                "adaptive": "high",
+                "max": "max"
+              }
+            },
+            "cost": {
+              "input": 1.74,
+              "output": 3.48,
+              "cacheRead": 0.145,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "accounts/fireworks/models/minimax-m3",
+            "name": "MiniMax M3",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 524288,
+            "maxTokens": 64000,
+            "compat": {
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["none", "low", "medium", "high"],
+              "reasoningEffortMap": {
+                "off": "none",
+                "none": "none",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "high",
+                "adaptive": "medium",
+                "max": "high"
+              }
+            },
+            "cost": {
+              "input": 0.3,
+              "output": 1.2,
+              "cacheRead": 0.06,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "accounts/fireworks/models/glm-5p1",
+            "name": "GLM-5.1",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 202752,
+            "maxTokens": 202752,
+            "compat": {
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["none", "low", "medium", "high"],
+              "reasoningEffortMap": {
+                "off": "none",
+                "none": "none",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "high",
+                "adaptive": "high",
+                "max": "high"
+              }
+            },
+            "cost": {
+              "input": 1.4,
+              "output": 4.4,
+              "cacheRead": 0.26,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "accounts/fireworks/models/gpt-oss-120b",
+            "name": "GPT-OSS 120B",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 131072,
+            "maxTokens": 131072,
+            "compat": {
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["low", "medium", "high"],
+              "reasoningEffortMap": {
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "high",
+                "adaptive": "medium",
+                "max": "high"
+              }
+            },
+            "cost": {
+              "input": 0.15,
+              "output": 0.6,
+              "cacheRead": 0.015,
+              "cacheWrite": 0
+            }
           }
         ]
       }

--- a/extensions/fireworks/provider-catalog.ts
+++ b/extensions/fireworks/provider-catalog.ts
@@ -14,6 +14,10 @@ const FIREWORKS_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
 export const FIREWORKS_BASE_URL = FIREWORKS_MANIFEST_PROVIDER.baseUrl;
 export const FIREWORKS_DEFAULT_MODEL_ID = "accounts/fireworks/routers/kimi-k2p5-turbo";
 export const FIREWORKS_K2_6_MODEL_ID = "accounts/fireworks/models/kimi-k2p6";
+export const FIREWORKS_DEEPSEEK_V4_MODEL_ID = "accounts/fireworks/models/deepseek-v4-pro";
+export const FIREWORKS_MINIMAX_M3_MODEL_ID = "accounts/fireworks/models/minimax-m3";
+export const FIREWORKS_GLM_5_1_MODEL_ID = "accounts/fireworks/models/glm-5p1";
+export const FIREWORKS_GPT_OSS_120B_MODEL_ID = "accounts/fireworks/models/gpt-oss-120b";
 
 function requireFireworksManifestModel(id: string): ModelDefinitionConfig {
   const model = FIREWORKS_MANIFEST_PROVIDER.models.find((entry) => entry.id === id);

--- a/extensions/fireworks/thinking-policy.ts
+++ b/extensions/fireworks/thinking-policy.ts
@@ -1,18 +1,39 @@
 // Fireworks plugin module implements thinking policy behavior.
 import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
-import { isFireworksKimiModelId } from "./model-id.js";
+import { buildFireworksCatalogModels } from "./provider-catalog.js";
 
-const FIREWORKS_KIMI_THINKING_PROFILE = {
-  levels: [{ id: "off" }],
-  defaultLevel: "off",
-} as const satisfies ProviderThinkingProfile;
+type FireworksThinkLevelId = ProviderThinkingProfile["levels"][number]["id"];
+
+const WIRE_EFFORT_TO_THINK_LEVEL: Record<string, FireworksThinkLevelId> = {
+  none: "off",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "xhigh",
+  max: "max",
+};
+
+const FIREWORKS_THINKING_PROFILES = new Map<string, ProviderThinkingProfile>();
+for (const model of buildFireworksCatalogModels()) {
+  if (!model.reasoning) {
+    FIREWORKS_THINKING_PROFILES.set(model.id, { levels: [{ id: "off" }] });
+    continue;
+  }
+  const efforts = model.compat?.supportedReasoningEfforts;
+  if (!efforts) {
+    continue;
+  }
+  const levels = efforts
+    .map((effort) => WIRE_EFFORT_TO_THINK_LEVEL[effort])
+    .filter((id): id is FireworksThinkLevelId => id !== undefined)
+    .map((id) => ({ id }));
+  if (levels.length > 0) {
+    FIREWORKS_THINKING_PROFILES.set(model.id, { levels });
+  }
+}
 
 export function resolveFireworksThinkingProfile(
   modelId: string,
 ): ProviderThinkingProfile | undefined {
-  if (!isFireworksKimiModelId(modelId)) {
-    return undefined;
-  }
-
-  return FIREWORKS_KIMI_THINKING_PROFILE;
+  return FIREWORKS_THINKING_PROFILES.get(modelId.trim());
 }


### PR DESCRIPTION
**TL;DR** I run OpenClaw against Fireworks serverless and wanted their current reasoning lineup — DeepSeek V4 Pro, MiniMax M3, GLM-5.1, GPT-OSS 120B — selectable like any bundled model instead of falling through to the dynamic-model guesswork. Cataloging DeepSeek V4 on Fireworks also trips a real bug: core's deepseek-native fallback injects `thinking` next to `reasoning_effort` and Fireworks rejects that request outright. The fix turned out to need zero new runtime code — one manifest compat field core already supports.

## Summary

**What does this add?** Four Fireworks serverless reasoning models to the bundled `extensions/fireworks` manifest catalog, each with `reasoning_effort` compat (supported efforts + level map) and a per-family thinking profile so thinking menus only offer levels the deployment actually accepts:

| model | input | context | thinking menu |
| --- | --- | --- | --- |
| `deepseek-v4-pro` | text | 1,048,576 | off/low/medium/high/xhigh/max |
| `minimax-m3` | text + image | 524,288 | off/low/medium/high |
| `glm-5p1` | text | 202,752 | off/low/medium/high |
| `gpt-oss-120b` | text | 131,072 | low/medium/high |

Thinking menus are **derived from each row's `supportedReasoningEfforts`** (`extensions/fireworks/thinking-policy.ts`) rather than hand-maintained per family, so the catalog row is the single source of truth and the `/think` menu can never drift from the wire contract.

**What does this fix? — DeepSeek V4 Pro 400.** Without the patch, selecting `fireworks/accounts/fireworks/models/deepseek-v4-pro` with thinking enabled kills every turn. Core's DeepSeek V4 fallback (`src/agents/embedded-agent-runner/extra-params.ts`) matches the id's last segment (`deepseek-v4-pro`) on any unowned OpenAI-compatible provider and injects `thinking: { type: "enabled" }` plus `reasoning_effort`. Fireworks rejects that payload:

```
{"error":{...,"message":"cannot specify both 'thinking' and 'reasoning_effort'"}}
```

Core already built the seam for exactly this class of deployment: `compat.thinkingFormat` ≠ `"deepseek"` suppresses the injected `thinking` entirely (even `{type:"disabled"}`) and strips deepseek replay fields, while `reasoning_effort` keeps flowing from the manifest map. The doc comment on `deepSeekV4NativeThinkingAllowedByCompat` names the use case (Azure AI Foundry DeepSeek V4 rejects `thinking` outright), and `extra-params.deepseek-v4-thinking-format.test.ts` pins the whole behavior. So the deepseek-v4-pro row carries `"thinkingFormat": "openai"` — no plugin runtime code, one manifest field core already supports.

**Note — GPT-OSS 120B is the first bundled no-off profile.** Its Fireworks deployment rejects `reasoning_effort:"none"` (`400 Invalid reasoning effort: none`, verified below), so its menu has no `off`. That exposes a *separate* core quirk: a session carrying a stored `off` that switches onto a no-off model was clamped **up** to the most expensive level. That fix is shared core logic, so it ships on its own — **#93335 / `fix/thinking-clamp-below-range`** (see Linked context). This PR is intentionally plugin-only; the two are best landed together.

**Why `supportsReasoningEffort: true` on every row.** Fireworks' baseUrl classifies as a proxy-like endpoint, so the transport's *detected* compat disables `reasoning_effort` by default; the explicit manifest flag is what keeps each model's effort contract on the wire.

**Where do the numbers come from?** Model ids, context windows, `reasoning_effort` ranges, and pricing (incl. cache-read rates) verified against the live Fireworks API (`/v1/models`, `/v1/chat/completions`) and `https://docs.fireworks.ai/serverless/pricing`. `minimax-m3` is absent from that account-scoped `/v1/models` listing, so it was confirmed with live completions across its full effort range.

## Linked context

- **Sibling core fix — #93335 / `fix/thinking-clamp-below-range`** clamps a below-range thinking request (e.g. a stored `off`) down to the cheapest level instead of up to the most expensive. GPT-OSS 120B (added here) is the first bundled profile that triggers it. Independent PRs; recommend landing together.
- **#90326 (same author, merged 2026-06-13, `22fdc39adb`)** makes core resolve bundled catalog params (`contextWindow`/`maxTokens`/`compat`) from `openclaw.plugin.json`. **This PR builds on that merged behavior** — the branch is rebased on current `main`, so the four rows are authoritative through core with no plugin-side resolution code. An earlier iteration re-implemented that resolution locally; all of it was deleted once #90326 landed (see Current review state).
- Core seam + tests: `extra-params.ts` (`deepSeekV4NativeThinkingAllowedByCompat`, non-native sanitizer), `extra-params.deepseek-v4-thinking-format.test.ts`.
- Sibling precedent: `extensions/deepseek/openclaw.plugin.json` ships the same `supportsReasoningEffort` compat; `deepseek-v4-pro` pricing matches the first-party row.
- Manifest compat keys (`thinkingFormat`, `supportedReasoningEfforts`, `reasoningEffortMap`) are existing config schema: `src/config/zod-schema.core.ts`, `src/config/types.models.ts`.

## Real behavior proof

Behavior or issue addressed: Fireworks DeepSeek V4 Pro turns failing with 400 "cannot specify both 'thinking' and 'reasoning_effort'" when thinking is enabled; the three other reasoning families missing from the bundled catalog (no pricing, wrong default thinking levels via dynamic fallback).
Real environment tested: live Fireworks serverless API (`api.fireworks.ai/inference/v1`) with a real API key; OpenClaw checkout of this branch on Linux/Node 24.
Exact steps or command run after this patch: `openclaw models list --all --provider fireworks --plain`, then one noninteractive agent turn per model, e.g. `openclaw agent --session-id fw-shot-ds -m "One sentence: why is the sky blue?" --model fireworks/accounts/fireworks/models/deepseek-v4-pro --thinking high` (and the minimax/glm/gpt-oss equivalents).
Evidence after fix: screenshot below; red→green at the same command: `openclaw agent --local --session-id fw-proof-ds -m "Say READY and nothing else." --model fireworks/accounts/fireworks/models/deepseek-v4-pro --thinking high` → before: `error=LLM request failed … rawError=400 cannot specify both 'thinking' and 'reasoning_effort'`; after: `READY`. Raw API contract probe: a direct `POST /v1/chat/completions` for `deepseek-v4-pro` with `{"thinking":{"type":"enabled"},"reasoning_effort":"low"}` returns the same 400, while `{"reasoning_effort":"low"}` alone returns a normal completion — the patched plugin emits the latter shape.
Observed result after fix: all four models listed in the catalog with pricing; live one-turn agent runs on this branch return model replies for all four families (deepseek-v4-pro/minimax-m2p7/glm-5p1/gpt-oss-120b), including a deepseek-v4-pro turn at `--thinking max` through the dynamic-id path.
What was not tested: Fire Pass / `routers/*-fast` ids (separate follow-up), image input (all four rows are text-only per the live API), `xhigh`/`max` efforts end-to-end on deepseek (mapped per Fireworks' documented effort list but not exercised in a live turn).

<img width="1478" height="881" alt="image" src="https://github.com/user-attachments/assets/7fbaa13f-c52c-49f9-9fe8-016d797a3418" />

## Tests and validation

- `extensions/fireworks` vitest: 18 passed (catalog compat incl. the new `thinkingFormat` assertion, per-family thinking profiles, dynamic family compat merge, dynamic-model fallbacks); `src/auto-reply/thinking.test.ts`: 48 passed incl. the new no-off clamp regression; clamp consumers (`agent-command.live-model-switch`, cron model-override forwarding): green.
- `docs/providers/fireworks.md`: built-in catalog table and dynamic-id thinking notes refreshed with the new models.
- Core seam test: `extra-params.deepseek-v4-thinking-format.test.ts` 8 passed (pre-existing; proves the manifest override path this PR relies on).
- `tsgo` core + extension lanes clean; oxlint clean; oxfmt clean.
- Autoreview loop (claude-fable-5 thinking-high + codex gpt-5.5 medium), nine rounds until convergence; final verdicts: claude "patch is correct (0.85)", codex "patch is correct (0.83), no actionable findings". The full finding-by-finding ledger is in "Current review state" below.

## Risk checklist

- **Plugin-only — no core changes.** Additive manifest rows; the only code is the data-driven thinking-profile derivation (`thinking-policy.ts`, replaces the old per-family Kimi matcher) and four id constants. Net **+265/−23** across 5 files, all under `extensions/fireworks/**` and `docs/**`.
- No config/default surface changes outside the plugin manifest; no migrations; existing configured models are unaffected (rows are additive, ids unchanged).
- Dynamic (non-cataloged) Fireworks ids keep the exact pre-PR behavior except `deepseek-v4*`, which gains the compat opt-out (those turns 400'd before, so nothing working changes). Non-cataloged ids get the generic thinking menu; only the four cataloged ids get derived menus.
- Thinking-menu levels are clamped to what Fireworks accepts per model (verified per effort via `curl`), so a user-selected unsupported level can no longer produce a rejected request.
- **Known dependency:** GPT-OSS 120B is no-off, so a stored thinking-`off` session switched onto it clamps up to the most expensive level until the sibling core fix (`fix/thinking-clamp-below-range`) lands. No other added model is affected (the rest are off-capable).

## Current review state

What is the next action? Maintainer review. Author attaches the terminal screenshot (catalog listing + one live turn per family + the `curl` effort matrix) at the placeholder above.

What is still waiting on author, maintainer, CI, or external proof? Author: screenshot. Maintainer: review/land decision + ordering vs the sibling core fix. CI: standard checks. No external proof outstanding.

Is this PR plugin-only? Yes. An earlier iteration of this branch carried much more — a per-family regex matcher (`model-id.ts`), a dynamic-family compat table (`index.ts`), exported `FIREWORKS_*_COMPAT` clones, and a core thinking-clamp fix. The first three were workarounds for core not resolving the plugin's `openclaw.plugin.json` catalog; once **#90326** merged they were deleted. The core clamp fix was split out to **`fix/thinking-clamp-below-range`** so this PR is purely additive plugin data + manifest-derived menus + the DeepSeek `thinkingFormat` opt-out (one manifest field).

Which bot or reviewer comments were addressed? None posted on the current revision yet. The branch was force-pushed to its surgical form after #90326 merged and after the core fix was split out; a prior over-scoped revision is superseded.

<details>
<summary>Review state guidance</summary>

1. The following clawsweeper's notes has been resolved as PR#90326 is merged: 
- `Pause this PR until https://github.com/openclaw/openclaw/pull/90326 establishes manifest-authoritative resolution, then rebase and rerun the combined Fireworks tests and live proof.`
- [P1] This PR and https://github.com/openclaw/openclaw/pull/90326 overlap the same resolver files, so the final merged shape needs one canonical manifest-resolution path rather than two competing sources of truth.

</details>
