### PR TITLE
docs: interpolate ClawHub npm release tag

### DIFF
--- a/scripts/docs-sync-publish.mjs
+++ b/scripts/docs-sync-publish.mjs
@@ -14,6 +14,7 @@ const SOURCE_CONFIG_PATH = path.join(SOURCE_DOCS_DIR, "docs.json");
 const INTERNAL_DOCS_DIRS = ["internal"];
 const DEFAULT_CLAWHUB_SOURCE_REPO = "openclaw/clawhub";
 const CLAWHUB_DOCS_TARGET_DIR = "clawhub";
+const CLAWHUB_NPM_RELEASE_TAG_TOKEN = "{{CLAWHUB_NPM_RELEASE_TAG}}";
 const CLAWHUB_REPO_ENV = "OPENCLAW_DOCS_SYNC_CLAWHUB_REPO";
 const DEFAULT_CLAWHUB_REPO_CANDIDATES = [
   path.resolve(ROOT, "..", "clawhub-docs-clawhub"),
@@ -288,6 +289,18 @@ function walkMarkdownFiles(entryPath, out = []) {
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function resolveClawHubNpmReleaseTag(repoPath) {
+  const packageJsonPath = path.join(repoPath, "packages", "clawhub", "package.json");
+  const packageJson = readJson(packageJsonPath);
+  const version = String(packageJson.version ?? "").trim();
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(
+      `ClawHub package version must be stable semver in ${packageJsonPath}; found "${version || "<missing>"}"`,
+    );
+  }
+  return `v${version}`;
 }
 
 function writeJson(filePath, value) {
@@ -591,6 +604,10 @@ function rewriteClawHubMarkdownLinks(raw, relativeSourcePath, source) {
   });
 }
 
+function interpolateClawHubDocsVariables(raw, variables) {
+  return raw.replaceAll(CLAWHUB_NPM_RELEASE_TAG_TOKEN, variables.npmReleaseTag);
+}
+
 /**
  * Mirrors ClawHub docs into the target docs tree.
  */
@@ -613,6 +630,7 @@ export function syncClawHubDocsTree(targetDocsDir, options = {}) {
     repository: options.sourceRepo || DEFAULT_CLAWHUB_SOURCE_REPO,
     sha: options.sourceSha || getGitHeadSha(repoPath),
   };
+  const npmReleaseTag = resolveClawHubNpmReleaseTag(repoPath);
 
   fs.rmSync(targetDir, { recursive: true, force: true });
   ensureDir(targetDir);
@@ -633,9 +651,10 @@ export function syncClawHubDocsTree(targetDocsDir, options = {}) {
 
     if (/\.mdx?$/iu.test(sourcePath)) {
       const raw = fs.readFileSync(sourcePath, "utf8");
+      const interpolated = interpolateClawHubDocsVariables(raw, { npmReleaseTag });
       fs.writeFileSync(
         targetPath,
-        rewriteClawHubMarkdownLinks(raw, relativeSourcePath, source),
+        rewriteClawHubMarkdownLinks(interpolated, relativeSourcePath, source),
         "utf8",
       );
     } else {
@@ -649,6 +668,7 @@ export function syncClawHubDocsTree(targetDocsDir, options = {}) {
     ...source,
     path: repoPath,
     files: copied,
+    npmReleaseTag,
   };
 }
 

--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -1,5 +1,9 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { parseArgs } from "../../scripts/docs-sync-publish.mjs";
+import { parseArgs, syncClawHubDocsTree } from "../../scripts/docs-sync-publish.mjs";
 
 describe("docs-sync-publish", () => {
   it("parses docs sync provenance args", () => {
@@ -42,5 +46,42 @@ describe("docs-sync-publish", () => {
         `${flag} requires a value`,
       );
     }
+  });
+
+  it("interpolates the ClawHub npm release tag from the ClawHub package version", () => {
+    const root = mkdtempSync(join(tmpdir(), "docs-sync-clawhub-"));
+    const clawhubRepo = join(root, "clawhub");
+    const targetDocs = join(root, "target-docs");
+
+    mkdirSync(join(clawhubRepo, "docs"), { recursive: true });
+    mkdirSync(join(clawhubRepo, "packages", "clawhub"), { recursive: true });
+    mkdirSync(targetDocs, { recursive: true });
+
+    writeFileSync(
+      join(clawhubRepo, "packages", "clawhub", "package.json"),
+      `${JSON.stringify({ version: "0.20.3" }, null, 2)}\n`,
+    );
+    writeFileSync(
+      join(clawhubRepo, "docs", "cli.md"),
+      [
+        "# CLI",
+        "",
+        "```yaml",
+        "uses: openclaw/clawhub/.github/workflows/package-publish.yml@{{CLAWHUB_NPM_RELEASE_TAG}}",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = syncClawHubDocsTree(targetDocs, {
+      repoPath: clawhubRepo,
+      sourceRepo: "openclaw/clawhub",
+      sourceSha: "abc123",
+    });
+
+    expect(result.npmReleaseTag).toBe("v0.20.3");
+    expect(readFileSync(join(targetDocs, "clawhub", "cli.md"), "utf8")).toContain(
+      "package-publish.yml@v0.20.3",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- interpolate `{{CLAWHUB_NPM_RELEASE_TAG}}` while syncing ClawHub docs into OpenClaw docs
- derive the tag from `packages/clawhub/package.json` as `v<version>`
- cover the sync behavior with a docs sync test

## Tests

- direct sync smoke against a temp ClawHub repo fixture
- `pnpm exec oxfmt --check scripts/docs-sync-publish.mjs test/scripts/docs-sync-publish.test.ts`
- `git diff --check -- scripts/docs-sync-publish.mjs test/scripts/docs-sync-publish.test.ts`
