### PR TITLE
feat(workboard): add workboard_delete tool and CLI command for card removal

### DIFF
--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -200,6 +200,25 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
       }
     });
 
+  workboard
+    .command("delete")
+    .argument("<id>", "Card id or prefix")
+    .description("Permanently delete a Workboard card")
+    .option("--json", "Print JSON", false)
+    .action(async (id: string, options: JsonOptions) => {
+      const cards = await params.store.list();
+      const { card, error } = resolveWorkboardCardByIdOrPrefix(cards, id);
+      if (!card) {
+        throw new Error(error);
+      }
+      const result = await params.store.delete(card.id);
+      if (options.json) {
+        writeJson(result);
+      } else {
+        writeLine(result.deleted ? `deleted ${card.id}` : `card not found: ${id}`);
+      }
+    });
+
   addGatewayClientOptions(
     workboard
       .command("dispatch")

--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -530,7 +530,7 @@ describe("workboard tools", () => {
     );
 
     const card = await store.create({ title: "Claimed card" });
-    const claimed = await store.claim(card.id, { ownerId: "main" });
+    await store.claim(card.id, { ownerId: "main" });
 
     await expect(
       otherTools.get("workboard_delete")?.execute("call-del", { id: card.id }),

--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -462,4 +462,106 @@ describe("workboard tools", () => {
     );
     expect(Buffer.from(attachment.contentBase64 as string, "base64").toString("utf8")).toBe("done");
   });
+
+  it("deletes an unclaimed card and removes references from parent cards", async () => {
+    const keyed = createMemoryStore();
+    const api = {
+      runtime: {
+        state: {
+          openKeyedStore: vi.fn(() => keyed),
+        },
+      },
+    } as unknown as OpenClawPluginApi;
+    const store = new WorkboardStore(keyed);
+    const tools = new Map(
+      createWorkboardTools({
+        api,
+        store,
+        context: { agentId: "main" } as never,
+      }).map((tool) => [tool.name, tool]),
+    );
+
+    const child = await store.create({ title: "Child card" });
+    const parent = await store.create({ title: "Parent card", parents: [child.id] });
+
+    // Parent should have a link to the child
+    const parentBefore = await store.get(parent.id);
+    expect(parentBefore?.metadata?.links?.some((l) => l.targetCardId === child.id)).toBe(true);
+
+    const result = readPayload(
+      await tools.get("workboard_delete")?.execute("call-del", { id: child.id }),
+    );
+    expect(result).toEqual({ deleted: true });
+
+    // Child should be gone
+    const list = readPayload(await tools.get("workboard_list")?.execute("call-list", {}));
+    expect(list.cards).toEqual([expect.objectContaining({ id: parent.id })]);
+
+    // Parent's link to child should be removed
+    const parentAfter = await store.get(parent.id);
+    expect(
+      parentAfter?.metadata?.links?.filter((l) => l.targetCardId === child.id) ?? [],
+    ).toHaveLength(0);
+  });
+
+  it("requires claim scope to delete a claimed card", async () => {
+    const keyed = createMemoryStore();
+    const api = {
+      runtime: {
+        state: {
+          openKeyedStore: vi.fn(() => keyed),
+        },
+      },
+    } as unknown as OpenClawPluginApi;
+    const store = new WorkboardStore(keyed);
+    const mainTools = new Map(
+      createWorkboardTools({
+        api,
+        store,
+        context: { agentId: "main" } as never,
+      }).map((tool) => [tool.name, tool]),
+    );
+    const otherTools = new Map(
+      createWorkboardTools({
+        api,
+        store,
+        context: { agentId: "other" } as never,
+      }).map((tool) => [tool.name, tool]),
+    );
+
+    const card = await store.create({ title: "Claimed card" });
+    const claimed = await store.claim(card.id, { ownerId: "main" });
+
+    await expect(
+      otherTools.get("workboard_delete")?.execute("call-del", { id: card.id }),
+    ).rejects.toThrow(/claimed by main/);
+
+    const result = readPayload(
+      await mainTools.get("workboard_delete")?.execute("call-del-2", { id: card.id }),
+    );
+    expect(result).toEqual({ deleted: true });
+  });
+
+  it("throws for nonexistent card", async () => {
+    const keyed = createMemoryStore();
+    const api = {
+      runtime: {
+        state: {
+          openKeyedStore: vi.fn(() => keyed),
+        },
+      },
+    } as unknown as OpenClawPluginApi;
+    const store = new WorkboardStore(keyed);
+    const tools = new Map(
+      createWorkboardTools({
+        api,
+        store,
+        context: { agentId: "main" } as never,
+      }).map((tool) => [tool.name, tool]),
+    );
+
+    await expect(
+      tools.get("workboard_delete")?.execute("call-del", { id: "nonexistent" }),
+    ).rejects.toThrow(/card not found/);
+  });
 });

--- a/extensions/workboard/src/tools.ts
+++ b/extensions/workboard/src/tools.ts
@@ -596,6 +596,34 @@ export function createWorkboardTools(params: {
       },
     },
     {
+      name: "workboard_delete",
+      label: "Workboard Delete",
+      description:
+        "Permanently delete a Workboard card and its associated events, attempts, comments, proofs, artifacts, and links. The card must not be claimed by another agent.",
+      parameters: Type.Object(
+        {
+          id: cardIdField(),
+          token: ScopedClaimTokenField,
+        },
+        { additionalProperties: false },
+      ),
+      execute: async (_toolCallId, rawParams) => {
+        const record = rawParams as Record<string, unknown>;
+        const id = readStringParam(record, "id", { required: true });
+        const token = record.token as string | undefined;
+        const card = await store.get(id);
+        if (!card) {
+          throw new Error(`card not found: ${id}`);
+        }
+        if (!canMutateCard(card, ownerId, token)) {
+          throw new Error(
+            `card is claimed by ${card.metadata?.claim?.ownerId ?? "another agent"}.`,
+          );
+        }
+        return jsonResult(await store.delete(id));
+      },
+    },
+    {
       name: "workboard_block",
       label: "Workboard Block",
       description: "Block a claimed Workboard card with a durable reason and release the claim.",


### PR DESCRIPTION
## Summary

Adds `workboard_delete` agent tool and `openclaw workboard delete` CLI command to permanently remove Workboard cards. Closes #92314.

**Problem:** The Workboard plugin has `WorkboardStore.delete()` and a gateway method `workboard.cards.delete`, but no agent-facing tool or CLI command. Agents cannot permanently remove cards.

**Changes:**
- **`tools.ts`**: Add `workboard_delete` tool with claim-scope authorization. Unclaimed cards can be deleted by any agent; claimed cards require the claim owner or a valid claim token.
- **`cli.ts`**: Add `openclaw workboard delete <id>` command with id-prefix resolution and `--json` output.
- **`tools.test.ts`**: Three new tests — delete unclaimed card with reference cleanup, claim-scope enforcement, and nonexistent-card error.

**Authorization model:** Follows the existing `canMutateCard` pattern used by `workboard_heartbeat`, `workboard_release`, etc. Hard-deletes the card row (with `ON DELETE CASCADE` on all child tables) plus cleans up KV-stored subscriptions, attachments, and cross-card link references via the existing `removeReferencesToCard` path.

## Real behavior proof

**Behavior addressed:** Agents can permanently delete Workboard cards through the `workboard_delete` tool. Claimed cards require claim ownership. Cross-card references are cleaned up.

**Environment tested:** macOS 26.4.1, Node.js 24.x, pnpm, upstream `main` at c1dca304.

**Steps run after the patch:**
1. Branch from `upstream/main`, apply changes.
2. Run `node scripts/run-vitest.mjs run extensions/workboard/src/tools.test.ts` to verify all 9 tool tests pass.
3. Run `node scripts/run-vitest.mjs run extensions/workboard/src/store.test.ts extensions/workboard/src/gateway.test.ts extensions/workboard/src/command.test.ts` to verify no regressions.

**Evidence after fix:**
```
$ node scripts/run-vitest.mjs run extensions/workboard/src/tools.test.ts

 ✓  extensions/workboard/src/tools.test.ts (9 tests) 48ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Duration  1.43s
```

**Observed result after fix:** All 9 tool tests pass including the 3 new delete tests. The `workboard_delete` tool correctly deletes unclaimed cards, enforces claim scope on claimed cards, throws for nonexistent cards, and cleans up parent-card link references.

**What was not tested:** End-to-end gateway dispatch, management UI delete button (not in scope).
