### PR TITLE
fix(memory-wiki): guard against missing agentIds in public artifact clone and sort

### DIFF
--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -236,7 +236,7 @@ export async function syncMemoryWikiBridgeSources(params: {
   });
   const agentIdsByWorkspace = new Map<string, string[]>();
   for (const artifact of publicArtifacts) {
-    agentIdsByWorkspace.set(artifact.workspaceDir, artifact.agentIds);
+    agentIdsByWorkspace.set(artifact.workspaceDir, artifact.agentIds ?? []);
   }
   const artifactCount = artifacts.length;
   for (const artifact of artifacts) {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -303,9 +303,14 @@ export function hasMemoryRuntime(): boolean {
 function cloneMemoryPublicArtifact(
   artifact: MemoryPluginPublicArtifact,
 ): MemoryPluginPublicArtifact {
+  const ids = artifact.agentIds;
   return {
     ...artifact,
-    agentIds: [...artifact.agentIds],
+    agentIds: Array.isArray(ids)
+      ? [...ids]
+      : ids && typeof ids[Symbol.iterator] === "function"
+        ? [...ids]
+        : [],
   };
 }
 
@@ -315,27 +320,27 @@ export async function listActiveMemoryPublicArtifacts(params: {
   const artifacts =
     (await memoryPluginState.capability?.capability.publicArtifacts?.listArtifacts(params)) ?? [];
   return artifacts.map(cloneMemoryPublicArtifact).toSorted((left, right) => {
-    const workspaceOrder = left.workspaceDir.localeCompare(right.workspaceDir);
+    const workspaceOrder = (left.workspaceDir ?? "").localeCompare(right.workspaceDir ?? "");
     if (workspaceOrder !== 0) {
       return workspaceOrder;
     }
-    const relativePathOrder = left.relativePath.localeCompare(right.relativePath);
+    const relativePathOrder = (left.relativePath ?? "").localeCompare(right.relativePath ?? "");
     if (relativePathOrder !== 0) {
       return relativePathOrder;
     }
-    const kindOrder = left.kind.localeCompare(right.kind);
+    const kindOrder = (left.kind ?? "").localeCompare(right.kind ?? "");
     if (kindOrder !== 0) {
       return kindOrder;
     }
-    const contentTypeOrder = left.contentType.localeCompare(right.contentType);
+    const contentTypeOrder = (left.contentType ?? "").localeCompare(right.contentType ?? "");
     if (contentTypeOrder !== 0) {
       return contentTypeOrder;
     }
-    const agentOrder = left.agentIds.join("\0").localeCompare(right.agentIds.join("\0"));
+    const agentOrder = (left.agentIds ?? []).join("\0").localeCompare((right.agentIds ?? []).join("\0"));
     if (agentOrder !== 0) {
       return agentOrder;
     }
-    return left.absolutePath.localeCompare(right.absolutePath);
+    return (left.absolutePath ?? "").localeCompare(right.absolutePath ?? "");
   });
 }
 


### PR DESCRIPTION
## What does this PR do?

Guards `wiki_*` tools against missing `agentIds` in memory plugin public artifacts. When `listMemoryHostPublicArtifacts()` returns artifacts without `agentIds`, the code crashes with `artifact.agentIds is not iterable`. This PR adds null-safety in three places: the clone function, the sort comparator, and the memory-wiki bridge map population.

## Related Issue
Fixes #92207

## Type of Change
- [x] Bug fix (non-breaking)

## Changes Made
- `src/plugins/memory-state.ts`: Guard `cloneMemoryPublicArtifact` against non-array/undefined `agentIds`; add null-safety to sort comparator fields
- `extensions/memory-wiki/src/bridge.ts`: Guard `agentIdsByWorkspace.set` with `?? []` fallback

## How to Test
1. `npx vitest run src/plugins/memory-state.test.ts --reporter=verbose` (14 tests pass)
2. `npx vitest run extensions/memory-wiki/src/bridge.test.ts --reporter=verbose` (10 tests pass)

## Real behavior proof

**Behavior or issue addressed:**
All `wiki_*` tools crash with `artifact.agentIds is not iterable` when `listMemoryHostPublicArtifacts()` returns artifacts whose `agentIds` field is undefined.

**Real environment tested:**
macOS 26.4.1, Node.js (from repo toolchain), source checkout at `575cae59`.

**Exact steps or command run after the patch:**
```bash
npx vitest run src/plugins/memory-state.test.ts extensions/memory-wiki/src/bridge.test.ts src/plugins/public-surface-loader.test.ts --reporter=verbose
```

**Evidence after fix:**
```
Test Files  3 passed (3)
     Tests  32 passed (32)
  Duration  2.11s
```

**Observed result after fix:**
All existing tests pass. The guard in `cloneMemoryPublicArtifact` now returns an empty array when `agentIds` is undefined or non-iterable, preventing the crash. The sort comparator handles null/undefined fields gracefully.

**What was not tested:**
Not tested in a live OpenClaw gateway with actual memory-wiki workspace — the fix is verified at the unit test level only. The root cause (memory plugin returning artifacts without `agentIds`) requires a specific workspace configuration to reproduce in production.
