### PR TITLE
#92239: Slack message delivered empty when blockquote line contains inline code span

### DIFF
--- a/extensions/slack/src/format.test.ts
+++ b/extensions/slack/src/format.test.ts
@@ -42,6 +42,27 @@ describe("markdownToSlackMrkdwn", () => {
       ["renders ordered lists with numbering", "2. two\n3. three", "2. two\n3. three"],
       ["renders headings as bold text", "# Title", "*Title*"],
       ["renders blockquotes", "> Quote", "> Quote"],
+      // Regression #92239: Slack mrkdwn renders empty when blockquote contains inline code
+      [
+        "replaces backtick code with bold inside blockquote lines",
+        "> `code` in blockquote",
+        "> *code* in blockquote",
+      ],
+      [
+        "preserves inline code outside blockquotes",
+        "`code` without blockquote",
+        "`code` without blockquote",
+      ],
+      [
+        "handles blockquote with inline code mid-sentence",
+        "> run `deploy` after build",
+        "> run *deploy* after build",
+      ],
+      [
+        "handles multiple code spans in one blockquote line",
+        "> before `one` middle `two` after",
+        "> before *one* middle *two* after",
+      ],
     ] as const;
     for (const [name, input, expected] of cases) {
       expect(markdownToSlackMrkdwn(input), name).toBe(expected);
@@ -92,5 +113,38 @@ describe("escapeSlackMrkdwn", () => {
 describe("normalizeSlackOutboundText", () => {
   it("normalizes markdown for outbound send/update paths", () => {
     expect(normalizeSlackOutboundText(" **bold** ")).toBe("*bold*");
+  });
+
+  it("sanitizes blockquote inline code to avoid Slack empty-message bug (#92239)", () => {
+    expect(normalizeSlackOutboundText("> `code` in blockquote")).toBe(
+      "> *code* in blockquote",
+    );
+  });
+
+  it("preserves inline code outside blockquotes", () => {
+    expect(normalizeSlackOutboundText("use `code` here")).toBe("use `code` here");
+  });
+});
+
+describe("sanitizeSlackBlockquoteCode (via markdownToSlackMrkdwn)", () => {
+  it("replaces inline code with bold in blockquote lines", () => {
+    expect(markdownToSlackMrkdwn("> `code` here")).toBe("> *code* here");
+  });
+
+  it("keeps inline code outside blockquotes unchanged", () => {
+    expect(markdownToSlackMrkdwn("`code` outside")).toBe("`code` outside");
+  });
+
+  it("handles blockquote lines without code unchanged", () => {
+    expect(markdownToSlackMrkdwn("> plain quote")).toBe("> plain quote");
+  });
+
+  it("handles multi-line text with mixed blockquote and non-blockquote code", () => {
+    const result = markdownToSlackMrkdwn(
+      "Top `code` here\n\n> `inner code` in quote\n\nBottom `more` text",
+    );
+    expect(result).toContain("> *inner code* in quote");
+    expect(result).toContain("Top `code` here");
+    expect(result).toContain("Bottom `more` text");
   });
 });

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -130,11 +130,34 @@ export function markdownToSlackMrkdwn(
     blockquotePrefix: "> ",
     tableMode: options.tableMode,
   });
-  return renderMarkdownWithMarkers(ir, buildSlackRenderOptions());
+  return sanitizeSlackBlockquoteCode(
+    renderMarkdownWithMarkers(ir, buildSlackRenderOptions()),
+  );
 }
 
 export function normalizeSlackOutboundText(markdown: string): string {
-  return markdownToSlackMrkdwn(markdown ?? "");
+  return sanitizeSlackBlockquoteCode(markdownToSlackMrkdwn(markdown ?? ""));
+}
+
+/**
+ * Slack mrkdwn can render an empty message when a blockquote line contains
+ * backtick-enclosed inline code (e.g. "> `code`").  Replace backtick
+ * formatting with bold inside blockquote lines to avoid the parser bug.
+ * See https://github.com/openclaw/openclaw/issues/92239.
+ */
+function sanitizeSlackBlockquoteCode(text: string): string {
+  if (!text || !text.includes("`")) {
+    return text;
+  }
+  return text
+    .split("\n")
+    .map((line) => {
+      if (line.startsWith("> ") && line.includes("`")) {
+        return line.replace(/`([^`]+)`/g, "*$1*");
+      }
+      return line;
+    })
+    .join("\n");
 }
 
 export function markdownToSlackMrkdwnChunks(
@@ -155,5 +178,5 @@ export function markdownToSlackMrkdwnChunks(
     limit,
     renderChunk: (chunk) => renderMarkdownWithMarkers(chunk, renderOptions),
     measureRendered: (rendered) => rendered.length,
-  }).map(({ rendered }) => rendered);
+  }).map(({ rendered }) => sanitizeSlackBlockquoteCode(rendered));
 }

--- a/scripts/repro-92239.ts
+++ b/scripts/repro-92239.ts
@@ -1,0 +1,64 @@
+import {
+  markdownToSlackMrkdwn,
+  normalizeSlackOutboundText,
+} from "../extensions/slack/src/format.js";
+
+const PASS = "✓";
+const FAIL = "✗";
+let passed = 0;
+let failed = 0;
+
+function assert(label: string, condition: boolean) {
+  if (condition) {
+    console.log(`  ${PASS} ${label}`);
+    passed += 1;
+  } else {
+    console.log(`  ${FAIL} ${label}`);
+    failed += 1;
+  }
+}
+
+console.log("=== Blockquote + inline code → bold (the fix) ===");
+
+assert(
+  "> `code` → > *code*",
+  markdownToSlackMrkdwn("> `code` in blockquote") === "> *code* in blockquote",
+);
+assert(
+  "> run `deploy` after build → > run *deploy* after build",
+  markdownToSlackMrkdwn("> run `deploy` after build") ===
+    "> run *deploy* after build",
+);
+
+console.log("\n=== Inline code OUTSIDE blockquotes preserved ===");
+assert(
+  "`code` outside blockquote unchanged",
+  markdownToSlackMrkdwn("`code` outside") === "`code` outside",
+);
+
+console.log("\n=== Blockquote WITHOUT code unchanged ===");
+assert(
+  "> plain quote unchanged",
+  markdownToSlackMrkdwn("> plain quote") === "> plain quote",
+);
+assert(
+  "> with <angle> brackets still works",
+  markdownToSlackMrkdwn("> run basecamp done <todo_id> after deploy") ===
+    "> run basecamp done &lt;todo_id&gt; after deploy",
+);
+
+console.log("\n=== Multi-line mixed content ===");
+const mixed = markdownToSlackMrkdwn(
+  "Top `code` here\n\n> `inner code` in quote\n\nBottom `more` text",
+);
+assert("multiline: blockquote has bold", mixed.includes("> *inner code* in quote"));
+assert("multiline: non-blockquote code preserved", mixed.includes("Top `code` here"));
+
+console.log("\n=== normalizeSlackOutboundText ===");
+assert(
+  "normalize also sanitizes",
+  normalizeSlackOutboundText("> `fix` applied") === "> *fix* applied",
+);
+
+console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Fix Slack messages silently rendering empty when a blockquote line contains
backtick-enclosed inline code. Slack's mrkdwn parser has a bug where
`> `code`` causes the entire message body to render blank — the gateway
reports delivery success but the user sees nothing. The fix replaces backtick
formatting with bold (`*`) inside blockquote lines, preserving visual
emphasis while avoiding the parser bug.

## Root Cause

Slack's mrkdwn parser fails silently (empty body) when a blockquote-prefixed
line starts with `>` and contains backtick-enclosed inline code spans. The
markdown-to-mrkdwn renderer correctly produces `> `code``, but Slack's own
rendering engine drops the entire message. Backtick code outside blockquotes
renders normally.

The fix adds `sanitizeSlackBlockquoteCode()` as a post-processing step in the
Slack mrkdwn pipeline (`format.ts`). It replaces backtick delimiters with
asterisk-bold delimiters only within blockquote lines, leaving all other inline
code untouched.

## Real behavior proof

Behavior addressed: Slack mrkdwn blockquote lines with inline code now render
as bold instead of triggering Slack's parser bug and producing an empty message.

Real environment tested: Linux 4.19.112-2.el8.x86_64, Node.js v22.22.0, tsx 4.x,
openclaw workspace import of production `extensions/slack/src/format.js`.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs extensions/slack/src/format.test.ts
./node_modules/.bin/tsx scripts/repro-92239.ts
```

Evidence after fix:

- `format.test.ts`: 14+ tests passed (including 4 new regression cases for #92239)
- `scripts/repro-92239.ts`: 8 assertions, 0 failed
- Blockquote + code: `> `code`` → `> *code*` (bold, not empty)
- Non-blockquote code: ``code`` preserved unchanged
- Blockquote without code: `> plain` preserved unchanged

Observed result after fix:

```
=== Blockquote + inline code → bold (the fix) ===
  ✓ > `code` → > *code*
  ✓ > run `deploy` after build → > run *deploy* after build

=== Inline code OUTSIDE blockquotes preserved ===
  ✓ `code` outside blockquote unchanged

=== Blockquote WITHOUT code unchanged ===
  ✓ > plain quote unchanged
  ✓ > with <angle> brackets still works

=== Multi-line mixed content ===
  ✓ multiline: blockquote has bold
  ✓ multiline: non-blockquote code preserved

=== normalizeSlackOutboundText ===
  ✓ normalize also sanitizes

=== Results: 8 passed, 0 failed ===
```

What was not tested: actual Slack API delivery with a real workspace. The
transformation is verified at the mrkdwn rendering layer; the Slack parser
bug is a known upstream issue (#3011, #92239).

## Regression Test Plan

- [x] `pnpm test -- --run extensions/slack/src/format.test.ts` passes
- [x] `tsx scripts/repro-92239.ts` passes (8 assertions, 0 failed)
- [ ] Change is minimal: 1 source file, +29 lines, no new dependencies

---

*AI-assisted: built with Claude Code*
