### PR TITLE
fix(telegram): keep spooled updates when the turn pipeline swallows failures

### DIFF
--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -42,6 +42,11 @@ import {
   resolveTelegramOutboundClientTimeoutFloorSeconds,
 } from "./client-fetch.js";
 import { resolveTelegramTransport } from "./fetch.js";
+import {
+  clearTelegramInboundProcessingFailureForUpdate,
+  hasTelegramInboundProcessingFailureForUpdate,
+  recordTelegramInboundProcessingFailure,
+} from "./inbound-processing-failures.js";
 import { stringifyTelegramRawUpdateForLog } from "./raw-update-log.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
@@ -178,6 +183,23 @@ export function createTelegramBotCore(
   bot.api.config.use(getOrCreateAccountThrottler(opts.token, botRuntime.apiThrottler));
   // Catch all errors from bot middleware to prevent unhandled rejections
   bot.catch((err) => {
+    // grammY consumes the error here, so handleUpdate resolves; record the
+    // failure so the spool consumer does not mistake this turn for a success.
+    const update = err.ctx?.update;
+    const message =
+      update?.message ??
+      update?.edited_message ??
+      update?.channel_post ??
+      update?.edited_channel_post ??
+      update?.business_message;
+    if (message) {
+      recordTelegramInboundProcessingFailure({
+        accountId: account.accountId,
+        chatId: message.chat.id,
+        messageId: message.message_id,
+        error: err,
+      });
+    }
     runtime.error?.(danger(`telegram bot error: ${formatUncaughtError(err)}`));
   });
 
@@ -211,9 +233,21 @@ export function createTelegramBotCore(
     if (!begin.accepted) {
       return;
     }
+    clearTelegramInboundProcessingFailureForUpdate({
+      accountId: account.accountId,
+      update: ctx.update,
+    });
     try {
       await next();
-      updateTracker.finishUpdate(begin.update, { completed: true });
+      // Downstream handlers swallow turn failures (log + user apology), so a
+      // resolved next() is not proof of completion; failed turns must not be
+      // marked completed or retries get deduplicated as already-handled.
+      updateTracker.finishUpdate(begin.update, {
+        completed: !hasTelegramInboundProcessingFailureForUpdate({
+          accountId: account.accountId,
+          update: ctx.update,
+        }),
+      });
     } catch (error) {
       updateTracker.finishUpdate(begin.update, { completed: false });
       throw error;

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -104,6 +104,7 @@ import {
 } from "./conversation-route.js";
 import { enforceTelegramDmAccess, isTelegramDmAccessAllowed } from "./dm-access.js";
 import { resolveTelegramExecApproval } from "./exec-approval-resolver.js";
+import { recordTelegramInboundProcessingFailure } from "./inbound-processing-failures.js";
 import {
   isTelegramExecApprovalApprover,
   isTelegramExecApprovalAuthorizedSender,
@@ -552,6 +553,16 @@ export const registerTelegramHandlers = ({
       });
     },
     onError: (err, items) => {
+      // Record per source message so whichever update carried each message in
+      // the isolated-ingress spool can resolve the coalesced flush failure.
+      for (const item of items) {
+        recordTelegramInboundProcessingFailure({
+          accountId,
+          chatId: item.msg.chat.id,
+          messageId: item.msg.message_id,
+          error: err,
+        });
+      }
       runtime.error?.(danger(`telegram debounce flush failed: ${String(err)}`));
       const chatId = items[0]?.msg.chat.id;
       if (chatId != null) {
@@ -2956,6 +2967,12 @@ export const registerTelegramHandlers = ({
       });
     } catch (err) {
       releaseDispatchDedupeKeys(dispatchDedupeKeys, err);
+      recordTelegramInboundProcessingFailure({
+        accountId,
+        chatId: event.chatId,
+        messageId: event.msg.message_id,
+        error: err,
+      });
       runtime.error?.(danger(`${event.errorMessage}: ${String(err)}`));
       if (err instanceof TelegramPairingStoreReadError) {
         await withTelegramApiErrorLogging({

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -18,6 +18,7 @@ import type { TelegramMessageContextOptions } from "./bot-message-context.types.
 import type { TelegramPromptContextEntry } from "./bot-message-context.types.js";
 import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
 import type { TelegramBotOptions } from "./bot.types.js";
+import { recordTelegramInboundProcessingFailure } from "./inbound-processing-failures.js";
 import { buildTelegramThreadParams } from "./bot/helpers.js";
 import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
 import type { TelegramReplyChainEntry } from "./message-cache.js";
@@ -201,6 +202,15 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         );
       }
     } catch (err) {
+      const failedMessageId = context.msg?.message_id;
+      if (context.chatId != null && typeof failedMessageId === "number") {
+        recordTelegramInboundProcessingFailure({
+          accountId: account.accountId,
+          chatId: context.chatId,
+          messageId: failedMessageId,
+          error: err,
+        });
+      }
       runtime.error?.(danger(`telegram message processing failed: ${String(err)}`));
       try {
         await bot.api.sendMessage(

--- a/extensions/telegram/src/inbound-processing-failures.test.ts
+++ b/extensions/telegram/src/inbound-processing-failures.test.ts
@@ -1,0 +1,160 @@
+// Telegram tests cover the inbound processing failure registry.
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearTelegramInboundProcessingFailureForUpdate,
+  hasTelegramInboundProcessingFailureForUpdate,
+  recordTelegramInboundProcessingFailure,
+  resetTelegramInboundProcessingFailuresForTests,
+  takeTelegramInboundProcessingFailureForUpdate,
+} from "./inbound-processing-failures.js";
+
+function messageUpdate(params: { chatId: number; messageId: number }) {
+  return {
+    update_id: 1,
+    message: {
+      message_id: params.messageId,
+      chat: { id: params.chatId, type: "private" },
+      text: "hi",
+    },
+  };
+}
+
+describe("telegram inbound processing failures", () => {
+  beforeEach(() => {
+    resetTelegramInboundProcessingFailuresForTests();
+  });
+
+  it("takes a recorded failure for the matching update once", () => {
+    const error = new Error("turn failed");
+    recordTelegramInboundProcessingFailure({
+      accountId: "default",
+      chatId: 7,
+      messageId: 99,
+      error,
+    });
+    const update = messageUpdate({ chatId: 7, messageId: 99 });
+    expect(hasTelegramInboundProcessingFailureForUpdate({ accountId: "default", update })).toBe(
+      true,
+    );
+    expect(
+      takeTelegramInboundProcessingFailureForUpdate({ accountId: "default", update })?.error,
+    ).toBe(error);
+    expect(takeTelegramInboundProcessingFailureForUpdate({ accountId: "default", update })).toBe(
+      undefined,
+    );
+  });
+
+  it("scopes failures by account, chat, and message", () => {
+    recordTelegramInboundProcessingFailure({
+      accountId: "default",
+      chatId: 7,
+      messageId: 99,
+      error: new Error("turn failed"),
+    });
+    expect(
+      takeTelegramInboundProcessingFailureForUpdate({
+        accountId: "other",
+        update: messageUpdate({ chatId: 7, messageId: 99 }),
+      }),
+    ).toBe(undefined);
+    expect(
+      takeTelegramInboundProcessingFailureForUpdate({
+        accountId: "default",
+        update: messageUpdate({ chatId: 7, messageId: 100 }),
+      }),
+    ).toBe(undefined);
+    expect(
+      takeTelegramInboundProcessingFailureForUpdate({
+        accountId: "default",
+        update: messageUpdate({ chatId: 8, messageId: 99 }),
+      }),
+    ).toBe(undefined);
+  });
+
+  it("treats a missing or undefined accountId as the default account", () => {
+    recordTelegramInboundProcessingFailure({
+      chatId: 7,
+      messageId: 99,
+      error: new Error("turn failed"),
+    });
+    expect(
+      takeTelegramInboundProcessingFailureForUpdate({
+        accountId: "default",
+        update: messageUpdate({ chatId: 7, messageId: 99 }),
+      }),
+    ).toBeDefined();
+  });
+
+  it("matches edited messages and channel posts", () => {
+    recordTelegramInboundProcessingFailure({
+      accountId: "default",
+      chatId: 7,
+      messageId: 99,
+      error: new Error("turn failed"),
+    });
+    expect(
+      takeTelegramInboundProcessingFailureForUpdate({
+        accountId: "default",
+        update: {
+          update_id: 2,
+          edited_message: { message_id: 99, chat: { id: 7, type: "private" } },
+        },
+      }),
+    ).toBeDefined();
+  });
+
+  it("ignores updates without a message envelope", () => {
+    recordTelegramInboundProcessingFailure({
+      accountId: "default",
+      chatId: 7,
+      messageId: 99,
+      error: new Error("turn failed"),
+    });
+    expect(
+      takeTelegramInboundProcessingFailureForUpdate({
+        accountId: "default",
+        update: { update_id: 3, callback_query: { id: "cb" } },
+      }),
+    ).toBe(undefined);
+    expect(
+      takeTelegramInboundProcessingFailureForUpdate({ accountId: "default", update: null }),
+    ).toBe(undefined);
+  });
+
+  it("clears stale records for an update before a fresh attempt", () => {
+    recordTelegramInboundProcessingFailure({
+      accountId: "default",
+      chatId: 7,
+      messageId: 99,
+      error: new Error("previous attempt failed"),
+    });
+    const update = messageUpdate({ chatId: 7, messageId: 99 });
+    clearTelegramInboundProcessingFailureForUpdate({ accountId: "default", update });
+    expect(hasTelegramInboundProcessingFailureForUpdate({ accountId: "default", update })).toBe(
+      false,
+    );
+  });
+
+  it("bounds the registry so untaken records cannot grow unbounded", () => {
+    for (let i = 0; i < 400; i += 1) {
+      recordTelegramInboundProcessingFailure({
+        accountId: "default",
+        chatId: 7,
+        messageId: i,
+        error: new Error(`failure ${i}`),
+      });
+    }
+    expect(
+      takeTelegramInboundProcessingFailureForUpdate({
+        accountId: "default",
+        update: messageUpdate({ chatId: 7, messageId: 0 }),
+      }),
+    ).toBe(undefined);
+    expect(
+      takeTelegramInboundProcessingFailureForUpdate({
+        accountId: "default",
+        update: messageUpdate({ chatId: 7, messageId: 399 }),
+      }),
+    ).toBeDefined();
+  });
+});

--- a/extensions/telegram/src/inbound-processing-failures.ts
+++ b/extensions/telegram/src/inbound-processing-failures.ts
@@ -1,0 +1,117 @@
+// Telegram plugin module records inbound processing failures that the turn
+// pipeline swallows (logged + user apology) so `bot.handleUpdate()` resolves.
+// The isolated-ingress spool consumer and the update tracker consult this
+// registry to distinguish failed turns from completed ones; without it a
+// failed turn is indistinguishable from success and the spooled update is
+// deleted, silently losing the message.
+const MAX_TRACKED_FAILURES = 256;
+
+type TelegramInboundProcessingFailure = {
+  error: unknown;
+};
+
+const failuresByKey = new Map<string, TelegramInboundProcessingFailure>();
+
+function normalizeAccountId(accountId?: string): string {
+  return accountId?.trim() || "default";
+}
+
+function buildFailureKey(params: {
+  accountId?: string;
+  chatId: number | string;
+  messageId: number | string;
+}): string {
+  return `${normalizeAccountId(params.accountId)}:${params.chatId}:${params.messageId}`;
+}
+
+type TelegramUpdateMessageRef = {
+  chatId: number;
+  messageId: number;
+};
+
+function collectUpdateMessageRefs(update: unknown): TelegramUpdateMessageRef[] {
+  if (!update || typeof update !== "object") {
+    return [];
+  }
+  const candidates = update as Record<string, unknown>;
+  const refs: TelegramUpdateMessageRef[] = [];
+  for (const field of [
+    "message",
+    "edited_message",
+    "channel_post",
+    "edited_channel_post",
+    "business_message",
+  ]) {
+    const message = candidates[field];
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const messageId = (message as { message_id?: unknown }).message_id;
+    const chat = (message as { chat?: unknown }).chat;
+    const chatId =
+      chat && typeof chat === "object" ? (chat as { id?: unknown }).id : undefined;
+    if (typeof messageId === "number" && typeof chatId === "number") {
+      refs.push({ chatId, messageId });
+    }
+  }
+  return refs;
+}
+
+/** Record a swallowed inbound processing failure for a chat message. */
+export function recordTelegramInboundProcessingFailure(params: {
+  accountId?: string;
+  chatId: number | string;
+  messageId: number | string;
+  error: unknown;
+}): void {
+  const key = buildFailureKey(params);
+  failuresByKey.delete(key);
+  failuresByKey.set(key, { error: params.error });
+  while (failuresByKey.size > MAX_TRACKED_FAILURES) {
+    const oldest = failuresByKey.keys().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    failuresByKey.delete(oldest);
+  }
+}
+
+/** Drop stale failure records for an update before a fresh processing attempt. */
+export function clearTelegramInboundProcessingFailureForUpdate(params: {
+  accountId?: string;
+  update: unknown;
+}): void {
+  for (const ref of collectUpdateMessageRefs(params.update)) {
+    failuresByKey.delete(buildFailureKey({ accountId: params.accountId, ...ref }));
+  }
+}
+
+/** Check whether the current processing attempt recorded a failure for an update. */
+export function hasTelegramInboundProcessingFailureForUpdate(params: {
+  accountId?: string;
+  update: unknown;
+}): boolean {
+  return collectUpdateMessageRefs(params.update).some((ref) =>
+    failuresByKey.has(buildFailureKey({ accountId: params.accountId, ...ref })),
+  );
+}
+
+/** Consume the recorded failure for an update, if any. */
+export function takeTelegramInboundProcessingFailureForUpdate(params: {
+  accountId?: string;
+  update: unknown;
+}): TelegramInboundProcessingFailure | undefined {
+  for (const ref of collectUpdateMessageRefs(params.update)) {
+    const key = buildFailureKey({ accountId: params.accountId, ...ref });
+    const failure = failuresByKey.get(key);
+    if (failure) {
+      failuresByKey.delete(key);
+      return failure;
+    }
+  }
+  return undefined;
+}
+
+export function resetTelegramInboundProcessingFailuresForTests(): void {
+  failuresByKey.clear();
+}

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -77,6 +77,8 @@ let beginTelegramReplyFence: typeof import("./telegram-reply-fence.js").beginTel
 let buildTelegramReplyFenceLaneKey: typeof import("./telegram-reply-fence.js").buildTelegramReplyFenceLaneKey;
 let endTelegramReplyFence: typeof import("./telegram-reply-fence.js").endTelegramReplyFence;
 let resetTelegramReplyFenceForTests: typeof import("./telegram-reply-fence.js").resetTelegramReplyFenceForTests;
+let recordTelegramInboundProcessingFailure: typeof import("./inbound-processing-failures.js").recordTelegramInboundProcessingFailure;
+let resetTelegramInboundProcessingFailuresForTests: typeof import("./inbound-processing-failures.js").resetTelegramInboundProcessingFailuresForTests;
 
 type TelegramApiMiddleware = (
   prev: (...args: unknown[]) => Promise<unknown>,
@@ -412,6 +414,7 @@ type TestTelegramUpdate = {
   message: {
     text: string;
     chat: { id: number; type: "supergroup" };
+    message_id?: number;
     message_thread_id?: number;
     is_topic_message?: boolean;
   };
@@ -424,6 +427,21 @@ function topicUpdate(updateId: number, threadId: number, text: string): TestTele
       text,
       message_thread_id: threadId,
       is_topic_message: true,
+      chat: { id: -100, type: "supergroup" },
+    },
+  };
+}
+
+function spooledMessageUpdate(params: {
+  updateId: number;
+  messageId: number;
+  text: string;
+}): TestTelegramUpdate {
+  return {
+    update_id: params.updateId,
+    message: {
+      text: params.text,
+      message_id: params.messageId,
       chat: { id: -100, type: "supergroup" },
     },
   };
@@ -617,6 +635,8 @@ describe("TelegramPollingSession", () => {
       endTelegramReplyFence,
       resetTelegramReplyFenceForTests,
     } = await import("./telegram-reply-fence.js"));
+    ({ recordTelegramInboundProcessingFailure, resetTelegramInboundProcessingFailuresForTests } =
+      await import("./inbound-processing-failures.js"));
   });
 
   beforeEach(() => {
@@ -627,6 +647,7 @@ describe("TelegramPollingSession", () => {
     sleepWithAbortMock.mockReset().mockResolvedValue(undefined);
     drainPendingDeliveriesMock.mockReset().mockResolvedValue(undefined);
     resetTelegramReplyFenceForTests();
+    resetTelegramInboundProcessingFailuresForTests();
     installTelegramIngressQueueRuntime(() =>
       path.join(os.tmpdir(), "openclaw-telegram-test-state"),
     );
@@ -1450,6 +1471,80 @@ describe("TelegramPollingSession", () => {
       expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
       expectLogIncludes(log, "spooled update 42 failed with non-retryable missing-agent-harness");
       expectLogExcludes(log, "spooled update 42 failed; keeping for retry");
+      abort.abort();
+      stopWorker();
+      await runPromise;
+    });
+  });
+
+  it("releases spooled updates when the turn pipeline swallowed the failure", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const log = vi.fn();
+      const handled: number[] = [];
+      await writeSpooledTestUpdates(tempDir, [
+        spooledMessageUpdate({ updateId: 42, messageId: 9001, text: "swallowed failure turn" }),
+      ]);
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        log,
+        drainIntervalMs: 10,
+        handleUpdate: async (update) => {
+          handled.push(update.update_id ?? -1);
+          if (handled.length === 1) {
+            // The turn pipeline logs and apologizes instead of rejecting, so
+            // handleUpdate resolves; only the failure registry knows.
+            recordTelegramInboundProcessingFailure({
+              accountId: "default",
+              chatId: -100,
+              messageId: 9001,
+              error: new Error("agent turn failed mid-flight"),
+            });
+          }
+        },
+      });
+
+      await vi.waitFor(() => expect(handled).toEqual([42, 42]));
+      await vi.waitFor(async () => expect(await pendingUpdateIds(tempDir, "all")).toEqual([]));
+      expect(await failedUpdateIds(tempDir)).toEqual([]);
+      expectLogIncludes(log, "spooled update 42 failed; keeping for retry");
+      abort.abort();
+      stopWorker();
+      await runPromise;
+    });
+  });
+
+  it("dead-letters spooled updates after repeated swallowed failures", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const log = vi.fn();
+      const handled: number[] = [];
+      await writeSpooledTestUpdates(tempDir, [
+        spooledMessageUpdate({ updateId: 42, messageId: 9002, text: "poison turn" }),
+      ]);
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        log,
+        drainIntervalMs: 10,
+        handleUpdate: async (update) => {
+          handled.push(update.update_id ?? -1);
+          recordTelegramInboundProcessingFailure({
+            accountId: "default",
+            chatId: -100,
+            messageId: 9002,
+            error: new Error("deterministic turn failure"),
+          });
+        },
+      });
+
+      await vi.waitFor(async () => expect(await failedUpdateIds(tempDir)).toEqual([42]));
+      expect(handled).toEqual([42, 42, 42]);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      expectLogIncludes(log, "spooled update 42 failed 3 times; dead-lettered");
       abort.abort();
       stopWorker();
       await runPromise;

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -21,6 +21,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 import type { TelegramTransport } from "./fetch.js";
+import { takeTelegramInboundProcessingFailureForUpdate } from "./inbound-processing-failures.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { TelegramPollingLivenessTracker } from "./polling-liveness.js";
 import { createTelegramPollingStatusPublisher } from "./polling-status.js";
@@ -120,6 +121,10 @@ const TELEGRAM_SPOOLED_HANDLER_ABORT_GRACE_MS = 5_000;
 const TELEGRAM_SPOOLED_HANDLER_TIMEOUT_ENV = "OPENCLAW_TELEGRAM_SPOOLED_HANDLER_TIMEOUT_MS";
 const TELEGRAM_SPOOLED_DRAIN_START_LIMIT = 100;
 const TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT = TELEGRAM_SPOOLED_DRAIN_START_LIMIT * 10;
+// Failed spooled updates are released for retry; a deterministic failure must
+// dead-letter after a few attempts or it would re-dispatch (and re-apologize
+// to the sender) on every drain cycle.
+const TELEGRAM_SPOOLED_UPDATE_MAX_PROCESSING_ATTEMPTS = 3;
 const TELEGRAM_POLLING_CLIENT_TIMEOUT_FLOOR_SECONDS = Math.ceil(
   TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS / 1000,
 );
@@ -533,6 +538,22 @@ export class TelegramPollingSession {
       });
       return false;
     }
+    // The turn pipeline swallows processing failures (log + user apology), so
+    // handleUpdate resolving does not prove the turn completed. Deleting the
+    // spooled update on a swallowed failure would lose the message silently.
+    // An undefined result usually means success; it can also mean the bounded
+    // failure registry evicted the record under very high failure volume.
+    const swallowedFailure = takeTelegramInboundProcessingFailureForUpdate({
+      accountId: this.opts.accountId,
+      update: params.update.update,
+    });
+    if (swallowedFailure) {
+      await this.#releaseFailedSpooledUpdate({
+        err: swallowedFailure.error,
+        update: params.update,
+      });
+      return false;
+    }
     try {
       await deleteTelegramSpooledUpdate(params.update);
       return true;
@@ -569,6 +590,30 @@ export class TelegramPollingSession {
       } catch (failErr) {
         this.opts.log(
           `[telegram][diag] spooled update ${params.update.updateId} failed with non-retryable ${nonRetryable.reason}, but could not be dead-lettered: ${formatErrorMessage(failErr)}`,
+        );
+      }
+    }
+    const attemptsAfterThisFailure = params.update.attempts + 1;
+    if (attemptsAfterThisFailure >= TELEGRAM_SPOOLED_UPDATE_MAX_PROCESSING_ATTEMPTS) {
+      try {
+        const failed = await failTelegramSpooledUpdateClaim({
+          update: params.update,
+          reason: "retry-exhausted",
+          message: formatErrorMessage(params.err),
+        });
+        if (failed) {
+          this.opts.log(
+            `[telegram][diag] spooled update ${params.update.updateId} failed ${attemptsAfterThisFailure} times; dead-lettered: ${formatErrorMessage(params.err)}`,
+          );
+          return;
+        }
+        this.opts.log(
+          `[telegram][diag] spooled update ${params.update.updateId} exhausted retries, but no processing marker remained to dead-letter.`,
+        );
+        return;
+      } catch (failErr) {
+        this.opts.log(
+          `[telegram][diag] spooled update ${params.update.updateId} exhausted retries, but could not be dead-lettered: ${formatErrorMessage(failErr)}`,
         );
       }
     }

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -37,6 +37,7 @@ export type TelegramSpooledUpdate = {
   path: string;
   update: unknown;
   receivedAt: number;
+  attempts: number;
   claim?: TelegramSpooledUpdateClaimOwner;
 };
 
@@ -173,6 +174,7 @@ function parseQueueRecord(
     path: pendingPath(spoolDir, payload.updateId),
     update: payload.update,
     receivedAt: payload.receivedAt,
+    attempts: record.attempts,
   };
 }
 


### PR DESCRIPTION
## Summary

- In Telegram **isolated polling ingress** mode (default-on), a spooled inbound update is permanently deleted even when processing it failed: the spool consumer keys deletion on `bot.handleUpdate()` resolving, but the turn pipeline swallows every processing error before it can reject (`processMessage` catch → log + apology, inbound-debounce `runFlush` → `onError`, `handleInboundMessageLike` catch, and grammY `bot.catch`). A failed turn is indistinguishable from a completed one, so a crash/restart during an in-flight turn loses the customer message silently and tracelessly.
- Outcome: a failed turn now releases the spool claim for retry (transient failures recover on the next drain or after restart), and dead-letters with reason `retry-exhausted` after 3 attempts (deterministic failures keep a tombstone with error context instead of looping every 500ms drain cycle or vanishing).
- Mechanism: a small bounded per-account failure registry (`inbound-processing-failures.ts`) keyed by `accountId:chatId:messageId`. The four swallow sites record into it (record-only; no control-flow changes, so live-mode UX — log + single apology — is unchanged). The update-tracker middleware clears stale records before `next()` and marks `finishUpdate completed:false` when the attempt recorded a failure — without this, a retried update is deduplicated as already-handled by `beginUpdate`'s watermark and deleted anyway. The spool consumer takes the record after `handleUpdate` resolves and routes it through the existing `#releaseFailedSpooledUpdate` (non-retryable dead-letter / release-for-retry), now with the attempts bound. `TelegramSpooledUpdate` gains `attempts`, mapped from the ingress-queue record (the queue already persists it; it increments on release).
- Intentionally out of scope: non-message update kinds (callback_query etc. — their handlers have separate swallow paths), `debounceMs > 0` coalesced flushes and media-group sibling updates (buffering detaches dispatch from the originating `handleUpdate`, a pre-existing tension with spool durability), and the webhook-less live-polling redelivery semantics beyond what `completed:false` already implies.
- Reviewer focus: the `completed:false` marking also affects live (non-isolated) polling — a swallowed turn failure now nacks the watermark, so the update is redelivered once after a gateway restart instead of being acked as completed. This matches the evident intent of `ackPolicy: "after_agent_dispatch"` and the existing `failedUpdateIds` machinery, but it is a behavior change worth a deliberate look. Also note the user-visible tradeoff: a user whose turn failed may receive the "Something went wrong" apology and later a successful reply when the retry lands.

## Linked context

Closes #92129

Related #92151 — touches the same report by adding `throw err;` after `processMessage`'s catch. That rethrow is caught by the inbound-debounce `runFlush` wrapper (which routes to `onError` and swallows, sending a second apology), and anything escaping further is consumed by `bot.catch` — so `handleUpdate` still resolves and the spool consumer still deletes the entry. An out-of-band failure signal plus the tracker/consumer integration in this PR is needed for the spooled update to survive; no rethrow is required.

Was this requested by a maintainer or owner? No — source-confirmed P1 from issue triage (`clawsweeper:queueable-fix`, `clawsweeper:fix-shape-clear`, `clawsweeper:source-repro`).

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: spooled Telegram updates deleted (message lost tracelessly) when the turn fails but the pipeline swallows the error; `deleteAfterRun`-style cleanup of the durable copy despite a failed turn.
- Real environment tested: macOS arm64, Node 22.22.2, fresh clone of `openclaw/openclaw` at `f1401b2c`, real SQLite-backed ingress spool (`channel_ingress_events`) in a scratch state dir, real `TelegramPollingSession` isolated-ingress drain loop. The failing turn is injected at the `bot.handleUpdate` seam (the subsystem's own validation seam) resolving-after-swallow, exactly as the production pipeline does per the four swallow sites above.
- Exact steps or command run after this patch: wrote one spooled update (`update_id 42`, real message envelope) via `writeTelegramSpooledUpdate`, ran the session drain loop (`drainIntervalMs 25`) for ~600ms with every turn failing-and-swallowing, then listed pending spool entries and diagnostics.
- Evidence after fix (copied output):

  ```
  === AFTER (fix branch) ===
  [repro] variant: patched (failure registry present)
  [repro] spool before drain: [42]
  [repro] turns attempted: 3
  [repro] spool pending after drain: []
  [repro] log: [telegram][diag] spooled update 42 failed; keeping for retry: agent turn aborted mid-flight
  [repro] log: [telegram][diag] spooled update 42 failed; keeping for retry: agent turn aborted mid-flight
  [repro] log: [telegram][diag] spooled update 42 failed 3 times; dead-lettered: agent turn aborted mid-flight
  ```

- Observed result after fix: bounded retries (exactly 3 dispatch attempts), claim released between attempts, dead-letter tombstone with the error message persisted in the failed queue. The transient-failure path (fail once, succeed on retry) is covered by the new regression test `releases spooled updates when the turn pipeline swallowed the failure`: the entry survives the failed attempt, is re-dispatched, and is deleted only after the successful turn.
- Before evidence (same scenario on unmodified `main` @ `f1401b2c`):

  ```
  === BEFORE (main @ f1401b2c) ===
  [repro] variant: main (no failure signal)
  [repro] spool before drain: [42]
  [repro] turns attempted: 1
  [repro] spool pending after drain: []
  ```

  One attempt, entry deleted, zero `spooled update 42` diagnostics — the message is gone with no artifacts, matching the issue report.
- What was not tested: a live Telegram bot end-to-end (no Telegram credentials available in this environment), `debounceMs > 0` coalesced flushes, media-group multi-update turns, multi-account setups beyond unit coverage.
- Proof limitations or environment constraints: per AGENTS.md, Telegram-live proof "when feasible" — not feasible here. The repro drives the real spool persistence, real drain/claim/release/dead-letter machinery, and the real consumer code; only the turn failure itself is injected at the `handleUpdate` seam, whose swallow behavior is verified at source (`bot-message.ts` catch, `inbound-debounce.ts` `runFlush`, `bot-handlers.runtime.ts` catch, `bot-core.ts` `bot.catch`). Happy to provide a live-run capture if a maintainer with a test bot wants to verify; the repro spec is reproducible from the diff context on request.

## Validation

- `pnpm test:extension telegram` — 124 files, 2047 tests, all pass
- `node scripts/run-vitest.mjs run extensions/telegram/src/polling-session.test.ts extensions/telegram/src/inbound-processing-failures.test.ts extensions/telegram/src/bot-message.test.ts extensions/telegram/src/bot-update-tracker.test.ts` — 80 tests, all pass (includes 2 new spool regression tests + 7 new registry tests)
- `pnpm check` — typecheck (tsgo), oxlint, and all policy guards pass except the `npm shrinkwrap guard`, which fails identically with zero dependency changes in this PR (`package.json` / `pnpm-lock.yaml` / `npm-shrinkwrap.json` are byte-identical to `origin/main`) — environment-side staleness, not introduced by this change.

## Notes

This PR is AI-assisted (agent-written under human direction, per CONTRIBUTING's AI/Vibe-Coded PR guidance); I understand the code and the tradeoffs described above. Session prompts/logs available on request.
