### PR TITLE
fix(cron): emit model.usage diagnostic events from isolated agent runs (fixes #92338)

### DIFF
--- a/src/cron/isolated-agent/run.diagnostic-events.test.ts
+++ b/src/cron/isolated-agent/run.diagnostic-events.test.ts
@@ -1,6 +1,10 @@
 // Run diagnostic event tests cover emitted diagnostics from isolated cron runs.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { onDiagnosticEvent, resetDiagnosticEventsForTest } from "../../infra/diagnostic-events.js";
+import {
+  onDiagnosticEvent,
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+} from "../../infra/diagnostic-events.js";
 import { resetDiagnosticStateForTest } from "../../logging/diagnostic.js";
 
 vi.mock("../../agents/auth-profiles/source-check.js", () => ({
@@ -181,5 +185,71 @@ describe("runCronIsolatedAgentTurn diagnostic events", () => {
       { type: "session.state", state: "idle", sessionId: "persisted-run-session" },
       { type: "message.processed", sessionId: "persisted-run-session" },
     ]);
+  });
+
+  it("emits a model.usage diagnostic event for cron runs with nonzero usage", async () => {
+    const usageEvents: Array<{
+      type: string;
+      channel?: string;
+      provider?: string;
+      model?: string;
+      usage?: { input?: number; output?: number };
+    }> = [];
+    const unsubscribe = onInternalDiagnosticEvent((evt) => {
+      const e = evt as { type: string };
+      if (e.type === "model.usage") {
+        usageEvents.push(evt as (typeof usageEvents)[number]);
+      }
+    });
+
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [{ text: "test output" }],
+        meta: {
+          agentMeta: {
+            sessionId: "cron-usage-session",
+            sessionFile: "/tmp/cron-usage-session.jsonl",
+            usage: { input: 50, output: 100 },
+          },
+        },
+      },
+      provider: "test-provider",
+      model: "test-model",
+    });
+
+    try {
+      const result = await runCronIsolatedAgentTurn(makeParams());
+      expect(result.status).toBe("ok");
+    } finally {
+      unsubscribe();
+    }
+
+    expect(usageEvents).toHaveLength(1);
+    expect(usageEvents[0]).toMatchObject({
+      type: "model.usage",
+      channel: "cron",
+      provider: "test-provider",
+      model: "test-model",
+      usage: { input: 50, output: 100 },
+    });
+  });
+
+  it("does not emit model.usage when usage is zero", async () => {
+    const usageEvents: Array<{ type: string }> = [];
+    const unsubscribe = onInternalDiagnosticEvent((evt) => {
+      const e = evt as { type: string };
+      if (e.type === "model.usage") {
+        usageEvents.push(e);
+      }
+    });
+
+    try {
+      const result = await runCronIsolatedAgentTurn(makeParams());
+      expect(result.status).toBe("ok");
+    } finally {
+      unsubscribe();
+    }
+
+    expect(usageEvents).toHaveLength(0);
   });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -16,7 +16,7 @@ import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { clearAgentRunContext } from "../../infra/agent-events.js";
-import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import {
   createSourceDeliveryPlan,
   resolveSourceDeliveryOutcome,
@@ -1035,6 +1035,37 @@ async function finalizeCronRun(params: {
       provider: providerUsed,
       usage: telemetryUsage,
     };
+    if (isDiagnosticsEnabled(prepared.cfgWithAgentDefaults)) {
+      const cacheRead = usage.cacheRead ?? 0;
+      const cacheWrite = usage.cacheWrite ?? 0;
+      const usagePromptTokens = input + cacheRead + cacheWrite;
+      emitTrustedDiagnosticEvent({
+        type: "model.usage",
+        sessionKey: prepared.agentSessionKey,
+        sessionId: prepared.currentRunSessionId(),
+        channel: "cron",
+        agentId: prepared.agentId,
+        provider: providerUsed,
+        model: modelUsed,
+        usage: {
+          input,
+          output,
+          cacheRead,
+          cacheWrite,
+          promptTokens: usagePromptTokens,
+          total:
+            typeof totalTokens === "number" && totalTokens > 0
+              ? totalTokens
+              : usagePromptTokens + output,
+        },
+        lastCallUsage,
+        context: {
+          limit: contextTokens,
+        },
+        costUsd: runEstimatedCostUsd,
+        durationMs: Date.now() - execution.runStartedAt,
+      });
+    }
   } else {
     telemetry = { model: modelUsed, provider: providerUsed };
   }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -5,6 +5,7 @@ import { hasAnyAuthProfileStoreSource } from "../../agents/auth-profiles/source-
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-routing.js";
 import { expandToolGroups, normalizeToolName } from "../../agents/tool-policy.js";
+import { deriveContextPromptTokens } from "../../agents/usage.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import {
@@ -17,6 +18,10 @@ import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { clearAgentRunContext } from "../../infra/agent-events.js";
 import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import {
+  createChildDiagnosticTraceContext,
+  freezeDiagnosticTraceContext,
+} from "../../infra/diagnostic-trace-context.js";
 import {
   createSourceDeliveryPlan,
   resolveSourceDeliveryOutcome,
@@ -1039,9 +1044,21 @@ async function finalizeCronRun(params: {
       const cacheRead = usage.cacheRead ?? 0;
       const cacheWrite = usage.cacheWrite ?? 0;
       const usagePromptTokens = input + cacheRead + cacheWrite;
+      const contextUsedTokens = deriveContextPromptTokens({
+        lastCallUsage,
+        promptTokens,
+        usage,
+      });
       emitTrustedDiagnosticEvent({
         type: "model.usage",
-        sessionKey: prepared.agentSessionKey,
+        ...(finalRunResult.diagnosticTrace
+          ? {
+              trace: freezeDiagnosticTraceContext(
+                createChildDiagnosticTraceContext(finalRunResult.diagnosticTrace),
+              ),
+            }
+          : {}),
+        sessionKey: prepared.runSessionKey,
         sessionId: prepared.currentRunSessionId(),
         channel: "cron",
         agentId: prepared.agentId,
@@ -1061,9 +1078,10 @@ async function finalizeCronRun(params: {
         lastCallUsage,
         context: {
           limit: contextTokens,
+          ...(contextUsedTokens !== undefined ? { used: contextUsedTokens } : {}),
         },
         costUsd: runEstimatedCostUsd,
-        durationMs: Date.now() - execution.runStartedAt,
+        durationMs: execution.runEndedAt - execution.runStartedAt,
       });
     }
   } else {


### PR DESCRIPTION
## What does this PR do?

Adds `model.usage` diagnostic event emission to the cron-isolated agent pipeline, closing the observability gap where all scheduled agent spend was invisible to OTel/diagnostics subscribers.

## Related Issue

Fixes #92338

## Type of Change

- [x] Bug fix (non-breaking)

## Changes Made

- `src/cron/isolated-agent/run.ts`: Import `emitTrustedDiagnosticEvent` and emit `model.usage` event in `finalizeCronRun` when usage is nonzero, matching the existing pattern from the auto-reply pipeline (`src/auto-reply/reply/agent-runner.ts:2056`)
- `src/cron/isolated-agent/run.diagnostic-events.test.ts`: Add two tests — one verifying `model.usage` emission with nonzero usage, one verifying no emission when usage is zero

## How to Test

1. `node scripts/run-vitest.mjs run src/cron/isolated-agent/run.diagnostic-events.test.ts`
2. All 5 tests should pass

## Real behavior proof

**Behavior or issue addressed:**
Cron-isolated agent runs compute token usage and persist it to the cron run log, but never emit a `model.usage` diagnostic event. This leaves `diagnostics-otel` (and any other subscriber filtering on `type: "model.usage"`) blind to all scheduled agent spend — heartbeats, dispatchers, scheduled tasks — even though those runs burn real API tokens.

**Real environment tested:**
macOS 26.4.1, Node.js v25.8.2, pnpm 11.2.2, OpenClaw workdir at `/Users/liuhao/.hermes/workdir/openclaw` (commit `7d8e17a1`)

**Exact steps or command run after the patch:**
```bash
node scripts/run-vitest.mjs run src/cron/isolated-agent/run.diagnostic-events.test.ts
```

**Evidence after fix:**
```
 RUN  v4.1.7 /Users/liuhao/.hermes/workdir/openclaw

 ✓  cron  src/cron/isolated-agent/run.diagnostic-events.test.ts (5 tests) 776ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start  12:47:57
   Duration  1.74s (transform 457ms, setup 71ms, import 849ms, tests 776ms)
```

Also verified existing usage accounting tests remain green:
```bash
node scripts/run-vitest.mjs run src/cron/isolated-agent/run.usage-accounting.test.ts
```
```
 ✓  cron  src/cron/isolated-agent/run.usage-accounting.test.ts (3 tests) 529ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

**Observed result after fix:**
- `model.usage` diagnostic event is emitted for cron runs with nonzero token usage, with correct `channel: "cron"`, provider, model, and usage breakdown
- No `model.usage` event emitted when usage is zero
- Existing lifecycle events (`message.queued`, `session.state`, `message.processed`) unaffected
- Existing usage accounting tests unaffected

**What was not tested:**
- Live OTel export to Prometheus/OTLP backend (requires infrastructure setup)
- Interaction with `diagnostics-otel` plugin subscriber
