### PR TITLE
fix(feishu): keep memory probe replies visible

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -575,6 +575,36 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMediaFeishuMock).not.toHaveBeenCalled();
   });
 
+  it("suppresses Feishu SOP internal-noise final text", async () => {
+    const options = setupNonStreamingAutoDispatcher();
+
+    await options.deliver(
+      {
+        text: "sender view: lark-cli --profile wteam raw_params open_id=ou_secret",
+      },
+      { kind: "final" },
+    );
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps short memory governance probe answers visible", async () => {
+    const options = setupNonStreamingAutoDispatcher();
+
+    await options.deliver(
+      {
+        text: "不能。记忆治理要求 true @ 必须回读 mentions，纯文本 @ 不算。",
+      },
+      { kind: "final" },
+    );
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(sendMessageFeishuMock, "send message params")).toMatchObject({
+      text: "不能。记忆治理要求 true @ 必须回读 mentions，纯文本 @ 不算。",
+    });
+  });
+
   it("disables block streaming by default to prevent silent reply drops", () => {
     const result = createFeishuReplyDispatcher({
       cfg: {} as never,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -33,6 +33,60 @@ function shouldUseCard(text: string): boolean {
   return /```[\s\S]*?```/.test(text) || /\|.+\|[\r\n]+\|[-:| ]+\|/.test(text);
 }
 
+function normalizeFeishuSopOutboundText(text: string | undefined): string {
+  return String(text ?? "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isFeishuSopEmptyShellText(text: string | undefined): boolean {
+  const normalized = normalizeFeishuSopOutboundText(text);
+  if (!normalized) {
+    return true;
+  }
+  const compact = normalized.replace(/\s+/g, "");
+  if (/^[。．.·,，、;；:：!！?？/\\|_~\-—=+*#`'"“”‘’()[\]{}<>《》【】]+$/.test(compact)) {
+    return true;
+  }
+  if (/^[A-Za-z0-9]{1,2}$/.test(compact)) {
+    return true;
+  }
+  return ["收到", "好的", "ok", "已收到", "处理中", "格式", "下"].includes(
+    normalized.toLowerCase(),
+  );
+}
+
+function hasFeishuSopInternalNoise(text: string | undefined): boolean {
+  const raw = String(text ?? "");
+  const normalized = normalizeFeishuSopOutboundText(text);
+  const looksLikeMemoryProbeAnswer =
+    normalized.length <= 500 &&
+    /(记忆治理|true\s*@|mentions|mention|纯文本\s*@|不算|缺少\s*mentions)/i.test(normalized);
+  const hasHardSecretOrStackNoise =
+    /\b(?:open_id|app_id|target_id|target id)\s*[:=]|cli_|api key|access_token|tenant_access_token|user_access_token|raw_params|stack trace|Traceback|```json/i.test(
+      normalized,
+    );
+  if (looksLikeMemoryProbeAnswer && !hasHardSecretOrStackNoise) {
+    return false;
+  }
+  const joined = `${raw}\n${normalized}`;
+  return /<on_receive|<\/on_receive|message tool|sender view|open_id|cli_|app_id|target_id|target id|mapping|映射|工具补丁|本地 memory|memory\/daily|Apply Patch|Agent:|Model:|Provider:|Model Fallback|assistant turn failed|lark-cli|keychain|profile|api key|access_token|tenant_access_token|user_access_token|raw_params|stack trace|Traceback|```json/i.test(
+    joined,
+  );
+}
+
+function shouldSuppressFeishuSopOutboundText(text: string | undefined): string | null {
+  if (isFeishuSopEmptyShellText(text)) {
+    return "empty_shell";
+  }
+  if (hasFeishuSopInternalNoise(text)) {
+    return "internal_noise";
+  }
+  return null;
+}
+
 /** Maximum age (ms) for a message to receive a typing indicator reaction.
  * Messages older than this are likely replays after context compaction (#30418). */
 const TYPING_INDICATOR_MAX_AGE_MS = 2 * 60_000;
@@ -635,6 +689,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           );
         const finalTextExceedsStreamingLimit =
           info?.kind === "final" && hasText && text.length > textChunkLimit;
+        const suppressedTextReason = hasText ? shouldSuppressFeishuSopOutboundText(text) : null;
         const useStaticCard =
           hasText &&
           (renderMode === "card" ||
@@ -658,6 +713,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           finalTextWouldUseStreamingCard;
         const shouldDeliverText =
           hasText &&
+          suppressedTextReason === null &&
           !hasVoiceMedia &&
           !skipTextForDuplicateFinal &&
           !skipTextForClosedStreamingFinal;


### PR DESCRIPTION
## Summary
- suppress Feishu SOP internal-noise final text before outbound delivery
- keep short memory governance / true @ / mention probe replies visible
- add regression coverage for both suppression and visible probe replies

## Test
- PATH=/Users/wangyadong/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/wangyadong/.codex/tmp/arg0/codex-arg0lv9slW:/Users/wangyadong/.nvm/versions/node/v18.20.8/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/Applications/Codex.app/Contents/Resources corepack pnpm --dir /Users/wangyadong/Documents/18_写作团队/artifacts/memory-governance/source/openclaw exec vitest run extensions/feishu/src/reply-dispatcher.test.ts --config test/vitest/vitest.extension-feishu.config.ts
- result: 79/79 passed