### PR TITLE
fix(model-picker): preserve auth profile override when selecting a model

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-d991fae868626a78a65ea66389f3d62a48479fe6af3bb2db71a22802aa41ceea  plugin-sdk-api-baseline.json
-4aa4f623cfc221bca16c00995cd278b15d1706aac074d8016d14e97e1d9423f7  plugin-sdk-api-baseline.jsonl
+1f7eb3a01ca546dc8712ce95e5a03c8713c1d7b7ff42c87aaa7ddb90235f4657  plugin-sdk-api-baseline.json
+b9b6f597e4f3afc88f69c1c1fea71b7dbbbcd511890d8328590d45f039321fc1  plugin-sdk-api-baseline.jsonl

--- a/extensions/discord/src/monitor/native-command-model-picker-apply.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-apply.ts
@@ -1,8 +1,12 @@
 // Discord plugin module implements native command model picker apply behavior.
 import { randomUUID } from "node:crypto";
+import { loadAuthProfileStoreForRuntime, resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import type { ChatCommandDefinition, CommandArgs } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { applyModelOverrideToSessionEntry } from "openclaw/plugin-sdk/model-session-runtime";
+import {
+  applyModelOverrideToSessionEntry,
+  shouldPreserveCompatibleAuthProfileOverride,
+} from "openclaw/plugin-sdk/model-session-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import {
@@ -34,12 +38,33 @@ type DiscordModelPickerApplyResult =
   | { status: "timeout"; noticeMessage: string }
   | { status: "failed"; noticeMessage: string };
 
+function resolveStoredAuthProfileProvider(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  entry: { authProfileOverride?: string };
+}): string | undefined {
+  const profileId = params.entry.authProfileOverride?.trim();
+  if (!profileId) {
+    return undefined;
+  }
+  try {
+    const agentDir = resolveAgentDir(params.cfg, params.agentId);
+    return loadAuthProfileStoreForRuntime(agentDir, {
+      readOnly: true,
+      allowKeychainPrompt: false,
+    }).profiles[profileId]?.provider;
+  } catch {
+    return undefined;
+  }
+}
+
 async function persistDiscordModelPickerOverride(params: {
   cfg: OpenClawConfig;
   route: ResolvedAgentRoute;
   provider: string;
   model: string;
   isDefault: boolean;
+  defaultProvider: string;
   runtime?: string;
 }): Promise<boolean> {
   const storePath = resolveStorePath(params.cfg.session?.store, {
@@ -64,6 +89,18 @@ async function persistDiscordModelPickerOverride(params: {
             isDefault: params.isDefault,
           },
           markLiveSwitchPending: true,
+          preserveAuthProfileOverride: shouldPreserveCompatibleAuthProfileOverride({
+            cfg: params.cfg,
+            entry,
+            currentProvider:
+              entry.providerOverride ?? entry.modelProvider ?? params.defaultProvider,
+            provider: params.provider,
+            storedAuthProfileProvider: resolveStoredAuthProfileProvider({
+              cfg: params.cfg,
+              agentId: params.route.agentId,
+              entry,
+            }),
+          }),
         }).updated || persisted;
       const runtime = params.runtime?.trim();
       if (runtime && runtime !== "auto" && runtime !== "default") {
@@ -87,10 +124,30 @@ async function persistDiscordModelPickerOverride(params: {
 // hidden /model dispatch routes through the shared directive path, which clears
 // authProfileOverride for a profile-less selection. Capture the override owned
 // by another source (CLI flag, session-level) so the picker can re-apply it.
-function captureAuthProfileOverride(cfg: OpenClawConfig, route: ResolvedAgentRoute) {
-  const storePath = resolveStorePath(cfg.session?.store, { agentId: route.agentId });
-  const entry = loadSessionStore(storePath, { skipCache: true })[route.sessionKey];
-  if (!entry?.authProfileOverride) {
+function captureAuthProfileOverride(params: {
+  cfg: OpenClawConfig;
+  route: ResolvedAgentRoute;
+  selectedProvider: string;
+  defaultProvider: string;
+}) {
+  const storePath = resolveStorePath(params.cfg.session?.store, {
+    agentId: params.route.agentId,
+  });
+  const entry = loadSessionStore(storePath, { skipCache: true })[params.route.sessionKey];
+  if (
+    !entry?.authProfileOverride ||
+    !shouldPreserveCompatibleAuthProfileOverride({
+      cfg: params.cfg,
+      entry,
+      currentProvider: entry.providerOverride ?? entry.modelProvider ?? params.defaultProvider,
+      provider: params.selectedProvider,
+      storedAuthProfileProvider: resolveStoredAuthProfileProvider({
+        cfg: params.cfg,
+        agentId: params.route.agentId,
+        entry,
+      }),
+    })
+  ) {
     return undefined;
   }
   return {
@@ -139,7 +196,12 @@ export async function applyDiscordModelPickerSelection(params: {
   settleMs: number;
   resolveCurrentModel: (route: ResolvedAgentRoute) => string;
 }): Promise<DiscordModelPickerApplyResult> {
-  const preservedAuthProfile = captureAuthProfileOverride(params.cfg, params.route);
+  const preservedAuthProfile = captureAuthProfileOverride({
+    cfg: params.cfg,
+    route: params.route,
+    selectedProvider: params.selectedProvider,
+    defaultProvider: params.defaultProvider,
+  });
   try {
     const dispatchResult = await withTimeout(
       params.dispatchCommandInteraction({
@@ -182,6 +244,7 @@ export async function applyDiscordModelPickerSelection(params: {
         isDefault:
           params.selectedProvider === params.defaultProvider &&
           params.selectedModel === params.defaultModel,
+        defaultProvider: params.defaultProvider,
         runtime: params.selectedRuntime,
       });
       await new Promise((resolve) => {
@@ -204,6 +267,7 @@ export async function applyDiscordModelPickerSelection(params: {
           isDefault:
             params.selectedProvider === params.defaultProvider &&
             params.selectedModel === params.defaultModel,
+          defaultProvider: params.defaultProvider,
           runtime: params.selectedRuntime,
         });
         await new Promise((resolve) => {

--- a/extensions/discord/src/monitor/native-command-model-picker-apply.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-apply.ts
@@ -5,7 +5,11 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { applyModelOverrideToSessionEntry } from "openclaw/plugin-sdk/model-session-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { patchSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  loadSessionStore,
+  patchSessionEntry,
+  resolveStorePath,
+} from "openclaw/plugin-sdk/session-store-runtime";
 import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ButtonInteraction, StringSelectMenuInteraction } from "../internal/discord.js";
 import {
@@ -79,6 +83,42 @@ async function persistDiscordModelPickerOverride(params: {
   return persisted;
 }
 
+// The model picker only selects a model; it never owns an auth profile. The
+// hidden /model dispatch routes through the shared directive path, which clears
+// authProfileOverride for a profile-less selection. Capture the override owned
+// by another source (CLI flag, session-level) so the picker can re-apply it.
+function captureAuthProfileOverride(cfg: OpenClawConfig, route: ResolvedAgentRoute) {
+  const storePath = resolveStorePath(cfg.session?.store, { agentId: route.agentId });
+  const entry = loadSessionStore(storePath, { skipCache: true })[route.sessionKey];
+  if (!entry?.authProfileOverride) {
+    return undefined;
+  }
+  return {
+    authProfileOverride: entry.authProfileOverride,
+    authProfileOverrideSource: entry.authProfileOverrideSource,
+    authProfileOverrideCompactionCount: entry.authProfileOverrideCompactionCount,
+  };
+}
+
+async function restoreAuthProfileOverride(
+  cfg: OpenClawConfig,
+  route: ResolvedAgentRoute,
+  preserved: NonNullable<ReturnType<typeof captureAuthProfileOverride>>,
+): Promise<void> {
+  const storePath = resolveStorePath(cfg.session?.store, { agentId: route.agentId });
+  await patchSessionEntry({
+    storePath,
+    sessionKey: route.sessionKey,
+    update: (entry) => {
+      // Re-apply only when the selection cleared it; intact override is a no-op.
+      if (entry.authProfileOverride === preserved.authProfileOverride) {
+        return null;
+      }
+      return preserved;
+    },
+  });
+}
+
 export async function applyDiscordModelPickerSelection(params: {
   interaction: ButtonInteraction | StringSelectMenuInteraction;
   selectionCommand: DiscordModelPickerSelectionCommand;
@@ -99,6 +139,7 @@ export async function applyDiscordModelPickerSelection(params: {
   settleMs: number;
   resolveCurrentModel: (route: ResolvedAgentRoute) => string;
 }): Promise<DiscordModelPickerApplyResult> {
+  const preservedAuthProfile = captureAuthProfileOverride(params.cfg, params.route);
   try {
     const dispatchResult = await withTimeout(
       params.dispatchCommandInteraction({
@@ -217,5 +258,12 @@ export async function applyDiscordModelPickerSelection(params: {
       status: "failed",
       noticeMessage: `❌ Failed to apply ${params.resolvedModelRef}. Try /model ${params.resolvedModelRef} directly.`,
     };
+  } finally {
+    // A model switch must never destroy an auth profile override the picker
+    // does not own, regardless of which apply path (hidden dispatch or direct
+    // persist) ran or whether it succeeded.
+    if (preservedAuthProfile) {
+      await restoreAuthProfileOverride(params.cfg, params.route, preservedAuthProfile);
+    }
   }
 }

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { ChannelType } from "discord-api-types/v10";
+import { resolveAgentDir, saveAuthProfileStore } from "openclaw/plugin-sdk/agent-runtime";
 import * as commandRegistryModule from "openclaw/plugin-sdk/command-auth-native";
 import type {
   ChatCommandDefinition,
@@ -72,6 +73,9 @@ function createModelPickerContext(): ModelPickerContext {
           policy: "open",
         },
       },
+    },
+    agents: {
+      list: [{ id: "worker", agentDir: path.join(tempDir, "worker-agent") }],
     },
   } as unknown as OpenClawConfig;
 
@@ -1028,7 +1032,13 @@ describe("Discord model picker interactions", () => {
     return { context, storePath };
   }
 
-  async function seedCliAuthProfileOverride(storePath: string) {
+  async function seedCliAuthProfileOverride(
+    storePath: string,
+    overrides: {
+      providerOverride?: string;
+      authProfileOverride?: string;
+    } = {},
+  ) {
     // An auth profile override established by a non-picker source (e.g. a CLI flag).
     await upsertSessionEntry({
       storePath,
@@ -1036,10 +1046,27 @@ describe("Discord model picker interactions", () => {
       entry: {
         updatedAt: Date.now(),
         sessionId: "bound-session",
-        authProfileOverride: "cli-profile",
+        authProfileOverride: overrides.authProfileOverride ?? "lmstudio:cli-profile",
         authProfileOverrideSource: "user",
+        ...(overrides.providerOverride ? { providerOverride: overrides.providerOverride } : {}),
       },
     });
+  }
+
+  function seedStoredAuthProfileProvider(
+    context: ModelPickerContext,
+    profileId: string,
+    provider: string,
+  ) {
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: { type: "api_key", provider, key: "sk-test" },
+        },
+      },
+      resolveAgentDir(context.cfg, "worker"),
+    );
   }
 
   async function runBoundPickerSubmit(
@@ -1065,7 +1092,7 @@ describe("Discord model picker interactions", () => {
     const entry = loadSessionStore(storePath, { skipCache: true })["agent:worker:subagent:bound"];
     expect(entry?.providerOverride).toBe("lmstudio");
     // The picker selected a model only; the unrelated auth profile override survives.
-    expect(entry?.authProfileOverride).toBe("cli-profile");
+    expect(entry?.authProfileOverride).toBe("lmstudio:cli-profile");
     expect(entry?.authProfileOverrideSource).toBe("user");
   });
 
@@ -1095,7 +1122,82 @@ describe("Discord model picker interactions", () => {
 
     const entry = loadSessionStore(storePath, { skipCache: true })["agent:worker:subagent:bound"];
     expect(entry?.providerOverride).toBe("lmstudio");
-    expect(entry?.authProfileOverride).toBe("cli-profile");
+    expect(entry?.authProfileOverride).toBe("lmstudio:cli-profile");
+    expect(entry?.authProfileOverrideSource).toBe("user");
+  });
+
+  it("does not restore an auth profile override for a different provider", async () => {
+    const { context, storePath } = seedBoundPickerContext();
+    await seedCliAuthProfileOverride(storePath, {
+      providerOverride: "anthropic",
+      authProfileOverride: "anthropic:default",
+    });
+
+    const dispatchSpy = vi.fn<DispatchDiscordCommandInteraction>().mockImplementation(async () => {
+      await upsertSessionEntry({
+        storePath,
+        sessionKey: "agent:worker:subagent:bound",
+        entry: {
+          updatedAt: Date.now(),
+          sessionId: "bound-session",
+          providerOverride: "lmstudio",
+          modelOverride: "unsloth/gemma-4-26b-a4b-it@iq4_xs",
+        },
+      });
+      return { accepted: true };
+    });
+
+    await runBoundPickerSubmit(context, dispatchSpy);
+
+    const entry = loadSessionStore(storePath, { skipCache: true })["agent:worker:subagent:bound"];
+    expect(entry?.providerOverride).toBe("lmstudio");
+    expect(entry?.authProfileOverride).toBeUndefined();
+    expect(entry?.authProfileOverrideSource).toBeUndefined();
+  });
+
+  it("clears an unprefixed auth profile override when picking a different provider", async () => {
+    const { context, storePath } = seedBoundPickerContext();
+    await seedCliAuthProfileOverride(storePath, {
+      providerOverride: "anthropic",
+      authProfileOverride: "work",
+    });
+
+    await runBoundPickerSubmit(context, createDispatchSpy());
+
+    const entry = loadSessionStore(storePath, { skipCache: true })["agent:worker:subagent:bound"];
+    expect(entry?.providerOverride).toBe("lmstudio");
+    expect(entry?.authProfileOverride).toBeUndefined();
+    expect(entry?.authProfileOverrideSource).toBeUndefined();
+  });
+
+  it("preserves an unprefixed auth profile override when the current provider matches", async () => {
+    const { context, storePath } = seedBoundPickerContext();
+    await seedCliAuthProfileOverride(storePath, {
+      providerOverride: "lmstudio",
+      authProfileOverride: "work",
+    });
+
+    await runBoundPickerSubmit(context, createDispatchSpy());
+
+    const entry = loadSessionStore(storePath, { skipCache: true })["agent:worker:subagent:bound"];
+    expect(entry?.providerOverride).toBe("lmstudio");
+    expect(entry?.authProfileOverride).toBe("work");
+    expect(entry?.authProfileOverrideSource).toBe("user");
+  });
+
+  it("preserves a store-only colon auth profile id when the stored provider matches", async () => {
+    const { context, storePath } = seedBoundPickerContext();
+    seedStoredAuthProfileProvider(context, "team:prod", "lmstudio");
+    await seedCliAuthProfileOverride(storePath, {
+      providerOverride: "anthropic",
+      authProfileOverride: "team:prod",
+    });
+
+    await runBoundPickerSubmit(context, createDispatchSpy());
+
+    const entry = loadSessionStore(storePath, { skipCache: true })["agent:worker:subagent:bound"];
+    expect(entry?.providerOverride).toBe("lmstudio");
+    expect(entry?.authProfileOverride).toBe("team:prod");
     expect(entry?.authProfileOverrideSource).toBe("user");
   });
 });

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -1009,4 +1009,93 @@ describe("Discord model picker interactions", () => {
     expect(payload).toContain(";a=back;v=providers;");
     expect(payload).toContain(";pb=");
   });
+
+  function seedBoundPickerContext() {
+    const context = createModelPickerContext();
+    context.threadBindings = createBoundThreadBindingManager({
+      accountId: "default",
+      threadId: "thread-bound",
+      targetSessionKey: "agent:worker:subagent:bound",
+      agentId: "worker",
+    });
+    const pickerData = createModelsProviderData({
+      anthropic: ["claude-sonnet-4-5"],
+      lmstudio: ["unsloth/gemma-4-26b-a4b-it@iq4_xs"],
+    });
+    const storePath = resolveStorePath(context.cfg.session?.store, { agentId: "worker" });
+    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
+    mockModelCommandPipeline(createModelCommandDefinition());
+    return { context, storePath };
+  }
+
+  async function seedCliAuthProfileOverride(storePath: string) {
+    // An auth profile override established by a non-picker source (e.g. a CLI flag).
+    await upsertSessionEntry({
+      storePath,
+      sessionKey: "agent:worker:subagent:bound",
+      entry: {
+        updatedAt: Date.now(),
+        sessionId: "bound-session",
+        authProfileOverride: "cli-profile",
+        authProfileOverrideSource: "user",
+      },
+    });
+  }
+
+  async function runBoundPickerSubmit(
+    context: ModelPickerContext,
+    dispatchCommandInteraction: DispatchDiscordCommandInteraction,
+  ) {
+    const button = createModelPickerFallbackButton(context, dispatchCommandInteraction);
+    const submitInteraction = createInteraction({ userId: "owner" });
+    submitInteraction.channel = { type: ChannelType.PublicThread, id: "thread-bound" };
+    await button.run(submitInteraction as unknown as PickerButtonInteraction, {
+      ...createModelsViewSubmitData(),
+      p: "lmstudio",
+      mi: "1",
+    });
+  }
+
+  it("preserves an auth profile override set by another source when picking a model", async () => {
+    const { context, storePath } = seedBoundPickerContext();
+    await seedCliAuthProfileOverride(storePath);
+
+    await runBoundPickerSubmit(context, createDispatchSpy());
+
+    const entry = loadSessionStore(storePath, { skipCache: true })["agent:worker:subagent:bound"];
+    expect(entry?.providerOverride).toBe("lmstudio");
+    // The picker selected a model only; the unrelated auth profile override survives.
+    expect(entry?.authProfileOverride).toBe("cli-profile");
+    expect(entry?.authProfileOverrideSource).toBe("user");
+  });
+
+  it("restores an auth profile override cleared by the hidden /model dispatch", async () => {
+    const { context, storePath } = seedBoundPickerContext();
+    await seedCliAuthProfileOverride(storePath);
+
+    // The hidden /model dispatch applies the model and, for a profile-less
+    // selection, clears the auth profile override via the shared directive path.
+    // This is the picker's primary persistence path, so the fallback persist is
+    // never reached and only the picker-level restore can save the override.
+    const dispatchSpy = vi.fn<DispatchDiscordCommandInteraction>().mockImplementation(async () => {
+      await upsertSessionEntry({
+        storePath,
+        sessionKey: "agent:worker:subagent:bound",
+        entry: {
+          updatedAt: Date.now(),
+          sessionId: "bound-session",
+          providerOverride: "lmstudio",
+          modelOverride: "unsloth/gemma-4-26b-a4b-it@iq4_xs",
+        },
+      });
+      return { accepted: true };
+    });
+
+    await runBoundPickerSubmit(context, dispatchSpy);
+
+    const entry = loadSessionStore(storePath, { skipCache: true })["agent:worker:subagent:bound"];
+    expect(entry?.providerOverride).toBe("lmstudio");
+    expect(entry?.authProfileOverride).toBe("cli-profile");
+    expect(entry?.authProfileOverrideSource).toBe("user");
+  });
 });

--- a/extensions/discord/src/monitor/native-command.options.test.ts
+++ b/extensions/discord/src/monitor/native-command.options.test.ts
@@ -31,9 +31,15 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
   };
 });
 
-vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
-  resolveHumanDelayConfig: () => undefined,
-}));
+vi.mock("openclaw/plugin-sdk/agent-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/agent-runtime")>(
+    "openclaw/plugin-sdk/agent-runtime",
+  );
+  return {
+    ...actual,
+    resolveHumanDelayConfig: () => undefined,
+  };
+});
 
 let listNativeCommandSpecs: typeof import("openclaw/plugin-sdk/command-auth-native").listNativeCommandSpecs;
 let createDiscordNativeCommand: typeof import("./native-command.js").createDiscordNativeCommand;

--- a/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
+++ b/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
@@ -99,27 +99,33 @@ vi.mock("openclaw/plugin-sdk/conversation-binding-runtime", async () => {
   );
 });
 
-vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
-  normalizeProviderId: (value: string) => value.trim().toLowerCase(),
-  resolveDefaultModelForAgent: (params: { cfg: OpenClawConfig }) => {
-    const configuredModel = params.cfg.agents?.defaults?.model;
-    const primary =
-      typeof configuredModel === "string"
-        ? configuredModel.trim()
-        : (configuredModel?.primary?.trim() ?? "");
-    const slashIndex = primary.indexOf("/");
-    if (slashIndex > 0 && slashIndex < primary.length - 1) {
+vi.mock("openclaw/plugin-sdk/agent-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/agent-runtime")>(
+    "openclaw/plugin-sdk/agent-runtime",
+  );
+  return {
+    ...actual,
+    normalizeProviderId: (value: string) => value.trim().toLowerCase(),
+    resolveDefaultModelForAgent: (params: { cfg: OpenClawConfig }) => {
+      const configuredModel = params.cfg.agents?.defaults?.model;
+      const primary =
+        typeof configuredModel === "string"
+          ? configuredModel.trim()
+          : (configuredModel?.primary?.trim() ?? "");
+      const slashIndex = primary.indexOf("/");
+      if (slashIndex > 0 && slashIndex < primary.length - 1) {
+        return {
+          provider: primary.slice(0, slashIndex).trim().toLowerCase(),
+          model: primary.slice(slashIndex + 1).trim(),
+        };
+      }
       return {
-        provider: primary.slice(0, slashIndex).trim().toLowerCase(),
-        model: primary.slice(slashIndex + 1).trim(),
+        provider: "anthropic",
+        model: "claude-sonnet-4.5",
       };
-    }
-    return {
-      provider: "anthropic",
-      model: "claude-sonnet-4.5",
-    };
-  },
-}));
+    },
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/models-provider-runtime", () => ({
   buildModelsProviderData: buildModelsProviderDataMock,

--- a/extensions/telegram/src/bot-handlers.agent.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.agent.runtime.ts
@@ -1,5 +1,6 @@
 // Telegram plugin module implements bot handlers.agent behavior.
 export {
+  loadAuthProfileStoreForRuntime,
   resolveAgentDir,
   resolveDefaultAgentId,
   resolveDefaultModelForAgent,

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -31,7 +31,10 @@ import {
   resolvePluginConversationBindingApproval,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
-import { applyModelOverrideToSessionEntry } from "openclaw/plugin-sdk/model-session-runtime";
+import {
+  applyModelOverrideToSessionEntry,
+  shouldPreserveCompatibleAuthProfileOverride,
+} from "openclaw/plugin-sdk/model-session-runtime";
 import { formatModelsAvailableHeader } from "openclaw/plugin-sdk/models-provider-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
@@ -56,6 +59,7 @@ import {
   type NormalizedAllowFrom,
 } from "./bot-access.js";
 import {
+  loadAuthProfileStoreForRuntime,
   resolveAgentDir,
   resolveDefaultAgentId,
   resolveDefaultModelForAgent,
@@ -166,6 +170,26 @@ import {
 } from "./network-errors.js";
 import { resolveTelegramPromptMediaPath } from "./prompt-media-path.js";
 import { buildInlineKeyboard } from "./send.js";
+
+function resolveStoredAuthProfileProvider(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  entry: { authProfileOverride?: string };
+}): string | undefined {
+  const profileId = params.entry.authProfileOverride?.trim();
+  if (!profileId) {
+    return undefined;
+  }
+  try {
+    const agentDir = resolveAgentDir(params.cfg, params.agentId);
+    return loadAuthProfileStoreForRuntime(agentDir, {
+      readOnly: true,
+      allowKeychainPrompt: false,
+    }).profiles[profileId]?.provider;
+  } catch {
+    return undefined;
+  }
+}
 
 export const registerTelegramHandlers = ({
   cfg,
@@ -2916,11 +2940,18 @@ export const registerTelegramHandlers = ({
                       model: selection.model,
                       isDefault: isDefaultSelection,
                     },
-                    // The picker selects a model only and never owns an auth
-                    // profile, so it must not silently delete an authProfileOverride
-                    // set by another source (CLI flag, session-level override).
-                    // Without this the default branch wipes it on every switch.
-                    preserveAuthProfileOverride: true,
+                    preserveAuthProfileOverride: shouldPreserveCompatibleAuthProfileOverride({
+                      cfg: runtimeCfg,
+                      entry,
+                      currentProvider:
+                        entry.providerOverride ?? entry.modelProvider ?? resolvedDefault.provider,
+                      provider: selection.provider,
+                      storedAuthProfileProvider: resolveStoredAuthProfileProvider({
+                        cfg: runtimeCfg,
+                        agentId: sessionState.agentId,
+                        entry,
+                      }),
+                    }),
                   });
                   return entry;
                 },

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2916,6 +2916,11 @@ export const registerTelegramHandlers = ({
                       model: selection.model,
                       isDefault: isDefaultSelection,
                     },
+                    // The picker selects a model only and never owns an auth
+                    // profile, so it must not silently delete an authProfileOverride
+                    // set by another source (CLI flag, session-level override).
+                    // Without this the default branch wipes it on every switch.
+                    preserveAuthProfileOverride: true,
                   });
                   return entry;
                 },

--- a/extensions/telegram/src/bot.media.e2e-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e-harness.ts
@@ -297,6 +297,7 @@ vi.mock("./bot.agent.runtime.js", () => ({
 }));
 
 vi.mock("./bot-handlers.agent.runtime.js", () => ({
+  loadAuthProfileStoreForRuntime: vi.fn(() => ({ version: 1, profiles: {} })),
   resolveAgentDir: vi.fn(() => "/tmp/agent"),
   resolveDefaultAgentId: vi.fn(() => "default"),
   resolveDefaultModelForAgent: vi.fn(() => ({

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -1,5 +1,6 @@
 // Telegram tests cover bot plugin behavior.
 import { rm } from "node:fs/promises";
+import { resolveAgentDir, saveAuthProfileStore } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   clearPluginInteractiveHandlers,
@@ -11,7 +12,7 @@ import {
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
-import { loadSessionStore } from "openclaw/plugin-sdk/session-store-runtime";
+import { loadSessionStore, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TelegramInteractiveHandlerContext } from "./interactive-dispatch.js";
@@ -1572,6 +1573,206 @@ describe("createTelegramBot", () => {
       expect(entry?.providerOverride).toBe("openai");
       expect(entry?.modelOverride).toBe("gpt-5.4");
       expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-html-1");
+    } finally {
+      await rm(storePath, { force: true });
+    }
+  });
+
+  it("preserves compatible auth profile overrides when selecting a Telegram model", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+    editMessageTextSpy.mockClear();
+
+    const storePath = `/tmp/openclaw-telegram-model-auth-compatible-${process.pid}-${Date.now()}.json`;
+
+    await rm(storePath, { force: true });
+    try {
+      const config = {
+        agents: {
+          list: [
+            {
+              id: "main",
+              agentDir: `${storePath}.agent`,
+            },
+          ],
+          defaults: {
+            model: "anthropic/claude-opus-4-6",
+            models: {
+              "anthropic/claude-opus-4-6": {},
+              "openai/gpt-5.4": {},
+            },
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+          },
+        },
+        session: {
+          store: storePath,
+        },
+      } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            "team:prod": { type: "api_key", provider: "openai", key: "sk-test" },
+          },
+        },
+        resolveAgentDir(config as OpenClawConfig, "main"),
+      );
+      loadConfig.mockReturnValue(config);
+      createTelegramBot({
+        token: "tok",
+        config,
+      });
+      const callbackHandler = onSpy.mock.calls.find(
+        (call) => call[0] === "callback_query",
+      )?.[1] as (ctx: Record<string, unknown>) => Promise<void>;
+      if (!callbackHandler) {
+        throw new Error("Expected Telegram callback_query handler");
+      }
+
+      const callbackCtx = {
+        callbackQuery: {
+          id: "cbq-model-auth-compatible-1",
+          data: "mdl_sel_openai/gpt-5.4",
+          from: { id: 9, first_name: "Ada", username: "ada_bot" },
+          message: {
+            chat: { id: 1234, type: "private" },
+            date: 1736380800,
+            message_id: 24,
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      };
+      await callbackHandler(callbackCtx);
+      const sessionKey = Object.keys(loadSessionStore(storePath, { skipCache: true }))[0];
+      if (!sessionKey) {
+        throw new Error("Expected Telegram model callback to create a session entry");
+      }
+      await upsertSessionEntry({
+        storePath,
+        sessionKey,
+        entry: {
+          updatedAt: Date.now(),
+          sessionId: "telegram-auth-compatible",
+          providerOverride: "openai",
+          modelOverride: "gpt-5.4",
+          authProfileOverride: "team:prod",
+          authProfileOverrideSource: "user",
+        },
+      });
+
+      await callbackHandler({
+        ...callbackCtx,
+        callbackQuery: {
+          ...callbackCtx.callbackQuery,
+          id: "cbq-model-auth-compatible-2",
+        },
+      });
+
+      const entry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+      expect(entry?.providerOverride).toBe("openai");
+      expect(entry?.authProfileOverride).toBe("team:prod");
+      expect(entry?.authProfileOverrideSource).toBe("user");
+      expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-auth-compatible-2");
+    } finally {
+      await rm(storePath, { force: true });
+      await rm(`${storePath}.agent`, { recursive: true, force: true });
+    }
+  });
+
+  it("clears incompatible auth profile overrides when selecting a Telegram model", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+    editMessageTextSpy.mockClear();
+
+    const storePath = `/tmp/openclaw-telegram-model-auth-incompatible-${process.pid}-${Date.now()}.json`;
+
+    await rm(storePath, { force: true });
+    try {
+      const config = {
+        agents: {
+          defaults: {
+            model: "anthropic/claude-opus-4-6",
+            models: {
+              "anthropic/claude-opus-4-6": {},
+              "openai/gpt-5.4": {},
+            },
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+          },
+        },
+        session: {
+          store: storePath,
+        },
+      } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+
+      loadConfig.mockReturnValue(config);
+      createTelegramBot({
+        token: "tok",
+        config,
+      });
+      const callbackHandler = onSpy.mock.calls.find(
+        (call) => call[0] === "callback_query",
+      )?.[1] as (ctx: Record<string, unknown>) => Promise<void>;
+      if (!callbackHandler) {
+        throw new Error("Expected Telegram callback_query handler");
+      }
+
+      const callbackCtx = {
+        callbackQuery: {
+          id: "cbq-model-auth-incompatible-1",
+          data: "mdl_sel_openai/gpt-5.4",
+          from: { id: 9, first_name: "Ada", username: "ada_bot" },
+          message: {
+            chat: { id: 1234, type: "private" },
+            date: 1736380800,
+            message_id: 25,
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      };
+      await callbackHandler(callbackCtx);
+      const sessionKey = Object.keys(loadSessionStore(storePath, { skipCache: true }))[0];
+      if (!sessionKey) {
+        throw new Error("Expected Telegram model callback to create a session entry");
+      }
+      await upsertSessionEntry({
+        storePath,
+        sessionKey,
+        entry: {
+          updatedAt: Date.now(),
+          sessionId: "telegram-auth-incompatible",
+          providerOverride: "anthropic",
+          modelOverride: "claude-opus-4-6",
+          authProfileOverride: "anthropic:default",
+          authProfileOverrideSource: "user",
+        },
+      });
+
+      await callbackHandler({
+        ...callbackCtx,
+        callbackQuery: {
+          ...callbackCtx.callbackQuery,
+          id: "cbq-model-auth-incompatible-2",
+        },
+      });
+
+      const entry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+      expect(entry?.providerOverride).toBe("openai");
+      expect(entry?.authProfileOverride).toBeUndefined();
+      expect(entry?.authProfileOverrideSource).toBeUndefined();
+      expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-auth-incompatible-2");
     } finally {
       await rm(storePath, { force: true });
     }

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -10,7 +10,8 @@ import {
   errorShape,
   type SessionsPatchParams,
 } from "../../packages/gateway-protocol/src/index.js";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { loadAuthProfileStoreForRuntime } from "../agents/auth-profiles/store.js";
 import {
   normalizeInheritedToolAllowlist,
   normalizeInheritedToolDenylist,
@@ -22,7 +23,6 @@ import {
   resolveDefaultModelForAgent,
   resolveSubagentConfiguredModelSelection,
 } from "../agents/model-selection.js";
-import { resolveProviderIdForAuth } from "../agents/provider-auth-aliases.js";
 import { normalizeGroupActivation } from "../auto-reply/group-activation.js";
 import {
   formatThinkingLevels,
@@ -49,7 +49,10 @@ import {
   parseTraceOverride,
   parseVerboseOverride,
 } from "../sessions/level-overrides.js";
-import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
+import {
+  applyModelOverrideToSessionEntry,
+  shouldPreserveCompatibleAuthProfileOverride,
+} from "../sessions/model-overrides.js";
 import { normalizeSendPolicy } from "../sessions/send-policy.js";
 import { parseSessionLabel } from "../sessions/session-label.js";
 
@@ -73,43 +76,6 @@ function normalizeExecAsk(raw: string): "off" | "on-miss" | "always" | undefined
   return undefined;
 }
 
-function shouldPreserveSessionAuthProfileOverride(params: {
-  cfg: OpenClawConfig;
-  entry: SessionEntry;
-  currentProvider: string;
-  provider: string;
-}): boolean {
-  const profileOverride = normalizeOptionalString(params.entry.authProfileOverride);
-  if (!profileOverride) {
-    return false;
-  }
-  const provider = normalizeOptionalLowercaseString(params.provider);
-  if (!provider) {
-    return false;
-  }
-  const resolvesToTargetProvider = (rawProvider: string | undefined): boolean => {
-    const candidate = normalizeOptionalLowercaseString(rawProvider);
-    if (!candidate) {
-      return false;
-    }
-    return (
-      resolveProviderIdForAuth(candidate, { config: params.cfg }) ===
-      resolveProviderIdForAuth(provider, { config: params.cfg })
-    );
-  };
-  const delimiterIndex = profileOverride.indexOf(":");
-  if (delimiterIndex < 0) {
-    return resolvesToTargetProvider(params.currentProvider);
-  }
-  const profileProvider = normalizeOptionalLowercaseString(
-    profileOverride.slice(0, delimiterIndex),
-  );
-  if (!profileProvider) {
-    return false;
-  }
-  return resolvesToTargetProvider(profileProvider);
-}
-
 function supportsSpawnLineage(storeKey: string): boolean {
   return isSubagentSessionKey(storeKey) || isAcpSessionKey(storeKey);
 }
@@ -128,6 +94,26 @@ function normalizeSubagentControlScope(raw: string): "children" | "none" | undef
     return normalized;
   }
   return undefined;
+}
+
+function resolveStoredAuthProfileProvider(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  entry: SessionEntry;
+}): string | undefined {
+  const profileId = normalizeOptionalString(params.entry.authProfileOverride);
+  if (!profileId) {
+    return undefined;
+  }
+  try {
+    const agentDir = resolveAgentDir(params.cfg, params.agentId);
+    return loadAuthProfileStoreForRuntime(agentDir, {
+      readOnly: true,
+      allowKeychainPrompt: false,
+    }).profiles[profileId]?.provider;
+  } catch {
+    return undefined;
+  }
 }
 
 type SessionPatchProjectionEntry = {
@@ -533,11 +519,16 @@ export async function projectSessionsPatchEntry(params: {
           model: resolvedDefault.model,
           isDefault: true,
         },
-        preserveAuthProfileOverride: shouldPreserveSessionAuthProfileOverride({
+        preserveAuthProfileOverride: shouldPreserveCompatibleAuthProfileOverride({
           cfg,
           currentProvider: next.providerOverride ?? next.modelProvider ?? resolvedDefault.provider,
           entry: next,
           provider: resolvedDefault.provider,
+          storedAuthProfileProvider: resolveStoredAuthProfileProvider({
+            cfg,
+            agentId: sessionAgentId,
+            entry: next,
+          }),
         }),
       });
       delete next.liveModelSwitchPending;
@@ -582,11 +573,16 @@ export async function projectSessionsPatchEntry(params: {
           isDefault,
         },
         profileOverride: trailingProfile || undefined,
-        preserveAuthProfileOverride: shouldPreserveSessionAuthProfileOverride({
+        preserveAuthProfileOverride: shouldPreserveCompatibleAuthProfileOverride({
           cfg,
           currentProvider: next.providerOverride ?? next.modelProvider ?? resolvedDefault.provider,
           entry: next,
           provider: resolved.ref.provider,
+          storedAuthProfileProvider: resolveStoredAuthProfileProvider({
+            cfg,
+            agentId: sessionAgentId,
+            entry: next,
+          }),
         }),
         markLiveSwitchPending: true,
       });

--- a/src/plugin-sdk/config-runtime.ts
+++ b/src/plugin-sdk/config-runtime.ts
@@ -91,7 +91,10 @@ export {
 export { resolveActiveTalkProviderConfig } from "../config/talk.js";
 export { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
 export { loadCronStore, resolveCronStorePath, saveCronStore } from "../cron/store.js";
-export { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
+export {
+  applyModelOverrideToSessionEntry,
+  shouldPreserveCompatibleAuthProfileOverride,
+} from "../sessions/model-overrides.js";
 export { coerceSecretRef } from "../config/types.secrets.js";
 export {
   resolveConfiguredSecretInputString,

--- a/src/plugin-sdk/model-session-runtime.ts
+++ b/src/plugin-sdk/model-session-runtime.ts
@@ -3,4 +3,7 @@
  */
 export { resolveChannelModelOverride } from "../channels/model-overrides.js";
 export { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
-export { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
+export {
+  applyModelOverrideToSessionEntry,
+  shouldPreserveCompatibleAuthProfileOverride,
+} from "../sessions/model-overrides.js";

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -1,9 +1,11 @@
 // Session model override tests cover model override parsing and validation.
 import { describe, expect, it } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   applyModelOverrideToSessionEntry,
   repairProviderWrappedModelOverride,
+  shouldPreserveCompatibleAuthProfileOverride,
 } from "./model-overrides.js";
 
 function applyOpenAiSelection(entry: SessionEntry) {
@@ -255,6 +257,168 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(result.updated).toBe(true);
     expect(entry.authProfileOverride).toBe("newprofile");
     expect(entry.liveModelSwitchPending).toBe(true);
+  });
+});
+
+describe("shouldPreserveCompatibleAuthProfileOverride", () => {
+  it("preserves provider-prefixed overrides for the selected provider", () => {
+    expect(
+      shouldPreserveCompatibleAuthProfileOverride({
+        cfg: {},
+        entry: {
+          sessionId: "sess-profile-provider-match",
+          updatedAt: 1,
+          authProfileOverride: "openai:work",
+        },
+        currentProvider: "anthropic",
+        provider: "openai",
+      }),
+    ).toBe(true);
+  });
+
+  it("clears provider-prefixed overrides for a different selected provider", () => {
+    expect(
+      shouldPreserveCompatibleAuthProfileOverride({
+        cfg: {},
+        entry: {
+          sessionId: "sess-profile-provider-change",
+          updatedAt: 1,
+          authProfileOverride: "anthropic:default",
+        },
+        currentProvider: "anthropic",
+        provider: "openai",
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves unprefixed overrides only when the current provider matches", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-profile-unprefixed",
+      updatedAt: 1,
+      authProfileOverride: "work",
+    };
+    expect(
+      shouldPreserveCompatibleAuthProfileOverride({
+        cfg: {},
+        entry,
+        currentProvider: "openai",
+        provider: "openai",
+      }),
+    ).toBe(true);
+    expect(
+      shouldPreserveCompatibleAuthProfileOverride({
+        cfg: {},
+        entry,
+        currentProvider: "anthropic",
+        provider: "openai",
+      }),
+    ).toBe(false);
+  });
+
+  it("uses configured profile metadata for colon-bearing profile ids", () => {
+    const cfg = {
+      auth: {
+        profiles: {
+          "work:prod": { provider: "openai", mode: "api_key" },
+        },
+      },
+    } as OpenClawConfig;
+    expect(
+      shouldPreserveCompatibleAuthProfileOverride({
+        cfg,
+        entry: {
+          sessionId: "sess-profile-configured-colon-id",
+          updatedAt: 1,
+          authProfileOverride: "work:prod",
+        },
+        currentProvider: "anthropic",
+        provider: "openai",
+      }),
+    ).toBe(true);
+    expect(
+      shouldPreserveCompatibleAuthProfileOverride({
+        cfg,
+        entry: {
+          sessionId: "sess-profile-configured-colon-id",
+          updatedAt: 1,
+          authProfileOverride: "work:prod",
+        },
+        currentProvider: "openai",
+        provider: "anthropic",
+      }),
+    ).toBe(false);
+  });
+
+  it("uses stored profile metadata for colon-bearing profile ids", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-profile-store-colon-id",
+      updatedAt: 1,
+      authProfileOverride: "team:prod",
+    };
+    expect(
+      shouldPreserveCompatibleAuthProfileOverride({
+        cfg: {},
+        entry,
+        currentProvider: "anthropic",
+        provider: "openai",
+        storedAuthProfileProvider: "openai",
+      }),
+    ).toBe(true);
+    expect(
+      shouldPreserveCompatibleAuthProfileOverride({
+        cfg: {},
+        entry,
+        currentProvider: "openai",
+        provider: "openai",
+        storedAuthProfileProvider: "anthropic",
+      }),
+    ).toBe(false);
+  });
+
+  it("clears unknown colon-bearing profile ids unless their prefix matches the selected provider", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-profile-unknown-colon-id",
+      updatedAt: 1,
+      authProfileOverride: "work:prod",
+    };
+    expect(
+      shouldPreserveCompatibleAuthProfileOverride({
+        cfg: {},
+        entry,
+        currentProvider: "openai",
+        provider: "openai",
+      }),
+    ).toBe(false);
+    expect(
+      shouldPreserveCompatibleAuthProfileOverride({
+        cfg: {},
+        entry,
+        currentProvider: "anthropic",
+        provider: "openai",
+      }),
+    ).toBe(false);
+  });
+
+  it("still treats known provider prefixes as provider-owned", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openai: { baseUrl: "https://api.openai.com/v1", models: [] },
+        },
+      },
+    } as OpenClawConfig;
+    expect(
+      shouldPreserveCompatibleAuthProfileOverride({
+        cfg,
+        entry: {
+          sessionId: "sess-profile-stale-provider-prefix",
+          updatedAt: 1,
+          authProfileOverride: "openai:work",
+        },
+        currentProvider: "anthropic",
+        provider: "anthropic",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -1,6 +1,11 @@
 // Session model override helpers normalize per-session provider model choices.
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
+import { resolveProviderIdForAuth } from "../agents/provider-auth-aliases.js";
 import type { SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 /** User or automatic model/provider override selection for a session entry. */
 export type ModelOverrideSelection = {
@@ -8,6 +13,59 @@ export type ModelOverrideSelection = {
   model: string;
   isDefault?: boolean;
 };
+
+export function shouldPreserveCompatibleAuthProfileOverride(params: {
+  cfg: OpenClawConfig;
+  entry: SessionEntry;
+  currentProvider: string;
+  provider: string;
+  storedAuthProfileProvider?: string;
+}): boolean {
+  const profileOverride = normalizeOptionalString(params.entry.authProfileOverride);
+  if (!profileOverride) {
+    return false;
+  }
+  const provider = normalizeOptionalLowercaseString(params.provider);
+  if (!provider) {
+    return false;
+  }
+  const resolvesProviderMatch = (
+    rawProvider: string | undefined,
+    targetProvider: string,
+  ): boolean => {
+    const candidate = normalizeOptionalLowercaseString(rawProvider);
+    if (!candidate) {
+      return false;
+    }
+    return (
+      resolveProviderIdForAuth(candidate, { config: params.cfg }) ===
+      resolveProviderIdForAuth(targetProvider, { config: params.cfg })
+    );
+  };
+  const resolvesToTargetProvider = (rawProvider: string | undefined): boolean =>
+    resolvesProviderMatch(rawProvider, provider);
+  const storedProfileProvider = normalizeOptionalString(params.storedAuthProfileProvider);
+  if (storedProfileProvider) {
+    return resolvesToTargetProvider(storedProfileProvider);
+  }
+  const configuredProfileProvider = normalizeOptionalString(
+    params.cfg.auth?.profiles?.[profileOverride]?.provider,
+  );
+  if (configuredProfileProvider) {
+    return resolvesToTargetProvider(configuredProfileProvider);
+  }
+  const delimiterIndex = profileOverride.indexOf(":");
+  if (delimiterIndex < 0) {
+    return resolvesToTargetProvider(params.currentProvider);
+  }
+  const profileProvider = normalizeOptionalLowercaseString(
+    profileOverride.slice(0, delimiterIndex),
+  );
+  if (!profileProvider) {
+    return false;
+  }
+  return resolvesToTargetProvider(profileProvider);
+}
 
 function clearFallbackOrigin(entry: SessionEntry): boolean {
   let updated = false;


### PR DESCRIPTION
## Summary

Fixes #92244.

Native Telegram and Discord model pickers select a model only, but the shared model-override helper clears `authProfileOverride` when no replacement profile is supplied. The pickers now preserve only auth profiles that are compatible with the newly selected provider, and clear stale incompatible provider-specific overrides.

## What changed

- Added a shared provider-aware compatibility helper for session auth-profile preservation.
- Discord picker direct persistence and hidden `/model` restore now preserve compatible auth profiles only.
- Telegram picker direct persistence now uses the same provider-aware preservation logic.
- Gateway session patching uses the same helper for model changes.
- Store-only colon-bearing profile IDs, such as `team:prod`, are resolved from auth profile store metadata instead of guessed from the string.
- Unknown colon-bearing IDs fail closed unless their prefix resolves to the selected provider.
- Updated plugin SDK API baseline for the new helper export.

## Real behavior proof

Behavior addressed: Discord and Telegram model pickers preserve auth profiles compatible with the selected provider, including store-only colon-bearing profile IDs, and clear incompatible provider-specific auth profiles.

Real environment tested: local OpenClaw checkout at `9c43553f0a9ee3a54a2aa66e61c13f20c1e41c76`, using the real session-store runtime, real auth-profile store runtime, and model-session runtime against on-disk temp stores.

Exact steps or command run after this patch:

- `node --import tsx - <<'TS' ...` real session-store/auth-store/model-helper proof
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/native-command.model-picker.test.ts extensions/telegram/src/bot.test.ts src/gateway/sessions-patch.test.ts src/sessions/model-overrides.test.ts`
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/native-command.options.test.ts extensions/discord/src/monitor/native-command.think-autocomplete.test.ts extensions/discord/src/monitor/native-command.model-picker.test.ts`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts extensions/telegram/src/bot.test.ts`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm plugin-sdk:api:check`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`

Evidence after fix:

```text
same-provider-prefixed-preserved: provider=openai auth=openai:work
same-provider-unprefixed-preserved: provider=openai auth=work
configured-colon-profile-preserved: provider=openai auth=work:prod
store-only-colon-profile-preserved: provider=openai auth=team:prod
cross-provider-prefixed-cleared: provider=openai auth=<cleared>
stale-unknown-prefixed-cleared: provider=openai auth=<cleared>
```

Observed result after fix: same-provider prefixed/unprefixed auth profiles remain attached after a model-only picker selection; configured and store-only colon-bearing profile IDs remain attached when metadata says they belong to the selected provider; incompatible provider-prefixed or unknown stale colon-bearing auth profiles are removed.

What was not tested: live native Telegram Desktop or Discord callback execution against real service credentials was not run locally. `check:changed` was attempted with the local-child fallback but currently fails in upstream `origin/main` outside this PR's files: `src/tasks/task-registry.test.ts` has pre-existing TypeScript errors in tests added by `5697ab810e4`.

## Verification

- Focused picker/session suite passed: 4 Vitest shards, 330 total tests.
- Affected Discord partial-runtime mock tests passed: 3 files, 40 tests.
- Telegram media harness import path plus main bot test passed: 3 files, 97 tests.
- Plugin SDK API baseline check passed.
- Autoreview clean on final commit.
