### PR TITLE
Fail closed for CLI-backed /btw fallback

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -77,6 +77,8 @@ vi.mock("./model-auth.js", () => ({
 }));
 
 vi.mock("./model-runtime-aliases.js", () => ({
+  isCliRuntimeAliasForProvider: ({ runtime, provider }: { runtime?: string; provider?: string }) =>
+    runtime === "claude-cli" && provider === "anthropic",
   resolveCliRuntimeExecutionProvider: ({
     provider,
     cfg,
@@ -640,6 +642,29 @@ describe("runBtwSideQuestion", () => {
 
     expect(result).toEqual({ text: "Direct fallback answer." });
     expect(streamSimpleMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed instead of using direct provider auth for CLI-runtime alias models", async () => {
+    await expect(
+      runSideQuestion({
+        cfg: {
+          agents: {
+            defaults: {
+              models: {
+                "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+              },
+            },
+          },
+        } as never,
+        model: "claude-opus-4-7",
+        sessionKey: DEFAULT_SESSION_KEY,
+      }),
+    ).rejects.toThrow(
+      "/btw is not yet supported for claude-cli-backed models. The selected model is routed through claude-cli; OpenClaw will not fall back to direct anthropic auth because that would use a different backend than the active session.",
+    );
+    expect(getApiKeyForModelMock).not.toHaveBeenCalled();
+    expect(streamSimpleMock).not.toHaveBeenCalled();
+    expect(registerProviderStreamForModelMock).not.toHaveBeenCalled();
   });
 
   it("does not let an auto-selected stale Anthropic profile suppress Claude CLI auth for BTW", async () => {

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -27,7 +27,6 @@ import { EmbeddedBlockChunker, type BlockReplyChunking } from "./embedded-agent-
 import { resolveModelWithRegistry } from "./embedded-agent-runner/model.js";
 import { getActiveEmbeddedRunSnapshot } from "./embedded-agent-runner/runs.js";
 import { resolveEmbeddedAgentStreamFn } from "./embedded-agent-runner/stream-resolution.js";
-import { applyPreparedRuntimeAuthToModel } from "./provider-request-config.js";
 import { resolveAvailableAgentHarnessPolicy, selectAgentHarness } from "./harness/selection.js";
 import {
   resolveImageSanitizationLimits,
@@ -39,8 +38,10 @@ import {
   getApiKeyForModel,
   requireApiKey,
 } from "./model-auth.js";
+import { isCliRuntimeAliasForProvider } from "./model-runtime-aliases.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "./openai-routing.js";
+import { applyPreparedRuntimeAuthToModel } from "./provider-request-config.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
 import { stripToolResultDetails } from "./session-transcript-repair.js";
 import { sanitizeImageBlocks } from "./tool-images.js";
@@ -378,6 +379,26 @@ export async function runBtwSideQuestion(
   }
   if (harness.id === "codex") {
     throw new Error(`Selected agent harness "${harness.id}" does not support /btw side questions.`);
+  }
+  const fallbackPolicy = resolveAvailableAgentHarnessPolicy({
+    provider: params.provider,
+    modelId: params.model,
+    config: params.cfg,
+    agentId: sessionAgentId,
+    sessionKey: params.sessionKey,
+  });
+  const fallbackRuntime = fallbackPolicy.runtime.trim();
+  if (
+    isCliRuntimeAliasForProvider({
+      runtime: fallbackRuntime,
+      provider: params.provider,
+      cfg: params.cfg,
+    })
+  ) {
+    throw new Error(
+      `/btw is not yet supported for ${fallbackRuntime}-backed models. ` +
+        `The selected model is routed through ${fallbackRuntime}; OpenClaw will not fall back to direct ${params.provider} auth because that would use a different backend than the active session.`,
+    );
   }
 
   const activeRunSnapshot = getActiveEmbeddedRunSnapshot(sessionId);


### PR DESCRIPTION
## Summary

Fixes #92168.

- fail closed when `/btw` would otherwise fall back to direct provider auth for a model routed through a CLI runtime alias
- preserve existing `/btw` direct fallback behavior for non-CLI/custom harnesses without side-question hooks
- add regression coverage proving CLI-runtime alias models do not call direct provider auth or direct streaming

## Verification

- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `node scripts/run-vitest.mjs src/agents/btw.test.ts -- --reporter=verbose`
- `node scripts/run-vitest.mjs src/agents/btw.test.ts -- --reporter=verbose -t "fails closed instead of using direct provider auth for CLI-runtime alias models|keeps the direct provider fallback for non-Codex harnesses without side-question hooks"`
- `git diff --check origin/main...HEAD -- src/agents/btw.ts src/agents/btw.test.ts`
- Crabbox real behavior proof: provider `aws`, lease `cbx_f4e7388d8cd9`, run `run_86ad8a73c5b5`, exit 0

## Real behavior proof

Behavior addressed: `/btw` no longer silently switches a CLI-runtime-backed model to direct provider auth/streaming when no side-question hook is available.

Real environment tested: local OpenClaw checkout on Node/Vitest agent test lane; AWS Crabbox Linux run from the production `/btw` command handler with isolated temp session state and no provider credentials.

Exact steps or command run after this patch: the full and focused Vitest commands listed above; Crabbox script invoked `handleBtwCommand` with a real persisted session transcript and `agents.defaults.models["anthropic/claude-opus-4-7"].agentRuntime.id = "claude-cli"`.

Evidence after fix: full `src/agents/btw.test.ts` passed 34/34; focused regression proof passed 2/2; Crabbox proof printed `OPENCLAW_92168_PROOF_PASS` and exited 0.

Observed result after fix: CLI-runtime alias `/btw` returns `⚠️ /btw failed: /btw is not yet supported for claude-cli-backed models... OpenClaw will not fall back to direct anthropic auth...`; the preserved non-CLI custom harness fallback reaches direct Anthropic auth lookup instead of being blocked as a CLI alias.

What was not tested: true Claude CLI side-question answering was not implemented or claimed; this PR is the interim fail-closed safety fix. No live provider request was made because the expected behavior occurs before provider auth or streaming.
