### PR TITLE
fix(update): hand off Linux service auto-updates

### DIFF
--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -342,6 +342,18 @@ describe("respawnGatewayProcessForUpdate", () => {
     );
   });
 
+  it("treats Linux OpenClaw gateway service markers as supervised for update restarts", () => {
+    clearSupervisorHints();
+    setPlatform("linux");
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    process.env.OPENCLAW_SERVICE_KIND = "gateway";
+
+    const result = respawnGatewayProcessForUpdate();
+
+    expect(result).toEqual({ mode: "supervised" });
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   it("returns failed when update detached respawn throws", () => {
     delete process.env.OPENCLAW_NO_RESPAWN;
     clearSupervisorHints();

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -104,7 +104,9 @@ export function respawnGatewayProcessForUpdate(
   if (isTruthy(process.env.OPENCLAW_NO_RESPAWN)) {
     return { mode: "disabled", detail: "OPENCLAW_NO_RESPAWN" };
   }
-  const supervisor = detectRespawnSupervisor(process.env);
+  const supervisor = detectRespawnSupervisor(process.env, process.platform, {
+    includeLinuxOpenClawGatewayServiceMarker: true,
+  });
   if (supervisor) {
     if (supervisor === "schtasks") {
       const restart = triggerOpenClawRestart();

--- a/src/infra/supervisor-markers.test.ts
+++ b/src/infra/supervisor-markers.test.ts
@@ -46,6 +46,39 @@ describe("detectRespawnSupervisor", () => {
     expect(detectRespawnSupervisor({ JOURNAL_STREAM: "" }, "linux")).toBeNull();
   });
 
+  it("detects Linux OpenClaw gateway service markers only for opt-in callers", () => {
+    const gatewayServiceEnv = {
+      OPENCLAW_SERVICE_MARKER: " openclaw ",
+      OPENCLAW_SERVICE_KIND: " gateway ",
+    };
+    expect(detectRespawnSupervisor(gatewayServiceEnv, "linux")).toBeNull();
+    expect(
+      detectRespawnSupervisor(gatewayServiceEnv, "linux", {
+        includeLinuxOpenClawGatewayServiceMarker: true,
+      }),
+    ).toBe("systemd");
+    expect(
+      detectRespawnSupervisor(
+        {
+          OPENCLAW_SERVICE_MARKER: "openclaw",
+          OPENCLAW_SERVICE_KIND: "worker",
+        },
+        "linux",
+        { includeLinuxOpenClawGatewayServiceMarker: true },
+      ),
+    ).toBeNull();
+    expect(
+      detectRespawnSupervisor(
+        {
+          OPENCLAW_SERVICE_MARKER: "other",
+          OPENCLAW_SERVICE_KIND: "gateway",
+        },
+        "linux",
+        { includeLinuxOpenClawGatewayServiceMarker: true },
+      ),
+    ).toBeNull();
+  });
+
   it("detects scheduled-task supervision on Windows from either hint family", () => {
     expect(
       detectRespawnSupervisor({ OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Gateway" }, "win32"),

--- a/src/infra/supervisor-markers.ts
+++ b/src/infra/supervisor-markers.ts
@@ -22,11 +22,22 @@ export const SUPERVISOR_HINT_ENV_VARS = [
 /** Supported supervisor families that can respawn the gateway after update/restart handoff. */
 export type RespawnSupervisor = "launchd" | "systemd" | "schtasks";
 
+export interface DetectRespawnSupervisorOptions {
+  includeLinuxOpenClawGatewayServiceMarker?: boolean;
+}
+
 function hasAnyHint(env: NodeJS.ProcessEnv, keys: readonly string[]): boolean {
   return keys.some((key) => {
     const value = env[key];
     return typeof value === "string" && value.trim().length > 0;
   });
+}
+
+function hasOpenClawGatewayServiceMarker(env: NodeJS.ProcessEnv): boolean {
+  return (
+    env.OPENCLAW_SERVICE_MARKER?.trim() === "openclaw" &&
+    env.OPENCLAW_SERVICE_KIND?.trim() === "gateway"
+  );
 }
 
 function isCurrentGatewayLaunchdJob(env: NodeJS.ProcessEnv): boolean {
@@ -43,6 +54,7 @@ function isCurrentGatewayLaunchdJob(env: NodeJS.ProcessEnv): boolean {
 export function detectRespawnSupervisor(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
+  options: DetectRespawnSupervisorOptions = {},
 ): RespawnSupervisor | null {
   if (platform === "darwin") {
     return hasAnyHint(env, SUPERVISOR_HINTS.launchd) || isCurrentGatewayLaunchdJob(env)
@@ -50,7 +62,11 @@ export function detectRespawnSupervisor(
       : null;
   }
   if (platform === "linux") {
-    return hasAnyHint(env, SUPERVISOR_HINTS.systemd) ? "systemd" : null;
+    return hasAnyHint(env, SUPERVISOR_HINTS.systemd) ||
+      (options.includeLinuxOpenClawGatewayServiceMarker === true &&
+        hasOpenClawGatewayServiceMarker(env))
+      ? "systemd"
+      : null;
   }
   if (platform === "win32") {
     if (hasAnyHint(env, SUPERVISOR_HINTS.schtasks)) {

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -537,6 +537,9 @@ describe("update-startup", () => {
     expect(runCommandWithTimeout).toHaveBeenCalledTimes(1);
     expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
     expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(detectRespawnSupervisorMock).toHaveBeenCalledWith(process.env, process.platform, {
+      includeLinuxOpenClawGatewayServiceMarker: true,
+    });
     const [argv, options] = requireFirstRunCommandCall();
     expect(argv).toEqual([
       process.execPath,
@@ -605,6 +608,36 @@ describe("update-startup", () => {
       tag: "beta",
       command: "openclaw update --yes --channel beta --timeout 2700",
       logPath: "/tmp/openclaw-handoff.log",
+    });
+  });
+
+  it("uses managed systemd handoff for Linux gateway service auto-updates", async () => {
+    mockPackageInstallStatus();
+    mockNpmChannelTag("beta", "2.0.0-beta.1");
+    detectRespawnSupervisorMock.mockReturnValue("systemd");
+
+    await runAutoUpdateCheckWithDefaults({
+      cfg: createBetaAutoUpdateConfig(),
+    });
+
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
+    expect(detectRespawnSupervisorMock).toHaveBeenCalledWith(process.env, process.platform, {
+      includeLinuxOpenClawGatewayServiceMarker: true,
+    });
+    expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        root: "/opt/openclaw",
+        timeoutMs: 45 * 60 * 1000,
+        channel: "beta",
+        restartDelayMs: 2000,
+        supervisor: "systemd",
+      }),
+    );
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledWith({
+      delayMs: 2000,
+      reason: "update.auto",
+      skipCooldown: true,
+      skipDeferral: true,
     });
   });
 

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -315,7 +315,9 @@ async function runAutoUpdateCommand(params: {
   timeoutMs: number;
   root?: string;
 }): Promise<AutoUpdateRunResult> {
-  const supervisor = detectRespawnSupervisor(process.env, process.platform);
+  const supervisor = detectRespawnSupervisor(process.env, process.platform, {
+    includeLinuxOpenClawGatewayServiceMarker: true,
+  });
   if (supervisor) {
     return await startManagedServiceAutoUpdateHandoff({
       channel: params.channel,


### PR DESCRIPTION
## Summary

Fixes #91823.

Linux gateway services installed with the older generic OpenClaw service markers can miss systemd-specific env hints during startup auto-update. That made startup auto-update run `openclaw update` as a direct child of the live gateway process, where the update command correctly refuses to mutate the active gateway service process.

This keeps Linux marker-only supervisor detection opt-in and applies it only to update-specific paths:

- startup auto-update now routes marker-only Linux OpenClaw gateway services through managed systemd handoff
- update respawn now uses the same opt-in classification so the post-update restart path stays consistent
- generic restart and default supervisor detection continue to ignore marker-only Linux service env

## Verification

- `node scripts/run-vitest.mjs src/infra/supervisor-markers.test.ts src/infra/update-startup.test.ts src/infra/process-respawn.test.ts -- --reporter=verbose`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - first run found a valid consistency issue between startup handoff and update respawn
  - final run: `autoreview clean: no accepted/actionable findings reported`

## Real behavior proof

Behavior addressed: Linux startup auto-update failed under a real user systemd gateway service when the service env had only stale generic OpenClaw service markers and no systemd-specific hints.

Real environment tested: Blacksmith Testbox through Crabbox, real user systemd service, packed OpenClaw package installed into a temporary npm prefix.

Exact steps or command run after this patch: Built and packed the branch, installed the tarball, created `openclaw-gateway.service` with `OPENCLAW_SERVICE_MARKER=openclaw`, `OPENCLAW_SERVICE_KIND=gateway`, and `UnsetEnvironment=OPENCLAW_SYSTEMD_UNIT INVOCATION_ID SYSTEMD_EXEC_PID JOURNAL_STREAM`, then started the gateway with auto-update enabled.

Evidence after fix: Testbox-through-Crabbox provider `blacksmith-testbox`, id `tbx_01ktwdrz6dq71amtvgk027qxch`, Actions run `27382176713`; output included `patch_present=1`, `health={"ok":true,"status":"live"}`, and `auto-update handoff started`.

Observed result after fix: The stale marker-only Linux service started managed update handoff and did not log `auto-update attempt failed`.

What was not tested: A full package update to completion was not allowed to mutate a persistent user install; the proof verifies the broken startup decision and handoff routing in an isolated packed-install service.

## Regression repro

Unpatched `origin/main` was rebuilt and tested with the same stale service shape.

- Testbox-through-Crabbox provider `blacksmith-testbox`, id `tbx_01ktwec4jjmhaf9em2xp2w1tr6`, Actions run `27382620484`
- output included `patch_present=0`, `health={"ok":true,"status":"live"}`, `auto-update attempt failed`, and manual `openclaw update` exited `1` with `Package updates cannot run from inside the gateway service process.`
