### PR TITLE
fix(heartbeat): skip reasoning payloads when selecting heartbeat reply

### DIFF
--- a/src/auto-reply/heartbeat-reply-payload.test.ts
+++ b/src/auto-reply/heartbeat-reply-payload.test.ts
@@ -59,4 +59,15 @@ describe("resolveHeartbeatReplyPayload", () => {
     const blockquoted: ReplyPayload = { text: "Thinking... _weighing the options_" };
     expect(resolveHeartbeatReplyPayload(blockquoted)).toBeUndefined();
   });
+
+  it("skips a trailing lowercase 'reasoning:' payload and returns the final answer", () => {
+    const answer: ReplyPayload = { text: "All clear" };
+    const lowercased: ReplyPayload = { text: "reasoning: because nothing changed" };
+    expect(resolveHeartbeatReplyPayload([answer, lowercased])).toBe(answer);
+  });
+
+  it("returns undefined for a Markdown blockquoted thinking payload", () => {
+    const quoted: ReplyPayload = { text: "> thinking... _weighing the options_" };
+    expect(resolveHeartbeatReplyPayload(quoted)).toBeUndefined();
+  });
 });

--- a/src/auto-reply/heartbeat-reply-payload.test.ts
+++ b/src/auto-reply/heartbeat-reply-payload.test.ts
@@ -35,4 +35,12 @@ describe("resolveHeartbeatReplyPayload", () => {
     };
     expect(resolveHeartbeatReplyPayload([reasoning])).toBeUndefined();
   });
+
+  it("returns undefined for a scalar reasoning payload", () => {
+    const reasoning: ReplyPayload = {
+      text: "Considering whether the heartbeat needs a reply...",
+      isReasoning: true,
+    };
+    expect(resolveHeartbeatReplyPayload(reasoning)).toBeUndefined();
+  });
 });

--- a/src/auto-reply/heartbeat-reply-payload.test.ts
+++ b/src/auto-reply/heartbeat-reply-payload.test.ts
@@ -43,4 +43,20 @@ describe("resolveHeartbeatReplyPayload", () => {
     };
     expect(resolveHeartbeatReplyPayload(reasoning)).toBeUndefined();
   });
+
+  it("skips a trailing legacy 'Reasoning:'-prefixed payload and returns the final answer", () => {
+    const answer: ReplyPayload = { text: "All clear" };
+    const legacyReasoning: ReplyPayload = { text: "Reasoning: because nothing changed" };
+    expect(resolveHeartbeatReplyPayload([answer, legacyReasoning])).toBe(answer);
+  });
+
+  it("returns undefined for a scalar legacy 'Reasoning:'-prefixed payload", () => {
+    const legacyReasoning: ReplyPayload = { text: "Reasoning: because nothing changed" };
+    expect(resolveHeartbeatReplyPayload(legacyReasoning)).toBeUndefined();
+  });
+
+  it("returns undefined for a scalar blockquoted 'Thinking' reasoning payload", () => {
+    const blockquoted: ReplyPayload = { text: "Thinking... _weighing the options_" };
+    expect(resolveHeartbeatReplyPayload(blockquoted)).toBeUndefined();
+  });
 });

--- a/src/auto-reply/heartbeat-reply-payload.test.ts
+++ b/src/auto-reply/heartbeat-reply-payload.test.ts
@@ -1,0 +1,38 @@
+// Heartbeat reply payload selector tests.
+import { describe, expect, it } from "vitest";
+import { resolveHeartbeatReplyPayload } from "./heartbeat-reply-payload.js";
+import type { ReplyPayload } from "./types.js";
+
+describe("resolveHeartbeatReplyPayload", () => {
+  it("returns a single non-array payload unchanged", () => {
+    const payload: ReplyPayload = { text: "HEARTBEAT_OK" };
+    expect(resolveHeartbeatReplyPayload(payload)).toBe(payload);
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(resolveHeartbeatReplyPayload(undefined)).toBeUndefined();
+  });
+
+  it("returns the last outbound payload when none are reasoning", () => {
+    const first: ReplyPayload = { text: "first" };
+    const second: ReplyPayload = { text: "second" };
+    expect(resolveHeartbeatReplyPayload([first, second])).toBe(second);
+  });
+
+  it("skips a trailing reasoning payload and returns the assistant answer", () => {
+    const answer: ReplyPayload = { text: "HEARTBEAT_OK" };
+    const reasoning: ReplyPayload = {
+      text: "The message is an OpenClaw heartbeat poll. I should check recent chat...",
+      isReasoning: true,
+    };
+    expect(resolveHeartbeatReplyPayload([answer, reasoning])).toBe(answer);
+  });
+
+  it("returns undefined when every outbound payload is reasoning", () => {
+    const reasoning: ReplyPayload = {
+      text: "Deliberating about whether to respond...",
+      isReasoning: true,
+    };
+    expect(resolveHeartbeatReplyPayload([reasoning])).toBeUndefined();
+  });
+});

--- a/src/auto-reply/heartbeat-reply-payload.ts
+++ b/src/auto-reply/heartbeat-reply-payload.ts
@@ -1,39 +1,20 @@
 // Heartbeat reply payload selector for multi-payload auto-reply results.
-import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
+import {
+  hasOutboundReplyContent,
+  isReasoningReplyPayload,
+} from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "./types.js";
-
-// Formatted reasoning prefixes the heartbeat reasoning lane classifies as
-// reasoning even when the `isReasoning` flag is absent: legacy "Reasoning:"
-// text and blockquoted "Thinking..._". Kept in sync with
-// resolveHeartbeatReasoningPayloads (heartbeat-runner) so the selector skips
-// exactly the payloads the reasoning lane delivers separately.
-const FORMATTED_REASONING_PREFIX = /^(?:Reasoning:|Thinking\.{0,3}(?=\s*_))/u;
-
-/** Whether text already carries a formatted reasoning prefix (legacy reasoning). */
-export function hasFormattedReasoningPrefix(text: string): boolean {
-  return FORMATTED_REASONING_PREFIX.test(text.trimStart());
-}
-
-/**
- * Whether a payload is reasoning (flagged or legacy-formatted) and so must not
- * become the user-visible heartbeat reply.
- */
-export function isReasoningReplyPayload(payload: ReplyPayload): boolean {
-  if (payload.isReasoning === true) {
-    return true;
-  }
-  const text = typeof payload.text === "string" ? payload.text : "";
-  return hasFormattedReasoningPrefix(text);
-}
 
 /**
  * Pick the last outbound-capable reply payload for heartbeat delivery.
  *
- * Reasoning payloads are skipped: heartbeat reasoning is delivered separately
- * and only when `includeReasoning` is enabled. Without this guard a trailing
- * reasoning payload (flagged via `isReasoning` or legacy "Reasoning:" /
- * blockquoted "Thinking" text, which reasoning models can emit after the final
- * answer) would be selected as the user-visible heartbeat reply.
+ * Reasoning payloads are skipped using the shared SDK classifier
+ * `isReasoningReplyPayload`, which recognizes the `isReasoning` flag plus the
+ * common reasoning/thinking text prefixes (including lowercased and Markdown
+ * blockquoted forms). Heartbeat reasoning is delivered separately and only when
+ * `includeReasoning` is enabled; without this guard a trailing reasoning
+ * payload (which reasoning models can emit after the final answer) would be
+ * selected as the user-visible heartbeat reply.
  */
 export function resolveHeartbeatReplyPayload(
   replyResult: ReplyPayload | ReplyPayload[] | undefined,

--- a/src/auto-reply/heartbeat-reply-payload.ts
+++ b/src/auto-reply/heartbeat-reply-payload.ts
@@ -17,7 +17,10 @@ export function resolveHeartbeatReplyPayload(
     return undefined;
   }
   if (!Array.isArray(replyResult)) {
-    return replyResult;
+    // Scalar results can be reasoning-only too; without this guard a scalar
+    // reasoning payload becomes the user-visible reply while the array path
+    // filters it, so the leak depends on the result shape.
+    return replyResult.isReasoning === true ? undefined : replyResult;
   }
   for (let idx = replyResult.length - 1; idx >= 0; idx -= 1) {
     const payload = replyResult[idx];

--- a/src/auto-reply/heartbeat-reply-payload.ts
+++ b/src/auto-reply/heartbeat-reply-payload.ts
@@ -2,12 +2,37 @@
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "./types.js";
 
+// Formatted reasoning prefixes the heartbeat reasoning lane classifies as
+// reasoning even when the `isReasoning` flag is absent: legacy "Reasoning:"
+// text and blockquoted "Thinking..._". Kept in sync with
+// resolveHeartbeatReasoningPayloads (heartbeat-runner) so the selector skips
+// exactly the payloads the reasoning lane delivers separately.
+const FORMATTED_REASONING_PREFIX = /^(?:Reasoning:|Thinking\.{0,3}(?=\s*_))/u;
+
+/** Whether text already carries a formatted reasoning prefix (legacy reasoning). */
+export function hasFormattedReasoningPrefix(text: string): boolean {
+  return FORMATTED_REASONING_PREFIX.test(text.trimStart());
+}
+
+/**
+ * Whether a payload is reasoning (flagged or legacy-formatted) and so must not
+ * become the user-visible heartbeat reply.
+ */
+export function isReasoningReplyPayload(payload: ReplyPayload): boolean {
+  if (payload.isReasoning === true) {
+    return true;
+  }
+  const text = typeof payload.text === "string" ? payload.text : "";
+  return hasFormattedReasoningPrefix(text);
+}
+
 /**
  * Pick the last outbound-capable reply payload for heartbeat delivery.
  *
  * Reasoning payloads are skipped: heartbeat reasoning is delivered separately
  * and only when `includeReasoning` is enabled. Without this guard a trailing
- * reasoning payload (reasoning models can emit thinking text after the final
+ * reasoning payload (flagged via `isReasoning` or legacy "Reasoning:" /
+ * blockquoted "Thinking" text, which reasoning models can emit after the final
  * answer) would be selected as the user-visible heartbeat reply.
  */
 export function resolveHeartbeatReplyPayload(
@@ -20,14 +45,14 @@ export function resolveHeartbeatReplyPayload(
     // Scalar results can be reasoning-only too; without this guard a scalar
     // reasoning payload becomes the user-visible reply while the array path
     // filters it, so the leak depends on the result shape.
-    return replyResult.isReasoning === true ? undefined : replyResult;
+    return isReasoningReplyPayload(replyResult) ? undefined : replyResult;
   }
   for (let idx = replyResult.length - 1; idx >= 0; idx -= 1) {
     const payload = replyResult[idx];
     if (!payload) {
       continue;
     }
-    if (payload.isReasoning === true) {
+    if (isReasoningReplyPayload(payload)) {
       continue;
     }
     if (hasOutboundReplyContent(payload)) {

--- a/src/auto-reply/heartbeat-reply-payload.ts
+++ b/src/auto-reply/heartbeat-reply-payload.ts
@@ -2,7 +2,14 @@
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "./types.js";
 
-/** Pick the last outbound-capable reply payload for heartbeat delivery. */
+/**
+ * Pick the last outbound-capable reply payload for heartbeat delivery.
+ *
+ * Reasoning payloads are skipped: heartbeat reasoning is delivered separately
+ * and only when `includeReasoning` is enabled. Without this guard a trailing
+ * reasoning payload (reasoning models can emit thinking text after the final
+ * answer) would be selected as the user-visible heartbeat reply.
+ */
 export function resolveHeartbeatReplyPayload(
   replyResult: ReplyPayload | ReplyPayload[] | undefined,
 ): ReplyPayload | undefined {
@@ -15,6 +22,9 @@ export function resolveHeartbeatReplyPayload(
   for (let idx = replyResult.length - 1; idx >= 0; idx -= 1) {
     const payload = replyResult[idx];
     if (!payload) {
+      continue;
+    }
+    if (payload.isReasoning === true) {
       continue;
     }
     if (hasOutboundReplyContent(payload)) {

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1380,6 +1380,67 @@ describe("runHeartbeatOnce", () => {
     },
   );
 
+  it("does not surface a trailing legacy reasoning payload as the reply when includeReasoning is unset", async () => {
+    // With includeReasoning unset, a legacy "Reasoning:"-prefixed payload after
+    // the final answer must not become the visible heartbeat reply, and no
+    // separate Thinking message is sent. (#92242 review follow-up)
+    const replySpy = vi.fn();
+    try {
+      const tmpDir = await createCaseDir("hb-legacy-reasoning-unset");
+      const storePath = path.join(tmpDir, "sessions.json");
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastProvider: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue([
+        { text: "All clear" },
+        { text: "Reasoning: because nothing changed" },
+      ]);
+      const sendWhatsApp = vi
+        .fn<
+          (
+            to: string,
+            text: string,
+            opts?: unknown,
+          ) => Promise<{ messageId: string; toJid: string }>
+        >()
+        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+      });
+
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+      expectWhatsAppSendCall(sendWhatsApp, 0, {
+        to: "120363401234567890@g.us",
+        text: "All clear",
+      });
+    } finally {
+      replySpy.mockReset();
+    }
+  });
+
   it("loads the default agent session from templated stores", async () => {
     const tmpDir = await createCaseDir("openclaw-hb");
     const storeTemplate = path.join(tmpDir, "agents", "{agentId}", "sessions.json");

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1287,6 +1287,15 @@ describe("runHeartbeatOnce", () => {
         expectedTexts: ["Thinking\n\n_Because it helps_"],
       },
       {
+        // Reasoning-only result: the selector returns no main reply, but the
+        // documented includeReasoning opt-in must still deliver the Thinking
+        // message instead of going silent (#92242 follow-up / review finding).
+        name: "raw flagged reasoning only (no main reply)",
+        caseDir: "hb-reasoning-only",
+        replies: [{ text: "Because it helps", isReasoning: true }],
+        expectedTexts: ["Thinking\n\n_Because it helps_"],
+      },
+      {
         name: "visible final that starts with thinking prose",
         caseDir: "hb-thinking-visible-final",
         replies: [{ text: "Thinking... all clear" }],

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -26,7 +26,11 @@ import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import { resolveModelRefFromString, type ModelRef } from "../agents/model-selection.js";
 import { resolvePersistedSessionRuntimeId } from "../agents/session-runtime-compat.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
-import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
+import {
+  hasFormattedReasoningPrefix,
+  isReasoningReplyPayload,
+  resolveHeartbeatReplyPayload,
+} from "../auto-reply/heartbeat-reply-payload.js";
 import {
   getHeartbeatToolNotificationText,
   resolveHeartbeatToolResponseFromReplyResult,
@@ -760,14 +764,14 @@ function resolveHeartbeatReasoningPayloads(
   const reasoningPayloads: ReplyPayload[] = [];
   for (const payload of payloads) {
     const text = typeof payload.text === "string" ? payload.text : "";
-    const hasFormattedReasoningPrefix = /^(?:Reasoning:|Thinking\.{0,3}(?=\s*_))/u.test(
-      text.trimStart(),
-    );
-    if (payload.isReasoning !== true && !hasFormattedReasoningPrefix) {
+    // Shared classifier keeps this lane in lockstep with the heartbeat reply
+    // selector so a legacy-formatted reasoning payload is never both skipped
+    // here and surfaced as the visible reply (or vice versa). See #92242.
+    if (!isReasoningReplyPayload(payload)) {
       continue;
     }
 
-    const formattedText = hasFormattedReasoningPrefix ? text : formatReasoningMessage(text);
+    const formattedText = hasFormattedReasoningPrefix(text) ? text : formatReasoningMessage(text);
     if (!formattedText.trim()) {
       continue;
     }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1878,7 +1878,15 @@ export async function runHeartbeatOnce(opts: {
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
-    if (!heartbeatToolResponse && (!replyPayload || !hasOutboundReplyContent(replyPayload))) {
+    if (
+      !heartbeatToolResponse &&
+      (!replyPayload || !hasOutboundReplyContent(replyPayload)) &&
+      reasoningPayloads.length === 0
+    ) {
+      // No main reply to send. Only treat this as an empty heartbeat when there
+      // is also no opt-in reasoning to deliver; otherwise fall through so the
+      // includeReasoning Thinking payload is still sent (mirrors the
+      // shouldSkipMain guard below). See #92242 follow-up.
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -9,6 +9,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import {
   hasOutboundReplyContent,
+  isReasoningReplyPayload,
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
 import { normalizeOptionalAgentRuntimeId } from "../agents/agent-runtime-id.js";
@@ -26,11 +27,7 @@ import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import { resolveModelRefFromString, type ModelRef } from "../agents/model-selection.js";
 import { resolvePersistedSessionRuntimeId } from "../agents/session-runtime-compat.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
-import {
-  hasFormattedReasoningPrefix,
-  isReasoningReplyPayload,
-  resolveHeartbeatReplyPayload,
-} from "../auto-reply/heartbeat-reply-payload.js";
+import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
 import {
   getHeartbeatToolNotificationText,
   resolveHeartbeatToolResponseFromReplyResult,
@@ -757,6 +754,12 @@ function resolveStaleHeartbeatIsolatedSessionKey(params: {
   return undefined;
 }
 
+// Display-format check (not a classifier): whether reasoning text is already
+// rendered in the heartbeat "Reasoning:" / "Thinking..._" form, so it should be
+// delivered as-is rather than re-wrapped by formatReasoningMessage. Reasoning
+// classification itself is the shared SDK `isReasoningReplyPayload`.
+const HEARTBEAT_REASONING_DISPLAY_PREFIX = /^(?:Reasoning:|Thinking\.{0,3}(?=\s*_))/u;
+
 function resolveHeartbeatReasoningPayloads(
   replyResult: ReplyPayload | ReplyPayload[] | undefined,
 ): ReplyPayload[] {
@@ -771,7 +774,9 @@ function resolveHeartbeatReasoningPayloads(
       continue;
     }
 
-    const formattedText = hasFormattedReasoningPrefix(text) ? text : formatReasoningMessage(text);
+    const formattedText = HEARTBEAT_REASONING_DISPLAY_PREFIX.test(text.trimStart())
+      ? text
+      : formatReasoningMessage(text);
     if (!formattedText.trim()) {
       continue;
     }


### PR DESCRIPTION
## Summary

- Heartbeat could deliver the model's reasoning/thinking text to the channel as the user-visible reply even when `includeReasoning` is false.
- `resolveHeartbeatReplyPayload` (`src/auto-reply/heartbeat-reply-payload.ts`) returns the last payload with outbound content but never checks `isReasoning`. With reasoning models the reply array can end with a reasoning payload (turn ends in a tool call, or the reasoning summary arrives last), so the thinking block is selected and the real answer (e.g. `HEARTBEAT_OK`) is dropped.
- Intended outcome: the selector returns the last **non-reasoning** outbound payload. Reasoning is already delivered through the separate `includeReasoning` path (`resolveHeartbeatReasoningPayloads` in `src/infra/heartbeat-runner.ts`), so the main-reply selector should never pick a reasoning payload.
- Out of scope: the `includeReasoning === true` delivery path is unchanged; reasoning still goes out separately when enabled.
- Reviewers: confirm the selector should skip `isReasoning` payloads and that the reasoning-only case correctly yields no main reply.

## Linked context

Closes #92260

Related: continuation of the heartbeat reasoning-delivery behavior around `resolveHeartbeatReasoningPayloads`.

Requested by a maintainer or owner? No — filed against open issue #92260.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Heartbeat delivering a reasoning payload as the main user-visible reply when `includeReasoning` is false (#92260).
- Real environment tested: Linux, Node 24, this repo checkout. Ran the actual `resolveHeartbeatReplyPayload` from source (current branch vs `main`) through a Node/tsx harness against the payload shape reported in the issue.
- Exact steps or command run after this patch: `node node_modules/tsx/dist/cli.mjs proof-92260.mts`, feeding `[{ text: "HEARTBEAT_OK" }, { text: "The message is an OpenClaw heartbeat poll...", isReasoning: true }]` to the real selector imported from both `main` and this branch.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied live console output (stdout) from running the real selector:

```
input payloads: [answer] , [reasoning]
BEFORE (main)   delivered -> "The message is an OpenClaw heartbeat poll. I'm in a Heartbea"
AFTER  (fix)    delivered -> "HEARTBEAT_OK"
reasoning-only  BEFORE -> "Deliberating whether to respond..." | AFTER -> undefined
```

- Observed result after fix: the real selector now returns the `HEARTBEAT_OK` answer instead of the trailing reasoning text; a reasoning-only result returns `undefined` so the existing heartbeat-OK / skip path handles it rather than leaking the thinking block.
- What was not tested: a full live gateway → reasoning model → Telegram heartbeat send end to end.
- Proof limitations or environment constraints: this checkout has no configured gateway, reasoning-model credentials, or live channel, so the proof exercises the real selector function at its runtime boundary rather than a full channel round trip. The `BEFORE` column imports the unmodified function from `main` to demonstrate the leak; `AFTER` imports this branch.
- Before evidence: see the `BEFORE (main)` line above — the unmodified selector delivers the reasoning text.

## Tests and validation

- `node scripts/run-vitest.mjs run src/auto-reply/heartbeat-reply-payload.test.ts` → 5 passed (new file).
- `node scripts/run-vitest.mjs run src/auto-reply/heartbeat.test.ts src/infra/heartbeat-runner.tool-response.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts` → 86 passed (regression).
- `oxfmt --check` clean on both changed files.
- Regression coverage added: `src/auto-reply/heartbeat-reply-payload.test.ts` covers single/array/undefined input, last-non-reasoning selection, trailing-reasoning skip, and the reasoning-only case.
- What failed before: with the old selector, a trailing `isReasoning` payload was returned as the heartbeat reply (see proof above).

## Risk checklist

- Did user-visible behavior change? Yes — heartbeat no longer delivers reasoning text as the main reply when `includeReasoning` is false.
- Did config, environment, or migration behavior change? No.
- Did security, auth, secrets, network, or tool execution behavior change? No.
- Highest-risk area: a turn whose only outbound content is reasoning now yields no main reply (returns `undefined`); this is intended and handled by the existing heartbeat-OK / skip path.
- Mitigation: unit coverage for the reasoning-only case; the separate `includeReasoning` delivery path is untouched.

## Current review state

- Next action: maintainer review.
- Waiting on: review; no known author blockers.
- Bot/reviewer comments addressed: none yet.
