### PR TITLE
Fix suppressed heartbeat commitment delivery

### DIFF
--- a/src/infra/heartbeat-runner.commitments.test.ts
+++ b/src/infra/heartbeat-runner.commitments.test.ts
@@ -6,6 +6,7 @@ import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
 import { loadCommitmentStore, saveCommitmentStore } from "../commitments/store.js";
 import type { CommitmentRecord, CommitmentStoreFile } from "../commitments/types.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { getLastHeartbeatEvent, resetHeartbeatEventsForTest } from "./heartbeat-events.js";
 import {
   runHeartbeatOnce,
   setHeartbeatsEnabled,
@@ -25,6 +26,7 @@ describe("runHeartbeatOnce commitments", () => {
     setHeartbeatsEnabled(true);
     vi.useRealTimers();
     vi.unstubAllEnvs();
+    resetHeartbeatEventsForTest();
   });
 
   function buildCommitment(params: {
@@ -392,6 +394,94 @@ describe("runHeartbeatOnce commitments", () => {
       status: "sent",
       attempts: 1,
       sentAtMs: nowMs,
+    });
+  });
+
+  it("does not mark suppressed commitment sends as delivered or duplicate-dismiss their retry", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      vi.stubEnv("OPENCLAW_STATE_DIR", tmpDir);
+      const sessionKey = "agent:main:telegram:user-155462274";
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+        commitments: { enabled: true },
+      };
+      await seedSessionStore(storePath, sessionKey, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "155462274",
+      });
+      await saveCommitmentStore(undefined, {
+        version: 1,
+        commitments: [buildCommitment({ id: "cm_interview", sessionKey, to: "155462274" })],
+      });
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m2",
+        chatId: "155462274",
+      });
+      replySpy
+        .mockResolvedValueOnce({ text: "No channel reply." })
+        .mockResolvedValueOnce({ text: "How did the interview go?" });
+
+      const runOnce = async () =>
+        await runHeartbeatOnce({
+          cfg,
+          agentId: "main",
+          sessionKey,
+          deps: {
+            getReplyFromConfig: replySpy,
+            telegram: sendTelegram,
+            getQueueSize: () => 0,
+            nowMs: () => nowMs,
+          },
+        });
+
+      const first = await runOnce();
+
+      expect(first.status).toBe("ran");
+      expect(sendTelegram).not.toHaveBeenCalled();
+      let store = await loadCommitmentStore();
+      expectCommitmentFields(store.commitments[0], {
+        id: "cm_interview",
+        status: "pending",
+        attempts: 1,
+        lastAttemptAtMs: nowMs,
+      });
+      expect(store.commitments[0]?.sentAtMs).toBeUndefined();
+      const sessionStoreAfterSuppressed = JSON.parse(
+        await fs.readFile(storePath, "utf-8"),
+      ) as Record<string, { lastHeartbeatText?: string; lastHeartbeatSentAt?: number }>;
+      expect(sessionStoreAfterSuppressed[sessionKey]?.lastHeartbeatText).toBeUndefined();
+      expect(sessionStoreAfterSuppressed[sessionKey]?.lastHeartbeatSentAt).toBeUndefined();
+      expect(getLastHeartbeatEvent()).toMatchObject({
+        status: "skipped",
+        reason: "no_visible_payload",
+      });
+
+      const second = await runOnce();
+
+      expect(second.status).toBe("ran");
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      store = await loadCommitmentStore();
+      expectCommitmentFields(store.commitments[0], {
+        id: "cm_interview",
+        status: "sent",
+        attempts: 2,
+        sentAtMs: nowMs,
+      });
+      expect(getLastHeartbeatEvent()).toMatchObject({
+        status: "sent",
+      });
     });
   });
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -2057,15 +2057,20 @@ export async function runHeartbeatOnce(opts: {
     if (send.status === "failed" || send.status === "partial_failed") {
       throw send.error;
     }
-    await markCommitmentsStatus({
-      cfg,
-      ids: dueCommitmentIds,
-      status: shouldSkipMain ? "dismissed" : "sent",
-      nowMs: startedAt,
-    });
+    const visibleSendSucceeded = send.status === "sent";
+    // Suppressed durable sends committed no visible channel message. Keep due
+    // commitments and heartbeat dedupe state active so a later heartbeat can retry.
+    if (shouldSkipMain || visibleSendSucceeded) {
+      await markCommitmentsStatus({
+        cfg,
+        ids: dueCommitmentIds,
+        status: shouldSkipMain ? "dismissed" : "sent",
+        nowMs: startedAt,
+      });
+    }
 
     // Record last delivered heartbeat payload for dedupe.
-    if (!shouldSkipMain && normalized.text.trim()) {
+    if (visibleSendSucceeded && !shouldSkipMain && normalized.text.trim()) {
       await updateSessionStore(storePath, (store) => {
         const current = store[sessionKey];
         if (!current) {
@@ -2079,17 +2084,22 @@ export async function runHeartbeatOnce(opts: {
       });
     }
 
-    const sentStatus = deliveredAgentRunFailure ? "failed" : "sent";
+    const eventStatus = deliveredAgentRunFailure
+      ? "failed"
+      : visibleSendSucceeded
+        ? "sent"
+        : "skipped";
     emitHeartbeatEvent({
-      status: sentStatus,
+      status: eventStatus,
       to: delivery.to,
       ...(deliveredAgentRunFailure ? { reason: "agent-runner-failure" } : {}),
+      ...(!deliveredAgentRunFailure && !visibleSendSucceeded ? { reason: send.reason } : {}),
       preview: previewText?.slice(0, 200),
       durationMs: Date.now() - startedAt,
       hasMedia: mediaUrls.length > 0,
       channel: delivery.channel,
       accountId: delivery.accountId,
-      indicatorType: visibility.useIndicator ? resolveIndicatorType(sentStatus) : undefined,
+      indicatorType: visibility.useIndicator ? resolveIndicatorType(eventStatus) : undefined,
     });
     await updateTaskTimestamps();
     consumeInspectedSystemEvents();


### PR DESCRIPTION
## Summary

Fixes #91948.

- Treat durable `suppressed` heartbeat sends as non-visible delivery, not successful commitment delivery.
- Keep due commitments pending and avoid writing heartbeat dedupe state when the durable send is suppressed.
- Emit a skipped heartbeat event with the durable suppression reason, then allow a later visible heartbeat to retry and mark the commitment sent.
- Add a regression test covering a suppressed `No channel reply.` heartbeat followed by a visible retry.

## Root Cause

`runHeartbeatOnce` called `sendDurableMessageBatch`, threw only for failed/partial failed statuses, and then treated every other result as delivered. That meant a `suppressed` durable result from outbound planning could mark inferred commitments `sent`, write `lastHeartbeatText`/`lastHeartbeatSentAt`, and emit a `sent` heartbeat event even though no channel message was visible.

## Verification

- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean; no accepted/actionable findings reported; overall patch correct `(0.86)`.
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.commitments.test.ts -- --reporter=verbose` - 10 tests passed after rebase.
- `node scripts/run-vitest.mjs src/channels/message/send.test.ts src/channels/turn/durable-delivery.test.ts src/auto-reply/reply/route-reply.test.ts -- --reporter=verbose` - 54 tests passed.
- Regression repro: with only the runtime fix temporarily reverted, the new focused test failed on current behavior with `expected 'sent' to deeply equal 'pending'`; after restoring the fix, the focused test passed.
- Live AWS Crabbox proof, run `run_6ac6aacdd5f2`: first suppressed Telegram heartbeat left the commitment `pending`, kept `sentAtMs` unset, did not write heartbeat dedupe state, and emitted `skipped` with `reason: no_visible_payload`; the next visible heartbeat sent exactly one Telegram message and marked the commitment `sent`.
