### PR TITLE
docs(templates): remove "React Like a Human!" section from default AGENTS.md

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -110,23 +110,6 @@ In group chats where you receive every message, be **smart about when to contrib
 
 Participate, don't dominate.
 
-### 😊 React Like a Human!
-
-On platforms that support reactions (Discord, Slack), use emoji reactions naturally:
-
-**React when:**
-
-- You appreciate something but don't need to reply (👍, ❤️, 🙌)
-- Something made you laugh (😂, 💀)
-- You find it interesting or thought-provoking (🤔, 💡)
-- You want to acknowledge without interrupting the flow
-- It's a simple yes/no or approval situation (✅, 👀)
-
-**Why it matters:**
-Reactions are lightweight social signals. Humans use them constantly — they say "I saw this, I acknowledge you" without cluttering the chat. You should too.
-
-**Don't overdo it:** One reaction per message max. Pick the one that fits best.
-
 ## Tools
 
 Skills provide your tools. When you need one, check its `SKILL.md`. Keep local notes (camera names, SSH details, voice preferences) in `TOOLS.md`.


### PR DESCRIPTION
## What

Removes the "React Like a Human!" section from `docs/reference/templates/AGENTS.md`.

## Why

The default `AGENTS.md` template that ships with new agents includes a section that aggressively encourages emoji reactions on platforms that support them (Discord, Slack):

> **React when:**
> - You appreciate something but don't need to reply (👍, ❤️, 🙌)
> - Something made you laugh (😂, 💀)
> - You find it interesting or thought-provoking (🤔, 💡)
> - You want to acknowledge without interrupting the flow
> - It's a simple yes/no or approval situation (✅, 👀)

In practice, freshly-provisioned agents react to **almost every message** with 👍 / ❤️ / ✅ / 👀 / 💀 etc. — which reads as performative engagement rather than helpful behavior. Operators end up either asking each agent to stop or stripping the section out of their workspace `AGENTS.md` after bootstrap.

The pattern is visible across newly-provisioned vs. older fleet claws: agents whose `AGENTS.md` still has this section react heavily; agents whose template predates it (or have had it removed) behave normally.

## What changes

- Deletes the `### 😊 React Like a Human!` heading and its body (17 lines).
- The preceding `### 💬 Know When to Speak!` block already covers when to participate vs. stay silent, so removal doesn't leave a gap.

## What stays

- Reactions are still fully available via the `message` tool (`action: react`).
- Operators who want this behavior can opt in by adding it to their own workspace `AGENTS.md` or `SOUL.md`.

## Out of scope

- Existing agents whose `AGENTS.md` was already bootstrapped from this template still contain the section. They'd need a workspace edit (or a fresh provisioning) to pick up the new default. That's a fleet-operator concern, not an upstream one.