### PR TITLE
fix(auto-reply): clear pendingFinalDelivery before abort check to prevent stuck sessions (#89115)

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -3136,11 +3136,11 @@ export async function dispatchReplyFromConfig(
     }
 
     if (attemptedFinalDelivery && !finalDeliveryFailed) {
-      throwIfDispatchOperationAborted();
       await clearPendingFinalDeliveryAfterSuccess({
         storePath: sessionStoreEntry.storePath,
         sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
       });
+      throwIfDispatchOperationAborted();
     }
 
     if (!suppressDelivery) {


### PR DESCRIPTION
## Summary

Fix a race condition in `dispatch-from-config.ts` where `throwIfDispatchOperationAborted()` is called **before** `clearPendingFinalDeliveryAfterSuccess()`. When `recoverStuckDiagnosticSession` aborts the embedded run between `sendFinalPayload` succeeding and the clear call running, the message is delivered to the user but `pendingFinalDelivery` is never cleared.

**Result:** the session stays in `pendingFinalDelivery: true` indefinitely. New inbound messages are blocked by the get-reply redelivery short-circuit — the agent "goes silent" after a successful reply.

**Fix:** reorder the two calls so `clearPendingFinalDeliveryAfterSuccess()` runs first. The message was already delivered successfully (guarded by `attemptedFinalDelivery && !finalDeliveryFailed`), so clearing the flag is correct regardless of whether the abort fires afterwards.

## Verification

- 201 existing dispatch-from-config tests pass (all green)
- Live proof script exercises the exact production `updateSessionStoreEntry` module with a real session store, demonstrating the clear-before-abort ordering
- The change is a pure reorder — zero new logic, zero new branches

## Real behavior proof

**Behavior addressed:** Race condition in dispatch-from-config where `throwIfDispatchOperationAborted()` before `clearPendingFinalDeliveryAfterSuccess()` leaves `pendingFinalDelivery` stuck after a successful delivery is followed by an abort.

**Real environment tested:** Node v22.19.0, Linux x64, commit 2f9085526b. Production session-store modules imported via tsx.

**Exact steps or command run after this patch:**

$ ./node_modules/.bin/tsx scripts/proof-89115-pending-delivery-race.mts

**Evidence after fix (terminal capture):**

=== PR #92397 live-proof: pending final delivery race fix (#89115) ===
Temp dir: /tmp/openclaw-proof-89115-SskHwB
Step 1: Bootstrapped session store with initial entry.

--- Step 2: Write pendingFinalDelivery flags (pre-clear state) ---
Flags written.

--- Step 3: Verify flags BEFORE clear ---
$ pendingFinalDelivery: true
$ pendingFinalDeliveryText: simulated pending reply text
$ pendingFinalDeliveryAttemptCount: 1
PASS: Flags are set.

--- Step 4: Clear flags (simulating fixed code path) ---
Clear completed.

--- Step 5: Verify flags AFTER clear ---
$ pendingFinalDelivery: undefined
$ pendingFinalDeliveryText: undefined
PASS: Flags cleared.

--- Step 6: Race simulation — clear survives simulated abort ---
Flags reset for race simulation.
A: clearPendingFinalDeliveryAfterSuccess() done (fixed order: clear first).
B: throwIfDispatchOperationAborted() threw (simulated abort).

$ pendingFinalDelivery after abort: undefined
$ pendingFinalDeliveryText after abort: undefined
PASS: Flags remain cleared even after abort throws — fixed code path works.

=== Summary ===
Issue #89115: Race in dispatch-from-config
Old: throwIfDispatchOperationAborted() BEFORE clear → stuck flag → silent agent
New: clearPendingFinalDeliveryAfterSuccess() FIRST → clean state → resilient to abort
PR: https://github.com/openclaw/openclaw/pull/92397

=== All scenarios passed ===
Cleaned up: /tmp/openclaw-proof-89115-SskHwB

**Observed result after fix:** The proof script imports the real production `updateSessionStoreEntry` from `src/config/sessions/store.js` and exercises the exact same clearing logic as `clearPendingFinalDeliveryAfterSuccess`. Step 6 simulates the race: it resets flags, runs the clear FIRST (fixed order), then throws a simulated abort, and verifies the flags remain cleared. With the old order (abort before clear), the clear would never execute and the flags would stay stuck.

**What was not tested:** The timing-dependent race itself cannot be reliably triggered in a deterministic script. The proof validates the semantic correctness of the reorder by exercising the production session-store module with the exact clearing logic, and demonstrating that the fixed order (clear → abort) preserves clean state even when abort throws. Live production verification would require sustained load with `stuckSessionAbortMs` configured.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
