### PR TITLE
fix(auto-reply): scope foreground reply fence per sender to fix group chat concurrent reply suppression

### DIFF
--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -667,4 +667,68 @@ describe("foreground reply freshness", () => {
       { kind: "final", text: "first chat final" },
     ]);
   });
+
+  it("keeps concurrent foreground finals isolated for different senders in the same group target", async () => {
+    const deliveries: Delivery[] = [];
+    const firstStarted = createDeferred<void>();
+    const releaseFirstFinal = createDeferred<void>();
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "user-a-msg") {
+          firstStarted.resolve();
+          await releaseFirstFinal.promise;
+          params.dispatcher.sendFinalReply({ text: "reply to user A" });
+          return queuedFinalResult();
+        }
+        if (params.ctx.MessageSid === "user-b-msg") {
+          params.dispatcher.sendFinalReply({ text: "reply to user B" });
+          return queuedFinalResult();
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    // Same group JID (OriginatingTo), same session, but different senders (From)
+    const groupSessionKey = "agent:main:whatsapp:group:120363@g.us";
+    const groupJid = "whatsapp:120363@g.us";
+    const firstDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({
+        MessageSid: "user-a-msg",
+        SessionKey: groupSessionKey,
+        From: "whatsapp:+1000",
+        OriginatingTo: groupJid,
+        ChatType: "group",
+      }),
+      deliveries,
+    );
+    await firstStarted.promise;
+
+    const secondDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({
+        MessageSid: "user-b-msg",
+        SessionKey: groupSessionKey,
+        From: "whatsapp:+2000",
+        OriginatingTo: groupJid,
+        ChatType: "group",
+      }),
+      deliveries,
+    );
+    await expect(secondDispatch).resolves.toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+
+    releaseFirstFinal.resolve();
+    await expect(firstDispatch).resolves.toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+
+    // Both replies must be delivered — User B's reply must NOT suppress User A's
+    expect(deliveries).toEqual([
+      { kind: "final", text: "reply to user B" },
+      { kind: "final", text: "reply to user A" },
+    ]);
+  });
 });

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -92,6 +92,10 @@ function resolveForegroundReplyFenceKey(finalized: FinalizedMsgContext): string 
   }
 
   // JSON keeps the composite key unambiguous across account/session/channel ids.
+  // Include the sender (From) so that in group chats, concurrent replies to
+  // different senders are isolated. Without this, a newer reply to User B
+  // can suppress an already-completed reply to User A in the same group.
+  const sender = normalizeForegroundReplyFencePart(finalized.From) ?? "unknown";
   return JSON.stringify([
     "foreground",
     channel,
@@ -99,6 +103,7 @@ function resolveForegroundReplyFenceKey(finalized: FinalizedMsgContext): string 
     sessionKey,
     normalizeChatType(finalized.ChatType) ?? "unknown",
     target,
+    sender,
   ]);
 }
 


### PR DESCRIPTION
## What does this PR do?

Scope the foreground reply fence per sender so concurrent replies to different users in the same group chat are not silently suppressed.

## Related Issue

Fixes #92186

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `src/auto-reply/dispatch.ts`: Include `From` (sender) in the foreground reply fence key. Previously the key was scoped per `(channel, account, session, chatType, target)` — in group chats, `target` is the group JID, so all concurrent replies in the group shared one fence. Adding `From` isolates per-sender.
- `src/auto-reply/dispatch.freshness.test.ts`: Added test verifying two concurrent replies to different senders in the same group are both delivered.

## How to Test

1. Configure WhatsApp group chat with `messages.groupChat.visibleReplies: "automatic"`
2. Have two users @mention the agent concurrently in the same group
3. Verify both replies are delivered (not just the latest one)

## Real behavior proof

**Behavior or issue addressed:**
With `messages.groupChat.visibleReplies: "automatic"`, when two users @mention the agent concurrently in a WhatsApp group, only the reply to the latest message is delivered. The reply to the earlier message is silently cancelled by the foreground reply fence because both replies share the same fence key (group JID as target).

**Real environment tested:**
macOS Sequoia 15.5, Node.js v22.22.3

**Exact steps or command run after the patch:**
```bash
npx vitest run src/auto-reply/dispatch.freshness.test.ts src/auto-reply/dispatch.test.ts
```

**Evidence after fix:**
```
 ✓ src/auto-reply/dispatch.freshness.test.ts (12 tests) 64ms
   ✓ keeps concurrent foreground finals isolated for different senders in the same group target

 ✓ src/auto-reply/dispatch.test.ts (18 tests) 28ms

 Test Files  2 passed (2)
      Tests  30 passed (30)
```

**Observed result after fix:**
New test verifies that two concurrent dispatches with the same `OriginatingTo` (group JID) and `SessionKey` but different `From` (sender) values both have their final replies delivered — neither is suppressed. The fence key now includes the sender, so concurrent replies to different users are isolated per-sender.

**What was not tested:**
Live WhatsApp group chat testing with two physical devices — this requires a real WhatsApp bridge setup which is not available in CI. The unit test accurately models the dispatch fence behavior as confirmed by the existing test suite coverage. Maintainer `proof:` override requested for live validation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/openclaw/openclaw/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/openclaw/openclaw/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've considered cross-platform impact — or N/A