### PR TITLE
OpenClaw 1 Codex reliability build

### DIFF
--- a/extensions/codex/npm-shrinkwrap.json
+++ b/extensions/codex/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/codex",
-  "version": "2026.5.21",
+  "version": "2026.5.26-openclaw.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/codex",
-      "version": "2026.5.21",
+      "version": "2026.5.26-openclaw.2",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "0.75.4",
         "@openai/codex": "0.132.0",
@@ -125,17 +125,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.13.tgz",
-      "integrity": "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==",
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.25",
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -144,15 +144,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.39.tgz",
-      "integrity": "sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -160,41 +160,55 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.41.tgz",
-      "integrity": "sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==",
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.43.tgz",
-      "integrity": "sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==",
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
+      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/credential-provider-env": "^3.972.39",
-        "@aws-sdk/credential-provider-http": "^3.972.41",
-        "@aws-sdk/credential-provider-login": "^3.972.43",
-        "@aws-sdk/credential-provider-process": "^3.972.39",
-        "@aws-sdk/credential-provider-sso": "^3.972.43",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.43",
-        "@aws-sdk/nested-clients": "^3.997.11",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.53.tgz",
+      "integrity": "sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-login": "^3.972.52",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.52",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -202,16 +216,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.43.tgz",
-      "integrity": "sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.52.tgz",
+      "integrity": "sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/nested-clients": "^3.997.11",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -219,21 +233,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.44.tgz",
-      "integrity": "sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.55.tgz",
+      "integrity": "sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.39",
-        "@aws-sdk/credential-provider-http": "^3.972.41",
-        "@aws-sdk/credential-provider-ini": "^3.972.43",
-        "@aws-sdk/credential-provider-process": "^3.972.39",
-        "@aws-sdk/credential-provider-sso": "^3.972.43",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.43",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-ini": "^3.972.53",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.52",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -241,15 +255,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.39.tgz",
-      "integrity": "sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -257,17 +271,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.43.tgz",
-      "integrity": "sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.52.tgz",
+      "integrity": "sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/nested-clients": "^3.997.11",
-        "@aws-sdk/token-providers": "3.1052.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/token-providers": "3.1066.0",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -275,16 +289,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1052.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1052.0.tgz",
-      "integrity": "sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==",
+      "version": "3.1066.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1066.0.tgz",
+      "integrity": "sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/nested-clients": "^3.997.11",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -292,16 +306,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.43.tgz",
-      "integrity": "sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.52.tgz",
+      "integrity": "sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/nested-clients": "^3.997.11",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -309,14 +323,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.17.tgz",
-      "integrity": "sha512-WFwdNcjchKZr7jKYgGimUZO8sSKQF/le7GGqgeCzz/lHozInE6b0gFJ1YMr8NaIeAoWJwgtrF7RE4/qMgosAdQ==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.21.tgz",
+      "integrity": "sha512-mVC0hOmwGJmNFezZ+wM8Sqfap/LjsMavEf2Evl0YWrLAcrdZOEdjnY8nRvgakVViWJSGm2eJxLuPVHGdeV06kA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -324,14 +338,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.13.tgz",
-      "integrity": "sha512-ECfsw7mf6G/sxNbKbGE3/h1xeIArY/yRI1IjDGYkLgDIankh+aDOtDRSr40LVlIHGL9+jEH1cVuxmbJ8NLL/1A==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.17.tgz",
+      "integrity": "sha512-tdbnXbw73ww62ABWP0G0Z/euvFowEEvAoi/zG4NaZo7HJFpfGho/Z65HyVzkJLT1cMsUregr4pTyxljlarT0wA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -339,17 +353,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.21.tgz",
-      "integrity": "sha512-yr+5+C7v9R55sAJ89A55Wrm7wIKPVn5cm6J3Hztnd5s/iwEUKxyJqCnIxJu4fVXgG9XBQD1Jc4rsWC1ozahJjA==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.28.tgz",
+      "integrity": "sha512-SCW06Zjugn86pq7+dxGnFcyWJuEWHT753HTU/Vj/OzVxP+NoShwdAr4ynxAcvWL883OgRVbSqW3ohnjIxwXjjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -357,36 +371,49 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.11.tgz",
-      "integrity": "sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==",
+      "version": "3.997.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.20.tgz",
+      "integrity": "sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.28",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.34",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.28.tgz",
-      "integrity": "sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==",
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
+      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.34.tgz",
+      "integrity": "sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -411,12 +438,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -424,9 +451,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "version": "3.965.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.7.tgz",
+      "integrity": "sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -436,13 +463,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.25.tgz",
-      "integrity": "sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
+      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
@@ -460,21 +486,21 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.4.tgz",
-      "integrity": "sha512-cGYbysb4EqUf0B28OeqFq2ppm1XF3bYBOP71q9dv38yf/UJfzMjiXBeNelrcio+QWIoVrW+xzYm7sMzYIUc9Og==",
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.5.tgz",
+      "integrity": "sha512-LHygOgsW2pgXKb3IkXkOAeZPovHr9VF+EixgXVsDNuB4jmhEOXgshy/zksZ7slkUAx10OQ9W1Ed/2jsnhd1NqA==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.75.4",
+        "@earendil-works/pi-ai": "^0.75.5",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -484,15 +510,16 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.4.tgz",
-      "integrity": "sha512-m/w8Hh3vQ0rAycwJiJWdzkypkn4295f4eq/966lDRy8aX5sk6bgYXH8TQmL16TO7Uwc7MbJG0QoyFHgX8RqXUQ==",
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.5.tgz",
+      "integrity": "sha512-zf1F5kXk1pqZeFShXOqq9ibUk8QdtRoLCDPAjO+hj44e3EUs9/GFO2qnhTC5+JA2uwVCx+WCNe1PiCjlBYWm5w==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
         "@google/genai": "1.52.0",
         "@mistralai/mistralai": "2.2.1",
+        "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
@@ -541,9 +568,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.4.tgz",
-      "integrity": "sha512-PDhKU7u6fmEcvHUFHzrRwGc/Ytokj/hO+X4RPf+MWKEGpvg3B1vHv88Ee+Dy33004tYkQF5YeXV4btJZcp5x1g==",
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.5.tgz",
+      "integrity": "sha512-LkXUM1/49pvzzeI39Y5wjBMlgafcCf67HCLhB9Z7yuXHy4XgT+VqxWcZVW5hBdhQsHZd0znjJotfGH1BzxMfiA==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -551,9 +578,6 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      },
-      "optionalDependencies": {
-        "koffi": "2.16.2"
       }
     },
     "node_modules/@google/genai": {
@@ -786,9 +810,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "funding": [
         {
           "type": "github",
@@ -926,13 +950,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz",
-      "integrity": "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -940,13 +964,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.4.tgz",
-      "integrity": "sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
+      "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -954,13 +978,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.4.tgz",
-      "integrity": "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -980,12 +1004,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.4.tgz",
-      "integrity": "sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.3",
         "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
@@ -994,13 +1018,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.4.tgz",
-      "integrity": "sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1008,9 +1032,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1081,6 +1105,18 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -1321,9 +1357,9 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -1378,9 +1414,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -1529,17 +1565,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/koffi": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
-      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -1547,9 +1572,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1814,16 +1839,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/codex",
-  "version": "2026.5.21",
+  "version": "2026.5.26-openclaw.2",
   "description": "OpenClaw Codex harness and model provider plugin",
   "repository": {
     "type": "git",
@@ -27,10 +27,10 @@
       "minHostVersion": ">=2026.5.1-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.5.21"
+      "pluginApi": ">=2026.5.26-openclaw.2"
     },
     "build": {
-      "openclawVersion": "2026.5.21"
+      "openclawVersion": "2026.5.26-openclaw.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -671,14 +671,8 @@ describe("bridgeCodexAppServerStartOptions", () => {
     ).toBeUndefined();
   });
 
-  it("answers refresh requests from a discovered inline Codex OAuth profile", async () => {
+  it("answers refresh requests from a still-valid inline Codex OAuth profile", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
-    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
-      access: "refreshed-ref-backed-access-token",
-      refresh: "refreshed-ref-backed-refresh-token",
-      expires: Date.now() + 60_000,
-      accountId: "account-ref-backed-refreshed",
-    });
     try {
       upsertAuthProfile({
         agentDir,
@@ -688,19 +682,19 @@ describe("bridgeCodexAppServerStartOptions", () => {
           provider: "openai-codex",
           access: "ref-backed-access-token",
           refresh: "ref-backed-refresh-token",
-          expires: Date.now() + 60_000,
+          expires: Date.now() + 24 * 60 * 60_000,
           accountId: "account-ref-backed",
           email: "codex@example.test",
         },
       });
 
       await expect(refreshCodexAppServerAuthTokens({ agentDir })).resolves.toEqual({
-        accessToken: "refreshed-ref-backed-access-token",
-        chatgptAccountId: "account-ref-backed-refreshed",
+        accessToken: "ref-backed-access-token",
+        chatgptAccountId: "account-ref-backed",
         chatgptPlanType: null,
       });
 
-      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("ref-backed-refresh-token");
+      expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
@@ -734,29 +728,23 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("answers refresh from native Codex CLI OAuth without persisting an OpenClaw profile", async () => {
+  it("answers refresh from still-valid native Codex CLI OAuth without persisting an OpenClaw profile", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const agentDir = path.join(root, "agent");
     const codexHome = path.join(root, "codex-cli");
     const authProfileStorePath = path.join(agentDir, "auth-profiles.json");
     vi.stubEnv("CODEX_HOME", codexHome);
-    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
-      access: "fresh-cli-access-token",
-      refresh: "fresh-cli-refresh-token",
-      expires: Date.now() + 60_000,
-      accountId: "account-cli-refreshed",
-    });
     try {
       await writeCodexCliAuthFile(codexHome);
 
       await expect(refreshCodexAppServerAuthTokens({ agentDir })).resolves.toEqual({
-        accessToken: "fresh-cli-access-token",
-        chatgptAccountId: "account-cli-refreshed",
+        accessToken: "cli-access-token",
+        chatgptAccountId: "account-cli",
         chatgptPlanType: null,
       });
 
       await expectPathMissing(authProfileStorePath);
-      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("cli-refresh-token");
+      expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
@@ -1155,7 +1143,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("answers app-server ChatGPT token refresh requests from the bound profile", async () => {
+  it("refreshes near-expiry app-server ChatGPT tokens from the bound profile", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
       access: "refreshed-access-token",
@@ -1194,7 +1182,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("does not persist an expired stale credential before forced token refresh succeeds", async () => {
+  it("does not persist a stale near-expiry credential before token refresh succeeds", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const currentExpiry = Date.now() + 60_000;
     oauthMocks.refreshOpenAICodexToken.mockImplementationOnce(async () => {

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -15,6 +15,7 @@ import {
   type AuthProfileStore,
   type OAuthCredential,
 } from "openclaw/plugin-sdk/agent-runtime";
+import { hasUsableOAuthCredential } from "openclaw/plugin-sdk/provider-auth";
 import type { CodexAppServerClient } from "./client.js";
 import type { CodexAppServerStartOptions } from "./config.js";
 import type {
@@ -477,7 +478,11 @@ async function resolveOAuthCredentialForCodexAppServer(
     isCodexAppServerAuthProvider(ownerCredential.provider, params.config)
       ? ownerCredential
       : undefined;
-  if (params.forceRefresh && !persistedOAuthCredential && overlaidOAuthCredential) {
+  const shouldRefreshRuntimeOnlyOAuthCredential =
+    !persistedOAuthCredential &&
+    overlaidOAuthCredential &&
+    !hasUsableOAuthCredential(overlaidOAuthCredential);
+  if (shouldRefreshRuntimeOnlyOAuthCredential) {
     const refreshedRuntimeCredential = await refreshOAuthCredentialForRuntime({
       credential: overlaidOAuthCredential,
     });
@@ -487,11 +492,15 @@ async function resolveOAuthCredentialForCodexAppServer(
     store.profiles[profileId] = refreshedRuntimeCredential;
     return refreshedRuntimeCredential;
   }
+  const shouldForceRefreshPersistedCredential =
+    params.forceRefresh &&
+    persistedOAuthCredential !== undefined &&
+    !hasUsableOAuthCredential(persistedOAuthCredential);
   const resolved = await resolveApiKeyForProfile({
     store,
     profileId,
     agentDir: ownerAgentDir,
-    forceRefresh: params.forceRefresh && Boolean(persistedOAuthCredential),
+    forceRefresh: shouldForceRefreshPersistedCredential,
   });
   const refreshed = loadAuthProfileStoreForSecretsRuntime(ownerAgentDir).profiles[profileId];
   const storedCredential = store.profiles[profileId];

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw",
-  "version": "2026.5.26-openclaw.5",
+  "version": "2026.5.26-openclaw.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw",
-      "version": "2026.5.26-openclaw.5",
+      "version": "2026.5.26-openclaw.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw",
-  "version": "2026.5.26-openclaw.4",
+  "version": "2026.5.26-openclaw.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw",
-      "version": "2026.5.26-openclaw.4",
+      "version": "2026.5.26-openclaw.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw",
-  "version": "2026.5.26-openclaw.3",
+  "version": "2026.5.26-openclaw.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw",
-      "version": "2026.5.26-openclaw.3",
+      "version": "2026.5.26-openclaw.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw",
-  "version": "2026.5.21",
+  "version": "2026.5.26-openclaw.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw",
-      "version": "2026.5.21",
+      "version": "2026.5.26-openclaw.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw",
-  "version": "2026.5.26-openclaw.1",
+  "version": "2026.5.26-openclaw.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw",
-      "version": "2026.5.26-openclaw.1",
+      "version": "2026.5.26-openclaw.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw",
-  "version": "2026.5.26-openclaw.2",
+  "version": "2026.5.26-openclaw.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw",
-      "version": "2026.5.26-openclaw.2",
+      "version": "2026.5.26-openclaw.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.5.26-openclaw.3",
+  "version": "2026.5.26-openclaw.4",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.5.26-openclaw.4",
+  "version": "2026.5.26-openclaw.5",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.5.26-openclaw.5",
+  "version": "2026.5.26-openclaw.6",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.5.26-openclaw.6",
+  "version": "2026.5.26-openclaw.7",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.5.21",
+  "version": "2026.5.26-openclaw.1",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.5.26-openclaw.2",
+  "version": "2026.5.26-openclaw.3",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.5.26-openclaw.1",
+  "version": "2026.5.26-openclaw.2",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyOAuthRefreshFailure,
+  classifyOAuthRefreshFailureReason,
+} from "./oauth-refresh-failure.js";
+
+describe("classifyOAuthRefreshFailureReason", () => {
+  it("classifies ended OpenAI app sessions as sign-in-required", () => {
+    expect(classifyOAuthRefreshFailureReason("401 app_session_terminated")).toBe("sign_in_again");
+    expect(classifyOAuthRefreshFailureReason("Your session has ended. Please log in again.")).toBe(
+      "sign_in_again",
+    );
+  });
+});
+
+describe("classifyOAuthRefreshFailure", () => {
+  it("extracts provider and reason from app-session-terminated refresh failures", () => {
+    expect(
+      classifyOAuthRefreshFailure(
+        "OAuth token refresh failed for openai-codex: 401 app_session_terminated: Your session has ended. Please log in again.",
+      ),
+    ).toEqual({
+      provider: "openai-codex",
+      reason: "sign_in_again",
+    });
+  });
+});

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -42,7 +42,13 @@ export function classifyOAuthRefreshFailureReason(
   if (lower.includes("invalid_grant")) {
     return "invalid_grant";
   }
-  if (lower.includes("signing in again") || lower.includes("sign in again")) {
+  if (
+    lower.includes("app_session_terminated") ||
+    lower.includes("session has ended") ||
+    lower.includes("log in again") ||
+    lower.includes("signing in again") ||
+    lower.includes("sign in again")
+  ) {
     return "sign_in_again";
   }
   if (lower.includes("invalid refresh token")) {

--- a/src/agents/harness/policy.ts
+++ b/src/agents/harness/policy.ts
@@ -3,7 +3,7 @@ import { resolveModelRuntimePolicy } from "../model-runtime-policy.js";
 import {
   isOpenAICodexProvider,
   openAIProviderUsesCodexRuntimeByDefault,
-} from "../openai-codex-routing.js";
+} from "../openai-codex-runtime-ids.js";
 import {
   normalizeEmbeddedAgentRuntime,
   type EmbeddedAgentRuntime,

--- a/src/agents/openai-codex-routing.ts
+++ b/src/agents/openai-codex-routing.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeEmbeddedAgentRuntime } from "./pi-embedded-runner/runtime.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
-import { findNormalizedProviderValue, normalizeProviderId } from "./provider-id.js";
+import { findNormalizedProviderValue } from "./provider-id.js";
 export {
   OPENAI_CODEX_PROVIDER_ID,
   OPENAI_PROVIDER_ID,

--- a/src/agents/openai-codex-routing.ts
+++ b/src/agents/openai-codex-routing.ts
@@ -1,82 +1,26 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { normalizeEmbeddedAgentRuntime } from "./pi-embedded-runner/runtime.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 import { findNormalizedProviderValue, normalizeProviderId } from "./provider-id.js";
-
-export const OPENAI_PROVIDER_ID = "openai";
-export const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
-
-function isOfficialOpenAIBaseUrl(baseUrl: unknown): boolean {
-  if (typeof baseUrl !== "string" || !baseUrl.trim()) {
-    return true;
-  }
-  try {
-    const url = new URL(baseUrl.trim());
-    return (
-      url.protocol === "https:" &&
-      url.hostname.toLowerCase() === "api.openai.com" &&
-      (url.pathname === "" ||
-        url.pathname === "/" ||
-        url.pathname === "/v1" ||
-        url.pathname === "/v1/")
-    );
-  } catch {
-    return false;
-  }
-}
-
-function openAIProviderUsesCustomBaseUrl(config: OpenClawConfig | undefined): boolean {
-  return !isOfficialOpenAIBaseUrl(config?.models?.providers?.openai?.baseUrl);
-}
-
-export function isOpenAIProvider(provider: string | undefined): boolean {
-  return normalizeProviderId(provider ?? "") === OPENAI_PROVIDER_ID;
-}
-
-export function isOpenAICodexProvider(provider: string | undefined): boolean {
-  return normalizeProviderId(provider ?? "") === OPENAI_CODEX_PROVIDER_ID;
-}
-
-export function openAIProviderUsesCodexRuntimeByDefault(params: {
-  provider?: string;
-  config?: OpenClawConfig;
-}): boolean {
-  return isOpenAIProvider(params.provider) && !openAIProviderUsesCustomBaseUrl(params.config);
-}
-
-export function parseModelRefProvider(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const slashIndex = value.trim().indexOf("/");
-  if (slashIndex <= 0) {
-    return undefined;
-  }
-  return normalizeProviderId(value.trim().slice(0, slashIndex));
-}
-
-export function modelRefUsesOpenAIProvider(value: unknown): boolean {
-  return parseModelRefProvider(value) === OPENAI_PROVIDER_ID;
-}
-
-export function modelSelectionShouldEnsureCodexPlugin(params: {
-  model?: string;
-  config?: OpenClawConfig;
-}): boolean {
-  const provider = parseModelRefProvider(params.model);
-  if (provider === OPENAI_CODEX_PROVIDER_ID) {
-    return true;
-  }
-  return provider === OPENAI_PROVIDER_ID && !openAIProviderUsesCustomBaseUrl(params.config);
-}
-
-export function hasOpenAICodexAuthProfileOverride(value: unknown): boolean {
-  return (
-    typeof value === "string" &&
-    normalizeOptionalLowercaseString(value)?.startsWith(`${OPENAI_CODEX_PROVIDER_ID}:`) === true
-  );
-}
+export {
+  OPENAI_CODEX_PROVIDER_ID,
+  OPENAI_PROVIDER_ID,
+  hasOpenAICodexAuthProfileOverride,
+  isOpenAICodexProvider,
+  isOpenAIProvider,
+  modelRefUsesOpenAIProvider,
+  modelSelectionShouldEnsureCodexPlugin,
+  openAIProviderUsesCodexRuntimeByDefault,
+  parseModelRefProvider,
+  resolveContextConfigProviderForRuntime,
+} from "./openai-codex-runtime-ids.js";
+import {
+  OPENAI_CODEX_PROVIDER_ID,
+  OPENAI_PROVIDER_ID,
+  hasOpenAICodexAuthProfileOverride,
+  isOpenAIProvider,
+  openAIProviderUsesCodexRuntimeByDefault,
+} from "./openai-codex-runtime-ids.js";
 
 function configuredOpenAIAuthOrderStartsWithCodexProfile(config: OpenClawConfig | undefined) {
   if (!openAIProviderUsesCodexRuntimeByDefault({ provider: OPENAI_PROVIDER_ID, config })) {
@@ -192,16 +136,4 @@ export function resolveSelectedOpenAIPiRuntimeProvider(params: {
     configuredOpenAIAuthOrderStartsWithCodexProfile(params.config)
     ? OPENAI_CODEX_PROVIDER_ID
     : params.provider;
-}
-
-export function resolveContextConfigProviderForRuntime(params: {
-  provider: string;
-  runtimeId?: string;
-}): string {
-  const provider = normalizeProviderId(params.provider);
-  const runtimeId = normalizeEmbeddedAgentRuntime(params.runtimeId);
-  if (provider === OPENAI_PROVIDER_ID && runtimeId === "codex") {
-    return OPENAI_CODEX_PROVIDER_ID;
-  }
-  return params.provider;
 }

--- a/src/agents/openai-codex-runtime-ids.ts
+++ b/src/agents/openai-codex-runtime-ids.ts
@@ -1,0 +1,90 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+import { normalizeEmbeddedAgentRuntime } from "./pi-embedded-runner/runtime.js";
+import { normalizeProviderId } from "./provider-id.js";
+
+export const OPENAI_PROVIDER_ID = "openai";
+export const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
+
+function isOfficialOpenAIBaseUrl(baseUrl: unknown): boolean {
+  if (typeof baseUrl !== "string" || !baseUrl.trim()) {
+    return true;
+  }
+  try {
+    const url = new URL(baseUrl.trim());
+    return (
+      url.protocol === "https:" &&
+      url.hostname.toLowerCase() === "api.openai.com" &&
+      (url.pathname === "" ||
+        url.pathname === "/" ||
+        url.pathname === "/v1" ||
+        url.pathname === "/v1/")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function openAIProviderUsesCustomBaseUrl(config: OpenClawConfig | undefined): boolean {
+  return !isOfficialOpenAIBaseUrl(config?.models?.providers?.openai?.baseUrl);
+}
+
+export function isOpenAIProvider(provider: string | undefined): boolean {
+  return normalizeProviderId(provider ?? "") === OPENAI_PROVIDER_ID;
+}
+
+export function isOpenAICodexProvider(provider: string | undefined): boolean {
+  return normalizeProviderId(provider ?? "") === OPENAI_CODEX_PROVIDER_ID;
+}
+
+export function openAIProviderUsesCodexRuntimeByDefault(params: {
+  provider?: string;
+  config?: OpenClawConfig;
+}): boolean {
+  return isOpenAIProvider(params.provider) && !openAIProviderUsesCustomBaseUrl(params.config);
+}
+
+export function parseModelRefProvider(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const slashIndex = value.trim().indexOf("/");
+  if (slashIndex <= 0) {
+    return undefined;
+  }
+  return normalizeProviderId(value.trim().slice(0, slashIndex));
+}
+
+export function modelRefUsesOpenAIProvider(value: unknown): boolean {
+  return parseModelRefProvider(value) === OPENAI_PROVIDER_ID;
+}
+
+export function modelSelectionShouldEnsureCodexPlugin(params: {
+  model?: string;
+  config?: OpenClawConfig;
+}): boolean {
+  const provider = parseModelRefProvider(params.model);
+  if (provider === OPENAI_CODEX_PROVIDER_ID) {
+    return true;
+  }
+  return provider === OPENAI_PROVIDER_ID && !openAIProviderUsesCustomBaseUrl(params.config);
+}
+
+export function hasOpenAICodexAuthProfileOverride(value: unknown): boolean {
+  return (
+    typeof value === "string" &&
+    normalizeOptionalLowercaseString(value)?.startsWith(`${OPENAI_CODEX_PROVIDER_ID}:`) === true
+  );
+}
+
+export function resolveContextConfigProviderForRuntime(params: {
+  provider: string;
+  runtimeId?: string;
+}): string {
+  const provider = normalizeProviderId(params.provider);
+  const runtimeId = normalizeEmbeddedAgentRuntime(params.runtimeId);
+  if (provider === OPENAI_PROVIDER_ID && runtimeId === "codex") {
+    return OPENAI_CODEX_PROVIDER_ID;
+  }
+  return params.provider;
+}

--- a/src/agents/openai-responses.reasoning-replay.test.ts
+++ b/src/agents/openai-responses.reasoning-replay.test.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage, Model, ToolResultMessage } from "@earendil-works
 import { streamOpenAIResponses } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
+import { buildOpenAIResponsesParams } from "./openai-transport-stream.js";
 
 function buildModel(): Model<"openai-responses"> {
   return {
@@ -14,6 +15,21 @@ function buildModel(): Model<"openai-responses"> {
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 128_000,
+    maxTokens: 4096,
+  };
+}
+
+function buildNativeCodexModel(): Model<"openai-codex-responses"> {
+  return {
+    id: "gpt-5.5",
+    name: "gpt-5.5",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api/codex",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
     maxTokens: 4096,
   };
 }
@@ -189,6 +205,30 @@ describe("openai-responses reasoning replay", () => {
     });
 
     expect(types).toContain("reasoning");
+    expect(types).toContain("message");
+  });
+
+  it("does not replay encrypted reasoning items for native OpenAI Codex Responses", () => {
+    const assistantWithText = buildAssistantMessage({
+      stopReason: "stop",
+      content: [buildReasoningPart(), { type: "text", text: "hello", textSignature: "msg_test" }],
+    });
+    const params = buildOpenAIResponsesParams(
+      buildNativeCodexModel(),
+      {
+        systemPrompt: "system",
+        messages: [
+          { role: "user", content: "Hi", timestamp: Date.now() },
+          assistantWithText,
+          { role: "user", content: "Ok", timestamp: Date.now() },
+        ],
+      },
+      { sessionId: "session", reasoningEffort: "high" },
+    );
+    const input = extractInput(params as Record<string, unknown>);
+    const types = extractInputTypes(input);
+
+    expect(types).not.toContain("reasoning");
     expect(types).toContain("message");
   });
 

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2028,7 +2028,10 @@ export function buildOpenAIResponsesParams(
     {
       includeSystemPrompt: !isCodexResponses,
       supportsDeveloperRole,
-      replayReasoningItems: true,
+      // Native Codex Responses encrypted reasoning is backend-bound and can be
+      // rejected as undecryptable on later turns; replay assistant text/tools,
+      // but do not resend stored encrypted reasoning blobs.
+      replayReasoningItems: !isNativeCodexResponses,
       replayResponsesItemIds: !isNativeCodexResponses,
       authProfileId: options?.authProfileId,
       sessionId: options?.sessionId,

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1539,6 +1539,11 @@ describe("classifyProviderRuntimeFailureKind", () => {
     expect(
       classifyProviderRuntimeFailureKind("401 input item ID does not belong to this connection"),
     ).toBe("replay_invalid");
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "400 code=invalid_encrypted_content Encrypted content could not be decrypted or parsed.",
+      ),
+    ).toBe("replay_invalid");
   });
 
   it("splits ambiguous provider runtime failures instead of collapsing to unknown", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -328,7 +328,7 @@ const DNS_ERROR_RE = /\benotfound\b|\beai_again\b|\bgetaddrinfo\b|\bno such host
 const INTERRUPTED_NETWORK_ERROR_RE =
   /\beconnrefused\b|\beconnreset\b|\beconnaborted\b|\benetreset\b|\behostunreach\b|\behostdown\b|\benetunreach\b|\bepipe\b|\bsocket hang up\b|\bconnection refused\b|\bconnection reset\b|\bconnection aborted\b|\bnetwork is unreachable\b|\bhost is unreachable\b|\bfetch failed\b|\bconnection error\b|\bnetwork request failed\b/i;
 const REPLAY_INVALID_RE =
-  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b/i;
+  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b|\binvalid_encrypted_content\b|\bencrypted content could not be decrypted or parsed\b/i;
 const SANDBOX_BLOCKED_RE =
   /\bapproval is required\b|\bapproval timed out\b|\bapproval was denied\b|\bblocked by sandbox\b|\bsandbox\b.*\b(?:blocked|denied|forbidden|disabled|not allowed)\b/i;
 const NO_BODY_HTTP_WRAPPER_RE =

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -24,7 +24,7 @@ import {
   maybeCompactAgentHarnessSession,
   resolveAgentHarnessPolicy,
 } from "../harness/selection.js";
-import { resolveContextConfigProviderForRuntime } from "../openai-codex-routing.js";
+import { resolveContextConfigProviderForRuntime } from "../openai-codex-runtime-ids.js";
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
 import type { CompactEmbeddedPiSessionParams } from "./compact.types.js";
 import { asCompactionHookRunner, runPostCompactionSideEffects } from "./compaction-hooks.js";

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -72,7 +72,7 @@ import {
 import { isFallbackSummaryError, runWithModelFallback } from "../model-fallback.js";
 import { supportsModelTools } from "../model-tool-support.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
-import { resolveContextConfigProviderForRuntime } from "../openai-codex-routing.js";
+import { resolveContextConfigProviderForRuntime } from "../openai-codex-runtime-ids.js";
 import { createBundleLspToolRuntime } from "../pi-bundle-lsp-runtime.js";
 import { createBundleMcpToolRuntime } from "../pi-bundle-mcp-tools.js";
 import { ensureSessionHeader } from "../pi-embedded-helpers.js";

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -63,11 +63,13 @@ import {
 } from "../model-auth.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
-  OPENAI_CODEX_PROVIDER_ID,
   listOpenAIAuthProfileProvidersForAgentRuntime,
-  resolveContextConfigProviderForRuntime,
   resolveSelectedOpenAIPiRuntimeProvider,
 } from "../openai-codex-routing.js";
+import {
+  OPENAI_CODEX_PROVIDER_ID,
+  resolveContextConfigProviderForRuntime,
+} from "../openai-codex-runtime-ids.js";
 import {
   retireSessionMcpRuntime,
   retireSessionMcpRuntimeForSessionKey,

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -23,7 +23,7 @@ import {
   resolveDefaultModelForAgent,
   resolveModelRefFromString,
 } from "./model-selection.js";
-import { OPENAI_CODEX_PROVIDER_ID, isOpenAIProvider } from "./openai-codex-routing.js";
+import { OPENAI_CODEX_PROVIDER_ID, isOpenAIProvider } from "./openai-codex-runtime-ids.js";
 import { resolveModel, resolveModelAsync } from "./pi-embedded-runner/model.js";
 import { prepareModelForSimpleCompletion } from "./simple-completion-transport.js";
 

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import { normalizeChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -29,6 +30,15 @@ import {
   type ReplyDispatcherWithTypingOptions,
 } from "./reply/reply-dispatcher.js";
 import type { ReplyDispatcher } from "./reply/reply-dispatcher.types.js";
+import {
+  classifyTurnTimingFailure,
+  createTelegramTurnTimingContext,
+  emitTurnTimingEvent,
+  getTurnTimingContextFromReplyOptions,
+  measureTurnTimingDurationMs,
+  wrapTurnTimingDispatcherOptions,
+  wrapTurnTimingReplyOptions,
+} from "./reply/turn-timing.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
 import type { GetReplyOptions, ReplyPayload } from "./types.js";
 
@@ -268,27 +278,63 @@ export async function dispatchInboundMessage(params: {
       source: "dispatchInboundMessage",
     });
   }
-  const result = await withReplyDispatcher({
-    dispatcher: params.dispatcher,
-    run: () =>
-      measureDiagnosticsTimelineSpan(
-        "auto_reply.dispatch_reply_from_config",
-        () =>
-          dispatchReplyFromConfig({
-            ctx: finalized,
-            cfg: params.cfg,
-            dispatcher: params.dispatcher,
-            replyOptions: params.replyOptions,
-            replyResolver: params.replyResolver,
-          }),
-        {
-          phase: "agent-turn",
-          config: params.cfg,
-          attributes: buildDispatchTimelineAttributes(finalized),
-        },
-      ),
-  });
-  return finalizeDispatchResult(result, params.dispatcher);
+  const turnTiming =
+    getTurnTimingContextFromReplyOptions(params.replyOptions) ??
+    createTelegramTurnTimingContext({
+      ctx: finalized,
+      runId: params.replyOptions?.runId,
+    });
+  const turnStartedAtMs = performance.now();
+  const turnReplyOptions = wrapTurnTimingReplyOptions(turnTiming, params.replyOptions);
+  emitTurnTimingEvent(turnTiming, { phase: "telegram.update_received" });
+  emitTurnTimingEvent(turnTiming, { phase: "gateway.dispatch_start" });
+  try {
+    const result = await withReplyDispatcher({
+      dispatcher: params.dispatcher,
+      run: () =>
+        measureDiagnosticsTimelineSpan(
+          "auto_reply.dispatch_reply_from_config",
+          () =>
+            dispatchReplyFromConfig({
+              ctx: finalized,
+              cfg: params.cfg,
+              dispatcher: params.dispatcher,
+              replyOptions: turnReplyOptions,
+              replyResolver: params.replyResolver,
+            }),
+          {
+            phase: "agent-turn",
+            config: params.cfg,
+            attributes: buildDispatchTimelineAttributes(finalized),
+          },
+        ),
+    });
+    const finalizedResult = finalizeDispatchResult(result, params.dispatcher);
+    const queuedCounts = params.dispatcher.getQueuedCounts();
+    const failedCounts = params.dispatcher.getFailedCounts();
+    const cancelledCounts = params.dispatcher.getCancelledCounts?.();
+    emitTurnTimingEvent(turnTiming, {
+      phase: "gateway.dispatch_complete",
+      durationMs: measureTurnTimingDurationMs(turnStartedAtMs),
+      outcome: "completed",
+      replyQueuedCount: queuedCounts.tool + queuedCounts.block + queuedCounts.final,
+      replyFailedCount: failedCounts.tool + failedCounts.block + failedCounts.final,
+      replyCancelledCount:
+        (cancelledCounts?.tool ?? 0) +
+        (cancelledCounts?.block ?? 0) +
+        (cancelledCounts?.final ?? 0),
+    });
+    return finalizedResult;
+  } catch (error) {
+    emitTurnTimingEvent(turnTiming, {
+      phase: "gateway.dispatch_error",
+      durationMs: measureTurnTimingDurationMs(turnStartedAtMs),
+      outcome: "error",
+      failureClass: classifyTurnTimingFailure(error),
+      errorName: error instanceof Error ? error.name : undefined,
+    });
+    throw error;
+  }
 }
 
 export async function dispatchInboundMessageWithBufferedDispatcher(params: {
@@ -300,6 +346,10 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
 }): Promise<DispatchInboundResult> {
   const finalized = finalizeInboundContext(params.ctx);
   const foregroundReplyFence = beginForegroundReplyFence(finalized);
+  const turnTiming = createTelegramTurnTimingContext({
+    ctx: finalized,
+    runId: params.replyOptions?.runId,
+  });
   const silentReplyContext = resolveDispatcherSilentReplyContext(finalized, params.cfg);
   const configuredBeforeDeliver =
     params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(finalized);
@@ -320,20 +370,21 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
       : undefined;
   const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
     createReplyDispatcherWithTyping({
-      ...params.dispatcherOptions,
+      ...wrapTurnTimingDispatcherOptions(turnTiming, params.dispatcherOptions),
       beforeDeliver,
       silentReplyContext: params.dispatcherOptions.silentReplyContext ?? silentReplyContext,
     });
+  const dispatchReplyOptions = wrapTurnTimingReplyOptions(turnTiming, {
+    ...params.replyOptions,
+    ...replyOptions,
+  });
   try {
     return await dispatchInboundMessage({
       ctx: finalized,
       cfg: params.cfg,
       dispatcher,
       replyResolver: params.replyResolver,
-      replyOptions: {
-        ...params.replyOptions,
-        ...replyOptions,
-      },
+      replyOptions: dispatchReplyOptions,
     });
   } finally {
     if (foregroundReplyFence) {
@@ -351,18 +402,23 @@ export async function dispatchInboundMessageWithDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onBlockReply">;
   replyResolver?: GetReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const silentReplyContext = resolveDispatcherSilentReplyContext(params.ctx, params.cfg);
+  const finalized = finalizeInboundContext(params.ctx);
+  const turnTiming = createTelegramTurnTimingContext({
+    ctx: finalized,
+    runId: params.replyOptions?.runId,
+  });
+  const silentReplyContext = resolveDispatcherSilentReplyContext(finalized, params.cfg);
   const dispatcher = createReplyDispatcher({
-    ...params.dispatcherOptions,
+    ...wrapTurnTimingDispatcherOptions(turnTiming, params.dispatcherOptions),
     beforeDeliver:
-      params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(params.ctx),
+      params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(finalized),
     silentReplyContext: params.dispatcherOptions.silentReplyContext ?? silentReplyContext,
   });
   return await dispatchInboundMessage({
-    ctx: params.ctx,
+    ctx: finalized,
     cfg: params.cfg,
     dispatcher,
     replyResolver: params.replyResolver,
-    replyOptions: params.replyOptions,
+    replyOptions: wrapTurnTimingReplyOptions(turnTiming, params.replyOptions),
   });
 }

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -26,6 +26,7 @@ const createReplyMediaPathNormalizerMock = vi.fn();
 const runPreflightCompactionIfNeededMock = vi.fn();
 const runMemoryFlushIfNeededMock = vi.fn();
 const enqueueFollowupRunMock = vi.fn();
+const resetReplyRunSessionMock = vi.fn();
 
 vi.mock("./agent-runner-utils.js", async () => {
   const actual =
@@ -72,6 +73,10 @@ vi.mock("./queue.js", async () => {
     enqueueFollowupRun: (...args: unknown[]) => enqueueFollowupRunMock(...args),
   };
 });
+
+vi.mock("./agent-runner-session-reset.js", () => ({
+  resetReplyRunSession: (...args: unknown[]) => resetReplyRunSessionMock(...args),
+}));
 
 const { runReplyAgent } = await import("./agent-runner.js");
 
@@ -179,6 +184,7 @@ describe("runReplyAgent runtime config", () => {
     createReplyMediaPathNormalizerMock.mockReturnValue((payload: unknown) => payload);
     runPreflightCompactionIfNeededMock.mockRejectedValue(sentinelError);
     runMemoryFlushIfNeededMock.mockResolvedValue(undefined);
+    resetReplyRunSessionMock.mockResolvedValue(true);
   });
 
   it("resolves direct reply runs before early helpers read config", async () => {
@@ -304,6 +310,39 @@ describe("runReplyAgent runtime config", () => {
     expect(result.text).toBe(`⚠️ ${codexMessage}`);
     const metadata = getReplyPayloadMetadata(result);
     expect(metadata?.deliverDespiteSourceReplySuppression).toBe(true);
+  });
+
+  it("resets the session and surfaces preflight compaction timeout failures", async () => {
+    const { followupRun, replyParams } = createDirectRuntimeReplyParams({
+      shouldFollowup: false,
+      isActive: false,
+    });
+    const sessionKey = "agent:main:main";
+    const activeSessionEntry = { sessionId: "session-1", updatedAt: 1 };
+    replyParams.sessionKey = sessionKey;
+    replyParams.sessionEntry = activeSessionEntry;
+    replyParams.sessionStore = { [sessionKey]: activeSessionEntry };
+    replyParams.storePath = "/tmp/openclaw-test-sessions.json";
+    const compactionError = new Error(
+      "Preflight compaction required but failed: timed out waiting for codex app-server compaction",
+    );
+    runPreflightCompactionIfNeededMock.mockRejectedValue(compactionError);
+
+    const result = await runReplyAgent(replyParams);
+
+    if (!result || Array.isArray(result)) {
+      throw new Error("expected a single preflight compaction recovery payload");
+    }
+    expect(result.text).toContain("I've reset our conversation to start fresh");
+    expect(result.text).toContain("reserveTokensFloor");
+    expect(getReplyPayloadMetadata(result)?.deliverDespiteSourceReplySuppression).toBe(true);
+    expect(resetReplyRunSessionMock).toHaveBeenCalledOnce();
+    expect(resetReplyRunSessionMock.mock.calls[0]?.[0]).toMatchObject({
+      options: { failureLabel: "preflight compaction failure" },
+      sessionKey,
+      followupRun,
+    });
+    expect(runMemoryFlushIfNeededMock).not.toHaveBeenCalled();
   });
 
   it("does not resolve secrets before the enqueue-followup queue path", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -4776,7 +4776,6 @@ describe("runAgentTurnWithFallback", () => {
       shouldEmitToolResult: () => true,
       shouldEmitToolOutput: () => false,
       pendingToolTasks: new Set(),
-      resetSessionAfterCompactionFailure: async () => false,
       resetSessionAfterRoleOrderingConflict: async () => false,
       isHeartbeat: false,
       sessionKey: "main",

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -100,6 +100,10 @@ vi.mock("../../agents/pi-embedded-helpers.js", () => ({
   isRateLimitErrorMessage: (message: string) =>
     /rate.limit|too many requests|429|usage limit/i.test(message),
   isTransientHttpError: () => false,
+  classifyProviderRuntimeFailureKind: (message: string) =>
+    /invalid_encrypted_content|encrypted content could not be decrypted or parsed/i.test(message)
+      ? "replay_invalid"
+      : "unclassified",
   sanitizeUserFacingText: (text?: string) => text ?? "",
 }));
 
@@ -4745,6 +4749,46 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE);
+    }
+  });
+
+  it("returns a session reset hint for OpenAI encrypted replay failures", async () => {
+    state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error(
+        "400 code=invalid_encrypted_content Encrypted content could not be decrypted or parsed.",
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Session history got out of sync. Please try again, or use /new to start a fresh session.",
+      );
     }
   });
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { performance } from "node:perf_hooks";
 import {
   hasOutboundReplyContent,
   resolveSendableOutboundReplyParts,
@@ -110,6 +111,13 @@ import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import type { ReplyMediaContext } from "./reply-media-paths.js";
 import { createReplyMediaContext } from "./reply-media-paths.runtime.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
+import {
+  classifyTurnTimingFailure,
+  createTelegramTurnTimingContext,
+  emitTurnTimingEvent,
+  measureTurnTimingDurationMs,
+  resolveTurnTimingRuntimeFamily,
+} from "./turn-timing.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
 // Maximum number of LiveSessionModelSwitchError retries before surfacing a
@@ -1236,6 +1244,10 @@ export async function runAgentTurnWithFallback(params: {
   };
 
   const runId = params.opts?.runId ?? crypto.randomUUID();
+  const turnTiming = createTelegramTurnTimingContext({
+    ctx: params.sessionCtx,
+    runId,
+  });
   if (isDiagnosticsEnabled(runtimeConfig)) {
     logSessionTurnCreated({
       runId,
@@ -1349,6 +1361,7 @@ export async function runAgentTurnWithFallback(params: {
   let fallbackModel = params.followupRun.run.model;
   let fallbackAttempts: RuntimeFallbackAttempt[] = [];
   let didRetryTransientHttpError = false;
+  let turnTimingRuntimeAttemptIndex = 0;
   let liveModelSwitchRetries = 0;
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.getActiveSessionEntry()?.systemPromptReport,
@@ -1665,6 +1678,8 @@ export async function runAgentTurnWithFallback(params: {
           return classification;
         },
         run: async (provider, model, runOptions) => {
+          const attemptIndex = ++turnTimingRuntimeAttemptIndex;
+          const retryCount = Math.max(0, attemptIndex - 1);
           const suppressQueuedUserPersistenceForCandidate =
             (params.followupRun.run.suppressNextUserMessagePersistence ?? false) ||
             queuedUserMessagePersistedAcrossFallback;
@@ -1739,95 +1754,135 @@ export async function runAgentTurnWithFallback(params: {
               originatingChannel: params.followupRun.originatingChannel,
               provider: params.sessionCtx.Provider,
             });
-            const result = await runCliAgentWithLifecycle({
-              runId,
-              provider: cliExecutionProvider,
-              onAgentRunStart: notifyAgentRunStart,
-              suppressAssistantBridge: params.followupRun.run.silentExpected,
-              onAssistantText: async (text) => {
-                const textForTyping = await handlePartialForTyping({ text } as ReplyPayload);
-                if (textForTyping === undefined || !params.opts?.onPartialReply) {
-                  return;
-                }
-                await params.opts.onPartialReply({ text: textForTyping });
-              },
-              onReasoningText: async (text) => {
-                await params.opts?.onReasoningStream?.({ text });
-              },
-              onErrorBeforeLifecycle: async () => {
-                if (!rollbackFallbackCandidateSelection) {
-                  return;
-                }
-                try {
-                  await rollbackFallbackCandidateSelection();
-                  clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
-                } catch (rollbackError) {
-                  logVerbose(
-                    `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
-                  );
-                }
-              },
-              runParams: {
-                sessionId: params.followupRun.run.sessionId,
-                sessionKey: params.sessionKey,
-                agentId: params.followupRun.run.agentId,
-                trigger: params.isHeartbeat ? "heartbeat" : "user",
-                sessionFile: params.followupRun.run.sessionFile,
-                workspaceDir: params.followupRun.run.workspaceDir,
-                config: runtimeConfig,
-                prompt: params.commandBody,
-                transcriptPrompt: params.transcriptCommandBody,
-                currentInboundEventKind: params.followupRun.currentInboundEventKind,
-                currentInboundContext: params.followupRun.currentInboundContext,
-                inputProvenance: params.followupRun.run.inputProvenance,
-                provider: cliExecutionProvider,
-                model,
-                thinkLevel: params.followupRun.run.thinkLevel,
-                timeoutMs: params.followupRun.run.timeoutMs,
-                runId,
-                lane: runLane,
-                extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-                sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
-                silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
-                extraSystemPromptStatic: params.followupRun.run.extraSystemPromptStatic,
-                ownerNumbers: params.followupRun.run.ownerNumbers,
-                cliSessionId: cliSessionBinding?.sessionId,
-                cliSessionBinding,
-                authProfileId: authProfile.authProfileId,
-                bootstrapPromptWarningSignaturesSeen,
-                bootstrapPromptWarningSignature:
-                  bootstrapPromptWarningSignaturesSeen[
-                    bootstrapPromptWarningSignaturesSeen.length - 1
-                  ],
-                images: currentTurnImages.images,
-                imageOrder: currentTurnImages.imageOrder,
-                skillsSnapshot: params.followupRun.run.skillsSnapshot,
-                messageChannel: params.followupRun.originatingChannel ?? undefined,
-                messageProvider: hookMessageProvider,
-                agentAccountId: params.followupRun.run.agentAccountId,
-                senderIsOwner: params.followupRun.run.senderIsOwner,
-                disableTools: params.opts?.disableTools,
-                abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
-                replyOperation: params.replyOperation,
-              },
-              transformResult: (rawResult) =>
-                isRoomEventCliRun && rawResult.meta.agentMeta
-                  ? (() => {
-                      const { cliSessionBinding: _cliSessionBinding, ...agentMeta } =
-                        rawResult.meta.agentMeta;
-                      return {
-                        ...rawResult,
-                        meta: {
-                          ...rawResult.meta,
-                          agentMeta: {
-                            ...agentMeta,
-                            sessionId: "",
-                          },
-                        },
-                      };
-                    })()
-                  : rawResult,
+            const routeFields = {
+              provider,
+              model,
+              runtime: cliExecutionProvider,
+              runtimeSource: sessionRuntimeOverride ? "session" : "config",
+              requestProvider: cliExecutionProvider,
+              runtimeFamily: resolveTurnTimingRuntimeFamily({
+                provider,
+                runtime: cliExecutionProvider,
+                requestProvider: cliExecutionProvider,
+              }),
+              attemptIndex,
+              retryCount,
+            };
+            emitTurnTimingEvent(turnTiming, {
+              phase: "runtime.route_selected",
+              ...routeFields,
             });
+            const requestStartedAtMs = performance.now();
+            emitTurnTimingEvent(turnTiming, {
+              phase: "runtime.request_start",
+              ...routeFields,
+            });
+            let result: Awaited<ReturnType<typeof runCliAgentWithLifecycle>>;
+            try {
+              result = await runCliAgentWithLifecycle({
+                runId,
+                provider: cliExecutionProvider,
+                onAgentRunStart: notifyAgentRunStart,
+                suppressAssistantBridge: params.followupRun.run.silentExpected,
+                onAssistantText: async (text) => {
+                  const textForTyping = await handlePartialForTyping({ text } as ReplyPayload);
+                  if (textForTyping === undefined || !params.opts?.onPartialReply) {
+                    return;
+                  }
+                  await params.opts.onPartialReply({ text: textForTyping });
+                },
+                onReasoningText: async (text) => {
+                  await params.opts?.onReasoningStream?.({ text });
+                },
+                onErrorBeforeLifecycle: async () => {
+                  if (!rollbackFallbackCandidateSelection) {
+                    return;
+                  }
+                  try {
+                    await rollbackFallbackCandidateSelection();
+                    clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
+                  } catch (rollbackError) {
+                    logVerbose(
+                      `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
+                    );
+                  }
+                },
+                runParams: {
+                  sessionId: params.followupRun.run.sessionId,
+                  sessionKey: params.sessionKey,
+                  agentId: params.followupRun.run.agentId,
+                  trigger: params.isHeartbeat ? "heartbeat" : "user",
+                  sessionFile: params.followupRun.run.sessionFile,
+                  workspaceDir: params.followupRun.run.workspaceDir,
+                  config: runtimeConfig,
+                  prompt: params.commandBody,
+                  transcriptPrompt: params.transcriptCommandBody,
+                  currentInboundEventKind: params.followupRun.currentInboundEventKind,
+                  currentInboundContext: params.followupRun.currentInboundContext,
+                  inputProvenance: params.followupRun.run.inputProvenance,
+                  provider: cliExecutionProvider,
+                  model,
+                  thinkLevel: params.followupRun.run.thinkLevel,
+                  timeoutMs: params.followupRun.run.timeoutMs,
+                  runId,
+                  lane: runLane,
+                  extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                  sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
+                  silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
+                  extraSystemPromptStatic: params.followupRun.run.extraSystemPromptStatic,
+                  ownerNumbers: params.followupRun.run.ownerNumbers,
+                  cliSessionId: cliSessionBinding?.sessionId,
+                  cliSessionBinding,
+                  authProfileId: authProfile.authProfileId,
+                  bootstrapPromptWarningSignaturesSeen,
+                  bootstrapPromptWarningSignature:
+                    bootstrapPromptWarningSignaturesSeen[
+                      bootstrapPromptWarningSignaturesSeen.length - 1
+                    ],
+                  images: currentTurnImages.images,
+                  imageOrder: currentTurnImages.imageOrder,
+                  skillsSnapshot: params.followupRun.run.skillsSnapshot,
+                  messageChannel: params.followupRun.originatingChannel ?? undefined,
+                  messageProvider: hookMessageProvider,
+                  agentAccountId: params.followupRun.run.agentAccountId,
+                  senderIsOwner: params.followupRun.run.senderIsOwner,
+                  disableTools: params.opts?.disableTools,
+                  abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
+                  replyOperation: params.replyOperation,
+                },
+                transformResult: (rawResult) =>
+                  isRoomEventCliRun && rawResult.meta.agentMeta
+                    ? (() => {
+                        const { cliSessionBinding: _cliSessionBinding, ...agentMeta } =
+                          rawResult.meta.agentMeta;
+                        return {
+                          ...rawResult,
+                          meta: {
+                            ...rawResult.meta,
+                            agentMeta: {
+                              ...agentMeta,
+                              sessionId: "",
+                            },
+                          },
+                        };
+                      })()
+                    : rawResult,
+              });
+              emitTurnTimingEvent(turnTiming, {
+                phase: "runtime.request_complete",
+                ...routeFields,
+                durationMs: measureTurnTimingDurationMs(requestStartedAtMs),
+              });
+            } catch (error) {
+              emitTurnTimingEvent(turnTiming, {
+                phase: "runtime.request_error",
+                ...routeFields,
+                durationMs: measureTurnTimingDurationMs(requestStartedAtMs),
+                failureClass: classifyTurnTimingFailure(error),
+                errorName: error instanceof Error ? error.name : undefined,
+              });
+              throw error;
+            }
             bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
               result.meta?.systemPromptReport,
             );
@@ -1866,6 +1921,29 @@ export async function runAgentTurnWithFallback(params: {
             (agentHarnessPolicy.runtime === "pi" && embeddedRunProvider !== provider
               ? "pi"
               : undefined);
+          const routeFields = {
+            provider,
+            model,
+            runtime: agentHarnessPolicy.runtime,
+            runtimeSource: agentHarnessPolicy.runtimeSource,
+            requestProvider: embeddedRunProvider,
+            runtimeFamily: resolveTurnTimingRuntimeFamily({
+              provider,
+              runtime: agentHarnessPolicy.runtime,
+              requestProvider: embeddedRunProvider,
+            }),
+            attemptIndex,
+            retryCount,
+          };
+          emitTurnTimingEvent(turnTiming, {
+            phase: "runtime.route_selected",
+            ...routeFields,
+          });
+          const requestStartedAtMs = performance.now();
+          emitTurnTimingEvent(turnTiming, {
+            phase: "runtime.request_start",
+            ...routeFields,
+          });
           return (async () => {
             let attemptCompactionCount = 0;
             const lifecycleBackstop = createEmbeddedLifecycleTerminalBackstop({
@@ -2224,6 +2302,11 @@ export async function runAgentTurnWithFallback(params: {
                 result.meta?.agentMeta?.compactionCount ?? 0,
               );
               attemptCompactionCount = Math.max(attemptCompactionCount, resultCompactionCount);
+              emitTurnTimingEvent(turnTiming, {
+                phase: "runtime.request_complete",
+                ...routeFields,
+                durationMs: measureTurnTimingDurationMs(requestStartedAtMs),
+              });
               return result;
             } catch (err) {
               if (rollbackFallbackCandidateSelection) {
@@ -2237,6 +2320,13 @@ export async function runAgentTurnWithFallback(params: {
                 }
               }
               lifecycleBackstop.emit("error", err);
+              emitTurnTimingEvent(turnTiming, {
+                phase: "runtime.request_error",
+                ...routeFields,
+                durationMs: measureTurnTimingDurationMs(requestStartedAtMs),
+                failureClass: classifyTurnTimingFailure(err),
+                errorName: err instanceof Error ? err.name : undefined,
+              });
               throw err;
             } finally {
               autoCompactionCount += attemptCompactionCount;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -651,7 +651,7 @@ function buildExternalRunFailureReply(
   };
 }
 
-function markAgentRunFailureReplyPayload<T extends ReplyPayload>(payload: T): T {
+export function markAgentRunFailureReplyPayload<T extends ReplyPayload>(payload: T): T {
   return markReplyPayloadForSourceSuppressionDelivery(payload);
 }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -41,6 +41,7 @@ import {
   isOverloadedErrorMessage,
   isRateLimitErrorMessage,
   isTransientHttpError,
+  classifyProviderRuntimeFailureKind,
 } from "../../agents/pi-embedded-helpers.js";
 import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers/sanitize-user-facing-text.js";
 import { isMessagingToolSendAction } from "../../agents/pi-embedded-messaging.js";
@@ -465,6 +466,10 @@ function hasBillingAttemptSummary(err: unknown): boolean {
   );
 }
 
+function isReplayInvalidRunFailureError(message: string): boolean {
+  return classifyProviderRuntimeFailureKind(message) === "replay_invalid";
+}
+
 function collapseRepeatedFailureDetail(message: string): string {
   const parts = message
     .split(/\s+\|\s+/u)
@@ -600,6 +605,12 @@ function buildExternalRunFailureReply(
   if (providerRequestError) {
     return {
       text: providerRequestError.userMessage,
+      isGenericRunnerFailure: false,
+    };
+  }
+  if (isReplayInvalidRunFailureError(normalizedMessage)) {
+    return {
+      text: "⚠️ Session history got out of sync. Please try again, or use /new to start a fresh session.",
       isGenericRunnerFailure: false,
     };
   }
@@ -1157,6 +1168,7 @@ export async function runAgentTurnWithFallback(params: {
   shouldEmitToolOutput: () => boolean;
   pendingToolTasks: Set<Promise<void>>;
   resetSessionAfterRoleOrderingConflict: (reason: string) => Promise<boolean>;
+  resetSessionAfterReplayInvalid?: (reason: string) => Promise<boolean>;
   isHeartbeat: boolean;
   sessionKey?: string;
   runtimePolicySessionKey?: string;
@@ -2426,6 +2438,16 @@ export async function runAgentTurnWithFallback(params: {
           setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
         });
         continue;
+      }
+
+      if (isReplayInvalidRunFailureError(message)) {
+        try {
+          await params.resetSessionAfterReplayInvalid?.(message);
+        } catch (resetErr) {
+          defaultRuntime.error(
+            `Failed to reset replay-invalid session ${params.sessionKey}: ${String(resetErr)}`,
+          );
+        }
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -9,7 +9,7 @@ import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-p
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { listLegacyRuntimeModelProviderAliases } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
-import { resolveContextConfigProviderForRuntime } from "../../agents/openai-codex-routing.js";
+import { resolveContextConfigProviderForRuntime } from "../../agents/openai-codex-runtime-ids.js";
 import { resolveSandboxConfigForAgent, resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import {
   derivePromptTokens,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -350,6 +350,53 @@ describe("runReplyAgent pending final delivery capture", () => {
     return JSON.parse(raw).main as SessionEntry;
   }
 
+  it("rotates poisoned replay-invalid sessions before returning reset guidance", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "poisoned-session",
+      sessionFile: "/tmp/poisoned-session.jsonl",
+      updatedAt: Date.now(),
+      sessionStartedAt: Date.now() - 10_000,
+      systemSent: true,
+      status: "running",
+      contextTokens: 272_000,
+      inputTokens: 877_883,
+      outputTokens: 5_500,
+      modelProvider: "openai-codex",
+      model: "gpt-5.5",
+      cliSessionBindings: { "codex-cli": { sessionId: "codex-session" } },
+    };
+    const sessionStore = { main: sessionEntry };
+    const storePath = await createSessionStoreFile(sessionEntry);
+    state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error(
+        "400 code=invalid_encrypted_content Encrypted content could not be decrypted or parsed.",
+      ),
+    );
+
+    const { run } = createMinimalRun({
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+      runOverrides: {
+        provider: "openai-codex",
+        model: "gpt-5.5",
+      },
+    });
+
+    const result = await run();
+    const stored = await readStoredMainSession(storePath);
+
+    expect(result).toMatchObject({
+      text: "⚠️ Session history got out of sync. Please try again, or use /new to start a fresh session.",
+    });
+    expect(stored.sessionId).not.toBe("poisoned-session");
+    expect(stored.systemSent).toBe(false);
+    expect(stored.status).toBeUndefined();
+    expect(stored.contextTokens).toBeUndefined();
+    expect(stored.cliSessionBindings).toBeUndefined();
+  });
+
   it("does not persist message-tool-only final replies for heartbeat replay", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -196,6 +196,7 @@ function createMinimalRun(params?: {
   return {
     typing,
     opts,
+    followupRun,
     run: async () => {
       const runReplyAgent = await getRunReplyAgent();
       return runReplyAgent({
@@ -373,7 +374,7 @@ describe("runReplyAgent pending final delivery capture", () => {
       ),
     );
 
-    const { run } = createMinimalRun({
+    const { followupRun, run } = createMinimalRun({
       sessionEntry,
       sessionStore,
       sessionKey: "main",
@@ -391,10 +392,18 @@ describe("runReplyAgent pending final delivery capture", () => {
       text: "⚠️ Session history got out of sync. Please try again, or use /new to start a fresh session.",
     });
     expect(stored.sessionId).not.toBe("poisoned-session");
+    expect(stored.sessionFile).toEqual(expect.any(String));
+    expect(stored.sessionFile).not.toBe("/tmp/poisoned-session.jsonl");
+    expect(followupRun.run.sessionId).toBe(stored.sessionId);
+    expect(followupRun.run.sessionFile).toBe(stored.sessionFile);
+    expect(vi.mocked(refreshQueuedFollowupSession)).toHaveBeenCalledWith({
+      key: "main",
+      previousSessionId: "poisoned-session",
+      nextSessionId: stored.sessionId,
+      nextSessionFile: stored.sessionFile,
+    });
     expect(stored.systemSent).toBe(false);
-    expect(stored.status).toBeUndefined();
     expect(stored.contextTokens).toBeUndefined();
-    expect(stored.cliSessionBindings).toBeUndefined();
   });
 
   it("does not persist message-tool-only final replies for heartbeat replay", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -59,7 +59,9 @@ import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
+  buildContextOverflowRecoveryText,
   buildKnownAgentRunFailureReplyPayload,
+  markAgentRunFailureReplyPayload,
   runAgentTurnWithFallback,
 } from "./agent-runner-execution.js";
 import {
@@ -111,6 +113,11 @@ const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 
 function isReplayInvalidAgentRunError(error: unknown): boolean {
   return classifyProviderRuntimeFailureKind(formatErrorMessage(error)) === "replay_invalid";
+}
+
+function isPreflightCompactionFailure(error: unknown): boolean {
+  const message = formatErrorMessage(error);
+  return message.includes("Preflight compaction required but failed:");
 }
 
 function markBeforeAgentRunBlockedPayloads(payloads: ReplyPayload[]): ReplyPayload[] {
@@ -2206,6 +2213,28 @@ export async function runReplyAgent(params: {
     }
     if (isReplayInvalidAgentRunError(error) && sessionKey) {
       await resetSessionAfterReplayInvalid(formatErrorMessage(error));
+    }
+    if (isPreflightCompactionFailure(error)) {
+      const reason = formatErrorMessage(error);
+      const resetApplied = await resetSession({
+        failureLabel: "preflight compaction failure",
+        buildLogMessage: (nextSessionId) =>
+          `Preflight compaction failure (${reason}). Restarting session ${sessionKey} -> ${nextSessionId}.`,
+      });
+      replyOperation.fail("run_failed", error);
+      return returnWithQueuedFollowupDrain(
+        markAgentRunFailureReplyPayload({
+          text: buildContextOverflowRecoveryText({
+            duringCompaction: true,
+            preserveSessionMapping: !resetApplied,
+            cfg,
+            agentId: followupRun.run.agentId,
+            primaryProvider: followupRun.run.provider,
+            primaryModel: followupRun.run.model,
+            activeSessionEntry,
+          }),
+        }),
+      );
     }
     const knownFailurePayload = buildKnownAgentRunFailureReplyPayload({
       err: error,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import {
   hasSessionAutoModelFallbackProvenance,
@@ -103,7 +102,6 @@ import {
   type ReplyOperation,
 } from "./reply-run-registry.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
-import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
 import { resolveSourceReplyVisibilityPolicy } from "./source-reply-delivery-mode.js";
 import { createTypingSignaler } from "./typing-mode.js";
@@ -113,54 +111,6 @@ const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 
 function isReplayInvalidAgentRunError(error: unknown): boolean {
   return classifyProviderRuntimeFailureKind(formatErrorMessage(error)) === "replay_invalid";
-}
-
-function buildReplayInvalidSessionResetPatch(now: number): Partial<SessionEntry> {
-  return {
-    sessionId: crypto.randomUUID(),
-    sessionFile: undefined,
-    updatedAt: now,
-    sessionStartedAt: now,
-    lastInteractionAt: now,
-    systemSent: false,
-    abortedLastRun: false,
-    status: undefined,
-    startedAt: undefined,
-    endedAt: undefined,
-    runtimeMs: undefined,
-    totalTokens: undefined,
-    inputTokens: undefined,
-    outputTokens: undefined,
-    totalTokensFresh: undefined,
-    estimatedCostUsd: undefined,
-    cacheRead: undefined,
-    cacheWrite: undefined,
-    contextTokens: undefined,
-    responseUsage: undefined,
-    modelProvider: undefined,
-    model: undefined,
-    agentHarnessId: undefined,
-    fallbackNoticeSelectedModel: undefined,
-    fallbackNoticeActiveModel: undefined,
-    fallbackNoticeReason: undefined,
-    compactionCount: 0,
-    memoryFlushAt: undefined,
-    memoryFlushCompactionCount: undefined,
-    memoryFlushContextHash: undefined,
-    pendingFinalDelivery: undefined,
-    pendingFinalDeliveryCreatedAt: undefined,
-    pendingFinalDeliveryLastAttemptAt: undefined,
-    pendingFinalDeliveryAttemptCount: undefined,
-    pendingFinalDeliveryLastError: undefined,
-    pendingFinalDeliveryText: undefined,
-    pendingFinalDeliveryContext: undefined,
-    pendingFinalDeliveryIntentId: undefined,
-    cliSessionIds: undefined,
-    cliSessionBindings: undefined,
-    claudeCliSessionId: undefined,
-    skillsSnapshot: undefined,
-    systemPromptReport: undefined,
-  };
 }
 
 function markBeforeAgentRunBlockedPayloads(payloads: ReplyPayload[]): ReplyPayload[] {
@@ -1209,52 +1159,44 @@ export async function runReplyAgent(params: {
       });
     }
   };
-  const resetSessionAfterReplayInvalid = async (reason: string): Promise<boolean> => {
-    if (!sessionKey) {
-      return false;
-    }
-    const oldSessionId = activeSessionEntry?.sessionId;
-    const patch = buildReplayInvalidSessionResetPatch(Date.now());
-    let didReset = false;
-    if (activeSessionStore && activeSessionEntry) {
-      const nextEntry = { ...activeSessionEntry, ...patch } as SessionEntry;
-      activeSessionStore[sessionKey] = nextEntry;
-      activeSessionEntry = nextEntry;
-      didReset = true;
-    }
-    if (storePath) {
-      try {
-        const updated = await updateSessionStoreEntry({
-          storePath,
-          sessionKey,
-          update: async () => patch,
-        });
-        if (updated) {
-          activeSessionEntry = updated;
-          if (activeSessionStore) {
-            activeSessionStore[sessionKey] = updated;
-          }
-          didReset = true;
-        }
-      } catch (resetError) {
-        logVerbose(
-          `failed to reset replay-invalid session ${sessionKey}: ${formatErrorMessage(resetError)}`,
-        );
-      }
-    }
-    if (!didReset) {
-      return false;
-    }
-    followupRun.run.sessionId = String(patch.sessionId);
-    activeIsNewSession = true;
-    clearSessionResetRuntimeState([sessionKey, oldSessionId]);
-    logVerbose(
-      `reset replay-invalid session ${sessionKey}` +
-        (oldSessionId ? ` (${oldSessionId} -> ${String(patch.sessionId)})` : "") +
-        ` after ${reason}`,
-    );
-    return true;
+  type SessionResetOptions = {
+    failureLabel: string;
+    buildLogMessage: (nextSessionId: string) => string;
+    cleanupTranscripts?: boolean;
   };
+  const resetSession = async ({
+    failureLabel,
+    buildLogMessage,
+    cleanupTranscripts,
+  }: SessionResetOptions): Promise<boolean> =>
+    await resetReplyRunSession({
+      options: {
+        failureLabel,
+        buildLogMessage,
+        cleanupTranscripts,
+      },
+      sessionKey,
+      queueKey,
+      activeSessionEntry,
+      activeSessionStore,
+      storePath,
+      messageThreadId:
+        typeof sessionCtx.MessageThreadId === "string" ? sessionCtx.MessageThreadId : undefined,
+      followupRun,
+      onActiveSessionEntry: (nextEntry) => {
+        activeSessionEntry = nextEntry;
+      },
+      onNewSession: () => {
+        activeIsNewSession = true;
+      },
+    });
+  const resetSessionAfterReplayInvalid = async (reason: string): Promise<boolean> =>
+    resetSession({
+      failureLabel: "replay-invalid session state",
+      buildLogMessage: (nextSessionId) =>
+        `Replay-invalid session state (${reason}). Restarting session ${sessionKey} -> ${nextSessionId}.`,
+      cleanupTranscripts: true,
+    });
 
   if (effectiveShouldSteer && isStreaming) {
     const steerSessionId =
@@ -1508,37 +1450,6 @@ export async function runReplyAgent(params: {
     });
 
     let responseUsageLine: string | undefined;
-    type SessionResetOptions = {
-      failureLabel: string;
-      buildLogMessage: (nextSessionId: string) => string;
-      cleanupTranscripts?: boolean;
-    };
-    const resetSession = async ({
-      failureLabel,
-      buildLogMessage,
-      cleanupTranscripts,
-    }: SessionResetOptions): Promise<boolean> =>
-      await resetReplyRunSession({
-        options: {
-          failureLabel,
-          buildLogMessage,
-          cleanupTranscripts,
-        },
-        sessionKey,
-        queueKey,
-        activeSessionEntry,
-        activeSessionStore,
-        storePath,
-        messageThreadId:
-          typeof sessionCtx.MessageThreadId === "string" ? sessionCtx.MessageThreadId : undefined,
-        followupRun,
-        onActiveSessionEntry: (nextEntry) => {
-          activeSessionEntry = nextEntry;
-        },
-        onNewSession: () => {
-          activeIsNewSession = true;
-        },
-      });
     const resetSessionAfterRoleOrderingConflict = async (reason: string): Promise<boolean> =>
       resetSession({
         failureLabel: "role ordering conflict",

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import {
   hasSessionAutoModelFallbackProvenance,
@@ -9,6 +10,7 @@ import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
+import { classifyProviderRuntimeFailureKind } from "../../agents/pi-embedded-helpers.js";
 import {
   formatEmbeddedPiQueueFailureSummary,
   queueEmbeddedPiMessageWithOutcomeAsync,
@@ -33,6 +35,7 @@ import {
   freezeDiagnosticTraceContext,
 } from "../../infra/diagnostic-trace-context.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
@@ -100,12 +103,65 @@ import {
   type ReplyOperation,
 } from "./reply-run-registry.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
+import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
 import { resolveSourceReplyVisibilityPolicy } from "./source-reply-delivery-mode.js";
 import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
+
+function isReplayInvalidAgentRunError(error: unknown): boolean {
+  return classifyProviderRuntimeFailureKind(formatErrorMessage(error)) === "replay_invalid";
+}
+
+function buildReplayInvalidSessionResetPatch(now: number): Partial<SessionEntry> {
+  return {
+    sessionId: crypto.randomUUID(),
+    sessionFile: undefined,
+    updatedAt: now,
+    sessionStartedAt: now,
+    lastInteractionAt: now,
+    systemSent: false,
+    abortedLastRun: false,
+    status: undefined,
+    startedAt: undefined,
+    endedAt: undefined,
+    runtimeMs: undefined,
+    totalTokens: undefined,
+    inputTokens: undefined,
+    outputTokens: undefined,
+    totalTokensFresh: undefined,
+    estimatedCostUsd: undefined,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+    contextTokens: undefined,
+    responseUsage: undefined,
+    modelProvider: undefined,
+    model: undefined,
+    agentHarnessId: undefined,
+    fallbackNoticeSelectedModel: undefined,
+    fallbackNoticeActiveModel: undefined,
+    fallbackNoticeReason: undefined,
+    compactionCount: 0,
+    memoryFlushAt: undefined,
+    memoryFlushCompactionCount: undefined,
+    memoryFlushContextHash: undefined,
+    pendingFinalDelivery: undefined,
+    pendingFinalDeliveryCreatedAt: undefined,
+    pendingFinalDeliveryLastAttemptAt: undefined,
+    pendingFinalDeliveryAttemptCount: undefined,
+    pendingFinalDeliveryLastError: undefined,
+    pendingFinalDeliveryText: undefined,
+    pendingFinalDeliveryContext: undefined,
+    pendingFinalDeliveryIntentId: undefined,
+    cliSessionIds: undefined,
+    cliSessionBindings: undefined,
+    claudeCliSessionId: undefined,
+    skillsSnapshot: undefined,
+    systemPromptReport: undefined,
+  };
+}
 
 function markBeforeAgentRunBlockedPayloads(payloads: ReplyPayload[]): ReplyPayload[] {
   return payloads.map((payload) =>
@@ -1153,6 +1209,52 @@ export async function runReplyAgent(params: {
       });
     }
   };
+  const resetSessionAfterReplayInvalid = async (reason: string): Promise<boolean> => {
+    if (!sessionKey) {
+      return false;
+    }
+    const oldSessionId = activeSessionEntry?.sessionId;
+    const patch = buildReplayInvalidSessionResetPatch(Date.now());
+    let didReset = false;
+    if (activeSessionStore && activeSessionEntry) {
+      const nextEntry = { ...activeSessionEntry, ...patch } as SessionEntry;
+      activeSessionStore[sessionKey] = nextEntry;
+      activeSessionEntry = nextEntry;
+      didReset = true;
+    }
+    if (storePath) {
+      try {
+        const updated = await updateSessionStoreEntry({
+          storePath,
+          sessionKey,
+          update: async () => patch,
+        });
+        if (updated) {
+          activeSessionEntry = updated;
+          if (activeSessionStore) {
+            activeSessionStore[sessionKey] = updated;
+          }
+          didReset = true;
+        }
+      } catch (resetError) {
+        logVerbose(
+          `failed to reset replay-invalid session ${sessionKey}: ${formatErrorMessage(resetError)}`,
+        );
+      }
+    }
+    if (!didReset) {
+      return false;
+    }
+    followupRun.run.sessionId = String(patch.sessionId);
+    activeIsNewSession = true;
+    clearSessionResetRuntimeState([sessionKey, oldSessionId]);
+    logVerbose(
+      `reset replay-invalid session ${sessionKey}` +
+        (oldSessionId ? ` (${oldSessionId} -> ${String(patch.sessionId)})` : "") +
+        ` after ${reason}`,
+    );
+    return true;
+  };
 
   if (effectiveShouldSteer && isStreaming) {
     const steerSessionId =
@@ -1466,6 +1568,7 @@ export async function runReplyAgent(params: {
         shouldEmitToolOutput,
         pendingToolTasks,
         resetSessionAfterRoleOrderingConflict,
+        resetSessionAfterReplayInvalid,
         isHeartbeat,
         sessionKey,
         runtimePolicySessionKey,
@@ -2189,6 +2292,9 @@ export async function runReplyAgent(params: {
           text: "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
         }),
       );
+    }
+    if (isReplayInvalidAgentRunError(error) && sessionKey) {
+      await resetSessionAfterReplayInvalid(formatErrorMessage(error));
     }
     const knownFailurePayload = buildKnownAgentRunFailureReplyPayload({
       err: error,

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -5,7 +5,7 @@ import {
   OPENAI_CODEX_PROVIDER_ID,
   OPENAI_PROVIDER_ID,
   resolveContextConfigProviderForRuntime,
-} from "../../agents/openai-codex-routing.js";
+} from "../../agents/openai-codex-runtime-ids.js";
 import { normalizeProviderId } from "../../agents/provider-id.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -7,7 +7,7 @@ import { resolveAgentHarnessPolicy } from "../../agents/harness/selection.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import { listLegacyRuntimeModelProviderAliases } from "../../agents/model-runtime-aliases.js";
 import { normalizeProviderId, type ModelAliasIndex } from "../../agents/model-selection.js";
-import { resolveContextConfigProviderForRuntime } from "../../agents/openai-codex-routing.js";
+import { resolveContextConfigProviderForRuntime } from "../../agents/openai-codex-runtime-ids.js";
 import { updateSessionStore } from "../../config/sessions/store.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";

--- a/src/auto-reply/reply/turn-timing.test.ts
+++ b/src/auto-reply/reply/turn-timing.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GetReplyOptions } from "../types.js";
+import {
+  classifyTurnTimingFailure,
+  createTelegramTurnTimingContext,
+  getTurnTimingContextFromReplyOptions,
+  resolveTurnTimingRuntimeFamily,
+  wrapTurnTimingReplyOptions,
+} from "./turn-timing.js";
+
+describe("turn timing helpers", () => {
+  it("creates a Telegram-only correlation context from safe message metadata", () => {
+    const timing = createTelegramTurnTimingContext({
+      ctx: {
+        Surface: "telegram",
+        SessionKey: "agent:operator:main",
+        MessageSid: "42",
+        ChatType: "direct",
+      },
+      runId: "run-1",
+    });
+
+    expect(timing).toMatchObject({
+      correlationId: "run-1",
+      channel: "telegram",
+      sessionKey: "agent:operator:main",
+      messageId: "42",
+      chatType: "direct",
+      firstOutputLogged: false,
+    });
+  });
+
+  it("does not create timing context for non-Telegram turns", () => {
+    expect(
+      createTelegramTurnTimingContext({
+        ctx: { Surface: "discord", SessionKey: "agent:operator:main" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("attaches timing context to wrapped reply options and preserves partial callbacks", async () => {
+    const onPartialReply = vi.fn();
+    const timing = createTelegramTurnTimingContext({
+      ctx: { Surface: "telegram", SessionKey: "agent:operator:main" },
+      runId: "run-2",
+    });
+
+    const wrapped = wrapTurnTimingReplyOptions(timing, {
+      onPartialReply,
+    } satisfies Omit<GetReplyOptions, "onBlockReply">);
+
+    expect(wrapped?.runId).toBe("run-2");
+    expect(getTurnTimingContextFromReplyOptions(wrapped)).toBe(timing);
+
+    await wrapped?.onPartialReply?.({ text: "hello" });
+
+    expect(onPartialReply).toHaveBeenCalledWith({ text: "hello" });
+    expect(timing?.firstOutputLogged).toBe(true);
+  });
+
+  it("classifies operational failure modes without logging raw error text", () => {
+    expect(classifyTurnTimingFailure(new Error("refresh_token_invalidated"))).toBe("auth_refresh");
+    expect(classifyTurnTimingFailure(new Error("GatewayDrainingError: gateway draining"))).toBe(
+      "gateway_restart",
+    );
+    expect(
+      classifyTurnTimingFailure(new Error("Cannot access 'providerId' before initialization")),
+    ).toBe("bootstrap");
+    expect(classifyTurnTimingFailure(new Error('No API key found for provider "openai"'))).toBe(
+      "model_routing",
+    );
+    expect(classifyTurnTimingFailure(new Error("HTTP 429 rate limit"))).toBe("provider_api");
+    expect(classifyTurnTimingFailure(new Error("Forbidden"), "telegram_send")).toBe(
+      "telegram_send",
+    );
+  });
+
+  it("resolves runtime families for Codex subscription, direct OpenAI, and provider routes", () => {
+    expect(
+      resolveTurnTimingRuntimeFamily({
+        provider: "openai-codex",
+        runtime: "codex",
+        requestProvider: "openai-codex",
+      }),
+    ).toBe("codex-subscription");
+    expect(
+      resolveTurnTimingRuntimeFamily({
+        provider: "openai",
+        runtime: "pi",
+        requestProvider: "openai",
+      }),
+    ).toBe("direct-openai-api");
+    expect(
+      resolveTurnTimingRuntimeFamily({
+        provider: "anthropic",
+        runtime: "pi",
+        requestProvider: "anthropic",
+      }),
+    ).toBe("provider-runtime");
+  });
+});

--- a/src/auto-reply/reply/turn-timing.ts
+++ b/src/auto-reply/reply/turn-timing.ts
@@ -1,0 +1,336 @@
+import { randomUUID } from "node:crypto";
+import { performance } from "node:perf_hooks";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "../../shared/string-coerce.js";
+import type { FinalizedMsgContext } from "../templating.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { ReplyDispatcherOptions } from "./reply-dispatcher.js";
+import type { ReplyDispatchKind } from "./reply-dispatcher.types.js";
+
+export const TURN_TIMING_SCHEMA_VERSION = "openclaw.turn_timing.v1";
+
+export type TurnTimingFailureClass =
+  | "auth_refresh"
+  | "bootstrap"
+  | "gateway_restart"
+  | "model_routing"
+  | "provider_api"
+  | "telegram_send"
+  | "unknown";
+
+export type TurnTimingRuntimeFamily =
+  | "codex-subscription"
+  | "direct-openai-api"
+  | "provider-runtime";
+
+export type TurnTimingContext = {
+  correlationId: string;
+  startedAtMs: number;
+  channel: "telegram";
+  sessionKey?: string;
+  messageId?: string;
+  chatType?: string;
+  firstOutputLogged: boolean;
+};
+
+type TurnTimingEventFields = {
+  phase:
+    | "telegram.update_received"
+    | "gateway.dispatch_start"
+    | "gateway.dispatch_complete"
+    | "gateway.dispatch_error"
+    | "runtime.route_selected"
+    | "runtime.request_start"
+    | "runtime.request_complete"
+    | "runtime.request_error"
+    | "reply.first_output"
+    | "reply.final_output"
+    | "telegram.send_start"
+    | "telegram.send_complete"
+    | "telegram.send_error";
+  durationMs?: number;
+  outcome?: "completed" | "error" | "skipped";
+  provider?: string;
+  model?: string;
+  runtime?: string;
+  runtimeSource?: string;
+  runtimeFamily?: TurnTimingRuntimeFamily;
+  requestProvider?: string;
+  retryCount?: number;
+  attemptIndex?: number;
+  replyKind?: ReplyDispatchKind | "partial";
+  payloadTextChars?: number;
+  payloadMediaCount?: number;
+  payloadIsError?: boolean;
+  replyQueuedCount?: number;
+  replyFailedCount?: number;
+  replyCancelledCount?: number;
+  failureClass?: TurnTimingFailureClass;
+  errorName?: string;
+};
+
+const log = createSubsystemLogger("auto-reply/turn-timing");
+const turnTimingContextKey = Symbol.for("openclaw.turnTimingContext");
+
+type TurnTimingAttachedReplyOptions = Omit<GetReplyOptions, "onBlockReply"> & {
+  [turnTimingContextKey]?: TurnTimingContext;
+};
+
+type TurnTimingMessageContext = Pick<
+  FinalizedMsgContext,
+  | "Provider"
+  | "Surface"
+  | "SessionKey"
+  | "CommandTargetSessionKey"
+  | "MessageSid"
+  | "MessageSidFirst"
+  | "MessageSidFull"
+  | "MessageSidLast"
+  | "ChatType"
+>;
+
+function resolveChannel(ctx: TurnTimingMessageContext): string {
+  return normalizeLowercaseStringOrEmpty(ctx.Surface ?? ctx.Provider ?? "");
+}
+
+export function isTelegramTurnContext(ctx: TurnTimingMessageContext): boolean {
+  return resolveChannel(ctx) === "telegram";
+}
+
+function resolveMessageId(ctx: TurnTimingMessageContext): string | undefined {
+  return normalizeOptionalString(
+    ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast,
+  );
+}
+
+export function createTelegramTurnTimingContext(params: {
+  ctx: TurnTimingMessageContext;
+  runId?: string;
+}): TurnTimingContext | undefined {
+  if (!isTelegramTurnContext(params.ctx)) {
+    return undefined;
+  }
+  return {
+    correlationId: normalizeOptionalString(params.runId) ?? `telegram-turn-${randomUUID()}`,
+    startedAtMs: performance.now(),
+    channel: "telegram",
+    sessionKey: normalizeOptionalString(
+      params.ctx.CommandTargetSessionKey ?? params.ctx.SessionKey,
+    ),
+    messageId: resolveMessageId(params.ctx),
+    chatType: normalizeOptionalString(params.ctx.ChatType),
+    firstOutputLogged: false,
+  };
+}
+
+function normalizeDurationMs(startedAtMs: number): number {
+  return Math.max(0, Math.round((performance.now() - startedAtMs) * 1000) / 1000);
+}
+
+export function measureTurnTimingDurationMs(startedAtMs: number): number {
+  return normalizeDurationMs(startedAtMs);
+}
+
+function readErrorName(error: unknown): string | undefined {
+  if (error && typeof error === "object" && "name" in error) {
+    return normalizeOptionalString(String((error as { name?: unknown }).name));
+  }
+  return undefined;
+}
+
+function readErrorText(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  return String(error ?? "");
+}
+
+export function classifyTurnTimingFailure(
+  error: unknown,
+  hint?: "telegram_send",
+): TurnTimingFailureClass {
+  if (hint === "telegram_send") {
+    return "telegram_send";
+  }
+  const message = readErrorText(error).toLowerCase();
+  if (
+    /(refresh[_ -]?token|token[_ -]?invalidated|auth[_ -]?block|oauth|login expired|reauth)/u.test(
+      message,
+    )
+  ) {
+    return "auth_refresh";
+  }
+  if (
+    /\b(gateway.*restart|gateway.*draining|command lane cleared|commandlanecleared)\b/u.test(
+      message,
+    )
+  ) {
+    return "gateway_restart";
+  }
+  if (
+    /\b(bootstrap|provider-?id|temporal dead zone|cannot access .+ before initialization|preflight compaction)\b/u.test(
+      message,
+    )
+  ) {
+    return "bootstrap";
+  }
+  if (
+    /\b(model routing|route selected|unknown provider|provider .+ not configured|no model|missing model|no api key found|missing api key)\b/u.test(
+      message,
+    )
+  ) {
+    return "model_routing";
+  }
+  if (
+    /\b(provider api|rate limit|overloaded|billing|http\s*[45]\d\d|status\s*[45]\d\d|api request)\b/u.test(
+      message,
+    )
+  ) {
+    return "provider_api";
+  }
+  return "unknown";
+}
+
+export function resolveTurnTimingRuntimeFamily(params: {
+  provider?: string;
+  runtime?: string;
+  requestProvider?: string;
+}): TurnTimingRuntimeFamily {
+  const provider = normalizeLowercaseStringOrEmpty(params.provider);
+  const runtime = normalizeLowercaseStringOrEmpty(params.runtime);
+  const requestProvider = normalizeLowercaseStringOrEmpty(params.requestProvider);
+  if (runtime === "codex" || provider === "openai-codex" || requestProvider === "openai-codex") {
+    return "codex-subscription";
+  }
+  return provider === "openai" || requestProvider === "openai"
+    ? "direct-openai-api"
+    : "provider-runtime";
+}
+
+function payloadSummary(
+  payload: ReplyPayload,
+): Pick<TurnTimingEventFields, "payloadTextChars" | "payloadMediaCount" | "payloadIsError"> {
+  const text = normalizeOptionalString(payload.text);
+  return {
+    payloadTextChars: text?.length ?? 0,
+    payloadMediaCount: Array.isArray(payload.mediaUrls) ? payload.mediaUrls.length : 0,
+    payloadIsError: payload.isError === true,
+  };
+}
+
+export function emitTurnTimingEvent(
+  timing: TurnTimingContext | undefined,
+  fields: TurnTimingEventFields,
+): void {
+  if (!timing) {
+    return;
+  }
+  log.info("turn_timing", {
+    schemaVersion: TURN_TIMING_SCHEMA_VERSION,
+    correlationId: timing.correlationId,
+    channel: timing.channel,
+    sessionKey: timing.sessionKey,
+    messageId: timing.messageId,
+    chatType: timing.chatType,
+    elapsedMs: normalizeDurationMs(timing.startedAtMs),
+    ...fields,
+    consoleMessage:
+      `turn_timing phase=${fields.phase} correlationId=${timing.correlationId}` +
+      (fields.runtimeFamily ? ` runtimeFamily=${fields.runtimeFamily}` : "") +
+      (fields.durationMs !== undefined ? ` durationMs=${fields.durationMs}` : "") +
+      (fields.failureClass ? ` failureClass=${fields.failureClass}` : ""),
+  });
+}
+
+function emitFirstOutputIfNeeded(
+  timing: TurnTimingContext | undefined,
+  fields: Omit<TurnTimingEventFields, "phase">,
+): void {
+  if (!timing || timing.firstOutputLogged) {
+    return;
+  }
+  timing.firstOutputLogged = true;
+  emitTurnTimingEvent(timing, { phase: "reply.first_output", ...fields });
+}
+
+export function getTurnTimingContextFromReplyOptions(
+  options: Omit<GetReplyOptions, "onBlockReply"> | undefined,
+): TurnTimingContext | undefined {
+  return (options as TurnTimingAttachedReplyOptions | undefined)?.[turnTimingContextKey];
+}
+
+export function wrapTurnTimingReplyOptions(
+  timing: TurnTimingContext | undefined,
+  options: Omit<GetReplyOptions, "onBlockReply"> | undefined,
+): TurnTimingAttachedReplyOptions | undefined {
+  if (!timing) {
+    return options;
+  }
+  const base: Omit<GetReplyOptions, "onBlockReply"> = options ?? {};
+  return {
+    ...base,
+    [turnTimingContextKey]: timing,
+    runId: timing.correlationId,
+    onPartialReply: async (
+      payload: Parameters<NonNullable<GetReplyOptions["onPartialReply"]>>[0],
+    ) => {
+      emitFirstOutputIfNeeded(timing, {
+        replyKind: "partial",
+        payloadTextChars: normalizeOptionalString(payload.text)?.length ?? 0,
+        payloadMediaCount: Array.isArray(payload.mediaUrls) ? payload.mediaUrls.length : 0,
+      });
+      await base.onPartialReply?.(payload);
+    },
+  };
+}
+
+export function wrapTurnTimingDispatcherOptions<T extends Pick<ReplyDispatcherOptions, "deliver">>(
+  timing: TurnTimingContext | undefined,
+  options: T,
+): T {
+  if (!timing) {
+    return options;
+  }
+  return {
+    ...options,
+    deliver: async (payload, info) => {
+      emitFirstOutputIfNeeded(timing, {
+        replyKind: info.kind,
+        ...payloadSummary(payload),
+      });
+      if (info.kind === "final") {
+        emitTurnTimingEvent(timing, {
+          phase: "reply.final_output",
+          replyKind: info.kind,
+          ...payloadSummary(payload),
+        });
+      }
+      const startedAtMs = performance.now();
+      emitTurnTimingEvent(timing, {
+        phase: "telegram.send_start",
+        replyKind: info.kind,
+      });
+      try {
+        const result = await options.deliver(payload, info);
+        emitTurnTimingEvent(timing, {
+          phase: "telegram.send_complete",
+          replyKind: info.kind,
+          durationMs: normalizeDurationMs(startedAtMs),
+        });
+        return result;
+      } catch (error) {
+        emitTurnTimingEvent(timing, {
+          phase: "telegram.send_error",
+          replyKind: info.kind,
+          durationMs: normalizeDurationMs(startedAtMs),
+          failureClass: classifyTurnTimingFailure(error, "telegram_send"),
+          errorName: readErrorName(error),
+        });
+        throw error;
+      }
+    },
+  };
+}

--- a/src/commands/models/list.auth-index.ts
+++ b/src/commands/models/list.auth-index.ts
@@ -13,7 +13,7 @@ import {
 import {
   OPENAI_CODEX_PROVIDER_ID,
   openAIProviderUsesCodexRuntimeByDefault,
-} from "../../agents/openai-codex-routing.js";
+} from "../../agents/openai-codex-runtime-ids.js";
 import { resolveProviderAuthAliasMap } from "../../agents/provider-auth-aliases.js";
 import { normalizeProviderIdForAuth } from "../../agents/provider-id.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -16,6 +16,7 @@ import { resolveAuthStorePathForDisplay } from "../../agents/auth-profiles/paths
 import { ensureAuthProfileStoreWithoutExternalProfiles as ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
 import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
 import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
+import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import {
   listProviderEnvAuthLookupKeys,
   resolveProviderEnvApiKeyCandidates,
@@ -104,6 +105,20 @@ type StatusSyntheticAuth = {
   credential?: string;
   mode?: ProviderSyntheticAuthResult["mode"];
   expiresAt?: number;
+};
+
+type StatusRuntimeRoute = {
+  source: "default" | "fallback";
+  index: number;
+  rawModel: string;
+  resolvedModel: string;
+  provider: string;
+  model: string;
+  runtime: string;
+  runtimeSource: string;
+  runtimeFamily: "codex-subscription" | "direct-openai-api" | "provider-runtime";
+  authProvider: string;
+  status: "usable" | "missing";
 };
 
 function loadProviderUsageRuntime(): Promise<ProviderUsageRuntime> {
@@ -579,6 +594,67 @@ export async function modelsStatusCommand(
         }),
       ).values(),
     ).toSorted((a, b) => a.provider.localeCompare(b.provider));
+    const resolveRuntimeRouteAuthProvider = (params: {
+      provider: string;
+      runtime: string;
+    }): string => {
+      if (
+        params.runtime === "codex" &&
+        openAIProviderUsesCodexRuntimeByDefault({ provider: params.provider, config: cfg })
+      ) {
+        return OPENAI_CODEX_PROVIDER_ID;
+      }
+      return resolveProviderAuthHealthId(params.provider);
+    };
+    const resolveRuntimeFamily = (params: {
+      provider: string;
+      runtime: string;
+    }): StatusRuntimeRoute["runtimeFamily"] => {
+      if (params.runtime === "codex") {
+        return "codex-subscription";
+      }
+      return normalizeProviderId(params.provider) === "openai"
+        ? "direct-openai-api"
+        : "provider-runtime";
+    };
+    const hasUsableRuntimeRouteAuth = (params: { authProvider: string }): boolean =>
+      hasUsableProviderAuth(params.authProvider);
+    const runtimeRouteInputs = [
+      { source: "default" as const, index: 0, raw: defaultLabel },
+      ...fallbacks.map((raw, index) => ({ source: "fallback" as const, index, raw })),
+    ];
+    const runtimeRoutes: StatusRuntimeRoute[] = runtimeRouteInputs.flatMap(
+      (entry): StatusRuntimeRoute[] => {
+        const ref = resolveStatusModelRef(entry.raw);
+        if (!ref?.provider || !ref.model) {
+          return [];
+        }
+        const provider = normalizeProviderId(ref.provider);
+        const policy = resolveAgentHarnessPolicy({
+          provider,
+          modelId: ref.model,
+          config: cfg,
+          agentId: workspaceAgentId,
+        });
+        const runtime = policy.runtime;
+        const authProvider = resolveRuntimeRouteAuthProvider({ provider, runtime });
+        return [
+          {
+            source: entry.source,
+            index: entry.index,
+            rawModel: entry.raw,
+            resolvedModel: modelKey(provider, ref.model),
+            provider,
+            model: ref.model,
+            runtime,
+            runtimeSource: policy.runtimeSource ?? "implicit",
+            runtimeFamily: resolveRuntimeFamily({ provider, runtime }),
+            authProvider,
+            status: hasUsableRuntimeRouteAuth({ authProvider }) ? "usable" : "missing",
+          },
+        ];
+      },
+    );
     const missingProvidersInUse = Array.from(
       new Set(
         providerUses
@@ -784,6 +860,7 @@ export async function modelsStatusCommand(
             enabled: shellFallbackEnabled,
             appliedKeys: applied,
           },
+          runtimeRoutes,
           providersWithOAuth: providersWithOauth,
           missingProvidersInUse,
           runtimeAuthRoutes,
@@ -989,6 +1066,20 @@ export async function modelsStatusCommand(
               route.effective.detail,
             )}`,
           )}${formatSeparator()}${formatKeyValue("status", route.status)}`,
+        );
+      }
+    }
+
+    if (runtimeRoutes.length > 0) {
+      runtime.log("");
+      runtime.log(colorize(rich, theme.heading, "Runtime routes"));
+      for (const route of runtimeRoutes) {
+        runtime.log(
+          `- ${theme.heading(route.source)} ${colorize(rich, theme.info, route.resolvedModel)} ` +
+            `${formatKeyValue("runtime", route.runtime)}${formatSeparator()}` +
+            `${formatKeyValue("family", route.runtimeFamily)}${formatSeparator()}` +
+            `${formatKeyValue("auth", route.authProvider)}${formatSeparator()}` +
+            `${formatKeyValue("status", route.status)}`,
         );
       }
     }

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -33,7 +33,7 @@ import {
 import {
   OPENAI_CODEX_PROVIDER_ID,
   openAIProviderUsesCodexRuntimeByDefault,
-} from "../../agents/openai-codex-routing.js";
+} from "../../agents/openai-codex-runtime-ids.js";
 import {
   resolveProviderAuthAliasMap,
   resolveProviderIdForAuth,

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -42,6 +42,15 @@ const mocks = vi.hoisted(() => {
     resolveAgentExplicitModelPrimary: vi.fn().mockReturnValue(undefined),
     resolveAgentEffectiveModelPrimary: vi.fn().mockReturnValue(undefined),
     resolveAgentModelFallbacksOverride: vi.fn().mockReturnValue(undefined),
+    resolveSessionAgentIds: vi.fn(({ agentId }: { agentId?: string } = {}) => ({
+      defaultAgentId: "main",
+      sessionAgentId: agentId?.trim().toLowerCase() || "main",
+    })),
+    listAgentEntries: vi.fn((config?: { agents?: { list?: unknown[] } }) =>
+      Array.isArray(config?.agents?.list)
+        ? config.agents.list.filter((entry) => entry !== null && typeof entry === "object")
+        : [],
+    ),
     listAgentIds: vi.fn().mockReturnValue(["main", "jeremiah"]),
     ensureAuthProfileStore: vi.fn().mockReturnValue(store),
     listProfilesForProvider: vi.fn((s: typeof store, provider: string) => {
@@ -146,6 +155,8 @@ vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentExplicitModelPrimary: mocks.resolveAgentExplicitModelPrimary,
   resolveAgentEffectiveModelPrimary: mocks.resolveAgentEffectiveModelPrimary,
   resolveAgentModelFallbacksOverride: mocks.resolveAgentModelFallbacksOverride,
+  resolveSessionAgentIds: mocks.resolveSessionAgentIds,
+  listAgentEntries: mocks.listAgentEntries,
   listAgentIds: mocks.listAgentIds,
 }));
 vi.mock("../../agents/workspace.js", () => ({
@@ -501,6 +512,137 @@ describe("modelsStatusCommand auth overview", () => {
       const payload = parseFirstJsonLog(localRuntime);
       expect(payload.auth.missingProvidersInUse).toStrictEqual([]);
       expect(localRuntime.exit).not.toHaveBeenCalledWith(1);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+    }
+  });
+
+  it("reports selected canonical OpenAI routes as Codex subscription routes", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5", fallbacks: ["openai/gpt-5.4"] },
+          models: {
+            "openai/gpt-5.5": {},
+            "openai/gpt-5.4": {},
+          },
+        },
+      },
+      models: { providers: {} },
+      env: { shellEnv: { enabled: false } },
+    });
+    mocks.store.profiles = {
+      "openai-codex:default": originalProfiles["openai-codex:default"],
+    };
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = parseFirstJsonLog(localRuntime);
+      expect(payload.auth.runtimeRoutes).toEqual([
+        {
+          source: "default",
+          index: 0,
+          rawModel: "openai/gpt-5.5",
+          resolvedModel: "openai/gpt-5.5",
+          provider: "openai",
+          model: "gpt-5.5",
+          runtime: "codex",
+          runtimeSource: "implicit",
+          runtimeFamily: "codex-subscription",
+          authProvider: "openai-codex",
+          status: "usable",
+        },
+        {
+          source: "fallback",
+          index: 0,
+          rawModel: "openai/gpt-5.4",
+          resolvedModel: "openai/gpt-5.4",
+          provider: "openai",
+          model: "gpt-5.4",
+          runtime: "codex",
+          runtimeSource: "implicit",
+          runtimeFamily: "codex-subscription",
+          authProvider: "openai-codex",
+          status: "usable",
+        },
+      ]);
+      expect(localRuntime.exit).not.toHaveBeenCalledWith(1);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+    }
+  });
+
+  it("reports direct OpenAI API routes distinctly and fails closed when auth is missing", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5", fallbacks: [] },
+          models: { "openai/gpt-5.5": {} },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://proxy.example.test/v1",
+            agentRuntime: { id: "pi" },
+            models: [],
+          },
+        },
+      },
+      env: { shellEnv: { enabled: false } },
+    });
+    mocks.store.profiles = {};
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = parseFirstJsonLog(localRuntime);
+      expect(payload.auth.runtimeRoutes).toEqual([
+        {
+          source: "default",
+          index: 0,
+          rawModel: "openai/gpt-5.5",
+          resolvedModel: "openai/gpt-5.5",
+          provider: "openai",
+          model: "gpt-5.5",
+          runtime: "pi",
+          runtimeSource: "provider",
+          runtimeFamily: "direct-openai-api",
+          authProvider: "openai",
+          status: "missing",
+        },
+      ]);
+      expect(payload.auth.missingProvidersInUse).toEqual(["openai"]);
+      expect(localRuntime.exit).toHaveBeenCalledWith(1);
     } finally {
       mocks.store.profiles = originalProfiles;
       if (originalLoadConfig) {

--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   pickLastDeliverablePayload,
   pickLastNonEmptyTextFromPayloads,
   pickSummaryFromPayloads,
+  resolveCronPayloadOutcome,
 } from "./helpers.js";
 
 type TextPayload = { text?: string | undefined; isError?: boolean | undefined };
@@ -147,6 +148,70 @@ describe("pickDeliverablePayloads", () => {
     ];
 
     expect(pickDeliverablePayloads(payloads)).toEqual([{ text: "last error", isError: true }]);
+  });
+});
+
+describe("resolveCronPayloadOutcome", () => {
+  it("keeps recovered read-only fetch warnings from failing cron runs", () => {
+    const finalText =
+      "Deploy is green. The live owner page and representative club claim CTA are verified.";
+
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [
+        { text: finalText },
+        {
+          text: '⚠️ 🛠️ `fetch https://mypadelway.com/owner -> search "Claim your venue"` failed',
+          isError: true,
+        },
+      ],
+      finalAssistantVisibleText: finalText,
+      preferFinalAssistantVisibleText: false,
+    });
+
+    expect(outcome.hasFatalErrorPayload).toBe(false);
+    expect(outcome.embeddedRunError).toBeUndefined();
+    expect(outcome.outputText).toBe(finalText);
+    expect(outcome.deliveryPayloads).toEqual([{ text: finalText }]);
+  });
+
+  it("keeps recovered read-only search warnings from failing cron runs", () => {
+    const finalText = "The fallback source verified the deploy.";
+
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [
+        { text: finalText },
+        {
+          text: '⚠️ 🛠️ `search "mypadelway owner copy"` failed',
+          isError: true,
+        },
+      ],
+      finalAssistantVisibleText: finalText,
+      preferFinalAssistantVisibleText: false,
+    });
+
+    expect(outcome.hasFatalErrorPayload).toBe(false);
+    expect(outcome.outputText).toBe(finalText);
+    expect(outcome.deliveryPayloads).toEqual([{ text: finalText }]);
+  });
+
+  it("keeps mutating tool warnings fatal after success-looking cron output", () => {
+    const finalText = "Done.";
+
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [
+        { text: finalText },
+        {
+          text: "⚠️ 🛠️ `write /tmp/report.md` failed",
+          isError: true,
+        },
+      ],
+      finalAssistantVisibleText: finalText,
+      preferFinalAssistantVisibleText: false,
+    });
+
+    expect(outcome.hasFatalErrorPayload).toBe(true);
+    expect(outcome.embeddedRunError).toBe("⚠️ 🛠️ `write /tmp/report.md` failed");
+    expect(outcome.outputText).toBe("⚠️ 🛠️ `write /tmp/report.md` failed");
   });
 });
 

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -206,6 +206,14 @@ function isCronToolWarning(text: string | undefined): boolean {
   return normalizeOptionalString(text)?.startsWith("⚠️ 🛠️ ") === true;
 }
 
+function isRecoveredReadOnlyCronToolWarning(text: string | undefined): boolean {
+  const normalized = normalizeOptionalString(text);
+  if (!normalized?.startsWith("⚠️ 🛠️ ")) {
+    return false;
+  }
+  return /^⚠️ 🛠️ `(?:fetch|search)\b/i.test(normalized);
+}
+
 function isNonTerminalToolErrorWarning(payload: object | undefined): boolean {
   return Boolean(payload && getReplyPayloadMetadata(payload)?.nonTerminalToolErrorWarning);
 }
@@ -280,12 +288,20 @@ export function resolveCronPayloadOutcome(params: {
     !hasStructuredDeliveryPayloads &&
     errorPayloads.length > 0 &&
     errorPayloads.every((payload) => isCronToolWarning(payload?.text));
+  const hasRecoveredReadOnlyToolWarning =
+    !params.runLevelError &&
+    params.failureSignal?.fatalForCron !== true &&
+    normalizedFinalAssistantVisibleText !== undefined &&
+    !hasStructuredDeliveryPayloads &&
+    errorPayloads.length > 0 &&
+    errorPayloads.every((payload) => isRecoveredReadOnlyCronToolWarning(payload?.text));
   const hasFatalStructuredErrorPayload =
     hasErrorPayload &&
     !hasSuccessfulPayloadAfterLastError &&
     !hasPendingPresentationWarning &&
     !hasNonTerminalToolErrorWarning &&
-    !hasRecoveredToolWarning;
+    !hasRecoveredToolWarning &&
+    !hasRecoveredReadOnlyToolWarning;
   // Keep structured/media announce payloads intact. Only collapse purely textual
   // cron announce output to the final assistant-visible answer.
   const shouldUseFinalAssistantVisibleText =

--- a/src/cron/isolated-agent/run.interim-retry.test.ts
+++ b/src/cron/isolated-agent/run.interim-retry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  makeIsolatedAgentTurnJob,
   makeIsolatedAgentTurnParams,
   setupRunCronIsolatedAgentTurnSuite,
 } from "./run.suite-helpers.js";
@@ -27,12 +28,18 @@ function requireEmbeddedAgentCall(index: number): { prompt?: string } {
 }
 
 function requireDeliveryRequest(): {
+  deliveryBestEffort?: boolean;
+  deliveryPayloadHasStructuredContent?: boolean;
   skipHeartbeatDelivery?: boolean;
+  synthesizedText?: unknown;
   deliveryPayloads?: unknown;
 } {
   const request = dispatchCronDeliveryMock.mock.calls[0]?.[0] as
     | {
+        deliveryBestEffort?: boolean;
+        deliveryPayloadHasStructuredContent?: boolean;
         skipHeartbeatDelivery?: boolean;
+        synthesizedText?: unknown;
         deliveryPayloads?: unknown;
       }
     | undefined;
@@ -127,7 +134,7 @@ describe("runCronIsolatedAgentTurn — interim ack retry", () => {
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
   });
 
-  it("delivers synthesized fatal failure signals even when the original payloads are empty", async () => {
+  it("suppresses synthesized fatal failure delivery when required cron failure alerts will report it", async () => {
     usePayloadTextExtraction();
     resolveCronDeliveryPlanMock.mockReturnValue({
       requested: true,
@@ -157,10 +164,53 @@ describe("runCronIsolatedAgentTurn — interim ack retry", () => {
     expect(result.status).toBe("error");
     expect(result.error).toBe("SYSTEM_RUN_DENIED: approval required");
     const deliveryRequest = requireDeliveryRequest();
+    expect(deliveryRequest.deliveryBestEffort).toBe(false);
+    expect(deliveryRequest.skipHeartbeatDelivery).toBe(false);
+    expect(deliveryRequest.deliveryPayloadHasStructuredContent).toBe(false);
+    expect(deliveryRequest.deliveryPayloads).toEqual([]);
+    expect(deliveryRequest.synthesizedText).toBeUndefined();
+  });
+
+  it("delivers synthesized fatal failure signals for best-effort cron delivery", async () => {
+    usePayloadTextExtraction();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "messagechat",
+      to: "123",
+    });
+    isHeartbeatOnlyResponseMock.mockReturnValue(true);
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        agentMeta: { usage: { input: 10, output: 20 } },
+        failureSignal: {
+          kind: "execution_denied",
+          source: "tool",
+          toolName: "exec",
+          code: "SYSTEM_RUN_DENIED",
+          message: "SYSTEM_RUN_DENIED: approval required",
+          fatalForCron: true,
+        },
+      },
+    });
+
+    mockRunCronFallbackPassthrough();
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({ delivery: { bestEffort: true } }),
+      }),
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("SYSTEM_RUN_DENIED: approval required");
+    const deliveryRequest = requireDeliveryRequest();
+    expect(deliveryRequest.deliveryBestEffort).toBe(true);
     expect(deliveryRequest.skipHeartbeatDelivery).toBe(false);
     expect(deliveryRequest.deliveryPayloads).toEqual([
       { text: "SYSTEM_RUN_DENIED: approval required", isError: true },
     ]);
+    expect(deliveryRequest.synthesizedText).toBe("SYSTEM_RUN_DENIED: approval required");
   });
 
   it("does not retry when descendants were spawned in this run even if they already settled", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1001,6 +1001,8 @@ async function finalizeCronRun(params: {
     !hasFatalErrorPayload &&
     isHeartbeatOnlyResponse(deliveryPayloads, resolveHeartbeatAckMaxChars(prepared.agentCfg));
   const { dispatchCronDelivery, resolveCronDeliveryBestEffort } = await loadCronDeliveryRuntime();
+  const deliveryBestEffort = resolveCronDeliveryBestEffort(prepared.input.job);
+  const suppressFatalErrorDelivery = hasFatalErrorPayload && !deliveryBestEffort;
   const sourceDeliveryOutcome = resolveSourceDeliveryOutcome(prepared.sourceDelivery, {
     didSendViaMessageTool: finalRunResult.didSendViaMessagingTool,
     messageToolSentTargets: finalRunResult.messagingToolSentTargets,
@@ -1021,10 +1023,12 @@ async function finalizeCronRun(params: {
     deliveryRequested: prepared.deliveryRequested,
     skipHeartbeatDelivery,
     sourceDeliveryOutcome,
-    deliveryBestEffort: resolveCronDeliveryBestEffort(prepared.input.job),
-    deliveryPayloadHasStructuredContent,
-    deliveryPayloads,
-    synthesizedText,
+    deliveryBestEffort,
+    deliveryPayloadHasStructuredContent: suppressFatalErrorDelivery
+      ? false
+      : deliveryPayloadHasStructuredContent,
+    deliveryPayloads: suppressFatalErrorDelivery ? [] : deliveryPayloads,
+    synthesizedText: suppressFatalErrorDelivery ? undefined : synthesizedText,
     ttsAuto: prepared.cronSession.sessionEntry.ttsAuto,
     summary,
     outputText,


### PR DESCRIPTION
## Summary
- carries the openclaw-1 Codex reliability build branch
- includes the provider-id TDZ/bootstrap fix already deployed in core package 2026.5.26-openclaw.2
- bumps @openclaw/codex package metadata/shrinkwrap to 2026.5.26-openclaw.2 for matching external plugin deployment

## Validation
- node scripts/generate-npm-shrinkwrap.mjs --package-dir extensions/codex --check
- node scripts/lib/plugin-npm-runtime-build.mjs extensions/codex
- unit-fast include: src/agents/openai-codex-routing.test.ts (9 passed)

## Known caveat
- extensions/codex/src/app-server/run-attempt.test.ts under the local extensions Vitest config ran 199/204 passing but failed five late tests with temp session binding ENOENT/unhandled rejections; this package bump changes no runtime source.