### PR TITLE
fix(codex): avoid refreshing valid app-server OAuth

### DIFF
--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -677,14 +677,8 @@ describe("bridgeCodexAppServerStartOptions", () => {
     ).toBeUndefined();
   });
 
-  it("answers refresh requests from a discovered inline Codex OAuth profile", async () => {
+  it("answers refresh requests from a still-valid inline Codex OAuth profile", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
-    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
-      access: "refreshed-ref-backed-access-token",
-      refresh: "refreshed-ref-backed-refresh-token",
-      expires: Date.now() + 60_000,
-      accountId: "account-ref-backed-refreshed",
-    });
     try {
       upsertAuthProfile({
         agentDir,
@@ -694,19 +688,19 @@ describe("bridgeCodexAppServerStartOptions", () => {
           provider: "openai",
           access: "ref-backed-access-token",
           refresh: "ref-backed-refresh-token",
-          expires: Date.now() + 60_000,
+          expires: Date.now() + 24 * 60 * 60_000,
           accountId: "account-ref-backed",
           email: "codex@example.test",
         },
       });
 
       await expect(refreshCodexAppServerAuthTokens({ agentDir })).resolves.toEqual({
-        accessToken: "refreshed-ref-backed-access-token",
-        chatgptAccountId: "account-ref-backed-refreshed",
+        accessToken: "ref-backed-access-token",
+        chatgptAccountId: "account-ref-backed",
         chatgptPlanType: null,
       });
 
-      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("ref-backed-refresh-token");
+      expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
@@ -740,29 +734,23 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("answers refresh from native Codex CLI OAuth without persisting an OpenClaw profile", async () => {
+  it("answers refresh from still-valid native Codex CLI OAuth without persisting an OpenClaw profile", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const agentDir = path.join(root, "agent");
     const codexHome = path.join(root, "codex-cli");
     const authProfileStorePath = path.join(agentDir, "auth-profiles.json");
     vi.stubEnv("CODEX_HOME", codexHome);
-    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
-      access: "fresh-cli-access-token",
-      refresh: "fresh-cli-refresh-token",
-      expires: Date.now() + 60_000,
-      accountId: "account-cli-refreshed",
-    });
     try {
       await writeCodexCliAuthFile(codexHome);
 
       await expect(refreshCodexAppServerAuthTokens({ agentDir })).resolves.toEqual({
-        accessToken: "fresh-cli-access-token",
-        chatgptAccountId: "account-cli-refreshed",
+        accessToken: "cli-access-token",
+        chatgptAccountId: "account-cli",
         chatgptPlanType: null,
       });
 
       await expectPathMissing(authProfileStorePath);
-      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("cli-refresh-token");
+      expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
@@ -1316,7 +1304,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("answers app-server ChatGPT token refresh requests from the bound profile", async () => {
+  it("refreshes near-expiry app-server ChatGPT tokens from the bound profile", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
       access: "refreshed-access-token",
@@ -1355,7 +1343,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("does not persist an expired stale credential before forced token refresh succeeds", async () => {
+  it("does not persist a stale near-expiry credential before token refresh succeeds", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const currentExpiry = Date.now() + 60_000;
     oauthMocks.refreshOpenAICodexToken.mockImplementationOnce(async () => {

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -18,6 +18,7 @@ import {
   type AuthProfileStore,
   type OAuthCredential,
 } from "openclaw/plugin-sdk/agent-runtime";
+import { hasUsableOAuthCredential } from "openclaw/plugin-sdk/provider-auth";
 import type { CodexAppServerClient } from "./client.js";
 import type { CodexAppServerStartOptions } from "./config.js";
 import type {
@@ -577,7 +578,11 @@ async function resolveOAuthCredentialForCodexAppServer(
     isCodexAppServerAuthProvider(ownerCredential.provider, params.config)
       ? ownerCredential
       : undefined;
-  if (params.forceRefresh && !persistedOAuthCredential && overlaidOAuthCredential) {
+  const shouldRefreshRuntimeOnlyOAuthCredential =
+    !persistedOAuthCredential &&
+    overlaidOAuthCredential &&
+    !hasUsableOAuthCredential(overlaidOAuthCredential);
+  if (shouldRefreshRuntimeOnlyOAuthCredential) {
     const refreshedRuntimeCredential = await refreshOAuthCredentialForRuntime({
       credential: overlaidOAuthCredential,
     });
@@ -587,11 +592,15 @@ async function resolveOAuthCredentialForCodexAppServer(
     store.profiles[profileId] = refreshedRuntimeCredential;
     return refreshedRuntimeCredential;
   }
+  const shouldForceRefreshPersistedCredential =
+    params.forceRefresh &&
+    persistedOAuthCredential !== undefined &&
+    !hasUsableOAuthCredential(persistedOAuthCredential);
   const resolved = await resolveApiKeyForProfile({
     store,
     profileId,
     agentDir: ownerAgentDir,
-    forceRefresh: params.forceRefresh && Boolean(persistedOAuthCredential),
+    forceRefresh: shouldForceRefreshPersistedCredential,
   });
   const refreshed = loadAuthProfileStoreForSecretsRuntime(ownerAgentDir).profiles[profileId];
   const storedCredential = store.profiles[profileId];

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -8,6 +8,7 @@ import {
   buildOAuthRefreshFailureLoginCommand,
   classifyOAuthRefreshFailure,
   classifyOAuthRefreshFailureError,
+  classifyOAuthRefreshFailureReason,
   OAuthRefreshFailureError,
 } from "./oauth-refresh-failure.js";
 
@@ -35,6 +36,21 @@ describe("oauth refresh failure hints", () => {
     ).toEqual({
       provider: "openai",
       reason: "invalid_grant",
+    });
+  });
+
+  it("classifies ended OpenAI app sessions as sign-in-required", () => {
+    expect(classifyOAuthRefreshFailureReason("401 app_session_terminated")).toBe("sign_in_again");
+    expect(classifyOAuthRefreshFailureReason("Your session has ended. Please log in again.")).toBe(
+      "sign_in_again",
+    );
+    expect(
+      classifyOAuthRefreshFailure(
+        "OAuth token refresh failed for openai-codex: 401 app_session_terminated: Your session has ended. Please log in again.",
+      ),
+    ).toEqual({
+      provider: "openai-codex",
+      reason: "sign_in_again",
     });
   });
 });

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -67,7 +67,13 @@ export function classifyOAuthRefreshFailureReason(
   if (lower.includes("invalid_grant")) {
     return "invalid_grant";
   }
-  if (lower.includes("signing in again") || lower.includes("sign in again")) {
+  if (
+    lower.includes("app_session_terminated") ||
+    lower.includes("session has ended") ||
+    lower.includes("log in again") ||
+    lower.includes("signing in again") ||
+    lower.includes("sign in again")
+  ) {
     return "sign_in_again";
   }
   if (lower.includes("invalid refresh token")) {


### PR DESCRIPTION
## Summary
- Avoid forced OAuth refresh for Codex app-server token callbacks when the selected OAuth credential is still usable.
- Keep near-expiry credentials refreshing through the existing provider-auth path.
- Classify OpenAI app-session termination messages as sign-in-required refresh failures.

## Verification
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/auth-bridge.test.ts src/agents/auth-profiles/oauth-refresh-failure.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/auth-bridge.ts extensions/codex/src/app-server/auth-bridge.test.ts src/agents/auth-profiles/oauth-refresh-failure.ts src/agents/auth-profiles/oauth-refresh-failure.test.ts`
- `git diff --check`

## Real behavior proof
Behavior addressed: Codex app-server auth token refresh callbacks no longer rotate a valid OpenAI/Codex OAuth credential merely because the app-server callback requested a refresh.
Real environment tested: Local macOS checkout on the clean PR worktree, using the repo Vitest wrapper for the Codex extension and auth-profile failure tests.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/codex/src/app-server/auth-bridge.test.ts src/agents/auth-profiles/oauth-refresh-failure.test.ts`
Evidence after fix: The app-server auth-bridge test now asserts still-valid inline and native Codex CLI OAuth credentials return the existing access token without calling `refreshOpenAICodexToken`; existing near-expiry refresh tests still pass.
Observed result after fix: 2 Vitest shards passed; the Codex app-server shard reported 43 tests passed and the auth failure shard reported 3 tests passed.
What was not tested: A live Codex app-server session against OpenAI production auth was not exercised from this PR branch; the live OpenClaw VM incident also included a separate gateway restart trigger handled in ops.
