### PR TITLE
fix(cron): require explicit message target proof

### DIFF
--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -346,6 +346,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
         },
         messageToolEnabled: true,
         messageToolForced: false,
+        requireExplicitMessageTargetEvidence: true,
         directFallback: true,
       }),
       skillsSnapshot: emptySkillsSnapshot,
@@ -900,13 +901,34 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     });
   });
 
-  it("skips cron fallback delivery when the message tool sends to the bound target", async () => {
-    await expectCronFallbackSkippedForMessageToolDelivery({
-      sentTargets: [],
-      job: {
-        id: "message-tool-bound-target",
-        name: "Message Tool Bound Target",
+  it("uses cron fallback delivery when the message tool returns no target evidence", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());
+    runEmbeddedAgentMock.mockResolvedValue(makeMessageToolRunResult([]));
+
+    const result = await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeAnnounceMessageToolJob({
+        id: "message-tool-no-target-evidence",
+        name: "Message Tool No Target Evidence",
+      }),
+    });
+
+    expect(dispatchCronDeliveryMock).toHaveBeenCalledTimes(1);
+    expectDispatchFields({
+      deliveryRequested: true,
+      sourceDeliveryOutcome: {
+        visibleDeliveries: [],
+        verifiedMessageToolDelivery: false,
+        satisfiesSourceDelivery: false,
+        unverifiedMessageToolDelivery: false,
       },
+    });
+    expectDeliveryFields(result.delivery, {
+      intended: { channel: "messagechat", to: "123", source: "explicit" },
+      resolved: { ok: true, channel: "messagechat", to: "123", source: "explicit" },
+      fallbackUsed: true,
+      delivered: true,
     });
   });
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -335,6 +335,7 @@ function resolveCronSourceDeliveryPlan(params: {
     target,
     messageToolEnabled: true,
     messageToolForced: false,
+    requireExplicitMessageTargetEvidence: true,
     directFallback: true,
     skipFallbackWhenMessageToolSentToTarget: params.resolvedDelivery.ok,
   });

--- a/src/infra/outbound/source-delivery-plan.test.ts
+++ b/src/infra/outbound/source-delivery-plan.test.ts
@@ -145,6 +145,46 @@ describe("source delivery plan", () => {
     expect(outcome.unverifiedMessageToolDelivery).toBe(false);
   });
 
+  it("synthesizes the planned target for legacy message-tool sends by default", () => {
+    const contract = createSourceDeliveryPlan({
+      owner: "message_tool_then_direct_fallback",
+      reason: "cron_announce",
+      target: { channel: "slack", to: "channel:C1" },
+    });
+
+    const outcome = resolveSourceDeliveryOutcome(contract, {
+      didSendViaMessageTool: true,
+    });
+
+    expect(outcome.visibleDeliveries).toEqual([
+      {
+        via: "message_tool",
+        verifiedTarget: true,
+        target: { tool: "message", provider: "slack", to: "channel:C1" },
+      },
+    ]);
+    expect(outcome.verifiedMessageToolDelivery).toBe(true);
+    expect(outcome.satisfiesSourceDelivery).toBe(true);
+  });
+
+  it("does not synthesize the planned target when explicit target evidence is required", () => {
+    const contract = createSourceDeliveryPlan({
+      owner: "message_tool_then_direct_fallback",
+      reason: "cron_announce",
+      target: { channel: "slack", to: "channel:C1" },
+      requireExplicitMessageTargetEvidence: true,
+    });
+
+    const outcome = resolveSourceDeliveryOutcome(contract, {
+      didSendViaMessageTool: true,
+    });
+
+    expect(outcome.visibleDeliveries).toEqual([]);
+    expect(outcome.verifiedMessageToolDelivery).toBe(false);
+    expect(outcome.satisfiesSourceDelivery).toBe(false);
+    expect(outcome.unverifiedMessageToolDelivery).toBe(false);
+  });
+
   it("does not synthesize an implicit target without a concrete recipient", () => {
     const contract = createSourceDeliveryPlan({
       owner: "direct_fallback",

--- a/src/infra/outbound/source-delivery-plan.ts
+++ b/src/infra/outbound/source-delivery-plan.ts
@@ -69,6 +69,7 @@ export type SourceDeliveryPlan = {
     enabled: boolean;
     force: boolean;
     requireExplicitTarget: boolean;
+    requireExplicitTargetEvidence: boolean;
     defaultTarget: boolean;
   };
   fallback: {
@@ -174,6 +175,7 @@ export function createSourceDeliveryPlan(params: {
   messageToolEnabled?: boolean;
   messageToolForced?: boolean;
   requireExplicitMessageTarget?: boolean;
+  requireExplicitMessageTargetEvidence?: boolean;
   directFallback?: boolean;
   skipFallbackWhenMessageToolSentToTarget?: boolean;
   fallbackBestEffort?: boolean;
@@ -197,6 +199,7 @@ export function createSourceDeliveryPlan(params: {
       enabled: params.messageToolEnabled ?? messageToolOwnsDelivery,
       force: params.messageToolForced ?? messageToolOwnsDelivery,
       requireExplicitTarget: params.requireExplicitMessageTarget ?? false,
+      requireExplicitTargetEvidence: params.requireExplicitMessageTargetEvidence ?? false,
       defaultTarget: Boolean(params.target?.channel || params.target?.to),
     },
     fallback: {
@@ -239,11 +242,12 @@ export function resolveSourceDeliveryOutcome(
 ): SourceDeliveryOutcome {
   const didSendViaMessageTool = params.didSendViaMessageTool === true;
   const explicitTargets = params.messageToolSentTargets ?? [];
-  // A send without explicit target metadata still counts when the plan has a default target.
+  // Cron completion accounting needs concrete target evidence. Legacy
+  // message-tool-owned flows may still use the plan target as the implicit send.
   const sentTargets =
     explicitTargets.length > 0
       ? explicitTargets
-      : didSendViaMessageTool
+      : didSendViaMessageTool && !plan.messageTool.requireExplicitTargetEvidence
         ? [resolveImplicitMessageToolDeliveryTarget(plan)].filter(
             (target): target is SourceDeliveryMessageToolTarget => Boolean(target),
           )


### PR DESCRIPTION
## Summary

Fix isolated cron announce delivery accounting so `didSendViaMessagingTool=true` without concrete target metadata cannot satisfy the configured cron delivery target.

Cron announce delivery now requires explicit message-tool target evidence before it treats a model/tool send as verified delivery to the configured channel. If a run only reports that a messaging tool was used, but `messagingToolSentTargets` is empty, cron keeps the direct announce fallback path instead of recording `delivered=true` from a synthesized default target.

## Evidence / Root Cause

Observed on a live Telegram cron digest job targeting `telegram/-5278454993`:

| Run seq | Time (local) | Recorded delivery | Trace detail | Observed issue |
| --- | --- | --- | --- | --- |
| 56 | 2026-06-10 14:36:02 | `delivered`, `fallbackUsed=1` | `messageToolSentTo=null` | Direct Telegram fallback delivered the digest. |
| 57 | 2026-06-11 07:19:04 | `delivered`, `fallbackUsed=0` | `messageToolSentTo=[{"channel":"telegram","to":"-5278454993"}]` | The group did not receive the digest body even though cron marked delivery successful. |
| 58 | 2026-06-12 07:19:14 | `delivered`, `fallbackUsed=0` | `messageToolSentTo=[{"channel":"telegram","to":"-5278454993"}]` | Same false-success shape. |
| 59 | 2026-06-12 09:56:02 | `delivered`, `fallbackUsed=0` | `messageToolSentTo=[{"channel":"telegram","to":"-5278454993"}]` | Manual rerun produced the same false-success shape. |
| 60 | 2026-06-12 10:16:33 | `delivered`, `fallbackUsed=1` | `messageToolSentTo=null` | After forcing direct fallback, the digest body was sent through Telegram. |

The failing run trajectory showed the model used `sessions_send`, but the embedded run result had `didSendViaMessagingTool=true` with `messagingToolSentTargets=[]`. `resolveSourceDeliveryOutcome()` treated that as a verified send by synthesizing the cron plan's default target. That made `satisfiesSourceDelivery=true`, so `dispatchCronDelivery()` skipped direct Telegram fallback and cron persisted `delivered=true` even though no concrete channel ack existed for the digest body.

Why `sessions_send` had no target metadata:

- `messagingToolSentTargets` is populated when the tool call exposes a concrete message target such as provider/channel/to.
- `sessions_send` is an inter-session/A2A path. It can return `delivery.status=pending` / `mode=announce` without synchronously proving a Telegram `sendMessage` happened for the outer cron run.
- In the root-cause-shaped validation, the model called `sessions_send` with `sessionKey=agent:main:telegram:group:-5278454993`; the tool returned pending announce delivery, the trajectory still had `messagingToolSentTargets=[]`, and the fixed cron path used direct fallback to produce the actual Telegram send ack.

So the bug is not that Telegram failed after receiving a direct send. The bug is that cron treated an unverified inter-session send as proof that the configured Telegram target received the digest. The old regression test encoded that bad case with `sentTargets: []` and expected cron fallback to be skipped.

## Fix

- Keep legacy implicit-target synthesis for existing message-tool-owned flows by default.
- Add `requireExplicitMessageTargetEvidence` to the source-delivery plan contract.
- Enable that flag only for cron announce source delivery.
- Make `resolveSourceDeliveryOutcome()` honor the flag before synthesizing a default target from `didSendViaMessagingTool=true`.
- Replace the empty-target cron regression so cron uses announce fallback when message-tool target evidence is absent.

## Real behavior proof

Behavior addressed: Cron no longer records an unverified message-tool send as delivery to the configured channel target.

Real environment tested: Live `openclaw2` cron run history for the Telegram digest job showed false-success runs with `fallbackUsed=0` and synthesized `messageToolSentTo`, followed by a direct-fallback successful run with `fallbackUsed=1`.

Evidence after fix:

- Operator screenshot confirmed the Telegram group displayed `CRON_DELIVERY_SMOKE_CODEX_1781232124` at 10:43, matching the live smoke run and Telegram `messageId=7015`. The raw screenshot is not uploaded to the public PR to avoid publishing chat UI/avatar details.
- Focused tests now cover empty `messageToolSentTargets`; the outcome remains unverified and cron fallback is used.
- Live smoke cron run log at `2026-06-12 10:43:07 CST` recorded `status=ok`, `summary=CRON_DELIVERY_SMOKE_CODEX_1781232124`, `deliveryStatus=delivered`, and `delivery.intended={channel:"telegram",to:"-5278454993",source:"explicit"}`.
- The same live trace (`28dc9a75652e503e0bde42e031f76e57`) logged Telegram adapter success: `telegram outbound send ok accountId=default chatId=-5278454993 messageId=7015 operation=sendMessage deliveryKind=text chunkCount=1`.

<img width="1394" height="418" alt="image" src="https://github.com/user-attachments/assets/bb01ac77-7052-4620-9b80-0a5a16e50385" />

Additional repeat validation on `openclaw2`:

- Command cron repeat: job `f5aca8d4-5830-40e1-8294-b9be02376b6a` produced `CRON_DELIVERY_SMOKE_REPEAT_1781234464` at `2026-06-12 11:22:08 CST`; Telegram adapter returned `messageId=7016` for `chatId=-5278454993`.
- Root-cause-shaped agent cron repeat: job `78b55500-96d5-4aa8-998a-787690fda53d` instructed the model to call `sessions_send` and then finish with `CRON_FALLBACK_REPEAT_1781234464`. The trajectory shows `sessions_send` returned `delivery.status=pending`, `didSendViaMessagingTool=true`, and `messagingToolSentTargets=[]`. The cron run then recorded `fallbackUsed=true`, `deliveryStatus=delivered`, and Telegram adapter returned `messageId=7017` for `chatId=-5278454993`.

What was not tested: I did not rerun the full digest job from this PR branch to avoid posting another digest into the Telegram group; the live host was separately hot-patched for operator validation.

## Verification

- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-cache-cron-target-evidence-1 node ./node_modules/vitest/vitest.mjs run src/infra/outbound/source-delivery-plan.test.ts` -> 12 tests passed
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-cache-cron-target-evidence-2 node ./node_modules/vitest/vitest.mjs run src/cron/isolated-agent/run.message-tool-policy.test.ts` -> 40 tests passed
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> `autoreview clean: no accepted/actionable findings reported`

Note: `node scripts/run-vitest.mjs ...` was initially attempted, but the wrapper waited behind an unrelated local heavy-check lock in another worktree. The two focused files were then run one at a time with raw `vitest run` and isolated cache paths.
