### PR TITLE
#92374: fix(dispatch): include message_sending hooks when channel supplies custom beforeDeliver

### DIFF
--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -755,7 +755,7 @@ describe("withReplyDispatcher", () => {
 
     expect(customBeforeDeliver).toHaveBeenCalledTimes(2);
     expect(customBeforeDeliver).toHaveBeenCalledWith({ text: "original" }, { kind: "final" });
-    expect(runMessageSending).not.toHaveBeenCalled();
+    expect(runMessageSending).toHaveBeenCalledTimes(2);
     expect(runReplyPayloadSending).toHaveBeenCalledTimes(2);
     expect(runReplyPayloadSending).toHaveBeenCalledWith(
       {
@@ -772,7 +772,7 @@ describe("withReplyDispatcher", () => {
         runId: undefined,
       },
     );
-    expect(payload).toEqual({ text: "original [custom] [plugin]" });
+    expect(payload).toEqual({ text: "message hook" });
     expect(payloadWithMetadata ? getReplyPayloadMetadata(payloadWithMetadata) : undefined).toEqual({
       assistantMessageIndex: 5,
     });

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -549,7 +549,11 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
     buildMessageSendingBeforeDeliver(finalized),
   );
   const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
+    ? combineBeforeDeliverHooks(
+        params.dispatcherOptions.beforeDeliver,
+        replyPayloadBeforeDeliver,
+        buildMessageSendingBeforeDeliver(finalized),
+      )
     : globalBeforeDeliver;
   const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
     foregroundReplyFence || configuredBeforeDeliver
@@ -643,7 +647,11 @@ export async function dispatchInboundMessageWithDispatcher(params: {
     buildMessageSendingBeforeDeliver(params.ctx),
   );
   const composedBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
+    ? combineBeforeDeliverHooks(
+        params.dispatcherOptions.beforeDeliver,
+        replyPayloadBeforeDeliver,
+        buildMessageSendingBeforeDeliver(params.ctx),
+      )
     : globalBeforeDeliver;
   const dispatcher = createReplyDispatcher({
     ...params.dispatcherOptions,


### PR DESCRIPTION
## Summary

Fix plugin `message_sending` hooks being silently bypassed on Telegram agent-reply delivery. When a channel supplies `dispatcherOptions.beforeDeliver`, the hook chain now always includes `buildMessageSendingBeforeDeliver` alongside the channel hook and `replyPayloadBeforeDeliver`.

## Root Cause

In `dispatchInboundMessageWithBufferedDispatcher` and `dispatchInboundMessageWithDispatcher`, when `params.dispatcherOptions.beforeDeliver` was set (e.g. Telegram's no-op), `combineBeforeDeliverHooks` composed only the channel hook + `replyPayloadBeforeDeliver`, excluding `buildMessageSendingBeforeDeliver` — the function that runs plugin `message_sending` hooks (cancel- and rewrite-capable).

`buildMessageSendingBeforeDeliver` only lived in `globalBeforeDeliver` (the fallback when no channel hook exists). This meant safety/guard extensions were silently inert on the highest-volume outbound path, with no bypass diagnostic.

## Real behavior proof

### behavior
`combineBeforeDeliverHooks` now receives three hooks when a channel supplies `beforeDeliver`:
1. Channel-supplied `beforeDeliver`
2. `replyPayloadBeforeDeliver` (plugin `reply_payload_sending` hooks)
3. `buildMessageSendingBeforeDeliver` (plugin `message_sending` hooks)

All three are composed into a single chain via `combineBeforeDeliverHooks`.

### environment
- OS: Windows 10 Enterprise LTSC
- Runtime: Node.js v24.14.0, vitest v4.1.7
- Setup: OpenClaw main branch (d4819948f37d)

### steps
1. Register a plugin `message_sending` hook
2. Send a message via Telegram (which supplies `beforeDeliver`)
3. Before fix: hook silently bypassed
4. After fix: hook fires in chain after channel hook and `reply_payload_sending`

### observedResult

**Test suite:**
```
 ✓  src/auto-reply/dispatch.test.ts (18 tests) 18 passed
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

Updated test "composes custom beforeDeliver with reply_payload_sending hooks":
- Now asserts `runMessageSending` IS called (was `not.toHaveBeenCalled`)
- Verifies message_sending hook can rewrite content in the composed chain

**Production change:**
```diff
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
+    ? combineBeforeDeliverHooks(
+        params.dispatcherOptions.beforeDeliver,
+        replyPayloadBeforeDeliver,
+        buildMessageSendingBeforeDeliver(finalized),
+      )
```
Same pattern applied to both `dispatchInboundMessageWithBufferedDispatcher` and `dispatchInboundMessageWithDispatcher`.

## Regression Test Plan

- [x] `pnpm test -- --run src/auto-reply/dispatch.test.ts` passes (18/18)
- [ ] Plugin message_sending hooks fire on Telegram agent replies
- [ ] Channel custom beforeDeliver still transforms payload before hooks
- [ ] Plugin hooks can still cancel messages (returns null)

---

*AI-assisted: built with Claude Code*