### PR TITLE
feat(coreweave): add CoreWeave Serverless Inference model provider

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -385,6 +385,11 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/cloudflare-ai-gateway/**"
+"extensions: coreweave":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/coreweave/**"
+          - "docs/providers/coreweave.md"
 "extensions: minimax-portal-auth":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1417,6 +1417,7 @@
                   "providers/claude-max-api-proxy",
                   "providers/cloudflare-ai-gateway",
                   "providers/comfy",
+                  "providers/coreweave",
                   "providers/deepgram",
                   "providers/deepinfra",
                   "providers/deepseek",

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-90 plugins
+91 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -84,6 +84,8 @@ Each entry lists the package, distribution route, and description.
 - **[comfy](/plugins/reference/comfy)** (`@openclaw/comfy-provider`) - included in OpenClaw. Adds ComfyUI model provider support to OpenClaw.
 
 - **[copilot-proxy](/plugins/reference/copilot-proxy)** (`@openclaw/copilot-proxy`) - included in OpenClaw. Adds Copilot Proxy model provider support to OpenClaw.
+
+- **[coreweave](/plugins/reference/coreweave)** (`@openclaw/coreweave-provider`) - included in OpenClaw. Adds CoreWeave model provider support to OpenClaw.
 
 - **[deepgram](/plugins/reference/deepgram)** (`@openclaw/deepgram-provider`) - included in OpenClaw. Adds media understanding provider support. Adds realtime transcription provider support.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 127
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 128
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/coreweave.md
+++ b/docs/plugins/reference/coreweave.md
@@ -1,0 +1,23 @@
+---
+summary: "Adds CoreWeave model provider support to OpenClaw."
+read_when:
+  - You are installing, configuring, or auditing the coreweave plugin
+title: "CoreWeave plugin"
+---
+
+# CoreWeave plugin
+
+Adds CoreWeave model provider support to OpenClaw.
+
+## Distribution
+
+- Package: `@openclaw/coreweave-provider`
+- Install route: included in OpenClaw
+
+## Surface
+
+providers: coreweave
+
+## Related docs
+
+- [coreweave](/providers/coreweave)

--- a/docs/providers/coreweave.md
+++ b/docs/providers/coreweave.md
@@ -1,0 +1,207 @@
+---
+summary: "Use CoreWeave Serverless Inference (formerly Weights & Biases Inference) in OpenClaw"
+read_when:
+  - You want open models served on CoreWeave GPUs in OpenClaw
+  - You want CoreWeave Serverless Inference setup guidance
+  - You are migrating from Weights & Biases Inference
+title: "CoreWeave Serverless Inference"
+---
+
+CoreWeave Serverless Inference (formerly **Weights & Biases Inference**) serves popular open models on CoreWeave GPUs through an OpenAI-compatible API. Use your existing Weights & Biases account to authenticate.
+
+## Why CoreWeave in OpenClaw
+
+- **Open frontier models** such as Kimi, GLM, DeepSeek, Qwen, and Llama on CoreWeave infrastructure.
+- **OpenAI-compatible** `/v1` endpoints, so OpenClaw talks to it like any OpenAI-style provider.
+- **Vendor-prefixed model ids** (for example `coreweave/Qwen/Qwen3-235B-A22B-Instruct-2507`).
+- **Refreshable catalog**: OpenClaw seeds a bundled catalog and refreshes it from the live `/models` endpoint.
+
+## Getting started
+
+<Steps>
+  <Step title="Get your API key">
+    1. Sign in at [wandb.ai/authorize](https://wandb.ai/authorize)
+    2. Copy your API key
+  </Step>
+  <Step title="Configure OpenClaw">
+    <Tabs>
+      <Tab title="Interactive (recommended)">
+        ```bash
+        openclaw onboard --auth-choice coreweave-api-key
+        ```
+
+        This will:
+        1. Prompt for your API key (or use existing `COREWEAVE_API_KEY`)
+        2. Show all available CoreWeave models
+        3. Let you pick your default model
+        4. Configure the provider automatically
+      </Tab>
+      <Tab title="Environment variable">
+        ```bash
+        export COREWEAVE_API_KEY="your-key"
+        ```
+      </Tab>
+      <Tab title="Non-interactive">
+        ```bash
+        openclaw onboard --non-interactive \
+          --auth-choice coreweave-api-key \
+          --coreweave-api-key "your-key"
+        ```
+      </Tab>
+    </Tabs>
+
+  </Step>
+  <Step title="Verify setup">
+    ```bash
+    openclaw agent --model coreweave/moonshotai/Kimi-K2.6 --message "Hello, are you working?"
+    ```
+  </Step>
+</Steps>
+
+## Project attribution
+
+Attribution is optional. CoreWeave Serverless Inference can attribute usage to a specific W&B team/project via an `openai-project` header. This is **optional** — if you omit it, W&B uses your default entity and a project named `inference`. Set it when you belong to more than one team or want usage attributed to a specific project, through the plugin config:
+
+```json5
+{
+  plugins: {
+    entries: {
+      coreweave: {
+        config: { project: "my-team/my-project" },
+      },
+    },
+  },
+}
+```
+
+When `project` is set, OpenClaw attaches `openai-project: team/project` to every request. When it is unset, no header is sent and W&B applies your default entity and the `inference` project.
+
+## Model selection
+
+After setup, OpenClaw shows all available CoreWeave models. Change your default any time:
+
+```bash
+openclaw models set coreweave/moonshotai/Kimi-K2.6
+openclaw models set coreweave/zai-org/GLM-5.1
+```
+
+List all available models:
+
+```bash
+openclaw models list --all --provider coreweave
+```
+
+You can also run `openclaw configure`, select **Model/auth**, and choose **CoreWeave Serverless Inference**.
+
+## Built-in catalog
+
+OpenClaw ships a seed catalog and refreshes it from the live `/models` endpoint, falling back to the seed catalog if the API is unreachable. A current snapshot of generally available models:
+
+| Model ID                                       | Name                         | Context | Features          |
+| ---------------------------------------------- | ---------------------------- | ------- | ----------------- |
+| `moonshotai/Kimi-K2.6`                         | Kimi K2.6 (default)          | 262k    | Reasoning, vision |
+| `moonshotai/Kimi-K2.5`                         | Kimi K2.5                    | 262k    | Reasoning, vision |
+| `zai-org/GLM-5.1`                              | GLM 5.1                      | 203k    | General           |
+| `deepseek-ai/DeepSeek-V4-Pro`                  | DeepSeek V4 Pro              | 1M      | General           |
+| `deepseek-ai/DeepSeek-V4-Flash`                | DeepSeek V4 Flash            | 1M      | General           |
+| `deepseek-ai/DeepSeek-V3.1`                    | DeepSeek V3.1                | 161k    | Reasoning         |
+| `Qwen/Qwen3-235B-A22B-Instruct-2507`           | Qwen3 235B A22B Instruct     | 262k    | General           |
+| `Qwen/Qwen3-235B-A22B-Thinking-2507`           | Qwen3 235B A22B Thinking     | 262k    | Reasoning         |
+| `Qwen/Qwen3-Coder-480B-A35B-Instruct`          | Qwen3 Coder 480B             | 262k    | Coding, tools     |
+| `Qwen/Qwen3-30B-A3B-Instruct-2507`             | Qwen3 30B A3B Instruct       | 262k    | General           |
+| `Qwen/Qwen3.6-35B-A3B`                         | Qwen3.6 35B A3B              | 262k    | Vision            |
+| `Qwen/Qwen3.6-27B`                             | Qwen3.6 27B                  | 262k    | Vision            |
+| `Qwen/Qwen3.5-35B-A3B`                         | Qwen3.5 35B A3B              | 262k    | Vision            |
+| `MiniMaxAI/MiniMax-M2.5`                       | MiniMax M2.5                 | 197k    | General           |
+| `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8` | NVIDIA Nemotron 3 Super 120B | 262k    | General           |
+| `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B`     | NVIDIA Nemotron 3 Ultra 550B | 262k    | General           |
+| `openai/gpt-oss-120b`                          | GPT OSS 120B                 | 131k    | Reasoning         |
+| `openai/gpt-oss-20b`                           | GPT OSS 20B                  | 131k    | Reasoning         |
+| `google/gemma-4-31B-it`                        | Gemma 4 31B                  | 262k    | Vision            |
+| `meta-llama/Llama-3.3-70B-Instruct`            | Llama 3.3 70B                | 128k    | General           |
+| `meta-llama/Llama-3.1-70B-Instruct`            | Llama 3.1 70B                | 128k    | General           |
+| `meta-llama/Llama-3.1-8B-Instruct`             | Llama 3.1 8B                 | 128k    | General           |
+| `microsoft/Phi-4-mini-instruct`                | Phi 4 Mini                   | 128k    | General           |
+| `ibm-granite/granite-4.1-8b`                   | Granite 4.1 8B               | 131k    | Tools             |
+| `JetBrains/Mellum2-12B-A2.5B-Instruct`         | Mellum2 12B                  | 131k    | Tools             |
+| `OpenPipe/Qwen3-14B-Instruct`                  | Qwen3 14B Instruct           | 32k     | General           |
+
+The full, current list lives in the CoreWeave docs (see Related). Model availability changes over time; `openclaw models list --provider coreweave` reflects what the live endpoint reports.
+
+## Pricing
+
+CoreWeave Serverless Inference is billed through your Weights & Biases account. See [the W&B Inference pricing page](https://wandb.ai/site/inference/) for current rates.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="API key not recognized">
+    ```bash
+    echo $COREWEAVE_API_KEY
+    openclaw models list | grep coreweave
+    ```
+
+    Get or rotate your key at [wandb.ai/authorize](https://wandb.ai/authorize).
+
+  </Accordion>
+
+  <Accordion title="Attributing usage to a team or project">
+    Usage attribution is optional. Omit `project` to use your default entity and the `inference` project. If you belong to multiple teams or want usage attributed to a specific project, set the `project` plugin config to `team/project`. See [Project attribution](#project-attribution) above.
+  </Accordion>
+
+  <Accordion title="Connection issues">
+    The endpoint is `https://api.inference.wandb.ai/v1`. Ensure your network allows HTTPS connections to that host.
+  </Accordion>
+</AccordionGroup>
+
+## Advanced configuration
+
+<AccordionGroup>
+  <Accordion title="Config file example">
+    ```json5
+    {
+      env: { COREWEAVE_API_KEY: "..." },
+      plugins: { entries: { coreweave: { config: { project: "my-team/my-project" } } } },
+      agents: { defaults: { model: { primary: "coreweave/moonshotai/Kimi-K2.6" } } },
+      models: {
+        mode: "merge",
+        providers: {
+          coreweave: {
+            baseUrl: "https://api.inference.wandb.ai/v1",
+            apiKey: "${COREWEAVE_API_KEY}",
+            api: "openai-completions",
+            models: [
+              {
+                id: "moonshotai/Kimi-K2.6",
+                name: "Kimi K2.6",
+                reasoning: true,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 262144,
+                maxTokens: 65536,
+              },
+            ],
+          },
+        },
+      },
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="CoreWeave Serverless Inference" href="https://wandb.ai/site/inference/" icon="globe">
+    Product overview and model lineup.
+  </Card>
+  <Card title="API documentation" href="https://docs.wandb.ai/inference" icon="book">
+    Inference API reference and developer docs.
+  </Card>
+  <Card title="Get an API key" href="https://wandb.ai/authorize" icon="key">
+    Create or rotate your access key.
+  </Card>
+</CardGroup>

--- a/extensions/coreweave/api.ts
+++ b/extensions/coreweave/api.ts
@@ -1,0 +1,9 @@
+// CoreWeave API module exposes the plugin public contract.
+export {
+  buildCoreweaveModelDefinition,
+  COREWEAVE_BASE_URL,
+  COREWEAVE_DEFAULT_MODEL_REF,
+  COREWEAVE_MODEL_CATALOG,
+  discoverCoreweaveModels,
+} from "./models.js";
+export { buildCoreweaveProvider, buildStaticCoreweaveProvider } from "./provider-catalog.js";

--- a/extensions/coreweave/index.test.ts
+++ b/extensions/coreweave/index.test.ts
@@ -1,0 +1,83 @@
+// CoreWeave tests cover catalog auth gating and the optional project header.
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+import {
+  coreweaveModelRowsCacheKey,
+  COREWEAVE_BASE_URL,
+  COREWEAVE_DEFAULT_MODEL_REF,
+  COREWEAVE_MODEL_CATALOG,
+} from "./models.js";
+
+type CatalogCtx = {
+  config: unknown;
+  resolveProviderApiKey: () => { apiKey: string | undefined };
+};
+
+// ProviderCatalogResult is a union; narrow to the single-provider variant.
+function readProvider(result: unknown) {
+  return result && typeof result === "object" && "provider" in result
+    ? (result as { provider: ModelProviderConfig }).provider
+    : null;
+}
+
+async function runLiveCatalog(ctx: CatalogCtx): Promise<ModelProviderConfig | null> {
+  const registered = await registerSingleProviderPlugin(plugin);
+  return readProvider(await registered.catalog?.run(ctx as never));
+}
+
+describe("coreweave provider plugin", () => {
+  it("returns null catalog when no API key is available", async () => {
+    const provider = await runLiveCatalog({
+      config: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+    });
+    expect(provider).toBeNull();
+  });
+
+  it("returns the static catalog with the resolved API key when a key is present", async () => {
+    const provider = await runLiveCatalog({
+      config: {},
+      resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+    });
+    expect(provider?.baseUrl).toBe(COREWEAVE_BASE_URL);
+    expect(provider?.apiKey).toBe("test-key");
+    expect(provider?.models?.length ?? 0).toBeGreaterThan(0);
+    expect(provider?.headers).toBeUndefined();
+  });
+
+  it("attaches the openai-project header when the plugin project config is set", async () => {
+    const provider = await runLiveCatalog({
+      config: {
+        plugins: { entries: { coreweave: { config: { project: "my-team/my-project" } } } },
+      },
+      resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+    });
+    expect(provider?.headers).toEqual({ "openai-project": "my-team/my-project" });
+  });
+
+  it("keeps the default model ref pointing at a real catalog row", () => {
+    const defaultId = COREWEAVE_DEFAULT_MODEL_REF.replace(/^coreweave\//, "");
+    expect(COREWEAVE_MODEL_CATALOG.some((m) => m.id === defaultId)).toBe(true);
+  });
+
+  it("exposes a static catalog for credential-free discovery", async () => {
+    const registered = await registerSingleProviderPlugin(plugin);
+    const provider = readProvider(await registered.staticCatalog?.run({ config: {} } as never));
+    expect(provider?.models?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("scopes the discovery cache by credential and project", () => {
+    const keyA = coreweaveModelRowsCacheKey({ apiKey: "key-a", project: "team/p1" });
+    // Different credential and different project must not reuse a cached row set.
+    expect(coreweaveModelRowsCacheKey({ apiKey: "key-b", project: "team/p1" })).not.toEqual(keyA);
+    expect(coreweaveModelRowsCacheKey({ apiKey: "key-a", project: "team/p2" })).not.toEqual(keyA);
+    // Distinct credentials must not collapse onto a shared anon/auth marker.
+    expect(coreweaveModelRowsCacheKey({})).not.toEqual(
+      coreweaveModelRowsCacheKey({ apiKey: "key-a" }),
+    );
+    // Identical inputs are stable so the TTL cache still hits.
+    expect(coreweaveModelRowsCacheKey({ apiKey: "key-a", project: "team/p1" })).toEqual(keyA);
+  });
+});

--- a/extensions/coreweave/index.ts
+++ b/extensions/coreweave/index.ts
@@ -1,0 +1,72 @@
+// CoreWeave Serverless Inference plugin entrypoint (formerly Weights & Biases Inference).
+import { resolvePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { applyCoreweaveConfig, COREWEAVE_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildCoreweaveProvider, buildStaticCoreweaveProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "coreweave";
+
+/** Reads the optional `team/project` openai-project scope from plugin config. */
+function resolveProjectScope(ctx: {
+  config?: Parameters<typeof resolvePluginConfigObject>[0];
+}): string | undefined {
+  return normalizeOptionalString(resolvePluginConfigObject(ctx.config, PROVIDER_ID)?.project);
+}
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "CoreWeave Serverless Inference Provider",
+  description: "Bundled CoreWeave Serverless Inference provider plugin",
+  provider: {
+    label: "CoreWeave Serverless Inference",
+    docsPath: "/providers/coreweave",
+    auth: [
+      {
+        methodId: "api-key",
+        label: "CoreWeave Serverless Inference API key",
+        hint: "Open models on CoreWeave GPUs (formerly Weights & Biases Inference)",
+        optionKey: "coreweaveApiKey",
+        flagName: "--coreweave-api-key",
+        envVar: "COREWEAVE_API_KEY",
+        promptMessage: "Enter CoreWeave Serverless Inference API key",
+        defaultModel: COREWEAVE_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyCoreweaveConfig(cfg),
+        noteTitle: "CoreWeave Serverless Inference",
+        noteMessage: [
+          "CoreWeave Serverless Inference (formerly Weights & Biases Inference) serves",
+          "open models on CoreWeave GPUs through an OpenAI-compatible API.",
+          "Get your API key at: https://wandb.ai/authorize",
+          "Optional: set the plugin `project` config ('team/project') to attribute usage;",
+          "otherwise W&B uses your default entity and an 'inference' project.",
+        ].join("\n"),
+        wizard: {
+          groupLabel: "CoreWeave Serverless Inference",
+        },
+      },
+    ],
+    catalog: {
+      order: "simple",
+      run: async (ctx) => {
+        const apiKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+        if (!apiKey) {
+          return null;
+        }
+        // Optional W&B usage attribution: when set, openai-project scopes every
+        // request (chat AND model discovery). When unset, W&B applies the default
+        // entity and an 'inference' project, so no header is sent.
+        const project = resolveProjectScope(ctx);
+        return {
+          provider: {
+            ...(await buildCoreweaveProvider(apiKey, project)),
+            apiKey,
+            ...(project ? { headers: { "openai-project": project } } : {}),
+          },
+        };
+      },
+      staticRun: async () => ({
+        provider: buildStaticCoreweaveProvider(),
+      }),
+    },
+  },
+});

--- a/extensions/coreweave/models.ts
+++ b/extensions/coreweave/models.ts
@@ -1,0 +1,163 @@
+// CoreWeave Serverless Inference model catalog plus live model discovery.
+// Endpoint is still the W&B inference host after the CoreWeave rebrand.
+import {
+  getCachedLiveProviderModelRows,
+  LiveModelCatalogHttpError,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { ssrfPolicyFromHttpBaseUrlAllowedHostname } from "openclaw/plugin-sdk/ssrf-runtime";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const log = createSubsystemLogger("coreweave-models");
+
+const COREWEAVE_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
+  providerId: "coreweave",
+  catalog: manifest.modelCatalog.providers.coreweave,
+});
+
+/** Base URL for CoreWeave Serverless Inference (OpenAI-compatible). */
+export const COREWEAVE_BASE_URL = COREWEAVE_MANIFEST_PROVIDER.baseUrl;
+const COREWEAVE_DEFAULT_MODEL_ID = "moonshotai/Kimi-K2.6";
+/** Default CoreWeave model ref used for onboarding. */
+export const COREWEAVE_DEFAULT_MODEL_REF = `coreweave/${COREWEAVE_DEFAULT_MODEL_ID}`;
+
+const COREWEAVE_DEFAULT_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+const COREWEAVE_DEFAULT_CONTEXT_WINDOW = 131_072;
+const COREWEAVE_DEFAULT_MAX_TOKENS = 32_768;
+const COREWEAVE_DISCOVERY_TIMEOUT_MS = 10_000;
+const COREWEAVE_DISCOVERY_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** Bundled CoreWeave catalog rows, sourced from the manifest single source of truth. */
+export const COREWEAVE_MODEL_CATALOG: ModelDefinitionConfig[] = COREWEAVE_MANIFEST_PROVIDER.models;
+
+type CoreweaveCatalogEntry = Omit<ModelDefinitionConfig, "cost"> & {
+  cost?: ModelDefinitionConfig["cost"];
+};
+
+/** Adds CoreWeave provider compat metadata and default cost to one catalog row. */
+export function buildCoreweaveModelDefinition(entry: CoreweaveCatalogEntry): ModelDefinitionConfig {
+  return {
+    ...entry,
+    cost: entry.cost ?? COREWEAVE_DEFAULT_COST,
+    compat: {
+      supportsUsageInStreaming: false,
+      ...entry.compat,
+    },
+  };
+}
+
+function staticCoreweaveModelDefinitions(): ModelDefinitionConfig[] {
+  return COREWEAVE_MODEL_CATALOG.map(buildCoreweaveModelDefinition);
+}
+
+interface CoreweaveModelRow {
+  id?: unknown;
+}
+
+/**
+ * Cache key for live `/models` discovery. Scopes by endpoint, the optional
+ * project (the openai-project scope applies to the listing request too), and the
+ * actual credential — so distinct keys or projects never share a cached row set.
+ * Keying on the raw credential is safe because the runtime hashes key parts.
+ */
+export function coreweaveModelRowsCacheKey(params: {
+  apiKey?: string;
+  project?: string;
+}): readonly string[] {
+  return [
+    "coreweave",
+    "model-rows",
+    `${COREWEAVE_BASE_URL}/models`,
+    params.apiKey ?? "",
+    params.project ?? "",
+  ];
+}
+
+async function fetchCoreweaveModelRows(
+  apiKey?: string,
+  project?: string,
+): Promise<readonly unknown[]> {
+  return await getCachedLiveProviderModelRows({
+    providerId: "coreweave",
+    endpoint: `${COREWEAVE_BASE_URL}/models`,
+    discoveryApiKey: apiKey,
+    timeoutMs: COREWEAVE_DISCOVERY_TIMEOUT_MS,
+    ttlMs: COREWEAVE_DISCOVERY_CACHE_TTL_MS,
+    cacheKeyParts: coreweaveModelRowsCacheKey({ apiKey, project }),
+    buildRequestHeaders: ({ discoveryApiKey }) => ({
+      Accept: "application/json",
+      ...(discoveryApiKey ? { Authorization: `Bearer ${discoveryApiKey}` } : {}),
+      ...(project ? { "openai-project": project } : {}),
+    }),
+    // Do not pin an empty/transient response for the full TTL; let recovery refresh.
+    shouldCacheRows: (rows) => rows.length > 0,
+    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(COREWEAVE_BASE_URL),
+    auditContext: "coreweave-model-discovery",
+  });
+}
+
+/**
+ * Discovers CoreWeave models from the live `/models` endpoint, mapping known ids
+ * onto the rich manifest catalog and minting lean rows for ids we have not seen.
+ * Falls back to the static catalog whenever discovery is unavailable.
+ */
+export async function discoverCoreweaveModels(
+  apiKey?: string,
+  project?: string,
+): Promise<ModelDefinitionConfig[]> {
+  if (process.env.NODE_ENV === "test" || process.env.VITEST) {
+    return staticCoreweaveModelDefinitions();
+  }
+
+  try {
+    const rows = await fetchCoreweaveModelRows(normalizeOptionalString(apiKey), project);
+    if (rows.length === 0) {
+      log.warn("No models in /models response, using static catalog");
+      return staticCoreweaveModelDefinitions();
+    }
+
+    const catalogById = new Map(COREWEAVE_MODEL_CATALOG.map((m) => [m.id, m]));
+    const seen = new Set<string>();
+    const models: ModelDefinitionConfig[] = [];
+    for (const row of rows as CoreweaveModelRow[]) {
+      const id = normalizeOptionalString(row?.id);
+      if (!id || seen.has(id)) {
+        continue;
+      }
+      seen.add(id);
+      const known = catalogById.get(id);
+      if (known) {
+        models.push(buildCoreweaveModelDefinition(known));
+        continue;
+      }
+      // Live id with no bundled metadata: infer reasoning from the id and keep a safe default shape.
+      const lowerId = normalizeLowercaseStringOrEmpty(id);
+      const reasoning = lowerId.includes("thinking") || lowerId.includes("reason");
+      models.push(
+        buildCoreweaveModelDefinition({
+          id,
+          name: id,
+          reasoning,
+          input: ["text"],
+          contextWindow: COREWEAVE_DEFAULT_CONTEXT_WINDOW,
+          maxTokens: COREWEAVE_DEFAULT_MAX_TOKENS,
+        }),
+      );
+    }
+
+    return models.length > 0 ? models : staticCoreweaveModelDefinitions();
+  } catch (error) {
+    if (error instanceof LiveModelCatalogHttpError) {
+      log.warn(`Failed to discover models: HTTP ${error.status}, using static catalog`);
+      return staticCoreweaveModelDefinitions();
+    }
+    log.warn(`Discovery failed: ${String(error)}, using static catalog`);
+    return staticCoreweaveModelDefinitions();
+  }
+}

--- a/extensions/coreweave/onboard.ts
+++ b/extensions/coreweave/onboard.ts
@@ -1,0 +1,28 @@
+// CoreWeave onboarding config helpers for API-key setup.
+import {
+  createModelCatalogPresetAppliers,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import {
+  buildCoreweaveModelDefinition,
+  COREWEAVE_BASE_URL,
+  COREWEAVE_DEFAULT_MODEL_REF,
+  COREWEAVE_MODEL_CATALOG,
+} from "./models.js";
+
+export { COREWEAVE_DEFAULT_MODEL_REF };
+
+const coreweavePresetAppliers = createModelCatalogPresetAppliers({
+  primaryModelRef: COREWEAVE_DEFAULT_MODEL_REF,
+  resolveParams: (_cfg: OpenClawConfig) => ({
+    providerId: "coreweave",
+    api: "openai-completions",
+    baseUrl: COREWEAVE_BASE_URL,
+    catalogModels: COREWEAVE_MODEL_CATALOG.map(buildCoreweaveModelDefinition),
+    aliases: [{ modelRef: COREWEAVE_DEFAULT_MODEL_REF, alias: "Kimi K2.6" }],
+  }),
+});
+
+export function applyCoreweaveConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return coreweavePresetAppliers.applyConfig(cfg);
+}

--- a/extensions/coreweave/openclaw.plugin.json
+++ b/extensions/coreweave/openclaw.plugin.json
@@ -1,0 +1,263 @@
+{
+  "id": "coreweave",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["coreweave"],
+  "providerAuthChoices": [
+    {
+      "provider": "coreweave",
+      "method": "api-key",
+      "choiceId": "coreweave-api-key",
+      "choiceLabel": "CoreWeave Serverless Inference API key",
+      "groupId": "coreweave",
+      "groupLabel": "CoreWeave Serverless Inference",
+      "groupHint": "Open models on CoreWeave GPUs (formerly Weights & Biases Inference)",
+      "optionKey": "coreweaveApiKey",
+      "cliFlag": "--coreweave-api-key",
+      "cliOption": "--coreweave-api-key <key>",
+      "cliDescription": "CoreWeave Serverless Inference API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "project": {
+        "type": "string",
+        "description": "Optional W&B/CoreWeave team/project in 'team/project' form, sent as the openai-project header to attribute usage. When unset, W&B uses your default entity and an 'inference' project."
+      }
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "coreweave",
+        "authMethods": ["api-key"],
+        "envVars": ["COREWEAVE_API_KEY"]
+      }
+    ]
+  },
+  "modelCatalog": {
+    "providers": {
+      "coreweave": {
+        "baseUrl": "https://api.inference.wandb.ai/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "moonshotai/Kimi-K2.6",
+            "name": "Kimi K2.6",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 65536
+          },
+          {
+            "id": "moonshotai/Kimi-K2.5",
+            "name": "Kimi K2.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 65536
+          },
+          {
+            "id": "zai-org/GLM-5.1",
+            "name": "GLM 5.1",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 202752,
+            "maxTokens": 65536
+          },
+          {
+            "id": "deepseek-ai/DeepSeek-V4-Pro",
+            "name": "DeepSeek V4 Pro",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 65536
+          },
+          {
+            "id": "deepseek-ai/DeepSeek-V4-Flash",
+            "name": "DeepSeek V4 Flash",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 65536
+          },
+          {
+            "id": "deepseek-ai/DeepSeek-V3.1",
+            "name": "DeepSeek V3.1",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 163840,
+            "maxTokens": 65536
+          },
+          {
+            "id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+            "name": "Qwen3 235B A22B Instruct",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 65536
+          },
+          {
+            "id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
+            "name": "Qwen3 235B A22B Thinking",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 65536
+          },
+          {
+            "id": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+            "name": "Qwen3 Coder 480B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 65536
+          },
+          {
+            "id": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "name": "Qwen3 30B A3B Instruct",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 32768
+          },
+          {
+            "id": "Qwen/Qwen3.6-35B-A3B",
+            "name": "Qwen3.6 35B A3B",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 32768
+          },
+          {
+            "id": "Qwen/Qwen3.6-27B",
+            "name": "Qwen3.6 27B",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 32768
+          },
+          {
+            "id": "Qwen/Qwen3.5-35B-A3B",
+            "name": "Qwen3.5 35B A3B",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 32768
+          },
+          {
+            "id": "MiniMaxAI/MiniMax-M2.5",
+            "name": "MiniMax M2.5",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 196608,
+            "maxTokens": 32768
+          },
+          {
+            "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
+            "name": "NVIDIA Nemotron 3 Super 120B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 65536
+          },
+          {
+            "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+            "name": "NVIDIA Nemotron 3 Ultra 550B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 65536
+          },
+          {
+            "id": "openai/gpt-oss-120b",
+            "name": "GPT OSS 120B",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 131072,
+            "maxTokens": 32768
+          },
+          {
+            "id": "openai/gpt-oss-20b",
+            "name": "GPT OSS 20B",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 131072,
+            "maxTokens": 32768
+          },
+          {
+            "id": "google/gemma-4-31B-it",
+            "name": "Gemma 4 31B",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 32768
+          },
+          {
+            "id": "meta-llama/Llama-3.3-70B-Instruct",
+            "name": "Llama 3.3 70B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 131072,
+            "maxTokens": 32768
+          },
+          {
+            "id": "meta-llama/Llama-3.1-70B-Instruct",
+            "name": "Llama 3.1 70B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 131072,
+            "maxTokens": 32768
+          },
+          {
+            "id": "meta-llama/Llama-3.1-8B-Instruct",
+            "name": "Llama 3.1 8B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 131072,
+            "maxTokens": 16384
+          },
+          {
+            "id": "microsoft/Phi-4-mini-instruct",
+            "name": "Phi 4 Mini",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 131072,
+            "maxTokens": 16384
+          },
+          {
+            "id": "ibm-granite/granite-4.1-8b",
+            "name": "Granite 4.1 8B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 131072,
+            "maxTokens": 16384
+          },
+          {
+            "id": "JetBrains/Mellum2-12B-A2.5B-Instruct",
+            "name": "Mellum2 12B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 131072,
+            "maxTokens": 16384
+          },
+          {
+            "id": "OpenPipe/Qwen3-14B-Instruct",
+            "name": "Qwen3 14B Instruct",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 32768,
+            "maxTokens": 16384
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "coreweave": "refreshable"
+    }
+  }
+}

--- a/extensions/coreweave/package.json
+++ b/extensions/coreweave/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/coreweave-provider",
+  "version": "2026.6.2",
+  "private": true,
+  "description": "OpenClaw CoreWeave Serverless Inference provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/coreweave/provider-catalog.ts
+++ b/extensions/coreweave/provider-catalog.ts
@@ -1,0 +1,30 @@
+// CoreWeave provider builders for static and dynamically discovered catalogs.
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  COREWEAVE_BASE_URL,
+  COREWEAVE_MODEL_CATALOG,
+  buildCoreweaveModelDefinition,
+  discoverCoreweaveModels,
+} from "./models.js";
+
+/** Builds the static CoreWeave provider catalog from bundled manifest metadata. */
+export function buildStaticCoreweaveProvider(): ModelProviderConfig {
+  return {
+    baseUrl: COREWEAVE_BASE_URL,
+    api: "openai-completions",
+    models: COREWEAVE_MODEL_CATALOG.map(buildCoreweaveModelDefinition),
+  };
+}
+
+/** Builds the CoreWeave provider with live model discovery, falling back to static. */
+export async function buildCoreweaveProvider(
+  apiKey?: string,
+  project?: string,
+): Promise<ModelProviderConfig> {
+  const models = await discoverCoreweaveModels(apiKey, project);
+  return {
+    baseUrl: COREWEAVE_BASE_URL,
+    api: "openai-completions",
+    models,
+  };
+}

--- a/extensions/coreweave/tsconfig.json
+++ b/extensions/coreweave/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,6 +575,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/coreweave:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/deepgram:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/scripts/generate-plugin-inventory-doc.mjs
+++ b/scripts/generate-plugin-inventory-doc.mjs
@@ -110,6 +110,7 @@ function humanizeId(value) {
     ["codex", "Codex"],
     ["cli", "CLI"],
     ["comfy", "ComfyUI"],
+    ["coreweave", "CoreWeave"],
     ["dashscope", "DashScope"],
     ["deepgram", "Deepgram"],
     ["deepinfra", "DeepInfra"],

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -437,6 +437,7 @@ const BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS = new Set([
   "codex",
   "comfy",
   "copilot-proxy",
+  "coreweave",
   "dashscope",
   "deepinfra",
   "deepseek",


### PR DESCRIPTION
## Summary

What problem does this PR solve?

OpenClaw has no first-class support for CoreWeave Serverless Inference (formerly Weights & Biases Inference); users must hand-wire a custom OpenAI-compatible provider (base URL, auth, per-model context windows, the personal-account `openai-project` header) — error-prone and undiscoverable.

Why does this matter now?

CoreWeave/W&B is a notable hosted endpoint for open models; this fills the same gap the bundled venice/chutes/deepinfra/xiaomi providers already address, with **zero new runtime dependencies**.

What is the intended outcome?

a bundled `coreweave` provider — `COREWEAVE_API_KEY` onboarding, base URL `https://api.inference.wandb.ai/v1` (`openai-completions`), manifest-backed seed catalog (26 models) + refreshable live `/v1/models` discovery, optional `project` config → `openai-project: team/project` header (required for personal accounts).

What is intentionally out of scope?

image/audio/video/embeddings surfaces — text models only for now.

What does success look like?

after `COREWEAVE_API_KEY` onboarding, users can select `coreweave/<model>` and get live completions; the catalog refreshes from `/v1/models` and falls back to the seed.

What should reviewers focus on?

(1) bundled-vs-external decision, (2) auth/provider routing parity with peer providers, (3) the single secops-owned `pnpm-lock.yaml` line (new-workspace entry only).

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #92232

Which issues, PRs, or discussions are related?

Related #73038 (DeepInfra bundled provider), #86179 (Xiaomi bundled provider)

Was this requested by a maintainer or owner?

No

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: no first-class CoreWeave Serverless Inference provider; this adds bundled `coreweave` support.
- Real environment tested: macOS, Node 22, real CoreWeave/W&B key (stored auth profile), branch `feat/coreweave-serverless-inference-provider`.
- Exact steps or command run after this patch:
  ```
  openclaw models list --provider coreweave
  openclaw agent --local --agent main --model coreweave/moonshotai/Kimi-K2.6 \
    --message "In one short sentence, what is CoreWeave?" --json
  ```
- Evidence after fix: copied live `--json` output from the `openclaw agent` run against `api.inference.wandb.ai`:
  ```json
  {
    "payloads": [{ "text": "CoreWeave is a cloud provider specializing in GPU-intensive compute for AI, machine learning, and visualization workloads." }],
    "meta": {
      "agentMeta": { "provider": "coreweave", "model": "moonshotai/Kimi-K2.6", "usage": { "input": 81, "output": 69, "total": 14134 } },
      "executionTrace": { "winnerProvider": "coreweave", "winnerModel": "moonshotai/Kimi-K2.6", "fallbackUsed": false, "attempts": [{ "provider": "coreweave", "model": "moonshotai/Kimi-K2.6", "result": "success" }], "runner": "embedded" },
      "requestShaping": { "authMode": "auth-profile" }
    }
  }
  ```
  `openclaw models list --provider coreweave` rendered all 26 seed models with vendor-prefixed ids preserved (e.g. `coreweave/Qwen/Qwen3-Coder-480B-A35B-Instruct`).
- Observed result after fix: live completion served by `coreweave/moonshotai/Kimi-K2.6` against `api.inference.wandb.ai`; no fallback.
- What was not tested: live inference on the other 25 catalog models (seed ids doc-sourced, live-refreshed via `/v1/models`); the personal-account `openai-project` header path (tested account uses a team/auth-profile setup).
- Proof limitations or environment constraints: the per-agent model-override allowlist limits ad-hoc `--model` to configured models; a full onboard registers the entire catalog.

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?

- `pnpm test:extension coreweave` — 5/5 passing
- `pnpm test src/plugins/contracts/package-manifest.contract.test.ts src/plugins/contracts/extension-runtime-dependencies.contract.test.ts` — passing
- `pnpm test src/plugins/bundled-capability-metadata.test.ts` — passing
- `pnpm tsgo:extensions` and `node scripts/check-src-extension-import-boundary.mjs --json` — clean
- `pnpm build` and `pnpm plugins:inventory:check` — clean
- Live `api.inference.wandb.ai` completion (see Real behavior proof)

What regression coverage was added or updated?

`extensions/coreweave/index.test.ts` (5 tests): auth gating returns null without a key, returns the catalog + resolved key with one, injects the `openai-project` header only when `project` is configured, exposes a credential-free static catalog, and guards that the default model ref exists in the catalog.

What failed before this fix, if known?

No coreweave provider existed; `coreweave/*` model refs were unresolved (`Unknown model`).

If no test was added, why not?

N/A — regression tests added.

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes — adds a new selectable provider (`enabledByDefault`, like peer providers; not auto-selected as anyone's default model).

Did config, environment, or migration behavior change? (`Yes/No`)

Yes (additive only) — new `COREWEAVE_API_KEY`, new optional `coreweave.project` plugin config, new `coreweave` id in the built-in provider overlay set. No migrations; no existing keys changed.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes — new outbound provider (`api.inference.wandb.ai`, SSRF-policy guarded) with API-key auth. `pnpm-lock.yaml` is `@openclaw/openclaw-secops`-owned; the only change there is the standard new-workspace-package entry (no dependency additions).

What is the highest-risk area?

Auth/provider routing for the new provider, plus the secops-owned lockfile entry.

How is that risk mitigated?

Follows the exact bundled OpenAI-compatible provider pattern (venice/chutes); live discovery falls back to the seed catalog; tests lock auth gating and the project header; live completion verified end to end. Lockfile change is a single additive workspace line — flagging for a secops glance.

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?

Maintainer decision on bundled-vs-external, and a secops glance at the one-line `pnpm-lock.yaml` entry.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on maintainer signal. Live proof supplied; CI not yet run on the upstream PR.

Which bot or reviewer comments were addressed?

None yet — will update after Codex/ClawSweeper review and resolve/reply to each.

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
