### PR TITLE
fix(telegram): restore sent-message ledger writes for delivery replies

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -39,6 +39,7 @@ import {
 } from "../format.js";
 import { resolveTelegramInteractiveTextFallback } from "../interactive-fallback.js";
 import { buildInlineKeyboard } from "../send.js";
+import { recordSentMessage } from "../sent-message-cache.js";
 import { resolveTelegramVoiceSend } from "../voice.js";
 import {
   buildTelegramSendParams,
@@ -902,6 +903,10 @@ export async function deliverReplies(params: {
         deliveredContents.push({ text: contentForSentHook, mediaUrls: mediaList });
       }
 
+      const sentSucceeded = progress.deliveredCount > deliveredCountBeforeReply;
+      if (sentSucceeded && typeof firstDeliveredMessageId === "number") {
+        recordSentMessage(params.chatId, firstDeliveredMessageId, params.cfg);
+      }
       emitMessageSentHooks({
         hookRunner,
         enabled: hasMessageSentHooks,
@@ -909,7 +914,7 @@ export async function deliverReplies(params: {
         chatId: params.chatId,
         accountId: params.accountId,
         content: contentForSentHook,
-        success: progress.deliveredCount > deliveredCountBeforeReply,
+        success: sentSucceeded,
         messageId: firstDeliveredMessageId,
         isGroup: params.mirrorIsGroup,
         groupId: params.mirrorGroupId,

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -2,6 +2,7 @@
 import type { Bot } from "grammy";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearSentMessageCache, wasSentByBot } from "../sent-message-cache.js";
 const { loadWebMedia } = vi.hoisted(() => ({
   loadWebMedia: vi.fn(),
 }));
@@ -205,6 +206,7 @@ function createVoiceFailureHarness(params: {
 
 describe("deliverReplies", () => {
   beforeEach(() => {
+    clearSentMessageCache();
     loadWebMedia.mockClear();
     probeVideoDimensions.mockReset();
     probeVideoDimensions.mockResolvedValue(undefined);
@@ -413,6 +415,20 @@ describe("deliverReplies", () => {
       accountId: "work",
       conversationId: "123",
     });
+  });
+
+  it("records sent messages in the Telegram ledger for successful deliveries", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 9, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [{ text: "hello" }],
+      runtime,
+      bot,
+    });
+
+    expect(wasSentByBot("123", 9)).toBe(true);
   });
 
   it("sets disable_notification when silent is true", async () => {


### PR DESCRIPTION
## Summary
- restore `recordSentMessage` for successful Telegram `deliverReplies` sends
- keep the existing `message_sent` hook behavior, but persist the same send into the sent-message ledger first
- add a regression test that verifies `wasSentByBot` sees delivery-path sends

Closes #92242

## Testing
- attempted: `pnpm exec vitest run extensions/telegram/src/bot/delivery.test.ts --project extension-telegram -t "records sent messages in the Telegram ledger for successful deliveries"`
  - note: the repo-wide Vitest project graph is unusually heavy in this worktree and did not finish quickly enough during this run, so I also added a focused regression test alongside direct diff inspection
