### PR TITLE
feat(telegram): add rich message API helpers

### DIFF
--- a/extensions/telegram/api.test.ts
+++ b/extensions/telegram/api.test.ts
@@ -1,6 +1,6 @@
 // Telegram tests cover api plugin behavior.
 import { describe, expect, it } from "vitest";
-import { escapeTelegramHtml, markdownToTelegramHtml } from "./api.js";
+import { escapeTelegramHtml, markdownToTelegramHtml, normalizeInputRichMessage } from "./api.js";
 
 describe("@openclaw/telegram api re-exports", () => {
   it("re-exports markdownToTelegramHtml as a working function", () => {
@@ -13,5 +13,12 @@ describe("@openclaw/telegram api re-exports", () => {
   it("re-exports escapeTelegramHtml that escapes Telegram-reserved characters", () => {
     expect(typeof escapeTelegramHtml).toBe("function");
     expect(escapeTelegramHtml("<b>x & y</b>")).toBe("&lt;b&gt;x &amp; y&lt;/b&gt;");
+  });
+
+  it("re-exports rich message helpers", () => {
+    expect(normalizeInputRichMessage({ markdown: "**ok**", skip_entity_detection: true })).toEqual({
+      markdown: "**ok**",
+      skip_entity_detection: true,
+    });
   });
 });

--- a/extensions/telegram/api.ts
+++ b/extensions/telegram/api.ts
@@ -140,6 +140,12 @@ export {
   parseTelegramThreadId,
 } from "./src/outbound-params.js";
 export {
+  type InputRichMessage,
+  normalizeInputRichMessage,
+  sendTelegramRichMessage,
+  sendTelegramRichMessageDraft,
+} from "./src/rich-message.js";
+export {
   probeTelegram,
   resetTelegramProbeFetcherCacheForTests,
   type TelegramProbe,

--- a/extensions/telegram/src/rich-message.test.ts
+++ b/extensions/telegram/src/rich-message.test.ts
@@ -1,0 +1,97 @@
+// Telegram tests cover Bot API 10.1 rich message helper payloads.
+import { describe, expect, it, vi } from "vitest";
+import { sendTelegramRichMessage, sendTelegramRichMessageDraft } from "./rich-message.js";
+
+describe("Telegram rich message helpers", () => {
+  it("sends rich HTML messages through the raw Bot API method", async () => {
+    const sendRichMessage = vi.fn().mockResolvedValue({ message_id: 11 });
+    const methodParams = {
+      message_thread_id: 42,
+      reply_parameters: { message_id: 7 },
+    };
+
+    await expect(
+      sendTelegramRichMessage({
+        api: { sendRichMessage } as never,
+        chatId: 123,
+        richMessage: {
+          html: "<b>Hello</b>",
+          is_rtl: true,
+          skip_entity_detection: false,
+        },
+        methodParams,
+      }),
+    ).resolves.toEqual({ message_id: 11 });
+
+    expect(sendRichMessage).toHaveBeenCalledWith(
+      123,
+      {
+        html: "<b>Hello</b>",
+        is_rtl: true,
+        skip_entity_detection: false,
+      },
+      methodParams,
+    );
+  });
+
+  it("sends rich markdown drafts with caller-provided thread params", async () => {
+    const sendRichMessageDraft = vi.fn().mockResolvedValue(true);
+    const methodParams = { message_thread_id: 99 };
+
+    await expect(
+      sendTelegramRichMessageDraft({
+        api: { sendRichMessageDraft } as never,
+        chatId: "123",
+        draftId: 17,
+        richMessage: {
+          markdown: "**Hello**",
+          skip_entity_detection: true,
+        },
+        methodParams,
+      }),
+    ).resolves.toBe(true);
+
+    expect(sendRichMessageDraft).toHaveBeenCalledWith(
+      "123",
+      17,
+      {
+        markdown: "**Hello**",
+        skip_entity_detection: true,
+      },
+      methodParams,
+    );
+  });
+
+  it.each([{ html: "" }, { html: "   " }, { markdown: "" }, { markdown: "\n\t" }])(
+    "rejects empty rich message content %#",
+    async (richMessage) => {
+      const sendRichMessage = vi.fn().mockResolvedValue({});
+
+      await expect(
+        sendTelegramRichMessage({
+          api: { sendRichMessage } as never,
+          chatId: 123,
+          richMessage: richMessage as never,
+        }),
+      ).rejects.toThrow(/must not be empty/);
+      expect(sendRichMessage).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects rich messages that provide both html and markdown", async () => {
+    const sendRichMessageDraft = vi.fn().mockResolvedValue(true);
+
+    await expect(
+      sendTelegramRichMessageDraft({
+        api: { sendRichMessageDraft } as never,
+        chatId: 123,
+        draftId: 17,
+        richMessage: {
+          html: "<b>Hello</b>",
+          markdown: "**Hello**",
+        } as never,
+      }),
+    ).rejects.toThrow("exactly one");
+    expect(sendRichMessageDraft).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/telegram/src/rich-message.test.ts
+++ b/extensions/telegram/src/rich-message.test.ts
@@ -12,7 +12,7 @@ describe("Telegram rich message helpers", () => {
 
     await expect(
       sendTelegramRichMessage({
-        api: { sendRichMessage } as never,
+        api: { raw: { sendRichMessage } } as never,
         chatId: 123,
         richMessage: {
           html: "<b>Hello</b>",
@@ -23,15 +23,15 @@ describe("Telegram rich message helpers", () => {
       }),
     ).resolves.toEqual({ message_id: 11 });
 
-    expect(sendRichMessage).toHaveBeenCalledWith(
-      123,
-      {
+    expect(sendRichMessage).toHaveBeenCalledWith({
+      chat_id: 123,
+      rich_message: {
         html: "<b>Hello</b>",
         is_rtl: true,
         skip_entity_detection: false,
       },
-      methodParams,
-    );
+      ...methodParams,
+    });
   });
 
   it("sends rich markdown drafts with caller-provided thread params", async () => {
@@ -40,7 +40,7 @@ describe("Telegram rich message helpers", () => {
 
     await expect(
       sendTelegramRichMessageDraft({
-        api: { sendRichMessageDraft } as never,
+        api: { raw: { sendRichMessageDraft } } as never,
         chatId: "123",
         draftId: 17,
         richMessage: {
@@ -51,15 +51,34 @@ describe("Telegram rich message helpers", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(sendRichMessageDraft).toHaveBeenCalledWith(
-      "123",
-      17,
-      {
+    expect(sendRichMessageDraft).toHaveBeenCalledWith({
+      chat_id: "123",
+      draft_id: 17,
+      rich_message: {
         markdown: "**Hello**",
         skip_entity_detection: true,
       },
-      methodParams,
-    );
+      ...methodParams,
+    });
+  });
+
+  it("keeps required rich message payload fields owned by the helper", async () => {
+    const sendRichMessage = vi.fn().mockResolvedValue({ message_id: 11 });
+
+    await sendTelegramRichMessage({
+      api: { raw: { sendRichMessage } } as never,
+      chatId: 123,
+      richMessage: { html: "<b>Hello</b>" },
+      methodParams: {
+        chat_id: 999,
+        rich_message: { markdown: "**override**" },
+      },
+    });
+
+    expect(sendRichMessage).toHaveBeenCalledWith({
+      chat_id: 123,
+      rich_message: { html: "<b>Hello</b>" },
+    });
   });
 
   it.each([{ html: "" }, { html: "   " }, { markdown: "" }, { markdown: "\n\t" }])(
@@ -69,7 +88,7 @@ describe("Telegram rich message helpers", () => {
 
       await expect(
         sendTelegramRichMessage({
-          api: { sendRichMessage } as never,
+          api: { raw: { sendRichMessage } } as never,
           chatId: 123,
           richMessage: richMessage as never,
         }),
@@ -83,7 +102,7 @@ describe("Telegram rich message helpers", () => {
 
     await expect(
       sendTelegramRichMessageDraft({
-        api: { sendRichMessageDraft } as never,
+        api: { raw: { sendRichMessageDraft } } as never,
         chatId: 123,
         draftId: 17,
         richMessage: {

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -1,0 +1,101 @@
+// Telegram rich message helpers cover Bot API methods newer than current grammY types.
+import type { Bot } from "grammy";
+
+type TelegramChatId = Parameters<Bot["api"]["sendMessage"]>[0];
+type TelegramApi = Bot["api"];
+type TelegramRichMessageParams = Record<string, unknown>;
+
+type InputRichMessageOptions = {
+  is_rtl?: boolean;
+  skip_entity_detection?: boolean;
+};
+
+export type InputRichMessage =
+  | (InputRichMessageOptions & {
+      html: string;
+      markdown?: never;
+    })
+  | (InputRichMessageOptions & {
+      html?: never;
+      markdown: string;
+    });
+
+type TelegramRichMessageApi = TelegramApi & {
+  sendRichMessage?: (
+    chatId: TelegramChatId,
+    richMessage: InputRichMessage,
+    params?: TelegramRichMessageParams,
+  ) => Promise<unknown>;
+  sendRichMessageDraft?: (
+    chatId: TelegramChatId,
+    draftId: number,
+    richMessage: InputRichMessage,
+    params?: TelegramRichMessageParams,
+  ) => Promise<unknown>;
+};
+
+export function normalizeInputRichMessage(richMessage: InputRichMessage): InputRichMessage {
+  const html = "html" in richMessage ? richMessage.html : undefined;
+  const markdown = "markdown" in richMessage ? richMessage.markdown : undefined;
+  const hasHtml = html !== undefined;
+  const hasMarkdown = markdown !== undefined;
+
+  if (hasHtml === hasMarkdown) {
+    throw new Error("Telegram rich message must specify exactly one of html or markdown.");
+  }
+
+  const kind = hasHtml ? "html" : "markdown";
+  const content = hasHtml ? html : markdown;
+  if (typeof content !== "string" || content.trim().length === 0) {
+    throw new Error(`Telegram rich message ${kind} must not be empty.`);
+  }
+
+  const flags = {
+    ...(richMessage.is_rtl !== undefined ? { is_rtl: richMessage.is_rtl } : {}),
+    ...(richMessage.skip_entity_detection !== undefined
+      ? { skip_entity_detection: richMessage.skip_entity_detection }
+      : {}),
+  };
+
+  return hasHtml ? { html: content, ...flags } : { markdown: content, ...flags };
+}
+
+export async function sendTelegramRichMessage(params: {
+  api: TelegramApi;
+  chatId: TelegramChatId;
+  richMessage: InputRichMessage;
+  methodParams?: TelegramRichMessageParams;
+}): Promise<unknown> {
+  const sendRichMessage = (params.api as TelegramRichMessageApi).sendRichMessage;
+  if (typeof sendRichMessage !== "function") {
+    throw new Error("Telegram Bot API client does not expose sendRichMessage.");
+  }
+
+  return await sendRichMessage.call(
+    params.api,
+    params.chatId,
+    normalizeInputRichMessage(params.richMessage),
+    params.methodParams,
+  );
+}
+
+export async function sendTelegramRichMessageDraft(params: {
+  api: TelegramApi;
+  chatId: TelegramChatId;
+  draftId: number;
+  richMessage: InputRichMessage;
+  methodParams?: TelegramRichMessageParams;
+}): Promise<unknown> {
+  const sendRichMessageDraft = (params.api as TelegramRichMessageApi).sendRichMessageDraft;
+  if (typeof sendRichMessageDraft !== "function") {
+    throw new Error("Telegram Bot API client does not expose sendRichMessageDraft.");
+  }
+
+  return await sendRichMessageDraft.call(
+    params.api,
+    params.chatId,
+    params.draftId,
+    normalizeInputRichMessage(params.richMessage),
+    params.methodParams,
+  );
+}

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -4,6 +4,15 @@ import type { Bot } from "grammy";
 type TelegramChatId = Parameters<Bot["api"]["sendMessage"]>[0];
 type TelegramApi = Bot["api"];
 type TelegramRichMessageParams = Record<string, unknown>;
+type TelegramSendRichMessagePayload = TelegramRichMessageParams & {
+  chat_id: TelegramChatId;
+  rich_message: InputRichMessage;
+};
+type TelegramSendRichMessageDraftPayload = TelegramRichMessageParams & {
+  chat_id: TelegramChatId;
+  draft_id: number;
+  rich_message: InputRichMessage;
+};
 
 type InputRichMessageOptions = {
   is_rtl?: boolean;
@@ -20,18 +29,9 @@ export type InputRichMessage =
       markdown: string;
     });
 
-type TelegramRichMessageApi = TelegramApi & {
-  sendRichMessage?: (
-    chatId: TelegramChatId,
-    richMessage: InputRichMessage,
-    params?: TelegramRichMessageParams,
-  ) => Promise<unknown>;
-  sendRichMessageDraft?: (
-    chatId: TelegramChatId,
-    draftId: number,
-    richMessage: InputRichMessage,
-    params?: TelegramRichMessageParams,
-  ) => Promise<unknown>;
+type TelegramRichMessageRawApi = {
+  sendRichMessage?: (payload: TelegramSendRichMessagePayload) => Promise<unknown>;
+  sendRichMessageDraft?: (payload: TelegramSendRichMessageDraftPayload) => Promise<unknown>;
 };
 
 export function normalizeInputRichMessage(richMessage: InputRichMessage): InputRichMessage {
@@ -66,17 +66,16 @@ export async function sendTelegramRichMessage(params: {
   richMessage: InputRichMessage;
   methodParams?: TelegramRichMessageParams;
 }): Promise<unknown> {
-  const sendRichMessage = (params.api as TelegramRichMessageApi).sendRichMessage;
+  const sendRichMessage = (params.api.raw as TelegramRichMessageRawApi).sendRichMessage;
   if (typeof sendRichMessage !== "function") {
     throw new Error("Telegram Bot API client does not expose sendRichMessage.");
   }
 
-  return await sendRichMessage.call(
-    params.api,
-    params.chatId,
-    normalizeInputRichMessage(params.richMessage),
-    params.methodParams,
-  );
+  return await sendRichMessage.call(params.api.raw, {
+    ...params.methodParams,
+    chat_id: params.chatId,
+    rich_message: normalizeInputRichMessage(params.richMessage),
+  });
 }
 
 export async function sendTelegramRichMessageDraft(params: {
@@ -86,16 +85,15 @@ export async function sendTelegramRichMessageDraft(params: {
   richMessage: InputRichMessage;
   methodParams?: TelegramRichMessageParams;
 }): Promise<unknown> {
-  const sendRichMessageDraft = (params.api as TelegramRichMessageApi).sendRichMessageDraft;
+  const sendRichMessageDraft = (params.api.raw as TelegramRichMessageRawApi).sendRichMessageDraft;
   if (typeof sendRichMessageDraft !== "function") {
     throw new Error("Telegram Bot API client does not expose sendRichMessageDraft.");
   }
 
-  return await sendRichMessageDraft.call(
-    params.api,
-    params.chatId,
-    params.draftId,
-    normalizeInputRichMessage(params.richMessage),
-    params.methodParams,
-  );
+  return await sendRichMessageDraft.call(params.api.raw, {
+    ...params.methodParams,
+    chat_id: params.chatId,
+    draft_id: params.draftId,
+    rich_message: normalizeInputRichMessage(params.richMessage),
+  });
 }


### PR DESCRIPTION
## Summary
- Add Telegram rich message helper primitives for portable actions and rich text rendering.
- Keep this as the first PR in the Telegram rich-message stack; later stack PRs build on this helper layer.

## Verification
- `node scripts/run-vitest.mjs extensions/telegram/src/rich-message.test.ts extensions/telegram/src/config-schema.test.ts extensions/telegram/src/bot/helpers.test.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/lane-delivery.test.ts`
  - 6 files, 275 tests passed.
- `node --import tsx scripts/generate-bundled-channel-config-metadata.ts --check`
- `git diff --check` for the prepared stack ranges.

A broader tsgo extension-tests attempt was killed after no output for too long, so it is not claimed as passing here.

## Real behavior proof

Behavior addressed: This PR adds low-level Telegram rich message helper primitives and keeps runtime delivery unchanged until the follow-up stacked PRs consume them.

Real environment tested: Local OpenClaw source checkout on Node 24.15.0, running the helper module directly through the repo's TypeScript runtime loader.

Exact steps or command run after this patch: Ran the rich message helper from the OpenClaw checkout and printed the normalized payload returned by the real helper implementation.

```sh
node --version
node --import tsx --input-type=module -e 'import { normalizeInputRichMessage } from "./extensions/telegram/src/rich-message.ts"; const payload = normalizeInputRichMessage({ html: "<b>Hello</b>", skip_entity_detection: true }); console.log(JSON.stringify(payload));'
```

Evidence after fix: Terminal output from the OpenClaw checkout:

```text
v24.15.0
{"html":"<b>Hello</b>","skip_entity_detection":true}
```

Observed result after fix: The helper accepted a valid rich HTML payload and returned the exact Telegram input shape with the optional entity-detection flag preserved. No Telegram message was sent because this PR intentionally stops at the helper layer.

What was not tested: Live Telegram delivery was not exercised for this PR alone; final replies and streaming previews are wired in later stacked PRs.


## Update after raw API repair

The latest push routes the rich message helpers through grammY's raw Bot API boundary instead of looking for top-level convenience methods that grammY 1.43.0 does not expose for Bot API 10.1 rich-message methods.

Additional verification after this patch:

```text
node scripts/run-vitest.mjs extensions/telegram/src/rich-message.test.ts extensions/telegram/src/config-schema.test.ts extensions/telegram/src/bot/helpers.test.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/lane-delivery.test.ts extensions/telegram/api.test.ts
Test Files  7 passed (7)
Tests  270 passed (270)

node --import tsx scripts/generate-bundled-channel-config-metadata.ts --check
pnpm exec oxfmt --check extensions/telegram/src/rich-message.ts extensions/telegram/src/rich-message.test.ts extensions/telegram/api.test.ts extensions/telegram/api.ts
pnpm exec oxlint extensions/telegram/src/rich-message.ts extensions/telegram/src/rich-message.test.ts extensions/telegram/api.test.ts extensions/telegram/api.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD
```

Real grammY boundary proof, using a `Bot` instance with an API transformer and no real token/network request:

```text
sendTelegramRichMessage -> {"method":"sendRichMessage","payload":{"message_thread_id":7,"chat_id":123,"rich_message":{"html":"<b>Hello</b>","skip_entity_detection":true}}}
sendTelegramRichMessageDraft -> {"method":"sendRichMessageDraft","payload":{"message_thread_id":7,"chat_id":"123","draft_id":17,"rich_message":{"markdown":"**Hello**"}}}
```

Observed result after fix: both helpers call grammY's `api.raw` method path with one Bot API payload object, preserving caller-supplied optional method parameters while keeping helper-owned `chat_id`, `draft_id`, and `rich_message` fields from being overridden by `methodParams`.
