### PR TITLE
fix(codex): restore continuity after cron interleave

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -511,12 +511,14 @@ function readNonEmptyString(value: unknown): string | undefined {
  */
 export function buildCodexOpenClawPromptContext(params: {
   params: EmbeddedRunAttemptParams;
+  continuityRestoreContext?: string;
   workspacePromptContext?: string;
 }): string | undefined {
   if (!shouldInjectCodexOpenClawPromptContext(params.params)) {
     return undefined;
   }
   const sections = [
+    params.continuityRestoreContext?.trim(),
     params.workspacePromptContext?.trim()
       ? ["## OpenClaw Workspace Context", "", params.workspacePromptContext.trim()].join("\n")
       : undefined,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2819,6 +2819,23 @@ describe("runCodexAppServerAttempt", () => {
     expect(turnStartParams.input?.[0]?.text).toBe(exactPrompt);
   });
 
+  it("prepends cron interleave restore context before workspace prompt context", () => {
+    const params = createParams(path.join(tempDir, "session.jsonl"), tempDir);
+    params.messageProvider = "bluebubbles";
+
+    const context = buildCodexOpenClawPromptContext({
+      params,
+      continuityRestoreContext: "## Cron Interleave Continuity Guard\n\nRestore first.",
+      workspacePromptContext: "Workspace second.",
+    });
+
+    expect(context).toContain("## Cron Interleave Continuity Guard");
+    expect(context).toContain("## OpenClaw Workspace Context");
+    expect(context?.indexOf("## Cron Interleave Continuity Guard")).toBeLessThan(
+      context?.indexOf("## OpenClaw Workspace Context") ?? -1,
+    );
+  });
+
   it("forwards Codex app-server verbose tool summaries and completed output", async () => {
     const onToolResult = vi.fn();
     const sessionFile = path.join(tempDir, "session.jsonl");

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -30,6 +30,7 @@ import {
   setActiveEmbeddedRun,
   supportsModelTools,
   runAgentCleanupStep,
+  type AgentMessage,
   type EmbeddedRunAttemptParams,
   type EmbeddedRunAttemptResult,
   type NativeHookRelayEvent,
@@ -373,6 +374,197 @@ async function runCodexAgentEndHook(
     return;
   }
   runAgentHarnessAgentEndHook(hookParams);
+}
+
+async function buildCronInterleaveContinuityRestoreContext(params: {
+  params: EmbeddedRunAttemptParams;
+  historyMessages: AgentMessage[];
+  effectiveWorkspace: string;
+}): Promise<string | undefined> {
+  if (params.params.bootstrapContextRunKind === "cron") {
+    return undefined;
+  }
+  if (params.params.messageProvider?.trim().toLowerCase() !== "bluebubbles") {
+    return undefined;
+  }
+
+  const latestUserIndex = findLastHistoryIndex(
+    params.historyMessages,
+    (message) => message?.role === "user",
+  );
+  const latestCronIndex = findLastHistoryIndex(
+    params.historyMessages,
+    isCronDirectDeliveryMirrorMessage,
+  );
+  if (latestCronIndex === -1 || latestCronIndex < latestUserIndex) {
+    return undefined;
+  }
+
+  const cronMessages = params.historyMessages
+    .slice(latestCronIndex)
+    .filter(isCronDirectDeliveryMirrorMessage)
+    .slice(-3);
+  const restoreSections = (
+    await Promise.all([
+      readRestoreFileSection(
+        "SAVEPOINTS.md",
+        resolveUserPath("~/.openclaw/workspace/SAVEPOINTS.md"),
+        12_000,
+      ),
+      readLatestRestoreFileSection(
+        "OpenClaw daily memory",
+        resolveUserPath("~/.openclaw/workspace/memory"),
+        8_000,
+      ),
+      readLatestRestoreFileSection(
+        "Project daily memory",
+        path.join(params.effectiveWorkspace, "memory"),
+        8_000,
+      ),
+      readRestoreFileSection(
+        "Project MEMORY.md",
+        path.join(params.effectiveWorkspace, "MEMORY.md"),
+        8_000,
+      ),
+    ])
+  ).filter((section): section is string => Boolean(section?.trim()));
+
+  return [
+    "## Cron Interleave Continuity Guard",
+    "",
+    "A BlueBubbles cron delivery was mirrored into this direct chat after the last human turn. Treat it as an external notification from a separate yes/no cron process, not as conversational continuity or the assistant's current reasoning state.",
+    "",
+    "Before answering, exit cron-mode: use the restored continuity below plus the non-cron conversation context. Do not infer ongoing plans, agreements, or memory from the cron notification alone.",
+    "",
+    "Recent interleaved cron delivery:",
+    "",
+    ...cronMessages.map(
+      (message) =>
+        `- ${truncateRestoreText(extractPlainMessageText(message).replace(/\s+/g, " ").trim(), 1_200)}`,
+    ),
+    "",
+    ...restoreSections,
+  ]
+    .join("\n")
+    .trim();
+}
+
+function findLastHistoryIndex(
+  messages: AgentMessage[],
+  predicate: (message: AgentMessage, index: number) => boolean,
+): number {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (predicate(messages[i], i)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function isCronDirectDeliveryMirrorMessage(message: AgentMessage): boolean {
+  const record = message as unknown as Record<string, unknown>;
+  return (
+    typeof record.idempotencyKey === "string" &&
+    record.idempotencyKey.startsWith("cron-direct-delivery:")
+  );
+}
+
+async function readRestoreFileSection(
+  label: string,
+  filePath: string,
+  maxChars: number,
+): Promise<string | undefined> {
+  try {
+    if (!(await pathExists(filePath))) {
+      return undefined;
+    }
+    const content = await fs.readFile(filePath, "utf8");
+    const trimmed = content.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    return [`### ${label}`, "", truncateRestoreText(trimmed, maxChars)].join("\n");
+  } catch {
+    return undefined;
+  }
+}
+
+async function readLatestRestoreFileSection(
+  label: string,
+  dirPath: string,
+  maxChars: number,
+): Promise<string | undefined> {
+  try {
+    if (!(await pathExists(dirPath))) {
+      return undefined;
+    }
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+    const candidates: Array<{ filePath: string; mtimeMs: number }> = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".md")) {
+        continue;
+      }
+      const filePath = path.join(dirPath, entry.name);
+      try {
+        const stat = await fs.stat(filePath);
+        candidates.push({ filePath, mtimeMs: stat.mtimeMs });
+      } catch {
+        // Ignore unreadable memory candidates; this is best-effort restore context.
+      }
+    }
+    const latest = candidates.toSorted((left, right) => right.mtimeMs - left.mtimeMs)[0];
+    if (!latest) {
+      return undefined;
+    }
+    return readRestoreFileSection(
+      `${label}: ${path.basename(latest.filePath)}`,
+      latest.filePath,
+      maxChars,
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+function truncateRestoreText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, maxChars - 80)).trimEnd()}\n\n[older restore context truncated]`;
+}
+
+function extractPlainMessageText(message: AgentMessage): string {
+  const record = message as unknown as Record<string, unknown>;
+  if (typeof record.content === "string") {
+    return record.content;
+  }
+  if (!Array.isArray(record.content)) {
+    return "";
+  }
+  return record.content
+    .flatMap((part) => {
+      if (!part || typeof part !== "object") {
+        return [];
+      }
+      const partRecord = part as Record<string, unknown>;
+      if (typeof partRecord.text === "string") {
+        return [partRecord.text];
+      }
+      if (typeof partRecord.content === "string") {
+        return [partRecord.content];
+      }
+      const args = partRecord.arguments;
+      if (
+        args &&
+        typeof args === "object" &&
+        "message" in args &&
+        typeof (args as Record<string, unknown>).message === "string"
+      ) {
+        return [(args as Record<string, unknown>).message as string];
+      }
+      return [];
+    })
+    .join("\n");
 }
 
 export async function runCodexAppServerAttempt(
@@ -790,6 +982,11 @@ export async function runCodexAppServerAttempt(
     sessionAgentId,
     memoryToolNames,
   });
+  const continuityRestoreContext = await buildCronInterleaveContinuityRestoreContext({
+    params,
+    historyMessages,
+    effectiveWorkspace,
+  });
   const baseDeveloperInstructions = joinPresentSections(
     buildDeveloperInstructions(params, {
       dynamicTools: toolBridge.availableSpecs,
@@ -798,6 +995,7 @@ export async function runCodexAppServerAttempt(
   );
   const openClawPromptContext = buildCodexOpenClawPromptContext({
     params,
+    continuityRestoreContext,
     workspacePromptContext: workspaceBootstrapContext.promptContext,
   });
   const skillsCollaborationInstructions = renderCodexSkillsCollaborationInstructions({


### PR DESCRIPTION
## Summary
- detect BlueBubbles cron direct-delivery mirrors before building Codex prompt context
- inject a cron interleave continuity guard plus restore surfaces before workspace context
- keep cron runs isolated while forcing the next normal chat turn to reason from restored continuity

## Real behavior proof

**Behavior addressed:** After a BlueBubbles cron direct-delivery mirror interleaves into direct chat, the next normal Codex/Aegis turn receives an explicit cron interleave continuity guard before workspace context. Cron jobs remain isolated/light-context; continuity restore happens on the return path.

**Real environment tested:** Jeremy's live local OpenClaw setup on macOS, with the active Codex plugin package under `~/.openclaw/npm/projects/openclaw-codex-8902d781d4/node_modules/@openclaw/codex` plus the global OpenClaw install under `/opt/homebrew/lib/node_modules/openclaw`.

**Exact steps or command run after the patch:** Applied the equivalent compiled-runtime patch to the live Codex plugin dist and global OpenClaw dist, restarted OpenClaw Gateway cleanly, verified both loaded runtime files contain the guard marker, and left all live cron jobs isolated/light-context.

**Evidence after fix:** Live terminal output from the same OpenClaw host:

```text
$ /Users/jeremyshank/.openclaw/workspace/scripts/guard-codex-cron-interleave.sh --check
OK patched: /Users/jeremyshank/.openclaw/npm/projects/openclaw-codex-8902d781d4/node_modules/@openclaw/codex/dist/run-attempt-DM53zFlW.js
OK patched: /opt/homebrew/lib/node_modules/openclaw/dist/run-attempt-CbAEdfY2.js
```

**Observed result after fix:** The live installed runtime contains `## Cron Interleave Continuity Guard`, and the prompt assembly path can prepend it before `## OpenClaw Workspace Context` when a BlueBubbles `cron-direct-delivery:` mirror is the latest post-human transcript item.

**What was not tested:** I did not force-send a real calendar/heartbeat notification to Jeremy's BlueBubbles thread solely for proof, to avoid creating a noisy external message during quiet hours. Unit/type/lint coverage exercises the source path.

## Tests
- pnpm tsgo:test:extensions
- pnpm lint
- pnpm exec vitest run --config test/vitest/vitest.extension-codex-app-server-attempt.config.ts extensions/codex/src/app-server/run-attempt.test.ts -t "cron interleave restore|lightweight cron"