### PR TITLE
fix(agents): classify structured unsupported model errors

### DIFF
--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -296,6 +296,9 @@ export interface AssistantMessage {
   usage: Usage;
   stopReason: StopReason;
   errorMessage?: string;
+  errorCode?: string;
+  errorType?: string;
+  errorBody?: string;
   timestamp: number; // Unix timestamp in milliseconds
 }
 

--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -571,6 +571,23 @@ describe("formatAssistantErrorText", () => {
       "LLM request failed: provider rejected the request schema or tool payload.",
     );
   });
+
+  it("uses structured error body detail for model-not-found copy", () => {
+    const msg = makeAssistantMessageFixture({
+      errorMessage: "400 Param Incorrect",
+      errorCode: "400",
+      errorBody:
+        '{"code":"400","message":"Param Incorrect","param":"Not supported model some-model-id"}',
+      content: [],
+    });
+
+    expect(formatAssistantErrorText(msg)).toBe(
+      "The selected model was not found by the provider. Check the model id or choose a different model.",
+    );
+    expect(formatUserFacingAssistantErrorText(msg)).toBe(
+      "The selected model was not found by the provider. Check the model id or choose a different model.",
+    );
+  });
 });
 
 describe("formatRawAssistantErrorForUi", () => {

--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -1,6 +1,7 @@
 // Covers provider error classifiers and failover reason mapping.
 import { describe, expect, it } from "vitest";
 import {
+  classifyAssistantFailoverReason,
   classifyProviderRuntimeFailureKind,
   classifyFailoverReason,
   classifyFailoverReasonFromHttpStatus,
@@ -1034,6 +1035,34 @@ describe("image dimension errors", () => {
       raw,
     });
     expect(isImageDimensionErrorMessage(raw)).toBe(true);
+  });
+});
+
+describe("classifyAssistantFailoverReason", () => {
+  it("uses structured assistant error bodies for model-not-found 400s", () => {
+    expect(
+      classifyAssistantFailoverReason({
+        role: "assistant",
+        api: "openai-completions",
+        provider: "openai",
+        model: "some-model-id",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "error",
+        errorMessage: "400 Param Incorrect",
+        errorCode: "400",
+        errorBody:
+          '{"code":"400","message":"Param Incorrect","param":"Not supported model some-model-id"}',
+        content: [],
+        timestamp: 0,
+      }),
+    ).toBe("model_not_found");
   });
 });
 

--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -12,6 +12,7 @@ export {
 } from "./embedded-agent-helpers/bootstrap.js";
 export {
   BILLING_ERROR_USER_MESSAGE,
+  classifyAssistantFailoverReason,
   classifyProviderRuntimeFailureKind,
   formatBillingErrorMessage,
   formatRateLimitOrOverloadedErrorCopy,

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -77,6 +77,10 @@ const sandboxToolPolicyAuditMessages = new WeakSet<AssistantMessage>();
 export const GENERIC_ASSISTANT_ERROR_TEXT = "LLM request failed.";
 const PROVIDER_SCHEMA_REJECTION_USER_TEXT =
   "LLM request failed: provider rejected the request schema or tool payload.";
+const MODEL_NOT_FOUND_USER_TEXT =
+  "The selected model was not found by the provider. Check the model id or choose a different model.";
+const MAX_FAILOVER_DETAIL_CANDIDATES = 12;
+const MAX_FAILOVER_DETAIL_CHARS = 1_000;
 
 /** Detect provider errors that require reasoning to stay enabled. */
 export function isReasoningConstraintErrorMessage(raw: string): boolean {
@@ -276,6 +280,7 @@ export type FailoverSignal = {
   errorType?: string;
   message?: string;
   provider?: string;
+  details?: readonly string[];
 };
 
 export type FailoverClassification =
@@ -286,6 +291,87 @@ export type FailoverClassification =
   | {
       kind: "context_overflow";
     };
+
+// Provider SDKs often keep semantic error fields outside Error.message.
+// These bounded candidates feed classification only; user-facing copy still
+// comes from the normal sanitized formatter path.
+function normalizeFailoverDetailString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.length > MAX_FAILOVER_DETAIL_CHARS
+    ? trimmed.slice(0, MAX_FAILOVER_DETAIL_CHARS)
+    : trimmed;
+}
+
+function appendFailoverDetailCandidate(candidates: string[], value: unknown): void {
+  const normalized =
+    typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+      ? normalizeFailoverDetailString(String(value))
+      : undefined;
+  if (!normalized || candidates.includes(normalized)) {
+    return;
+  }
+  candidates.push(normalized);
+}
+
+function collectFailoverDetailCandidates(
+  value: unknown,
+  candidates: string[],
+  seen: Set<object>,
+): void {
+  if (
+    candidates.length >= MAX_FAILOVER_DETAIL_CANDIDATES ||
+    value === undefined ||
+    value === null
+  ) {
+    return;
+  }
+  if (typeof value === "string") {
+    appendFailoverDetailCandidate(candidates, value);
+    const trimmed = value.trim();
+    if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+      return;
+    }
+    try {
+      collectFailoverDetailCandidates(JSON.parse(trimmed) as unknown, candidates, seen);
+    } catch {
+      // Non-JSON detail strings are still useful as direct classifier candidates.
+    }
+    return;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    appendFailoverDetailCandidate(candidates, value);
+    return;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return;
+  }
+  if (seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+  const record = value as Record<string, unknown>;
+  for (const key of ["message", "param", "code", "type", "error", "detail", "body"]) {
+    collectFailoverDetailCandidates(record[key], candidates, seen);
+    if (candidates.length >= MAX_FAILOVER_DETAIL_CANDIDATES) {
+      return;
+    }
+  }
+}
+
+export function extractFailoverSignalDetails(...values: unknown[]): string[] | undefined {
+  const candidates: string[] = [];
+  const seen = new Set<object>();
+  for (const value of values) {
+    collectFailoverDetailCandidates(value, candidates, seen);
+    if (candidates.length >= MAX_FAILOVER_DETAIL_CANDIDATES) {
+      break;
+    }
+  }
+  return candidates.length > 0 ? candidates : undefined;
+}
 
 export type ProviderRuntimeFailureKind =
   | "auth_scope"
@@ -302,6 +388,7 @@ export type ProviderRuntimeFailureKind =
   | "rate_limit"
   | "dns"
   | "timeout"
+  | "model_not_found"
   | "schema"
   | "sandbox_blocked"
   | "replay_invalid"
@@ -1009,6 +1096,49 @@ function classifyFailoverClassificationFromMessage(
   return null;
 }
 
+function classificationReason(
+  classification: FailoverClassification | null,
+): FailoverReason | undefined {
+  return classification?.kind === "reason" ? classification.reason : undefined;
+}
+
+function classifyFailoverDetailCandidates(
+  details: readonly string[] | undefined,
+  provider: string | undefined,
+  includeProviderPluginHooks: boolean,
+): FailoverClassification | null {
+  for (const detail of details ?? []) {
+    const classification = classifyFailoverClassificationFromMessage(detail, provider, {
+      includeProviderPluginHooks,
+    });
+    if (classification) {
+      return classification;
+    }
+  }
+  return null;
+}
+
+function mergeMessageAndDetailClassification(
+  messageClassification: FailoverClassification | null,
+  detailClassification: FailoverClassification | null,
+): FailoverClassification | null {
+  if (!messageClassification) {
+    return detailClassification;
+  }
+  if (!detailClassification) {
+    return messageClassification;
+  }
+  if (messageClassification.kind === "context_overflow") {
+    return messageClassification;
+  }
+  if (detailClassification.kind === "context_overflow") {
+    return detailClassification;
+  }
+  return classificationReason(messageClassification) === "format"
+    ? detailClassification
+    : messageClassification;
+}
+
 export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassification | null {
   const inferredStatus = inferSignalStatus(signal);
   const explicitStatus =
@@ -1029,6 +1159,11 @@ export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassifi
         includeProviderPluginHooks: !hasStructuredProviderSignal,
       })
     : null;
+  const detailClassification = classifyFailoverDetailCandidates(
+    signal.details,
+    signal.provider,
+    !hasStructuredProviderSignal,
+  );
   const providerPluginReason =
     hasStructuredProviderSignal &&
     signal.provider &&
@@ -1043,7 +1178,7 @@ export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassifi
       : null;
   const effectiveMessageClassification = providerPluginReason
     ? toReasonClassification(providerPluginReason)
-    : messageClassification;
+    : mergeMessageAndDetailClassification(messageClassification, detailClassification);
   const codeReason = classifyFailoverReasonFromCode(signal.code);
   if (codeReason === "auth_permanent") {
     return toReasonClassification(codeReason);
@@ -1110,6 +1245,12 @@ export function classifyProviderRuntimeFailureKind(
   if (failoverClassification?.kind === "reason" && failoverClassification.reason === "rate_limit") {
     return "rate_limit";
   }
+  if (
+    failoverClassification?.kind === "reason" &&
+    failoverClassification.reason === "model_not_found"
+  ) {
+    return "model_not_found";
+  }
   if (message && isDnsTransportErrorMessage(message)) {
     return "dns";
   }
@@ -1155,6 +1296,32 @@ export function classifyProviderRuntimeFailureKind(
   return "unclassified";
 }
 
+function buildAssistantFailoverSignal(
+  msg: AssistantMessage,
+  opts?: { provider?: string },
+): FailoverSignal {
+  return {
+    status: extractLeadingHttpStatus(msg.errorMessage?.trim() ?? "")?.code,
+    code: msg.errorCode,
+    errorType: msg.errorType,
+    message: msg.errorMessage?.trim() || undefined,
+    provider: opts?.provider ?? msg.provider,
+    details: extractFailoverSignalDetails(msg.errorBody),
+  };
+}
+
+export function classifyAssistantFailoverReason(
+  msg: AssistantMessage | undefined,
+  opts?: { provider?: string },
+): FailoverReason | null {
+  if (!msg || msg.stopReason !== "error") {
+    return null;
+  }
+  return failoverReasonFromClassification(
+    classifyFailoverSignal(buildAssistantFailoverSignal(msg, opts)),
+  );
+}
+
 export function formatAssistantErrorText(
   msg: AssistantMessage,
   opts?: { cfg?: OpenClawConfig; sessionKey?: string; provider?: string; model?: string },
@@ -1169,9 +1336,8 @@ export function formatAssistantErrorText(
   }
 
   const providerRuntimeFailureKind = classifyProviderRuntimeFailureKind({
-    status: extractLeadingHttpStatus(raw)?.code,
+    ...buildAssistantFailoverSignal(msg, { provider: opts?.provider }),
     message: raw,
-    provider: opts?.provider ?? msg.provider,
   });
 
   const unknownTool =
@@ -1262,6 +1428,10 @@ export function formatAssistantErrorText(
 
   if (providerRuntimeFailureKind === "proxy") {
     return "LLM request failed: proxy or tunnel configuration blocked the provider request.";
+  }
+
+  if (providerRuntimeFailureKind === "model_not_found") {
+    return MODEL_NOT_FOUND_USER_TEXT;
   }
 
   if (isContextOverflowError(raw)) {
@@ -1580,8 +1750,5 @@ export function isFailoverErrorMessage(raw: string, opts?: { provider?: string }
 }
 
 export function isFailoverAssistantError(msg: AssistantMessage | undefined): boolean {
-  if (!msg || msg.stopReason !== "error") {
-    return false;
-  }
-  return isFailoverErrorMessage(msg.errorMessage ?? "", { provider: msg.provider });
+  return classifyAssistantFailoverReason(msg) !== null;
 }

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -211,6 +211,10 @@ export const mockedFormatBillingErrorMessage = vi.fn(() => "");
 export const mockedClassifyFailoverReason = vi.fn<(raw: string) => FailoverReason | null>(
   () => null,
 );
+export const mockedClassifyAssistantFailoverReason = vi.fn(
+  (assistant?: { errorMessage?: string | null }): FailoverReason | null =>
+    mockedClassifyFailoverReason(assistant?.errorMessage ?? ""),
+);
 export const mockedExtractObservedOverflowTokenCount = vi.fn((msg?: string) => {
   const match = msg?.match(/prompt is too long:\s*([\d,]+)\s+tokens\s*>\s*[\d,]+\s+maximum/i);
   return match?.[1] ? Number(match[1].replaceAll(",", "")) : undefined;
@@ -384,6 +388,11 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
 
   mockedClassifyFailoverReason.mockReset();
   mockedClassifyFailoverReason.mockReturnValue(null);
+  mockedClassifyAssistantFailoverReason.mockReset();
+  mockedClassifyAssistantFailoverReason.mockImplementation(
+    (assistant?: { errorMessage?: string | null }): FailoverReason | null =>
+      mockedClassifyFailoverReason(assistant?.errorMessage ?? ""),
+  );
   mockedFormatBillingErrorMessage.mockReset();
   mockedFormatBillingErrorMessage.mockReturnValue("");
   mockedFormatAssistantErrorText.mockReset();
@@ -624,6 +633,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
   vi.doMock("../embedded-agent-helpers.js", () => ({
     formatBillingErrorMessage: mockedFormatBillingErrorMessage,
     classifyFailoverReason: mockedClassifyFailoverReason,
+    classifyAssistantFailoverReason: mockedClassifyAssistantFailoverReason,
     extractObservedOverflowTokenCount: mockedExtractObservedOverflowTokenCount,
     formatAssistantErrorText: mockedFormatAssistantErrorText,
     isAuthAssistantError: mockedIsAuthAssistantError,

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -53,6 +53,7 @@ import {
 } from "../command/session.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import {
+  classifyAssistantFailoverReason,
   classifyFailoverReason,
   extractObservedOverflowTokenCount,
   type FailoverReason,
@@ -2797,12 +2798,7 @@ export async function runEmbeddedAgent(
           const rateLimitFailure = isRateLimitAssistantError(assistantForFailover);
           const billingFailure = isBillingAssistantError(assistantForFailover);
           const failoverFailure = isFailoverAssistantError(assistantForFailover);
-          const assistantFailoverReason = classifyFailoverReason(
-            assistantForFailover?.errorMessage ?? "",
-            {
-              provider: assistantForFailover?.provider,
-            },
-          );
+          const assistantFailoverReason = classifyAssistantFailoverReason(assistantForFailover);
           const assistantProviderStarted =
             Boolean(currentAttemptAssistant?.provider) ||
             idleTimedOut ||

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -199,6 +199,26 @@ describe("buildEmbeddedRunPayloads", () => {
     expectNoPayloadTextContaining(payloads, "LLM request rejected");
   });
 
+  it("uses structured provider details for model-not-found reply payloads", () => {
+    const payloads = buildPayloads({
+      lastAssistant: makeAssistant({
+        stopReason: "error",
+        errorMessage: "400 Param Incorrect",
+        errorCode: "400",
+        errorBody:
+          '{"code":"400","message":"Param Incorrect","param":"Not supported model some-model-id"}',
+        content: [],
+      }),
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "The selected model was not found by the provider. Check the model id or choose a different model.",
+      isError: true,
+    });
+    expectNoPayloadTextContaining(payloads, "some-model-id");
+    expectNoPayloadTextContaining(payloads, "Param Incorrect");
+  });
+
   it("suppresses escaped structured provider error messages in user-facing reply payloads", () => {
     const rawError =
       '{"type":"error","error":{"type":"invalid_request_error","message":"SECRET\\nCANARY_69737"}}';

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -649,6 +649,40 @@ describe("failover-error", () => {
     ).toBe("model_not_found");
   });
 
+  it("uses structured OpenAI-compatible param detail for model-not-found 400s", () => {
+    const err = Object.assign(new Error("400 Param Incorrect"), {
+      status: 400,
+      code: "400",
+      param: "Not supported model some-model-id",
+      error: {
+        code: "400",
+        message: "Param Incorrect",
+        param: "Not supported model some-model-id",
+      },
+    });
+
+    expect(resolveFailoverReasonFromError(err)).toBe("model_not_found");
+    expect(describeFailoverError(err)).toMatchObject({
+      message: "400 Param Incorrect",
+      reason: "model_not_found",
+      status: 400,
+      code: "400",
+    });
+  });
+
+  it("keeps unsupported capability details classified as format", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 400,
+        message: "400 Param Incorrect",
+        error: {
+          message: "Param Incorrect",
+          param: "This model is not supported for tool calling.",
+        },
+      }),
+    ).toBe("format");
+  });
+
   it("treats HTTP 422 as format error", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -8,6 +8,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { readErrorName } from "../infra/errors.js";
 import {
   classifyFailoverSignal,
+  extractFailoverSignalDetails,
   inferSignalStatus,
   isUnclassifiedNoBodyHttpSignal,
   type FailoverClassification,
@@ -237,6 +238,26 @@ function getProvider(err: unknown): string | undefined {
   return findErrorProperty(err, readDirectProvider);
 }
 
+function readDirectErrorDetails(err: unknown): string[] | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const candidate = err as {
+    body?: unknown;
+    detail?: unknown;
+    error?: unknown;
+    errorBody?: unknown;
+    param?: unknown;
+  };
+  return extractFailoverSignalDetails(
+    candidate.param,
+    candidate.errorBody,
+    candidate.body,
+    candidate.detail,
+    candidate.error,
+  );
+}
+
 function readDirectErrorMessage(err: unknown): string | undefined {
   if (err instanceof Error) {
     return err.message || undefined;
@@ -271,6 +292,7 @@ function normalizeDirectErrorSignal(err: unknown): FailoverSignal {
     errorType: readDirectErrorType(err),
     message: message || undefined,
     provider: readDirectProvider(err),
+    details: readDirectErrorDetails(err),
   };
 }
 
@@ -390,6 +412,7 @@ function normalizeErrorSignal(err: unknown, providerHint?: string): FailoverSign
     errorType: getErrorType(err),
     message: message || undefined,
     provider: getProvider(err) ?? providerHint,
+    details: readDirectErrorDetails(err),
   };
 }
 

--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -33,6 +33,12 @@ describe("live model error helpers", () => {
     ).toBe(true);
     expect(
       isModelNotFoundErrorMessage(
+        '{"error":{"code":"400","message":"Param Incorrect","param":"Not supported model some-model-id"}}',
+      ),
+    ).toBe(true);
+    expect(isModelNotFoundErrorMessage("Not supported model some-model-id")).toBe(true);
+    expect(
+      isModelNotFoundErrorMessage(
         "404 The free model has been deprecated. Transition to qwen/qwen3.6-plus for continued paid access.",
       ),
     ).toBe(true);
@@ -45,6 +51,13 @@ describe("live model error helpers", () => {
       isModelNotFoundErrorMessage("The deployment does not exist or you do not have access."),
     ).toBe(false);
     expect(isModelNotFoundErrorMessage('{"error":{"message":"Resource missing","code":404}}')).toBe(
+      false,
+    );
+    expect(isModelNotFoundErrorMessage("This model is not supported for tool calling.")).toBe(
+      false,
+    );
+    expect(isModelNotFoundErrorMessage("This model does not support image inputs.")).toBe(false);
+    expect(isModelNotFoundErrorMessage("Reasoning effort is not supported for this model.")).toBe(
       false,
     );
     expect(isModelNotFoundErrorMessage("request ended without sending any chunks")).toBe(false);

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -28,6 +28,9 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
   if (/not_found_error/i.test(msg)) {
     return true;
   }
+  if (/\bnot supported model\b/i.test(msg)) {
+    return true;
+  }
   if (/model:\s*[a-z0-9._/-]+/i.test(msg) && /not(?:[_\-\s])?found/i.test(msg)) {
     return true;
   }

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -3,6 +3,10 @@ import { createServer } from "node:http";
 import type { Api, Model } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import {
+  classifyAssistantFailoverReason,
+  formatUserFacingAssistantErrorText,
+} from "./embedded-agent-helpers.js";
+import {
   buildOpenAIResponsesParams,
   buildOpenAICompletionsParams,
   createOpenAICompletionsTransportStreamFn,
@@ -1572,6 +1576,83 @@ describe("openai transport stream", () => {
       });
       expect(String(errorPayload?.errorBody)).toContain("Quota exceeded");
       expect(String(errorPayload?.errorBody)).not.toContain("sk-secret1234567890abcd");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("classifies OpenAI-compatible unsupported-model detail from failed chat requests", async () => {
+    const server = createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(400, {
+          "content-type": "application/json; charset=utf-8",
+          "x-request-id": "req_not_supported_model",
+        });
+        res.end(
+          JSON.stringify({
+            error: {
+              code: "400",
+              message: "Param Incorrect",
+              param: "Not supported model some-model-id",
+            },
+          }),
+        );
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const model = {
+        id: "some-model-id",
+        name: "Some Model",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200_000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">;
+      const stream = createOpenAICompletionsTransportStreamFn()(
+        model,
+        {
+          systemPrompt: "system",
+          messages: [{ role: "user", content: "Reply OK", timestamp: Date.now() }],
+          tools: [],
+        } as never,
+        { apiKey: "test-key" } as never,
+      );
+
+      let errorPayload: Record<string, unknown> | undefined;
+      for await (const event of stream as AsyncIterable<{
+        type: string;
+        error?: Record<string, unknown>;
+      }>) {
+        if (event.type === "error") {
+          errorPayload = event.error;
+        }
+      }
+
+      expect(errorPayload).toMatchObject({
+        stopReason: "error",
+        errorMessage: "400 Param Incorrect",
+        errorCode: "400",
+      });
+      expect(String(errorPayload?.errorBody)).toContain("Not supported model some-model-id");
+      expect(classifyAssistantFailoverReason(errorPayload as never)).toBe("model_not_found");
+      expect(formatUserFacingAssistantErrorText(errorPayload as never)).toBe(
+        "The selected model was not found by the provider. Check the model id or choose a different model.",
+      );
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
@@ -10183,9 +10264,7 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
   });
 
   it("preserves reasoning_content replay for Gemma 4 openai-completions models", () => {
-    const assistant = getAssistantMessage(
-      buildReplayParams(gemma4Model, "reasoning_content"),
-    );
+    const assistant = getAssistantMessage(buildReplayParams(gemma4Model, "reasoning_content"));
 
     expect(assistant.reasoning_content).toBe("Need to answer politely.");
     expect(assistant).not.toHaveProperty("reasoning_details");


### PR DESCRIPTION
## Summary

- Preserve structured provider error details for failover classification without changing stored/displayed `errorMessage`.
- Classify OpenAI-compatible `Not supported model <model-id>` details as `model_not_found` instead of schema/tool-payload failures.
- Add typed assistant error metadata and full-path regression coverage for thrown SDK-shaped errors, assistant `errorBody`, user-facing payloads, and OpenAI-compatible transport loopback.

Closes #92118

## Real behavior proof

Behavior addressed: OpenAI-compatible providers can return HTTP 400 bodies where `error.message` is `Param Incorrect` while `error.param` contains `Not supported model <model-id>`. OpenClaw now classifies that as `model_not_found` and avoids misleading schema/tool-payload copy.

Real environment tested: AWS Crabbox Linux lease `cbx_f55aeccc0a97` (`c7a.8xlarge`), run `run_de58983b891d`, using the dirty branch sync with a loopback OpenAI-compatible HTTP server returning the exact reported payload.

Exact steps or command run after this patch: Crabbox script started a local `/v1/chat/completions` loopback server returning `{"error":{"code":"400","message":"Param Incorrect","param":"Not supported model some-model-id"}}`, then called `createOpenAICompletionsTransportStreamFn()` and checked `resolveFailoverReasonFromError()`, `classifyAssistantFailoverReason()`, and `formatUserFacingAssistantErrorText()`.

Evidence after fix: The Crabbox proof printed `OPENCLAW_92118_FIXED_PROOF` with `dependencyShapeClassification.reason: "model_not_found"`, `classifications.assistantFailoverReason: "model_not_found"`, and user-facing text `The selected model was not found by the provider. Check the model id or choose a different model.`

Observed result after fix: The exact reported payload no longer falls through to schema/tool-payload copy.

What was not tested: A live third-party Xiaomi/MiFY credentialed provider call was not run; the proof uses a local OpenAI-compatible loopback server with the exact reported response body and real OpenClaw OpenAI-compatible transport.

## Verification

- `.agents/skills/autoreview/scripts/autoreview --mode local` (ran twice after formatting; final result: clean, no accepted/actionable findings)
- `node scripts/run-vitest.mjs src/agents/live-model-errors.test.ts src/agents/failover-error.test.ts src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts src/agents/openai-transport-stream.test.ts` (2 shards, 616 tests passed)
- `../crabbox/bin/crabbox run --provider aws ...` (`run_de58983b891d`, `cbx_f55aeccc0a97`) for the reported loopback repro/fix proof
- `git diff --check`
