### PR TITLE
fix(agents): preserve runtime settings overrides [AI-assisted]

### DIFF
--- a/src/agents/agent-project-settings.test.ts
+++ b/src/agents/agent-project-settings.test.ts
@@ -186,4 +186,29 @@ describe("createPreparedEmbeddedAgentSettingsManager", () => {
       await fs.rm(baseDir, { recursive: true, force: true });
     }
   });
+
+  it("keeps compaction reserve overrides after disabling runtime retry", () => {
+    const settingsManager = createPreparedEmbeddedAgentSettingsManager({
+      cwd: "/tmp/workspace",
+      agentDir: "/tmp/agent",
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              reserveTokensFloor: 50_000,
+              keepRecentTokens: 16_000,
+            },
+          },
+        },
+      },
+      contextTokenBudget: 200_000,
+    });
+
+    expect(settingsManager.getRetryEnabled()).toBe(false);
+    expect(settingsManager.getCompactionSettings()).toEqual({
+      enabled: true,
+      reserveTokens: 50_000,
+      keepRecentTokens: 16_000,
+    });
+  });
 });

--- a/src/agents/agent-settings.test.ts
+++ b/src/agents/agent-settings.test.ts
@@ -10,6 +10,7 @@ import {
   resolveCompactionReserveTokensFloor,
   shouldDisableAgentAutoCompaction,
 } from "./agent-settings.js";
+import { SettingsManager } from "./sessions/settings-manager.js";
 
 describe("applyAgentCompactionSettingsFromConfig", () => {
   it("bumps reserveTokens when below floor", () => {
@@ -568,6 +569,29 @@ describe("applyAgentAutoCompactionGuard", () => {
 
     expect(result).toEqual({ supported: true, disabled: true });
     expect(setCompactionEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("preserves configured reserve tokens when disabling embedded auto-compaction", () => {
+    const settingsManager = SettingsManager.inMemory({
+      compaction: { enabled: true, reserveTokens: 16_384 },
+    });
+
+    applyAgentCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: { agents: { defaults: { compaction: { reserveTokensFloor: 50_000 } } } },
+      contextTokenBudget: 200_000,
+    });
+    const result = applyAgentAutoCompactionGuard({
+      settingsManager,
+      compactionMode: "safeguard",
+    });
+
+    expect(result).toEqual({ supported: true, disabled: true });
+    expect(settingsManager.getCompactionSettings()).toEqual({
+      enabled: false,
+      reserveTokens: 50_000,
+      keepRecentTokens: 20_000,
+    });
   });
 
   // Default-mode runs against ordinary providers must keep OpenClaw runtime's auto-compaction

--- a/src/agents/sessions/settings-manager.test.ts
+++ b/src/agents/sessions/settings-manager.test.ts
@@ -1,0 +1,49 @@
+/** Tests session settings manager runtime overrides. */
+import { describe, expect, it } from "vitest";
+import { SettingsManager } from "./settings-manager.js";
+
+describe("SettingsManager runtime overrides", () => {
+  it("preserves compaction overrides after global setting writes", async () => {
+    const settingsManager = SettingsManager.inMemory({
+      compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 },
+    });
+
+    settingsManager.applyOverrides({
+      compaction: { reserveTokens: 50_000, keepRecentTokens: 16_000 },
+    });
+    settingsManager.setCompactionEnabled(false);
+
+    expect(settingsManager.getCompactionSettings()).toEqual({
+      enabled: false,
+      reserveTokens: 50_000,
+      keepRecentTokens: 16_000,
+    });
+
+    await settingsManager.flush();
+    await settingsManager.reload();
+
+    expect(settingsManager.getCompactionSettings()).toEqual({
+      enabled: false,
+      reserveTokens: 50_000,
+      keepRecentTokens: 16_000,
+    });
+  });
+
+  it("preserves runtime overrides after project setting writes", async () => {
+    const settingsManager = SettingsManager.inMemory({
+      compaction: { reserveTokens: 16_384 },
+    });
+
+    settingsManager.applyOverrides({ compaction: { reserveTokens: 50_000 } });
+    settingsManager.setProjectPackages(["npm:@openclaw/example"]);
+
+    expect(settingsManager.getPackages()).toEqual(["npm:@openclaw/example"]);
+    expect(settingsManager.getCompactionReserveTokens()).toBe(50_000);
+
+    await settingsManager.flush();
+    await settingsManager.reload();
+
+    expect(settingsManager.getPackages()).toEqual(["npm:@openclaw/example"]);
+    expect(settingsManager.getCompactionReserveTokens()).toBe(50_000);
+  });
+});

--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -250,7 +250,9 @@ export class SettingsManager {
   private storage: SettingsStorage;
   private globalSettings: Settings;
   private projectSettings: Settings;
-  private settings: Settings;
+  private settings: Settings = {};
+  // Non-persisted overrides layered above global/project settings for this manager.
+  private runtimeOverrides: Settings = {};
   private modifiedFields = new Set<keyof Settings>(); // Track global fields modified during session
   private modifiedNestedFields = new Map<keyof Settings, Set<string>>(); // Track global nested field modifications
   private modifiedProjectFields = new Set<keyof Settings>(); // Track project fields modified during session
@@ -274,7 +276,7 @@ export class SettingsManager {
     this.globalSettingsLoadError = globalLoadError;
     this.projectSettingsLoadError = projectLoadError;
     this.errors = [...initialErrors];
-    this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
+    this.recomputeSettings();
   }
 
   /** Create a SettingsManager that loads from files */
@@ -417,6 +419,13 @@ export class SettingsManager {
     return structuredClone(this.projectSettings);
   }
 
+  private recomputeSettings(): void {
+    this.settings = deepMergeSettings(
+      deepMergeSettings(this.globalSettings, this.projectSettings),
+      this.runtimeOverrides,
+    );
+  }
+
   async reload(): Promise<void> {
     await this.writeQueue;
     const globalLoad = SettingsManager.tryLoadFromStorage(this.storage, "global");
@@ -442,12 +451,13 @@ export class SettingsManager {
       this.recordError("project", projectLoad.error);
     }
 
-    this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
+    this.recomputeSettings();
   }
 
-  /** Apply additional overrides on top of current settings */
+  /** Apply non-persisted overrides on top of global/project settings. */
   applyOverrides(overrides: Partial<Settings>): void {
-    this.settings = deepMergeSettings(this.settings, overrides);
+    this.runtimeOverrides = deepMergeSettings(this.runtimeOverrides, overrides);
+    this.recomputeSettings();
   }
 
   /** Mark a global field as modified during this session */
@@ -541,7 +551,7 @@ export class SettingsManager {
   }
 
   private save(): void {
-    this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
+    this.recomputeSettings();
 
     if (this.globalSettingsLoadError) {
       return;
@@ -563,7 +573,7 @@ export class SettingsManager {
 
   private saveProjectSettings(settings: Settings): void {
     this.projectSettings = structuredClone(settings);
-    this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
+    this.recomputeSettings();
 
     if (this.projectSettingsLoadError) {
       return;


### PR DESCRIPTION
## Summary
- keep `SettingsManager.applyOverrides()` as a runtime override layer instead of merging it only into the current settings snapshot
- recompute effective settings from global + project + runtime overrides after `save()` and `reload()`
- cover the embedded compaction path where `reserveTokensFloor` is applied before runtime auto-compaction/retry guards write settings

## Why
Embedded agent runs can apply a configured compaction reserve floor, then call setters such as `setCompactionEnabled(false)` or `setRetryEnabled(false)`. Those setters call `save()`, and `save()` previously rebuilt `settings` from global/project settings only. That dropped runtime overrides from `applyOverrides()`, so a configured reserve floor such as `50000` could fall back to the default runtime reserve (`16384`) inside the same turn.

## Real behavior proof
- Behavior or issue addressed: Embedded agent runtime settings keep configured compaction reserve overrides after runtime guard writes and reloads. This covers the case where `reserveTokensFloor=50000` must remain the effective reserve after `setCompactionEnabled(false)` persists `enabled=false`.
- Real environment tested: Local macOS source checkout of `openclaw/openclaw` at `origin/main` (`575cae59d4`) plus this patch, Node via the repo toolchain, no channel credentials or provider API keys used.
- Exact steps or command run after this patch:
  1. Created a real `SettingsManager.inMemory({ compaction: { enabled: true, reserveTokens: 16384 } })` from the patched source modules.
  2. Called `applyAgentCompactionSettingsFromConfig()` with `agents.defaults.compaction.reserveTokensFloor=50000` and `contextTokenBudget=200000`.
  3. Called `applyAgentAutoCompactionGuard()` with `compactionMode: "safeguard"`, which writes `compaction.enabled=false` through the real `SettingsManager` setter.
  4. Called `settingsManager.reload()` and printed `settingsManager.getCompactionSettings()`.
- Evidence after fix:
  ```sh
  node --import tsx -e 'import { SettingsManager } from "./src/agents/sessions/settings-manager.ts"; import { applyAgentAutoCompactionGuard, applyAgentCompactionSettingsFromConfig } from "./src/agents/agent-settings.ts"; const settingsManager = SettingsManager.inMemory({ compaction: { enabled: true, reserveTokens: 16384 } }); applyAgentCompactionSettingsFromConfig({ settingsManager, cfg: { agents: { defaults: { compaction: { reserveTokensFloor: 50000 } } } }, contextTokenBudget: 200000 }); applyAgentAutoCompactionGuard({ settingsManager, compactionMode: "safeguard" }); await settingsManager.reload(); console.log(JSON.stringify(settingsManager.getCompactionSettings()));'
  ```
  Output copied from the local run:
  ```json
  {"enabled":false,"reserveTokens":50000,"keepRecentTokens":20000}
  ```
- Observed result after fix: The effective settings keep `enabled=false` from the guard write and keep `reserveTokens=50000` from the runtime override after reload. Before this patch, runtime overrides were only merged into the current `settings` snapshot, so a later write/reload path could drop the configured reserve back to the backing settings/default.
- What was not tested: I did not run a live Telegram/OpenClaw gateway turn or a provider-backed model request for this PR. The proof uses the real local OpenClaw settings and compaction modules without external credentials.

AI-assisted PR; I understand the code path. Maintainer edits are OK on this fork branch.

## Tests
- `node scripts/test-projects.mjs src/agents/agent-settings.test.ts src/agents/agent-project-settings.test.ts src/agents/sessions/settings-manager.test.ts`
- `pnpm tsgo:core`
- `pnpm exec oxlint src/agents/sessions/settings-manager.ts src/agents/sessions/settings-manager.test.ts src/agents/agent-project-settings.test.ts src/agents/agent-settings.test.ts`
- `git diff --check`
- `codex review --base origin/main` (no actionable regressions)

Not fully run: `pnpm check` after the final patch. I ran it once; all preflight guards through shrinkwrap passed, then typecheck caught the missing definite assignment initializer that this commit fixes. A later `pnpm tsgo:core` passed. `pnpm lint` via `scripts/run-oxlint-shards.mjs` stalled locally with no worker CPU, so I ran oxlint directly on the touched files instead.
