### PR TITLE
fix(agents): carry provenance through active subagent wakes

### DIFF
--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -202,7 +202,7 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 322),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10388),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10389),
     publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5214),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",

--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -8,7 +8,9 @@ import {
   listActiveReplyRunSessionIds,
   resolveActiveReplyRunSessionId,
 } from "../../auto-reply/reply/reply-run-registry.js";
+import type { InputProvenance } from "../../sessions/input-provenance.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import type { DeliveryContext } from "../../utils/delivery-context.shared.js";
 
 /**
  * Shared process state for embedded-agent runs, queues, and snapshots.
@@ -30,7 +32,9 @@ export type EmbeddedAgentQueueHandle = {
 export type EmbeddedAgentQueueMessageOptions = {
   steeringMode?: "all";
   debounceMs?: number;
+  deliveryContext?: DeliveryContext;
   deliveryTimeoutMs?: number;
+  inputProvenance?: InputProvenance;
   waitForTranscriptCommit?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 };

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
@@ -2,11 +2,38 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   cancelQueuedSteeringMessage,
+  steerActiveSessionWithOptionalDeliveryWait,
   steerAndWaitForTranscriptCommit,
   type EmbeddedAgentActiveSessionSteerTarget,
 } from "./attempt.queue-message.js";
 
 describe("embedded OpenClaw queued steering cancellation", () => {
+  it("passes input provenance into the real active steer call", async () => {
+    const steer = vi.fn(async () => {});
+    const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
+      steer,
+      subscribe: () => () => {},
+    };
+
+    await steerActiveSessionWithOptionalDeliveryWait(activeSession, "completion from child", {
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:child:run",
+        sourceChannel: "telegram",
+        sourceTool: "subagent_announce",
+      },
+    });
+
+    expect(steer).toHaveBeenCalledWith("completion from child", {
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:child:run",
+        sourceChannel: "telegram",
+        sourceTool: "subagent_announce",
+      },
+    });
+  });
+
   it("waits for the queued user message_end transcript boundary", async () => {
     // A queued steer is only durable once the user message_end event lands in
     // the active transcript.

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
@@ -2,7 +2,12 @@
  * Steers active embedded sessions and waits for transcript commits when needed.
  */
 import { toErrorObject } from "../../../infra/errors.js";
+import type { InputProvenance } from "../../../sessions/input-provenance.js";
 import { log } from "../logger.js";
+
+export type EmbeddedAgentActiveSessionSteerOptions = {
+  inputProvenance?: InputProvenance;
+};
 
 /**
  * Minimal active-session surface needed to steer a running attempt and observe
@@ -11,7 +16,7 @@ import { log } from "../logger.js";
 export type EmbeddedAgentActiveSessionSteerTarget = {
   agent?: unknown;
   getSteeringMessages?(): readonly string[];
-  steer(text: string): Promise<void>;
+  steer(text: string, options?: EmbeddedAgentActiveSessionSteerOptions): Promise<void>;
   subscribe(listener: (event: unknown) => void): () => void;
 };
 
@@ -126,6 +131,7 @@ export async function steerAndWaitForTranscriptCommit(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,
   timeoutMs: number,
+  options?: EmbeddedAgentActiveSessionSteerOptions,
 ): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     let settled = false;
@@ -206,7 +212,7 @@ export async function steerAndWaitForTranscriptCommit(
         scheduleTerminalCancellation();
       }
     });
-    activeSession.steer(text).catch((err: unknown) => {
+    activeSession.steer(text, options).catch((err: unknown) => {
       finish(err);
     });
   });
@@ -219,15 +225,22 @@ export async function steerAndWaitForTranscriptCommit(
 export async function steerActiveSessionWithOptionalDeliveryWait(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,
-  options: { deliveryTimeoutMs?: number; waitForTranscriptCommit?: boolean } | undefined,
+  options:
+    | ({ deliveryTimeoutMs?: number; waitForTranscriptCommit?: boolean } &
+        EmbeddedAgentActiveSessionSteerOptions)
+    | undefined,
 ): Promise<void> {
+  const steerOptions: EmbeddedAgentActiveSessionSteerOptions | undefined = options?.inputProvenance
+    ? { inputProvenance: options.inputProvenance }
+    : undefined;
   if (options?.waitForTranscriptCommit !== true) {
-    await activeSession.steer(text);
+    await activeSession.steer(text, steerOptions);
     return;
   }
   await steerAndWaitForTranscriptCommit(
     activeSession,
     text,
     options.deliveryTimeoutMs ?? DEFAULT_QUEUE_TRANSCRIPT_COMMIT_TIMEOUT_MS,
+    steerOptions,
   );
 }

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -369,7 +369,23 @@ function prepareEmbeddedAgentQueueMessage(
 ): PreparedEmbeddedAgentQueueMessage {
   const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
   if (!handle) {
-    const queuedReplyRunMessage = queueReplyRunMessage(sessionId, text);
+    const replyRunQueueOptions =
+      options?.deliveryContext ||
+      options?.inputProvenance ||
+      options?.sourceReplyDeliveryMode ||
+      options?.deliveryTimeoutMs !== undefined
+        ? {
+            ...(options.deliveryContext ? { deliveryContext: options.deliveryContext } : {}),
+            ...(options.inputProvenance ? { inputProvenance: options.inputProvenance } : {}),
+            ...(options.sourceReplyDeliveryMode
+              ? { sourceReplyDeliveryMode: options.sourceReplyDeliveryMode }
+              : {}),
+            ...(options.deliveryTimeoutMs !== undefined
+              ? { deliveryTimeoutMs: options.deliveryTimeoutMs }
+              : {}),
+          }
+        : undefined;
+    const queuedReplyRunMessage = queueReplyRunMessage(sessionId, text, replyRunQueueOptions);
     if (queuedReplyRunMessage) {
       logMessageQueued({ sessionId, source: "embedded-agent-runner" });
       return {

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -24,6 +24,10 @@ import {
 import { resetApiProviders } from "../../llm/providers/register-builtins.js";
 import { cleanupSessionResources } from "../../llm/session-resources.js";
 import { streamSimple } from "../../llm/stream.js";
+import {
+  applyInputProvenanceToUserMessage,
+  type InputProvenance,
+} from "../../sessions/input-provenance.js";
 import type {
   AssistantMessage,
   ImageContent,
@@ -213,6 +217,10 @@ export type AgentSessionEvent =
 /** Listener function for agent session events */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
 export type AgentSessionWriteLockRunner = <T>(run: () => Promise<T> | T) => Promise<T>;
+export type AgentSessionSteerOptions = {
+  images?: ImageContent[];
+  inputProvenance?: InputProvenance;
+};
 
 // ============================================================================
 // Types
@@ -1356,7 +1364,7 @@ export class AgentSession {
    * @param images Optional image attachments to include with the message
    * @throws Error if text is an extension command
    */
-  async steer(text: string, images?: ImageContent[]): Promise<void> {
+  async steer(text: string, imagesOrOptions?: ImageContent[] | AgentSessionSteerOptions): Promise<void> {
     // Check for extension commands (cannot be queued)
     if (text.startsWith("/")) {
       this.throwIfExtensionCommand(text);
@@ -1366,7 +1374,8 @@ export class AgentSession {
     let expandedText = this.expandSkillCommand(text);
     expandedText = expandPromptTemplate(expandedText, [...this.promptTemplates]);
 
-    await this.queueSteer(expandedText, images);
+    const options = Array.isArray(imagesOrOptions) ? { images: imagesOrOptions } : imagesOrOptions;
+    await this.queueSteer(expandedText, options);
   }
 
   /**
@@ -1392,18 +1401,23 @@ export class AgentSession {
   /**
    * Internal: Queue a steering message (already expanded, no extension command check).
    */
-  private async queueSteer(text: string, images?: ImageContent[]): Promise<void> {
+  private async queueSteer(text: string, options?: AgentSessionSteerOptions): Promise<void> {
     this.steeringMessages.push(text);
     this.emitQueueUpdate();
     const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
-    if (images) {
-      content.push(...images);
+    if (options?.images) {
+      content.push(...options.images);
     }
-    this.agent.steer({
-      role: "user",
-      content,
-      timestamp: Date.now(),
-    });
+    this.agent.steer(
+      applyInputProvenanceToUserMessage(
+        {
+          role: "user",
+          content,
+          timestamp: Date.now(),
+        },
+        options?.inputProvenance,
+      ),
+    );
   }
 
   /**

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -24,10 +24,6 @@ import {
 import { resetApiProviders } from "../../llm/providers/register-builtins.js";
 import { cleanupSessionResources } from "../../llm/session-resources.js";
 import { streamSimple } from "../../llm/stream.js";
-import {
-  applyInputProvenanceToUserMessage,
-  type InputProvenance,
-} from "../../sessions/input-provenance.js";
 import type {
   AssistantMessage,
   ImageContent,
@@ -36,6 +32,10 @@ import type {
   TextContent,
 } from "../../llm/types.js";
 import { isContextOverflow } from "../../llm/utils/overflow.js";
+import {
+  applyInputProvenanceToUserMessage,
+  type InputProvenance,
+} from "../../sessions/input-provenance.js";
 import type {
   Agent,
   AgentEvent,
@@ -1191,7 +1191,10 @@ export class AgentSession {
         if (options.streamingBehavior === "followUp") {
           await this.queueFollowUp(expandedText, currentImages);
         } else {
-          await this.queueSteer(expandedText, currentImages);
+          await this.queueSteer(
+            expandedText,
+            currentImages ? { images: currentImages } : undefined,
+          );
         }
         preflightResult?.(true);
         return;
@@ -1364,7 +1367,10 @@ export class AgentSession {
    * @param images Optional image attachments to include with the message
    * @throws Error if text is an extension command
    */
-  async steer(text: string, imagesOrOptions?: ImageContent[] | AgentSessionSteerOptions): Promise<void> {
+  async steer(
+    text: string,
+    imagesOrOptions?: ImageContent[] | AgentSessionSteerOptions,
+  ): Promise<void> {
     // Check for extension commands (cannot be queued)
     if (text.startsWith("/")) {
       this.throwIfExtensionCommand(text);

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -244,6 +244,38 @@ describe("createAgentSession attribution headers", () => {
 });
 
 describe("createAgentSession tool defaults", () => {
+  it("attaches input provenance to queued steering user messages", async () => {
+    const { session } = await createAgentSession({
+      model: testModel,
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    await session.steer("completion from child", {
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:child:run",
+        sourceChannel: "telegram",
+        sourceTool: "subagent_announce",
+      },
+    });
+
+    const queuedMessages = (session.agent as unknown as { steeringQueue: { messages: unknown[] } })
+      .steeringQueue.messages;
+    expect(queuedMessages).toHaveLength(1);
+    expect(queuedMessages[0]).toMatchObject({
+      role: "user",
+      provenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:child:run",
+        sourceChannel: "telegram",
+        sourceTool: "subagent_announce",
+      },
+    });
+  });
+
   it("forwards max thinking budgets from settings to the agent", async () => {
     const { session } = await createAgentSession({
       model: testModel,

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -643,6 +643,12 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
       accountId?: string;
       threadId?: string | number;
     };
+    completionDirectOrigin?: {
+      channel?: string;
+      to?: string;
+      accountId?: string;
+      threadId?: string | number;
+    };
   }) {
     const callGateway = createGatewayMock();
     let activityChecks = 0;
@@ -682,6 +688,7 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
       triggerMessage: "child done",
       steerMessage: "child done",
       requesterOrigin: params.requesterOrigin,
+      completionDirectOrigin: params.completionDirectOrigin,
       requesterIsSubagent: false,
       expectsCompletionMessage: false,
       directIdempotencyKey: "announce-no-external-route",

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -736,6 +736,31 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
     expect(callGateway).not.toHaveBeenCalled();
   });
 
+  it("preserves the requester external route when the completion origin is internal", async () => {
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
+    await deliverSteeredAnnouncement({
+      queueEmbeddedAgentMessageWithOutcome,
+      completionDirectOrigin: {
+        channel: "webchat",
+        to: "session:child-completion",
+        accountId: "webchat-account",
+      },
+      requesterOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "171.222",
+      },
+    });
+
+    const options = mockCallArg(queueEmbeddedAgentMessageWithOutcome, 0, 2);
+    expect(options.inputProvenance).toEqual({
+      kind: "inter_session",
+      sourceChannel: "webchat",
+      sourceTool: "subagent_announce",
+    });
+  });
+
   it.each(["followup", "collect", "interrupt"] as const)(
     "steers active requester announces even in %s mode",
     async (mode) => {
@@ -790,6 +815,11 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
         debounceMs: 0,
         waitForTranscriptCommit: true,
         deliveryTimeoutMs: 120_000,
+        inputProvenance: {
+          kind: "inter_session",
+          sourceChannel: "webchat",
+          sourceTool: "subagent_announce",
+        },
       },
     );
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenNthCalledWith(
@@ -800,6 +830,11 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
         steeringMode: "all",
         debounceMs: 0,
         deliveryTimeoutMs: 120_000,
+        inputProvenance: {
+          kind: "inter_session",
+          sourceChannel: "webchat",
+          sourceTool: "subagent_announce",
+        },
       },
     );
   });
@@ -1090,6 +1125,11 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         debounceMs: 500,
         waitForTranscriptCommit: true,
         deliveryTimeoutMs: 120_000,
+        inputProvenance: {
+          kind: "inter_session",
+          sourceChannel: "webchat",
+          sourceTool: "subagent_announce",
+        },
       },
     );
     expect(callGateway).not.toHaveBeenCalled();
@@ -2139,6 +2179,11 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         deliveryTimeoutMs: 120_000,
         steeringMode: "all",
         waitForTranscriptCommit: true,
+        inputProvenance: {
+          kind: "inter_session",
+          sourceChannel: "webchat",
+          sourceTool: "subagent_announce",
+        },
       },
     );
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenNthCalledWith(
@@ -2149,6 +2194,11 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         debounceMs: 500,
         deliveryTimeoutMs: 120_000,
         steeringMode: "all",
+        inputProvenance: {
+          kind: "inter_session",
+          sourceChannel: "webchat",
+          sourceTool: "subagent_announce",
+        },
       },
     );
     expect(sendMessage).not.toHaveBeenCalled();
@@ -2378,6 +2428,11 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         debounceMs: 500,
         waitForTranscriptCommit: true,
         deliveryTimeoutMs: 10,
+        inputProvenance: {
+          kind: "inter_session",
+          sourceChannel: "webchat",
+          sourceTool: "subagent_announce",
+        },
       },
     );
     expect(callGateway).toHaveBeenCalledTimes(1);
@@ -3986,6 +4041,11 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         debounceMs: 500,
         waitForTranscriptCommit: true,
         deliveryTimeoutMs: 120_000,
+        inputProvenance: {
+          kind: "inter_session",
+          sourceChannel: "webchat",
+          sourceTool: "video_generate",
+        },
       },
     );
     expect(callGateway).not.toHaveBeenCalled();

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -24,6 +24,7 @@ import { defaultRuntime } from "../runtime.js";
 import {
   isAgentMediatedCompletionSourceTool,
   shouldPreserveUserFacingSessionStateForInputProvenance,
+  type InputProvenance,
 } from "../sessions/input-provenance.js";
 import { deriveSessionChatTypeFromKey } from "../sessions/session-chat-type-shared.js";
 import { isCronRunSessionKey, isCronSessionKey } from "../sessions/session-key-utils.js";
@@ -609,6 +610,7 @@ export function loadSessionEntryByKey(sessionKey: string) {
 
 async function maybeSteerSubagentAnnounce(params: {
   deliveryTimeoutMs?: number;
+  inputProvenance?: InputProvenance;
   requesterSessionKey: string;
   steerMessage: string;
   signal?: AbortSignal;
@@ -638,6 +640,7 @@ async function maybeSteerSubagentAnnounce(params: {
   // Queue modes such as followup/collect apply to user prompts, not this path.
   const queueOptions: EmbeddedAgentQueueMessageOptions = {
     deliveryTimeoutMs: params.deliveryTimeoutMs,
+    ...(params.inputProvenance ? { inputProvenance: params.inputProvenance } : {}),
     steeringMode: "all",
     ...(queueSettings.debounceMs !== undefined ? { debounceMs: queueSettings.debounceMs } : {}),
     waitForTranscriptCommit: true,
@@ -1400,8 +1403,15 @@ async function sendSubagentAnnounceDirectly(params: {
       requesterActivity.sessionId &&
       requesterActivity.isActive
     ) {
+      const wakeInputProvenance: InputProvenance = {
+        kind: "inter_session",
+        ...(params.sourceSessionKey ? { sourceSessionKey: params.sourceSessionKey } : {}),
+        sourceChannel: params.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
+        sourceTool: params.sourceTool ?? "subagent_announce",
+      };
       const wakeOptions: EmbeddedAgentQueueMessageOptions = {
         deliveryTimeoutMs: announceTimeoutMs,
+        inputProvenance: wakeInputProvenance,
         steeringMode: "all",
         ...(completionSourceReplyDeliveryMode
           ? { sourceReplyDeliveryMode: completionSourceReplyDeliveryMode }
@@ -1732,6 +1742,12 @@ export async function deliverSubagentAnnouncement(params: {
         deliveryTimeoutMs: resolveSubagentAnnounceTimeoutMs(
           subagentAnnounceDeliveryDeps.getRuntimeConfig(),
         ),
+        inputProvenance: {
+          kind: "inter_session",
+          ...(params.sourceSessionKey ? { sourceSessionKey: params.sourceSessionKey } : {}),
+          sourceChannel: params.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
+          sourceTool: params.sourceTool ?? "subagent_announce",
+        },
         requesterSessionKey: params.requesterSessionKey,
         steerMessage: params.steerMessage,
         signal: params.signal,

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -7,6 +7,9 @@ import {
 } from "../../logging/diagnostic-run-activity.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { resolveTimerTimeoutMs } from "../../shared/number-coercion.js";
+import type { InputProvenance } from "../../sessions/input-provenance.js";
+import type { DeliveryContext } from "../../utils/delivery-context.shared.js";
+import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 import type { ReplyFollowupAdmissionBarrierTimeoutPolicy } from "./reply-dispatcher.types.js";
 
 export type ReplyRunKey = string;
@@ -15,11 +18,19 @@ export type ReplyBackendKind = "embedded" | "cli";
 
 export type ReplyBackendCancelReason = "user_abort" | "restart" | "superseded";
 
+export type ReplyRunQueueMessageOptions = {
+  deliveryContext?: DeliveryContext;
+  deliveryTimeoutMs?: number;
+  inputProvenance?: InputProvenance;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  waitForTranscriptCommit?: boolean;
+};
+
 export type ReplyBackendHandle = {
   readonly kind: ReplyBackendKind;
   cancel(reason?: ReplyBackendCancelReason): void;
   isStreaming(): boolean;
-  queueMessage?: (text: string) => Promise<void>;
+  queueMessage?: (text: string, options?: ReplyRunQueueMessageOptions) => Promise<void>;
   /**
    * Compatibility-only hook so legacy "abort compacting runs" paths can still
    * find embedded runs that are compacting during the main run phase.
@@ -704,7 +715,11 @@ export function isReplyRunStreamingForSessionId(sessionId: string): boolean {
   return getAttachedBackend(operation)?.isStreaming() ?? false;
 }
 
-export function queueReplyRunMessage(sessionId: string, text: string): boolean {
+export function queueReplyRunMessage(
+  sessionId: string,
+  text: string,
+  options?: ReplyRunQueueMessageOptions,
+): boolean {
   const operation = resolveReplyRunForCurrentSessionId(sessionId);
   const backend = operation ? getAttachedBackend(operation) : undefined;
   if (!operation || operation.phase !== "running" || !backend?.queueMessage) {
@@ -713,7 +728,11 @@ export function queueReplyRunMessage(sessionId: string, text: string): boolean {
   if (!backend.isStreaming()) {
     return false;
   }
-  void backend.queueMessage(text);
+  if (options) {
+    void backend.queueMessage(text, options);
+  } else {
+    void backend.queueMessage(text);
+  }
   return true;
 }
 


### PR DESCRIPTION
## Summary

Refs #91356, #91330, #91333.

Carry typed `inputProvenance` through active subagent wake steering so resumed requester turns keep an explicit inter-session provenance signal instead of arriving as untyped queued messages.

This is intentionally narrower than the closed #91333 approach. It does not suppress automatic-mode finals based on ordinary `message(action="send")` receipts, and it does not infer terminal source-reply ownership from `messageId`, target matching, or prose.

## Why

The maintainer feedback on #91330/#91333 clarified the unsafe boundary: a successful send proves delivery, but it does not prove that the send was the terminal source reply. That replacement needs an explicit terminal-source-reply contract and thread identity; this PR does not attempt that.

This patch only handles the active wake side: when a subagent completion wakes an active requester session, the runtime already knows this is an inter-session wake. The queued steering message should carry that typed provenance through the active run / reply-run bridge so downstream routing and final-selection logic can reason from explicit metadata instead of an untyped internal wake.

## Changes

- Add active-session steering options for `inputProvenance`.
- Preserve the existing `AgentSession.steer(text, images)` call shape while allowing `steer(text, { images, inputProvenance })`.
- Apply provenance to queued steering user messages with `applyInputProvenanceToUserMessage`.
- Carry queue options through reply-run fallback queueing without changing the legacy no-options call shape.
- Pass `subagent_announce` / completion provenance through active requester wake queue options.
- Add regression coverage for active wake, retry/best-effort, stale-thread handoff, generated-media wake, and reply-run fallback paths.

## Real behavior proof

Behavior or issue addressed: active subagent completion wakes could cross the requester-session boundary as untyped steering messages, even though the runtime already knows the wake is an inter-session `subagent_announce`/completion handoff.

Real environment tested: local OpenClaw source checkout at PR head `c0d4598971eb73a7d6b0787fa3b0cb09b21bb592` on branch `agent/xiaozhua/active-wake-provenance-clean`. The after-fix runtime proof used a temporary OpenClaw test state/config on macOS with channels/cron/browser/canvas disabled and exercised the real `deliverSubagentAnnouncement` active-wake dispatch path. The final queue sink was instrumented only to capture the active embedded-run queue options, so no private channel, model, or credential was required.

Exact steps or command run after this patch:

```bash
# Runtime trace from the PR head; temporary proof script only, not committed.
OPENCLAW_PROOF_HEAD=$(git rev-parse HEAD)   node --import tsx .artifacts/pr-proof/pr92251-runtime-proof.mjs | tee /tmp/pr92251-runtime-proof.out

# Focused regression and CI-style gates run locally on the same PR head.
git diff --check
NODE_OPTIONS=--max-old-space-size=8192 pnpm tsgo:prod
NODE_OPTIONS=--max-old-space-size=8192 pnpm check:test-types
NODE_OPTIONS=--max-old-space-size=8192 pnpm run test:extensions:package-boundary:compile
pnpm run lint:extensions:bundled
```

Evidence after fix:

```text
PR_92251_ACTIVE_WAKE_RUNTIME_PROOF_BEGIN
{
  "command": "node --import tsx .artifacts/pr-proof/pr92251-runtime-proof.mjs",
  "gitHead": "c0d4598971eb73a7d6b0787fa3b0cb09b21bb592",
  "stateLabel": "pr-92251-active-wake-proof",
  "workspaceBasename": "workspace",
  "result": {
    "delivered": true,
    "path": "steered",
    "deliveredAt": 1765460000100,
    "enqueuedAt": 1765460000000,
    "phases": [
      {
        "phase": "steer-primary",
        "delivered": true,
        "path": "steered",
        "deliveredAt": 1765460000100,
        "enqueuedAt": 1765460000000
      }
    ]
  },
  "queueCallCount": 1,
  "queueCall": {
    "sessionId": "runtime-proof-active-session",
    "text": "redacted child completion payload",
    "options": {
      "deliveryTimeoutMs": 120000,
      "inputProvenance": {
        "kind": "inter_session",
        "sourceSessionKey": "agent:subagent:redacted-child",
        "sourceChannel": "webchat",
        "sourceTool": "subagent_announce"
      },
      "steeringMode": "all",
      "debounceMs": 0,
      "waitForTranscriptCommit": true
    }
  }
}
PR_92251_ACTIVE_WAKE_RUNTIME_PROOF_END
```

Additional local gate evidence from the same PR head:

```text
git diff --check: passed
pnpm tsgo:prod: passed
pnpm check:test-types: passed
pnpm run test:extensions:package-boundary:compile: passed
pnpm run lint:extensions:bundled: Found 0 warnings and 0 errors on 5904 files
```

Observed result after fix: the active requester wake stayed on the `steered` path and queued exactly one active embedded-run message. The captured queue options include explicit `inputProvenance` with `kind: "inter_session"`, `sourceSessionKey: "agent:subagent:redacted-child"`, `sourceChannel: "webchat"`, and `sourceTool: "subagent_announce"`, plus `steeringMode: "all"` and `waitForTranscriptCommit: true`. This shows the runtime handoff now carries provenance through the active wake boundary instead of sending an untyped steering message.

What was not tested: no live Telegram/Slack/bncr end-to-end run was performed on this machine because Docker is not installed here and no provider API env vars are present in the shell (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY` absent). #91356 was closed as not reproducible in current core, so this PR remains framed as route/provenance boundary hardening rather than a claimed live-channel product fix.
