### PR TITLE
fix(gateway): build row metadata context for single session lists

### DIFF
--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -72,7 +72,11 @@ const subagentRegistryReadMock = vi.hoisted(() => {
 
 vi.mock("../agents/subagent-registry-read.js", () => subagentRegistryReadMock);
 
-import { loadGatewaySessionRow } from "./session-utils.js";
+import {
+  listSessionsFromStore,
+  listSessionsFromStoreAsync,
+  loadGatewaySessionRow,
+} from "./session-utils.js";
 
 const MAIN_AGENT_ID = "main";
 const TEST_MODEL = "openai/gpt-5.4";
@@ -234,6 +238,59 @@ describe("single gateway session row child-session cache", () => {
 
         setSubagentControllerRun(fixture.child, fixture.newParent, now + 25);
         expectChildMovedToNewParent(fixture, now);
+      },
+    );
+  });
+
+  test("builds shared subagent metadata context for single-row session lists", async () => {
+    await withSingleRowCacheStore(
+      "openclaw-single-row-list-context-",
+      "/tmp/openclaw-single-row-list-context",
+      async ({ now, storePath }) => {
+        const store: Record<string, SessionEntry> = {
+          "agent:main:discord:channel:parent": parentSession("parent", now),
+        };
+        const cfg: OpenClawConfig = {
+          agents: {
+            list: [
+              {
+                id: MAIN_AGENT_ID,
+                default: true,
+                workspace: "/tmp/openclaw-single-row-list-context",
+              },
+            ],
+            defaults: { model: { primary: TEST_MODEL } },
+          },
+        } as OpenClawConfig;
+
+        const syncListed = listSessionsFromStore({
+          cfg,
+          storePath,
+          store,
+          opts: { agentId: MAIN_AGENT_ID, limit: 1 },
+        });
+
+        expect(syncListed.sessions).toHaveLength(1);
+        expect(subagentRegistryReadMock.buildSubagentRunReadIndex).toHaveBeenCalledTimes(
+          1,
+        );
+
+        vi.clearAllMocks();
+
+        const asyncListed = await listSessionsFromStoreAsync({
+          cfg,
+          storePath,
+          store,
+          opts: { agentId: MAIN_AGENT_ID, limit: 1 },
+        });
+
+        expect(asyncListed.sessions).toHaveLength(1);
+        expect(subagentRegistryReadMock.buildSubagentRunReadIndex).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(
+          subagentRegistryReadMock.getSessionDisplaySubagentRunByChildSessionKey,
+        ).not.toHaveBeenCalled();
       },
     );
   });

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -274,6 +274,9 @@ describe("single gateway session row child-session cache", () => {
         expect(subagentRegistryReadMock.buildSubagentRunReadIndex).toHaveBeenCalledTimes(
           1,
         );
+        expect(
+          subagentRegistryReadMock.getSessionDisplaySubagentRunByChildSessionKey,
+        ).not.toHaveBeenCalled();
 
         vi.clearAllMocks();
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -2747,7 +2747,7 @@ export function listSessionsFromStore(params: {
       : undefined;
   const sharedRowContext =
     fullRowContext ??
-    (entries.length > 1 ? buildSessionListRowMetadataContext({ now }) : undefined);
+    (entries.length > 0 ? buildSessionListRowMetadataContext({ now }) : undefined);
 
   const sessions = entries.map(([key, entry], index) => {
     const includeTranscriptFields = index < sessionListTranscriptFieldRows;
@@ -2837,7 +2837,7 @@ export async function listSessionsFromStoreAsync(params: {
       : undefined;
   const sharedRowContext =
     fullRowContext ??
-    (entries.length > 1 ? buildSessionListRowMetadataContext({ now }) : undefined);
+    (entries.length > 0 ? buildSessionListRowMetadataContext({ now }) : undefined);
 
   const sessions: GatewaySessionRow[] = [];
   for (let i = 0; i < entries.length; i++) {


### PR DESCRIPTION
## Summary

This fixes a residual `sessions.list` single-row performance path: when a safe list request is reduced to exactly one row (`limit=1`), the row builder skipped the shared session-list metadata context and fell back to uncached per-row subagent metadata lookups.

The change builds the request-scoped row metadata context whenever the selected row set is non-empty, for both sync and async session list builders:

```ts
entries.length > 0 ? buildSessionListRowMetadataContext({ now }) : undefined
```

It also adds a focused regression in `session-utils.single-row-cache.test.ts` covering `listSessionsFromStore()` and `listSessionsFromStoreAsync()` with `agentId` + `limit: 1`.

## Duplication / overlap gate

Checked before opening this PR:

- Current `origin/main` still has `entries.length > 1` in both sync and async session-list builders.
- Recent upstream commits did not touch `src/gateway/session-utils.ts` or `src/gateway/session-utils.single-row-cache.test.ts`.
- #90814 / #90819 are adjacent but not duplicates: they address plugin workspace-dir concurrency causing O(rows) metadata scans; this PR addresses the single-row shared rowContext gap. The #90819 branch still has the target `entries.length > 1` condition.
- #81108 is adjacent and touches session utilities, but its `entries.length > 0` logic is for checkpoint preview maps; it leaves this shared rowContext condition unchanged.
- Historical related work (#86788/#86794, #88166, #75013, #74970, #77187) improved nearby sessions.list/cache paths, but current `origin/main` still has this single-row metadata-context gap.

Related: #92057, #90814, #90819, #86788, #86794, #88166, #75013.

## Why

Local isolated investigation found a strong limit-specific split:

- `sessions.list` with `agentId=main`, `activeMinutes=60`, `limit=1`: median ~8196 ms
- Same request with `limit=2`: median ~41.55 ms

An isolated patched rehearsal of the generated runtime chunk changed the `limit=1` median to ~41.8 ms, matching the `limit=2` path. This indicated the issue was the single-row rowContext branch, not session cleanup or general CLI overhead.

## Validation

- `git diff --check`
- Guarded focused gateway Vitest:

```bash
CI=1 corepack pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/session-utils.single-row-cache.test.ts --maxWorkers=1 --no-file-parallelism --reporter=default --testTimeout=30000
```

Result:

- 3 test files passed
- 12 tests passed
- duration 18.04s on the fresh `origin/main` branch

## Real behavior proof

- Behavior addressed: `sessions.list` safe-list requests with `limit=1` now build the shared row metadata context for a single selected session row instead of falling back to uncached per-row subagent metadata lookup.
- Real setup tested: Disposable/stage OpenClaw source checkout at PR head `24991c0b05`, Node v22 on Linux arm64, with `OPENCLAW_SKIP_CHANNELS=1`, a disposable `OPENCLAW_STATE_DIR`, a synthetic session store, and a synthetic SQLite-backed subagent registry containing 12,000 public-safe `subagent_runs` rows. No live user gateway, channel credential, provider credential, or production state was used.
- Exact steps or command run after this patch:
  1. Created a disposable OpenClaw state directory and config in the stage checkout.
  2. Wrote one synthetic `agent:main:subagent:*` session row to a disposable session store.
  3. Persisted 12,000 synthetic subagent registry rows through OpenClaw's SQLite subagent registry persistence path.
  4. Ran the patched gateway async session-list path with `agentId=main` and `limit=1`:
     `node --import tsx .artifacts/behavior-92362/prove-sessions-list-real-behavior.ts`
- Evidence after fix: Terminal transcript from the disposable stage setup:

  ```text
  $ SYNTHETIC_SUBAGENT_RUNS=12000 node --import tsx .artifacts/behavior-92362/prove-sessions-list-real-behavior.ts
  OpenClaw PR #92362 real behavior proof (public-safe stage setup)
  repo: <stage-checkout>
  state: <stage-checkout>/.artifacts/behavior-92362/stage-proof-20260612T224213899Z/state
  store: <stage-checkout>/.artifacts/behavior-92362/stage-proof-20260612T224213899Z/sessions.json
  artifact: <stage-checkout>/.artifacts/behavior-92362/stage-proof-20260612T224213899Z/after-fix-real-behavior.json
  synthetic persisted subagent_runs: 12000
  listSessionsFromStoreAsync limit=1 (gateway async list path): 1 session(s), 803.192ms, key=agent:main:subagent:child-proof-0001, subagentRunState=interrupted, status=undefined
  listSessionsFromStoreAsync limit=1 (repeat after metadata cache): 1 session(s), 442.45ms, key=agent:main:subagent:child-proof-0001, subagentRunState=interrupted, status=undefined
  ```

- Observed result after fix: The patched gateway async session-list path returned the single selected synthetic subagent session for `limit=1` while using persisted SQLite-backed subagent registry data. The cold stage run completed in 803.192 ms and the repeat run completed in 442.45 ms with one returned row: `agent:main:subagent:child-proof-0001`.
- What was not tested: No live production Gateway was patched or restarted; no live user state, channel credentials, provider credentials, or installed dist hotfix were used. Broader full-suite gateway regression was not rerun in this proof step.

## Change Type

- [x] Bug fix
- [x] Test
- [ ] Docs
- [ ] Breaking change
