### PR TITLE
fix(webchat): ensure senderLabel is properly normalized to prevent empty string display

### DIFF
--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -438,7 +438,7 @@ export function renderMessageGroup(
     name: opts.userName ?? null,
     avatar: opts.userAvatar ?? null,
   });
-  const userLabel = group.senderLabel?.trim();
+  const userLabel = group.senderLabel?.trim() || null;
   const who =
     normalizedRole === "user"
       ? (userLabel ?? resolvedUserName)


### PR DESCRIPTION
## Summary

Fix issue #92327 where inter-session messages from sessions_send showed no sender attribution in WebChat UI.

## Root Cause

The  (nullish coalescing) operator only falls back for  or , not for empty strings. When  was an empty string, the expression  would use the empty string instead of falling back to "Assistant".

## Fix

Convert empty or whitespace-only senderLabel to null before using the ?? operator:



This ensures that:
- Empty strings become null and trigger fallback
- Whitespace-only strings become null and trigger fallback  
- Valid sender labels are preserved

## Verification

The fix is minimal and focused on the specific issue. It doesn't change any other behavior.

Closes #92327