### PR TITLE
fix(agents): use thinking-level fallback for programmatic spawn instead of hard throw (fixes #92412)

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1541,8 +1541,11 @@ async function agentCommandInternal(
         catalog: thinkingCatalog,
       })
     ) {
-      const explicitThink = Boolean(thinkOnce || thinkOverride);
-      if (explicitThink) {
+      // Only throw for interactive --think CLI flags (user can correct the value).
+      // Programmatic thinkOverride (from sessions_spawn / session-patch) gets
+      // the resolveSupportedThinkingLevel fallback below — callers cannot handle
+      // unexpected throws and the cron path already uses the same fallback.
+      if (thinkOnce) {
         throw new Error(
           `Thinking level "${resolvedThinkLevel}" is not supported for ${provider}/${model}. Use one of: ${formatThinkingLevels(provider, model, ", ", thinkingCatalog)}.`,
         );


### PR DESCRIPTION
## Summary

When `sessions_spawn` is called with a thinking level the target model doesn't support (e.g. `thinking="xhigh"` for a model using a different reasoning-level vocabulary), the agent command throws hard and the child process dies. The orchestrator receives `{ status: "accepted" }` but the spawn never completes, producing non-deterministic half-failures in parallel fan-outs.

The root cause is at `src/agents/agent-command.ts:1544`: the throw condition uses `Boolean(thinkOnce || thinkOverride)`, which catches both interactive CLI `--think` flags AND programmatic `thinkOverride` from `sessions_spawn`. The fallback path (`resolveSupportedThinkingLevel` at line 1553) already exists but is unreachable for programmatic calls because the throw fires first.

## Fix

Change the throw condition from `if (explicitThink)` (where `explicitThink = Boolean(thinkOnce || thinkOverride)`) to `if (thinkOnce)`. This way:

- **Interactive `--think` CLI flag** (`thinkOnce`): still throws — the user sees the error and can correct the value
- **Programmatic `thinkOverride`** (from `sessions_spawn` / `session-patch`): falls through to `resolveSupportedThinkingLevel` — graceful fallback, no crash

This matches the existing pattern at the same file where the cron path already uses the same fallback.

## Real behavior proof

- **Behavior addressed:** Programmatic `sessions_spawn` with unsupported thinking level no longer throws; falls back to closest supported level instead
- **Environment tested:** macOS 26.4.1, Node.js v25.8.2, OpenClaw build from `fix/sessions-spawn-thinking-fallback` branch (rebased on `fed2c366`)
- **Steps run after the patch:**
```
cd /Users/liuhao/.hermes/workdir/openclaw && pnpm build
grep -n "if (thinkOnce)" dist/agent-command-D16JC9-i.js
```
- **Evidence after fix:**
```
✓ built in 508ms
1148:			if (thinkOnce) throw new Error(`Thinking level "${resolvedThinkLevel}" is not supported for ${provider}/${model}. Use one of: ${formatThinkingLevels(provider, model, ", ", thinkingCatalog)}.`);
```
- **Observed result after fix:** The compiled code throws only when `thinkOnce` is truthy (interactive CLI). Programmatic `thinkOverride` from `sessions_spawn` skips the throw and reaches the `resolveSupportedThinkingLevel` fallback at compiled line ~1152.
- **What was not tested:** Live spawn with an actual unsupported thinking level (requires multi-agent setup with a model that rejects specific thinking levels). The logic change is verified via compiled output inspection.
