### PR TITLE
fix(openai-responses): collapse cumulative message snapshots

### DIFF
--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.does-not-append-text-end-content-is.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.does-not-append-text-end-content-is.test.ts
@@ -7,6 +7,7 @@ import {
   emitAssistantTextDelta,
   emitAssistantTextEnd,
 } from "./embedded-agent-subscribe.e2e-harness.js";
+import { createOpenAiResponsesTextEvent } from "./embedded-agent-subscribe.openai-responses.test-helpers.js";
 
 describe("subscribeEmbeddedAgentSession", () => {
   function setupTextEndSubscription() {
@@ -107,6 +108,45 @@ describe("subscribeEmbeddedAgentSession", () => {
       "Let me grab actual eBay prices:",
       "Let me grab actual prices from eBay:",
       "eBay blocks live pricing:",
+    ]);
+  });
+
+  it("sends only the suffix when OpenAI Responses text_end snapshots grow on one text block", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    const emitResponsesSnapshot = (text: string) => {
+      emit(
+        createOpenAiResponsesTextEvent({
+          type: "text_end",
+          text,
+          id: "msg_cumulative_snapshot",
+          signaturePhase: "final_answer",
+          partialPhase: "final_answer",
+          messagePhase: "final_answer",
+        }),
+      );
+    };
+
+    emitResponsesSnapshot("Transformer attention starts with Q/K/V.");
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(1);
+    });
+
+    emitResponsesSnapshot(
+      "Transformer attention starts with Q/K/V. Multi-head attention projects the sequence once.",
+    );
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(2);
+    });
+
+    expect(extractTextPayloads(onBlockReply.mock.calls)).toEqual([
+      "Transformer attention starts with Q/K/V.",
+      " Multi-head attention projects the sequence once.",
+    ]);
+    expect(subscription.assistantTexts).toEqual([
+      "Transformer attention starts with Q/K/V.",
+      " Multi-head attention projects the sequence once.",
     ]);
   });
 

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -68,7 +68,7 @@ function createAssistantOutput(model: Model<"openai-completions">): OpenAIComple
 }
 
 function createResponsesAssistantOutput(
-  model: Model<"azure-openai-responses">,
+  model: Model<"azure-openai-responses"> | Model<"openai-responses">,
 ): OpenAIResponsesOutput {
   return {
     role: "assistant" as const,
@@ -96,6 +96,21 @@ function createAzureResponsesModel(): Model<"azure-openai-responses"> {
     api: "azure-openai-responses",
     provider: "azure-openai-responses-devdiv",
     baseUrl: "https://example.openai.azure.com/openai/responses",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8192,
+  };
+}
+
+function createBedrockMantleGpt5ResponsesModel(): Model<"openai-responses"> {
+  return {
+    id: "openai.gpt-5.5",
+    name: "Bedrock Mantle GPT-5.5",
+    api: "openai-responses",
+    provider: "amazon-bedrock-mantle",
+    baseUrl: "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
     reasoning: true,
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -2056,6 +2071,137 @@ describe("openai transport stream", () => {
       totalTokens: 7,
     });
     expect(output.responseId).toBe("resp_azure_text");
+  });
+
+  it("collapses cumulative Bedrock Mantle GPT-5 message snapshots from completed Responses output", async () => {
+    const model = createBedrockMantleGpt5ResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await testing.processResponsesStream(
+      streamChunks([
+        {
+          type: "response.completed",
+          response: {
+            id: "resp_prefix_backfill",
+            status: "completed",
+            output: [
+              {
+                type: "message",
+                id: "msg_prefix_1",
+                role: "assistant",
+                phase: "final_answer",
+                content: [
+                  {
+                    type: "output_text",
+                    text: "Transformer attention starts with Q/K/V.",
+                  },
+                ],
+              },
+              {
+                type: "message",
+                id: "msg_prefix_2",
+                role: "assistant",
+                phase: "final_answer",
+                content: [
+                  {
+                    type: "output_text",
+                    text: "Transformer attention starts with Q/K/V. The final answer continues once.",
+                  },
+                ],
+              },
+            ],
+            usage: {
+              input_tokens: 4,
+              output_tokens: 8,
+              total_tokens: 12,
+            },
+          },
+        },
+      ]),
+      output,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+      model,
+    );
+
+    expect(output.content).toMatchObject([
+      {
+        type: "text",
+        text: "Transformer attention starts with Q/K/V. The final answer continues once.",
+      },
+    ]);
+    expect(
+      events.filter((event) => event.type === "text_end").map((event) => event.content),
+    ).toEqual([
+      "Transformer attention starts with Q/K/V.",
+      "Transformer attention starts with Q/K/V. The final answer continues once.",
+    ]);
+    expect(output.responseId).toBe("resp_prefix_backfill");
+  });
+
+  it("keeps Azure completed Responses output items that intentionally share a prefix", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await testing.processResponsesStream(
+      streamChunks([
+        {
+          type: "response.completed",
+          response: {
+            id: "resp_azure_prefix_backfill",
+            status: "completed",
+            output: [
+              {
+                type: "message",
+                id: "msg_prefix_1",
+                role: "assistant",
+                phase: "final_answer",
+                content: [
+                  {
+                    type: "output_text",
+                    text: "Transformer attention starts with Q/K/V.",
+                  },
+                ],
+              },
+              {
+                type: "message",
+                id: "msg_prefix_2",
+                role: "assistant",
+                phase: "final_answer",
+                content: [
+                  {
+                    type: "output_text",
+                    text: "Transformer attention starts with Q/K/V. A separate answer can share the prefix.",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ]),
+      output,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+      model,
+    );
+
+    expect(output.content).toMatchObject([
+      {
+        type: "text",
+        text: "Transformer attention starts with Q/K/V.",
+      },
+      {
+        type: "text",
+        text: "Transformer attention starts with Q/K/V. A separate answer can share the prefix.",
+      },
+    ]);
+    expect(
+      events.filter((event) => event.type === "text_end").map((event) => event.content),
+    ).toEqual([
+      "Transformer attention starts with Q/K/V.",
+      "Transformer attention starts with Q/K/V. A separate answer can share the prefix.",
+    ]);
+    expect(output.responseId).toBe("resp_azure_prefix_backfill");
   });
 
   it("skips null and non-object OpenAI-compatible stream chunks", async () => {
@@ -10183,9 +10329,7 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
   });
 
   it("preserves reasoning_content replay for Gemma 4 openai-completions models", () => {
-    const assistant = getAssistantMessage(
-      buildReplayParams(gemma4Model, "reasoning_content"),
-    );
+    const assistant = getAssistantMessage(buildReplayParams(gemma4Model, "reasoning_content"));
 
     expect(assistant.reasoning_content).toBe("Need to answer politely.");
     expect(assistant).not.toHaveProperty("reasoning_details");

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -38,6 +38,7 @@ import { isOpenAICompatibleAzureResponsesBaseUrl } from "../shared/azure-openai-
 import {
   isResponsesTextContentPartType,
   isResponsesTextDeltaEventType,
+  shouldCollapseResponsesCumulativeTextSnapshot,
 } from "../shared/openai-responses-stream-compat.js";
 import { createReasoningTagTextPartitioner } from "../shared/text/reasoning-tag-text-partitioner.js";
 import { CHARS_PER_TOKEN_ESTIMATE, estimateStringChars } from "../utils/cjk-chars.js";
@@ -1453,29 +1454,74 @@ async function processResponsesStream(
   const eventTypes = new Map<string, number>();
   const sseDebugMode = resolveModelSseDebugMode();
   const blockIndex = () => output.content.length - 1;
+  let lastCompletedMessageTextBlock:
+    | {
+        index: number;
+        text: string;
+      }
+    | undefined;
+  const replacePriorCumulativeTextSnapshot = (
+    currentTextBlock: Record<string, unknown>,
+    text: string,
+    textSignature: string,
+  ): number | undefined => {
+    if (!lastCompletedMessageTextBlock) {
+      return undefined;
+    }
+    const previousBlock = output.content[lastCompletedMessageTextBlock.index];
+    if (
+      !isRecord(previousBlock) ||
+      previousBlock.type !== "text" ||
+      !shouldCollapseResponsesCumulativeTextSnapshot(
+        model,
+        lastCompletedMessageTextBlock.text,
+        text,
+      )
+    ) {
+      return undefined;
+    }
+    previousBlock.text = text;
+    previousBlock.textSignature = textSignature;
+    const currentIndex = output.content.indexOf(currentTextBlock);
+    if (currentIndex >= 0) {
+      output.content.splice(currentIndex, 1);
+    }
+    lastCompletedMessageTextBlock = {
+      index: lastCompletedMessageTextBlock.index,
+      text,
+    };
+    return lastCompletedMessageTextBlock.index;
+  };
   const appendCompletedResponseTextItem = (item: Record<string, unknown>) => {
     const text = readResponsesOutputMessageText(item);
     if (!text) {
       return;
     }
+    const textSignature = encodeTextSignatureV1(
+      stringifyUnknown(item.id),
+      (item.phase as "commentary" | "final_answer" | undefined) ?? undefined,
+    );
     const block: Record<string, unknown> = {
       type: "text",
       text,
-      textSignature: encodeTextSignatureV1(
-        stringifyUnknown(item.id),
-        (item.phase as "commentary" | "final_answer" | undefined) ?? undefined,
-      ),
+      textSignature,
     };
     output.content.push(block);
-    stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+    const contentIndex =
+      replacePriorCumulativeTextSnapshot(block, text, textSignature) ?? blockIndex();
+    if (contentIndex === blockIndex()) {
+      lastCompletedMessageTextBlock = { index: contentIndex, text };
+    }
+    stream.push({ type: "text_start", contentIndex, partial: output });
     stream.push({
       type: "text_end",
-      contentIndex: blockIndex(),
+      contentIndex,
       content: text,
       partial: output,
     });
   };
   const appendCompletedResponseToolCallItem = (item: Record<string, unknown>) => {
+    lastCompletedMessageTextBlock = undefined;
     const args = parseStreamingJson(stringifyJsonLike(item.arguments, "{}"));
     const block = {
       type: "toolCall",
@@ -1554,6 +1600,7 @@ async function processResponsesStream(
         output.content.push(currentBlock);
         stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
       } else if (item.type === "function_call") {
+        lastCompletedMessageTextBlock = undefined;
         currentItem = item;
         currentBlock = {
           type: "toolCall",
@@ -1624,7 +1671,7 @@ async function processResponsesStream(
         currentBlock = null;
       } else if (item.type === "message" && currentBlock?.type === "text") {
         const content = Array.isArray(item.content) ? item.content : [];
-        currentBlock.text = content
+        const text = content
           .map((part) => {
             const contentPart = part as { type?: string; text?: string; refusal?: string };
             return isResponsesTextContentPartType(contentPart.type)
@@ -1632,18 +1679,27 @@ async function processResponsesStream(
               : (contentPart.refusal ?? "");
           })
           .join("");
-        currentBlock.textSignature = encodeTextSignatureV1(
+        const textSignature = encodeTextSignatureV1(
           stringifyUnknown(item.id),
           (item.phase as "commentary" | "final_answer" | undefined) ?? undefined,
         );
+        currentBlock.text = text;
+        currentBlock.textSignature = textSignature;
+        // Bedrock Mantle GPT-5.x can emit each final-answer message item as a
+        // from-the-start snapshot. Keep the latest snapshot instead of appending
+        // every prefix copy to the final assistant content.
+        const contentIndex =
+          replacePriorCumulativeTextSnapshot(currentBlock, text, textSignature) ?? blockIndex();
+        lastCompletedMessageTextBlock = { index: contentIndex, text };
         stream.push({
           type: "text_end",
-          contentIndex: blockIndex(),
-          content: stringifyUnknown(currentBlock.text),
+          contentIndex,
+          content: text,
           partial: output,
         });
         currentBlock = null;
       } else if (item.type === "function_call") {
+        lastCompletedMessageTextBlock = undefined;
         const args =
           currentBlock?.type === "toolCall" && currentBlock.partialJson
             ? parseStreamingJson(stringifyJsonLike(currentBlock.partialJson, "{}"))

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -53,6 +53,14 @@ const nativeOpenAIModel = {
   maxTokens: 8192,
 } satisfies Model<"openai-responses">;
 
+const bedrockMantleGpt5Model = {
+  ...nativeOpenAIModel,
+  id: "openai.gpt-5.5",
+  name: "Bedrock Mantle GPT-5.5",
+  provider: "amazon-bedrock-mantle",
+  baseUrl: "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+} satisfies Model<"openai-responses">;
+
 const proxyOpenAIModel = {
   ...nativeOpenAIModel,
   id: "custom-model",
@@ -60,12 +68,12 @@ const proxyOpenAIModel = {
   baseUrl: "https://proxy.example.com/v1",
 } satisfies Model<"openai-responses">;
 
-function createAssistantOutput(): AssistantMessage {
+function createAssistantOutput(model: Model = nativeOpenAIModel): AssistantMessage {
   return {
     role: "assistant",
-    api: nativeOpenAIModel.api,
-    provider: nativeOpenAIModel.provider,
-    model: nativeOpenAIModel.id,
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
     usage: {
       input: 0,
       output: 0,
@@ -453,6 +461,267 @@ describe("convertResponsesMessages", () => {
 });
 
 describe("processResponsesStream", () => {
+  it("collapses cumulative message snapshots from Bedrock Mantle GPT-5 Responses streams", async () => {
+    const output = createAssistantOutput(bedrockMantleGpt5Model);
+    const { stream, events } = createCapturedAssistantMessageEventStream();
+
+    await processResponsesStream(
+      responseEvents([
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "message",
+            id: "msg_prefix_1",
+            role: "assistant",
+            content: [],
+            status: "in_progress",
+          },
+        },
+        {
+          type: "response.content_part.added",
+          part: { type: "output_text", text: "" },
+        },
+        {
+          type: "response.output_text.delta",
+          delta: "Transformer attention starts with Q/K/V.",
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_prefix_1",
+            role: "assistant",
+            content: [
+              {
+                type: "output_text",
+                text: "Transformer attention starts with Q/K/V.",
+                annotations: [],
+              },
+            ],
+            phase: "final_answer",
+            status: "completed",
+          },
+        },
+        {
+          type: "response.output_item.added",
+          item: { type: "reasoning", id: "rs_boundary", summary: [] },
+        },
+        {
+          type: "response.reasoning_text.delta",
+          delta: "checking structure",
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "reasoning",
+            id: "rs_boundary",
+            summary: [{ type: "summary_text", text: "checking structure" }],
+          },
+        },
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "message",
+            id: "msg_prefix_2",
+            role: "assistant",
+            content: [],
+            status: "in_progress",
+          },
+        },
+        {
+          type: "response.content_part.added",
+          part: { type: "output_text", text: "" },
+        },
+        {
+          type: "response.output_text.delta",
+          delta: "Transformer attention starts with Q/K/V. The final answer continues once.",
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_prefix_2",
+            role: "assistant",
+            content: [
+              {
+                type: "output_text",
+                text: "Transformer attention starts with Q/K/V. The final answer continues once.",
+                annotations: [],
+              },
+            ],
+            phase: "final_answer",
+            status: "completed",
+          },
+        },
+        {
+          type: "response.completed",
+          response: {
+            id: "resp_prefix",
+            status: "completed",
+          },
+        },
+      ]),
+      output,
+      stream,
+      bedrockMantleGpt5Model,
+    );
+
+    const textBlocks = output.content.filter((block) => block.type === "text");
+    expect(textBlocks).toEqual([
+      {
+        type: "text",
+        text: "Transformer attention starts with Q/K/V. The final answer continues once.",
+        textSignature: expect.any(String),
+      },
+    ]);
+    expect(
+      events.filter((event) => event.type === "text_end").map((event) => event.content),
+    ).toEqual([
+      "Transformer attention starts with Q/K/V.",
+      "Transformer attention starts with Q/K/V. The final answer continues once.",
+    ]);
+  });
+
+  it("keeps native OpenAI Responses prefix-sharing message items separate", async () => {
+    const output = createAssistantOutput(nativeOpenAIModel);
+    const { stream } = createCapturedAssistantMessageEventStream();
+
+    await processResponsesStream(
+      responseEvents([
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "message",
+            id: "msg_first",
+            role: "assistant",
+            content: [],
+            status: "in_progress",
+          },
+        },
+        { type: "response.content_part.added", part: { type: "output_text", text: "" } },
+        { type: "response.output_text.delta", delta: "The safe prefix." },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_first",
+            role: "assistant",
+            content: [{ type: "output_text", text: "The safe prefix.", annotations: [] }],
+            phase: "final_answer",
+            status: "completed",
+          },
+        },
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "message",
+            id: "msg_second",
+            role: "assistant",
+            content: [],
+            status: "in_progress",
+          },
+        },
+        { type: "response.content_part.added", part: { type: "output_text", text: "" } },
+        {
+          type: "response.output_text.delta",
+          delta: "The safe prefix. A separate answer can intentionally share it.",
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_second",
+            role: "assistant",
+            content: [
+              {
+                type: "output_text",
+                text: "The safe prefix. A separate answer can intentionally share it.",
+                annotations: [],
+              },
+            ],
+            phase: "final_answer",
+            status: "completed",
+          },
+        },
+      ]),
+      output,
+      stream,
+      nativeOpenAIModel,
+    );
+
+    expect(
+      output.content
+        .filter((block) => block.type === "text")
+        .map((block) => ("text" in block ? block.text : "")),
+    ).toEqual([
+      "The safe prefix.",
+      "The safe prefix. A separate answer can intentionally share it.",
+    ]);
+  });
+
+  it("keeps separate Responses message items when they are not a prefix chain", async () => {
+    const output = createAssistantOutput();
+    const { stream } = createCapturedAssistantMessageEventStream();
+
+    await processResponsesStream(
+      responseEvents([
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "message",
+            id: "msg_first",
+            role: "assistant",
+            content: [],
+            status: "in_progress",
+          },
+        },
+        { type: "response.content_part.added", part: { type: "output_text", text: "" } },
+        { type: "response.output_text.delta", delta: "First independent answer." },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_first",
+            role: "assistant",
+            content: [{ type: "output_text", text: "First independent answer.", annotations: [] }],
+            status: "completed",
+          },
+        },
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "message",
+            id: "msg_second",
+            role: "assistant",
+            content: [],
+            status: "in_progress",
+          },
+        },
+        { type: "response.content_part.added", part: { type: "output_text", text: "" } },
+        { type: "response.output_text.delta", delta: "Second independent answer." },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_second",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Second independent answer.", annotations: [] }],
+            status: "completed",
+          },
+        },
+      ]),
+      output,
+      stream,
+      nativeOpenAIModel,
+    );
+
+    expect(
+      output.content
+        .filter((block) => block.type === "text")
+        .map((block) => ("text" in block ? block.text : "")),
+    ).toEqual(["First independent answer.", "Second independent answer."]);
+  });
+
   it.each([
     ["omits arguments", undefined],
     ["sends empty arguments", ""],

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -20,6 +20,7 @@ import {
   type AzureResponsesTextDeltaEvent,
   isAzureResponsesTextDeltaEvent,
   isResponsesTextContentPartType,
+  shouldCollapseResponsesCumulativeTextSnapshot,
 } from "../../shared/openai-responses-stream-compat.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import type {
@@ -578,6 +579,44 @@ export async function processResponsesStream<TApi extends Api>(
     null;
   const blocks = output.content;
   const blockIndex = () => blocks.length - 1;
+  let lastCompletedMessageTextBlock:
+    | {
+        index: number;
+        text: string;
+      }
+    | undefined;
+
+  const replacePriorCumulativeTextSnapshot = (
+    currentTextBlock: TextContent,
+    text: string,
+    textSignature: string,
+  ): number | undefined => {
+    if (!lastCompletedMessageTextBlock) {
+      return undefined;
+    }
+    const previousBlock = blocks[lastCompletedMessageTextBlock.index];
+    if (
+      previousBlock?.type !== "text" ||
+      !shouldCollapseResponsesCumulativeTextSnapshot(
+        model,
+        lastCompletedMessageTextBlock.text,
+        text,
+      )
+    ) {
+      return undefined;
+    }
+    previousBlock.text = text;
+    previousBlock.textSignature = textSignature;
+    const currentIndex = blocks.indexOf(currentTextBlock);
+    if (currentIndex >= 0) {
+      blocks.splice(currentIndex, 1);
+    }
+    lastCompletedMessageTextBlock = {
+      index: lastCompletedMessageTextBlock.index,
+      text,
+    };
+    return lastCompletedMessageTextBlock.index;
+  };
 
   for await (const event of openaiStream) {
     if (event.type === "response.created") {
@@ -766,18 +805,27 @@ export async function processResponsesStream<TApi extends Api>(
         currentBlock = null;
       } else if (item.type === "message" && currentBlock?.type === "text") {
         // Support both OpenAI "output_text" and Azure "text" content types
-        currentBlock.text = item.content
+        const text = item.content
           .map((c) => (c.type === "output_text" || c.type === "text" ? c.text : c.refusal))
           .join("");
-        currentBlock.textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
+        const textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
+        currentBlock.text = text;
+        currentBlock.textSignature = textSignature;
+        // Bedrock Mantle GPT-5.x can emit each final-answer message item as a
+        // from-the-start snapshot. Keep the latest snapshot instead of appending
+        // every prefix copy to the final assistant content.
+        const contentIndex =
+          replacePriorCumulativeTextSnapshot(currentBlock, text, textSignature) ?? blockIndex();
+        lastCompletedMessageTextBlock = { index: contentIndex, text };
         stream.push({
           type: "text_end",
-          contentIndex: blockIndex(),
-          content: currentBlock.text,
+          contentIndex,
+          content: text,
           partial: output,
         });
         currentBlock = null;
       } else if (item.type === "function_call") {
+        lastCompletedMessageTextBlock = undefined;
         const args =
           currentBlock?.type === "toolCall" && currentBlock.partialJson
             ? parseStreamingJson(currentBlock.partialJson)

--- a/src/shared/openai-responses-stream-compat.ts
+++ b/src/shared/openai-responses-stream-compat.ts
@@ -49,3 +49,53 @@ export function isAzureResponsesTextDeltaEvent(event: {
 }): event is AzureResponsesTextDeltaEvent {
   return isAzureResponsesTextDeltaEventType(event.type) && typeof event.delta === "string";
 }
+
+export function shouldCollapseResponsesCumulativeTextSnapshot(
+  model: { api?: unknown; provider?: unknown; id?: unknown; baseUrl?: unknown },
+  previousText: string,
+  nextText: string,
+): boolean {
+  if (!isBedrockMantleGpt5OpenAIResponsesModel(model)) {
+    return false;
+  }
+  if (!previousText || !nextText) {
+    return false;
+  }
+  if (nextText === previousText || nextText.startsWith(previousText)) {
+    return true;
+  }
+  const previousTrimmed = previousText.trimEnd();
+  const nextTrimmed = nextText.trimEnd();
+  return (
+    previousTrimmed.length > 0 &&
+    (nextTrimmed === previousTrimmed || nextTrimmed.startsWith(previousTrimmed))
+  );
+}
+
+function isBedrockMantleGpt5OpenAIResponsesModel(model: {
+  api?: unknown;
+  provider?: unknown;
+  id?: unknown;
+  baseUrl?: unknown;
+}): boolean {
+  const api = normalizeCompatToken(model.api);
+  if (api !== "openai-responses") {
+    return false;
+  }
+  const provider = normalizeCompatToken(model.provider);
+  const baseUrl = normalizeCompatToken(model.baseUrl);
+  const isMantleProvider =
+    provider === "amazon-bedrock-mantle" ||
+    provider === "bedrock-mantle" ||
+    provider.includes("bedrock-mantle") ||
+    baseUrl.includes("bedrock-mantle");
+  if (!isMantleProvider) {
+    return false;
+  }
+  const modelId = normalizeCompatToken(model.id);
+  return /(?:^|[./:_-])gpt-5(?:[./:_-]|$)/.test(modelId);
+}
+
+function normalizeCompatToken(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}


### PR DESCRIPTION
## Summary

- Collapse cumulative OpenAI Responses `message` output snapshots when a later completed message is the same text or a prefix-superset of the previous completed message.
- Scope that collapse to the affected Bedrock Mantle GPT-5.x `openai-responses` model family so native OpenAI/Azure prefix-sharing message items remain separate.
- Apply the mitigation in both Responses stream consumers: the generic provider helper and the agent transport helper, including completed-response backfill.
- Reset the cumulative snapshot chain across function/tool calls so independent post-tool messages are not merged.
- Add downstream subscriber proof that repeated growing OpenAI Responses `text_end` snapshots are delivered as suffixes, not duplicate full block replies.

## Linked context

Closes #91959.

## Real behavior proof

Behavior addressed: Bedrock Mantle models using the `openai-responses` path can emit multiple completed assistant `message` items where each later item repeats the previous answer from the start and extends it. OpenClaw previously kept every completed message text block, so the final visible assistant text could contain repeated prefix copies. After this patch, prefix-superset snapshots replace the prior text block and the final assistant content keeps the latest copy once.

Real environment tested: Local OpenClaw checkout at head `6ad9e84409` on Node `v24.15.0`, Darwin arm64. The proof imports the patched production `processResponsesStream(...)` from `src/llm/providers/openai-responses-shared.ts` and replays a redacted Mantle-shaped Responses stream: `message` snapshot, reasoning boundary, longer `message` snapshot, then `response.completed`. The follow-up subscriber regression also replays growing OpenAI Responses `text_end` snapshots through the text-end block reply delivery layer.

Exact steps or command run after this patch: From the repository root, ran a source-runtime replay with `node --import /Users/andy/openclaw/node_modules/tsx/dist/esm/index.mjs --input-type=module`, importing `createResponsesAssistantOutput` and `processResponsesStream` from `./src/llm/providers/openai-responses-shared.ts`, then yielding the cumulative `response.output_item.done` message sequence described above. Also ran the focused subscriber test command listed under Verification for same-block growing `text_end` snapshots.

Evidence after fix:

```text
textBlockCount=1
openingOccurrences=1
finalText=Transformer attention starts with Q/K/V. Multi-head attention projects the sequence once.
textEndEvents=Transformer attention starts with Q/K/V. | Transformer attention starts with Q/K/V. Multi-head attention projects the sequence once.
```

Subscriber proof after fix:

```text
OpenAI Responses text_end snapshots:
1. "Transformer attention starts with Q/K/V."
2. "Transformer attention starts with Q/K/V. Multi-head attention projects the sequence once."
Delivered block replies:
1. "Transformer attention starts with Q/K/V."
2. " Multi-head attention projects the sequence once."
```

Observed result after fix: The replayed cumulative snapshot sequence leaves one final text block and the opening phrase appears once in the final assistant text. The stream still observes both completed snapshots, and the text-end subscriber path sends only the suffix for a later growing snapshot rather than redispatching the full repeated prefix.

What was not tested: No live Bedrock Mantle / AWS provider round-trip was run from this machine. The proof uses a source-runtime replay of the raw Responses event shape reported in #91959 through the patched production parser plus a downstream subscriber regression for repeated growing `text_end` snapshots. CI remains responsible for broad platform and package-lane coverage.

## Verification

- `env PNPM_CONFIG_MODULES_DIR=/Users/andy/openclaw/node_modules node scripts/run-vitest.mjs src/llm/providers/openai-responses-shared.test.ts` -> 1 file / 17 tests passed
- `env PNPM_CONFIG_MODULES_DIR=/Users/andy/openclaw/node_modules node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts --testNamePattern 'Responses|response|openai transport stream'` -> 2 files / 444 tests passed / 60 skipped
- `env PNPM_CONFIG_MODULES_DIR=/Users/andy/openclaw/node_modules node scripts/run-vitest.mjs src/llm/providers/openai-responses-shared.test.ts --testNamePattern 'Bedrock Mantle|native OpenAI Responses prefix-sharing|keeps separate Responses'` -> 1 file / 3 tests passed / 14 skipped
- `env PNPM_CONFIG_MODULES_DIR=/Users/andy/openclaw/node_modules node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts --testNamePattern 'Bedrock Mantle GPT-5|Azure completed Responses output'` -> 2 files / 4 tests passed / 500 skipped
- `env PNPM_CONFIG_MODULES_DIR=/Users/andy/openclaw/node_modules node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.does-not-append-text-end-content-is.test.ts --testNamePattern 'OpenAI Responses text_end snapshots grow'` -> 2 files / 2 tests passed / 16 skipped
- `/Users/andy/openclaw/node_modules/.bin/oxfmt --check src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.does-not-append-text-end-content-is.test.ts src/shared/openai-responses-stream-compat.ts src/llm/providers/openai-responses-shared.ts src/agents/openai-transport-stream.ts src/llm/providers/openai-responses-shared.test.ts src/agents/openai-transport-stream.test.ts` -> clean
- `env PNPM_CONFIG_MODULES_DIR=/Users/andy/openclaw/node_modules node scripts/run-oxlint.mjs src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.does-not-append-text-end-content-is.test.ts src/shared/openai-responses-stream-compat.ts src/llm/providers/openai-responses-shared.ts src/agents/openai-transport-stream.ts src/llm/providers/openai-responses-shared.test.ts src/agents/openai-transport-stream.test.ts` -> clean
- `env PNPM_CONFIG_MODULES_DIR=/Users/andy/openclaw/node_modules node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo` -> pass
- `git diff --check` -> clean

## Risk

Did user-visible behavior change? (`Yes/No`) Yes. Users of affected Bedrock Mantle GPT-5.x `openai-responses` models that emit cumulative message snapshots should see the final answer once instead of repeated prefix copies.

Did config, environment, or migration behavior change? (`Yes/No`) No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) No.

What is the highest-risk area? Treating two same-response assistant message items with shared prefixes as snapshots when a provider intended two separate visible messages.

How is that risk mitigated? The collapse only happens for the Bedrock Mantle GPT-5.x `openai-responses` model family, inside one Responses stream, when the later completed message text is equal to or starts with the previous completed message text. Function calls reset the chain, non-prefix message items remain separate, and the subscriber regression verifies growing `text_end` snapshots dispatch only the suffix instead of duplicate full replies.



## Update after ClawSweeper review

- Replaced the original global text-prefix collapse with a model-scoped boundary: only `openai-responses` models from `amazon-bedrock-mantle` / Bedrock Mantle endpoints with GPT-5.x model ids can collapse cumulative snapshots.
- Added regression coverage proving native OpenAI streamed prefix-sharing message items and Azure completed-response prefix-sharing items remain separate.
- Re-ran focused and broad touched-file validation after the scoped change: shared Responses tests 17/17 passed; transport Responses/openai pattern 444 passed / 60 skipped; subscriber text-end regression 2 passed / 16 skipped; oxfmt, oxlint, tsgo, and `git diff --check` passed.
- Still not tested here: live Bedrock Mantle/AWS after-fix round trip. The source replay uses the raw event shape documented in #91959; live Mantle proof needs a configured AWS/Mantle environment.

