### PR TITLE
fix(heartbeat): skip reasoning payloads when includeReasoning is false (#92260)

### DIFF
--- a/src/auto-reply/heartbeat-reply-payload.test.ts
+++ b/src/auto-reply/heartbeat-reply-payload.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { resolveHeartbeatReplyPayload } from "./heartbeat-reply-payload.js";
+
+describe("resolveHeartbeatReplyPayload", () => {
+  it("returns undefined for undefined input", () => {
+    expect(resolveHeartbeatReplyPayload(undefined)).toBeUndefined();
+  });
+
+  it("returns single payload directly", () => {
+    const payload = { text: "hello" };
+    expect(resolveHeartbeatReplyPayload(payload)).toBe(payload);
+  });
+
+  it("returns undefined for single reasoning payload when includeReasoning is false", () => {
+    const payload = { text: "thinking...", isReasoning: true };
+    expect(
+      resolveHeartbeatReplyPayload(payload, { includeReasoning: false }),
+    ).toBeUndefined();
+  });
+
+  it("returns single reasoning payload when includeReasoning is true", () => {
+    const payload = { text: "thinking...", isReasoning: true };
+    expect(
+      resolveHeartbeatReplyPayload(payload, { includeReasoning: true }),
+    ).toBe(payload);
+  });
+
+  it("returns single reasoning payload by default (backward compat)", () => {
+    const payload = { text: "thinking...", isReasoning: true };
+    expect(resolveHeartbeatReplyPayload(payload)).toBe(payload);
+  });
+
+  it("picks the last outbound payload from array", () => {
+    const payloads = [{ text: "first" }, { text: "last" }];
+    expect(resolveHeartbeatReplyPayload(payloads)).toBe(payloads[1]);
+  });
+
+  it("skips reasoning payloads when includeReasoning is false", () => {
+    const payloads = [
+      { text: "answer" },
+      { text: "thinking...", isReasoning: true },
+    ];
+    expect(
+      resolveHeartbeatReplyPayload(payloads, { includeReasoning: false }),
+    ).toBe(payloads[0]);
+  });
+
+  it("returns undefined when all payloads are reasoning and includeReasoning is false", () => {
+    const payloads = [
+      { text: "think step 1", isReasoning: true },
+      { text: "think step 2", isReasoning: true },
+    ];
+    expect(
+      resolveHeartbeatReplyPayload(payloads, { includeReasoning: false }),
+    ).toBeUndefined();
+  });
+
+  it("returns reasoning payload when includeReasoning is true", () => {
+    const payloads = [
+      { text: "answer" },
+      { text: "thinking...", isReasoning: true },
+    ];
+    expect(
+      resolveHeartbeatReplyPayload(payloads, { includeReasoning: true }),
+    ).toBe(payloads[1]);
+  });
+
+  it("skips null/undefined entries in array", () => {
+    const payloads = [null, { text: "answer" }] as any[];
+    expect(resolveHeartbeatReplyPayload(payloads)).toBe(payloads[1]);
+  });
+
+  it("returns undefined when no outbound content exists", () => {
+    const payloads = [{}];
+    expect(resolveHeartbeatReplyPayload(payloads)).toBeUndefined();
+  });
+
+  it("handles reasoning payload without isReasoning flag as normal payload", () => {
+    const payloads = [{ text: "normal text" }];
+    expect(
+      resolveHeartbeatReplyPayload(payloads, { includeReasoning: false }),
+    ).toBe(payloads[0]);
+  });
+});

--- a/src/auto-reply/heartbeat-reply-payload.ts
+++ b/src/auto-reply/heartbeat-reply-payload.ts
@@ -2,19 +2,32 @@
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "./types.js";
 
+export interface ResolveHeartbeatReplyPayloadOptions {
+  /** When false, skip reasoning/thinking payloads (isReasoning === true). */
+  includeReasoning?: boolean;
+}
+
 /** Pick the last outbound-capable reply payload for heartbeat delivery. */
 export function resolveHeartbeatReplyPayload(
   replyResult: ReplyPayload | ReplyPayload[] | undefined,
+  options?: ResolveHeartbeatReplyPayloadOptions,
 ): ReplyPayload | undefined {
   if (!replyResult) {
     return undefined;
   }
   if (!Array.isArray(replyResult)) {
+    if (options?.includeReasoning === false && replyResult.isReasoning === true) {
+      return undefined;
+    }
     return replyResult;
   }
+  const skipReasoning = options?.includeReasoning === false;
   for (let idx = replyResult.length - 1; idx >= 0; idx -= 1) {
     const payload = replyResult[idx];
     if (!payload) {
+      continue;
+    }
+    if (skipReasoning && payload.isReasoning === true) {
       continue;
     }
     if (hasOutboundReplyContent(payload)) {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1796,8 +1796,10 @@ export async function runHeartbeatOnce(opts: {
       opts.deps?.getReplyFromConfig ?? (await loadHeartbeatRunnerRuntime()).getReplyFromConfig;
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const heartbeatToolResponse = resolveHeartbeatToolResponseFromReplyResult(replyResult);
-    const replyPayload = resolveHeartbeatReplyPayload(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;
+    const replyPayload = resolveHeartbeatReplyPayload(replyResult, {
+      includeReasoning,
+    });
     const reasoningPayloads = includeReasoning
       ? resolveHeartbeatReasoningPayloads(replyResult).filter((payload) => payload !== replyPayload)
       : [];

--- a/src/plugin-sdk/reply-runtime.ts
+++ b/src/plugin-sdk/reply-runtime.ts
@@ -27,6 +27,7 @@ export {
   stripHeartbeatToken,
 } from "../auto-reply/heartbeat.js";
 export { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
+export type { ResolveHeartbeatReplyPayloadOptions } from "../auto-reply/heartbeat-reply-payload.js";
 export { getReplyFromConfig } from "../auto-reply/reply/get-reply.js";
 export { HEARTBEAT_TOKEN, isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 export { isAbortRequestText } from "../auto-reply/reply/abort.js";


### PR DESCRIPTION
## What does this PR do?

Fixes `resolveHeartbeatReplyPayload` to skip reasoning/thinking payloads when `includeReasoning` is false, preventing the heartbeat from delivering internal model reasoning as a user-visible channel message.

## Related Issue

Fixes #92260

## Type of Change

- [x] Bug fix (non-breaking)

## Changes Made

- `src/auto-reply/heartbeat-reply-payload.ts`: Added optional `includeReasoning` option to `resolveHeartbeatReplyPayload`. When `false`, payloads with `isReasoning === true` are skipped during selection.
- `src/infra/heartbeat-runner.ts`: Moved `includeReasoning` computation before the `resolveHeartbeatReplyPayload` call and passes it through.
- `src/plugin-sdk/reply-runtime.ts`: Added type export for `ResolveHeartbeatReplyPayloadOptions`.
- `src/auto-reply/heartbeat-reply-payload.test.ts`: Added 12 test cases covering reasoning payload skipping, backward compatibility, and edge cases.

## How to Test

1. Run: `node scripts/run-vitest.mjs run src/auto-reply/heartbeat-reply-payload.test.ts`
2. All 12 tests should pass
3. Also verify plugin-sdk tests: `node scripts/run-vitest.mjs run src/plugin-sdk/reply-payload.test.ts`

## Real behavior proof

**Behavior or issue addressed:**
`resolveHeartbeatReplyPayload` iterates reply payloads in reverse and returns the last one with outbound content. It never checked `isReasoning`, so when a reasoning model (e.g. `xai/grok-4.3`) places a reasoning payload after the final text payload, the reasoning text was selected as the heartbeat reply and delivered to the channel — even when `includeReasoning` is `false`.

**Real environment tested:**
macOS, Node.js v22, vitest 4.1.7

**Exact steps or command run after the patch:**
```bash
node scripts/run-vitest.mjs run src/auto-reply/heartbeat-reply-payload.test.ts --reporter=verbose
```

**Evidence after fix:**
```
 ✓  unit-fast  src/auto-reply/heartbeat-reply-payload.test.ts > resolveHeartbeatReplyPayload > returns undefined for undefined input
 ✓  unit-fast  src/auto-reply/heartbeat-reply-payload.test.ts > resolveHeartbeatReplyPayload > returns single payload directly
 ✓  unit-fast  src/auto-reply/heartbeat-reply-payload.test.ts > resolveHeartbeatReplyPayload > returns undefined for single reasoning payload when includeReasoning is false
 ✓  unit-fast  src/auto-reply/heartbeat-reply-payload.test.ts > resolveHeartbeatReplyPayload > returns single reasoning payload when includeReasoning is true
 ✓  unit-fast  src/auto-reply/heartbeat-reply-payload.test.ts > resolveHeartbeatReplyPayload > returns single reasoning payload by default (backward compat)
 ✓  unit-fast  src/auto-reply/heartbeat-reply-payload.test.ts > resolveHeartbeatReplyPayload > picks the last outbound payload from array
 ✓  unit-fast  src/auto-reply/heartbeat-reply-payload.test.ts > resolveHeartbeatReplyPayload > skips reasoning payloads when includeReasoning is false
 ✓  unit-fast  src/auto-reply/heartbeat-reply-payload.test.ts > resolveHeartbeatReplyPayload > returns undefined when all payloads are reasoning and includeReasoning is false
 ✓  unit-fast  src/auto-reply/heartbeat-reply-payload.test.ts > resolveHeartbeatReplyPayload > returns reasoning payload when includeReasoning is true
 ✓  unit-fast  src/auto-reply/heartbeat-reply-payload.test.ts > resolveHeartbeatReplyPayload > skips null/undefined entries in array
 ✓  unit-fast  src/auto-reply/heartbeat-reply-payload.test.ts > resolveHeartbeatReplyPayload > returns undefined when no outbound content exists
 ✓  unit-fast  src/auto-reply/heartbeat-reply-payload.test.ts > resolveHeartbeatReplyPayload > handles reasoning payload without isReasoning flag as normal payload

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

**Observed result after fix:**
Reasoning payloads are correctly skipped when `includeReasoning` is false. The fix is backward-compatible — existing callers without the options parameter retain the previous behavior.

**What was not tested:**
Full OpenClaw gateway with a live reasoning model (e.g. xai/grok). The fix is verified via focused unit tests on the payload selection logic.

## Checklist
- [x] Read Contributing Guide
- [x] Conventional Commits
- [x] Searched for duplicates
- [x] Only related changes
- [x] Tests pass
- [x] Added tests
