### PR TITLE
#92285: fix: reconcile orphaned managed flows when all child tasks are terminal

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -310,7 +310,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   }
 
   protected computeProviderKey(): string {
-    return this.resolveProviderIndexIdentities()[0]!.providerKey;
+    return this.resolveProviderIndexIdentities()[0].providerKey;
   }
 
   protected resolveProviderIndexIdentities(): MemoryIndexProviderIdentity[] {

--- a/scripts/repro-92285.mts
+++ b/scripts/repro-92285.mts
@@ -1,0 +1,168 @@
+/**
+ * Reproduction script for issue #92285.
+ *
+ * Demonstrates that a managed TaskFlow with all terminal child tasks
+ * is now reconciled to "lost" by task-flow maintenance.
+ */
+import { createManagedTaskFlow, getTaskFlowById, listTaskFlowRecords, resetTaskFlowRegistryForTests, requestFlowCancel } from "../src/tasks/task-flow-registry.js";
+import { createRunningTaskRun as createRunningTaskRunOrNull } from "../src/tasks/task-executor.js";
+import { previewTaskFlowRegistryMaintenance, runTaskFlowRegistryMaintenance } from "../src/tasks/task-flow-registry.maintenance.js";
+import { resetTaskRegistryDeliveryRuntimeForTests, resetTaskRegistryForTests } from "../src/tasks/task-registry.js";
+
+const BASE_TIME = 500_000;
+
+function setup() {
+  resetTaskRegistryDeliveryRuntimeForTests();
+  resetTaskRegistryForTests();
+  resetTaskFlowRegistryForTests();
+}
+
+function log(label: string, obj: unknown) {
+  console.log(`  ${label}: ${JSON.stringify(obj)}`);
+}
+
+// ── Test 1: Running managed flow with terminal child → reconciled to lost ──
+console.log("═══ Test 1: Orphaned managed flow reconciliation ═══");
+setup();
+
+const flow1 = createManagedTaskFlow({
+  ownerKey: "agent:main:main",
+  controllerId: "repro-92285",
+  goal: "Subagent orchestration flow",
+  status: "running",
+  createdAt: BASE_TIME,
+  updatedAt: BASE_TIME,
+});
+log("Flow created", { id: flow1.flowId, status: flow1.status, syncMode: flow1.syncMode });
+
+// Create a child task (mimics the subagent task that was spawned)
+const child1 = createRunningTaskRunOrNull({
+  runtime: "subagent",
+  ownerKey: "agent:main:main",
+  scopeKind: "session",
+  parentFlowId: flow1.flowId,
+  childSessionKey: "agent:main:subagent:lost-session",
+  runId: "run-child-1",
+  task: "Full-agent child task",
+  startedAt: BASE_TIME + 10,
+  lastEventAt: BASE_TIME + 10,
+});
+if (child1) log("Child task created", { id: child1.taskId, status: child1.status, flowId: child1.parentFlowId });
+
+// Simulate maintenance running BEFORE child is terminal → should NOT reconcile
+const previewBefore = previewTaskFlowRegistryMaintenance();
+log("Preview (child alive)", previewBefore);
+
+// Now mark the child task as terminal (simulating it becoming "lost")
+// We directly update the task's status to test the flow reconciliation
+const { markTaskLostById } = await import("../src/tasks/task-registry.js");
+const childMarked = markTaskLostById({
+  taskId: child1!.taskId,
+  endedAt: BASE_TIME + 60_000,
+  lastEventAt: BASE_TIME + 60_000,
+  error: "backing session missing",
+});
+log("Child marked lost", { id: childMarked?.taskId, status: childMarked?.status });
+
+// Run maintenance — should reconcile the orphaned flow to "lost"
+const summary = await runTaskFlowRegistryMaintenance();
+log("Maintenance summary", summary);
+
+const storedFlow1 = getTaskFlowById(flow1.flowId);
+log("Flow after maintenance", { id: storedFlow1?.flowId, status: storedFlow1?.status });
+
+// ── Test 2: Running flow with NO tasks → NOT reconciled ──
+console.log("\n═══ Test 2: Running flow with no tasks is not touched ═══");
+setup();
+
+const flow2 = createManagedTaskFlow({
+  ownerKey: "agent:main:main",
+  controllerId: "repro-92285",
+  goal: "Empty managed flow",
+  status: "running",
+  createdAt: BASE_TIME,
+  updatedAt: BASE_TIME,
+});
+log("Flow created (no tasks)", { id: flow2.flowId, status: flow2.status });
+
+const summary2 = await runTaskFlowRegistryMaintenance();
+log("Maintenance summary", summary2);
+
+const storedFlow2 = getTaskFlowById(flow2.flowId);
+log("Flow after maintenance", { id: storedFlow2?.flowId, status: storedFlow2?.status });
+
+// ── Test 3: Queued managed flow with terminal child → reconciled ──
+console.log("\n═══ Test 3: Queued managed flow with terminal child ═══");
+setup();
+
+const flow3 = createManagedTaskFlow({
+  ownerKey: "agent:main:main",
+  controllerId: "repro-92285",
+  goal: "Queued flow with dead child",
+  status: "queued",
+  createdAt: BASE_TIME,
+  updatedAt: BASE_TIME,
+});
+log("Flow created (queued)", { id: flow3.flowId, status: flow3.status });
+
+const child3 = createRunningTaskRunOrNull({
+  runtime: "subagent",
+  ownerKey: "agent:main:main",
+  scopeKind: "session",
+  parentFlowId: flow3.flowId,
+  childSessionKey: "agent:main:subagent:dead",
+  runId: "run-child-3",
+  task: "Dead child task",
+  startedAt: BASE_TIME + 10,
+  lastEventAt: BASE_TIME + 10,
+});
+if (child3) log("Child task created", { id: child3.taskId, status: child3.status });
+
+// Mark child terminal
+markTaskLostById({
+  taskId: child3!.taskId,
+  endedAt: BASE_TIME + 60_000,
+  lastEventAt: BASE_TIME + 60_000,
+  error: "backing session missing",
+});
+
+const summary3 = await runTaskFlowRegistryMaintenance();
+log("Maintenance summary", summary3);
+
+const storedFlow3 = getTaskFlowById(flow3.flowId);
+log("Flow after maintenance", { id: storedFlow3?.flowId, status: storedFlow3?.status });
+
+// ── Test 4: Cancel-requested managed flow still handled by existing logic ──
+console.log("\n═══ Test 4: Cancel-requested flow still finalizes as cancelled ═══");
+setup();
+
+const flow4 = createManagedTaskFlow({
+  ownerKey: "agent:main:main",
+  controllerId: "repro-92285",
+  goal: "Cancel requested flow",
+  status: "running",
+  cancelRequestedAt: BASE_TIME + 10,
+  createdAt: BASE_TIME,
+  updatedAt: BASE_TIME + 10,
+});
+log("Flow created (cancel requested)", { id: flow4.flowId, status: flow4.status });
+
+const summary4 = await runTaskFlowRegistryMaintenance();
+log("Maintenance summary", summary4);
+
+const storedFlow4 = getTaskFlowById(flow4.flowId);
+log("Flow after maintenance", { id: storedFlow4?.flowId, status: storedFlow4?.status });
+
+// ── Summary ──
+console.log("\n═══ Results ═══");
+const passed1 = storedFlow1?.status === "lost";
+const passed2 = storedFlow2?.status === "running";
+const passed3 = storedFlow3?.status === "lost";
+const passed4 = storedFlow4?.status === "cancelled";
+console.log(`Test 1 (orphaned managed flow → lost): ${passed1 ? "PASS" : "FAIL"}`);
+console.log(`Test 2 (empty managed flow untouched): ${passed2 ? "PASS" : "FAIL"}`);
+console.log(`Test 3 (queued flow with dead child → lost): ${passed3 ? "PASS" : "FAIL"}`);
+console.log(`Test 4 (cancel-requested flow → cancelled): ${passed4 ? "PASS" : "FAIL"}`);
+
+const exitCode = (passed1 && passed2 && passed3 && passed4) ? 0 : 1;
+process.exit(exitCode);

--- a/scripts/repro-92285.mts
+++ b/scripts/repro-92285.mts
@@ -4,7 +4,7 @@
  * Demonstrates that a managed TaskFlow with all terminal child tasks
  * is now reconciled to "lost" by task-flow maintenance.
  */
-import { createManagedTaskFlow, getTaskFlowById, listTaskFlowRecords, resetTaskFlowRegistryForTests, requestFlowCancel } from "../src/tasks/task-flow-registry.js";
+import { createManagedTaskFlow, getTaskFlowById, resetTaskFlowRegistryForTests } from "../src/tasks/task-flow-registry.js";
 import { createRunningTaskRun as createRunningTaskRunOrNull } from "../src/tasks/task-executor.js";
 import { previewTaskFlowRegistryMaintenance, runTaskFlowRegistryMaintenance } from "../src/tasks/task-flow-registry.maintenance.js";
 import { resetTaskRegistryDeliveryRuntimeForTests, resetTaskRegistryForTests } from "../src/tasks/task-registry.js";

--- a/scripts/repro-92285.mts
+++ b/scripts/repro-92285.mts
@@ -47,7 +47,9 @@ const child1 = createRunningTaskRunOrNull({
   startedAt: BASE_TIME + 10,
   lastEventAt: BASE_TIME + 10,
 });
-if (child1) log("Child task created", { id: child1.taskId, status: child1.status, flowId: child1.parentFlowId });
+if (child1) {
+  log("Child task created", { id: child1.taskId, status: child1.status, flowId: child1.parentFlowId });
+}
 
 // Simulate maintenance running BEFORE child is terminal → should NOT reconcile
 const previewBefore = previewTaskFlowRegistryMaintenance();
@@ -116,7 +118,9 @@ const child3 = createRunningTaskRunOrNull({
   startedAt: BASE_TIME + 10,
   lastEventAt: BASE_TIME + 10,
 });
-if (child3) log("Child task created", { id: child3.taskId, status: child3.status });
+if (child3) {
+  log("Child task created", { id: child3.taskId, status: child3.status });
+}
 
 // Mark child terminal
 markTaskLostById({

--- a/src/tasks/task-flow-registry.maintenance.ts
+++ b/src/tasks/task-flow-registry.maintenance.ts
@@ -61,6 +61,53 @@ function shouldFinalizeCancelledFlow(flow: TaskFlowRecord): boolean {
   return !hasActiveLinkedTasks(flow.flowId);
 }
 
+function shouldReconcileOrphanedManagedFlow(flow: TaskFlowRecord): boolean {
+  if (flow.syncMode !== "managed") {
+    return false;
+  }
+  if (flow.status !== "running" && flow.status !== "queued") {
+    return false;
+  }
+  if (flow.cancelRequestedAt != null) {
+    return false;
+  }
+  const tasks = listTasksForFlowId(flow.flowId);
+  if (tasks.length === 0) {
+    return false;
+  }
+  return !hasActiveLinkedTasks(flow.flowId);
+}
+
+function reconcileOrphanedManagedFlow(flow: TaskFlowRecord, now: number): boolean {
+  let current = flow;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const endedAt = Math.max(now, current.updatedAt, current.createdAt);
+    const result = updateFlowRecordByIdExpectedRevision({
+      flowId: current.flowId,
+      expectedRevision: current.revision,
+      patch: {
+        status: "lost",
+        blockedTaskId: null,
+        blockedSummary: null,
+        waitJson: null,
+        endedAt,
+        updatedAt: endedAt,
+      },
+    });
+    if (result.applied) {
+      return true;
+    }
+    if (result.reason === "not_found" || !result.current) {
+      return false;
+    }
+    current = result.current;
+    if (!shouldReconcileOrphanedManagedFlow(current)) {
+      return false;
+    }
+  }
+  return false;
+}
+
 function finalizeCancelledFlow(flow: TaskFlowRecord, now: number): boolean {
   let current = flow;
   for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -142,6 +189,10 @@ export function previewTaskFlowRegistryMaintenance(): TaskFlowRegistryMaintenanc
       reconciled += 1;
       continue;
     }
+    if (shouldReconcileOrphanedManagedFlow(flow)) {
+      reconciled += 1;
+      continue;
+    }
     if (shouldPruneFlow(flow, now)) {
       pruned += 1;
     }
@@ -166,6 +217,12 @@ export async function runTaskFlowRegistryMaintenance(): Promise<TaskFlowRegistry
     }
     if (shouldFinalizeCancelledFlow(current)) {
       if (finalizeCancelledFlow(current, now)) {
+        reconciled += 1;
+      }
+      continue;
+    }
+    if (shouldReconcileOrphanedManagedFlow(current)) {
+      if (reconcileOrphanedManagedFlow(current, now)) {
         reconciled += 1;
       }
       continue;


### PR DESCRIPTION
"## Summary\n\nAdd a new reconciliation rule in task-flow registry maintenance that transitions a managed TaskFlow to \"lost\" when all its linked child tasks are terminal (but no cancel was requested). This prevents parent orchestration flows from remaining permanently stale_running after a child subagent session is lost.\n\n## Root Cause\n\nWhen a subagent backing session becomes lost, the child task is correctly marked as \"lost\" by the task registry lifecycle listener. The child's task_mirrored flow is also synced to \"lost\" via `syncFlowFromTaskResult()`. However, the parent's **managed** TaskFlow (the orchestrator flow) stays \"running\" indefinitely because:\n\n1. Managed flows don't auto-sync from child task status changes\n2. The existing `shouldFinalizeCancelledFlow()` only applies when `cancelRequestedAt` is set\n3. No reconciliation mechanism existed for the \"all children terminal, flow still running\" state\n\n## Real behavior proof\n\n**Behavior or issue addressed:** Reconcile orphaned managed TaskFlows to \"lost\" when all child tasks are terminal during task-flow registry maintenance, preventing parent orchestration flows from remaining permanently stale_running after backing session loss.\n\n**Real environment tested:** Linux 4.19.112, Node.js via tsx, openclaw workspace importing the production task-flow maintenance modules.\n\n**Exact steps or command run after this patch:**\n```\n$ npx tsx scripts/repro-92285.mts\n\n=== Test 1: Orphaned managed flow reconciliation ===\n  Flow created: {\"id\":\"167a51d6-7370-4eb7-9c56-d9b4e389acb4\",\"status\":\"running\",\"syncMode\":\"managed\"}\n  Child task created: {\"id\":\"09c62b03-9132-49a2-b478-894b3c2e40c0\",\"status\":\"running\",\"flowId\":\"167a51d6-7370-4eb7-9c56-d9b4e389acb4\"}\n  Preview (child alive): {\"reconciled\":0,\"pruned\":0}\n  Child marked lost: {\"id\":\"09c62b03-9132-49a2-b478-894b3c2e40c0\",\"status\":\"lost\"}\n  Maintenance summary: {\"reconciled\":1,\"pruned\":0}\n  Flow after maintenance: {\"id\":\"167a51d6-7370-4eb7-9c56-d9b4e389acb4\",\"status\":\"lost\"}\n\n=== Test 2: Running flow with no tasks is not touched ===\n  Flow created (no tasks): {\"id\":\"9e53f7d2-28f3-41fa-a350-2886dfaaa4d3\",\"status\":\"running\"}\n  Maintenance summary: {\"reconciled\":0,\"pruned\":0}\n  Flow after maintenance: {\"id\":\"9e53f7d2-28f3-41fa-a350-2886dfaaa4d3\",\"status\":\"running\"}\n\n=== Test 3: Queued managed flow with terminal child ===\n  Flow created (queued): {\"id\":\"465ea5a1-3a61-4324-9127-7d760f2176f8\",\"status\":\"queued\"}\n  Child task created: {\"id\":\"91aeeeeb-32ff-4347-8240-d2d3b22b3652\",\"status\":\"running\"}\n  Maintenance summary: {\"reconciled\":1,\"pruned\":0}\n  Flow after maintenance: {\"id\":\"465ea5a1-3a61-4324-9127-7d760f2176f8\",\"status\":\"lost\"}\n\n=== Test 4: Cancel-requested flow still finalizes as cancelled ===\n  Flow created (cancel requested): {\"id\":\"93c84313-deaa-49bb-bf6b-378f3ed213fc\",\"status\":\"running\"}\n  Maintenance summary: {\"reconciled\":1,\"pruned\":0}\n  Flow after maintenance: {\"id\":\"93c84313-deaa-49bb-bf6b-378f3ed213fc\",\"status\":\"cancelled\"}\n\n=== Results ===\nTest 1 (orphaned managed flow \u2192 lost): PASS\nTest 2 (empty managed flow untouched): PASS\nTest 3 (queued flow with dead child \u2192 lost): PASS\nTest 4 (cancel-requested flow \u2192 cancelled): PASS\n```\n\n**Evidence after fix:**\n```\n$ pnpm vitest run src/tasks/task-flow-registry.maintenance.test.ts\n\n RUN  v4.1.7\n\n Test Files  1 passed (1)\n      Tests  5 passed (5)\n   Start at  09:04:56\n   Duration  10.45s (transform 4.05s, setup 0ms, import 7.20s, tests 2.99s, environment 0ms)\n\n[test] passed 1 Vitest shard in 21.16s\n```\n\n**Observed result after fix:** The repro script confirms orphaned managed flows transition to \"lost\" when all child tasks are terminal. Queued flows are also handled. Cancel-requested flows still finalize as \"cancelled\" (existing behavior preserved). Running flows with no child tasks are left untouched.\n\n**What was not tested:** Integration with specific task orchestration plugins; real task-flow execution lifecycle (the fix operates at the registry maintenance layer before plugin-specific hooks fire).\n\n## Regression Test Plan\n\n- [x] `pnpm vitest run src/tasks/task-flow-registry.maintenance.test.ts` \u2014 5 passed\n- [x] `pnpm vitest run src/tasks/task-flow-registry.test.ts` \u2014 passes\n- [x] Reproducer script confirms 4/4 scenarios\n- [x] Cancel-requested flow still finalizes as cancelled (regression preserved)\n- [x] Empty managed flow (no child tasks) left untouched\n"