### PR TITLE
Fix live orphan session transcript visibility

### DIFF
--- a/extensions/memory-core/src/session-search-visibility.qmd.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.qmd.test.ts
@@ -407,6 +407,27 @@ describe("filterMemorySearchHitsBySessionVisibility for QMD", () => {
     expect(filtered).toStrictEqual([]);
   });
 
+  it("denies ownerless legacy QMD orphan hits when no session-store key remains", async () => {
+    combinedSessionStore = {};
+    const hit: MemorySearchResult = {
+      path: "qmd/sessions-main/ownerless-orphan.md",
+      source: "sessions",
+      score: 1,
+      snippet: "x",
+      startLine: 1,
+      endLine: 2,
+    };
+
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg: asOpenClawConfig({ tools: { sessions: { visibility: "agent" } } }),
+      requesterSessionKey: "agent:main:main",
+      sandboxed: false,
+      hits: [hit],
+    });
+
+    expect(filtered).toStrictEqual([]);
+  });
+
   it("keeps mapped archived QMD session hits when no session-store key remains", async () => {
     combinedSessionStore = {};
     const searchPath = "qmd/sessions-main/archived-jsonl-deleted-2026-02-16t22-26-33-000z.md";

--- a/extensions/memory-core/src/session-search-visibility.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.test.ts
@@ -983,4 +983,23 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     });
     expect(filtered).toStrictEqual([]);
   });
+
+  it("does not treat a same-agent orphan filename as proven self-session lineage", async () => {
+    combinedSessionStore = {};
+    const hit: MemorySearchResult = {
+      path: "sessions/main/main.jsonl",
+      source: "sessions",
+      score: 1,
+      snippet: "x",
+      startLine: 1,
+      endLine: 2,
+    };
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg: asOpenClawConfig({ tools: { sessions: { visibility: "self" } } }),
+      requesterSessionKey: "agent:main:main",
+      sandboxed: false,
+      hits: [hit],
+    });
+    expect(filtered).toStrictEqual([]);
+  });
 });

--- a/extensions/memory-core/src/session-search-visibility.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.test.ts
@@ -940,4 +940,47 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
       agentId: "main",
     });
   });
+
+  it("keeps same-agent live orphan transcript hits", async () => {
+    combinedSessionStore = {};
+    const hit: MemorySearchResult = {
+      path: "sessions/main/live-orphan.jsonl",
+      source: "sessions",
+      score: 1,
+      snippet: "x",
+      startLine: 1,
+      endLine: 2,
+    };
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg: asOpenClawConfig({ tools: { sessions: { visibility: "agent" } } }),
+      requesterSessionKey: "agent:main:main",
+      sandboxed: false,
+      hits: [hit],
+    });
+    expect(filtered).toEqual([hit]);
+  });
+
+  it("drops cross-agent live orphan transcript hits", async () => {
+    combinedSessionStore = {};
+    const hit: MemorySearchResult = {
+      path: "sessions/peer/live-orphan.jsonl",
+      source: "sessions",
+      score: 1,
+      snippet: "x",
+      startLine: 1,
+      endLine: 2,
+    };
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg: asOpenClawConfig({
+        tools: {
+          sessions: { visibility: "all" },
+          agentToAgent: { enabled: true, allow: ["*"] },
+        },
+      }),
+      requesterSessionKey: "agent:main:main",
+      sandboxed: false,
+      hits: [hit],
+    });
+    expect(filtered).toStrictEqual([]);
+  });
 });

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -331,17 +331,19 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
     ) {
       continue;
     }
-    const archivedOwnerMatchesScope = Boolean(
-      identity.archived &&
-      ((identity.ownerAgentId &&
-        (!scopedAgentId ||
-          normalizeAgentIdForCompare(identity.ownerAgentId) ===
-            normalizeAgentIdForCompare(scopedAgentId))) ||
-        (isQmdSessionHit && scopedAgentId)),
+    const ownerMatchesScope = Boolean(
+      identity.ownerAgentId &&
+      (!scopedAgentId ||
+        normalizeAgentIdForCompare(identity.ownerAgentId) ===
+          normalizeAgentIdForCompare(scopedAgentId)),
     );
-    const archivedOwnerAgentId = archivedOwnerMatchesScope
-      ? (identity.ownerAgentId ?? scopedAgentId)
-      : undefined;
+    const qmdArchivedOwnerMatchesScope = Boolean(
+      identity.archived && isQmdSessionHit && scopedAgentId,
+    );
+    const fallbackOwnerAgentId =
+      ownerMatchesScope || qmdArchivedOwnerMatchesScope
+        ? (identity.ownerAgentId ?? scopedAgentId)
+        : undefined;
     const liveKeys = identity.liveStem
       ? resolveTranscriptStemToSessionKeys({
           store: combinedSessionStore,
@@ -359,7 +361,7 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
               store: combinedSessionStore,
               stem: identity.stem,
               allowQmdSlugFallback: isQmdSessionHit && !identity.archived,
-              ...(archivedOwnerAgentId ? { archivedOwnerAgentId } : {}),
+              ...(fallbackOwnerAgentId ? { ownerAgentId: fallbackOwnerAgentId } : {}),
             }),
     });
     if (keys.length === 0) {

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -154,14 +154,6 @@ function filterSessionKeysByScopedAgent(params: {
   });
 }
 
-function synthesizeLiveOwnerSessionKey(params: {
-  ownerAgentId: string | undefined;
-  stem: string;
-}): string[] {
-  const ownerAgentId = normalizeAgentIdForCompare(params.ownerAgentId);
-  return ownerAgentId ? [`agent:${ownerAgentId}:${params.stem}`] : [];
-}
-
 export async function filterMemorySearchHitsBySessionVisibility(params: {
   cfg: OpenClawConfig;
   agentId?: string;
@@ -339,19 +331,23 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
     ) {
       continue;
     }
-    const ownerMatchesScope = Boolean(
-      identity.ownerAgentId &&
-      (!scopedAgentId ||
-        normalizeAgentIdForCompare(identity.ownerAgentId) ===
-          normalizeAgentIdForCompare(scopedAgentId)),
-    );
-    const qmdArchivedOwnerMatchesScope = Boolean(
-      identity.archived && isQmdSessionHit && scopedAgentId,
-    );
-    const archivedOwnerAgentId =
-      identity.archived && (ownerMatchesScope || qmdArchivedOwnerMatchesScope)
-        ? (identity.ownerAgentId ?? scopedAgentId)
+    const sameAgentLiveOwnerId =
+      !identity.archived &&
+      normalizedScopedAgentId &&
+      normalizedOwnerAgentId === normalizedScopedAgentId
+        ? normalizedOwnerAgentId
         : undefined;
+    const archivedOwnerMatchesScope = Boolean(
+      identity.archived &&
+      ((identity.ownerAgentId &&
+        (!scopedAgentId ||
+          normalizeAgentIdForCompare(identity.ownerAgentId) ===
+            normalizeAgentIdForCompare(scopedAgentId))) ||
+        (isQmdSessionHit && scopedAgentId)),
+    );
+    const archivedOwnerAgentId = archivedOwnerMatchesScope
+      ? (identity.ownerAgentId ?? scopedAgentId)
+      : undefined;
     const liveKeys = identity.liveStem
       ? resolveTranscriptStemToSessionKeys({
           store: combinedSessionStore,
@@ -372,12 +368,9 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
                 allowQmdSlugFallback: isQmdSessionHit && !identity.archived,
                 ...(archivedOwnerAgentId ? { archivedOwnerAgentId } : {}),
               });
-              return resolvedKeys.length > 0 || identity.archived || !ownerMatchesScope
+              return resolvedKeys.length > 0 || !sameAgentLiveOwnerId
                 ? resolvedKeys
-                : synthesizeLiveOwnerSessionKey({
-                    ownerAgentId: identity.ownerAgentId,
-                    stem: identity.stem,
-                  });
+                : [`agent:${sameAgentLiveOwnerId}:${identity.stem}`];
             })(),
     });
     if (keys.length === 0) {

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -154,6 +154,14 @@ function filterSessionKeysByScopedAgent(params: {
   });
 }
 
+function synthesizeLiveOwnerSessionKey(params: {
+  ownerAgentId: string | undefined;
+  stem: string;
+}): string[] {
+  const ownerAgentId = normalizeAgentIdForCompare(params.ownerAgentId);
+  return ownerAgentId ? [`agent:${ownerAgentId}:${params.stem}`] : [];
+}
+
 export async function filterMemorySearchHitsBySessionVisibility(params: {
   cfg: OpenClawConfig;
   agentId?: string;
@@ -340,8 +348,8 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
     const qmdArchivedOwnerMatchesScope = Boolean(
       identity.archived && isQmdSessionHit && scopedAgentId,
     );
-    const fallbackOwnerAgentId =
-      ownerMatchesScope || qmdArchivedOwnerMatchesScope
+    const archivedOwnerAgentId =
+      identity.archived && (ownerMatchesScope || qmdArchivedOwnerMatchesScope)
         ? (identity.ownerAgentId ?? scopedAgentId)
         : undefined;
     const liveKeys = identity.liveStem
@@ -357,12 +365,20 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
       keys:
         liveKeys.length > 0
           ? liveKeys
-          : resolveTranscriptStemToSessionKeys({
-              store: combinedSessionStore,
-              stem: identity.stem,
-              allowQmdSlugFallback: isQmdSessionHit && !identity.archived,
-              ...(fallbackOwnerAgentId ? { ownerAgentId: fallbackOwnerAgentId } : {}),
-            }),
+          : (() => {
+              const resolvedKeys = resolveTranscriptStemToSessionKeys({
+                store: combinedSessionStore,
+                stem: identity.stem,
+                allowQmdSlugFallback: isQmdSessionHit && !identity.archived,
+                ...(archivedOwnerAgentId ? { archivedOwnerAgentId } : {}),
+              });
+              return resolvedKeys.length > 0 || identity.archived || !ownerMatchesScope
+                ? resolvedKeys
+                : synthesizeLiveOwnerSessionKey({
+                    ownerAgentId: identity.ownerAgentId,
+                    stem: identity.stem,
+                  });
+            })(),
     });
     if (keys.length === 0) {
       continue;

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -355,25 +355,25 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
           allowQmdSlugFallback: false,
         })
       : [];
+    const resolvedKeys =
+      liveKeys.length > 0
+        ? liveKeys
+        : resolveTranscriptStemToSessionKeys({
+            store: combinedSessionStore,
+            stem: identity.stem,
+            allowQmdSlugFallback: isQmdSessionHit && !identity.archived,
+            ...(archivedOwnerAgentId ? { archivedOwnerAgentId } : {}),
+          });
     const keys = filterSessionKeysByScopedAgent({
       cfg: params.cfg,
       scopedAgentId,
-      keys:
-        liveKeys.length > 0
-          ? liveKeys
-          : (() => {
-              const resolvedKeys = resolveTranscriptStemToSessionKeys({
-                store: combinedSessionStore,
-                stem: identity.stem,
-                allowQmdSlugFallback: isQmdSessionHit && !identity.archived,
-                ...(archivedOwnerAgentId ? { archivedOwnerAgentId } : {}),
-              });
-              return resolvedKeys.length > 0 || !sameAgentLiveOwnerId
-                ? resolvedKeys
-                : [`agent:${sameAgentLiveOwnerId}:${identity.stem}`];
-            })(),
+      keys: resolvedKeys,
     });
     if (keys.length === 0) {
+      const agentWideVisibility = visibility === "agent" || visibility === "all";
+      if (sameAgentLiveOwnerId && agentWideVisibility && !conversationRecall) {
+        next.push(hit);
+      }
       continue;
     }
     const allowed = areSessionKeysAllowed(keys);

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -1148,6 +1148,72 @@ describe("searchMemoryWiki", () => {
     ]);
   });
 
+  it("keeps same-agent owner-qualified live orphan session hits", async () => {
+    const { config } = await createQueryVault({
+      initialize: true,
+      config: { search: { backend: "shared", corpus: "memory" } },
+    });
+    const manager = createMemoryManager({
+      searchResults: [
+        {
+          path: "sessions/secondary/live-orphan.jsonl",
+          startLine: 1,
+          endLine: 2,
+          score: 30,
+          snippet: "same-agent orphan",
+          source: "sessions",
+        },
+      ],
+    });
+    getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
+
+    const results = await searchMemoryWiki({
+      config,
+      appConfig: createAppConfig(),
+      agentId: "secondary",
+      query: "orphan",
+    });
+
+    expect(results.map((result) => result.path)).toEqual(["sessions/secondary/live-orphan.jsonl"]);
+  });
+
+  it("drops cross-agent and ownerless QMD live orphan session hits", async () => {
+    const { config } = await createQueryVault({
+      initialize: true,
+      config: { search: { backend: "shared", corpus: "memory" } },
+    });
+    const manager = createMemoryManager({
+      searchResults: [
+        {
+          path: "sessions/other/live-orphan.jsonl",
+          startLine: 1,
+          endLine: 2,
+          score: 30,
+          snippet: "cross-agent orphan",
+          source: "sessions",
+        },
+        {
+          path: "qmd/sessions-secondary/ownerless-orphan.md",
+          startLine: 1,
+          endLine: 2,
+          score: 20,
+          snippet: "ownerless qmd orphan",
+          source: "sessions",
+        },
+      ],
+    });
+    getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
+
+    const results = await searchMemoryWiki({
+      config,
+      appConfig: createAppConfig(),
+      agentId: "secondary",
+      query: "orphan",
+    });
+
+    expect(results).toStrictEqual([]);
+  });
+
   it("discovers pages in nested subdirectories", async () => {
     const { rootDir, config } = await createQueryVault({
       initialize: true,
@@ -1665,6 +1731,31 @@ describe("getMemoryWikiPage", () => {
       agentSessionKey: "agent:main:child-session",
       sandboxed: true,
       lookup: "qmd/sessions-main/sibling-session.md",
+    });
+
+    expect(result).toBeNull();
+    expect(manager.readFile).not.toHaveBeenCalled();
+  });
+
+  it("does not read ownerless QMD live orphan session paths", async () => {
+    const { config } = await createQueryVault({
+      initialize: true,
+      config: { search: { backend: "shared", corpus: "memory" } },
+    });
+    const manager = createMemoryManager({
+      readResult: {
+        path: "qmd/sessions-main/ownerless-orphan.md",
+        text: "ownerless orphan transcript",
+      },
+    });
+    getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
+
+    const result = await getMemoryWikiPage({
+      config,
+      appConfig: createSessionVisibilityAppConfig(),
+      agentSessionKey: "agent:main:main",
+      sandboxed: true,
+      lookup: "qmd/sessions-main/ownerless-orphan.md",
     });
 
     expect(result).toBeNull();

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -119,6 +119,13 @@ function createSessionVisibilityAppConfig(): OpenClawConfig {
   } as OpenClawConfig;
 }
 
+function createAgentSessionVisibilityAppConfig(): OpenClawConfig {
+  return {
+    agents: { list: [{ id: "main", default: true }, { id: "secondary" }] },
+    tools: { sessions: { visibility: "agent" } },
+  } as OpenClawConfig;
+}
+
 function mockSessionTranscriptStore() {
   loadCombinedSessionStoreForGatewayMock.mockReturnValue({
     storePath: "(test)",
@@ -1169,7 +1176,7 @@ describe("searchMemoryWiki", () => {
 
     const results = await searchMemoryWiki({
       config,
-      appConfig: createAppConfig(),
+      appConfig: createAgentSessionVisibilityAppConfig(),
       agentId: "secondary",
       query: "orphan",
     });
@@ -1208,6 +1215,35 @@ describe("searchMemoryWiki", () => {
       config,
       appConfig: createAppConfig(),
       agentId: "secondary",
+      query: "orphan",
+    });
+
+    expect(results).toStrictEqual([]);
+  });
+
+  it("does not treat an orphan filename as proven self-session lineage", async () => {
+    const { config } = await createQueryVault({
+      initialize: true,
+      config: { search: { backend: "shared", corpus: "memory" } },
+    });
+    const manager = createMemoryManager({
+      searchResults: [
+        {
+          path: "sessions/main/main.jsonl",
+          startLine: 1,
+          endLine: 2,
+          score: 30,
+          snippet: "unproven self orphan",
+          source: "sessions",
+        },
+      ],
+    });
+    getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
+
+    const results = await searchMemoryWiki({
+      config,
+      appConfig: createSessionVisibilityAppConfig(),
+      agentSessionKey: "agent:main:main",
       query: "orphan",
     });
 

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -1278,26 +1278,26 @@ async function createSessionMemoryPathVisibilityChecker(params: {
           allowQmdSlugFallback: false,
         })
       : [];
+    const resolvedKeys =
+      liveKeys.length > 0
+        ? liveKeys
+        : resolveTranscriptStemToSessionKeys({
+            store: combinedSessionStore,
+            stem: identity.stem,
+            allowQmdSlugFallback: isQmdSessionPath && !identity.archived,
+            ...(archivedOwnerAgentId ? { archivedOwnerAgentId } : {}),
+          });
     const keys = filterSessionKeysByScopedAgent({
       cfg: params.cfg,
       scopedAgentId,
-      keys:
-        liveKeys.length > 0
-          ? liveKeys
-          : (() => {
-              const resolvedKeys = resolveTranscriptStemToSessionKeys({
-                store: combinedSessionStore,
-                stem: identity.stem,
-                allowQmdSlugFallback: isQmdSessionPath && !identity.archived,
-                ...(archivedOwnerAgentId ? { archivedOwnerAgentId } : {}),
-              });
-              return resolvedKeys.length > 0 || !sameAgentLiveOwnerId
-                ? resolvedKeys
-                : [`agent:${sameAgentLiveOwnerId}:${identity.stem}`];
-            })(),
+      keys: resolvedKeys,
     });
+    if (keys.length === 0) {
+      const agentWideVisibility = visibility === "agent" || visibility === "all";
+      return Boolean(sameAgentLiveOwnerId && agentWideVisibility);
+    }
     if (!guard) {
-      return Boolean(scopedAgentId && keys.length > 0);
+      return Boolean(scopedAgentId);
     }
     return keys.some((key) => guard.check(key).allowed);
   };

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -1210,14 +1210,6 @@ function filterSessionKeysByScopedAgent(params: {
   });
 }
 
-function synthesizeLiveOwnerSessionKey(params: {
-  ownerAgentId: string | undefined;
-  stem: string;
-}): string[] {
-  const ownerAgentId = normalizeLowercaseStringOrEmpty(params.ownerAgentId);
-  return ownerAgentId ? [`agent:${ownerAgentId}:${params.stem}`] : [];
-}
-
 async function createSessionMemoryPathVisibilityChecker(params: {
   cfg: OpenClawConfig;
   agentId: string | undefined;
@@ -1264,17 +1256,21 @@ async function createSessionMemoryPathVisibilityChecker(params: {
     ) {
       return false;
     }
-    const ownerMatchesScope = Boolean(
-      identity.ownerAgentId &&
-      (!normalizedScopedAgentId || normalizedOwnerAgentId === normalizedScopedAgentId),
-    );
-    const qmdArchivedOwnerMatchesScope = Boolean(
-      identity.archived && isQmdSessionPath && scopedAgentId,
-    );
-    const archivedOwnerAgentId =
-      identity.archived && (ownerMatchesScope || qmdArchivedOwnerMatchesScope)
-        ? (identity.ownerAgentId ?? scopedAgentId)
+    const sameAgentLiveOwnerId =
+      !identity.archived &&
+      normalizedScopedAgentId &&
+      normalizedOwnerAgentId === normalizedScopedAgentId
+        ? normalizedOwnerAgentId
         : undefined;
+    const archivedOwnerMatchesScope = Boolean(
+      identity.archived &&
+      ((identity.ownerAgentId &&
+        (!normalizedScopedAgentId || normalizedOwnerAgentId === normalizedScopedAgentId)) ||
+        (isQmdSessionPath && scopedAgentId)),
+    );
+    const archivedOwnerAgentId = archivedOwnerMatchesScope
+      ? (identity.ownerAgentId ?? scopedAgentId)
+      : undefined;
     const liveKeys = identity.liveStem
       ? resolveTranscriptStemToSessionKeys({
           store: combinedSessionStore,
@@ -1295,12 +1291,9 @@ async function createSessionMemoryPathVisibilityChecker(params: {
                 allowQmdSlugFallback: isQmdSessionPath && !identity.archived,
                 ...(archivedOwnerAgentId ? { archivedOwnerAgentId } : {}),
               });
-              return resolvedKeys.length > 0 || identity.archived || !ownerMatchesScope
+              return resolvedKeys.length > 0 || !sameAgentLiveOwnerId
                 ? resolvedKeys
-                : synthesizeLiveOwnerSessionKey({
-                    ownerAgentId: identity.ownerAgentId,
-                    stem: identity.stem,
-                  });
+                : [`agent:${sameAgentLiveOwnerId}:${identity.stem}`];
             })(),
     });
     if (!guard) {

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -1210,6 +1210,14 @@ function filterSessionKeysByScopedAgent(params: {
   });
 }
 
+function synthesizeLiveOwnerSessionKey(params: {
+  ownerAgentId: string | undefined;
+  stem: string;
+}): string[] {
+  const ownerAgentId = normalizeLowercaseStringOrEmpty(params.ownerAgentId);
+  return ownerAgentId ? [`agent:${ownerAgentId}:${params.stem}`] : [];
+}
+
 async function createSessionMemoryPathVisibilityChecker(params: {
   cfg: OpenClawConfig;
   agentId: string | undefined;
@@ -1263,8 +1271,8 @@ async function createSessionMemoryPathVisibilityChecker(params: {
     const qmdArchivedOwnerMatchesScope = Boolean(
       identity.archived && isQmdSessionPath && scopedAgentId,
     );
-    const fallbackOwnerAgentId =
-      ownerMatchesScope || qmdArchivedOwnerMatchesScope
+    const archivedOwnerAgentId =
+      identity.archived && (ownerMatchesScope || qmdArchivedOwnerMatchesScope)
         ? (identity.ownerAgentId ?? scopedAgentId)
         : undefined;
     const liveKeys = identity.liveStem
@@ -1280,12 +1288,20 @@ async function createSessionMemoryPathVisibilityChecker(params: {
       keys:
         liveKeys.length > 0
           ? liveKeys
-          : resolveTranscriptStemToSessionKeys({
-              store: combinedSessionStore,
-              stem: identity.stem,
-              allowQmdSlugFallback: isQmdSessionPath && !identity.archived,
-              ...(fallbackOwnerAgentId ? { ownerAgentId: fallbackOwnerAgentId } : {}),
-            }),
+          : (() => {
+              const resolvedKeys = resolveTranscriptStemToSessionKeys({
+                store: combinedSessionStore,
+                stem: identity.stem,
+                allowQmdSlugFallback: isQmdSessionPath && !identity.archived,
+                ...(archivedOwnerAgentId ? { archivedOwnerAgentId } : {}),
+              });
+              return resolvedKeys.length > 0 || identity.archived || !ownerMatchesScope
+                ? resolvedKeys
+                : synthesizeLiveOwnerSessionKey({
+                    ownerAgentId: identity.ownerAgentId,
+                    stem: identity.stem,
+                  });
+            })(),
     });
     if (!guard) {
       return Boolean(scopedAgentId && keys.length > 0);

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -1256,15 +1256,17 @@ async function createSessionMemoryPathVisibilityChecker(params: {
     ) {
       return false;
     }
-    const archivedOwnerMatchesScope = Boolean(
-      identity.archived &&
-      ((identity.ownerAgentId &&
-        (!normalizedScopedAgentId || normalizedOwnerAgentId === normalizedScopedAgentId)) ||
-        (isQmdSessionPath && scopedAgentId)),
+    const ownerMatchesScope = Boolean(
+      identity.ownerAgentId &&
+      (!normalizedScopedAgentId || normalizedOwnerAgentId === normalizedScopedAgentId),
     );
-    const archivedOwnerAgentId = archivedOwnerMatchesScope
-      ? (identity.ownerAgentId ?? scopedAgentId)
-      : undefined;
+    const qmdArchivedOwnerMatchesScope = Boolean(
+      identity.archived && isQmdSessionPath && scopedAgentId,
+    );
+    const fallbackOwnerAgentId =
+      ownerMatchesScope || qmdArchivedOwnerMatchesScope
+        ? (identity.ownerAgentId ?? scopedAgentId)
+        : undefined;
     const liveKeys = identity.liveStem
       ? resolveTranscriptStemToSessionKeys({
           store: combinedSessionStore,
@@ -1282,7 +1284,7 @@ async function createSessionMemoryPathVisibilityChecker(params: {
               store: combinedSessionStore,
               stem: identity.stem,
               allowQmdSlugFallback: isQmdSessionPath && !identity.archived,
-              ...(archivedOwnerAgentId ? { archivedOwnerAgentId } : {}),
+              ...(fallbackOwnerAgentId ? { ownerAgentId: fallbackOwnerAgentId } : {}),
             }),
     });
     if (!guard) {

--- a/src/plugin-sdk/session-transcript-hit.ts
+++ b/src/plugin-sdk/session-transcript-hit.ts
@@ -181,8 +181,8 @@ export function resolveTranscriptStemToSessionKeys(params: {
   if (normalizedDeduped.length > 0) {
     return normalizedDeduped.length === 1 ? normalizedDeduped : [];
   }
-  const fallbackOwnerAgentId = normalizeOptionalString(params.archivedOwnerAgentId);
-  return fallbackOwnerAgentId
-    ? [`agent:${normalizeAgentId(fallbackOwnerAgentId)}:${params.stem}`]
+  const archivedOwnerAgentId = normalizeOptionalString(params.archivedOwnerAgentId);
+  return archivedOwnerAgentId
+    ? [`agent:${normalizeAgentId(archivedOwnerAgentId)}:${params.stem}`]
     : [];
 }

--- a/src/plugin-sdk/session-transcript-hit.ts
+++ b/src/plugin-sdk/session-transcript-hit.ts
@@ -134,6 +134,7 @@ export function resolveTranscriptStemToSessionKeys(params: {
   store: Record<string, SessionEntry>;
   stem: string;
   archivedOwnerAgentId?: string;
+  ownerAgentId?: string;
   allowQmdSlugFallback?: boolean;
 }): string[] {
   const { store } = params;
@@ -181,8 +182,10 @@ export function resolveTranscriptStemToSessionKeys(params: {
   if (normalizedDeduped.length > 0) {
     return normalizedDeduped.length === 1 ? normalizedDeduped : [];
   }
-  const archivedOwnerAgentId = normalizeOptionalString(params.archivedOwnerAgentId);
-  return archivedOwnerAgentId
-    ? [`agent:${normalizeAgentId(archivedOwnerAgentId)}:${params.stem}`]
+  const fallbackOwnerAgentId = normalizeOptionalString(
+    params.ownerAgentId ?? params.archivedOwnerAgentId,
+  );
+  return fallbackOwnerAgentId
+    ? [`agent:${normalizeAgentId(fallbackOwnerAgentId)}:${params.stem}`]
     : [];
 }

--- a/src/plugin-sdk/session-transcript-hit.ts
+++ b/src/plugin-sdk/session-transcript-hit.ts
@@ -134,7 +134,6 @@ export function resolveTranscriptStemToSessionKeys(params: {
   store: Record<string, SessionEntry>;
   stem: string;
   archivedOwnerAgentId?: string;
-  ownerAgentId?: string;
   allowQmdSlugFallback?: boolean;
 }): string[] {
   const { store } = params;
@@ -182,9 +181,7 @@ export function resolveTranscriptStemToSessionKeys(params: {
   if (normalizedDeduped.length > 0) {
     return normalizedDeduped.length === 1 ? normalizedDeduped : [];
   }
-  const fallbackOwnerAgentId = normalizeOptionalString(
-    params.ownerAgentId ?? params.archivedOwnerAgentId,
-  );
+  const fallbackOwnerAgentId = normalizeOptionalString(params.archivedOwnerAgentId);
   return fallbackOwnerAgentId
     ? [`agent:${normalizeAgentId(fallbackOwnerAgentId)}:${params.stem}`]
     : [];


### PR DESCRIPTION
## Summary
- allow owner-scoped live transcript hits to fall back to synthetic session keys when the combined session store has no entry
- keep the fallback scoped to the transcript owner/current agent so cross-agent live orphan hits still fail closed
- apply the same resolution path to memory-core search filtering and memory-wiki session path checks

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: live transcript search hits with paths like `sessions/<agent>/<uuid>.jsonl` were dropped when the combined session store had no metadata entry, even when the hit belongs to the requesting/scoped agent.
- Real environment tested: temporary local checkout of this PR on Linux, current PR head `4d643f948cce2c114d2285b370e60b3cedf8549b` (`fix/live-session-orphan-visibility`), Node `v24.15.0`, repo dependencies installed with `corepack pnpm install --frozen-lockfile`.
- Exact steps or command run after this patch: ran a live Node smoke script from the repository root importing the current `extensions/memory-core/src/session-search-visibility.ts`, with an empty combined session store and three real session-hit path shapes: same-agent owner-scoped, cross-agent owner-scoped, and legacy basename-only. Then ran the targeted plugin-sdk, memory-core, and memory-wiki Vitest files.
- Evidence after fix (copied live terminal output from current head):

```text
$ git rev-parse HEAD
4d643f948cce2c114d2285b370e60b3cedf8549b

$ node --import tsx --input-type=module <<'EOF'
import { filterMemorySearchHitsBySessionVisibility } from './extensions/memory-core/src/session-search-visibility.ts';

const cfg = {
  tools: {
    sessions: { visibility: 'all' },
    agentToAgent: { enabled: true, allow: ['*'] },
  },
};
const cases = [
  { label: 'memory-core same-agent live orphan', path: 'sessions/main/live-orphan.jsonl' },
  { label: 'memory-core cross-agent live orphan', path: 'sessions/peer/live-orphan.jsonl' },
  { label: 'memory-core legacy basename-only live orphan', path: 'sessions/live-orphan.jsonl' },
];
for (const c of cases) {
  const hit = { path: c.path, source: 'sessions', score: 1, snippet: 'x', startLine: 1, endLine: 1 };
  const filtered = await filterMemorySearchHitsBySessionVisibility({
    cfg,
    agentId: 'main',
    requesterSessionKey: 'agent:main:main',
    sandboxed: false,
    hits: [hit],
  });
  console.log(`${c.label}: ${filtered.length === 1 ? 'kept' : 'dropped'} (${c.path})`);
}
EOF
memory-core same-agent live orphan: kept (sessions/main/live-orphan.jsonl)
memory-core cross-agent live orphan: dropped (sessions/peer/live-orphan.jsonl)
memory-core legacy basename-only live orphan: dropped (sessions/live-orphan.jsonl)
```

- Observed result after fix: the real memory-core search visibility path keeps same-agent `sessions/main/*.jsonl` orphan hits by synthesizing `agent:main:<stem>` internally, while cross-agent `sessions/peer/*.jsonl` and legacy basename-only `sessions/*.jsonl` orphan hits still fail closed.
- Memory-wiki coverage: `extensions/memory-wiki/src/query.ts` now uses the same internal live-owner fallback inside `createSessionMemoryPathVisibilityChecker`, and the targeted memory-wiki query test file was run with the memory extension shard below.
- What was not tested: a full long-running OpenClaw gateway with an embedding index refresh and UI search interaction.
- Proof limitations or environment constraints: this is a local runtime smoke against the actual patched source plus targeted regression tests; it is not a screenshot/recording or a persisted gateway index replay.
- Before evidence (optional but encouraged): prior current-main code only synthesized missing-store keys from `archivedOwnerAgentId`, so a live owner-scoped path with an empty store returned no key and was filtered out.

## Tests

```text
$ node scripts/run-vitest.mjs run src/plugin-sdk/session-transcript-hit.test.ts extensions/memory-core/src/session-search-visibility.test.ts extensions/memory-wiki/src/query.test.ts
[test] starting test/vitest/vitest.plugin-sdk.config.ts

 RUN  v4.1.8 /tmp/openclaw-pr92261.COWzMD


 Test Files  1 passed (1)
      Tests  30 passed (30)
   Start at  17:46:06
   Duration  2.76s (transform 2.10s, setup 456ms, import 2.16s, tests 19ms, environment 0ms)

[test] starting test/vitest/vitest.extension-memory.config.ts

 RUN  v4.1.8 /tmp/openclaw-pr92261.COWzMD


 Test Files  2 passed (2)
      Tests  59 passed (59)
   Start at  17:46:11
   Duration  5.04s (transform 7.03s, setup 771ms, import 8.41s, tests 421ms, environment 0ms)

[test] passed 2 Vitest shards in 13.59s
```

Fixes the live `sessions/<agent>/<uuid>.jsonl` orphan variant related to #53550, #73471, #76452, and #83518.


## Maintainer scope cut (2026-07-21)

Peter approved only owner-qualified, same-agent live orphan visibility. The reworked branch now requires all of the following before an unmapped live transcript can surface: a canonical `sessions/<agent>/<stem>.jsonl` owner, exact match with the active scoped agent, and agent-wide session visibility (`agent` or `all`). It does not fabricate a logical session key from the filename, so `self`/`tree` visibility cannot mistake an orphan basename for proven session lineage.

Ownerless QMD orphans and cross-agent orphans stay hidden until a real session-store or artifact mapping proves ownership. Negative regressions cover memory-core QMD fallback, memory-wiki search, memory-wiki reads, cross-agent owner-qualified paths, and the filename-equals-requester-key security case.

Current focused proof at head `fbd7111c114d5db3cd0d54507a3bdf06dfae3093`: `src/plugin-sdk/session-transcript-hit.test.ts`, both memory-core visibility suites, and `extensions/memory-wiki/src/query.test.ts` passed (4 files, 113 tests). Targeted `node scripts/check-changed.mjs` passed on Blacksmith Testbox `tbx_01ky431j3aw7rjt55wvscedcnx`; final AutoReview was clean at 0.93 confidence after the synthetic-lineage finding was fixed.
