### PR TITLE
fix(tools): reject malformed availability expressions

### DIFF
--- a/src/tools/availability.test.ts
+++ b/src/tools/availability.test.ts
@@ -11,6 +11,16 @@ const baseDescriptor: ToolDescriptor = {
   executor: { kind: "core", executorId: "example" },
 };
 
+function descriptorWithAvailability(availability: unknown): ToolDescriptor {
+  return { ...baseDescriptor, availability } as ToolDescriptor;
+}
+
+function sparseArray(): unknown[] {
+  const values: unknown[] = [];
+  values.length = 1;
+  return values;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
@@ -254,5 +264,69 @@ describe("evaluateToolAvailability", () => {
         context: { authProviderIds: new Set(["openai"]) },
       }).map((entry) => entry.reason),
     ).toEqual(["unsupported-signal"]);
+  });
+
+  it.each([
+    null,
+    "invalid",
+    [],
+    { kind: "auth" },
+    { kind: "config", path: "plugins.demo" },
+    { kind: "config", path: [1] },
+    { kind: "config", path: [], check: "invalid" },
+    { kind: "context", key: "", equals: {} },
+    { allOf: "invalid" },
+    { anyOf: [null] },
+    { allOf: [], anyOf: [] },
+    { allOf: sparseArray() },
+    { anyOf: sparseArray() },
+    { kind: "config", path: sparseArray() },
+  ])("rejects malformed availability without throwing: %j", (availability) => {
+    expect(
+      evaluateToolAvailability({ descriptor: descriptorWithAvailability(availability) }),
+    ).toStrictEqual([
+      {
+        reason: "unsupported-signal",
+        message: "Unsupported availability expression",
+      },
+    ]);
+  });
+
+  it("rejects cyclic availability expressions without overflowing", () => {
+    const availability: { allOf: unknown[] } = { allOf: [] };
+    availability.allOf.push(availability);
+
+    expect(
+      evaluateToolAvailability({ descriptor: descriptorWithAvailability(availability) }),
+    ).toStrictEqual([
+      {
+        reason: "unsupported-signal",
+        message: "Unsupported availability expression",
+      },
+    ]);
+  });
+
+  it("allows one availability expression to be shared between sibling branches", () => {
+    const signal = { kind: "auth", providerId: "openai" } as const;
+    const descriptor: ToolDescriptor = {
+      ...baseDescriptor,
+      availability: { allOf: [signal, signal] },
+    };
+
+    expect(
+      evaluateToolAvailability({
+        descriptor,
+        context: { authProviderIds: new Set(["openai"]) },
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it.each([
+    [{ allOf: [] }, "Empty availability allOf group"],
+    [{ anyOf: [] }, "Empty availability anyOf group"],
+  ] as const)("preserves precise empty-group diagnostics", (availability, message) => {
+    expect(
+      evaluateToolAvailability({ descriptor: descriptorWithAvailability(availability) }),
+    ).toStrictEqual([{ reason: "unsupported-signal", message }]);
   });
 });

--- a/src/tools/availability.ts
+++ b/src/tools/availability.ts
@@ -68,8 +68,71 @@ function hasConfiguredValue(params: {
   return true;
 }
 
-function hasAvailabilityExpressionShape(value: ToolAvailabilityExpression): boolean {
-  return "kind" in value || "allOf" in value || "anyOf" in value;
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isJsonPrimitive(value: unknown): value is JsonPrimitive {
+  return value === null || ["string", "number", "boolean"].includes(typeof value);
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && Array.from(value).every((entry) => typeof entry === "string");
+}
+
+function isAvailabilitySignal(
+  value: Record<string, unknown>,
+): value is Record<string, unknown> & ToolAvailabilitySignal {
+  switch (value.kind) {
+    case "always":
+      return true;
+    case "auth":
+      return isNonEmptyString(value.providerId);
+    case "config":
+      return (
+        isStringArray(value.path) &&
+        (value.check === undefined ||
+          value.check === "exists" ||
+          value.check === "non-empty" ||
+          value.check === "available")
+      );
+    case "env":
+      return isNonEmptyString(value.name);
+    case "plugin-enabled":
+      return isNonEmptyString(value.pluginId);
+    case "context":
+      return isNonEmptyString(value.key) && (!("equals" in value) || isJsonPrimitive(value.equals));
+    default:
+      return false;
+  }
+}
+
+function isAvailabilityExpression(
+  value: unknown,
+  active: WeakSet<object>,
+): value is ToolAvailabilityExpression {
+  if (!value || typeof value !== "object" || Array.isArray(value) || active.has(value)) {
+    return false;
+  }
+  active.add(value);
+  try {
+    const expression = value as Record<string, unknown>;
+    const shapeCount =
+      Number("kind" in expression) + Number("allOf" in expression) + Number("anyOf" in expression);
+    if (shapeCount !== 1) {
+      return false;
+    }
+    if ("kind" in expression) {
+      return isAvailabilitySignal(expression);
+    }
+    const entries = "allOf" in expression ? expression.allOf : expression.anyOf;
+    return (
+      Array.isArray(entries) &&
+      Array.from(entries).every((entry) => isAvailabilityExpression(entry, active))
+    );
+  } finally {
+    active.delete(value);
+  }
 }
 
 function diagnostic(
@@ -172,8 +235,11 @@ export function evaluateToolAvailability(params: {
   context?: ToolAvailabilityContext;
 }): readonly ToolAvailabilityDiagnostic[] {
   const context = params.context ?? {};
-  const availability = params.descriptor.availability ?? { kind: "always" };
-  if (!hasAvailabilityExpressionShape(availability)) {
+  const availability = params.descriptor.availability;
+  if (availability === undefined) {
+    return [];
+  }
+  if (!isAvailabilityExpression(availability, new WeakSet())) {
     return [
       {
         reason: "unsupported-signal",


### PR DESCRIPTION
## What Problem This Solves

`ToolDescriptor` availability is typed in TypeScript, but external JavaScript can still provide malformed runtime values. The existing shallow key check can throw on nested primitives, overflow on cycles, or let sparse groups evaluate as available.

## Why This Change Was Made

- Validate availability expressions recursively before evaluation, including required signal fields and group arrays.
- Treat the `WeakSet` as the active recursion stack so true cycles are rejected while shared sibling expressions remain valid.
- Materialize array indices during validation so sparse groups and config paths cannot skip checks.
- Preserve existing behavior for absent availability and the precise empty-`allOf` / empty-`anyOf` diagnostics.

The submitted ten-file callback/cache/plugin design was replaced with this evaluator-owned path. Current plugin availability is manifest-first; adding a second runtime-tool availability contract and repeated hot-path logging would recreate an ownership model removed from `main`.

## User Impact

Malformed or cyclic descriptors now fail closed with the existing `unsupported-signal` diagnostic instead of throwing, overflowing, or exposing a tool. Valid descriptors and public types are unchanged; there is no new config, callback, cache, or plugin API.

## Evidence

- Regression coverage for explicit `null`, malformed signals/groups, ambiguous shapes, sparse groups/paths, true cycles, shared children, and precise empty-group diagnostics.
- `oxfmt` on both changed files; `git diff --check` clean.
- Three autoreview passes; the first two found and drove fixes for explicit-null and sparse-array fail-open paths. Final pass: clean, 0.94 confidence.
- Exact-head hosted CI: [45 jobs passed, 11 scope-skipped](https://github.com/openclaw/openclaw/actions/runs/29152354527).
- Sanitized AWS focused proof: [33/33 tests passed](https://crabbox.openclaw.ai/portal/runs/run_ea4dddbbf9f9).
- Sanitized AWS changed gate: [core/core-test type checks, lint, and routed guards passed](https://crabbox.openclaw.ai/portal/runs/run_58148ec9f23c).
- Packed public-SDK consumer: [build, canonical pack, normal npm install, and JavaScript assertions passed](https://crabbox.openclaw.ai/portal/runs/run_7a0137008e98). Marker: `PACKED_CONSUMER_OK valid=4 invalid=6`; tarball SHA-256 `df31c27d0123ec5562a3006d3e94fda6374e4b9eff07dddc16dab7e347d9b993`.

No changelog entry: `CHANGELOG.md` is release-owned in this repository.
