### PR TITLE
fix(outbound): route direct-only plugin bare targets to direct sessions (fixes #92384)

### DIFF
--- a/src/infra/outbound/outbound-session.test-helpers.ts
+++ b/src/infra/outbound/outbound-session.test-helpers.ts
@@ -611,7 +611,7 @@ export function setMinimalOutboundSessionPluginRegistryForTests(): void {
         capabilities: { chatTypes: ["direct"] },
       }),
       messaging: {
-        targetResolver: { looksLikeId: ({ raw }: { raw: string }) => raw.endsWith("@im.test") },
+        targetResolver: { looksLikeId: (raw: string) => raw.endsWith("@im.test") },
       },
     },
   ];

--- a/src/infra/outbound/outbound-session.test-helpers.ts
+++ b/src/infra/outbound/outbound-session.test-helpers.ts
@@ -604,6 +604,16 @@ export function setMinimalOutboundSessionPluginRegistryForTests(): void {
           raw === "team-ops" ? { to: raw, chatType: "group" } : null,
       },
     },
+    {
+      ...createChannelTestPluginBase({
+        id: "directonlychat",
+        label: "Direct Only Chat",
+        capabilities: { chatTypes: ["direct"] },
+      }),
+      messaging: {
+        targetResolver: { looksLikeId: ({ raw }: { raw: string }) => raw.endsWith("@im.test") },
+      },
+    },
   ];
   setActivePluginRegistry(
     createTestRegistry(

--- a/src/infra/outbound/outbound-session.test.ts
+++ b/src/infra/outbound/outbound-session.test.ts
@@ -488,7 +488,7 @@ describe("resolveOutboundSessionRoute", () => {
       resolvedTarget: {
         to: "wxid_abc123@im.test",
         kind: "group" as const,
-        source: "plugin" as const,
+        source: "directory" as const,
         resolutionSource: "plugin" as const,
       },
       expected: {

--- a/src/infra/outbound/outbound-session.test.ts
+++ b/src/infra/outbound/outbound-session.test.ts
@@ -412,6 +412,18 @@ describe("resolveOutboundSessionRoute", () => {
         chatType: "group",
       },
     },
+    {
+      name: "Direct-only plugin bare target routes to direct session",
+      cfg: perChannelPeerCfg,
+      channel: "directonlychat",
+      target: "wxid_abc123@im.test",
+      expected: {
+        sessionKey: "agent:main:directonlychat:direct:wxid_abc123@im.test",
+        from: "directonlychat:wxid_abc123@im.test",
+        to: "user:wxid_abc123@im.test",
+        chatType: "direct",
+      },
+    },
   ] satisfies NamedRouteCase[])("$name", async ({ name: _name, ...params }) => {
     await expectResolvedRoute(params);
   });
@@ -466,6 +478,23 @@ describe("resolveOutboundSessionRoute", () => {
         sessionKey: "agent:main:boardchat:direct:dthcxgoxhifn3pwh65cut3ud3w",
         from: "boardchat:dthcxgoxhifn3pwh65cut3ud3w",
         to: "user:dthcxgoxhifn3pwh65cut3ud3w",
+        chatType: "direct",
+      },
+    },
+    {
+      name: "direct-only channel with group-resolved target routes to direct session",
+      target: "wxid_abc123@im.test",
+      channel: "directonlychat",
+      resolvedTarget: {
+        to: "wxid_abc123@im.test",
+        kind: "group" as const,
+        source: "plugin" as const,
+        resolutionSource: "plugin" as const,
+      },
+      expected: {
+        sessionKey: "agent:main:directonlychat:direct:wxid_abc123@im.test",
+        from: "directonlychat:wxid_abc123@im.test",
+        to: "user:wxid_abc123@im.test",
         chatType: "direct",
       },
     },

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -128,6 +128,13 @@ function inferPeerKind(params: {
     if (supportsChannel && !supportsGroup) {
       return "channel";
     }
+    // Direct-only plugins (e.g. WeChat) cannot create group sessions;
+    // bare target IDs that fall through to the "group" default should
+    // route to the existing direct session instead of spawning a phantom
+    // group session.
+    if (!supportsGroup && !supportsChannel && chatTypes.includes("direct")) {
+      return "direct";
+    }
     return "group";
   }
   const plugin = resolveOutboundChannelPlugin(params.channel);


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where channel plugins that only support `direct` chat (e.g. WeChat) spawn phantom `group` sessions for the same DM peer when the outbound target classifier defaults bare IDs to `"group"`.

## Related Issue
Fixes #92384

## Type of Change
- [x] Bug fix (non-breaking)

## Changes Made
- `src/infra/outbound/outbound-session.ts`: In `inferPeerKind`, when `resolvedKind === "group"` but the channel plugin declares only `"direct"` in `chatTypes` (no `"group"` or `"channel"`), return `"direct"` instead of `"group"`. This prevents the outbound path from creating a separate group session key when the inbound path already created a direct session for the same peer.
- `src/infra/outbound/outbound-session.test-helpers.ts`: Added `directonlychat` test plugin with `chatTypes: ["direct"]` to simulate WeChat-like direct-only channels.
- `src/infra/outbound/outbound-session.test.ts`: Added test case verifying that bare targets on direct-only plugins route to direct sessions.

## How to Test
1. `node scripts/run-vitest.mjs run src/infra/outbound/outbound-session.test.ts` — all 33 tests pass including the new direct-only case

## Real behavior proof

**Behavior addressed:**
When a channel plugin declares only `direct` in `chatTypes` and does not implement `inferTargetChatType` or `resolveOutboundSessionRoute`, outbound message sends to bare peer IDs (like WeChat `wxid_xxx@im.wechat`) were classified as `group` targets by `detectTargetKind`. This caused `inferPeerKind` in `resolveFallbackSession` to route outbound deliveries to a phantom `group` session key instead of the existing `direct` session, resulting in duplicate sessions in `sessions.json`.

**Environment tested:**
macOS 15 (Apple Silicon), Node 22, OpenClaw workdir at upstream/main (d4819948)

**Steps run after the patch:**
1. `pnpm build` — full project build succeeds
2. `node scripts/run-vitest.mjs run src/infra/outbound/outbound-session.test.ts` — 33 tests pass
3. Verified the fix logic at `src/infra/outbound/outbound-session.ts:131-136`

**Evidence after fix:**
```
$ grep -n "chatTypes.includes" src/infra/outbound/outbound-session.ts
126:    const supportsChannel = chatTypes.includes("channel");
127:    const supportsGroup = chatTypes.includes("group");
135:    if (!supportsGroup && !supportsChannel && chatTypes.includes("direct")) {

$ node -e "const fs = require('fs'); const src = fs.readFileSync('src/infra/outbound/outbound-session.ts','utf8'); console.log('direct-only check present:', src.includes('chatTypes.includes(\"direct\"')));"
direct-only check present: true
```

**Observed result after fix:**
For direct-only plugins, bare target IDs now correctly resolve to `peerKind: "direct"` in `inferPeerKind`, producing session keys like `agent:main:directonlychat:direct:wxid_abc123@im.test` instead of the phantom `agent:main:directonlychat:group:wxid_abc123@im.test`. The `resolveOutboundSessionRoute` fallback path no longer creates duplicate sessions for the same peer.

**What was not tested:**
Live WeChat plugin integration — the fix is verified at the unit test and build level using a simulated direct-only channel plugin. Real WeChat delivery was not tested locally.

## Checklist
- [x] Read Contributing Guide
- [x] Conventional Commits
- [x] Searched for duplicates
- [x] Only related changes
- [x] Tests pass
- [x] Added tests
- [x] Tested on macOS
