### PR TITLE
fix(gateway): resolve plugin method scope from channel-pinned registry in gateway mode

### DIFF
--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -3,7 +3,11 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
-import { setActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  pinActivePluginChannelRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
 import {
   authorizeOperatorScopesForMethod,
   isGatewayMethodClassified,
@@ -224,6 +228,60 @@ describe("method scope resolution", () => {
     expect(resolveLeastPrivilegeOperatorScopesForMethod(RESERVED_ADMIN_PLUGIN_METHOD)).toEqual([
       "operator.admin",
     ]);
+  });
+});
+
+describe("plugin scope resolution in gateway (channel-pinned) mode", () => {
+  // Regression: in gateway mode the plugin registry is installed via
+  // pinActivePluginChannelRegistry (channel surface) and `activeRegistry` is
+  // never set. Scope resolution must read the channel-pinned registry; otherwise
+  // every plugin-registered gateway method falls through to the admin default
+  // and rejects operator.write clients (e.g. a bridge plugin's own gateway
+  // method registered with operator.write).
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("resolves a plugin gateway method scope from the channel-pinned registry", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.gatewayHandlers["plugin.bridge.register"] = pluginHandler;
+    registry.gatewayMethodDescriptors.push(
+      createPluginGatewayMethodDescriptor({
+        pluginId: "bridge",
+        name: "plugin.bridge.register",
+        handler: pluginHandler,
+        scope: "operator.write",
+      }),
+    );
+    pinActivePluginChannelRegistry(registry);
+
+    expect(resolveLeastPrivilegeOperatorScopesForMethod("plugin.bridge.register")).toEqual([
+      "operator.write",
+    ]);
+  });
+
+  it("resolves a plugin session action scope from the channel-pinned registry", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.sessionActions = [
+      {
+        pluginId: "scope-plugin",
+        pluginName: "Scope Plugin",
+        source: "test",
+        action: {
+          id: "view",
+          requiredScopes: ["operator.read"],
+          handler: () => ({ result: { ok: true } }),
+        },
+      },
+    ];
+    pinActivePluginChannelRegistry(registry);
+
+    expect(
+      resolveLeastPrivilegeOperatorScopesForMethod("plugins.sessionAction", {
+        pluginId: "scope-plugin",
+        actionId: "view",
+      }),
+    ).toEqual(["operator.read"]);
   });
 });
 

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -1,7 +1,7 @@
 // Gateway method authorization scope resolver.
 // Maps static and plugin-defined gateway methods to operator scopes.
 import { normalizeOptionalString as normalizeSessionActionParam } from "@openclaw/normalization-core/string-coerce";
-import { getPluginRegistryState } from "../plugins/runtime-state.js";
+import { getActivePluginChannelRegistryFromState } from "../plugins/runtime-state.js";
 import { resolveReservedGatewayMethodScope } from "../shared/gateway-method-policy.js";
 import {
   isCoreGatewayMethodClassified,
@@ -51,9 +51,13 @@ function resolveScopedMethod(method: string): OperatorScope | undefined {
   if (reservedScope) {
     return reservedScope;
   }
-  const pluginDescriptor = getPluginRegistryState()?.activeRegistry?.gatewayMethodDescriptors?.find(
-    (descriptor) => descriptor.name === method,
-  );
+  // In gateway mode plugins are pinned to the channel/httpRoute surfaces, not
+  // activeRegistry. Use the channel-surface helper, which returns
+  // channel.registry ?? activeRegistry and so covers gateway + standalone/test.
+  const pluginDescriptor =
+    getActivePluginChannelRegistryFromState()?.gatewayMethodDescriptors?.find(
+      (descriptor) => descriptor.name === method,
+    );
   const pluginScope = pluginDescriptor?.scope;
   return pluginScope === "node" || pluginScope === "dynamic" ? undefined : pluginScope;
 }
@@ -102,7 +106,7 @@ function resolveSessionActionRegisteredScopes(params: unknown): OperatorScope[] 
   if (!pluginId || !actionId) {
     return undefined;
   }
-  const registration = getPluginRegistryState()?.activeRegistry?.sessionActions?.find(
+  const registration = getActivePluginChannelRegistryFromState()?.sessionActions?.find(
     (entry) => entry.pluginId === pluginId && entry.action.id === actionId,
   );
   if (!registration) {


### PR DESCRIPTION
# fix(gateway): resolve plugin method scope from channel-pinned registry

> Suggested PR title: **fix(gateway): resolve plugin method scope from channel-pinned registry in gateway mode**
> Branch: `fix/gateway-plugin-method-scope-channel-registry` (one commit, off `main`)

🤖 **AI-assisted** (Claude Code). Author understands the change; human-run evidence below.

## Problem

In gateway mode the active plugin registry is installed on the **channel surface**
via `pinActivePluginChannelRegistry()`; the flat `activeRegistry` field is never
set in that code path. But `src/gateway/method-scopes.ts` reads
`getPluginRegistryState()?.activeRegistry` directly in two places:

- `resolveScopedMethod()` → `gatewayMethodDescriptors` lookup
- `resolveSessionActionRegisteredScopes()` → `sessionActions` lookup

So in gateway mode **every plugin-registered gateway method / session action
fails to resolve its declared scope**, falls through to the `ADMIN_SCOPE`
default, and is then rejected for any `operator.write` client — e.g. a bridge
plugin calling its own gateway method registered with `operator.write`.

`method-scopes.ts` is the only place in the channel/gateway code still reading
`activeRegistry` directly; the rest of the codebase already uses
`getActivePluginChannelRegistryFromState()` (which returns
`channel.registry ?? activeRegistry`). The existing tests only exercised the
`setActivePluginRegistry`/`activeRegistry` path, never the channel-pinned
(gateway) path — which is why this shipped.

## Fix

Use `getActivePluginChannelRegistryFromState()` for both lookups, so scope
resolution works in **both** gateway and standalone/test modes. One-line import
swap + the two call sites.

## Tests

Adds regression tests to `method-scopes.test.ts` exercising the **channel-pinned**
path (`pinActivePluginChannelRegistry`) for both a gateway method and a session
action — the path that previously had no coverage.

## Real behavior proof

Built `main` (Node 24.16, `pnpm build`) and ran the new tests against the real
resolver + the real `pinActivePluginChannelRegistry` (not a mock):

**Without the fix** (revert `method-scopes.ts`, keep the test) — both fail:
```
× resolves a plugin gateway method scope from the channel-pinned registry
    AssertionError: expected [] to deeply equal [ 'operator.write' ]
× resolves a plugin session action scope from the channel-pinned registry
    AssertionError: expected [ 'operator.admin', …(5) ] to deeply equal [ 'operator.read' ]
```
(i.e. the plugin method resolves to "unknown" → admin-only, and the session
action falls back to the broad CLI default — exactly the production symptom.)

**With the fix** — full suite green:
```
✓ src/gateway/method-scopes.test.ts (77 tests)   # ×3 project configs = 231 passed
```

**Production:** this exact fix is deployed on our own OpenClaw gateway (source
install, v2026.5.28) running an MCP bridge plugin that registers
`operator.write` gateway methods; with the patch those calls succeed, without it
they were rejected as admin-only.

> Not run: a full network-client demo with a dedicated `operator.write`-scoped
> token (the gateway has no CLI flag to downscope a local caller; the local
> operator is always admin, which masks the bug). The unit regression drives the
> real resolver through the real channel-pin path, and the fix is in production.

## Gates
Against `main` (Node 24.16): `pnpm build` ✅, `pnpm check` (whole-repo
lint+typecheck) ✅, full `pnpm test` ✅ (incl. `method-scopes.test.ts` 77/77).

## Notes
- No `CHANGELOG.md` edit (per CONTRIBUTING).
- "Allow edits by maintainers" enabled.
