### PR TITLE
Fix configured DeepSeek model transport inheritance

### DIFF
--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -1088,6 +1088,374 @@ describe("resolveModel", () => {
     });
   });
 
+  it("inherits bundled static transport for configured provider fallback models", () => {
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
+      provider: "deepseek",
+      id: "deepseek-v4-pro",
+      name: "DeepSeek V4 Pro",
+      api: "openai-completions",
+      baseUrl: "https://api.deepseek.com",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
+      contextWindow: 1_000_000,
+      maxTokens: 384_000,
+      compat: {
+        supportsUsageInStreaming: true,
+        supportsReasoningEffort: true,
+        maxTokensField: "max_tokens",
+      },
+    });
+    const cfg = {
+      models: {
+        providers: {
+          deepseek: {
+            baseUrl: "",
+            models: [
+              {
+                id: "deepseek-v4-pro",
+                name: "Custom DeepSeek V4 Pro",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 32_768,
+                maxTokens: 4_096,
+                compat: {
+                  supportsReasoningEffort: false,
+                },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg);
+    const model = expectResolvedModel(result);
+
+    expectRecordFields(model, {
+      name: "Custom DeepSeek V4 Pro",
+      api: "openai-completions",
+      baseUrl: "https://api.deepseek.com",
+      reasoning: false,
+      contextWindow: 32_768,
+      maxTokens: 4_096,
+    });
+    expect(model.compat).toEqual(
+      expect.objectContaining({
+        supportsUsageInStreaming: true,
+        supportsReasoningEffort: false,
+        maxTokensField: "max_tokens",
+      }),
+    );
+    expect(resolveBundledStaticCatalogModelMock).toHaveBeenCalledWith({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      cfg,
+      workspaceDir: expect.any(String),
+      includeRuntimeDiscovery: true,
+    });
+  });
+
+  it("fills missing configured provider runtime transport from bundled static metadata", async () => {
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
+      provider: "deepseek",
+      id: "deepseek-v4-pro",
+      name: "DeepSeek V4 Pro",
+      api: "openai-completions",
+      baseUrl: "https://api.deepseek.com",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
+      contextWindow: 1_000_000,
+      maxTokens: 384_000,
+      compat: {
+        supportsUsageInStreaming: true,
+        supportsReasoningEffort: true,
+        maxTokensField: "max_tokens",
+      },
+    });
+    const cfg = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-pro",
+                name: "Custom DeepSeek V4 Pro",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 32_768,
+                maxTokens: 4_096,
+                thinkingLevelMap: { off: null },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const baseRuntimeHooks = createRuntimeHooks();
+    const runProviderDynamicModel = vi.fn(() => ({
+      provider: "deepseek",
+      id: "deepseek-v4-pro",
+      name: "Custom DeepSeek V4 Pro",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 32_768,
+      maxTokens: 4_096,
+    }));
+
+    const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg, {
+      runtimeHooks: {
+        ...baseRuntimeHooks,
+        runProviderDynamicModel,
+      },
+      skipAgentDiscovery: true,
+    });
+    const model = expectResolvedModel(result);
+
+    expectRecordFields(model, {
+      api: "openai-completions",
+      baseUrl: "https://api.deepseek.com",
+      reasoning: false,
+      contextWindow: 32_768,
+      maxTokens: 4_096,
+    });
+    expect(model.compat).toEqual(
+      expect.objectContaining({
+        supportsUsageInStreaming: true,
+        supportsReasoningEffort: true,
+        maxTokensField: "max_tokens",
+      }),
+    );
+    expect(runProviderDynamicModel).toHaveBeenCalled();
+  });
+
+  it("resolves configured DeepSeek probe models through bundled static transport without agent discovery", async () => {
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
+      provider: "deepseek",
+      id: "deepseek-v4-pro",
+      name: "DeepSeek V4 Pro",
+      api: "openai-completions",
+      baseUrl: "https://api.deepseek.com",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
+      contextWindow: 1_000_000,
+      maxTokens: 384_000,
+      compat: {
+        supportsUsageInStreaming: true,
+        supportsReasoningEffort: true,
+        maxTokensField: "max_tokens",
+      },
+    });
+    const cfg = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-pro",
+                name: "Custom DeepSeek V4 Pro",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 32_768,
+                maxTokens: 4_096,
+                thinkingLevelMap: { off: null },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg, {
+      runtimeHooks: createRuntimeHooks(),
+      skipAgentDiscovery: true,
+    });
+    const model = expectResolvedModel(result);
+
+    expectRecordFields(model, {
+      name: "Custom DeepSeek V4 Pro",
+      api: "openai-completions",
+      baseUrl: "https://api.deepseek.com",
+      reasoning: false,
+      contextWindow: 32_768,
+      maxTokens: 4_096,
+    });
+    expect(model.compat).toEqual(
+      expect.objectContaining({
+        supportsUsageInStreaming: true,
+        supportsReasoningEffort: true,
+        maxTokensField: "max_tokens",
+      }),
+    );
+    expect((model as { thinkingLevelMap?: unknown }).thinkingLevelMap).toEqual({ off: null });
+  });
+
+  it("keeps provider runtime transport ahead of bundled static fallback metadata", async () => {
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
+      provider: "deepseek",
+      id: "deepseek-v4-pro",
+      name: "DeepSeek V4 Pro",
+      api: "openai-completions",
+      baseUrl: "https://api.deepseek.com",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
+      contextWindow: 1_000_000,
+      maxTokens: 384_000,
+    });
+    const cfg = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-pro",
+                name: "Custom DeepSeek V4 Pro",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 32_768,
+                maxTokens: 4_096,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const baseRuntimeHooks = createRuntimeHooks();
+    const runProviderDynamicModel = vi.fn(() => ({
+      provider: "deepseek",
+      id: "deepseek-v4-pro",
+      name: "Runtime DeepSeek V4 Pro",
+      api: "openai-responses" as const,
+      baseUrl: "https://runtime.deepseek.example/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 32_768,
+      maxTokens: 4_096,
+    }));
+
+    const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg, {
+      runtimeHooks: {
+        ...baseRuntimeHooks,
+        runProviderDynamicModel,
+      },
+      skipAgentDiscovery: true,
+    });
+    const model = expectResolvedModel(result);
+
+    expectRecordFields(model, {
+      api: "openai-responses",
+      baseUrl: "https://runtime.deepseek.example/v1",
+      reasoning: false,
+      contextWindow: 32_768,
+      maxTokens: 4_096,
+    });
+    expect(runProviderDynamicModel).toHaveBeenCalled();
+  });
+
+  it("keeps configured transport overrides ahead of bundled static fallback metadata", () => {
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
+      provider: "deepseek",
+      id: "deepseek-v4-pro",
+      name: "DeepSeek V4 Pro",
+      api: "openai-completions",
+      baseUrl: "https://api.deepseek.com",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
+      contextWindow: 1_000_000,
+      maxTokens: 384_000,
+    });
+    const cfg = {
+      models: {
+        providers: {
+          deepseek: {
+            baseUrl: "https://deepseek-proxy.example.com/v1",
+            api: "openai-completions",
+            models: [
+              {
+                id: "deepseek-v4-pro",
+                name: "Custom DeepSeek V4 Pro",
+                baseUrl: "https://deepseek-model-proxy.example.com/v1",
+                api: "openai-responses",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 32_768,
+                maxTokens: 4_096,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg);
+    const model = expectResolvedModel(result);
+
+    expectRecordFields(model, {
+      api: "openai-responses",
+      baseUrl: "https://deepseek-model-proxy.example.com/v1",
+      contextWindow: 32_768,
+      maxTokens: 4_096,
+    });
+  });
+
+  it("keeps bundled static baseUrl when provider api is configured without a baseUrl", () => {
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
+      provider: "deepseek",
+      id: "deepseek-v4-pro",
+      name: "DeepSeek V4 Pro",
+      api: "openai-responses",
+      baseUrl: "https://api.deepseek.com",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
+      contextWindow: 1_000_000,
+      maxTokens: 384_000,
+    });
+    const cfg = {
+      models: {
+        providers: {
+          deepseek: {
+            api: "openai-completions",
+            models: [
+              {
+                id: "deepseek-v4-pro",
+                name: "Custom DeepSeek V4 Pro",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 32_768,
+                maxTokens: 4_096,
+                thinkingLevelMap: { off: null },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg);
+    const model = expectResolvedModel(result);
+
+    expectRecordFields(model, {
+      api: "openai-completions",
+      baseUrl: "https://api.deepseek.com",
+      contextWindow: 32_768,
+      maxTokens: 4_096,
+    });
+    expect(model.thinkingLevelMap).toEqual({ off: null });
+  });
+
   it("keeps provider token overrides ahead of bundled static fallback metadata", () => {
     resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
       provider: "xiaomi-token-plan",
@@ -1223,11 +1591,39 @@ describe("resolveModel", () => {
     const claudeModel = expectResolvedModel(claude);
     expect(claudeModel.api).toBe("anthropic-messages");
     expect(claudeModel.baseUrl).toBe("http://localhost:8080");
+    expect(claudeModel.maxTokens).toBeUndefined();
 
     const gpt = resolveModelForTest("my-router", "my-router/gpt", "/tmp/agent", cfg);
     const gptModel = expectResolvedModel(gpt);
     expect(gptModel.api).toBe("openai-completions");
     expect(gptModel.baseUrl).toBe("http://localhost:8080/v1");
+  });
+
+  it("preserves normalized inline provider transport when static metadata is merged", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "my-gemini": {
+            api: "google-generative-ai",
+            baseUrl: "https://generativelanguage.googleapis.com",
+            models: [
+              {
+                id: "gemini-pro",
+                name: "Gemini Pro",
+                input: ["text"],
+                contextWindow: 32_768,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("my-gemini", "gemini-pro", "/tmp/agent", cfg);
+    const model = expectResolvedModel(result);
+
+    expect(model.api).toBe("google-generative-ai");
+    expect(model.baseUrl).toBe("https://generativelanguage.googleapis.com/v1beta");
   });
 
   it("defaults baseUrl-only local custom fallback models to chat completions", () => {

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -358,18 +358,27 @@ function resolveConfiguredProviderDefaultApi(params: {
   if (explicit) {
     return explicit;
   }
-  if (!providerConfig?.baseUrl) {
+  const providerConfiguredBaseUrl = normalizeTransportBaseUrl(providerConfig?.baseUrl);
+  if (!providerConfiguredBaseUrl) {
     return undefined;
   }
   const normalized = resolveProviderTransport({
     provider: params.provider,
     api: undefined,
-    baseUrl: providerConfig.baseUrl,
+    baseUrl: providerConfiguredBaseUrl,
     cfg: params.cfg,
     workspaceDir: params.workspaceDir,
     runtimeHooks: params.runtimeHooks,
   });
   return normalized.api ?? "openai-completions";
+}
+
+function normalizeTransportBaseUrl(baseUrl: unknown): string | undefined {
+  if (typeof baseUrl !== "string") {
+    return undefined;
+  }
+  const trimmed = baseUrl.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 function resolveProviderRequestTimeoutMs(timeoutSeconds: unknown): number | undefined {
@@ -481,6 +490,33 @@ function findConfiguredProviderModel(
       modelId,
     }),
   );
+}
+
+function mergeStaticCatalogInlineModel(
+  staticCatalogModel: StaticCatalogFallbackModel | undefined,
+  inlineModel: Model,
+): Model {
+  if (!staticCatalogModel) {
+    return inlineModel;
+  }
+  const compat = mergeModelCompat(staticCatalogModel.compat, inlineModel.compat);
+  const mediaInput = mergeModelMediaInput(staticCatalogModel.mediaInput, inlineModel.mediaInput);
+  const params = mergeModelParams(
+    readModelParams(staticCatalogModel.params),
+    readModelParams(inlineModel.params),
+  );
+  return {
+    ...staticCatalogModel,
+    ...inlineModel,
+    api: inlineModel.api ?? staticCatalogModel.api,
+    baseUrl:
+      normalizeTransportBaseUrl(inlineModel.baseUrl) ??
+      normalizeTransportBaseUrl(staticCatalogModel.baseUrl),
+    headers: inlineModel.headers ?? staticCatalogModel.headers,
+    ...(compat ? { compat } : {}),
+    ...(mediaInput ? { mediaInput } : {}),
+    ...(params ? { params } : {}),
+  } as Model;
 }
 
 function hasConfiguredFallbackSurface(params: {
@@ -620,6 +656,15 @@ function applyConfiguredProviderOverrides(params: {
     (discoveredModel.id !== modelId
       ? findConfiguredProviderModel(providerConfig, params.provider, discoveredModel.id)
       : undefined);
+  const configuredStaticCatalogModel = configuredModel
+    ? (resolveBundledStaticCatalogModel({
+        provider: params.provider,
+        modelId,
+        cfg: params.cfg,
+        workspaceDir: params.workspaceDir,
+        includeRuntimeDiscovery: true,
+      }) as StaticCatalogFallbackModel | undefined)
+    : undefined;
   const metadataOverrideModel =
     params.preferDiscoveredModelMetadata && isModelsAddMetadataModel({ model: configuredModel })
       ? undefined
@@ -673,6 +718,7 @@ function applyConfiguredProviderOverrides(params: {
     };
   }
   const resolvedParams = mergeModelParams(
+    readModelParams(configuredStaticCatalogModel?.params),
     readModelParams(discoveredModel.params),
     providerParams,
     defaultModelParams,
@@ -692,16 +738,32 @@ function applyConfiguredProviderOverrides(params: {
     workspaceDir: params.workspaceDir,
     runtimeHooks: params.runtimeHooks,
   });
-  const resolvedTransportApi =
-    metadataOverrideModel?.api ??
-    (params.preferDiscoveredTransport
-      ? (discoveredModel.api ?? providerConfig.api ?? providerDefaultApi)
-      : (providerConfig.api ?? discoveredModel.api ?? providerDefaultApi));
-  const resolvedTransportBaseUrl =
-    metadataOverrideModel?.baseUrl ??
-    (params.preferDiscoveredTransport
-      ? (discoveredModel.baseUrl ?? providerConfig.baseUrl)
-      : (providerConfig.baseUrl ?? discoveredModel.baseUrl));
+  const metadataOverrideBaseUrl = normalizeTransportBaseUrl(metadataOverrideModel?.baseUrl);
+  const providerConfiguredBaseUrl = normalizeTransportBaseUrl(providerConfig.baseUrl);
+  const discoveredBaseUrl = normalizeTransportBaseUrl(discoveredModel.baseUrl);
+  const configuredStaticCatalogBaseUrl = normalizeTransportBaseUrl(
+    configuredStaticCatalogModel?.baseUrl,
+  );
+  const resolvedTransportApi = params.preferDiscoveredTransport
+    ? (discoveredModel.api ??
+      metadataOverrideModel?.api ??
+      providerConfig.api ??
+      configuredStaticCatalogModel?.api ??
+      providerDefaultApi)
+    : (metadataOverrideModel?.api ??
+      providerConfig.api ??
+      discoveredModel.api ??
+      configuredStaticCatalogModel?.api ??
+      providerDefaultApi);
+  const resolvedTransportBaseUrl = params.preferDiscoveredTransport
+    ? (discoveredBaseUrl ??
+      metadataOverrideBaseUrl ??
+      providerConfiguredBaseUrl ??
+      configuredStaticCatalogBaseUrl)
+    : (metadataOverrideBaseUrl ??
+      providerConfiguredBaseUrl ??
+      discoveredBaseUrl ??
+      configuredStaticCatalogBaseUrl);
 
   const resolvedTransport = resolveProviderTransport({
     provider: params.provider,
@@ -716,7 +778,16 @@ function applyConfiguredProviderOverrides(params: {
     metadataOverrideModel?.contextWindow ?? providerConfig.contextWindow;
   const resolvedMaxTokens =
     metadataOverrideModel?.maxTokens ?? providerConfig.maxTokens ?? discoveredModel.maxTokens;
-  const resolvedCompat = mergeModelCompat(discoveredModel.compat, metadataOverrideModel?.compat);
+  const normalizedResolvedMaxTokens =
+    typeof resolvedMaxTokens === "number" && Number.isFinite(resolvedMaxTokens)
+      ? typeof resolvedContextWindow === "number" && Number.isFinite(resolvedContextWindow)
+        ? Math.min(resolvedMaxTokens, resolvedContextWindow)
+        : resolvedMaxTokens
+      : undefined;
+  const resolvedCompat = mergeModelCompat(
+    mergeModelCompat(configuredStaticCatalogModel?.compat, discoveredModel.compat),
+    metadataOverrideModel?.compat,
+  );
   const resolvedReasoning = resolveMergedConfiguredModelReasoning({
     provider: params.provider,
     configuredCompat: metadataOverrideModel?.compat,
@@ -728,10 +799,12 @@ function applyConfiguredProviderOverrides(params: {
     provider: params.provider,
     api:
       resolvedTransport.api ??
+      normalizeResolvedTransportApi(configuredStaticCatalogModel?.api) ??
       normalizeResolvedTransportApi(discoveredModel.api) ??
       providerDefaultApi ??
       "openai-responses",
-    baseUrl: resolvedTransport.baseUrl ?? discoveredModel.baseUrl,
+    baseUrl:
+      resolvedTransport.baseUrl ?? configuredStaticCatalogModel?.baseUrl ?? discoveredModel.baseUrl,
     discoveredHeaders,
     providerHeaders,
     modelHeaders: configuredHeaders,
@@ -754,10 +827,9 @@ function applyConfiguredProviderOverrides(params: {
           metadataOverrideModel?.contextTokens ??
           providerConfig.contextTokens ??
           discoveredModel.contextTokens,
-        maxTokens:
-          typeof resolvedContextWindow === "number"
-            ? Math.min(resolvedMaxTokens, resolvedContextWindow)
-            : resolvedMaxTokens,
+        ...(normalizedResolvedMaxTokens !== undefined
+          ? { maxTokens: normalizedResolvedMaxTokens }
+          : {}),
         ...(resolvedParams ? { params: resolvedParams } : {}),
         ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
         headers: requestConfig.headers,
@@ -766,7 +838,10 @@ function applyConfiguredProviderOverrides(params: {
           : {}),
         compat: resolvedCompat,
         mediaInput: mergeModelMediaInput(
-          discoveredModel.mediaInput,
+          mergeModelMediaInput(
+            configuredStaticCatalogModel?.mediaInput,
+            discoveredModel.mediaInput,
+          ),
           metadataOverrideModel?.mediaInput,
         ),
       },
@@ -808,13 +883,13 @@ function resolveExplicitModelWithRegistry(params: {
     ) {
       return { kind: "suppressed" };
     }
-    const resolvedParams = mergeConfiguredRuntimeModelParams({
-      cfg,
+    const staticCatalogModel = resolveBundledStaticCatalogModel({
       provider,
       modelId,
-      providerParams: providerConfig?.params,
-      configuredParams: inlineMatch.params,
-    });
+      cfg,
+      workspaceDir,
+      includeRuntimeDiscovery: true,
+    }) as StaticCatalogFallbackModel | undefined;
     return {
       kind: "resolved",
       model: normalizeResolvedModel({
@@ -822,16 +897,16 @@ function resolveExplicitModelWithRegistry(params: {
         cfg,
         agentDir,
         workspaceDir,
-        model: {
-          ...inlineMatch,
-          reasoning: resolveConfiguredModelReasoning({
-            provider,
-            compat: inlineMatch.compat,
-            reasoning: inlineMatch.reasoning,
-          }),
-          ...(resolvedParams ? { params: resolvedParams } : {}),
-          ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
-        } as Model,
+        model: applyConfiguredProviderOverrides({
+          provider,
+          discoveredModel: mergeStaticCatalogInlineModel(staticCatalogModel, inlineMatch as Model),
+          providerConfig,
+          modelId,
+          cfg,
+          runtimeHooks,
+          workspaceDir,
+          preferDiscoveredTransport: true,
+        }),
         runtimeHooks,
       }),
     };
@@ -1045,37 +1120,48 @@ function resolveConfiguredFallbackModel(params: {
   if (!hasConfiguredFallbackSurface({ providerConfig, configuredModel, modelId })) {
     return undefined;
   }
-  const staticCatalogModel = configuredModel
-    ? undefined
-    : (resolveBundledStaticCatalogModel({
-        provider,
-        modelId,
-        cfg,
-        workspaceDir,
-        includeRuntimeDiscovery: true,
-      }) as StaticCatalogFallbackModel | undefined);
+  const staticCatalogModel = resolveBundledStaticCatalogModel({
+    provider,
+    modelId,
+    cfg,
+    workspaceDir,
+    includeRuntimeDiscovery: true,
+  }) as StaticCatalogFallbackModel | undefined;
   const metadataModel = configuredModel ?? staticCatalogModel;
-  const fallbackCompat = configuredModel?.compat ?? staticCatalogModel?.compat;
-  const fallbackMediaInput = configuredModel?.mediaInput ?? staticCatalogModel?.mediaInput;
+  const fallbackCompat = mergeModelCompat(staticCatalogModel?.compat, configuredModel?.compat);
+  const fallbackMediaInput = mergeModelMediaInput(
+    staticCatalogModel?.mediaInput,
+    configuredModel?.mediaInput,
+  );
   const providerHeaders = sanitizeModelHeaders(providerConfig?.headers, {
     stripSecretRefMarkers: true,
   });
   const providerRequest = sanitizeConfiguredModelProviderRequest(providerConfig?.request);
-  const modelHeaders = sanitizeModelHeaders(metadataModel?.headers, {
+  const staticCatalogHeaders = sanitizeModelHeaders(staticCatalogModel?.headers, {
+    stripSecretRefMarkers: true,
+  });
+  const modelHeaders = sanitizeModelHeaders(configuredModel?.headers, {
     stripSecretRefMarkers: true,
   });
   const resolvedParams = mergeConfiguredRuntimeModelParams({
     cfg,
     provider,
     modelId,
+    discoveredParams: staticCatalogModel?.params,
     providerParams: providerConfig?.params,
-    configuredParams: metadataModel?.params,
+    configuredParams: configuredModel?.params,
   });
+  const providerConfiguredApi = normalizeResolvedTransportApi(providerConfig?.api);
+  const configuredModelBaseUrl = normalizeTransportBaseUrl(configuredModel?.baseUrl);
+  const providerConfiguredBaseUrl = normalizeTransportBaseUrl(providerConfig?.baseUrl);
+  const staticCatalogBaseUrl = normalizeTransportBaseUrl(staticCatalogModel?.baseUrl);
   const fallbackTransport = resolveProviderTransport({
     provider,
     modelId,
     api:
       normalizeResolvedTransportApi(configuredModel?.api) ??
+      providerConfiguredApi ??
+      normalizeResolvedTransportApi(staticCatalogModel?.api) ??
       resolveConfiguredProviderDefaultApi({
         provider,
         providerConfig,
@@ -1083,9 +1169,8 @@ function resolveConfiguredFallbackModel(params: {
         workspaceDir,
         runtimeHooks,
       }) ??
-      normalizeResolvedTransportApi(staticCatalogModel?.api) ??
       "openai-responses",
-    baseUrl: configuredModel?.baseUrl ?? providerConfig?.baseUrl ?? staticCatalogModel?.baseUrl,
+    baseUrl: configuredModelBaseUrl ?? providerConfiguredBaseUrl ?? staticCatalogBaseUrl,
     cfg,
     workspaceDir,
     runtimeHooks,
@@ -1094,6 +1179,7 @@ function resolveConfiguredFallbackModel(params: {
     provider,
     api: fallbackTransport.api ?? "openai-responses",
     baseUrl: fallbackTransport.baseUrl,
+    discoveredHeaders: staticCatalogHeaders,
     providerHeaders,
     modelHeaders,
     authHeader: providerConfig?.authHeader,
@@ -1126,6 +1212,9 @@ function resolveConfiguredFallbackModel(params: {
             modelName: metadataModel?.name ?? modelId,
             input: metadataModel?.input,
           }),
+          ...(configuredModel?.thinkingLevelMap !== undefined
+            ? { thinkingLevelMap: configuredModel.thinkingLevelMap }
+            : {}),
           cost: metadataModel?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
           contextWindow:
             configuredModel?.contextWindow ??

--- a/src/plugins/manifest-metadata-scan.ts
+++ b/src/plugins/manifest-metadata-scan.ts
@@ -2,10 +2,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString as normalizeTrimmedString } from "@openclaw/normalization-core/string-coerce";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
+import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { readPersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
 
 type PluginManifestMetadataRecord = {
@@ -21,7 +21,6 @@ type CandidateDir = {
   origin?: string;
 };
 
-const OPENCLAW_PACKAGE_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 const PLUGIN_MANIFEST_FILENAME = "openclaw.plugin.json";
 let manifestMetadataCache:
   | {
@@ -45,31 +44,6 @@ function resolveStateDir(env: NodeJS.ProcessEnv): string {
   }
   const home = env.OPENCLAW_HOME ?? env.HOME ?? env.USERPROFILE ?? os.homedir();
   return path.join(home, ".openclaw");
-}
-
-function areBundledPluginsDisabled(env: NodeJS.ProcessEnv): boolean {
-  const value = normalizeTrimmedString(env.OPENCLAW_DISABLE_BUNDLED_PLUGINS)?.toLowerCase();
-  return value === "1" || value === "true";
-}
-
-function hasManifestDir(root: string | undefined): root is string {
-  return Boolean(root && fs.existsSync(root));
-}
-
-function resolveBundledPluginRoot(env: NodeJS.ProcessEnv): string | undefined {
-  if (areBundledPluginsDisabled(env)) {
-    return undefined;
-  }
-
-  const override = normalizeTrimmedString(env.OPENCLAW_BUNDLED_PLUGINS_DIR);
-  if (override) {
-    return resolveUserPath(override, env);
-  }
-
-  const sourceRoot = path.join(OPENCLAW_PACKAGE_ROOT, "extensions");
-  const runtimeRoot = path.join(OPENCLAW_PACKAGE_ROOT, "dist-runtime", "extensions");
-  const distRoot = path.join(OPENCLAW_PACKAGE_ROOT, "dist", "extensions");
-  return [sourceRoot, runtimeRoot, distRoot].find(hasManifestDir);
 }
 
 function listChildPluginDirs(
@@ -171,7 +145,7 @@ export function listOpenClawPluginManifestMetadata(
   let order = 0;
   candidates.push(...listPersistedIndexPluginDirs(env, order));
   order = candidates.length;
-  candidates.push(...listChildPluginDirs(resolveBundledPluginRoot(env), 2, order, "bundled"));
+  candidates.push(...listChildPluginDirs(resolveBundledPluginsDir(env), 2, order, "bundled"));
   order = candidates.length;
   candidates.push(
     ...listChildPluginDirs(path.join(resolveStateDir(env), "extensions"), 4, order, "global"),


### PR DESCRIPTION
## Summary

Fixes #92148.

Configured provider model rows that only override metadata now inherit bundled static catalog transport for known bundled provider models instead of falling through to the OpenAI Responses default. This keeps configured/runtime transport overrides ahead of static fallback metadata, treats blank configured `baseUrl` values as absent, and makes the built manifest scanner use the shared bundled plugin directory resolver so packaged runtime can find bundled static metadata.

## Verification

- `pnpm test src/agents/embedded-agent-runner/model.test.ts src/plugins/manifest-metadata-scan.test.ts src/agents/embedded-agent-runner/model.static-catalog.test.ts`
- `pnpm build`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- Crabbox provider `azure`, lease `cbx_3afa72390208`, run `run_152bba89a0c0`:
  - focused tests passed remotely
  - patched remote build passed
  - patched live packaged DeepSeek probe returned `status: ok` for `deepseek/deepseek-v4-pro`
  - reversed-patch regression baseline rebuilt and reproduced the old OpenAI-routed 401 path

## Real behavior proof

Behavior addressed: configured DeepSeek model rows without explicit transport no longer route to the OpenAI Responses API.

Real environment tested: Azure Crabbox Linux lease `cbx_3afa72390208`, run `run_152bba89a0c0`, with `DEEPSEEK_API_KEY` injected from 1Password only into the proof command.

Exact steps or command run after this patch: built the packaged CLI on Crabbox, then ran `node ./openclaw.mjs models status --json --probe --probe-provider deepseek --probe-timeout 45000 --probe-concurrency 1 --probe-max-tokens 8` against an isolated config whose default model was `deepseek/deepseek-v4-pro` and whose configured DeepSeek model row omitted `api` and `baseUrl`.

Evidence after fix: the patched live probe summary was `status: ok`, `provider: deepseek`, `model: deepseek/deepseek-v4-pro`, with no `openai-responses`, OpenAI API-key URL, or 401 marker.

Observed result after fix: OpenClaw used the DeepSeek-compatible chat transport inherited from bundled static metadata and authenticated successfully against DeepSeek.

What was not tested: no GUI flow; this issue is in model/provider transport resolution and was verified through the packaged CLI probe path.
