### PR TITLE
fix: start typing for queued followup turns and honor configured typingMode for Telegram room events

### DIFF
--- a/extensions/telegram/src/agent-config.test.ts
+++ b/extensions/telegram/src/agent-config.test.ts
@@ -1,0 +1,35 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import {
+  resolveConfiguredTypingMode,
+  resolveTelegramConfigReasoningDefault,
+} from "./agent-config.js";
+
+describe("resolveConfiguredTypingMode", () => {
+  it("returns undefined when no typing mode is configured anywhere", () => {
+    const cfg = { agents: {} } as OpenClawConfig;
+    expect(resolveConfiguredTypingMode(cfg)).toBeUndefined();
+  });
+
+  it("returns the agents.defaults typing mode", () => {
+    const cfg = {
+      agents: { defaults: { typingMode: "instant" } },
+    } as OpenClawConfig;
+    expect(resolveConfiguredTypingMode(cfg)).toBe("instant");
+  });
+
+  it("prefers the session override over agents.defaults", () => {
+    const cfg = {
+      session: { typingMode: "message" },
+      agents: { defaults: { typingMode: "instant" } },
+    } as OpenClawConfig;
+    expect(resolveConfiguredTypingMode(cfg)).toBe("message");
+  });
+});
+
+describe("resolveTelegramConfigReasoningDefault", () => {
+  it("keeps existing fallback behavior", () => {
+    const cfg = { agents: {} } as OpenClawConfig;
+    expect(resolveTelegramConfigReasoningDefault(cfg, "main")).toBe("off");
+  });
+});

--- a/extensions/telegram/src/agent-config.ts
+++ b/extensions/telegram/src/agent-config.ts
@@ -1,5 +1,5 @@
 // Telegram helper module supports agent config behavior.
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { OpenClawConfig, TypingMode } from "openclaw/plugin-sdk/config-contracts";
 
 type ReasoningDefault = "on" | "stream" | "off";
 
@@ -19,4 +19,13 @@ export function resolveTelegramConfigReasoningDefault(
     (entry) => normalizeAgentId(entry?.id) === id,
   )?.reasoningDefault;
   return agentDefault ?? cfg.agents?.defaults?.reasoningDefault ?? "off";
+}
+
+/**
+ * Returns the explicitly configured typing mode (session override first, then
+ * agents.defaults), mirroring how get-reply resolves it. Returns undefined
+ * when the operator never set one, so callers can keep legacy defaults.
+ */
+export function resolveConfiguredTypingMode(cfg: OpenClawConfig): TypingMode | undefined {
+  return cfg.session?.typingMode ?? cfg.agents?.defaults?.typingMode;
 }

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -59,7 +59,10 @@ import {
   logVerbose,
   sleepWithAbort,
 } from "openclaw/plugin-sdk/runtime-env";
-import { resolveTelegramConfigReasoningDefault } from "./agent-config.js";
+import {
+  resolveConfiguredTypingMode,
+  resolveTelegramConfigReasoningDefault,
+} from "./agent-config.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { normalizeAllowFrom } from "./bot-access.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -2281,7 +2284,12 @@ export const dispatchTelegramMessage = async ({
                         },
                       }
                     : undefined,
-                  suppressTyping: isRoomEvent,
+                  // Room events default to quiet typing, but an explicitly
+                  // configured typingMode must win: typing-indicators docs
+                  // define the modes with no room-event exception, and
+                  // resolveTypingMode maps message_tool_only turns to
+                  // "instant" — unreachable if this flag is unconditional.
+                  suppressTyping: isRoomEvent && resolveConfiguredTypingMode(cfg) === undefined,
                   onPartialReply:
                     answerLane.stream || reasoningLane.stream
                       ? (payload) =>

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -598,6 +598,46 @@ function createQueuedRun(
 }
 
 describe("createFollowupRunner reply-lane admission", () => {
+  it("starts run-start typing for queued turns like fresh turns do", async () => {
+    // Regression: queued/steered turns previously never signaled run-start
+    // typing, so message-tool turns (silent streamed final) showed no typing
+    // at all. "instant" is documented as "as soon as the model loop begins"
+    // with no queued-turn exception. See #92267.
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+    const typing = createMockTypingController();
+    const runner = createFollowupRunner({
+      typing,
+      typingMode: "instant",
+      sessionKey: "main",
+      defaultModel: "anthropic/claude",
+    });
+
+    await runner(createQueuedRun({}));
+
+    expect(typing.startTypingLoop).toHaveBeenCalled();
+  });
+
+  it("does not start run-start typing when typingMode gates on text", async () => {
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+    const typing = createMockTypingController();
+    const runner = createFollowupRunner({
+      typing,
+      typingMode: "message",
+      sessionKey: "main",
+      defaultModel: "anthropic/claude",
+    });
+
+    await runner(createQueuedRun({}));
+
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+  });
+
   it("passes prepared media user turns to embedded runtime dispatch", async () => {
     const preparedUserTurnMessage = {
       role: "user",

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -454,6 +454,11 @@ export function createFollowupRunner(params: {
       typing.markDispatchIdle();
       return;
     }
+    // Queued/steered turns must start typing the same way fresh turns do in
+    // runReplyAgent: `instant` is documented as "as soon as the model loop
+    // begins" with no queued-turn exception. Without this, message-tool turns
+    // (whose streamed final is the silent token) never show typing at all.
+    await typingSignals.signalRunStart();
     const endDeliveryCorrelations = (queued.deliveryCorrelations ?? [])
       .map((correlation) => correlation.begin())
       .filter((end): end is () => void => typeof end === "function");

--- a/src/plugin-sdk/config-contracts.ts
+++ b/src/plugin-sdk/config-contracts.ts
@@ -55,4 +55,5 @@ export type {
   TtsConfig,
   TtsModelOverrideConfig,
   TtsProvider,
+  TypingMode,
 } from "../config/types.js";


### PR DESCRIPTION
Fixes #92267

## Problem

`agents.defaults.typingMode: "instant"` is silently ineffective for message-tool delivery setups — the configuration the ambient-room-events docs recommend (`unmentionedInbound: "room_event"` + `visibleReplies: "message_tool"`). Two independent gaps:

**Gap 1 — queued/steered turns never start typing.** `createFollowupRunner` builds the typing signaler but never calls `signalRunStart()`; its only trigger is streamed renderable text, which `message_tool` turns never produce (their streamed final is the silent token). With `messages.queue.mode: "steer"` and long-running sessions, most real inbound messages take this path — observed in production as a full day of Telegram traffic with 42 `sendMessage` operations and **zero** `sendChatAction` calls, in DMs and groups alike. `runReplyAgent` already signals run start for fresh turns; the docs define `instant` as "start typing as soon as the model loop begins, even if the run later returns only the silent reply token", with no queued-turn exception.

**Gap 2 — Telegram hardcodes `suppressTyping` for room events.** `bot-message-dispatch.ts` sets `suppressTyping: isRoomEvent` unconditionally while simultaneously setting `sourceReplyDeliveryMode: "message_tool_only"` — the exact mode `resolveTypingMode()` deliberately maps to `"instant"`. The suppression check runs first, so that mapping and any explicit operator-configured `typingMode` are unreachable for unmentioned group turns.

## Fix

- `followup-runner.ts`: call `typingSignals.signalRunStart()` at follow-up run start, mirroring `runReplyAgent`. The signaler gates on mode internally, so `message`/`thinking`/`never` semantics are unchanged; existing `markRunComplete`/`markDispatchIdle` teardown already handles cleanup (silent turns drop typing promptly).
- `bot-message-dispatch.ts`: suppress room-event typing only when the operator never configured a typing mode — `isRoomEvent && resolveConfiguredTypingMode(cfg) === undefined`. The new resolver (session override, then `agents.defaults`) mirrors how `get-reply` resolves the effective mode. Default installs keep today's quiet ambient-room behavior.
- `plugin-sdk/config-contracts.ts`: re-export `TypingMode` for the resolver's signature.

## Tests

- `followup-runner.test.ts`: queued turns start run-start typing under `instant`, and do not under `message` (regression for gap 1).
- `agent-config.test.ts` (new): resolver precedence (unset → undefined, defaults, session override) plus a guard on the existing reasoning-default fallback.

`vitest run` on both touched suites: 79 passed. `tsgo:core` and `tsgo:extensions` clean; oxlint/oxfmt applied.

## Verification beyond tests

Both changes were first applied to a live 2026.6.5 deployment (as dist patches with identical semantics) and verified by the affected user: typing restored in DMs (gap 1 path) and in unmentioned group-topic messages (gap 2 path), with message-tool final delivery unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Real behavior proof

**Behavior or issue addressed:** Telegram typing indicator (`sendChatAction: typing`) now appears during agent runs for both queued/steered turns and unmentioned group `room_event` turns with `typingMode: "instant"`, where previously neither path ever issued a `sendChatAction`; it still stops when the message-tool reply lands.

**Real environment tested:** Production OpenClaw 2026.6.5 on a macOS gateway (LaunchAgent), Telegram channel polling, Codex app-server runtime, `agents.defaults.typingMode: "instant"`, `messages.queue.mode: "steer"`, `messages.groupChat: { unmentionedInbound: "room_event", visibleReplies: "message_tool" }`; both fixes applied to the live deployment with semantics identical to this PR and the gateway restarted.

**Exact steps or command run after this patch:** (1) restart gateway with both fixes applied; (2) send a DM to an agent whose session is mid-run (follow-up/steered path); (3) send an unmentioned message in an always-on group topic (room_event path); (4) observe the Telegram client and audit gateway logs for `sendChatAction`.

**Evidence after fix:** Telegram client visibly rendered the "typing…" indicator within ~1–2s of the inbound message on both the DM and the group-topic turn and held it through each run until the message-tool reply was delivered (operator-observed live); before the fix, a full day of runtime logs showed 42 `sendMessage` operations and 0 `sendChatAction` entries, and a direct Bot API `sendChatAction` returned `{"ok":true}` and rendered — isolating the gap to the run pipeline. Screen recording from the live deployment available on request.

**Observed result after fix:** Both previously-dead typing paths show live typing through the full run and stop on message-tool delivery; silent (`NO_REPLY`) turns tear typing down promptly; message-tool final delivery, mentioned-group, and fresh-DM behavior unchanged.

**What was not tested:** `typingMode: "thinking"` under this setup (needs streamed reasoning); heartbeat turns (excluded by design in the signaler); other channels sharing the room-event pattern (e.g. Discord's analogous flag, out of scope for this PR).
