### PR TITLE
fix(qqbot): keep markdown table chunks valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - UI/mobile/TUI: preserve dashboard session parent lineage, WebChat backscroll, reset soft command args, sidebar session picker interactivity, collapsed workspace files, resolved `/model` confirmation refs, and stale foreground iOS Gateway reconnects. (#90658, #92622, #91353, #92705, #92779, #92773, #92552) Thanks @luoyanglang, @TurboTheTurtle, @zhouhe-xydt, @NianJiuZst, @shakkernerd, @NarahariRaghava, and @Solvely-Colin.
 - Release and test reliability: extend slow Gateway/full-suite watchdogs, split local full-suite shards when throttled, stabilize plugin auth marker fixtures, avoid brittle provider-ref error text, and keep QA Lab bootstrap selection assertions aligned with flow-only scenarios. (#92652)
 - Agent routing: route subagent RPC callbacks addressed to an agent-shaped `--to` target to the correct session key instead of falling back to the main session, so WeChat (and other channel) session-key callbacks reach the intended subagent session. (#90231) Thanks @zhangguiping-xydt.
+- QQBot delivery: keep markdown table chunks self-contained across message boundaries by preserving table state across block deliveries, flushing unfinished table-row fragments as plain text, and detecting short pipe-terminated rows by column count so split rows are not sent as malformed markdown. (#92428) Thanks @sliverp.
 
 ## 2026.6.6
 

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -26,6 +26,7 @@ import { qqbotChannelConfigSchema } from "./config-schema.js";
 import { qqbotDoctor } from "./doctor.js";
 import { loadCredentialBackup, saveCredentialBackup } from "./engine/config/credential-backup.js";
 import { clearAccountCredentials } from "./engine/config/credentials.js";
+import { chunkQQBotMarkdownText } from "./engine/messaging/markdown-table-chunking.js";
 import {
   normalizeTarget as coreNormalizeTarget,
   looksLikeQQBotTarget,
@@ -264,7 +265,8 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
   },
   outbound: {
     deliveryMode: "direct",
-    chunker: (text, limit) => getQQBotRuntime().channel.text.chunkMarkdownText(text, limit),
+    chunker: (text, limit) =>
+      chunkQQBotMarkdownText(text, limit, getQQBotRuntime().channel.text.chunkMarkdownText),
     chunkerMode: "markdown",
     textChunkLimit: 5000,
     sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -658,4 +658,110 @@ describe("dispatchOutbound", () => {
     expect(finalized?.Surface).toBe("qqbot");
     expect(finalized?.ChatType).toBe("direct");
   });
+
+  it("keeps markdown table chunks self-contained across block deliveries", async () => {
+    const runtime = makeRuntime({
+      onDispatch: async ({ deliver }) => {
+        await deliver(
+          {
+            text: ["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n"),
+          },
+          { kind: "block" },
+        );
+        await deliver({ text: ["| 2 | beta |", "| 3 | gamma |"].join("\n") }, { kind: "block" });
+      },
+    });
+
+    await dispatchOutbound(makeInbound(), {
+      runtime,
+      cfg: {},
+      account,
+    });
+
+    expect(sendTextMock).toHaveBeenCalledTimes(2);
+    expect(sendTextMock.mock.calls[0]?.[1]).toBe(
+      ["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n"),
+    );
+    expect(sendTextMock.mock.calls[1]?.[1]).toBe(
+      ["| Id | Value |", "|---:|---|", "| 2 | beta |", "| 3 | gamma |"].join("\n"),
+    );
+  });
+
+  it("waits for a table separator when a block ends after the header", async () => {
+    const runtime = makeRuntime({
+      onDispatch: async ({ deliver }) => {
+        await deliver({ text: "| Id | Value |" }, { kind: "block" });
+        await deliver({ text: ["|---:|---|", "| 1 | alpha |"].join("\n") }, { kind: "block" });
+      },
+    });
+
+    await dispatchOutbound(makeInbound(), {
+      runtime,
+      cfg: {},
+      account,
+    });
+
+    expect(sendTextMock.mock.calls.map((call) => call[1])).toEqual([
+      ["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n"),
+    ]);
+  });
+
+  it("flushes unfinished markdown table row fragments as plain text fields", async () => {
+    const runtime = makeRuntime({
+      onDispatch: async ({ deliver }) => {
+        await deliver(
+          {
+            text: ["| Id | Function | Status |", "|---:|---|---|", "| 1 | auth | ok |"].join("\n"),
+          },
+          { kind: "block" },
+        );
+        await deliver({ text: "| 10 | analyzeerror_patterns | 无需重试" }, { kind: "block" });
+      },
+    });
+
+    await dispatchOutbound(makeInbound(), {
+      runtime,
+      cfg: {},
+      account,
+    });
+
+    expect(sendTextMock.mock.calls.map((call) => call[1])).toEqual([
+      ["| Id | Function | Status |", "|---:|---|---|", "| 1 | auth | ok |"].join("\n"),
+      ["Id: 10", "Function: analyzeerror_patterns", "Status: 无需重试"].join("\n"),
+    ]);
+  });
+
+  it("holds short table rows until a following block completes the columns", async () => {
+    const runtime = makeRuntime({
+      onDispatch: async ({ deliver }) => {
+        await deliver(
+          {
+            text: [
+              "| Id | Time | Owner | Note |",
+              "|---:|---|---|---|",
+              "| 16 | 40ms | He | ok |",
+              "| 17 | 100ms |",
+            ].join("\n"),
+          },
+          { kind: "block" },
+        );
+        await deliver({ text: "Lin | daily cap |" }, { kind: "block" });
+      },
+    });
+
+    await dispatchOutbound(makeInbound(), {
+      runtime,
+      cfg: {},
+      account,
+    });
+
+    expect(sendTextMock.mock.calls.map((call) => call[1])).toEqual([
+      ["| Id | Time | Owner | Note |", "|---:|---|---|---|", "| 16 | 40ms | He | ok |"].join("\n"),
+      [
+        "| Id | Time | Owner | Note |",
+        "|---:|---|---|---|",
+        "| 17 | 100ms | Lin | daily cap |",
+      ].join("\n"),
+    ]);
+  });
 });

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -13,10 +13,12 @@
 import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "openclaw/plugin-sdk/reply-chunking";
 import type { FinalizedMsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import { createQQBotMarkdownChunker } from "../messaging/markdown-table-chunking.js";
 import {
   parseAndSendMediaTags,
   sendPlainReply,
   sendTextOnlyReply,
+  TEXT_CHUNK_LIMIT,
   type DeliverDeps,
 } from "../messaging/outbound-deliver.js";
 import {
@@ -277,6 +279,9 @@ export async function dispatchOutbound(
   });
 
   // ---- Deliver deps ----
+  const markdownChunker = createQQBotMarkdownChunker((text, limit) =>
+    runtime.channel.text.chunkMarkdownText(text, limit),
+  );
   const deliverDeps: DeliverDeps = {
     mediaSender: {
       sendPhoto: (target, imageUrl) => sendPhoto(target, imageUrl),
@@ -286,7 +291,35 @@ export async function dispatchOutbound(
       sendDocument: (target, filePath) => sendDocument(target, filePath),
       sendMedia: (opts) => sendMedia(opts),
     },
-    chunkText: (text, limit) => runtime.channel.text.chunkMarkdownText(text, limit),
+    chunkText: (text, limit) => markdownChunker.chunkText(text, limit),
+  };
+  const flushPendingMarkdownText = async (): Promise<void> => {
+    const pendingChunks = markdownChunker.flushPendingText(TEXT_CHUNK_LIMIT);
+    if (pendingChunks.length === 0) {
+      return;
+    }
+    const passthroughDeps: DeliverDeps = {
+      ...deliverDeps,
+      chunkText: (text) => [text],
+    };
+    for (const chunk of pendingChunks) {
+      await sendTextOnlyReply(
+        chunk,
+        {
+          type: event.type,
+          senderId: event.senderId,
+          messageId: event.messageId,
+          channelId: event.channelId,
+          groupOpenid: event.groupOpenid,
+          msgIdx: event.msgIdx,
+        },
+        { account, qualifiedTarget, log },
+        sendWithRetry,
+        () => undefined,
+        passthroughDeps,
+      );
+      recordOutbound();
+    }
   };
 
   const replyDeps: ReplyDispatcherDeps = {
@@ -690,6 +723,7 @@ export async function dispatchOutbound(
       toolFallbackSent = true;
       await sendToolFallback();
     }
+    await flushPendingMarkdownText();
     if (streamingController && !streamingController.isTerminalPhase) {
       try {
         streamingController.markFullyComplete();

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
@@ -1,0 +1,254 @@
+// QQ Bot Markdown chunking tests cover message-boundary table repair.
+import { describe, expect, it } from "vitest";
+import {
+  chunkQQBotMarkdownText,
+  createQQBotMarkdownChunker,
+  type QQBotBaseMarkdownChunker,
+} from "./markdown-table-chunking.js";
+
+const baseChunker: QQBotBaseMarkdownChunker = (text, limit) =>
+  text.length <= limit ? [text] : [text.slice(0, limit), text.slice(limit)];
+
+describe("chunkQQBotMarkdownText", () => {
+  it("prefixes continuation chunks with the active table header", () => {
+    const text = [
+      "| Id | Value |",
+      "|---:|---|",
+      "| 1 | alpha |",
+      "| 2 | beta |",
+      "| 3 | gamma |",
+    ].join("\n");
+
+    expect(chunkQQBotMarkdownText(text, 45, baseChunker)).toEqual([
+      ["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n"),
+      ["| Id | Value |", "|---:|---|", "| 2 | beta |"].join("\n"),
+      ["| Id | Value |", "|---:|---|", "| 3 | gamma |"].join("\n"),
+    ]);
+  });
+
+  it("keeps table state across streaming block flushes", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    expect(
+      chunker.chunkText(["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n"), 120),
+    ).toEqual([["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n")]);
+    expect(chunker.chunkText(["| 2 | beta |", "| 3 | gamma |"].join("\n"), 120)).toEqual([
+      ["| Id | Value |", "|---:|---|", "| 2 | beta |", "| 3 | gamma |"].join("\n"),
+    ]);
+  });
+
+  it("keeps a possible table header until a later separator confirms the table", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    expect(chunker.chunkText("| Id | Value |", 120)).toEqual([]);
+    expect(
+      chunker.chunkText(["|---:|---|", "| 1 | alpha |", "| 2 | beta |"].join("\n"), 120),
+    ).toEqual([["| Id | Value |", "|---:|---|", "| 1 | alpha |", "| 2 | beta |"].join("\n")]);
+  });
+
+  it("flushes a possible table header as text when the next block is not a separator", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    expect(chunker.chunkText("| maybe | header |", 120)).toEqual([]);
+    expect(chunker.chunkText("plain continuation", 120)).toEqual([
+      ["| maybe | header |", "plain continuation"].join("\n"),
+    ]);
+  });
+
+  it("does not prefix after a table is closed by a blank line", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    chunker.chunkText(["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n") + "\n\n", 120);
+
+    expect(chunker.chunkText("| not | a continuation |", 120)).toEqual([]);
+    expect(chunker.flushPendingText(120)).toEqual(["| not | a continuation |"]);
+  });
+
+  it("renders an oversized table row as fields instead of splitting the row", () => {
+    const text = [
+      "| Id | Error | Retry |",
+      "|---|---|---|",
+      `| 003 | ${"当前无错误信息，处理流程正常运行".repeat(8)} | 当前重试次数为零 |`,
+      "| 004 | ok | zero |",
+    ].join("\n");
+
+    const chunks = chunkQQBotMarkdownText(text, 80, baseChunker);
+
+    expect(chunks[0]).toContain("Id: 003");
+    expect(chunks[0]).toContain("Error:");
+    expect(chunks.some((chunk) => chunk.startsWith("| 当前无错误信息"))).toBe(false);
+    expect(chunks.at(-1)).toBe(
+      ["| Id | Error | Retry |", "|---|---|---|", "| 004 | ok | zero |"].join("\n"),
+    );
+  });
+
+  it("buffers a table row fragment across streaming block flushes", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    expect(
+      chunker.chunkText(
+        ["| Id | Function | Status |", "|---:|---|---|", "| 1 | auth | ok |"].join("\n"),
+        160,
+      ),
+    ).toEqual([["| Id | Function | Status |", "|---:|---|---|", "| 1 | auth | ok |"].join("\n")]);
+
+    expect(chunker.chunkText("| 5 | generatemonthly_sales", 160)).toEqual([]);
+    expect(chunker.chunkText("_by_region | ok |", 160)).toEqual([
+      [
+        "| Id | Function | Status |",
+        "|---:|---|---|",
+        "| 5 | generatemonthly_sales_by_region | ok |",
+      ].join("\n"),
+    ]);
+  });
+
+  it("buffers a pipe-terminated row until it reaches the table column count", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    expect(
+      chunker.chunkText(
+        ["| Id | Time | Owner | Note |", "|---:|---|---|---|", "| 16 | 40ms | He | ok |"].join(
+          "\n",
+        ),
+        200,
+      ),
+    ).toEqual([
+      ["| Id | Time | Owner | Note |", "|---:|---|---|---|", "| 16 | 40ms | He | ok |"].join("\n"),
+    ]);
+
+    expect(chunker.chunkText("| 17 | 100ms |", 200)).toEqual([]);
+    expect(chunker.chunkText("Lin | daily cap |", 200)).toEqual([
+      [
+        "| Id | Time | Owner | Note |",
+        "|---:|---|---|---|",
+        "| 17 | 100ms | Lin | daily cap |",
+      ].join("\n"),
+    ]);
+  });
+
+  it("flushes an unfinished table row fragment as plain fields", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    chunker.chunkText(
+      ["| Id | Function | Status |", "|---:|---|---|", "| 1 | auth | ok |"].join("\n"),
+      160,
+    );
+    expect(chunker.chunkText("| 10 | analyzeerror_patterns | 无需重试", 160)).toEqual([]);
+
+    expect(chunker.flushPendingText(160)).toEqual([
+      ["Id: 10", "Function: analyzeerror_patterns", "Status: 无需重试"].join("\n"),
+    ]);
+  });
+
+  it("does not emit malformed pipe fragments without table context", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    expect(chunker.chunkText("| 5 | reportbuilder.ts | generatemonthly_sales", 160)).toEqual([]);
+    expect(chunker.flushPendingText(160)).toEqual(["5 reportbuilder.ts generatemonthly_sales"]);
+  });
+
+  it("keeps fenced code blocks self-contained across streaming block flushes", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    expect(chunker.chunkText(["```ts", "const a = 1;"].join("\n"), 200)).toEqual([]);
+    expect(chunker.chunkText(["const b = 2;", "```"].join("\n"), 200)).toEqual([
+      ["```ts", "const a = 1;", "const b = 2;", "```"].join("\n"),
+    ]);
+  });
+
+  it("joins a fenced code line split across block deliveries", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    expect(
+      chunker.chunkText(["```python", "    pool_timeout: float = 30."].join("\n"), 200),
+    ).toEqual([]);
+    expect(
+      chunker.chunkText(["0", "    def get_dsn(self) -> str:", "```"].join("\n"), 200),
+    ).toEqual([
+      ["```python", "    pool_timeout: float = 30.0", "    def get_dsn(self) -> str:", "```"].join(
+        "\n",
+      ),
+    ]);
+  });
+
+  it("keeps long fenced chunks under the QQ markdown byte safety limit", () => {
+    const lines = Array.from(
+      { length: 90 },
+      (_, index) =>
+        `        value_${String(index).padStart(3, "0")} = "这是一行用于测试 QQ markdown 不要接近平台截断线的 Python 代码"`,
+    );
+    const text = ["```python", ...lines].join("\n");
+    const chunks = chunkQQBotMarkdownText(text, 5000, baseChunker);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(3600);
+      expect(chunk.startsWith("```python\n")).toBe(true);
+      expect(chunk.endsWith("\n```")).toBe(true);
+    }
+  });
+
+  it("allows ASCII fenced chunks past the old 1800 character fallback", () => {
+    const lines = Array.from(
+      { length: 90 },
+      (_, index) =>
+        `        value_${String(index).padStart(3, "0")} = "ascii markdown budget should use bytes not a short character cap"`,
+    );
+    const chunks = chunkQQBotMarkdownText(["```python", ...lines].join("\n"), 5000, baseChunker);
+
+    expect(chunks.some((chunk) => chunk.length > 1800)).toBe(true);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(3600);
+      expect(chunk.startsWith("```python\n")).toBe(true);
+      expect(chunk.endsWith("\n```")).toBe(true);
+    }
+  });
+
+  it("keeps fenced formula blocks self-contained across streaming block flushes", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    expect(chunker.chunkText(["```math", "E = mc^2"].join("\n"), 200)).toEqual([]);
+    expect(chunker.chunkText(["a^2 + b^2 = c^2", "```"].join("\n"), 200)).toEqual([
+      ["```math", "E = mc^2", "a^2 + b^2 = c^2", "```"].join("\n"),
+    ]);
+  });
+
+  it("splits fenced code chunks between lines for every viable limit", () => {
+    const firstLine = `const value001 = "用于测试代码行保持完整";`;
+    const secondLine = `const value002 = "用于测试代码行保持完整";`;
+    const singleLineFenceLength = Buffer.byteLength(["```ts", firstLine, "```"].join("\n"));
+    const wholeFenceLength = Buffer.byteLength(["```ts", firstLine, secondLine, "```"].join("\n"));
+
+    for (let limit = singleLineFenceLength; limit < wholeFenceLength; limit++) {
+      const chunker = createQQBotMarkdownChunker(baseChunker);
+      const chunks = [
+        ...chunker.chunkText(["```ts", firstLine, secondLine].join("\n"), limit),
+        ...chunker.flushPendingText(limit),
+      ];
+
+      expect(chunks).toEqual([
+        ["```ts", firstLine, "```"].join("\n"),
+        ["```ts", secondLine, "```"].join("\n"),
+      ]);
+    }
+  });
+
+  it("handles prose before and after a table split at row boundaries", () => {
+    const text = [
+      "前置说明第一段，长度足够触发普通文本先发送。",
+      "前置说明第二段继续解释。",
+      "| Id | Value |",
+      "|---:|---|",
+      "| 1 | alpha |",
+      "| 2 | beta |",
+      "后置说明第一段，表格结束后继续普通文字。",
+      "后置说明第二段。",
+    ].join("\n");
+
+    expect(chunkQQBotMarkdownText(text, 180, baseChunker)).toEqual([
+      "前置说明第一段，长度足够触发普通文本先发送。\n前置说明第二段继续解释。",
+      ["| Id | Value |", "|---:|---|", "| 1 | alpha |", "| 2 | beta |"].join("\n"),
+      "后置说明第一段，表格结束后继续普通文字。\n后置说明第二段。",
+    ]);
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -1,0 +1,594 @@
+// QQ Bot Markdown chunking keeps each sent message self-contained.
+
+export type QQBotBaseMarkdownChunker = (text: string, limit: number) => string[];
+
+const QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT = 3600;
+
+type TableHeader = {
+  header: string;
+  separator: string;
+  cells: string[];
+};
+
+type ActiveFence = {
+  openLine: string;
+  closeLine: string;
+  marker: string;
+};
+
+export type QQBotMarkdownChunker = {
+  chunkText: (text: string, limit: number) => string[];
+  flushPendingText: (limit: number) => string[];
+};
+
+export function chunkQQBotMarkdownText(
+  text: string,
+  limit: number,
+  baseChunker: QQBotBaseMarkdownChunker,
+): string[] {
+  const chunker = createQQBotMarkdownChunker(baseChunker);
+  return [...chunker.chunkText(text, limit), ...chunker.flushPendingText(limit)];
+}
+
+export function createQQBotMarkdownChunker(
+  baseChunker: QQBotBaseMarkdownChunker,
+): QQBotMarkdownChunker {
+  const state = new QQBotMarkdownChunkingState(baseChunker);
+  return {
+    chunkText: (text, limit) => state.chunkText(text, limit),
+    flushPendingText: (limit) => state.flushPendingText(limit),
+  };
+}
+
+class QQBotMarkdownChunkingState {
+  private activeTable: TableHeader | null = null;
+  private pendingHeaderLine: string | null = null;
+  private pendingHeaderCells: string[] = [];
+  private tableLines: string[] = [];
+  private textLines: string[] = [];
+  private pendingRowFragment: string | null = null;
+  private activeFence: ActiveFence | null = null;
+  private pendingTextFenceOpenLine: string | null = null;
+  private pendingFenceLineFragment: string | null = null;
+
+  constructor(private readonly baseChunker: QQBotBaseMarkdownChunker) {}
+
+  chunkText(text: string, limit: number): string[] {
+    if (!text) {
+      return [];
+    }
+    if (limit <= 0) {
+      return this.baseChunker(text, limit);
+    }
+    const chunkLimit = resolveQQBotMarkdownChunkLimit(limit);
+
+    const chunks: string[] = [];
+    const textWithPendingRow = this.consumePendingRowPrefix(text);
+    const textWithPendingFenceLine = this.consumePendingFenceLinePrefix(textWithPendingRow);
+    const hasTrailingNewline = textWithPendingFenceLine.endsWith("\n");
+    const lines = textWithPendingFenceLine.split("\n");
+    for (const [index, line] of lines.entries()) {
+      const isTrailingSplitLine = index === lines.length - 1 && line === "";
+      this.consumeLine(line, {
+        limit: chunkLimit,
+        chunks,
+        hasTrailingNewline,
+        isTrailingSplitLine,
+        isLastLine: index === lines.length - 1,
+      });
+    }
+    this.flushText(chunks, chunkLimit);
+    this.flushTable(chunks);
+    return chunks;
+  }
+
+  flushPendingText(limit: number): string[] {
+    const chunkLimit = resolveQQBotMarkdownChunkLimit(limit);
+    const chunks: string[] = [];
+    this.flushPendingRowFragment(chunks, chunkLimit);
+    this.flushPendingFenceLineFragment();
+    this.flushPendingHeaderAsText();
+    this.flushText(chunks, chunkLimit);
+    this.flushTable(chunks);
+    return chunks;
+  }
+
+  private consumeLine(
+    line: string,
+    params: {
+      limit: number;
+      chunks: string[];
+      hasTrailingNewline: boolean;
+      isTrailingSplitLine: boolean;
+      isLastLine: boolean;
+    },
+  ): void {
+    const fence = parseFenceLine(line);
+    if (fence) {
+      this.endTable(params.chunks);
+      if (!this.activeFence) {
+        this.pushTextLine(line);
+        this.activeFence = fence;
+        this.clearPendingTableHeader();
+        return;
+      }
+      if (isClosingFenceLine(line, this.activeFence)) {
+        this.pushFenceTextLine(line);
+        this.activeFence = null;
+        this.clearPendingTableHeader();
+        return;
+      }
+      this.pushFenceTextLine(line);
+      this.clearPendingTableHeader();
+      return;
+    }
+
+    if (this.activeFence) {
+      if (params.isLastLine && !params.hasTrailingNewline) {
+        this.pendingFenceLineFragment = mergeFenceLineFragments(
+          this.pendingFenceLineFragment,
+          line,
+        );
+        return;
+      }
+      this.pushFenceTextLine(line);
+      return;
+    }
+
+    if (
+      isIncompleteTableRowFragment(line) ||
+      (this.activeTable && isShortTableRowLine(line, this.activeTable))
+    ) {
+      if (params.isLastLine) {
+        this.flushText(params.chunks, params.limit);
+        this.pendingRowFragment = mergeRowFragments(this.pendingRowFragment, line);
+        return;
+      }
+      this.pushTextLine(renderMalformedPipeLineAsText(line));
+      return;
+    }
+
+    if (this.pendingHeaderLine && isTableSeparatorLine(line)) {
+      this.flushText(params.chunks, params.limit);
+      this.activeTable = {
+        header: this.pendingHeaderLine,
+        separator: line,
+        cells: this.pendingHeaderCells,
+      };
+      this.pendingHeaderLine = null;
+      this.pendingHeaderCells = [];
+      this.ensureTableHeader();
+      return;
+    }
+
+    if (isTableRowLine(line) && this.activeTable && !isTableSeparatorLine(line)) {
+      this.flushText(params.chunks, params.limit);
+      this.appendTableRow(line, params.limit, params.chunks);
+      return;
+    }
+
+    if (this.activeTable) {
+      if (!line.trim() && params.isTrailingSplitLine) {
+        return;
+      }
+      this.endTable(params.chunks);
+    }
+
+    if (isTableRowLine(line) && !isTableSeparatorLine(line)) {
+      this.flushText(params.chunks, params.limit);
+      this.pendingHeaderLine = line;
+      this.pendingHeaderCells = splitTableCells(line);
+      return;
+    }
+
+    this.flushPendingHeaderAsText();
+    this.pushTextLine(line);
+  }
+
+  private pushTextLine(line: string): void {
+    this.textLines.push(line);
+  }
+
+  private pushFenceTextLine(line: string): void {
+    if (this.textLines.length === 0 && this.activeFence) {
+      this.pendingTextFenceOpenLine = this.activeFence.openLine;
+    }
+    this.textLines.push(line);
+  }
+
+  private appendTableRow(line: string, limit: number, chunks: string[]): void {
+    const rowMessage = [this.activeTable!.header, this.activeTable!.separator, line].join("\n");
+    if (utf8ByteLength(rowMessage) > limit) {
+      this.dropHeaderOnlyTableChunk();
+      this.flushTable(chunks);
+      this.pushOversizedTableRow(line, limit, chunks);
+      return;
+    }
+
+    this.ensureTableHeader();
+    const candidate = [...this.tableLines, line].join("\n");
+    if (utf8ByteLength(candidate) <= limit) {
+      this.tableLines.push(line);
+      return;
+    }
+
+    this.flushTable(chunks);
+    this.ensureTableHeader();
+    this.tableLines.push(line);
+  }
+
+  private pushOversizedTableRow(line: string, limit: number, chunks: string[]): void {
+    const text = renderTableRowAsFields(this.activeTable!.cells, splitTableCells(line));
+    pushBaseChunks(chunks, text, limit, this.baseChunker);
+  }
+
+  private ensureTableHeader(): void {
+    if (this.tableLines.length > 0 || !this.activeTable) {
+      return;
+    }
+    this.tableLines.push(this.activeTable.header, this.activeTable.separator);
+  }
+
+  private flushText(chunks: string[], limit: number): void {
+    if (this.textLines.length === 0) {
+      return;
+    }
+    if (this.flushFenceText(chunks, limit)) {
+      return;
+    }
+    let text = this.textLines.join("\n");
+    this.textLines = [];
+    if (this.pendingTextFenceOpenLine) {
+      text = `${this.pendingTextFenceOpenLine}\n${text}`;
+      this.pendingTextFenceOpenLine = null;
+    }
+    if (this.activeFence) {
+      text = `${text}\n${this.activeFence.closeLine}`;
+    }
+    if (!text) {
+      return;
+    }
+    pushBaseChunks(chunks, text, limit, this.baseChunker);
+  }
+
+  private flushFenceText(chunks: string[], limit: number): boolean {
+    const pendingFenceOpenLine = this.pendingTextFenceOpenLine;
+    const firstLineFence = pendingFenceOpenLine ? null : parseFenceLine(this.textLines[0] ?? "");
+    const fence = pendingFenceOpenLine ? parseFenceLine(pendingFenceOpenLine) : firstLineFence;
+    if (!fence) {
+      return false;
+    }
+
+    const bodyLines = pendingFenceOpenLine ? [...this.textLines] : this.textLines.slice(1);
+    this.textLines = [];
+    this.pendingTextFenceOpenLine = null;
+    if (bodyLines.length > 0 && isClosingFenceLine(bodyLines[bodyLines.length - 1], fence)) {
+      bodyLines.pop();
+    }
+    if (this.activeFence && bodyLines.length === 0) {
+      return true;
+    }
+
+    pushFenceLineChunks({
+      chunks,
+      openLine: fence.openLine,
+      closeLine: fence.closeLine,
+      bodyLines,
+      limit,
+      baseChunker: this.baseChunker,
+    });
+    return true;
+  }
+
+  private consumePendingFenceLinePrefix(text: string): string {
+    if (!this.pendingFenceLineFragment) {
+      return text;
+    }
+    const separator = shouldJoinFenceLineFragments(this.pendingFenceLineFragment, text) ? "" : "\n";
+    const merged = `${this.pendingFenceLineFragment}${separator}${text}`;
+    this.pendingFenceLineFragment = null;
+    return merged;
+  }
+
+  private flushPendingFenceLineFragment(): void {
+    if (!this.pendingFenceLineFragment) {
+      return;
+    }
+    this.pushFenceTextLine(this.pendingFenceLineFragment);
+    this.pendingFenceLineFragment = null;
+  }
+
+  private flushPendingHeaderAsText(): void {
+    if (!this.pendingHeaderLine) {
+      return;
+    }
+    this.pushTextLine(this.pendingHeaderLine);
+    this.pendingHeaderLine = null;
+    this.pendingHeaderCells = [];
+  }
+
+  private clearPendingTableHeader(): void {
+    this.pendingHeaderLine = null;
+    this.pendingHeaderCells = [];
+  }
+
+  private consumePendingRowPrefix(text: string): string {
+    if (!this.pendingRowFragment) {
+      return text;
+    }
+    const separator =
+      this.pendingRowFragment.trimEnd().endsWith("|") && text && !/^[\s|]/.test(text) ? " " : "";
+    const merged = `${this.pendingRowFragment}${separator}${text}`;
+    this.pendingRowFragment = null;
+    return merged;
+  }
+
+  private flushPendingRowFragment(chunks: string[], limit: number): void {
+    if (!this.pendingRowFragment) {
+      return;
+    }
+    const fragment = this.pendingRowFragment;
+    this.pendingRowFragment = null;
+    const text = this.activeTable
+      ? renderTableRowAsFields(this.activeTable.cells, splitPartialTableCells(fragment))
+      : renderMalformedPipeLineAsText(fragment);
+    pushBaseChunks(chunks, text, limit, this.baseChunker);
+  }
+
+  private flushTable(chunks: string[]): void {
+    if (this.tableLines.length === 0) {
+      return;
+    }
+    chunks.push(this.tableLines.join("\n"));
+    this.tableLines = [];
+  }
+
+  private dropHeaderOnlyTableChunk(): void {
+    if (
+      this.activeTable &&
+      this.tableLines.length === 2 &&
+      this.tableLines[0] === this.activeTable.header &&
+      this.tableLines[1] === this.activeTable.separator
+    ) {
+      this.tableLines = [];
+    }
+  }
+
+  private endTable(chunks: string[]): void {
+    this.flushTable(chunks);
+    this.activeTable = null;
+  }
+}
+
+function isTableRowLine(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith("|") && trimmed.endsWith("|") && splitTableCells(trimmed).length >= 2;
+}
+
+function resolveQQBotMarkdownChunkLimit(limit: number): number {
+  return Math.min(limit, QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT);
+}
+
+function pushBaseChunks(
+  chunks: string[],
+  text: string,
+  byteLimit: number,
+  baseChunker: QQBotBaseMarkdownChunker,
+): void {
+  for (const chunk of baseChunker(text, byteLimit)) {
+    if (!chunk) {
+      continue;
+    }
+    if (utf8ByteLength(chunk) <= byteLimit) {
+      chunks.push(chunk);
+      continue;
+    }
+    chunks.push(...splitByUtf8ByteLimit(chunk, byteLimit));
+  }
+}
+
+function splitByUtf8ByteLimit(text: string, byteLimit: number): string[] {
+  if (!text) {
+    return [];
+  }
+  const chunks: string[] = [];
+  let current = "";
+  let currentBytes = 0;
+  for (const char of text) {
+    const charBytes = utf8ByteLength(char);
+    if (current && currentBytes + charBytes > byteLimit) {
+      chunks.push(current);
+      current = "";
+      currentBytes = 0;
+    }
+    current += char;
+    currentBytes += charBytes;
+  }
+  if (current) {
+    chunks.push(current);
+  }
+  return chunks;
+}
+
+function utf8ByteLength(text: string): number {
+  return Buffer.byteLength(text, "utf8");
+}
+
+function isIncompleteTableRowFragment(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    trimmed.startsWith("|") && !trimmed.endsWith("|") && splitPartialTableCells(trimmed).length >= 2
+  );
+}
+
+function isShortTableRowLine(line: string, table: TableHeader): boolean {
+  if (!isTableRowLine(line) || isTableSeparatorLine(line)) {
+    return false;
+  }
+  return splitTableCells(line).length < table.cells.length;
+}
+
+function isTableSeparatorLine(line: string): boolean {
+  if (!isTableRowLine(line)) {
+    return false;
+  }
+  const cells = splitTableCells(line);
+  return cells.length > 0 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()));
+}
+
+function splitTableCells(line: string): string[] {
+  const trimmed = line.trim();
+  return trimmed
+    .slice(1, -1)
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+function splitPartialTableCells(line: string): string[] {
+  const trimmed = line.trim();
+  return trimmed
+    .replace(/^\|/, "")
+    .split("|")
+    .map((cell) => cell.trim())
+    .filter((cell) => cell.length > 0);
+}
+
+function mergeRowFragments(pending: string | null, next: string): string {
+  return pending ? `${pending}${next}` : next;
+}
+
+function mergeFenceLineFragments(pending: string | null, next: string): string {
+  return pending ? `${pending}${next}` : next;
+}
+
+function shouldJoinFenceLineFragments(pending: string, next: string): boolean {
+  if (!next || next.startsWith("\n")) {
+    return true;
+  }
+  const trimmedPending = pending.trimEnd();
+  const trimmedNext = next.trimStart();
+  if (!trimmedPending || !trimmedNext) {
+    return true;
+  }
+  if (/\d\.$/.test(trimmedPending) && /^\d/.test(trimmedNext)) {
+    return true;
+  }
+  if (/[.([{:,+\-*/%=&|^<>\\]$/.test(trimmedPending)) {
+    return true;
+  }
+  return hasUnclosedQuote(trimmedPending) || hasUnclosedDelimiter(trimmedPending);
+}
+
+function hasUnclosedQuote(line: string): boolean {
+  let single = false;
+  let double = false;
+  let escaped = false;
+  for (const char of line) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === "'" && !double) {
+      single = !single;
+      continue;
+    }
+    if (char === '"' && !single) {
+      double = !double;
+    }
+  }
+  return single || double;
+}
+
+function hasUnclosedDelimiter(line: string): boolean {
+  const stack: string[] = [];
+  const pairs: Record<string, string> = { "(": ")", "[": "]", "{": "}" };
+  const closers = new Set(Object.values(pairs));
+  for (const char of line) {
+    if (pairs[char]) {
+      stack.push(pairs[char]);
+      continue;
+    }
+    if (closers.has(char)) {
+      if (stack.at(-1) === char) {
+        stack.pop();
+      }
+    }
+  }
+  return stack.length > 0;
+}
+
+function renderMalformedPipeLineAsText(line: string): string {
+  return splitPartialTableCells(line).join(" ");
+}
+
+function renderTableRowAsFields(headers: string[], cells: string[]): string {
+  return cells
+    .map((cell, index) => {
+      const header = headers[index]?.trim();
+      return header ? `${header}: ${cell}` : cell;
+    })
+    .join("\n");
+}
+
+function pushFenceLineChunks(params: {
+  chunks: string[];
+  openLine: string;
+  closeLine: string;
+  bodyLines: string[];
+  limit: number;
+  baseChunker: QQBotBaseMarkdownChunker;
+}): void {
+  const { chunks, openLine, closeLine, bodyLines, limit, baseChunker } = params;
+  let currentLines: string[] = [];
+  const render = (lines: string[]) => [openLine, ...lines, closeLine].join("\n");
+  const flushCurrent = (): void => {
+    if (currentLines.length === 0) {
+      return;
+    }
+    chunks.push(render(currentLines));
+    currentLines = [];
+  };
+
+  for (const line of bodyLines) {
+    const candidate = [...currentLines, line];
+    if (utf8ByteLength(render(candidate)) <= limit) {
+      currentLines = candidate;
+      continue;
+    }
+    flushCurrent();
+    const singleLineChunk = render([line]);
+    if (utf8ByteLength(singleLineChunk) <= limit) {
+      currentLines = [line];
+      continue;
+    }
+    pushBaseChunks(chunks, singleLineChunk, limit, baseChunker);
+  }
+
+  if (currentLines.length > 0 || bodyLines.length === 0) {
+    chunks.push(render(currentLines));
+  }
+}
+
+function parseFenceLine(line: string): ActiveFence | null {
+  const match = line.match(/^(\s*)(`{3,}|~{3,})/);
+  if (!match?.[2]) {
+    return null;
+  }
+  return {
+    openLine: line,
+    closeLine: `${match[1] ?? ""}${match[2]}`,
+    marker: match[2],
+  };
+}
+
+function isClosingFenceLine(line: string, fence: ActiveFence): boolean {
+  const markerChar = fence.marker[0] === "`" ? "`" : "~";
+  const match = line.match(/^(\s*)(`{3,}|~{3,})\s*$/);
+  return Boolean(
+    match?.[2] && match[2][0] === markerChar && match[2].length >= fence.marker.length,
+  );
+}

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
@@ -73,7 +73,7 @@ export interface DeliverDeps {
 // ---- Exported types ----
 
 /** Maximum text length for a single QQ Bot message. */
-const TEXT_CHUNK_LIMIT = 5000;
+export const TEXT_CHUNK_LIMIT = 5000;
 
 interface DeliverEventContext {
   type: "c2c" | "guild" | "dm" | "group";


### PR DESCRIPTION
Summary
- Add a QQ Bot markdown chunker that keeps table chunks self-contained across message boundaries.
- Preserve table state across block deliveries and flush unfinished table-row fragments as plain text fields.
- Detect short pipe-terminated rows by table column count so split rows are not sent as malformed markdown.

Verification
- node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
- node scripts/run-tsgo.mjs -p extensions/qqbot/tsconfig.json --noEmit
- git diff --check