### PR TITLE
Fix dashboard history projection and approval followups

### DIFF
--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -16,8 +16,8 @@ vi.mock("../infra/outbound/message.js", () => ({
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { writeSessionStoreForTest } from "../config/sessions/test-helpers.js";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
+import { writeSessionStoreForTest } from "../config/sessions/test-helpers.js";
 import { sendMessage } from "../infra/outbound/message.js";
 import {
   buildExecApprovalFollowupPrompt,
@@ -138,6 +138,20 @@ describe("exec approval followup", () => {
       deliver: false,
       channel: undefined,
       to: undefined,
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("suppresses prompt persistence for session-resume followups", async () => {
+    await sendExecApprovalFollowup({
+      approvalId: "req-hidden-prompt",
+      sessionKey: "agent:main:main",
+      resultText: "Exec finished (gateway id=req-hidden-prompt, code 0)\nok",
+    });
+
+    expectGatewayAgentFollowup({
+      sessionKey: "agent:main:main",
+      suppressPromptPersistence: true,
     });
     expect(sendMessage).not.toHaveBeenCalled();
   });

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -268,6 +268,7 @@ function buildAgentFollowupArgs(params: {
   return {
     sessionKey: params.sessionKey,
     message: buildExecApprovalFollowupPrompt(params.resultText),
+    suppressPromptPersistence: true,
     deliver: deliveryTarget.deliver,
     ...(deliveryTarget.deliver ? { bestEffortDeliver: true as const } : {}),
     channel: deliveryTarget.deliver ? deliveryTarget.channel : fallbackChannel,

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -1595,6 +1595,44 @@ function projectSessionsSendInterSessionMessages(
   return changed ? projected : messages;
 }
 
+function isRecentChatDisplayToolCallOnlyAssistant(message: Record<string, unknown>): boolean {
+  if (message.role !== "assistant" || !Array.isArray(message.content)) {
+    return false;
+  }
+  let hasToolCallBlock = false;
+  for (const block of message.content) {
+    const entry = readRecord(block);
+    if (!entry) {
+      return false;
+    }
+    const type = normalizeToolHistoryType(entry.type);
+    if (type === "toolcall" || type === "tooluse") {
+      hasToolCallBlock = true;
+      continue;
+    }
+    if (type === "text") {
+      if (typeof entry.text === "string" && entry.text.trim()) {
+        return false;
+      }
+      continue;
+    }
+    if (type === "thinking") {
+      continue;
+    }
+    return false;
+  }
+  return hasToolCallBlock;
+}
+
+function filterRecentChatDisplayMessages(
+  messages: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+  if (!messages.some(isRecentChatDisplayToolCallOnlyAssistant)) {
+    return messages;
+  }
+  return messages.filter((message) => !isRecentChatDisplayToolCallOnlyAssistant(message));
+}
+
 export function projectChatDisplayMessages(
   messages: unknown[],
   options?: { maxChars?: number; stripEnvelope?: boolean },
@@ -1630,10 +1668,12 @@ export function projectRecentChatDisplayMessages(
   messages: unknown[],
   options?: { maxChars?: number; maxMessages?: number; stripEnvelope?: boolean },
 ): Array<Record<string, unknown>> {
-  return limitChatDisplayMessages(
-    projectChatDisplayMessages(messages, options),
-    options?.maxMessages,
-  );
+  const projected = projectChatDisplayMessages(messages, options);
+  const recentDisplayMessages =
+    typeof options?.maxMessages === "number"
+      ? filterRecentChatDisplayMessages(projected)
+      : projected;
+  return limitChatDisplayMessages(recentDisplayMessages, options?.maxMessages);
 }
 
 export function projectChatDisplayMessage(

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1282,6 +1282,39 @@ describe("projectRecentChatDisplayMessages", () => {
     });
   });
 
+  it("does not let toolCall-only assistant messages hide recent user context", () => {
+    const result = projectRecentChatDisplayMessages(
+      [
+        {
+          role: "user",
+          content: [{ type: "text", text: "please keep my last prompt visible" }],
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-read-only",
+              name: "read",
+              arguments: { path: "AGENTS.md" },
+            },
+          ],
+          timestamp: 2,
+        },
+      ],
+      { maxMessages: 1 },
+    );
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "please keep my last prompt visible" }],
+        timestamp: 1,
+      },
+    ]);
+  });
+
   it("keeps pure commentary assistant messages hidden", () => {
     const result = projectRecentChatDisplayMessages([
       {


### PR DESCRIPTION
Fixes dashboard history projection so toolCall-only assistant messages do not hide recent user context, and suppresses prompt persistence for exec approval follow-up resumes.

This is a clean replacement for #92312 with only the intended minimal diff.

Tests:
- pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/server-methods.test.ts src/gateway/session-history-state.test.ts
- pnpm exec vitest run --config test/vitest/vitest.agents.config.ts src/agents/bash-tools.exec-approval-followup.test.ts
- ./node_modules/.bin/oxfmt --check --threads=1 src/gateway/chat-display-projection.ts src/gateway/server-methods/server-methods.test.ts src/agents/bash-tools.exec-approval-followup.ts src/agents/bash-tools.exec-approval-followup.test.ts

## Real behavior proof

**Behavior or issue addressed:** Two operator-dashboard regressions. (1) The most recent user prompt vanished from chat history when the last assistant turn was a toolCall-only message (a read/exec tool call with no visible text): the recency window kept the toolCall-only assistant turn and dropped the user prompt. (2) After an async exec approval completed, the synthetic resume prompt ("An async command the user already approved has completed...") was persisted as a `role: "user"` message, polluting the visible transcript and model context with a fake user turn.

**Real environment tested:** A real OpenClaw gateway runtime started from this branch's worktree on macOS (Darwin, Apple Silicon), exercising the genuine gateway server, session store, exec approval manager, and chat-history projection. The model backend is a deterministic local stub HTTP server (no real LLM) so the exec tool call and the approval follow-up fire reproducibly; every other layer is the real runtime path.

**Exact steps or command run after this patch:** For fix 1, against a normally-started gateway over the operator socket, `node openclaw.mjs gateway call agent` seeds a turn, then `node openclaw.mjs gateway call chat.history` with `limit: 1` reads it back. At that point the transcript holds exactly two turns (seq 1 user "RUN_PROOF_EXEC now", seq 2 assistant toolCall-only exec), and `limit: 1` is the worst case for the bug. For fix 2, a real in-process gateway with an operator client runs `client.request("agent", ...)`, then `client.request("exec.approval.resolve", { id, decision: "allow-once" })`, then the on-disk session transcript JSONL is read and its roles counted.

**Evidence after fix:** Fix 1 live `chat.history` runtime output with `limit: 1` returns the user prompt, not the toolCall-only assistant turn:
```
{
  "sessionKey": "agent:main:main",
  "messages": [
    {
      "role": "user",
      "content": [ { "type": "text", "text": "RUN_PROOF_EXEC now" } ],
      "timestamp": 1781237219317,
      "__openclaw": { "id": "3cd9ea06", "seq": 1 }
    }
  ]
}
```
Fix 2 live gateway runtime log of the approval cycle, plus the resulting on-disk transcript role breakdown and per-record dump (the exec result reaches the agent as a toolResult and the turn continues, with no second user turn synthesized):
```
[proof] pending approval: 72b31326-6ffb-4210-bdc1-311f8abb9a1a command: printf 'PROOF_ASYNC_EXEC_OUTPUT\n'
[ws] res ok exec.approval.waitDecision 282ms
[proof] resolved approval: {"ok":true}
[proof] transcript role counts: {"user":1,"assistant":2,"toolResult":1}
[proof] follow-up completion persisted as role=user message? false
[proof] chat.history user-role follow-up messages: 0

4 role=user        text:RUN_PROOF_EXEC now
5 role=assistant    toolCall:exec
6 role=toolResult   text:PROOF_ASYNC_EXEC_OUTPUT
7 role=assistant    text:Standing by.
```

**Observed result after fix:** For fix 1, with a `limit: 1` recency window the live gateway returns the seq 1 user prompt; before this patch the same query returned only the seq 2 toolCall-only assistant turn and the user prompt disappeared. For fix 2, the async approval completion is delivered to the agent through the toolResult channel (record 6) and the assistant continues the turn (record 7), while the transcript retains a single `role: "user"` turn (the original prompt) and the "already approved has completed" resume is not written as a user message. The completion payload still reaches model context; only the spurious user-turn persistence is suppressed.

**What was not tested:** A real third-party LLM was not used (the backend was a deterministic local stub so the tool call and follow-up are reproducible); the projection and persistence code under test is provider-independent. Multi-session and cross-channel delivery variants were covered only by the existing unit suites, not this live run.
