### PR TITLE
fix(config): allow model.compat.sendSessionAffinityHeaders in ModelCompatSchema

### DIFF
--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -216,6 +216,13 @@ const ModelCompatSchema = z
     supportsDeveloperRole: z.boolean().optional(),
     supportsReasoningEffort: z.boolean().optional(),
     supportsUsageInStreaming: z.boolean().optional(),
+    // Consumed at runtime by getCompat()/detectCompat and the OpenAI-compat
+    // and Anthropic providers (session_id / x-client-request-id /
+    // x-session-affinity headers for prompt-cache routing, e.g. Fireworks,
+    // Cloudflare AI Gateway). Declared in the ModelCompat type but missing
+    // from this strict schema, so a valid config was rejected (same drift
+    // class as issue #89660).
+    sendSessionAffinityHeaders: z.boolean().optional(),
     supportsTools: z.boolean().optional(),
     supportsStrictMode: z.boolean().optional(),
     requiresStringContent: z.boolean().optional(),

--- a/src/config/zod-schema.models.test.ts
+++ b/src/config/zod-schema.models.test.ts
@@ -50,4 +50,30 @@ describe("ModelsConfigSchema", () => {
 
     expect(result.success).toBe(true);
   });
+
+  it("accepts compat.sendSessionAffinityHeaders", () => {
+    // The field is consumed at runtime (getCompat/detectCompat plus the
+    // openai-completions and anthropic providers) and is present in the
+    // ModelCompat type, but was missing from the strict Zod schema, so a valid
+    // config setting it was rejected with "Unrecognized key(s)" — the same drift
+    // class as issue #89660.
+    const result = ModelsConfigSchema.safeParse({
+      providers: {
+        "my-proxy": {
+          baseUrl: "https://my-proxy.example.com/v1",
+          models: [
+            {
+              id: "some-model",
+              name: "Some Model",
+              compat: {
+                sendSessionAffinityHeaders: true,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
 });


### PR DESCRIPTION
# fix(config): allow model.compat.sendSessionAffinityHeaders in ModelCompatSchema

> Suggested PR title: **fix(config): allow model.compat.sendSessionAffinityHeaders in ModelCompatSchema**
> Branch: `fix/modelcompat-allow-sendSessionAffinityHeaders` (one commit, off `main`)

🤖 **AI-assisted** (Claude Code). Author understands the change; human-run evidence below.

## Problem

`sendSessionAffinityHeaders` is part of the `ModelCompat` type
(`SupportedOpenAICompatFields` in `src/config/types.models.ts`) and is consumed
at runtime:

- `src/llm/providers/openai-completions.ts` — `getCompat()`/`detectCompat` read
  `model.compat.sendSessionAffinityHeaders` and emit the
  `session_id` / `x-client-request-id` / `x-session-affinity` headers.
- `src/llm/providers/anthropic.ts` — auto-enables it for Fireworks / Cloudflare
  AI Gateway.

But it is **missing from the strict `ModelCompatSchema`** in
`src/config/zod-schema.core.ts`. Because the schema is `.strict()`, setting this
documented field in a provider's model config is rejected with
`Unrecognized key(s)` and the gateway **fails config validation at startup
(fail-closed)** — with `Restart=always` that becomes a restart loop.

This is the same schema↔type drift class already fixed for
`requiresReasoningContentOnAssistantMessages` (issue **#89660**), which has a
regression test in `zod-schema.models.test.ts`.

## Fix

Add `sendSessionAffinityHeaders: z.boolean().optional()` to `ModelCompatSchema`,
next to the other `supports*` flags. Plus a regression test mirroring the
#89660 one.

## Real behavior proof

Built both `main` (stock) and the patched branch (Node 24.16, `pnpm build`) and
started the real gateway with a config that sets the field:

```jsonc
// ~/.openclaw/openclaw.json
"models": { "providers": { "my-proxy": { "baseUrl": "...", "api": "openai-completions",
  "models": [{ "id": "some-model", "name": "Some Model",
    "compat": { "sendSessionAffinityHeaders": true } }] } } }
```

**Stock `main` — gateway refuses to start:**
```
Gateway failed to start: Invalid config at .../openclaw.json.
models.providers.my-proxy.models.0.compat: Invalid input
```

**Patched — gateway boots normally:**
```
[gateway] loading configuration…
[gateway] http server listening (8 plugins: …; 1.0s)
[gateway] ready
```

Unit test (`zod-schema.models.test.ts`): fails without the fix
(`expected false to be true` — config rejected), passes with it.

## Gates
Against `main` (Node 24.16): `pnpm build` ✅, `pnpm check` (whole-repo
lint+typecheck) ✅, full `pnpm test` ✅.

## Notes
- Same minimal one-field approach as #89660; other drifted compat fields
  (`cacheControlFormat`, `zaiToolStream`, `openRouterRouting`, …) are out of
  scope here.
- No `CHANGELOG.md` edit (per CONTRIBUTING).
- "Allow edits by maintainers" enabled.
