### PR TITLE
#92117: fix(test): prevent mock state leakage in async model discovery test

### DIFF
--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -476,16 +476,25 @@ describe("prepareSimpleCompletionModel", () => {
   });
 
   it("can preserve asynchronous provider model discovery", async () => {
-    hoisted.resolveModelAsyncMock.mockResolvedValueOnce({
-      model: {
-        provider: "anthropic",
-        id: "claude-opus-4-6",
-      },
-      authStorage: {
-        setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
-      },
-      modelRegistry: {},
-    });
+    // Replace the default mock implementation (which calls resolveModelMock) with
+    // one that returns the resolved model directly, so the sync resolveModel path
+    // is never exercised even if mockResolvedValueOnce state leaks from another test.
+    hoisted.resolveModelAsyncMock.mockImplementation(() =>
+      Promise.resolve({
+        model: {
+          provider: "anthropic",
+          id: "claude-opus-4-6",
+        },
+        authStorage: {
+          setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
+        },
+        modelRegistry: {},
+      }),
+    );
+    // Explicitly clear the sync mock to guard against call-history leakage from
+    // prior tests in the file (vi.hoisted mocks can retain call state across
+    // tests in some Vitest runner configurations).
+    hoisted.resolveModelMock.mockClear();
 
     const result = await prepareSimpleCompletionModel({
       cfg: undefined,


### PR DESCRIPTION
## Summary

Fix a flaky test in `simple-completion-runtime.test.ts` that was causing two CI lanes (`checks-node-agentic-agents-core-models`, `checks-node-agentic-agents-core-runtime`) to fail intermittently on main and on unrelated PRs.

## Root Cause

The test `can preserve asynchronous provider model discovery` relied on `mockResolvedValueOnce` to override the default `resolveModelAsyncMock` implementation. The default implementation (set in `beforeEach`) internally calls `resolveModelMock`. When the one-shot `mockResolvedValueOnce` was not consumed by this test — due to mock state leakage across `vi.hoisted` mocks in certain Vitest runner configurations — the default fallback fired, which called `resolveModelMock`, failing the `expect(hoisted.resolveModelMock).not.toHaveBeenCalled()` assertion.

The test was introduced in commit `25ca39e876` ("fix(tts): preserve async model discovery") and has been failing on the commit itself as it landed on main.

## Real behavior proof

### behavior
Replace `mockResolvedValueOnce` with a direct `mockImplementation` that returns the resolved model without chaining through `resolveModelMock`. Add explicit `mockClear()` on `resolveModelMock` before the call to guard against call-history leakage.

### environment
- OS: Linux 4.19.112-2.el8.x86_64
- Runtime: Node.js (pnpm + vitest 4.1.7)
- Setup: OpenClaw workspace at `/home/0668001085/workspace/openclaw`

### steps
1. Run the failing test before the fix → observe `AssertionError: expected "vi.fn()" to not be called at all`
2. Apply the fix: replace `mockResolvedValueOnce` with `mockImplementation`, add `mockClear()`
3. Run the test after the fix → all 17 tests pass

### observedResult

**Test suite output (after fix):**
```
$ pnpm test -- --run src/agents/simple-completion-runtime.test.ts

 RUN  v4.1.7

 Test Files  1 passed (1)
      Tests  17 passed (17)
   Duration  5.56s

[test] passed 1 Vitest shard in 15.41s
```

**Broader test suite (no regressions):**
```
$ pnpm test -- --run src/agents/simple-completion-runtime.test.ts src/agents/embedded-agent-runner/model.test.ts

 Test Files  2 passed (2)
      Tests  124 passed (124)
   Duration  43.86s
```

**Production change:**
```diff
-    hoisted.resolveModelAsyncMock.mockResolvedValueOnce({
-      model: { provider: "anthropic", id: "claude-opus-4-6" },
-      ...
-    });
+    hoisted.resolveModelAsyncMock.mockImplementation(() =>
+      Promise.resolve({
+        model: { provider: "anthropic", id: "claude-opus-4-6" },
+        ...
+      }),
+    );
+    hoisted.resolveModelMock.mockClear();
```

## Regression Test Plan

- [x] `pnpm test -- --run src/agents/simple-completion-runtime.test.ts` passes (17/17)
- [x] `pnpm test -- --run src/agents/embedded-agent-runner/model.test.ts` passes (107/107)
- [x] No production code changed — this is a test-only fix
- [x] Expected to resolve the red CI lanes `checks-node-agentic-agents-core-models` and `checks-node-agentic-agents-core-runtime` on main

---

*AI-assisted: built with Claude Code*
