### PR TITLE
fix(agent): continue after source message tool replies

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1,9 +1,17 @@
 // Agent Core tests cover agent loop behavior.
+import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import { agentLoop, agentLoopContinue } from "./agent-loop.js";
 import { createAssistantMessageEventStream } from "./llm.js";
 import type { AssistantMessage, Message, Model } from "./llm.js";
-import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, StreamFn } from "./types.js";
+import type {
+  AgentContext,
+  AgentEvent,
+  AgentLoopConfig,
+  AgentMessage,
+  AgentTool,
+  StreamFn,
+} from "./types.js";
 
 const model: Model = {
   id: "test-model",
@@ -140,6 +148,146 @@ describe("agentLoop streaming updates", () => {
     for (const update of deltaUpdates) {
       expect(update.assistantMessageEvent).not.toHaveProperty("partial");
     }
+  });
+});
+
+describe("agentLoop tool termination", () => {
+  function makeAssistantMessage(content: AssistantMessage["content"]): AssistantMessage {
+    return {
+      role: "assistant",
+      content,
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: content.some((item) => item.type === "toolCall") ? "toolUse" : "stop",
+      timestamp: 1,
+    };
+  }
+
+  function makeTool(name: string, executed: string[]): AgentTool {
+    return {
+      name,
+      label: name,
+      description: name,
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        executed.push(name);
+        return {
+          content: [{ type: "text", text: `${name} result` }],
+          details: { name },
+        };
+      },
+    };
+  }
+
+  it("continues after a side-effect tool result when afterToolCall records it without terminate", async () => {
+    const executed: string[] = [];
+    let turn = 0;
+    const streamFn: StreamFn = () => {
+      turn += 1;
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message =
+          turn === 1
+            ? makeAssistantMessage([
+                { type: "toolCall", id: "call-message", name: "message", arguments: {} },
+              ])
+            : turn === 2
+              ? makeAssistantMessage([
+                  { type: "toolCall", id: "call-exec", name: "exec", arguments: {} },
+                ])
+              : makeAssistantMessage([{ type: "text", text: "done" }]);
+        stream.push({
+          type: "done",
+          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
+          message,
+        });
+        stream.end();
+      });
+      return stream;
+    };
+    let recordedSideEffect = false;
+
+    const stream = agentLoop(
+      [{ role: "user", content: "hello", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [makeTool("message", executed), makeTool("exec", executed)],
+      },
+      {
+        ...config,
+        afterToolCall: async ({ toolCall }) => {
+          if (toolCall.name === "message") {
+            recordedSideEffect = true;
+          }
+          return undefined;
+        },
+      },
+      undefined,
+      streamFn,
+    );
+
+    const events = await collectEvents(stream);
+
+    expect(recordedSideEffect).toBe(true);
+    expect(turn).toBe(3);
+    expect(executed).toEqual(["message", "exec"]);
+    expect(events.filter((event) => event.type === "tool_execution_start")).toHaveLength(2);
+    expect(events.at(-1)).toMatchObject({ type: "agent_end" });
+  });
+
+  it("stops after a tool result only when the finalized result explicitly terminates", async () => {
+    const executed: string[] = [];
+    let turn = 0;
+    const streamFn: StreamFn = () => {
+      turn += 1;
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message =
+          turn === 1
+            ? makeAssistantMessage([
+                { type: "toolCall", id: "call-message", name: "message", arguments: {} },
+              ])
+            : makeAssistantMessage([
+                { type: "toolCall", id: "call-exec", name: "exec", arguments: {} },
+              ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "hello", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [makeTool("message", executed), makeTool("exec", executed)],
+      },
+      {
+        ...config,
+        afterToolCall: async ({ toolCall }) =>
+          toolCall.name === "message" ? { terminate: true } : undefined,
+      },
+      undefined,
+      streamFn,
+    );
+
+    const events = await collectEvents(stream);
+
+    expect(turn).toBe(1);
+    expect(executed).toEqual(["message"]);
+    expect(events.filter((event) => event.type === "tool_execution_start")).toHaveLength(1);
+    expect(events.at(-1)).toMatchObject({ type: "agent_end" });
   });
 });
 

--- a/src/agents/agent-tool-handler-state.test-helpers.ts
+++ b/src/agents/agent-tool-handler-state.test-helpers.ts
@@ -29,6 +29,7 @@ export function createBaseToolHandlerState() {
     messagingToolSentTextsNormalized: [] as string[],
     messagingToolSentMediaUrls: [] as string[],
     messagingToolSourceReplyPayloads: [],
+    messageToolOnlySourceReplyDelivered: false,
     messagingToolSentTargets: [] as unknown[],
     deterministicApprovalPromptSent: false,
     blockBuffer: "",

--- a/src/agents/embedded-agent-message-tool-source-reply.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.ts
@@ -1,0 +1,184 @@
+/**
+ * Detects message-tool sends that delivered a visible reply to the current source.
+ */
+import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
+import { isMessageToolSendActionName } from "./embedded-agent-messaging.js";
+import { isToolResultError } from "./embedded-agent-subscribe.tools.js";
+import { normalizeToolName } from "./tool-policy.js";
+
+const MESSAGE_TOOL_NAME = "message";
+const EXPLICIT_MESSAGE_ROUTE_KEYS = ["channel", "target", "to", "channelId", "provider"];
+const DRY_RUN_DELIVERY_STATUS = "dry_run";
+const SENT_DELIVERY_STATUS = "sent";
+const RESULT_ENVELOPE_KEYS = [
+  "details",
+  "payload",
+  "result",
+  "results",
+  "sendResult",
+  "toolResult",
+];
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function hasStringValue(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasExplicitMessageRoute(args: Record<string, unknown>): boolean {
+  if (EXPLICIT_MESSAGE_ROUTE_KEYS.some((key) => hasStringValue(args[key]))) {
+    return true;
+  }
+  return Array.isArray(args.targets) && args.targets.some((value) => hasStringValue(value));
+}
+
+function normalizeStatus(value: unknown): string | undefined {
+  return typeof value === "string" ? value.trim().toLowerCase() : undefined;
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function recordHasDeliveredMessageId(record: Record<string, unknown>): boolean {
+  if (hasStringValue(record.messageId)) {
+    return true;
+  }
+  const receipt = record.receipt;
+  if (!receipt || typeof receipt !== "object" || Array.isArray(receipt)) {
+    return false;
+  }
+  const receiptRecord = receipt as Record<string, unknown>;
+  return (
+    hasStringValue(receiptRecord.primaryPlatformMessageId) ||
+    (Array.isArray(receiptRecord.platformMessageIds) &&
+      receiptRecord.platformMessageIds.some((value) => hasStringValue(value)))
+  );
+}
+
+function deliveryEnvelopeIndicatesDryRun(value: unknown, depth = 0): boolean {
+  if (!value || typeof value !== "object" || depth > 4) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => deliveryEnvelopeIndicatesDryRun(item, depth + 1));
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    record.dryRun === true ||
+    normalizeStatus(record.deliveryStatus) === DRY_RUN_DELIVERY_STATUS
+  ) {
+    return true;
+  }
+
+  const content = record.content;
+  if (Array.isArray(content)) {
+    for (const item of content) {
+      if (deliveryEnvelopeIndicatesDryRun(item, depth + 1)) {
+        return true;
+      }
+      if (item && typeof item === "object" && !Array.isArray(item)) {
+        const text = (item as Record<string, unknown>).text;
+        if (typeof text === "string") {
+          const parsed = parseJsonRecord(text);
+          if (parsed && deliveryEnvelopeIndicatesDryRun(parsed, depth + 1)) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+
+  return RESULT_ENVELOPE_KEYS.some((key) =>
+    deliveryEnvelopeIndicatesDryRun(record[key], depth + 1),
+  );
+}
+
+function deliveryEnvelopeIndicatesDelivered(value: unknown, depth = 0): boolean {
+  if (!value || typeof value !== "object" || depth > 4) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => deliveryEnvelopeIndicatesDelivered(item, depth + 1));
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    normalizeStatus(record.deliveryStatus) === SENT_DELIVERY_STATUS ||
+    recordHasDeliveredMessageId(record)
+  ) {
+    return true;
+  }
+
+  const content = record.content;
+  if (Array.isArray(content)) {
+    for (const item of content) {
+      if (deliveryEnvelopeIndicatesDelivered(item, depth + 1)) {
+        return true;
+      }
+      if (item && typeof item === "object" && !Array.isArray(item)) {
+        const text = (item as Record<string, unknown>).text;
+        if (typeof text === "string") {
+          const parsed = parseJsonRecord(text);
+          if (parsed && deliveryEnvelopeIndicatesDelivered(parsed, depth + 1)) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+
+  return RESULT_ENVELOPE_KEYS.some((key) =>
+    deliveryEnvelopeIndicatesDelivered(record[key], depth + 1),
+  );
+}
+
+/**
+ * Only implicit-route, non-dry-run, delivered `message.send` calls qualify.
+ * Explicit routes and other messaging tools are outbound side effects, not source replies.
+ */
+export function isDeliveredMessageToolOnlySourceReplyResult(params: {
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  toolName: string;
+  args?: unknown;
+  result?: unknown;
+  hookResult?: unknown;
+  isError?: boolean;
+}): boolean {
+  if (params.sourceReplyDeliveryMode !== "message_tool_only") {
+    return false;
+  }
+  if (normalizeToolName(params.toolName) !== MESSAGE_TOOL_NAME) {
+    return false;
+  }
+  const args = asRecord(params.args);
+  if (!isMessageToolSendActionName(args.action) || hasExplicitMessageRoute(args)) {
+    return false;
+  }
+  if (params.isError || isToolResultError(params.result) || isToolResultError(params.hookResult)) {
+    return false;
+  }
+  if (
+    args.dryRun === true ||
+    deliveryEnvelopeIndicatesDryRun(params.result) ||
+    deliveryEnvelopeIndicatesDryRun(params.hookResult)
+  ) {
+    return false;
+  }
+  return (
+    deliveryEnvelopeIndicatesDelivered(params.result) ||
+    deliveryEnvelopeIndicatesDelivered(params.hookResult)
+  );
+}

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3034,6 +3034,8 @@ export async function runEmbeddedAgent(
             suppressToolErrorWarnings: params.suppressToolErrorWarnings,
             inlineToolResultsAllowed: false,
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+            didDeliverSourceReplyViaMessageTool:
+              attempt.didDeliverSourceReplyViaMessageTool === true,
             messagingToolSourceReplyPayloads: attempt.messagingToolSourceReplyPayloads,
             sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
             agentId: params.agentId,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3283,6 +3283,7 @@ export async function runEmbeddedAttempt(
           shouldEmitToolResult: params.shouldEmitToolResult,
           shouldEmitToolOutput: params.shouldEmitToolOutput,
           sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+          hasDeliveredMessageToolOnlySourceReply: () => didDeliverSourceReplyViaMessageTool,
           onToolResult: params.onToolResult,
           onReasoningStream: params.onReasoningStream,
           onReasoningEnd: params.onReasoningEnd,

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
@@ -1,18 +1,19 @@
-// Message-tool terminal tests cover message_tool_only delivery, where a
-// successful source message send should end the run without duplicate replies.
+// Message-tool delivery tests cover message_tool_only delivery, where a
+// successful source message send records source reply evidence without ending
+// the run before the model can observe the tool result.
 import type { Agent, AfterToolCallContext } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it, vi } from "vitest";
 import {
   installMessageToolOnlyTerminalHook,
-  shouldTerminateAfterMessageToolOnlySend,
+  isDeliveredMessageToolOnlySourceReply,
 } from "./message-tool-terminal.js";
 
-describe("message-tool-only terminal sends", () => {
-  it("marks successful message-tool-only sends as terminal", () => {
+describe("message-tool-only source replies", () => {
+  it("marks successful message-tool-only sends as delivered source replies", () => {
     // Direct send evidence can come from the tool result or hook result; either
     // path means the source reply was delivered and no automatic reply is needed.
     expect(
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: "message_tool_only",
         context: createAfterToolCallContext({
           toolName: "message",
@@ -21,7 +22,7 @@ describe("message-tool-only terminal sends", () => {
       }),
     ).toBe(true);
     expect(
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: "message_tool_only",
         context: createAfterToolCallContext({
           toolName: "message",
@@ -31,7 +32,7 @@ describe("message-tool-only terminal sends", () => {
       }),
     ).toBe(true);
     expect(
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: "message_tool_only",
         context: createAfterToolCallContext({
           toolName: "message",
@@ -43,9 +44,9 @@ describe("message-tool-only terminal sends", () => {
     ).toBe(true);
   });
 
-  it("does not terminate automatic delivery, non-send actions, explicit routes, or failed sends", () => {
+  it("ignores automatic delivery, non-send actions, explicit routes, or failed sends", () => {
     expect(
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: "automatic",
         context: createAfterToolCallContext({
           toolName: "message",
@@ -54,7 +55,7 @@ describe("message-tool-only terminal sends", () => {
       }),
     ).toBe(false);
     expect(
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: "message_tool_only",
         context: createAfterToolCallContext({
           toolName: "message",
@@ -63,7 +64,7 @@ describe("message-tool-only terminal sends", () => {
       }),
     ).toBe(false);
     expect(
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: "message_tool_only",
         context: createAfterToolCallContext({
           toolName: "message",
@@ -72,7 +73,7 @@ describe("message-tool-only terminal sends", () => {
       }),
     ).toBe(false);
     expect(
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: "message_tool_only",
         context: createAfterToolCallContext({
           toolName: "sessions_send",
@@ -81,7 +82,7 @@ describe("message-tool-only terminal sends", () => {
       }),
     ).toBe(false);
     expect(
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: "message_tool_only",
         context: createAfterToolCallContext({
           toolName: "message",
@@ -92,11 +93,11 @@ describe("message-tool-only terminal sends", () => {
     ).toBe(false);
   });
 
-  it("does not terminate dry-run or non-delivered sends", () => {
+  it("ignores dry-run or non-delivered sends", () => {
     // Dry runs and suppressed sends are observable tool activity, not delivered
     // replies, so they cannot close the turn.
     expect(
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: "message_tool_only",
         context: createAfterToolCallContext({
           toolName: "message",
@@ -105,7 +106,7 @@ describe("message-tool-only terminal sends", () => {
       }),
     ).toBe(false);
     expect(
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: "message_tool_only",
         context: createAfterToolCallContext({
           toolName: "message",
@@ -123,7 +124,7 @@ describe("message-tool-only terminal sends", () => {
       }),
     ).toBe(false);
     expect(
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: "message_tool_only",
         context: createAfterToolCallContext({
           toolName: "message",
@@ -133,7 +134,7 @@ describe("message-tool-only terminal sends", () => {
       }),
     ).toBe(false);
     expect(
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: "message_tool_only",
         context: createAfterToolCallContext({
           toolName: "message",
@@ -147,9 +148,9 @@ describe("message-tool-only terminal sends", () => {
     ).toBe(false);
   });
 
-  it("does not terminate suppressed sends without delivery evidence", () => {
+  it("ignores suppressed sends without delivery evidence", () => {
     expect(
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: "message_tool_only",
         context: createAfterToolCallContext({
           toolName: "message",
@@ -160,7 +161,7 @@ describe("message-tool-only terminal sends", () => {
     ).toBe(false);
   });
 
-  it("preserves existing after-tool-call output while adding the terminal hint", async () => {
+  it("preserves existing after-tool-call output while recording delivered source replies", async () => {
     const previousAfterToolCall = vi.fn(async () => ({
       content: [{ type: "text" as const, text: "rewritten" }],
       details: { rewritten: true },
@@ -183,9 +184,28 @@ describe("message-tool-only terminal sends", () => {
     ).resolves.toEqual({
       content: [{ type: "text", text: "rewritten" }],
       details: { rewritten: true },
-      terminate: true,
     });
     expect(previousAfterToolCall).toHaveBeenCalledTimes(1);
+    expect(onDeliveredSourceReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("records delivery evidence without rewriting the default result", async () => {
+    const agent = {} as unknown as Agent;
+    const onDeliveredSourceReply = vi.fn();
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+      onDeliveredSourceReply,
+    });
+
+    await expect(
+      agent.afterToolCall?.(
+        createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "visible reply" },
+        }),
+      ),
+    ).resolves.toBeUndefined();
     expect(onDeliveredSourceReply).toHaveBeenCalledTimes(1);
   });
 

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
@@ -1,24 +1,9 @@
-/**
- * Detects message-tool-only sends that should terminate an agent turn.
- */
 import type { SourceReplyDeliveryMode } from "../../../auto-reply/get-reply-options.types.js";
-import { isMessageToolSendActionName } from "../../embedded-agent-messaging.js";
-import { isToolResultError } from "../../embedded-agent-subscribe.tools.js";
+/**
+ * Detects message-tool-only sends that delivered a visible source reply.
+ */
+import { isDeliveredMessageToolOnlySourceReplyResult } from "../../embedded-agent-message-tool-source-reply.js";
 import type { AfterToolCallContext, AfterToolCallResult, Agent } from "../../runtime/index.js";
-import { normalizeToolName } from "../../tool-policy.js";
-
-const MESSAGE_TOOL_NAME = "message";
-const EXPLICIT_MESSAGE_ROUTE_KEYS = ["channel", "target", "to", "channelId", "provider"];
-const DRY_RUN_DELIVERY_STATUS = "dry_run";
-const SENT_DELIVERY_STATUS = "sent";
-const RESULT_ENVELOPE_KEYS = [
-  "details",
-  "payload",
-  "result",
-  "results",
-  "sendResult",
-  "toolResult",
-];
 
 function argsRecordForToolCall(context: AfterToolCallContext): Record<string, unknown> {
   if (context.args && typeof context.args === "object" && !Array.isArray(context.args)) {
@@ -30,168 +15,27 @@ function argsRecordForToolCall(context: AfterToolCallContext): Record<string, un
     : {};
 }
 
-function hasStringValue(value: unknown): boolean {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
-function hasExplicitMessageRoute(args: Record<string, unknown>): boolean {
-  if (EXPLICIT_MESSAGE_ROUTE_KEYS.some((key) => hasStringValue(args[key]))) {
-    return true;
-  }
-  return Array.isArray(args.targets) && args.targets.some((value) => hasStringValue(value));
-}
-
-function normalizeStatus(value: unknown): string | undefined {
-  return typeof value === "string" ? value.trim().toLowerCase() : undefined;
-}
-
-function parseJsonRecord(value: string): Record<string, unknown> | undefined {
-  try {
-    const parsed = JSON.parse(value);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function recordHasDeliveredMessageId(record: Record<string, unknown>): boolean {
-  if (hasStringValue(record.messageId)) {
-    return true;
-  }
-  const receipt = record.receipt;
-  if (!receipt || typeof receipt !== "object" || Array.isArray(receipt)) {
-    return false;
-  }
-  const receiptRecord = receipt as Record<string, unknown>;
-  return (
-    hasStringValue(receiptRecord.primaryPlatformMessageId) ||
-    (Array.isArray(receiptRecord.platformMessageIds) &&
-      receiptRecord.platformMessageIds.some((value) => hasStringValue(value)))
-  );
-}
-
-function deliveryEnvelopeIndicatesDryRun(value: unknown, depth = 0): boolean {
-  if (!value || typeof value !== "object" || depth > 4) {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    return value.some((item) => deliveryEnvelopeIndicatesDryRun(item, depth + 1));
-  }
-
-  const record = value as Record<string, unknown>;
-  if (
-    record.dryRun === true ||
-    normalizeStatus(record.deliveryStatus) === DRY_RUN_DELIVERY_STATUS
-  ) {
-    return true;
-  }
-
-  const content = record.content;
-  if (Array.isArray(content)) {
-    for (const item of content) {
-      if (deliveryEnvelopeIndicatesDryRun(item, depth + 1)) {
-        return true;
-      }
-      if (item && typeof item === "object" && !Array.isArray(item)) {
-        const text = (item as Record<string, unknown>).text;
-        if (typeof text === "string") {
-          const parsed = parseJsonRecord(text);
-          if (parsed && deliveryEnvelopeIndicatesDryRun(parsed, depth + 1)) {
-            return true;
-          }
-        }
-      }
-    }
-  }
-
-  return RESULT_ENVELOPE_KEYS.some((key) =>
-    deliveryEnvelopeIndicatesDryRun(record[key], depth + 1),
-  );
-}
-
-function deliveryEnvelopeIndicatesDelivered(value: unknown, depth = 0): boolean {
-  if (!value || typeof value !== "object" || depth > 4) {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    return value.some((item) => deliveryEnvelopeIndicatesDelivered(item, depth + 1));
-  }
-
-  const record = value as Record<string, unknown>;
-  if (
-    normalizeStatus(record.deliveryStatus) === SENT_DELIVERY_STATUS ||
-    recordHasDeliveredMessageId(record)
-  ) {
-    return true;
-  }
-
-  const content = record.content;
-  if (Array.isArray(content)) {
-    for (const item of content) {
-      if (deliveryEnvelopeIndicatesDelivered(item, depth + 1)) {
-        return true;
-      }
-      if (item && typeof item === "object" && !Array.isArray(item)) {
-        const text = (item as Record<string, unknown>).text;
-        if (typeof text === "string") {
-          const parsed = parseJsonRecord(text);
-          if (parsed && deliveryEnvelopeIndicatesDelivered(parsed, depth + 1)) {
-            return true;
-          }
-        }
-      }
-    }
-  }
-
-  return RESULT_ENVELOPE_KEYS.some((key) =>
-    deliveryEnvelopeIndicatesDelivered(record[key], depth + 1),
-  );
-}
-
 /**
- * Determines whether a `message.send` tool call should end the turn in
- * message-tool-only delivery mode. Only implicit-route, non-dry-run, delivered
- * sends qualify; explicit routes and errors keep the model loop alive.
+ * Determines whether a `message.send` tool call delivered a visible source reply
+ * in message-tool-only delivery mode. Only implicit-route, non-dry-run,
+ * delivered sends qualify; explicit routes and errors are not source replies.
  */
-export function shouldTerminateAfterMessageToolOnlySend(params: {
+export function isDeliveredMessageToolOnlySourceReply(params: {
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   context: AfterToolCallContext;
   hookResult?: AfterToolCallResult;
 }): boolean {
-  if (params.sourceReplyDeliveryMode !== "message_tool_only") {
-    return false;
-  }
-  const toolName = normalizeToolName(params.context.toolCall.name);
-  if (toolName !== MESSAGE_TOOL_NAME) {
-    return false;
-  }
-  const args = argsRecordForToolCall(params.context);
-  if (!isMessageToolSendActionName(args.action) || hasExplicitMessageRoute(args)) {
-    return false;
-  }
-  const isError = params.hookResult?.isError ?? params.context.isError;
-  if (isError || isToolResultError(params.context.result)) {
-    return false;
-  }
-  if (
-    args.dryRun === true ||
-    deliveryEnvelopeIndicatesDryRun(params.context.result) ||
-    deliveryEnvelopeIndicatesDryRun(params.hookResult)
-  ) {
-    return false;
-  }
-  if (
-    !deliveryEnvelopeIndicatesDelivered(params.context.result) &&
-    !deliveryEnvelopeIndicatesDelivered(params.hookResult)
-  ) {
-    return false;
-  }
-  return true;
+  return isDeliveredMessageToolOnlySourceReplyResult({
+    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+    toolName: params.context.toolCall.name,
+    args: argsRecordForToolCall(params.context),
+    result: params.context.result,
+    hookResult: params.hookResult,
+    isError: params.hookResult?.isError ?? params.context.isError,
+  });
 }
 
-/** Installs an after-tool hook that terminates the turn after a qualifying message send. */
+/** Installs an after-tool hook that records source reply delivery evidence. */
 export function installMessageToolOnlyTerminalHook(params: {
   agent: Agent;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
@@ -204,14 +48,14 @@ export function installMessageToolOnlyTerminalHook(params: {
   params.agent.afterToolCall = async (context, signal) => {
     const hookResult = await previousAfterToolCall?.(context, signal);
     if (
-      shouldTerminateAfterMessageToolOnlySend({
+      isDeliveredMessageToolOnlySourceReply({
         sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
         context,
         hookResult,
       })
     ) {
       params.onDeliveredSourceReply?.();
-      return { ...hookResult, terminate: true };
+      return hookResult;
     }
     return hookResult;
   };

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -261,6 +261,20 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("suppresses terminal assistant text after direct message-tool source replies", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["ordinary final should stay private"],
+      didSendViaMessagingTool: true,
+      didDeliverSourceReplyViaMessageTool: true,
+      sourceReplyDeliveryMode: "message_tool_only",
+      sessionKey: "agent:main",
+      agentId: "main",
+      runId: "run-1",
+    });
+
+    expect(payloads).toEqual([]);
+  });
+
   it("preserves rich-only internal message-tool source replies", () => {
     const presentation = {
       blocks: [

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -242,6 +242,7 @@ export function buildEmbeddedRunPayloads(params: {
   suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
   inlineToolResultsAllowed: boolean;
   didSendViaMessagingTool?: boolean;
+  didDeliverSourceReplyViaMessageTool?: boolean;
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   agentId?: string;
@@ -310,10 +311,15 @@ export function buildEmbeddedRunPayloads(params: {
     });
   });
   const hasSourceReplyPayload = replyItems.length > sourceReplyStartIndex;
+  const deliveredSourceReplyViaMessageTool =
+    params.sourceReplyDeliveryMode === "message_tool_only" &&
+    params.didDeliverSourceReplyViaMessageTool === true;
 
   const useMarkdown = params.toolResultFormat === "markdown";
   const suppressAssistantArtifacts =
-    params.didSendDeterministicApprovalPrompt === true || hasSourceReplyPayload;
+    params.didSendDeterministicApprovalPrompt === true ||
+    hasSourceReplyPayload ||
+    deliveredSourceReplyViaMessageTool;
   const nonEmptyAssistantTexts = params.assistantTexts.filter((text) => text.trim().length > 0);
   const currentAssistant = params.currentAssistant ?? undefined;
   const assistantForPayload =

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -157,6 +157,15 @@ function shouldSuppressDeterministicApprovalOutput(
   return state.deterministicApprovalPromptPending || state.deterministicApprovalPromptSent;
 }
 
+function hasMessageToolOnlySourceDelivery(ctx: EmbeddedAgentSubscribeContext): boolean {
+  return (
+    ctx.params.sourceReplyDeliveryMode === "message_tool_only" &&
+    (ctx.state.messageToolOnlySourceReplyDelivered ||
+      ctx.params.hasDeliveredMessageToolOnlySourceReply?.() === true ||
+      (ctx.state.messagingToolSourceReplyPayloads?.length ?? 0) > 0)
+  );
+}
+
 function appendBlockReplyChunk(ctx: EmbeddedAgentSubscribeContext, chunk: string) {
   if (ctx.blockChunker) {
     ctx.blockChunker.append(chunk);
@@ -580,6 +589,7 @@ export function handleMessageUpdate(
     return;
   }
   const suppressDeterministicApprovalOutput = shouldSuppressDeterministicApprovalOutput(ctx.state);
+  const suppressMessageToolOnlySourceReplyOutput = hasMessageToolOnlySourceDelivery(ctx);
 
   const assistantEvent = evt.assistantMessageEvent;
   const assistantPhase = resolveAssistantMessagePhase(msg);
@@ -597,7 +607,10 @@ export function handleMessageUpdate(
   }
 
   if (evtType === "thinking_start" || evtType === "thinking_delta" || evtType === "thinking_end") {
-    if (evtType === "thinking_start" || evtType === "thinking_delta") {
+    if (
+      !suppressMessageToolOnlySourceReplyOutput &&
+      (evtType === "thinking_start" || evtType === "thinking_delta")
+    ) {
       openReasoningStream(ctx);
     }
     const thinkingDelta = typeof assistantRecord?.delta === "string" ? assistantRecord.delta : "";
@@ -612,12 +625,12 @@ export function handleMessageUpdate(
       delta: thinkingDelta,
       content: thinkingContent,
     });
-    if (ctx.state.streamReasoning) {
+    if (!suppressMessageToolOnlySourceReplyOutput && ctx.state.streamReasoning) {
       // Prefer full partial-message thinking when available; fall back to event payloads.
       const partialThinking = extractAssistantThinking(msg);
       ctx.emitReasoningStream(partialThinking || thinkingContent || thinkingDelta);
     }
-    if (evtType === "thinking_end") {
+    if (!suppressMessageToolOnlySourceReplyOutput && evtType === "thinking_end") {
       if (!ctx.state.reasoningStreamOpen) {
         openReasoningStream(ctx);
       }
@@ -690,7 +703,7 @@ export function handleMessageUpdate(
     }
   }
 
-  if (ctx.state.streamReasoning) {
+  if (!suppressMessageToolOnlySourceReplyOutput && ctx.state.streamReasoning) {
     // Handle partial <think> tags: stream whatever reasoning is visible so far.
     ctx.emitReasoningStream(extractThinkingFromTaggedStream(ctx.state.deltaBuffer));
   }
@@ -764,11 +777,19 @@ export function handleMessageUpdate(
     });
   }
   if (next) {
-    if (!wasThinking && ctx.state.partialBlockState.thinking) {
+    if (
+      !suppressMessageToolOnlySourceReplyOutput &&
+      !wasThinking &&
+      ctx.state.partialBlockState.thinking
+    ) {
       openReasoningStream(ctx);
     }
     // Detect when thinking block ends (</think> tag processed)
-    if (wasThinking && !ctx.state.partialBlockState.thinking) {
+    if (
+      !suppressMessageToolOnlySourceReplyOutput &&
+      wasThinking &&
+      !ctx.state.partialBlockState.thinking
+    ) {
       emitReasoningEnd(ctx);
     }
     const parsedDelta = visibleDelta ? ctx.consumePartialReplyDirectives(visibleDelta) : null;
@@ -822,7 +843,11 @@ export function handleMessageUpdate(
     ctx.state.lastStreamedAssistant = nextRawStreamText;
     ctx.state.lastStreamedAssistantCleaned = cleanedText;
 
-    if (ctx.params.silentExpected || suppressDeterministicApprovalOutput) {
+    if (
+      ctx.params.silentExpected ||
+      suppressDeterministicApprovalOutput ||
+      suppressMessageToolOnlySourceReplyOutput
+    ) {
       shouldEmit = false;
     }
 
@@ -844,6 +869,7 @@ export function handleMessageUpdate(
   if (
     !ctx.params.silentExpected &&
     !suppressDeterministicApprovalOutput &&
+    !suppressMessageToolOnlySourceReplyOutput &&
     ctx.params.onBlockReply &&
     ctx.blockChunking &&
     ctx.state.blockReplyBreak === "text_end"
@@ -854,6 +880,7 @@ export function handleMessageUpdate(
   if (
     !ctx.params.silentExpected &&
     !suppressDeterministicApprovalOutput &&
+    !suppressMessageToolOnlySourceReplyOutput &&
     evtType === "text_end" &&
     ctx.state.blockReplyBreak === "text_end"
   ) {
@@ -880,6 +907,7 @@ export function handleMessageEnd(
   const assistantPhase = resolveAssistantMessagePhase(assistantMessage);
   const suppressVisibleAssistantOutput = shouldSuppressAssistantVisibleOutput(assistantMessage);
   const suppressDeterministicApprovalOutput = shouldSuppressDeterministicApprovalOutput(ctx.state);
+  const suppressMessageToolOnlySourceReplyOutput = hasMessageToolOnlySourceDelivery(ctx);
   ctx.noteLastAssistant(assistantMessage);
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);
   ctx.commitAssistantUsage();
@@ -965,6 +993,7 @@ export function handleMessageEnd(
   if (
     !ctx.params.silentExpected &&
     !suppressDeterministicApprovalOutput &&
+    !suppressMessageToolOnlySourceReplyOutput &&
     (cleanedText || hasMedia) &&
     (!ctx.state.emittedAssistantUpdate ||
       shouldReplaceFinalStream ||
@@ -998,6 +1027,7 @@ export function handleMessageEnd(
   const shouldEmitReasoning = Boolean(
     !ctx.params.silentExpected &&
     !suppressDeterministicApprovalOutput &&
+    !suppressMessageToolOnlySourceReplyOutput &&
     ctx.state.includeReasoning &&
     trimmedReasoning &&
     onBlockReply &&
@@ -1053,6 +1083,7 @@ export function handleMessageEnd(
   if (
     !ctx.params.silentExpected &&
     !suppressDeterministicApprovalOutput &&
+    !suppressMessageToolOnlySourceReplyOutput &&
     text &&
     onBlockReply &&
     (ctx.state.blockReplyBreak === "message_end" ||
@@ -1132,11 +1163,21 @@ export function handleMessageEnd(
   if (!shouldEmitReasoningBeforeAnswer) {
     maybeEmitReasoning();
   }
-  if (!ctx.params.silentExpected && ctx.state.streamReasoning && rawThinking) {
+  if (
+    !ctx.params.silentExpected &&
+    !suppressMessageToolOnlySourceReplyOutput &&
+    ctx.state.streamReasoning &&
+    rawThinking
+  ) {
     ctx.emitReasoningStream(rawThinking);
   }
 
-  if (!ctx.params.silentExpected && ctx.state.blockReplyBreak === "text_end" && onBlockReply) {
+  if (
+    !ctx.params.silentExpected &&
+    !suppressMessageToolOnlySourceReplyOutput &&
+    ctx.state.blockReplyBreak === "text_end" &&
+    onBlockReply
+  ) {
     emitSplitResultAsBlockReply(ctx.consumeReplyDirectives("", { final: true }));
   }
 

--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -40,6 +40,8 @@ function createMockContext(overrides?: {
       messagingToolSentTexts: [],
       messagingToolSentTextsNormalized: [],
       messagingToolSentMediaUrls: [],
+      messagingToolSourceReplyPayloads: [],
+      messageToolOnlySourceReplyDelivered: false,
       messagingToolSentTargets: [],
       deterministicApprovalPromptPending: false,
       deterministicApprovalPromptSent: false,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -77,6 +77,7 @@ function createTestContext(): {
       messagingToolSentTextsNormalized: [],
       messagingToolSentMediaUrls: [],
       messagingToolSourceReplyPayloads: [],
+      messageToolOnlySourceReplyDelivered: false,
       messagingToolSentTargets: [],
       successfulCronAdds: 0,
       deterministicApprovalPromptSent: false,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -39,6 +39,7 @@ import type { ApplyPatchSummary } from "./apply-patch.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { sanitizeForConsole } from "./console-sanitize.js";
 import { normalizeTextForComparison } from "./embedded-agent-helpers.js";
+import { isDeliveredMessageToolOnlySourceReplyResult } from "./embedded-agent-message-tool-source-reply.js";
 import { isMessagingTool, isMessagingToolSendAction } from "./embedded-agent-messaging.js";
 import type { MessagingToolSourceReplyPayload } from "./embedded-agent-messaging.types.js";
 import { mergeEmbeddedRunReplayState } from "./embedded-agent-runner/replay-state.js";
@@ -1274,6 +1275,17 @@ export async function handleToolExecutionEnd(
     if (committedMediaUrls.length > 0) {
       ctx.state.messagingToolSentMediaUrls.push(...committedMediaUrls);
       ctx.trimMessagingToolSent();
+    }
+    if (
+      isDeliveredMessageToolOnlySourceReplyResult({
+        sourceReplyDeliveryMode: ctx.params.sourceReplyDeliveryMode,
+        toolName,
+        args: startArgs,
+        result,
+        isError: isToolError,
+      })
+    ) {
+      ctx.state.messageToolOnlySourceReplyDelivered = true;
     }
     const sourceReplyPayload = extractMessagingToolSourceReplyPayload(result);
     if (sourceReplyPayload) {

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -161,6 +161,7 @@ export type EmbeddedAgentSubscribeState = {
   heartbeatToolResponse?: HeartbeatToolResponse;
   messagingToolSentMediaUrls: string[];
   messagingToolSourceReplyPayloads: MessagingToolSourceReplyPayload[];
+  messageToolOnlySourceReplyDelivered: boolean;
   pendingMessagingTexts: Map<string, string>;
   pendingMessagingTargets: Map<string, MessagingToolSend>;
   successfulCronAdds: number;
@@ -276,6 +277,7 @@ type ToolHandlerParams = Pick<
   | "agentId"
   | "toolResultFormat"
   | "toolProgressDetail"
+  | "sourceReplyDeliveryMode"
 >;
 
 type ToolHandlerState = Pick<
@@ -302,6 +304,7 @@ type ToolHandlerState = Pick<
   | "messagingToolSentTextsNormalized"
   | "messagingToolSentMediaUrls"
   | "messagingToolSourceReplyPayloads"
+  | "messageToolOnlySourceReplyDelivered"
   | "messagingToolSentTargets"
   | "heartbeatToolResponse"
   | "successfulCronAdds"

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.suppresses-message-end-block-replies-message-tool.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.suppresses-message-end-block-replies-message-tool.test.ts
@@ -10,18 +10,36 @@ import {
 } from "./embedded-agent-subscribe.e2e-harness.js";
 import { subscribeEmbeddedAgentSession } from "./embedded-agent-subscribe.js";
 
-function createBlockReplyHarness(blockReplyBreak: "message_end" | "text_end") {
+function createBlockReplyHarness(
+  blockReplyBreak: "message_end" | "text_end",
+  options: {
+    sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
+    hasDeliveredMessageToolOnlySourceReply?: () => boolean;
+    reasoningMode?: "off" | "on" | "stream";
+    onReasoningEnd?: () => void;
+    onReasoningStream?: (payload: { text?: string }) => void;
+  } = {},
+) {
   // Harness exposes both emitted block replies and subscription state so tests
   // can distinguish suppression from missing delivery tracking.
   const { session, emit } = createStubSessionHarness();
   const onBlockReply = vi.fn();
+  const onPartialReply = vi.fn();
+  const onAgentEvent = vi.fn();
   const subscription = subscribeEmbeddedAgentSession({
     session,
     runId: "run",
     onBlockReply,
+    onPartialReply,
+    onAgentEvent,
+    onReasoningEnd: options.onReasoningEnd,
+    onReasoningStream: options.onReasoningStream,
     blockReplyBreak,
+    reasoningMode: options.reasoningMode,
+    sourceReplyDeliveryMode: options.sourceReplyDeliveryMode,
+    hasDeliveredMessageToolOnlySourceReply: options.hasDeliveredMessageToolOnlySourceReply,
   });
-  return { emit, onBlockReply, subscription };
+  return { emit, onAgentEvent, onBlockReply, onPartialReply, subscription };
 }
 
 async function emitMessageToolLifecycle(params: {
@@ -29,6 +47,7 @@ async function emitMessageToolLifecycle(params: {
   toolCallId: string;
   message: string;
   media?: string;
+  to?: string | null;
   result: unknown;
 }) {
   // Message tool sends are modeled as normal tool start/end events because the
@@ -37,7 +56,12 @@ async function emitMessageToolLifecycle(params: {
     type: "tool_execution_start",
     toolName: "message",
     toolCallId: params.toolCallId,
-    args: { action: "send", to: "+1555", message: params.message, media: params.media },
+    args: {
+      action: "send",
+      ...(params.to === null ? {} : { to: params.to ?? "+1555" }),
+      message: params.message,
+      media: params.media,
+    },
   });
   // Wait for async handler to complete.
   await Promise.resolve();
@@ -81,6 +105,230 @@ describe("subscribeEmbeddedAgentSession", () => {
       result: "ok",
     });
     emitAssistantMessageEnd(emit, messageText);
+    await Promise.resolve();
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("suppresses later message_end block replies after message-tool-only delivery", async () => {
+    const { emit, onBlockReply } = createBlockReplyHarness("message_end", {
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    await emitMessageToolLifecycle({
+      emit,
+      toolCallId: "tool-message-continue",
+      message: "Starting the requested work.",
+      to: null,
+      result: { details: { deliveryStatus: "sent" } },
+    });
+    emitAssistantMessageEnd(emit, "Done.");
+    await Promise.resolve();
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("suppresses later text_end block replies after message-tool-only delivery", async () => {
+    const { emit, onBlockReply } = createBlockReplyHarness("text_end", {
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    await emitMessageToolLifecycle({
+      emit,
+      toolCallId: "tool-message-text-end-continue",
+      message: "Starting the requested work.",
+      to: null,
+      result: { details: { deliveryStatus: "sent" } },
+    });
+    emitAssistantTextEndBlock(emit, "Done.");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress source replies after explicit routed message-tool-only sends", async () => {
+    const { emit, onBlockReply } = createBlockReplyHarness("message_end", {
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    await emitMessageToolLifecycle({
+      emit,
+      toolCallId: "tool-message-routed",
+      message: "Sent somewhere else.",
+      to: "+1555",
+      result: { details: { deliveryStatus: "sent" } },
+    });
+    emitAssistantMessageEnd(emit, "Reply to the current source.");
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not suppress source replies after non-message messaging tools send", async () => {
+    const { emit, onBlockReply } = createBlockReplyHarness("message_end", {
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    emit({
+      type: "tool_execution_start",
+      toolName: "sessions_send",
+      toolCallId: "tool-sessions-send",
+      args: { message: "Sent to a spawned session." },
+    });
+    await Promise.resolve();
+    emit({
+      type: "tool_execution_end",
+      toolName: "sessions_send",
+      toolCallId: "tool-sessions-send",
+      isError: false,
+      result: { details: { deliveryStatus: "sent" } },
+    });
+    emitAssistantMessageEnd(emit, "Reply to the current source.");
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("preserves source-reply suppression across compaction retries", async () => {
+    const { emit, onBlockReply } = createBlockReplyHarness("message_end", {
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    await emitMessageToolLifecycle({
+      emit,
+      toolCallId: "tool-message-before-compaction",
+      message: "Starting the requested work.",
+      to: null,
+      result: { details: { deliveryStatus: "sent" } },
+    });
+    emit({ type: "compaction_end", willRetry: true, result: { summary: "compacted" } });
+    await Promise.resolve();
+    emitAssistantMessageEnd(emit, "Done after compaction.");
+    await Promise.resolve();
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("preserves internal source-reply payloads across compaction retries", async () => {
+    const { emit, subscription } = createBlockReplyHarness("message_end", {
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    await emitMessageToolLifecycle({
+      emit,
+      toolCallId: "tool-message-internal-before-compaction",
+      message: "Visible terminal answer.",
+      result: {
+        details: {
+          status: "ok",
+          deliveryStatus: "sent",
+          sourceReplySink: "internal-ui",
+          sourceReply: { text: "Visible terminal answer." },
+        },
+      },
+    });
+    emit({ type: "compaction_end", willRetry: true, result: { summary: "compacted" } });
+    await Promise.resolve();
+
+    expect(subscription.getMessagingToolSourceReplyPayloads()).toEqual([
+      { text: "Visible terminal answer." },
+    ]);
+  });
+
+  it("suppresses later assistant stream and partial replies after message-tool-only delivery", async () => {
+    const { emit, onAgentEvent, onPartialReply } = createBlockReplyHarness("text_end", {
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    await emitMessageToolLifecycle({
+      emit,
+      toolCallId: "tool-message-before-partial",
+      message: "Starting the requested work.",
+      to: null,
+      result: { details: { deliveryStatus: "sent" } },
+    });
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "Done." });
+    await Promise.resolve();
+
+    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(onAgentEvent.mock.calls.some((call) => call[0]?.stream === "assistant")).toBe(false);
+  });
+
+  it("suppresses later reasoning streams after message-tool-only delivery", async () => {
+    const onReasoningStream = vi.fn();
+    const onReasoningEnd = vi.fn();
+    const { emit } = createBlockReplyHarness("message_end", {
+      sourceReplyDeliveryMode: "message_tool_only",
+      reasoningMode: "stream",
+      onReasoningEnd,
+      onReasoningStream,
+    });
+
+    await emitMessageToolLifecycle({
+      emit,
+      toolCallId: "tool-message-before-reasoning",
+      message: "Starting the requested work.",
+      to: null,
+      result: { details: { deliveryStatus: "sent" } },
+    });
+    emit({
+      type: "message_update",
+      message: { role: "assistant", content: [{ type: "thinking", thinking: "private" }] },
+      assistantMessageEvent: { type: "thinking_delta", delta: "private" },
+    });
+    emit({
+      type: "message_update",
+      message: { role: "assistant", content: [{ type: "thinking", thinking: "private" }] },
+      assistantMessageEvent: { type: "thinking_end" },
+    });
+    await Promise.resolve();
+
+    expect(onReasoningStream).not.toHaveBeenCalled();
+    expect(onReasoningEnd).not.toHaveBeenCalled();
+  });
+
+  it("suppresses later tagged reasoning streams after message-tool-only delivery", async () => {
+    const onReasoningStream = vi.fn();
+    const onReasoningEnd = vi.fn();
+    const { emit } = createBlockReplyHarness("message_end", {
+      sourceReplyDeliveryMode: "message_tool_only",
+      reasoningMode: "stream",
+      onReasoningEnd,
+      onReasoningStream,
+    });
+
+    await emitMessageToolLifecycle({
+      emit,
+      toolCallId: "tool-message-before-tagged-reasoning",
+      message: "Starting the requested work.",
+      to: null,
+      result: { details: { deliveryStatus: "sent" } },
+    });
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "<think>private reasoning" });
+    emitAssistantTextDelta({ emit, delta: "</think>Done." });
+    await Promise.resolve();
+
+    expect(onReasoningStream).not.toHaveBeenCalled();
+    expect(onReasoningEnd).not.toHaveBeenCalled();
+  });
+
+  it("uses runner-level delivery evidence when tool result details were rewritten", async () => {
+    const { emit, onBlockReply } = createBlockReplyHarness("message_end", {
+      sourceReplyDeliveryMode: "message_tool_only",
+      hasDeliveredMessageToolOnlySourceReply: () => true,
+    });
+
+    await emitMessageToolLifecycle({
+      emit,
+      toolCallId: "tool-message-rewritten-result",
+      message: "Starting the requested work.",
+      to: null,
+      result: { details: { rewritten: true } },
+    });
+    emitAssistantMessageEnd(emit, "Done after rewritten tool result.");
     await Promise.resolve();
 
     expect(onBlockReply).not.toHaveBeenCalled();

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -223,6 +223,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     heartbeatToolResponse: undefined,
     messagingToolSentMediaUrls: [],
     messagingToolSourceReplyPayloads: [],
+    messageToolOnlySourceReplyDelivered: false,
     pendingMessagingTexts: new Map(),
     pendingMessagingTargets: new Map(),
     successfulCronAdds: 0,
@@ -959,6 +960,11 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     output += text.slice(lastIndex);
     return output;
   };
+  const hasMessageToolOnlySourceDelivery = () =>
+    params.sourceReplyDeliveryMode === "message_tool_only" &&
+    (state.messageToolOnlySourceReplyDelivered ||
+      params.hasDeliveredMessageToolOnlySourceReply?.() === true ||
+      messagingToolSourceReplyPayloads.length > 0);
 
   const emitBlockChunk = (
     text: string,
@@ -986,6 +992,10 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       state.lastDeliveredBlockReplyText = blockReplyText;
       state.toolExecutionSinceLastBlockReply = false;
     };
+    if (hasMessageToolOnlySourceDelivery()) {
+      markBlockReplyTextHandled();
+      return;
+    }
     let chunk = blockReplyText;
     let slicedPrefixReplay = false;
     const lastDeliveredBlockReplyText = state.lastDeliveredBlockReplyText;
@@ -1194,7 +1204,6 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     messagingToolSentTextsNormalized.length = 0;
     messagingToolSentTargets.length = 0;
     messagingToolSentMediaUrls.length = 0;
-    messagingToolSourceReplyPayloads.length = 0;
     pendingMessagingTexts.clear();
     pendingMessagingTargets.clear();
     state.successfulCronAdds = 0;

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -41,6 +41,8 @@ export type SubscribeEmbeddedAgentSessionParams = {
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  /** Attempt-owned delivery proof for message-tool-only source replies. */
+  hasDeliveredMessageToolOnlySourceReply?: () => boolean;
   onToolResult?: (payload: ReplyPayload) => void | Promise<void>;
   onReasoningStream?: (payload: {
     text?: string;


### PR DESCRIPTION
## Summary

- Fixes the `message_tool_only` source-reply path so a visible `message.send` reply is no longer treated as an agent-loop terminator.
- Tracks delivered implicit current-source `message.send` calls as source-reply evidence, lets the model continue to follow-up tools, and suppresses duplicate later assistant/reasoning/block/terminal replies.
- Keeps explicit routed message sends, failed sends, dry runs, and non-message messaging tools out of the source-reply suppression path.
- Intentionally out of scope: changing channel-specific visible reply policy, tool schemas, or provider/model behavior.
- Review focus: source-reply detection boundaries, duplicate suppression after delivery, and continuation behavior across runner/subscription/payload paths.

## Linked context

Closes #92169

Related #92169

Requested by maintainer in the issue-fix workflow.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Slack `message_tool_only` replies with Anthropic stopped after the visible `message.send` source reply instead of continuing to the next promised tool call.
- Real environment tested: AWS Crabbox Linux, live Slack credential leased from Convex (`kind: slack`, `role: maintainer`), live Anthropic `anthropic/claude-sonnet-4-6`.
- Exact steps or command run after this patch: AWS Crabbox `run_f52b14085f24`, lease `cbx_736570b923ff`, built the patched branch with `pnpm build`, then ran the live Slack harness that posts a Slack prompt requiring `message.send`, then `exec`, then final text.
- Evidence after fix: proof JSON from `run_f52b14085f24` reported `messageObserved: true` and `execObservedInFile: true` for marker file `/tmp/openclaw-92169-B0272D7E03-exec.txt`.
- Observed result after fix: the visible Slack source reply was sent, and the same agent turn continued to execute the follow-up `exec` tool.
- What was not tested: Telegram or Discord live transports; this issue was reproduced and fixed through Slack's reported path.
- Proof limitations or environment constraints: Slack/Anthropic credentials were injected through 1Password and Convex broker env; no secrets are included here.
- Before evidence: AWS Crabbox `run_fb91c7cef561`, lease `cbx_a798f624f3b4`, detached latest `origin/main` at `3b78d41a9e8d8344339271ffb8cee7e00e5eff41`, built with `pnpm build`, then ran the same live Slack harness. It reported `messageObserved: true`, `execObservedInFile: false`, `execObservedInSlack: false`, and `finalObservedInSlack: false`.

## Tests and validation

- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean; no accepted/actionable findings.
- `pnpm test src/agents/embedded-agent-runner/run/payloads.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.suppresses-message-end-block-replies-message-tool.test.ts src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts packages/agent-core/src/agent-loop.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/agents/embedded-agent-subscribe.handlers.messages.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/discord/src/monitor/message-handler.process.test.ts extensions/telegram/src/bot-message-dispatch.test.ts -- --reporter=verbose`: passed.
- `git diff --check HEAD~1..HEAD`: passed.
- Crabbox fix proof: `run_f52b14085f24`, `cbx_736570b923ff`, passed with `messageObserved: true`, `execObservedInFile: true`.
- Crabbox regression repro on current main: `run_fb91c7cef561`, `cbx_a798f624f3b4`, reproduced with `messageObserved: true`, `execObservedInFile: false`.

Regression coverage added/updated:

- Agent loop now proves tool-result continuation after `afterToolCall` hooks that do not explicitly terminate.
- Message-tool source-reply detection now covers implicit current-source sends, explicit route exclusions, failed sends, dry runs, non-message tools, result rewriting, compaction retry, assistant stream suppression, reasoning stream suppression, block reply suppression, and terminal payload suppression.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
Yes.

Did config, environment, or migration behavior change? (`Yes/No`)
No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
Yes, narrowly: tool execution can continue after an implicit current-source `message.send` in `message_tool_only` mode instead of ending the run.

What is the highest-risk area?
Suppressing only duplicate source-reply presentation while preserving normal final replies for explicit routed sends, failed sends, dry runs, and other messaging tools.

How is that risk mitigated?
The source-reply predicate rejects explicit routing fields and non-delivered results, and focused tests cover the sibling positive/negative cases plus live Slack continuation proof.

## Current review state

What is the next action?
CI and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?
Waiting on CI. Live fix proof and current-main regression repro are complete.

Which bot or reviewer comments were addressed?
Local autoreview findings were addressed before opening the PR; latest autoreview was clean.
