### PR TITLE
Fix heartbeat reasoning payload selection

### DIFF
--- a/src/auto-reply/heartbeat-reply-payload.test.ts
+++ b/src/auto-reply/heartbeat-reply-payload.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolveHeartbeatReplyPayload } from "./heartbeat-reply-payload.js";
+import type { ReplyPayload } from "./types.js";
+
+describe("resolveHeartbeatReplyPayload", () => {
+  it("selects the last visible outbound payload instead of later reasoning", () => {
+    const finalPayload: ReplyPayload = { text: "HEARTBEAT_OK" };
+    const reasoningPayload: ReplyPayload = {
+      text: "private chain of thought",
+      isReasoning: true,
+    };
+
+    expect(resolveHeartbeatReplyPayload([finalPayload, reasoningPayload])).toBe(finalPayload);
+  });
+
+  it("selects the last visible outbound payload instead of later legacy-prefixed reasoning", () => {
+    const finalPayload: ReplyPayload = { text: "Final alert" };
+
+    expect(
+      resolveHeartbeatReplyPayload([
+        finalPayload,
+        { text: "Reasoning:\n_private details_" },
+        { text: "Thinking\n\n_private details_" },
+      ]),
+    ).toBe(finalPayload);
+  });
+
+  it("returns undefined when the only payload is reasoning", () => {
+    const reasoningPayload: ReplyPayload = {
+      text: "private chain of thought",
+      isReasoning: true,
+    };
+
+    expect(resolveHeartbeatReplyPayload(reasoningPayload)).toBeUndefined();
+    expect(resolveHeartbeatReplyPayload([reasoningPayload])).toBeUndefined();
+    expect(resolveHeartbeatReplyPayload({ text: "Reasoning:\n_private details_" })).toBeUndefined();
+  });
+
+  it("continues scanning past empty and reasoning payloads", () => {
+    const visiblePayload: ReplyPayload = { text: "Final alert" };
+    const payloads: ReplyPayload[] = [
+      { text: "Earlier alert" },
+      visiblePayload,
+      { text: "internal thinking", isReasoning: true },
+      {},
+    ];
+
+    expect(resolveHeartbeatReplyPayload(payloads)).toBe(visiblePayload);
+  });
+});

--- a/src/auto-reply/heartbeat-reply-payload.test.ts
+++ b/src/auto-reply/heartbeat-reply-payload.test.ts
@@ -21,6 +21,7 @@ describe("resolveHeartbeatReplyPayload", () => {
         finalPayload,
         { text: "Reasoning:\n_private details_" },
         { text: "Thinking\n\n_private details_" },
+        { text: "> reasoning:\n> _private details_" },
       ]),
     ).toBe(finalPayload);
   });
@@ -34,6 +35,9 @@ describe("resolveHeartbeatReplyPayload", () => {
     expect(resolveHeartbeatReplyPayload(reasoningPayload)).toBeUndefined();
     expect(resolveHeartbeatReplyPayload([reasoningPayload])).toBeUndefined();
     expect(resolveHeartbeatReplyPayload({ text: "Reasoning:\n_private details_" })).toBeUndefined();
+    expect(
+      resolveHeartbeatReplyPayload({ text: "> thinking\n> _private details_" }),
+    ).toBeUndefined();
   });
 
   it("continues scanning past empty and reasoning payloads", () => {

--- a/src/auto-reply/heartbeat-reply-payload.ts
+++ b/src/auto-reply/heartbeat-reply-payload.ts
@@ -2,7 +2,20 @@
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "./types.js";
 
-/** Pick the last outbound-capable reply payload for heartbeat delivery. */
+const HEARTBEAT_REASONING_PREFIX_PATTERN = /^(?:Reasoning:|Thinking\.{0,3}(?=\s*_))/u;
+
+export function hasHeartbeatReasoningPrefix(text: string): boolean {
+  return HEARTBEAT_REASONING_PREFIX_PATTERN.test(text.trimStart());
+}
+
+export function isHeartbeatReasoningPayload(
+  payload: Pick<ReplyPayload, "isReasoning" | "text">,
+): boolean {
+  const text = typeof payload.text === "string" ? payload.text : "";
+  return payload.isReasoning === true || hasHeartbeatReasoningPrefix(text);
+}
+
+/** Pick the last non-reasoning outbound-capable reply payload for heartbeat delivery. */
 export function resolveHeartbeatReplyPayload(
   replyResult: ReplyPayload | ReplyPayload[] | undefined,
 ): ReplyPayload | undefined {
@@ -10,11 +23,14 @@ export function resolveHeartbeatReplyPayload(
     return undefined;
   }
   if (!Array.isArray(replyResult)) {
-    return replyResult;
+    return isHeartbeatReasoningPayload(replyResult) ? undefined : replyResult;
   }
   for (let idx = replyResult.length - 1; idx >= 0; idx -= 1) {
     const payload = replyResult[idx];
     if (!payload) {
+      continue;
+    }
+    if (isHeartbeatReasoningPayload(payload)) {
       continue;
     }
     if (hasOutboundReplyContent(payload)) {

--- a/src/auto-reply/heartbeat-reply-payload.ts
+++ b/src/auto-reply/heartbeat-reply-payload.ts
@@ -1,18 +1,18 @@
 // Heartbeat reply payload selector for multi-payload auto-reply results.
-import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
+import {
+  hasOutboundReplyContent,
+  isReasoningReplyPayload,
+} from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "./types.js";
 
-const HEARTBEAT_REASONING_PREFIX_PATTERN = /^(?:Reasoning:|Thinking\.{0,3}(?=\s*_))/u;
-
 export function hasHeartbeatReasoningPrefix(text: string): boolean {
-  return HEARTBEAT_REASONING_PREFIX_PATTERN.test(text.trimStart());
+  return isReasoningReplyPayload({ text });
 }
 
 export function isHeartbeatReasoningPayload(
   payload: Pick<ReplyPayload, "isReasoning" | "text">,
 ): boolean {
-  const text = typeof payload.text === "string" ? payload.text : "";
-  return payload.isReasoning === true || hasHeartbeatReasoningPrefix(text);
+  return isReasoningReplyPayload(payload);
 }
 
 /** Pick the last non-reasoning outbound-capable reply payload for heartbeat delivery. */

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1363,6 +1363,10 @@ describe("runHeartbeatOnce", () => {
         name: "legacy-prefixed reasoning after HEARTBEAT_OK",
         replies: [{ text: "HEARTBEAT_OK" }, { text: "Reasoning:\n_Because it helps_" }],
       },
+      {
+        name: "blockquoted reasoning after HEARTBEAT_OK",
+        replies: [{ text: "HEARTBEAT_OK" }, { text: "> reasoning:\n> _Because it helps_" }],
+      },
     ]),
   )(
     "does not deliver late reasoning payloads when includeReasoning is unset: $name",

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1254,6 +1254,18 @@ describe("runHeartbeatOnce", () => {
         expectedTexts: ["Thinking\n\n_Because it helps_"],
       },
       {
+        name: "raw flagged reasoning only",
+        caseDir: "hb-reasoning-only",
+        replies: [{ text: "Because it helps", isReasoning: true }],
+        expectedTexts: ["Thinking\n\n_Because it helps_"],
+      },
+      {
+        name: "legacy-prefixed reasoning only",
+        caseDir: "hb-reasoning-legacy-only",
+        replies: [{ text: "Reasoning:\n_Because it helps_" }],
+        expectedTexts: ["Reasoning:\n_Because it helps_"],
+      },
+      {
         name: "visible final that starts with thinking prose",
         caseDir: "hb-thinking-visible-final",
         replies: [{ text: "Thinking... all clear" }],
@@ -1332,6 +1344,78 @@ describe("runHeartbeatOnce", () => {
             text,
           });
         }
+      } finally {
+        replySpy.mockReset();
+      }
+    },
+  );
+
+  it.each(
+    typedCases<{
+      name: string;
+      replies: Array<{ text: string; isReasoning?: boolean }>;
+    }>([
+      {
+        name: "flagged reasoning after HEARTBEAT_OK",
+        replies: [{ text: "HEARTBEAT_OK" }, { text: "Because it helps", isReasoning: true }],
+      },
+      {
+        name: "legacy-prefixed reasoning after HEARTBEAT_OK",
+        replies: [{ text: "HEARTBEAT_OK" }, { text: "Reasoning:\n_Because it helps_" }],
+      },
+    ]),
+  )(
+    "does not deliver late reasoning payloads when includeReasoning is unset: $name",
+    async ({ replies }) => {
+      const replySpy = vi.fn();
+      try {
+        const tmpDir = await createCaseDir("hb-reasoning-default-hidden");
+        const storePath = path.join(tmpDir, "sessions.json");
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              workspace: tmpDir,
+              heartbeat: {
+                every: "5m",
+                target: "whatsapp",
+              },
+            },
+          },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+          session: { store: storePath },
+        };
+        const sessionKey = resolveMainSessionKey(cfg);
+
+        await fs.writeFile(
+          storePath,
+          JSON.stringify({
+            [sessionKey]: {
+              sessionId: "sid",
+              updatedAt: Date.now(),
+              lastChannel: "whatsapp",
+              lastProvider: "whatsapp",
+              lastTo: "120363401234567890@g.us",
+            },
+          }),
+        );
+
+        replySpy.mockResolvedValue(replies);
+        const sendWhatsApp = vi
+          .fn<
+            (
+              to: string,
+              text: string,
+              opts?: unknown,
+            ) => Promise<{ messageId: string; toJid: string }>
+          >()
+          .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+        await runHeartbeatOnce({
+          cfg,
+          deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+        });
+
+        expect(sendWhatsApp).toHaveBeenCalledTimes(0);
       } finally {
         replySpy.mockReset();
       }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -25,7 +25,11 @@ import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import { resolveModelRefFromString, type ModelRef } from "../agents/model-selection.js";
 import { resolvePersistedSessionRuntimeId } from "../agents/session-runtime-compat.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
-import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
+import {
+  hasHeartbeatReasoningPrefix,
+  isHeartbeatReasoningPayload,
+  resolveHeartbeatReplyPayload,
+} from "../auto-reply/heartbeat-reply-payload.js";
 import {
   getHeartbeatToolNotificationText,
   resolveHeartbeatToolResponseFromReplyResult,
@@ -745,10 +749,8 @@ function resolveHeartbeatReasoningPayloads(
   const reasoningPayloads: ReplyPayload[] = [];
   for (const payload of payloads) {
     const text = typeof payload.text === "string" ? payload.text : "";
-    const hasFormattedReasoningPrefix = /^(?:Reasoning:|Thinking\.{0,3}(?=\s*_))/u.test(
-      text.trimStart(),
-    );
-    if (payload.isReasoning !== true && !hasFormattedReasoningPrefix) {
+    const hasFormattedReasoningPrefix = hasHeartbeatReasoningPrefix(text);
+    if (!isHeartbeatReasoningPayload(payload)) {
       continue;
     }
 
@@ -1833,7 +1835,11 @@ export async function runHeartbeatOnce(opts: {
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
-    if (!heartbeatToolResponse && (!replyPayload || !hasOutboundReplyContent(replyPayload))) {
+    if (
+      !heartbeatToolResponse &&
+      (!replyPayload || !hasOutboundReplyContent(replyPayload)) &&
+      reasoningPayloads.length === 0
+    ) {
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,


### PR DESCRIPTION
## Summary

Fixes #92260.

This fixes heartbeat main-reply selection so reasoning payloads are not delivered as the visible heartbeat reply when `includeReasoning` is unset. The selector now skips flagged reasoning payloads (`isReasoning: true`) and the same common reasoning text forms already recognized by the shared reply-payload reasoning detector, including legacy `Reasoning:` / `Thinking...` forms and blockquoted reasoning.

The runner still preserves the explicit opt-in path: when `agents.defaults.heartbeat.includeReasoning: true`, reasoning-only responses continue to deliver through the separate reasoning delivery path instead of being treated as empty replies.

## Patch-level comparison

I checked for competing open PRs before opening this: none were open for #92260 when this PR was prepared. The closest competing patch was closed PR #92262.

Compared with #92262, this branch is intentionally different in a few ways:

- It avoids adding a new public `ResolveHeartbeatReplyPayloadOptions` export through `src/plugin-sdk/reply-runtime.ts`.
- It handles flagged reasoning and the existing prefixed/blockquote reasoning forms recognized by `isReasoningReplyPayload`.
- It adds runner-level regression coverage proving default `includeReasoning` suppression on the actual heartbeat send path, not only selector unit tests.
- It preserves and tests the opt-in `includeReasoning: true` behavior for reasoning-only responses, including the regression caught during autoreview.

Maintainers should feel free to prefer another branch if it fits the intended API direction better. I kept the comparison explicit so the delta is reviewable side-by-side with #92262.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Heartbeat replies no longer select reasoning payloads as the main visible reply when reasoning is disabled by default.
- Real environment tested: Local OpenClaw checkout at `1d36bdf2ce876dc18c7644da8e308f049fa23fc8`, Node 24.16.0, production `runHeartbeatOnce`, real temporary `OpenClawConfig`, real session-store JSON file, real plugin registry registration, isolated `OPENCLAW_HOME` / `OPENCLAW_STATE_DIR` under `/tmp`, and a local Telegram-shaped outbound adapter that records delivery attempts without contacting Telegram.
- Exact steps or command run after this patch:

```bash
OPENCLAW_PROOF_HEAD=1d36bdf2ce876dc18c7644da8e308f049fa23fc8 \
OPENCLAW_HOME=/tmp/openclaw-hb-proof-home \
OPENCLAW_STATE_DIR=/tmp/openclaw-hb-proof-home/state \
node --import tsx /tmp/openclaw-heartbeat-proof.ts
```

- Evidence after fix (terminal capture / copied console output):

```text
OpenClaw heartbeat behavior proof
head=1d36bdf2ce876dc18c7644da8e308f049fa23fc8
[
  {
    "case": "default suppresses late blockquoted reasoning after HEARTBEAT_OK",
    "includeReasoning": false,
    "status": "ran",
    "deliveryCount": 0,
    "deliveredTexts": [],
    "disallowedReasoningDelivered": false,
    "sessionStore": "sessions.json"
  },
  {
    "case": "default sends visible final and ignores later reasoning",
    "includeReasoning": false,
    "status": "ran",
    "deliveryCount": 1,
    "deliveredTexts": [
      "Visible heartbeat update"
    ],
    "disallowedReasoningDelivered": false,
    "sessionStore": "sessions.json"
  },
  {
    "case": "includeReasoning true still delivers reasoning-only output",
    "includeReasoning": true,
    "status": "ran",
    "deliveryCount": 1,
    "deliveredTexts": [
      "Thinking\n\n_private chain of thought_"
    ],
    "disallowedReasoningDelivered": false,
    "sessionStore": "sessions.json"
  }
]
```

- Observed result after fix: With `includeReasoning` unset, a late blockquoted reasoning payload after `HEARTBEAT_OK` produced zero outbound sends, and a visible final heartbeat update followed by reasoning delivered only the visible final text. With `includeReasoning: true`, a reasoning-only response still delivered through the explicit reasoning path.
- What was not tested: No live xAI/OpenAI Responses model and no real Telegram network delivery were used. The model reply ordering and outbound network call were locally controlled to isolate the heartbeat payload-selection behavior.
- Proof limitations or environment constraints: Live Telegram/provider proof would require credentials and a model response ordering that reproduces the reporter's payload order; this local proof targets the heartbeat runner layer identified as the root cause in #92260.

## Tests and validation

Focused commands run:

```bash
node scripts/run-vitest.mjs src/auto-reply/heartbeat-reply-payload.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts src/plugin-sdk/reply-payload.test.ts
git diff --check
/Users/harjothk/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 .agents/skills/autoreview/scripts/autoreview --mode local
```

Results:

- `node scripts/run-vitest.mjs ...` passed 3 Vitest shards: 4 selector tests, 44 infra heartbeat runner tests, and 53 plugin-sdk reply-payload tests.
- `git diff --check` passed.
- Autoreview initially found two regressions; both were fixed. Final autoreview result: `autoreview clean: no accepted/actionable findings reported`.

Regression coverage added:

- Selector tests cover late flagged reasoning, legacy-prefixed reasoning, blockquoted reasoning, reasoning-only inputs, and scan-through behavior.
- Heartbeat runner tests cover default-hidden late reasoning after `HEARTBEAT_OK`, legacy-prefixed and blockquoted late reasoning, and `includeReasoning: true` reasoning-only delivery.
