### PR TITLE
feat(telegram): add rich-message Bot API 10.1 transport fallback

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -178,6 +178,7 @@ async function deliverTextReply(params: {
 }): Promise<number | undefined> {
   let firstDeliveredMessageId: number | undefined;
   const chunks = filterEmptyTelegramTextChunks(params.chunkText(params.replyText));
+  const useSingleChunkMarkdownRichPath = chunks.length === 1;
   await sendChunkedTelegramReplyText({
     chunks,
     progress: params.progress,
@@ -190,7 +191,7 @@ async function deliverTextReply(params: {
       const messageId = await sendTelegramText(
         params.bot,
         params.chatId,
-        chunk.html,
+        useSingleChunkMarkdownRichPath ? params.replyText : chunk.html,
         params.runtime,
         {
           replyToMessageId,
@@ -199,7 +200,7 @@ async function deliverTextReply(params: {
           replyQuotePosition: params.replyQuotePosition,
           replyQuoteEntities: params.replyQuoteEntities,
           thread: params.thread,
-          textMode: "html",
+          textMode: useSingleChunkMarkdownRichPath ? "markdown" : "html",
           plainText: chunk.text,
           linkPreview: params.linkPreview,
           silent: params.silent,
@@ -229,6 +230,7 @@ async function sendPendingFollowUpText(params: {
   progress: DeliveryProgress;
 }): Promise<void> {
   const chunks = filterEmptyTelegramTextChunks(params.chunkText(params.text));
+  const useSingleChunkMarkdownRichPath = chunks.length === 1;
   await sendChunkedTelegramReplyText({
     chunks,
     progress: params.progress,
@@ -237,15 +239,21 @@ async function sendPendingFollowUpText(params: {
     replyMarkup: params.replyMarkup,
     markDelivered,
     sendChunk: async ({ chunk, replyToMessageId, replyMarkup }) => {
-      await sendTelegramText(params.bot, params.chatId, chunk.html, params.runtime, {
-        replyToMessageId,
-        thread: params.thread,
-        textMode: "html",
-        plainText: chunk.text,
-        linkPreview: params.linkPreview,
-        silent: params.silent,
-        replyMarkup,
-      });
+      await sendTelegramText(
+        params.bot,
+        params.chatId,
+        useSingleChunkMarkdownRichPath ? params.text : chunk.html,
+        params.runtime,
+        {
+          replyToMessageId,
+          thread: params.thread,
+          textMode: useSingleChunkMarkdownRichPath ? "markdown" : "html",
+          plainText: chunk.text,
+          linkPreview: params.linkPreview,
+          silent: params.silent,
+          replyMarkup,
+        },
+      );
     },
   });
 }
@@ -292,24 +300,31 @@ async function sendTelegramVoiceFallbackText(opts: {
 }): Promise<number | undefined> {
   let firstDeliveredMessageId: number | undefined;
   const chunks = filterEmptyTelegramTextChunks(opts.chunkText(opts.text));
+  const useSingleChunkMarkdownRichPath = chunks.length === 1;
   let appliedReplyTo = false;
   for (const chunk of chunks) {
     // Only apply reply reference, quote text, and buttons to the first chunk.
     const replyToForChunk = !appliedReplyTo ? opts.replyToId : undefined;
     const applyQuoteForChunk = !appliedReplyTo;
-    const messageId = await sendTelegramText(opts.bot, opts.chatId, chunk.html, opts.runtime, {
-      replyToMessageId: replyToForChunk,
-      replyQuoteMessageId: applyQuoteForChunk ? opts.replyQuoteMessageId : undefined,
-      replyQuoteText: applyQuoteForChunk ? opts.replyQuoteText : undefined,
-      replyQuotePosition: applyQuoteForChunk ? opts.replyQuotePosition : undefined,
-      replyQuoteEntities: applyQuoteForChunk ? opts.replyQuoteEntities : undefined,
-      thread: opts.thread,
-      textMode: "html",
-      plainText: chunk.text,
-      linkPreview: opts.linkPreview,
-      silent: opts.silent,
-      replyMarkup: !appliedReplyTo ? opts.replyMarkup : undefined,
-    });
+    const messageId = await sendTelegramText(
+      opts.bot,
+      opts.chatId,
+      useSingleChunkMarkdownRichPath ? opts.text : chunk.html,
+      opts.runtime,
+      {
+        replyToMessageId: replyToForChunk,
+        replyQuoteMessageId: applyQuoteForChunk ? opts.replyQuoteMessageId : undefined,
+        replyQuoteText: applyQuoteForChunk ? opts.replyQuoteText : undefined,
+        replyQuotePosition: applyQuoteForChunk ? opts.replyQuotePosition : undefined,
+        replyQuoteEntities: applyQuoteForChunk ? opts.replyQuoteEntities : undefined,
+        thread: opts.thread,
+        textMode: useSingleChunkMarkdownRichPath ? "markdown" : "html",
+        plainText: chunk.text,
+        linkPreview: opts.linkPreview,
+        silent: opts.silent,
+        replyMarkup: !appliedReplyTo ? opts.replyMarkup : undefined,
+      },
+    );
     if (firstDeliveredMessageId == null) {
       firstDeliveredMessageId = messageId;
     }

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -162,7 +162,7 @@ export async function sendTelegramText(
             (await sendTelegramRichMessage({
               api: bot.api,
               chatId,
-              richMessage: buildTelegramInputRichMessage(htmlText),
+              richMessage: buildTelegramInputRichMessage(text, textMode),
               requestParams: {
                 ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
                 ...normalizeTelegramRichSendParams(effectiveParams),

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -11,6 +11,13 @@ import {
   getTelegramNativeQuoteReplyMessageId,
   removeTelegramNativeQuoteParam,
 } from "../reply-parameters.js";
+import {
+  buildTelegramInputRichMessage,
+  canSendTelegramRichMessage,
+  isTelegramRichMethodUnavailableError,
+  normalizeTelegramRichSendParams,
+  sendTelegramRichMessage,
+} from "../rich-message.js";
 import { buildInlineKeyboard } from "../send.js";
 import type { TelegramThreadSpec } from "./helpers.js";
 
@@ -140,6 +147,38 @@ export async function sendTelegramText(
     return await sendPlainFallback();
   }
   try {
+    if (canSendTelegramRichMessage({ api: bot.api, linkPreview: opts?.linkPreview })) {
+      try {
+        const res = await sendTelegramWithThreadFallback({
+          operation: "sendRichMessage",
+          runtime,
+          thread: opts?.thread,
+          requestParams: baseParams,
+          shouldLog: (err) => {
+            const errText = formatErrorMessage(err);
+            return !PARSE_ERR_RE.test(errText) && !EMPTY_TEXT_ERR_RE.test(errText);
+          },
+          send: async (effectiveParams) =>
+            (await sendTelegramRichMessage({
+              api: bot.api,
+              chatId,
+              richMessage: buildTelegramInputRichMessage(htmlText),
+              requestParams: {
+                ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
+                ...normalizeTelegramRichSendParams(effectiveParams),
+              },
+            })) as { message_id: number },
+        });
+        runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${res.message_id}`);
+        return res.message_id;
+      } catch (err) {
+        if (!isTelegramRichMethodUnavailableError(err)) {
+          throw err;
+        }
+        runtime.log?.(`telegram sendRichMessage unavailable; retrying with HTML parse_mode`);
+      }
+    }
+
     const res = await sendTelegramWithThreadFallback({
       operation: "sendMessage",
       runtime,

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -215,14 +215,15 @@ describe("deliverReplies", () => {
     messageHookRunner.runMessageSent.mockReset();
   });
 
-  it("uses sendRichMessage when the raw Telegram Bot API exposes it", async () => {
+  it("uses sendRichMessage with markdown payload when the raw Telegram Bot API exposes it", async () => {
     const runtime = createRuntime(false);
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: "123" } });
     const sendRichMessage = vi.fn().mockResolvedValue({ message_id: 2, chat: { id: "123" } });
     const bot = createBot({ sendMessage, raw: { sendRichMessage } });
+    const markdownText = "| Name | Value |\n| --- | --- |\n| hello | **world** |";
 
     await deliverWith({
-      replies: [{ text: "hello **world**" }],
+      replies: [{ text: markdownText }],
       runtime,
       bot,
     });
@@ -230,7 +231,7 @@ describe("deliverReplies", () => {
     expect(sendRichMessage).toHaveBeenCalledTimes(1);
     expect(sendRichMessage).toHaveBeenCalledWith({
       chat_id: "123",
-      rich_message: { html: "hello <b>world</b>" },
+      rich_message: { markdown: markdownText },
     });
     expect(sendMessage).not.toHaveBeenCalled();
   });

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -215,6 +215,26 @@ describe("deliverReplies", () => {
     messageHookRunner.runMessageSent.mockReset();
   });
 
+  it("uses sendRichMessage when the raw Telegram Bot API exposes it", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+    const sendRichMessage = vi.fn().mockResolvedValue({ message_id: 2, chat: { id: "123" } });
+    const bot = createBot({ sendMessage, raw: { sendRichMessage } });
+
+    await deliverWith({
+      replies: [{ text: "hello **world**" }],
+      runtime,
+      bot,
+    });
+
+    expect(sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(sendRichMessage).toHaveBeenCalledWith({
+      chat_id: "123",
+      rich_message: { html: "hello <b>world</b>" },
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("skips audioAsVoice-only payloads without logging an error", async () => {
     const runtime = createRuntime(false);
 

--- a/extensions/telegram/src/dm-access.test.ts
+++ b/extensions/telegram/src/dm-access.test.ts
@@ -127,6 +127,39 @@ describe("enforceTelegramDmAccess", () => {
     expect(createChannelPairingChallengeIssuerMock).not.toHaveBeenCalled();
   });
 
+  it("uses sendRichMessage for pairing replies when the Bot API exposes it", async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const sendRichMessage = vi.fn(async () => undefined);
+    createChannelPairingChallengeIssuerMock.mockReturnValueOnce(
+      ({
+        sendPairingReply,
+      }: Parameters<ReturnType<typeof createChannelPairingChallengeIssuer>>[0]) =>
+        (async () => {
+          await sendPairingReply("Pairing code: **123456**");
+        })(),
+    );
+
+    const allowed = await enforceTelegramDmAccess({
+      isGroup: false,
+      dmPolicy: "pairing",
+      msg: createDmMessage(),
+      chatId: 42,
+      effectiveDmAllow: normalizeAllowFrom([]),
+      accountId: "main",
+      bot: { api: { sendMessage, raw: { sendRichMessage } } } as never,
+      logger: { info: vi.fn() },
+      upsertPairingRequest: upsertChannelPairingRequestMock,
+    });
+
+    expect(allowed).toBe(false);
+    expect(sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(sendRichMessage).toHaveBeenCalledWith({
+      chat_id: 42,
+      rich_message: { html: "Pairing code: <b>123456</b>" },
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("issues a pairing challenge for unauthorized DMs under pairing policy", async () => {
     const sendMessage = vi.fn(async () => undefined);
     const logger = { info: vi.fn() };

--- a/extensions/telegram/src/dm-access.ts
+++ b/extensions/telegram/src/dm-access.ts
@@ -13,6 +13,12 @@ import {
   createTelegramIngressResolver,
   telegramAllowEntries,
 } from "./ingress.js";
+import {
+  buildTelegramInputRichMessage,
+  canSendTelegramRichMessage,
+  isTelegramRichMethodUnavailableError,
+  sendTelegramRichMessage,
+} from "./rich-message.js";
 
 type TelegramDmAccessLogger = {
   info: (obj: Record<string, unknown>, msg: string) => void;
@@ -156,9 +162,26 @@ export async function enforceTelegramDmAccess(params: {
         },
         sendPairingReply: async (text) => {
           const html = renderTelegramHtmlText(text);
+          const canSendRich = canSendTelegramRichMessage({ api: bot.api });
           await withTelegramApiErrorLogging({
-            operation: "sendMessage",
-            fn: () => bot.api.sendMessage(chatId, html, { parse_mode: "HTML" }),
+            operation: canSendRich ? "sendRichMessage" : "sendMessage",
+            fn: async () => {
+              if (canSendRich) {
+                try {
+                  await sendTelegramRichMessage({
+                    api: bot.api,
+                    chatId,
+                    richMessage: buildTelegramInputRichMessage(html),
+                  });
+                  return;
+                } catch (err) {
+                  if (!isTelegramRichMethodUnavailableError(err)) {
+                    throw err;
+                  }
+                }
+              }
+              await bot.api.sendMessage(chatId, html, { parse_mode: "HTML" });
+            },
           });
         },
         onReplyError: (err) => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -532,6 +532,38 @@ describe("createTelegramDraftStream", () => {
     });
   });
 
+  it("falls back to parse_mode HTML when rich preview transport gets 404 Not Found", async () => {
+    const api = createMockDraftApi() as ReturnType<typeof createMockDraftApi> & {
+      raw: {
+        sendRichMessage: ReturnType<typeof vi.fn>;
+        editMessageText: ReturnType<typeof vi.fn>;
+      };
+    };
+    api.raw = {
+      sendRichMessage: vi
+        .fn()
+        .mockRejectedValueOnce(Object.assign(new Error("404: Not Found"), { error_code: 404 })),
+      editMessageText: vi
+        .fn()
+        .mockRejectedValueOnce(Object.assign(new Error("404: Not Found"), { error_code: 404 })),
+    };
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      renderText: (text) => ({ text: `<i>${text}</i>`, parseMode: "HTML" }),
+    });
+
+    stream.update("hello");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "<i>hello</i>", { parse_mode: "HTML" });
+
+    stream.update("hello again");
+    await stream.flush();
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "<i>hello again</i>", {
+      parse_mode: "HTML",
+    });
+  });
+
   it("supports rendered previews with parse_mode", async () => {
     const api = createMockDraftApi();
     const stream = createTelegramDraftStream({

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -498,6 +498,40 @@ describe("createTelegramDraftStream", () => {
     expect(warn).toHaveBeenCalledWith("telegram stream preview failed: read ECONNRESET");
   });
 
+  it("uses rich send/edit transports for rendered HTML previews when available", async () => {
+    const api = createMockDraftApi() as ReturnType<typeof createMockDraftApi> & {
+      raw: {
+        sendRichMessage: ReturnType<typeof vi.fn>;
+        editMessageText: ReturnType<typeof vi.fn>;
+      };
+    };
+    api.raw = {
+      sendRichMessage: vi.fn().mockResolvedValue({ message_id: 17 }),
+      editMessageText: vi.fn().mockResolvedValue(true),
+    };
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      renderText: (text) => ({ text: `<i>${text}</i>`, parseMode: "HTML" }),
+    });
+
+    stream.update("hello");
+    await stream.flush();
+    expect(api.raw.sendRichMessage).toHaveBeenCalledWith({
+      chat_id: 123,
+      rich_message: { html: "<i>hello</i>" },
+    });
+    expect(api.sendMessage).not.toHaveBeenCalled();
+
+    stream.update("hello again");
+    await stream.flush();
+    expect(api.raw.editMessageText).toHaveBeenCalledWith({
+      chat_id: 123,
+      message_id: 17,
+      rich_message: { html: "<i>hello again</i>" },
+    });
+  });
+
   it("supports rendered previews with parse_mode", async () => {
     const api = createMockDraftApi();
     const stream = createTelegramDraftStream({

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -15,6 +15,15 @@ import {
   readTelegramRetryAfterMs,
 } from "./network-errors.js";
 import { normalizeTelegramReplyToMessageId } from "./outbound-params.js";
+import {
+  buildTelegramInputRichMessage,
+  canEditTelegramRichMessage,
+  canSendTelegramRichMessage,
+  editTelegramRichMessageText,
+  isTelegramRichMethodUnavailableError,
+  normalizeTelegramRichSendParams,
+  sendTelegramRichMessage,
+} from "./rich-message.js";
 
 const TELEGRAM_STREAM_MAX_CHARS = 4096;
 const DEFAULT_THROTTLE_MS = 1000;
@@ -143,6 +152,20 @@ export function createTelegramDraftStream(params: {
     renderedText: string;
     renderedParseMode: "HTML" | undefined;
   }) => {
+    if (sendArgs.renderedParseMode === "HTML" && canSendTelegramRichMessage({ api: params.api })) {
+      try {
+        return await sendTelegramRichMessage({
+          api: params.api,
+          chatId,
+          richMessage: buildTelegramInputRichMessage(sendArgs.renderedText),
+          requestParams: normalizeTelegramRichSendParams(replyParams),
+        });
+      } catch (err) {
+        if (!isTelegramRichMethodUnavailableError(err)) {
+          throw err;
+        }
+      }
+    }
     const sendParams = sendArgs.renderedParseMode
       ? {
           ...replyParams,
@@ -159,6 +182,21 @@ export function createTelegramDraftStream(params: {
     if (typeof streamMessageId === "number") {
       streamVisibleSinceMs ??= Date.now();
       if (renderedParseMode) {
+        if (canEditTelegramRichMessage(params.api)) {
+          try {
+            await editTelegramRichMessageText({
+              api: params.api,
+              chatId,
+              messageId: streamMessageId,
+              richMessage: buildTelegramInputRichMessage(renderedText),
+            });
+            return true;
+          } catch (err) {
+            if (!isTelegramRichMethodUnavailableError(err)) {
+              throw err;
+            }
+          }
+        }
         await params.api.editMessageText(chatId, streamMessageId, renderedText, {
           parse_mode: renderedParseMode,
         });

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -206,12 +206,12 @@ export function createTelegramDraftStream(params: {
       return true;
     }
     messageSendAttempted = true;
-    let sent: Awaited<ReturnType<typeof sendRenderedMessage>>;
+    let sent: { message_id?: number } | null | undefined;
     try {
-      sent = await sendRenderedMessage({
+      sent = (await sendRenderedMessage({
         renderedText,
         renderedParseMode,
-      });
+      })) as { message_id?: number } | null | undefined;
     } catch (err) {
       if (isSafeToRetrySendError(err) || isTelegramClientRejection(err)) {
         messageSendAttempted = false;

--- a/extensions/telegram/src/native-tool-progress-draft.test.ts
+++ b/extensions/telegram/src/native-tool-progress-draft.test.ts
@@ -12,6 +12,8 @@ describe("createNativeTelegramToolProgressDraft", () => {
         _params?: Record<string, unknown>,
       ) => implementation?.(),
     );
+  const createSendRichMessageDraftMock = (implementation?: () => Promise<unknown>) =>
+    vi.fn(async (_params?: Record<string, unknown>) => implementation?.());
 
   it("returns undefined when the Bot API client has no sendMessageDraft method", () => {
     const draft = createNativeTelegramToolProgressDraft({
@@ -20,6 +22,26 @@ describe("createNativeTelegramToolProgressDraft", () => {
     } as never);
 
     expect(draft).toBeUndefined();
+  });
+
+  it("uses sendRichMessageDraft when the Bot API exposes the raw rich draft method", async () => {
+    const sendRichMessageDraft = createSendRichMessageDraftMock();
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { raw: { sendRichMessageDraft } },
+      chatId: 123,
+      thread: { id: 456, scope: "dm" },
+    } as never);
+
+    expect(draft).toBeDefined();
+    await draft?.update("Running command");
+
+    expect(sendRichMessageDraft).toHaveBeenCalledTimes(1);
+    expect(sendRichMessageDraft).toHaveBeenCalledWith({
+      chat_id: 123,
+      draft_id: expect.any(Number),
+      rich_message: { html: "Running command" },
+      message_thread_id: 456,
+    });
   });
 
   it("updates the same non-zero draft id for animated native progress", async () => {

--- a/extensions/telegram/src/native-tool-progress-draft.test.ts
+++ b/extensions/telegram/src/native-tool-progress-draft.test.ts
@@ -64,6 +64,27 @@ describe("createNativeTelegramToolProgressDraft", () => {
     });
   });
 
+  it("falls back to sendMessageDraft when rich draft gets 404 Not Found", async () => {
+    const sendMessageDraft = createSendMessageDraftMock();
+    const sendRichMessageDraft = createSendRichMessageDraftMock(async () => {
+      throw Object.assign(new Error("404: Not Found"), { error_code: 404 });
+    });
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { sendMessageDraft, raw: { sendRichMessageDraft } },
+      chatId: 123,
+      thread: { id: 456, scope: "dm" },
+    } as never);
+
+    expect(draft).toBeDefined();
+    await expect(draft?.update("Running command")).resolves.toBe(true);
+
+    expect(sendRichMessageDraft).toHaveBeenCalledTimes(1);
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+    expect(sendMessageDraft).toHaveBeenLastCalledWith(123, expect.any(Number), "Running command", {
+      message_thread_id: 456,
+    });
+  });
+
   it("stops after a Telegram rejection so callers can fall back silently", async () => {
     const sendMessageDraft = createSendMessageDraftMock(async () => {
       throw new Error("Bad Request: method is unavailable");

--- a/extensions/telegram/src/native-tool-progress-draft.ts
+++ b/extensions/telegram/src/native-tool-progress-draft.ts
@@ -2,6 +2,13 @@
 import type { Bot } from "grammy";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
+import { renderTelegramHtmlText } from "./format.js";
+import {
+  buildTelegramInputRichMessage,
+  canSendTelegramRichMessageDraft,
+  isTelegramRichMethodUnavailableError,
+  sendTelegramRichMessageDraft,
+} from "./rich-message.js";
 
 const TELEGRAM_NATIVE_DRAFT_MAX_CHARS = 4096;
 const TELEGRAM_DRAFT_ID_STATE_KEY = Symbol.for("openclaw.telegramNativeDraftIdState");
@@ -17,18 +24,64 @@ type TelegramSendMessageDraft = (
   },
 ) => Promise<unknown>;
 
+type NativeTelegramDraftSender = {
+  mode: "rich" | "plain";
+  send: (
+    chatId: Parameters<Bot["api"]["sendMessage"]>[0],
+    draftId: number,
+    text: string,
+    params?: {
+      message_thread_id?: number;
+    },
+  ) => Promise<unknown>;
+};
+
 export type NativeTelegramToolProgressDraft = {
   update: (text: string) => Promise<boolean>;
   stop: () => void;
 };
 
-function resolveSendMessageDraftApi(api: Bot["api"]): TelegramSendMessageDraft | undefined {
+function resolvePlainSendMessageDraftApi(api: Bot["api"]): TelegramSendMessageDraft | undefined {
   const sendMessageDraft = (api as Bot["api"] & { sendMessageDraft?: TelegramSendMessageDraft })
     .sendMessageDraft;
   if (typeof sendMessageDraft !== "function") {
     return undefined;
   }
   return sendMessageDraft.bind(api as object);
+}
+
+function resolveNativeTelegramDraftSender(api: Bot["api"]): NativeTelegramDraftSender | undefined {
+  const sendPlainDraft = resolvePlainSendMessageDraftApi(api);
+  if (canSendTelegramRichMessageDraft(api)) {
+    return {
+      mode: "rich",
+      send: async (chatId, draftId, text, params) => {
+        const htmlText = renderTelegramHtmlText(text, { textMode: "html" });
+        try {
+          return await sendTelegramRichMessageDraft({
+            api,
+            chatId,
+            draftId,
+            richMessage: buildTelegramInputRichMessage(htmlText),
+            requestParams: params,
+          });
+        } catch (err) {
+          if (!isTelegramRichMethodUnavailableError(err) || !sendPlainDraft) {
+            throw err;
+          }
+          return await sendPlainDraft(chatId, draftId, text, params);
+        }
+      },
+    };
+  }
+  if (!sendPlainDraft) {
+    return undefined;
+  }
+  return {
+    mode: "plain",
+    send: async (chatId, draftId, text, params) =>
+      await sendPlainDraft(chatId, draftId, text, params),
+  };
 }
 
 function allocateTelegramDraftId(): number {
@@ -54,8 +107,8 @@ export function createNativeTelegramToolProgressDraft(params: {
   thread?: TelegramThreadSpec | null;
   log?: (message: string) => void;
 }): NativeTelegramToolProgressDraft | undefined {
-  const sendMessageDraft = resolveSendMessageDraftApi(params.api);
-  if (!sendMessageDraft) {
+  const draftSender = resolveNativeTelegramDraftSender(params.api);
+  if (!draftSender) {
     return undefined;
   }
 
@@ -77,7 +130,7 @@ export function createNativeTelegramToolProgressDraft(params: {
         return true;
       }
       try {
-        await sendMessageDraft(
+        await draftSender.send(
           params.chatId,
           draftId,
           normalizedText,

--- a/extensions/telegram/src/rich-message.test.ts
+++ b/extensions/telegram/src/rich-message.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { isTelegramRichMethodUnavailableError } from "./rich-message.js";
+
+describe("telegram rich-message classifier", () => {
+  it("treats nested HttpError-style 404 status as rich-method unavailable", () => {
+    const err = {
+      message: "Network request for 'sendRichMessage' failed!",
+      error: {
+        status: 404,
+        statusText: "Not Found",
+      },
+    };
+
+    // oxlint-disable-next-line vitest/prefer-to-be-truthy
+    expect(isTelegramRichMethodUnavailableError(err)).toBe(true);
+  });
+
+  it("treats nested string 404 status on legacy/custom apiRoot responses as unavailable", () => {
+    const err = {
+      cause: {
+        response: {
+          status: "404",
+          statusCode: "404",
+        },
+      },
+    };
+
+    // oxlint-disable-next-line vitest/prefer-to-be-truthy
+    expect(isTelegramRichMethodUnavailableError(err)).toBe(true);
+  });
+
+  it("does not classify unrelated transport failures as rich-method unavailable", () => {
+    const err = {
+      error: {
+        status: 500,
+        statusText: "Internal Server Error",
+      },
+    };
+
+    // oxlint-disable-next-line vitest/prefer-to-be-falsy
+    expect(isTelegramRichMethodUnavailableError(err)).toBe(false);
+  });
+});

--- a/extensions/telegram/src/rich-message.test.ts
+++ b/extensions/telegram/src/rich-message.test.ts
@@ -11,7 +11,6 @@ describe("telegram rich-message classifier", () => {
       },
     };
 
-    // oxlint-disable-next-line vitest/prefer-to-be-truthy
     expect(isTelegramRichMethodUnavailableError(err)).toBe(true);
   });
 
@@ -25,7 +24,6 @@ describe("telegram rich-message classifier", () => {
       },
     };
 
-    // oxlint-disable-next-line vitest/prefer-to-be-truthy
     expect(isTelegramRichMethodUnavailableError(err)).toBe(true);
   });
 
@@ -37,7 +35,6 @@ describe("telegram rich-message classifier", () => {
       },
     };
 
-    // oxlint-disable-next-line vitest/prefer-to-be-falsy
     expect(isTelegramRichMethodUnavailableError(err)).toBe(false);
   });
 });

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -1,0 +1,247 @@
+// Telegram plugin module implements rich-message Bot API 10.1 shims.
+import type { Bot } from "grammy";
+
+export type TelegramInputRichMessage = {
+  html?: string;
+  markdown?: string;
+  is_rtl?: boolean;
+  skip_entity_detection?: boolean;
+};
+
+type TelegramRawSendRichMessageParams = {
+  chat_id: number | string;
+  rich_message: TelegramInputRichMessage;
+  message_thread_id?: number;
+  direct_messages_topic_id?: number;
+  disable_notification?: boolean;
+  protect_content?: boolean;
+  allow_paid_broadcast?: boolean;
+  message_effect_id?: string;
+  suggested_post_parameters?: unknown;
+  reply_parameters?: unknown;
+  reply_markup?: unknown;
+};
+
+type TelegramRawSendRichMessageDraftParams = {
+  chat_id: number | string;
+  draft_id: number;
+  rich_message: TelegramInputRichMessage;
+  message_thread_id?: number;
+};
+
+type TelegramRawEditRichMessageTextParams = {
+  business_connection_id?: string;
+  chat_id?: number | string;
+  message_id?: number;
+  inline_message_id?: string;
+  rich_message: TelegramInputRichMessage;
+  link_preview_options?: unknown;
+  reply_markup?: unknown;
+};
+
+type TelegramRawApi = {
+  sendRichMessage?: (params: TelegramRawSendRichMessageParams) => Promise<unknown>;
+  sendRichMessageDraft?: (params: TelegramRawSendRichMessageDraftParams) => Promise<unknown>;
+  editMessageText?: (params: TelegramRawEditRichMessageTextParams) => Promise<unknown>;
+};
+
+type TelegramDirectSendRichMessage = (
+  chatId: number | string,
+  richMessage: TelegramInputRichMessage,
+  params?: Omit<TelegramRawSendRichMessageParams, "chat_id" | "rich_message">,
+) => Promise<unknown>;
+
+type TelegramDirectSendRichMessageDraft = (
+  chatId: number | string,
+  draftId: number,
+  richMessage: TelegramInputRichMessage,
+  params?: Omit<TelegramRawSendRichMessageDraftParams, "chat_id" | "draft_id" | "rich_message">,
+) => Promise<unknown>;
+
+type TelegramApiWithRichMethods = Bot["api"] & {
+  raw?: TelegramRawApi;
+  sendRichMessage?: TelegramDirectSendRichMessage;
+  sendRichMessageDraft?: TelegramDirectSendRichMessageDraft;
+};
+
+const TELEGRAM_RICH_METHOD_UNAVAILABLE_RE =
+  /\bmethod is unavailable\b|\bmethod not found\b|\bunknown method\b/i;
+
+function formatTelegramRichError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
+
+function resolveTelegramRawApi(api: Bot["api"]): TelegramRawApi | undefined {
+  const raw = (api as TelegramApiWithRichMethods).raw;
+  return raw && typeof raw === "object" ? raw : undefined;
+}
+
+export function isTelegramRichMethodUnavailableError(err: unknown): boolean {
+  return TELEGRAM_RICH_METHOD_UNAVAILABLE_RE.test(formatTelegramRichError(err));
+}
+
+export function buildTelegramInputRichMessage(htmlText: string): TelegramInputRichMessage {
+  return { html: htmlText };
+}
+
+export function canSendTelegramRichMessage(params: {
+  api: Bot["api"];
+  linkPreview?: boolean;
+}): boolean {
+  if (params.linkPreview === false) {
+    return false;
+  }
+  return resolveSendRichMessageApi(params.api) !== undefined;
+}
+
+export function canSendTelegramRichMessageDraft(api: Bot["api"]): boolean {
+  return resolveSendRichMessageDraftApi(api) !== undefined;
+}
+
+export function canEditTelegramRichMessage(api: Bot["api"]): boolean {
+  return resolveEditTelegramRichTextApi(api) !== undefined;
+}
+
+export function normalizeTelegramRichSendParams(
+  params: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!params) {
+    return {};
+  }
+  const normalized = { ...params };
+  const replyToMessageId = normalized.reply_to_message_id;
+  const hasReplyParameters =
+    normalized.reply_parameters != null && typeof normalized.reply_parameters === "object";
+  if (
+    !hasReplyParameters &&
+    typeof replyToMessageId === "number" &&
+    Number.isFinite(replyToMessageId)
+  ) {
+    normalized.reply_parameters = {
+      message_id: Math.trunc(replyToMessageId),
+      allow_sending_without_reply: true,
+    };
+  }
+  delete normalized.reply_to_message_id;
+  delete normalized.allow_sending_without_reply;
+  return normalized;
+}
+
+export async function sendTelegramRichMessage(params: {
+  api: Bot["api"];
+  chatId: number | string;
+  richMessage: TelegramInputRichMessage;
+  requestParams?: Omit<TelegramRawSendRichMessageParams, "chat_id" | "rich_message">;
+}): Promise<unknown> {
+  const sendRichMessage = resolveSendRichMessageApi(params.api);
+  if (!sendRichMessage) {
+    throw new Error("Telegram Bot API client does not expose sendRichMessage.");
+  }
+  return await sendRichMessage(params.chatId, params.richMessage, params.requestParams);
+}
+
+export async function sendTelegramRichMessageDraft(params: {
+  api: Bot["api"];
+  chatId: number | string;
+  draftId: number;
+  richMessage: TelegramInputRichMessage;
+  requestParams?: Omit<
+    TelegramRawSendRichMessageDraftParams,
+    "chat_id" | "draft_id" | "rich_message"
+  >;
+}): Promise<unknown> {
+  const sendRichMessageDraft = resolveSendRichMessageDraftApi(params.api);
+  if (!sendRichMessageDraft) {
+    throw new Error("Telegram Bot API client does not expose sendRichMessageDraft.");
+  }
+  return await sendRichMessageDraft(
+    params.chatId,
+    params.draftId,
+    params.richMessage,
+    params.requestParams,
+  );
+}
+
+export async function editTelegramRichMessageText(params: {
+  api: Bot["api"];
+  chatId: number | string;
+  messageId: number;
+  richMessage: TelegramInputRichMessage;
+  requestParams?: Omit<
+    TelegramRawEditRichMessageTextParams,
+    "chat_id" | "message_id" | "rich_message"
+  >;
+}): Promise<unknown> {
+  const editRichMessageText = resolveEditTelegramRichTextApi(params.api);
+  if (!editRichMessageText) {
+    throw new Error("Telegram Bot API client does not expose rich editMessageText.");
+  }
+  return await editRichMessageText(
+    params.chatId,
+    params.messageId,
+    params.richMessage,
+    params.requestParams,
+  );
+}
+
+function resolveSendRichMessageApi(api: Bot["api"]): TelegramDirectSendRichMessage | undefined {
+  const richApi = api as TelegramApiWithRichMethods;
+  if (typeof richApi.sendRichMessage === "function") {
+    return richApi.sendRichMessage.bind(api as object);
+  }
+  const raw = resolveTelegramRawApi(api);
+  if (typeof raw?.sendRichMessage !== "function") {
+    return undefined;
+  }
+  return async (chatId, richMessage, requestParams) =>
+    await raw.sendRichMessage?.({
+      chat_id: chatId,
+      rich_message: richMessage,
+      ...(requestParams ?? {}),
+    });
+}
+
+function resolveSendRichMessageDraftApi(
+  api: Bot["api"],
+): TelegramDirectSendRichMessageDraft | undefined {
+  const richApi = api as TelegramApiWithRichMethods;
+  if (typeof richApi.sendRichMessageDraft === "function") {
+    return richApi.sendRichMessageDraft.bind(api as object);
+  }
+  const raw = resolveTelegramRawApi(api);
+  if (typeof raw?.sendRichMessageDraft !== "function") {
+    return undefined;
+  }
+  return async (chatId, draftId, richMessage, requestParams) =>
+    await raw.sendRichMessageDraft?.({
+      chat_id: chatId,
+      draft_id: draftId,
+      rich_message: richMessage,
+      ...(requestParams ?? {}),
+    });
+}
+
+function resolveEditTelegramRichTextApi(api: Bot["api"]) {
+  const raw = resolveTelegramRawApi(api);
+  if (typeof raw?.editMessageText !== "function") {
+    return undefined;
+  }
+  return async (
+    chatId: number | string,
+    messageId: number,
+    richMessage: TelegramInputRichMessage,
+    requestParams?: Omit<
+      TelegramRawEditRichMessageTextParams,
+      "chat_id" | "message_id" | "rich_message"
+    >,
+  ) =>
+    await raw.editMessageText?.({
+      chat_id: chatId,
+      message_id: messageId,
+      rich_message: richMessage,
+      ...(requestParams ?? {}),
+    });
+}

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -40,23 +40,32 @@ type TelegramRawEditRichMessageTextParams = {
 };
 
 type TelegramRawApi = {
-  sendRichMessage?: (params: TelegramRawSendRichMessageParams) => Promise<unknown>;
-  sendRichMessageDraft?: (params: TelegramRawSendRichMessageDraftParams) => Promise<unknown>;
+  sendRichMessage?: (
+    params: TelegramRawSendRichMessageParams,
+  ) => Promise<TelegramRichMessageResult>;
+  sendRichMessageDraft?: (
+    params: TelegramRawSendRichMessageDraftParams,
+  ) => Promise<TelegramRichMessageResult>;
   editMessageText?: (params: TelegramRawEditRichMessageTextParams) => Promise<unknown>;
+};
+
+export type TelegramRichMessageResult = {
+  message_id?: number;
+  chat?: { id?: string | number };
 };
 
 type TelegramDirectSendRichMessage = (
   chatId: number | string,
   richMessage: TelegramInputRichMessage,
   params?: Omit<TelegramRawSendRichMessageParams, "chat_id" | "rich_message">,
-) => Promise<unknown>;
+) => Promise<TelegramRichMessageResult>;
 
 type TelegramDirectSendRichMessageDraft = (
   chatId: number | string,
   draftId: number,
   richMessage: TelegramInputRichMessage,
   params?: Omit<TelegramRawSendRichMessageDraftParams, "chat_id" | "draft_id" | "rich_message">,
-) => Promise<unknown>;
+) => Promise<TelegramRichMessageResult>;
 
 type TelegramApiWithRichMethods = Bot["api"] & {
   raw?: TelegramRawApi;
@@ -65,7 +74,7 @@ type TelegramApiWithRichMethods = Bot["api"] & {
 };
 
 const TELEGRAM_RICH_METHOD_UNAVAILABLE_RE =
-  /\bmethod is unavailable\b|\bmethod not found\b|\bunknown method\b/i;
+  /\bmethod is unavailable\b|\bmethod not found\b|\bunknown method\b|\b404\b.*\bnot found\b|\bnot found\b.*\b404\b/i;
 
 function formatTelegramRichError(err: unknown): string {
   if (err instanceof Error) {
@@ -74,17 +83,60 @@ function formatTelegramRichError(err: unknown): string {
   return String(err);
 }
 
+function toStatusCode(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  if (typeof value === "string" && /^\d+$/u.test(value.trim())) {
+    return Math.trunc(Number(value));
+  }
+  return undefined;
+}
+
+function isTelegramRichMethodUnavailableStatus(err: unknown, seen = new Set<unknown>()): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  if (seen.has(err)) {
+    return false;
+  }
+  seen.add(err);
+  const record = err as {
+    error_code?: unknown;
+    status?: unknown;
+    statusCode?: unknown;
+    error?: unknown;
+    response?: { status?: unknown; statusCode?: unknown };
+    cause?: unknown;
+  };
+  return (
+    toStatusCode(record.error_code) === 404 ||
+    toStatusCode(record.status) === 404 ||
+    toStatusCode(record.statusCode) === 404 ||
+    toStatusCode(record.response?.status) === 404 ||
+    toStatusCode(record.response?.statusCode) === 404 ||
+    (record.error !== undefined && isTelegramRichMethodUnavailableStatus(record.error, seen)) ||
+    (record.cause !== undefined && isTelegramRichMethodUnavailableStatus(record.cause, seen))
+  );
+}
+
 function resolveTelegramRawApi(api: Bot["api"]): TelegramRawApi | undefined {
   const raw = (api as TelegramApiWithRichMethods).raw;
   return raw && typeof raw === "object" ? raw : undefined;
 }
 
 export function isTelegramRichMethodUnavailableError(err: unknown): boolean {
-  return TELEGRAM_RICH_METHOD_UNAVAILABLE_RE.test(formatTelegramRichError(err));
+  return (
+    TELEGRAM_RICH_METHOD_UNAVAILABLE_RE.test(formatTelegramRichError(err)) ||
+    isTelegramRichMethodUnavailableStatus(err)
+  );
 }
 
-export function buildTelegramInputRichMessage(htmlText: string): TelegramInputRichMessage {
-  return { html: htmlText };
+export function buildTelegramInputRichMessage(
+  text: string,
+  textMode: "markdown" | "html" = "html",
+): TelegramInputRichMessage {
+  return textMode === "markdown" ? { markdown: text } : { html: text };
 }
 
 export function canSendTelegramRichMessage(params: {
@@ -135,7 +187,7 @@ export async function sendTelegramRichMessage(params: {
   chatId: number | string;
   richMessage: TelegramInputRichMessage;
   requestParams?: Omit<TelegramRawSendRichMessageParams, "chat_id" | "rich_message">;
-}): Promise<unknown> {
+}): Promise<TelegramRichMessageResult> {
   const sendRichMessage = resolveSendRichMessageApi(params.api);
   if (!sendRichMessage) {
     throw new Error("Telegram Bot API client does not expose sendRichMessage.");
@@ -152,7 +204,7 @@ export async function sendTelegramRichMessageDraft(params: {
     TelegramRawSendRichMessageDraftParams,
     "chat_id" | "draft_id" | "rich_message"
   >;
-}): Promise<unknown> {
+}): Promise<TelegramRichMessageResult> {
   const sendRichMessageDraft = resolveSendRichMessageDraftApi(params.api);
   if (!sendRichMessageDraft) {
     throw new Error("Telegram Bot API client does not expose sendRichMessageDraft.");
@@ -193,14 +245,15 @@ function resolveSendRichMessageApi(api: Bot["api"]): TelegramDirectSendRichMessa
     return richApi.sendRichMessage.bind(api as object);
   }
   const raw = resolveTelegramRawApi(api);
-  if (typeof raw?.sendRichMessage !== "function") {
+  const sendRichMessage = raw?.sendRichMessage;
+  if (typeof sendRichMessage !== "function") {
     return undefined;
   }
   return async (chatId, richMessage, requestParams) =>
-    await raw.sendRichMessage?.({
+    await sendRichMessage({
       chat_id: chatId,
       rich_message: richMessage,
-      ...(requestParams ?? {}),
+      ...requestParams,
     });
 }
 
@@ -212,21 +265,23 @@ function resolveSendRichMessageDraftApi(
     return richApi.sendRichMessageDraft.bind(api as object);
   }
   const raw = resolveTelegramRawApi(api);
-  if (typeof raw?.sendRichMessageDraft !== "function") {
+  const sendRichMessageDraft = raw?.sendRichMessageDraft;
+  if (typeof sendRichMessageDraft !== "function") {
     return undefined;
   }
   return async (chatId, draftId, richMessage, requestParams) =>
-    await raw.sendRichMessageDraft?.({
+    await sendRichMessageDraft({
       chat_id: chatId,
       draft_id: draftId,
       rich_message: richMessage,
-      ...(requestParams ?? {}),
+      ...requestParams,
     });
 }
 
 function resolveEditTelegramRichTextApi(api: Bot["api"]) {
   const raw = resolveTelegramRawApi(api);
-  if (typeof raw?.editMessageText !== "function") {
+  const editMessageText = raw?.editMessageText;
+  if (typeof editMessageText !== "function") {
     return undefined;
   }
   return async (
@@ -238,10 +293,10 @@ function resolveEditTelegramRichTextApi(api: Bot["api"]) {
       "chat_id" | "message_id" | "rich_message"
     >,
   ) =>
-    await raw.editMessageText?.({
+    await editMessageText({
       chat_id: chatId,
       message_id: messageId,
       rich_message: richMessage,
-      ...(requestParams ?? {}),
+      ...requestParams,
     });
 }

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -786,10 +786,7 @@ describe("sendMessageTelegram", () => {
     const api = {
       sendMessage,
       raw: { sendRichMessage },
-    } as unknown as {
-      sendMessage: typeof sendMessage;
-      raw: { sendRichMessage: typeof sendRichMessage };
-    };
+    } as unknown as Bot["api"];
     const markdownText = "| Name | Value |\n| --- | --- |\n| hello | **world** |";
 
     const res = await sendMessageTelegram("123", markdownText, {
@@ -813,10 +810,7 @@ describe("sendMessageTelegram", () => {
     const api = {
       sendMessage,
       raw: { sendRichMessage },
-    } as unknown as {
-      sendMessage: typeof sendMessage;
-      raw: { sendRichMessage: typeof sendRichMessage };
-    };
+    } as unknown as Bot["api"];
 
     const res = await sendMessageTelegram("123", "hello **world**", {
       cfg: TELEGRAM_TEST_CFG,
@@ -3155,11 +3149,7 @@ describe("editMessageTelegram", () => {
       sendMessage,
       raw: { editMessageText: richEditMessageText },
       editMessageText: vi.fn(),
-    } as unknown as {
-      sendMessage: typeof sendMessage;
-      raw: { editMessageText: typeof richEditMessageText };
-      editMessageText: ReturnType<typeof vi.fn>;
-    };
+    } as unknown as Bot["api"];
     const markdownText = "hello **world**";
 
     await editMessageTelegram("123", 1, markdownText, {
@@ -3183,10 +3173,7 @@ describe("editMessageTelegram", () => {
     const api = {
       raw: { editMessageText: richEditMessageText },
       editMessageText: legacyEditMessageText,
-    } as unknown as {
-      raw: { editMessageText: typeof richEditMessageText };
-      editMessageText: typeof legacyEditMessageText;
-    };
+    } as unknown as Bot["api"];
 
     await editMessageTelegram("123", 1, "hello **world**", {
       token: "tok",

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -3145,10 +3145,11 @@ describe("editMessageTelegram", () => {
   it("uses rich editMessageText with markdown payload when the raw Telegram Bot API exposes it", async () => {
     const sendMessage = vi.fn();
     const richEditMessageText = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+    const legacyEditMessageText = vi.fn();
     const api = {
       sendMessage,
       raw: { editMessageText: richEditMessageText },
-      editMessageText: vi.fn(),
+      editMessageText: legacyEditMessageText,
     } as unknown as Bot["api"];
     const markdownText = "hello **world**";
 
@@ -3163,7 +3164,7 @@ describe("editMessageTelegram", () => {
       message_id: 1,
       rich_message: { markdown: markdownText },
     });
-    expect(api.editMessageText).not.toHaveBeenCalled();
+    expect(legacyEditMessageText).not.toHaveBeenCalled();
   });
 
   it("falls back when rich editMessageText gets 404 Not Found from a lagging apiRoot", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -780,6 +780,31 @@ describe("sendMessageTelegram", () => {
     );
   });
 
+  it("uses sendRichMessage when the raw Telegram Bot API exposes it", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 41, chat: { id: "123" } });
+    const sendRichMessage = vi.fn().mockResolvedValue({ message_id: 42, chat: { id: "123" } });
+    const api = {
+      sendMessage,
+      raw: { sendRichMessage },
+    } as unknown as {
+      sendMessage: typeof sendMessage;
+      raw: { sendRichMessage: typeof sendRichMessage };
+    };
+
+    const res = await sendMessageTelegram("123", "hello **world**", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+    });
+
+    expect(sendRichMessage).toHaveBeenCalledWith({
+      chat_id: "123",
+      rich_message: { html: "hello <b>world</b>" },
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(res).toEqual({ messageId: "42", chatId: "123" });
+  });
+
   it("falls back to plain text when Telegram rejects HTML and preserves send params", async () => {
     const parseErr = new Error(
       "400: Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 9",
@@ -3097,6 +3122,33 @@ describe("shared send behaviors", () => {
 });
 
 describe("editMessageTelegram", () => {
+  it("uses rich editMessageText when the raw Telegram Bot API exposes it", async () => {
+    const sendMessage = vi.fn();
+    const richEditMessageText = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+    const api = {
+      sendMessage,
+      raw: { editMessageText: richEditMessageText },
+      editMessageText: vi.fn(),
+    } as unknown as {
+      sendMessage: typeof sendMessage;
+      raw: { editMessageText: typeof richEditMessageText };
+      editMessageText: ReturnType<typeof vi.fn>;
+    };
+
+    await editMessageTelegram("123", 1, "hello **world**", {
+      token: "tok",
+      cfg: {},
+      api,
+    });
+
+    expect(richEditMessageText).toHaveBeenCalledWith({
+      chat_id: "123",
+      message_id: 1,
+      rich_message: { html: "hello <b>world</b>" },
+    });
+    expect(api.editMessageText).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: "buttons undefined keeps existing keyboard",

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -780,9 +780,36 @@ describe("sendMessageTelegram", () => {
     );
   });
 
-  it("uses sendRichMessage when the raw Telegram Bot API exposes it", async () => {
+  it("uses sendRichMessage with markdown payload when the raw Telegram Bot API exposes it", async () => {
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 41, chat: { id: "123" } });
     const sendRichMessage = vi.fn().mockResolvedValue({ message_id: 42, chat: { id: "123" } });
+    const api = {
+      sendMessage,
+      raw: { sendRichMessage },
+    } as unknown as {
+      sendMessage: typeof sendMessage;
+      raw: { sendRichMessage: typeof sendRichMessage };
+    };
+    const markdownText = "| Name | Value |\n| --- | --- |\n| hello | **world** |";
+
+    const res = await sendMessageTelegram("123", markdownText, {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+    });
+
+    expect(sendRichMessage).toHaveBeenCalledWith({
+      chat_id: "123",
+      rich_message: { markdown: markdownText },
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(res).toEqual({ messageId: "42", chatId: "123" });
+  });
+
+  it("falls back when sendRichMessage gets 404 Not Found from a lagging apiRoot", async () => {
+    const unavailableError = Object.assign(new Error("404: Not Found"), { error_code: 404 });
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 43, chat: { id: "123" } });
+    const sendRichMessage = vi.fn().mockRejectedValueOnce(unavailableError);
     const api = {
       sendMessage,
       raw: { sendRichMessage },
@@ -797,12 +824,11 @@ describe("sendMessageTelegram", () => {
       api,
     });
 
-    expect(sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: { html: "hello <b>world</b>" },
+    expect(sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith("123", "hello <b>world</b>", {
+      parse_mode: "HTML",
     });
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(res).toEqual({ messageId: "42", chatId: "123" });
+    expect(res).toEqual({ messageId: "43", chatId: "123" });
   });
 
   it("falls back to plain text when Telegram rejects HTML and preserves send params", async () => {
@@ -3122,7 +3148,7 @@ describe("shared send behaviors", () => {
 });
 
 describe("editMessageTelegram", () => {
-  it("uses rich editMessageText when the raw Telegram Bot API exposes it", async () => {
+  it("uses rich editMessageText with markdown payload when the raw Telegram Bot API exposes it", async () => {
     const sendMessage = vi.fn();
     const richEditMessageText = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: "123" } });
     const api = {
@@ -3134,8 +3160,9 @@ describe("editMessageTelegram", () => {
       raw: { editMessageText: typeof richEditMessageText };
       editMessageText: ReturnType<typeof vi.fn>;
     };
+    const markdownText = "hello **world**";
 
-    await editMessageTelegram("123", 1, "hello **world**", {
+    await editMessageTelegram("123", 1, markdownText, {
       token: "tok",
       cfg: {},
       api,
@@ -3144,9 +3171,33 @@ describe("editMessageTelegram", () => {
     expect(richEditMessageText).toHaveBeenCalledWith({
       chat_id: "123",
       message_id: 1,
-      rich_message: { html: "hello <b>world</b>" },
+      rich_message: { markdown: markdownText },
     });
     expect(api.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("falls back when rich editMessageText gets 404 Not Found from a lagging apiRoot", async () => {
+    const unavailableError = Object.assign(new Error("404: Not Found"), { error_code: 404 });
+    const legacyEditMessageText = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+    const richEditMessageText = vi.fn().mockRejectedValueOnce(unavailableError);
+    const api = {
+      raw: { editMessageText: richEditMessageText },
+      editMessageText: legacyEditMessageText,
+    } as unknown as {
+      raw: { editMessageText: typeof richEditMessageText };
+      editMessageText: typeof legacyEditMessageText;
+    };
+
+    await editMessageTelegram("123", 1, "hello **world**", {
+      token: "tok",
+      cfg: {},
+      api,
+    });
+
+    expect(richEditMessageText).toHaveBeenCalledTimes(1);
+    expect(legacyEditMessageText).toHaveBeenCalledWith("123", 1, "hello <b>world</b>", {
+      parse_mode: "HTML",
+    });
   });
 
   it.each([

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -41,6 +41,16 @@ import {
   resolveTelegramSendThreadSpec,
 } from "./reply-parameters.js";
 import {
+  buildTelegramInputRichMessage,
+  canEditTelegramRichMessage,
+  canSendTelegramRichMessage,
+  editTelegramRichMessageText,
+  isTelegramRichMethodUnavailableError,
+  normalizeTelegramRichSendParams,
+  sendTelegramRichMessage,
+  type TelegramInputRichMessage,
+} from "./rich-message.js";
+import {
   buildOutboundMediaLoadOptions,
   getImageMetadata,
   isGifMedia,
@@ -645,7 +655,13 @@ export async function sendMessageTelegram(
   type TelegramTextChunk = {
     plainText: string;
     htmlText?: string;
+    richMessage?: TelegramInputRichMessage;
   };
+
+  const canSendRichText = canSendTelegramRichMessage({
+    api,
+    linkPreview: linkPreviewEnabled,
+  });
 
   const sendTelegramTextChunk = async (
     chunk: TelegramTextChunk,
@@ -668,9 +684,37 @@ export async function sendMessageTelegram(
             : api.sendMessage(chatId, chunk.plainText),
         label,
       );
-    const result = !chunk.htmlText
-      ? await requestPlain("message")
-      : await withTelegramHtmlParseFallback({
+    let result: unknown;
+    if (!chunk.htmlText) {
+      result = await requestPlain("message");
+    } else if (chunk.richMessage && canSendRichText) {
+      try {
+        result = await withTelegramHtmlParseFallback({
+          label: "sendRichMessage",
+          verbose: opts.verbose,
+          requestHtml: (label) =>
+            requestWithChatNotFound(
+              () =>
+                sendTelegramRichMessage({
+                  api,
+                  chatId,
+                  richMessage: chunk.richMessage ?? buildTelegramInputRichMessage(chunk.htmlText),
+                  requestParams: normalizeTelegramRichSendParams(plainParams),
+                }),
+              label,
+            ),
+          requestPlain,
+        });
+      } catch (err) {
+        if (!isTelegramRichMethodUnavailableError(err)) {
+          throw err;
+        }
+        if (opts.verbose) {
+          sendLogger.warn(
+            `telegram sendRichMessage unavailable, retrying with HTML parse_mode: ${formatErrorMessage(err)}`,
+          );
+        }
+        result = await withTelegramHtmlParseFallback({
           label: "message",
           verbose: opts.verbose,
           requestHtml: (label) =>
@@ -684,6 +728,23 @@ export async function sendMessageTelegram(
             ),
           requestPlain,
         });
+      }
+    } else {
+      result = await withTelegramHtmlParseFallback({
+        label: "message",
+        verbose: opts.verbose,
+        requestHtml: (label) =>
+          requestWithChatNotFound(
+            () =>
+              api.sendMessage(chatId, chunk.htmlText ?? chunk.plainText, {
+                parse_mode: "HTML" as const,
+                ...plainParams,
+              }),
+            label,
+          ),
+        requestPlain,
+      });
+    }
     return { result, acceptedParams: params };
   };
 
@@ -771,6 +832,7 @@ export async function sendMessageTelegram(
     const plainTextChunks = splitTelegramPlainTextFallback(fallbackText, htmlChunks.length, 4000);
     return htmlChunks.map((htmlTextLocal, index) => ({
       htmlText: htmlTextLocal,
+      richMessage: buildTelegramInputRichMessage(htmlTextLocal),
       plainText: plainTextChunks[index] ?? htmlTextLocal,
     }));
   };
@@ -1481,6 +1543,39 @@ export async function editMessageTelegram(
         ),
     });
 
+  const performRichTextEdit = () =>
+    withTelegramHtmlParseFallback({
+      label: "editRichMessageText",
+      verbose: opts.verbose,
+      requestHtml: (retryLabel) =>
+        requestWithEditShouldLog(
+          () =>
+            editTelegramRichMessageText({
+              api,
+              chatId,
+              messageId,
+              richMessage: buildTelegramInputRichMessage(htmlText),
+              requestParams: {
+                ...(textEditParams.link_preview_options
+                  ? { link_preview_options: textEditParams.link_preview_options }
+                  : {}),
+                ...(replyMarkup !== undefined ? { reply_markup: replyMarkup } : {}),
+              },
+            }),
+          retryLabel,
+          (err) => !isTelegramMessageNotModifiedError(err),
+        ),
+      requestPlain: (retryLabel) =>
+        requestWithEditShouldLog(
+          () =>
+            Object.keys(plainTextParams).length > 0
+              ? api.editMessageText(chatId, messageId, plainText, plainTextParams)
+              : api.editMessageText(chatId, messageId, plainText),
+          retryLabel,
+          (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
+        ),
+    });
+
   const performCaptionEdit = () =>
     withTelegramHtmlParseFallback({
       label: "editMessageCaption",
@@ -1505,7 +1600,23 @@ export async function editMessageTelegram(
       await performCaptionEdit();
     } else {
       try {
-        await performTextEdit();
+        if (canEditTelegramRichMessage(api)) {
+          try {
+            await performRichTextEdit();
+          } catch (err) {
+            if (!isTelegramRichMethodUnavailableError(err)) {
+              throw err;
+            }
+            if (opts.verbose) {
+              sendLogger.warn(
+                `telegram rich editMessageText unavailable, retrying with HTML parse_mode: ${formatErrorMessage(err)}`,
+              );
+            }
+            await performTextEdit();
+          }
+        } else {
+          await performTextEdit();
+        }
       } catch (err) {
         if (editMode === "auto" && isTelegramMessageHasNoTextError(err)) {
           await performCaptionEdit();

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -770,11 +770,10 @@ export async function sendMessageTelegram(
       if (!chunk) {
         continue;
       }
-      const { result: res, acceptedParams } = await sendTelegramTextChunk(
+      const { result: message, acceptedParams } = await sendTelegramTextChunk(
         chunk,
         buildTextParams(index === chunks.length - 1),
       );
-      const message = res as TelegramMessageLike | null | undefined;
       const messageId = resolveTelegramMessageIdOrThrow(message, context);
       recordSentMessage(chatId, messageId, cfg);
       await recordOutboundMessageForPromptContext({

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -685,7 +685,8 @@ export async function sendMessageTelegram(
         label,
       );
     let result: unknown;
-    if (!chunk.htmlText) {
+    const htmlText = chunk.htmlText;
+    if (!htmlText) {
       result = await requestPlain("message");
     } else if (chunk.richMessage && canSendRichText) {
       try {
@@ -698,7 +699,7 @@ export async function sendMessageTelegram(
                 sendTelegramRichMessage({
                   api,
                   chatId,
-                  richMessage: chunk.richMessage ?? buildTelegramInputRichMessage(chunk.htmlText),
+                  richMessage: chunk.richMessage ?? buildTelegramInputRichMessage(htmlText),
                   requestParams: normalizeTelegramRichSendParams(plainParams),
                 }),
               label,
@@ -720,7 +721,7 @@ export async function sendMessageTelegram(
           requestHtml: (label) =>
             requestWithChatNotFound(
               () =>
-                api.sendMessage(chatId, chunk.htmlText ?? chunk.plainText, {
+                api.sendMessage(chatId, htmlText, {
                   parse_mode: "HTML" as const,
                   ...plainParams,
                 }),
@@ -736,7 +737,7 @@ export async function sendMessageTelegram(
         requestHtml: (label) =>
           requestWithChatNotFound(
             () =>
-              api.sendMessage(chatId, chunk.htmlText ?? chunk.plainText, {
+              api.sendMessage(chatId, htmlText, {
                 parse_mode: "HTML" as const,
                 ...plainParams,
               }),
@@ -773,13 +774,14 @@ export async function sendMessageTelegram(
         chunk,
         buildTextParams(index === chunks.length - 1),
       );
-      const messageId = resolveTelegramMessageIdOrThrow(res, context);
+      const message = res as TelegramMessageLike | null | undefined;
+      const messageId = resolveTelegramMessageIdOrThrow(message, context);
       recordSentMessage(chatId, messageId, cfg);
       await recordOutboundMessageForPromptContext({
         cfg,
         account,
         chatId,
-        message: res,
+        message: (message ?? {}) as TelegramMessageLike,
         messageId,
         text: chunk.plainText,
         ...(acceptedParams?.message_thread_id !== undefined
@@ -787,7 +789,7 @@ export async function sendMessageTelegram(
           : {}),
       });
       lastMessageId = String(messageId);
-      lastChatId = String(res?.chat?.id ?? chatId);
+      lastChatId = String(message?.chat?.id ?? chatId);
       lastAcceptedParams = acceptedParams;
       sentChunkCount += 1;
     }
@@ -830,11 +832,23 @@ export async function sendMessageTelegram(
       return fixedPlainTextChunks.map((plainText) => ({ plainText }));
     }
     const plainTextChunks = splitTelegramPlainTextFallback(fallbackText, htmlChunks.length, 4000);
-    return htmlChunks.map((htmlTextLocal, index) => ({
-      htmlText: htmlTextLocal,
-      richMessage: buildTelegramInputRichMessage(htmlTextLocal),
-      plainText: plainTextChunks[index] ?? htmlTextLocal,
-    }));
+    const chunks = htmlChunks.map((htmlTextLocal, index) => {
+      const chunk: TelegramTextChunk = {
+        htmlText: htmlTextLocal,
+        plainText: plainTextChunks[index] ?? htmlTextLocal,
+      };
+      if (textMode === "html") {
+        chunk.richMessage = buildTelegramInputRichMessage(htmlTextLocal);
+      }
+      return chunk;
+    });
+    if (textMode === "markdown" && chunks.length === 1) {
+      chunks[0] = {
+        ...chunks[0],
+        richMessage: buildTelegramInputRichMessage(rawText, "markdown"),
+      };
+    }
+    return chunks;
   };
 
   const sendChunkedText = async (rawText: string, context: string) =>
@@ -1554,7 +1568,7 @@ export async function editMessageTelegram(
               api,
               chatId,
               messageId,
-              richMessage: buildTelegramInputRichMessage(htmlText),
+              richMessage: buildTelegramInputRichMessage(text, textMode),
               requestParams: {
                 ...(textEditParams.link_preview_options
                   ? { link_preview_options: textEditParams.link_preview_options }

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -770,10 +770,11 @@ export async function sendMessageTelegram(
       if (!chunk) {
         continue;
       }
-      const { result: message, acceptedParams } = await sendTelegramTextChunk(
+      const { result, acceptedParams } = await sendTelegramTextChunk(
         chunk,
         buildTextParams(index === chunks.length - 1),
       );
+      const message = result as TelegramMessageLike | null | undefined;
       const messageId = resolveTelegramMessageIdOrThrow(message, context);
       recordSentMessage(chatId, messageId, cfg);
       await recordOutboundMessageForPromptContext({

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -781,7 +781,7 @@ export async function sendMessageTelegram(
         cfg,
         account,
         chatId,
-        message: (message ?? {}) as TelegramMessageLike,
+        message: message ?? {},
         messageId,
         text: chunk.plainText,
         ...(acceptedParams?.message_thread_id !== undefined


### PR DESCRIPTION
## Summary
- add a typed Telegram rich-message shim that works through raw Bot API 10.1 methods when grammY types lag behind
- use rich send/edit/draft transports across Telegram send, delivery, DM pairing, stream preview, and native tool-progress draft flows
- keep hard fallback to existing HTML/plain transports, including the send-path exception when `linkPreview === false`
- treat legacy/custom endpoint `404 Not Found` rich-method failures as rich-method-unavailable fallback candidates
- preserve rich markdown for the validated single-chunk markdown path by sending `rich_message.markdown` from the original markdown text instead of already-rendered Telegram HTML
- keep multi-chunk markdown, draft, and progress flows on the old fallback path for safety

## Real behavior proof
- Behavior or issue addressed: single-chunk markdown Telegram send/edit should use the rich-message transport when available, while keeping the conservative fallback design for other flows.
- Real environment tested: local OpenClaw checkout on Linux (Node 22) against a live paired Telegram DM using the configured bot token; the proof message was sent, edited, and then deleted.
- Exact steps or command run after this patch: `pnpm exec tsx .tmp/telegram-rich-proof.ts`
- Evidence after fix (copied live output):

```text
[proof] rich send available true
[proof] rich edit available true
[proof] raw.sendRichMessage {"chat_id":"<paired-dm>","rich_keys":["markdown"],"markdown_preview":"Rich proof start\n\n| Name | Value |\n| --- | --- |\n| hello | **world** |","has_reply_markup":false}
[telegram] outbound send ok accountId=default chatId=<paired-dm> messageId=15322 operation=sendMessage deliveryKind=text chunkCount=1
[proof] sendMessageTelegram result {"messageId":"15322","chatId":"<paired-dm>"}
[proof] raw.editMessageText {"chat_id":"<paired-dm>","message_id":15322,"rich_keys":["markdown"],"markdown_preview":"Rich proof edited\n\n| Name | Value |\n| --- | --- |\n| hello | **world+edit** |"}
[proof] editMessageTelegram result {"ok":true,"messageId":"15322","chatId":"<paired-dm>"}
[proof] cleanup deleteMessage ok {"chatId":"<paired-dm>","messageId":"15322"}
```

- Observed result after fix: the live run went through `raw.sendRichMessage` with `rich_message.markdown` built from the original markdown text, then through `raw.editMessageText` with `rich_message.markdown` on edit; both calls succeeded against Telegram and returned the same live message id before cleanup.
- What was not tested: a live legacy/custom `apiRoot` endpoint that returns `404 Not Found` for rich methods; multi-chunk markdown, draft, and progress flows in a live Telegram environment.
- Proof limitations or environment constraints: this is copied terminal output from a private DM proof run, so chat identity is redacted and the temporary proof script was kept local/uncommitted.
- Before evidence (optional but encouraged): before this follow-up, the branch already had unit coverage for the fallback logic, but not a copied live rich send/edit proof section in the PR body.

## Testing
- `node scripts/run-vitest.mjs run extensions/telegram/src/send.test.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/rich-message.test.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/native-tool-progress-draft.test.ts` → `220 passed`
- `pnpm exec oxlint extensions/telegram/src/rich-message.ts extensions/telegram/src/send.ts extensions/telegram/src/bot/delivery.send.ts extensions/telegram/src/bot/delivery.replies.ts extensions/telegram/src/send.test.ts extensions/telegram/src/rich-message.test.ts --tsconfig extensions/telegram/tsconfig.json`
