### PR TITLE
fix(codex): isolate CODEX_HOME per authProfileId to prevent cross-acc…

### DIFF
--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -1,4 +1,5 @@
 // Codex tests cover auth bridge plugin behavior.
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -131,6 +132,11 @@ function createStartOptions(
   };
 }
 
+function resolveIsolatedCodexHome(agentDir: string, authProfileId: string): string {
+  const segment = `account-${createHash("sha256").update(authProfileId).digest("hex").slice(0, 16)}`;
+  return path.join(resolveCodexAppServerHomeDir(agentDir), segment);
+}
+
 async function expectPathMissing(filePath: string): Promise<void> {
   try {
     await fs.access(filePath);
@@ -200,6 +206,33 @@ describe("bridgeCodexAppServerStartOptions", () => {
       await expect(fs.access(codexHome)).resolves.toBeUndefined();
       await expectPathMissing(nativeHome);
       expect(startOptions.env).toBeUndefined();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("isolates CODEX_HOME by authProfileId to prevent cross-account state pollution", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const startOptions = createStartOptions();
+    const authProfileId = "openai:shared-agent-bad-account";
+    const expectedSegment = `account-${createHash("sha256").update(authProfileId).digest("hex").slice(0, 16)}`;
+    try {
+      const baseCodexHome = resolveCodexAppServerHomeDir(agentDir);
+      const isolatedCodexHome = path.join(baseCodexHome, expectedSegment);
+
+      await expect(
+        bridgeCodexAppServerStartOptions({
+          startOptions,
+          agentDir,
+          authProfileId,
+        }),
+      ).resolves.toEqual({
+        ...startOptions,
+        env: {
+          CODEX_HOME: isolatedCodexHome,
+        },
+      });
+      await expect(fs.access(isolatedCodexHome)).resolves.toBeUndefined();
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
@@ -326,7 +359,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       ).resolves.toEqual({
         ...startOptions,
         env: {
-          CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
+          CODEX_HOME: resolveIsolatedCodexHome(agentDir, "openai:work"),
         },
         clearEnv: ["FOO", "CODEX_API_KEY", "OPENAI_API_KEY"],
       });
@@ -358,7 +391,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       ).resolves.toEqual({
         ...startOptions,
         env: {
-          CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
+          CODEX_HOME: resolveIsolatedCodexHome(agentDir, "openai:work"),
         },
         clearEnv: ["FOO", "CODEX_API_KEY", "OPENAI_API_KEY"],
       });
@@ -390,7 +423,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       ).resolves.toEqual({
         ...startOptions,
         env: {
-          CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
+          CODEX_HOME: resolveIsolatedCodexHome(agentDir, "openai:work"),
         },
       });
     } finally {

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -61,6 +61,7 @@ export async function bridgeCodexAppServerStartOptions(params: {
   const isolatedStartOptions = await withAgentCodexHomeEnvironment(
     params.startOptions,
     params.agentDir,
+    params.authProfileId ?? undefined,
   );
   if (params.authProfileId === null) {
     return isolatedStartOptions;
@@ -295,13 +296,21 @@ export function resolveCodexAppServerNativeHomeDir(agentDir: string): string {
   return path.join(resolveCodexAppServerHomeDir(agentDir), CODEX_APP_SERVER_NATIVE_HOME_DIRNAME);
 }
 
+function hashAuthProfileIdForHome(authProfileId: string): string {
+  return createHash("sha256").update(authProfileId).digest("hex").slice(0, 16);
+}
+
 async function withAgentCodexHomeEnvironment(
   startOptions: CodexAppServerStartOptions,
   agentDir: string,
+  authProfileId?: string,
 ): Promise<CodexAppServerStartOptions> {
-  const codexHome = startOptions.env?.[CODEX_HOME_ENV_VAR]?.trim()
+  const baseCodexHome = startOptions.env?.[CODEX_HOME_ENV_VAR]?.trim()
     ? startOptions.env[CODEX_HOME_ENV_VAR]
     : resolveCodexAppServerHomeDir(agentDir);
+  const codexHome = authProfileId
+    ? path.join(baseCodexHome, `account-${hashAuthProfileIdForHome(authProfileId)}`)
+    : baseCodexHome;
   const nativeHome = startOptions.env?.[HOME_ENV_VAR]?.trim()
     ? startOptions.env[HOME_ENV_VAR]
     : undefined;

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -681,6 +681,16 @@ export class CodexAppServerEventProjector {
     if (usage) {
       this.tokenUsage = usage;
     }
+    const cachedTokens = readNumber(current, "cached_tokens") ?? readNumber(current, "cachedTokens");
+    const inputTokens = readNumber(current, "input_tokens") ?? readNumber(current, "inputTokens");
+    if (cachedTokens !== undefined || inputTokens !== undefined) {
+      embeddedAgentLog.debug("codex app-server token usage snapshot", {
+        threadId: this.threadId,
+        cachedTokens,
+        inputTokens,
+        outputTokens: readNumber(current, "output_tokens") ?? readNumber(current, "outputTokens"),
+      });
+    }
   }
 
   private handleGuardianReviewNotification(method: string, params: JsonObject): void {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2043,6 +2043,13 @@ export async function runCodexAppServerAttempt(
         workspaceBootstrapContext.heartbeatCollaborationInstructions,
     });
     codexModelCallDiagnostics.setRequestPayloadBytes(utf8JsonByteLength(turnStartParams));
+    embeddedAgentLog.debug("codex app-server turn/start payload sizing", {
+      sessionId: params.sessionId,
+      threadId: thread.threadId,
+      promptChars: codexTurnPromptText.length,
+      developerInstructionsChars: buildRenderedCodexDeveloperInstructions()?.length ?? 0,
+      turnStartPayloadBytes: utf8JsonByteLength(turnStartParams),
+    });
     const startedTurn = assertCodexTurnStartResponse(
       await client.request("turn/start", turnStartParams, {
         timeoutMs: params.timeoutMs,


### PR DESCRIPTION
fix #92275

# Issue #92275 PR Comment

## Transformation Plan Details
- **Root Cause**: When multiple Codex OAuth accounts on the same machine use the same Agent configuration, they share the same `CODEX_HOME` directory. The Codex app-server persists local state (session transcripts, auth caches, doc indexes) in this directory, causing cross-account state pollution. This manifests as abnormally inflated `cached_tokens` on the first message after `/new` (~46k vs ~11k).
- **Core Strategy**: During `bridgeCodexAppServerStartOptions`, derive a stable subdirectory from the first 16 chars of the SHA-256 hash of `authProfileId` and inject it into the `CODEX_HOME` path, achieving per-auth-account isolation of Codex local storage.

## Transformation Content Details
- **`extensions/codex/src/app-server/auth-bridge.ts`**
  - Added optional `authProfileId` parameter to `withAgentCodexHomeEnvironment`
  - When `authProfileId` is present, create an `account-<hash>` subdirectory under the base `CODEX_HOME` and ensure it is pre-created
  - Updated `bridgeCodexAppServerStartOptions` to pass `authProfileId` through
- **`extensions/codex/src/app-server/auth-bridge.test.ts`**
  - Added regression test: `isolates CODEX_HOME by authProfileId to prevent cross-account state pollution`
  - Added helper `resolveIsolatedCodexHome` to compute isolated paths consistently
  - Updated 3 existing tests that explicitly pass `authProfileId` to expect the new isolated path
- **`extensions/codex/src/app-server/event-projector.ts`**
  - Added `embeddedAgentLog.debug` in `handleTokenUsage` to snapshot `cachedTokens`, `inputTokens`, and `outputTokens` for future diagnostics
- **`extensions/codex/src/app-server/run-attempt.ts`**
  - Added `embeddedAgentLog.debug` in `startCodexTurn` to record `promptChars`, `developerInstructionsChars`, and `turnStartPayloadBytes` on every turn start

## Test Points
1. **Regression test**: Confirms that when `authProfileId` is provided, `CODEX_HOME` lands under `account-<hash>` and the directory is auto-created
2. **Existing test compatibility**: Updated 3 tests that explicitly pass `authProfileId` to match the new isolated path expectations
3. **Full suite pass**: `auth-bridge.test.ts` (44 tests), `run-attempt.test.ts` (98 tests), and `event-projector.test.ts` (79 tests) all pass, 221 tests with zero failures

## Next Steps
1. **User validation**: Ask the affected user to run `/new` after the update and verify that `context` drops from ~48k to the normal ~19k level seen on the good account
2. **Log observation**: Enable debug-level logging and monitor `codex app-server token usage snapshot` and `codex app-server turn/start payload sizing` to confirm `cachedTokens` and `turnStartPayloadBytes` are within normal ranges
3. **State cleanup**: If desired, manually clean up historical residue in the old shared `{agentDir}/codex-home/` directory to reclaim disk space
4. **Documentation update**: Update the Codex harness reference docs to describe the `CODEX_HOME` isolation behavior in multi-account scenarios
