### PR TITLE
fix(gateway): show OAuth auth URLs in wizard prompts

### DIFF
--- a/extensions/chutes/index.ts
+++ b/extensions/chutes/index.ts
@@ -38,24 +38,28 @@ async function runChutesOAuth(ctx: ProviderAuthContext): Promise<ProviderAuthRes
       })
     ).trim();
   const clientSecret = normalizeOptionalString(process.env.CHUTES_CLIENT_SECRET);
+  const presentsAuthChallenge = ctx.prompter.presentsAuthChallenge === true;
+  const collapseManualIntro = isRemote && presentsAuthChallenge;
 
-  await ctx.prompter.note(
-    isRemote
-      ? [
-          "You are running in a remote/VPS environment.",
-          "A URL will be shown for you to open in your LOCAL browser.",
-          "After signing in, paste the redirect URL back here.",
-          "",
-          `Redirect URI: ${redirectUri}`,
-        ].join("\n")
-      : [
-          "Browser will open for Chutes authentication.",
-          "If the callback doesn't auto-complete, paste the redirect URL.",
-          "",
-          `Redirect URI: ${redirectUri}`,
-        ].join("\n"),
-    "Chutes OAuth",
-  );
+  if (!collapseManualIntro) {
+    await ctx.prompter.note(
+      isRemote
+        ? [
+            "You are running in a remote/VPS environment.",
+            "A URL will be shown for you to open in your LOCAL browser.",
+            "After signing in, paste the redirect URL back here.",
+            "",
+            `Redirect URI: ${redirectUri}`,
+          ].join("\n")
+        : [
+            "Browser will open for Chutes authentication.",
+            "If the callback doesn't auto-complete, paste the redirect URL.",
+            "",
+            `Redirect URI: ${redirectUri}`,
+          ].join("\n"),
+      "Chutes OAuth",
+    );
+  }
 
   const progress = ctx.prompter.progress("Starting Chutes OAuth…");
   try {
@@ -66,6 +70,13 @@ async function runChutesOAuth(ctx: ProviderAuthContext): Promise<ProviderAuthRes
       spin: progress,
       openUrl: ctx.openUrl,
       localBrowserMessage: "Complete sign-in in browser…",
+      manualPromptMessage: collapseManualIntro
+        ? [
+            "After signing in, paste the redirect URL back here.",
+            "",
+            `Redirect URI: ${redirectUri}`,
+          ].join("\n")
+        : undefined,
     });
 
     const creds = await loginChutes({

--- a/extensions/google/gemini-cli-provider.ts
+++ b/extensions/google/gemini-cli-provider.ts
@@ -72,7 +72,11 @@ export function buildGoogleGeminiCliProvider(): ProviderPlugin {
               openUrl: ctx.openUrl,
               log: (msg) => ctx.runtime.log(msg),
               note: ctx.prompter.note,
-              prompt: async (message) => ctx.prompter.text({ message }),
+              presentsAuthChallenge: ctx.prompter.presentsAuthChallenge === true,
+              prompt: async (message) =>
+                ctx.prompter.text({
+                  message,
+                }),
               progress: spin,
             });
 

--- a/extensions/google/oauth.shared.ts
+++ b/extensions/google/oauth.shared.ts
@@ -37,6 +37,7 @@ export type GeminiCliOAuthCredentials = {
 
 export type GeminiCliOAuthContext = {
   isRemote: boolean;
+  presentsAuthChallenge?: boolean;
   openUrl: (url: string) => Promise<void>;
   log: (msg: string) => void;
   note: (message: string, title?: string) => Promise<void>;

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -2,6 +2,10 @@
 import { join, parse } from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+const oauthRuntimeMocks = vi.hoisted(() => ({
+  loginGeminiCliOAuth: vi.fn(),
+}));
+
 vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
     "openclaw/plugin-sdk/runtime-env",
@@ -11,6 +15,10 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
     isWSL2Sync: () => false,
   };
 });
+
+vi.mock("./oauth.runtime.js", () => ({
+  loginGeminiCliOAuth: oauthRuntimeMocks.loginGeminiCliOAuth,
+}));
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
@@ -756,17 +764,24 @@ describe("loginGeminiCliOAuth", () => {
 
   type LoginGeminiCliOAuthFn = (options: {
     isRemote: boolean;
+    presentsAuthChallenge?: boolean;
     openUrl: () => Promise<void>;
     log: (msg: string) => void;
-    note: () => Promise<void>;
-    prompt: () => Promise<string>;
+    note: (message: string, title?: string) => Promise<void>;
+    prompt: (message: string) => Promise<string>;
     progress: { update: () => void; stop: () => void };
   }) => Promise<{ projectId?: string }>;
 
-  async function runRemoteLoginWithCapturedAuthUrl(loginGeminiCliOAuth: LoginGeminiCliOAuthFn) {
+  async function runRemoteLoginWithCapturedAuthUrl(
+    loginGeminiCliOAuth: LoginGeminiCliOAuthFn,
+    options: { presentsAuthChallenge?: boolean } = {},
+  ) {
     let authUrl = "";
+    const note = vi.fn(async () => {});
+    const promptCalls: string[] = [];
     const result = await loginGeminiCliOAuth({
       isRemote: true,
+      presentsAuthChallenge: options.presentsAuthChallenge,
       openUrl: async () => {},
       log: (msg) => {
         const found = msg.match(/https:\/\/accounts\.google\.com\/o\/oauth2\/v2\/auth\?[^\s]+/);
@@ -774,14 +789,15 @@ describe("loginGeminiCliOAuth", () => {
           authUrl = found[0];
         }
       },
-      note: async () => {},
-      prompt: async () => {
+      note,
+      prompt: async (message) => {
+        promptCalls.push(message);
         const state = new URL(authUrl).searchParams.get("state");
         return `http://localhost:8085/oauth2callback?code=oauth-code&state=${state}`;
       },
       progress: { update: () => {}, stop: () => {} },
     });
-    return { result, authUrl };
+    return { result, authUrl, note, promptCalls };
   }
 
   async function runProjectDiscoveryExpectingProjectId(projectId: string) {
@@ -894,6 +910,62 @@ describe("loginGeminiCliOAuth", () => {
       "PKCE code verifier",
     );
     expect(codeVerifier).not.toBe(authState);
+  });
+
+  it("includes the manual OAuth auth URL in the prompt message", async () => {
+    installGeminiOAuthFetchMock(({ url }) => {
+      if (url === LOAD_PROD) {
+        return responseJson({
+          currentTier: { id: "standard-tier" },
+          cloudaicompanionProject: { id: "prod-project" },
+        });
+      }
+      return undefined;
+    });
+
+    const { loginGeminiCliOAuth } = await import("./oauth.js");
+    const { authUrl, promptCalls } = await runRemoteLoginWithCapturedAuthUrl(loginGeminiCliOAuth);
+
+    expect(promptCalls).toEqual([
+      [
+        "Open this URL in your LOCAL browser:",
+        "",
+        authUrl,
+        "",
+        "After signing in, copy the redirect URL and paste it here:",
+      ].join("\n"),
+    ]);
+  });
+
+  it("collapses manual OAuth instructions into the auth URL prompt for auth-presenting clients", async () => {
+    installGeminiOAuthFetchMock(({ url }) => {
+      if (url === LOAD_PROD) {
+        return responseJson({
+          currentTier: { id: "standard-tier" },
+          cloudaicompanionProject: { id: "prod-project" },
+        });
+      }
+      return undefined;
+    });
+
+    const { loginGeminiCliOAuth } = await import("./oauth.js");
+    const { authUrl, note, promptCalls } = await runRemoteLoginWithCapturedAuthUrl(
+      loginGeminiCliOAuth,
+      {
+        presentsAuthChallenge: true,
+      },
+    );
+
+    expect(note).not.toHaveBeenCalled();
+    expect(promptCalls).toEqual([
+      [
+        "Open this URL in your LOCAL browser:",
+        "",
+        authUrl,
+        "",
+        "After signing in, copy the redirect URL and paste it here:",
+      ].join("\n"),
+    ]);
   });
 
   it("rejects manual callback input when the returned state does not match", async () => {
@@ -1081,5 +1153,77 @@ describe("loginGeminiCliOAuth", () => {
 
     expect(Number.isSafeInteger(result.expires)).toBe(true);
     expect(result.expires).toBeLessThanOrEqual(beforeRefresh);
+  });
+});
+
+describe("Gemini CLI provider OAuth wiring", () => {
+  beforeEach(() => {
+    oauthRuntimeMocks.loginGeminiCliOAuth.mockReset();
+  });
+
+  it("forwards manual OAuth URLs into wizard text messages", async () => {
+    const authUrl = "https://accounts.google.com/o/oauth2/v2/auth?state=abc";
+    oauthRuntimeMocks.loginGeminiCliOAuth.mockImplementation(
+      async (ctx: {
+        presentsAuthChallenge?: boolean;
+        prompt: (message: string) => Promise<string>;
+      }) => {
+        expect(ctx.presentsAuthChallenge).toBe(true);
+        await ctx.prompt(
+          [
+            "Open this URL in your LOCAL browser:",
+            "",
+            authUrl,
+            "",
+            "After signing in, copy the redirect URL and paste it here:",
+          ].join("\n"),
+        );
+        return {
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+          email: "lobster@openclaw.ai",
+        };
+      },
+    );
+
+    const { buildGoogleGeminiCliProvider } = await import("./gemini-cli-provider.js");
+    const provider = buildGoogleGeminiCliProvider();
+    const method = provider.auth?.find((candidate) => candidate.id === "oauth");
+    if (!method) {
+      throw new Error("expected Gemini CLI OAuth method");
+    }
+
+    const spin = { update: vi.fn(), stop: vi.fn() };
+    const text = vi.fn(async () => "http://localhost:8085/oauth2callback?code=oauth-code");
+
+    await method.run({
+      isRemote: true,
+      openUrl: vi.fn(async () => {}),
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn((code: number) => {
+          throw new Error(`exit:${code}`);
+        }),
+      },
+      prompter: {
+        presentsAuthChallenge: true,
+        note: vi.fn(async () => {}),
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => spin),
+        text,
+      },
+    } as never);
+
+    expect(text).toHaveBeenCalledWith({
+      message: [
+        "Open this URL in your LOCAL browser:",
+        "",
+        authUrl,
+        "",
+        "After signing in, copy the redirect URL and paste it here:",
+      ].join("\n"),
+    });
   });
 });

--- a/extensions/google/oauth.ts
+++ b/extensions/google/oauth.ts
@@ -19,20 +19,24 @@ export async function loginGeminiCliOAuth(
   ctx: GeminiCliOAuthContext,
 ): Promise<GeminiCliOAuthCredentials> {
   const needsManual = shouldUseManualOAuthFlow(ctx.isRemote);
-  await ctx.note(
-    needsManual
-      ? [
-          "You are running in a remote/VPS environment.",
-          "A URL will be shown for you to open in your LOCAL browser.",
-          "After signing in, copy the redirect URL and paste it back here.",
-        ].join("\n")
-      : [
-          "Browser will open for Google authentication.",
-          "Sign in with your Google account for Gemini CLI access.",
-          "The callback will be captured automatically on localhost:8085.",
-        ].join("\n"),
-    "Gemini CLI OAuth",
-  );
+  const presentsAuthChallenge = ctx.presentsAuthChallenge === true;
+  const collapseManualIntro = needsManual && presentsAuthChallenge;
+  if (!collapseManualIntro) {
+    await ctx.note(
+      needsManual
+        ? [
+            "You are running in a remote/VPS environment.",
+            "A URL will be shown for you to open in your LOCAL browser.",
+            "After signing in, copy the redirect URL and paste it back here.",
+          ].join("\n")
+        : [
+            "Browser will open for Google authentication.",
+            "Sign in with your Google account for Gemini CLI access.",
+            "The callback will be captured automatically on localhost:8085.",
+          ].join("\n"),
+      "Gemini CLI OAuth",
+    );
+  }
 
   const { verifier, challenge } = generatePkce();
   const state = generateOAuthState();
@@ -82,7 +86,15 @@ async function manualFlow(
   ctx.progress.update("OAuth URL ready");
   ctx.log(`\nOpen this URL in your LOCAL browser:\n\n${authUrl}\n`);
   ctx.progress.update("Waiting for you to paste the callback URL...");
-  const callbackInput = await ctx.prompt("Paste the redirect URL here: ");
+  const callbackInput = await ctx.prompt(
+    [
+      "Open this URL in your LOCAL browser:",
+      "",
+      authUrl,
+      "",
+      "After signing in, copy the redirect URL and paste it here:",
+    ].join("\n"),
+  );
   const parsed = parseCallbackInput(callbackInput);
   if ("error" in parsed) {
     throw new Error(parsed.error, cause ? { cause } : undefined);

--- a/extensions/msteams/src/oauth.ts
+++ b/extensions/msteams/src/oauth.ts
@@ -111,7 +111,15 @@ async function manualFlow(
   ctx.progress.update("OAuth URL ready");
   ctx.log(`\nOpen this URL in your LOCAL browser:\n\n${authUrl}\n`);
   ctx.progress.update("Waiting for you to paste the callback URL...");
-  const callbackInput = await ctx.prompt("Paste the redirect URL here: ");
+  const callbackInput = await ctx.prompt(
+    [
+      "Open this URL in your LOCAL browser:",
+      "",
+      authUrl,
+      "",
+      "After signing in, copy the redirect URL and paste it here:",
+    ].join("\n"),
+  );
   const parsed = parseCallbackInput(callbackInput, state);
   if ("error" in parsed) {
     throw new Error(parsed.error, cause ? { cause } : undefined);

--- a/extensions/openai/openai-chatgpt-oauth.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth.runtime.test.ts
@@ -1,10 +1,18 @@
 // Openai tests cover openai chatgpt oauth plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { testing } from "./openai-chatgpt-oauth.runtime.js";
+
+const loginOpenAICodexMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./openai-chatgpt-oauth-flow.runtime.js", () => ({
+  loginOpenAICodex: loginOpenAICodexMock,
+}));
+
+import { loginOpenAICodexOAuth, testing } from "./openai-chatgpt-oauth.runtime.js";
 
 describe("OpenAI Codex OAuth runtime", () => {
   afterEach(() => {
+    loginOpenAICodexMock.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -21,5 +29,49 @@ describe("OpenAI Codex OAuth runtime", () => {
 
     expect(timeoutSpy).toHaveBeenCalledWith(MAX_TIMER_TIMEOUT_MS);
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("collapses auth-presenting instructions into the redirect paste prompt", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 302 }));
+    const note = vi.fn(async () => {});
+    const createVpsAwareHandlers = vi.fn(() => ({
+      onAuth: vi.fn(),
+      onPrompt: vi.fn(async () => "http://localhost:1455/auth/callback?code=test"),
+    }));
+    loginOpenAICodexMock.mockResolvedValueOnce({
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+    });
+
+    await loginOpenAICodexOAuth({
+      isRemote: true,
+      openUrl: vi.fn(async () => {}),
+      prompter: {
+        presentsAuthChallenge: true,
+        note,
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      } as never,
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+      } as never,
+      oauth: {
+        createVpsAwareHandlers,
+      },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(note).not.toHaveBeenCalled();
+    expect(createVpsAwareHandlers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manualPromptMessage: [
+          "After signing in, paste the authorization code or full redirect URL here.",
+          "If this OpenClaw process can receive the browser callback, sign-in may finish automatically before you paste.",
+        ].join("\n"),
+      }),
+    );
   });
 });

--- a/extensions/openai/openai-chatgpt-oauth.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth.runtime.ts
@@ -267,6 +267,8 @@ export async function loginOpenAICodexOAuth(params: {
   localBrowserMessage?: string;
 }): Promise<OAuthCredentials | null> {
   const { prompter, runtime, isRemote, openUrl, localBrowserMessage } = params;
+  const presentsAuthChallenge = prompter.presentsAuthChallenge === true;
+  const collapseManualIntro = isRemote && presentsAuthChallenge;
 
   ensureGlobalUndiciEnvProxyDispatcher();
 
@@ -278,21 +280,23 @@ export async function loginOpenAICodexOAuth(params: {
     throw new Error(`OpenAI Codex OAuth prerequisites failed: ${preflight.message}`);
   }
 
-  await prompter.note(
-    isRemote
-      ? [
-          "You are running in a remote/VPS environment.",
-          "A URL will be shown for you to open in your LOCAL browser.",
-          "Open it, sign in, then paste the redirect URL here.",
-          "If this OpenClaw process can receive the browser callback, sign-in may finish automatically before you paste.",
-        ].join("\n")
-      : [
-          "Browser will open for OpenAI authentication.",
-          "If the callback doesn't auto-complete, paste the redirect URL.",
-          "OpenAI OAuth uses localhost:1455 for the callback.",
-        ].join("\n"),
-    "OpenAI Codex OAuth",
-  );
+  if (!collapseManualIntro) {
+    await prompter.note(
+      isRemote
+        ? [
+            "You are running in a remote/VPS environment.",
+            "A URL will be shown for you to open in your LOCAL browser.",
+            "Open it, sign in, then paste the redirect URL here.",
+            "If this OpenClaw process can receive the browser callback, sign-in may finish automatically before you paste.",
+          ].join("\n")
+        : [
+            "Browser will open for OpenAI authentication.",
+            "If the callback doesn't auto-complete, paste the redirect URL.",
+            "OpenAI OAuth uses localhost:1455 for the callback.",
+          ].join("\n"),
+      "OpenAI Codex OAuth",
+    );
+  }
 
   const spin = prompter.progress("Starting OAuth flow...");
   let progressActive = true;
@@ -320,7 +324,12 @@ export async function loginOpenAICodexOAuth(params: {
       spin,
       openUrl,
       localBrowserMessage: localBrowserMessage ?? "Complete sign-in in browser...",
-      manualPromptMessage: manualInputPromptMessage,
+      manualPromptMessage: collapseManualIntro
+        ? [
+            "After signing in, paste the authorization code or full redirect URL here.",
+            "If this OpenClaw process can receive the browser callback, sign-in may finish automatically before you paste.",
+          ].join("\n")
+        : manualInputPromptMessage,
     });
     const onAuth = (event: Parameters<typeof baseOnAuth>[0]) => {
       browserAuthStarted = true;

--- a/extensions/openrouter/oauth.test.ts
+++ b/extensions/openrouter/oauth.test.ts
@@ -196,11 +196,10 @@ describe("OpenRouter OAuth", () => {
 
     expect(openUrl).not.toHaveBeenCalled();
     expect(log.mock.calls[0]?.[0]).toContain("https://openrouter.ai/auth?");
-    expect(text).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: "Paste the OpenRouter redirect URL",
-      }),
-    );
+    const prompt = text.mock.calls[0]?.[0];
+    expect(prompt?.message).toContain("Open this URL in your LOCAL browser:");
+    expect(prompt?.message).toContain("https://openrouter.ai/auth?");
+    expect(prompt?.message).toContain("After signing in, paste the OpenRouter redirect URL here:");
     expect(result.defaultModel).toBe("openrouter/auto");
     expect(result.profiles).toEqual([
       {

--- a/extensions/openrouter/oauth.ts
+++ b/extensions/openrouter/oauth.ts
@@ -296,9 +296,18 @@ export async function waitForOpenRouterOAuthCallback(params: {
 async function promptForOpenRouterRedirect(
   ctx: ProviderAuthContext,
   expectedState: string,
+  authorizeUrl?: string,
 ): Promise<string> {
   const input = await ctx.prompter.text({
-    message: "Paste the OpenRouter redirect URL",
+    message: authorizeUrl
+      ? [
+          "Open this URL in your LOCAL browser:",
+          "",
+          authorizeUrl,
+          "",
+          "After signing in, paste the OpenRouter redirect URL here:",
+        ].join("\n")
+      : "Paste the OpenRouter redirect URL",
     placeholder: `${OPENROUTER_OAUTH_REDIRECT_URI}?state=...&code=...`,
     validate: (value: string) => (value.trim().length > 0 ? undefined : "Required"),
   });
@@ -333,14 +342,17 @@ async function resolveOpenRouterOAuthCode(
 
   if (ctx.isRemote) {
     ctx.runtime.log(`\nOpen this URL in your LOCAL browser:\n\n${params.authorizeUrl}\n`);
-    return await promptForOpenRouterRedirect(ctx, params.state);
+    return await promptForOpenRouterRedirect(ctx, params.state, params.authorizeUrl);
   }
 
   const callbackPromise = params
     .waitForCallback({ expectedState: params.state, onProgress: params.onProgress })
     .catch(async () => {
       params.onProgress("OAuth callback not detected; waiting for redirect URL...");
-      return { code: await promptForOpenRouterRedirect(ctx, params.state), state: params.state };
+      return {
+        code: await promptForOpenRouterRedirect(ctx, params.state, params.authorizeUrl),
+        state: params.state,
+      };
     });
   void callbackPromise.catch(() => undefined);
 

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -614,6 +614,32 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     expect(result.defaultModel).toBe("google/gemini-3.1-pro-preview");
   });
 
+  it("treats auth-presenting prompters as remote provider auth clients", async () => {
+    let receivedIsRemote: boolean | undefined;
+    const method: ProviderAuthMethod = {
+      id: "oauth",
+      label: "OAuth",
+      kind: "oauth",
+      run: async (ctx) => {
+        receivedIsRemote = ctx.isRemote;
+        return { profiles: [] };
+      },
+    };
+
+    await runProviderPluginAuthMethod({
+      config: {},
+      runtime: {} as ApplyAuthChoiceParams["runtime"],
+      prompter: {
+        presentsAuthChallenge: true,
+        note: vi.fn(async () => {}),
+      } as unknown as ApplyAuthChoiceParams["prompter"],
+      method,
+    });
+
+    expect(isRemoteEnvironment).toHaveBeenCalledOnce();
+    expect(receivedIsRemote).toBe(true);
+  });
+
   it("replaces provider-owned default model maps during auth migrations", async () => {
     const method: ProviderAuthMethod = {
       id: "local",

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -285,7 +285,7 @@ export async function runProviderPluginAuthMethod(params: {
     opts: params.opts,
     secretInputMode: params.secretInputMode,
     allowSecretRefPrompt: params.allowSecretRefPrompt,
-    isRemote: isRemoteEnvironment(),
+    isRemote: isRemoteEnvironment() || params.prompter.presentsAuthChallenge === true,
     openUrl: async (url) => {
       await openUrl(url);
     },

--- a/src/plugins/provider-oauth-flow.test.ts
+++ b/src/plugins/provider-oauth-flow.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { createVpsAwareOAuthHandlers } from "./provider-oauth-flow.js";
+
+const AUTH_URL = "https://auth.example.test/oauth/authorize?state=abc";
+
+function createOAuthHarness(params: { isRemote: boolean }) {
+  const spin = { update: vi.fn(), stop: vi.fn() };
+  const text = vi.fn(async () => "http://localhost/callback?code=test");
+  const prompter = {
+    text,
+  } as unknown as WizardPrompter;
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn((code: number) => {
+      throw new Error(`exit:${code}`);
+    }),
+  } satisfies RuntimeEnv;
+  const openUrl = vi.fn(async () => {});
+  const handlers = createVpsAwareOAuthHandlers({
+    isRemote: params.isRemote,
+    prompter,
+    runtime,
+    spin,
+    openUrl,
+    localBrowserMessage: "Complete sign-in in browser...",
+    manualPromptMessage: "Paste the redirect URL",
+  });
+  return { handlers, text, openUrl };
+}
+
+describe("createVpsAwareOAuthHandlers", () => {
+  it("includes the authorization URL in remote OAuth text prompts", async () => {
+    const { handlers, text } = createOAuthHarness({
+      isRemote: true,
+    });
+
+    await handlers.onAuth({ url: AUTH_URL });
+
+    expect(text).toHaveBeenCalledWith({
+      message: [
+        "Open this URL in your LOCAL browser:",
+        "",
+        AUTH_URL,
+        "",
+        "Paste the redirect URL",
+      ].join("\n"),
+      validate: expect.any(Function),
+    });
+  });
+
+  it("includes the authorization URL in local fallback prompts", async () => {
+    const { handlers, text } = createOAuthHarness({
+      isRemote: false,
+    });
+
+    await handlers.onAuth({ url: AUTH_URL });
+    await handlers.onPrompt({ message: "Paste the redirect URL", placeholder: "http://localhost" });
+
+    expect(text).toHaveBeenCalledWith({
+      message: [
+        "Open this URL in your LOCAL browser:",
+        "",
+        AUTH_URL,
+        "",
+        "Paste the redirect URL",
+      ].join("\n"),
+      placeholder: "http://localhost",
+      validate: expect.any(Function),
+    });
+  });
+
+  it("keeps local fallback prompts unchanged before an auth URL is available", async () => {
+    const { handlers, text } = createOAuthHarness({ isRemote: false });
+
+    await handlers.onPrompt({ message: "Paste the redirect URL" });
+
+    expect(text).toHaveBeenCalledWith({
+      message: "Paste the redirect URL",
+      validate: expect.any(Function),
+    });
+  });
+});

--- a/src/plugins/provider-oauth-flow.ts
+++ b/src/plugins/provider-oauth-flow.ts
@@ -7,6 +7,10 @@ export type OAuthPrompt = { message: string; placeholder?: string };
 
 const validateRequiredInput = (value: string) => (value.trim().length > 0 ? undefined : "Required");
 
+function withOAuthUrl(message: string, url: string): string {
+  return ["Open this URL in your LOCAL browser:", "", url, "", message].join("\n");
+}
+
 /** Creates OAuth callbacks that use local browser auth locally and manual code entry on VPS hosts. */
 export function createVpsAwareOAuthHandlers(params: {
   isRemote: boolean;
@@ -20,17 +24,20 @@ export function createVpsAwareOAuthHandlers(params: {
   onAuth: (event: { url: string }) => Promise<void>;
   onPrompt: (prompt: OAuthPrompt) => Promise<string>;
 } {
-  const manualPromptMessage = params.manualPromptMessage ?? "Paste the redirect URL";
+  const manualPromptMessage =
+    params.manualPromptMessage ?? "After signing in, paste the redirect URL here.";
   // Remote hosts cannot open the user's browser, so auth starts in onAuth and finishes in onPrompt.
   let manualCodePromise: Promise<string> | undefined;
+  let lastAuthUrl: string | undefined;
 
   return {
     onAuth: async ({ url }) => {
+      lastAuthUrl = url;
       if (params.isRemote) {
         params.spin.stop("OAuth URL ready");
         params.runtime.log(`\nOpen this URL in your LOCAL browser:\n\n${url}\n`);
         manualCodePromise = params.prompter.text({
-          message: manualPromptMessage,
+          message: withOAuthUrl(manualPromptMessage, url),
           validate: validateRequiredInput,
         });
         return;
@@ -45,7 +52,7 @@ export function createVpsAwareOAuthHandlers(params: {
         return manualCodePromise;
       }
       const code = await params.prompter.text({
-        message: prompt.message,
+        message: lastAuthUrl ? withOAuthUrl(prompt.message, lastAuthUrl) : prompt.message,
         placeholder: prompt.placeholder,
         validate: validateRequiredInput,
       });

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -40,6 +40,7 @@ export type WizardProgress = {
 };
 
 export type WizardPrompter = {
+  presentsAuthChallenge?: boolean;
   intro: (title: string) => Promise<void>;
   outro: (message: string) => Promise<void>;
   note: (message: string, title?: string) => Promise<void>;

--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -131,4 +131,14 @@ describe("WizardSession", () => {
     }
     await session.answer(plainStep.id, "alice");
   });
+
+  test("marks RPC prompters as auth-presenting clients", async () => {
+    const session = new WizardSession(async (prompter) => {
+      expect(prompter.presentsAuthChallenge).toBe(true);
+      await prompter.note("ready");
+    });
+
+    const step = await session.next();
+    expect(step.step?.type).toBe("note");
+  });
 });

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -1,6 +1,11 @@
 // Wizard session helpers track onboarding session ids and state.
 import { randomUUID } from "node:crypto";
-import { WizardCancelledError, type WizardProgress, type WizardPrompter } from "./prompts.js";
+import {
+  WizardCancelledError,
+  type WizardProgress,
+  type WizardPrompter,
+  type WizardTextParams,
+} from "./prompts.js";
 
 // WizardSession exposes interactive setup as a step/answer protocol for remote
 // clients while reusing the same WizardPrompter contract as the local CLI.
@@ -49,6 +54,8 @@ function createDeferred<T>(): Deferred<T> {
 }
 
 class WizardSessionPrompter implements WizardPrompter {
+  readonly presentsAuthChallenge = true;
+
   constructor(private session: WizardSession) {}
 
   async intro(title: string): Promise<void> {
@@ -115,13 +122,7 @@ class WizardSessionPrompter implements WizardPrompter {
     return (Array.isArray(res) ? res : []) as T[];
   }
 
-  async text(params: {
-    message: string;
-    initialValue?: string;
-    placeholder?: string;
-    validate?: (value: string) => string | undefined;
-    sensitive?: boolean;
-  }): Promise<string> {
+  async text(params: WizardTextParams): Promise<string> {
     const res = await this.prompt({
       type: "text",
       message: params.message,


### PR DESCRIPTION
## Summary

When OAuth setup runs through an RPC wizard client, the gateway can ask for a redirect URL while only printing the authorization URL to gateway stdout. That leaves clients like the Windows companion without the link the user needs to open.

This PR makes redirect-paste OAuth prompts self-contained by including the generated authorization URL directly in the wizard text prompt. Terminal logging is preserved.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: RPC wizard OAuth setup now shows the generated authorization URL in the same text prompt that asks for the redirect URL.
Real environment tested: Windows companion app driving an OpenClaw gateway wizard OAuth setup flow, plus the local Windows OpenClaw worktree.
Exact steps or command run after this patch: Opened the Windows companion, started the gateway/provider OAuth wizard flow, verified the wizard prompt displayed the authorization URL before the redirect URL input, opened the URL in a browser, and completed the redirect paste step. Also ran `node scripts/run-vitest.mjs run src\plugins\provider-oauth-flow.test.ts extensions\openai\openai-chatgpt-oauth.runtime.test.ts extensions\google\oauth.test.ts extensions\openrouter\oauth.test.ts src\commands\auth-choice.apply.plugin-provider.test.ts src\wizard\session.test.ts`; `pnpm tsgo:core && pnpm tsgo:core:test && pnpm tsgo:extensions && pnpm tsgo:extensions:test`; `pnpm exec oxlint <touched files>`; `git diff --check`.
Evidence after fix: Human verification confirmed the Windows companion wizard showed the OAuth authorization URL inline with the redirect paste prompt. Focused tests also assert authorization URLs are included in prompt messages for the shared OAuth helper, Gemini, OpenAI ChatGPT/Codex, and OpenRouter paths.
Observed result after fix: The Windows companion flow exposed the authorization URL in the wizard prompt and the redirect paste step could be completed. Focused Vitest passed 5 shards / 64 tests; TypeScript core/test and extensions/test checks passed; direct oxlint on touched files passed; `git diff --check` passed.
What was not tested: Full repository `pnpm check`, full repository `pnpm test`, and every provider's live OAuth service.
Before evidence (optional but encouraged): Before this patch, the gateway printed the authorization URL to `runtime.log` / stdout while the wizard step only asked for a redirect URL.

## Root Cause (if applicable)

- Root cause: OAuth redirect flows treated runtime logs as the user-facing place to show authorization URLs, but RPC wizard clients receive wizard steps rather than gateway stdout.
- Missing detection / guardrail: Existing tests covered local CLI/provider OAuth behavior but not whether RPC-visible prompt messages contained the URL needed to complete manual redirect flows.
- Contributing context (if known): RPC wizard clients need the auth challenge rendered in-band even when the gateway process itself can write the URL to logs.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/provider-oauth-flow.test.ts`, `extensions/openai/openai-chatgpt-oauth.runtime.test.ts`, `extensions/google/oauth.test.ts`, `extensions/openrouter/oauth.test.ts`, `src/commands/auth-choice.apply.plugin-provider.test.ts`, `src/wizard/session.test.ts`.
- Scenario the test should lock in: Manual OAuth redirect prompts include the generated authorization URL in the prompt message; auth-presenting RPC prompters use the manual path; CLI/non-auth-presenting paths keep their existing note/log behavior.
- Why this is the smallest reliable guardrail: It covers the shared helper, representative provider integrations, and wizard/auth-choice seam without requiring live OAuth credentials.
- Existing test that already covers this (if any): N/A; focused coverage was added/updated.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

RPC wizard clients now receive OAuth authorization URLs directly in the text prompt message for redirect-paste flows. Terminal CLI users still see URL logging and the same prompt flow.

## Diagram (if applicable)

```text
Before:
OAuth provider -> gateway runtime.log(url) -> RPC client only sees "paste redirect URL"

After:
OAuth provider -> wizard text message includes url -> RPC client shows url + paste box -> user completes login
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A. The authorization URL was already intentionally logged for user action; this change carries the same non-secret authorization URL in the wizard prompt message. Redirect URLs containing authorization codes remain user input.

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Node/pnpm OpenClaw worktree
- Model/provider: Windows companion OAuth wizard flow, plus OpenAI ChatGPT/Codex OAuth, Chutes/shared OAuth helper, Google Gemini CLI OAuth, and OpenRouter OAuth seams via focused tests
- Integration/channel (if any): Gateway wizard / provider auth prompts
- Relevant config (redacted): OAuth credentials and generated authorization URLs redacted

### Steps

1. Open the Windows companion against the patched gateway.
2. Start a provider OAuth wizard flow that uses redirect-URL paste.
3. Confirm the wizard text prompt includes the generated authorization URL and the redirect paste instruction.
4. Open the authorization URL in the browser and complete the redirect paste step.

### Expected

- The protocol-visible text step message contains the authorization URL needed to complete OAuth.

### Actual

- The Windows companion showed the authorization URL in the wizard prompt and the redirect paste step completed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Windows companion OAuth wizard prompt showed the generated authorization URL inline with the redirect paste prompt; shared OAuth helper remote and local fallback prompts include the authorization URL; Gemini manual OAuth prompt includes the URL; OpenAI auth-presenting flow collapses copy into the redirect paste prompt; OpenRouter remote OAuth prompt includes the URL.
- Edge cases checked: Existing terminal logging remains; local fallback prompt stays unchanged before an auth URL exists.
- What you did **not** verify: Full repository test suite and every provider's live OAuth service.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Authorization URLs become visible in a wizard prompt message instead of only gateway logs.
  - Mitigation: These URLs were already intentionally shown/logged for users and do not contain the returned authorization code; the secret-bearing redirect remains user input.
- Risk: Prompt messages become longer for OAuth redirect flows.
  - Mitigation: The longer prompt is self-contained and preserves compatibility for clients that render only message text.

AI-assisted: Yes. Implemented with Copilot-assisted sessions and reviewed by separate adversarial compatibility passes before simplifying to the message-only approach.