### PR TITLE
fix(anthropic-vertex): stop re-marking cache_control on transport-budgeted payloads

### DIFF
--- a/extensions/anthropic-vertex/stream-runtime.test.ts
+++ b/extensions/anthropic-vertex/stream-runtime.test.ts
@@ -3,8 +3,6 @@ import { createAssistantMessageEventStream, type Model } from "openclaw/plugin-s
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { AnthropicVertexStreamDeps } from "./stream-runtime.js";
 
-const SYSTEM_PROMPT_CACHE_BOUNDARY = "\n<!-- OPENCLAW_CACHE_BOUNDARY -->\n";
-
 function createStreamDeps(): {
   deps: AnthropicVertexStreamDeps;
   streamAnthropicMock: ReturnType<typeof vi.fn>;
@@ -50,8 +48,6 @@ function makeModel(params: {
   } as Model<"anthropic-messages">;
 }
 
-const CACHE_BOUNDARY_PROMPT = `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`;
-
 type PayloadHook = (payload: unknown, payloadModel: unknown) => Promise<unknown>;
 
 function streamAnthropicCall(streamAnthropicMock: ReturnType<typeof vi.fn>): unknown[] {
@@ -72,8 +68,8 @@ function streamTransportOptions(
   return options as Record<string, unknown>;
 }
 
-function captureCacheBoundaryPayloadHook(
-  onPayload: PayloadHook,
+function captureTransportPayloadHook(
+  onPayload: PayloadHook | undefined,
   deps: AnthropicVertexStreamDeps,
   streamAnthropicMock: ReturnType<typeof vi.fn>,
 ) {
@@ -82,14 +78,8 @@ function captureCacheBoundaryPayloadHook(
 
   void streamFn(
     model,
-    {
-      systemPrompt: CACHE_BOUNDARY_PROMPT,
-      messages: [{ role: "user", content: "Hello" }],
-    } as never,
-    {
-      cacheRetention: "short",
-      onPayload,
-    } as never,
+    { messages: [{ role: "user", content: "Hello" }] } as never,
+    { cacheRetention: "short", ...(onPayload ? { onPayload } : {}) } as never,
   );
 
   const transportOptions = streamTransportOptions(streamAnthropicMock);
@@ -97,32 +87,59 @@ function captureCacheBoundaryPayloadHook(
   return { model, onPayload: transportOptions.onPayload as PayloadHook | undefined };
 }
 
-function buildExpectedCacheBoundaryPayload(messageText: string) {
+// Mirrors the shared anthropic-messages transport output: cache boundary already
+// split (uncached dynamic suffix) and all four cache_control markers allocated.
+function buildBudgetedTransportPayload() {
   return {
     system: [
-      {
-        type: "text",
-        text: "Stable prefix",
-        cache_control: { type: "ephemeral" },
-      },
-      {
-        type: "text",
-        text: "Dynamic suffix",
-      },
+      { type: "text", text: "Stable prefix", cache_control: { type: "ephemeral" } },
+      { type: "text", text: "Dynamic suffix" },
+    ],
+    tools: [
+      { name: "exec", input_schema: { type: "object" }, cache_control: { type: "ephemeral" } },
     ],
     messages: [
       {
         role: "user",
+        content: [{ type: "text", text: "Hello", cache_control: { type: "ephemeral" } }],
+      },
+      { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "exec", input: {} }] },
+      {
+        role: "user",
         content: [
           {
-            type: "text",
-            text: messageText,
+            type: "tool_result",
+            tool_use_id: "t1",
+            content: [],
             cache_control: { type: "ephemeral" },
           },
         ],
       },
     ],
   };
+}
+
+function countCacheControlMarkers(payload: unknown): number {
+  let count = 0;
+  const visit = (value: unknown) => {
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+    if (!value || typeof value !== "object") {
+      return;
+    }
+    const record = value as Record<string, unknown>;
+    if (record.cache_control !== undefined) {
+      count += 1;
+    }
+    visit(record.content);
+  };
+  const record = payload as Record<string, unknown>;
+  visit(record.system);
+  visit(record.tools);
+  visit(record.messages);
+  return count;
 }
 
 describe("createAnthropicVertexStreamFn", () => {
@@ -343,63 +360,35 @@ describe("createAnthropicVertexStreamFn", () => {
     expect(transportOptions).not.toHaveProperty("temperature");
   });
 
-  it("applies Anthropic cache-boundary shaping before forwarding payload hooks", async () => {
+  it("keeps already-budgeted cache_control markers intact when forwarding payload hooks", async () => {
     const { deps, streamAnthropicMock } = createStreamDeps();
     const onPayload = vi.fn(async (payload: unknown) => payload);
-    const { model, onPayload: transportPayloadHook } = captureCacheBoundaryPayloadHook(
+    const { model, onPayload: transportPayloadHook } = captureTransportPayloadHook(
       onPayload,
       deps,
       streamAnthropicMock,
     );
-    const payload = {
-      system: [
-        {
-          type: "text",
-          text: CACHE_BOUNDARY_PROMPT,
-          cache_control: { type: "ephemeral" },
-        },
-      ],
-      messages: [{ role: "user", content: "Hello" }],
-    };
+    const payload = buildBudgetedTransportPayload();
 
     const nextPayload = await transportPayloadHook?.(payload, model);
 
-    const expectedPayload = buildExpectedCacheBoundaryPayload("Hello");
-    expect(onPayload).toHaveBeenCalledWith(expectedPayload, model);
-    expect(nextPayload).toEqual(expectedPayload);
+    expect(onPayload).toHaveBeenCalledWith(payload, model);
+    expect(countCacheControlMarkers(nextPayload)).toBe(4);
+    expect((nextPayload as ReturnType<typeof buildBudgetedTransportPayload>).system[1]).toEqual({
+      type: "text",
+      text: "Dynamic suffix",
+    });
   });
 
-  it("reapplies Anthropic cache-boundary shaping when payload hooks return a fresh payload", async () => {
+  it("omits the transport payload hook when the caller provides none", () => {
     const { deps, streamAnthropicMock } = createStreamDeps();
-    const onPayload = vi.fn(async () => ({
-      system: [
-        {
-          type: "text",
-          text: CACHE_BOUNDARY_PROMPT,
-        },
-      ],
-      messages: [{ role: "user", content: "Hello again" }],
-    }));
-    const { model, onPayload: transportPayloadHook } = captureCacheBoundaryPayloadHook(
-      onPayload,
+    const { onPayload: transportPayloadHook } = captureTransportPayloadHook(
+      undefined,
       deps,
       streamAnthropicMock,
     );
 
-    const nextPayload = await transportPayloadHook?.(
-      {
-        system: [
-          {
-            type: "text",
-            text: CACHE_BOUNDARY_PROMPT,
-          },
-        ],
-        messages: [{ role: "user", content: "Hello" }],
-      },
-      model,
-    );
-
-    expect(nextPayload).toEqual(buildExpectedCacheBoundaryPayload("Hello again"));
+    expect(transportPayloadHook).toBeUndefined();
   });
 
   it("omits maxTokens when neither the model nor request provide a finite limit", () => {

--- a/extensions/anthropic-vertex/stream-runtime.ts
+++ b/extensions/anthropic-vertex/stream-runtime.ts
@@ -1,6 +1,6 @@
 /**
  * Anthropic Vertex stream runtime. It constructs Vertex SDK clients and adapts
- * OpenClaw stream options into Anthropic Messages payload policy.
+ * OpenClaw stream options for the shared Anthropic Messages transport.
  */
 import { AnthropicVertex as AnthropicVertexSdk } from "@anthropic-ai/vertex-sdk";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
@@ -18,10 +18,6 @@ import {
   supportsClaudeNativeMaxEffort,
   supportsClaudeNativeXhighEffort,
 } from "openclaw/plugin-sdk/provider-model-shared";
-import {
-  applyAnthropicPayloadPolicyToParams,
-  resolveAnthropicPayloadPolicy,
-} from "openclaw/plugin-sdk/provider-stream-shared";
 import { resolveAnthropicVertexClientRegion, resolveAnthropicVertexProjectId } from "./region.js";
 
 type AnthropicVertexTransportOptions = ProviderStreamOptions & {
@@ -120,36 +116,6 @@ function resolveAnthropicVertexMaxTokens(params: {
   return requested ?? modelMax;
 }
 
-function createAnthropicVertexOnPayload(params: {
-  model: { api: string; baseUrl?: string; provider: string };
-  cacheRetention: ProviderStreamOptions["cacheRetention"] | undefined;
-  onPayload: ProviderStreamOptions["onPayload"] | undefined;
-}): NonNullable<ProviderStreamOptions["onPayload"]> {
-  const policy = resolveAnthropicPayloadPolicy({
-    provider: params.model.provider,
-    api: params.model.api,
-    baseUrl: params.model.baseUrl,
-    cacheRetention: params.cacheRetention,
-    enableCacheControl: true,
-  });
-
-  function applyPolicy(payload: unknown): unknown {
-    if (payload && typeof payload === "object" && !Array.isArray(payload)) {
-      applyAnthropicPayloadPolicyToParams(payload as Record<string, unknown>, policy);
-    }
-    return payload;
-  }
-
-  return async (payload, model) => {
-    const shapedPayload = applyPolicy(payload);
-    const nextPayload = await params.onPayload?.(shapedPayload, model);
-    if (nextPayload === undefined || nextPayload === shapedPayload) {
-      return shapedPayload;
-    }
-    return applyPolicy(nextPayload);
-  };
-}
-
 /**
  * Create a StreamFn that routes through OpenClaw's generic model stream with an
  * injected `AnthropicVertex` client.  All streaming, message conversion, and
@@ -200,11 +166,10 @@ export function createAnthropicVertexStreamFn(
       cacheRetention: options?.cacheRetention,
       sessionId: options?.sessionId,
       headers: options?.headers,
-      onPayload: createAnthropicVertexOnPayload({
-        model: transportModel,
-        cacheRetention: options?.cacheRetention,
-        onPayload: options?.onPayload,
-      }),
+      // The shared anthropic-messages transport already splits the system prompt
+      // cache boundary and budgets all cache_control markers; re-applying the
+      // payload policy here marked the uncached suffix and breached the 4-marker cap.
+      onPayload: options?.onPayload,
       maxRetryDelayMs: options?.maxRetryDelayMs,
       metadata: options?.metadata,
     };


### PR DESCRIPTION
### Summary

- **Problem**: Issue #91982 reports that `anthropic-vertex` requests are intermittently rejected with `FailoverError: LLM request rejected: A maximum of 4 blocks with cache_control may be provided. Found 5.` In the reporter's production deployment the rejection fires whenever active-memory recall injects context into the turn, forcing a model fallback on every hit; the only workaround is disabling active-memory.
- **Root cause**: the request passes through two cache-control writers. The shared anthropic-messages transport (`src/llm/providers/anthropic.ts`) builds the payload with full marker budgeting: it splits the system prompt at the cache boundary into a stable prefix (with `cache_control`) and an intentionally uncached dynamic suffix, marks the tool array, and gives the message pass only the remaining budget (`4 - system - tools`), so legitimate payloads can carry exactly four markers. The vertex plugin then ran `applyAnthropicPayloadPolicyToParams` again on that finished payload inside its `onPayload` hook (`createAnthropicVertexOnPayload` in `extensions/anthropic-vertex/stream-runtime.ts`). That helper is written for raw payloads (the agents-side `anthropic-transport-stream.ts` builds its system blocks with no markers and boundary text intact): any system text block with no boundary marker and no `cache_control` gets a marker added unconditionally. Post-transport, the dynamic suffix is exactly such a block, so the shim adds a fifth marker and Anthropic rejects the request. Turns that don't fill the budget stay at four and pass, which is why the failure tracks active-memory hits rather than every request.
- **Provenance**: the shim was added in `1a13c34f5b` ("close cache boundary transport gaps"), when the then-external transport did not understand the OpenClaw cache boundary and the plugin-level policy pass was the only splitter. `eef24d452f` ("preserve provider prompt cache boundaries", shipped in v2026.6.2-beta.1) moved boundary splitting and marker budgeting natively into the shared transport, which turned the shim from a gap-closer into a double-application. The reporter's first failures on 2026.6.5 line up with that release.
- **Fix**: delete the shim and forward the caller's `onPayload` hook unchanged. The shared transport is the single owner of cache-control budgeting for this API family, which is already how the plain `anthropic` provider behaves (its wrapper applies the payload policy only for `service_tier`, without `enableCacheControl`).
- **What changed**: `extensions/anthropic-vertex/stream-runtime.ts` removes `createAnthropicVertexOnPayload` and its policy imports and passes `options?.onPayload` straight through (net −35 lines); the stale tests that encoded the pre-split payload shape are replaced with regression tests for the budgeted-payload invariant.
- **What did NOT change (scope boundary)**: config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`). Plugin surface unchanged (no exported signature, manifest, `api.ts`, or SDK changes; `createAnthropicVertexStreamFn` keeps its signature). The shared transport, the agents-side anthropic transport (which builds raw payloads and correctly applies the policy once), and the `anthropic` plugin's service-tier wrapper are untouched.

### Reproduction

1. Configure `anthropic-vertex` as the primary provider with prompt caching at its defaults, and enable active-memory for the agent.
2. Drive a turn whose payload legitimately uses the full marker budget — an agentic turn where the transport marks the stable system prefix, the tool array, the last user text block, and the trailing `tool_result` fallback (the reporter hits this whenever a memory recall injects context).
3. The system prompt contains the cache boundary, so the transport emits a cached stable prefix plus an uncached dynamic suffix.
4. **Before this PR**: the vertex `onPayload` shim re-runs the payload policy on the finished payload, adds `cache_control` to the dynamic suffix, and Vertex `StreamRawPredict` returns 400 `A maximum of 4 blocks with cache_control may be provided. Found 5.`, triggering a model fallback.
5. **After this PR**: the payload reaches the wire exactly as the transport budgeted it (at most four markers, dynamic suffix uncached) and the request is accepted.

### Real behavior proof

**Behavior addressed (#91982)**: an `anthropic-vertex` payload that already carries the transport's full cache-control budget is no longer re-marked on its way out, so requests that previously breached Anthropic's four-marker cap with `Found 5` now keep exactly the budgeted markers and the dynamic system suffix stays uncached.

**Real environment tested (Linux x64, Node v22.22.3 — Vitest against the production vertex stream runtime)**: `createAnthropicVertexStreamFn` from the shipped plugin module, exercised through its injectable transport seam; the regression payload mirrors the shared transport's real output shape (split system prefix/suffix, marked tools, marked user text, marked trailing tool_result).

**Exact steps or command run after this patch**: `pnpm test extensions/anthropic-vertex/stream-runtime.test.ts`; `pnpm tsgo:extensions && pnpm tsgo:extensions:test`; `node scripts/run-oxlint.mjs` and format check on the changed files; `.agents/skills/autoreview/scripts/autoreview --engine claude --thinking claude=max`.

**Evidence after fix (Vitest output for the touched test file)**:

```text
 Test Files  1 passed (1)
      Tests  25 passed (25)
```

**Observed result after fix**: the transport options forward the caller's payload hook unchanged; a payload carrying the transport's four budgeted markers keeps exactly four after the hook path runs, with the dynamic suffix block still uncached; when the caller supplies no hook, the transport sets none.

**What was not tested**: a live Vertex AI `StreamRawPredict` round-trip against GCP (no Vertex credentials in this environment). The reporter's GCP Cloud Logging captures in #91982 document the live failure mode this removes.

**Repro confirmation**: both new tests fail on the unpatched tree — the marker count comes back as `expected 5 to be 4`, the same five-marker breach the reporter logged, and a transport-injected hook appears where none was supplied — and pass with the fix, so the tests cover the production change.

### Risk / Mitigation

- **Risk**: vertex payloads could lose prompt caching if nothing re-applied markers. **Mitigation**: the shared anthropic-messages transport applies cache-control budgeting for every request on this API family before `onPayload` runs, and the vertex stream function routes all requests through it — the same single-owner arrangement the plain `anthropic` provider already ships with.
- **Risk**: a downstream `onPayload` consumer relied on the shim re-shaping its returned payload. **Mitigation**: every runtime supplier was audited (anthropic payload logging, command delivery logging, diagnostics byte accounting, and the `before_provider_request` plugin hook); all of them inspect or patch the finished payload and none construct boundary-marked system arrays, and the plain anthropic path likewise sends hook results without re-policing.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Integrations

### Linked Issue/PR

Fixes #91982
