### PR TITLE
fix(approvals): distinguish expired, already-resolved, and unknown approval ids

### DIFF
--- a/src/gateway/exec-approval-manager.test.ts
+++ b/src/gateway/exec-approval-manager.test.ts
@@ -87,4 +87,106 @@ describe("ExecApprovalManager", () => {
       "approval expiry is unavailable",
     );
   });
+
+  describe("classifyApprovalId", () => {
+    it("classifies pending, unknown, and unseen ids without leaking existence", () => {
+      const manager = new ExecApprovalManager();
+      const record = manager.create({ command: "echo ok" }, 60_000, "approval-classify-pending");
+      void manager.register(record, 60_000);
+
+      expect(manager.classifyApprovalId("approval-classify-pending")).toBe("pending");
+      expect(manager.classifyApprovalId("never-existed")).toBe("unknown");
+      expect(manager.classifyApprovalId("   ")).toBe("unknown");
+      // A record the caller cannot see must not be revealed as pending.
+      expect(manager.classifyApprovalId("approval-classify-pending", { filter: () => false })).toBe(
+        "unknown",
+      );
+
+      manager.resolve("approval-classify-pending", "allow-once");
+    });
+
+    it("distinguishes resolved from expired records still inside the grace window", () => {
+      const manager = new ExecApprovalManager();
+      const resolvedRecord = manager.create(
+        { command: "echo ok" },
+        60_000,
+        "approval-grace-resolved",
+      );
+      void manager.register(resolvedRecord, 60_000);
+      expect(manager.resolve("approval-grace-resolved", "allow-once")).toBe(true);
+      expect(manager.classifyApprovalId("approval-grace-resolved")).toBe("resolved");
+
+      const expiredRecord = manager.create(
+        { command: "echo ok" },
+        60_000,
+        "approval-grace-expired",
+      );
+      void manager.register(expiredRecord, 60_000);
+      expect(manager.expire("approval-grace-expired")).toBe(true);
+      expect(manager.classifyApprovalId("approval-grace-expired")).toBe("expired");
+    });
+
+    it("keeps resolved/expired classification after the grace window archives the record", () => {
+      vi.useFakeTimers();
+      try {
+        const manager = new ExecApprovalManager();
+        const resolvedRecord = manager.create(
+          { command: "echo ok" },
+          600_000,
+          "approval-archive-resolved",
+        );
+        void manager.register(resolvedRecord, 600_000);
+        manager.resolve("approval-archive-resolved", "allow-once");
+
+        const expiredRecord = manager.create(
+          { command: "echo ok" },
+          600_000,
+          "approval-archive-expired",
+        );
+        void manager.register(expiredRecord, 600_000);
+        manager.expire("approval-archive-expired");
+
+        // Fire the 15s grace cleanup; the live records are dropped but archived.
+        vi.advanceTimersByTime(15_000);
+
+        expect(manager.getSnapshot("approval-archive-resolved")).toBeNull();
+        expect(manager.getSnapshot("approval-archive-expired")).toBeNull();
+        expect(manager.classifyApprovalId("approval-archive-resolved")).toBe("resolved");
+        expect(manager.classifyApprovalId("approval-archive-expired")).toBe("expired");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("classifies a consumed allow-once approval as resolved", () => {
+      const manager = new ExecApprovalManager();
+      const record = manager.create({ command: "echo ok" }, 60_000, "approval-consumed");
+      void manager.register(record, 60_000);
+      manager.resolve("approval-consumed", "allow-once");
+      expect(manager.consumeAllowOnce("approval-consumed")).toBe(true);
+      // decision moved to consumedDecision; still a resolved terminal state.
+      expect(manager.classifyApprovalId("approval-consumed")).toBe("resolved");
+    });
+
+    it("evicts the oldest archived terminal record beyond the bounded cap", () => {
+      vi.useFakeTimers();
+      try {
+        const manager = new ExecApprovalManager();
+        // Cap is MAX_RECENTLY_TERMINATED (512). Archive one past it and assert FIFO eviction.
+        const total = 513;
+        for (let index = 0; index < total; index += 1) {
+          const id = `approval-evict-${index}`;
+          const record = manager.create({ command: "echo ok" }, 600_000, id);
+          void manager.register(record, 600_000);
+          manager.resolve(id, "allow-once");
+        }
+        vi.advanceTimersByTime(15_000);
+
+        expect(manager.classifyApprovalId("approval-evict-0")).toBe("unknown");
+        expect(manager.classifyApprovalId(`approval-evict-${total - 1}`)).toBe("resolved");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -12,6 +12,15 @@ import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 // Grace period to keep resolved entries for late awaitDecision calls
 const RESOLVED_ENTRY_GRACE_MS = 15_000;
 
+// Bounded archive of terminated (resolved/expired) approval ids so a resolve
+// attempt arriving after the grace window can still be told apart as
+// already-resolved vs expired vs genuinely unknown instead of collapsing to
+// "unknown or expired approval id". Capped to avoid unbounded growth.
+const MAX_RECENTLY_TERMINATED = 512;
+
+/** Terminal classification of an approval id for resolve-time UX messaging. */
+export type ApprovalIdClassification = "pending" | "resolved" | "expired" | "unknown";
+
 function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
   const unref = (timer as { unref?: () => void }).unref;
   if (typeof unref === "function") {
@@ -28,6 +37,16 @@ function scheduleResolvedEntryCleanup(cleanup: () => void): void {
 
 function resolveApprovalTimeoutMs(timeoutMs: number): number {
   return resolveTimerTimeoutMs(timeoutMs, 1);
+}
+
+/**
+ * A terminated record carries a decision (including a consumed allow-once) when
+ * it was resolved by an operator; an elapsed window leaves no decision.
+ */
+function terminalStateOf<TPayload>(record: ExecApprovalRecord<TPayload>): "resolved" | "expired" {
+  return record.decision !== undefined || record.consumedDecision !== undefined
+    ? "resolved"
+    : "expired";
 }
 
 type ExecApprovalRequestPayload = InfraExecApprovalRequestPayload;
@@ -63,6 +82,22 @@ export type ExecApprovalIdLookupResult =
 
 export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
   private pending = new Map<string, PendingEntry<TPayload>>();
+  // Insertion-ordered archive of recently terminated records (FIFO eviction).
+  private recentlyTerminated = new Map<string, ExecApprovalRecord<TPayload>>();
+
+  private archiveTerminatedRecord(record: ExecApprovalRecord<TPayload>): void {
+    // Refresh insertion order so the newest terminal state wins and survives
+    // eviction longest.
+    this.recentlyTerminated.delete(record.id);
+    this.recentlyTerminated.set(record.id, record);
+    while (this.recentlyTerminated.size > MAX_RECENTLY_TERMINATED) {
+      const oldest = this.recentlyTerminated.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.recentlyTerminated.delete(oldest);
+    }
+  }
 
   create(request: TPayload, timeoutMs: number, id?: string | null): ExecApprovalRecord<TPayload> {
     const now = Date.now();
@@ -151,6 +186,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       // Only delete if the entry hasn't been replaced
       if (this.pending.get(recordId) === pending) {
         this.pending.delete(recordId);
+        this.archiveTerminatedRecord(pending.record);
       }
     });
     return true;
@@ -172,6 +208,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     scheduleResolvedEntryCleanup(() => {
       if (this.pending.get(recordId) === pending) {
         this.pending.delete(recordId);
+        this.archiveTerminatedRecord(pending.record);
       }
     });
     return true;
@@ -180,6 +217,32 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
   getSnapshot(recordId: string): ExecApprovalRecord<TPayload> | null {
     const entry = this.pending.get(recordId);
     return entry?.record ?? null;
+  }
+
+  /**
+   * Classifies an approval id for resolve-time UX without leaking records the
+   * caller cannot see. A terminated record with a recorded decision is
+   * "resolved"; one whose window elapsed with no decision is "expired". Live
+   * records still in the grace window are classified from their current state,
+   * and ids the caller cannot see (or never existed) are "unknown".
+   */
+  classifyApprovalId(
+    input: string,
+    opts: { filter?: (record: ExecApprovalRecord<TPayload>) => boolean } = {},
+  ): ApprovalIdClassification {
+    const normalized = input.trim();
+    if (!normalized) {
+      return "unknown";
+    }
+    const live = this.pending.get(normalized)?.record;
+    if (live && (opts.filter?.(live) ?? true)) {
+      return live.resolvedAtMs === undefined ? "pending" : terminalStateOf(live);
+    }
+    const archived = this.recentlyTerminated.get(normalized);
+    if (archived && (opts.filter?.(archived) ?? true)) {
+      return terminalStateOf(archived);
+    }
+    return "unknown";
   }
 
   listPendingRecords(): ExecApprovalRecord<TPayload>[] {

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -850,6 +850,128 @@ describe("handlePendingApprovalRequest", () => {
     expect(manager.getSnapshot(record.id)?.decision).toBeUndefined();
   });
 
+  it("reports an expired approval distinctly while it is still in the grace window", async () => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create({ command: "echo ok" }, 60_000, "approval-expired-grace");
+    void manager.register(record, 60_000);
+    expect(manager.expire("approval-expired-grace")).toBe(true);
+    const respond = vi.fn();
+
+    await handleApprovalResolve({
+      manager,
+      inputId: record.id,
+      decision: "allow-once",
+      respond,
+      context: {
+        broadcast: vi.fn(),
+        broadcastToConnIds: vi.fn(),
+      } as unknown as GatewayRequestContext,
+      client: createApprovalClient({
+        connId: "conn-operator",
+        clientId: GATEWAY_CLIENT_IDS.IOS_APP,
+        scopes: ["operator.admin"],
+      }),
+      resolvedEventName: "exec.approval.resolved",
+      buildResolvedEvent: ({ approvalId, decision, snapshot }) => ({
+        id: approvalId,
+        decision,
+        request: snapshot.request,
+      }),
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: "approval expired",
+        details: expect.objectContaining({ reason: "APPROVAL_EXPIRED" }),
+      }),
+    );
+  });
+
+  it("reports expired vs already-resolved distinctly after the grace window archives the record", async () => {
+    vi.useFakeTimers();
+    try {
+      const manager = new ExecApprovalManager();
+      const expiredRecord = manager.create(
+        { command: "echo ok" },
+        600_000,
+        "approval-expired-archived",
+      );
+      void manager.register(expiredRecord, 600_000);
+      manager.expire("approval-expired-archived");
+      const resolvedRecord = manager.create(
+        { command: "echo ok" },
+        600_000,
+        "approval-resolved-archived",
+      );
+      void manager.register(resolvedRecord, 600_000);
+      manager.resolve("approval-resolved-archived", "allow-once");
+      // Fire the grace cleanup so both live records move to the bounded archive.
+      vi.advanceTimersByTime(15_000);
+
+      const client = createApprovalClient({
+        connId: "conn-operator",
+        clientId: GATEWAY_CLIENT_IDS.IOS_APP,
+        scopes: ["operator.admin"],
+      });
+      const baseArgs = {
+        manager,
+        decision: "allow-once" as const,
+        context: {
+          broadcast: vi.fn(),
+          broadcastToConnIds: vi.fn(),
+        } as unknown as GatewayRequestContext,
+        client,
+        resolvedEventName: "exec.approval.resolved",
+        buildResolvedEvent: ({
+          approvalId,
+          decision,
+          snapshot,
+        }: {
+          approvalId: string;
+          decision: string;
+          snapshot: { request: unknown };
+        }) => ({ id: approvalId, decision, request: snapshot.request }),
+      };
+
+      const expiredRespond = vi.fn();
+      await handleApprovalResolve({
+        ...baseArgs,
+        inputId: "approval-expired-archived",
+        respond: expiredRespond,
+      });
+      expect(expiredRespond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          message: "approval expired",
+          details: expect.objectContaining({ reason: "APPROVAL_EXPIRED" }),
+        }),
+      );
+
+      const resolvedRespond = vi.fn();
+      await handleApprovalResolve({
+        ...baseArgs,
+        inputId: "approval-resolved-archived",
+        // Submit a different decision so this is not treated as an idempotent retry.
+        decision: "deny",
+        respond: resolvedRespond,
+      });
+      expect(resolvedRespond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          message: "approval already resolved",
+          details: expect.objectContaining({ reason: "APPROVAL_ALREADY_RESOLVED" }),
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not wait on decisions for approvals hidden from the caller", async () => {
     const manager = new ExecApprovalManager();
     const record = manager.create(

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -22,8 +22,15 @@ const APPROVAL_NOT_FOUND_DETAILS = {
   remediation: "Re-request the action; pending approvals are cleared after expiry or restart.",
 } as const;
 
+const APPROVAL_EXPIRED_DETAILS = {
+  reason: "APPROVAL_EXPIRED",
+  remediation:
+    "The approval window elapsed before a decision was submitted. Re-run the command to request a fresh approval.",
+} as const;
+
 const APPROVAL_ALREADY_RESOLVED_DETAILS = {
   reason: "APPROVAL_ALREADY_RESOLVED",
+  remediation: "This approval was already decided. Re-run the command if you need to run it again.",
 } as const;
 
 function resolveRecordedApprovalDecision<TPayload>(
@@ -94,6 +101,26 @@ function respondUnknownOrExpiredApproval(respond: RespondFn): void {
     undefined,
     errorShape(ErrorCodes.INVALID_REQUEST, "unknown or expired approval id", {
       details: APPROVAL_NOT_FOUND_DETAILS,
+    }),
+  );
+}
+
+function respondApprovalExpired(respond: RespondFn): void {
+  respond(
+    false,
+    undefined,
+    errorShape(ErrorCodes.INVALID_REQUEST, "approval expired", {
+      details: APPROVAL_EXPIRED_DETAILS,
+    }),
+  );
+}
+
+function respondApprovalAlreadyResolved(respond: RespondFn): void {
+  respond(
+    false,
+    undefined,
+    errorShape(ErrorCodes.INVALID_REQUEST, "approval already resolved", {
+      details: APPROVAL_ALREADY_RESOLVED_DETAILS,
     }),
   );
 }
@@ -546,22 +573,44 @@ export async function handleApprovalResolve<TPayload, TResolvedEvent extends obj
       exposeAmbiguousPrefixError: params.exposeAmbiguousPrefixError,
     });
     if (resolvedRepeat.ok) {
+      const recordedDecision = resolveRecordedApprovalDecision(resolvedRepeat.snapshot);
       // Treat repeated identical resolves as successful retries; a conflicting
       // retry is rejected so stale operators cannot overwrite the first choice.
-      if (resolveRecordedApprovalDecision(resolvedRepeat.snapshot) === params.decision) {
+      if (recordedDecision === params.decision) {
         params.respond(true, { ok: true }, undefined);
         return;
       }
-      params.respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "approval already resolved", {
-          details: APPROVAL_ALREADY_RESOLVED_DETAILS,
-        }),
-      );
+      // A terminated record still in the grace window with no recorded decision
+      // expired rather than being resolved; tell the operator so, not "already
+      // resolved".
+      if (recordedDecision === undefined) {
+        respondApprovalExpired(params.respond);
+        return;
+      }
+      respondApprovalAlreadyResolved(params.respond);
       return;
     }
-    respondPendingApprovalLookupError({ respond: params.respond, response: resolved.response });
+    // The id was not pending and not in the resolved grace window. Preserve the
+    // ambiguous-prefix error as-is; otherwise consult the terminal archive so an
+    // expired or already-resolved id is reported distinctly instead of always
+    // collapsing to "unknown or expired approval id".
+    if (resolved.response !== "missing") {
+      respondPendingApprovalLookupError({ respond: params.respond, response: resolved.response });
+      return;
+    }
+    const terminalState = params.manager.classifyApprovalId(params.inputId, {
+      filter: (record) =>
+        isApprovalRecordVisibleToClient({ record, client: params.client ?? null }),
+    });
+    if (terminalState === "expired") {
+      respondApprovalExpired(params.respond);
+      return;
+    }
+    if (terminalState === "resolved") {
+      respondApprovalAlreadyResolved(params.respond);
+      return;
+    }
+    respondUnknownOrExpiredApproval(params.respond);
     return;
   }
 

--- a/src/infra/approval-errors.test.ts
+++ b/src/infra/approval-errors.test.ts
@@ -1,6 +1,10 @@
 // Covers approval-not-found error detection.
 import { describe, expect, it } from "vitest";
-import { isApprovalNotFoundError } from "./approval-errors.js";
+import {
+  isApprovalAlreadyResolvedError,
+  isApprovalExpiredError,
+  isApprovalNotFoundError,
+} from "./approval-errors.js";
 
 describe("isApprovalNotFoundError", () => {
   it("matches direct approval-not-found gateway codes", () => {
@@ -26,5 +30,49 @@ describe("isApprovalNotFoundError", () => {
   it("ignores unrelated errors", () => {
     expect(isApprovalNotFoundError(new Error("network timeout"))).toBe(false);
     expect(isApprovalNotFoundError("unknown or expired approval id")).toBe(false);
+  });
+});
+
+describe("isApprovalExpiredError", () => {
+  it("matches direct expired gateway codes", () => {
+    const err = new Error("approval expired") as Error & { gatewayCode?: string };
+    err.gatewayCode = "APPROVAL_EXPIRED";
+    expect(isApprovalExpiredError(err)).toBe(true);
+  });
+
+  it("matches structured expired details", () => {
+    const err = new Error("approval expired") as Error & { details?: { reason?: string } };
+    err.details = { reason: "APPROVAL_EXPIRED" };
+    expect(isApprovalExpiredError(err)).toBe(true);
+  });
+
+  it("matches message-only expired errors", () => {
+    expect(isApprovalExpiredError(new Error("approval expired"))).toBe(true);
+  });
+
+  it("does not treat unknown-or-expired or resolved errors as expired", () => {
+    expect(isApprovalExpiredError(new Error("unknown or expired approval id"))).toBe(false);
+    expect(isApprovalExpiredError(new Error("approval already resolved"))).toBe(false);
+    expect(isApprovalExpiredError("approval expired")).toBe(false);
+  });
+});
+
+describe("isApprovalAlreadyResolvedError", () => {
+  it("matches structured already-resolved details", () => {
+    const err = new Error("approval already resolved") as Error & {
+      details?: { reason?: string };
+    };
+    err.details = { reason: "APPROVAL_ALREADY_RESOLVED" };
+    expect(isApprovalAlreadyResolvedError(err)).toBe(true);
+  });
+
+  it("matches message-only already-resolved errors", () => {
+    expect(isApprovalAlreadyResolvedError(new Error("approval already resolved"))).toBe(true);
+  });
+
+  it("ignores unrelated and expired errors", () => {
+    expect(isApprovalAlreadyResolvedError(new Error("approval expired"))).toBe(false);
+    expect(isApprovalAlreadyResolvedError(new Error("network timeout"))).toBe(false);
+    expect(isApprovalAlreadyResolvedError("approval already resolved")).toBe(false);
   });
 });

--- a/src/infra/approval-errors.ts
+++ b/src/infra/approval-errors.ts
@@ -3,6 +3,8 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 
 const INVALID_REQUEST = "INVALID_REQUEST";
 const APPROVAL_NOT_FOUND = "APPROVAL_NOT_FOUND";
+const APPROVAL_EXPIRED = "APPROVAL_EXPIRED";
+const APPROVAL_ALREADY_RESOLVED = "APPROVAL_ALREADY_RESOLVED";
 
 function readErrorCode(value: unknown): string | null {
   return typeof value === "string" ? (normalizeOptionalString(value) ?? null) : null;
@@ -33,4 +35,44 @@ export function isApprovalNotFoundError(err: unknown): boolean {
     return true;
   }
   return /unknown or expired approval id/i.test(err.message);
+}
+
+/**
+ * Detects that an approval failed because its window elapsed before a decision
+ * was submitted (distinct from a genuinely unknown id). The operator should
+ * re-run the command to request a fresh approval.
+ */
+export function isApprovalExpiredError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const gatewayCode = readErrorCode((err as { gatewayCode?: unknown }).gatewayCode);
+  if (gatewayCode === APPROVAL_EXPIRED) {
+    return true;
+  }
+  const detailsReason = readApprovalNotFoundDetailsReason((err as { details?: unknown }).details);
+  if (detailsReason === APPROVAL_EXPIRED) {
+    return true;
+  }
+  return /approval expired/i.test(err.message);
+}
+
+/**
+ * Detects that an approval was already decided. A duplicate submit of the same
+ * decision succeeds silently during the resolved grace window; this fires for
+ * the conflicting or post-grace duplicate that the gateway rejects.
+ */
+export function isApprovalAlreadyResolvedError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const gatewayCode = readErrorCode((err as { gatewayCode?: unknown }).gatewayCode);
+  if (gatewayCode === APPROVAL_ALREADY_RESOLVED) {
+    return true;
+  }
+  const detailsReason = readApprovalNotFoundDetailsReason((err as { details?: unknown }).details);
+  if (detailsReason === APPROVAL_ALREADY_RESOLVED) {
+    return true;
+  }
+  return /approval already resolved/i.test(err.message);
 }


### PR DESCRIPTION
Resolving an exec/plugin approval that was not currently pending previously collapsed three different situations — the approval **expired**, it was **already resolved**, or the id was **never seen** — into a single `unknown or expired approval id` error. Operators could not tell whether to re-run the command (expired) or whether their decision had already landed (resolved), which is one of the concrete failure modes behind "Failed to submit approval: unknown or expired approval id".

## What changed

- `ExecApprovalManager` keeps a **bounded FIFO archive** of terminated records (512 entries) and exposes `classifyApprovalId()`, which **respects caller visibility** so it never leaks the existence of approvals the caller could not otherwise see.
- `handleApprovalResolve` now reports an elapsed window as **`approval expired`** (`reason: APPROVAL_EXPIRED`, with remediation) both inside the resolved-grace window and after the record is archived, and reports a post-grace decided approval as **`approval already resolved`**. Genuinely unknown ids keep the existing `unknown or expired approval id` message. Same-decision idempotent retries during the grace window are unchanged.
- Adds `isApprovalExpiredError` / `isApprovalAlreadyResolvedError` detectors alongside the existing `isApprovalNotFoundError`.

## Tests

- `pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/exec-approval-manager.test.ts src/gateway/server-methods/approval-shared.test.ts` — classify pending/resolved/expired/unknown, visibility filtering, post-grace archive, FIFO eviction; in-grace and post-grace expired vs already-resolved resolution.
- `pnpm exec vitest run --config vitest.config.ts src/infra/approval-errors.test.ts` — new detectors.
- `./node_modules/.bin/oxfmt --check` on all changed files.

## Real behavior proof

**Behavior or issue addressed:** Submitting an approval that is no longer pending returned the same `unknown or expired approval id` whether it had expired, had already been resolved, or never existed, so the operator had no idea whether re-running the command would help. This change makes an expired approval report `approval expired` (with an `APPROVAL_EXPIRED` reason and remediation) distinctly from a genuinely unknown id, including after the in-memory grace window has elapsed and the record has moved to the bounded archive.

**Real environment tested:** A real OpenClaw gateway runtime started from this branch's worktree on macOS (Darwin, Apple Silicon), exercising the genuine gateway server, `ExecApprovalManager`, and the `exec.approval.request` / `exec.approval.resolve` server methods over a websocket operator connection. No model backend is involved — approvals are created and resolved directly through the real gateway methods.

**Exact steps or command run after this patch:** A standalone operator client connects to the in-process gateway and calls `exec.approval.request` (with a short or long `timeoutMs`) to register a real approval, lets the short one elapse, waits past the 15s resolved-grace window so the record is archived, then calls `exec.approval.resolve` for: an expired-but-in-grace id, an expired-and-archived id, and a never-issued id, capturing each error.

**Evidence after fix:** Live error responses returned by the running gateway's `exec.approval.resolve`:
```
# expired, still inside the 15s grace window
{"ok":false,"error":{"message":"approval expired","reason":"APPROVAL_EXPIRED","code":"INVALID_REQUEST"}}

# expired, AFTER the grace window (record served from the bounded terminal archive)
request("echo expired-archived", timeout=1200) -> id=ff40df94-4ee1-467a-bf4c-1759e3f13aaa
expired post-grace -> {"ok":false,"error":{"message":"approval expired","reason":"APPROVAL_EXPIRED","code":"INVALID_REQUEST"}}

# genuinely unknown id
scenario 4: unknown -> {"ok":false,"error":{"message":"unknown or expired approval id","reason":"APPROVAL_NOT_FOUND","code":"INVALID_REQUEST"}}
```

**Observed result after fix:** An expired approval returns `approval expired` / `APPROVAL_EXPIRED` both within the grace window and after the record is archived, while a never-issued id still returns `unknown or expired approval id` / `APPROVAL_NOT_FOUND`. Before this patch all of these returned the same `unknown or expired approval id`. The remediation text now tells the operator to re-run the command to request a fresh approval.

**What was not tested:** The already-resolved-after-grace path (`approval already resolved`) was exercised through the unit suite rather than this live run, because a gateway approval with no interactive delivery route is expired by the gateway before it can be decided in this headless harness; the resolved-vs-expired classification itself is covered by `exec-approval-manager.test.ts` and `approval-shared.test.ts`. No third-party model or channel was used.
