### PR TITLE
feat(agents/mcp): scope MCP servers per-agent via generic agents allowlist [AI-assisted]

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -24,14 +24,15 @@ Use [`openclaw acp`](/cli/acp) when OpenClaw should host a coding harness sessio
 
 OpenClaw has several MCP surfaces. Pick the one that matches who owns the agent runtime and who owns the tools.
 
-| Goal                                                                | Use                                                                  | Why                                                                                                             |
-| ------------------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Let an external MCP client read/send OpenClaw channel conversations | `openclaw mcp serve`                                                 | OpenClaw is the MCP server and exposes Gateway-backed conversations over stdio.                                 |
-| Save third-party MCP servers for OpenClaw-managed agent runs        | `openclaw mcp add`, `set`, `configure`, `tools`, `login`             | OpenClaw is the MCP client-side registry and later projects those servers into eligible runtimes.               |
-| Check a saved server without running an agent turn                  | `openclaw mcp status`, `doctor`, `probe`                             | `status` and `doctor` inspect config; `probe` opens a live MCP connection and lists capabilities.               |
-| Edit MCP config from a browser                                      | Control UI `/mcp`                                                    | The page shows inventory, enablement, OAuth/filter summaries, command hints, and a scoped `mcp` editor.         |
-| Give Codex app-server a scoped native MCP server                    | `mcp.servers.<name>.codex`                                           | The `codex` block only affects Codex app-server thread projection and is stripped before native config handoff. |
-| Run ACP-hosted harness sessions                                     | [`openclaw acp`](/cli/acp) and [ACP Agents](/tools/acp-agents-setup) | ACP bridge mode does not accept per-session MCP server injection; configure gateway/plugin bridges instead.     |
+| Goal                                                                | Use                                                                  | Why                                                                                                                   |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Let an external MCP client read/send OpenClaw channel conversations | `openclaw mcp serve`                                                 | OpenClaw is the MCP server and exposes Gateway-backed conversations over stdio.                                       |
+| Save third-party MCP servers for OpenClaw-managed agent runs        | `openclaw mcp add`, `set`, `configure`, `tools`, `login`             | OpenClaw is the MCP client-side registry and later projects those servers into eligible runtimes.                     |
+| Check a saved server without running an agent turn                  | `openclaw mcp status`, `doctor`, `probe`                             | `status` and `doctor` inspect config; `probe` opens a live MCP connection and lists capabilities.                     |
+| Edit MCP config from a browser                                      | Control UI `/mcp`                                                    | The page shows inventory, enablement, OAuth/filter summaries, command hints, and a scoped `mcp` editor.               |
+| Scope an MCP server to specific agents on every runtime             | `mcp.servers.<name>.agents`                                          | Allowlist of OpenClaw agent ids. Omit for all agents; present scopes to the listed agents and fails closed otherwise. |
+| Give Codex app-server a scoped native MCP server                    | `mcp.servers.<name>.codex`                                           | The `codex` block only affects Codex app-server thread projection and is stripped before native config handoff.       |
+| Run ACP-hosted harness sessions                                     | [`openclaw acp`](/cli/acp) and [ACP Agents](/tools/acp-agents-setup) | ACP bridge mode does not accept per-session MCP server injection; configure gateway/plugin bridges instead.           |
 
 <Tip>
 If you are not sure which path you need, start with `openclaw mcp status --verbose`. It shows what OpenClaw has saved without starting any MCP servers.
@@ -399,11 +400,20 @@ Those saved definitions are for runtimes that OpenClaw launches or configures la
 
 Runtime adapters may normalize this shared registry into the shape their downstream client expects. For example, embedded OpenClaw consumes OpenClaw `transport` values directly, while Claude Code and Gemini receive CLI-native `type` values such as `http`, `sse`, or `stdio`.
 
+Use the top-level `agents` array on a server to scope it to specific OpenClaw
+agent ids across every runtime (Claude, Gemini, embedded, and Codex
+app-server). When omitted, the server is available to every agent. When
+present, only the listed agents receive it. Empty, blank, or invalid agent
+lists fail closed, so a misconfigured scope never silently widens to all
+agents. OpenClaw strips `agents` before handing the launched server config to
+the downstream runtime.
+
 Codex app-server also honors an optional `codex` block on each server. This is
 OpenClaw projection metadata for Codex app-server threads only; it does not
 change ACP sessions, generic Codex harness config, or other runtime adapters.
-Use non-empty `codex.agents` to project a server only into specific OpenClaw
-agent ids. Empty, blank, or invalid agent lists are rejected by config
+`codex.agents` is the Codex-only equivalent of the generic `agents` allowlist;
+when both are set, the generic `agents` array takes precedence on every
+runtime. Empty, blank, or invalid agent lists are rejected by config
 validation and omitted by the runtime projection path instead of becoming
 global. Use `codex.defaultToolsApprovalMode` (`auto`, `prompt`, or `approve`)
 to emit Codex's native `default_tools_approval_mode` for a trusted server.

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -421,6 +421,7 @@ function createCatalogFingerprint(servers: Record<string, unknown>): string {
 function loadSessionMcpConfig(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
   logDiagnostics?: boolean;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
 }): {
@@ -430,6 +431,7 @@ function loadSessionMcpConfig(params: {
   const loaded = loadEmbeddedAgentMcpConfig({
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
+    agentId: params.agentId,
     manifestRegistry: params.manifestRegistry,
   });
   if (params.logDiagnostics !== false) {
@@ -490,11 +492,13 @@ export function createSessionMcpRuntime(params: {
   sessionKey?: string;
   workspaceDir: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
 }): SessionMcpRuntime {
   const { loaded, fingerprint: configFingerprint } = loadSessionMcpConfig({
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
+    agentId: params.agentId,
     logDiagnostics: true,
     manifestRegistry: params.manifestRegistry,
   });
@@ -961,6 +965,7 @@ function createSessionMcpRuntimeManager(
       const { fingerprint: nextFingerprint } = loadSessionMcpConfig({
         workspaceDir: params.workspaceDir,
         cfg: params.cfg,
+        agentId: params.agentId,
         logDiagnostics: false,
       });
       const existing = runtimesBySessionId.get(params.sessionId);
@@ -997,6 +1002,7 @@ function createSessionMcpRuntimeManager(
           sessionKey: params.sessionKey,
           workspaceDir: params.workspaceDir,
           cfg: params.cfg,
+          agentId: params.agentId,
           configFingerprint: nextFingerprint,
         }),
       ).then((runtime) => {
@@ -1080,6 +1086,7 @@ export async function getOrCreateSessionMcpRuntime(params: {
   sessionKey?: string;
   workspaceDir: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
 }): Promise<SessionMcpRuntime> {
   return await getSessionMcpRuntimeManager().getOrCreate(params);
 }

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -92,6 +92,7 @@ export type SessionMcpRuntimeManager = {
     sessionKey?: string;
     workspaceDir: string;
     cfg?: OpenClawConfig;
+    agentId?: string;
   }) => Promise<SessionMcpRuntime>;
   bindSessionKey: (sessionKey: string, sessionId: string) => void;
   resolveSessionId: (sessionKey: string) => string | undefined;

--- a/src/agents/agent-project-settings-snapshot.ts
+++ b/src/agents/agent-project-settings-snapshot.ts
@@ -100,6 +100,7 @@ function loadBundleSettingsFile(params: {
 export function loadEnabledBundleAgentSettingsSnapshot(params: {
   cwd: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
   env?: NodeJS.ProcessEnv;
   pluginMetadataSnapshot?: PluginMetadataSnapshot;
 }): AgentSettingsSnapshot {
@@ -174,6 +175,7 @@ export function loadEnabledBundleAgentSettingsSnapshot(params: {
   const embeddedAgentMcp = loadEmbeddedAgentMcpConfig({
     workspaceDir,
     cfg: config,
+    agentId: params.agentId,
     manifestRegistry: metadataSnapshot.manifestRegistry,
   });
   for (const diagnostic of embeddedAgentMcp.diagnostics) {

--- a/src/agents/agent-project-settings.ts
+++ b/src/agents/agent-project-settings.ts
@@ -13,6 +13,7 @@ function createEmbeddedAgentSettingsManager(params: {
   cwd: string;
   agentDir: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
   pluginMetadataSnapshot?: PluginMetadataSnapshot;
 }): SettingsManager {
   const fileSettingsManager = SettingsManager.create(params.cwd, params.agentDir);
@@ -20,6 +21,7 @@ function createEmbeddedAgentSettingsManager(params: {
   const pluginSettings = loadEnabledBundleAgentSettingsSnapshot({
     cwd: params.cwd,
     cfg: params.cfg,
+    agentId: params.agentId,
     pluginMetadataSnapshot: params.pluginMetadataSnapshot,
   });
   const hasPluginSettings = Object.keys(pluginSettings).length > 0;
@@ -53,6 +55,7 @@ export function createPreparedEmbeddedAgentSettingsManager(params: {
   cwd: string;
   agentDir: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
   pluginMetadataSnapshot?: PluginMetadataSnapshot;
   /** Resolved context window budget so reserve-token floor can be capped for small models. */
   contextTokenBudget?: number;

--- a/src/agents/bundle-mcp-config.test.ts
+++ b/src/agents/bundle-mcp-config.test.ts
@@ -1,5 +1,7 @@
 /** Tests merging bundled MCP defaults with OpenClaw user MCP configuration. */
 import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveSessionAgentIds } from "./agent-scope.js";
 import { loadMergedBundleMcpConfig, toCliBundleMcpServerConfig } from "./bundle-mcp-config.js";
 
 const mocks = vi.hoisted(() => ({
@@ -96,5 +98,129 @@ describe("loadMergedBundleMcpConfig", () => {
     });
 
     expect(merged.config.mcpServers).not.toHaveProperty("bundleProbe");
+  });
+
+  it("keeps servers with no agents allowlist visible to every agent", () => {
+    const merged = loadMergedBundleMcpConfig({
+      workspaceDir: "/workspace",
+      agentId: "max",
+      cfg: {
+        mcp: {
+          servers: {
+            finance: { command: "node", args: ["finance.mjs"] },
+          },
+        },
+      },
+    });
+
+    expect(merged.config.mcpServers).toHaveProperty("finance");
+  });
+
+  it("includes an agent-scoped server for a listed agent and strips the agents metadata", () => {
+    const merged = loadMergedBundleMcpConfig({
+      workspaceDir: "/workspace",
+      agentId: "migdalia",
+      cfg: {
+        mcp: {
+          servers: {
+            finance: { command: "node", args: ["finance.mjs"], agents: ["migdalia"] },
+          },
+        },
+      },
+    });
+
+    expect(merged.config.mcpServers).toHaveProperty("finance");
+    // `agents` is an OpenClaw-side scoping control; it must not reach the launched server.
+    expect(merged.config.mcpServers.finance).not.toHaveProperty("agents");
+  });
+
+  it("excludes an agent-scoped server for a non-listed agent", () => {
+    const merged = loadMergedBundleMcpConfig({
+      workspaceDir: "/workspace",
+      agentId: "max",
+      cfg: {
+        mcp: {
+          servers: {
+            finance: { command: "node", args: ["finance.mjs"], agents: ["migdalia"] },
+          },
+        },
+      },
+    });
+
+    expect(merged.config.mcpServers).not.toHaveProperty("finance");
+  });
+
+  it("fails closed when an agent-scoped server runs without an agent id", () => {
+    const merged = loadMergedBundleMcpConfig({
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            finance: { command: "node", args: ["finance.mjs"], agents: ["migdalia"] },
+          },
+        },
+      },
+    });
+
+    expect(merged.config.mcpServers).not.toHaveProperty("finance");
+  });
+
+  it("fails closed when the agents allowlist is empty", () => {
+    const merged = loadMergedBundleMcpConfig({
+      workspaceDir: "/workspace",
+      agentId: "migdalia",
+      cfg: {
+        mcp: {
+          servers: {
+            finance: { command: "node", args: ["finance.mjs"], agents: [] },
+          },
+        },
+      },
+    });
+
+    expect(merged.config.mcpServers).not.toHaveProperty("finance");
+  });
+
+  it("scopes via the session-key-resolved agent when no explicit agentId is set", () => {
+    // Regression: the embedded/CLI runner resolves the active agent from the
+    // session key (sessionAgentId), NOT the raw optional params.agentId. The
+    // merge must receive that resolved id, or a session-keyed run with no
+    // explicit agentId fails closed and the scoped server silently vanishes.
+    const cfg = {
+      agents: { list: [{ id: "migdalia" }, { id: "max", default: true }] },
+      mcp: {
+        servers: {
+          finance: { command: "node", args: ["finance.mjs"], agents: ["migdalia"] },
+        },
+      },
+    } as OpenClawConfig;
+
+    // No explicit agentId; the agent is encoded only in the session key.
+    const { sessionAgentId } = resolveSessionAgentIds({
+      sessionKey: "agent:migdalia:main",
+      config: cfg,
+      agentId: undefined,
+    });
+    expect(sessionAgentId).toBe("migdalia");
+
+    const merged = loadMergedBundleMcpConfig({
+      workspaceDir: "/workspace",
+      agentId: sessionAgentId,
+      cfg,
+    });
+    expect(merged.config.mcpServers).toHaveProperty("finance");
+
+    // And a different session-keyed agent (max) correctly does NOT receive it.
+    const maxResolved = resolveSessionAgentIds({
+      sessionKey: "agent:max:main",
+      config: cfg,
+      agentId: undefined,
+    });
+    const maxMerged = loadMergedBundleMcpConfig({
+      workspaceDir: "/workspace",
+      agentId: maxResolved.sessionAgentId,
+      cfg,
+    });
+    expect(maxMerged.config.mcpServers).not.toHaveProperty("finance");
   });
 });

--- a/src/agents/bundle-mcp-config.ts
+++ b/src/agents/bundle-mcp-config.ts
@@ -11,6 +11,7 @@ import {
   type BundleMcpServerConfig,
 } from "../plugins/bundle-mcp.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";
 
 type MergedBundleMcpConfig = {
   config: BundleMcpConfig;
@@ -48,10 +49,58 @@ export function toCliBundleMcpServerConfig(server: BundleMcpServerConfig): Bundl
   return next as BundleMcpServerConfig;
 }
 
+function normalizeAgentIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter((entry) => isValidAgentId(entry))
+    .map((entry) => normalizeAgentId(entry));
+}
+
+/**
+ * Shared per-agent MCP allowlist gate used by every runtime (CLI, embedded, and
+ * Codex app-server). `hasAllowlist=false` means the server declared no scope, so
+ * it stays visible to every agent (historical behavior). When a scope is
+ * declared, an empty/invalid list or a run with no agent id fails closed, so a
+ * misconfigured scope never silently widens to all agents. Both the generic
+ * `agents` field and Codex's nested `codex.agents` route through this so the two
+ * surfaces can never diverge in behavior.
+ */
+export function isMcpServerAllowedForAgentIds(
+  hasAllowlist: boolean,
+  allowlist: unknown,
+  agentId: string | undefined,
+): boolean {
+  if (!hasAllowlist) {
+    return true;
+  }
+  const agentIds = normalizeAgentIds(allowlist);
+  if (agentIds.length === 0 || !agentId) {
+    return false;
+  }
+  return agentIds.includes(normalizeAgentId(agentId));
+}
+
+/**
+ * Resolves the generic per-server `agents` allowlist for the shared CLI/embedded
+ * merge. Codex's app-server path layers `codex.agents` precedence on top via
+ * isMcpServerAllowedForAgentIds directly.
+ */
+function isMcpServerAllowedForAgent(
+  server: Record<string, unknown>,
+  agentId: string | undefined,
+): boolean {
+  return isMcpServerAllowedForAgentIds(Object.hasOwn(server, "agents"), server.agents, agentId);
+}
+
 /** Loads enabled bundled MCP servers and overlays user config by server name. */
 export function loadMergedBundleMcpConfig(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
   mapConfiguredServer?: BundleMcpServerMapper;
 }): MergedBundleMcpConfig {
@@ -67,7 +116,10 @@ export function loadMergedBundleMcpConfig(params: {
       .map(([name]) => name),
   );
   const enabledConfiguredMcp = Object.fromEntries(
-    Object.entries(configuredMcp).filter(([, server]) => server.enabled !== false),
+    Object.entries(configuredMcp).filter(
+      ([, server]) =>
+        server.enabled !== false && isMcpServerAllowedForAgent(server, params.agentId),
+    ),
   );
   const enabledBundleMcp = Object.fromEntries(
     Object.entries(bundleMcp.config.mcpServers).filter(
@@ -82,10 +134,12 @@ export function loadMergedBundleMcpConfig(params: {
       mcpServers: {
         ...enabledBundleMcp,
         ...Object.fromEntries(
-          Object.entries(enabledConfiguredMcp).map(([name, server]) => [
-            name,
-            mapConfiguredServer(server as BundleMcpServerConfig, name),
-          ]),
+          Object.entries(enabledConfiguredMcp).map(([name, server]) => {
+            // `agents` is an OpenClaw-side scoping control, not a downstream MCP
+            // field. Strip it so it never leaks into the launched server config.
+            const { agents: _agents, ...downstream } = server as Record<string, unknown>;
+            return [name, mapConfiguredServer(downstream as BundleMcpServerConfig, name)];
+          }),
         ),
       } satisfies BundleMcpConfig["mcpServers"],
     },

--- a/src/agents/cli-runner/bundle-mcp-codex.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.ts
@@ -4,7 +4,7 @@
 import { normalizeConfiguredMcpServers } from "../../config/mcp-config-normalize.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { BundleMcpConfig, BundleMcpServerConfig } from "../../plugins/bundle-mcp.js";
-import { isValidAgentId, normalizeAgentId } from "../../routing/session-key.js";
+import { isMcpServerAllowedForAgentIds } from "../bundle-mcp-config.js";
 import { buildCodexMcpServersConfig, normalizeCodexMcpServerConfig } from "../codex-mcp-config.js";
 import { isRecord } from "./bundle-mcp-adapter-shared.js";
 import { serializeTomlInlineValue } from "./toml-inline.js";
@@ -27,34 +27,31 @@ type CodexUserMcpServersProjectionOptions = {
   agentId?: string;
 };
 
-function normalizeAgentIds(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return value
-    .filter((entry): entry is string => typeof entry === "string")
-    .map((entry) => entry.trim())
-    .filter((entry) => isValidAgentId(entry))
-    .map((entry) => normalizeAgentId(entry));
-}
-
 function readCodexProjectionConfig(server: BundleMcpServerConfig): Record<string, unknown> {
   return isRecord(server.codex) ? server.codex : {};
 }
 
+/**
+ * The generic top-level `agents` allowlist applies to every runtime and takes
+ * precedence; `codex.agents` remains as a Codex-only override for servers that
+ * want different scoping on the app-server path. Both route through the shared
+ * gate so generic-`agents` scoping is enforced here too — without this, a server
+ * scoped only via the generic field would silently widen to all agents on the
+ * Codex app-server runtime.
+ */
 function isCodexMcpServerAllowedForAgent(
   server: BundleMcpServerConfig,
   options: CodexUserMcpServersProjectionOptions | undefined,
 ): boolean {
+  if (Object.hasOwn(server, "agents")) {
+    return isMcpServerAllowedForAgentIds(true, server.agents, options?.agentId);
+  }
   const codex = readCodexProjectionConfig(server);
-  if (!Object.hasOwn(codex, "agents")) {
-    return true;
-  }
-  const agentIds = normalizeAgentIds(codex.agents);
-  if (agentIds.length === 0 || !options?.agentId) {
-    return false;
-  }
-  return agentIds.includes(normalizeAgentId(options.agentId));
+  return isMcpServerAllowedForAgentIds(
+    Object.hasOwn(codex, "agents"),
+    codex.agents,
+    options?.agentId,
+  );
 }
 
 /** Returns Codex CLI args with TOML MCP server overrides injected. */

--- a/src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts
@@ -267,6 +267,54 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
     expect(patch).toBeUndefined();
   });
 
+  it("honors the generic top-level agents allowlist on the Codex app-server path", () => {
+    // Regression: a server scoped only via the generic `agents` field must not
+    // silently widen to every agent on the Codex app-server runtime.
+    const cfg = {
+      mcp: {
+        servers: {
+          finance: {
+            transport: "stdio",
+            command: "node",
+            args: ["finance-mcp.js"],
+            agents: ["migdalia"],
+          },
+          global: { transport: "stdio", command: "node", args: ["global-mcp.js"] },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const migdaliaPatch = buildCodexUserMcpServersThreadConfigPatch(cfg, {
+      agentId: "migdalia",
+    });
+    expect(Object.keys(migdaliaPatch!.mcp_servers).toSorted()).toEqual(["finance", "global"]);
+
+    const maxPatch = buildCodexUserMcpServersThreadConfigPatch(cfg, { agentId: "max" });
+    expect(Object.keys(maxPatch!.mcp_servers).toSorted()).toEqual(["global"]);
+    expect(maxPatch!.mcp_servers).not.toHaveProperty("finance");
+  });
+
+  it("lets the generic agents allowlist take precedence over codex.agents", () => {
+    const cfg = {
+      mcp: {
+        servers: {
+          scoped: {
+            transport: "stdio",
+            command: "node",
+            args: ["scoped-mcp.js"],
+            agents: ["migdalia"],
+            codex: { agents: ["max"] },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    // Generic `agents` wins: migdalia (in generic list) gets it...
+    expect(buildCodexUserMcpServersThreadConfigPatch(cfg, { agentId: "migdalia" })).toBeDefined();
+    // ...and max (only in codex.agents) does not.
+    expect(buildCodexUserMcpServersThreadConfigPatch(cfg, { agentId: "max" })).toBeUndefined();
+  });
+
   it("preserves multiple user MCP servers as independent mcp_servers entries", () => {
     const patch = buildCodexUserMcpServersThreadConfigPatch({
       mcp: {

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -149,6 +149,7 @@ export async function prepareCliBundleMcpConfig(params: {
   backend: CliBackendConfig;
   workspaceDir: string;
   config?: OpenClawConfig;
+  agentId?: string;
   additionalConfig?: BundleMcpConfig;
   env?: Record<string, string>;
   warn?: (message: string) => void;
@@ -180,6 +181,7 @@ export async function prepareCliBundleMcpConfig(params: {
   const bundleConfig = loadMergedBundleMcpConfig({
     workspaceDir: params.workspaceDir,
     cfg: params.config,
+    agentId: params.agentId,
     mapConfiguredServer: toCliBundleMcpServerConfig,
   });
   for (const diagnostic of bundleConfig.diagnostics) {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -277,6 +277,7 @@ export async function prepareCliRunContext(
     backend: backendResolved.config,
     workspaceDir,
     config: params.config,
+    agentId: sessionAgentId,
     additionalConfig: mcpLoopbackRuntime
       ? prepareDeps.createMcpLoopbackServerConfig(mcpLoopbackRuntime.port)
       : undefined,

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -64,6 +64,9 @@ type CliCompactionDeps = {
     agentDir: string;
     cfg?: OpenClawConfig;
     contextTokenBudget?: number;
+    // Scopes per-agent MCP servers in the settings snapshot; must be the
+    // session-key-resolved agent id, not the raw optional caller agentId.
+    agentId?: string;
   }) => SettingsManagerLike | Promise<SettingsManagerLike>;
   applyAgentAutoCompactionGuard: (params: {
     settingsManager: SettingsManagerLike;
@@ -515,6 +518,7 @@ export async function runCliTurnCompactionLifecycle(params: {
     agentDir: params.agentDir,
     cfg: params.cfg,
     contextTokenBudget,
+    agentId: params.sessionAgentId,
   });
 
   const preemptiveCompaction = cliCompactionDeps.shouldPreemptivelyCompactBeforePrompt({

--- a/src/agents/embedded-agent-mcp.ts
+++ b/src/agents/embedded-agent-mcp.ts
@@ -18,11 +18,13 @@ type EmbeddedAgentMcpConfig = {
 export function loadEmbeddedAgentMcpConfig(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
 }): EmbeddedAgentMcpConfig {
   const bundleMcp = loadMergedBundleMcpConfig({
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
+    agentId: params.agentId,
     manifestRegistry: params.manifestRegistry,
   });
 

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -96,8 +96,8 @@ import { isFallbackSummaryError, runWithModelFallback } from "../model-fallback.
 import { supportsModelTools } from "../model-tool-support.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import { wrapStreamFnTextTransforms } from "../plugin-text-transforms.js";
-import { applyPreparedRuntimeAuthToModel } from "../provider-request-config.js";
 import { resolveAgentPromptSurfaceForSessionKey } from "../prompt-surface.js";
+import { applyPreparedRuntimeAuthToModel } from "../provider-request-config.js";
 import { registerProviderStreamForModel } from "../provider-stream.js";
 import { collectRuntimeChannelCapabilities } from "../runtime-capabilities.js";
 import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
@@ -1180,6 +1180,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
         cwd: effectiveCwd,
         agentDir,
         cfg: params.config,
+        agentId: sessionAgentId,
         pluginMetadataSnapshot: getCurrentPluginMetadataSnapshot({
           config: params.config,
           env: process.env,

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.mcp-agent-scope.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.mcp-agent-scope.test.ts
@@ -1,0 +1,100 @@
+// Regression coverage for per-agent MCP scoping wiring in runEmbeddedAttempt.
+//
+// The bug this guards: attempt.ts must forward the session-key-resolved agent
+// id (sessionAgentId), NOT the raw optional params.agentId, into both
+// getOrCreateSessionMcpRuntime and createPreparedEmbeddedAgentSettingsManager.
+// When a run carries no explicit agentId and the agent is encoded only in the
+// session key, passing the raw params.agentId (undefined) scopes MCP servers
+// against the wrong/default agent and a scoped server silently fails closed.
+//
+// Teeth: this is a spy-on-arg test (per src/agents/embedded-agent-runner/run/CLAUDE.md
+// "spy-on-arg over full runEmbeddedAttempt"). It drives an attempt with
+// { sessionKey: "agent:migdalia:main", agentId: undefined } and asserts the spies
+// received agentId: "migdalia". Reverting attempt.ts line 1490 (getOrCreateSessionMcpRuntime)
+// or line 2096 (createPreparedEmbeddedAgentSettingsManager) back to
+// `agentId: params.agentId` makes the corresponding assertion fail with
+// `undefined` instead of "migdalia".
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  cleanupTempPaths,
+  createContextEngineAttemptRunner,
+  createContextEngineBootstrapAndAssemble,
+  getHoisted,
+  preloadRunEmbeddedAttemptForTests,
+  resetEmbeddedAttemptHarness,
+} from "./attempt.spawn-workspace.test-support.js";
+
+const hoisted = getHoisted();
+const tempPaths: string[] = [];
+
+describe("runEmbeddedAttempt per-agent MCP scoping wiring", () => {
+  beforeAll(async () => {
+    await preloadRunEmbeddedAttemptForTests();
+  });
+
+  beforeEach(() => {
+    resetEmbeddedAttemptHarness();
+  });
+
+  afterEach(async () => {
+    await cleanupTempPaths(tempPaths);
+    tempPaths.length = 0;
+  });
+
+  it("forwards the session-key-resolved agent id to the MCP runtime and settings manager", async () => {
+    // No explicit agentId in the attempt params; the agent is encoded only in
+    // the session key. The runner must resolve "migdalia" from the key and pass
+    // it down to the MCP scoping seams.
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey: "agent:migdalia:main",
+      tempPaths,
+      attemptOverrides: {
+        // disableTools:false enables the bundle-MCP runtime path
+        // (shouldCreateBundleMcpRuntimeForAttempt) so getOrCreateSessionMcpRuntime fires.
+        disableTools: false,
+        // agentId stays undefined on purpose: the only source of the agent is
+        // the session key. Setting it would defeat the regression.
+        agentId: undefined,
+      },
+    });
+
+    const mcpRuntimeCall = hoisted.getOrCreateSessionMcpRuntimeMock.mock.calls[0]?.[0] as
+      | { agentId?: string; sessionKey?: string }
+      | undefined;
+    expect(hoisted.getOrCreateSessionMcpRuntimeMock).toHaveBeenCalled();
+    expect(mcpRuntimeCall?.sessionKey).toBe("agent:migdalia:main");
+    // The wire under test: attempt.ts must pass the resolved sessionAgentId, not
+    // the raw (undefined) params.agentId.
+    expect(mcpRuntimeCall?.agentId).toBe("migdalia");
+
+    const settingsManagerCall = hoisted.createPreparedEmbeddedAgentSettingsManagerMock.mock
+      .calls[0]?.[0] as { agentId?: string } | undefined;
+    expect(hoisted.createPreparedEmbeddedAgentSettingsManagerMock).toHaveBeenCalled();
+    expect(settingsManagerCall?.agentId).toBe("migdalia");
+  });
+
+  it("does not resolve a different agent's id into the MCP scoping seams", async () => {
+    // A session-keyed run for a different agent (max) must scope against "max",
+    // proving the id is genuinely session-key-derived and not a constant.
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey: "agent:max:main",
+      tempPaths,
+      attemptOverrides: {
+        disableTools: false,
+        agentId: undefined,
+      },
+    });
+
+    const mcpRuntimeCall = hoisted.getOrCreateSessionMcpRuntimeMock.mock.calls[0]?.[0] as
+      | { agentId?: string }
+      | undefined;
+    expect(mcpRuntimeCall?.agentId).toBe("max");
+    expect(mcpRuntimeCall?.agentId).not.toBe("migdalia");
+
+    const settingsManagerCall = hoisted.createPreparedEmbeddedAgentSettingsManagerMock.mock
+      .calls[0]?.[0] as { agentId?: string } | undefined;
+    expect(settingsManagerCall?.agentId).toBe("max");
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -96,6 +96,8 @@ type AttemptSpawnWorkspaceHoisted = {
   systemPromptTexts: string[];
   embeddedSystemPromptInputs: unknown[];
   sessionManager: SessionManagerMocks;
+  getOrCreateSessionMcpRuntimeMock: AsyncUnknownMock;
+  createPreparedEmbeddedAgentSettingsManagerMock: UnknownMock;
 };
 
 export function createSubscriptionMock(): SubscriptionMock {
@@ -133,6 +135,33 @@ export function createSubscriptionMock(): SubscriptionMock {
     getItemLifecycle: () => ({ startedCount: 0, completedCount: 0, activeCount: 0 }),
     isCompacting: () => false,
     isCompactionInFlight: () => false,
+  };
+}
+
+// Minimal settings-manager stub shared by the hoisted mock factory and the
+// harness reset. Declared as a function so it is hoisted ahead of the
+// vi.hoisted() block that captures it.
+function createPreparedSettingsManagerStub() {
+  return {
+    reload: async () => {},
+    getCompactionReserveTokens: () => 0,
+    getCompactionKeepRecentTokens: () => 40_000,
+    getDefaultProvider: () => undefined,
+    getDefaultModel: () => undefined,
+    getDefaultThinkingLevel: () => undefined,
+    getBlockImages: () => false,
+    getSteeringMode: () => undefined,
+    getFollowUpMode: () => undefined,
+    getTransport: () => undefined,
+    getThinkingBudgets: () => undefined,
+    getProviderRetrySettings: () => ({ maxRetryDelayMs: undefined }),
+    getImageAutoResize: () => false,
+    getShellCommandPrefix: () => undefined,
+    getShellPath: () => undefined,
+    getGlobalSettings: () => ({}),
+    getProjectSettings: () => ({}),
+    applyOverrides: () => {},
+    setCompactionEnabled: () => {},
   };
 }
 
@@ -208,6 +237,16 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     flushPendingToolResults: vi.fn(),
     clearPendingToolResults: vi.fn(),
   };
+  // Spies on the per-agent MCP wiring seams: the runner must forward the
+  // session-key-resolved agent id (not the raw optional params.agentId) into
+  // both of these, or a session-keyed run with no explicit agentId scopes MCP
+  // servers against the wrong agent.
+  const getOrCreateSessionMcpRuntimeMock = vi.fn<(...args: unknown[]) => Promise<unknown>>(
+    async () => undefined,
+  );
+  const createPreparedEmbeddedAgentSettingsManagerMock = vi.fn((..._args: unknown[]) =>
+    createPreparedSettingsManagerStub(),
+  );
   return {
     spawnSubagentDirectMock,
     createAgentSessionMock,
@@ -242,6 +281,8 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     systemPromptTexts,
     embeddedSystemPromptInputs,
     sessionManager,
+    getOrCreateSessionMcpRuntimeMock,
+    createPreparedEmbeddedAgentSettingsManagerMock,
   };
 });
 
@@ -412,27 +453,8 @@ vi.mock("../../docs-path.js", () => ({
 }));
 
 vi.mock("../../agent-project-settings.js", () => ({
-  createPreparedEmbeddedAgentSettingsManager: () => ({
-    reload: async () => {},
-    getCompactionReserveTokens: () => 0,
-    getCompactionKeepRecentTokens: () => 40_000,
-    getDefaultProvider: () => undefined,
-    getDefaultModel: () => undefined,
-    getDefaultThinkingLevel: () => undefined,
-    getBlockImages: () => false,
-    getSteeringMode: () => undefined,
-    getFollowUpMode: () => undefined,
-    getTransport: () => undefined,
-    getThinkingBudgets: () => undefined,
-    getProviderRetrySettings: () => ({ maxRetryDelayMs: undefined }),
-    getImageAutoResize: () => false,
-    getShellCommandPrefix: () => undefined,
-    getShellPath: () => undefined,
-    getGlobalSettings: () => ({}),
-    getProjectSettings: () => ({}),
-    applyOverrides: () => {},
-    setCompactionEnabled: () => {},
-  }),
+  createPreparedEmbeddedAgentSettingsManager: (...args: unknown[]) =>
+    hoisted.createPreparedEmbeddedAgentSettingsManagerMock(...args),
 }));
 
 vi.mock("../../agent-settings.js", () => ({
@@ -603,7 +625,8 @@ vi.mock("../../agent-tools.js", () => ({
 
 vi.mock("../../agent-bundle-mcp-tools.js", () => ({
   createBundleMcpToolRuntime: async () => undefined,
-  getOrCreateSessionMcpRuntime: async () => undefined,
+  getOrCreateSessionMcpRuntime: (...args: unknown[]) =>
+    hoisted.getOrCreateSessionMcpRuntimeMock(...args),
   materializeBundleMcpToolsForRun: async () => undefined,
   retireSessionMcpRuntime: async () => true,
 }));
@@ -1018,6 +1041,10 @@ export function resetEmbeddedAttemptHarness(
     .mockReset()
     .mockReturnValue({ messages: params.sessionMessages ?? [] });
   hoisted.sessionManager.appendCustomEntry.mockReset();
+  hoisted.getOrCreateSessionMcpRuntimeMock.mockReset().mockResolvedValue(undefined);
+  hoisted.createPreparedEmbeddedAgentSettingsManagerMock
+    .mockReset()
+    .mockImplementation(() => createPreparedSettingsManagerStub());
   if (params.subscribeImpl) {
     hoisted.subscribeEmbeddedAgentSessionMock.mockImplementation(params.subscribeImpl);
   }

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1487,6 +1487,7 @@ export async function runEmbeddedAttempt(
           sessionKey: params.sessionKey,
           workspaceDir: effectiveWorkspace,
           cfg: params.config,
+          agentId: sessionAgentId,
         })
       : undefined;
     bundleMcpRuntime = bundleMcpSessionRuntime
@@ -2092,6 +2093,7 @@ export async function runEmbeddedAttempt(
         cwd: effectiveCwd,
         agentDir,
         cfg: params.config,
+        agentId: sessionAgentId,
         pluginMetadataSnapshot: getCurrentAttemptPluginMetadataSnapshot(),
         contextTokenBudget: params.contextTokenBudget,
       });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1580,6 +1580,8 @@ export const FIELD_HELP: Record<string, string> = {
   mcp: "Global MCP server definitions managed by OpenClaw. Embedded OpenClaw and other runtime adapters can consume these servers without storing them inside runtime-owned project settings.",
   "mcp.servers":
     "Named MCP server definitions. OpenClaw stores them in its own config and runtime adapters decide which transports are supported at execution time.",
+  "mcp.servers.*.agents":
+    "Optional non-empty OpenClaw agent ids allowed to receive this MCP server across CLI and embedded runtimes. Empty, blank, or invalid lists fail closed; when omitted, the server is available to every agent. Generalizes the Codex-only codex.agents allowlist to all runtimes.",
   "mcp.servers.*.codex":
     "OpenClaw projection metadata for Codex app-server threads only. It does not affect ACP sessions or generic Codex harness config. Omit this block to keep the server available to every Codex app-server agent with Codex's default MCP approval behavior.",
   "mcp.servers.*.toolFilter":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -756,6 +756,7 @@ export const FIELD_LABELS: Record<string, string> = {
   mcp: "MCP",
   "mcp.servers": "MCP Servers",
   "mcp.servers.*.enabled": "MCP Server Enabled",
+  "mcp.servers.*.agents": "MCP Server Agents",
   "mcp.servers.*.auth": "MCP Server Auth",
   "mcp.servers.*.oauth": "MCP OAuth",
   "mcp.servers.*.oauth.scope": "MCP OAuth Scope",

--- a/src/config/types.mcp.ts
+++ b/src/config/types.mcp.ts
@@ -24,6 +24,14 @@ export type McpServerToolFilterConfig = {
 export type McpServerConfig = {
   /** Set false to keep the saved definition while excluding it from runtime/probe sessions. */
   enabled?: boolean;
+  /**
+   * OpenClaw agent ids allowed to receive this server. When omitted, every
+   * agent receives it (current behavior). When present, only the listed agents
+   * do. Generalizes the Codex-only `codex.agents` allowlist to the shared
+   * CLI/embedded runtime merge so a server can be scoped to one agent on every
+   * runtime, not just Codex.
+   */
+  agents?: string[];
   /** Stdio transport: command to spawn. */
   command?: string;
   /** Stdio transport: arguments for the command. */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -386,6 +386,15 @@ const TalkSchema = z
 const McpServerSchema = z
   .object({
     enabled: z.boolean().optional(),
+    agents: z
+      .array(
+        z
+          .string()
+          .trim()
+          .regex(/^[a-z0-9][a-z0-9_-]{0,63}$/i),
+      )
+      .min(1)
+      .optional(),
     command: z.string().optional(),
     args: z.array(z.string()).optional(),
     env: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),


### PR DESCRIPTION
## Summary

Adds per-agent MCP server scoping across **all** runtimes via a generic top-level `agents: [...]` allowlist on `mcp.servers.<name>`.

**Problem.** `loadMergedBundleMcpConfig` (the shared merge every CLI + embedded agent runtime consumes) handed the entire global `mcp.servers` set to every agent — no per-agent filter. Only the Codex app-server path had per-agent scoping, via a `codex: { agents: [...] }` allowlist. So an operator running multiple agents could not scope a server (e.g. a finance MCP, a printer MCP) to a single agent on the Claude/Gemini/embedded runtimes; every agent saw every server.

**Fix.** Generalize the existing, proven `codex.agents` pattern into a single shared gate that every runtime calls:

- New optional `agents?: string[]` on `McpServerConfig`. Omit → visible to all agents (unchanged behavior, fully backward-compatible). Present → only the listed agents. Empty/invalid list, or a run with no resolved agent id → **fails closed** (a misconfigured scope can never silently widen to all agents).
- One shared helper `isMcpServerAllowedForAgentIds(hasAllowlist, allowlist, agentId)` in `bundle-mcp-config.ts`. Both the generic `agents` field and Codex's nested `codex.agents` route through it, so the two surfaces can never diverge in behavior. The generic `agents` field takes precedence over `codex.agents` on the Codex path.
- `agentId` threaded through both runtime paths: CLI (`prepare.ts` passes the resolved `sessionAgentId`) and embedded (`attempt.ts` → `getOrCreateSessionMcpRuntime` / `createPreparedEmbeddedAgentSettingsManager` → `loadSessionMcpConfig` / `loadEnabledBundleAgentSettingsSnapshot`). The resolved `sessionAgentId` (session-key-derived, default-fallback) is used everywhere, not the raw optional `params.agentId`.
- The `agents` field is OpenClaw-side scoping metadata and is stripped before the server config reaches the launched downstream runtime (it never leaks into the Claude/Gemini/Codex server config).
- Zod validation (`agents` = non-empty array of agent-id-regex strings), schema labels/help, and `docs/cli/mcp.md` (routing-table row + prose stating precedence) all updated to keep the config contract aligned.

This is a net consolidation: the Codex-only allowlist logic and the new generic logic share one helper rather than two near-identical implementations.

## Why a generic field (config-bar justification)

Per the repo's high config/env bar: there is no existing primitive that scopes a *server* per agent. `toolFilter` filters tools within a server; `enabled` is a global on/off; `codex.agents` is Codex-only by design. This generalizes that last one to every runtime and removes the divergence between them, rather than adding a parallel surface.

## Backward compatibility

Fully additive. A server with no `agents` key behaves exactly as before (visible to all agents). No migration needed. `codex.agents` continues to work; when both are set the generic `agents` wins on every runtime.

## Real behavior proof

Verified live against a running gateway (OpenClaw 2026.6.5) with the feature applied to the dist bundle and a real multi-agent `openclaw.json` (`mcp.servers` = openweathermap, agent-bridge-bambu, playwright, imap, finance; finance scoped `agents: ["migdalia"]`, agent-bridge-bambu scoped `agents: ["3d-engineer"]`, the other three unscoped).

Calling the merge with each agent id (real config, real session-key id-resolution primitives) produced:

```
migdalia     -> finance, imap, openweathermap, playwright
max          -> imap, openweathermap, playwright
3d-engineer  -> agent-bridge-bambu, imap, openweathermap, playwright
voyager      -> imap, openweathermap, playwright
no agentId   -> imap, openweathermap, playwright   (scoped servers fail closed)
```

- `finance` (scoped to migdalia) reaches **only** migdalia; max/3d-engineer/voyager do not see it.
- `agent-bridge-bambu` (scoped to 3d-engineer) reaches **only** 3d-engineer.
- Unscoped servers (imap, openweathermap, playwright) reach every agent (unchanged behavior).
- With no resolved agent id, both scoped servers fail closed (absent) — a misconfigured/missing-id run never widens a scoped server to all agents.
- `openclaw config validate` accepts the `agents` field on `mcp.servers.<name>` (Zod validator added).

What was NOT tested: the Codex app-server projection path was verified by unit test (generic-`agents` precedence over `codex.agents`) but not driven on a live Codex thread in this run.

## Supplemental automated checks

- `pnpm tsgo:core` — 0 errors
- `bundle-mcp-config.test.ts` — 10 tests pass (incl. fail-closed-on-no-agentId, empty-list-fails-closed, generic-precedence, session-key-resolved-agent)
- `bundle-mcp-codex.user-config.test.ts` — 14 tests pass (incl. generic-`agents` honored on the Codex app-server path + precedence over `codex.agents`)
- New `attempt.spawn-workspace.mcp-agent-scope.test.ts` — teeth-bearing spy test: drives a `runEmbeddedAttempt` with `{sessionKey: "agent:migdalia:main", agentId: undefined}` and asserts both `getOrCreateSessionMcpRuntime` and `createPreparedEmbeddedAgentSettingsManager` receive the resolved `agentId: "migdalia"` (verified to fail if the wiring regresses to `params.agentId`)
- `pnpm build` — clean, 0 ineffective dynamic imports, 0 import cycles

[AI-assisted]

