### PR TITLE
fix(memory-core): CJK textScore=0 and empty MATCH LIKE fallback

### DIFF
--- a/extensions/memory-core/src/memory/hybrid.ts
+++ b/extensions/memory-core/src/memory/hybrid.ts
@@ -49,6 +49,13 @@ export function bm25RankToScore(rank: number): number {
   return 1 / (1 + rank);
 }
 
+/**
+ * Check if two line ranges overlap.
+ */
+function linesOverlap(aStart: number, aEnd: number, bStart: number, bEnd: number): boolean {
+  return aStart <= bEnd && bStart <= aEnd;
+}
+
 export async function mergeHybridResults(params: {
   vector: HybridVectorResult[];
   keyword: HybridKeywordResult[];
@@ -87,6 +94,9 @@ export async function mergeHybridResults(params: {
     }
   >();
 
+  // Secondary index: group vector results by path for fallback matching
+  const vectorByPath = new Map<string, HybridVectorResult[]>();
+
   for (const r of params.vector) {
     byId.set(r.id, {
       id: r.id,
@@ -98,26 +108,60 @@ export async function mergeHybridResults(params: {
       vectorScore: r.vectorScore,
       textScore: 0,
     });
+    const existing = vectorByPath.get(r.path);
+    if (existing) {
+      existing.push(r);
+    } else {
+      vectorByPath.set(r.path, [r]);
+    }
   }
 
   for (const r of params.keyword) {
     const existing = byId.get(r.id);
     if (existing) {
+      // Exact chunk ID match — update textScore directly
       existing.textScore = r.textScore;
       if (r.snippet && r.snippet.length > 0) {
         existing.snippet = r.snippet;
       }
     } else {
-      byId.set(r.id, {
-        id: r.id,
-        path: r.path,
-        startLine: r.startLine,
-        endLine: r.endLine,
-        source: r.source,
-        snippet: r.snippet,
-        vectorScore: 0,
-        textScore: r.textScore,
-      });
+      // No chunk ID match — try path + line range overlap as fallback
+      // Pick the overlapping vector chunk with the highest vectorScore
+      const candidates = vectorByPath.get(r.path);
+      let merged = false;
+      if (candidates) {
+        let best: HybridVectorResult | undefined;
+        for (const v of candidates) {
+          if (linesOverlap(r.startLine, r.endLine, v.startLine, v.endLine)) {
+            if (!best || v.vectorScore > best.vectorScore) {
+              best = v;
+            }
+          }
+        }
+        if (best) {
+          const entry = byId.get(best.id)!;
+          entry.textScore = Math.max(entry.textScore, r.textScore);
+          if (r.startLine < entry.startLine) entry.startLine = r.startLine;
+          if (r.endLine > entry.endLine) entry.endLine = r.endLine;
+          if (r.snippet && r.snippet.length > 0) {
+            entry.snippet = r.snippet;
+          }
+          merged = true;
+        }
+      }
+      if (!merged) {
+        // No overlap found — add as keyword-only entry
+        byId.set(r.id, {
+          id: r.id,
+          path: r.path,
+          startLine: r.startLine,
+          endLine: r.endLine,
+          source: r.source,
+          snippet: r.snippet,
+          vectorScore: 0,
+          textScore: r.textScore,
+        });
+      }
     }
   }
 

--- a/extensions/memory-core/src/memory/hybrid.ts
+++ b/extensions/memory-core/src/memory/hybrid.ts
@@ -141,8 +141,12 @@ export async function mergeHybridResults(params: {
         if (best) {
           const entry = byId.get(best.id)!;
           entry.textScore = Math.max(entry.textScore, r.textScore);
-          if (r.startLine < entry.startLine) entry.startLine = r.startLine;
-          if (r.endLine > entry.endLine) entry.endLine = r.endLine;
+          if (r.startLine < entry.startLine) {
+            entry.startLine = r.startLine;
+          }
+          if (r.endLine > entry.endLine) {
+            entry.endLine = r.endLine;
+          }
           if (r.snippet && r.snippet.length > 0) {
             entry.snippet = r.snippet;
           }

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -114,7 +114,7 @@ function planKeywordSearch(params: {
   const matchTerms: string[] = [];
   const substringTerms: string[] = [];
   for (const token of tokens) {
-    if (SHORT_CJK_TRIGRAM_RE.test(token) && Array.from(token).length < 3) {
+    if (SHORT_CJK_TRIGRAM_RE.test(token)) {
       substringTerms.push(token);
       continue;
     }

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -364,6 +364,27 @@ export async function searchKeyword(params: {
           params.limit,
         ) as typeof rows;
       usedMatch = true;
+      // If MATCH returned 0 rows, fall back to LIKE for better recall
+      if (rows.length === 0) {
+        const queryTokens = normalizeStringEntries(params.query.match(FTS_QUERY_TOKEN_RE) ?? []);
+        const allTerms = uniqueStrings([...queryTokens, ...plan.substringTerms]);
+        const fbLike = allTerms.map(() => " OR text LIKE ? ESCAPE '\'").join("");
+        const fbParams = allTerms.map((term) => `%${escapeLikePattern(term)}%`);
+        rows = params.db
+          .prepare(
+            `SELECT id, path, source, start_line, end_line, text,
+` +
+              `       0 AS rank
+` +
+              `  FROM ${params.ftsTable}
+` +
+              ` WHERE 1=0${fbLike}${liveChunkClause}${params.sourceFilter.sql}
+` +
+              ` LIMIT ?`,
+          )
+          .all(...fbParams, ...params.sourceFilter.params, params.limit) as typeof rows;
+        usedMatch = false;
+      }
     } catch (matchErr) {
       // FTS5 MATCH can fail on certain token patterns depending on the
       // Node.js sqlite runtime and tokenizer (e.g. unicode61 vs trigram).

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -368,7 +368,7 @@ export async function searchKeyword(params: {
       if (rows.length === 0) {
         const queryTokens = normalizeStringEntries(params.query.match(FTS_QUERY_TOKEN_RE) ?? []);
         const allTerms = uniqueStrings([...queryTokens, ...plan.substringTerms]);
-        const fbLike = allTerms.map(() => " OR text LIKE ? ESCAPE '\'").join("");
+        const fbLike = allTerms.map(() => " OR text LIKE ? ESCAPE '\\'").join("");
         const fbParams = allTerms.map((term) => `%${escapeLikePattern(term)}%`);
         rows = params.db
           .prepare(


### PR DESCRIPTION
## Summary

Fixes three related bugs that cause `textScore: 0` in hybrid memory search for CJK queries (e.g. "飞书插件配置", "股票分析").

## Bug 1: CJK tokens bypass LIKE path (trigram tokenizer)

In `planKeywordSearch`, CJK tokens with 3+ characters were sent to `matchTerms` as quoted phrase matches (`MATCH "飞书插件配置"`), which rarely match with the trigram tokenizer. The `< 3` character threshold incorrectly routed long CJK strings to the MATCH path.

**Fix:** Remove the `< 3` threshold so all CJK tokens go to `substringTerms` for LIKE matching.

## Bug 2: No LIKE fallback when MATCH returns 0 rows

When FTS5 MATCH returned 0 rows (not an exception), no LIKE fallback triggered. This affected both CJK queries and short English tokens (e.g. `AI`, `A`) that the trigram tokenizer cannot index.

**Fix:** Add LIKE fallback with OR-based matching when MATCH returns empty.

## Bug 3: mergeHybridResults discards textScore when chunk IDs don't overlap (#92337)

When keyword and vector results have different chunk IDs (common with CJK/trigram queries), the keyword search results were effectively discarded — `textScore` stayed 0 even though `searchKeyword` returned valid results.

**Fix:** Add path + line range overlap fallback in `mergeHybridResults`:
- Build a `vectorByPath` secondary index grouped by file path
- When no exact chunk ID match: find the vector chunk with the highest `vectorScore` on the same path with overlapping line ranges
- Merge `textScore` into that vector entry (using `Math.max`, expanded line range)
- If no overlap found: preserve original keyword-only behavior

## Real behavior proof

- **Behavior or issue addressed**: CJK memory search returns `textScore: 0` for all results when querying with multi-character Chinese strings (e.g. "股票分析", "A股投研"). Root cause: (1) CJK tokens bypass LIKE path, (2) no LIKE fallback when MATCH returns 0 rows, (3) `mergeHybridResults` discards textScore when keyword/vector chunk IDs don't overlap.
- **Real environment tested**: macOS arm64, OpenClaw 2026.6.5, Ollama qwen3-embedding:4b, memory store with 73 indexed files / 358 chunks, SQLite with trigram tokenizer.
- **Exact steps or command run after this patch**:
```bash
openclaw memory search --json --max-results 10 "股票分析"
openclaw memory search --json --max-results 10 "A股投研"
openclaw memory search --json --max-results 10 "memory plugin"
```
- **Evidence after fix**:
```console
$ openclaw memory search --json --max-results 10 "股票分析"
  "textScore": 1,
  "vectorScore": 0.5289,
  "score": 0.6703

$ openclaw memory search --json --max-results 10 "A股投研"
  "textScore": 1,
  "vectorScore": 0.5008,
  "score": 0.6506

$ openclaw memory search --json --max-results 10 "memory plugin"
  "textScore": 0.7530,
  "vectorScore": 0.6297,
  "score": 0.6667
```
- **Observed result after fix**:
  - "股票分析": textScore=1, keyword+vector merged successfully
  - "A股投研": textScore=1, keyword+vector merged successfully
  - "memory plugin": textScore=0.75, keyword+vector merged successfully
  - "飞书插件配置": textScore=0 — keyword results exist but from different files than vector results (LIKE fallback limitation, tracked in #92728)
- **What was not tested**: CJK+English mixed queries (e.g. "OpenClaw配置") — LIKE fallback limitation tracked in #92728.

## Files Changed

- `extensions/memory-core/src/memory/manager-search.ts` — `planKeywordSearch` + `searchKeyword` (Bug 1 & 2)
- `extensions/memory-core/src/memory/hybrid.ts` — `mergeHybridResults` (Bug 3)

Closes #92061
Fixes #92337
