### PR TITLE
fix(webchat): surface Codex commentary progress

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -322,7 +322,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `streaming.progress.commentary` (default: `false`) opts into assistant commentary/preamble text in the temporary progress draft
     - legacy `channels.telegram.streamMode` and boolean `streaming` values are detected; run `openclaw doctor --fix` to migrate them to `channels.telegram.streaming.mode`
 
-    Tool-progress preview updates are the short status lines shown while tools run, for example command execution, file reads, planning updates, patch summaries, or Codex preamble/commentary text in Codex app-server mode. Telegram keeps these enabled by default to match released OpenClaw behavior from `v2026.4.22` and later.
+    Tool-progress preview updates are the short status lines shown while tools run, for example command execution, file reads, planning updates, or patch summaries. Telegram keeps these enabled by default to match released OpenClaw behavior from `v2026.4.22` and later.
 
     Direct chats can use native Telegram drafts for these tool-progress lines without persisting tool chatter into chat history. Native drafts stop before answer text starts; final answers stay on the normal persistent delivery path. This lane is off by default and should be gated to trusted DM IDs first:
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1376,7 +1376,6 @@
                   "clawhub/publishing",
                   "clawhub/plugin-validation-fixes",
                   "clawhub/skill-format",
-                  "clawhub/soul-format",
                   "clawhub/auth",
                   "clawhub/telemetry",
                   "clawhub/troubleshooting"

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -157,6 +157,7 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
   state.chatStreamSegments = [];
   state.chatThinkingLevel = null;
   state.chatStream = null;
+  state.chatStreamKind = null;
   state.chatSideResult = null;
   state.lastError = null;
   state.chatError = null;

--- a/ui/src/ui/app-tool-stream.node.test.ts
+++ b/ui/src/ui/app-tool-stream.node.test.ts
@@ -23,6 +23,7 @@ function createHost(overrides?: Partial<MutableHost>): MutableHost {
     sessionKey: "main",
     chatRunId: null,
     chatStream: null,
+    chatStreamKind: null,
     chatStreamStartedAt: null,
     chatStreamSegments: [],
     toolStreamById: new Map<string, ToolStreamEntry>(),
@@ -109,6 +110,28 @@ describe("app-tool-stream fallback lifecycle handling", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("projects item preamble progress into the transient chat stream", () => {
+    const host = createHost();
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "item",
+      ts: TOOL_STREAM_TEST_NOW,
+      sessionKey: "main",
+      data: {
+        itemId: "msg-commentary",
+        kind: "preamble",
+        phase: "update",
+        progressText: "Checking the app-server stream",
+      },
+    });
+
+    expect(host.chatStream).toBe("Checking the app-server stream");
+    expect(host.chatStreamKind).toBe("progress");
+    expect(host.chatStreamStartedAt).toBe(TOOL_STREAM_TEST_NOW);
   });
 
   it("accepts session-scoped fallback lifecycle events when no run is active", () => {

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -60,6 +60,7 @@ type ToolStreamHost = {
   } | null;
   chatRunId: string | null;
   chatStream: string | null;
+  chatStreamKind?: "assistant" | "progress" | null;
   chatStreamStartedAt: number | null;
   chatStreamSegments: Array<{ text: string; ts: number; toolCallId?: string }>;
   toolStreamById: Map<string, ToolStreamEntry>;
@@ -436,6 +437,7 @@ export function resetToolStream(host: ToolStreamHost) {
   host.toolStreamOrder = [];
   host.chatToolMessages = [];
   host.chatStreamSegments = [];
+  host.chatStreamKind = null;
 }
 
 export type CompactionStatus = {
@@ -758,6 +760,18 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     return;
   }
 
+  if (payload.stream === "item") {
+    const data = payload.data ?? {};
+    const kind = toTrimmedString(data.kind);
+    const progressText = toTrimmedString(data.progressText);
+    if (kind === "preamble" && progressText) {
+      host.chatStream = progressText;
+      host.chatStreamKind = "progress";
+      host.chatStreamStartedAt ??= typeof payload.ts === "number" ? payload.ts : Date.now();
+    }
+    return;
+  }
+
   if (payload.stream !== "tool") {
     return;
   }
@@ -789,6 +803,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     if (
       host.chatRunId &&
       payload.runId === host.chatRunId &&
+      host.chatStreamKind !== "progress" &&
       host.chatStream &&
       host.chatStream.trim().length > 0
     ) {
@@ -797,6 +812,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
         { text: host.chatStream, ts: now, toolCallId },
       ];
       host.chatStream = null;
+      host.chatStreamKind = null;
       host.chatStreamStartedAt = null;
     }
     entry = {

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -110,6 +110,7 @@ export type AppViewState = {
   activityAtBottom: boolean;
   chatStreamSegments: Array<{ text: string; ts: number }>;
   chatStream: string | null;
+  chatStreamKind?: "assistant" | "progress" | null;
   chatStreamStartedAt: number | null;
   chatRunId: string | null;
   chatSideResult: ChatSideResult | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -265,6 +265,7 @@ export class OpenClawApp extends LitElement {
   @state() activityAtBottom = true;
   @state() chatStreamSegments: Array<{ text: string; ts: number }> = [];
   @state() chatStream: string | null = null;
+  @state() chatStreamKind: "assistant" | "progress" | null = null;
   @state() chatStreamStartedAt: number | null = null;
   @state() chatRunId: string | null = null;
   @state() chatSideResult: ChatSideResult | null = null;

--- a/ui/src/ui/chat/run-lifecycle.ts
+++ b/ui/src/ui/chat/run-lifecycle.ts
@@ -35,6 +35,7 @@ type RunLifecycleHost = Omit<Partial<Parameters<typeof resetToolStream>[0]>, "he
   hello?: { snapshot?: unknown } | null;
   chatRunId?: string | null;
   chatStream?: string | null;
+  chatStreamKind?: "assistant" | "progress" | null;
   chatStreamStartedAt?: number | null;
   chatSideResultTerminalRuns?: Set<string>;
   compactionStatus?: CompactionStatus | null;
@@ -185,6 +186,7 @@ export function reconcileChatRunLifecycle(host: RunLifecycleHost, options: Recon
   }
   if (options.clearChatStream) {
     host.chatStream = null;
+    host.chatStreamKind = null;
     host.chatStreamStartedAt = null;
   }
   if (options.clearLocalRun) {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -27,6 +27,7 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
     chatRunId: null,
     chatSending: false,
     chatStream: null,
+    chatStreamKind: null,
     chatStreamStartedAt: null,
     chatThinkingLevel: null,
     client: null,
@@ -790,6 +791,27 @@ describe("handleChatEvent", () => {
     expect(state.chatMessages).toHaveLength(2);
     expect(state.chatMessages[0]).toEqual(existingMessage);
     expectTextChatMessage(state.chatMessages[1], "assistant", "Here is my reply");
+  });
+
+  it("does not persist progress-only stream text on final", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Checking the app-server stream",
+      chatStreamKind: "progress",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamKind).toBe(null);
+    expect(state.chatMessages).toStrictEqual([]);
   });
 
   it("does not persist empty or whitespace-only stream on final", () => {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -191,8 +191,10 @@ function materializeVisibleAssistantStreamMessages(
     replacementMessages?: unknown[];
   } = {},
 ): unknown[] {
+  const includeCurrent = state.chatStreamKind === "progress" ? false : opts.includeCurrent;
   return materializeVisibleStreamState(messages, state, {
     ...opts,
+    includeCurrent,
     isHiddenAssistantMessage: shouldHideAssistantChatMessage,
     isHiddenStreamText: isHiddenAssistantStreamText,
   });
@@ -402,6 +404,7 @@ export type ChatState = {
   chatAttachments: ChatAttachment[];
   chatRunId: string | null;
   chatStream: string | null;
+  chatStreamKind?: "assistant" | "progress" | null;
   chatStreamStartedAt: number | null;
   lastError: string | null;
   chatError?: string | null;
@@ -766,6 +769,7 @@ async function loadChatHistoryUncached(
           clearToolStreamSegments(state);
         }
         state.chatStream = null;
+        state.chatStreamKind = null;
         state.chatStreamStartedAt = null;
         recordChatHistoryTiming(state, "stream-reset", startedAtMs, {
           requestSessionKey: sessionKey,
@@ -778,6 +782,7 @@ async function loadChatHistoryUncached(
         state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state);
         maybeResetToolStream(state);
         state.chatStream = null;
+        state.chatStreamKind = null;
         state.chatStreamStartedAt = null;
       } else if (historyReplacedToolStream) {
         state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state, {
@@ -788,7 +793,10 @@ async function loadChatHistoryUncached(
           streamReconciliation.isHiddenStreamText,
         );
         if (state.chatStream === null) {
+          state.chatStreamKind = null;
           state.chatStreamStartedAt = null;
+        } else {
+          state.chatStreamKind = "assistant";
         }
         maybeResetToolStream(state);
       } else if (historyReplacedSomeToolStream) {
@@ -802,7 +810,10 @@ async function loadChatHistoryUncached(
         });
         state.chatStream = visibleCurrentTail;
         if (state.chatStream === null) {
+          state.chatStreamKind = null;
           state.chatStreamStartedAt = null;
+        } else {
+          state.chatStreamKind = "assistant";
         }
         prunePersistedToolStreamMessages(state, persistedToolStreamIds);
       }
@@ -1102,6 +1113,7 @@ export async function sendChatMessage(
   const runId = generateUUID();
   state.chatRunId = runId;
   state.chatStream = "";
+  state.chatStreamKind = "assistant";
   state.chatStreamStartedAt = now;
 
   try {
@@ -1293,6 +1305,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       !isAssistantHeartbeatAckForDisplay(payload.message)
     ) {
       state.chatStream = next;
+      state.chatStreamKind = "assistant";
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);


### PR DESCRIPTION
## What This PR Fixes

OpenClaw's default Codex app-server harness already emits live commentary while an agent is thinking or working. Those updates arrive in WebChat as agent events with:

- `stream: "item"`
- `data.kind: "preamble"`
- `data.progressText: "..."`

Before this PR, WebChat ignored those `item/preamble` events, so long Codex runs could look silent until a final answer or a tool card appeared.

This PR makes WebChat show that commentary as transient progress text during the active run, while preserving the existing rule that commentary/progress should not be saved as final assistant history.

## Surfaces

| Surface | Before | After |
| --- | --- | --- |
| WebChat | Ignored Codex app-server `item/preamble` commentary. Long runs could appear silent. | Shows `progressText` in the live transient chat stream while the run is active. |
| Telegram | Current main already routes preamble/commentary through the progress-draft compositor. | No runtime Telegram code change here; docs clarify that Codex commentary requires `channels.telegram.streaming.progress.commentary=true`. |
| ACP / ACPX | PR #89505 covered opt-in ACP parent commentary progress. | Not changed here. This PR is for the native/default Codex app-server path. |
| Chat history | Risk of treating streamed text as assistant output if projected naively. | Progress-only stream text is tagged as `progress` and cleared on final/abort/error without becoming assistant history. |

## Runtime Flow

```mermaid
flowchart LR
  A["Codex app-server"] --> B["agent event: stream=item"]
  B --> C["kind=preamble"]
  C --> D["progressText"]
  D --> E["WebChat transient chatStream"]
  E --> F["Visible live commentary during run"]
  F --> G["Terminal event"]
  G --> H["Clear progress-only stream"]
  H --> I["Do not persist as assistant message"]
```

## Surface Split

```mermaid
flowchart TB
  P["Commentary progress source"] --> N["Native Codex app-server item/preamble"]
  P --> A["ACP parent stream"]

  N --> W["WebChat"]
  N --> T["Telegram progress draft compositor"]

  A --> R["Handled by earlier ACP-focused PR #89505"]

  W --> WF["This PR: project progressText into transient chat stream"]
  T --> TF["Config gate: channels.telegram.streaming.progress.commentary=true"]
```

## Implementation Notes

- Adds `chatStreamKind: "assistant" | "progress"` so WebChat can distinguish answer text from commentary progress.
- Projects native Codex app-server `item/preamble` `progressText` into the transient chat stream.
- Prevents progress-only text from being materialized into `chatMessages` on terminal events.
- Keeps existing assistant delta behavior tagged as `assistant`.
- Clarifies Telegram docs so tool-progress previews are not conflated with Codex commentary.
- Removes stale `clawhub/soul-format` navigation from `docs/docs.json`; the synced ClawHub docs no longer publish that page, and this was the failing `check-docs` link-audit item.

## Why This Is Safe

```mermaid
flowchart TD
  A["Incoming WebChat stream text"] --> B{"chatStreamKind?"}
  B -->|"assistant"| C["May materialize into assistant history"]
  B -->|"progress"| D["Display only while run is active"]
  D --> E["Terminal event clears stream"]
  E --> F["No persisted assistant message"]
```

The patch intentionally keeps progress text transient. Assistant deltas still use the normal assistant stream path, and final messages still come from the normal terminal/final delivery path.

## Validation

- Local focused tests:
  - `pnpm vitest run ui/src/ui/app-tool-stream.node.test.ts ui/src/ui/controllers/chat.test.ts extensions/telegram/src/bot-message-dispatch.test.ts src/channels/progress-draft-compositor.test.ts src/config/schema.test.ts`
  - Result: 5 files passed, 326 tests passed.
- Local docs link audit:
  - `pnpm docs:check-links`
  - Result: `broken_links=0`.
- GitHub Actions on head `95577f46ffac94fb5d9791c93f58394b55acd44b`:
  - 125 successful checks.
  - 8 skipped checks.
  - 0 pending checks.
  - 0 failing checks.
- Real behavior proof gate:
  - Passing after the embedded after-fix terminal output below.

## Real Behavior Proof

- **Behavior or issue addressed**: WebChat now surfaces native Codex app-server `stream: "item"`, `kind: "preamble"` commentary progress as transient conversation text while a run is active, without storing that progress as assistant history after the run finalizes.
- **Real environment tested**: Local OpenClaw checkout at `/Volumes/LEXAR/repos/openclaw-native-commentary-progress` on macOS, using Node with `tsx` against the actual WebChat event handlers in `ui/src/ui/app-tool-stream.ts` and `ui/src/ui/controllers/chat.ts`.
- **Exact steps or command run after this patch**: Ran a Node replay of the actual WebChat handlers with a Codex app-server `item/preamble` event containing `progressText: "Checking the app-server stream"`, then sent the run `final` event.
- **Evidence after fix**: Terminal output copied from the after-patch run:

```json
{
  "afterPreamble": {
    "chatStream": "Checking the app-server stream",
    "chatStreamKind": "progress",
    "chatStreamStartedAt": 1760000000000,
    "chatMessages": []
  },
  "finalResult": "final",
  "afterFinal": {
    "chatRunId": null,
    "chatStream": null,
    "chatStreamKind": null,
    "chatMessages": []
  }
}
```

- **Observed result after fix**: The preamble progress text appears in the transient `chatStream` with `chatStreamKind: "progress"` during the run, and after the final event the transient stream is cleared while `chatMessages` remains empty, so commentary progress is not persisted as assistant content.
- **What was not tested**: No Telegram bot was launched in this proof run; Telegram behavior is covered by the existing config-gated compositor tests and requires `channels.telegram.streaming.progress.commentary=true` in runtime config.
