### PR TITLE
fix(codex): preserve memory prompt registration

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -854,7 +854,7 @@ function renderCodexMemoryToolSearchBridge(toolNames: readonly string[]): string
   if (memoryToolNames.length === 0) {
     return undefined;
   }
-  return `Codex may expose ${memoryToolNames.join(" and ")} as deferred tools. Use \`tool_search\` first if the memory tools are not already loaded, then call the loaded memory tool before answering.`;
+  return `Codex may expose ${memoryToolNames.join(" and ")} as deferred tools. When the memory guidance above calls for memory recall, use an already-loaded memory tool directly. If the needed memory tool is deferred and not currently callable, use \`tool_search\` to load it, then call that memory tool.`;
 }
 
 /** Returns whether the current dynamic tool list can serve workspace memory. */

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -815,8 +815,8 @@ function renderCodexWorkspaceMemoryCollaborationInstructions(params: {
   citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
 }): string | undefined {
   const memoryRecallInstructions = params.memoryToolRouted
-    ? buildMemorySystemPromptAddition({
-        availableTools: new Set(params.toolNames),
+    ? renderCodexMemoryRecallInstructions({
+        toolNames: params.toolNames,
         citationsMode: params.citationsMode,
       })
     : undefined;
@@ -826,6 +826,69 @@ function renderCodexWorkspaceMemoryCollaborationInstructions(params: {
   });
   const sections = [memoryRecallInstructions, memoryReferenceInstructions].filter(isNonEmptyString);
   return sections.length > 0 ? sections.join("\n\n") : undefined;
+}
+
+function renderCodexMemoryRecallInstructions(params: {
+  toolNames: readonly string[];
+  citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
+}): string | undefined {
+  const availableTools = new Set(params.toolNames);
+  const memoryPrompt =
+    buildMemorySystemPromptAddition({
+      availableTools,
+      citationsMode: params.citationsMode,
+    }) ??
+    buildCodexFallbackMemorySystemPromptAddition({
+      availableTools,
+      citationsMode: params.citationsMode,
+    });
+  const toolSearchBridge = renderCodexMemoryToolSearchBridge(params.toolNames);
+  const sections = [memoryPrompt, toolSearchBridge].filter(isNonEmptyString);
+  return sections.length > 0 ? sections.join("\n").trim() : undefined;
+}
+
+function buildCodexFallbackMemorySystemPromptAddition(params: {
+  availableTools: Set<string>;
+  citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
+}): string | undefined {
+  const hasMemorySearch = params.availableTools.has("memory_search");
+  const hasMemoryGet = params.availableTools.has("memory_get");
+  if (!hasMemorySearch && !hasMemoryGet) {
+    return undefined;
+  }
+
+  const toolGuidance = (() => {
+    if (hasMemorySearch && hasMemoryGet) {
+      return "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md + indexed session transcripts; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.";
+    }
+    if (hasMemorySearch) {
+      return "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md + indexed session transcripts and answer from the matching results. If low confidence after search, say you checked.";
+    }
+    return "Before answering anything about prior work, decisions, dates, people, preferences, or todos that already point to a specific memory file or note: run memory_get to pull only the needed lines. If low confidence after reading them, say you checked.";
+  })();
+
+  const lines = ["## Memory Recall", toolGuidance];
+  if (params.citationsMode === "off") {
+    lines.push(
+      "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",
+    );
+  } else {
+    lines.push(
+      "Citations: include Source: <path#line> when it helps the user verify memory snippets.",
+    );
+  }
+  return lines.join("\n").trim();
+}
+
+function renderCodexMemoryToolSearchBridge(toolNames: readonly string[]): string | undefined {
+  const memoryToolNames = toolNames
+    .map((name) => normalizeCodexDynamicToolName(name))
+    .filter((name) => CODEX_MEMORY_TOOL_NAMES.has(name))
+    .toSorted();
+  if (memoryToolNames.length === 0) {
+    return undefined;
+  }
+  return `Codex may expose ${memoryToolNames.join(" and ")} as deferred tools. Use \`tool_search\` first if the memory tools are not already loaded, then call the loaded memory tool before answering.`;
 }
 
 /** Returns whether the current dynamic tool list can serve workspace memory. */

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -833,51 +833,17 @@ function renderCodexMemoryRecallInstructions(params: {
   citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
 }): string | undefined {
   const availableTools = new Set(params.toolNames);
-  const memoryPrompt =
-    buildMemorySystemPromptAddition({
-      availableTools,
-      citationsMode: params.citationsMode,
-    }) ??
-    buildCodexFallbackMemorySystemPromptAddition({
-      availableTools,
-      citationsMode: params.citationsMode,
-    });
-  const toolSearchBridge = renderCodexMemoryToolSearchBridge(params.toolNames);
-  const sections = [memoryPrompt, toolSearchBridge].filter(isNonEmptyString);
-  return sections.length > 0 ? sections.join("\n").trim() : undefined;
-}
-
-function buildCodexFallbackMemorySystemPromptAddition(params: {
-  availableTools: Set<string>;
-  citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
-}): string | undefined {
-  const hasMemorySearch = params.availableTools.has("memory_search");
-  const hasMemoryGet = params.availableTools.has("memory_get");
-  if (!hasMemorySearch && !hasMemoryGet) {
+  const memoryPrompt = buildMemorySystemPromptAddition({
+    availableTools,
+    citationsMode: params.citationsMode,
+  });
+  if (!memoryPrompt) {
+    // Memory recall policy belongs to the active memory plugin.
+    // Codex-side fallback text can mask plugin lifecycle bugs or misdescribe third-party memory tools.
     return undefined;
   }
-
-  const toolGuidance = (() => {
-    if (hasMemorySearch && hasMemoryGet) {
-      return "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md + indexed session transcripts; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.";
-    }
-    if (hasMemorySearch) {
-      return "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md + indexed session transcripts and answer from the matching results. If low confidence after search, say you checked.";
-    }
-    return "Before answering anything about prior work, decisions, dates, people, preferences, or todos that already point to a specific memory file or note: run memory_get to pull only the needed lines. If low confidence after reading them, say you checked.";
-  })();
-
-  const lines = ["## Memory Recall", toolGuidance];
-  if (params.citationsMode === "off") {
-    lines.push(
-      "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",
-    );
-  } else {
-    lines.push(
-      "Citations: include Source: <path#line> when it helps the user verify memory snippets.",
-    );
-  }
-  return lines.join("\n").trim();
+  const toolSearchBridge = renderCodexMemoryToolSearchBridge(params.toolNames);
+  return [memoryPrompt, toolSearchBridge].filter(isNonEmptyString).join("\n").trim();
 }
 
 function renderCodexMemoryToolSearchBridge(toolNames: readonly string[]): string | undefined {

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -15,6 +15,7 @@ import {
   type EmbeddedRunAttemptResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentWorkspaceDir } from "openclaw/plugin-sdk/agent-runtime";
+import { buildMemorySystemPromptAddition } from "openclaw/plugin-sdk/core";
 import type { CodexDynamicToolSpec, JsonValue } from "./protocol.js";
 import { isJsonObject } from "./protocol.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
@@ -249,9 +250,11 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
         turnScopedDeveloperInstructionFiles,
       ),
       memoryCollaborationInstructions: shouldInjectCodexOpenClawPromptContext(params.params)
-        ? renderCodexWorkspaceMemoryReference({
+        ? renderCodexWorkspaceMemoryCollaborationInstructions({
             files: memoryReferenceFiles,
             toolNames: params.memoryToolNames,
+            memoryToolRouted: memoryToolsAvailable,
+            citationsMode: params.params.config?.memory?.citations,
           })
         : undefined,
       heartbeatCollaborationInstructions:
@@ -803,6 +806,26 @@ export function renderCodexWorkspaceMemoryReference(params: {
     lines.push(`- ${file.path}`);
   }
   return lines.join("\n").trim();
+}
+
+function renderCodexWorkspaceMemoryCollaborationInstructions(params: {
+  files: EmbeddedContextFile[];
+  toolNames: readonly string[];
+  memoryToolRouted: boolean;
+  citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
+}): string | undefined {
+  const memoryRecallInstructions = params.memoryToolRouted
+    ? buildMemorySystemPromptAddition({
+        availableTools: new Set(params.toolNames),
+        citationsMode: params.citationsMode,
+      })
+    : undefined;
+  const memoryReferenceInstructions = renderCodexWorkspaceMemoryReference({
+    files: params.files,
+    toolNames: params.toolNames,
+  });
+  const sections = [memoryRecallInstructions, memoryReferenceInstructions].filter(isNonEmptyString);
+  return sections.length > 0 ? sections.join("\n\n") : undefined;
 }
 
 /** Returns whether the current dynamic tool list can serve workspace memory. */

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resetDiagnosticEventsForTest } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { clearInternalHooks, resetGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
+import { clearMemoryPluginState } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { clearPluginCommands } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { afterEach, beforeEach, expect, vi } from "vitest";
@@ -495,6 +496,7 @@ export function setupRunAttemptTestHooks(): void {
   beforeEach(async () => {
     vi.useRealTimers();
     clearInternalHooks();
+    clearMemoryPluginState();
     resetAgentEventsForTest();
     resetDiagnosticEventsForTest();
     vi.stubEnv("OPENCLAW_TRAJECTORY", "0");
@@ -512,6 +514,7 @@ export function setupRunAttemptTestHooks(): void {
     testing.clearPendingCodexNativeHookRelayUnregistersForTests();
     resetCodexRateLimitCacheForTests();
     nativeHookRelayTesting.clearNativeHookRelaysForTests();
+    clearMemoryPluginState();
     clearPluginCommands();
     resetAgentEventsForTest();
     resetDiagnosticEventsForTest();

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2277,6 +2277,12 @@ describe("runCodexAppServerAttempt", () => {
     );
     expect(collaborationInstructions).toContain("memory_search");
     expect(collaborationInstructions).toContain("memory_get");
+    expect(collaborationInstructions).toContain(
+      "When the memory guidance above calls for memory recall, use an already-loaded memory tool directly.",
+    );
+    expect(collaborationInstructions).toContain(
+      "If the needed memory tool is deferred and not currently callable, use `tool_search` to load it, then call that memory tool.",
+    );
     expect(collaborationInstructions).not.toContain(memorySummary);
     expect(inputText).not.toContain("OpenClaw runtime context for this turn:");
     expect(inputText).not.toContain("does not override Codex system/developer instructions");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2363,6 +2363,35 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).not.toContain(datedMemory);
   });
 
+  it("falls back to Codex memory recall guidance when the memory prompt builder is absent", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const datedMemory = "User avoids Chase cards while over 5/24.";
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "memory/2026-06-09.md"), datedMemory);
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("memory_search"),
+      createRuntimeDynamicTool("memory_get"),
+    ]);
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    setAgentWorkspaceForTest(params, workspaceDir);
+
+    const { collaborationInstructions, inputText } = await buildCodexTurnContextForTest(
+      params,
+      workspaceDir,
+    );
+
+    expect(collaborationInstructions).toContain("## Memory Recall");
+    expect(collaborationInstructions).toContain("run memory_search");
+    expect(collaborationInstructions).toContain("then use memory_get");
+    expect(collaborationInstructions).toContain("Use `tool_search` first");
+    expect(collaborationInstructions).not.toContain(datedMemory);
+    expect(inputText).toBe("hello");
+    expect(inputText).not.toContain(datedMemory);
+  });
+
   it("sends workspace bootstrap instructions through Codex app-server payloads", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2363,12 +2363,12 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).not.toContain(datedMemory);
   });
 
-  it("falls back to Codex memory recall guidance when the memory prompt builder is absent", async () => {
+  it("does not synthesize memory recall guidance without a registered memory prompt builder", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
-    const datedMemory = "User avoids Chase cards while over 5/24.";
-    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
-    await fs.writeFile(path.join(workspaceDir, "memory/2026-06-09.md"), datedMemory);
+    const memorySummary = "User avoids Chase cards while over 5/24.";
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("memory_search"),
       createRuntimeDynamicTool("memory_get"),
@@ -2383,13 +2383,12 @@ describe("runCodexAppServerAttempt", () => {
       workspaceDir,
     );
 
-    expect(collaborationInstructions).toContain("## Memory Recall");
-    expect(collaborationInstructions).toContain("run memory_search");
-    expect(collaborationInstructions).toContain("then use memory_get");
-    expect(collaborationInstructions).toContain("Use `tool_search` first");
-    expect(collaborationInstructions).not.toContain(datedMemory);
+    expect(collaborationInstructions).not.toContain("## Memory Recall");
+    expect(collaborationInstructions).toContain("OpenClaw Workspace Memory");
+    expect(collaborationInstructions).not.toContain("Use `tool_search` first");
+    expect(collaborationInstructions).not.toContain(memorySummary);
     expect(inputText).toBe("hello");
-    expect(inputText).not.toContain(datedMemory);
+    expect(inputText).not.toContain(memorySummary);
   });
 
   it("sends workspace bootstrap instructions through Codex app-server payloads", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -12,6 +12,7 @@ import {
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { initializeGlobalHookRunner, registerInternalHook } from "openclaw/plugin-sdk/hook-runtime";
+import { registerMemoryCapability } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { registerPluginCommand } from "openclaw/plugin-sdk/plugin-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
@@ -395,6 +396,37 @@ function createRuntimeDynamicTool(name: string): RuntimeDynamicToolForTest {
       details: {},
     })),
   };
+}
+
+function registerMemoryPromptForTest() {
+  registerMemoryCapability("memory-core", {
+    promptBuilder({ availableTools }) {
+      const hasMemorySearch = availableTools.has("memory_search");
+      const hasMemoryGet = availableTools.has("memory_get");
+      if (hasMemorySearch && hasMemoryGet) {
+        return [
+          "## Memory Recall",
+          "Test recall: run memory_search on MEMORY.md + memory/*.md + indexed session transcripts; then use memory_get.",
+          "",
+        ];
+      }
+      if (hasMemorySearch) {
+        return [
+          "## Memory Recall",
+          "Test recall: run memory_search on MEMORY.md + memory/*.md + indexed session transcripts.",
+          "",
+        ];
+      }
+      if (hasMemoryGet) {
+        return [
+          "## Memory Recall",
+          "Test recall: run memory_get for a specific memory file or note.",
+          "",
+        ];
+      }
+      return [];
+    },
+  });
 }
 
 function buildEmptyCodexToolTelemetry(): CodexAppServerToolTelemetry {
@@ -2203,6 +2235,7 @@ describe("runCodexAppServerAttempt", () => {
     await fs.writeFile(path.join(workspaceDir, "TOOLS.md"), toolGuidance);
     await fs.writeFile(path.join(workspaceDir, "USER.md"), userProfile);
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+    registerMemoryPromptForTest();
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("memory_search"),
       createRuntimeDynamicTool("memory_get"),
@@ -2236,6 +2269,8 @@ describe("runCodexAppServerAttempt", () => {
     expect(collaborationInstructions).toContain(identityGuidance);
     expect(collaborationInstructions).not.toContain(toolGuidance);
     expect(collaborationInstructions).toContain(userProfile);
+    expect(collaborationInstructions).toContain("## Memory Recall");
+    expect(collaborationInstructions).toContain("MEMORY.md + memory/*.md");
     expect(collaborationInstructions).toContain("OpenClaw Workspace Memory");
     expect(collaborationInstructions).toContain(
       "MEMORY.md exists in the active agent workspace as a memory file, not an instruction file",
@@ -2295,6 +2330,37 @@ describe("runCodexAppServerAttempt", () => {
       injectedChars: agentsGuidance.length,
       truncated: false,
     });
+  });
+
+  it("adds memory recall guidance when dated memory notes exist without root MEMORY.md", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const datedMemory = "User avoids Chase cards while over 5/24.";
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "memory/2026-06-09.md"), datedMemory);
+    registerMemoryPromptForTest();
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("memory_search"),
+      createRuntimeDynamicTool("memory_get"),
+    ]);
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    setAgentWorkspaceForTest(params, workspaceDir);
+
+    const { collaborationInstructions, inputText } = await buildCodexTurnContextForTest(
+      params,
+      workspaceDir,
+    );
+
+    expect(collaborationInstructions).toContain("## Memory Recall");
+    expect(collaborationInstructions).toContain("MEMORY.md + memory/*.md");
+    expect(collaborationInstructions).toContain("memory_search");
+    expect(collaborationInstructions).toContain("memory_get");
+    expect(collaborationInstructions).not.toContain("OpenClaw Workspace Memory");
+    expect(collaborationInstructions).not.toContain(datedMemory);
+    expect(inputText).toBe("hello");
+    expect(inputText).not.toContain(datedMemory);
   });
 
   it("sends workspace bootstrap instructions through Codex app-server payloads", async () => {
@@ -2405,6 +2471,7 @@ describe("runCodexAppServerAttempt", () => {
     const memorySummary = "Memory summary goes here.";
     await fs.mkdir(workspaceDir, { recursive: true });
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+    registerMemoryPromptForTest();
     testing.setOpenClawCodingToolsFactoryForTests(() => [createRuntimeDynamicTool("memory_get")]);
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
@@ -2417,6 +2484,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).not.toContain("memory_get");
     expect(inputText).not.toContain("memory_search");
     expect(inputText).not.toContain(memorySummary);
+    expect(collaborationInstructions).toContain("## Memory Recall");
     expect(collaborationInstructions).toContain("OpenClaw Workspace Memory");
     expect(collaborationInstructions).toContain("memory_get");
     expect(collaborationInstructions).not.toContain("memory_search");
@@ -2595,6 +2663,7 @@ describe("runCodexAppServerAttempt", () => {
     const memorySummary = "Memory summary goes here.";
     await fs.mkdir(workspaceDir, { recursive: true });
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+    registerMemoryPromptForTest();
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("memory_search"),
       createRuntimeDynamicTool("memory_get"),
@@ -2604,10 +2673,10 @@ describe("runCodexAppServerAttempt", () => {
     params.runtimePlan = createCodexRuntimePlanFixture();
     setAgentWorkspaceForTest(params, path.join(tempDir, "memory-workspace"));
 
-    const { inputText, systemPromptReport } = await buildCodexTurnContextForTest(
-      params,
-      workspaceDir,
-    );
+    const { collaborationInstructions, inputText, systemPromptReport } =
+      await buildCodexTurnContextForTest(params, workspaceDir);
+    expect(collaborationInstructions).not.toContain("## Memory Recall");
+    expect(collaborationInstructions).not.toContain("OpenClaw Workspace Memory");
     expect(inputText).not.toContain("OpenClaw Workspace Memory");
     expect(inputText).toContain(memorySummary);
 

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -35,7 +35,10 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       ({ onlyPluginIds }: { onlyPluginIds?: readonly string[] }) =>
         (onlyPluginIds ?? []).filter((pluginId) => pluginId === "openai"),
     );
-    mocks.resolveActivatableProviderOwnerPluginIds.mockReturnValue([]);
+    mocks.resolveActivatableProviderOwnerPluginIds.mockImplementation(
+      ({ pluginIds }: { pluginIds: readonly string[] }) =>
+        pluginIds.filter((pluginId) => pluginId === "memory-core"),
+    );
     vi.resetModules();
     ({ ensureSelectedAgentHarnessPlugin } = await import("./runtime-plugin.js"));
   });
@@ -62,7 +65,7 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       expect.objectContaining({
         scope: "all",
         workspaceDir: "/tmp/workspace",
-        onlyPluginIds: ["codex", "openai"],
+        onlyPluginIds: ["codex", "openai", "memory-core"],
       }),
     );
   });
@@ -88,7 +91,7 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       expect.objectContaining({
         scope: "all",
         workspaceDir: "/tmp/workspace",
-        onlyPluginIds: ["codex", "openai"],
+        onlyPluginIds: ["codex", "openai", "memory-core"],
       }),
     );
   });
@@ -116,10 +119,10 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       expect.objectContaining({
         scope: "all",
         workspaceDir: "/tmp/workspace",
-        onlyPluginIds: ["copilot"],
+        onlyPluginIds: ["copilot", "memory-core"],
         config: expect.objectContaining({
           plugins: expect.objectContaining({
-            allow: ["copilot"],
+            allow: ["copilot", "memory-core"],
             entries: expect.objectContaining({
               copilot: expect.objectContaining({ enabled: true }),
             }),
@@ -198,6 +201,74 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
             entries: expect.objectContaining({
               codex: expect.objectContaining({ enabled: true }),
               openai: expect.objectContaining({ enabled: true }),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("keeps an allowed memory slot plugin in Codex harness scoped loads", async () => {
+    await ensureSelectedAgentHarnessPlugin({
+      provider: "openai",
+      modelId: "gpt-5.5-pro",
+      config: {
+        plugins: {
+          allow: ["codex", "openai", "memory-core"],
+          entries: {
+            codex: { enabled: true },
+            openai: { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "all",
+        workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["codex", "openai", "memory-core"],
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["codex", "openai", "memory-core"],
+            entries: expect.objectContaining({
+              codex: expect.objectContaining({ enabled: true }),
+              openai: expect.objectContaining({ enabled: true }),
+              "memory-core": expect.objectContaining({ enabled: true }),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("does not auto-activate an untrusted workspace memory slot plugin", async () => {
+    await ensureSelectedAgentHarnessPlugin({
+      provider: "openai",
+      modelId: "gpt-5.5-pro",
+      config: {
+        plugins: {
+          slots: { memory: "workspace-memory" },
+        },
+      } as OpenClawConfig,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(mocks.resolveActivatableProviderOwnerPluginIds).toHaveBeenCalledWith({
+      pluginIds: ["workspace-memory"],
+      config: expect.any(Object),
+      workspaceDir: "/tmp/workspace",
+    });
+    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "all",
+        workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["codex", "openai"],
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            entries: expect.not.objectContaining({
+              "workspace-memory": expect.anything(),
             }),
           }),
         }),
@@ -292,12 +363,17 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     });
 
     expect(mocks.resolveBundledProviderCompatPluginIds).not.toHaveBeenCalled();
-    expect(mocks.resolveActivatableProviderOwnerPluginIds).not.toHaveBeenCalled();
+    expect(mocks.resolveActivatableProviderOwnerPluginIds).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveActivatableProviderOwnerPluginIds).toHaveBeenCalledWith({
+      pluginIds: ["memory-core"],
+      config: undefined,
+      workspaceDir: "/tmp/workspace",
+    });
     expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
       expect.objectContaining({
         scope: "all",
         workspaceDir: "/tmp/workspace",
-        onlyPluginIds: ["codex"],
+        onlyPluginIds: ["codex", "memory-core"],
       }),
     );
   });

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -256,10 +256,13 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     });
 
     expect(mocks.resolveActivatableProviderOwnerPluginIds).toHaveBeenCalledWith({
-      pluginIds: ["workspace-memory"],
+      pluginIds: ["openai"],
       config: expect.any(Object),
       workspaceDir: "/tmp/workspace",
     });
+    expect(mocks.resolveActivatableProviderOwnerPluginIds).not.toHaveBeenCalledWith(
+      expect.objectContaining({ pluginIds: ["workspace-memory"] }),
+    );
     expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
       expect.objectContaining({
         scope: "all",
@@ -352,7 +355,7 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     );
   });
 
-  it("keeps a Codex scoped load narrow when the provider has no owner plugin", async () => {
+  it("keeps real bundled memory-core in a Codex scoped load when the provider has no owner plugin", async () => {
     mocks.resolveOwningPluginIdsForProvider.mockReturnValueOnce(undefined);
 
     await ensureSelectedAgentHarnessPlugin({
@@ -363,12 +366,7 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     });
 
     expect(mocks.resolveBundledProviderCompatPluginIds).not.toHaveBeenCalled();
-    expect(mocks.resolveActivatableProviderOwnerPluginIds).toHaveBeenCalledTimes(1);
-    expect(mocks.resolveActivatableProviderOwnerPluginIds).toHaveBeenCalledWith({
-      pluginIds: ["memory-core"],
-      config: undefined,
-      workspaceDir: "/tmp/workspace",
-    });
+    expect(mocks.resolveActivatableProviderOwnerPluginIds).not.toHaveBeenCalled();
     expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
       expect.objectContaining({
         scope: "all",

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -3,7 +3,12 @@
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withActivatedPluginIds } from "../../plugins/activation-context.js";
-import { normalizePluginsConfig } from "../../plugins/config-state.js";
+import { resolveEffectivePluginActivationState } from "../../plugins/config-state.js";
+import { isPluginEnabledByDefaultForPlatform } from "../../plugins/default-enablement.js";
+import {
+  loadPluginRegistrySnapshot,
+  normalizePluginsConfigWithRegistry,
+} from "../../plugins/plugin-registry.js";
 import {
   resolveActivatableProviderOwnerPluginIds,
   resolveBundledProviderCompatPluginIds,
@@ -44,7 +49,12 @@ function resolveSelectedMemoryPluginIds(params: {
   config: OpenClawConfig | undefined;
   workspaceDir: string;
 }): string[] {
-  const memorySlot = normalizePluginsConfig(params.config?.plugins).slots.memory;
+  const registry = loadPluginRegistrySnapshot({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+  });
+  const plugins = normalizePluginsConfigWithRegistry(params.config?.plugins, registry);
+  const memorySlot = plugins.slots.memory;
   if (
     typeof memorySlot !== "string" ||
     memorySlot.trim().length === 0 ||
@@ -52,11 +62,18 @@ function resolveSelectedMemoryPluginIds(params: {
   ) {
     return [];
   }
-  return resolveActivatableProviderOwnerPluginIds({
-    pluginIds: [memorySlot],
-    config: params.config,
-    workspaceDir: params.workspaceDir,
+  const plugin = registry.plugins.find((entry) => entry.pluginId === memorySlot);
+  if (!plugin?.startup.memory) {
+    return [];
+  }
+  const activationState = resolveEffectivePluginActivationState({
+    id: plugin.pluginId,
+    origin: plugin.origin,
+    config: plugins,
+    rootConfig: params.config,
+    enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin),
   });
+  return activationState.activated ? [plugin.pluginId] : [];
 }
 
 function resolveHarnessPluginIds(params: {

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -3,6 +3,7 @@
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withActivatedPluginIds } from "../../plugins/activation-context.js";
+import { normalizePluginsConfig } from "../../plugins/config-state.js";
 import {
   resolveActivatableProviderOwnerPluginIds,
   resolveBundledProviderCompatPluginIds,
@@ -37,6 +38,25 @@ function dedupePluginIds(values: readonly string[]): string[] {
 function restrictiveAllowlistOmitsPlugin(config: OpenClawConfig | undefined, pluginId: string) {
   const allow = config?.plugins?.allow ?? [];
   return allow.length > 0 && !allow.includes(pluginId);
+}
+
+function resolveSelectedMemoryPluginIds(params: {
+  config: OpenClawConfig | undefined;
+  workspaceDir: string;
+}): string[] {
+  const memorySlot = normalizePluginsConfig(params.config?.plugins).slots.memory;
+  if (
+    typeof memorySlot !== "string" ||
+    memorySlot.trim().length === 0 ||
+    restrictiveAllowlistOmitsPlugin(params.config, memorySlot)
+  ) {
+    return [];
+  }
+  return resolveActivatableProviderOwnerPluginIds({
+    pluginIds: [memorySlot],
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+  });
 }
 
 function resolveHarnessPluginIds(params: {
@@ -140,15 +160,20 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
     config: params.config,
     workspaceDir: params.workspaceDir,
   });
+  const memoryPluginIds = resolveSelectedMemoryPluginIds({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+  });
+  const scopedPluginIds = dedupePluginIds([...pluginIds, ...memoryPluginIds]);
   const configWithAllowedRuntimePlugins = withRuntimePluginIdsAllowed({
     config: params.config,
     requiredPluginId: runtime,
-    pluginIds,
+    pluginIds: scopedPluginIds,
   });
   const activatedConfig =
     withActivatedPluginIds({
       config: configWithAllowedRuntimePlugins,
-      pluginIds,
+      pluginIds: scopedPluginIds,
     }) ?? configWithAllowedRuntimePlugins;
   ensurePluginRegistryLoaded({
     scope: "all",
@@ -159,6 +184,6 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
         }
       : {}),
     workspaceDir: params.workspaceDir,
-    onlyPluginIds: pluginIds,
+    onlyPluginIds: scopedPluginIds,
   });
 }

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -375,7 +375,7 @@ beforeEach(() => {
 });
 
 describe("agentCommand", () => {
-  it("enables the Codex runtime plugin and provider owner for one-shot OpenAI model overrides", async () => {
+  it("enables Codex, provider owner, and memory slot plugins for one-shot OpenAI model overrides", async () => {
     await withTempHome(async (home) => {
       const storePath = path.join(home, "sessions.json");
       mockConfig(home, storePath, { models: undefined });
@@ -396,7 +396,7 @@ describe("agentCommand", () => {
         expect(registryLoad?.config).toBeTypeOf("object");
         expect(registryLoad?.activationSourceConfig).toBeTypeOf("object");
         expect(registryLoad?.workspaceDir).toBe(path.join(home, "openclaw"));
-        expect(registryLoad?.onlyPluginIds).toEqual(["codex", "openai"]);
+        expect(registryLoad?.onlyPluginIds).toEqual(["codex", "openai", "memory-core"]);
       }
       expectLastRunProviderModel("openai", "gpt-5.2");
     });


### PR DESCRIPTION
## Summary

- Fix a Codex memory-recall regression: a fresh Codex run could keep memory tools available while the compiled prompt omitted the `## Memory Recall` guidance that tells the model when and how to use them.
- The regression came from a late scoped plugin-registry load for the Codex/OpenAI harness. That scoped load kept the harness/provider plugins but dropped the selected memory plugin from the active runtime registrations.
- The live repro/proof uses a Telegram `/new` direct-message flow, but the root cause is not channel-specific; the fix is in shared Codex harness plugin loading and prompt assembly.
- The fix keeps the configured, trusted memory-slot plugin in that scoped harness load and then renders memory guidance from the active memory capability registration.
- No new config, environment variable, migration, channel-specific behavior, or public API surface is added.
- AI-assisted contribution: yes. Local autoreview completed.

Review focus:

- `src/agents/harness/runtime-plugin.ts`: the selected memory slot should be preserved only when normal allowlist and activation/trust checks allow it.
- `extensions/codex/src/app-server/attempt-context.ts`: Codex should consume the memory plugin's registered prompt guidance and should not invent a separate memory policy when that registration is missing.

Out of scope:

- Changing memory tool behavior, memory search ranking, channel delivery, provider selection, or user config shape.

## Linked context

- Reported workflow: in a private Telegram bot direct chat, start a fresh session with `/new`, then ask the same memory-dependent question again.
- Expected result: the fresh Codex run still receives memory-recall guidance and can call `memory_search` / `memory_get` before replying.
- Scope note: Telegram is the repro and after-fix proof surface; the code change targets shared Codex harness/runtime registration rather than the Telegram adapter.

## Root cause

OpenClaw prewarms plugin runtimes at Gateway startup, which registers the active memory plugin's prompt builder. Later, before starting the selected native Codex harness, OpenClaw performs a scoped plugin-registry load for just the harness and provider-owner plugins.

On `main`, that scoped load did not include the selected memory plugin. Because runtime capability registration is process-global and follows the active plugin registry, the memory prompt builder was removed from the active memory capability state. The dynamic memory tools were still visible to the Codex turn, but the plugin-owned prompt section that tells Codex to use those tools was missing.

This PR fixes the owner-boundary problem by including the configured memory slot plugin in the scoped Codex/Copilot harness load after the same allowlist and activation checks used for runtime owner plugins. Codex then renders memory guidance only through the active memory plugin prompt builder.

## Real behavior proof

- Behavior or issue addressed: Live proof for the observed Telegram direct-message repro: `/new` starts a fresh external-channel session, the same 77-character memory-dependent question is sent through a private Telegram bot chat, and the compiled Codex prompt should include exactly one plugin-registered `## Memory Recall` section while `memory_search` and `memory_get` remain available. The underlying bug is shared Codex harness memory prompt registration, not Telegram delivery.
- Real environment tested: local Gateway built from this PR branch, `dist/index.js`, private Telegram bot polling (`<redacted-bot>`), direct Telegram chat (`<redacted-chat>`), OpenAI provider `openai/gpt-5.5`, model API `openai-chatgpt-responses`.
- Exact steps or command run after this patch: built the branch, restarted the Gateway from `dist/index.js`, confirmed Gateway status, sent `/new` in the private Telegram chat, then sent the same 77-character memory-dependent question that previously reproduced the missing Memory Recall section.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Redacted runtime log excerpt and compiled trajectory fields from the after-fix Telegram run:

```text
Gateway ready: 2026-06-12T05:05:48.822Z http server listening (4 plugins: brave, codex, memory-core, telegram; 3.5s)
Telegram polling ready: 2026-06-12T05:05:50.035Z [default] starting provider (<redacted-bot>)
Runtime plugin prewarm complete: 2026-06-12T05:05:59.123Z agent runtime plugins pre-warmed in 79ms
Inbound Telegram message: 2026-06-12T05:09:52.728Z telegram:<redacted-user> -> <redacted-bot> (direct, 77 chars)
Trajectory: 53873c9a-8e34-4e16-9818-f94d2714e825.trajectory.jsonl line 2
contextCompiledTs: 2026-06-12T05:09:55.305Z
sessionKey: agent:main:telegram:direct:<redacted-chat>
runId: 4789badf-af6e-46d3-9e71-e7cca5fb3599
provider: openai
model: gpt-5.5
modelApi: openai-chatgpt-responses
memoryRecallSectionCount: 1
memoryToolsInPrompt: { memory_search: true, memory_get: true }
memory_search result: success at 2026-06-12T05:10:21.987Z
memory_search result: success at 2026-06-12T05:10:27.144Z
memory_get result: success at 2026-06-12T05:10:41.120Z
Telegram outbound send: success at 2026-06-12T05:12:03.707Z, chatId=<redacted-chat>, messageId=<redacted-message>, deliveryKind=text
Session ended: success at 2026-06-12T05:12:07.030Z
```

- Observed result after fix: In the Telegram proof run, the compiled prompt contains exactly one plugin-registered Memory Recall section, memory tools are still present and callable, `memory_search` / `memory_get` succeed before the reply, and the Telegram response is delivered successfully.
- What was not tested: No known gap for the reported Telegram proof path. The live run did not separately exercise other channels or CLI/TUI entry points; targeted tests cover the shared Codex harness and prompt-composition path outside the Telegram adapter. Additional coverage not included here: Crabbox visual recording and broad changed/full CI gates; broad validation is covered by GitHub PR CI. Bot handle, chat id, user id, and message id are redacted because the tested bot/chat are private.
- Before evidence (optional but encouraged): Redacted before-fix trajectory and runtime log excerpt showing the failure mode:

```text
Inbound Telegram message: 2026-06-12T04:15:10.784Z telegram:<redacted-user> -> <redacted-bot> (direct, 77 chars)
Trajectory: 96ef0d3b-22d8-46de-8bf0-630bdaea521e.trajectory.jsonl line 2
contextCompiledTs: 2026-06-12T04:15:13.684Z
sessionKey: agent:main:telegram:direct:<redacted-chat>
runId: a963cc5a-3fa2-4283-90a3-d4ae9e828f02
memoryRecallSectionCount: 0
memoryToolsInPrompt: { memory_search: true, memory_get: true }
```

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/harness/runtime-plugin.test.ts` -> 12 passed
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts` -> 100 passed
- `git diff --check origin/main...HEAD` -> clean
- `pnpm build` -> passed after rebase onto `origin/main`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings

Regression coverage added/updated:

- Codex prompt composition now proves registered memory prompt text is used.
- Codex prompt composition now proves no synthetic Memory Recall guidance appears when no memory prompt builder is registered.
- Harness runtime tests now prove the selected memory slot is included in scoped loads only after activation/trust filtering.

## Risk checklist

Did user-visible behavior change? (`Yes/No`): Yes, fresh Codex runs that use the shared harness/plugin path regain plugin-owned Memory Recall guidance when memory tools are available. Telegram is the live proof surface for this PR.

Did config, environment, or migration behavior change? (`Yes/No`): No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`): No new surface; the fix reuses existing activation/trust filtering before preserving the selected memory plugin in scoped loads.

What is the highest-risk area? Plugin activation boundaries for memory slots during harness scoped loads.

How is that risk mitigated? The implementation uses the existing activatable-owner resolver and adds regression coverage for allowed memory slots and untrusted workspace memory plugins.

## Current review state

Next action: maintainer review of the draft PR.

Waiting on: GitHub PR CI and maintainer decision.

Bot/reviewer comments addressed: The Real behavior proof section has parser-friendly required labels, redacted runtime log evidence, observed result, and before-fix evidence. The public PR body does not disclose the private bot handle.


