### PR TITLE
fix(tools): emit warning for empty allOf/anyOf availability groups (fixes #92361)

### DIFF
--- a/src/tools/availability.ts
+++ b/src/tools/availability.ts
@@ -134,7 +134,9 @@ function evaluateExpression(
       return [
         {
           reason: "unsupported-signal",
-          message: "Empty availability allOf group",
+          signal: { kind: "always" },
+          message:
+            "Empty availability allOf group — this is an authoring error; the group should contain at least one entry",
         },
       ];
     }
@@ -145,7 +147,9 @@ function evaluateExpression(
       return [
         {
           reason: "unsupported-signal",
-          message: "Empty availability anyOf group",
+          signal: { kind: "always" },
+          message:
+            "Empty availability anyOf group — this is an authoring error; the group should contain at least one entry",
         },
       ];
     }
@@ -177,9 +181,19 @@ export function evaluateToolAvailability(params: {
     return [
       {
         reason: "unsupported-signal",
+        signal: { kind: "always" },
         message: "Unsupported availability expression",
       },
     ];
   }
-  return evaluateExpression(availability, context);
+  const diagnostics = evaluateExpression(availability, context);
+  if (diagnostics.some((d) => d.reason === "unsupported-signal")) {
+    console.warn(
+      `[openclaw:tools] Tool "${params.descriptor.name}" has malformed availability — ${diagnostics
+        .filter((d) => d.reason === "unsupported-signal")
+        .map((d) => d.message)
+        .join("; ")}`,
+    );
+  }
+  return diagnostics;
 }

--- a/src/tools/planner.test.ts
+++ b/src/tools/planner.test.ts
@@ -108,7 +108,9 @@ describe("buildToolPlan", () => {
     expect(hiddenTool.diagnostics).toEqual([
       {
         reason: "unsupported-signal",
-        message: "Empty availability allOf group",
+        signal: { kind: "always" },
+        message:
+          "Empty availability allOf group — this is an authoring error; the group should contain at least one entry",
       },
     ]);
   });


### PR DESCRIPTION
## What does this PR do?

Emit a `console.warn` diagnostic when tool availability descriptors contain empty `allOf`/`anyOf` groups, instead of silently hiding the tool. Also adds the `signal` property to these diagnostics for consistency with other diagnostic types.

## Related Issue

Fixes #92361

## Type of Change

- [x] Bug fix (non-breaking)

## Changes Made

- `src/tools/availability.ts`: Add `signal` property to empty-group diagnostics; emit `console.warn` in `evaluateToolAvailability` when `unsupported-signal` diagnostics are detected
- `src/tools/planner.test.ts`: Update test expectation to match new diagnostic shape

## How to Test

1. `node scripts/run-vitest.mjs run src/tools/availability.test.ts` — all 9 tests pass
2. `node scripts/run-vitest.mjs run src/tools/planner.test.ts` — all 6 tests pass
3. Observe `console.warn` output in stderr for the malformed-availability test case

## Real behavior proof

**Behavior or issue addressed:**
Empty `allOf`/`anyOf` arrays in tool availability descriptors produce `unsupported-signal` diagnostics that are silently consumed — tools are hidden with no actionable feedback to authors. This is an authoring error that should be surfaced at evaluation time.

**Real environment tested:**
macOS 26.4.1, Node.js v22, pnpm, OpenClaw main branch (d4819948)

**Exact steps or command run after the patch:**
```bash
cd /Users/liuhao/.hermes/workdir/openclaw
node scripts/run-vitest.mjs run src/tools/availability.test.ts src/tools/planner.test.ts
```

**Evidence after fix:**
```
stderr | src/tools/planner.test.ts > buildToolPlan > hides descriptors with malformed empty allOf availability
[openclaw:tools] Tool "malformed" has malformed availability — Empty availability allOf group — this is an authoring error; the group should contain at least one entry

stderr | src/tools/availability.test.ts > evaluateToolAvailability > surfaces an unsupported-signal sibling even when another anyOf branch is available
[openclaw:tools] Tool "example" has malformed availability — Empty availability allOf group — this is an authoring error; the group should contain at least one entry

 ✓  unit  src/tools/planner.test.ts (6 tests) 29ms
 ✓  unit  src/tools/availability.test.ts (9 tests) 32ms

 Test Files  2 passed (2)
      Tests  15 passed (15)
```

**Observed result after fix:**
Warning is emitted with tool name and descriptive message when empty availability groups are detected. All 15 tests pass.

**What was not tested:**
Live gateway startup with malformed descriptors (the fix is in the pure evaluation layer, no gateway integration needed).
