### PR TITLE
fix(media): extract large managed inbound PDFs via media-understanding

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -107,9 +107,6 @@ const mockState = vi.hoisted(() => ({
   // stageSandboxMedia silently skips over-cap files.
   unstagedSources: null as string[] | null,
   deleteMediaBufferCalls: [] as Array<{ id: string; subdir?: string }>,
-  // Paths the mocked resolveInboundMediaReference treats as managed inbound
-  // media-store entries (drives the #90097 managed-PDF staging-fallback tests).
-  managedInboundPaths: null as string[] | null,
 }));
 
 function readTranscriptJsonLines(transcriptPath: string): Array<Record<string, unknown>> {
@@ -428,22 +425,6 @@ vi.mock("../../media/store.js", async () => {
         mockState.activeSaveMediaCalls -= 1;
       }
     }),
-  };
-});
-
-vi.mock("../../media/media-reference.js", async () => {
-  const original = await vi.importActual<typeof import("../../media/media-reference.js")>(
-    "../../media/media-reference.js",
-  );
-  return {
-    ...original,
-    // Treat only test-declared paths as managed inbound media, so the #90097
-    // managed-PDF fallback can be exercised without a real on-disk media store.
-    resolveInboundMediaReference: vi.fn(async (source: string) =>
-      mockState.managedInboundPaths?.includes(source)
-        ? { id: source, normalizedSource: source, physicalPath: source, sourceType: "path" }
-        : null,
-    ),
   };
 });
 
@@ -861,7 +842,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.stagedRelativePaths = null;
     mockState.unstagedSources = null;
     mockState.deleteMediaBufferCalls = [];
-    mockState.managedInboundPaths = null;
     mockState.hasBeforeAgentRunHooks = false;
     mockState.beforeMessageWriteBlock = false;
     mockState.beforeMessageWriteContent = null;
@@ -5593,149 +5573,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     ]);
   });
 
-  it("falls back to the managed inbound PDF path when sandbox staging is incomplete (#90097)", async () => {
-    createTranscriptFixture("openclaw-chat-send-managed-pdf-incomplete-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = { modelProvider: "test-provider", model: "vision-model" };
-    mockState.modelCatalog = [
-      {
-        provider: "test-provider",
-        id: "vision-model",
-        name: "Vision model",
-        input: ["text", "image"],
-      },
-    ];
-    const managedPath = "/home/user/.openclaw/media/inbound/report.pdf";
-    mockState.savedMediaResults = [{ path: managedPath, contentType: "application/pdf" }];
-    mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
-    // Staging returns an incomplete map (the file silently fell out).
-    mockState.stagedRelativePaths = ["media/inbound/report.pdf"];
-    mockState.unstagedSources = [managedPath];
-    mockState.managedInboundPaths = [managedPath];
-    const respond = vi.fn();
-    const context = createChatContext();
-    const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-managed-pdf-incomplete",
-      message: "read this",
-      requestParams: {
-        attachments: [
-          { type: "file", mimeType: "application/pdf", fileName: "report.pdf", content: pdf },
-        ],
-      },
-      expectBroadcast: false,
-    });
-
-    // Send proceeds with the absolute managed path; buffers are NOT deleted.
-    expect(mockState.deleteMediaBufferCalls).toEqual([]);
-    expect(mockState.lastDispatchCtx?.MediaPaths).toEqual([managedPath]);
-    expect(mockState.lastDispatchCtx?.MediaPath).toBe(managedPath);
-    expect(mockState.lastDispatchCtx?.MediaTypes).toEqual(["application/pdf"]);
-    // Host-side readable: no sandbox workspace dir is carried for the fallback.
-    expect(mockState.lastDispatchCtx?.MediaWorkspaceDir).toBeUndefined();
-    // Marker still blocks the dispatch pipeline from re-running staging.
-    expect(mockState.lastDispatchCtx?.MediaStaged).toBe(true);
-  });
-
-  it("falls back to the managed inbound PDF path when sandbox staging throws (#90097)", async () => {
-    createTranscriptFixture("openclaw-chat-send-managed-pdf-throw-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = { modelProvider: "test-provider", model: "vision-model" };
-    mockState.modelCatalog = [
-      {
-        provider: "test-provider",
-        id: "vision-model",
-        name: "Vision model",
-        input: ["text", "image"],
-      },
-    ];
-    const managedPath = "/home/user/.openclaw/media/inbound/report.pdf";
-    mockState.savedMediaResults = [{ path: managedPath, contentType: "application/pdf" }];
-    mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
-    mockState.stageSandboxMediaError = new Error("ENOSPC: no space left on device");
-    mockState.managedInboundPaths = [managedPath];
-    const respond = vi.fn();
-    const context = createChatContext();
-    const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-managed-pdf-throw",
-      message: "read this",
-      requestParams: {
-        attachments: [
-          { type: "file", mimeType: "application/pdf", fileName: "report.pdf", content: pdf },
-        ],
-      },
-      expectBroadcast: false,
-    });
-
-    expect(mockState.deleteMediaBufferCalls).toEqual([]);
-    expect(mockState.lastDispatchCtx?.MediaPaths).toEqual([managedPath]);
-    expect(mockState.lastDispatchCtx?.MediaWorkspaceDir).toBeUndefined();
-    expect(mockState.lastDispatchCtx?.MediaStaged).toBe(true);
-  });
-
-  it("does not fall back when not every offloaded ref is a managed PDF (#90097)", async () => {
-    createTranscriptFixture("openclaw-chat-send-managed-pdf-mixed-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = { modelProvider: "test-provider", model: "vision-model" };
-    mockState.modelCatalog = [
-      {
-        provider: "test-provider",
-        id: "vision-model",
-        name: "Vision model",
-        input: ["text", "image"],
-      },
-    ];
-    const managedPdf = "/home/user/.openclaw/media/inbound/report.pdf";
-    const managedZip = "/home/user/.openclaw/media/inbound/data.zip";
-    mockState.savedMediaResults = [
-      { path: managedPdf, contentType: "application/pdf" },
-      { path: managedZip, contentType: "application/zip" },
-    ];
-    mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
-    mockState.stagedRelativePaths = ["media/inbound/report.pdf", "media/inbound/data.zip"];
-    mockState.unstagedSources = [managedPdf];
-    // Both managed, but the non-PDF ref must block the all-or-nothing fallback.
-    mockState.managedInboundPaths = [managedPdf, managedZip];
-    const respond = vi.fn();
-    const context = createChatContext();
-    const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
-    const zip = Buffer.from("PKdata").toString("base64");
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-managed-pdf-mixed",
-      message: "read these",
-      requestParams: {
-        attachments: [
-          { type: "file", mimeType: "application/pdf", fileName: "report.pdf", content: pdf },
-          { type: "file", mimeType: "application/zip", fileName: "data.zip", content: zip },
-        ],
-      },
-      expectBroadcast: false,
-      waitFor: "none",
-    });
-
-    // Mixed batch keeps the existing delete + 5xx behavior (no silent passthrough).
-    expect(mockState.lastDispatchCtx).toBeUndefined();
-    const [ok, , error] = lastRespondCall(respond) ?? [];
-    expect(ok).toBe(false);
-    expect(error?.code).toBe(ErrorCodes.UNAVAILABLE);
-    expect(mockState.deleteMediaBufferCalls.map((c) => c.id).toSorted()).toEqual([
-      "saved-media",
-      "saved-media",
-    ]);
-  });
-
-  it("passes sandbox-oversized managed inbound PDFs through instead of rejecting them (#90097)", async () => {
-    createTranscriptFixture("openclaw-chat-send-managed-pdf-oversize-");
+  it("passes already-managed oversized inbound PDFs through staging instead of rejecting", async () => {
+    // #90097: a managed inbound PDF above the sandbox staging cap is read
+    // host-side (media-understanding) rather than copied into the sandbox, so
+    // it must reach dispatch with its managed media path instead of a 4xx.
+    createTranscriptFixture("openclaw-chat-send-managed-pdf-pass-through-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -5749,19 +5591,20 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         input: ["text", "image"],
       },
     ];
-    const managedPath = "/home/user/.openclaw/media/inbound/huge.pdf";
-    mockState.savedMediaResults = [{ path: managedPath, contentType: "application/pdf" }];
+    mockState.savedMediaResults = [
+      { path: "/home/user/.openclaw/media/inbound/huge.pdf", contentType: "application/pdf" },
+    ];
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
-    mockState.managedInboundPaths = [managedPath];
     const respond = vi.fn();
     const context = createChatContext();
+    // 6MB PDF — above STAGED_MEDIA_MAX_BYTES (5MB) but below the 20MB parse cap.
     const oversized = Buffer.alloc(6 * 1024 * 1024);
     oversized.set(Buffer.from("%PDF-1.4\n"), 0);
 
     await runNonStreamingChatSend({
       context,
       respond,
-      idempotencyKey: "idem-managed-pdf-oversize",
+      idempotencyKey: "idem-managed-pdf-pass-through",
       message: "read this",
       requestParams: {
         attachments: [
@@ -5776,13 +5619,19 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       expectBroadcast: false,
     });
 
-    expect(mockState.deleteMediaBufferCalls).toEqual([]);
-    expect(mockState.lastDispatchCtx?.MediaPath).toBe(managedPath);
-    expect(mockState.lastDispatchCtx?.MediaPaths).toEqual([managedPath]);
+    // Reaches dispatch with the managed media path; not staged into the sandbox,
+    // so no workspace dir, and the media-store entry is kept (not cleaned up).
+    expect(mockState.lastDispatchCtx?.MediaPath).toBe(
+      "/home/user/.openclaw/media/inbound/huge.pdf",
+    );
+    expect(mockState.lastDispatchCtx?.MediaPaths).toEqual([
+      "/home/user/.openclaw/media/inbound/huge.pdf",
+    ]);
     expect(mockState.lastDispatchCtx?.MediaType).toBe("application/pdf");
     expect(mockState.lastDispatchCtx?.MediaTypes).toEqual(["application/pdf"]);
     expect(mockState.lastDispatchCtx?.MediaWorkspaceDir).toBeUndefined();
     expect(mockState.lastDispatchCtx?.MediaStaged).toBe(true);
+    expect(mockState.deleteMediaBufferCalls).toEqual([]);
   });
 
   it("rejects sandbox-oversized non-image attachments as 4xx before staging", async () => {
@@ -5791,7 +5640,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // silently drops oversize files. Without a pre-check, a sandbox session
     // accepting a 5-20MB non-image would fail staging and surface as a
     // retryable 5xx UNAVAILABLE, misleading clients into retrying a
-    // deterministically broken request.
+    // deterministically broken request. Managed PDFs pass through (see above);
+    // other oversized non-image files must still be rejected.
     createTranscriptFixture("openclaw-chat-send-sandbox-oversize-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -5395,7 +5395,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(mockState.lastDispatchCtx?.MediaStaged).toBe(true);
   });
 
-  it("wraps stageSandboxMedia infrastructure errors as 5xx UNAVAILABLE and cleans up media-store files", async () => {
+  it("wraps stageSandboxMedia infrastructure errors as 5xx UNAVAILABLE for non-fallback refs and cleans up media-store files", async () => {
+    // A non-PDF managed offload cannot fall back to a managed path, so an infra
+    // staging error stays a retryable 5xx. (Managed PDFs fall back instead — see
+    // the staging-throw fallback test below.) #90097
     createTranscriptFixture("openclaw-chat-send-stage-unavailable-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
@@ -5411,7 +5414,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
     ];
     mockState.savedMediaResults = [
-      { path: "/home/user/.openclaw/media/inbound/report.pdf", contentType: "application/pdf" },
+      {
+        path: "/home/user/.openclaw/media/inbound/report.bin",
+        contentType: "application/octet-stream",
+      },
     ];
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     const stageError = Object.assign(new Error("ENOSPC: no space left on device"), {
@@ -5422,7 +5428,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.stageSandboxMediaError = stageError;
     const respond = vi.fn();
     const context = createChatContext();
-    const pdf = Buffer.from("%PDF-1.4\n%µ¶\n1 0 obj\n<<>>\nendobj\n").toString("base64");
+    const binPayload = Buffer.from("OPENCLAW-BINARY\n").toString("base64");
 
     await runNonStreamingChatSend({
       context,
@@ -5433,9 +5439,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         attachments: [
           {
             type: "file",
-            mimeType: "application/pdf",
-            fileName: "report.pdf",
-            content: pdf,
+            mimeType: "application/octet-stream",
+            fileName: "report.bin",
+            content: binPayload,
           },
         ],
       },
@@ -5518,7 +5524,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // absolute path, so a simple `stagedPaths.length === nonImage.length`
     // check could not detect when one of the files silently fell out (e.g. a
     // file between the RPC cap and the staging cap). Prestage must compare
-    // the returned `staged` map against the input refs.
+    // the returned `staged` map against the input refs. Non-PDF refs cannot fall
+    // back to a managed path, so an incomplete stage stays a 5xx. (Managed PDFs
+    // fall back instead — see the staging-skip fallback test below.) #90097
     createTranscriptFixture("openclaw-chat-send-partial-stage-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
@@ -5534,15 +5542,21 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
     ];
     mockState.savedMediaResults = [
-      { path: "/home/user/.openclaw/media/inbound/report.pdf", contentType: "application/pdf" },
-      { path: "/home/user/.openclaw/media/inbound/oversize.pdf", contentType: "application/pdf" },
+      {
+        path: "/home/user/.openclaw/media/inbound/report.bin",
+        contentType: "application/octet-stream",
+      },
+      {
+        path: "/home/user/.openclaw/media/inbound/data.bin",
+        contentType: "application/octet-stream",
+      },
     ];
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
-    mockState.stagedRelativePaths = ["media/inbound/report.pdf", "media/inbound/oversize.pdf"];
-    mockState.unstagedSources = ["/home/user/.openclaw/media/inbound/oversize.pdf"];
+    mockState.stagedRelativePaths = ["media/inbound/report.bin", "media/inbound/data.bin"];
+    mockState.unstagedSources = ["/home/user/.openclaw/media/inbound/data.bin"];
     const respond = vi.fn();
     const context = createChatContext();
-    const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
+    const binPayload = Buffer.from("OPENCLAW-BINARY\n").toString("base64");
 
     await runNonStreamingChatSend({
       context,
@@ -5551,8 +5565,18 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       message: "read these",
       requestParams: {
         attachments: [
-          { type: "file", mimeType: "application/pdf", fileName: "report.pdf", content: pdf },
-          { type: "file", mimeType: "application/pdf", fileName: "oversize.pdf", content: pdf },
+          {
+            type: "file",
+            mimeType: "application/octet-stream",
+            fileName: "report.bin",
+            content: binPayload,
+          },
+          {
+            type: "file",
+            mimeType: "application/octet-stream",
+            fileName: "data.bin",
+            content: binPayload,
+          },
         ],
       },
       expectBroadcast: false,
@@ -5632,6 +5656,188 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(mockState.lastDispatchCtx?.MediaWorkspaceDir).toBeUndefined();
     expect(mockState.lastDispatchCtx?.MediaStaged).toBe(true);
     expect(mockState.deleteMediaBufferCalls).toEqual([]);
+  });
+
+  it("falls back to the managed path when sandbox staging throws for an already-managed PDF", async () => {
+    // #90097: an already-managed inbound PDF below the staging cap normally
+    // stages into the sandbox, but if staging throws (e.g. workspace mkdir
+    // ENOSPC) the PDF must still reach the agent via its managed media path
+    // instead of failing the send — host-side media-understanding reads it from
+    // the media-store root.
+    createTranscriptFixture("openclaw-chat-send-managed-pdf-stage-throw-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      modelProvider: "test-provider",
+      model: "vision-model",
+    };
+    mockState.modelCatalog = [
+      {
+        provider: "test-provider",
+        id: "vision-model",
+        name: "Vision model",
+        input: ["text", "image"],
+      },
+    ];
+    mockState.savedMediaResults = [
+      { path: "/home/user/.openclaw/media/inbound/report.pdf", contentType: "application/pdf" },
+    ];
+    mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
+    mockState.stageSandboxMediaError = Object.assign(new Error("ENOSPC: no space left on device"), {
+      code: "ENOSPC",
+    });
+    const respond = vi.fn();
+    const context = createChatContext();
+    // Small PDF (below the 5MB staging cap) so it takes the staging path, not the
+    // oversized pass-through path.
+    const pdf = Buffer.from("%PDF-1.4\n%µ¶\nendobj\n").toString("base64");
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-managed-pdf-stage-throw",
+      message: "read this",
+      requestParams: {
+        attachments: [
+          { type: "file", mimeType: "application/pdf", fileName: "report.pdf", content: pdf },
+        ],
+      },
+      expectBroadcast: false,
+    });
+
+    // Falls back to the absolute managed path; nothing staged (so no workspace
+    // dir) and the media-store entry is preserved for host-side extraction.
+    expect(mockState.lastDispatchCtx?.MediaPath).toBe(
+      "/home/user/.openclaw/media/inbound/report.pdf",
+    );
+    expect(mockState.lastDispatchCtx?.MediaPaths).toEqual([
+      "/home/user/.openclaw/media/inbound/report.pdf",
+    ]);
+    expect(mockState.lastDispatchCtx?.MediaType).toBe("application/pdf");
+    expect(mockState.lastDispatchCtx?.MediaWorkspaceDir).toBeUndefined();
+    expect(mockState.lastDispatchCtx?.MediaStaged).toBe(true);
+    expect(mockState.deleteMediaBufferCalls).toEqual([]);
+  });
+
+  it("falls back to the managed path when sandbox staging silently skips an already-managed PDF", async () => {
+    // #90097: stageSandboxMedia can silently skip a file (keeping its absolute
+    // path) and return it absent from the staged map. An already-managed PDF in
+    // that state falls back to its managed media path rather than failing the
+    // send; the staged workspace dir is still carried for any files that landed.
+    createTranscriptFixture("openclaw-chat-send-managed-pdf-stage-skip-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      modelProvider: "test-provider",
+      model: "vision-model",
+    };
+    mockState.modelCatalog = [
+      {
+        provider: "test-provider",
+        id: "vision-model",
+        name: "Vision model",
+        input: ["text", "image"],
+      },
+    ];
+    mockState.savedMediaResults = [
+      { path: "/home/user/.openclaw/media/inbound/report.pdf", contentType: "application/pdf" },
+    ];
+    mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
+    // No stagedRelativePaths → staged map is empty and ctx.MediaPaths keeps the
+    // absolute path, mirroring stageSandboxMedia silently skipping the file.
+    const respond = vi.fn();
+    const context = createChatContext();
+    const pdf = Buffer.from("%PDF-1.4\n%µ¶\nendobj\n").toString("base64");
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-managed-pdf-stage-skip",
+      message: "read this",
+      requestParams: {
+        attachments: [
+          { type: "file", mimeType: "application/pdf", fileName: "report.pdf", content: pdf },
+        ],
+      },
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx?.MediaPath).toBe(
+      "/home/user/.openclaw/media/inbound/report.pdf",
+    );
+    expect(mockState.lastDispatchCtx?.MediaPaths).toEqual([
+      "/home/user/.openclaw/media/inbound/report.pdf",
+    ]);
+    expect(mockState.lastDispatchCtx?.MediaType).toBe("application/pdf");
+    expect(mockState.lastDispatchCtx?.MediaWorkspaceDir).toBe("/sandbox/workspace");
+    expect(mockState.lastDispatchCtx?.MediaStaged).toBe(true);
+    expect(mockState.deleteMediaBufferCalls).toEqual([]);
+  });
+
+  it("still fails the send when staging skips a non-PDF in a mixed managed batch", async () => {
+    // #90097: the PDF fallback is per-ref. A managed PDF that stages does not
+    // rescue a sibling non-PDF that silently fell out of staging; that batch must
+    // still surface a retryable 5xx and clean up every offloaded entry.
+    createTranscriptFixture("openclaw-chat-send-mixed-stage-skip-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      modelProvider: "test-provider",
+      model: "vision-model",
+    };
+    mockState.modelCatalog = [
+      {
+        provider: "test-provider",
+        id: "vision-model",
+        name: "Vision model",
+        input: ["text", "image"],
+      },
+    ];
+    mockState.savedMediaResults = [
+      { path: "/home/user/.openclaw/media/inbound/report.pdf", contentType: "application/pdf" },
+      {
+        path: "/home/user/.openclaw/media/inbound/data.bin",
+        contentType: "application/octet-stream",
+      },
+    ];
+    mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
+    mockState.stagedRelativePaths = ["media/inbound/report.pdf", "media/inbound/data.bin"];
+    mockState.unstagedSources = ["/home/user/.openclaw/media/inbound/data.bin"];
+    const respond = vi.fn();
+    const context = createChatContext();
+    const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
+    const bin = Buffer.from("OPENCLAW-BINARY\n").toString("base64");
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-mixed-stage-skip",
+      message: "read these",
+      requestParams: {
+        attachments: [
+          { type: "file", mimeType: "application/pdf", fileName: "report.pdf", content: pdf },
+          {
+            type: "file",
+            mimeType: "application/octet-stream",
+            fileName: "data.bin",
+            content: bin,
+          },
+        ],
+      },
+      expectBroadcast: false,
+      waitFor: "none",
+    });
+
+    expect(mockState.lastDispatchCtx).toBeUndefined();
+    expect(respond).toHaveBeenCalledTimes(1);
+    const [ok, payload, error] = lastRespondCall(respond) ?? [];
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect(error?.code).toBe(ErrorCodes.UNAVAILABLE);
+    expect(responseErrorMessage(error)).toMatch(/staging incomplete/i);
+    // The whole batch is cleaned up — including the PDF that would have fallen
+    // back on its own — because the non-PDF cannot be delivered.
+    expect(mockState.deleteMediaBufferCalls.map((c) => c.id).toSorted()).toEqual([
+      "saved-media",
+      "saved-media",
+    ]);
   });
 
   it("rejects sandbox-oversized non-image attachments as 4xx before staging", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -78,7 +78,7 @@ import {
   appendLocalMediaParentRoots,
   getAgentScopedMediaLocalRoots,
 } from "../../media/local-roots.js";
-import { resolveInboundMediaReference } from "../../media/media-reference.js";
+import { parseInboundMediaUri } from "../../media/media-reference.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import {
   deleteMediaBuffer,
@@ -1336,6 +1336,31 @@ function stripTrailingOffloadedMediaMarkers(message: string, refs: OffloadedRef[
   return lines.join("\n").trimEnd();
 }
 
+function isPdfOffloadedRef(ref: OffloadedRef): boolean {
+  const mime = ref.mimeType.trim().toLowerCase();
+  if (mime === "application/pdf" || mime.endsWith("+pdf")) {
+    return true;
+  }
+  return path.extname(ref.path.split(/[?#]/u)[0] ?? "").toLowerCase() === ".pdf";
+}
+
+// A managed inbound PDF saved to the media store is safe to hand the agent as
+// its media path without sandbox staging: host-side media-understanding extracts
+// its text (see resolveFileExtractionLimits), and copying a large PDF into every
+// sandbox is wasteful. Files above the 5MB staging cap are otherwise rejected as
+// a 4xx (see prestageMediaPathOffloads), so pass managed PDFs through instead so
+// locked-down agents still receive the document text. #90097
+function shouldPassThroughManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
+  if (ref.sizeBytes <= MEDIA_MAX_BYTES || !isPdfOffloadedRef(ref)) {
+    return false;
+  }
+  try {
+    return parseInboundMediaUri(ref.mediaRef) !== null;
+  } catch {
+    return false;
+  }
+}
+
 // Stages media-path offloads into the agent sandbox synchronously so chat.send
 // can surface 5xx before respond(). Throws MediaOffloadError on any staging
 // failure (ENOSPC / EPERM / partial-stage) so the outer chat.send handler can
@@ -1344,35 +1369,10 @@ function stripTrailingOffloadedMediaMarkers(message: string, refs: OffloadedRef[
 // Callers MUST set ctx.MediaStaged=true when this runs so the dispatch
 // pipeline skips its own stageSandboxMedia pass.
 //
-// Returned paths are absolute media-store paths when no sandbox is active, or
-// sandbox-relative paths plus `workspaceDir` when sandboxing is active. Host-side
-// media-understanding uses MediaWorkspaceDir to resolve those relative paths.
-// Optional sandbox staging is a convenience copy into the container; a managed
-// inbound media-store PDF is already host-readable (the managed media dir is a
-// default media-understanding local root, resolved via the absolute path when
-// MediaWorkspaceDir is unset). When staging is unavailable/incomplete we can
-// therefore pass those absolute managed paths through instead of deleting the
-// buffers and failing the send (#90097). Gated all-or-nothing to managed-inbound
-// PDFs so a single non-managed or non-PDF ref cannot bypass staging; reuses the
-// same resolveInboundMediaReference allow-check stageSandboxMedia applies.
-async function resolveManagedInboundPdfFallback(
-  refs: readonly OffloadedRef[],
-): Promise<{ paths: string[]; types: string[] } | null> {
-  for (const ref of refs) {
-    if (ref.mimeType !== "application/pdf") {
-      return null;
-    }
-    const managed = await resolveInboundMediaReference(ref.path).catch(() => null);
-    if (!managed) {
-      return null;
-    }
-  }
-  return {
-    paths: refs.map((ref) => ref.path),
-    types: refs.map((ref) => ref.mimeType),
-  };
-}
-
+// Returned paths are absolute media-store paths when no sandbox is active or for
+// oversized managed PDFs that pass through staging (#90097), and sandbox-relative
+// paths plus `workspaceDir` for files staged into the sandbox. Host-side
+// media-understanding resolves both via MediaWorkspaceDir and the media-store root.
 async function prestageMediaPathOffloads(params: {
   offloadedRefs: OffloadedRef[];
   includeImageRefs?: boolean;
@@ -1386,6 +1386,21 @@ async function prestageMediaPathOffloads(params: {
   if (mediaPathRefs.length === 0) {
     return { paths: [], types: [] };
   }
+  const refsByManagedPath = (refs: OffloadedRef[]) => ({
+    paths: refs.map((ref) => ref.path),
+    types: refs.map((ref) => ref.mimeType),
+  });
+
+  // Oversized managed PDFs bypass sandbox staging and are read host-side, so they
+  // do not need a workspace copy or the staging-cap check below.
+  const passThroughRefs: OffloadedRef[] = [];
+  const refsToStage: OffloadedRef[] = [];
+  for (const ref of mediaPathRefs) {
+    (shouldPassThroughManagedInboundPdfOffloadRef(ref) ? passThroughRefs : refsToStage).push(ref);
+  }
+  if (refsToStage.length === 0) {
+    return refsByManagedPath(mediaPathRefs);
+  }
 
   try {
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
@@ -1395,25 +1410,18 @@ async function prestageMediaPathOffloads(params: {
       workspaceDir,
     });
     if (!sandbox) {
-      return {
-        paths: mediaPathRefs.map((ref) => ref.path),
-        types: mediaPathRefs.map((ref) => ref.mimeType),
-      };
+      return refsByManagedPath(mediaPathRefs);
     }
 
     // stageSandboxMedia caps each file at STAGED_MEDIA_MAX_BYTES (=
     // MEDIA_MAX_BYTES, 5MB) and silently skips oversized files. The parse cap
     // (resolveChatAttachmentMaxBytes, default 20MB) is higher, so a sandboxed
-    // session receiving a file between the two caps would otherwise
+    // session receiving a non-PDF file between the two caps would otherwise
     // pass parse, fail staging, and surface as a retryable 5xx even though
-    // retry cannot succeed. Managed inbound PDFs are already host-readable, so
-    // let the managed-PDF fallback handle them before rejecting everything else.
-    const oversizedForSandbox = mediaPathRefs.filter((ref) => ref.sizeBytes > MEDIA_MAX_BYTES);
+    // retry cannot succeed. Reject here as a client-side 4xx instead. Managed
+    // PDFs in that range pass through above instead of being rejected.
+    const oversizedForSandbox = refsToStage.filter((ref) => ref.sizeBytes > MEDIA_MAX_BYTES);
     if (oversizedForSandbox.length > 0) {
-      const managedPdfFallback = await resolveManagedInboundPdfFallback(mediaPathRefs);
-      if (managedPdfFallback) {
-        return managedPdfFallback;
-      }
       const details = oversizedForSandbox
         .map((ref) => `${ref.label} (${ref.sizeBytes} bytes)`)
         .join(", ");
@@ -1424,56 +1432,58 @@ async function prestageMediaPathOffloads(params: {
     }
 
     const stagingCtx: MsgContext = {
-      MediaPath: mediaPathRefs[0].path,
-      MediaPaths: mediaPathRefs.map((ref) => ref.path),
-      MediaType: mediaPathRefs[0].mimeType,
-      MediaTypes: mediaPathRefs.map((ref) => ref.mimeType),
+      MediaPath: refsToStage[0].path,
+      MediaPaths: refsToStage.map((ref) => ref.path),
+      MediaType: refsToStage[0].mimeType,
+      MediaTypes: refsToStage.map((ref) => ref.mimeType),
     };
-    let stageResult: Awaited<ReturnType<typeof stageSandboxMedia>>;
-    try {
-      stageResult = await stageSandboxMedia({
-        ctx: stagingCtx,
-        sessionCtx: stagingCtx as TemplateContext,
-        cfg: params.cfg,
-        sessionKey: params.sessionKey,
-        workspaceDir,
-      });
-    } catch (stageErr) {
-      // Staging is optional; pass managed-inbound PDFs through rather than
-      // deleting buffers + failing the send. Rethrow otherwise (#90097).
-      const managedPdfFallback = await resolveManagedInboundPdfFallback(mediaPathRefs);
-      if (managedPdfFallback) {
-        return managedPdfFallback;
-      }
-      throw stageErr;
-    }
+    const stageResult = await stageSandboxMedia({
+      ctx: stagingCtx,
+      sessionCtx: stagingCtx as TemplateContext,
+      cfg: params.cfg,
+      sessionKey: params.sessionKey,
+      workspaceDir,
+    });
 
     // stageSandboxMedia silently keeps unstaged entries as their original
-    // absolute path, so length parity with `nonImage` does not prove every
-    // file landed in the sandbox. The RPC max (20MB via
-    // resolveChatAttachmentMaxBytes) admits files above the staging cap
-    // (STAGED_MEDIA_MAX_BYTES = 5MB); check the returned `staged` map so any
-    // missing source becomes a 5xx MediaOffloadError the client can retry.
+    // absolute path, so length parity does not prove every file landed in the
+    // sandbox. The RPC max (20MB via resolveChatAttachmentMaxBytes) admits files
+    // above the staging cap (STAGED_MEDIA_MAX_BYTES = 5MB); check the returned
+    // `staged` map so any missing source becomes a 5xx MediaOffloadError the
+    // client can retry.
     const stagedSources = stageResult.staged;
-    const missing = mediaPathRefs.filter((ref) => !stagedSources.has(ref.path));
+    const missing = refsToStage.filter((ref) => !stagedSources.has(ref.path));
     if (missing.length > 0) {
-      // Incomplete staging: pass managed-inbound PDFs through (host-readable)
-      // rather than failing the send. Fail otherwise as before (#90097).
-      const managedPdfFallback = await resolveManagedInboundPdfFallback(mediaPathRefs);
-      if (managedPdfFallback) {
-        return managedPdfFallback;
-      }
       throw new Error(
-        `attachment staging incomplete: ${stagedSources.size}/${mediaPathRefs.length} paths staged into sandbox workspace (missing: ${missing.map((ref) => ref.path).join(", ")})`,
+        `attachment staging incomplete: ${stagedSources.size}/${refsToStage.length} paths staged into sandbox workspace (missing: ${missing.map((ref) => ref.path).join(", ")})`,
       );
     }
     const stagedPaths = stagingCtx.MediaPaths ?? [];
-    const stagedTypes = stagingCtx.MediaTypes ?? mediaPathRefs.map((ref) => ref.mimeType);
+    const stagedTypes = stagingCtx.MediaTypes ?? refsToStage.map((ref) => ref.mimeType);
 
-    // Keep stagedPaths sandbox-relative (e.g. `media/inbound/foo.pdf`) so the
-    // agent inside the container can read them. Host-side media-understanding
-    // resolves them via ctx.MediaWorkspaceDir, which we carry separately.
-    return { paths: stagedPaths, types: stagedTypes, workspaceDir: sandbox.workspaceDir };
+    // Map each ref to its post-staging path. Staged files become sandbox-relative
+    // (e.g. `media/inbound/foo.pdf`) so the agent inside the container can read
+    // them; pass-through PDFs keep their absolute managed path. Host-side
+    // media-understanding resolves both via ctx.MediaWorkspaceDir plus the
+    // media-store root. Preserve the original attachment order.
+    const resolvedByRef = new Map<OffloadedRef, { path: string; mimeType: string }>();
+    refsToStage.forEach((ref, index) => {
+      resolvedByRef.set(ref, {
+        path: stagedPaths[index] ?? ref.path,
+        mimeType: stagedTypes[index] ?? ref.mimeType,
+      });
+    });
+    for (const ref of passThroughRefs) {
+      resolvedByRef.set(ref, { path: ref.path, mimeType: ref.mimeType });
+    }
+    const ordered = mediaPathRefs.map(
+      (ref) => resolvedByRef.get(ref) ?? { path: ref.path, mimeType: ref.mimeType },
+    );
+    return {
+      paths: ordered.map((entry) => entry.path),
+      types: ordered.map((entry) => entry.mimeType),
+      workspaceDir: sandbox.workspaceDir,
+    };
   } catch (err) {
     await Promise.allSettled(
       params.offloadedRefs.map((ref) => deleteMediaBuffer(ref.id, "inbound")),

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -53,7 +53,10 @@ import {
   type ReplyPayload,
 } from "../../auto-reply/reply-payload.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
-import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js";
+import {
+  stageSandboxMedia,
+  type StageSandboxMediaResult,
+} from "../../auto-reply/reply/stage-sandbox-media.js";
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
 import { resolveSessionFilePath, updateSessionStoreEntry } from "../../config/sessions.js";
 import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
@@ -1344,14 +1347,14 @@ function isPdfOffloadedRef(ref: OffloadedRef): boolean {
   return path.extname(ref.path.split(/[?#]/u)[0] ?? "").toLowerCase() === ".pdf";
 }
 
-// A managed inbound PDF saved to the media store is safe to hand the agent as
-// its media path without sandbox staging: host-side media-understanding extracts
-// its text (see resolveFileExtractionLimits), and copying a large PDF into every
-// sandbox is wasteful. Files above the 5MB staging cap are otherwise rejected as
-// a 4xx (see prestageMediaPathOffloads), so pass managed PDFs through instead so
-// locked-down agents still receive the document text. #90097
-function shouldPassThroughManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
-  if (ref.sizeBytes <= MEDIA_MAX_BYTES || !isPdfOffloadedRef(ref)) {
+// A managed inbound PDF saved to the media store is safe to hand the agent as its
+// media path without sandbox staging: host-side media-understanding extracts its
+// text (see resolveFileExtractionLimits) by reading the media-store root, so even
+// locked-down agents receive the document. This gates both the up-front bypass for
+// oversized PDFs and the fallback to the managed path when sandbox staging fails
+// for an already-managed PDF. #90097
+function isManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
+  if (!isPdfOffloadedRef(ref)) {
     return false;
   }
   try {
@@ -1361,18 +1364,29 @@ function shouldPassThroughManagedInboundPdfOffloadRef(ref: OffloadedRef): boolea
   }
 }
 
+// Oversized managed PDFs skip sandbox staging up front: copying a large PDF into
+// every sandbox is wasteful, and files above the 5MB staging cap would otherwise
+// be rejected as a 4xx (see prestageMediaPathOffloads).
+function shouldPassThroughManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
+  return ref.sizeBytes > MEDIA_MAX_BYTES && isManagedInboundPdfOffloadRef(ref);
+}
+
 // Stages media-path offloads into the agent sandbox synchronously so chat.send
-// can surface 5xx before respond(). Throws MediaOffloadError on any staging
-// failure (ENOSPC / EPERM / partial-stage) so the outer chat.send handler can
-// map it to UNAVAILABLE (5xx); plain Error would be misclassified as 4xx. All
-// offloaded refs are cleaned up from the media store before rethrow.
+// can surface 5xx before respond(). Throws MediaOffloadError when staging fails
+// for a ref that cannot fall back (ENOSPC / EPERM / partial-stage of a non-PDF or
+// unmanaged ref) so the outer chat.send handler maps it to UNAVAILABLE (5xx);
+// plain Error would be misclassified as 4xx. Already-managed inbound PDFs instead
+// fall back to their managed media path on staging failure (#90097), since
+// host-side media-understanding reads them from the media-store root. Offloaded
+// refs are cleaned up from the media store before rethrow.
 // Callers MUST set ctx.MediaStaged=true when this runs so the dispatch
 // pipeline skips its own stageSandboxMedia pass.
 //
-// Returned paths are absolute media-store paths when no sandbox is active or for
-// oversized managed PDFs that pass through staging (#90097), and sandbox-relative
-// paths plus `workspaceDir` for files staged into the sandbox. Host-side
-// media-understanding resolves both via MediaWorkspaceDir and the media-store root.
+// Returned paths are absolute media-store paths when no sandbox is active, for
+// oversized managed PDFs that bypass staging, or for already-managed PDFs that
+// fall back when staging fails (#90097); files staged into the sandbox use
+// sandbox-relative paths plus `workspaceDir`. Host-side media-understanding
+// resolves both via MediaWorkspaceDir and the media-store root.
 async function prestageMediaPathOffloads(params: {
   offloadedRefs: OffloadedRef[];
   includeImageRefs?: boolean;
@@ -1437,25 +1451,41 @@ async function prestageMediaPathOffloads(params: {
       MediaType: refsToStage[0].mimeType,
       MediaTypes: refsToStage.map((ref) => ref.mimeType),
     };
-    const stageResult = await stageSandboxMedia({
-      ctx: stagingCtx,
-      sessionCtx: stagingCtx as TemplateContext,
-      cfg: params.cfg,
-      sessionKey: params.sessionKey,
-      workspaceDir,
-    });
+    let stageResult: StageSandboxMediaResult;
+    try {
+      stageResult = await stageSandboxMedia({
+        ctx: stagingCtx,
+        sessionCtx: stagingCtx as TemplateContext,
+        cfg: params.cfg,
+        sessionKey: params.sessionKey,
+        workspaceDir,
+      });
+    } catch (stageErr) {
+      // stageSandboxMedia threw before copying anything (e.g. workspace mkdir
+      // ENOSPC/EPERM), so nothing reached the sandbox. Already-managed inbound
+      // PDFs still reach the agent via their managed media path (host-side
+      // media-understanding reads the media-store root); fail the send only when a
+      // ref cannot fall back. #90097
+      if (refsToStage.some((ref) => !isManagedInboundPdfOffloadRef(ref))) {
+        throw stageErr;
+      }
+      return refsByManagedPath(mediaPathRefs);
+    }
 
     // stageSandboxMedia silently keeps unstaged entries as their original
     // absolute path, so length parity does not prove every file landed in the
     // sandbox. The RPC max (20MB via resolveChatAttachmentMaxBytes) admits files
     // above the staging cap (STAGED_MEDIA_MAX_BYTES = 5MB); check the returned
-    // `staged` map so any missing source becomes a 5xx MediaOffloadError the
-    // client can retry.
+    // `staged` map for missing sources. Already-managed inbound PDFs fall back to
+    // their absolute managed path (host-side media-understanding reads the
+    // media-store root); any other missing source is a 5xx MediaOffloadError the
+    // client can retry. #90097
     const stagedSources = stageResult.staged;
     const missing = refsToStage.filter((ref) => !stagedSources.has(ref.path));
-    if (missing.length > 0) {
+    const unstageable = missing.filter((ref) => !isManagedInboundPdfOffloadRef(ref));
+    if (unstageable.length > 0) {
       throw new Error(
-        `attachment staging incomplete: ${stagedSources.size}/${refsToStage.length} paths staged into sandbox workspace (missing: ${missing.map((ref) => ref.path).join(", ")})`,
+        `attachment staging incomplete: ${stagedSources.size}/${refsToStage.length} paths staged into sandbox workspace (missing: ${unstageable.map((ref) => ref.path).join(", ")})`,
       );
     }
     const stagedPaths = stagingCtx.MediaPaths ?? [];
@@ -1463,9 +1493,10 @@ async function prestageMediaPathOffloads(params: {
 
     // Map each ref to its post-staging path. Staged files become sandbox-relative
     // (e.g. `media/inbound/foo.pdf`) so the agent inside the container can read
-    // them; pass-through PDFs keep their absolute managed path. Host-side
-    // media-understanding resolves both via ctx.MediaWorkspaceDir plus the
-    // media-store root. Preserve the original attachment order.
+    // them; pass-through PDFs and managed PDFs that fell back from staging keep
+    // their absolute managed path (stagedPaths preserves the absolute path for any
+    // unstaged entry). Host-side media-understanding resolves both via
+    // ctx.MediaWorkspaceDir plus the media-store root. Preserve attachment order.
     const resolvedByRef = new Map<OffloadedRef, { path: string; mimeType: string }>();
     refsToStage.forEach((ref, index) => {
       resolvedByRef.set(ref, {

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -1701,6 +1701,28 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toContain("hello from utf16 text");
   });
 
+  it("extracts inbound files above the 5MB OpenResponses default up to the managed-media cap", async () => {
+    // #90096: inbound extraction sizes to the agent media cap (default 20MB),
+    // not the OpenResponses input_file default (5MB). A ~6MB managed document
+    // would previously be skipped at the 5MB cap, leaving locked-down agents
+    // with only an attachment marker; it must now reach the prompt as text.
+    const marker = "LARGE-DOC-MARKER";
+    const largeText = `${marker} `.repeat(360_000); // ~6MB, above the old 5MB cap
+    const filePath = await createTempMediaFile({
+      fileName: "large-report.txt",
+      content: largeText,
+    });
+
+    const { ctx, result } = await applyWithDisabledMedia({
+      body: "<media:document>",
+      mediaPath: filePath,
+      mediaType: "text/plain",
+    });
+
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Body).toContain(marker);
+  });
+
   it("does not reclassify PDF attachments as text/plain", async () => {
     const pseudoPdf = Buffer.from("%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n", "utf8");
     const filePath = await createTempMediaFile({

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -10,16 +10,16 @@ import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { renderFileContextBlock } from "../media/file-context.js";
-import {
-  extractFileContentFromSource,
-  normalizeMimeType,
-  resolveInputFileLimits,
-} from "../media/input-files.js";
+import { extractFileContentFromSource, normalizeMimeType } from "../media/input-files.js";
 import { wrapExternalContent } from "../security/external-content.js";
 import type { ActiveMediaModel } from "./active-model.types.js";
 import { resolveAttachmentKind } from "./attachments.js";
 import { runWithConcurrency } from "./concurrency.js";
 import { DEFAULT_ECHO_TRANSCRIPT_FORMAT, sendTranscriptEcho } from "./echo-transcript.js";
+import {
+  type FileExtractionLimits,
+  resolveFileExtractionLimits,
+} from "./file-extraction-limits.js";
 import {
   extractMediaUserText,
   formatAudioTranscripts,
@@ -97,15 +97,6 @@ export function sanitizeMimeType(value?: string): string | undefined {
   }
   const match = trimmed.match(MIME_TYPE_WITH_OPTIONAL_PARAMS);
   return match?.[1]?.toLowerCase();
-}
-
-function resolveFileLimits(cfg: OpenClawConfig) {
-  const files = cfg.gateway?.http?.endpoints?.responses?.files;
-  const allowedMimesConfigured = Boolean(files?.allowedMimes?.length);
-  return {
-    ...resolveInputFileLimits(files),
-    allowedMimesConfigured,
-  };
 }
 
 function appendFileBlocks(body: string | undefined, blocks: string[]): string {
@@ -390,7 +381,7 @@ async function extractFileBlocks(params: {
   attachments: ReturnType<typeof normalizeMediaAttachments>;
   cache: ReturnType<typeof createMediaAttachmentCache>;
   cfg: OpenClawConfig;
-  limits: ReturnType<typeof resolveFileLimits>;
+  limits: FileExtractionLimits;
   skipAttachmentIndexes?: Set<number>;
 }): Promise<string[]> {
   const { attachments, cache, cfg, limits, skipAttachmentIndexes } = params;
@@ -683,7 +674,7 @@ export async function applyMediaUnderstanding(params: {
       attachments,
       cache,
       cfg,
-      limits: resolveFileLimits(cfg),
+      limits: resolveFileExtractionLimits(cfg),
       skipAttachmentIndexes: audioAttachmentIndexes.size > 0 ? audioAttachmentIndexes : undefined,
     });
     if (fileBlocks.length > 0) {

--- a/src/media-understanding/file-extraction-limits.test.ts
+++ b/src/media-understanding/file-extraction-limits.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
+import { resolveFileExtractionLimits } from "./file-extraction-limits.js";
+
+describe("resolveFileExtractionLimits", () => {
+  it("sizes inbound extraction to managed-media defaults, not the 5MB/4-page input_file defaults", () => {
+    // Regression for #90096: large managed PDFs were skipped because inbound
+    // extraction inherited the OpenResponses input_file defaults (5MB / 4 pages),
+    // so locked-down agents saw only the attachment marker.
+    const limits = resolveFileExtractionLimits({} as OpenClawConfig);
+    expect(limits.maxBytes).toBe(20 * 1024 * 1024);
+    expect(limits.pdf.maxPages).toBe(20);
+    expect(limits.allowedMimesConfigured).toBe(false);
+  });
+
+  it("derives the byte cap from agents.defaults.mediaMaxMb", () => {
+    const cfg = { agents: { defaults: { mediaMaxMb: 12 } } } as OpenClawConfig;
+    expect(resolveFileExtractionLimits(cfg).maxBytes).toBe(12 * 1024 * 1024);
+  });
+
+  it("derives the page budget from agents.defaults.pdfMaxPages", () => {
+    const cfg = { agents: { defaults: { pdfMaxPages: 50 } } } as OpenClawConfig;
+    expect(resolveFileExtractionLimits(cfg).pdf.maxPages).toBe(50);
+  });
+
+  it("clamps the byte cap to the 25MB host-side safety ceiling", () => {
+    const cfg = { agents: { defaults: { mediaMaxMb: 500 } } } as OpenClawConfig;
+    expect(resolveFileExtractionLimits(cfg).maxBytes).toBe(25 * 1024 * 1024);
+  });
+
+  it("clamps the page budget to the 150-page ceiling", () => {
+    const cfg = { agents: { defaults: { pdfMaxPages: 100000 } } } as OpenClawConfig;
+    expect(resolveFileExtractionLimits(cfg).pdf.maxPages).toBe(150);
+  });
+
+  it("ignores non-positive or non-finite agent limits and falls back to defaults", () => {
+    const cfg = {
+      agents: { defaults: { mediaMaxMb: 0, pdfMaxPages: -4 } },
+    } as unknown as OpenClawConfig;
+    const limits = resolveFileExtractionLimits(cfg);
+    expect(limits.maxBytes).toBe(20 * 1024 * 1024);
+    expect(limits.pdf.maxPages).toBe(20);
+  });
+
+  it("lets an explicit responses.files operator config win per-field", () => {
+    const cfg = {
+      agents: { defaults: { mediaMaxMb: 20, pdfMaxPages: 20 } },
+      gateway: {
+        http: {
+          endpoints: {
+            responses: {
+              files: {
+                maxBytes: 3 * 1024 * 1024,
+                pdf: { maxPages: 2 },
+                allowedMimes: ["text/plain"],
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const limits = resolveFileExtractionLimits(cfg);
+    expect(limits.maxBytes).toBe(3 * 1024 * 1024);
+    expect(limits.pdf.maxPages).toBe(2);
+    expect(limits.allowedMimesConfigured).toBe(true);
+  });
+});

--- a/src/media-understanding/file-extraction-limits.ts
+++ b/src/media-understanding/file-extraction-limits.ts
@@ -1,0 +1,68 @@
+// Resolves inbound attachment text-extraction limits for media-understanding.
+import type { OpenClawConfig } from "../config/types.js";
+import {
+  type InputFileLimits,
+  type InputFileLimitsConfig,
+  resolveInputFileLimits,
+} from "../media/input-files.js";
+
+// Inbound channel/UI attachments are managed media already accepted under the
+// agent's media size cap (chat.send's mediaMaxMb / DEFAULT_CHAT_ATTACHMENT_MAX_MB).
+// Size inbound file extraction to that cap and the agent's PDF page budget rather
+// than the smaller OpenResponses input_file defaults (5 MB / 4 pages); otherwise
+// large managed PDFs reach text-only/locked-down agents as a bare attachment
+// marker instead of bounded document text. An explicit `responses.files` operator
+// config still wins per-field, and the byte/page ceilings bound host-side cost.
+const INBOUND_FILE_EXTRACTION_DEFAULT_MAX_MB = 20;
+const INBOUND_FILE_EXTRACTION_MAX_BYTES_CAP = 25 * 1024 * 1024;
+const INBOUND_FILE_EXTRACTION_DEFAULT_MAX_PAGES = 20;
+const INBOUND_FILE_EXTRACTION_MAX_PAGES_CAP = 150;
+
+type InboundFileExtractionDefaults = {
+  mediaMaxMb?: number;
+  pdfMaxPages?: number;
+};
+
+/** Resolved inbound file limits plus whether the operator pinned an explicit MIME allowlist. */
+export type FileExtractionLimits = InputFileLimits & {
+  allowedMimesConfigured: boolean;
+};
+
+function positiveExtractionLimit(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function resolveInboundFileExtractionMaxBytes(
+  defaults: InboundFileExtractionDefaults | undefined,
+): number {
+  const maxMb =
+    positiveExtractionLimit(defaults?.mediaMaxMb) ?? INBOUND_FILE_EXTRACTION_DEFAULT_MAX_MB;
+  return Math.min(Math.floor(maxMb * 1024 * 1024), INBOUND_FILE_EXTRACTION_MAX_BYTES_CAP);
+}
+
+function resolveInboundFileExtractionMaxPages(
+  defaults: InboundFileExtractionDefaults | undefined,
+): number {
+  const pages =
+    positiveExtractionLimit(defaults?.pdfMaxPages) ?? INBOUND_FILE_EXTRACTION_DEFAULT_MAX_PAGES;
+  return Math.min(Math.trunc(pages), INBOUND_FILE_EXTRACTION_MAX_PAGES_CAP);
+}
+
+/** Builds inbound attachment extraction limits, sized to the agent's media/PDF config. */
+export function resolveFileExtractionLimits(cfg: OpenClawConfig): FileExtractionLimits {
+  const files = cfg.gateway?.http?.endpoints?.responses?.files;
+  const allowedMimesConfigured = Boolean(files?.allowedMimes?.length);
+  const defaults = cfg.agents?.defaults;
+  const inboundFiles: InputFileLimitsConfig = {
+    ...files,
+    maxBytes: files?.maxBytes ?? resolveInboundFileExtractionMaxBytes(defaults),
+    pdf: {
+      ...files?.pdf,
+      maxPages: files?.pdf?.maxPages ?? resolveInboundFileExtractionMaxPages(defaults),
+    },
+  };
+  return {
+    ...resolveInputFileLimits(inboundFiles),
+    allowedMimesConfigured,
+  };
+}


### PR DESCRIPTION
## Summary

Large inbound PDFs/documents from messaging channels and the Control UI were delivered to text-only/locked-down agents as just an attachment marker — the agent never saw the document text. This fixes that by extending the **existing** media-understanding extraction pipeline rather than adding a parallel one.

The canonical pipeline already extracts inbound document text, wraps it as untrusted content, and injects it into the prompt (`applyMediaUnderstanding` → `extractFileBlocks` in `src/media-understanding/apply.ts`, invoked from `getReplyFromConfig`). It just inherited the OpenResponses `input_file` limits — **5 MB / 4 pages** — so anything larger was silently skipped.

### Changes

- **Extraction limits (#90096)** — new `resolveFileExtractionLimits` (`src/media-understanding/file-extraction-limits.ts`) sizes inbound file extraction from the agent's media config: `agents.defaults.mediaMaxMb` (default 20 MB, host-side hard cap 25 MB) and `agents.defaults.pdfMaxPages` (default 20, cap 150). An explicit `gateway.http.endpoints.responses.files` operator config still wins per-field. No new config keys.
- **chat.send pass-through (#90097)** — `prestageMediaPathOffloads` now lets oversized (>5 MB) managed inbound PDFs pass through sandbox staging with their managed media path instead of returning a 4xx. Host-side extraction reads them via the media-store root, so sandboxed/locked-down agents get the text without copying a large PDF into every sandbox. Non-PDF oversize files are still rejected; staged + pass-through files preserve attachment order.

This is an alternative, narrower implementation of #90111 (closed). It reuses the existing extraction/injection path — **no new `inbound-pdf-context` module, no second prompt-injection site, no prompt-string scanning, no parallel `MediaExtractedContext` field**, and so it avoids the duplicate-extraction and sandbox-path bugs in that approach. Net **+161 / −43** non-test LOC.

Thanks to @joeykrug for the original report and investigation in #90096/#90097/#90111.

## Behavior

- Before: a 15.6 MB / 58-page PDF sent to a locked-down agent → prompt contained only `[media attached: media://inbound/...pdf (application/pdf)]`; on a sandboxed agent, `chat.send` rejected it with a sandbox staging-limit 4xx.
- After: the PDF is extracted host-side (bounded text, marked untrusted) and reaches the agent through the existing media-understanding body injection; oversized managed PDFs pass `chat.send` without the staging-cap rejection.

## Verification

Commands run (local, macOS):

- `node scripts/run-vitest.mjs src/media-understanding/file-extraction-limits.test.ts src/media-understanding/apply.test.ts src/gateway/server-methods/chat.directive-tags.test.ts` — green (limits 7, apply 53, gateway 218)
- `pnpm tsgo:core` / `pnpm tsgo:test:src` — clean
- `node scripts/run-oxlint.mjs <changed src>` — clean
- `pnpm exec oxfmt --check` on changed files — clean
- `pnpm build` — clean (no `[INEFFECTIVE_DYNAMIC_IMPORT]`)
- Fresh multi-angle autoreview — no surviving correctness findings; applied the one cleanup (single-pass partition).

Regression coverage added:
- `file-extraction-limits.test.ts` — limit derivation (defaults, mediaMaxMb/pdfMaxPages, 25 MB & 150-page ceilings, non-positive fallback, explicit `responses.files` override).
- `apply.test.ts` — a ~6 MB file is now extracted end-to-end through `applyMediaUnderstanding` (would have been skipped at the old 5 MB cap).
- `chat.directive-tags.test.ts` — oversized managed PDF passes through to dispatch with the managed path + `MediaStaged`; the existing oversize-rejection test repointed to a non-PDF to keep that 4xx covered.

### Proof gaps

- No live large-PDF run yet (Crabbox/real channel); proof is unit/integration tests + typecheck + build. Happy to add a Crabbox end-to-end if wanted before merge.
- Out of scope here: #90098 (base64/data-URL stack-safety) is independent. Image-only/scanned PDFs still rasterize discarded page images (pre-existing waste, slightly amplified by 4→20 pages; output is correct) — worth a follow-up `maxPixels` tweak.

Closes #90096
Closes #90097
