### PR TITLE
fix(llm): collapse cumulative openai-responses message snapshots instead of concatenating [AI-assisted]

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -438,6 +438,7 @@ describe("openai transport stream", () => {
   it("collapses cumulative message snapshot items into one text block (#91959)", async () => {
     const model = createAzureResponsesModel();
     const output = createResponsesAssistantOutput(model);
+    const pushSpy = vi.fn();
     const snapshot1 = "Scaled dot-product attention";
     const snapshot2 = "Scaled dot-product attention divides by sqrt(d_k)";
     const snapshot3 = "Scaled dot-product attention divides by sqrt(d_k) before softmax.";
@@ -472,7 +473,7 @@ describe("openai transport stream", () => {
         },
       ]),
       output,
-      { push: vi.fn() },
+      { push: pushSpy },
       model,
     );
 
@@ -482,6 +483,18 @@ describe("openai transport stream", () => {
         text: snapshot3,
         textSignature: '{"v":1,"id":"msg_3","phase":"final_answer"}',
       },
+    ]);
+    // Balanced lifecycle: one text_start, all events on index 0, and each
+    // collapsed snapshot re-ends the same block.
+    const textEvents = pushSpy.mock.calls
+      .map(([event]) => event as { type: string; contentIndex?: number })
+      .filter((event) => event.type.startsWith("text_"));
+    expect(textEvents.map((event) => [event.type, event.contentIndex])).toEqual([
+      ["text_start", 0],
+      ["text_delta", 0],
+      ["text_end", 0],
+      ["text_end", 0],
+      ["text_end", 0],
     ]);
   });
 

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -435,6 +435,154 @@ describe("openai transport stream", () => {
     ]);
   });
 
+  it("collapses cumulative message snapshot items into one text block (#91959)", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+    const snapshot1 = "Scaled dot-product attention";
+    const snapshot2 = "Scaled dot-product attention divides by sqrt(d_k)";
+    const snapshot3 = "Scaled dot-product attention divides by sqrt(d_k) before softmax.";
+    const messageItem = (id: string, text: string) => ({
+      type: "message",
+      id,
+      phase: "final_answer",
+      content: [{ type: "output_text", text }],
+    });
+
+    await testing.processResponsesStream(
+      streamChunks([
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_1", phase: "final_answer" },
+        },
+        { type: "response.output_text.delta", delta: snapshot1 },
+        { type: "response.output_item.done", item: messageItem("msg_1", snapshot1) },
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_2", phase: "final_answer" },
+        },
+        { type: "response.output_item.done", item: messageItem("msg_2", snapshot2) },
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_3", phase: "final_answer" },
+        },
+        { type: "response.output_item.done", item: messageItem("msg_3", snapshot3) },
+        {
+          type: "response.completed",
+          response: { id: "resp-snapshots", status: "completed" },
+        },
+      ]),
+      output,
+      { push: vi.fn() },
+      model,
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "text",
+        text: snapshot3,
+        textSignature: '{"v":1,"id":"msg_1","phase":"final_answer"}',
+      },
+    ]);
+  });
+
+  it("keeps prefix-nested message items separated by a tool call as separate blocks", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+    const messageEvents = (id: string, text: string) => [
+      { type: "response.output_item.added", item: { type: "message", id } },
+      {
+        type: "response.output_item.done",
+        item: { type: "message", id, content: [{ type: "output_text", text }] },
+      },
+    ];
+
+    await testing.processResponsesStream(
+      streamChunks([
+        ...messageEvents("msg_1", "Done."),
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "write",
+            arguments: "{}",
+          },
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "write",
+            arguments: "{}",
+          },
+        },
+        ...messageEvents("msg_2", "Done."),
+        {
+          type: "response.completed",
+          response: { id: "resp-tool-boundary", status: "completed" },
+        },
+      ]),
+      output,
+      { push: vi.fn() },
+      model,
+    );
+
+    // The post-tool message is a real reply, not a snapshot of the pre-tool one.
+    expect(output.content.map((block) => block.type)).toEqual(["text", "toolCall", "text"]);
+    expect(output.content[2]).toMatchObject({ type: "text", text: "Done." });
+  });
+
+  it("collapses cumulative message snapshots in completed-response backfill (#91959)", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+
+    await testing.processResponsesStream(
+      streamChunks([
+        {
+          type: "response.completed",
+          response: {
+            id: "resp-backfill-snapshots",
+            status: "completed",
+            output: [
+              {
+                type: "message",
+                id: "msg_1",
+                role: "assistant",
+                content: [{ type: "output_text", text: "The answer" }],
+              },
+              {
+                type: "message",
+                id: "msg_2",
+                role: "assistant",
+                content: [{ type: "output_text", text: "The answer is 42." }],
+              },
+              {
+                type: "message",
+                id: "msg_3",
+                role: "assistant",
+                content: [{ type: "output_text", text: "The answer" }],
+              },
+            ],
+          },
+        },
+      ]),
+      output,
+      { push: vi.fn() },
+      model,
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "text",
+        text: "The answer is 42.",
+        textSignature: '{"v":1,"id":"msg_1"}',
+      },
+    ]);
+  });
+
   it("backfills Azure Responses completed function calls when item events are absent", async () => {
     const model = createAzureResponsesModel();
     const output = createResponsesAssistantOutput(model);

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -480,7 +480,7 @@ describe("openai transport stream", () => {
       {
         type: "text",
         text: snapshot3,
-        textSignature: '{"v":1,"id":"msg_1","phase":"final_answer"}',
+        textSignature: '{"v":1,"id":"msg_3","phase":"final_answer"}',
       },
     ]);
   });
@@ -574,11 +574,18 @@ describe("openai transport stream", () => {
       model,
     );
 
+    // msg_2 strictly extends msg_1 and collapses into it; msg_3 shrinks back
+    // and is an independently identified message, so it stays a real block.
     expect(output.content).toEqual([
       {
         type: "text",
         text: "The answer is 42.",
-        textSignature: '{"v":1,"id":"msg_1"}',
+        textSignature: '{"v":1,"id":"msg_2"}',
+      },
+      {
+        type: "text",
+        text: "The answer",
+        textSignature: '{"v":1,"id":"msg_3"}',
       },
     ]);
   });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -603,6 +603,48 @@ describe("openai transport stream", () => {
     ]);
   });
 
+  it("keeps backfill message items separated by a reasoning item as distinct blocks", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+
+    await testing.processResponsesStream(
+      streamChunks([
+        {
+          type: "response.completed",
+          response: {
+            id: "resp-backfill-reasoning-boundary",
+            status: "completed",
+            output: [
+              {
+                type: "message",
+                id: "msg_1",
+                role: "assistant",
+                content: [{ type: "output_text", text: "Step one." }],
+              },
+              { type: "reasoning", id: "rs_1", summary: [] },
+              {
+                type: "message",
+                id: "msg_2",
+                role: "assistant",
+                content: [{ type: "output_text", text: "Step one. Step two." }],
+              },
+            ],
+          },
+        },
+      ]),
+      output,
+      { push: vi.fn() },
+      model,
+    );
+
+    // A reasoning item is a real boundary even in backfill: msg_2 must not
+    // collapse into msg_1 despite being a strict extension (mirrors streaming).
+    expect(output.content).toEqual([
+      { type: "text", text: "Step one.", textSignature: '{"v":1,"id":"msg_1"}' },
+      { type: "text", text: "Step one. Step two.", textSignature: '{"v":1,"id":"msg_2"}' },
+    ]);
+  });
+
   it("backfills Azure Responses completed function calls when item events are absent", async () => {
     const model = createAzureResponsesModel();
     const output = createResponsesAssistantOutput(model);

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -38,6 +38,7 @@ import { isOpenAICompatibleAzureResponsesBaseUrl } from "../shared/azure-openai-
 import {
   isResponsesTextContentPartType,
   isResponsesTextDeltaEventType,
+  resolveResponsesMessageSnapshotCollapse,
 } from "../shared/openai-responses-stream-compat.js";
 import { createReasoningTagTextPartitioner } from "../shared/text/reasoning-tag-text-partitioner.js";
 import { CHARS_PER_TOKEN_ESTIMATE, estimateStringChars } from "../utils/cjk-chars.js";
@@ -1474,6 +1475,11 @@ async function processResponsesStream(
 ) {
   let currentItem: Record<string, unknown> | null = null;
   let currentBlock: Record<string, unknown> | null = null;
+  let lastTextBlock: {
+    block: Record<string, unknown>;
+    index: number;
+    phase: "commentary" | "final_answer" | undefined;
+  } | null = null;
   const streamStartedAt = Date.now();
   let eventCount = 0;
   const eventTypes = new Map<string, number>();
@@ -1484,15 +1490,36 @@ async function processResponsesStream(
     if (!text) {
       return;
     }
+    const phase = (item.phase as "commentary" | "final_answer" | undefined) ?? undefined;
+    const collapse = resolveResponsesMessageSnapshotCollapse({
+      prior: lastTextBlock && {
+        text: stringifyUnknown(lastTextBlock.block.text),
+        phase: lastTextBlock.phase,
+      },
+      nextText: text,
+      nextPhase: phase,
+    });
+    if (collapse.kind === "drop") {
+      return;
+    }
+    if (collapse.kind === "extend" && lastTextBlock) {
+      // Cumulative snapshot of the prior message item: replace, don't append (#91959).
+      lastTextBlock.block.text = collapse.text;
+      stream.push({
+        type: "text_end",
+        contentIndex: lastTextBlock.index,
+        content: collapse.text,
+        partial: output,
+      });
+      return;
+    }
     const block: Record<string, unknown> = {
       type: "text",
       text,
-      textSignature: encodeTextSignatureV1(
-        stringifyUnknown(item.id),
-        (item.phase as "commentary" | "final_answer" | undefined) ?? undefined,
-      ),
+      textSignature: encodeTextSignatureV1(stringifyUnknown(item.id), phase),
     };
     output.content.push(block);
+    lastTextBlock = { block, index: blockIndex(), phase };
     stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
     stream.push({
       type: "text_end",
@@ -1502,6 +1529,8 @@ async function processResponsesStream(
     });
   };
   const appendCompletedResponseToolCallItem = (item: Record<string, unknown>) => {
+    // A tool call is a real message boundary; never collapse text across it.
+    lastTextBlock = null;
     const args = parseStreamingJson(stringifyJsonLike(item.arguments, "{}"));
     const block = {
       type: "toolCall",
@@ -1569,6 +1598,11 @@ async function processResponsesStream(
       output.responseId = stringifyUnknown((event.response as { id?: string } | undefined)?.id);
     } else if (type === "response.output_item.added") {
       const item = event.item as Record<string, unknown>;
+      if (item.type !== "message") {
+        // Snapshot collapse only applies to back-to-back message items; any
+        // other item is a real boundary (see resolveResponsesMessageSnapshotCollapse).
+        lastTextBlock = null;
+      }
       if (item.type === "reasoning") {
         currentItem = item;
         currentBlock = { type: "thinking", thinking: "" };
@@ -1623,6 +1657,9 @@ async function processResponsesStream(
       }
     } else if (type === "response.output_item.done") {
       const item = event.item as Record<string, unknown>;
+      if (item.type !== "message") {
+        lastTextBlock = null;
+      }
       if (item.type === "reasoning" && currentBlock?.type === "thinking") {
         const summary = Array.isArray(item.summary)
           ? item.summary
@@ -1658,16 +1695,39 @@ async function processResponsesStream(
               : (contentPart.refusal ?? "");
           })
           .join("");
-        currentBlock.textSignature = encodeTextSignatureV1(
-          stringifyUnknown(item.id),
-          (item.phase as "commentary" | "final_answer" | undefined) ?? undefined,
-        );
-        stream.push({
-          type: "text_end",
-          contentIndex: blockIndex(),
-          content: stringifyUnknown(currentBlock.text),
-          partial: output,
+        const phase = (item.phase as "commentary" | "final_answer" | undefined) ?? undefined;
+        const collapse = resolveResponsesMessageSnapshotCollapse({
+          prior: lastTextBlock && {
+            text: stringifyUnknown(lastTextBlock.block.text),
+            phase: lastTextBlock.phase,
+          },
+          nextText: stringifyUnknown(currentBlock.text),
+          nextPhase: phase,
         });
+        if (collapse.kind === "keep") {
+          currentBlock.textSignature = encodeTextSignatureV1(stringifyUnknown(item.id), phase);
+          lastTextBlock = { block: currentBlock, index: blockIndex(), phase };
+          stream.push({
+            type: "text_end",
+            contentIndex: blockIndex(),
+            content: stringifyUnknown(currentBlock.text),
+            partial: output,
+          });
+        } else if (lastTextBlock) {
+          // Cumulative snapshot of the prior message item: replace its text
+          // instead of appending another copy. The first item's signature is
+          // kept so replay and stream-item identity stay stable (#91959).
+          output.content.pop();
+          if (collapse.kind === "extend") {
+            lastTextBlock.block.text = collapse.text;
+            stream.push({
+              type: "text_end",
+              contentIndex: lastTextBlock.index,
+              content: collapse.text,
+              partial: output,
+            });
+          }
+        }
         currentBlock = null;
       } else if (item.type === "function_call") {
         const args =

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1499,12 +1499,11 @@ async function processResponsesStream(
       nextText: text,
       nextPhase: phase,
     });
-    if (collapse.kind === "drop") {
-      return;
-    }
     if (collapse.kind === "extend" && lastTextBlock) {
-      // Cumulative snapshot of the prior message item: replace, don't append (#91959).
+      // Cumulative snapshot of the prior message item: replace, don't append;
+      // the newest item's signature carries the content for replay (#91959).
       lastTextBlock.block.text = collapse.text;
+      lastTextBlock.block.textSignature = encodeTextSignatureV1(stringifyUnknown(item.id), phase);
       stream.push({
         type: "text_end",
         contentIndex: lastTextBlock.index,
@@ -1704,7 +1703,23 @@ async function processResponsesStream(
           nextText: stringifyUnknown(currentBlock.text),
           nextPhase: phase,
         });
-        if (collapse.kind === "keep") {
+        if (collapse.kind === "extend" && lastTextBlock) {
+          // Cumulative snapshot of the prior message item: replace its text
+          // instead of appending another copy. The newest item's signature is
+          // kept so replay carries the item that produced this content (#91959).
+          output.content.pop();
+          lastTextBlock.block.text = collapse.text;
+          lastTextBlock.block.textSignature = encodeTextSignatureV1(
+            stringifyUnknown(item.id),
+            phase,
+          );
+          stream.push({
+            type: "text_end",
+            contentIndex: lastTextBlock.index,
+            content: collapse.text,
+            partial: output,
+          });
+        } else {
           currentBlock.textSignature = encodeTextSignatureV1(stringifyUnknown(item.id), phase);
           lastTextBlock = { block: currentBlock, index: blockIndex(), phase };
           stream.push({
@@ -1713,20 +1728,6 @@ async function processResponsesStream(
             content: stringifyUnknown(currentBlock.text),
             partial: output,
           });
-        } else if (lastTextBlock) {
-          // Cumulative snapshot of the prior message item: replace its text
-          // instead of appending another copy. The first item's signature is
-          // kept so replay and stream-item identity stay stable (#91959).
-          output.content.pop();
-          if (collapse.kind === "extend") {
-            lastTextBlock.block.text = collapse.text;
-            stream.push({
-              type: "text_end",
-              contentIndex: lastTextBlock.index,
-              content: collapse.text,
-              partial: output,
-            });
-          }
         }
         currentBlock = null;
       } else if (item.type === "function_call") {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1480,11 +1480,29 @@ async function processResponsesStream(
     index: number;
     phase: "commentary" | "final_answer" | undefined;
   } | null = null;
+  // While a message item may still be a cumulative snapshot of lastTextBlock,
+  // its public block is deferred so a collapsed item never leaves an
+  // unbalanced text_start behind (#91959). null = no deferral in progress.
+  let pendingMessageText: string | null = null;
   const streamStartedAt = Date.now();
   let eventCount = 0;
   const eventTypes = new Map<string, number>();
   const sseDebugMode = resolveModelSseDebugMode();
   const blockIndex = () => output.content.length - 1;
+  const appendPendingMessageDelta = (delta: string) => {
+    pendingMessageText = `${pendingMessageText ?? ""}${delta}`;
+    const priorText = stringifyUnknown(lastTextBlock?.block.text);
+    if (priorText.startsWith(pendingMessageText) || pendingMessageText.startsWith(priorText)) {
+      return;
+    }
+    // Diverged from the prior text: this is a distinct message, so open its
+    // block now and replay the withheld text as one delta.
+    currentBlock = { type: "text", text: pendingMessageText };
+    output.content.push(currentBlock);
+    stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+    stream.push({ type: "text_delta", contentIndex: blockIndex(), delta: pendingMessageText });
+    pendingMessageText = null;
+  };
   const appendCompletedResponseTextItem = (item: Record<string, unknown>) => {
     const text = readResponsesOutputMessageText(item);
     if (!text) {
@@ -1601,6 +1619,7 @@ async function processResponsesStream(
         // Snapshot collapse only applies to back-to-back message items; any
         // other item is a real boundary (see resolveResponsesMessageSnapshotCollapse).
         lastTextBlock = null;
+        pendingMessageText = null;
       }
       if (item.type === "reasoning") {
         currentItem = item;
@@ -1609,9 +1628,14 @@ async function processResponsesStream(
         stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
       } else if (item.type === "message") {
         currentItem = item;
-        currentBlock = { type: "text", text: "" };
-        output.content.push(currentBlock);
-        stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+        if (lastTextBlock) {
+          currentBlock = null;
+          pendingMessageText = "";
+        } else {
+          currentBlock = { type: "text", text: "" };
+          output.content.push(currentBlock);
+          stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+        }
       } else if (item.type === "function_call") {
         currentItem = item;
         currentBlock = {
@@ -1635,13 +1659,17 @@ async function processResponsesStream(
         });
       }
     } else if (isResponsesTextDeltaEventType(type) || type === "response.refusal.delta") {
-      if (currentItem?.type === "message" && currentBlock?.type === "text") {
-        currentBlock.text = `${stringifyUnknown(currentBlock.text)}${stringifyUnknown(event.delta)}`;
-        stream.push({
-          type: "text_delta",
-          contentIndex: blockIndex(),
-          delta: stringifyUnknown(event.delta),
-        });
+      if (currentItem?.type === "message") {
+        if (pendingMessageText !== null) {
+          appendPendingMessageDelta(stringifyUnknown(event.delta));
+        } else if (currentBlock?.type === "text") {
+          currentBlock.text = `${stringifyUnknown(currentBlock.text)}${stringifyUnknown(event.delta)}`;
+          stream.push({
+            type: "text_delta",
+            contentIndex: blockIndex(),
+            delta: stringifyUnknown(event.delta),
+          });
+        }
       }
     } else if (type === "response.function_call_arguments.delta") {
       if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
@@ -1658,6 +1686,7 @@ async function processResponsesStream(
       const item = event.item as Record<string, unknown>;
       if (item.type !== "message") {
         lastTextBlock = null;
+        pendingMessageText = null;
       }
       if (item.type === "reasoning" && currentBlock?.type === "thinking") {
         const summary = Array.isArray(item.summary)
@@ -1684,9 +1713,12 @@ async function processResponsesStream(
           partial: output,
         });
         currentBlock = null;
-      } else if (item.type === "message" && currentBlock?.type === "text") {
+      } else if (
+        item.type === "message" &&
+        (currentBlock?.type === "text" || pendingMessageText !== null)
+      ) {
         const content = Array.isArray(item.content) ? item.content : [];
-        currentBlock.text = content
+        const finalText = content
           .map((part) => {
             const contentPart = part as { type?: string; text?: string; refusal?: string };
             return isResponsesTextContentPartType(contentPart.type)
@@ -1695,19 +1727,23 @@ async function processResponsesStream(
           })
           .join("");
         const phase = (item.phase as "commentary" | "final_answer" | undefined) ?? undefined;
-        const collapse = resolveResponsesMessageSnapshotCollapse({
-          prior: lastTextBlock && {
-            text: stringifyUnknown(lastTextBlock.block.text),
-            phase: lastTextBlock.phase,
-          },
-          nextText: stringifyUnknown(currentBlock.text),
-          nextPhase: phase,
-        });
+        const collapse =
+          pendingMessageText !== null
+            ? resolveResponsesMessageSnapshotCollapse({
+                prior: lastTextBlock && {
+                  text: stringifyUnknown(lastTextBlock.block.text),
+                  phase: lastTextBlock.phase,
+                },
+                nextText: finalText,
+                nextPhase: phase,
+              })
+            : ({ kind: "keep" } as const);
+        pendingMessageText = null;
         if (collapse.kind === "extend" && lastTextBlock) {
           // Cumulative snapshot of the prior message item: replace its text
-          // instead of appending another copy. The newest item's signature is
-          // kept so replay carries the item that produced this content (#91959).
-          output.content.pop();
+          // instead of appending another copy. The deferred block was never
+          // started publicly, and the newest item's signature is kept so
+          // replay carries the item that produced this content (#91959).
           lastTextBlock.block.text = collapse.text;
           lastTextBlock.block.textSignature = encodeTextSignatureV1(
             stringifyUnknown(item.id),
@@ -1720,6 +1756,14 @@ async function processResponsesStream(
             partial: output,
           });
         } else {
+          if (currentBlock?.type !== "text") {
+            // Deferred distinct message: open its block now, balanced with the
+            // text_end below.
+            currentBlock = { type: "text", text: "" };
+            output.content.push(currentBlock);
+            stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+          }
+          currentBlock.text = finalText;
           currentBlock.textSignature = encodeTextSignatureV1(stringifyUnknown(item.id), phase);
           lastTextBlock = { block: currentBlock, index: blockIndex(), phase };
           stream.push({

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1546,8 +1546,6 @@ async function processResponsesStream(
     });
   };
   const appendCompletedResponseToolCallItem = (item: Record<string, unknown>) => {
-    // A tool call is a real message boundary; never collapse text across it.
-    lastTextBlock = null;
     const args = parseStreamingJson(stringifyJsonLike(item.arguments, "{}"));
     const block = {
       type: "toolCall",
@@ -1580,7 +1578,12 @@ async function processResponsesStream(
       }
       if (rawItem.type === "message") {
         appendCompletedResponseTextItem(rawItem);
-      } else if (rawItem.type === "function_call") {
+        continue;
+      }
+      // Any non-message item (reasoning, tool call) is a real boundary; a later
+      // message must not collapse across it, mirroring the streaming path.
+      lastTextBlock = null;
+      if (rawItem.type === "function_call") {
         appendCompletedResponseToolCallItem(rawItem);
       }
     }

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -587,6 +587,237 @@ describe("processResponsesStream", () => {
       "toolcall_end",
     ]);
   });
+
+  it("collapses cumulative message snapshot items into one text block (#91959)", async () => {
+    const output = createAssistantOutput();
+    const stream = new AssistantMessageEventStream();
+    const events: Array<Record<string, unknown>> = [];
+    const collect = (async () => {
+      for await (const event of stream) {
+        events.push(event as unknown as Record<string, unknown>);
+      }
+    })();
+
+    const snapshot1 = "Self-attention computes";
+    const snapshot2 = "Self-attention computes Q/K/V projections";
+    const snapshot3 = "Self-attention computes Q/K/V projections for each token.";
+    const messageItem = (id: string, text: string) => ({
+      type: "message",
+      id,
+      phase: "final_answer",
+      content: [{ type: "output_text", text }],
+    });
+
+    await processResponsesStream(
+      responseEvents([
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_1", phase: "final_answer" },
+        },
+        { type: "response.content_part.added", part: { type: "output_text", text: "" } },
+        { type: "response.output_text.delta", delta: snapshot1 },
+        { type: "response.output_item.done", item: messageItem("msg_1", snapshot1) },
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_2", phase: "final_answer" },
+        },
+        { type: "response.output_item.done", item: messageItem("msg_2", snapshot2) },
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_3", phase: "final_answer" },
+        },
+        { type: "response.output_item.done", item: messageItem("msg_3", snapshot3) },
+        { type: "response.completed", response: { id: "resp_1", status: "completed" } },
+      ]),
+      output,
+      stream,
+      nativeOpenAIModel,
+    );
+    stream.end();
+    await collect;
+
+    expect(output.content).toEqual([
+      {
+        type: "text",
+        text: snapshot3,
+        textSignature: JSON.stringify({ v: 1, id: "msg_1", phase: "final_answer" }),
+      },
+    ]);
+    const textEnds = events.filter((event) => event.type === "text_end");
+    expect(textEnds.map((event) => event.contentIndex)).toEqual([0, 0, 0]);
+    expect(textEnds.at(-1)?.content).toBe(snapshot3);
+  });
+
+  it("drops a repeated message snapshot without growing the text block", async () => {
+    const output = createAssistantOutput();
+    const stream = new AssistantMessageEventStream();
+    const collect = (async () => {
+      for await (const _event of stream) {
+        // drain
+      }
+    })();
+
+    await processResponsesStream(
+      responseEvents([
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_1", phase: "final_answer" },
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_1",
+            phase: "final_answer",
+            content: [{ type: "output_text", text: "Hello world." }],
+          },
+        },
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_2", phase: "final_answer" },
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_2",
+            phase: "final_answer",
+            content: [{ type: "output_text", text: "Hello world." }],
+          },
+        },
+        { type: "response.completed", response: { id: "resp_1", status: "completed" } },
+      ]),
+      output,
+      stream,
+      nativeOpenAIModel,
+    );
+    stream.end();
+    await collect;
+
+    expect(output.content).toEqual([
+      {
+        type: "text",
+        text: "Hello world.",
+        textSignature: JSON.stringify({ v: 1, id: "msg_1", phase: "final_answer" }),
+      },
+    ]);
+  });
+
+  it("keeps prefix-nested message items separated by a reasoning item as separate blocks", async () => {
+    const output = createAssistantOutput();
+    const stream = new AssistantMessageEventStream();
+    const collect = (async () => {
+      for await (const _event of stream) {
+        // drain
+      }
+    })();
+
+    await processResponsesStream(
+      responseEvents([
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_1", phase: "final_answer" },
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_1",
+            phase: "final_answer",
+            content: [{ type: "output_text", text: "Step one." }],
+          },
+        },
+        { type: "response.output_item.added", item: { type: "reasoning" } },
+        {
+          type: "response.output_item.done",
+          item: { type: "reasoning", id: "rs_1", summary: [] },
+        },
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_2", phase: "final_answer" },
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_2",
+            phase: "final_answer",
+            content: [{ type: "output_text", text: "Step one. Step two." }],
+          },
+        },
+        { type: "response.completed", response: { id: "resp_1", status: "completed" } },
+      ]),
+      output,
+      stream,
+      nativeOpenAIModel,
+    );
+    stream.end();
+    await collect;
+
+    // Collapsing across the reasoning block would orphan it for replay.
+    expect(output.content.map((block) => block.type)).toEqual(["text", "thinking", "text"]);
+    expect(output.content[2]).toMatchObject({ type: "text", text: "Step one. Step two." });
+  });
+
+  it("keeps prefix-nested message items with different phases as separate blocks", async () => {
+    const output = createAssistantOutput();
+    const stream = new AssistantMessageEventStream();
+    const collect = (async () => {
+      for await (const _event of stream) {
+        // drain
+      }
+    })();
+
+    await processResponsesStream(
+      responseEvents([
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_1", phase: "commentary" },
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_1",
+            phase: "commentary",
+            content: [{ type: "output_text", text: "Done" }],
+          },
+        },
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_2", phase: "final_answer" },
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_2",
+            phase: "final_answer",
+            content: [{ type: "output_text", text: "Done." }],
+          },
+        },
+        { type: "response.completed", response: { id: "resp_1", status: "completed" } },
+      ]),
+      output,
+      stream,
+      nativeOpenAIModel,
+    );
+    stream.end();
+    await collect;
+
+    expect(output.content).toEqual([
+      {
+        type: "text",
+        text: "Done",
+        textSignature: JSON.stringify({ v: 1, id: "msg_1", phase: "commentary" }),
+      },
+      {
+        type: "text",
+        text: "Done.",
+        textSignature: JSON.stringify({ v: 1, id: "msg_2", phase: "final_answer" }),
+      },
+    ]);
+  });
 });
 
 describe("Azure OpenAI Responses content type support", () => {

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -640,7 +640,7 @@ describe("processResponsesStream", () => {
       {
         type: "text",
         text: snapshot3,
-        textSignature: JSON.stringify({ v: 1, id: "msg_1", phase: "final_answer" }),
+        textSignature: JSON.stringify({ v: 1, id: "msg_3", phase: "final_answer" }),
       },
     ]);
     const textEnds = events.filter((event) => event.type === "text_end");
@@ -648,7 +648,10 @@ describe("processResponsesStream", () => {
     expect(textEnds.at(-1)?.content).toBe(snapshot3);
   });
 
-  it("drops a repeated message snapshot without growing the text block", async () => {
+  it.each([
+    ["identical", "Hello world.", "Hello world."],
+    ["shrinking", "Step one. Step two.", "Step one."],
+  ])("keeps %s adjacent same-phase message items as distinct blocks", async (_label, a, b) => {
     const output = createAssistantOutput();
     const stream = new AssistantMessageEventStream();
     await processResponsesStream(
@@ -663,7 +666,7 @@ describe("processResponsesStream", () => {
             type: "message",
             id: "msg_1",
             phase: "final_answer",
-            content: [{ type: "output_text", text: "Hello world." }],
+            content: [{ type: "output_text", text: a }],
           },
         },
         {
@@ -676,7 +679,7 @@ describe("processResponsesStream", () => {
             type: "message",
             id: "msg_2",
             phase: "final_answer",
-            content: [{ type: "output_text", text: "Hello world." }],
+            content: [{ type: "output_text", text: b }],
           },
         },
         { type: "response.completed", response: { id: "resp_1", status: "completed" } },
@@ -687,11 +690,18 @@ describe("processResponsesStream", () => {
     );
     stream.end();
 
+    // Only strict extensions collapse; equal or shrinking items are real,
+    // independently identified messages and must never be removed.
     expect(output.content).toEqual([
       {
         type: "text",
-        text: "Hello world.",
+        text: a,
         textSignature: JSON.stringify({ v: 1, id: "msg_1", phase: "final_answer" }),
+      },
+      {
+        type: "text",
+        text: b,
+        textSignature: JSON.stringify({ v: 1, id: "msg_2", phase: "final_answer" }),
       },
     ]);
   });

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -643,9 +643,18 @@ describe("processResponsesStream", () => {
         textSignature: JSON.stringify({ v: 1, id: "msg_3", phase: "final_answer" }),
       },
     ]);
-    const textEnds = events.filter((event) => event.type === "text_end");
-    expect(textEnds.map((event) => event.contentIndex)).toEqual([0, 0, 0]);
-    expect(textEnds.at(-1)?.content).toBe(snapshot3);
+    // Balanced lifecycle: exactly one text_start, every event on index 0, and
+    // each collapsed snapshot re-ends the same block with its grown content.
+    expect(events.map((event) => [event.type, event.contentIndex])).toEqual([
+      ["text_start", 0],
+      ["text_delta", 0],
+      ["text_end", 0],
+      ["text_end", 0],
+      ["text_end", 0],
+    ]);
+    expect(
+      events.filter((event) => event.type === "text_end").map((event) => event.content),
+    ).toEqual([snapshot1, snapshot2, snapshot3]);
   });
 
   it.each([
@@ -654,6 +663,12 @@ describe("processResponsesStream", () => {
   ])("keeps %s adjacent same-phase message items as distinct blocks", async (_label, a, b) => {
     const output = createAssistantOutput();
     const stream = new AssistantMessageEventStream();
+    const events: Array<Record<string, unknown>> = [];
+    const collect = (async () => {
+      for await (const event of stream) {
+        events.push(event as unknown as Record<string, unknown>);
+      }
+    })();
     await processResponsesStream(
       responseEvents([
         {
@@ -689,6 +704,7 @@ describe("processResponsesStream", () => {
       nativeOpenAIModel,
     );
     stream.end();
+    await collect;
 
     // Only strict extensions collapse; equal or shrinking items are real,
     // independently identified messages and must never be removed.
@@ -703,6 +719,87 @@ describe("processResponsesStream", () => {
         text: b,
         textSignature: JSON.stringify({ v: 1, id: "msg_2", phase: "final_answer" }),
       },
+    ]);
+    // The deferred second item still opens and closes its own block.
+    expect(events.map((event) => [event.type, event.contentIndex])).toEqual([
+      ["text_start", 0],
+      ["text_end", 0],
+      ["text_start", 1],
+      ["text_end", 1],
+    ]);
+  });
+
+  it("streams a deferred distinct message live once its text diverges from the prior block", async () => {
+    const output = createAssistantOutput();
+    const stream = new AssistantMessageEventStream();
+    const events: Array<Record<string, unknown>> = [];
+    const collect = (async () => {
+      for await (const event of stream) {
+        events.push(event as unknown as Record<string, unknown>);
+      }
+    })();
+
+    await processResponsesStream(
+      responseEvents([
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_1", phase: "final_answer" },
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_1",
+            phase: "final_answer",
+            content: [{ type: "output_text", text: "Hello." }],
+          },
+        },
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_2", phase: "final_answer" },
+        },
+        { type: "response.content_part.added", part: { type: "output_text", text: "" } },
+        { type: "response.output_text.delta", delta: "Good" },
+        { type: "response.output_text.delta", delta: "bye" },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_2",
+            phase: "final_answer",
+            content: [{ type: "output_text", text: "Goodbye" }],
+          },
+        },
+        { type: "response.completed", response: { id: "resp_1", status: "completed" } },
+      ]),
+      output,
+      stream,
+      nativeOpenAIModel,
+    );
+    stream.end();
+    await collect;
+
+    expect(output.content).toEqual([
+      {
+        type: "text",
+        text: "Hello.",
+        textSignature: JSON.stringify({ v: 1, id: "msg_1", phase: "final_answer" }),
+      },
+      {
+        type: "text",
+        text: "Goodbye",
+        textSignature: JSON.stringify({ v: 1, id: "msg_2", phase: "final_answer" }),
+      },
+    ]);
+    // The withheld prefix is replayed as one delta at divergence ("Good"
+    // diverges from "Hello."), then later deltas stream live.
+    expect(events.map((event) => [event.type, event.contentIndex, event.delta ?? null])).toEqual([
+      ["text_start", 0, null],
+      ["text_end", 0, null],
+      ["text_start", 1, null],
+      ["text_delta", 1, "Good"],
+      ["text_delta", 1, "bye"],
+      ["text_end", 1, null],
     ]);
   });
 

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -651,12 +651,6 @@ describe("processResponsesStream", () => {
   it("drops a repeated message snapshot without growing the text block", async () => {
     const output = createAssistantOutput();
     const stream = new AssistantMessageEventStream();
-    const collect = (async () => {
-      for await (const _event of stream) {
-        // drain
-      }
-    })();
-
     await processResponsesStream(
       responseEvents([
         {
@@ -692,7 +686,6 @@ describe("processResponsesStream", () => {
       nativeOpenAIModel,
     );
     stream.end();
-    await collect;
 
     expect(output.content).toEqual([
       {
@@ -706,12 +699,6 @@ describe("processResponsesStream", () => {
   it("keeps prefix-nested message items separated by a reasoning item as separate blocks", async () => {
     const output = createAssistantOutput();
     const stream = new AssistantMessageEventStream();
-    const collect = (async () => {
-      for await (const _event of stream) {
-        // drain
-      }
-    })();
-
     await processResponsesStream(
       responseEvents([
         {
@@ -752,7 +739,6 @@ describe("processResponsesStream", () => {
       nativeOpenAIModel,
     );
     stream.end();
-    await collect;
 
     // Collapsing across the reasoning block would orphan it for replay.
     expect(output.content.map((block) => block.type)).toEqual(["text", "thinking", "text"]);
@@ -762,12 +748,6 @@ describe("processResponsesStream", () => {
   it("keeps prefix-nested message items with different phases as separate blocks", async () => {
     const output = createAssistantOutput();
     const stream = new AssistantMessageEventStream();
-    const collect = (async () => {
-      for await (const _event of stream) {
-        // drain
-      }
-    })();
-
     await processResponsesStream(
       responseEvents([
         {
@@ -803,7 +783,6 @@ describe("processResponsesStream", () => {
       nativeOpenAIModel,
     );
     stream.end();
-    await collect;
 
     expect(output.content).toEqual([
       {

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -585,8 +585,31 @@ export async function processResponsesStream<TApi extends Api>(
     index: number;
     phase: TextSignatureV1["phase"] | undefined;
   } | null = null;
+  // While a message item may still be a cumulative snapshot of lastTextBlock,
+  // its public block is deferred so a collapsed item never leaves an
+  // unbalanced text_start behind (#91959). null = no deferral in progress.
+  let pendingMessageText: string | null = null;
   const blocks = output.content;
   const blockIndex = () => blocks.length - 1;
+  const appendPendingMessageDelta = (delta: string) => {
+    pendingMessageText = `${pendingMessageText ?? ""}${delta}`;
+    const priorText = lastTextBlock?.block.text ?? "";
+    if (priorText.startsWith(pendingMessageText) || pendingMessageText.startsWith(priorText)) {
+      return;
+    }
+    // Diverged from the prior text: this is a distinct message, so open its
+    // block now and replay the withheld text as one delta.
+    currentBlock = { type: "text", text: pendingMessageText };
+    blocks.push(currentBlock);
+    stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+    stream.push({
+      type: "text_delta",
+      contentIndex: blockIndex(),
+      delta: pendingMessageText,
+      partial: output,
+    });
+    pendingMessageText = null;
+  };
 
   for await (const event of openaiStream) {
     if (event.type === "response.created") {
@@ -597,6 +620,7 @@ export async function processResponsesStream<TApi extends Api>(
         // Snapshot collapse only applies to back-to-back message items; any
         // other item is a real boundary (see resolveResponsesMessageSnapshotCollapse).
         lastTextBlock = null;
+        pendingMessageText = null;
       }
       if (item.type === "reasoning") {
         currentItem = item;
@@ -605,9 +629,14 @@ export async function processResponsesStream<TApi extends Api>(
         stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
       } else if (item.type === "message") {
         currentItem = item;
-        currentBlock = { type: "text", text: "" };
-        output.content.push(currentBlock);
-        stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+        if (lastTextBlock) {
+          currentBlock = null;
+          pendingMessageText = "";
+        } else {
+          currentBlock = { type: "text", text: "" };
+          output.content.push(currentBlock);
+          stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+        }
       } else if (item.type === "function_call") {
         currentItem = item;
         currentBlock = {
@@ -677,54 +706,66 @@ export async function processResponsesStream<TApi extends Api>(
         }
       }
     } else if (event.type === "response.output_text.delta") {
-      if (currentItem?.type === "message" && currentBlock?.type === "text") {
+      if (currentItem?.type === "message") {
         if (!currentItem.content || currentItem.content.length === 0) {
           continue;
         }
         const lastPart = currentItem.content[currentItem.content.length - 1];
         if (isResponsesTextContentPartType(lastPart?.type)) {
-          currentBlock.text += event.delta;
           lastPart.text += event.delta;
-          stream.push({
-            type: "text_delta",
-            contentIndex: blockIndex(),
-            delta: event.delta,
-            partial: output,
-          });
+          if (pendingMessageText !== null) {
+            appendPendingMessageDelta(event.delta);
+          } else if (currentBlock?.type === "text") {
+            currentBlock.text += event.delta;
+            stream.push({
+              type: "text_delta",
+              contentIndex: blockIndex(),
+              delta: event.delta,
+              partial: output,
+            });
+          }
         }
       }
     } else if (isAzureResponsesTextDeltaEvent(event)) {
-      if (currentItem?.type === "message" && currentBlock?.type === "text") {
+      if (currentItem?.type === "message") {
         currentItem.content = currentItem.content || [];
         let lastPart = currentItem.content[currentItem.content.length - 1];
         if (lastPart?.type !== "text") {
           lastPart = { type: "text", text: "" };
           currentItem.content.push(lastPart);
         }
-        currentBlock.text += event.delta;
         lastPart.text += event.delta;
-        stream.push({
-          type: "text_delta",
-          contentIndex: blockIndex(),
-          delta: event.delta,
-          partial: output,
-        });
-      }
-    } else if (event.type === "response.refusal.delta") {
-      if (currentItem?.type === "message" && currentBlock?.type === "text") {
-        if (!currentItem.content || currentItem.content.length === 0) {
-          continue;
-        }
-        const lastPart = currentItem.content[currentItem.content.length - 1];
-        if (lastPart?.type === "refusal") {
+        if (pendingMessageText !== null) {
+          appendPendingMessageDelta(event.delta);
+        } else if (currentBlock?.type === "text") {
           currentBlock.text += event.delta;
-          lastPart.refusal += event.delta;
           stream.push({
             type: "text_delta",
             contentIndex: blockIndex(),
             delta: event.delta,
             partial: output,
           });
+        }
+      }
+    } else if (event.type === "response.refusal.delta") {
+      if (currentItem?.type === "message") {
+        if (!currentItem.content || currentItem.content.length === 0) {
+          continue;
+        }
+        const lastPart = currentItem.content[currentItem.content.length - 1];
+        if (lastPart?.type === "refusal") {
+          lastPart.refusal += event.delta;
+          if (pendingMessageText !== null) {
+            appendPendingMessageDelta(event.delta);
+          } else if (currentBlock?.type === "text") {
+            currentBlock.text += event.delta;
+            stream.push({
+              type: "text_delta",
+              contentIndex: blockIndex(),
+              delta: event.delta,
+              partial: output,
+            });
+          }
         }
       }
     } else if (event.type === "response.function_call_arguments.delta") {
@@ -767,6 +808,7 @@ export async function processResponsesStream<TApi extends Api>(
       const item = event.item;
       if (item.type !== "message") {
         lastTextBlock = null;
+        pendingMessageText = null;
       }
 
       if (item.type === "reasoning" && currentBlock?.type === "thinking") {
@@ -781,22 +823,32 @@ export async function processResponsesStream<TApi extends Api>(
           partial: output,
         });
         currentBlock = null;
-      } else if (item.type === "message" && currentBlock?.type === "text") {
+      } else if (
+        item.type === "message" &&
+        (currentBlock?.type === "text" || pendingMessageText !== null)
+      ) {
         // Support both OpenAI "output_text" and Azure "text" content types
-        currentBlock.text = item.content
+        const finalText = item.content
           .map((c) => (c.type === "output_text" || c.type === "text" ? c.text : c.refusal))
           .join("");
         const phase = item.phase ?? undefined;
-        const collapse = resolveResponsesMessageSnapshotCollapse({
-          prior: lastTextBlock && { text: lastTextBlock.block.text, phase: lastTextBlock.phase },
-          nextText: currentBlock.text,
-          nextPhase: phase,
-        });
+        const collapse =
+          pendingMessageText !== null
+            ? resolveResponsesMessageSnapshotCollapse({
+                prior: lastTextBlock && {
+                  text: lastTextBlock.block.text,
+                  phase: lastTextBlock.phase,
+                },
+                nextText: finalText,
+                nextPhase: phase,
+              })
+            : ({ kind: "keep" } as const);
+        pendingMessageText = null;
         if (collapse.kind === "extend" && lastTextBlock) {
           // Cumulative snapshot of the prior message item: replace its text
-          // instead of appending another copy. The newest item's signature is
-          // kept so replay carries the item that produced this content (#91959).
-          blocks.pop();
+          // instead of appending another copy. The deferred block was never
+          // started publicly, and the newest item's signature is kept so
+          // replay carries the item that produced this content (#91959).
           lastTextBlock.block.text = collapse.text;
           lastTextBlock.block.textSignature = encodeTextSignatureV1(item.id, phase);
           stream.push({
@@ -806,6 +858,14 @@ export async function processResponsesStream<TApi extends Api>(
             partial: output,
           });
         } else {
+          if (currentBlock?.type !== "text") {
+            // Deferred distinct message: open its block now, balanced with the
+            // text_end below.
+            currentBlock = { type: "text", text: "" };
+            blocks.push(currentBlock);
+            stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+          }
+          currentBlock.text = finalText;
           currentBlock.textSignature = encodeTextSignatureV1(item.id, phase);
           lastTextBlock = { block: currentBlock, index: blockIndex(), phase };
           stream.push({

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -792,7 +792,20 @@ export async function processResponsesStream<TApi extends Api>(
           nextText: currentBlock.text,
           nextPhase: phase,
         });
-        if (collapse.kind === "keep") {
+        if (collapse.kind === "extend" && lastTextBlock) {
+          // Cumulative snapshot of the prior message item: replace its text
+          // instead of appending another copy. The newest item's signature is
+          // kept so replay carries the item that produced this content (#91959).
+          blocks.pop();
+          lastTextBlock.block.text = collapse.text;
+          lastTextBlock.block.textSignature = encodeTextSignatureV1(item.id, phase);
+          stream.push({
+            type: "text_end",
+            contentIndex: lastTextBlock.index,
+            content: collapse.text,
+            partial: output,
+          });
+        } else {
           currentBlock.textSignature = encodeTextSignatureV1(item.id, phase);
           lastTextBlock = { block: currentBlock, index: blockIndex(), phase };
           stream.push({
@@ -801,20 +814,6 @@ export async function processResponsesStream<TApi extends Api>(
             content: currentBlock.text,
             partial: output,
           });
-        } else if (lastTextBlock) {
-          // Cumulative snapshot of the prior message item: replace its text
-          // instead of appending another copy. The first item's signature is
-          // kept so replay and stream-item identity stay stable (#91959).
-          blocks.pop();
-          if (collapse.kind === "extend") {
-            lastTextBlock.block.text = collapse.text;
-            stream.push({
-              type: "text_end",
-              contentIndex: lastTextBlock.index,
-              content: collapse.text,
-              partial: output,
-            });
-          }
         }
         currentBlock = null;
       } else if (item.type === "function_call") {

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -20,6 +20,7 @@ import {
   type AzureResponsesTextDeltaEvent,
   isAzureResponsesTextDeltaEvent,
   isResponsesTextContentPartType,
+  resolveResponsesMessageSnapshotCollapse,
 } from "../../shared/openai-responses-stream-compat.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import type {
@@ -579,6 +580,11 @@ export async function processResponsesStream<TApi extends Api>(
     | null = null;
   let currentBlock: ThinkingContent | TextContent | (ToolCall & { partialJson: string }) | null =
     null;
+  let lastTextBlock: {
+    block: TextContent;
+    index: number;
+    phase: TextSignatureV1["phase"] | undefined;
+  } | null = null;
   const blocks = output.content;
   const blockIndex = () => blocks.length - 1;
 
@@ -587,6 +593,11 @@ export async function processResponsesStream<TApi extends Api>(
       output.responseId = event.response.id;
     } else if (event.type === "response.output_item.added") {
       const item = event.item;
+      if (item.type !== "message") {
+        // Snapshot collapse only applies to back-to-back message items; any
+        // other item is a real boundary (see resolveResponsesMessageSnapshotCollapse).
+        lastTextBlock = null;
+      }
       if (item.type === "reasoning") {
         currentItem = item;
         currentBlock = { type: "thinking", thinking: "" };
@@ -754,6 +765,9 @@ export async function processResponsesStream<TApi extends Api>(
       }
     } else if (event.type === "response.output_item.done") {
       const item = event.item;
+      if (item.type !== "message") {
+        lastTextBlock = null;
+      }
 
       if (item.type === "reasoning" && currentBlock?.type === "thinking") {
         const summaryText = item.summary?.map((s) => s.text).join("\n\n") || "";
@@ -772,13 +786,36 @@ export async function processResponsesStream<TApi extends Api>(
         currentBlock.text = item.content
           .map((c) => (c.type === "output_text" || c.type === "text" ? c.text : c.refusal))
           .join("");
-        currentBlock.textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
-        stream.push({
-          type: "text_end",
-          contentIndex: blockIndex(),
-          content: currentBlock.text,
-          partial: output,
+        const phase = item.phase ?? undefined;
+        const collapse = resolveResponsesMessageSnapshotCollapse({
+          prior: lastTextBlock && { text: lastTextBlock.block.text, phase: lastTextBlock.phase },
+          nextText: currentBlock.text,
+          nextPhase: phase,
         });
+        if (collapse.kind === "keep") {
+          currentBlock.textSignature = encodeTextSignatureV1(item.id, phase);
+          lastTextBlock = { block: currentBlock, index: blockIndex(), phase };
+          stream.push({
+            type: "text_end",
+            contentIndex: blockIndex(),
+            content: currentBlock.text,
+            partial: output,
+          });
+        } else if (lastTextBlock) {
+          // Cumulative snapshot of the prior message item: replace its text
+          // instead of appending another copy. The first item's signature is
+          // kept so replay and stream-item identity stay stable (#91959).
+          blocks.pop();
+          if (collapse.kind === "extend") {
+            lastTextBlock.block.text = collapse.text;
+            stream.push({
+              type: "text_end",
+              contentIndex: lastTextBlock.index,
+              content: collapse.text,
+              partial: output,
+            });
+          }
+        }
         currentBlock = null;
       } else if (item.type === "function_call") {
         const args =

--- a/src/shared/openai-responses-stream-compat.ts
+++ b/src/shared/openai-responses-stream-compat.ts
@@ -50,15 +50,15 @@ export function isAzureResponsesTextDeltaEvent(event: {
   return isAzureResponsesTextDeltaEventType(event.type) && typeof event.delta === "string";
 }
 
-export type ResponsesMessageSnapshotCollapse =
-  | { kind: "extend"; text: string }
-  | { kind: "drop" }
-  | { kind: "keep" };
+export type ResponsesMessageSnapshotCollapse = { kind: "extend"; text: string } | { kind: "keep" };
 
 // Some openai-responses providers re-emit the assistant message as cumulative
-// snapshot items — each a prefix-superset of the previous one — instead of one
-// final message item. Same-phase snapshots must replace the prior text block,
-// not append to it, or the visible reply repeats once per snapshot (#91959).
+// snapshot items — each a strict prefix-superset of the previous one — instead
+// of one final message item. A same-phase strict extension replaces the prior
+// text block, or the visible reply repeats once per snapshot (#91959).
+// Extension-only on purpose: equal or shrinking adjacent items stay distinct
+// (the Responses protocol allows multiple message items per response), so a
+// false positive can only merge rendering — it can never lose text.
 // `prior` must be the immediately preceding output item: collapsing across
 // reasoning/function_call boundaries would drop real post-tool messages and
 // orphan reasoning items, which OpenAI replay rejects.
@@ -73,9 +73,6 @@ export function resolveResponsesMessageSnapshotCollapse(params: {
   }
   if (nextText.length > prior.text.length && nextText.startsWith(prior.text)) {
     return { kind: "extend", text: nextText };
-  }
-  if (prior.text.startsWith(nextText)) {
-    return { kind: "drop" };
   }
   return { kind: "keep" };
 }

--- a/src/shared/openai-responses-stream-compat.ts
+++ b/src/shared/openai-responses-stream-compat.ts
@@ -49,3 +49,33 @@ export function isAzureResponsesTextDeltaEvent(event: {
 }): event is AzureResponsesTextDeltaEvent {
   return isAzureResponsesTextDeltaEventType(event.type) && typeof event.delta === "string";
 }
+
+export type ResponsesMessageSnapshotCollapse =
+  | { kind: "extend"; text: string }
+  | { kind: "drop" }
+  | { kind: "keep" };
+
+// Some openai-responses providers re-emit the assistant message as cumulative
+// snapshot items — each a prefix-superset of the previous one — instead of one
+// final message item. Same-phase snapshots must replace the prior text block,
+// not append to it, or the visible reply repeats once per snapshot (#91959).
+// `prior` must be the immediately preceding output item: collapsing across
+// reasoning/function_call boundaries would drop real post-tool messages and
+// orphan reasoning items, which OpenAI replay rejects.
+export function resolveResponsesMessageSnapshotCollapse(params: {
+  prior: { text: string; phase: string | undefined } | null;
+  nextText: string;
+  nextPhase: string | undefined;
+}): ResponsesMessageSnapshotCollapse {
+  const { prior, nextText } = params;
+  if (!prior?.text || !nextText || prior.phase !== params.nextPhase) {
+    return { kind: "keep" };
+  }
+  if (nextText.length > prior.text.length && nextText.startsWith(prior.text)) {
+    return { kind: "extend", text: nextText };
+  }
+  if (prior.text.startsWith(nextText)) {
+    return { kind: "drop" };
+  }
+  return { kind: "keep" };
+}


### PR DESCRIPTION
## Summary

Fixes #91959 — Bedrock Mantle's `openai-responses` endpoint (GPT-5.x with reasoning enabled) re-emits the assistant message as many **cumulative snapshot items**, each a strict prefix-superset of the previous one, instead of a single final message item. The corruption is server-side (confirmed in the issue via raw `curl`, streaming and non-streaming, usage billed once), but both OpenClaw stream consumers appended one text block per item, so the final visible reply, the session transcript, and the replay context repeated the answer once per snapshot (observed 49–80×).

This adds a generic rule in the shared compat seam (`resolveResponsesMessageSnapshotCollapse`): a message item whose text strictly extends the **immediately preceding** text block, with a matching phase, replaces that block (last-wins); identical or shrinking same-phase snapshots are dropped. The first item's `textSignature` is kept so replay and stream-item identity stay stable. Any non-message output item (reasoning, tool call) resets the tracking, so genuinely distinct post-tool messages (e.g. repeated Codex commentary around tool calls) are never merged and reasoning items are never orphaned for replay. Different-phase (`commentary`/`final_answer`) items keep today's separate-block behavior. Applied in the agent transport stream, the shared LLM consumer, and the completed-response backfill; no provider-name keying.

Known scope cut: if a snapshot-emitting provider also re-streams the prefix as `output_text.delta` events, streaming *previews* can still transiently show duplicated text mid-stream (downstream phase-aware rendering self-heals at item boundaries); the canonical message, final visible text, transcript, and replay are correct.

AI-assisted (Claude Code), directed and reviewed by the PR author. Session logs available on request.

## Real behavior proof

Behavior addressed: A real agent turn against a Responses stream shaped exactly like the corrupted Bedrock Mantle output returned the answer repeated once per snapshot in `finalAssistantVisibleText` (#91959).

Real environment tested: macOS (Darwin 25.5.0), Node 22.22.1, real CLI end-to-end: `openclaw agent --local` (embedded agent runner, real openai-responses transport, real session store) on a scratch `OPENCLAW_STATE_DIR`, with a custom provider (`api: "openai-responses"`, `baseUrl: http://127.0.0.1:38291/v1`) backed by a local mock server that replays the corrupted wire shape documented in the issue: a reasoning item followed by 4 cumulative `message` snapshot items (each its own `output_item.added` / `output_text.delta` / `output_item.done` sequence, `phase: "final_answer"`, strictly prefix-increasing), then `response.completed` with single-copy usage. Live Bedrock Mantle was not reachable from this environment; the wire shape follows the issue's raw SSE captures.

Exact steps or command run after this patch:
1. `node mantle-mock-server.mjs` (serves the corrupted SSE stream on `127.0.0.1:38291`)
2. `OPENCLAW_STATE_DIR=/tmp/openclaw-91959-proof openclaw agent --local --session-key proof-91959 --model mantlemock/gpt-5.5-mock --json -m "Explain the Transformer self-attention mechanism."`
3. Inspect `meta.finalAssistantVisibleText`: length and occurrence count of the opening phrase.

Evidence after fix: copied live output — terminal output (stdout) from the real `openclaw agent --local` runs, inspecting `meta.finalAssistantVisibleText` of the run's `--json` result.

Before (same command, same mock stream, the three touched source files from `origin/main`):

```
visible text length: 696
opening-phrase occurrences: 4
--- first 400 chars ---
Self-attention projects each token into Q, K and V vectors.
Self-attention projects each token into Q, K and V vectors. Scaled dot-product attention divides QK^T by sqrt(d_k) before the softmax.
Self-attention projects each token into Q, K and V vectors. Scaled dot-product attention divides QK^T by sqrt(d_k) before the softmax. Multi-head attention runs several projections in parallel and concaten
```

After (this patch):

```
visible text length: 280
opening-phrase occurrences: 1
--- text ---
Self-attention projects each token into Q, K and V vectors. Scaled dot-product attention divides QK^T by sqrt(d_k) before the softmax. Multi-head attention runs several projections in parallel and concatenates the heads. Positional encodings such as RoPE inject order information.
```

Observed result after fix: the reply contains the answer a single time; the persisted assistant message holds one text block carrying the first snapshot item's signature.

What was not tested: live Bedrock Mantle (no AWS credentials in this environment — the server-side corruption itself is already evidenced in the issue by raw `curl` transcripts from @DaiMingNJ); GPT-5.4-shaped variants (`replayInvalid=true` runs); multi-turn replay against a live provider after a collapsed turn; channel streaming previews during the corrupted stream (covered by code reading only, see scope cut above).

## Verification

- `pnpm test src/llm/**` (24 files, 227 tests) and `src/agents/openai-transport-stream.test.ts` + responses replay/payload/subscriber suites (31 files, ~400 tests): all green after rebase onto `origin/main` (d4819948f37).
- New regression tests: cumulative-snapshot collapse (streaming + backfill, both consumers), repeated-snapshot drop, and negatives pinning the boundaries — different phases, a reasoning item between snapshots, and a tool call between prefix-nested messages must NOT collapse. The collapse tests fail without the fix (verified by reverting the three source files).
- `pnpm build` green; `tsgo` core + core-test lanes green; oxlint/oxfmt clean; `pnpm check:import-cycles` green (0 cycles).
- `pnpm check:changed` delegates to Blacksmith Testbox, which is not reachable from this environment (crabbox binary sanity check fails locally) — relying on PR CI for the canonical changed gates.
- Local `codex review --base origin/main` hit the account usage limit (resets 11:41 AM local); a multi-agent adversarial review pass (7 finder angles + verification) was run instead, and its main finding — the first iteration could collapse across reasoning/tool-call boundaries, risking dropped post-tool messages and orphaned reasoning items in replay — is fixed and pinned by the negative tests above.

Release-note context: user-facing fix — replies through `openai-responses` providers that emit cumulative message snapshots (observed: Bedrock Mantle with GPT-5.x reasoning) no longer repeat the answer dozens of times; transcripts and replay context stay clean. Surface: `src/agents/openai-transport-stream.ts`, `src/llm/providers/openai-responses-shared.ts`, `src/shared/openai-responses-stream-compat.ts`. Reported by @phoenixyy with server-side evidence from @DaiMingNJ in #91959.
