### PR TITLE
fix(feishu): ignore bot_p2p_chat_entered_v1 events to prevent gateway restarts (fixes #42351)

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -305,6 +305,10 @@ function registerEventHandlers(
     "im.message.message_read_v1": async () => {
       // Ignore read receipts
     },
+    "im.chat.access_event.bot_p2p_chat_entered_v1": async () => {
+      // Ignore p2p chat entered events — these fire when a user opens the bot
+      // private chat window and carry no actionable payload.
+    },
     "im.chat.member.bot.added_v1": async (data) => {
       try {
         const event = parseFeishuBotAddedEventPayload(data);


### PR DESCRIPTION
## What

Register a no-op handler for `im.chat.access_event.bot_p2p_chat_entered_v1` in the Feishu channel plugin so the event is silently consumed instead of triggering a "no handle" warning that can accumulate and cause gateway restarts.

## Why

Fixes #42351

When a user opens a Feishu bot's private chat window, the platform sends a `bot_p2p_chat_entered_v1` event. The Lark SDK's `EventDispatcher.invoke()` logs a warning (`no im.chat.access_event.bot_p2p_chat_entered_v1 handle`) for unregistered event types. In WebSocket mode, repeated unhandled events can trigger gateway restarts (~10s downtime), disconnecting webchat sessions.

## How

Added a no-op `async () => {}` handler for the event type in `registerEventHandlers()`, following the same pattern as the existing `im.message.message_read_v1` ignore handler. The event carries no actionable payload for OpenClaw — it's purely a "user opened the chat window" notification.

## Real behavior proof

**Behavior addressed:** Feishu `bot_p2p_chat_entered_v1` events are now handled by a registered no-op handler instead of falling through to the SDK's unregistered-event warning path.

**Environment tested:** macOS 26.4.1, Node.js v25.7.0, OpenClaw main branch (9827490f)

**Steps run after the patch:**
1. `node scripts/run-vitest.mjs run extensions/feishu/src/monitor.lifecycle.test.ts` — 14 tests passed
2. `node scripts/run-vitest.mjs run extensions/feishu/src/bot.test.ts` — 77 tests passed
3. Verified the handler is registered by reading the source: `extensions/feishu/src/monitor.account.ts:308-311`

**Evidence after fix:**
```
✓ extension-feishu  extensions/feishu/src/monitor.lifecycle.test.ts (14 tests) 94ms
✓ extension-feishu  extensions/feishu/src/bot.test.ts (77 tests) 52ms
```

Handler registration confirmed in source:
```typescript
"im.chat.access_event.bot_p2p_chat_entered_v1": async () => {
  // Ignore p2p chat entered events — these fire when a user opens the bot
  // private chat window and carry no actionable payload.
},
```

**Observed result after fix:** The event type now has a registered handler. The Lark SDK's `EventDispatcher.invoke()` will execute the handler (which is a no-op) instead of logging the "no handle" warning. This prevents the accumulation pattern that leads to gateway restarts.

**What was not tested:** Live Feishu WebSocket connection with real `bot_p2p_chat_entered_v1` events (requires Feishu bot credentials and a running gateway with WebSocket mode). The fix is structurally identical to the existing `message_read_v1` ignore handler, which is proven in production.
