### PR TITLE
fix(moonshot): backfill reasoning_content on assistant tool-call replay messages

### DIFF
--- a/extensions/moonshot/moonshot.live.test.ts
+++ b/extensions/moonshot/moonshot.live.test.ts
@@ -99,11 +99,11 @@ describeLive("moonshot plugin live", () => {
   }, 180_000);
 });
 
-function resolveKimiK27CodeModels(): Model<"openai-completions">[] {
+function resolveMoonshotModels(modelId: string): Model<"openai-completions">[] {
   const provider = buildMoonshotProvider();
-  const model = provider.models.find((entry) => entry.id === "kimi-k2.7-code");
+  const model = provider.models.find((entry) => entry.id === modelId);
   if (!model) {
-    throw new Error("Moonshot catalog does not include kimi-k2.7-code");
+    throw new Error(`Moonshot catalog does not include ${modelId}`);
   }
   const defaultModel = {
     provider: "moonshot",
@@ -128,17 +128,104 @@ async function collectDoneMessage(
   let doneMessage: AssistantMessage | undefined;
   for await (const event of stream) {
     if (event.type === "error") {
-      throw new Error(event.error?.errorMessage || "Moonshot K2.7 live request failed");
+      throw new Error(event.error?.errorMessage || "Moonshot live request failed");
     }
     if (event.type === "done") {
       doneMessage = event.message;
     }
   }
   if (!doneMessage) {
-    throw new Error("Moonshot K2.7 live stream ended without a done message");
+    throw new Error("Moonshot live stream ended without a done message");
   }
   return doneMessage;
 }
+
+describeModelLive("moonshot K2.6 replay live", () => {
+  it("accepts a cross-model tool-call replay after backfilling reasoning_content", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const wrappedStream = provider.wrapStreamFn?.({
+      provider: "moonshot",
+      modelId: "kimi-k2.6",
+      thinkingLevel: "low",
+      streamFn: streamSimple,
+    } as never);
+    if (!wrappedStream) {
+      throw new Error("Moonshot provider did not register a stream wrapper");
+    }
+
+    const tool = createNoopTool();
+    const replayContext: Context = {
+      messages: [
+        {
+          role: "user",
+          content: "Call the noop tool.",
+          timestamp: Date.now(),
+        },
+        {
+          role: "assistant",
+          api: "openai-responses",
+          provider: "openai",
+          model: "gpt-5.5",
+          stopReason: "toolUse",
+          content: [{ type: "toolCall", id: "call_cross_model", name: "noop", arguments: {} }],
+          timestamp: Date.now(),
+        } as AssistantMessage,
+        {
+          role: "toolResult",
+          toolCallId: "call_cross_model",
+          toolName: "noop",
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+          timestamp: Date.now(),
+        },
+        {
+          role: "user",
+          content: "The tool returned ok. Reply with exactly: ok",
+          timestamp: Date.now(),
+        },
+      ],
+      tools: [tool],
+    };
+
+    const runScenario = async (model: Model<"openai-completions">) => {
+      let payload: Record<string, unknown> | undefined;
+      const response = await collectDoneMessage(
+        wrappedStream(model, replayContext, {
+          apiKey: MOONSHOT_API_KEY,
+          maxTokens: 256,
+          onPayload: (value) => {
+            payload = value as Record<string, unknown>;
+          },
+        }) as AsyncIterable<{
+          type: string;
+          message?: AssistantMessage;
+          error?: AssistantMessage;
+        }>,
+      );
+
+      const messages = payload?.messages as Array<Record<string, unknown>> | undefined;
+      const replayedAssistant = messages?.find(
+        (message) => message.role === "assistant" && Array.isArray(message.tool_calls),
+      );
+      expect(replayedAssistant?.reasoning_content).toBe("");
+      expect(response.stopReason).not.toBe("error");
+    };
+
+    let lastAuthError: unknown;
+    for (const model of resolveMoonshotModels("kimi-k2.6")) {
+      try {
+        await runScenario(model);
+        return;
+      } catch (error) {
+        if (!isMoonshotAuthDrift(error)) {
+          throw error;
+        }
+        lastAuthError = error;
+      }
+    }
+    throw toLintErrorObject(lastAuthError, "Moonshot K2.6 rejected the API key in both regions");
+  }, 180_000);
+});
 
 describeModelLive("moonshot K2.7 Code live", () => {
   it("omits thinking controls and completes a replayed tool turn", async () => {
@@ -244,7 +331,7 @@ describeModelLive("moonshot K2.7 Code live", () => {
     };
 
     let lastAuthError: unknown;
-    for (const model of resolveKimiK27CodeModels()) {
+    for (const model of resolveMoonshotModels("kimi-k2.7-code")) {
       try {
         await runScenario(model);
         return;

--- a/src/agents/embedded-agent-runner-extraparams-moonshot.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams-moonshot.test.ts
@@ -178,7 +178,6 @@ describe("applyExtraParamsToAgent Moonshot", () => {
 
     expect(payload.thinking).toEqual({ type: "disabled" });
   });
-
   it("omits thinking controls and broadens pinned tool choice for kimi-k2.7-code", () => {
     const payload = runExtraParamsPayloadCase({
       provider: "moonshot",
@@ -186,6 +185,14 @@ describe("applyExtraParamsToAgent Moonshot", () => {
       thinkingLevel: "off",
       payload: {
         model: "kimi-k2.7-code",
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "read", arguments: "{}" } },
+            ],
+          },
+        ],
       },
       cfg: {
         agents: {
@@ -220,5 +227,63 @@ describe("applyExtraParamsToAgent Moonshot", () => {
     expect(payload).not.toHaveProperty("n");
     expect(payload).not.toHaveProperty("presence_penalty");
     expect(payload).not.toHaveProperty("frequency_penalty");
+    const messages = payload.messages as Array<Record<string, unknown>>;
+    expect(messages[0].reasoning_content).toBe("");
+  });
+
+  it("repairs only missing assistant tool-call reasoning_content when thinking is enabled", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "moonshot",
+      modelId: "kimi-k2.6",
+      thinkingLevel: "low",
+      payload: {
+        model: "kimi-k2.6",
+        messages: [
+          { role: "user", content: "hello" },
+          {
+            role: "assistant",
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "read", arguments: "{}" } },
+            ],
+          },
+          {
+            role: "assistant",
+            reasoning_content: "native reasoning",
+            tool_calls: [
+              { id: "call_2", type: "function", function: { name: "read", arguments: "{}" } },
+            ],
+          },
+          { role: "assistant", content: "done" },
+          { role: "tool", tool_call_id: "call_1", content: "file contents" },
+        ],
+      },
+    });
+
+    expect(payload.thinking).toEqual({ type: "enabled" });
+    const messages = payload.messages as Array<Record<string, unknown>>;
+    expect(messages[1].reasoning_content).toBe("");
+    expect(messages[2].reasoning_content).toBe("native reasoning");
+    expect(messages[3]).not.toHaveProperty("reasoning_content");
+  });
+
+  it("does not backfill reasoning_content when thinking is disabled", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "moonshot",
+      modelId: "kimi-k2.5",
+      thinkingLevel: "off",
+      payload: {
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "read", arguments: "{}" } },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = payload.messages as Array<Record<string, unknown>>;
+    expect(messages[0].reasoning_content).toBeUndefined();
   });
 });

--- a/src/llm/providers/stream-wrappers/moonshot-thinking.ts
+++ b/src/llm/providers/stream-wrappers/moonshot-thinking.ts
@@ -81,6 +81,23 @@ function asPayloadRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+function ensureMoonshotToolCallReasoningContent(payloadObj: Record<string, unknown>): void {
+  if (!Array.isArray(payloadObj.messages)) {
+    return;
+  }
+  for (const message of payloadObj.messages) {
+    const record = asPayloadRecord(message);
+    if (
+      record?.role === "assistant" &&
+      Array.isArray(record.tool_calls) &&
+      record.tool_calls.length > 0 &&
+      !("reasoning_content" in record)
+    ) {
+      record.reasoning_content = "";
+    }
+  }
+}
+
 function sanitizeKimiK27Payload(payloadObj: Record<string, unknown>): void {
   delete payloadObj.thinking;
   delete payloadObj.reasoning_effort;
@@ -97,7 +114,20 @@ function sanitizeKimiK27AfterCaller(
   value: unknown,
   fallbackPayload: Record<string, unknown>,
 ): unknown {
-  sanitizeKimiK27Payload(asPayloadRecord(value) ?? fallbackPayload);
+  const finalPayload = asPayloadRecord(value) ?? fallbackPayload;
+  sanitizeKimiK27Payload(finalPayload);
+  ensureMoonshotToolCallReasoningContent(finalPayload);
+  return value;
+}
+
+function finalizeMoonshotPayloadAfterCaller(
+  value: unknown,
+  fallbackPayload: Record<string, unknown>,
+  thinkingEnabled: boolean,
+): unknown {
+  if (thinkingEnabled) {
+    ensureMoonshotToolCallReasoningContent(asPayloadRecord(value) ?? fallbackPayload);
+  }
   return value;
 }
 
@@ -193,7 +223,14 @@ export function createMoonshotThinkingWrapper(
               delete thinkingObj.keep;
             }
           }
-          return originalOnPayload?.(payload, payloadModel);
+          const result = originalOnPayload?.(payload, payloadModel);
+          const thinkingEnabled = effectiveThinkingType === "enabled";
+          if (result && typeof (result as Promise<unknown>).then === "function") {
+            return Promise.resolve(result).then((resolved) =>
+              finalizeMoonshotPayloadAfterCaller(resolved, payloadObj, thinkingEnabled),
+            );
+          }
+          return finalizeMoonshotPayloadAfterCaller(result, payloadObj, thinkingEnabled);
         },
       });
     };


### PR DESCRIPTION
## Summary

Fixes the `reasoning_content is missing in assistant tool call message` 400 error when using Moonshot/Kimi models with thinking enabled in long sessions, after LCM compaction, cross-model fallback, or `/compact`.

## Problem

When thinking mode is enabled for Moonshot models, the API requires `reasoning_content` on all replayed assistant tool-call messages. After LCM compaction, cross-model fallback, or session compression—the replayed history loses this field, causing:

> `400 thinking is enabled but reasoning_content is missing in assistant tool call message at index N`

This is a provider-agnostic regression affecting Moonshot/Kimi and any OpenAI-compatible upstream requiring `reasoning_content` replay preservation.

## Solution

In `createMoonshotThinkingWrapper`, when thinking is enabled: walk `payloadObj.messages` and backfill `reasoning_content: ""` on assistant messages containing `tool_calls` that are missing the field.

Follows the same provider-owned backfill pattern already used by:
- Kimi Coding (`extensions/kimi-coding/stream.ts:90-106`)
- DeepSeek V4 (`src/plugin-sdk/provider-stream-shared.ts:401-425`)

### Changes

- **`src/llm/providers/stream-wrappers/moonshot-thinking.ts`** — Backfills missing replay `reasoning_content` after caller payload hooks when Moonshot thinking is active; K2.7 always receives the repair.
- **`src/agents/embedded-agent-runner-extraparams-moonshot.test.ts`** — Covers backfill, preservation, disabled thinking, and K2.7.
- **`extensions/moonshot/moonshot.live.test.ts`** — Replays a synthetic cross-model assistant tool call into live K2.6 and retains the existing K2.7 replay scenario.

## Real behavior proof

Behavior addressed: Moonshot/Kimi models return 400 when thinking is enabled and replayed assistant tool-call messages are missing `reasoning_content`. The `ensureMoonshotToolCallReasoningContent` helper backfills `reasoning_content: ""` on assistant tool-call messages before the outbound API request is dispatched.

Real environment tested: GitHub Actions Blacksmith Ubuntu runner, Node 24.15.0, real `MOONSHOT_API_KEY`, exact commit `64c63046c9648c6e25ed4b17e294b6f8bdbb1742`.

Exact steps or command run after this patch:

```bash
OPENCLAW_LIVE_TEST=1 pnpm test:live -- extensions/moonshot/moonshot.live.test.ts
node scripts/run-vitest.mjs src/agents/embedded-agent-runner-extraparams-moonshot.test.ts extensions/moonshot/index.test.ts extensions/moonshot/moonshot.live.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json
```

Evidence after fix: [live workflow run 27451498132](https://github.com/openclaw/openclaw/actions/runs/27451498132), focused [Moonshot job 81147644615](https://github.com/openclaw/openclaw/actions/runs/27451498132/job/81147644615). The job checked out the exact SHA and passed all 7 tests, including `accepts a cross-model tool-call replay after backfilling reasoning_content` against K2.6 and `omits thinking controls and completes a replayed tool turn` against K2.7.

Observed result after fix: K2.6 accepted the repaired cross-model tool-call replay and completed the request; K2.7 replay also completed. Local focused tests, core/test type checks, lint/format, PR CI, and fresh autoreview are green.

What was not tested: A naturally accumulated 15-20 turn session crossing the LCM compaction threshold. The live test directly exercises the resulting malformed replay shape against the real Moonshot API.

## Related

Fixes https://github.com/openclaw/openclaw/issues/71491

## AI-Assisted

This PR was prepared with assistance from Claude Code.
