### PR TITLE
fix(gateway): never return an empty chat.history transcript

### DIFF
--- a/src/gateway/server-methods/chat-history-budget.test.ts
+++ b/src/gateway/server-methods/chat-history-budget.test.ts
@@ -1,0 +1,73 @@
+// Covers the chat.history final byte-budget fallback, including the sentinel
+// that prevents an empty (blank) transcript from being returned to the dashboard.
+import { describe, expect, it } from "vitest";
+import { enforceChatHistoryFinalBudget } from "./chat.js";
+
+type DisplayMessage = {
+  role?: string;
+  content?: Array<{ type?: string; text?: string }>;
+};
+
+function firstText(messages: unknown[]): string {
+  const msg = messages[0] as DisplayMessage | undefined;
+  return msg?.content?.[0]?.text ?? "";
+}
+
+describe("enforceChatHistoryFinalBudget", () => {
+  it("passes through history that already fits the budget", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+      { role: "assistant", content: [{ type: "text", text: "hi" }] },
+    ];
+    const result = enforceChatHistoryFinalBudget({ messages, maxBytes: 1_000_000 });
+    expect(result.messages).toEqual(messages);
+    expect(result.placeholderCount).toBe(0);
+  });
+
+  it("returns the empty array unchanged for empty input", () => {
+    const result = enforceChatHistoryFinalBudget({ messages: [], maxBytes: 10 });
+    expect(result.messages).toEqual([]);
+    expect(result.placeholderCount).toBe(0);
+  });
+
+  it("keeps just the last message when the full set is over budget but the last fits", () => {
+    const big = { role: "user", content: [{ type: "text", text: "x".repeat(4000) }] };
+    const last = { role: "assistant", content: [{ type: "text", text: "ok" }] };
+    const result = enforceChatHistoryFinalBudget({ messages: [big, last], maxBytes: 2_000 });
+    expect(result.messages).toEqual([last]);
+    expect(result.placeholderCount).toBe(0);
+  });
+
+  it("falls back to a small placeholder when even the last message is too large", () => {
+    const last = {
+      role: "assistant",
+      timestamp: 1,
+      content: [{ type: "text", text: "y".repeat(4000) }],
+      __openclaw: { id: "abc", seq: 7 },
+    };
+    const result = enforceChatHistoryFinalBudget({ messages: [last], maxBytes: 2_000 });
+    expect(result.messages).toHaveLength(1);
+    expect(firstText(result.messages)).toContain("chat.history omitted: message too large");
+    expect(result.placeholderCount).toBe(1);
+  });
+
+  it("returns a metadata-free sentinel (never an empty transcript) when even the placeholder is over budget", () => {
+    // A pathological message whose oversized-placeholder copy is itself too
+    // large because it carries very large transcript metadata.
+    const hugeId = "z".repeat(4000);
+    const message = {
+      role: "user",
+      timestamp: 1,
+      content: [{ type: "text", text: "hi" }],
+      __openclaw: { id: hugeId, seq: 1 },
+    };
+    const result = enforceChatHistoryFinalBudget({ messages: [message], maxBytes: 1_000 });
+
+    // The critical guarantee: the dashboard never receives an empty history.
+    expect(result.messages).toHaveLength(1);
+    expect(firstText(result.messages)).toContain("chat.history unavailable");
+    // The sentinel does not carry the oversized source metadata.
+    expect((result.messages[0] as Record<string, unknown>).__openclaw).toBeUndefined();
+    expect(result.placeholderCount).toBe(1);
+  });
+});

--- a/src/gateway/server-methods/chat-history-budget.test.ts
+++ b/src/gateway/server-methods/chat-history-budget.test.ts
@@ -67,7 +67,7 @@ describe("enforceChatHistoryFinalBudget", () => {
     expect(result.messages).toHaveLength(1);
     expect(firstText(result.messages)).toContain("chat.history unavailable");
     // The sentinel does not carry the oversized source metadata.
-    expect((result.messages[0] as Record<string, unknown>).__openclaw).toBeUndefined();
+    expect((result.messages[0] as Record<string, unknown>)["__openclaw"]).toBeUndefined();
     expect(result.placeholderCount).toBe(1);
   });
 });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -523,6 +523,22 @@ export { sanitizeChatSendMessageInput } from "../chat-input-sanitize.js";
 
 export const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
+const CHAT_HISTORY_UNAVAILABLE_SENTINEL =
+  "[chat.history unavailable: transcript too large to display; the full history is preserved on disk]";
+
+/**
+ * A minimal, metadata-free notice returned when even a single oversized
+ * placeholder cannot fit the chat-history byte budget. Returning this instead
+ * of an empty array guarantees the dashboard never renders a blank transcript,
+ * which otherwise reads to the operator as total history loss.
+ */
+function buildChatHistoryUnavailableSentinel(): Record<string, unknown> {
+  return {
+    role: "assistant",
+    timestamp: Date.now(),
+    content: [{ type: "text", text: CHAT_HISTORY_UNAVAILABLE_SENTINEL }],
+  };
+}
 const CHAT_STARTUP_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS = 25;
 const MANAGED_OUTGOING_IMAGE_PATH_PREFIX = "/api/chat/media/outgoing/";
 let chatHistoryPlaceholderEmitCount = 0;
@@ -1543,7 +1559,11 @@ export function enforceChatHistoryFinalBudget(params: { messages: unknown[]; max
   if (jsonUtf8Bytes([placeholder]) <= maxBytes) {
     return { messages: [placeholder], placeholderCount: 1 };
   }
-  return { messages: [], placeholderCount: 0 };
+  // The oversized placeholder still does not fit (e.g. the source message
+  // carried very large metadata). Never return an empty history — that renders
+  // as a blank transcript and reads as data loss even though the on-disk
+  // transcript is intact. Fall back to a small metadata-free sentinel.
+  return { messages: [buildChatHistoryUnavailableSentinel()], placeholderCount: 1 };
 }
 
 function resolveTranscriptPath(params: {


### PR DESCRIPTION
`enforceChatHistoryFinalBudget` returned an **empty array** when even a single oversized-message placeholder could not fit the chat-history byte budget — for example when the source transcript message carried very large metadata (a corrupted or huge `__openclaw.id`). An empty `chat.history` response renders as a **blank transcript** on the dashboard, which reads to the operator as **total history loss**, even though the full transcript is intact on disk. This is one of the concrete causes behind "the whole chat history disappears".

## What changed

- In the final byte-budget fallback (the branch that previously returned `{ messages: [] }`), return a minimal, **metadata-free sentinel** message instead. The dashboard now always renders at least a self-describing notice (`[chat.history unavailable: transcript too large to display; the full history is preserved on disk]`) rather than a blank pane.
- The sentinel deliberately does **not** copy the oversized source metadata, so it is guaranteed small and cannot re-trigger the budget overflow.

## Tests

- `pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/chat-history-budget.test.ts` — pass-through, last-message-only, per-message placeholder, and the new sentinel fallback (asserts the result is never empty).
- Existing `src/gateway/server.chat.gateway-server-chat-b.test.ts` oversized-history coverage still passes.
- `./node_modules/.bin/oxfmt --check` on the changed files.

## Real behavior proof

**Behavior or issue addressed:** When a session transcript contained a message whose oversized-placeholder representation still exceeded the 6 MB chat-history budget, `enforceChatHistoryFinalBudget` returned an empty array and the dashboard showed a completely blank transcript — indistinguishable from losing the whole conversation. The fix makes that fallback return a small sentinel notice so the history pane is never blank.

**Real environment tested:** Ran the actual production chat-history budget pipeline from this branch on macOS (Darwin, Apple Silicon) via `node` — the same `replaceOversizedChatHistoryMessages` and `enforceChatHistoryFinalBudget` functions the gateway's `chat.history` handler calls — against a pathological transcript message carrying ~7.5 MB of metadata, at the production 6 MB budget.

**Exact steps or command run after this patch:** `node --import tsx proof-empty-history.mts`, which builds a real display message with a ~7.5 MB `__openclaw.id`, runs stage 1 (`replaceOversizedChatHistoryMessages`) and stage 2 (`enforceChatHistoryFinalBudget`) exactly as `chat.history` does, and prints the resulting transcript.

**Evidence after fix:** Console output from running the production pipeline:
```
[proofA2] source message bytes: 7500116 (budget 6291456)
[proofA2] after replaceOversized: placeholder bytes=7500177 replacedCount=1
[proofA2] placeholder still exceeds budget? true
[proofA2] enforceChatHistoryFinalBudget -> messages.length=1
[proofA2] first message text: "[chat.history unavailable: transcript too large to display; the full history is preserved on disk]"
[proofA2] carries source metadata? false
[proofA2] PROOF PASS: blank transcript replaced by a self-describing sentinel
```

**Observed result after fix:** The pipeline returns a single sentinel message (`messages.length=1`) carrying the self-describing notice and no oversized metadata. Before this patch the identical input produced `messages.length=0` — a blank transcript on the dashboard. The on-disk transcript is untouched either way.

**What was not tested:** This exercised the production budget functions directly via node rather than through a full websocket `chat.history` round-trip, because naturally producing a >6 MB single-message placeholder inside a live session is impractical; the surrounding `chat.history` wiring is covered by the existing gateway server-chat suite. No model or channel was involved.
