### PR TITLE
fix(anthropic): strip thinking blocks from history when thinking is disabled (fixes #92360)

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -1585,6 +1585,95 @@ describe("anthropic transport stream", () => {
     ]);
   });
 
+  it("replaces a completed thinking-only turn when the current request disables thinking", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [
+          { role: "user", content: "hello" },
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "stop",
+            timestamp: 0,
+            content: [
+              {
+                type: "thinking",
+                thinking: "private reasoning",
+                thinkingSignature: "sig_1",
+              },
+              {
+                type: "thinking",
+                thinking: "[Reasoning redacted]",
+                thinkingSignature: "opaque_1",
+                redacted: true,
+              },
+            ],
+          },
+          { role: "user", content: "again" },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const payload = latestAnthropicRequest().payload;
+    const assistantMessage = findRecord(payload.messages, (record) => record.role === "assistant");
+    expect(payload.thinking).toEqual({ type: "disabled" });
+    expect(assistantMessage.content).toEqual([
+      { type: "text", text: "[assistant reasoning omitted]" },
+    ]);
+  });
+
+  it("preserves signed thinking for an active tool turn when new thinking is disabled", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [
+          { role: "user", content: "look it up" },
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            content: [
+              {
+                type: "thinking",
+                thinking: "call lookup",
+                thinkingSignature: "sig_tool",
+              },
+              { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            content: [{ type: "text", text: "42" }],
+            isError: false,
+          },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const assistantMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "assistant",
+    );
+    expect(assistantMessage.content).toEqual([
+      { type: "thinking", thinking: "call lookup", signature: "sig_tool" },
+      { type: "tool_use", id: "call_1", name: "lookup", input: {} },
+    ]);
+  });
+
   it("backfills empty reasoning_content thinking blocks for compatible Anthropic tool-use replays", async () => {
     await runTransportStream(
       makeAnthropicTransportModel({

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -6,6 +6,10 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { getEnvApiKey } from "../llm/env-api-keys.js";
 import { calculateCost, clampThinkingLevel } from "../llm/model-utils.js";
+import {
+  ANTHROPIC_OMITTED_REASONING_TEXT,
+  findActiveAnthropicToolTurnAssistantIndex,
+} from "../llm/providers/anthropic-thinking-replay.js";
 import type { AnthropicOptions } from "../llm/providers/anthropic.js";
 import type {
   AssistantMessageDiagnostic,
@@ -372,11 +376,18 @@ function convertAnthropicMessages(
   messages: Context["messages"],
   model: AnthropicTransportModel,
   isOAuthToken: boolean,
-  options?: { allowReasoningContentReplay?: boolean },
+  options?: {
+    allowReasoningContentReplay?: boolean;
+    replayThinkingEnabled?: boolean;
+  },
 ) {
   const params: Array<Record<string, unknown>> = [];
   const allowReasoningContentReplay = options?.allowReasoningContentReplay === true;
+  const replayThinkingEnabled = options?.replayThinkingEnabled !== false;
   const transformedMessages = transformTransportMessages(messages, model, normalizeToolCallId);
+  const activeToolTurnAssistantIndex = replayThinkingEnabled
+    ? -1
+    : findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
   for (let i = 0; i < transformedMessages.length; i += 1) {
     const msg = transformedMessages[i];
     if (msg.role === "user") {
@@ -428,6 +439,7 @@ function convertAnthropicMessages(
     if (msg.role === "assistant") {
       const blocks: Array<Record<string, unknown>> = [];
       const reasoningContent: string[] = [];
+      let omittedThinking = false;
       for (const block of msg.content) {
         if (block.type === "text") {
           if (block.text.trim().length > 0) {
@@ -439,6 +451,12 @@ function convertAnthropicMessages(
           continue;
         }
         if (block.type === "thinking") {
+          const thinkingSignature = block.thinkingSignature?.trim();
+          const isReasoningContent = thinkingSignature === "reasoning_content";
+          if (!replayThinkingEnabled && i !== activeToolTurnAssistantIndex && !isReasoningContent) {
+            omittedThinking = true;
+            continue;
+          }
           if (block.redacted) {
             blocks.push({
               type: "redacted_thinking",
@@ -446,9 +464,7 @@ function convertAnthropicMessages(
             });
             continue;
           }
-          const thinkingSignature = block.thinkingSignature?.trim();
-          const hasNativeThinkingSignature =
-            Boolean(thinkingSignature) && thinkingSignature !== "reasoning_content";
+          const hasNativeThinkingSignature = Boolean(thinkingSignature) && !isReasoningContent;
           if (block.thinking.trim().length === 0 && !hasNativeThinkingSignature) {
             continue;
           }
@@ -489,6 +505,9 @@ function convertAnthropicMessages(
             input: coerceTransportToolCallArguments(block.arguments),
           });
         }
+      }
+      if (blocks.length === 0 && omittedThinking) {
+        blocks.push({ type: "text", text: ANTHROPIC_OMITTED_REASONING_TEXT });
       }
       if (blocks.length > 0) {
         const assistantMsg: Record<string, unknown> = { role: "assistant", content: blocks };
@@ -899,6 +918,8 @@ function buildAnthropicParams(
   isOAuthToken: boolean,
   options: AnthropicTransportOptions | undefined,
 ) {
+  const fable5 = usesClaudeFable5MessagesContract(model);
+  const replayThinkingEnabled = fable5 || options?.thinkingEnabled === true;
   const maxTokens = resolveAnthropicMessagesMaxTokens({
     modelMaxTokens: model.maxTokens,
     requestedMaxTokens: options?.maxTokens,
@@ -920,6 +941,7 @@ function buildAnthropicParams(
     messages: ensureNonEmptyAnthropicMessages(
       convertAnthropicMessages(context.messages, model, isOAuthToken, {
         allowReasoningContentReplay: supportsReasoningContentReplay(model),
+        replayThinkingEnabled,
       }),
     ),
     max_tokens: maxTokens,
@@ -961,7 +983,6 @@ function buildAnthropicParams(
   if (context.tools) {
     params.tools = convertAnthropicTools(context.tools, isOAuthToken);
   }
-  const fable5 = usesClaudeFable5MessagesContract(model);
   if (fable5 || model.reasoning || supportsAdaptiveThinking(model)) {
     if (fable5 || options?.thinkingEnabled) {
       if (supportsAdaptiveThinking(model)) {

--- a/src/llm/providers/anthropic-thinking-replay.ts
+++ b/src/llm/providers/anthropic-thinking-replay.ts
@@ -1,0 +1,58 @@
+type ReplayMessage = {
+  role?: unknown;
+  content?: unknown;
+  toolCallId?: unknown;
+};
+
+export const ANTHROPIC_OMITTED_REASONING_TEXT = "[assistant reasoning omitted]";
+
+function asReplayMessage(value: unknown): ReplayMessage | undefined {
+  return value && typeof value === "object" ? (value as ReplayMessage) : undefined;
+}
+
+/**
+ * Anthropic tool results continue the preceding assistant turn. Preserve that
+ * turn's signed thinking even when the next request disables new thinking.
+ */
+export function findActiveAnthropicToolTurnAssistantIndex(messages: readonly unknown[]): number {
+  const toolResultIds = new Set<string>();
+  let index = messages.length - 1;
+
+  while (index >= 0) {
+    const message = asReplayMessage(messages[index]);
+    if (message?.role !== "toolResult") {
+      break;
+    }
+    if (typeof message.toolCallId === "string") {
+      toolResultIds.add(message.toolCallId);
+    }
+    index -= 1;
+  }
+
+  if (toolResultIds.size === 0) {
+    return -1;
+  }
+
+  const assistant = asReplayMessage(messages[index]);
+  if (assistant?.role !== "assistant" || !Array.isArray(assistant.content)) {
+    return -1;
+  }
+
+  const toolCallIds = new Set<string>();
+  for (const block of assistant.content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as { type?: unknown; id?: unknown };
+    if (
+      (record.type === "toolCall" ||
+        record.type === "tool_use" ||
+        record.type === "function_call") &&
+      typeof record.id === "string"
+    ) {
+      toolCallIds.add(record.id);
+    }
+  }
+
+  return [...toolResultIds].every((toolCallId) => toolCallIds.has(toolCallId)) ? index : -1;
+}

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -242,6 +242,100 @@ describe("Anthropic provider", () => {
     expect(result.responseModel).toBe("claude-fable-5");
   });
 
+  it("strips thinking blocks from history when thinking is explicitly disabled", async () => {
+    let capturedPayload: unknown;
+    const client = {
+      messages: {
+        create: vi.fn(() => ({
+          asResponse: () =>
+            Promise.resolve(
+              createSseResponse([
+                {
+                  type: "message_start",
+                  message: {
+                    id: "msg_1",
+                    model: "claude-sonnet-4-6",
+                    usage: { input_tokens: 1, output_tokens: 0 },
+                  },
+                },
+                {
+                  type: "message_delta",
+                  delta: { stop_reason: "end_turn" },
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+                { type: "message_stop" },
+              ]),
+            ),
+        })),
+      },
+    };
+
+    const stream = streamAnthropic(
+      makeAnthropicModel(),
+      {
+        messages: [
+          { role: "user", content: "hello", timestamp: 0 },
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "stop",
+            timestamp: 0,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            content: [
+              {
+                type: "thinking",
+                thinking: "deep reasoning about the answer",
+                thinkingSignature: "sig_1",
+              },
+              {
+                type: "text",
+                text: "Here is the answer.",
+              },
+            ],
+          },
+          { role: "user", content: "again", timestamp: 0 },
+        ],
+      },
+      {
+        apiKey: "***",
+        client: client as never,
+        thinkingEnabled: false,
+        onPayload: (payload) => {
+          capturedPayload = payload;
+        },
+      },
+    );
+
+    await stream.result();
+
+    const payload = capturedPayload as { messages: Array<{ role: string; content: unknown[] }> };
+    const assistantMessage = payload.messages.find((message) => message.role === "assistant");
+    // Thinking block with signature should be converted to plain text, not sent as thinking type
+    expect(assistantMessage?.content).toEqual([
+      {
+        type: "text",
+        text: "deep reasoning about the answer",
+      },
+      {
+        type: "text",
+        text: "Here is the answer.",
+      },
+    ]);
+    // No thinking or redacted_thinking blocks should be present
+    const contentStr = JSON.stringify(assistantMessage?.content);
+    expect(contentStr).not.toContain('"type":"thinking"');
+    expect(contentStr).not.toContain('"type":"redacted_thinking"');
+  });
+
   it.each([
     ["anthropic", "sk-ant-provider"],
     ["anthropic-vertex", "vertex-token"],

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -242,45 +242,99 @@ describe("Anthropic provider", () => {
     expect(result.responseModel).toBe("claude-fable-5");
   });
 
-  it("strips thinking blocks from history when thinking is explicitly disabled", async () => {
-    let capturedPayload: unknown;
-    const client = {
-      messages: {
-        create: vi.fn(() => ({
-          asResponse: () =>
-            Promise.resolve(
-              createSseResponse([
+  it.each([
+    {
+      label: "omitted",
+      thinkingEnabled: undefined,
+      expectedThinking: undefined,
+      visibleText: undefined,
+      expectedContent: [{ type: "text", text: "[assistant reasoning omitted]" }],
+    },
+    {
+      label: "explicitly disabled",
+      thinkingEnabled: false,
+      expectedThinking: { type: "disabled" },
+      visibleText: "Visible answer.",
+      expectedContent: [{ type: "text", text: "Visible answer." }],
+    },
+  ])(
+    "omits completed-turn thinking when thinking is $label",
+    async ({ thinkingEnabled, expectedThinking, visibleText, expectedContent }) => {
+      let capturedPayload: unknown;
+      const stream = streamAnthropic(
+        makeAnthropicModel(),
+        {
+          messages: [
+            { role: "user", content: "hello", timestamp: 0 },
+            {
+              role: "assistant",
+              provider: "anthropic",
+              api: "anthropic-messages",
+              model: "claude-sonnet-4-6",
+              stopReason: "stop",
+              timestamp: 0,
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              content: [
                 {
-                  type: "message_start",
-                  message: {
-                    id: "msg_1",
-                    model: "claude-sonnet-4-6",
-                    usage: { input_tokens: 1, output_tokens: 0 },
-                  },
+                  type: "thinking",
+                  thinking: "private reasoning",
+                  thinkingSignature: "sig_1",
                 },
                 {
-                  type: "message_delta",
-                  delta: { stop_reason: "end_turn" },
-                  usage: { input_tokens: 1, output_tokens: 1 },
+                  type: "thinking",
+                  thinking: "[Reasoning redacted]",
+                  thinkingSignature: "opaque_1",
+                  redacted: true,
                 },
-                { type: "message_stop" },
-              ]),
-            ),
-        })),
-      },
-    };
+                ...(visibleText ? [{ type: "text" as const, text: visibleText }] : []),
+              ],
+            },
+            { role: "user", content: "again", timestamp: 0 },
+          ],
+        },
+        {
+          apiKey: "sk-ant-provider",
+          thinkingEnabled,
+          onPayload: (payload) => {
+            capturedPayload = payload;
+            throw new Error("stop before network");
+          },
+        },
+      );
 
+      await stream.result();
+
+      const payload = capturedPayload as {
+        messages: Array<{ role: string; content: unknown[] }>;
+        thinking?: unknown;
+      };
+      expect(payload.thinking).toEqual(expectedThinking);
+      expect(payload.messages.find((message) => message.role === "assistant")?.content).toEqual(
+        expectedContent,
+      );
+    },
+  );
+
+  it("preserves signed thinking for an active tool turn when new thinking is disabled", async () => {
+    let capturedPayload: unknown;
     const stream = streamAnthropic(
       makeAnthropicModel(),
       {
         messages: [
-          { role: "user", content: "hello", timestamp: 0 },
+          { role: "user", content: "look it up", timestamp: 0 },
           {
             role: "assistant",
             provider: "anthropic",
             api: "anthropic-messages",
             model: "claude-sonnet-4-6",
-            stopReason: "stop",
+            stopReason: "toolUse",
             timestamp: 0,
             usage: {
               input: 0,
@@ -293,47 +347,41 @@ describe("Anthropic provider", () => {
             content: [
               {
                 type: "thinking",
-                thinking: "deep reasoning about the answer",
-                thinkingSignature: "sig_1",
+                thinking: "call lookup",
+                thinkingSignature: "sig_tool",
               },
-              {
-                type: "text",
-                text: "Here is the answer.",
-              },
+              { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
             ],
           },
-          { role: "user", content: "again", timestamp: 0 },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            content: [{ type: "text", text: "42" }],
+            isError: false,
+            timestamp: 0,
+          },
         ],
       },
       {
-        apiKey: "***",
-        client: client as never,
+        apiKey: "sk-ant-provider",
         thinkingEnabled: false,
         onPayload: (payload) => {
           capturedPayload = payload;
+          throw new Error("stop before network");
         },
       },
     );
 
     await stream.result();
 
-    const payload = capturedPayload as { messages: Array<{ role: string; content: unknown[] }> };
-    const assistantMessage = payload.messages.find((message) => message.role === "assistant");
-    // Thinking block with signature should be converted to plain text, not sent as thinking type
-    expect(assistantMessage?.content).toEqual([
-      {
-        type: "text",
-        text: "deep reasoning about the answer",
-      },
-      {
-        type: "text",
-        text: "Here is the answer.",
-      },
+    const payload = capturedPayload as {
+      messages: Array<{ role: string; content: unknown[] }>;
+    };
+    expect(payload.messages.find((message) => message.role === "assistant")?.content).toEqual([
+      { type: "thinking", thinking: "call lookup", signature: "sig_tool" },
+      { type: "tool_use", id: "call_1", name: "lookup", input: {} },
     ]);
-    // No thinking or redacted_thinking blocks should be present
-    const contentStr = JSON.stringify(assistantMessage?.content);
-    expect(contentStr).not.toContain('"type":"thinking"');
-    expect(contentStr).not.toContain('"type":"redacted_thinking"');
   });
 
   it.each([

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -50,6 +50,10 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import {
+  ANTHROPIC_OMITTED_REASONING_TEXT,
+  findActiveAnthropicToolTurnAssistantIndex,
+} from "./anthropic-thinking-replay.js";
 import { resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.js";
@@ -1054,6 +1058,8 @@ function buildParams(
   isOAuthTokenResult: boolean,
   options?: AnthropicOptions,
 ): MessageCreateParamsStreaming {
+  const fable5 = usesClaudeFable5MessagesContract(model);
+  const replayThinkingEnabled = fable5 || options?.thinkingEnabled === true;
   const { cacheControl } = getCacheControl(model, options?.cacheRetention);
   const system = buildAnthropicSystemBlocks(context.systemPrompt, isOAuthTokenResult, cacheControl);
   const compat = context.tools?.length ? getAnthropicCompat(model) : undefined;
@@ -1080,7 +1086,7 @@ function buildParams(
       isOAuthTokenResult,
       cacheControl,
       messageCacheControlLimit,
-      options?.thinkingEnabled,
+      replayThinkingEnabled,
     ),
     max_tokens: options?.maxTokens ?? model.maxTokens,
     stream: true,
@@ -1110,7 +1116,6 @@ function buildParams(
   // Configure thinking mode: always-on adaptive (Fable 5), adaptive (Opus
   // 4.6+ and Sonnet 4.6),
   // budget-based (older models), or explicitly disabled.
-  const fable5 = usesClaudeFable5MessagesContract(model);
   if (fable5 || model.reasoning || supportsAdaptiveThinking(model)) {
     if (fable5 || options?.thinkingEnabled) {
       // Default to "summarized" so Opus 4.7+ and Mythos Preview behave like
@@ -1167,12 +1172,15 @@ function convertMessages(
   isOAuthTokenValue: boolean,
   cacheControl?: CacheControlEphemeral,
   messageCacheControlLimit = 4,
-  thinkingEnabled?: boolean,
+  replayThinkingEnabled = true,
 ): MessageParam[] {
   const params: MessageParam[] = [];
 
   // Transform messages for cross-provider compatibility
   const transformedMessages = transformMessages(messages, model, normalizeToolCallId);
+  const activeToolTurnAssistantIndex = replayThinkingEnabled
+    ? -1
+    : findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
 
   for (let i = 0; i < transformedMessages.length; i++) {
     const msg = transformedMessages[i];
@@ -1218,6 +1226,7 @@ function convertMessages(
       }
     } else if (msg.role === "assistant") {
       const blocks: ContentBlockParam[] = [];
+      let omittedThinking = false;
 
       for (const block of msg.content) {
         if (block.type === "text") {
@@ -1229,16 +1238,8 @@ function convertMessages(
             text: sanitizeSurrogates(block.text),
           });
         } else if (block.type === "thinking") {
-          // When thinking is explicitly disabled for the current request, Anthropic
-          // rejects history containing thinking/redacted_thinking blocks. Strip them
-          // and convert to plain text where possible to preserve context.
-          if (thinkingEnabled === false) {
-            if (!block.redacted && block.thinking?.trim()) {
-              blocks.push({
-                type: "text",
-                text: sanitizeSurrogates(block.thinking),
-              });
-            }
+          if (!replayThinkingEnabled && i !== activeToolTurnAssistantIndex) {
+            omittedThinking = true;
             continue;
           }
           // Redacted thinking: pass the opaque payload back as redacted_thinking
@@ -1283,6 +1284,9 @@ function convertMessages(
             input: block.arguments ?? {},
           });
         }
+      }
+      if (blocks.length === 0 && omittedThinking) {
+        blocks.push({ type: "text", text: ANTHROPIC_OMITTED_REASONING_TEXT });
       }
       if (blocks.length === 0) {
         continue;

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1080,6 +1080,7 @@ function buildParams(
       isOAuthTokenResult,
       cacheControl,
       messageCacheControlLimit,
+      options?.thinkingEnabled,
     ),
     max_tokens: options?.maxTokens ?? model.maxTokens,
     stream: true,
@@ -1166,6 +1167,7 @@ function convertMessages(
   isOAuthTokenValue: boolean,
   cacheControl?: CacheControlEphemeral,
   messageCacheControlLimit = 4,
+  thinkingEnabled?: boolean,
 ): MessageParam[] {
   const params: MessageParam[] = [];
 
@@ -1227,6 +1229,18 @@ function convertMessages(
             text: sanitizeSurrogates(block.text),
           });
         } else if (block.type === "thinking") {
+          // When thinking is explicitly disabled for the current request, Anthropic
+          // rejects history containing thinking/redacted_thinking blocks. Strip them
+          // and convert to plain text where possible to preserve context.
+          if (thinkingEnabled === false) {
+            if (!block.redacted && block.thinking?.trim()) {
+              blocks.push({
+                type: "text",
+                text: sanitizeSurrogates(block.thinking),
+              });
+            }
+            continue;
+          }
           // Redacted thinking: pass the opaque payload back as redacted_thinking
           if (block.redacted) {
             blocks.push({


### PR DESCRIPTION
## Summary

Fixes #92360.

Anthropic replay now follows the current request's effective thinking mode across both OpenClaw Anthropic transports:

- completed assistant turns omit native `thinking` and `redacted_thinking` blocks when the new request disables or omits thinking
- the assistant turn immediately followed by matching trailing tool results preserves signed/redacted thinking unchanged, as required by Anthropic tool-use replay
- thinking-only completed turns retain a neutral assistant placeholder so replay ordering remains valid
- Fable's always-enabled thinking behavior remains unchanged
- MiMo/Xiaomi `reasoning_content` compatibility behavior remains unchanged
- OpenAI transport and replay code is unchanged

The shared helper keeps active-tool-turn detection identical in:

- the legacy Anthropic SDK provider
- the managed Anthropic transport

## Verification

- Focused unit/regression tests: 219 passed
- Targeted oxlint: passed
- Testbox changed gate: passed
  - Testbox: `tbx_01kv28hk7st7ej3e820xk52448`
  - Actions: https://github.com/openclaw/openclaw/actions/runs/27489086489
- Fresh Codex autoreview of the committed branch: no actionable findings

### Live Anthropic proof

Real `anthropic/claude-sonnet-4-6` sequence:

1. generated a real signed-thinking tool call
2. continued that tool call with thinking disabled and confirmed the signed thinking block remained in the payload
3. sent a later request with thinking disabled and confirmed completed-turn replay contained zero native thinking blocks

Observed:

```text
first_tool_call=1 first_thinking_blocks=1
active_tool_continuation=ok payload_thinking_blocks=1
completed_turn_replay=ok payload_thinking_blocks=0
```

### Live OpenAI regression proof

Ran the repository live selected-model lane with `openai/gpt-5.5`. Prompt, tool-read, tool-exec, image, and tool-only regression scenarios all passed: 94/94.

## Real behavior proof

Behavior addressed: persistent Anthropic sessions no longer fail after thinking is disabled or omitted, while official Anthropic tool-result continuation still receives the original signed thinking block unchanged.

Real environment tested: macOS, Node.js, OpenClaw working tree, live Anthropic and OpenAI APIs.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/llm/providers/anthropic.test.ts src/agents/anthropic-transport-stream.test.ts src/agents/embedded-agent-runner/thinking.test.ts src/agents/embedded-agent-runner.sanitize-session-history.test.ts

node scripts/run-oxlint.mjs src/llm/providers/anthropic-thinking-replay.ts src/llm/providers/anthropic.ts src/llm/providers/anthropic.test.ts src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts

env -u ANTHROPIC_API_KEY OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_TEST_QUIET=0 OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.5,anthropic/claude-sonnet-4-6" OPENCLAW_LIVE_GATEWAY_MAX_MODELS=0 OPENCLAW_LIVE_GATEWAY_MODEL_CONCURRENCY=1 pnpm test:live -- src/gateway/gateway-models.profiles.live.test.ts

node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed
```

Evidence after fix: copied live terminal output from the Anthropic payload capture:

```text
first_tool_call=1 first_thinking_blocks=1
active_tool_continuation=ok payload_thinking_blocks=1
completed_turn_replay=ok payload_thinking_blocks=0
credential_attempt=3 credential_count=9
```

The separate OpenAI live lane reported 94/94 passing scenarios without changes to OpenAI code.

Observed result after fix: both Anthropic transport paths implement the same replay rule, and official Anthropic tool calling remains intact.

What was not tested: no cross-OS live Anthropic run; the remote Linux changed gate passed.
