### PR TITLE
Fix stale cron catch-up after schedule updates

### DIFF
--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -248,6 +248,78 @@ describe("CronService restart catch-up", () => {
     }
   });
 
+  it("does not defer a cron slot that predates a schedule update (#91944)", async () => {
+    const store = await makeStorePath();
+    const updateNow = Date.parse("2026-06-09T22:30:00.000Z");
+    const restartNow = Date.parse("2026-06-10T20:33:00.000Z");
+    const nextMonthlyRun = Date.parse("2026-06-11T15:18:00.000Z");
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+
+    await writeStoreJobs(store.storePath, [
+      {
+        id: "monthly-agent-report",
+        name: "monthly agent report",
+        enabled: true,
+        createdAtMs: Date.parse("2026-04-10T15:18:00.000Z"),
+        updatedAtMs: Date.parse("2026-05-10T15:18:00.000Z"),
+        schedule: { kind: "cron", expr: "18 15 10 * *", tz: "UTC" },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "monthly report" },
+        state: {
+          lastRunAtMs: Date.parse("2026-05-10T15:18:00.000Z"),
+          lastRunStatus: "ok",
+          nextRunAtMs: Date.parse("2026-06-10T15:18:00.000Z"),
+        },
+      },
+    ]);
+
+    const updateCron = createRestartCronService({
+      storePath: store.storePath,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      nowMs: () => updateNow,
+      runIsolatedAgentJob,
+    });
+
+    try {
+      const updated = await updateCron.update("monthly-agent-report", {
+        schedule: { kind: "cron", expr: "18 15 11 * *", tz: "UTC" },
+      });
+      expect(updated.state.nextRunAtMs).toBe(nextMonthlyRun);
+      expect(updated.state.scheduleUpdatedAtMs).toBe(updateNow);
+    } finally {
+      updateCron.stop();
+    }
+
+    const restartCron = createRestartCronService({
+      storePath: store.storePath,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      nowMs: () => restartNow,
+      runIsolatedAgentJob,
+      startupDeferredMissedAgentJobDelayMs: 120_000,
+    });
+
+    try {
+      await restartCron.start();
+
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(enqueueSystemEvent).not.toHaveBeenCalled();
+      expect(requestHeartbeat).not.toHaveBeenCalled();
+
+      const listedJobs = await restartCron.list({ includeDisabled: true });
+      const updated = listedJobs.find((job) => job.id === "monthly-agent-report");
+      expect(updated?.state.nextRunAtMs).toBe(nextMonthlyRun);
+      expect(updated?.state.lastRunAtMs).toBe(Date.parse("2026-05-10T15:18:00.000Z"));
+    } finally {
+      restartCron.stop();
+      await store.cleanup();
+    }
+  });
+
   it("marks interrupted recurring jobs failed instead of replaying them on startup", async () => {
     const dueAt = Date.parse("2025-12-13T16:00:00.000Z");
     const staleRunningAt = Date.parse("2025-12-13T16:30:00.000Z");

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -488,6 +488,7 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
 
     nextJob.updatedAtMs = now;
     if (scheduleChanged || enabledChanged) {
+      nextJob.state.scheduleUpdatedAtMs = now;
       if (isJobEnabled(nextJob)) {
         nextJob.state.nextRunAtMs = computeJobNextRunAtMs(nextJob, now);
       } else {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1066,7 +1066,19 @@ function isRunnableJob(params: {
     // Only replay a "missed slot" when there is concrete run history.
     return false;
   }
+  if (scheduleActivatedAfterCandidateSlot(job, previousRunAtMs)) {
+    return false;
+  }
   return previousRunAtMs > lastRunAtMs;
+}
+
+function scheduleActivatedAfterCandidateSlot(job: CronJob, previousRunAtMs: number): boolean {
+  const scheduleUpdatedAtMs = job.state.scheduleUpdatedAtMs;
+  return (
+    typeof scheduleUpdatedAtMs === "number" &&
+    Number.isFinite(scheduleUpdatedAtMs) &&
+    previousRunAtMs < scheduleUpdatedAtMs
+  );
 }
 
 function isErrorBackoffPending(state: CronServiceState, job: CronJob, nowMs: number): boolean {
@@ -1141,6 +1153,7 @@ function deferPendingBackoffMissedCronSlots(
       !Number.isFinite(previousRunAtMs) ||
       typeof lastRunAtMs !== "number" ||
       !Number.isFinite(lastRunAtMs) ||
+      scheduleActivatedAfterCandidateSlot(job, previousRunAtMs) ||
       previousRunAtMs <= lastRunAtMs
     ) {
       continue;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -283,6 +283,8 @@ type CronCommandPayloadPatch = {
 export type CronJobState = {
   nextRunAtMs?: number;
   runningAtMs?: number;
+  /** Last schedule/enabled update; catch-up must not replay older inferred slots. */
+  scheduleUpdatedAtMs?: number;
   lastRunAtMs?: number;
   /** Preferred execution outcome field. */
   lastRunStatus?: CronRunStatus;


### PR DESCRIPTION
## Summary

Fixes #91944.

Cron restart catch-up can infer a missed cron slot from `lastRunAtMs` even when `nextRunAtMs` already points to the future. That catch-up path is valid for ordinary restart recovery, but after `cron.update` changes scheduling inputs it can replay an old slot that predates the new schedule's activation.

This change records when schedule/enabled inputs are updated and makes startup catch-up skip inferred cron slots older than that activation time. The focused regression covers the reported monthly schedule shape, an isolated `agentTurn`, and the 120s startup deferral path.

## Real behavior proof

Behavior addressed: a cron job updated from a day-10 monthly schedule to a day-11 monthly schedule no longer gets treated as a missed day-11 slot from the previous month and deferred to `gateway startup + 120s` on restart.

Real environment tested: local macOS source checkout at `26b5b5efb9` with Node 24.15.0 and pnpm 11.2.2. The runtime proof used an isolated `OPENCLAW_STATE_DIR` and OpenClaw's real SQLite cron store path, then imported the source `CronService`, `saveCronStore`, and `loadCronStore` modules directly from this PR head.

Exact steps or command run after this patch:
- `corepack pnpm install --frozen-lockfile`
- `node --import tsx --input-type=module` from the repository root with a stdin script that seeded the SQLite-backed cron store, called `CronService.update("monthly-agent-report", { schedule: { kind: "cron", expr: "18 15 11 * *", tz: "UTC" } })` at `2026-06-09T22:30:00.000Z`, then started a fresh `CronService` at `2026-06-10T20:33:00.000Z` with `startupDeferredMissedAgentJobDelayMs: 120000`.
- `node scripts/run-vitest.mjs src/cron/service.restart-catchup.test.ts --testNamePattern "does not defer a cron slot that predates a schedule update|replays the most recent missed cron slot|defers overdue isolated"`
- `node scripts/run-vitest.mjs src/cron/service.restart-catchup.test.ts`
- `node scripts/run-vitest.mjs src/commands/doctor/cron/index.test.ts`
- `node scripts/run-vitest.mjs src/cron/store.test.ts src/cron/service.issue-regressions.test.ts`
- `node scripts/run-vitest.mjs src/cron/service/timer.regression.test.ts src/cron/service/ops.test.ts`
- `git diff --check`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`

Evidence after fix: terminal output from the runtime proof script on PR head `26b5b5efb9`:

```json
{
  "proof": "#91944 cron schedule-update restart catch-up",
  "sourceCheckout": "/Users/andy/openclaw-91944-cron-migration",
  "stateRoot": "/var/folders/sl/5dkd3zq12dv65j6jx57zq1hc0000gn/T/openclaw-91944-proof-9sMwyj",
  "sqlitePath": "/var/folders/sl/5dkd3zq12dv65j6jx57zq1hc0000gn/T/openclaw-91944-proof-9sMwyj/state/openclaw.sqlite",
  "scenario": {
    "oldSchedule": "18 15 10 * * UTC",
    "newSchedule": "18 15 11 * * UTC",
    "updateNow": "2026-06-09T22:30:00.000Z",
    "restartNow": "2026-06-10T20:33:00.000Z",
    "legacyCandidateSlot": "2026-05-11T15:18:00.000Z",
    "startupDeferralTarget": "2026-06-10T20:35:00.000Z"
  },
  "afterCronUpdate": {
    "persistedSchedule": {
      "kind": "cron",
      "expr": "18 15 11 * *",
      "tz": "UTC"
    },
    "scheduleUpdatedAtMs": "2026-06-09T22:30:00.000Z",
    "nextRunAtMs": "2026-06-11T15:18:00.000Z"
  },
  "afterRestart": {
    "nextRunAtMs": "2026-06-11T15:18:00.000Z",
    "lastRunAtMs": "2026-05-10T15:18:00.000Z",
    "lastRunStatus": "ok",
    "isolatedAgentRuns": 0,
    "systemEvents": 0,
    "heartbeats": 0,
    "persistedNextRunAtMs": "2026-06-11T15:18:00.000Z"
  },
  "result": "PASS: restart did not defer or replay the pre-update cron slot; next run stayed on 2026-06-11T15:18:00.000Z"
}
```

Observed result after fix: after the schedule update, `nextRunAtMs` is `2026-06-11T15:18:00.000Z` and `scheduleUpdatedAtMs` is `2026-06-09T22:30:00.000Z`. Starting the cron service during the reported June 10 restart window leaves `nextRunAtMs` persisted at June 11, keeps `lastRunAtMs` at the real May 10 run, and makes zero isolated-agent, system-event, or heartbeat calls.

What was not tested: no live gateway upgrade, launchd double-restart, or Telegram delivery was run. The live proof is local source-runtime behavior through OpenClaw's cron service and SQLite state store for the scheduler state sequence from the issue.

## Verification

- `node scripts/run-vitest.mjs src/cron/service.restart-catchup.test.ts` - 15 passed
- `node scripts/run-vitest.mjs src/commands/doctor/cron/index.test.ts` - 25 passed
- `node scripts/run-vitest.mjs src/cron/store.test.ts src/cron/service.issue-regressions.test.ts` - 43 passed
- `node scripts/run-vitest.mjs src/cron/service/timer.regression.test.ts src/cron/service/ops.test.ts` - 66 passed
- `git diff --check`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`

Remote `crabbox-wrapper` changed-check attempts were not usable in this shell: default Azure lacked CLI/auth, Blacksmith Testbox requires Crabbox >= 0.22.0 while the local binary is 0.20.0, and local-container lacked Docker. The same changed check completed locally after dependencies were installed.

