### PR TITLE
fix(agents): classify embedded prompt lock error as permanent announce failure

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -4969,19 +4969,15 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
   });
 
-  // ─── session-file-changed send-evidence behaviour (#91527) ─────────────────
-
-  it("does not retry when session-file-changed error carries send evidence (permanent, fixes #91527)", async () => {
-    // When a send already occurred, the error must be treated as permanent to
-    // prevent duplicate outbound messages.
+  it("does not retry session-file-changed failures with send evidence", async () => {
     const sendErr = new OutboundDeliveryError("outbound delivery failed", {
       cause: new Error("outbound delivery failed"),
       results: [{ channel: "telegram", messageId: "msg-1" }],
     });
     const callGateway = vi.fn(async () => {
-      const err = new Error("session file changed while embedded prompt lock was released");
-      err.cause = sendErr;
-      throw err;
+      throw new Error("session file changed while embedded prompt lock was released", {
+        cause: sendErr,
+      });
     }) as unknown as typeof runtimeCallGateway;
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock(["no_active_run"]);
     const result = await deliverSlackChannelAnnouncement({
@@ -4993,28 +4989,23 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       directIdempotencyKey: "announce-permanent-lock-error-evidence",
     });
 
-    // Should fail immediately without retries (send evidence present).
     expect(result.delivered).toBe(false);
     expect(result.path).toBe("direct");
     expect(result.terminal).toBe(true);
     expect(result.phases?.map((phase) => phase.phase)).toEqual(["direct-primary"]);
-    // Only one call — no retry attempts.
     expect(callGateway).toHaveBeenCalledTimes(1);
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
   });
 
-  it("does not fallback-steer after wrapped prompt-lock takeover error with send evidence", async () => {
-    const takeoverErr = new Error(
-      "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+  it("does not fallback-steer after wrapped prompt-lock takeover with send evidence", async () => {
+    const takeoverErr = Object.assign(
+      new Error("session file changed while embedded prompt lock was released: /tmp/session.jsonl"),
+      { name: "EmbeddedAttemptSessionTakeoverError" },
     );
-    takeoverErr.name = "EmbeddedAttemptSessionTakeoverError";
 
-    const promptErr = new Error("some model error");
-    (promptErr as unknown as Record<string, unknown>).visibleReplySent = true;
-
-    const wrapperErr = new Error("some model error", { cause: takeoverErr });
-    wrapperErr.name = "EmbeddedAttemptSessionTakeoverError";
-    Object.assign(wrapperErr, {
+    const promptErr = Object.assign(new Error("some model error"), { visibleReplySent: true });
+    const wrapperErr = Object.assign(new Error("some model error", { cause: takeoverErr }), {
+      name: "EmbeddedAttemptSessionTakeoverError",
       cleanupError: takeoverErr,
       promptError: promptErr,
     });
@@ -5041,15 +5032,13 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
   });
 
-  it("allows retry when session-file-changed error has no send evidence (pre-send recovery)", async () => {
-    // Without send evidence, the error may be pre-send — retry can recover.
+  it("retries session-file-changed failures without send evidence", async () => {
     let attempts = 0;
     const callGateway = vi.fn(async () => {
       attempts++;
       if (attempts <= 1) {
         throw new Error("session file changed while embedded prompt lock was released");
       }
-      // Second attempt succeeds
       return {
         result: {
           payloads: [{ text: "recovered after retry" }],
@@ -5066,23 +5055,23 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       directIdempotencyKey: "announce-retry-lock-error-no-evidence",
     });
 
-    // Should succeed after retry (no send evidence → transient).
     expect(result.delivered).toBe(true);
     expect(result.path).toBe("direct");
     expect(callGateway).toHaveBeenCalledTimes(2);
   });
 
-  it("classifies session-file-changed error as has-send-evidence when OutboundDeliveryError with sentBeforeError is in the chain", () => {
+  it("detects send evidence from OutboundDeliveryError in the error chain", () => {
     const err = new Error(
       "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+      {
+        cause: new OutboundDeliveryError("outbound delivery failed", {
+          cause: new Error("outbound delivery failed"),
+          results: [{ channel: "telegram", messageId: "msg-1" }],
+        }),
+      },
     );
-    err.cause = new OutboundDeliveryError("outbound delivery failed", {
-      cause: new Error("outbound delivery failed"),
-      results: [{ channel: "telegram", messageId: "msg-1" }],
-    });
 
     expect(testing.isSessionFileChangedAnnounceError(err.message)).toBe(true);
-    // OutboundDeliveryError with at least one ok result has sentBeforeError: true
     expect(testing.hasAnnounceSendEvidence(err)).toBe(true);
   });
 
@@ -5096,41 +5085,36 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("detects send evidence from visibleReplySent flag on session-file-changed error", () => {
-    const err = new Error(
-      "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+    const err = Object.assign(
+      new Error("session file changed while embedded prompt lock was released: /tmp/session.jsonl"),
+      { visibleReplySent: true },
     );
-    (err as unknown as Record<string, unknown>).visibleReplySent = true;
 
     expect(testing.hasAnnounceSendEvidence(err)).toBe(true);
   });
 
   it("detects send evidence from sentBeforeError flag on session-file-changed error", () => {
-    const err = new Error(
-      "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+    const err = Object.assign(
+      new Error("session file changed while embedded prompt lock was released: /tmp/session.jsonl"),
+      { sentBeforeError: true },
     );
-    (err as unknown as Record<string, unknown>).sentBeforeError = true;
 
     expect(testing.hasAnnounceSendEvidence(err)).toBe(true);
   });
 
-  it("detects send evidence recursively through promptError field (EmbeddedAttemptPromptErrorWithCleanupTakeoverError pattern)", () => {
-    // This mirrors the shape of EmbeddedAttemptPromptErrorWithCleanupTakeoverError:
-    // name = "EmbeddedAttemptSessionTakeoverError", carries a promptError field
-    const takeoverErr = new Error(
-      "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+  it("detects send evidence recursively through promptError", () => {
+    const takeoverErr = Object.assign(
+      new Error("session file changed while embedded prompt lock was released: /tmp/session.jsonl"),
+      { name: "EmbeddedAttemptSessionTakeoverError" },
     );
-    takeoverErr.name = "EmbeddedAttemptSessionTakeoverError";
 
-    const promptErr = new Error("some model error");
-    (promptErr as unknown as Record<string, unknown>).visibleReplySent = true;
+    const promptErr = Object.assign(new Error("some model error"), { visibleReplySent: true });
 
-    // The wrapper error uses the prompt error's message as its own message
-    // and carries promptError as a field
-    const wrapperErr = new Error("some model error", { cause: takeoverErr });
-    wrapperErr.name = "EmbeddedAttemptSessionTakeoverError";
-    (wrapperErr as unknown as Record<string, unknown>).promptError = promptErr;
+    const wrapperErr = Object.assign(new Error("some model error", { cause: takeoverErr }), {
+      name: "EmbeddedAttemptSessionTakeoverError",
+      promptError: promptErr,
+    });
 
-    // The message contains the model error text, not the session-file-changed text
     expect(testing.hasAnnounceSendEvidence(wrapperErr)).toBe(true);
     expect(testing.hasSessionFileChangedAnnounceError(wrapperErr)).toBe(true);
   });

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -4969,31 +4969,133 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
   });
 
-  it("does not retry when embedded prompt lock file changed error occurs (permanent, fixes #91527)", async () => {
-    // The session file changed error is a concurrent-session race: the parent
-    // transcript is being modified while the subagent completion tries to
-    // inject. Each retry independently triggers a duplicate outbound send.
-    // Classifying it as permanent prevents the 3x duplicate announce pattern.
+  // ─── session-file-changed send-evidence behaviour (#91527) ─────────────────
+
+  it("does not retry when session-file-changed error carries send evidence (permanent, fixes #91527)", async () => {
+    // When a send already occurred, the error must be treated as permanent to
+    // prevent duplicate outbound messages.
+    const sendErr = new OutboundDeliveryError("outbound delivery failed", {
+      cause: new Error("outbound delivery failed"),
+      results: [{ channel: "telegram", messageId: "msg-1" }],
+    });
     const callGateway = vi.fn(async () => {
-      throw new Error(
+      const err = new Error(
         "session file changed while embedded prompt lock was released",
       );
+      err.cause = sendErr;
+      throw err;
     }) as unknown as typeof runtimeCallGateway;
     const queueEmbeddedAgentMessageWithOutcome =
       createQueueOutcomeSequenceMock(["no_active_run"]);
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
       queueEmbeddedAgentMessageWithOutcome,
-      sessionId: "requester-session-lock-race",
+      sessionId: "requester-session-lock-race-evidence",
       isActive: true,
       expectsCompletionMessage: true,
-      directIdempotencyKey: "announce-permanent-lock-error",
+      directIdempotencyKey: "announce-permanent-lock-error-evidence",
     });
 
-    // Should fail immediately without retries (permanent error, not transient).
+    // Should fail immediately without retries (send evidence present).
     expect(result.delivered).toBe(false);
     expect(result.path).toBe("direct");
     // Only one call — no retry attempts.
     expect(callGateway).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows retry when session-file-changed error has no send evidence (pre-send recovery)", async () => {
+    // Without send evidence, the error may be pre-send — retry can recover.
+    let attempts = 0;
+    const callGateway = vi.fn(async () => {
+      attempts++;
+      if (attempts <= 1) {
+        throw new Error(
+          "session file changed while embedded prompt lock was released",
+        );
+      }
+      // Second attempt succeeds
+      return {
+        result: {
+          payloads: [{ text: "recovered after retry" }],
+        },
+      };
+    }) as unknown as typeof runtimeCallGateway;
+    const queueEmbeddedAgentMessageWithOutcome =
+      createQueueOutcomeSequenceMock(["no_active_run"]);
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      queueEmbeddedAgentMessageWithOutcome,
+      sessionId: "requester-session-lock-race-no-evidence",
+      isActive: true,
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-retry-lock-error-no-evidence",
+    });
+
+    // Should succeed after retry (no send evidence → transient).
+    expect(result.delivered).toBe(true);
+    expect(result.path).toBe("direct");
+    expect(callGateway).toHaveBeenCalledTimes(2);
+  });
+
+  it("classifies session-file-changed error as has-send-evidence when OutboundDeliveryError with sentBeforeError is in the chain", () => {
+    const err = new Error(
+      "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+    );
+    err.cause = new OutboundDeliveryError("outbound delivery failed", {
+      cause: new Error("outbound delivery failed"),
+      results: [{ channel: "telegram", messageId: "msg-1" }],
+    });
+
+    expect(testing.isSessionFileChangedAnnounceError(err.message)).toBe(true);
+    // OutboundDeliveryError with at least one ok result has sentBeforeError: true
+    expect(testing.hasAnnounceSendEvidence(err)).toBe(true);
+  });
+
+  it("classifies session-file-changed error as no-send-evidence when the error chain has no send markers", () => {
+    const err = new Error(
+      "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+    );
+
+    expect(testing.isSessionFileChangedAnnounceError(err.message)).toBe(true);
+    expect(testing.hasAnnounceSendEvidence(err)).toBe(false);
+  });
+
+  it("detects send evidence from visibleReplySent flag on session-file-changed error", () => {
+    const err = new Error(
+      "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+    );
+    (err as unknown as Record<string, unknown>).visibleReplySent = true;
+
+    expect(testing.hasAnnounceSendEvidence(err)).toBe(true);
+  });
+
+  it("detects send evidence from sentBeforeError flag on session-file-changed error", () => {
+    const err = new Error(
+      "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+    );
+    (err as unknown as Record<string, unknown>).sentBeforeError = true;
+
+    expect(testing.hasAnnounceSendEvidence(err)).toBe(true);
+  });
+
+  it("detects send evidence recursively through promptError field (EmbeddedAttemptPromptErrorWithCleanupTakeoverError pattern)", () => {
+    // This mirrors the shape of EmbeddedAttemptPromptErrorWithCleanupTakeoverError:
+    // name = "EmbeddedAttemptSessionTakeoverError", carries a promptError field
+    const takeoverErr = new Error(
+      "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+    );
+    takeoverErr.name = "EmbeddedAttemptSessionTakeoverError";
+
+    const promptErr = new Error("some model error");
+    (promptErr as unknown as Record<string, unknown>).visibleReplySent = true;
+
+    // The wrapper error uses the prompt error's message as its own message
+    // and carries promptError as a field
+    const wrapperErr = new Error("some model error", { cause: takeoverErr });
+    wrapperErr.name = "EmbeddedAttemptSessionTakeoverError";
+    (wrapperErr as unknown as Record<string, unknown>).promptError = promptErr;
+
+    // The message contains the model error text, not the session-file-changed text
+    expect(testing.hasAnnounceSendEvidence(wrapperErr)).toBe(true);
   });
 });

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -4968,4 +4968,32 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       bestEffortDeliver: true,
     });
   });
+
+  it("does not retry when embedded prompt lock file changed error occurs (permanent, fixes #91527)", async () => {
+    // The session file changed error is a concurrent-session race: the parent
+    // transcript is being modified while the subagent completion tries to
+    // inject. Each retry independently triggers a duplicate outbound send.
+    // Classifying it as permanent prevents the 3x duplicate announce pattern.
+    const callGateway = vi.fn(async () => {
+      throw new Error(
+        "session file changed while embedded prompt lock was released",
+      );
+    }) as unknown as typeof runtimeCallGateway;
+    const queueEmbeddedAgentMessageWithOutcome =
+      createQueueOutcomeSequenceMock(["no_active_run"]);
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      queueEmbeddedAgentMessageWithOutcome,
+      sessionId: "requester-session-lock-race",
+      isActive: true,
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-permanent-lock-error",
+    });
+
+    // Should fail immediately without retries (permanent error, not transient).
+    expect(result.delivered).toBe(false);
+    expect(result.path).toBe("direct");
+    // Only one call — no retry attempts.
+    expect(callGateway).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -5003,6 +5003,44 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
   });
 
+  it("does not fallback-steer after wrapped prompt-lock takeover error with send evidence", async () => {
+    const takeoverErr = new Error(
+      "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+    );
+    takeoverErr.name = "EmbeddedAttemptSessionTakeoverError";
+
+    const promptErr = new Error("some model error");
+    (promptErr as unknown as Record<string, unknown>).visibleReplySent = true;
+
+    const wrapperErr = new Error("some model error", { cause: takeoverErr });
+    wrapperErr.name = "EmbeddedAttemptSessionTakeoverError";
+    Object.assign(wrapperErr, {
+      cleanupError: takeoverErr,
+      promptError: promptErr,
+    });
+
+    const callGateway = vi.fn(async () => {
+      throw wrapperErr;
+    }) as unknown as typeof runtimeCallGateway;
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock(["no_active_run"]);
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      queueEmbeddedAgentMessageWithOutcome,
+      sessionId: "requester-session-lock-race-wrapped-evidence",
+      isActive: true,
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-permanent-wrapped-lock-error-evidence",
+    });
+
+    expect(result.delivered).toBe(false);
+    expect(result.path).toBe("direct");
+    expect(result.error).toBe("some model error");
+    expect(result.terminal).toBe(true);
+    expect(result.phases?.map((phase) => phase.phase)).toEqual(["direct-primary"]);
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
+  });
+
   it("allows retry when session-file-changed error has no send evidence (pre-send recovery)", async () => {
     // Without send evidence, the error may be pre-send — retry can recover.
     let attempts = 0;
@@ -5094,5 +5132,6 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
     // The message contains the model error text, not the session-file-changed text
     expect(testing.hasAnnounceSendEvidence(wrapperErr)).toBe(true);
+    expect(testing.hasSessionFileChangedAnnounceError(wrapperErr)).toBe(true);
   });
 });

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -4979,14 +4979,11 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       results: [{ channel: "telegram", messageId: "msg-1" }],
     });
     const callGateway = vi.fn(async () => {
-      const err = new Error(
-        "session file changed while embedded prompt lock was released",
-      );
+      const err = new Error("session file changed while embedded prompt lock was released");
       err.cause = sendErr;
       throw err;
     }) as unknown as typeof runtimeCallGateway;
-    const queueEmbeddedAgentMessageWithOutcome =
-      createQueueOutcomeSequenceMock(["no_active_run"]);
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock(["no_active_run"]);
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
       queueEmbeddedAgentMessageWithOutcome,
@@ -4999,8 +4996,11 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     // Should fail immediately without retries (send evidence present).
     expect(result.delivered).toBe(false);
     expect(result.path).toBe("direct");
+    expect(result.terminal).toBe(true);
+    expect(result.phases?.map((phase) => phase.phase)).toEqual(["direct-primary"]);
     // Only one call — no retry attempts.
     expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
   });
 
   it("allows retry when session-file-changed error has no send evidence (pre-send recovery)", async () => {
@@ -5009,9 +5009,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     const callGateway = vi.fn(async () => {
       attempts++;
       if (attempts <= 1) {
-        throw new Error(
-          "session file changed while embedded prompt lock was released",
-        );
+        throw new Error("session file changed while embedded prompt lock was released");
       }
       // Second attempt succeeds
       return {
@@ -5020,8 +5018,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         },
       };
     }) as unknown as typeof runtimeCallGateway;
-    const queueEmbeddedAgentMessageWithOutcome =
-      createQueueOutcomeSequenceMock(["no_active_run"]);
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock(["no_active_run"]);
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
       queueEmbeddedAgentMessageWithOutcome,

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -4974,11 +4974,11 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       cause: new Error("outbound delivery failed"),
       results: [{ channel: "telegram", messageId: "msg-1" }],
     });
-    const callGateway = vi.fn(async () => {
+    const callGateway: typeof runtimeCallGateway = vi.fn(async () => {
       throw new Error("session file changed while embedded prompt lock was released", {
         cause: sendErr,
       });
-    }) as unknown as typeof runtimeCallGateway;
+    });
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock(["no_active_run"]);
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
@@ -5010,9 +5010,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       promptError: promptErr,
     });
 
-    const callGateway = vi.fn(async () => {
+    const callGateway: typeof runtimeCallGateway = vi.fn(async () => {
       throw wrapperErr;
-    }) as unknown as typeof runtimeCallGateway;
+    });
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock(["no_active_run"]);
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
@@ -5034,7 +5034,11 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
   it("retries session-file-changed failures without send evidence", async () => {
     let attempts = 0;
-    const callGateway = vi.fn(async () => {
+    const callGatewaySpy = vi.fn();
+    const callGateway: typeof runtimeCallGateway = async <
+      T = Record<string, unknown>,
+    >(): Promise<T> => {
+      callGatewaySpy();
       attempts++;
       if (attempts <= 1) {
         throw new Error("session file changed while embedded prompt lock was released");
@@ -5043,8 +5047,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         result: {
           payloads: [{ text: "recovered after retry" }],
         },
-      };
-    }) as unknown as typeof runtimeCallGateway;
+      } as T;
+    };
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock(["no_active_run"]);
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
@@ -5057,7 +5061,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
     expect(result.delivered).toBe(true);
     expect(result.path).toBe("direct");
-    expect(callGateway).toHaveBeenCalledTimes(2);
+    expect(callGatewaySpy).toHaveBeenCalledTimes(2);
   });
 
   it("detects send evidence from OutboundDeliveryError in the error chain", () => {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -380,6 +380,13 @@ const TRANSIENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /\b(econnreset|econnrefused|etimedout|enotfound|ehostunreach|network error)\b/i,
 ];
 
+// Embedded prompt lock errors are a concurrent-session race: the parent session
+// transcript is being modified while the subagent completion tries to inject.
+// Retrying does not help because the parent turn-maintenance lane continues
+// writing; each retry independently triggers a duplicate outbound send (see #91527).
+const SESSION_FILE_CHANGED_ANNOUNCE_RE =
+  /session file changed while embedded prompt lock was released/i;
+
 const PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /unsupported channel/i,
   /unknown channel/i,
@@ -390,13 +397,12 @@ const PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /forbidden: bot was kicked/i,
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
-  // Embedded prompt lock errors are a concurrent-session race: the parent
-  // session transcript is being modified while the subagent completion tries
-  // to inject. Retrying does not help because the parent turn-maintenance
-  // lane continues writing; each retry independently triggers a duplicate
-  // outbound send (see #91527).
-  /session file changed while embedded prompt lock was released/i,
+  SESSION_FILE_CHANGED_ANNOUNCE_RE,
 ];
+
+function isSessionFileChangedAnnounceError(message: string): boolean {
+  return SESSION_FILE_CHANGED_ANNOUNCE_RE.test(message);
+}
 
 function isTransientAnnounceDeliveryError(error: unknown): boolean {
   const message = summarizeDeliveryError(error);
@@ -404,6 +410,12 @@ function isTransientAnnounceDeliveryError(error: unknown): boolean {
     return false;
   }
   if (PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message))) {
+    // Safety valve: a session-file-changed error without send evidence is still
+    // transient — the send may not have occurred yet, so retry can recover.
+    // When send evidence exists, the error is truly permanent (duplicate prevention).
+    if (isSessionFileChangedAnnounceError(message) && !hasAnnounceSendEvidence(error)) {
+      return true;
+    }
     return false;
   }
   return TRANSIENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message));
@@ -442,6 +454,66 @@ function didVisibleSendFailAfterPartialDelivery(error: unknown): boolean {
   };
   return (
     maybeDeliveryError.sentBeforeError === true || maybeDeliveryError.visibleReplySent === true
+  );
+}
+
+/**
+ * Walk the error chain to determine whether any outbound send occurred before
+ * the error was thrown.  Used as structured send evidence for the session-file-
+ * changed takeover error: when a send has already happened, retrying would
+ * produce duplicate channel messages (#91527).
+ *
+ * Evidence sources (recursive through cause / error / reason chains):
+ *  1. An `OutboundDeliveryError` with `sentBeforeError: true`
+ *  2. A generic error carrying `sentBeforeError: true` or `visibleReplySent: true`
+ *  3. An `EmbeddedAttemptPromptErrorWithCleanupTakeoverError` whose `promptError`
+ *     field implies the model ran (and may have sent) before the takeover was
+ *     detected — recurse into `promptError` for further evidence
+ */
+function hasAnnounceSendEvidence(error: unknown, seen: Set<object> = new Set()): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  if (seen.has(error)) {
+    return false;
+  }
+  seen.add(error);
+
+  // Evidence 1: OutboundDeliveryError with confirmed send-before-error
+  if (isOutboundDeliveryError(error) && error.sentBeforeError) {
+    return true;
+  }
+
+  // Evidence 2: generic sentBeforeError / visibleReplySent flags
+  const maybe = error as {
+    sentBeforeError?: unknown;
+    visibleReplySent?: unknown;
+    promptError?: unknown;
+  };
+  if (maybe.sentBeforeError === true || maybe.visibleReplySent === true) {
+    return true;
+  }
+
+  // Evidence 3: EmbeddedAttemptPromptErrorWithCleanupTakeoverError carries a
+  // promptError field — the model completed its run before the takeover was
+  // detected, so tool calls (including send_message) may have executed.
+  // Recurse into promptError in case it carries its own send evidence.
+  if (maybe.promptError !== undefined) {
+    if (hasAnnounceSendEvidence(maybe.promptError, seen)) {
+      return true;
+    }
+  }
+
+  // Walk nested cause / error / reason chains
+  const candidate = error as {
+    cause?: unknown;
+    error?: unknown;
+    reason?: unknown;
+  };
+  return (
+    hasAnnounceSendEvidence(candidate.cause, seen) ||
+    hasAnnounceSendEvidence(candidate.error, seen) ||
+    hasAnnounceSendEvidence(candidate.reason, seen)
   );
 }
 
@@ -1514,7 +1586,10 @@ async function sendSubagentAnnounceDirectly(params: {
           }),
       });
     } catch (err) {
-      if (isPermanentAnnounceDeliveryError(err)) {
+      // Permanent + send evidence already exists → no recovery possible,
+      // retrying would only produce duplicates (#91527).  Session-file-changed
+      // errors without send evidence fall through to the fallback paths below.
+      if (isPermanentAnnounceDeliveryError(err) && hasAnnounceSendEvidence(err)) {
         throw err;
       }
       if (
@@ -1791,5 +1866,8 @@ export const testing = {
         }
       : defaultSubagentAnnounceDeliveryDeps;
   },
+  // Exported for focused testing of session-file-changed send-evidence behavior (#91527)
+  hasAnnounceSendEvidence,
+  isSessionFileChangedAnnounceError,
 };
 export { testing as __testing };

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -390,6 +390,12 @@ const PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /forbidden: bot was kicked/i,
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
+  // Embedded prompt lock errors are a concurrent-session race: the parent
+  // session transcript is being modified while the subagent completion tries
+  // to inject. Retrying does not help because the parent turn-maintenance
+  // lane continues writing; each retry independently triggers a duplicate
+  // outbound send (see #91527).
+  /session file changed while embedded prompt lock was released/i,
 ];
 
 function isTransientAnnounceDeliveryError(error: unknown): boolean {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -380,10 +380,6 @@ const TRANSIENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /\b(econnreset|econnrefused|etimedout|enotfound|ehostunreach|network error)\b/i,
 ];
 
-// Embedded prompt lock errors are a concurrent-session race: the parent session
-// transcript is being modified while the subagent completion tries to inject.
-// Retrying does not help because the parent turn-maintenance lane continues
-// writing; each retry independently triggers a duplicate outbound send (see #91527).
 const SESSION_FILE_CHANGED_ANNOUNCE_RE =
   /session file changed while embedded prompt lock was released/i;
 
@@ -404,15 +400,32 @@ function isSessionFileChangedAnnounceError(message: string): boolean {
   return SESSION_FILE_CHANGED_ANNOUNCE_RE.test(message);
 }
 
-function hasSessionFileChangedAnnounceError(
+const ANNOUNCE_ERROR_CHAIN_KEYS = [
+  "cause",
+  "cleanupError",
+  "error",
+  "promptError",
+  "reason",
+] as const;
+type AnnounceErrorChainKey = (typeof ANNOUNCE_ERROR_CHAIN_KEYS)[number];
+type AnnounceErrorRecord = Partial<Record<AnnounceErrorChainKey, unknown>> & {
+  sentBeforeError?: unknown;
+  visibleReplySent?: unknown;
+};
+
+function isAnnounceErrorRecord(error: unknown): error is AnnounceErrorRecord {
+  return Boolean(error && typeof error === "object");
+}
+
+function hasAnnounceErrorMatch(
   error: unknown,
+  matches: (candidate: unknown) => boolean,
   seen: Set<object> = new Set(),
 ): boolean {
-  const message = summarizeDeliveryError(error);
-  if (message && isSessionFileChangedAnnounceError(message)) {
+  if (matches(error)) {
     return true;
   }
-  if (!error || typeof error !== "object") {
+  if (!isAnnounceErrorRecord(error)) {
     return false;
   }
   if (seen.has(error)) {
@@ -420,19 +433,12 @@ function hasSessionFileChangedAnnounceError(
   }
   seen.add(error);
 
-  const candidate = error as {
-    cause?: unknown;
-    cleanupError?: unknown;
-    error?: unknown;
-    promptError?: unknown;
-    reason?: unknown;
-  };
-  return (
-    hasSessionFileChangedAnnounceError(candidate.cause, seen) ||
-    hasSessionFileChangedAnnounceError(candidate.cleanupError, seen) ||
-    hasSessionFileChangedAnnounceError(candidate.error, seen) ||
-    hasSessionFileChangedAnnounceError(candidate.promptError, seen) ||
-    hasSessionFileChangedAnnounceError(candidate.reason, seen)
+  return ANNOUNCE_ERROR_CHAIN_KEYS.some((key) => hasAnnounceErrorMatch(error[key], matches, seen));
+}
+
+function hasSessionFileChangedAnnounceError(error: unknown): boolean {
+  return hasAnnounceErrorMatch(error, (candidate) =>
+    isSessionFileChangedAnnounceError(summarizeDeliveryError(candidate)),
   );
 }
 
@@ -447,9 +453,6 @@ function isTransientAnnounceDeliveryError(error: unknown): boolean {
 
   const sessionFileChanged = hasSessionFileChangedAnnounceError(error);
   if (sessionFileChanged) {
-    // Safety valve: a session-file-changed error without send evidence is still
-    // transient — the send may not have occurred yet, so retry can recover.
-    // When send evidence exists, the error is truly permanent (duplicate prevention).
     return !hasAnnounceSendEvidence(error);
   }
 
@@ -486,77 +489,22 @@ function isSessionWriteLockAnnounceAgentError(error: unknown): boolean {
   );
 }
 
-function didVisibleSendFailAfterPartialDelivery(error: unknown): boolean {
+function hasDirectAnnounceSendEvidence(error: unknown): boolean {
   if (isOutboundDeliveryError(error) && error.sentBeforeError) {
     return true;
   }
-  const maybeDeliveryError = error as {
-    sentBeforeError?: unknown;
-    visibleReplySent?: unknown;
-  };
-  return (
-    maybeDeliveryError.sentBeforeError === true || maybeDeliveryError.visibleReplySent === true
-  );
+  if (!isAnnounceErrorRecord(error)) {
+    return false;
+  }
+  return error.sentBeforeError === true || error.visibleReplySent === true;
 }
 
-/**
- * Walk the error chain to determine whether any outbound send occurred before
- * the error was thrown.  Used as structured send evidence for the session-file-
- * changed takeover error: when a send has already happened, retrying would
- * produce duplicate channel messages (#91527).
- *
- * Evidence sources (recursive through cause / error / reason chains):
- *  1. An `OutboundDeliveryError` with `sentBeforeError: true`
- *  2. A generic error carrying `sentBeforeError: true` or `visibleReplySent: true`
- *  3. An `EmbeddedAttemptPromptErrorWithCleanupTakeoverError` whose `promptError`
- *     field implies the model ran (and may have sent) before the takeover was
- *     detected — recurse into `promptError` for further evidence
- */
-function hasAnnounceSendEvidence(error: unknown, seen: Set<object> = new Set()): boolean {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-  if (seen.has(error)) {
-    return false;
-  }
-  seen.add(error);
+function didVisibleSendFailAfterPartialDelivery(error: unknown): boolean {
+  return hasAnnounceSendEvidence(error);
+}
 
-  // Evidence 1: OutboundDeliveryError with confirmed send-before-error
-  if (isOutboundDeliveryError(error) && error.sentBeforeError) {
-    return true;
-  }
-
-  // Evidence 2: generic sentBeforeError / visibleReplySent flags
-  const maybe = error as {
-    sentBeforeError?: unknown;
-    visibleReplySent?: unknown;
-    promptError?: unknown;
-  };
-  if (maybe.sentBeforeError === true || maybe.visibleReplySent === true) {
-    return true;
-  }
-
-  // Evidence 3: EmbeddedAttemptPromptErrorWithCleanupTakeoverError carries a
-  // promptError field — the model completed its run before the takeover was
-  // detected, so tool calls (including send_message) may have executed.
-  // Recurse into promptError in case it carries its own send evidence.
-  if (maybe.promptError !== undefined) {
-    if (hasAnnounceSendEvidence(maybe.promptError, seen)) {
-      return true;
-    }
-  }
-
-  // Walk nested cause / error / reason chains
-  const candidate = error as {
-    cause?: unknown;
-    error?: unknown;
-    reason?: unknown;
-  };
-  return (
-    hasAnnounceSendEvidence(candidate.cause, seen) ||
-    hasAnnounceSendEvidence(candidate.error, seen) ||
-    hasAnnounceSendEvidence(candidate.reason, seen)
-  );
+function hasAnnounceSendEvidence(error: unknown): boolean {
+  return hasAnnounceErrorMatch(error, hasDirectAnnounceSendEvidence);
 }
 
 async function waitForAnnounceRetryDelay(ms: number, signal?: AbortSignal): Promise<void> {
@@ -1628,9 +1576,6 @@ async function sendSubagentAnnounceDirectly(params: {
           }),
       });
     } catch (err) {
-      // Permanent + send evidence already exists → no recovery possible,
-      // retrying would only produce duplicates (#91527).  Session-file-changed
-      // errors without send evidence fall through to the fallback paths below.
       if (isPermanentAnnounceDeliveryError(err) && hasAnnounceSendEvidence(err)) {
         throw err;
       }
@@ -1910,7 +1855,6 @@ export const testing = {
         }
       : defaultSubagentAnnounceDeliveryDeps;
   },
-  // Exported for focused testing of session-file-changed send-evidence behavior (#91527)
   hasAnnounceSendEvidence,
   hasSessionFileChangedAnnounceError,
   isSessionFileChangedAnnounceError,

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1776,10 +1776,12 @@ async function sendSubagentAnnounceDirectly(params: {
       path: "direct",
     };
   } catch (err) {
+    const terminal = isPermanentAnnounceDeliveryError(err) && hasAnnounceSendEvidence(err);
     return {
       delivered: false,
       path: "direct",
       error: summarizeDeliveryError(err),
+      ...(terminal ? { terminal: true } : {}),
     };
   }
 }

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -464,9 +464,9 @@ function isTransientAnnounceDeliveryError(error: unknown): boolean {
 
 function isPermanentAnnounceDeliveryError(error: unknown): boolean {
   const message = summarizeDeliveryError(error);
-  return Boolean(
+  return (
     (message && PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message))) ||
-    hasSessionFileChangedAnnounceError(error),
+    hasSessionFileChangedAnnounceError(error)
   );
 }
 

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -499,10 +499,6 @@ function hasDirectAnnounceSendEvidence(error: unknown): boolean {
   return error.sentBeforeError === true || error.visibleReplySent === true;
 }
 
-function didVisibleSendFailAfterPartialDelivery(error: unknown): boolean {
-  return hasAnnounceSendEvidence(error);
-}
-
 function hasAnnounceSendEvidence(error: unknown): boolean {
   return hasAnnounceErrorMatch(error, hasDirectAnnounceSendEvidence);
 }
@@ -959,7 +955,7 @@ async function deliverGeneratedMediaCompletionDirect(params: {
       path: "direct",
     };
   } catch (err) {
-    const terminal = didVisibleSendFailAfterPartialDelivery(err);
+    const terminal = hasAnnounceSendEvidence(err);
     return {
       delivered: false,
       path: "direct",

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -404,18 +404,59 @@ function isSessionFileChangedAnnounceError(message: string): boolean {
   return SESSION_FILE_CHANGED_ANNOUNCE_RE.test(message);
 }
 
-function isTransientAnnounceDeliveryError(error: unknown): boolean {
+function hasSessionFileChangedAnnounceError(
+  error: unknown,
+  seen: Set<object> = new Set(),
+): boolean {
   const message = summarizeDeliveryError(error);
-  if (!message) {
+  if (message && isSessionFileChangedAnnounceError(message)) {
+    return true;
+  }
+  if (!error || typeof error !== "object") {
     return false;
   }
-  if (PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message))) {
+  if (seen.has(error)) {
+    return false;
+  }
+  seen.add(error);
+
+  const candidate = error as {
+    cause?: unknown;
+    cleanupError?: unknown;
+    error?: unknown;
+    promptError?: unknown;
+    reason?: unknown;
+  };
+  return (
+    hasSessionFileChangedAnnounceError(candidate.cause, seen) ||
+    hasSessionFileChangedAnnounceError(candidate.cleanupError, seen) ||
+    hasSessionFileChangedAnnounceError(candidate.error, seen) ||
+    hasSessionFileChangedAnnounceError(candidate.promptError, seen) ||
+    hasSessionFileChangedAnnounceError(candidate.reason, seen)
+  );
+}
+
+function isTransientAnnounceDeliveryError(error: unknown): boolean {
+  const message = summarizeDeliveryError(error);
+  const topLevelPermanent = Boolean(
+    message && PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message)),
+  );
+  if (topLevelPermanent && !isSessionFileChangedAnnounceError(message)) {
+    return false;
+  }
+
+  const sessionFileChanged = hasSessionFileChangedAnnounceError(error);
+  if (sessionFileChanged) {
     // Safety valve: a session-file-changed error without send evidence is still
     // transient — the send may not have occurred yet, so retry can recover.
     // When send evidence exists, the error is truly permanent (duplicate prevention).
-    if (isSessionFileChangedAnnounceError(message) && !hasAnnounceSendEvidence(error)) {
-      return true;
-    }
+    return !hasAnnounceSendEvidence(error);
+  }
+
+  if (!message) {
+    return false;
+  }
+  if (topLevelPermanent) {
     return false;
   }
   return TRANSIENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message));
@@ -424,7 +465,8 @@ function isTransientAnnounceDeliveryError(error: unknown): boolean {
 function isPermanentAnnounceDeliveryError(error: unknown): boolean {
   const message = summarizeDeliveryError(error);
   return Boolean(
-    message && PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message)),
+    (message && PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message))) ||
+    hasSessionFileChangedAnnounceError(error),
   );
 }
 
@@ -1870,6 +1912,7 @@ export const testing = {
   },
   // Exported for focused testing of session-file-changed send-evidence behavior (#91527)
   hasAnnounceSendEvidence,
+  hasSessionFileChangedAnnounceError,
   isSessionFileChangedAnnounceError,
 };
 export { testing as __testing };

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -5,7 +5,7 @@ import type { EmbeddedAgentQueueMessageOutcome } from "./embedded-agent-runner/r
 import { createSubagentAnnounceDeliveryRuntimeMock } from "./subagent-announce.test-support.js";
 
 type AgentCallRequest = { method?: string; params?: Record<string, unknown> };
-type AgentCallResponse = { runId?: string; status: string; error?: string };
+type AgentCallResponse = { runId?: string; status: string; error?: string; terminal?: boolean };
 
 const agentSpy = vi.fn(
   async (_req: AgentCallRequest): Promise<AgentCallResponse> => ({
@@ -149,10 +149,15 @@ vi.mock("./subagent-announce-delivery.js", () => ({
               threadId: effectiveOrigin?.threadId,
             }),
       },
-    })) as { status?: string; error?: string };
+    })) as { status?: string; error?: string; terminal?: boolean };
 
     if (response.status === "error") {
-      return { delivered: false, path: "direct", error: response.error ?? "agent delivery failed" };
+      return {
+        delivered: false,
+        path: "direct",
+        error: response.error ?? "agent delivery failed",
+        ...(response.terminal === true ? { terminal: true } : {}),
+      };
     }
 
     return { delivered: true, path: "direct" };
@@ -598,5 +603,52 @@ describe("subagent announce seam flow", () => {
       "[warn] Subagent completion direct announce failed for run run-direct-failure-log: Outbound not configured for slack",
     );
     logSpy.mockRestore();
+  });
+
+  it("treats terminal direct completion failures as announced for cleanup", async () => {
+    let deliveryResult:
+      | {
+          delivered: boolean;
+          path: string;
+          error?: string;
+          terminal?: boolean;
+        }
+      | undefined;
+    agentSpy.mockResolvedValueOnce({
+      status: "error",
+      error: "prompt lock failed after visible send",
+      terminal: true,
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:slack",
+      childRunId: "run-terminal-direct-failure",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: {
+        channel: "slack",
+        to: "C123",
+      },
+      task: "deliver completion",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "done",
+      expectsCompletionMessage: true,
+      onDeliveryResult: (delivery) => {
+        deliveryResult = delivery;
+      },
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(deliveryResult).toMatchObject({
+      delivered: false,
+      path: "direct",
+      error: "prompt lock failed after visible send",
+      terminal: true,
+    });
   });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -597,7 +597,7 @@ export async function runSubagentAnnounceFlow(params: {
       signal: params.signal,
     });
     params.onDeliveryResult?.(delivery);
-    didAnnounce = delivery.delivered;
+    didAnnounce = delivery.delivered || delivery.terminal === true;
     if (!delivery.delivered && delivery.path === "direct" && delivery.error) {
       defaultRuntime.log(
         `[warn] Subagent completion direct announce failed for run ${params.childRunId}: ${delivery.error}`,

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -587,6 +587,50 @@ describe("subagent registry lifecycle hardening", () => {
     });
   });
 
+  it("finalizes terminal visible-send failures without scheduling completion retry", async () => {
+    const persist = vi.fn();
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      expectsCompletionMessage: true,
+      retainAttachmentsOnKeep: true,
+    });
+    const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
+      async (announceParams) => {
+        announceParams.onDeliveryResult?.({
+          delivered: false,
+          path: "direct",
+          error: "prompt lock failed after visible send",
+          terminal: true,
+        });
+        return true;
+      },
+    );
+
+    const controller = createLifecycleController({ entry, persist, runSubagentAnnounceFlow });
+
+    await expect(
+      controller.completeSubagentRun({
+        runId: entry.runId,
+        endedAt: 4_000,
+        outcome: { status: "ok" },
+        reason: SUBAGENT_ENDED_REASON_COMPLETE,
+        triggerCleanup: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    await vi.waitFor(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
+    expect(entry.delivery?.status).toBe("delivered");
+    expect(entry.delivery?.lastError).toBeUndefined();
+    expect(entry.delivery?.payload).toBeUndefined();
+    expect(entry.delivery?.suspendedAt).toBeUndefined();
+    expect(entry.delivery?.suspendedReason).toBeUndefined();
+    expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    expectFields(firstCallArg(taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId), {
+      runId: entry.runId,
+      deliveryStatus: "delivered",
+    });
+  });
+
   it("skips announce delivery when completion messages are disabled", async () => {
     const persist = vi.fn();
     const entry = createRunEntry({


### PR DESCRIPTION
## What Problem This Solves

Subagent completion announcements can retry after an embedded prompt lock-change race even when the first attempt already produced a visible outbound send. On Telegram this can show the same completion message multiple times.

Fixes #91527.

## Why This Change Was Made

The announce path now treats session-file-changed failures as retryable only when there is no send evidence. If the error chain contains committed send evidence, the failure is terminal for that announce attempt, so dispatch does not fallback-steer or retry into a duplicate send.

The cleanup pass also carries terminal delivery state through subagent lifecycle cleanup so completed runs are finalized instead of scheduling another completion retry.

## User Impact

Users should see one subagent completion message for this prompt-lock race instead of repeated duplicate completion messages.

## Evidence

- `node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts src/agents/subagent-announce.test.ts src/agents/subagent-registry-lifecycle.test.ts`
  - 3 files passed
  - 150 tests passed
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - clean: no accepted/actionable findings
- `git diff --check`
  - clean

Proof gap: no live Telegram transcript or recording was added in this branch. The fix is covered by focused source-level regression tests for duplicate-send prevention, retry-without-evidence, and lifecycle cleanup finalization.
