### PR TITLE
fix(outbound): honor top-level image param as send media source (#92407)

### DIFF
--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -454,6 +454,38 @@ describe("runMessageAction media behavior", () => {
     });
   });
 
+  it("treats top-level image param as a send media source", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "workspace",
+          source: "test",
+          plugin: workspacePlugin,
+        },
+      ]),
+    );
+
+    await withSandbox(async (sandboxDir) => {
+      const result = await runDrySend({
+        cfg: workspaceConfig,
+        actionParams: {
+          channel: "workspace",
+          target: "12345678",
+          message: "1/7",
+          image: "/workspace/photo.jpg",
+        },
+        sandboxRoot: sandboxDir,
+      });
+
+      expect(result.kind).toBe("send");
+      if (result.kind !== "send") {
+        throw new Error("expected send result");
+      }
+      expect(result.sendResult?.mediaUrl).toBe(path.join(sandboxDir, "photo.jpg"));
+      expect(result.sendResult?.mediaUrls).toEqual([path.join(sandboxDir, "photo.jpg")]);
+    });
+  });
+
   it("sends structured attachments as media urls", async () => {
     setActivePluginRegistry(
       createTestRegistry([

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -939,7 +939,8 @@ async function buildSendPayloadParts(params: {
     readStringParam(actionParams, "mediaUrl", { trim: false }) ??
     readStringParam(actionParams, "path", { trim: false }) ??
     readStringParam(actionParams, "filePath", { trim: false }) ??
-    readStringParam(actionParams, "fileUrl", { trim: false });
+    readStringParam(actionParams, "fileUrl", { trim: false }) ??
+    readStringParam(actionParams, "image", { trim: false });
   const mediaUrlHints = readStringArrayParam(actionParams, "mediaUrls") ?? [];
   const attachmentMediaHints = collectMessageAttachmentMediaHints(actionParams.attachments);
   const hasMediaHint =


### PR DESCRIPTION
## Summary

Fixes #92407.

When an agent called the `message` tool with `action: "send"` and a top-level `image` param, the shared outbound runner recognized `image` for sandbox validation and media-access hints, but `buildSendPayloadParts` omitted it from the generic send payload. The channel then delivered text only while the tool returned `ok: true`, so the agent had no signal to retry.

## Changes

- `src/infra/outbound/message-action-runner.ts`:
  - Added `image` to the `mediaHint` resolution chain in `buildSendPayloadParts`, so a send action treats `image` as a first-class media source.
  - The change is scoped to the send-specific payload builder; action-specific `image` semantics for non-send actions (e.g., event cover images) are preserved.
- `src/infra/outbound/message-action-runner.media.test.ts`: Added regression test `treats top-level image param as a send media source`.

## Real behavior proof

**Behavior addressed:** message tool `image` param was silently dropped on send, delivering text without the requested attachment while returning `ok: true`.

**Real environment tested:** Mantis native Telegram Desktop proof on PR #92416, comparing current main baseline `d4819948f37d45fe8f1428401316eaae456cdf16` with this PR head `297cd5bb38b582e950474aeeb4f794bc88d50a4d`.

**Exact steps or command run after this patch:** Mantis `telegram-desktop-proof` ran from `pull_request_target` and exercised native Telegram Desktop delivery. Run: https://github.com/openclaw/openclaw/actions/runs/27407968372

**Evidence after fix:** Mantis posted before/after native Telegram Desktop proof showing the image attachment delivery path succeeds for this PR. Artifact: https://github.com/openclaw/openclaw/actions/runs/27407968372/artifacts/7588961814. Published proof: https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-92416/run-27407968372-1/index.json

**Observed result after fix:** The candidate proof passed at `297cd5bb38b582e950474aeeb4f794bc88d50a4d`; Telegram Desktop received the photo attachment rather than a text-only success for the `image` media-source send path.

**What was not tested:** No additional channel-specific live proof was run beyond Telegram Desktop. The code change is channel-agnostic and covered by focused outbound runner regression tests.

## Verification

- `node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.media.test.ts --run` — 33 tests passed (including the new regression test)
- `node scripts/run-vitest.mjs src/infra/outbound/message-action-params.test.ts --run` — 32 tests passed
- `node scripts/run-vitest.mjs src/agents/tools/message-tool.test.ts --run` — 99 tests passed
- Mantis Telegram Desktop proof: https://github.com/openclaw/openclaw/actions/runs/27407968372

## Behavior addressed

- Prevents silent attachment loss when agents use `image` as the media-source param name on `message` `send`.
- Keeps `image` semantics unchanged for non-send message actions.
