### PR TITLE
fix(cli): mark local models (Ollama) available in models list without auth

### DIFF
--- a/src/commands/models/list.model-row.test.ts
+++ b/src/commands/models/list.model-row.test.ts
@@ -56,4 +56,36 @@ describe("toModelRow", () => {
       expect(row.local).toBe(true);
     }
   });
+
+  it("marks local models available even without auth", () => {
+    const row = toModelRow({
+      model: {
+        ...OPENROUTER_MODEL,
+        provider: "ollama",
+        baseUrl: "http://127.0.0.1:11434/v1",
+      } as never,
+      key: "ollama/qwen3.6:35b-a3b",
+      tags: [],
+      // No availableKeys and no auth — simulates the Ollama case
+    });
+
+    expect(row.local).toBe(true);
+    expect(row.available).toBe(true);
+  });
+
+  it("marks local models available even when availableKeys excludes them", () => {
+    const row = toModelRow({
+      model: {
+        ...OPENROUTER_MODEL,
+        provider: "ollama",
+        baseUrl: "http://localhost:11434/v1",
+      } as never,
+      key: "ollama/qwen3.6:35b-a3b",
+      tags: [],
+      availableKeys: new Set(), // empty — no auth profiles
+    });
+
+    expect(row.local).toBe(true);
+    expect(row.available).toBe(true);
+  });
 });

--- a/src/commands/models/list.model-row.ts
+++ b/src/commands/models/list.model-row.ts
@@ -54,10 +54,12 @@ export function toModelRow(params: {
   // Prefer model-level registry availability when present.
   // Fall back to provider-level auth heuristics only if registry availability isn't available,
   // or if the caller marks this as a synthetic/forward-compat model that won't appear in getAvailable().
-  const available =
+  // Local providers (e.g. Ollama) serve on loopback without API keys — always available when present.
+  const authFallbackAvailable =
     availableKeys !== undefined && !allowProviderAvailabilityFallback
       ? modelIsAvailable
       : modelIsAvailable || (params.hasAuthForProvider?.(model.provider) ?? false);
+  const available = local || authFallbackAvailable;
   const aliasTags = aliases.length > 0 ? [`alias:${aliases.join(",")}`] : [];
   const mergedTags = new Set(tags);
   if (aliasTags.length > 0) {


### PR DESCRIPTION
## What does this PR do?
Fixes `openclaw models list` showing `available: false` for local Ollama models that are running and working. Local providers serve on loopback addresses without API keys, so auth-based availability checks should not gate them.

## Related Issue
Fixes #92224

## Type of Change
- [x] Bug fix (non-breaking)

## Changes Made
- `src/commands/models/list.model-row.ts`: Local models (loopback baseUrl) are now always marked available regardless of auth profile status. The existing `isLocalBaseUrl()` check was already computed (`local`) but not used in the availability logic.
- `src/commands/models/list.model-row.test.ts`: Added 2 regression tests — (1) local model without auth keys is available, (2) local model excluded from `availableKeys` set is still available.

## How to Test
1. Have Ollama running with a model loaded
2. Run `openclaw models list --json`
3. Verify `"available": true` for ollama models

**Unit test alternative:**
```bash
npx vitest run src/commands/models/list.model-row.test.ts --reporter=verbose
```

## Real behavior proof

**Behavior or issue addressed:**
`openclaw models list --json` shows `"available": false` for local Ollama models that work fine in active sessions.

**Root cause:**
`toModelRow()` derives `available` from `hasConfiguredAuth()` via `availableKeys`. Local providers (Ollama, LM Studio, etc.) don't require API keys, so auth checks always return false.

**Fix:**
Use the already-computed `local` flag (from `isLocalBaseUrl()`) to bypass auth-based availability for local providers: `const available = local || authFallbackAvailable`.

**Real environment tested:**
- macOS 26.4.1 (Darwin arm64)
- Node v25.8.2
- vitest 4.1.5

**Exact steps or command run after the patch:**
```bash
cd openclaw && npx vitest run src/commands/models/list.model-row.test.ts --reporter=verbose
```

**Evidence after fix:**
```
RUN  v4.1.5 /Users/liuhao/.hermes/workdir/openclaw

 ✓  unit-fast  src/commands/models/list.model-row.test.ts > toModelRow > keeps native context metadata and effective runtime context tokens distinct 1ms
 ✓  unit-fast  src/commands/models/list.model-row.test.ts > toModelRow > marks models available from auth profiles without loading model discovery 0ms
 ✓  unit-fast  src/commands/models/list.model-row.test.ts > toModelRow > marks bracketed IPv6 loopback base URLs as local 0ms
 ✓  unit-fast  src/commands/models/list.model-row.test.ts > toModelRow > marks local models available even without auth 0ms
 ✓  unit-fast  src/commands/models/list.model-row.test.ts > toModelRow > marks local models available even when availableKeys excludes them 0ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  01:39:51
   Duration  426ms (transform 150ms, setup 0ms, import 356ms, tests 2ms, environment 0ms)
```

**Observed result after fix:**
All 5 tests pass. The 2 new regression tests confirm that:
1. Local models (127.0.0.1 loopback) with no auth keys → `available: true`
2. Local models (localhost) with empty `availableKeys` set → `available: true`

**What was not tested:**
Manual end-to-end testing with a live Ollama instance (no Ollama daemon on this machine). The fix is a one-line boolean change (`local || authFallbackAvailable`) and the existing `isLocalBaseUrl()` helper is already tested for IPv4/IPv6 loopback addresses.

## Checklist
- [x] Read Contributing Guide
- [x] Conventional Commits
- [x] Searched for duplicates
- [x] Only related changes
- [x] Tests pass
- [x] Added tests
- [x] Tested on macOS
