### PR TITLE
Fix doctor preview channel SecretRef resolution

### DIFF
--- a/src/cli/command-config-resolution.ts
+++ b/src/cli/command-config-resolution.ts
@@ -16,6 +16,8 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
   allowedPaths?: Set<string>;
   forcedActivePaths?: Set<string>;
   optionalActivePaths?: Set<string>;
+  allowLocalExecSecretRefs?: boolean;
+  scrubUnresolvedSecretRefs?: boolean;
   runtime?: RuntimeEnv;
   autoEnable?: boolean;
   env?: NodeJS.ProcessEnv;
@@ -32,6 +34,12 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
     ...(params.allowedPaths ? { allowedPaths: params.allowedPaths } : {}),
     ...(params.forcedActivePaths ? { forcedActivePaths: params.forcedActivePaths } : {}),
     ...(params.optionalActivePaths ? { optionalActivePaths: params.optionalActivePaths } : {}),
+    ...(params.allowLocalExecSecretRefs !== undefined
+      ? { allowLocalExecSecretRefs: params.allowLocalExecSecretRefs }
+      : {}),
+    ...(params.scrubUnresolvedSecretRefs !== undefined
+      ? { scrubUnresolvedSecretRefs: params.scrubUnresolvedSecretRefs }
+      : {}),
   });
   if (params.runtime) {
     for (const entry of diagnostics) {

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -1,5 +1,8 @@
 // Command secret gateway tests cover secret resolution for gateway-backed CLI commands.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
@@ -18,6 +21,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 const { callGateway } = mocks;
+const tempRoots = new Set<string>();
 
 vi.mock("../gateway/call.js", () => ({
   callGateway: mocks.callGateway,
@@ -35,6 +39,13 @@ vi.mock("../utils/message-channel.js", () => ({
 beforeEach(() => {
   callGateway.mockReset();
   commandSecretGatewayTesting.resetDepsForTest();
+});
+
+afterEach(async () => {
+  for (const root of tempRoots) {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+  tempRoots.clear();
 });
 
 describe("resolveCommandSecretRefsViaGateway", () => {
@@ -83,6 +94,56 @@ describe("resolveCommandSecretRefsViaGateway", () => {
     expect(
       result.diagnostics.some((entry) => entry.includes("resolved command secrets locally")),
     ).toBe(true);
+  }
+
+  async function createExecProviderConfig(refId: string): Promise<{
+    config: OpenClawConfig;
+    markerPath: string;
+  }> {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-command-secret-exec-"));
+    tempRoots.add(root);
+    const markerPath = path.join(root, "executed");
+    const resolverScript = [
+      "const fs = require('node:fs');",
+      "let stdin = '';",
+      "process.stdin.on('data', (chunk) => { stdin += chunk; });",
+      "process.stdin.on('end', () => {",
+      "  const request = JSON.parse(stdin);",
+      "  fs.writeFileSync(process.env.OPENCLAW_EXEC_MARKER, 'executed');",
+      "  const values = Object.fromEntries(request.ids.map((id) => [id, 'exec-local-key']));",
+      "  process.stdout.write(JSON.stringify({ protocolVersion: 1, values }));",
+      "});",
+    ].join("\n");
+    return {
+      markerPath,
+      config: {
+        ...buildTalkTestProviderConfig({
+          source: "exec",
+          provider: "default",
+          id: refId,
+        }),
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+              args: ["-e", resolverScript],
+              env: { OPENCLAW_EXEC_MARKER: markerPath },
+              allowInsecurePath: true,
+              allowSymlinkCommand: true,
+              jsonOnly: true,
+            },
+          },
+        },
+      } as OpenClawConfig,
+    };
+  }
+
+  async function markerExists(markerPath: string): Promise<boolean> {
+    return await fs.access(markerPath).then(
+      () => true,
+      () => false,
+    );
   }
 
   function readPath(root: unknown, pathSegments: readonly string[]): unknown {
@@ -558,6 +619,133 @@ describe("resolveCommandSecretRefsViaGateway", () => {
         result.diagnostics.some((entry) => entry.includes("resolved command secrets locally")),
       ).toBe(true);
     });
+  });
+
+  it("keeps local exec SecretRef fallback enabled by default", async () => {
+    const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
+    callGateway.mockRejectedValueOnce(new Error("gateway closed"));
+
+    const result = await resolveCommandSecretRefsViaGateway({
+      config,
+      commandName: "memory status",
+      targetIds: new Set(["talk.providers.*.apiKey"]),
+      mode: "read_only_status",
+    });
+
+    expect(await markerExists(markerPath)).toBe(true);
+    expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("exec-local-key");
+    expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("resolved_local");
+    expectGatewayUnavailableLocalFallbackDiagnostics(result);
+  });
+
+  it("skips local exec SecretRef fallback when the caller disallows exec providers", async () => {
+    const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
+    callGateway.mockRejectedValueOnce(new Error("gateway closed"));
+
+    const result = await resolveCommandSecretRefsViaGateway({
+      config,
+      commandName: "doctor preview",
+      targetIds: new Set(["talk.providers.*.apiKey"]),
+      mode: "read_only_status",
+      allowLocalExecSecretRefs: false,
+    });
+
+    expect(await markerExists(markerPath)).toBe(false);
+    expect(readTalkProviderApiKey(result.resolvedConfig)).toBeUndefined();
+    expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("unresolved");
+    expect(result.diagnostics).toContain(
+      `doctor preview: ${TALK_TEST_PROVIDER_API_KEY_PATH} is unavailable in this command path; continuing with degraded read-only config.`,
+    );
+    expect(
+      result.diagnostics.some((entry) =>
+        entry.includes(
+          "doctor preview: skipped local exec SecretRef resolution for talk.providers.acme-speech.apiKey",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      result.diagnostics.some((entry) =>
+        entry.includes("attempted local command-secret resolution"),
+      ),
+    ).toBe(true);
+  });
+
+  it("can preserve unresolved SecretRefs when local exec fallback is disabled", async () => {
+    const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
+    callGateway.mockRejectedValueOnce(new Error("gateway closed"));
+
+    const result = await resolveCommandSecretRefsViaGateway({
+      config,
+      commandName: "doctor preview",
+      targetIds: new Set(["talk.providers.*.apiKey"]),
+      mode: "read_only_status",
+      allowLocalExecSecretRefs: false,
+      scrubUnresolvedSecretRefs: false,
+    });
+
+    expect(await markerExists(markerPath)).toBe(false);
+    expect(readTalkProviderApiKey(result.resolvedConfig)).toEqual({
+      source: "exec",
+      provider: "default",
+      id: "talk/providers/api-key",
+    });
+    expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("unresolved");
+    expect(result.hadUnresolvedTargets).toBe(true);
+  });
+
+  it("skips gateway resolution when gateway credentials would execute exec SecretRefs", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_GATEWAY_PASSWORD: undefined,
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        TALK_API_KEY: "local-fallback-key",
+      },
+      async () => {
+        const result = await resolveCommandSecretRefsViaGateway({
+          config: {
+            ...buildTalkTestProviderConfig({
+              source: "env",
+              provider: "env",
+              id: "TALK_API_KEY",
+            }),
+            gateway: {
+              auth: {
+                mode: "token",
+                token: { source: "exec", provider: "vault", id: "gateway/token" },
+              },
+            },
+            secrets: {
+              providers: {
+                env: { source: "env" },
+                vault: {
+                  source: "exec",
+                  command: process.execPath,
+                  args: ["-e", 'process.stdout.write(\'{"values":{"gateway/token":"x"}}\')'],
+                  allowInsecurePath: true,
+                  allowSymlinkCommand: true,
+                  jsonOnly: true,
+                },
+              },
+            },
+          } as OpenClawConfig,
+          commandName: "doctor preview",
+          targetIds: new Set(["talk.providers.*.apiKey"]),
+          mode: "read_only_status",
+          allowLocalExecSecretRefs: false,
+        });
+
+        expect(callGateway).not.toHaveBeenCalled();
+        expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("local-fallback-key");
+        expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("resolved_local");
+        expect(
+          result.diagnostics.some((entry) =>
+            entry.includes(
+              "doctor preview: skipped gateway secrets.resolve because gateway credentials use exec SecretRefs at gateway.auth.token",
+            ),
+          ),
+        ).toBe(true);
+      },
+    );
   });
 
   it("falls back to local resolution for web search SecretRefs when gateway is unavailable", async () => {

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -8,6 +8,12 @@ import { validateSecretsResolveResult } from "../../packages/gateway-protocol/sr
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { callGateway } from "../gateway/call.js";
+import { gatewaySecretInputPathCanWin } from "../gateway/credentials-secret-inputs.js";
+import {
+  ALL_GATEWAY_SECRET_INPUT_PATHS,
+  readGatewaySecretInputValue,
+  type SupportedGatewaySecretInputPath,
+} from "../gateway/secret-input-paths.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveManifestContractOwnerPluginId } from "../plugins/plugin-registry.js";
 import {
@@ -48,6 +54,11 @@ type CommandSecretTargetState =
   | "resolved_local"
   | "inactive_surface"
   | "unresolved";
+
+type CommandSecretResolutionPolicy = {
+  allowExecSecretRefs: boolean;
+  scrubUnresolvedSecretRefs: boolean;
+};
 
 type GatewaySecretsResolveResult = {
   ok?: boolean;
@@ -481,6 +492,65 @@ function hasForcedActivePaths(paths: ReadonlySet<string> | undefined): boolean {
   return paths !== undefined && paths.size > 0;
 }
 
+function resolveLocalResolutionPolicy(params: {
+  allowLocalExecSecretRefs?: boolean;
+  scrubUnresolvedSecretRefs?: boolean;
+}): CommandSecretResolutionPolicy {
+  return {
+    allowExecSecretRefs: params.allowLocalExecSecretRefs !== false,
+    scrubUnresolvedSecretRefs: params.scrubUnresolvedSecretRefs !== false,
+  };
+}
+
+function collectActiveGatewayExecSecretRefCredentialPaths(
+  config: OpenClawConfig,
+): SupportedGatewaySecretInputPath[] {
+  const defaults = config.secrets?.defaults;
+  return ALL_GATEWAY_SECRET_INPUT_PATHS.filter((path) => {
+    const { ref } = resolveSecretInputRef({
+      value: readGatewaySecretInputValue(config, path),
+      defaults,
+    });
+    return (
+      ref?.source === "exec" &&
+      gatewaySecretInputPathCanWin({
+        config,
+        path,
+        env: process.env,
+      })
+    );
+  });
+}
+
+async function resolveCommandSecretRefsWithoutGateway(params: {
+  config: OpenClawConfig;
+  commandName: string;
+  targetIds: Set<string>;
+  preflightDiagnostics: string[];
+  mode: CommandSecretResolutionMode;
+  allowedPaths?: ReadonlySet<string>;
+  forcedActivePaths?: ReadonlySet<string>;
+  optionalActivePaths?: ReadonlySet<string>;
+  resolutionPolicy: CommandSecretResolutionPolicy;
+  reasonDiagnostic: string;
+}): Promise<ResolveCommandSecretsResult> {
+  const fallback = await resolveCommandSecretRefsLocally({
+    config: params.config,
+    commandName: params.commandName,
+    targetIds: params.targetIds,
+    preflightDiagnostics: params.preflightDiagnostics,
+    mode: params.mode,
+    allowedPaths: params.allowedPaths,
+    forcedActivePaths: params.forcedActivePaths,
+    optionalActivePaths: params.optionalActivePaths,
+    resolutionPolicy: params.resolutionPolicy,
+  });
+  return {
+    ...fallback,
+    diagnostics: dedupeDiagnostics([...fallback.diagnostics, params.reasonDiagnostic]),
+  };
+}
+
 async function callGatewaySecretsResolve(params: {
   config: OpenClawConfig;
   commandName: string;
@@ -544,6 +614,7 @@ async function resolveCommandSecretRefsLocally(params: {
   allowedPaths?: ReadonlySet<string>;
   forcedActivePaths?: ReadonlySet<string>;
   optionalActivePaths?: ReadonlySet<string>;
+  resolutionPolicy: CommandSecretResolutionPolicy;
 }): Promise<ResolveCommandSecretsResult> {
   const sourceConfig = params.config;
   const resolvedConfig = structuredClone(params.config);
@@ -643,6 +714,7 @@ async function resolveCommandSecretRefsLocally(params: {
       mode: params.mode,
       commandName: params.commandName,
       localResolutionDiagnostics,
+      resolutionPolicy: params.resolutionPolicy,
     });
   }
   let analyzed = commandSecretGatewayDeps.analyzeCommandSecretAssignmentsFromSnapshot({
@@ -671,12 +743,15 @@ async function resolveCommandSecretRefsLocally(params: {
     analyzed,
     resolvedState: "resolved_local",
   });
-  if (!enforcesResolvedSecrets(params.mode) && analyzed.unresolved.length > 0) {
-    scrubUnresolvedAssignments(resolvedConfig, analyzed.unresolved);
-  } else if (analyzed.unresolved.length > 0) {
-    throw new Error(
-      `${params.commandName}: ${analyzed.unresolved[0]?.path ?? "target"} is unresolved in the active runtime snapshot.`,
-    );
+  if (analyzed.unresolved.length > 0) {
+    if (enforcesResolvedSecrets(params.mode)) {
+      throw new Error(
+        `${params.commandName}: ${analyzed.unresolved[0]?.path ?? "target"} is unresolved in the active runtime snapshot.`,
+      );
+    }
+    if (params.resolutionPolicy.scrubUnresolvedSecretRefs) {
+      scrubUnresolvedAssignments(resolvedConfig, analyzed.unresolved);
+    }
   }
 
   return {
@@ -766,6 +841,7 @@ async function resolveTargetSecretLocally(params: {
   mode: CommandSecretResolutionMode;
   commandName: string;
   localResolutionDiagnostics: string[];
+  resolutionPolicy: CommandSecretResolutionPolicy;
 }): Promise<void> {
   const defaults = params.sourceConfig.secrets?.defaults;
   const { ref } = resolveSecretInputRef({
@@ -781,6 +857,14 @@ async function resolveTargetSecretLocally(params: {
       !params.forcedActivePaths?.has(params.target.path) &&
       !params.optionalActivePaths?.has(params.target.path))
   ) {
+    return;
+  }
+  if (ref.source === "exec" && !params.resolutionPolicy.allowExecSecretRefs) {
+    if (!enforcesResolvedSecrets(params.mode)) {
+      params.localResolutionDiagnostics.push(
+        `${params.commandName}: skipped local exec SecretRef resolution for ${params.target.path}; rerun with --allow-exec to execute configured exec providers.`,
+      );
+    }
     return;
   }
 
@@ -816,8 +900,14 @@ export async function resolveCommandSecretRefsViaGateway(params: {
   allowedPaths?: ReadonlySet<string>;
   forcedActivePaths?: ReadonlySet<string>;
   optionalActivePaths?: ReadonlySet<string>;
+  allowLocalExecSecretRefs?: boolean;
+  scrubUnresolvedSecretRefs?: boolean;
 }): Promise<ResolveCommandSecretsResult> {
   const mode = normalizeCommandSecretResolutionMode(params.mode);
+  const resolutionPolicy = resolveLocalResolutionPolicy({
+    allowLocalExecSecretRefs: params.allowLocalExecSecretRefs,
+    scrubUnresolvedSecretRefs: params.scrubUnresolvedSecretRefs,
+  });
   const configuredTargetRefPaths = collectConfiguredTargetRefPaths({
     config: params.config,
     targetIds: params.targetIds,
@@ -845,6 +935,23 @@ export async function resolveCommandSecretRefsViaGateway(params: {
       hadUnresolvedTargets: false,
     };
   }
+  const gatewayExecSecretRefCredentialPaths = resolutionPolicy.allowExecSecretRefs
+    ? []
+    : collectActiveGatewayExecSecretRefCredentialPaths(params.config);
+  if (gatewayExecSecretRefCredentialPaths.length > 0) {
+    return await resolveCommandSecretRefsWithoutGateway({
+      config: params.config,
+      commandName: params.commandName,
+      targetIds: params.targetIds,
+      preflightDiagnostics: preflight.diagnostics,
+      mode,
+      allowedPaths: params.allowedPaths,
+      forcedActivePaths: params.forcedActivePaths,
+      optionalActivePaths: params.optionalActivePaths,
+      resolutionPolicy,
+      reasonDiagnostic: `${params.commandName}: skipped gateway secrets.resolve because gateway credentials use exec SecretRefs at ${gatewayExecSecretRefCredentialPaths.join(", ")}; rerun with --allow-exec to execute configured exec providers.`,
+    });
+  }
 
   let payload: GatewaySecretsResolveResult;
   try {
@@ -868,6 +975,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
         allowedPaths: params.allowedPaths,
         forcedActivePaths: params.forcedActivePaths,
         optionalActivePaths: params.optionalActivePaths,
+        resolutionPolicy,
       });
       const recoveredLocally = Object.values(fallback.targetStatesByPath).some(
         (state) => state === "resolved_local",
@@ -1003,6 +1111,8 @@ export async function resolveCommandSecretRefsViaGateway(params: {
         mode,
         allowedPaths: new Set(analyzed.unresolved.map((entry) => entry.path)),
         forcedActivePaths: params.forcedActivePaths,
+        optionalActivePaths: params.optionalActivePaths,
+        resolutionPolicy,
       });
       for (const unresolved of analyzed.unresolved) {
         if (localFallback.targetStatesByPath[unresolved.path] !== "resolved_local") {
@@ -1029,7 +1139,9 @@ export async function resolveCommandSecretRefsViaGateway(params: {
             `${params.commandName}: ${stillUnresolved[0]?.path ?? "target"} is unresolved in the active runtime snapshot.`,
           );
         }
-        scrubUnresolvedAssignments(resolvedConfig, stillUnresolved);
+        if (resolutionPolicy.scrubUnresolvedSecretRefs) {
+          scrubUnresolvedAssignments(resolvedConfig, stillUnresolved);
+        }
         diagnostics = dedupeDiagnostics([
           ...diagnostics,
           ...localFallback.diagnostics,
@@ -1050,7 +1162,9 @@ export async function resolveCommandSecretRefsViaGateway(params: {
       if (enforcesResolvedSecrets(mode)) {
         throw error;
       }
-      scrubUnresolvedAssignments(resolvedConfig, analyzed.unresolved);
+      if (resolutionPolicy.scrubUnresolvedSecretRefs) {
+        scrubUnresolvedAssignments(resolvedConfig, analyzed.unresolved);
+      }
       diagnostics = dedupeDiagnostics([
         ...diagnostics,
         `${params.commandName}: local fallback after incomplete gateway snapshot failed (${formatErrorMessage(error)}).`,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -331,6 +331,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       cfg: candidate,
       doctorFixCommand,
       env: process.env,
+      allowExec: params.options.allowExec === true,
     });
     emitDoctorNotes({
       note,

--- a/src/commands/doctor/shared/channel-doctor.test.ts
+++ b/src/commands/doctor/shared/channel-doctor.test.ts
@@ -1,9 +1,11 @@
 // Channel doctor tests cover shared channel health checks and repair hints.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizeResolvedSecretInputString } from "../../../config/types.secrets.js";
 import {
   collectChannelDoctorCompatibilityMutations,
   collectChannelDoctorEmptyAllowlistExtraWarnings,
   collectChannelDoctorMutableAllowlistWarnings,
+  collectChannelDoctorPreviewWarnings,
   collectChannelDoctorStaleConfigMutations,
   createChannelDoctorEmptyAllowlistPolicyHooks,
 } from "./channel-doctor.js";
@@ -175,6 +177,28 @@ describe("channel doctor compatibility mutations", () => {
     expect(normalizeCompatibilityConfig).toHaveBeenCalledTimes(1);
     expectMatrixDoctorLookupCalls(cfg);
     expect(mocks.getBundledChannelSetupPlugin).not.toHaveBeenCalledWith("discord");
+  });
+
+  it("keeps unresolved SecretRef preview reads non-fatal", async () => {
+    const collectPreviewWarnings = vi.fn(() => {
+      normalizeResolvedSecretInputString({
+        value: { source: "exec", provider: "default", id: "matrix/access-token" },
+        path: "channels.matrix.accessToken",
+      });
+      return ["unreachable"];
+    });
+    mockReadOnlyMatrixPlugin({ collectPreviewWarnings });
+    const cfg = createMatrixEnabledConfig();
+
+    const result = await collectChannelDoctorPreviewWarnings({
+      cfg: cfg as never,
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(result).toEqual([
+      "- channels.matrix: configured SecretRef at channels.matrix.accessToken is unavailable in doctor preview; skipping secret-backed channel preview checks.",
+    ]);
+    expect(collectPreviewWarnings).toHaveBeenCalledTimes(1);
   });
 
   it("merges partial doctor adapters instead of masking runtime-only hooks", async () => {

--- a/src/commands/doctor/shared/channel-doctor.ts
+++ b/src/commands/doctor/shared/channel-doctor.ts
@@ -13,8 +13,10 @@ import type {
   ChannelDoctorSequenceResult,
 } from "../../../channels/plugins/types.adapters.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { isUnresolvedSecretInputError } from "../../../config/types.secrets.js";
 
 type ChannelDoctorEntry = {
+  id: string;
   doctor: ChannelDoctorAdapter;
 };
 
@@ -227,7 +229,7 @@ function listChannelDoctorEntries(
     if (!doctor) {
       continue;
     }
-    entries.push({ doctor });
+    entries.push({ id, doctor });
   }
   return entries;
 }
@@ -366,7 +368,18 @@ export async function collectChannelDoctorPreviewWarnings(params: {
     cfg: params.cfg,
     env: params.env,
   })) {
-    const lines = await entry.doctor.collectPreviewWarnings?.(params);
+    let lines: string[] | undefined;
+    try {
+      lines = await entry.doctor.collectPreviewWarnings?.(params);
+    } catch (error) {
+      if (!isUnresolvedSecretInputError(error)) {
+        throw error;
+      }
+      warnings.push(
+        `- channels.${entry.id}: configured SecretRef at ${error.path} is unavailable in doctor preview; skipping secret-backed channel preview checks.`,
+      );
+      continue;
+    }
     if (lines?.length) {
       warnings.push(...lines);
     }

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -36,7 +36,26 @@ const activeToolSchemaState = vi.hoisted(() => ({
   warnings: [] as string[],
 }));
 
+const commandSecretState = vi.hoisted(() => ({
+  targetIds: new Set<string>(),
+  resolvedConfig: undefined as OpenClawConfig | undefined,
+  diagnostics: [] as string[],
+}));
+
 const tempRoots = new Set<string>();
+
+vi.mock("../../../cli/command-secret-gateway.js", () => ({
+  resolveCommandSecretRefsViaGateway: vi.fn(async (params: { config: OpenClawConfig }) => ({
+    resolvedConfig: commandSecretState.resolvedConfig ?? params.config,
+    diagnostics: commandSecretState.diagnostics,
+    targetStatesByPath: {},
+    hadUnresolvedTargets: false,
+  })),
+}));
+
+vi.mock("../../../cli/command-secret-targets.js", () => ({
+  getConfiguredChannelsCommandSecretTargetIds: vi.fn(() => commandSecretState.targetIds),
+}));
 
 vi.mock("../channel-capabilities.js", () => {
   const fallback = {
@@ -228,6 +247,9 @@ describe("doctor preview warnings", () => {
     manifestState.diagnostics = [];
     staleOAuthShadowState.warnings = [];
     activeToolSchemaState.warnings = [];
+    commandSecretState.targetIds = new Set<string>();
+    commandSecretState.resolvedConfig = undefined;
+    commandSecretState.diagnostics = [];
   });
 
   afterEach(() => {
@@ -295,6 +317,79 @@ describe("doctor preview warnings", () => {
     expect(
       warnings.some((warning) => warning.includes('channels.signal.allowFrom: set to ["*"]')),
     ).toBe(true);
+  });
+
+  it("resolves configured channel SecretRefs before collecting channel preview warnings", async () => {
+    const rawConfig = {
+      channels: {
+        telegram: {
+          botToken: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const resolvedConfig = {
+      channels: {
+        telegram: {
+          botToken: "resolved-token",
+          allowFrom: ["@alice"],
+        },
+      },
+    } as unknown as OpenClawConfig;
+    commandSecretState.targetIds = new Set(["channels.telegram.botToken"]);
+    commandSecretState.resolvedConfig = resolvedConfig;
+    commandSecretState.diagnostics = [
+      "doctor preview: gateway secrets.resolve unavailable (gateway closed); resolved command secrets locally.",
+    ];
+
+    const { resolveCommandSecretRefsViaGateway } =
+      await import("../../../cli/command-secret-gateway.js");
+    const notes = await collectDoctorPreviewNotes({
+      cfg: rawConfig,
+      doctorFixCommand: "openclaw doctor --fix",
+      env: {},
+    });
+
+    expect(resolveCommandSecretRefsViaGateway).toHaveBeenCalledWith({
+      config: rawConfig,
+      commandName: "doctor preview",
+      targetIds: commandSecretState.targetIds,
+      mode: "read_only_status",
+      allowLocalExecSecretRefs: false,
+      scrubUnresolvedSecretRefs: false,
+    });
+    expect(notes.warningNotes).toContain(commandSecretState.diagnostics[0]);
+    expect(
+      notes.warningNotes.some(
+        (warning) =>
+          warning.includes("Telegram allowFrom contains 1") && warning.includes("(e.g. @alice)"),
+      ),
+    ).toBe(true);
+  });
+
+  it("allows doctor preview to opt into local exec SecretRef resolution", async () => {
+    commandSecretState.targetIds = new Set(["channels.telegram.botToken"]);
+    const { resolveCommandSecretRefsViaGateway } =
+      await import("../../../cli/command-secret-gateway.js");
+
+    await collectDoctorPreviewNotes({
+      cfg: {
+        channels: {
+          telegram: {
+            botToken: { source: "exec", provider: "default", id: "telegram/bot-token" },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      doctorFixCommand: "openclaw doctor --fix",
+      env: {},
+      allowExec: true,
+    });
+
+    expect(resolveCommandSecretRefsViaGateway).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        allowLocalExecSecretRefs: true,
+        scrubUnresolvedSecretRefs: false,
+      }),
+    );
   });
 
   it("warns when a normalized legacy Codex provider cannot be auto-merged", async () => {

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -764,11 +764,37 @@ export type DoctorPreviewNotes = {
   warningNotes: string[];
 };
 
+async function resolveDoctorChannelPreviewConfig(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  allowExec?: boolean;
+}): Promise<{ cfg: OpenClawConfig; diagnostics: string[] }> {
+  const [{ resolveCommandSecretRefsViaGateway }, { getConfiguredChannelsCommandSecretTargetIds }] =
+    await Promise.all([
+      import("../../../cli/command-secret-gateway.js"),
+      import("../../../cli/command-secret-targets.js"),
+    ]);
+  const targetIds = getConfiguredChannelsCommandSecretTargetIds(params.cfg, params.env);
+  if (targetIds.size === 0) {
+    return { cfg: params.cfg, diagnostics: [] };
+  }
+  const resolved = await resolveCommandSecretRefsViaGateway({
+    config: params.cfg,
+    commandName: "doctor preview",
+    targetIds,
+    mode: "read_only_status",
+    allowLocalExecSecretRefs: params.allowExec === true,
+    scrubUnresolvedSecretRefs: false,
+  });
+  return { cfg: resolved.resolvedConfig, diagnostics: resolved.diagnostics };
+}
+
 /** Collect info and warning notes for doctor preview mode. */
 export async function collectDoctorPreviewNotes(params: {
   cfg: OpenClawConfig;
   doctorFixCommand: string;
   env?: NodeJS.ProcessEnv;
+  allowExec?: boolean;
 }): Promise<DoctorPreviewNotes> {
   const infoNotes: string[] = [];
   const warnings: string[] = [];
@@ -802,9 +828,15 @@ export async function collectDoctorPreviewNotes(params: {
   }
 
   if (hasChannelConfig) {
+    const channelPreviewConfig = await resolveDoctorChannelPreviewConfig({
+      cfg: params.cfg,
+      env,
+      allowExec: params.allowExec,
+    });
+    warnings.push(...channelPreviewConfig.diagnostics);
     const { collectChannelDoctorPreviewWarnings } = await loadChannelDoctorModule();
     const channelDoctorWarnings = await collectChannelDoctorPreviewWarnings({
-      cfg: params.cfg,
+      cfg: channelPreviewConfig.cfg,
       doctorFixCommand: params.doctorFixCommand,
       env,
     });
@@ -974,6 +1006,7 @@ export async function collectDoctorPreviewWarnings(params: {
   cfg: OpenClawConfig;
   doctorFixCommand: string;
   env?: NodeJS.ProcessEnv;
+  allowExec?: boolean;
 }): Promise<string[]> {
   return (await collectDoctorPreviewNotes(params)).warningNotes;
 }

--- a/src/config/types.secrets.resolution.test.ts
+++ b/src/config/types.secrets.resolution.test.ts
@@ -1,9 +1,11 @@
 // Verifies secret resolution config types and defaults.
 import { describe, expect, it } from "vitest";
 import {
+  isUnresolvedSecretInputError,
   normalizeResolvedSecretInputString,
   parseLegacySecretRefEnvMarker,
   resolveSecretInputString,
+  UnresolvedSecretInputError,
 } from "./types.secrets.js";
 
 describe("resolveSecretInputString", () => {
@@ -70,6 +72,25 @@ describe("resolveSecretInputString", () => {
         path: "models.providers.openai.apiKey",
       }),
     ).toThrow(/unresolved SecretRef/);
+  });
+
+  it("throws a typed unresolved SecretRef error in strict mode", () => {
+    let thrown: unknown;
+    try {
+      resolveSecretInputString({
+        value: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+        path: "models.providers.openai.apiKey",
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UnresolvedSecretInputError);
+    expect(isUnresolvedSecretInputError(thrown)).toBe(true);
+    expect(thrown).toMatchObject({
+      path: "models.providers.openai.apiKey",
+      ref: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+    });
   });
 });
 

--- a/src/config/types.secrets.ts
+++ b/src/config/types.secrets.ts
@@ -179,10 +179,28 @@ function formatSecretRefLabel(ref: SecretRef): string {
   return `${ref.source}:${ref.provider}:${ref.id}`;
 }
 
+/** Error thrown when strict secret reads encounter a configured but unresolved SecretRef. */
+export class UnresolvedSecretInputError extends Error {
+  readonly path: string;
+  readonly ref: SecretRef;
+
+  constructor(params: { path: string; ref: SecretRef }) {
+    super(
+      `${params.path}: unresolved SecretRef "${formatSecretRefLabel(params.ref)}". Resolve this command against an active gateway runtime snapshot before reading it.`,
+    );
+    this.name = "UnresolvedSecretInputError";
+    this.path = params.path;
+    this.ref = params.ref;
+  }
+}
+
+/** Narrow errors from strict secret read sites without parsing user-facing messages. */
+export function isUnresolvedSecretInputError(value: unknown): value is UnresolvedSecretInputError {
+  return value instanceof UnresolvedSecretInputError;
+}
+
 function createUnresolvedSecretInputError(params: { path: string; ref: SecretRef }): Error {
-  return new Error(
-    `${params.path}: unresolved SecretRef "${formatSecretRefLabel(params.ref)}". Resolve this command against an active gateway runtime snapshot before reading it.`,
-  );
+  return new UnresolvedSecretInputError(params);
 }
 
 /** Throw when a secret field still contains an unresolved SecretRef at a read site. */


### PR DESCRIPTION
## Summary

- Fix doctor preview to resolve configured channel SecretRefs before channel doctor checks so file/env-backed channel credentials do not abort read-only doctor runs.
- Preserve unresolved SecretRefs in doctor preview and handle typed unresolved SecretRef reads from channel doctor adapters as non-fatal degraded preview warnings.
- Keep default doctor exec safety intact by skipping gateway `secrets.resolve` when gateway credentials would require exec-backed SecretRefs without `--allow-exec`.

Fixes #91939.

## Verification

- `git diff --check`
- `node scripts/run-vitest.mjs src/cli/command-secret-gateway.test.ts src/config/types.secrets.resolution.test.ts src/commands/doctor/shared/channel-doctor.test.ts src/commands/doctor/shared/preview-warnings.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean; no accepted/actionable findings)
- Crabbox AWS proof: `run_55cc85e094c9`, lease `cbx_30402b8de8bc`, slug `pearl-prawn`
  - File-backed Nextcloud Talk `botSecret` SecretRef: `doctor --non-interactive` exited 0, no unresolved SecretRef abort, no missing bot secret warning.
  - Exec-backed channel SecretRef plus exec-backed gateway auth without `--allow-exec`: `doctor --non-interactive` exited 0, exec provider did not run, gateway/local exec skip diagnostics present, unresolved channel preview handled non-fatally.
