### PR TITLE
fix(openshell): stage individual file to flat temp dir before upload to avoid tar dir-exists error

### DIFF
--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -366,21 +366,33 @@ class OpenShellSandboxBackendImpl {
       script: 'mkdir -p -- "$(dirname -- "$1")"',
       args: [remotePath],
     });
-    const result = await runOpenShellCli({
-      context: this.params.execContext,
-      args: [
-        "sandbox",
-        "upload",
-        "--no-git-ignore",
-        this.params.execContext.sandboxName,
-        localPath,
-        path.posix.dirname(remotePath),
-      ],
-      cwd: this.params.createParams.workspaceDir,
-    });
-    if (result.code !== 0) {
-      throw new Error(result.stderr.trim() || "openshell sandbox upload failed");
-    }
+    // Stage the file to a flat temp directory (basename only) so that tar
+    // does not try to recreate directory components that already exist on
+    // the remote sandbox. Upload the flat file directly to the exact remote
+    // path to avoid inserting a random temp-directory basename into the
+    // destination (OpenShell preserves the source directory basename).
+    await withTempWorkspace(
+      { rootDir: resolveOpenShellTmpRoot(), prefix: "openclaw-openshell-upload-" },
+      async ({ dir: tmpDir }) => {
+        const stagedPath = path.join(tmpDir, path.basename(localPath));
+        await fs.copyFile(localPath, stagedPath);
+        const result = await runOpenShellCli({
+          context: this.params.execContext,
+          args: [
+            "sandbox",
+            "upload",
+            "--no-git-ignore",
+            this.params.execContext.sandboxName,
+            stagedPath,
+            remotePath,
+          ],
+          cwd: this.params.createParams.workspaceDir,
+        });
+        if (result.code !== 0) {
+          throw new Error(result.stderr.trim() || "openshell sandbox upload failed");
+        }
+      },
+    );
   }
 
   private async ensureSandboxExists(): Promise<void> {


### PR DESCRIPTION
## Summary
- In OpenShell mirror mode, the `write` tool fails with `tar: <dir>: Cannot open: File exists` when writing any file whose host path contains a directory component that already exists on the remote sandbox
- Root cause: `syncLocalPathToRemote` passes the full local path (with directory components) directly to `openshell sandbox upload`. The tar-based upload preserves directory entries, causing tar to fail when extracting into a remote directory where those subdirectories already exist
- This PR fixes the issue by staging the file into a flat temp directory (basename only) before uploading, matching the proven approach used by `uploadPathToRemote` for full workspace syncs
- Fixes #60961

## Verification
- `pnpm test extensions/openshell` — 41 passed, 0 failed (4 test files)
- Autoreview: clean — no findings
- CI: pending

## Real behavior proof
Behavior addressed: OpenShell mirror mode write tool failing with tar "File exists" error when writing files into existing subdirectories (e.g. `memory/2026-04-04.md`)
Real environment tested: Linux 4.19.112, Node 22, commit 49afdbff9a. E2E with live OpenShell sandbox (SSH to remote host) not available locally — Crabbox/CI-only.
Exact steps or command run after this patch: `pnpm test extensions/openshell -- --run`
Evidence after fix:
```console
$ pnpm test extensions/openshell -- --run
 RUN  v4.1.7

 Test Files  4 passed (4)
      Tests  41 passed (41)
   Start at  15:36:47
   Duration  5.52s (transform 6.01s, setup 2.39s, import 10.64s, tests 1.14s, environment 1ms)

[test] passed 1 Vitest shard in 16.46s
```
All 41 tests pass. The fix follows the exact same pattern as the already-working `uploadPathToRemote` method in the same file (`extensions/openshell/src/backend.ts:540`).
Observed result after fix: The fix stages the file to a flat temp dir (basename only) before upload, preventing tar from encountering pre-existing directory components on the remote sandbox.
What was not tested: Live OpenShell sandbox E2E test (requires Crabbox/CI environment with SSH access to an OpenShell sandbox).
