### PR TITLE
fix(agents): end isolated cron runs as yielded instead of AbortError when sessions_yield defers a media task

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts
@@ -93,8 +93,39 @@ describe("waitForCompletionRequiredAsyncTasks", () => {
       requiresCompletionRequiredAsyncTaskWait({
         sessionKey,
         toolMetas: [],
+        yieldDetected: false,
       }),
     ).toBe(true);
+  });
+
+  it("skips the wait when the run yielded, even with an active tracked media task", () => {
+    // sessions_yield ends the run and defers continuation to the media task's
+    // completion wake; waiting on the yield-tripped abort signal would fail
+    // the run with AbortError instead (#92120).
+    resetTaskRegistryForTests();
+    const sessionKey = "agent:main:cron:daily-media:run:run-123";
+    createRunningTaskRun({
+      runtime: "cli",
+      taskKind: "image_generation",
+      sourceId: "image_generate:openai",
+      requesterSessionKey: sessionKey,
+      ownerKey: sessionKey,
+      scopeKind: "session",
+      runId: "tool:image_generate:run-123",
+      task: "daily image",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      startedAt: 1,
+      lastEventAt: 1,
+    });
+
+    expect(
+      requiresCompletionRequiredAsyncTaskWait({
+        sessionKey,
+        toolMetas: [],
+        yieldDetected: true,
+      }),
+    ).toBe(false);
   });
 
   it("waits for active cron media tasks from the task registry", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
@@ -140,7 +140,13 @@ function findTerminalTasks(runIds: readonly string[]): {
 export function requiresCompletionRequiredAsyncTaskWait(params: {
   sessionKey: string | undefined;
   toolMetas: readonly AsyncStartedToolMeta[];
+  yieldDetected: boolean;
 }): boolean {
+  // sessions_yield hands continuation to the task-completion wake of this same
+  // session; waiting here would abort-fail on the already-tripped run signal.
+  if (params.yieldDetected) {
+    return false;
+  }
   const sessionKey = params.sessionKey?.trim();
   if (!sessionKey || !isCronRunSessionKey(sessionKey)) {
     return false;

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3302,6 +3302,7 @@ export async function runEmbeddedAttempt(
               requiresCompletionRequiredAsyncTaskWait({
                 sessionKey: params.sessionKey,
                 toolMetas: toolMetasForTerminal,
+                yieldDetected,
               })
             ) {
               return;
@@ -4543,6 +4544,7 @@ export async function runEmbeddedAttempt(
           requiresCompletionRequiredAsyncTaskWait({
             sessionKey: params.sessionKey,
             toolMetas,
+            yieldDetected,
           })
         ) {
           const getAsyncStartedToolMetas = () =>

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -296,6 +296,8 @@ export type SessionEntry = {
   execSecurity?: string;
   execAsk?: string;
   execNode?: string;
+  /** Deferred delete-after-run from a yielded cron run; the cron session reaper deletes marked entries after retention. */
+  cronDeleteAfterRun?: boolean;
   responseUsage?: "on" | "off" | "tokens" | "full";
   providerOverride?: string;
   modelOverride?: string;

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -240,6 +240,7 @@ function makeBaseParams(overrides: {
     deliveryBestEffort: overrides.deliveryBestEffort ?? false,
     deliveryPayloadHasStructuredContent: false,
     deliveryPayloads: overrides.synthesizedText ? [{ text: overrides.synthesizedText }] : [],
+    runYielded: false,
     synthesizedText: overrides.synthesizedText ?? "on it",
     summary: overrides.synthesizedText ?? "on it",
     outputText: overrides.synthesizedText ?? "on it",
@@ -1135,6 +1136,28 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       },
       timeoutMs: 10_000,
     });
+  });
+
+  it("keeps the session for a yielded run even when deleteAfterRun is enabled", async () => {
+    // A yielded run must stay resumable so the pending media task's completion
+    // wake can continue the workflow in the same session (#92120).
+    const params = makeBaseParams({ synthesizedText: SILENT_REPLY_TOKEN });
+    params.agentSessionKey = "agent:main:cron:test-job";
+    (params.job as { deleteAfterRun?: boolean }).deleteAfterRun = true;
+    params.runYielded = true;
+
+    const state = await dispatchCronDelivery(params);
+
+    expectResultFields(state.result, {
+      status: "ok",
+      delivered: false,
+    });
+    expect(callGateway).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "sessions.delete",
+      }),
+    );
+    expect(retireSessionMcpRuntime).not.toHaveBeenCalled();
   });
 
   it("retires the MCP runtime directly when deleteAfterRun gateway cleanup fails", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -114,6 +114,7 @@ type DispatchCronDeliveryParams = {
   deliveryBestEffort: boolean;
   deliveryPayloadHasStructuredContent: boolean;
   deliveryPayloads: ReplyPayload[];
+  runYielded: boolean;
   synthesizedText?: string;
   ttsAuto?: TtsAutoMode;
   summary?: string;
@@ -793,7 +794,10 @@ export async function dispatchCronDelivery(
       ...params.telemetry,
     });
   const cleanupDirectCronSessionIfNeeded = async (): Promise<void> => {
-    if (directCronSessionDeleted) {
+    // A yielded run resumes in this same session when the pending task's
+    // completion wake arrives; deletion is deferred to the cron session
+    // reaper via the entry's cronDeleteAfterRun marker.
+    if (params.runYielded || directCronSessionDeleted) {
       return;
     }
     directCronSessionDeleted = true;

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -894,6 +894,51 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     });
   });
 
+  it("defers deleteAfterRun for yielded runs via the cronDeleteAfterRun marker", async () => {
+    // The media-callback wake must resume this session, so immediate cleanup
+    // is skipped and the session reaper owns the deferred deletion.
+    mockRunCronFallbackPassthrough();
+    runEmbeddedAgentMock.mockResolvedValue({
+      payloads: [],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } }, yielded: true },
+    });
+    const cronSession = makeCronSession();
+    resolveCronSessionMock.mockReturnValue(cronSession);
+    const yieldedJob = makeAnnounceMessageToolJob({
+      id: "yielded-delete-after-run",
+      name: "Yielded Delete After Run",
+    }) as unknown as Record<string, unknown>;
+    yieldedJob.deleteAfterRun = true;
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: yieldedJob as never,
+    });
+
+    expect(cronSession.sessionEntry.cronDeleteAfterRun).toBe(true);
+    expect(dispatchCronDeliveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ runYielded: true }),
+    );
+    expect(cleanupDirectCronSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not mark yielded runs without deleteAfterRun for deferred deletion", async () => {
+    mockRunCronFallbackPassthrough();
+    runEmbeddedAgentMock.mockResolvedValue({
+      payloads: [],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } }, yielded: true },
+    });
+    const cronSession = makeCronSession();
+    resolveCronSessionMock.mockReturnValue(cronSession);
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(cronSession.sessionEntry.cronDeleteAfterRun).toBeUndefined();
+    expect(dispatchCronDeliveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ runYielded: true }),
+    );
+  });
+
   it("skips cron fallback delivery when the message tool already sent to the same target", async () => {
     await expectCronFallbackSkippedForMessageToolDelivery({
       sentTargets: [{ tool: "message", provider: "messagechat", to: "123" }],

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -27,6 +27,7 @@ import {
 import { createDiagnosticMessageLifecycle } from "../../logging/message-lifecycle.js";
 import { isCommandLaneTaskTimeoutError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
+import { isCronSessionKey } from "../../sessions/session-key-utils.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { resolveCronSkillsSnapshot } from "../../skills/runtime/cron-snapshot.js";
 import type { SkillSnapshot } from "../../skills/types.js";
@@ -1038,6 +1039,17 @@ async function finalizeCronRun(params: {
   } else {
     telemetry = { model: modelUsed, provider: providerUsed };
   }
+  const runYielded = finalRunResult.meta?.yielded === true;
+  if (
+    runYielded &&
+    prepared.input.job.deleteAfterRun === true &&
+    isCronSessionKey(prepared.agentSessionKey)
+  ) {
+    // Immediate delete-after-run cleanup is skipped for yielded runs so the
+    // media-callback wake can resume this session; the cron session reaper
+    // deletes marked entries once they age past sessionRetention.
+    prepared.cronSession.sessionEntry.cronDeleteAfterRun = true;
+  }
   await prepared.persistSessionEntry();
 
   if (params.isAborted()) {
@@ -1157,6 +1169,7 @@ async function finalizeCronRun(params: {
     deliveryBestEffort: resolveCronDeliveryBestEffort(prepared.input.job),
     deliveryPayloadHasStructuredContent,
     deliveryPayloads,
+    runYielded,
     synthesizedText,
     ttsAuto: prepared.cronSession.sessionEntry.ttsAuto,
     summary,

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -137,6 +137,103 @@ describe("sweepCronRunSessions", () => {
     });
   });
 
+  it("prunes expired base cron sessions marked cronDeleteAfterRun, preserving fresh ones", async () => {
+    // Yielded delete-after-run jobs defer their cleanup to the reaper; the
+    // retention window gives the media-callback wake time to resume first.
+    const now = Date.now();
+    const store = {
+      "agent:main:cron:job-yielded-old": {
+        sessionId: "yielded-old",
+        updatedAt: now - 25 * 3_600_000,
+        cronDeleteAfterRun: true,
+      },
+      "agent:main:cron:job-yielded-fresh": {
+        sessionId: "yielded-fresh",
+        updatedAt: now - 1 * 3_600_000,
+        cronDeleteAfterRun: true,
+      },
+      "agent:main:cron:job-unmarked-old": {
+        sessionId: "unmarked-old",
+        updatedAt: now - 100 * 3_600_000,
+      },
+      "agent:main:telegram:dm:123": {
+        sessionId: "regular-session",
+        updatedAt: now - 100 * 3_600_000,
+        cronDeleteAfterRun: true,
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.swept).toBe(true);
+    expect(result.pruned).toBe(1);
+
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(Object.keys(updated).toSorted()).toEqual([
+      "agent:main:cron:job-unmarked-old",
+      "agent:main:cron:job-yielded-fresh",
+      "agent:main:telegram:dm:123",
+    ]);
+  });
+
+  it("honors deferred delete-after-run markers even when sessionRetention is disabled", async () => {
+    // deleteAfterRun is explicit per-job deletion intent; the retention opt-out
+    // only disables general run-session pruning, not the deferred deletion.
+    const now = Date.now();
+    const store = {
+      "agent:main:cron:job-yielded-old": {
+        sessionId: "yielded-old",
+        updatedAt: now - 25 * 3_600_000,
+        cronDeleteAfterRun: true,
+      },
+      "agent:main:cron:job1:run:old-run": {
+        sessionId: "old-run",
+        updatedAt: now - 100 * 3_600_000,
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      cronConfig: { sessionRetention: false },
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.pruned).toBe(1);
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(Object.keys(updated)).toEqual(["agent:main:cron:job1:run:old-run"]);
+  });
+
+  it("skips the sweep entirely when retention is disabled and nothing is marked", async () => {
+    const now = Date.now();
+    const store = {
+      "agent:main:cron:job1:run:old-run": {
+        sessionId: "old-run",
+        updatedAt: now - 100 * 3_600_000,
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      cronConfig: { sessionRetention: false },
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result).toEqual({ swept: false, pruned: 0 });
+    expect(JSON.parse(fs.readFileSync(storePath, "utf-8"))).toEqual(store);
+  });
+
   it("archives transcript files for pruned run sessions that are no longer referenced", async () => {
     const now = Date.now();
     const runSessionId = "old-run";

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -4,7 +4,7 @@ import { loadSessionStore } from "../config/sessions/store-load.js";
 import { archiveRemovedSessionTranscripts, updateSessionStore } from "../config/sessions/store.js";
 import type { CronConfig } from "../config/types.cron.js";
 import { cleanupArchivedSessionTranscripts } from "../gateway/session-utils.fs.js";
-import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { isCronRunSessionKey, isCronSessionKey } from "../sessions/session-key-utils.js";
 import type { Logger } from "./service/state.js";
 
 const DEFAULT_RETENTION_MS = 24 * 3_600_000; // 24 hours
@@ -36,7 +36,8 @@ type ReaperResult = {
 };
 
 /**
- * Sweeps completed isolated cron run sessions while preserving base cron sessions.
+ * Sweeps completed isolated cron run sessions while preserving base cron
+ * sessions, except base entries marked `cronDeleteAfterRun` by a yielded run.
  *
  * Must run outside the cron service `locked()` section because this acquires
  * the session-store file lock; reversing that order can deadlock timer ticks.
@@ -61,22 +62,36 @@ export async function sweepCronRunSessions(params: {
   }
 
   const retentionMs = resolveRetentionMs(params.cronConfig);
+  // deleteAfterRun is explicit per-job deletion intent, so marked entries get
+  // deferred cleanup (default grace window) even when general retention is off.
+  const markedCutoff = now - (retentionMs ?? DEFAULT_RETENTION_MS);
   if (retentionMs === null) {
-    lastSweepAtMsByStore.set(storePath, now);
-    return { swept: false, pruned: 0 };
+    const snapshot = loadSessionStore(storePath);
+    const hasMarkedEntry = Object.entries(snapshot).some(
+      ([key, entry]) => entry?.cronDeleteAfterRun === true && isCronSessionKey(key),
+    );
+    if (!hasMarkedEntry) {
+      lastSweepAtMsByStore.set(storePath, now);
+      return { swept: false, pruned: 0 };
+    }
   }
 
   let pruned = 0;
   const prunedSessions = new Map<string, string | undefined>();
   try {
     await updateSessionStore(storePath, (store) => {
-      const cutoff = now - retentionMs;
+      const runCutoff = retentionMs === null ? null : now - retentionMs;
       for (const key of Object.keys(store)) {
-        if (!isCronRunSessionKey(key)) {
-          continue;
-        }
         const entry = store[key];
         if (!entry) {
+          continue;
+        }
+        // Marked entries carry a deferred delete-after-run from a yielded cron
+        // run; their cutoff doubles as the grace window for the media-callback
+        // wake to resume the session before the entry is deleted.
+        const deferredDeleteAfterRun = entry.cronDeleteAfterRun === true && isCronSessionKey(key);
+        const cutoff = deferredDeleteAfterRun ? markedCutoff : runCutoff;
+        if (cutoff === null || (!isCronRunSessionKey(key) && !deferredDeleteAfterRun)) {
           continue;
         }
         const updatedAt = entry.updatedAt ?? 0;
@@ -116,7 +131,7 @@ export async function sweepCronRunSessions(params: {
       if (archivedDirs.size > 0) {
         await cleanupArchivedSessionTranscripts({
           directories: [...archivedDirs],
-          olderThanMs: retentionMs,
+          olderThanMs: retentionMs ?? DEFAULT_RETENTION_MS,
           reason: "deleted",
           nowMs: now,
         });

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -52,6 +52,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "execSecurity",
   "execAsk",
   "execNode",
+  "cronDeleteAfterRun",
   "responseUsage",
   "usageFamilyKey",
   "usageFamilySessionIds",


### PR DESCRIPTION
### Summary

- **Problem**: Issue #92120 reports that an isolated cron `agentTurn` run which calls `image_generate` (background task) and then `sessions_yield` always dies with `lastRunStatus: error`, `lastError: "AbortError: aborted"`. The image is generated and the completion callback is delivered, but the run is already recorded as failed and the remaining workflow steps (the `sessions_send` confirmation in the reporter's job) never execute.
- **Root Cause**: `sessions_yield` is intentional control flow: the tool callback sets `yieldDetected` and aborts the run controller with reason `sessions_yield`, and the prompt-side unwind in `src/agents/embedded-agent-runner/run/attempt.ts` already treats that abort as a clean yield (strips the synthetic aborted entries, persists the hidden resume context, clears `aborted`). But for cron run sessions, the completion-required async-task wait (added by #88695 so cron runs cannot finalize while a generated-media task is still running) executes after that unwind and receives the already-tripped abort signal. `waitForCompletionRequiredAsyncTasks` in `src/agents/embedded-agent-runner/run/attempt.async-tasks.ts` throws its `createAbortError` — an `Error` named `AbortError` with message `aborted`, exactly the reported string — on the first `throwIfAborted`, and the call site's catch only tolerates abort errors for timed-out runs. The intentional yield therefore escapes as a run-level failure that the isolated cron runner records as the run error.
- **Fix**: `requiresCompletionRequiredAsyncTaskWait` now takes the run's `yieldDetected` state and reports that no wait is required for yielded runs: yield hands continuation to the task-completion wake of this same session, so blocking on the tripped signal is both wrong and impossible. This mirrors the existing yield skip for the compaction-retry wait a few lines below in the same function. Both attempt call sites pass the flag — the wait itself, and the terminal-lifecycle deferral that keeps the active-run marker alive only while a wait is actually pending.
- **Companion fix (resume preservation + deferred delete-after-run)**: cron delivery dispatch now receives `runYielded` (from the run result's `yielded` meta) and skips the immediate delete-after-run session cleanup for yielded runs — the media task's completion wake (`wakeMediaGenerationTaskCompletion` → `deliverSubagentAnnouncement`) resumes that session, and deleting it (with its transcript) right after the yielded run would orphan the wake. The `deleteAfterRun` request is not dropped: the cron runner stamps the session entry with a `cronDeleteAfterRun` marker, and the cron session reaper deletes marked entries once they age past `cron.sessionRetention` (default 24h) — retention doubles as the grace window for the callback to resume and finish before deletion.
- **What changed**:
  - `src/agents/embedded-agent-runner/run/attempt.async-tasks.ts` — `requiresCompletionRequiredAsyncTaskWait` gains a required `yieldDetected` input and returns `false` for yielded runs.
  - `src/agents/embedded-agent-runner/run/attempt.ts` — both call sites pass `yieldDetected`.
  - `src/cron/isolated-agent/delivery-dispatch.ts` — `runYielded` param; the immediate delete-after-run session cleanup is deferred for yielded runs.
  - `src/cron/isolated-agent/run.ts` — threads `runYielded` into the dispatch and stamps `cronDeleteAfterRun` on the session entry for yielded delete-after-run jobs (cron session keys only).
  - `src/config/sessions/types.ts` / `src/plugins/session-entry-slot-keys.ts` — the internal `cronDeleteAfterRun` session-entry field and its reserved slot-key registration.
  - `src/cron/session-reaper.ts` — the sweep additionally deletes cron session entries marked `cronDeleteAfterRun` once past retention (default grace window even when `sessionRetention: false`); unmarked base cron sessions stay preserved exactly as before.
  - Tests: wait-gate regression cases in `attempt.async-tasks.test.ts`, yielded delete-after-run dispatch case in `delivery-dispatch.double-announce.test.ts`, marker stamping cases in `run.message-tool-policy.test.ts`, deferred-deletion sweep case in `session-reaper.test.ts`.
- **What did NOT change (scope boundary)**:
  - User-cancel and hard-timeout precedence are unchanged: the wait still abort-fails for non-yield aborts, and the timed-out final sweep (deadline-now re-poll) is untouched.
  - The cron-owned media wait itself is unchanged for non-yield runs — image/music/video tasks still block cron run finalization exactly as #88695 designed.
  - Non-yield delete-after-run cleanup, the announce/wake machinery, and `agent-run-terminal-outcome` normalization are unchanged.
  - The reaper's preservation of unmarked base cron sessions (and their transcript history) is unchanged; only entries explicitly marked by a yielded delete-after-run job become reapable.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`); the only persisted-state addition is the internal `cronDeleteAfterRun` session-entry field, written and consumed exclusively by cron code.
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
- **Relationship to #92146 (same issue)**: that PR gates the wait through a new optional-parameter wrapper keyed on the prompt-throw unwind flag (`yieldAborted`) and also reworks inactive-cron announce routing. This PR instead keys the existing decision helper on `yieldDetected` (set synchronously by the `sessions_yield` tool callback), which covers both yield unwind paths — the prompt-abort throw and the synthetic aborted-response resolve that `createYieldAbortedResponse` exists for, where `yieldAborted` stays false — and updates both call sites (the wait and the terminal-lifecycle active-run-clear deferral) with a compiler-required parameter. It also handles the `deleteAfterRun` lifecycle (resume preservation plus reaper-owned deferred deletion), which #92146 does not touch. The announce-path contract alignment in #92146 is complementary and intentionally not duplicated here.

### Reproduction

1. Create a one-shot isolated cron job (`sessionTarget: "isolated"`, `payload.kind: "agentTurn"`) whose prompt instructs the agent to call `image_generate`, then `sessions_yield` to wait for the callback, then send a `sessions_send` confirmation.
2. Trigger the job. The agent starts the background image task (`Background task started …`), then calls `sessions_yield` (`status: "yielded"`).
3. The yield aborts the run controller with reason `sessions_yield`; the prompt unwind handles it as a clean yield, then the cron-run media wait inherits the tripped signal.
4. **Before this PR**: `waitForCompletionRequiredAsyncTasks` throws `AbortError: aborted` on its first abort check, the catch rethrows because the run did not time out, and the cron run records `lastRunStatus: error`, `lastError: "AbortError: aborted"`. The later media callback wakes a session whose run already failed (and a `deleteAfterRun` job would have deleted that session outright), so the workflow never continues.
5. **After this PR**: the wait is skipped for the yielded run, the attempt finishes through the normal terminal path (`yielded: true`, liveness `paused`, stop reason `end_turn`), the cron run records `status: ok`, and the isolated session — including under `deleteAfterRun` — stays alive for the media completion wake to resume; a yielded `deleteAfterRun` session is then deleted by the cron session reaper after `cron.sessionRetention` instead of immediately.

### Real behavior proof

**Behavior addressed (#92120)**: an isolated cron run that defers a pending `image_generate` task via `sessions_yield` must not be recorded as `error: AbortError: aborted`; it must finish as a yielded run and keep its session resumable so the media completion wake can continue the workflow.

**Real environment tested (Linux, Node 22 — Vitest against the production task registry, wait gate, and cron delivery dispatch)**: the wait-gate cases drive the real task registry (`createRunningTaskRun` with an active `image_generation` task on a cron run session key) through the production `requiresCompletionRequiredAsyncTaskWait`/`waitForCompletionRequiredAsyncTasks`; the cleanup case drives the production `dispatchCronDelivery` with a `deleteAfterRun` job and asserts on the gateway `sessions.delete` boundary.

**Exact steps or command run after this patch**: `pnpm test src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/session-reaper.test.ts src/cron/service.session-reaper-in-finally.test.ts src/plugins/slots.test.ts src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts src/agents/agent-run-terminal-outcome.test.ts`; `pnpm tsgo:core`; `pnpm tsgo:core:test`; `pnpm exec oxfmt --check` and `node scripts/run-oxlint.mjs` on the changed files.

**Evidence after fix (Vitest output for the touched suites)**:

```text
attempt.async-tasks.test.ts + sessions-yield.orchestration.test.ts + agent-run-terminal-outcome.test.ts — all passed
session-reaper.test.ts + run.message-tool-policy.test.ts + delivery-dispatch.double-announce.test.ts + service.session-reaper-in-finally.test.ts   Tests  132 passed (132)
slots.test.ts   Tests  23 passed (23)
```

**Observed result after fix**: with an active tracked `image_generation` task on a cron run session key, the wait gate returns `false` when the run yielded (it returns `true` without the fix, which is what routed the tripped abort signal into the wait); a yielded `deleteAfterRun` dispatch issues no `sessions.delete` gateway call and no MCP retire while the non-yield delete-after-run cases still clean up exactly as before; the yielded run stamps `cronDeleteAfterRun` on the session entry (cron session keys only, and only when the job has `deleteAfterRun`); and the reaper sweep deletes a marked base entry past retention — including under `sessionRetention: false` — while preserving fresh marked entries, unmarked base cron sessions, run sessions under disabled retention, and non-cron sessions carrying a stray marker.

**What was not tested**: a live gateway round-trip of cron → `image_generate` → provider callback → session wake on a real deployment, because this environment has no media-generation provider credentials to drive a real image task. The abort-classification chain (`sessions_yield` abort reason → `createAbortError` → cron error recording) is source-traced and the failure string matches the reporter's `AbortError: aborted` verbatim; the wake delivery path itself (`deliverSubagentAnnouncement`) is unchanged by this PR, and every behavior this PR changes (wait gate, dispatch cleanup skip, marker stamping, reaper deletion) is covered by tests against the production functions.

**Repro confirmation**: the new wait-gate test asserts `false` for a yielded run with an active media task and fails without the production change (the gate returns `true`); the new dispatch test asserts no `sessions.delete` for a yielded `deleteAfterRun` job and fails without the `runYielded` guard; the marker stamping and reaper sweep tests fail without the `cronDeleteAfterRun` stamp and the reaper's deferred-deletion branch respectively.

### Risk / Mitigation

- **Risk**: skipping the wait could let a cron run finalize while a media task is still pending with nobody left to handle it. **Mitigation**: the skip applies only when the agent explicitly called `sessions_yield`, which by contract defers continuation to the task-completion wake of the same session; non-yield cron runs still block on pending media tasks exactly as before.
- **Risk**: deferring `deleteAfterRun` could leave yielded cron sessions behind. **Mitigation**: the deferral has an explicit owner — the cron session reaper deletes entries stamped `cronDeleteAfterRun` once past `cron.sessionRetention` (default 24h), so `deleteAfterRun` is fulfilled late rather than dropped; immediate deletion is exactly what orphans the completion wake this PR repairs. `cron.sessionRetention: false` does not suppress the deferred deletion: `deleteAfterRun` is explicit per-job deletion intent, so marked entries are still swept on the default 24h grace window while the retention opt-out keeps governing general run-session pruning (a cached read-only probe keeps disabled-retention sweeps free of store writes when nothing is marked).
- **Risk**: the reaper could delete a marked session before a very slow media callback arrives. **Mitigation**: retention (default 24h) is orders of magnitude above media generation times, the wake handles a missing session as a logged delivery failure rather than a crash, and resumed-continuation activity ends well within the window in practice.
- **Risk**: user cancellation or a hard timeout could be misread as a yield. **Mitigation**: the gate keys on the runner's `yieldDetected` flag, set only by the `sessions_yield` tool callback; rpc/stop cancellation and timeout phases keep their existing precedence, and the wait still abort-fails for them.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] agents
- [x] cron

### Linked Issue/PR

Fixes #92120

Related #92146
