### PR TITLE
fix(openai-responses): use instructions parameter for system prompt instead of input array

### DIFF
--- a/src/llm/providers/openai-responses.ts
+++ b/src/llm/providers/openai-responses.ts
@@ -194,6 +194,7 @@ function buildParams(
   options?: OpenAIResponsesOptions,
 ) {
   const messages = convertResponsesMessages(model, context, OPENAI_TOOL_CALL_PROVIDERS, {
+    includeSystemPrompt: false,
     replayResponsesItemIds: options?.replayResponsesItemIds ?? false,
   });
 
@@ -201,6 +202,7 @@ function buildParams(
   const compat = getCompat(model);
   const params: ResponseCreateParamsStreaming = {
     model: model.id,
+    instructions: context.systemPrompt ?? undefined,
     input: messages,
     stream: true,
     prompt_cache_key:


### PR DESCRIPTION
## Summary

Fixes #92400

The `openai-responses` adapter was placing the system prompt as a `role: "system"` message inside the `input` array. Per the [OpenAI Responses API specification](https://platform.openai.com/docs/api-reference/responses/create), system-level instructions should be passed via the top-level `instructions` parameter, not as a message in `input`.

This follows the same pattern already used by the `openai-chatgpt-responses` adapter (`src/llm/providers/openai-chatgpt-responses.ts:482-491`).

## Changes

- Pass `includeSystemPrompt: false` to `convertResponsesMessages` so system prompt is excluded from the `input` array
- Set `instructions: context.systemPrompt ?? undefined` in the request params

## Test plan

- [x] Existing tests pass: `node scripts/run-vitest.mjs run src/llm/providers/openai-responses-shared.test.ts` — 14/14 pass
- [x] Stream wrapper tests pass: `node scripts/run-vitest.mjs run src/llm/providers/stream-wrappers/openai.test.ts` — 26/26 pass
- [x] Build passes: `pnpm build` completes successfully

---

## Real behavior proof

**Behavior addressed:** The `openai-responses` adapter placed system prompts in the `input` array instead of the `instructions` parameter.

**Environment tested:** macOS Tahoe 26.4.1, Node.js v24.2.0, OpenClaw dev build at commit 2f01ff93.

**Steps run after the patch:**

```
node -e "const fs = require('fs'); const code = fs.readFileSync('src/llm/providers/openai-responses.ts', 'utf8'); console.log('includeSystemPrompt: false:', code.includes('includeSystemPrompt: false')); console.log('instructions field:', code.includes('instructions: context.systemPrompt'));"
node -e "const fs = require('fs'); const fixed = fs.readFileSync('src/llm/providers/openai-responses.ts', 'utf8'); const codex = fs.readFileSync('src/llm/providers/openai-chatgpt-responses.ts', 'utf8'); console.log('Pattern match with Codex adapter:', fixed.includes('includeSystemPrompt: false') && codex.includes('includeSystemPrompt: false') && fixed.includes('instructions: context.systemPrompt') && codex.includes('instructions: context.systemPrompt'));"
node scripts/run-vitest.mjs run src/llm/providers/openai-responses-shared.test.ts
node scripts/run-vitest.mjs run src/llm/providers/stream-wrappers/openai.test.ts
pnpm build
```

**Evidence after fix:**

```
includeSystemPrompt: false: true
instructions field: true
Pattern match with Codex adapter: true
✓  unit  src/llm/providers/openai-responses-shared.test.ts (14 tests) 63ms
✓  unit  src/llm/providers/stream-wrappers/openai.test.ts (26 tests) 24ms
[build-all] phase timings: total 89.9s
```

**Observed result after fix:** The `openai-responses` adapter now passes the system prompt via the top-level `instructions` parameter, matching the OpenAI Responses API specification and the existing `openai-chatgpt-responses` adapter pattern.

**What was not tested:** Live API calls against the OpenAI Responses API (requires API key). Azure OpenAI Responses adapter has the same pattern issue but is out of scope for this PR.
