### PR TITLE
fix(plugins): guard against missing agentIds in memory-wiki public artifacts (#92207)

### DIFF
--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -18,6 +18,7 @@ import {
   registerMemoryRuntime,
   resolveMemoryFlushPlan,
   restoreMemoryPluginState,
+  type MemoryPluginPublicArtifact,
 } from "./memory-state.js";
 
 function createMemoryRuntime() {
@@ -240,6 +241,82 @@ describe("memory plugin state", () => {
         relativePath: "MEMORY.md",
         absolutePath: "/tmp/workspace/MEMORY.md",
         agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+  });
+
+  it("treats missing agentIds as empty when cloning public artifacts", async () => {
+    registerMemoryCapability("memory-lancedb", {
+      publicArtifacts: {
+        async listArtifacts() {
+          return [
+            {
+              kind: "memory-root",
+              workspaceDir: "/tmp/workspace",
+              relativePath: "MEMORY.md",
+              absolutePath: "/tmp/workspace/MEMORY.md",
+              agentIds: undefined,
+              contentType: "markdown" as const,
+            } as unknown as MemoryPluginPublicArtifact,
+          ];
+        },
+      },
+    });
+
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual([
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/workspace",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/workspace/MEMORY.md",
+        agentIds: [],
+        contentType: "markdown",
+      },
+    ]);
+  });
+
+  it("sorts public artifacts with missing agentIds without crashing", async () => {
+    registerMemoryCapability("memory-lancedb", {
+      publicArtifacts: {
+        async listArtifacts() {
+          return [
+            {
+              kind: "daily-note",
+              workspaceDir: "/tmp/workspace",
+              relativePath: "memory/2026-04-07.md",
+              absolutePath: "/tmp/workspace/memory/2026-04-07.md",
+              agentIds: undefined,
+              contentType: "markdown" as const,
+            } as unknown as MemoryPluginPublicArtifact,
+            {
+              kind: "daily-note",
+              workspaceDir: "/tmp/workspace",
+              relativePath: "memory/2026-04-06.md",
+              absolutePath: "/tmp/workspace/memory/2026-04-06.md",
+              agentIds: ["main"],
+              contentType: "markdown" as const,
+            },
+          ];
+        },
+      },
+    });
+
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual([
+      {
+        kind: "daily-note",
+        workspaceDir: "/tmp/workspace",
+        relativePath: "memory/2026-04-06.md",
+        absolutePath: "/tmp/workspace/memory/2026-04-06.md",
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+      {
+        kind: "daily-note",
+        workspaceDir: "/tmp/workspace",
+        relativePath: "memory/2026-04-07.md",
+        absolutePath: "/tmp/workspace/memory/2026-04-07.md",
+        agentIds: [],
         contentType: "markdown",
       },
     ]);

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -305,7 +305,7 @@ function cloneMemoryPublicArtifact(
 ): MemoryPluginPublicArtifact {
   return {
     ...artifact,
-    agentIds: [...artifact.agentIds],
+    agentIds: Array.isArray(artifact.agentIds) ? [...artifact.agentIds] : [],
   };
 }
 
@@ -331,7 +331,9 @@ export async function listActiveMemoryPublicArtifacts(params: {
     if (contentTypeOrder !== 0) {
       return contentTypeOrder;
     }
-    const agentOrder = left.agentIds.join("\0").localeCompare(right.agentIds.join("\0"));
+    const agentOrder = (left.agentIds ?? [])
+      .join("\0")
+      .localeCompare((right.agentIds ?? []).join("\0"));
     if (agentOrder !== 0) {
       return agentOrder;
     }


### PR DESCRIPTION
## Summary

Fixes #92207.

Some memory plugins omit `agentIds` when listing public artifacts. The core clone and sort paths in `src/plugins/memory-state.ts` previously spread or joined `artifact.agentIds` directly, causing `artifact.agentIds is not iterable` crashes when wiki tools queried public artifacts.

## Changes

- `src/plugins/memory-state.ts`:
  - `cloneMemoryPublicArtifact` now falls back to `[]` when `agentIds` is missing or not an array.
  - The `toSorted` comparator now coalesces missing `agentIds` to `[]` before joining for ordering.
- `src/plugins/memory-state.test.ts`: Added regression tests for artifacts with missing `agentIds` during cloning and sorting.

## Verification

- `node scripts/run-vitest.mjs src/plugins/memory-state.test.ts --run` — 16 tests passed (including 2 new regression tests)
- `node scripts/run-vitest.mjs extensions/memory-wiki/src/bridge.test.ts --run` — 10 tests passed

## Branch cleanup

- Removed the unrelated `NO_REPLY` commit that was accidentally stacked on this branch; the PR now contains only the memory-wiki `agentIds` fix.

## Real behavior proof

**Behavior addressed:** `wiki_*` tool crashes when a memory plugin returns public artifacts without the `agentIds` field (`artifact.agentIds is not iterable`).

**Real environment tested:** Local Linux checkout of this branch, Node v22.22.0, pnpm 11.2.2.

**Exact steps or command run after this patch:**

```bash
cd /home/0668000780/开源社区提交2/openclaw
git checkout fix/memory-wiki-missing-agentids
pnpm exec tsx /tmp/repro-92378.mjs
```

The reproduction script registers a tiny in-memory public-artifact provider that returns two wiki artifacts: one with `agentIds` omitted and one with `agentIds: [\"agent-a\"]`, then calls `listActiveMemoryPublicArtifacts({ cfg: {} })`.

**Evidence after fix:**

```
=== Repro #92378: missing agentIds in memory-wiki public artifacts ===

listActiveMemoryPublicArtifacts succeeded
count: 2
- home.md agentIds: []
- notes.md agentIds: ["agent-a"]
```

**Observed result after fix:** The artifact missing `agentIds` is cloned with `agentIds: []`, the sort comparator does not throw, and the function returns both artifacts in deterministic order.

**What was not tested:** A full live `wiki_search` / `wiki_status` invocation against a running OpenClaw agent (local `pnpm install` is blocked by the system CMake version being below `node-llama-cpp`'s 3.19 requirement); the failing code path is exercised directly by the reproduction script and the regression tests.