### PR TITLE
fix(recovery): reset command lane when abort leaves pre-existing task blocked

### DIFF
--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -259,6 +259,40 @@ describe("stuck session recovery", () => {
     expect(mocks.resetCommandLane).not.toHaveBeenCalled();
   });
 
+  it("releases the session lane when abort+drain succeeds but the lane task is still executing", async () => {
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-1");
+    mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+    mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.resetCommandLane.mockReturnValue(1);
+    mocks.getCommandLaneActiveTaskIds.mockReturnValue([101]).mockReturnValue([101]);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:main:main",
+      queuedCount: 0,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      ageMs: 720_000,
+      queueDepth: 0,
+      allowActiveAbort: true,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      action: "abort_embedded_run",
+      aborted: true,
+      drained: true,
+      forceCleared: false,
+      released: 1,
+    });
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:main:main");
+  });
+
   it("keeps the lane when a fresh turn started during the abort even with lane-queued work", async () => {
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-fresh-queued");
     mocks.abortEmbeddedAgentRun.mockReturnValue(true);

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -252,7 +252,8 @@ export async function recoverStuckDiagnosticSession(
       }
     }
 
-    const queuedCount = sessionLane ? getCommandLaneSnapshot(sessionLane).queuedCount : 0;
+    const postAbortLaneSnapshot = sessionLane ? getCommandLaneSnapshot(sessionLane) : undefined;
+    const queuedCount = postAbortLaneSnapshot?.queuedCount ?? 0;
     // A task id active now but not before the abort means the lane already
     // unwedged and pumped fresh work; resetting it would double-run the lane.
     const laneStartedFreshTask =
@@ -261,10 +262,23 @@ export async function recoverStuckDiagnosticSession(
     // Queued turns ride the session queue (params.queueDepth), not only the lane
     // queue; without this signal a cleanly aborted wedged lane never resets.
     const hasQueuedSessionWork = (params.queueDepth ?? 0) > 0;
+    // A run may have been aborted+drained from the embedded-run registry while its
+    // underlying command-lane task is still executing (e.g. waitForCompactionRetry
+    // or in-flight tool execution). If the lane is still blocked by pre-existing
+    // active tasks we must reset it so queued work can drain.
+    const laneStillBlockedByPreExistingTask =
+      !laneStartedFreshTask &&
+      postAbortLaneSnapshot !== undefined &&
+      postAbortLaneSnapshot.activeCount > 0;
     const released =
       sessionLane &&
       !laneStartedFreshTask &&
-      (queuedCount > 0 || hasQueuedSessionWork || !activeSessionId || !aborted || !drained)
+      (queuedCount > 0 ||
+        hasQueuedSessionWork ||
+        !activeSessionId ||
+        !aborted ||
+        !drained ||
+        laneStillBlockedByPreExistingTask)
         ? resetCommandLane(sessionLane)
         : 0;
 


### PR DESCRIPTION
fix #92270
# PR Comment for Issue #92270

> **Branch**: `fix/92270-stuck-session-recovery-lane-release`
> **Files Changed**:
> - `src/logging/diagnostic-stuck-session-recovery.runtime.ts`
> - `src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`

---

## 1. Solution Overview

This fix addresses Issue #92270 where stuck-session recovery reports `status=aborted` with `released=0` while the wedge persists for hours.

### Root Cause

`recoverStuckDiagnosticSession` decided whether to call `resetCommandLane` solely based on `queuedCount` and `queueDepth` after a successful `abort+drain`, ignoring the possibility that the command lane still has an underlying active task (e.g., a run stuck in `waitForCompactionRetry` or in-flight tool execution). This left `activeCount > 0` unhandled, blocking queued work forever.

### Fix Strategy

After the abort completes, additionally check `postAbortLaneSnapshot.activeCount`. If the lane has not started a new fresh task but `activeCount > 0`, force `resetCommandLane` to unblock the lane so queued work can drain.

---

## 2. Changes Detail

| File | Change Description |
|------|--------------------|
| `src/logging/diagnostic-stuck-session-recovery.runtime.ts` | 1. Read `postAbortLaneSnapshot` after abort (previously only `queuedCount` was read).<br>2. Introduce `laneStillBlockedByPreExistingTask`: when `!laneStartedFreshTask && postAbortLaneSnapshot.activeCount > 0`, include `resetCommandLane` in the release logic.<br>3. Ensure mutual exclusion with existing `laneStartedFreshTask` to avoid killing healthy fresh tasks. |
| `src/logging/diagnostic-stuck-session-recovery.runtime.test.ts` | Add new test case: mock a scenario where `abort+drain` succeeds with `queueDepth=0` but lane `activeCount=1`. Verify `resetCommandLane` is called and outcome has `released=1`. |

---

## 3. Test Coverage

### New Test

**`"releases the session lane when abort+drain succeeds but the lane task is still executing"`**
- **Input**: `allowActiveAbort=true`, `abortEmbeddedAgentRun` returns true, `waitForEmbeddedAgentRunEnd` returns true (simulating successful abort+drain).
- **Lane state**: `getCommandLaneActiveTaskIds` always returns `[101]` (no fresh task); `getCommandLaneSnapshot` returns `activeCount=1, queuedCount=0`.
- **Assertions**: `resetCommandLane` is called once; outcome is `{ status: "aborted", released: 1 }`.

### Regression Tests

All 22 existing tests pass, ensuring no breakage for:
- `laneStartedFreshTask === true` (lane already pumped fresh work during abort) — lane is preserved.
- `queuedCount > 0` or `hasQueuedSessionWork` — lane reset works as before.
- `forceClear` and `noop` paths remain unchanged.

### Verification Command

```bash
node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
# Result: 23 passed (22 existing + 1 new)
```

---

## 4. Next Steps

1. **Code Review**: Please focus on the mutual exclusion between `laneStillBlockedByPreExistingTask` and `laneStartedFreshTask` to ensure we never reset a healthy fresh task.
2. **Root-cause follow-up (optional)**: This fix addresses the recovery-layer symptom. Long-term, the underlying reason why `waitForCompactionRetry` and similar paths do not respect abort signals should still be investigated (see related Issues #12085, #13341, #14228, #16331) so that `drained=true` after abort truly means the task ended.
3. **Stale target binding**: If `sessionId=unknown` combined with aborting the wrong session still occurs, consider adding explicit mismatch detection and lane-level escalation in the `activeSessionId` resolution logic inside `recoverStuckDiagnosticSession`.

---

*Comment generated for PR targeting Issue #92270.*
