### PR TITLE
Fix Telegram spooled buffered replay

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-8a2769df428906990ee0d1bf8b0423f2a099b053c64c816d092ff84d61e11633  plugin-sdk-api-baseline.json
-28b798973f3fb2a5b33ccbb6e3c1ac0453fa234a3a1c6cdc27935c27639bd104  plugin-sdk-api-baseline.jsonl
+fbb605dd3077cb40826330ee3120e1955824b9f4b10acb908e654e333ed1a1ff  plugin-sdk-api-baseline.json
+407f0fd91ea56310b75b332f533ac3e76e769b0ea02d8e1977fa550c348ac26c  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-fbb605dd3077cb40826330ee3120e1955824b9f4b10acb908e654e333ed1a1ff  plugin-sdk-api-baseline.json
-407f0fd91ea56310b75b332f533ac3e76e769b0ea02d8e1977fa550c348ac26c  plugin-sdk-api-baseline.jsonl
+ff7bd86cb1b243e0c94fdf9a74e7f985a7d73685b2b0cd0a8761972d145ca7a5  plugin-sdk-api-baseline.json
+a65283a99e28a300adffa26ed171a3e8b215d9c95e8a1656fc5ae8fd7fc011c6  plugin-sdk-api-baseline.jsonl

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -28,6 +28,12 @@ import type { TelegramBotDeps } from "./bot-deps.js";
 import { registerTelegramHandlers } from "./bot-handlers.runtime.js";
 import { createTelegramMessageProcessor } from "./bot-message.js";
 import { registerTelegramNativeCommands } from "./bot-native-commands.js";
+import {
+  getTelegramSpooledReplayDeferredParticipant,
+  isTelegramSpooledReplayUpdate,
+  runWithTelegramUpdateProcessingFrame,
+  TelegramSpooledReplayProcessingError,
+} from "./bot-processing-outcome.js";
 import { createTelegramUpdateTracker } from "./bot-update-tracker.js";
 import type { TelegramUpdateKeyContext } from "./bot-updates.js";
 import { resolveDefaultAgentId } from "./bot.agent.runtime.js";
@@ -212,7 +218,29 @@ export function createTelegramBotCore(
       return;
     }
     try {
-      await next();
+      const { result } = await runWithTelegramUpdateProcessingFrame(async () => {
+        await next();
+      });
+      const deferredWork = getTelegramSpooledReplayDeferredParticipant();
+      if (deferredWork) {
+        void deferredWork.task
+          .then((deferredResult) => {
+            updateTracker.finishUpdate(begin.update, {
+              completed: deferredResult.kind !== "failed-retryable",
+            });
+          })
+          .catch(() => {
+            updateTracker.finishUpdate(begin.update, { completed: false });
+          });
+        return;
+      }
+      if (result?.kind === "failed-retryable") {
+        if (isTelegramSpooledReplayUpdate(ctx.update)) {
+          throw new TelegramSpooledReplayProcessingError(result.error);
+        }
+        updateTracker.finishUpdate(begin.update, { completed: true });
+        return;
+      }
       updateTracker.finishUpdate(begin.update, { completed: true });
     } catch (error) {
       updateTracker.finishUpdate(begin.update, { completed: false });

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -73,6 +73,12 @@ import type {
 import { parseTelegramNativeCommandCallbackData } from "./bot-native-commands.js";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import {
+  createTelegramSpooledReplayDeferredParticipant,
+  isTelegramSpooledReplayUpdate,
+  type TelegramMessageProcessingResult,
+  type TelegramSpooledReplayDeferredParticipant,
+} from "./bot-processing-outcome.js";
+import {
   MEDIA_GROUP_TIMEOUT_MS,
   type MediaGroupEntry,
   type TelegramUpdateKeyContext,
@@ -133,6 +139,7 @@ import {
   claimTelegramMessageDispatchReplay,
   commitTelegramMessageDispatchReplay,
   createTelegramMessageDispatchReplayGuard,
+  forgetTelegramMessageDispatchReplay,
   releaseTelegramMessageDispatchReplay,
 } from "./message-dispatch-dedupe.js";
 import {
@@ -208,6 +215,7 @@ export const registerTelegramHandlers = ({
     groupConfig?: TelegramGroupConfig;
     topicConfig?: TelegramTopicConfig;
     dispatchDedupeKeys: string[];
+    spooledReplayParticipants: TelegramSpooledReplayDeferredParticipant[];
   };
 
   const mediaGroupBuffer = new Map<string, BufferedMediaGroupEntry>();
@@ -227,6 +235,7 @@ export const registerTelegramHandlers = ({
     messages: Array<{ msg: Message; ctx: TelegramContext; receivedAtMs: number }>;
     promptContextMinTimestampMs?: number;
     dispatchDedupeKeys: string[];
+    spooledReplayParticipants: TelegramSpooledReplayDeferredParticipant[];
     timer: ReturnType<typeof setTimeout>;
   };
   const textFragmentBuffer = new Map<string, TextFragmentEntry>();
@@ -261,6 +270,26 @@ export const registerTelegramHandlers = ({
     threadId?: number;
     promptContextMinTimestampMs?: number;
     dispatchDedupeKeys: string[];
+    spooledReplayParticipant?: TelegramSpooledReplayDeferredParticipant;
+  };
+  const resolveTelegramDebounceEntryMs = (entry: TelegramDebounceEntry): number =>
+    entry.debounceLane === "forward" ? FORWARD_BURST_DEBOUNCE_MS : debounceMs;
+  const shouldDebounceTelegramEntry = (entry: TelegramDebounceEntry): boolean => {
+    const text = getTelegramTextParts(entry.msg).text;
+    const hasDebounceableText = shouldDebounceTextInbound({
+      text,
+      cfg,
+      commandOptions: { botUsername: entry.botUsername },
+    });
+    if (entry.debounceLane === "forward") {
+      // Forwarded bursts often split text + media into adjacent updates.
+      // Debounce media-only forward entries too so they can coalesce.
+      return hasDebounceableText || entry.allMedia.length > 0;
+    }
+    if (!hasDebounceableText) {
+      return false;
+    }
+    return entry.allMedia.length === 0;
   };
   const normalizePromptContextMinTimestampMs = (timestampMs?: number) =>
     typeof timestampMs === "number" && Number.isFinite(timestampMs) ? timestampMs : undefined;
@@ -299,6 +328,32 @@ export const registerTelegramHandlers = ({
       keys,
     });
   };
+  const forgetDispatchDedupeKeys = async (keys: readonly string[]) => {
+    await forgetTelegramMessageDispatchReplay({
+      guard: messageDispatchReplayGuard,
+      keys,
+    });
+  };
+  const buildFailedProcessingResult = (error: unknown): TelegramMessageProcessingResult => ({
+    kind: "failed-retryable",
+    error,
+  });
+  const settleSpooledReplayParticipants = (
+    participants: readonly TelegramSpooledReplayDeferredParticipant[],
+    result: TelegramMessageProcessingResult,
+  ) => {
+    for (const participant of new Set(participants)) {
+      participant.settle(result);
+    }
+  };
+  const createSpooledReplayParticipantForBufferedWork = (
+    key: string,
+  ): TelegramSpooledReplayDeferredParticipant | undefined =>
+    createTelegramSpooledReplayDeferredParticipant(key) ?? undefined;
+  const spooledReplayOptions = (
+    participants: readonly TelegramSpooledReplayDeferredParticipant[],
+  ): Pick<TelegramMessageContextOptions, "spooledReplay"> =>
+    participants.length > 0 ? { spooledReplay: true } : {};
   const claimMessageDispatchDedupe = async (
     msg: Message,
   ): Promise<{ process: true; keys: string[] } | { process: false }> => {
@@ -479,84 +534,96 @@ export const registerTelegramHandlers = ({
   const inboundDebouncer = createInboundDebouncer<TelegramDebounceEntry>({
     debounceMs,
     serializeImmediate: true,
-    resolveDebounceMs: (entry) =>
-      entry.debounceLane === "forward" ? FORWARD_BURST_DEBOUNCE_MS : debounceMs,
+    resolveDebounceMs: resolveTelegramDebounceEntryMs,
     buildKey: (entry) => entry.debounceKey,
-    shouldDebounce: (entry) => {
-      const text = getTelegramTextParts(entry.msg).text;
-      const hasDebounceableText = shouldDebounceTextInbound({
-        text,
-        cfg,
-        commandOptions: { botUsername: entry.botUsername },
-      });
-      if (entry.debounceLane === "forward") {
-        // Forwarded bursts often split text + media into adjacent updates.
-        // Debounce media-only forward entries too so they can coalesce.
-        return hasDebounceableText || entry.allMedia.length > 0;
-      }
-      if (!hasDebounceableText) {
-        return false;
-      }
-      return entry.allMedia.length === 0;
-    },
+    shouldDebounce: shouldDebounceTelegramEntry,
     onFlush: async (entries) => {
+      const spooledReplayParticipants = entries
+        .map((entry) => entry.spooledReplayParticipant)
+        .filter(
+          (participant): participant is TelegramSpooledReplayDeferredParticipant =>
+            participant !== undefined,
+        );
       const last = entries.at(-1);
       if (!last) {
         return;
       }
-      if (entries.length === 1) {
-        await processMessageWithReplyChain({
-          ctx: last.ctx,
-          msg: last.msg,
-          allMedia: last.allMedia,
-          storeAllowFrom: last.storeAllowFrom,
-          options: {
-            receivedAtMs: last.receivedAtMs,
-            ingressBuffer: "inbound-debounce",
-            ...promptContextBoundaryOptions(last.promptContextMinTimestampMs),
-          },
-          dispatchDedupeKeys: last.dispatchDedupeKeys,
+      try {
+        if (entries.length === 1) {
+          const result = await processMessageWithReplyChain({
+            ctx: last.ctx,
+            msg: last.msg,
+            allMedia: last.allMedia,
+            storeAllowFrom: last.storeAllowFrom,
+            options: {
+              receivedAtMs: last.receivedAtMs,
+              ingressBuffer: "inbound-debounce",
+              ...promptContextBoundaryOptions(last.promptContextMinTimestampMs),
+              ...spooledReplayOptions(spooledReplayParticipants),
+            },
+            dispatchDedupeKeys: last.dispatchDedupeKeys,
+          });
+          settleSpooledReplayParticipants(spooledReplayParticipants, result);
+          return;
+        }
+        const combinedText = entries
+          .map((entry) => getTelegramTextParts(entry.msg).text)
+          .filter(Boolean)
+          .join("\n");
+        const combinedMedia = entries.flatMap((entry) => entry.allMedia);
+        if (!combinedText.trim() && combinedMedia.length === 0) {
+          settleSpooledReplayParticipants(spooledReplayParticipants, { kind: "skipped" });
+          return;
+        }
+        const first = entries[0];
+        const promptContextMinTimestampMs = latestPromptContextMinTimestampMs(
+          ...entries.map((entry) => entry.promptContextMinTimestampMs),
+        );
+        const baseCtx = first.ctx;
+        const syntheticMessage = buildSyntheticTextMessage({
+          base: first.msg,
+          text: combinedText,
+          date: last.msg.date ?? first.msg.date,
         });
-        return;
+        const messageIdOverride = last.msg.message_id ? String(last.msg.message_id) : undefined;
+        const syntheticCtx = buildSyntheticContext(baseCtx, syntheticMessage);
+        const result = await processMessageWithReplyChain({
+          ctx: syntheticCtx,
+          msg: syntheticMessage,
+          allMedia: combinedMedia,
+          storeAllowFrom: first.storeAllowFrom,
+          options: {
+            ...(messageIdOverride ? { messageIdOverride } : {}),
+            receivedAtMs: first.receivedAtMs,
+            ingressBuffer: "inbound-debounce",
+            ...promptContextBoundaryOptions(promptContextMinTimestampMs),
+            ...spooledReplayOptions(spooledReplayParticipants),
+          },
+          dispatchDedupeKeys: mergeDispatchDedupeKeys(
+            ...entries.map((entry) => entry.dispatchDedupeKeys),
+          ),
+        });
+        settleSpooledReplayParticipants(spooledReplayParticipants, result);
+      } catch (err) {
+        settleSpooledReplayParticipants(
+          spooledReplayParticipants,
+          buildFailedProcessingResult(err),
+        );
+        throw err;
       }
-      const combinedText = entries
-        .map((entry) => getTelegramTextParts(entry.msg).text)
-        .filter(Boolean)
-        .join("\n");
-      const combinedMedia = entries.flatMap((entry) => entry.allMedia);
-      if (!combinedText.trim() && combinedMedia.length === 0) {
-        return;
-      }
-      const first = entries[0];
-      const promptContextMinTimestampMs = latestPromptContextMinTimestampMs(
-        ...entries.map((entry) => entry.promptContextMinTimestampMs),
-      );
-      const baseCtx = first.ctx;
-      const syntheticMessage = buildSyntheticTextMessage({
-        base: first.msg,
-        text: combinedText,
-        date: last.msg.date ?? first.msg.date,
-      });
-      const messageIdOverride = last.msg.message_id ? String(last.msg.message_id) : undefined;
-      const syntheticCtx = buildSyntheticContext(baseCtx, syntheticMessage);
-      await processMessageWithReplyChain({
-        ctx: syntheticCtx,
-        msg: syntheticMessage,
-        allMedia: combinedMedia,
-        storeAllowFrom: first.storeAllowFrom,
-        options: {
-          ...(messageIdOverride ? { messageIdOverride } : {}),
-          receivedAtMs: first.receivedAtMs,
-          ingressBuffer: "inbound-debounce",
-          ...promptContextBoundaryOptions(promptContextMinTimestampMs),
-        },
-        dispatchDedupeKeys: mergeDispatchDedupeKeys(
-          ...entries.map((entry) => entry.dispatchDedupeKeys),
-        ),
-      });
     },
     onError: (err, items) => {
+      const spooledReplayParticipants = items
+        .map((item) => item.spooledReplayParticipant)
+        .filter(
+          (participant): participant is TelegramSpooledReplayDeferredParticipant =>
+            participant !== undefined,
+        );
+      settleSpooledReplayParticipants(spooledReplayParticipants, buildFailedProcessingResult(err));
       runtime.error?.(danger(`telegram debounce flush failed: ${String(err)}`));
+      if (spooledReplayParticipants.length > 0) {
+        return;
+      }
       const chatId = items[0]?.msg.chat.id;
       if (chatId != null) {
         const threadId = items[0]?.msg.message_thread_id;
@@ -572,6 +639,15 @@ export const registerTelegramHandlers = ({
       }
     },
     onCancel: (items) => {
+      settleSpooledReplayParticipants(
+        items
+          .map((item) => item.spooledReplayParticipant)
+          .filter(
+            (participant): participant is TelegramSpooledReplayDeferredParticipant =>
+              participant !== undefined,
+          ),
+        { kind: "skipped" },
+      );
       releaseDispatchDedupeKeys(
         mergeDispatchDedupeKeys(...items.map((item) => item.dispatchDedupeKeys)),
       );
@@ -812,6 +888,7 @@ export const registerTelegramHandlers = ({
       const primaryEntry = captionMsg ?? entry.messages[0];
       if (!primaryEntry) {
         releaseDispatchDedupeKeys(entry.dispatchDedupeKeys);
+        settleSpooledReplayParticipants(entry.spooledReplayParticipants, { kind: "skipped" });
         return;
       }
 
@@ -832,6 +909,7 @@ export const registerTelegramHandlers = ({
         })
       ) {
         releaseDispatchDedupeKeys(entry.dispatchDedupeKeys);
+        settleSpooledReplayParticipants(entry.spooledReplayParticipants, { kind: "skipped" });
         return;
       }
 
@@ -886,16 +964,24 @@ export const registerTelegramHandlers = ({
         }).catch(() => {});
       }
 
-      await processMessageWithReplyChain({
+      const result = await processMessageWithReplyChain({
         ctx: primaryEntry.ctx,
         msg: primaryEntry.msg,
         allMedia,
         storeAllowFrom: entry.storeAllowFrom,
-        options: promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
+        options: {
+          ...promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
+          ...spooledReplayOptions(entry.spooledReplayParticipants),
+        },
         dispatchDedupeKeys: entry.dispatchDedupeKeys,
       });
+      settleSpooledReplayParticipants(entry.spooledReplayParticipants, result);
     } catch (err) {
       releaseDispatchDedupeKeys(entry.dispatchDedupeKeys, err);
+      settleSpooledReplayParticipants(
+        entry.spooledReplayParticipants,
+        buildFailedProcessingResult(err),
+      );
       runtime.error?.(danger(`media group handler failed: ${String(err)}`));
     }
   };
@@ -908,12 +994,14 @@ export const registerTelegramHandlers = ({
       const last = entry.messages.at(-1);
       if (!first || !last) {
         releaseDispatchDedupeKeys(entry.dispatchDedupeKeys);
+        settleSpooledReplayParticipants(entry.spooledReplayParticipants, { kind: "skipped" });
         return;
       }
 
       const combinedText = entry.messages.map((m) => m.msg.text ?? "").join("");
       if (!combinedText.trim()) {
         releaseDispatchDedupeKeys(entry.dispatchDedupeKeys);
+        settleSpooledReplayParticipants(entry.spooledReplayParticipants, { kind: "skipped" });
         return;
       }
 
@@ -927,7 +1015,7 @@ export const registerTelegramHandlers = ({
       const baseCtx = first.ctx;
 
       const syntheticCtx = buildSyntheticContext(baseCtx, syntheticMessage);
-      await processMessageWithReplyChain({
+      const result = await processMessageWithReplyChain({
         ctx: syntheticCtx,
         msg: syntheticMessage,
         allMedia: [],
@@ -937,11 +1025,17 @@ export const registerTelegramHandlers = ({
           receivedAtMs: first.receivedAtMs,
           ingressBuffer: "text-fragment",
           ...promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
+          ...spooledReplayOptions(entry.spooledReplayParticipants),
         },
         dispatchDedupeKeys: entry.dispatchDedupeKeys,
       });
+      settleSpooledReplayParticipants(entry.spooledReplayParticipants, result);
     } catch (err) {
       releaseDispatchDedupeKeys(entry.dispatchDedupeKeys, err);
+      settleSpooledReplayParticipants(
+        entry.spooledReplayParticipants,
+        buildFailedProcessingResult(err),
+      );
       runtime.error?.(danger(`text fragment handler failed: ${String(err)}`));
     }
   };
@@ -1125,8 +1219,10 @@ export const registerTelegramHandlers = ({
     storeAllowFrom: string[];
     options?: TelegramMessageContextOptions;
     dispatchDedupeKeys?: string[];
-  }) => {
+  }): Promise<TelegramMessageProcessingResult> => {
     let dispatchDedupeCommitted = false;
+    const spooledReplay =
+      params.options?.spooledReplay === true || isTelegramSpooledReplayUpdate(params.ctx.update);
     try {
       const replyChainNodes = await buildReplyChainForMessage(params.msg);
       const { replyMedia, replyChain } = await resolveReplyMediaForChain(
@@ -1138,7 +1234,7 @@ export const registerTelegramHandlers = ({
         replyChainNodes,
         params.options,
       );
-      const dispatched = await processMessage(
+      const result = await processMessage(
         params.ctx,
         params.allMedia,
         params.storeAllowFrom,
@@ -1153,11 +1249,18 @@ export const registerTelegramHandlers = ({
           },
         },
       );
-      if (!dispatched && !dispatchDedupeCommitted) {
+      if (result.kind === "completed" && !dispatchDedupeCommitted) {
+        await commitDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
+      } else if (result.kind === "failed-retryable" && dispatchDedupeCommitted && spooledReplay) {
+        await forgetDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
+      } else if (result.kind !== "completed" && !dispatchDedupeCommitted) {
         releaseDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
       }
+      return result;
     } catch (err) {
-      if (!dispatchDedupeCommitted) {
+      if (dispatchDedupeCommitted && spooledReplay) {
+        await forgetDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
+      } else if (!dispatchDedupeCommitted) {
         releaseDispatchDedupeKeys(params.dispatchDedupeKeys ?? [], err);
       }
       throw err;
@@ -1727,6 +1830,12 @@ export const registerTelegramHandlers = ({
             existing.messages.length + 1 <= TELEGRAM_TEXT_FRAGMENT_MAX_PARTS &&
             nextTotalChars <= TELEGRAM_TEXT_FRAGMENT_MAX_TOTAL_CHARS
           ) {
+            const spooledReplayParticipant = createSpooledReplayParticipantForBufferedWork(
+              `text-fragment:${key}:${msg.message_id}`,
+            );
+            if (spooledReplayParticipant) {
+              existing.spooledReplayParticipants.push(spooledReplayParticipant);
+            }
             existing.messages.push({ msg, ctx, receivedAtMs: nowMs });
             existing.promptContextMinTimestampMs = latestPromptContextMinTimestampMs(
               existing.promptContextMinTimestampMs,
@@ -1749,10 +1858,14 @@ export const registerTelegramHandlers = ({
 
       const shouldStart = text.length >= TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS;
       if (shouldStart) {
+        const spooledReplayParticipant = createSpooledReplayParticipantForBufferedWork(
+          `text-fragment:${key}:${msg.message_id}`,
+        );
         const entry: TextFragmentEntry = {
           key,
           messages: [{ msg, ctx, receivedAtMs: nowMs }],
           dispatchDedupeKeys,
+          spooledReplayParticipants: spooledReplayParticipant ? [spooledReplayParticipant] : [],
           ...promptContextBoundaryOptions(promptContextMinTimestampMs),
           timer: setTimeout(() => {}, TELEGRAM_TEXT_FRAGMENT_MAX_GAP_MS),
         };
@@ -1769,6 +1882,7 @@ export const registerTelegramHandlers = ({
         clearTimeout(existing.timer);
         textFragmentBuffer.delete(key);
         releaseDispatchDedupeKeys(existing.dispatchDedupeKeys);
+        settleSpooledReplayParticipants(existing.spooledReplayParticipants, { kind: "skipped" });
       }
     }
 
@@ -1779,6 +1893,12 @@ export const registerTelegramHandlers = ({
       const mediaGroupKey = `media:${chatId}:${threadId ?? "main"}:${mediaGroupId}`;
       const existing = mediaGroupBuffer.get(mediaGroupKey);
       if (existing) {
+        const spooledReplayParticipant = createSpooledReplayParticipantForBufferedWork(
+          `media-group:${mediaGroupKey}:${msg.message_id}`,
+        );
+        if (spooledReplayParticipant) {
+          existing.spooledReplayParticipants.push(spooledReplayParticipant);
+        }
         clearTimeout(existing.timer);
         existing.messages.push({ msg, ctx });
         existing.promptContextMinTimestampMs = latestPromptContextMinTimestampMs(
@@ -1796,6 +1916,9 @@ export const registerTelegramHandlers = ({
           });
         }, mediaGroupTimeoutMs);
       } else {
+        const spooledReplayParticipant = createSpooledReplayParticipantForBufferedWork(
+          `media-group:${mediaGroupKey}:${msg.message_id}`,
+        );
         const entry: BufferedMediaGroupEntry = {
           messages: [{ msg, ctx }],
           storeAllowFrom,
@@ -1809,6 +1932,7 @@ export const registerTelegramHandlers = ({
           groupConfig,
           topicConfig,
           dispatchDedupeKeys,
+          spooledReplayParticipants: spooledReplayParticipant ? [spooledReplayParticipant] : [],
           ...promptContextBoundaryOptions(promptContextMinTimestampMs),
           timer: setTimeout(() => {
             mediaGroupBuffer.delete(mediaGroupKey);
@@ -1928,7 +2052,7 @@ export const registerTelegramHandlers = ({
         );
       }
     }
-    await inboundDebouncer.enqueue({
+    const debounceEntry: TelegramDebounceEntry = {
       ctx,
       msg,
       allMedia,
@@ -1939,7 +2063,17 @@ export const registerTelegramHandlers = ({
       botUsername,
       ...promptContextBoundaryOptions(promptContextMinTimestampMs),
       dispatchDedupeKeys,
-    });
+    };
+    if (
+      debounceEntry.debounceKey &&
+      resolveTelegramDebounceEntryMs(debounceEntry) > 0 &&
+      shouldDebounceTelegramEntry(debounceEntry)
+    ) {
+      debounceEntry.spooledReplayParticipant = createSpooledReplayParticipantForBufferedWork(
+        `inbound-debounce:${debounceEntry.debounceKey}`,
+      );
+    }
+    await inboundDebouncer.enqueue(debounceEntry);
   };
   bot.on("callback_query", async (ctx) => {
     const callback = ctx.callbackQuery;

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1221,8 +1221,13 @@ export const registerTelegramHandlers = ({
     dispatchDedupeKeys?: string[];
   }): Promise<TelegramMessageProcessingResult> => {
     let dispatchDedupeCommitted = false;
+    let dispatchDedupeRollbackAttempted = false;
     const spooledReplay =
       params.options?.spooledReplay === true || isTelegramSpooledReplayUpdate(params.ctx.update);
+    const forgetCommittedDispatchDedupeKeys = async () => {
+      dispatchDedupeRollbackAttempted = true;
+      await forgetDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
+    };
     try {
       const replyChainNodes = await buildReplyChainForMessage(params.msg);
       const { replyMedia, replyChain } = await resolveReplyMediaForChain(
@@ -1252,14 +1257,14 @@ export const registerTelegramHandlers = ({
       if (result.kind === "completed" && !dispatchDedupeCommitted) {
         await commitDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
       } else if (result.kind === "failed-retryable" && dispatchDedupeCommitted && spooledReplay) {
-        await forgetDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
+        await forgetCommittedDispatchDedupeKeys();
       } else if (result.kind !== "completed" && !dispatchDedupeCommitted) {
         releaseDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
       }
       return result;
     } catch (err) {
-      if (dispatchDedupeCommitted && spooledReplay) {
-        await forgetDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
+      if (dispatchDedupeCommitted && spooledReplay && !dispatchDedupeRollbackAttempted) {
+        await forgetCommittedDispatchDedupeKeys();
       } else if (!dispatchDedupeCommitted) {
         releaseDispatchDedupeKeys(params.dispatchDedupeKeys ?? [], err);
       }

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -25,6 +25,7 @@ export type TelegramMessageContextOptions = {
   receivedAtMs?: number;
   ingressBuffer?: "inbound-debounce" | "text-fragment";
   promptContextMinTimestampMs?: number;
+  spooledReplay?: boolean;
 };
 
 export type TelegramPromptContextEntry = NonNullable<

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -523,10 +523,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
     telegramDeps?: TelegramBotDeps;
     bot?: Bot;
     replyToMode?: Parameters<typeof dispatchTelegramMessage>[0]["replyToMode"];
+    retryDispatchErrors?: boolean;
+    suppressFailureFallback?: boolean;
     textLimit?: number;
   }) {
     const bot = params.bot ?? createBot();
-    await dispatchTelegramMessage({
+    return await dispatchTelegramMessage({
       context: params.context,
       bot,
       cfg: params.cfg ?? {},
@@ -537,6 +539,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: params.telegramCfg ?? {},
       telegramDeps: params.telegramDeps ?? telegramDepsForTest,
       opts: { token: "token" },
+      retryDispatchErrors: params.retryDispatchErrors,
+      suppressFailureFallback: params.suppressFailureFallback,
     });
   }
 
@@ -2399,6 +2403,23 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(firstPartialUpdateOrder).toBeLessThan(rotationOrder);
     expect(rotationOrder).toBeLessThan(nextPartialUpdateOrder);
     expect(deliverReplies).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns retryable when spooled replay suppresses fallback after non-silent delivery skip", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      dispatcherOptions.onSkip?.({ text: "final answer" }, { kind: "final", reason: "failed" });
+      return { queuedFinal: false };
+    });
+
+    const result = await dispatchWithContext({
+      context: createContext(),
+      retryDispatchErrors: true,
+      suppressFailureFallback: true,
+    });
+
+    expect(result).toMatchObject({ kind: "failed-retryable" });
+    expect((result as { error?: unknown }).error).toBeInstanceOf(Error);
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 
   it("keeps tool progress visible after a partial-streamed intermediate block", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2422,6 +2422,25 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("does not return retryable after spooled replay already showed visible output", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "partial answer" }, { kind: "block" });
+      dispatcherOptions.onSkip?.({ text: "final answer" }, { kind: "final", reason: "empty" });
+      return { queuedFinal: false };
+    });
+
+    const result = await dispatchWithContext({
+      context: createContext(),
+      retryDispatchErrors: true,
+      suppressFailureFallback: true,
+    });
+
+    expect(result).toEqual({ kind: "completed" });
+    expect(answerDraftStream.update).toHaveBeenCalledWith("partial answer");
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("keeps tool progress visible after a partial-streamed intermediate block", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2407,7 +2407,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
   it("returns retryable when spooled replay suppresses fallback after non-silent delivery skip", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
-      dispatcherOptions.onSkip?.({ text: "final answer" }, { kind: "final", reason: "failed" });
+      dispatcherOptions.onSkip?.({ text: "final answer" }, { kind: "final", reason: "empty" });
       return { queuedFinal: false };
     });
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -251,7 +251,13 @@ type DispatchTelegramMessageParams = {
   telegramCfg: TelegramAccountConfig;
   telegramDeps?: TelegramBotDeps;
   opts: Pick<TelegramBotOptions, "token" | "mediaMaxMb">;
+  retryDispatchErrors?: boolean;
+  suppressFailureFallback?: boolean;
 };
+
+export type TelegramDispatchResult =
+  | { kind: "completed" }
+  | { kind: "failed-retryable"; error: unknown };
 
 type TelegramReasoningLevel = "off" | "on" | "stream";
 
@@ -721,6 +727,8 @@ export const dispatchTelegramMessage = async ({
   telegramCfg,
   telegramDeps: injectedTelegramDeps,
   opts,
+  retryDispatchErrors = false,
+  suppressFailureFallback = false,
 }: DispatchTelegramMessageParams) => {
   const dispatchStartedAt = Date.now();
   const dispatchContext = resolveDispatchTelegramContext({ cfg, context });
@@ -2539,12 +2547,13 @@ export const dispatchTelegramMessage = async ({
     if (!isRoomEvent || deliveryState.snapshot().delivered) {
       clearGroupHistory();
     }
-    return;
+    return { kind: "completed" };
   }
   let sentFallback = false;
   const deliverySummary = deliveryState.snapshot();
   const shouldSendFailureFallback =
     !isRoomEvent &&
+    !suppressFailureFallback &&
     (dispatchError ||
       (!deliverySummary.delivered &&
         (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0)));
@@ -2599,6 +2608,16 @@ export const dispatchTelegramMessage = async ({
 
   const hasFinalResponse =
     deliverySummary.delivered || sentFallback || suppressSilentReplyFallback || queuedFinal;
+  const deliveryFailureWithoutFinalResponse =
+    !deliverySummary.delivered &&
+    (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0);
+  const retryableDispatchFailure =
+    dispatchError ??
+    (deliveryFailureWithoutFinalResponse
+      ? new Error(
+          `Telegram reply delivery failed without a final response (failed=${deliverySummary.failedNonSilent}, skipped=${deliverySummary.skippedNonSilent})`,
+        )
+      : null);
 
   if (statusReactionController && !hasFinalResponse) {
     void finalizeTelegramStatusReaction({ outcome: "error", hasFinalResponse: false }).catch(
@@ -2611,12 +2630,16 @@ export const dispatchTelegramMessage = async ({
   const shouldClearGroupHistory =
     !isRoomEvent || deliverySummary.delivered || sentFallback || queuedFinal;
 
+  if (retryableDispatchFailure && retryDispatchErrors && !hasFinalResponse) {
+    return { kind: "failed-retryable", error: retryableDispatchFailure };
+  }
+
   if (!hasFinalResponse) {
     if (!shouldClearGroupHistory) {
-      return;
+      return { kind: "completed" };
     }
     clearGroupHistory();
-    return;
+    return { kind: "completed" };
   }
 
   // Fire-and-forget: auto-rename DM topic on first message.
@@ -2690,4 +2713,5 @@ export const dispatchTelegramMessage = async ({
   if (shouldClearGroupHistory) {
     clearGroupHistory();
   }
+  return { kind: "completed" };
 };

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -729,7 +729,7 @@ export const dispatchTelegramMessage = async ({
   opts,
   retryDispatchErrors = false,
   suppressFailureFallback = false,
-}: DispatchTelegramMessageParams) => {
+}: DispatchTelegramMessageParams): Promise<TelegramDispatchResult> => {
   const dispatchStartedAt = Date.now();
   const dispatchContext = resolveDispatchTelegramContext({ cfg, context });
   const telegramDeps =
@@ -2479,7 +2479,7 @@ export const dispatchTelegramMessage = async ({
         },
       });
       if (!turnResult.dispatched) {
-        return;
+        return { kind: "completed" };
       }
       ({ queuedFinal } = turnResult.dispatchResult);
       suppressSilentReplyFallback =

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -30,11 +30,15 @@ vi.mock("./bot-message-dispatch.js", () => ({
 
 let createTelegramMessageProcessor: typeof import("./bot-message.js").createTelegramMessageProcessor;
 let formatTelegramInboundLogLine: typeof import("./bot-message.js").formatTelegramInboundLogLine;
+let runWithTelegramUpdateProcessingFrame: typeof import("./bot-processing-outcome.js").runWithTelegramUpdateProcessingFrame;
+let withTelegramSpooledReplayUpdate: typeof import("./bot-processing-outcome.js").withTelegramSpooledReplayUpdate;
 
 describe("telegram bot message processor", () => {
   beforeAll(async () => {
     ({ createTelegramMessageProcessor, formatTelegramInboundLogLine } =
       await import("./bot-message.js"));
+    ({ runWithTelegramUpdateProcessingFrame, withTelegramSpooledReplayUpdate } =
+      await import("./bot-processing-outcome.js"));
   });
 
   beforeEach(() => {
@@ -74,6 +78,8 @@ describe("telegram bot message processor", () => {
   async function processSampleMessage(
     processMessage: ReturnType<typeof createTelegramMessageProcessor>,
     lifecycle?: import("./bot-message.js").TelegramMessageProcessorLifecycle,
+    primaryCtxOverrides: Record<string, unknown> = {},
+    options: Parameters<typeof processMessage>[3] = {},
   ) {
     return await processMessage(
       {
@@ -81,10 +87,11 @@ describe("telegram bot message processor", () => {
           chat: { id: 123, type: "private", title: "chat" },
           message_id: 456,
         },
+        ...primaryCtxOverrides,
       } as unknown as Parameters<typeof processMessage>[0],
       [],
       [],
-      {},
+      options,
       undefined,
       undefined,
       undefined,
@@ -97,14 +104,15 @@ describe("telegram bot message processor", () => {
     sendMessage: ReturnType<typeof vi.fn>,
   ) {
     const runtimeError = vi.fn();
+    const dispatchError = new Error("dispatch exploded");
     buildTelegramMessageContext.mockResolvedValue(createMessageContext(context));
-    dispatchTelegramMessage.mockRejectedValue(new Error("dispatch exploded"));
+    dispatchTelegramMessage.mockRejectedValue(dispatchError);
     const processMessage = createTelegramMessageProcessor({
       ...baseDeps,
       bot: { api: { sendMessage } },
       runtime: { error: runtimeError },
     } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
-    return { processMessage, runtimeError };
+    return { processMessage, runtimeError, dispatchError };
   }
 
   function createMessageContext(context: Record<string, unknown> = {}) {
@@ -132,7 +140,7 @@ describe("telegram bot message processor", () => {
     );
 
     const processMessage = createTelegramMessageProcessor(baseDeps);
-    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
+    await expect(processSampleMessage(processMessage)).resolves.toEqual({ kind: "completed" });
 
     expect(sendTyping).toHaveBeenCalledTimes(1);
     expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
@@ -154,7 +162,9 @@ describe("telegram bot message processor", () => {
     );
 
     const processMessage = createTelegramMessageProcessor(baseDeps);
-    await expect(processSampleMessage(processMessage, { onDispatchStart })).resolves.toBe(true);
+    await expect(processSampleMessage(processMessage, { onDispatchStart })).resolves.toEqual({
+      kind: "completed",
+    });
 
     expect(sendTyping).toHaveBeenCalledTimes(1);
     expect(onDispatchStart).toHaveBeenCalledTimes(1);
@@ -172,7 +182,9 @@ describe("telegram bot message processor", () => {
     buildTelegramMessageContext.mockResolvedValue(null);
 
     const processMessage = createTelegramMessageProcessor(baseDeps);
-    await expect(processSampleMessage(processMessage, { onDispatchStart })).resolves.toBe(false);
+    await expect(processSampleMessage(processMessage, { onDispatchStart })).resolves.toEqual({
+      kind: "skipped",
+    });
 
     expect(onDispatchStart).not.toHaveBeenCalled();
     expect(dispatchTelegramMessage).not.toHaveBeenCalled();
@@ -194,7 +206,7 @@ describe("telegram bot message processor", () => {
     );
 
     const processMessage = createTelegramMessageProcessor(baseDeps);
-    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
+    await expect(processSampleMessage(processMessage)).resolves.toEqual({ kind: "completed" });
 
     expect(sendTyping).not.toHaveBeenCalled();
     expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
@@ -203,7 +215,7 @@ describe("telegram bot message processor", () => {
   it("skips dispatch when no context is produced", async () => {
     buildTelegramMessageContext.mockResolvedValue(null);
     const processMessage = createTelegramMessageProcessor(baseDeps);
-    await expect(processSampleMessage(processMessage)).resolves.toBe(false);
+    await expect(processSampleMessage(processMessage)).resolves.toEqual({ kind: "skipped" });
     expect(dispatchTelegramMessage).not.toHaveBeenCalled();
     expect(telegramInboundInfo).not.toHaveBeenCalled();
   });
@@ -237,7 +249,7 @@ describe("telegram bot message processor", () => {
     );
 
     const processMessage = createTelegramMessageProcessor(baseDeps);
-    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
+    await expect(processSampleMessage(processMessage)).resolves.toEqual({ kind: "completed" });
 
     expect(sendTyping).toHaveBeenCalledTimes(1);
     expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
@@ -245,7 +257,7 @@ describe("telegram bot message processor", () => {
 
   it("sends user-visible fallback when dispatch throws", async () => {
     const sendMessage = vi.fn().mockResolvedValue(undefined);
-    const { processMessage, runtimeError } = createDispatchFailureHarness(
+    const { processMessage, runtimeError, dispatchError } = createDispatchFailureHarness(
       {
         chatId: 123,
         threadSpec: { id: 456, scope: "forum" },
@@ -253,7 +265,9 @@ describe("telegram bot message processor", () => {
       },
       sendMessage,
     );
-    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
+    const result = await processSampleMessage(processMessage);
+
+    expect(result).toEqual({ kind: "failed-retryable", error: dispatchError });
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,
@@ -265,9 +279,104 @@ describe("telegram bot message processor", () => {
     );
   });
 
+  it("suppresses user-visible fallback while replaying a spooled update", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const { processMessage, runtimeError, dispatchError } = createDispatchFailureHarness(
+      {
+        chatId: 123,
+        route: { sessionKey: "agent:main:main" },
+      },
+      sendMessage,
+    );
+    const update = { update_id: 123456 };
+    const result = await withTelegramSpooledReplayUpdate(update, async () =>
+      processSampleMessage(processMessage, undefined, { update }),
+    );
+
+    expect(result).toEqual({ kind: "failed-retryable", error: dispatchError });
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(runtimeError).toHaveBeenCalledWith(
+      "telegram message processing failed: Error: dispatch exploded",
+    );
+  });
+
+  it("suppresses user-visible fallback for synthetic buffered spooled replay contexts", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const { processMessage, runtimeError, dispatchError } = createDispatchFailureHarness(
+      {
+        chatId: 123,
+        route: { sessionKey: "agent:main:main" },
+      },
+      sendMessage,
+    );
+    const result = await processSampleMessage(
+      processMessage,
+      undefined,
+      {},
+      { spooledReplay: true },
+    );
+
+    expect(result).toEqual({ kind: "failed-retryable", error: dispatchError });
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(dispatchTelegramMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retryDispatchErrors: true,
+        suppressFailureFallback: true,
+      }),
+    );
+    expect(runtimeError).toHaveBeenCalledWith(
+      "telegram message processing failed: Error: dispatch exploded",
+    );
+  });
+
+  it("does not record buffered spooled replay failures into the ambient update frame", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const { processMessage, dispatchError } = createDispatchFailureHarness(
+      {
+        chatId: 123,
+        route: { sessionKey: "agent:main:main" },
+      },
+      sendMessage,
+    );
+
+    const frame = await runWithTelegramUpdateProcessingFrame(async () =>
+      processSampleMessage(processMessage, undefined, {}, { spooledReplay: true }),
+    );
+
+    expect(frame.value).toEqual({ kind: "failed-retryable", error: dispatchError });
+    expect(frame.result).toBeUndefined();
+  });
+
+  it("propagates spooled dispatcher failure results without sending fallback", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const dispatchError = new Error("agent dispatch failed");
+    const runtimeError = vi.fn();
+    buildTelegramMessageContext.mockResolvedValue(createMessageContext({ chatId: 123 }));
+    dispatchTelegramMessage.mockResolvedValue({ kind: "failed-retryable", error: dispatchError });
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      bot: { api: { sendMessage } },
+      runtime: { error: runtimeError },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+    const update = { update_id: 123457 };
+    const result = await withTelegramSpooledReplayUpdate(update, async () =>
+      processSampleMessage(processMessage, undefined, { update }),
+    );
+
+    expect(result).toEqual({ kind: "failed-retryable", error: dispatchError });
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(dispatchTelegramMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retryDispatchErrors: true,
+        suppressFailureFallback: true,
+      }),
+    );
+    expect(runtimeError).not.toHaveBeenCalled();
+  });
+
   it("omits message_thread_id for General-topic fallback replies", async () => {
     const sendMessage = vi.fn().mockResolvedValue(undefined);
-    const { processMessage } = createDispatchFailureHarness(
+    const { processMessage, dispatchError } = createDispatchFailureHarness(
       {
         chatId: 123,
         threadSpec: { id: 1, scope: "forum" },
@@ -275,7 +384,9 @@ describe("telegram bot message processor", () => {
       },
       sendMessage,
     );
-    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
+    const result = await processSampleMessage(processMessage);
+
+    expect(result).toEqual({ kind: "failed-retryable", error: dispatchError });
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,
@@ -286,14 +397,16 @@ describe("telegram bot message processor", () => {
 
   it("swallows fallback delivery failures after dispatch throws", async () => {
     const sendMessage = vi.fn().mockRejectedValue(new Error("blocked by user"));
-    const { processMessage, runtimeError } = createDispatchFailureHarness(
+    const { processMessage, runtimeError, dispatchError } = createDispatchFailureHarness(
       {
         chatId: 123,
         route: { sessionKey: "agent:main:main" },
       },
       sendMessage,
     );
-    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
+    const result = await processSampleMessage(processMessage);
+
+    expect(result).toEqual({ kind: "failed-retryable", error: dispatchError });
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -17,6 +17,11 @@ import {
 import type { TelegramMessageContextOptions } from "./bot-message-context.types.js";
 import type { TelegramPromptContextEntry } from "./bot-message-context.types.js";
 import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
+import {
+  isTelegramSpooledReplayUpdate,
+  recordTelegramMessageProcessingResult,
+  type TelegramMessageProcessingResult,
+} from "./bot-processing-outcome.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 import { buildTelegramThreadParams } from "./bot/helpers.js";
 import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
@@ -118,6 +123,12 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     const ingressDebugEnabled =
       shouldLogVerbose() || process.env.OPENCLAW_DEBUG_TELEGRAM_INGRESS === "1";
     const ingressContextStartMs = ingressReceivedAtMs ? Date.now() : undefined;
+    const recordCurrentUpdateProcessingResult = (result: TelegramMessageProcessingResult) => {
+      if (options?.spooledReplay === true) {
+        return;
+      }
+      recordTelegramMessageProcessingResult(result);
+    };
     const context = await buildTelegramMessageContext({
       primaryCtx,
       allMedia,
@@ -152,7 +163,9 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
             (options?.ingressBuffer ? ` buffer=${options.ingressBuffer}` : ""),
         );
       }
-      return false;
+      const result: TelegramMessageProcessingResult = { kind: "skipped" };
+      recordCurrentUpdateProcessingResult(result);
+      return result;
     }
     if (ingressDebugEnabled && ingressReceivedAtMs && ingressContextStartMs) {
       logVerbose(
@@ -181,8 +194,10 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       }),
     );
     await lifecycle?.onDispatchStart?.();
+    const spooledReplay =
+      options?.spooledReplay === true || isTelegramSpooledReplayUpdate(primaryCtx.update);
     try {
-      await dispatchTelegramMessage({
+      const dispatchResult = await dispatchTelegramMessage({
         context,
         bot,
         cfg,
@@ -193,23 +208,43 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         telegramCfg,
         telegramDeps,
         opts,
+        retryDispatchErrors: spooledReplay,
+        suppressFailureFallback: spooledReplay,
       });
+      if (dispatchResult?.kind === "failed-retryable") {
+        const result: TelegramMessageProcessingResult = {
+          kind: "failed-retryable",
+          error: dispatchResult.error,
+        };
+        recordCurrentUpdateProcessingResult(result);
+        return result;
+      }
       if (ingressDebugEnabled && ingressReceivedAtMs) {
         logVerbose(
           `telegram ingress: chatId=${context.chatId} dispatchCompleteMs=${Date.now() - ingressReceivedAtMs}` +
             (options?.ingressBuffer ? ` buffer=${options.ingressBuffer}` : ""),
         );
       }
+      const result: TelegramMessageProcessingResult = { kind: "completed" };
+      recordCurrentUpdateProcessingResult(result);
+      return result;
     } catch (err) {
       runtime.error?.(danger(`telegram message processing failed: ${String(err)}`));
-      try {
-        await bot.api.sendMessage(
-          context.chatId,
-          "Something went wrong while processing your request. Please try again.",
-          buildTelegramThreadParams(context.threadSpec),
-        );
-      } catch {}
+      if (!spooledReplay) {
+        try {
+          await bot.api.sendMessage(
+            context.chatId,
+            "Something went wrong while processing your request. Please try again.",
+            buildTelegramThreadParams(context.threadSpec),
+          );
+        } catch {}
+      }
+      const result: TelegramMessageProcessingResult = {
+        kind: "failed-retryable",
+        error: err,
+      };
+      recordCurrentUpdateProcessingResult(result);
+      return result;
     }
-    return true;
   };
 };

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -65,6 +65,7 @@ import {
   syncTelegramMenuCommands as syncTelegramMenuCommandsRuntime,
   type TelegramMenuCommand,
 } from "./bot-native-command-menu.js";
+import type { TelegramMessageProcessingResult } from "./bot-processing-outcome.js";
 import type { TelegramUpdateKeyContext } from "./bot-updates.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 import {
@@ -444,7 +445,7 @@ export type RegisterTelegramHandlerParams = {
     replyChain?: import("./message-cache.js").TelegramReplyChainEntry[],
     promptContext?: import("./bot-message-context.types.js").TelegramPromptContextEntry[],
     lifecycle?: import("./bot-message.js").TelegramMessageProcessorLifecycle,
-  ) => Promise<boolean>;
+  ) => Promise<TelegramMessageProcessingResult>;
   logger: ReturnType<typeof getChildLogger>;
 };
 

--- a/extensions/telegram/src/bot-processing-outcome.ts
+++ b/extensions/telegram/src/bot-processing-outcome.ts
@@ -1,0 +1,126 @@
+// Telegram plugin module tracks per-update processing outcomes.
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type TelegramMessageProcessingResult =
+  | { kind: "completed" }
+  | { kind: "skipped" }
+  | { kind: "failed-retryable"; error: unknown };
+
+type TelegramUpdateProcessingFrame = {
+  result?: TelegramMessageProcessingResult;
+};
+
+type TelegramSpooledReplayFrame = {
+  deferredWork?: TelegramSpooledReplayDeferredParticipant;
+};
+
+export type TelegramSpooledReplayDeferredParticipant = {
+  key: string;
+  task: Promise<TelegramMessageProcessingResult>;
+  settle: (result: TelegramMessageProcessingResult) => void;
+};
+
+const telegramUpdateProcessingFrames = new AsyncLocalStorage<TelegramUpdateProcessingFrame>();
+const telegramSpooledReplayFrames = new AsyncLocalStorage<TelegramSpooledReplayFrame>();
+const telegramSpooledReplayUpdates = new WeakSet<object>();
+
+export class TelegramSpooledReplayProcessingError extends Error {
+  override readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super(`telegram spooled update processing failed: ${String(cause)}`);
+    this.name = "TelegramSpooledReplayProcessingError";
+    this.cause = cause;
+  }
+}
+
+export async function runWithTelegramUpdateProcessingFrame<T>(
+  fn: () => Promise<T>,
+): Promise<{ value: T; result?: TelegramMessageProcessingResult }> {
+  const frame: TelegramUpdateProcessingFrame = {};
+  const value = await telegramUpdateProcessingFrames.run(frame, fn);
+  return frame.result ? { value, result: frame.result } : { value };
+}
+
+export function recordTelegramMessageProcessingResult(
+  result: TelegramMessageProcessingResult,
+): void {
+  const frame = telegramUpdateProcessingFrames.getStore();
+  if (!frame) {
+    return;
+  }
+  if (result.kind === "failed-retryable") {
+    frame.result = result;
+    return;
+  }
+  if (!frame.result || frame.result.kind === "skipped") {
+    frame.result = result;
+  }
+}
+
+function createTelegramSpooledReplayParticipant(
+  key: string,
+): TelegramSpooledReplayDeferredParticipant {
+  let settled = false;
+  let resolveTask: (result: TelegramMessageProcessingResult) => void = () => {};
+  const task = new Promise<TelegramMessageProcessingResult>((resolve) => {
+    resolveTask = resolve;
+  });
+  return {
+    key,
+    task,
+    settle: (result) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolveTask(result);
+    },
+  };
+}
+
+export function createTelegramSpooledReplayDeferredParticipant(
+  key: string,
+): TelegramSpooledReplayDeferredParticipant | null {
+  const frame = telegramSpooledReplayFrames.getStore();
+  if (!frame) {
+    return null;
+  }
+  const participant = createTelegramSpooledReplayParticipant(key);
+  frame.deferredWork = participant;
+  return participant;
+}
+
+export function getTelegramSpooledReplayDeferredParticipant():
+  | TelegramSpooledReplayDeferredParticipant
+  | undefined {
+  return telegramSpooledReplayFrames.getStore()?.deferredWork;
+}
+
+export async function runWithTelegramSpooledReplayUpdate<T>(
+  update: object,
+  fn: () => Promise<T>,
+): Promise<{ value: T; deferredWork?: TelegramSpooledReplayDeferredParticipant }> {
+  const frame: TelegramSpooledReplayFrame = {};
+  telegramSpooledReplayUpdates.add(update);
+  try {
+    const value = await telegramSpooledReplayFrames.run(frame, fn);
+    return frame.deferredWork ? { value, deferredWork: frame.deferredWork } : { value };
+  } finally {
+    telegramSpooledReplayUpdates.delete(update);
+  }
+}
+
+export async function withTelegramSpooledReplayUpdate<T>(
+  update: object,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return (await runWithTelegramSpooledReplayUpdate(update, fn)).value;
+}
+
+export function isTelegramSpooledReplayUpdate(update: unknown): boolean {
+  return (
+    telegramSpooledReplayFrames.getStore() !== undefined ||
+    (typeof update === "object" && update !== null && telegramSpooledReplayUpdates.has(update))
+  );
+}

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -63,6 +63,13 @@ const {
   resolveTelegramScopedGroupConfig,
   setTelegramBotRuntimeForTest,
 } = await import("./bot-core.js");
+const {
+  createTelegramSpooledReplayDeferredParticipant,
+  recordTelegramMessageProcessingResult,
+  runWithTelegramSpooledReplayUpdate,
+  TelegramSpooledReplayProcessingError,
+  withTelegramSpooledReplayUpdate,
+} = await import("./bot-processing-outcome.js");
 const { resolveTelegramConversationRoute } = await import("./conversation-route.js");
 const { clearAccountThrottlersForTest } = await import("./account-throttler.js");
 const {
@@ -840,6 +847,146 @@ describe("createTelegramBot", () => {
       }
     },
   );
+
+  it("settles spooled replay participants when stop cancels pending inbound debounce", async () => {
+    const DEBOUNCE_MS = 4321;
+    loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          envelopeTimezone: "utc",
+        },
+      },
+      messages: {
+        inbound: {
+          debounceMs: DEBOUNCE_MS,
+        },
+      },
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    installPerKeySequentializer();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getOnHandler("message") as (
+        ctx: TelegramMiddlewareTestContext,
+      ) => Promise<void>;
+      const firstUpdate = { update_id: 201 };
+      const replay = await runWithTelegramSpooledReplayUpdate(firstUpdate, async () => {
+        await runTelegramMiddlewareChain({
+          ctx: {
+            update: firstUpdate,
+            message: {
+              chat: { id: 7, type: "private" },
+              text: "first",
+              date: 1736380800,
+              message_id: 201,
+              from: { id: 42, first_name: "Ada" },
+            },
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({}),
+          },
+          finalHandler: messageHandler,
+        });
+      });
+
+      const deferredWork = replay.deferredWork;
+      expect(deferredWork).toBeDefined();
+      if (!deferredWork) {
+        throw new Error("Expected spooled replay deferred work");
+      }
+      await runTelegramMiddlewareChain({
+        ctx: {
+          update: { update_id: 202 },
+          message: {
+            chat: { id: 7, type: "private" },
+            text: "stop",
+            date: 1736380801,
+            message_id: 202,
+            from: { id: 42, first_name: "Ada" },
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        },
+        finalHandler: messageHandler,
+      });
+
+      await expect(deferredWork.task).resolves.toEqual({ kind: "skipped" });
+      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        (call) => call[1] === DEBOUNCE_MS,
+      );
+      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(
+        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
+      );
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("settles spooled replay participants when stop cancels pending text fragments", async () => {
+    loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          envelopeTimezone: "utc",
+        },
+      },
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    installPerKeySequentializer();
+
+    createTelegramBot({ token: "tok" });
+    const messageHandler = getOnHandler("message") as (
+      ctx: TelegramMiddlewareTestContext,
+    ) => Promise<void>;
+    const firstUpdate = { update_id: 211 };
+    const replay = await runWithTelegramSpooledReplayUpdate(firstUpdate, async () => {
+      await runTelegramMiddlewareChain({
+        ctx: {
+          update: firstUpdate,
+          message: {
+            chat: { id: 7, type: "private" },
+            text: "A".repeat(4050),
+            date: 1736380800,
+            message_id: 211,
+            from: { id: 42, first_name: "Ada" },
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        },
+        finalHandler: messageHandler,
+      });
+    });
+
+    const deferredWork = replay.deferredWork;
+    expect(deferredWork).toBeDefined();
+    if (!deferredWork) {
+      throw new Error("Expected spooled replay deferred work");
+    }
+    await runTelegramMiddlewareChain({
+      ctx: {
+        update: { update_id: 212 },
+        message: {
+          chat: { id: 7, type: "private" },
+          text: "stop",
+          date: 1736380801,
+          message_id: 212,
+          from: { id: 42, first_name: "Ada" },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({}),
+      },
+      finalHandler: messageHandler,
+    });
+
+    await expect(deferredWork.task).resolves.toEqual({ kind: "skipped" });
+  });
 
   it("lets stop cancel pending same-chat forwarded debounce", async () => {
     const DEBOUNCE_MS = 4321;
@@ -2347,6 +2494,213 @@ describe("createTelegramBot", () => {
     await flushTelegramTestMicrotasks();
     expect(retryHandler).toHaveBeenCalledTimes(1);
     expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([202]);
+  });
+
+  it("persists recorded dispatch failures during normal polling", async () => {
+    sequentializeSpy.mockImplementationOnce(
+      () => async (_ctx: unknown, next: () => Promise<void>) => {
+        await next();
+      },
+    );
+
+    const onUpdateId = vi.fn();
+
+    createTelegramBot({
+      token: "tok",
+      updateOffset: {
+        lastUpdateId: 500,
+        onUpdateId,
+      },
+    });
+
+    type Middleware = (
+      ctx: Record<string, unknown>,
+      next: () => Promise<void>,
+    ) => Promise<void> | void;
+
+    const middlewares = middlewareUseSpy.mock.calls
+      .map((call) => call[0])
+      .filter((fn): fn is Middleware => typeof fn === "function");
+
+    const runMiddlewareChain = async (
+      ctx: Record<string, unknown>,
+      finalNext: () => Promise<void>,
+    ) => {
+      let idx = -1;
+      const dispatch = async (i: number): Promise<void> => {
+        if (i <= idx) {
+          throw new Error("middleware dispatch called multiple times");
+        }
+        idx = i;
+        const fn = middlewares[i];
+        if (!fn) {
+          await finalNext();
+          return;
+        }
+        await fn(ctx, async () => dispatch(i + 1));
+      };
+      await dispatch(0);
+    };
+
+    const dispatchError = new Error("dispatch exploded");
+    await runMiddlewareChain({ update: { update_id: 501 } }, async () => {
+      recordTelegramMessageProcessingResult({
+        kind: "failed-retryable",
+        error: dispatchError,
+      });
+    });
+    await flushTelegramTestMicrotasks();
+    expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([501]);
+
+    await runMiddlewareChain({ update: { update_id: 502 } }, async () => {});
+    await flushTelegramTestMicrotasks();
+    expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([501, 502]);
+  });
+
+  it("rejects recorded dispatch failures during isolated spool replay", async () => {
+    sequentializeSpy.mockImplementationOnce(
+      () => async (_ctx: unknown, next: () => Promise<void>) => {
+        await next();
+      },
+    );
+
+    const onUpdateId = vi.fn();
+
+    createTelegramBot({
+      token: "tok",
+      updateOffset: {
+        lastUpdateId: 600,
+        onUpdateId,
+      },
+    });
+
+    type Middleware = (
+      ctx: Record<string, unknown>,
+      next: () => Promise<void>,
+    ) => Promise<void> | void;
+
+    const middlewares = middlewareUseSpy.mock.calls
+      .map((call) => call[0])
+      .filter((fn): fn is Middleware => typeof fn === "function");
+
+    const runMiddlewareChain = async (
+      ctx: Record<string, unknown>,
+      finalNext: () => Promise<void>,
+    ) => {
+      let idx = -1;
+      const dispatch = async (i: number): Promise<void> => {
+        if (i <= idx) {
+          throw new Error("middleware dispatch called multiple times");
+        }
+        idx = i;
+        const fn = middlewares[i];
+        if (!fn) {
+          await finalNext();
+          return;
+        }
+        await fn(ctx, async () => dispatch(i + 1));
+      };
+      await dispatch(0);
+    };
+
+    const update = { update_id: 601 };
+    const dispatchError = new Error("dispatch exploded");
+    await expect(
+      withTelegramSpooledReplayUpdate(update, async () => {
+        await runMiddlewareChain({ update }, async () => {
+          recordTelegramMessageProcessingResult({
+            kind: "failed-retryable",
+            error: dispatchError,
+          });
+        });
+      }),
+    ).rejects.toMatchObject({
+      name: TelegramSpooledReplayProcessingError.name,
+      cause: dispatchError,
+    });
+    await flushTelegramTestMicrotasks();
+    expect(onUpdateId).not.toHaveBeenCalled();
+  });
+
+  it("keeps deferred spooled failures retryable in the same bot tracker", async () => {
+    sequentializeSpy.mockImplementationOnce(
+      () => async (_ctx: unknown, next: () => Promise<void>) => {
+        await next();
+      },
+    );
+
+    const onUpdateId = vi.fn();
+
+    createTelegramBot({
+      token: "tok",
+      updateOffset: {
+        lastUpdateId: 700,
+        onUpdateId,
+      },
+    });
+
+    type Middleware = (
+      ctx: Record<string, unknown>,
+      next: () => Promise<void>,
+    ) => Promise<void> | void;
+
+    const middlewares = middlewareUseSpy.mock.calls
+      .map((call) => call[0])
+      .filter((fn): fn is Middleware => typeof fn === "function");
+
+    const runMiddlewareChain = async (
+      ctx: Record<string, unknown>,
+      finalNext: () => Promise<void>,
+    ) => {
+      let idx = -1;
+      const dispatch = async (i: number): Promise<void> => {
+        if (i <= idx) {
+          throw new Error("middleware dispatch called multiple times");
+        }
+        idx = i;
+        const fn = middlewares[i];
+        if (!fn) {
+          await finalNext();
+          return;
+        }
+        await fn(ctx, async () => dispatch(i + 1));
+      };
+      await dispatch(0);
+    };
+
+    const update = { update_id: 701 };
+    const replay = await runWithTelegramSpooledReplayUpdate(update, async () => {
+      await runMiddlewareChain({ update }, async () => {
+        const participant = createTelegramSpooledReplayDeferredParticipant("test:deferred");
+        if (!participant) {
+          throw new Error("expected spooled replay participant");
+        }
+      });
+    });
+    const deferredWork = replay.deferredWork;
+    expect(deferredWork).toBeDefined();
+    if (!deferredWork) {
+      throw new Error("Expected deferred spooled work");
+    }
+    await flushTelegramTestMicrotasks();
+    expect(onUpdateId).not.toHaveBeenCalled();
+
+    deferredWork.settle({
+      kind: "failed-retryable",
+      error: new Error("deferred dispatch failed"),
+    });
+    await flushTelegramTestMicrotasks();
+    expect(onUpdateId).not.toHaveBeenCalled();
+
+    let retried = false;
+    await runWithTelegramSpooledReplayUpdate(update, async () => {
+      await runMiddlewareChain({ update }, async () => {
+        retried = true;
+      });
+    });
+    await flushTelegramTestMicrotasks();
+    expect(retried).toBe(true);
+    expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([701]);
   });
 
   it("skips replayed update ids even when the semantic update key differs", async () => {

--- a/extensions/telegram/src/bot/types.ts
+++ b/extensions/telegram/src/bot/types.ts
@@ -19,6 +19,7 @@ export type TelegramGetChat = (chatId: number | string) => Promise<TelegramChatD
  */
 export type TelegramContext = {
   message: Message;
+  update?: unknown;
   me?: UserFromGetMe;
   getFile: TelegramGetFile;
 };

--- a/extensions/telegram/src/message-dispatch-dedupe.test.ts
+++ b/extensions/telegram/src/message-dispatch-dedupe.test.ts
@@ -11,8 +11,11 @@ import {
   claimTelegramMessageDispatchReplay,
   commitTelegramMessageDispatchReplay,
   createTelegramMessageDispatchReplayGuard,
+  forgetTelegramMessageDispatchReplay,
   releaseTelegramMessageDispatchReplay,
   TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE,
+  TelegramMessageDispatchReplayForgetError,
+  type TelegramMessageDispatchReplayGuard,
 } from "./message-dispatch-dedupe.js";
 
 const tempDirs: string[] = [];
@@ -202,6 +205,29 @@ describe("Telegram message dispatch replay guard", () => {
     await expect(duplicate).resolves.toEqual({
       kind: "claimed",
       key: first.key,
+    });
+  });
+
+  it("fails rollback when a committed dispatch key cannot be forgotten", async () => {
+    const guard = {
+      claim: async () => ({ kind: "claimed" }),
+      commit: async () => true,
+      forget: async (key: string) => key !== "failed-key",
+      hasRecent: async () => false,
+      warmup: async () => 0,
+      clearMemory: () => {},
+      memorySize: () => 0,
+      release: () => {},
+    } satisfies TelegramMessageDispatchReplayGuard;
+
+    await expect(
+      forgetTelegramMessageDispatchReplay({
+        guard,
+        keys: ["ok-key", "failed-key", "failed-key"],
+      }),
+    ).rejects.toMatchObject({
+      name: TelegramMessageDispatchReplayForgetError.name,
+      failures: [{ key: "failed-key" }],
     });
   });
 });

--- a/extensions/telegram/src/message-dispatch-dedupe.ts
+++ b/extensions/telegram/src/message-dispatch-dedupe.ts
@@ -11,7 +11,8 @@ export const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID = "telegram-messag
 export const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_MEMORY_MAX_ENTRIES = 50_000;
 export const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_MAX_ENTRIES = 50_000;
 
-export type TelegramMessageDispatchReplayGuard = ClaimableDedupe;
+export type TelegramMessageDispatchReplayGuard = ClaimableDedupe &
+  Required<Pick<ClaimableDedupe, "forget">>;
 
 export type TelegramMessageDispatchClaim =
   | { kind: "claimed"; key: string }
@@ -127,6 +128,18 @@ export async function commitTelegramMessageDispatchReplay(params: {
   await Promise.all(
     keys.map((key) =>
       params.guard.commit(key, { namespace: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE }),
+    ),
+  );
+}
+
+export async function forgetTelegramMessageDispatchReplay(params: {
+  guard: TelegramMessageDispatchReplayGuard;
+  keys?: readonly string[];
+}): Promise<void> {
+  const keys = normalizeReplayKeys(params.keys);
+  await Promise.all(
+    keys.map((key) =>
+      params.guard.forget(key, { namespace: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE }),
     ),
   );
 }

--- a/extensions/telegram/src/message-dispatch-dedupe.ts
+++ b/extensions/telegram/src/message-dispatch-dedupe.ts
@@ -19,6 +19,32 @@ export type TelegramMessageDispatchClaim =
   | { kind: "duplicate" }
   | { kind: "invalid" };
 
+export type TelegramMessageDispatchReplayForgetFailure = {
+  key: string;
+  error?: unknown;
+};
+
+export class TelegramMessageDispatchReplayForgetError extends Error {
+  readonly failures: TelegramMessageDispatchReplayForgetFailure[];
+  override readonly cause: unknown;
+
+  constructor(failures: readonly TelegramMessageDispatchReplayForgetFailure[]) {
+    const count = failures.length;
+    super(`telegram message dispatch dedupe rollback failed for ${count} key(s)`, {
+      cause: failures.find((failure) => failure.error !== undefined)?.error,
+    });
+    this.name = "TelegramMessageDispatchReplayForgetError";
+    this.failures = [...failures];
+    this.cause = failures.find((failure) => failure.error !== undefined)?.error;
+  }
+}
+
+export function isTelegramMessageDispatchReplayForgetError(
+  error: unknown,
+): error is TelegramMessageDispatchReplayForgetError {
+  return error instanceof TelegramMessageDispatchReplayForgetError;
+}
+
 function sanitizeFileSegment(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -137,11 +163,23 @@ export async function forgetTelegramMessageDispatchReplay(params: {
   keys?: readonly string[];
 }): Promise<void> {
   const keys = normalizeReplayKeys(params.keys);
-  await Promise.all(
-    keys.map((key) =>
-      params.guard.forget(key, { namespace: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE }),
-    ),
-  );
+  const failures = (
+    await Promise.all(
+      keys.map(async (key): Promise<TelegramMessageDispatchReplayForgetFailure | null> => {
+        try {
+          const forgotten = await params.guard.forget(key, {
+            namespace: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE,
+          });
+          return forgotten ? null : { key };
+        } catch (error) {
+          return { key, error };
+        }
+      }),
+    )
+  ).filter((failure): failure is TelegramMessageDispatchReplayForgetFailure => Boolean(failure));
+  if (failures.length > 0) {
+    throw new TelegramMessageDispatchReplayForgetError(failures);
+  }
 }
 
 export function releaseTelegramMessageDispatchReplay(params: {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -73,6 +73,11 @@ let listTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.js"
 let listTelegramSpooledUpdates: typeof import("./telegram-ingress-spool.js").listTelegramSpooledUpdates;
 let recoverStaleTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.js").recoverStaleTelegramSpooledUpdateClaims;
 let writeTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.js").writeTelegramSpooledUpdate;
+let createTelegramSpooledReplayDeferredParticipant: typeof import("./bot-processing-outcome.js").createTelegramSpooledReplayDeferredParticipant;
+type TelegramMessageProcessingResult =
+  import("./bot-processing-outcome.js").TelegramMessageProcessingResult;
+type TelegramSpooledReplayDeferredParticipant =
+  import("./bot-processing-outcome.js").TelegramSpooledReplayDeferredParticipant;
 let beginTelegramReplyFence: typeof import("./telegram-reply-fence.js").beginTelegramReplyFence;
 let buildTelegramReplyFenceLaneKey: typeof import("./telegram-reply-fence.js").buildTelegramReplyFenceLaneKey;
 let endTelegramReplyFence: typeof import("./telegram-reply-fence.js").endTelegramReplyFence;
@@ -612,6 +617,8 @@ describe("TelegramPollingSession", () => {
       recoverStaleTelegramSpooledUpdateClaims,
       writeTelegramSpooledUpdate,
     } = await import("./telegram-ingress-spool.js"));
+    ({ createTelegramSpooledReplayDeferredParticipant } =
+      await import("./bot-processing-outcome.js"));
     ({
       beginTelegramReplyFence,
       buildTelegramReplyFenceLaneKey,
@@ -1336,6 +1343,137 @@ describe("TelegramPollingSession", () => {
       await vi.waitFor(() => expect(events).toEqual(["topic10:first", "topic11"]));
       expect(await pendingUpdateIds(tempDir, "all")).toEqual([42, 44]);
       expectLogIncludes(log, "spooled update 42 failed; keeping for retry");
+      abort.abort();
+      stopWorker();
+      await runPromise;
+    });
+  });
+
+  it("holds buffered spooled claims until deferred processing settles without blocking same-lane buffering", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const participants: TelegramSpooledReplayDeferredParticipant[] = [];
+      const events: string[] = [];
+      await writeSpooledTestUpdates(tempDir, [
+        topicUpdate(42, 10, "first buffered topic 10 turn"),
+        topicUpdate(43, 10, "second buffered topic 10 turn"),
+      ]);
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        drainIntervalMs: 10,
+        handleUpdate: async (update) => {
+          events.push(`topic10:${update.update_id}`);
+          const participant = createTelegramSpooledReplayDeferredParticipant(
+            `test-buffer:${update.update_id}`,
+          );
+          if (!participant) {
+            throw new Error("expected spooled replay participant");
+          }
+          participants.push(participant);
+        },
+      });
+
+      await vi.waitFor(() => expect(events).toEqual(["topic10:42", "topic10:43"]));
+      await vi.waitFor(async () =>
+        expect(
+          (await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).map(
+            (claim) => claim.updateId,
+          ),
+        ).toEqual([42, 43]),
+      );
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+
+      const completed: TelegramMessageProcessingResult = { kind: "completed" };
+      for (const participant of participants) {
+        participant.settle(completed);
+      }
+      await vi.waitFor(async () =>
+        expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]),
+      );
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      abort.abort();
+      stopWorker();
+      await runPromise;
+    });
+  });
+
+  it("releases buffered spooled claims for retry when deferred processing fails", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const log = vi.fn();
+      const participants: TelegramSpooledReplayDeferredParticipant[] = [];
+      await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "buffered failure")]);
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        log,
+        drainIntervalMs: 10,
+        handleUpdate: async (update) => {
+          const participant = createTelegramSpooledReplayDeferredParticipant(
+            `test-buffer:${update.update_id}`,
+          );
+          if (!participant) {
+            throw new Error("expected spooled replay participant");
+          }
+          participants.push(participant);
+        },
+      });
+
+      await vi.waitFor(() => expect(participants).toHaveLength(1));
+      await vi.waitFor(async () =>
+        expect(
+          (await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).map(
+            (claim) => claim.updateId,
+          ),
+        ).toEqual([42]),
+      );
+
+      abort.abort();
+      participants[0]?.settle({
+        kind: "failed-retryable",
+        error: new Error("buffered dispatch failed"),
+      });
+      await vi.waitFor(async () => expect(await pendingUpdateIds(tempDir, "all")).toEqual([42]));
+      expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]);
+      expectLogIncludes(log, "spooled update 42 failed; keeping for retry");
+      stopWorker();
+      await runPromise;
+    });
+  });
+
+  it("fails buffered spooled claims instead of requeueing when deferred processing times out", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const log = vi.fn();
+      const participants: TelegramSpooledReplayDeferredParticipant[] = [];
+      await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "buffered timeout")]);
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        log,
+        drainIntervalMs: 10,
+        spooledUpdateHandlerTimeoutMs: 20,
+        handleUpdate: async (update) => {
+          const participant = createTelegramSpooledReplayDeferredParticipant(
+            `test-buffer:${update.update_id}`,
+          );
+          if (!participant) {
+            throw new Error("expected spooled replay participant");
+          }
+          participants.push(participant);
+        },
+      });
+
+      await vi.waitFor(() => expect(participants).toHaveLength(1));
+      await vi.waitFor(async () => expect(await failedUpdateIds(tempDir)).toEqual([42]));
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]);
+      expectLogIncludes(log, "buffered processing timed out behind update 42");
+      expectLogExcludes(log, "spooled update 42 failed; keeping for retry");
       abort.abort();
       stopWorker();
       await runPromise;

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -74,6 +74,7 @@ let listTelegramSpooledUpdates: typeof import("./telegram-ingress-spool.js").lis
 let recoverStaleTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.js").recoverStaleTelegramSpooledUpdateClaims;
 let writeTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.js").writeTelegramSpooledUpdate;
 let createTelegramSpooledReplayDeferredParticipant: typeof import("./bot-processing-outcome.js").createTelegramSpooledReplayDeferredParticipant;
+let TelegramMessageDispatchReplayForgetError: typeof import("./message-dispatch-dedupe.js").TelegramMessageDispatchReplayForgetError;
 type TelegramMessageProcessingResult =
   import("./bot-processing-outcome.js").TelegramMessageProcessingResult;
 type TelegramSpooledReplayDeferredParticipant =
@@ -619,6 +620,7 @@ describe("TelegramPollingSession", () => {
     } = await import("./telegram-ingress-spool.js"));
     ({ createTelegramSpooledReplayDeferredParticipant } =
       await import("./bot-processing-outcome.js"));
+    ({ TelegramMessageDispatchReplayForgetError } = await import("./message-dispatch-dedupe.js"));
     ({
       beginTelegramReplyFence,
       buildTelegramReplyFenceLaneKey,
@@ -1439,6 +1441,56 @@ describe("TelegramPollingSession", () => {
       await vi.waitFor(async () => expect(await pendingUpdateIds(tempDir, "all")).toEqual([42]));
       expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]);
       expectLogIncludes(log, "spooled update 42 failed; keeping for retry");
+      stopWorker();
+      await runPromise;
+    });
+  });
+
+  it("dead-letters buffered spooled claims when dispatch dedupe rollback fails", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const log = vi.fn();
+      const participants: TelegramSpooledReplayDeferredParticipant[] = [];
+      const events: string[] = [];
+      let attempts = 0;
+      await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "buffered rollback failure")]);
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        log,
+        drainIntervalMs: 10,
+        handleUpdate: async (update) => {
+          attempts += 1;
+          if (attempts === 1) {
+            events.push(`dispatch:${update.update_id}`);
+            const participant = createTelegramSpooledReplayDeferredParticipant(
+              `test-buffer:${update.update_id}`,
+            );
+            if (!participant) {
+              throw new Error("expected spooled replay participant");
+            }
+            participants.push(participant);
+            return;
+          }
+          events.push(`duplicate-skip:${update.update_id}`);
+        },
+      });
+
+      await vi.waitFor(() => expect(participants).toHaveLength(1));
+      participants[0]?.settle({
+        kind: "failed-retryable",
+        error: new TelegramMessageDispatchReplayForgetError([{ key: "committed-dispatch-key" }]),
+      });
+
+      await vi.waitFor(async () => expect(await failedUpdateIds(tempDir)).toEqual([42]));
+      expect(events).toEqual(["dispatch:42"]);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]);
+      expectLogIncludes(log, "non-retryable dispatch-dedupe-rollback-failed");
+      expectLogExcludes(log, "spooled update 42 failed; keeping for retry");
+
+      abort.abort();
       stopWorker();
       await runPromise;
     });

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -19,6 +19,11 @@ import {
 } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
+import {
+  runWithTelegramSpooledReplayUpdate,
+  type TelegramMessageProcessingResult,
+  type TelegramSpooledReplayDeferredParticipant,
+} from "./bot-processing-outcome.js";
 import { createTelegramBot } from "./bot.js";
 import type { TelegramTransport } from "./fetch.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
@@ -263,6 +268,22 @@ type SpooledUpdateHandlerState = {
   timeoutMessage?: string;
 };
 
+type DeferredSpooledUpdateClaimState = {
+  claimKey: string;
+  laneKey: string;
+  task: Promise<void>;
+  timer?: ReturnType<typeof setTimeout>;
+  timedOutMessage?: string;
+  update: ClaimedTelegramSpooledUpdate;
+  updateId: number;
+};
+
+const deferredSpooledUpdateClaimsByKey = new Map<string, DeferredSpooledUpdateClaimState>();
+
+function buildDeferredSpooledUpdateClaimKey(update: ClaimedTelegramSpooledUpdate): string {
+  return `${update.pendingPath}:${update.claim.claimToken}`;
+}
+
 type SpooledUpdateDrainResult = {
   blockedByLane: Set<string>;
   started: number;
@@ -304,6 +325,7 @@ export class TelegramPollingSession {
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
   #spooledUpdateHandlerKeys = new Set<string>();
+  #deferredSpooledUpdateClaimKeys = new Set<string>();
   #transportState: TelegramPollingTransportState;
   #status: ReturnType<typeof createTelegramPollingStatusPublisher>;
   #stallThresholdMs: number;
@@ -527,16 +549,26 @@ export class TelegramPollingSession {
     bot: TelegramBot;
     update: ClaimedTelegramSpooledUpdate;
   }): Promise<boolean> {
+    let replay: { deferredWork?: TelegramSpooledReplayDeferredParticipant };
     try {
-      await params.bot.handleUpdate(
-        params.update.update as Parameters<typeof params.bot.handleUpdate>[0],
-      );
+      const update = params.update.update as Parameters<typeof params.bot.handleUpdate>[0];
+      replay = await runWithTelegramSpooledReplayUpdate(update, async () => {
+        await params.bot.handleUpdate(update);
+      });
     } catch (err) {
       await this.#releaseFailedSpooledUpdate({
         err,
         update: params.update,
       });
       return false;
+    }
+    if (replay.deferredWork) {
+      this.#registerDeferredSpooledUpdate({
+        deferredWork: replay.deferredWork,
+        laneKey: this.#spooledUpdateLaneKey(params.update),
+        update: params.update,
+      });
+      return true;
     }
     try {
       await deleteTelegramSpooledUpdate(params.update);
@@ -547,6 +579,116 @@ export class TelegramPollingSession {
       );
       return false;
     }
+  }
+
+  #registerDeferredSpooledUpdate(params: {
+    deferredWork: TelegramSpooledReplayDeferredParticipant;
+    laneKey: string;
+    update: ClaimedTelegramSpooledUpdate;
+  }): void {
+    const claimKey = buildDeferredSpooledUpdateClaimKey(params.update);
+    const previous = deferredSpooledUpdateClaimsByKey.get(claimKey);
+    if (previous) {
+      if (previous.timer) {
+        clearTimeout(previous.timer);
+      }
+      deferredSpooledUpdateClaimsByKey.delete(claimKey);
+    }
+    let settled = false;
+    let state: DeferredSpooledUpdateClaimState;
+    const finish = async (result: TelegramMessageProcessingResult): Promise<void> => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (state.timer) {
+        clearTimeout(state.timer);
+      }
+      if (deferredSpooledUpdateClaimsByKey.get(claimKey) === state) {
+        deferredSpooledUpdateClaimsByKey.delete(claimKey);
+      }
+      this.#deferredSpooledUpdateClaimKeys.delete(claimKey);
+      if (result.kind === "failed-retryable") {
+        if (state.timedOutMessage) {
+          await this.#failTimedOutDeferredSpooledUpdate(state);
+          return;
+        }
+        await this.#releaseFailedSpooledUpdate({
+          err: result.error,
+          update: params.update,
+        });
+        return;
+      }
+      try {
+        await deleteTelegramSpooledUpdate(params.update);
+      } catch (err) {
+        this.opts.log(
+          `[telegram][diag] spooled update ${params.update.updateId} completed after buffered processing but processing marker cleanup failed: ${formatErrorMessage(err)}`,
+        );
+      }
+    };
+    state = {
+      claimKey,
+      laneKey: params.laneKey,
+      task: params.deferredWork.task.then(finish, async (err) => {
+        await finish({ kind: "failed-retryable", error: err });
+      }),
+      update: params.update,
+      updateId: params.update.updateId,
+    };
+    state.timer = setTimeout(() => {
+      const age = formatDurationPrecise(this.#spooledUpdateHandlerTimeoutMs);
+      state.timedOutMessage = `Telegram isolated polling spool buffered processing timed out behind update ${params.update.updateId} on lane ${params.laneKey} after ${age}; marking the update failed, aborting active reply work, and keeping the claim out of retry while the buffered task settles.`;
+      params.deferredWork.settle({
+        kind: "failed-retryable",
+        error: new Error(state.timedOutMessage),
+      });
+    }, this.#spooledUpdateHandlerTimeoutMs);
+    state.timer.unref?.();
+    deferredSpooledUpdateClaimsByKey.set(claimKey, state);
+    this.#deferredSpooledUpdateClaimKeys.add(claimKey);
+  }
+
+  #isDeferredSpooledUpdateClaim(update: ClaimedTelegramSpooledUpdate): boolean {
+    return deferredSpooledUpdateClaimsByKey.has(buildDeferredSpooledUpdateClaimKey(update));
+  }
+
+  async #failTimedOutDeferredSpooledUpdate(state: DeferredSpooledUpdateClaimState): Promise<void> {
+    const message =
+      state.timedOutMessage ??
+      `Telegram isolated polling spool buffered processing timed out behind update ${state.updateId} on lane ${state.laneKey}; marking the update failed.`;
+    try {
+      const failed = await failTelegramSpooledUpdateClaim({
+        update: state.update,
+        reason: "handler-timeout",
+        message,
+      });
+      if (!failed) {
+        this.opts.log(
+          `[telegram][diag] timed out buffered spooled update ${state.updateId} no longer had a processing marker to fail.`,
+        );
+        this.#status.notePollingError(message);
+        return;
+      }
+    } catch (err) {
+      this.opts.log(
+        `[telegram][diag] timed out buffered spooled update ${state.updateId} could not be marked failed: ${formatErrorMessage(err)}`,
+      );
+      this.#status.notePollingError(message);
+      return;
+    }
+    const scopedReplyFenceLaneKey = buildTelegramReplyFenceLaneKey({
+      accountId: this.opts.accountId,
+      sequentialKey: state.laneKey,
+    });
+    const abortedReplyWork = supersedeTelegramReplyFenceLane(scopedReplyFenceLaneKey);
+    if (!abortedReplyWork) {
+      this.opts.log(
+        `[telegram][diag] timed out buffered spooled update ${state.updateId} had no active reply fence on lane ${state.laneKey}.`,
+      );
+    }
+    this.opts.log(`[telegram] ${message}`);
+    this.#status.notePollingError(message);
   }
 
   async #releaseFailedSpooledUpdate(params: {
@@ -591,11 +733,14 @@ export class TelegramPollingSession {
   }
 
   async #waitForSpooledUpdateHandlers(): Promise<void> {
-    await Promise.allSettled(
-      [...this.#spooledUpdateHandlerKeys]
+    await Promise.allSettled([
+      ...[...this.#spooledUpdateHandlerKeys]
         .map((handlerKey) => activeSpooledUpdateHandlersByLane.get(handlerKey)?.task)
         .filter((task): task is Promise<boolean> => Boolean(task)),
-    );
+      ...[...this.#deferredSpooledUpdateClaimKeys]
+        .map((claimKey) => deferredSpooledUpdateClaimsByKey.get(claimKey)?.task)
+        .filter((task): task is Promise<void> => Boolean(task)),
+    ]);
   }
 
   #spooledUpdateLaneKey(update: TelegramSpooledUpdate): string {
@@ -624,6 +769,7 @@ export class TelegramPollingSession {
       spoolDir: params.spoolDir,
       staleMs: 0,
       shouldRecover: (claim) =>
+        !this.#isDeferredSpooledUpdateClaim(claim) &&
         !activeLaneKeys.has(this.#spooledUpdateLaneKey(claim)) &&
         !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim),
     });
@@ -632,7 +778,9 @@ export class TelegramPollingSession {
         await listTelegramSpooledUpdateClaims({
           spoolDir: params.spoolDir,
         })
-      ).map((claim) => this.#spooledUpdateLaneKey(claim)),
+      )
+        .filter((claim) => !this.#isDeferredSpooledUpdateClaim(claim))
+        .map((claim) => this.#spooledUpdateLaneKey(claim)),
     );
     const updates = await listTelegramSpooledUpdates({
       spoolDir: params.spoolDir,

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -281,7 +281,7 @@ type DeferredSpooledUpdateClaimState = {
 const deferredSpooledUpdateClaimsByKey = new Map<string, DeferredSpooledUpdateClaimState>();
 
 function buildDeferredSpooledUpdateClaimKey(update: ClaimedTelegramSpooledUpdate): string {
-  return `${update.pendingPath}:${update.claim.claimToken}`;
+  return `${update.pendingPath}:${update.claim?.claimToken ?? update.claim?.processId ?? "claimed"}`;
 }
 
 type SpooledUpdateDrainResult = {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -595,7 +595,6 @@ export class TelegramPollingSession {
       deferredSpooledUpdateClaimsByKey.delete(claimKey);
     }
     let settled = false;
-    let state: DeferredSpooledUpdateClaimState;
     const finish = async (result: TelegramMessageProcessingResult): Promise<void> => {
       if (settled) {
         return;
@@ -627,10 +626,10 @@ export class TelegramPollingSession {
         );
       }
     };
-    state = {
+    const state: DeferredSpooledUpdateClaimState = {
       claimKey,
       laneKey: params.laneKey,
-      task: params.deferredWork.task.then(finish, async (err) => {
+      task: params.deferredWork.task.then(finish, async (err: unknown) => {
         await finish({ kind: "failed-retryable", error: err });
       }),
       update: params.update,

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -26,6 +26,7 @@ import {
 } from "./bot-processing-outcome.js";
 import { createTelegramBot } from "./bot.js";
 import type { TelegramTransport } from "./fetch.js";
+import { isTelegramMessageDispatchReplayForgetError } from "./message-dispatch-dedupe.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { TelegramPollingLivenessTracker } from "./polling-liveness.js";
 import { createTelegramPollingStatusPublisher } from "./polling-status.js";
@@ -141,7 +142,7 @@ function normalizeTelegramAccountId(accountId?: string | null): string {
 }
 
 type NonRetryableSpooledUpdateFailure = {
-  reason: "missing-agent-harness";
+  reason: "missing-agent-harness" | "dispatch-dedupe-rollback-failed";
   message: string;
 };
 
@@ -153,6 +154,11 @@ function resolveNonRetryableSpooledUpdateFailure(
     current.error,
   ])) {
     const message = formatErrorMessage(candidate);
+    if (isTelegramMessageDispatchReplayForgetError(candidate)) {
+      // A committed dispatch key that cannot be rolled back makes retry unsafe:
+      // the next replay can be duplicate-suppressed and then deleted.
+      return { reason: "dispatch-dedupe-rollback-failed", message };
+    }
     if (
       readErrorName(candidate) === MISSING_AGENT_HARNESS_ERROR_NAME ||
       MISSING_AGENT_HARNESS_MESSAGE_RE.test(message)

--- a/src/plugin-sdk/memory-host-events.test.ts
+++ b/src/plugin-sdk/memory-host-events.test.ts
@@ -223,6 +223,19 @@ describe("createClaimableDedupe", () => {
     await expect(dedupe.claim("line:evt-2")).resolves.toEqual({ kind: "claimed" });
   });
 
+  it("forgets committed claimable entries", async () => {
+    const dedupe = createClaimableDedupe({
+      ttlMs: 10_000,
+      memoryMaxSize: 100,
+    });
+
+    await expect(dedupe.claim("line:evt-3")).resolves.toEqual({ kind: "claimed" });
+    await expect(dedupe.commit("line:evt-3")).resolves.toBe(true);
+    await expect(dedupe.claim("line:evt-3")).resolves.toEqual({ kind: "duplicate" });
+    await expect(dedupe.forget("line:evt-3")).resolves.toBe(true);
+    await expect(dedupe.claim("line:evt-3")).resolves.toEqual({ kind: "claimed" });
+  });
+
   it("supports persistent-backed recent checks and warmup", async () => {
     const root = await createTempDir("openclaw-claimable-dedupe-");
     const writer = createClaimableDedupe({
@@ -250,6 +263,18 @@ describe("createClaimableDedupe", () => {
     expect(await reader.warmup("acct")).toBe(1);
     await expect(reader.claim("m1", { namespace: "acct" })).resolves.toEqual({
       kind: "duplicate",
+    });
+    await expect(reader.forget("m1", { namespace: "acct" })).resolves.toBe(true);
+    const afterForget = createClaimableDedupe({
+      ttlMs: 10_000,
+      memoryMaxSize: 100,
+      pluginId: "test-claimable-dedupe",
+      namespacePrefix: "test-claimable-dedupe",
+      stateMaxEntries: 1000,
+      env: { ...process.env, OPENCLAW_STATE_DIR: root },
+    });
+    await expect(afterForget.claim("m1", { namespace: "acct" })).resolves.toEqual({
+      kind: "claimed",
     });
   });
 

--- a/src/plugin-sdk/persistent-dedupe.ts
+++ b/src/plugin-sdk/persistent-dedupe.ts
@@ -104,6 +104,8 @@ export type PersistentDedupe = {
   checkAndRecord: (key: string, options?: PersistentDedupeCheckOptions) => Promise<boolean>;
   /** Checks memory/disk recency without recording a new timestamp. */
   hasRecent: (key: string, options?: PersistentDedupeCheckOptions) => Promise<boolean>;
+  /** Removes a recorded key from process memory and persisted storage. */
+  forget: (key: string, options?: PersistentDedupeCheckOptions) => Promise<boolean>;
   /** Loads recent disk entries into memory for one namespace and returns the loaded count. */
   warmup: (namespace?: string, onError?: (error: unknown) => void) => Promise<number>;
   /** Clears only process-local memory; persisted namespace files are left intact. */
@@ -154,6 +156,8 @@ export type ClaimableDedupe = {
   ) => void;
   /** Checks whether the key is recent without claiming or committing it. */
   hasRecent: (key: string, options?: PersistentDedupeCheckOptions) => Promise<boolean>;
+  /** Removes an active or committed key from memory and persisted storage when supported. */
+  forget?: (key: string, options?: PersistentDedupeCheckOptions) => Promise<boolean>;
   /** Warms persistent storage into memory when configured; memory-only guards return zero. */
   warmup: (namespace?: string, onError?: (error: unknown) => void) => Promise<number>;
   /** Clears process-local caches and in-memory persistent state. */
@@ -556,9 +560,30 @@ export function createPersistentDedupe(options: PersistentDedupeOptions): Persis
     return hasRecentInner(trimmed, namespace, scopedKey, now, onDiskError);
   }
 
+  async function forget(
+    key: string,
+    dedupeOptions?: PersistentDedupeCheckOptions,
+  ): Promise<boolean> {
+    const trimmed = key.trim();
+    if (!trimmed) {
+      return false;
+    }
+    const namespace = resolveNamespace(dedupeOptions?.namespace);
+    const scopedKey = resolveScopedKey(namespace, trimmed);
+    memory.delete(scopedKey);
+
+    try {
+      return getStore(namespace).delete(resolveEntryKey(trimmed));
+    } catch (error) {
+      (dedupeOptions?.onDiskError ?? options.onDiskError)?.(error);
+      return false;
+    }
+  }
+
   return {
     checkAndRecord,
     hasRecent,
+    forget,
     warmup,
     clearMemory: () => memory.clear(),
     memorySize: () => memory.size(),
@@ -570,7 +595,9 @@ function createReleasedClaimError(scopedKey: string): Error {
 }
 
 /** Create a claim/commit/release dedupe guard backed by memory and optional persistent storage. */
-export function createClaimableDedupe(options: ClaimableDedupeOptions): ClaimableDedupe {
+export function createClaimableDedupe(
+  options: ClaimableDedupeOptions,
+): ClaimableDedupe & Required<Pick<ClaimableDedupe, "forget">> {
   const ttlMs = resolveNonNegativeIntegerOption(options.ttlMs, 0);
   const memoryMaxSize = resolveNonNegativeIntegerOption(options.memoryMaxSize, 0);
   const memory = createDedupeCache({ ttlMs, maxSize: memoryMaxSize });
@@ -620,6 +647,26 @@ export function createClaimableDedupe(options: ClaimableDedupeOptions): Claimabl
       return persistent.hasRecent(trimmed, dedupeOptions);
     }
     return memory.peek(scopedKey, dedupeOptions?.now);
+  }
+
+  async function forget(
+    key: string,
+    dedupeOptions?: PersistentDedupeCheckOptions,
+  ): Promise<boolean> {
+    const trimmed = key.trim();
+    if (!trimmed) {
+      return false;
+    }
+    const namespace = resolveNamespace(dedupeOptions?.namespace);
+    const scopedKey = resolveScopedKey(namespace, trimmed);
+    const claimValue = inflight.get(scopedKey);
+    claimValue?.reject(createReleasedClaimError(scopedKey));
+    inflight.delete(scopedKey);
+    if (persistent) {
+      return persistent.forget(trimmed, dedupeOptions);
+    }
+    memory.delete(scopedKey);
+    return true;
   }
 
   async function claim(
@@ -710,6 +757,7 @@ export function createClaimableDedupe(options: ClaimableDedupeOptions): Claimabl
     commit,
     release,
     hasRecent,
+    forget,
     warmup: persistent?.warmup ?? (async () => 0),
     clearMemory: () => {
       persistent?.clearMemory();


### PR DESCRIPTION
## Summary

- Fix Telegram spooled replay so buffered/deferred message processing keeps ownership of the update lifecycle until final reply dispatch settles.
- Keep retryable buffered dispatch failures pending in the ingress spool without advancing the Telegram update watermark or leaving stale claims.
- Add focused coverage for deferred spooled participants, same-lane buffering, retryable failures, timeout handling, and dedupe cleanup.

Fixes #92129

## Verification

- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/polling-session.test.ts src/plugin-sdk/memory-host-events.test.ts`
- `pnpm plugin-sdk:api:check`
- `git diff --check`
- `$autoreview` clean before commit
- AWS Crabbox live Telegram fix proof: `run_b62d06ee011a`, lease `cbx_7a4380b42748`, provider `aws`, exit `0`

## Real behavior proof

Behavior addressed: Telegram isolated-ingress spooled replay no longer acknowledges or cleans up a live update before buffered final dispatch settles.

Real environment tested: AWS Crabbox Linux (`cbx_7a4380b42748`) using Convex-leased `telegram` kind credentials for live driver/SUT Telegram bots. No `telegram-user` credential was leased.

Exact steps or command run after this patch: Started a live Telegram polling session from this branch with isolated ingress enabled, sent a real driver-bot group message to the SUT bot, forced `dispatchReplyWithBufferedBlockDispatcher` to throw `LIVE_PROOF_DISPATCH_FAILURE`, then inspected the product Telegram ingress spool, claims, and persisted update watermark.

Evidence after fix: `OPENCLAW_92129_LIVE_FIX_PROOF={"status":"pass","marker":"OPENCLAW-92129-LIVE-1781218662647-06g4j5","sentMessageId":20593,"spooledUpdateId":785090139,"pendingIds":[785090139],"claimIds":[],"dispatchCalls":13,"persistedUpdateIds":[]}`

Observed result after fix: The live Telegram update remains pending for retry, has no stuck claim, dispatch failure is exercised, and the update id is not persisted.

What was not tested: Full repository CI is pending on this PR.
