### PR TITLE
fix(memory): report vector store ready when indexed chunks exist but probe was skipped

### DIFF
--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1146,7 +1146,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         : undefined,
       vector: {
         enabled: this.vector.enabled,
-        storeAvailable: this.vector.available ?? undefined,
+        storeAvailable: this.vector.available ?? (this.hasIndexedChunks() ? true : undefined),
         semanticAvailable: this.vector.semanticAvailable,
         available: this.vector.semanticAvailable,
         extensionPath: this.vector.extensionPath,


### PR DESCRIPTION
## What does this PR do?

Fixes `openclaw memory status` (without `--deep`) reporting "Vector store: unknown" even when indexed chunks exist in the DB. The `status()` method now uses `hasIndexedChunks()` as a fallback when `vector.available` is null (probe not yet run or failed silently).

## Related Issue

Fixes #92102

## Type of Change
- [x] Bug fix (non-breaking)

## Changes Made
- `extensions/memory-core/src/memory/manager.ts`: Changed `storeAvailable` fallback from `undefined` to `this.hasIndexedChunks() ? true : undefined` when `vector.available` is null.

## How to Test
1. Build a memory index with `openclaw memory index --agent main`
2. Run `openclaw memory status --agent main` (without `--deep`)
3. Before fix: "Vector store: unknown"
4. After fix: "Vector store: ready" (if chunks exist)

## Real behavior proof

**Behavior or issue addressed:**
`openclaw memory status` shows "Vector store: unknown" on CLI fast path when sqlite-vec lazy init hasn't triggered, even though chunks exist in the DB.

**Real environment tested:**
macOS 15.5, Node.js v24.x, upstream main at 9827490f

**Exact steps or command run after the patch:**
```bash
node scripts/run-vitest.mjs run extensions/memory-core/src/memory/index.test.ts --reporter=verbose
```

**Evidence after fix:**
```
 ✓ 48 tests passed
 - "reports vector availability after probe" ✅
 - "probes sqlite vector store availability without initializing embeddings" ✅
 - "marks older vector indexes dirty after vector store probing" ✅
 - "keeps empty vector indexes clean after vector store probing" ✅
```

All 48 existing tests pass. The fix reuses the existing `hasIndexedChunks()` method which is already used in `refreshIndexIdentityDirty()` for the same purpose — detecting whether an index exists without loading sqlite-vec.

**What was not tested:**
Not tested in a live gateway with actual sqlite-vec extension. The fix is a display-only change to the `status()` return value — it does not modify any data paths, write operations, or vector search logic.

## Checklist
- [x] Read Contributing Guide
- [x] Conventional Commits
- [x] Searched for duplicates
- [x] Only related changes
- [x] Tests pass
- [x] Tested on macOS
