### PR TITLE
fix(memory-wiki): guard against missing agentIds in cloneMemoryPublicArtifact

### DIFF
--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -305,7 +305,7 @@ function cloneMemoryPublicArtifact(
 ): MemoryPluginPublicArtifact {
   return {
     ...artifact,
-    agentIds: [...artifact.agentIds],
+    agentIds: [...(artifact.agentIds ?? [])],
   };
 }
 
@@ -331,7 +331,7 @@ export async function listActiveMemoryPublicArtifacts(params: {
     if (contentTypeOrder !== 0) {
       return contentTypeOrder;
     }
-    const agentOrder = left.agentIds.join("\0").localeCompare(right.agentIds.join("\0"));
+    const agentOrder = (left.agentIds ?? []).join("\0").localeCompare((right.agentIds ?? []).join("\0"));
     if (agentOrder !== 0) {
       return agentOrder;
     }


### PR DESCRIPTION
## Summary

Fixes #92207: All `wiki_*` tools throw `artifact.agentIds is not iterable` because `listMemoryHostPublicArtifacts()` may omit `agentIds` for some workspaces.

**Fix**: Guard `artifact.agentIds` with `?? []` in:
1. `cloneMemoryPublicArtifact` — spread operator on potentially undefined `agentIds`
2. `.toSorted()` comparator — `.join("\0")` calls on potentially undefined `agentIds`

## Linked context

Closes #92207

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** wiki_* tools crash with "agentIds is not iterable" when memory plugin artifacts omit agentIds
- **Real environment tested:** macOS, Node v22.22.3, latest upstream/main (301213a05)
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs run src/plugins/memory-state.test.ts --reporter=verbose
```

- **Evidence after fix (copied live output):**

```
 ✓ memory plugin state > stores the registered memory runtime
 ✓ memory plugin state > restoreMemoryPluginState swaps both prompt and flush state
 ✓ memory plugin state > clearMemoryPluginState resets both registries
 ...
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

- **Observed result after fix:** `artifact.agentIds ?? []` guards prevent crash when `agentIds` is undefined. The defensive null-safety fix is deterministic.
- **What was not tested:** Live gateway with full memory plugin producing artifacts with missing agentIds. The fix is a mechanical null-guard on two spread/join call sites.

## Tests and validation

**Which commands did you run?**
```bash
node scripts/run-vitest.mjs run src/plugins/memory-state.test.ts
# 14 passed (1 test file)
```

## Risk checklist

**Did user-visible behavior change?** Yes — wiki_* tools no longer crash when agentIds is missing.
**Did config, environment, or migration behavior change?** No
**Did security, auth, secrets, network, or tool execution behavior change?** No
**What is the highest-risk area?** None — deterministic null-guard.
**How is that risk mitigated?** `?? []` is the standard JS pattern for defaulting missing arrays.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Code <noreply@anthropic.com>