### PR TITLE
fix: don't defer text delta streaming for before_agent_finalize hooks

### DIFF
--- a/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
@@ -43,7 +43,9 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
       text: "First answer.",
     });
     expect(onBlockReply).not.toHaveBeenCalled();
-    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(false);
+    // Gateway SSE events stream immediately even when a before_agent_finalize
+    // hook is registered; only partial replies and block replies are deferred.
+    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(true);
 
     emit({
       type: "agent_end",
@@ -67,7 +69,10 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
       }),
     );
     expect(onBlockReply).not.toHaveBeenCalled();
-    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(false);
+    // Gateway assistant events were already emitted during generation;
+    // suppressTerminalDelivery clears deferred buffers but cannot retract
+    // already-streamed SSE.
+    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(true);
     expect(hasLifecycleEndEvent(onAgentEvent.mock.calls)).toBe(false);
   });
 
@@ -134,7 +139,9 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
       emit,
       text: "Visible stream.",
     });
-    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(false);
+    // Gateway SSE events stream immediately during generation; only channel
+    // partial replies are deferred until the terminal gate resolves.
+    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(true);
     expect(onPartialReply).not.toHaveBeenCalled();
 
     emit({

--- a/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
@@ -262,4 +262,72 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
       expect.objectContaining({ text: "Accepted answer." }),
     );
   });
+
+  it("carries replace flag on the second attempt after a suppressed terminal delivery", async () => {
+    const onAgentEvent = vi.fn();
+    const onBeforeTerminalDelivery = vi.fn(async () => ({
+      suppressTerminalDelivery: true,
+    }));
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run-before-terminal-replace",
+      onAgentEvent,
+      onBeforeTerminalDelivery,
+      blockReplyBreak: "message_end",
+    });
+
+    // First attempt: text streams immediately.
+    emitAssistantTextDeltaAndEnd({
+      emit,
+      text: "First try.",
+    });
+    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(true);
+
+    // Record call count before hook suppression.
+    const callCountBeforeSuppress = onAgentEvent.mock.calls.length;
+
+    // Hook suppresses terminal delivery, which sets assistantTextReplace.
+    emit({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "First try." }],
+          stopReason: "stop",
+        },
+      ],
+      willRetry: false,
+    });
+    await vi.waitFor(() => expect(onBeforeTerminalDelivery).toHaveBeenCalledTimes(1));
+
+    // Second attempt: the first text delta after suppress must carry replace=true
+    // so the gateway projector clears the stale first-attempt buffer.
+    emitAssistantTextDeltaAndEnd({
+      emit,
+      text: "Revised answer.",
+    });
+
+    await subscription.waitForPendingEvents();
+
+    // Only consider events emitted after the suppress.
+    const postSuppressEvents = onAgentEvent.mock.calls
+      .slice(callCountBeforeSuppress)
+      .map((call) => call[0])
+      .filter((e) => e?.stream === "assistant");
+
+    const firstPostSuppressWithText = postSuppressEvents.find(
+      (e) =>
+        typeof (e as { data?: { text?: string } }).data?.text === "string" &&
+        (e as { data?: { text?: string } }).data!.text!.length > 0,
+    );
+    expect(firstPostSuppressWithText).toBeDefined();
+    expect((firstPostSuppressWithText as { data?: { replace?: boolean } }).data?.replace).toBe(
+      true,
+    );
+
+    // Subsequent events should not carry replace (flag was cleared).
+    const subsequentReplaceEvents = postSuppressEvents
+      .slice(1)
+      .filter((e) => (e as { data?: { replace?: boolean } }).data?.replace === true);
+    expect(subsequentReplaceEvents).toHaveLength(0);
+  });
 });

--- a/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
@@ -263,7 +263,10 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
     );
   });
 
-  it("carries replace flag on the second attempt after a suppressed terminal delivery", async () => {
+  it("emits a replace signal when the terminal gate suppresses delivery for revision", async () => {
+    // suppressTerminalDelivery must directly emit a replace event (not via
+    // subscription state) because production revision creates a new
+    // subscription with fresh state for the second attempt.
     const onAgentEvent = vi.fn();
     const onBeforeTerminalDelivery = vi.fn(async () => ({
       suppressTerminalDelivery: true,
@@ -282,10 +285,9 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
     });
     expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(true);
 
-    // Record call count before hook suppression.
-    const callCountBeforeSuppress = onAgentEvent.mock.calls.length;
-
-    // Hook suppresses terminal delivery, which sets assistantTextReplace.
+    // Hook suppresses terminal delivery. The lifecycle handler must emit
+    // a replace event so the gateway projector clears the stale buffer
+    // from the first attempt before the second attempt starts.
     emit({
       type: "agent_end",
       messages: [
@@ -298,36 +300,19 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
       willRetry: false,
     });
     await vi.waitFor(() => expect(onBeforeTerminalDelivery).toHaveBeenCalledTimes(1));
-
-    // Second attempt: the first text delta after suppress must carry replace=true
-    // so the gateway projector clears the stale first-attempt buffer.
-    emitAssistantTextDeltaAndEnd({
-      emit,
-      text: "Revised answer.",
-    });
-
     await subscription.waitForPendingEvents();
 
-    // Only consider events emitted after the suppress.
-    const postSuppressEvents = onAgentEvent.mock.calls
-      .slice(callCountBeforeSuppress)
+    // The suppressTerminalDelivery path must emit a replace-only event
+    // (no text) so the gateway clears rawBuffers for this runId.
+    const replaceEvent = onAgentEvent.mock.calls
       .map((call) => call[0])
-      .filter((e) => e?.stream === "assistant");
-
-    const firstPostSuppressWithText = postSuppressEvents.find(
-      (e) =>
-        typeof (e as { data?: { text?: string } }).data?.text === "string" &&
-        (e as { data?: { text?: string } }).data!.text!.length > 0,
-    );
-    expect(firstPostSuppressWithText).toBeDefined();
-    expect((firstPostSuppressWithText as { data?: { replace?: boolean } }).data?.replace).toBe(
-      true,
-    );
-
-    // Subsequent events should not carry replace (flag was cleared).
-    const subsequentReplaceEvents = postSuppressEvents
-      .slice(1)
-      .filter((e) => (e as { data?: { replace?: boolean } }).data?.replace === true);
-    expect(subsequentReplaceEvents).toHaveLength(0);
+      .find(
+        (e) =>
+          e?.stream === "assistant" &&
+          (e as { data?: { replace?: boolean } }).data?.replace === true,
+      );
+    expect(replaceEvent).toBeDefined();
+    // No lifecycle end because the run continues with a revision attempt.
+    expect(hasLifecycleEndEvent(onAgentEvent.mock.calls)).toBe(false);
   });
 });

--- a/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./embedded-agent-subscribe.e2e-harness.js";
 
 function hasAssistantEvent(calls: Array<unknown[]>): boolean {
-  // The gate buffers assistant stream events; tests use this helper to assert
+  // The gate buffers channel partial replies; gateway SSE events stream immediately.
   // nothing leaks before the terminal decision resolves.
   return calls.some((call) => {
     const event = call[0] as { stream?: string } | undefined;
@@ -123,7 +123,7 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
     expect(onBlockReply).not.toHaveBeenCalled();
   });
 
-  it("defers assistant stream and partial replies until the terminal gate continues", async () => {
+  it("defers channel partial replies but streams gateway SSE until the terminal gate continues", async () => {
     const onAgentEvent = vi.fn();
     const onPartialReply = vi.fn();
     const onBeforeTerminalDelivery = vi.fn(async () => undefined);

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -298,10 +298,19 @@ export function handleAgentEnd(
   const suppressTerminalDelivery = () => {
     ctx.clearDeferredAssistantEvents();
     ctx.clearDeferredBlockReplies();
-    // Mark that the second attempt's first assistant text event should
-    // carry replace=true so the gateway projector clears the stale
-    // buffer from the first (suppressed) attempt.
-    ctx.state.assistantTextReplace = true;
+    // The first attempt's SSE text was already emitted to the gateway
+    // projector. Emit a replace signal now (before the subscription is
+    // discarded) so the gateway clears the raw buffer for this runId.
+    // The second attempt's fresh subscription will then fill a clean buffer.
+    emitAgentEvent({
+      runId: ctx.params.runId,
+      stream: "assistant",
+      data: { replace: true },
+    });
+    void ctx.params.onAgentEvent?.({
+      stream: "assistant",
+      data: { replace: true },
+    });
     finalizeAgentEnd();
   };
 

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -298,6 +298,10 @@ export function handleAgentEnd(
   const suppressTerminalDelivery = () => {
     ctx.clearDeferredAssistantEvents();
     ctx.clearDeferredBlockReplies();
+    // Mark that the second attempt's first assistant text event should
+    // carry replace=true so the gateway projector clears the stale
+    // buffer from the first (suppressed) attempt.
+    ctx.state.assistantTextReplace = true;
     finalizeAgentEnd();
   };
 

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -282,16 +282,40 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     data: EmbeddedAgentSubscribeContext["state"]["deferredAssistantEvents"][number]["data"],
     options?: { emitPartialReply?: boolean },
   ) => {
-    const delivery = { data, emitPartialReply: options?.emitPartialReply === true };
-    emitAssistantStreamDataSafely(delivery);
+    // Gateway SSE events always emit immediately so webchat streaming
+    // works even when a before_agent_finalize hook is registered.
+    // Only channel partial replies (Telegram/Discord live preview) are
+    // deferred until the terminal gate resolves.
+    emitAgentEvent({
+      runId: params.runId,
+      stream: "assistant",
+      data,
+    });
+    void params.onAgentEvent?.({
+      stream: "assistant",
+      data,
+    });
+    const emitPartialReply =
+      options?.emitPartialReply === true && params.onPartialReply && state.shouldEmitPartialReplies;
+    if (emitPartialReply) {
+      if (state.deferBlockReplyDelivery) {
+        state.deferredAssistantEvents.push({ data, emitPartialReply: true });
+      } else {
+        void params.onPartialReply(data);
+      }
+    }
   };
   const flushDeferredAssistantEvents = () => {
     if (state.deferredAssistantEvents.length === 0) {
       return;
     }
+    // Only flush partial replies; gateway SSE events were already emitted
+    // immediately during generation.
     const deferred = state.deferredAssistantEvents.splice(0);
     for (const delivery of deferred) {
-      emitAssistantStreamDataSafely(delivery);
+      if (delivery.emitPartialReply && params.onPartialReply && state.shouldEmitPartialReplies) {
+        void params.onPartialReply(delivery.data);
+      }
     }
   };
   const clearDeferredAssistantEvents = () => {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -283,10 +283,6 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     options?: { emitPartialReply?: boolean },
   ) => {
     const delivery = { data, emitPartialReply: options?.emitPartialReply === true };
-    if (state.deferBlockReplyDelivery) {
-      state.deferredAssistantEvents.push(delivery);
-      return;
-    }
     emitAssistantStreamDataSafely(delivery);
   };
   const flushDeferredAssistantEvents = () => {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -194,10 +194,6 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     deferBlockReplyDelivery: typeof params.onBeforeTerminalDelivery === "function",
     deferredBlockReplies: [],
     deferredAssistantEvents: [],
-    // When a before_agent_finalize hook requests a revision, the first
-    // attempt's SSE text was already emitted. Set a replace flag so the
-    // second attempt signals the gateway projector to clear the stale buffer.
-    assistantTextReplace: false,
     toolExecutionSinceLastBlockReply: false,
     reasoningStreamOpen: false,
     assistantMessageIndex: 0,
@@ -273,20 +269,14 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     // works even when a before_agent_finalize hook is registered.
     // Only channel partial replies (Telegram/Discord live preview) are
     // deferred until the terminal gate resolves.
-    const hasText = typeof (data as { text?: string }).text === "string";
-    const withReplace =
-      state.assistantTextReplace && hasText ? { ...data, replace: true as const } : data;
-    if (state.assistantTextReplace && hasText) {
-      state.assistantTextReplace = false;
-    }
     emitAgentEvent({
       runId: params.runId,
       stream: "assistant",
-      data: withReplace,
+      data,
     });
     void params.onAgentEvent?.({
       stream: "assistant",
-      data: withReplace,
+      data,
     });
     const emitPartialReply =
       options?.emitPartialReply === true && params.onPartialReply && state.shouldEmitPartialReplies;

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -261,23 +261,6 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
   const partialReplyDirectiveAccumulator = createStreamingDirectiveAccumulator();
   const shouldAllowSilentTurnText = (text: string | undefined) =>
     Boolean(text && isSilentReplyText(text, SILENT_REPLY_TOKEN));
-  const emitAssistantStreamDataSafely = (
-    delivery: EmbeddedAgentSubscribeContext["state"]["deferredAssistantEvents"][number],
-  ) => {
-    const { data } = delivery;
-    emitAgentEvent({
-      runId: params.runId,
-      stream: "assistant",
-      data,
-    });
-    void params.onAgentEvent?.({
-      stream: "assistant",
-      data,
-    });
-    if (delivery.emitPartialReply && params.onPartialReply && state.shouldEmitPartialReplies) {
-      void params.onPartialReply(data);
-    }
-  };
   const emitAssistantStreamData = (
     data: EmbeddedAgentSubscribeContext["state"]["deferredAssistantEvents"][number]["data"],
     options?: { emitPartialReply?: boolean },

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -194,6 +194,10 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     deferBlockReplyDelivery: typeof params.onBeforeTerminalDelivery === "function",
     deferredBlockReplies: [],
     deferredAssistantEvents: [],
+    // When a before_agent_finalize hook requests a revision, the first
+    // attempt's SSE text was already emitted. Set a replace flag so the
+    // second attempt signals the gateway projector to clear the stale buffer.
+    assistantTextReplace: false,
     toolExecutionSinceLastBlockReply: false,
     reasoningStreamOpen: false,
     assistantMessageIndex: 0,
@@ -269,14 +273,20 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     // works even when a before_agent_finalize hook is registered.
     // Only channel partial replies (Telegram/Discord live preview) are
     // deferred until the terminal gate resolves.
+    const hasText = typeof (data as { text?: string }).text === "string";
+    const withReplace =
+      state.assistantTextReplace && hasText ? { ...data, replace: true as const } : data;
+    if (state.assistantTextReplace && hasText) {
+      state.assistantTextReplace = false;
+    }
     emitAgentEvent({
       runId: params.runId,
       stream: "assistant",
-      data,
+      data: withReplace,
     });
     void params.onAgentEvent?.({
       stream: "assistant",
-      data,
+      data: withReplace,
     });
     const emitPartialReply =
       options?.emitPartialReply === true && params.onPartialReply && state.shouldEmitPartialReplies;

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -301,7 +301,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       if (state.deferBlockReplyDelivery) {
         state.deferredAssistantEvents.push({ data, emitPartialReply: true });
       } else {
-        void params.onPartialReply(data);
+        void params.onPartialReply!(data);
       }
     }
   };
@@ -314,7 +314,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     const deferred = state.deferredAssistantEvents.splice(0);
     for (const delivery of deferred) {
       if (delivery.emitPartialReply && params.onPartialReply && state.shouldEmitPartialReplies) {
-        void params.onPartialReply(delivery.data);
+        void params.onPartialReply!(delivery.data);
       }
     }
   };

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -297,7 +297,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     const deferred = state.deferredAssistantEvents.splice(0);
     for (const delivery of deferred) {
       if (delivery.emitPartialReply && params.onPartialReply && state.shouldEmitPartialReplies) {
-        void params.onPartialReply!(delivery.data);
+        void params.onPartialReply(delivery.data);
       }
     }
   };

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1246,6 +1246,51 @@ describe("agent event handler", () => {
     nowSpy.mockRestore();
   });
 
+  it("broadcasts a replace-only chat delta to clear the Control UI on before_agent_finalize revision", () => {
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => 11_700);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-revision-replace", {
+      sessionKey: "session-revision-replace",
+      clientRunId: "client-revision-replace",
+    });
+
+    // Stream the first attempt's text.
+    handler({
+      runId: "run-revision-replace",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "First attempt text" },
+    });
+
+    // The before_agent_finalize gate emits a replace-only assistant event
+    // to signal that the first attempt's visible text must be cleared.
+    handler({
+      runId: "run-revision-replace",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { replace: true },
+    });
+
+    const chatCalls = chatBroadcastCalls(broadcast);
+    // At least one delta (the first attempt text) plus the replace delta.
+    const replaceCall = chatCalls.find(([, payload]) => {
+      const p = payload as { replace?: boolean };
+      return p.replace === true;
+    });
+    expect(replaceCall).toBeDefined();
+    const replacePayload = replaceCall![1] as {
+      deltaText?: string;
+      replace?: boolean;
+      state?: string;
+    };
+    expect(replacePayload.state).toBe("delta");
+    expect(replacePayload.deltaText).toBe("");
+    expect(replacePayload.replace).toBe(true);
+    nowSpy.mockRestore();
+  });
+
   it("flushes throttled shorter replacement deltas before final", () => {
     let now = 11_700;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1248,7 +1248,7 @@ describe("agent event handler", () => {
 
   it("broadcasts a replace-only chat delta to clear the Control UI on before_agent_finalize revision", () => {
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => 11_700);
-    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    const { broadcast, chatRunState, handler } = createHarness();
     chatRunState.registry.add("run-revision-replace", {
       sessionKey: "session-revision-replace",
       clientRunId: "client-revision-replace",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -615,10 +615,10 @@ export function createAgentEventHandler({
     seq: number,
     text: string,
     delta?: unknown,
-    opts?: { controlUiVisible?: boolean },
+    opts?: { controlUiVisible?: boolean; replace?: boolean },
   ) => {
     const cleaned = normalizeLiveAssistantEventText({ text, delta });
-    const previousRawText = chatRunState.rawBuffers.get(clientRunId) ?? "";
+    const previousRawText = opts?.replace ? "" : (chatRunState.rawBuffers.get(clientRunId) ?? "");
     const mergedRawText = resolveMergedAssistantText({
       previousText: previousRawText,
       nextText: cleaned.text,
@@ -1224,6 +1224,7 @@ export function createAgentEventHandler({
           evt.data.delta,
           {
             controlUiVisible: isControlUiVisible,
+            replace: (evt.data as { replace?: boolean }).replace === true,
           },
         );
       }

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1215,6 +1215,25 @@ export function createAgentEventHandler({
       ) {
         // before_agent_finalize revision clears the first attempt's
         // streamed SSE so the second attempt starts with a fresh buffer.
+        // Send a replace delta to clear the Control UI's visible text,
+        // then clear server-side throttle state.
+        const staleText = chatRunState.buffers.get(clientRunId) ?? "";
+        sendChatPayload(sessionKey, {
+          runId: clientRunId,
+          sessionKey,
+          ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
+          seq: evt.seq,
+          state: "delta" as const,
+          deltaText: "",
+          replace: true as const,
+          message: staleText
+            ? {
+                role: "assistant",
+                content: [{ type: "text", text: staleText }],
+                timestamp: Date.now(),
+              }
+            : undefined,
+        });
         clearBufferedChatState(clientRunId);
       }
       if (

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -615,10 +615,10 @@ export function createAgentEventHandler({
     seq: number,
     text: string,
     delta?: unknown,
-    opts?: { controlUiVisible?: boolean; replace?: boolean },
+    opts?: { controlUiVisible?: boolean },
   ) => {
     const cleaned = normalizeLiveAssistantEventText({ text, delta });
-    const previousRawText = opts?.replace ? "" : (chatRunState.rawBuffers.get(clientRunId) ?? "");
+    const previousRawText = chatRunState.rawBuffers.get(clientRunId) ?? "";
     const mergedRawText = resolveMergedAssistantText({
       previousText: previousRawText,
       nextText: cleaned.text,
@@ -1211,6 +1211,15 @@ export function createAgentEventHandler({
       if (
         !isAborted &&
         evt.stream === "assistant" &&
+        (evt.data as { replace?: boolean }).replace === true
+      ) {
+        // before_agent_finalize revision clears the first attempt's
+        // streamed SSE so the second attempt starts with a fresh buffer.
+        clearBufferedChatState(clientRunId);
+      }
+      if (
+        !isAborted &&
+        evt.stream === "assistant" &&
         typeof evt.data?.text === "string" &&
         !shouldSuppressAssistantEventForLiveChat(evt.data)
       ) {
@@ -1224,7 +1233,6 @@ export function createAgentEventHandler({
           evt.data.delta,
           {
             controlUiVisible: isControlUiVisible,
-            replace: (evt.data as { replace?: boolean }).replace === true,
           },
         );
       }

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -371,6 +371,39 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Alpha");
   });
 
+  it("clears the stream on a replace delta then streams a second attempt", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Rejected first draft",
+    });
+    // Replace delta from before_agent_finalize revision clears the visible
+    // text so the second attempt starts with a fresh stream.
+    const replacePayload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      deltaText: "",
+      replace: true,
+    };
+    expect(handleChatEvent(state, replacePayload)).toBe("delta");
+    expect(state.chatStream).toBe("");
+
+    // Second attempt streams new text after the replace.
+    const secondPayload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      deltaText: "Revised answer",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Revised answer" }],
+      },
+    };
+    expect(handleChatEvent(state, secondPayload)).toBe("delta");
+    expect(state.chatStream).toBe("Revised answer");
+  });
+
   it("adopts the run id for selected-session live deltas observed from another channel", () => {
     const state = createState({
       sessionKey: "agent:main:feishu:direct:peer-1",


### PR DESCRIPTION
## Summary

Any plugin registering a `before_agent_finalize` hook silently disables all text streaming in webchat. The user sees "in progress" → "done" with no visible output, then a wall of text appears all at once after a long pause.

The root cause: `emitAssistantStreamData` defers ALL assistant output (gateway SSE + channel partial replies) when `onBeforeTerminalDelivery` is set. Gateway SSE events are ephemeral text deltas for webchat streaming — they should emit immediately. Only channel partial replies (Telegram/Discord live preview) need to be gated for hook inspection.

**Fix (split approach):** `emitAssistantStreamData` always emits gateway SSE events (`emitAgentEvent` / `onAgentEvent`) immediately. Only channel partial replies (`onPartialReply`) are deferred until the `before_agent_finalize` terminal gate resolves. `flushDeferredAssistantEvents` only replays partial replies (gateway events were already emitted). Removed dead `emitAssistantStreamDataSafely` (no callers after the split).

**Revision fix:** When `before_agent_finalize` returns `suppressTerminalDelivery: true`, the first attempt's SSE text was already streamed to the gateway projector. `suppressTerminalDelivery` now emits a `replace: true` assistant event directly. The gateway detects this signal and (1) sends a client-visible replace-only chat delta (`deltaText: ""`, `replace: true`) to clear the Control UI's visible text, then (2) clears server-side throttle state. The second attempt streams into a fresh buffer.

## Linked context

No linked issue — discovered during local debugging of a user config where `hook-logger` (which registers `before_agent_finalize`) was installed.

## Root cause analysis

The call chain:

1. **`attempt.ts:3165`** — `hookRunner?.hasHooks("before_agent_finalize")` → `onBeforeTerminalDelivery` is created
2. **`embedded-agent-subscribe.ts:194`** — `deferBlockReplyDelivery = true`
3. **`embedded-agent-subscribe.ts:286-288`** (original code) — `emitAssistantStreamData` checks `deferBlockReplyDelivery` and pushes everything into `deferredAssistantEvents`
4. All events are flushed in a single burst at `deliverTerminal()` line 259
5. Result: 469 text delta events emitted in ~200ms instead of streaming over 35s

PR #87703 (which introduced the guard) was correct to gate block replies and partial replies for hooks, but it over-applied deferral to gateway SSE events that don't need it.

## Fix

`src/agents/embedded-agent-subscribe.ts` — Split `emitAssistantStreamData`:

- Gateway SSE (`emitAgentEvent` / `onAgentEvent`): always emitted immediately
- Channel partial replies (`onPartialReply`): deferred when `deferBlockReplyDelivery` is set, flushed when the terminal gate resolves
- `flushDeferredAssistantEvents`: only replays partial replies, doesn't re-emit gateway events
- `emitAssistantStreamDataSafely`: removed (no callers)

## Real behavior proof

- Behavior or issue addressed: Webchat text streaming disabled when any plugin registers `before_agent_finalize` hook
- Real environment tested: macOS 15.5, Node 24, source-built gateway on port 18789 using `~/.openclaw` config with `hook-logger` plugin (installed from npm `@scotthuang/hook-logger`) that registers `before_agent_finalize`
- Exact steps or command run after this patch:
  1. `pnpm build` — clean build of the fixed code
  2. `bash ~/.codebuddy/skills/openclaw-source-dev/scripts/oc-dev.sh restartStable` — restart gateway with `.openclaw` config
  3. Open webchat in browser at `http://127.0.0.1:18789/` and send a message using model `deepseek/deepseek-v4-flash`
- Evidence after fix:

```
 ✓ |agents| subscribeEmbeddedAgentSession before terminal delivery > suppresses deferred block replies when the terminal gate requests a revision
 ✓ |agents| subscribeEmbeddedAgentSession before terminal delivery > waits for async terminal gate decisions before draining
 ✓ |agents| subscribeEmbeddedAgentSession before terminal delivery > defers channel partial replies but streams gateway SSE until the terminal gate continues
 ✓ |agents| subscribeEmbeddedAgentSession before terminal delivery > does not send final-only assistant events through partial replies
 ✓ |agents| subscribeEmbeddedAgentSession before terminal delivery > finalizes normally when the terminal gate rejects
 ✓ |agents| subscribeEmbeddedAgentSession before terminal delivery > flushes deferred block replies when the terminal gate continues
 ✓ |agents| subscribeEmbeddedAgentSession before terminal delivery > emits a replace signal when the terminal gate suppresses delivery for revision
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

```
 ✓ |gateway-server| agent event handler > broadcasts a replace-only chat delta to clear the Control UI on before_agent_finalize revision
 ✓ |gateway-server| agent event handler > marks non-prefix replacement deltas explicitly
 Test Files  1 passed (1)
      Tests  86 passed (86)
```

```
 ✓ |ui| chat controller > clears the stream on a replace delta then streams a second attempt
 ✓ |ui| chat controller > replaces the stream when gateway deltaText marks a replacement
 Test Files  1 passed (1)
      Tests  118 passed (118)
```

- Live Webchat evidence (before/after comparison, `hook-logger` plugin enabled):
  - **Before fix (stable npm gateway):** [📹 before-fix video — 

https://github.com/user-attachments/assets/1c3cb741-38c0-4642-bc62-ba6884cd61c5

]
  - **After fix (PR branch, same config):** [📹 after-fix video — 

https://github.com/user-attachments/assets/f878694b-883b-437b-bf42-72a641e7687c

]

- Observed result after fix: Webchat streaming works correctly with `hook-logger` enabled. Text appears character by character as the model generates, matching the streaming behavior when no `before_agent_finalize` hook is registered.
- Before evidence: Before the fix, webchat stuck on "in progress" for the full generation duration, then all text flushed in a single burst at termination.
- What was not tested: Other plugins that register `before_agent_finalize` (e.g. Codex native hook relay). The code path is identical for all hook registrations.

## Tests and validation

- `pnpm test src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts` — 7 passed (stream split + replace signal)
- `pnpm test src/gateway/server-chat.agent-events.test.ts` — 86 passed (gateway replace delta broadcast)
- `pnpm test ui/src/ui/controllers/chat.test.ts` — 118 passed (Control UI two-attempt replace flow)
- `pnpm tsgo:core` — clean
- `pnpm build` — clean
- `npx oxfmt --check` on all changed files — clean
- Manual webchat smoke test with `hook-logger` enabled/disabled — streaming works in both cases

## Risk checklist

- User-visible behavior change? `Yes` — webchat streams text incrementally when `before_agent_finalize` hooks are registered, instead of showing all text at once at the end
- Config, environment, or migration behavior change? `No`
- Security, auth, secrets, network, or tool execution behavior change? `No`
- Highest-risk area: A hook that returns `suppressTerminalDelivery` on revision may briefly show streamed text that gets replaced in the final reply
- How is that risk mitigated? The hook still receives the full response and can suppress/modify terminal delivery; only the ephemeral preview is visible earlier. Channel partial replies remain fully gated.

## Current review state

- Next action: `@clawsweeper re-review` — PR body updated with real behavior proof (211+ tests across gateway, Control UI, and agent subscribe surfaces) and gateway chat-delta replace evidence