### PR TITLE
fix(dispatch): include message_sending hooks when channel supplies custom beforeDeliver (fixes #92374)

### DIFF
--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -710,7 +710,7 @@ describe("withReplyDispatcher", () => {
     expect(dispatcherOptions.silentReplyContext?.conversationType).toBe("direct");
   });
 
-  it("composes custom beforeDeliver with reply_payload_sending hooks", async () => {
+  it("composes custom beforeDeliver with reply_payload_sending and message_sending hooks", async () => {
     const customBeforeDeliver = vi.fn(async (payload: { text?: string }) => ({
       text: `${payload.text ?? ""} [custom]`,
     }));
@@ -755,7 +755,18 @@ describe("withReplyDispatcher", () => {
 
     expect(customBeforeDeliver).toHaveBeenCalledTimes(2);
     expect(customBeforeDeliver).toHaveBeenCalledWith({ text: "original" }, { kind: "final" });
-    expect(runMessageSending).not.toHaveBeenCalled();
+    expect(runMessageSending).toHaveBeenCalledTimes(2);
+    expect(runMessageSending).toHaveBeenCalledWith(
+      {
+        content: "original [custom] [plugin]",
+        to: "conv-1",
+      },
+      {
+        accountId: "acct-1",
+        channelId: "threads",
+        conversationId: "conv-1",
+      },
+    );
     expect(runReplyPayloadSending).toHaveBeenCalledTimes(2);
     expect(runReplyPayloadSending).toHaveBeenCalledWith(
       {
@@ -772,7 +783,7 @@ describe("withReplyDispatcher", () => {
         runId: undefined,
       },
     );
-    expect(payload).toEqual({ text: "original [custom] [plugin]" });
+    expect(payload).toEqual({ text: "message hook" });
     expect(payloadWithMetadata ? getReplyPayloadMetadata(payloadWithMetadata) : undefined).toEqual({
       assistantMessageIndex: 5,
     });

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -549,7 +549,11 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
     buildMessageSendingBeforeDeliver(finalized),
   );
   const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
+    ? combineBeforeDeliverHooks(
+        params.dispatcherOptions.beforeDeliver,
+        replyPayloadBeforeDeliver,
+        buildMessageSendingBeforeDeliver(finalized),
+      )
     : globalBeforeDeliver;
   const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
     foregroundReplyFence || configuredBeforeDeliver
@@ -643,7 +647,11 @@ export async function dispatchInboundMessageWithDispatcher(params: {
     buildMessageSendingBeforeDeliver(params.ctx),
   );
   const composedBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
+    ? combineBeforeDeliverHooks(
+        params.dispatcherOptions.beforeDeliver,
+        replyPayloadBeforeDeliver,
+        buildMessageSendingBeforeDeliver(params.ctx),
+      )
     : globalBeforeDeliver;
   const dispatcher = createReplyDispatcher({
     ...params.dispatcherOptions,


### PR DESCRIPTION
### Summary

- **Problem**: When a channel (e.g. Telegram) supplies `dispatcherOptions.beforeDeliver`, the documented `message_sending` plugin hook is silently excluded from the before-deliver composition chain. Plugin guard/filter extensions register and load normally but their outbound interception is never invoked on channel agent-reply paths.
- **Root Cause**: Both `dispatchInboundMessageWithBufferedDispatcher` and `dispatchInboundMessageWithDispatcher` build `globalBeforeDeliver` with `buildMessageSendingBeforeDeliver` included, but when `params.dispatcherOptions.beforeDeliver` is set they switch to a `configuredBeforeDeliver`/`composedBeforeDeliver` that composes only the channel hook with `replyPayloadBeforeDeliver` — omitting `buildMessageSendingBeforeDeliver`.
- **Fix**: Add `buildMessageSendingBeforeDeliver(...)` as the third argument to `combineBeforeDeliverHooks` in both configured/composed branches, so the hook chain runs: channel beforeDeliver → reply_payload_sending → message_sending.
- **What changed**:
  - `src/auto-reply/dispatch.ts` — two dispatch functions each gain one `buildMessageSendingBeforeDeliver` call in the configured branch (+10 lines net, including formatting)
- **What did NOT change (scope boundary)**:
  - Preview-finalized (draft stream) agent finals — those bypass `deliverReplies` entirely (tracked separately in the issue body as layer 2)
  - No startup warning for silent bypass — tracked separately (issue body layer 3)
  - Channel implementations — the fix is in the shared dispatcher, covers all channels uniformly

### Reproduction

1. Register a plugin with `api.on("message_sending", handler)`.
2. Confirm the plugin loads (registration log appears at gateway start).
3. Send a DM to a Telegram-connected agent and receive its conversational reply.
4. **Before this PR**: reply is delivered; `message_sending` hook never fires. The internal `message:sent` event fires, confirming the send traversed the instrumented path, but the plugin hook is bypassed.
5. **After this PR**: `message_sending` hook fires for every outbound reply, regardless of whether the channel supplies `beforeDeliver`.

### Real behavior proof

**Behavior or issue addressed (#92374)**: Outbound `message_sending` plugin hooks are now included in the before-deliver composition when a channel provides custom `beforeDeliver`, closing the silent bypass on channel agent-reply paths.

**Real environment tested**: Linux, Node 22 — CI-equivalent test harness exercising `dispatchInboundMessageWithDispatcher` and `dispatchInboundMessageWithBufferedDispatcher` composition paths.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/auto-reply/dispatch.test.ts`

**Evidence after fix**:
```text
 RUN  v4.1.7 /home/0668001395/openclawProject1

 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  20:02:46
   Duration  3.60s (transform 1.60s, setup 388ms, import 2.85s, tests 98ms, environment 0ms)

[test] passed 1 Vitest shard in 13.25s
```

**Observed result after fix**: The "composes custom beforeDeliver with reply_payload_sending and message_sending hooks" case now verifies that `runMessageSending` is called with the expected content after both the channel hook and `replyPayloadBeforeDeliver` have transformed the payload. The existing "runs message_sending hooks before inbound dispatcher delivery" and "runs message_sending after reply_payload_sending for inbound dispatcher delivery" cases continue to exercise the global path — confirming the fix does not alter existing hook ordering behavior.

**What was not tested**: Live Telegram end-to-end round-trip was not driven; the preview-finalized (draft stream) path was not covered by this fix.

**Repro confirmation**: Before the fix, the test case explicitly asserted `expect(runMessageSending).not.toHaveBeenCalled()` — confirming message_sending was bypassed when `beforeDeliver` was present. After the fix, that assertion is replaced with `expect(runMessageSending).toHaveBeenCalledTimes(2)` with verified call arguments, and the full suite of 18 dispatch composition cases continues to produce the expected results across both dispatch paths.

### Risk / Mitigation

- **Risk**: Adding `message_sending` to the configured composition could cause duplicate hook execution if any path already runs it downstream.
  **Mitigation**: The `combineBeforeDeliverHooks` function chains hooks in order; both dispatch paths now use identical composition: channel → reply_payload_sending → message_sending. The existing cases for `message_sending` on the global path confirm no double-execution regressions. Additionally, `buildMessageSendingBeforeDeliver` returns `undefined` when no hooks are registered, making this a no-op for channels without message_sending plugins.
- **Risk**: Hook ordering puts channel normalization before plugin security cancellation, so a channel transform could alter content after a prior message_sending cancellation boundary.
  **Mitigation**: Channel normalization runs first in the chain (as it did before), and message_sending is the last hook — it can cancel or rewrite the final product of normalization + reply_payload_sending, which is the correct security ordering.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] auto-reply / dispatch
- [x] plugin-sdk hooks

### Regression Test Plan

- `node scripts/run-vitest.mjs src/auto-reply/dispatch.test.ts`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #92374
