### PR TITLE
fix(feishu): redact audit-sensitive contact info

### DIFF
--- a/extensions/feishu/src/audit-redaction.ts
+++ b/extensions/feishu/src/audit-redaction.ts
@@ -1,0 +1,77 @@
+const EMAIL_ADDRESS_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const CHINA_MAINLAND_MOBILE_RE =
+  /(?<![\dA-Za-z])(?:\+?86[-\s]?)?1[3-9]\d[-\s]?\d{4}[-\s]?\d{4}(?![\dA-Za-z])/g;
+const CHINA_SERVICE_PHONE_RE =
+  /(?<![\dA-Za-z])(?:95\d{3}|(?:400|800)[-\s]?\d{3}[-\s]?\d{4})(?![\dA-Za-z])/g;
+
+const EMAIL_REDACTION_TEXT = "[email redacted]";
+const PHONE_REDACTION_TEXT = "[phone redacted]";
+const FEISHU_VISIBLE_TEXT_TAGS = new Set(["markdown", "plain_text", "lark_md"]);
+const FEISHU_TEMPLATE_VARIABLE_KEYS = new Set(["template_variable", "template_variables"]);
+const FEISHU_OPAQUE_CARD_KEYS = new Set(["value"]);
+
+type JsonRecord = Record<string, unknown>;
+
+/**
+ * Feishu may reject bot messages that include contact identifiers with audit
+ * code 230028. Redact them at the Feishu outbound boundary so a successful
+ * agent result is not followed by a failed delivery fallback.
+ */
+export function redactFeishuAuditSensitiveText(text: string): string {
+  return text
+    .replace(EMAIL_ADDRESS_RE, EMAIL_REDACTION_TEXT)
+    .replace(CHINA_MAINLAND_MOBILE_RE, PHONE_REDACTION_TEXT)
+    .replace(CHINA_SERVICE_PHONE_RE, PHONE_REDACTION_TEXT);
+}
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isVisibleTextNode(record: JsonRecord): boolean {
+  return typeof record.tag === "string" && FEISHU_VISIBLE_TEXT_TAGS.has(record.tag);
+}
+
+function redactFeishuTemplateVariableValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    return redactFeishuAuditSensitiveText(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactFeishuTemplateVariableValue(item));
+  }
+  if (!isJsonRecord(value)) {
+    return value;
+  }
+
+  const redacted: JsonRecord = {};
+  for (const [key, item] of Object.entries(value)) {
+    redacted[key] = redactFeishuTemplateVariableValue(item);
+  }
+  return redacted;
+}
+
+function redactFeishuCardVisibleValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactFeishuCardVisibleValue(item));
+  }
+  if (!isJsonRecord(value)) {
+    return value;
+  }
+
+  const redactsContent = isVisibleTextNode(value);
+  const redacted: JsonRecord = {};
+  for (const [key, item] of Object.entries(value)) {
+    redacted[key] = FEISHU_OPAQUE_CARD_KEYS.has(key)
+      ? item
+      : redactsContent && key === "content" && typeof item === "string"
+        ? redactFeishuAuditSensitiveText(item)
+        : FEISHU_TEMPLATE_VARIABLE_KEYS.has(key)
+          ? redactFeishuTemplateVariableValue(item)
+          : redactFeishuCardVisibleValue(item);
+  }
+  return redacted;
+}
+
+export function redactFeishuCardVisibleText<T extends JsonRecord>(card: T): T {
+  return redactFeishuCardVisibleValue(card) as T;
+}

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -1,6 +1,7 @@
 // Feishu tests cover send plugin behavior.
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
+import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
 import { buildFeishuPostMessagePayload, buildMarkdownCard } from "./send.js";
 
 const {
@@ -62,6 +63,7 @@ let editMessageFeishu: typeof import("./send.js").editMessageFeishu;
 let getMessageFeishu: typeof import("./send.js").getMessageFeishu;
 let listFeishuThreadMessages: typeof import("./send.js").listFeishuThreadMessages;
 let resolveFeishuCardTemplate: typeof import("./send.js").resolveFeishuCardTemplate;
+let sendCardFeishu: typeof import("./send.js").sendCardFeishu;
 let sendMessageFeishu: typeof import("./send.js").sendMessageFeishu;
 
 describe("buildFeishuPostMessagePayload", () => {
@@ -115,6 +117,7 @@ describe("getMessageFeishu", () => {
       getMessageFeishu,
       listFeishuThreadMessages,
       resolveFeishuCardTemplate,
+      sendCardFeishu,
       sendMessageFeishu,
     } = await import("./send.js"));
   });
@@ -291,6 +294,129 @@ describe("getMessageFeishu", () => {
         ],
       },
     });
+  });
+
+  it("redacts audit-sensitive contact info in post markdown without rewriting mention elements", async () => {
+    const create = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om_redacted" } });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          reply: vi.fn(),
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+
+    await sendMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      to: "oc_send",
+      text: "Latest invoice came from billing@example.com; call +86 138-1234-5678 or 95530.",
+      mentions: [{ openId: "ou_target", name: "Target User", key: "@_user_1" }],
+    });
+
+    const content = JSON.parse(create.mock.calls[0]![0].data.content) as {
+      zh_cn: { content: Array<Array<{ tag: string; text?: string; user_id?: string }>> };
+    };
+    expect(content.zh_cn.content[0]).toEqual([
+      { tag: "at", user_id: "ou_target", user_name: "Target User" },
+      {
+        tag: "md",
+        text: "Latest invoice came from [email redacted]; call [phone redacted] or [phone redacted].",
+      },
+    ]);
+  });
+
+  it("redacts visible card text without rewriting action payloads", async () => {
+    const create = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om_card" } });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          reply: vi.fn(),
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+    const actionValue = {
+      ...createFeishuCardInteractionEnvelope({
+        k: "meta",
+        a: "test.audit_redaction.fixture",
+        m: {
+          command: "/mail 51fapiao@ceair.com",
+          phone: "95530",
+        },
+      }),
+      template_variables: { email: "callback@example.com" },
+    };
+
+    await sendCardFeishu({
+      cfg: {} as ClawdbotConfig,
+      to: "oc_send",
+      card: {
+        header: {
+          title: { tag: "plain_text", content: "Owner billing@example.com" },
+        },
+        template_variable: {
+          owner: "billing@example.com",
+          support: "95530",
+        },
+        template_variables: {
+          hotline: "400-123-4567",
+        },
+        body: {
+          elements: [
+            { tag: "markdown", content: "Contact 51fapiao@ceair.com or 400-123-4567" },
+            {
+              tag: "action",
+              actions: [
+                {
+                  tag: "button",
+                  text: { tag: "plain_text", content: "Call 95530" },
+                  url: "https://example.com/support?phone=95530",
+                  value: actionValue,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    const card = JSON.parse(create.mock.calls[0]![0].data.content) as {
+      header: { title: { content: string } };
+      template_variable: { owner: string; support: string };
+      template_variables: { hotline: string };
+      body: {
+        elements: [
+          { content: string },
+          {
+            actions: Array<{
+              text: { content: string };
+              url: string;
+              value: typeof actionValue;
+            }>;
+          },
+        ];
+      };
+    };
+    const action = card.body.elements[1].actions[0]!;
+    expect(card.header.title.content).toBe("Owner [email redacted]");
+    expect(card.template_variable).toEqual({
+      owner: "[email redacted]",
+      support: "[phone redacted]",
+    });
+    expect(card.template_variables).toEqual({
+      hotline: "[phone redacted]",
+    });
+    expect(card.body.elements[0].content).toBe("Contact [email redacted] or [phone redacted]");
+    expect(action.text.content).toBe("Call [phone redacted]");
+    expect(action.url).toBe("https://example.com/support?phone=95530");
+    expect(action.value).toEqual(actionValue);
   });
 
   it("extracts text content from interactive card elements", async () => {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -8,6 +8,7 @@ import {
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { redactFeishuAuditSensitiveText, redactFeishuCardVisibleText } from "./audit-redaction.js";
 import { createFeishuClient } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import type { MentionTarget } from "./mention-target.types.js";
@@ -569,7 +570,7 @@ export function buildFeishuPostMessagePayload(params: {
     ...buildFeishuPostMentionElements(mentions),
     {
       tag: "md",
-      text: messageText,
+      text: redactFeishuAuditSensitiveText(messageText),
     },
   ];
   return {
@@ -633,7 +634,7 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
   const { cfg, to, card, replyToMessageId, replyInThread, allowTopLevelReplyFallback, accountId } =
     params;
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
-  const content = JSON.stringify(card);
+  const content = JSON.stringify(redactFeishuCardVisibleText(card));
 
   const directParams = { receiveId, receiveIdType, content, msgType: "interactive" };
   return sendReplyOrFallbackDirect(client, {
@@ -670,7 +671,7 @@ export async function editMessageFeishu(params: {
   const client = createFeishuClient(account);
 
   if (card) {
-    const content = JSON.stringify(card);
+    const content = JSON.stringify(redactFeishuCardVisibleText(card));
     const response = await client.im.message.patch({
       path: { message_id: messageId },
       data: { content },

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -38,6 +38,11 @@ type StreamingRequest = {
   res: ServerResponse;
 };
 
+type RecordedStreamingFetchCall = {
+  url: URL;
+  body: string;
+};
+
 const serverStops: Array<() => Promise<void>> = [];
 const HERMETIC_PUBLIC_LOOKUP_ADDRESS = "93.184.216.34";
 
@@ -132,6 +137,36 @@ function createMemoryFetch(
     ) as FeishuStreamingFetch,
     lookupFn: hermeticPublicLookup,
   };
+}
+
+function createRecordedStreamingFetch(): {
+  calls: RecordedStreamingFetchCall[];
+  deps: StreamingFetchDeps;
+} {
+  const calls: RecordedStreamingFetchCall[] = [];
+  const deps = createMemoryFetch((url, body) => {
+    calls.push({ url, body });
+    if (url.pathname.includes("/auth/")) {
+      return jsonResponse({
+        code: 0,
+        msg: "ok",
+        tenant_access_token: "token",
+        expire: 7200,
+      });
+    }
+    if (url.pathname.endsWith("/cardkit/v1/cards")) {
+      return jsonResponse({ code: 0, msg: "ok", data: { card_id: "card_1" } });
+    }
+    return jsonResponse({ code: 0, msg: "ok" });
+  });
+  return { calls, deps };
+}
+
+function findRecordedCall(
+  calls: readonly RecordedStreamingFetchCall[],
+  pathnameMatch: (pathname: string) => boolean,
+): RecordedStreamingFetchCall | undefined {
+  return calls.find((call) => pathnameMatch(call.url.pathname));
 }
 
 function writeJson(res: ServerResponse, payload: unknown, status = 200): void {
@@ -1037,6 +1072,155 @@ describe("FeishuStreamingSession", () => {
     expect(log).toHaveBeenCalledWith(
       "Final update failed: Error: Update card content failed with HTTP 500",
     );
+  });
+
+  it("redacts audit-sensitive contact info in streaming card payloads", async () => {
+    const { calls, deps } = createRecordedStreamingFetch();
+    const create = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om_1" } });
+    const client = {
+      im: {
+        message: {
+          create,
+        },
+      },
+    } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0];
+    const session = new FeishuStreamingSession(
+      client,
+      {
+        appId: "app_stream_redaction",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    );
+
+    await session.start("oc_1", "chat_id", {
+      header: { title: "Owner bob@example.com 13812345678" },
+      note: "Hotline 95530",
+    });
+    await session.update("Reach alice@example.com via 400-123-4567");
+    await session.close("Final call 13912345678 or 95530", {
+      note: "cc billing@example.com",
+    });
+
+    const createCall = findRecordedCall(calls, (pathname) =>
+      pathname.endsWith("/cardkit/v1/cards"),
+    );
+    const createBody = JSON.parse(createCall?.body ?? "{}") as { data?: string };
+    const cardJson = JSON.parse(createBody.data ?? "{}") as {
+      header: { title: { content: string } };
+      body: { elements: Array<{ content?: string }> };
+    };
+    expect(cardJson.header.title.content).toBe("Owner [email redacted] [phone redacted]");
+    expect(cardJson.body.elements[2]?.content).toBe(
+      "<font color='grey'>Hotline [phone redacted]</font>",
+    );
+
+    const updateCall = findRecordedCall(calls, (pathname) =>
+      pathname.includes("/elements/content/content"),
+    );
+    const updateBody = JSON.parse(updateCall?.body ?? "{}") as { content?: string };
+    expect(updateBody.content).toBe("Reach [email redacted] via [phone redacted]");
+
+    const replaceCall = findRecordedCall(calls, (pathname) =>
+      pathname.endsWith("/elements/content"),
+    );
+    const replaceBody = JSON.parse(replaceCall?.body ?? "{}") as { element?: string };
+    const replaceElement = JSON.parse(replaceBody.element ?? "{}") as { content?: string };
+    expect(replaceElement.content).toBe("Final call [phone redacted] or [phone redacted]");
+
+    const noteCall = findRecordedCall(calls, (pathname) =>
+      pathname.includes("/elements/note/content"),
+    );
+    const noteBody = JSON.parse(noteCall?.body ?? "{}") as { content?: string };
+    expect(noteBody.content).toBe("<font color='grey'>cc [email redacted]</font>");
+
+    const closeCall = findRecordedCall(calls, (pathname) => pathname.endsWith("/settings"));
+    const closeBody = JSON.parse(closeCall?.body ?? "{}") as { settings?: string };
+    const closeSettings = JSON.parse(closeBody.settings ?? "{}") as {
+      config?: { summary?: { content?: string } };
+    };
+    expect(closeSettings.config?.summary?.content).toBe(
+      "Final call [phone redacted] or [phone redacted]",
+    );
+  });
+
+  it("redacts streaming close summaries before truncation", async () => {
+    const { calls, deps } = createRecordedStreamingFetch();
+    const session = new FeishuStreamingSession(
+      {} as never,
+      {
+        appId: "app_stream_summary_redaction",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_summary",
+        messageId: "om_summary",
+        sequence: 1,
+        currentText: "",
+        sentText: "",
+        hasNote: false,
+      },
+      lastUpdateTime: 0,
+    });
+
+    await session.close(`${".".repeat(43)} 400-123-4567 after the cutoff`);
+
+    const closeCall = findRecordedCall(calls, (pathname) => pathname.endsWith("/settings"));
+    const closeBody = JSON.parse(closeCall?.body ?? "{}") as { settings?: string };
+    const closeSettings = JSON.parse(closeBody.settings ?? "{}") as {
+      config?: { summary?: { content?: string } };
+    };
+    const summary = closeSettings.config?.summary?.content ?? "";
+
+    expect(summary).not.toContain("400");
+    expect(summary).not.toContain("123");
+  });
+
+  it("keeps streaming merge state unredacted while redacting outbound payloads", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(5_000);
+    const updateBodies: string[] = [];
+    const deps = mockFetches(updateBodies);
+    const session = new FeishuStreamingSession(
+      {} as never,
+      {
+        appId: "app_stream_merge_redaction",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_merge",
+        messageId: "om_merge",
+        sequence: 1,
+        currentText: "",
+        sentText: "",
+        hasNote: false,
+      },
+      lastUpdateTime: 0,
+    });
+
+    await session.update("Reach alice@example.com");
+    await session.update("Reach alice@example.com now with invoice context");
+
+    const updateContents = updateBodies.map((body) => {
+      const parsed = JSON.parse(body) as { content?: string };
+      return parsed.content;
+    });
+    expect(updateContents).toEqual([
+      "Reach [email redacted]",
+      "Reach [email redacted] now with invoice context",
+    ]);
+    const internals = session as unknown as { state: StreamingSessionState | null };
+    expect(internals.state?.currentText).toBe("Reach alice@example.com now with invoice context");
+    expect(internals.state?.sentText).toBe("Reach alice@example.com now with invoice context");
   });
 
   it("bounds streaming token cache lifetime when token expiry overflows", async () => {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { redactFeishuAuditSensitiveText } from "./audit-redaction.js";
 import { FEISHU_HTTP_TIMEOUT_MS } from "./client-timeout.js";
 import { getFeishuUserAgent } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
@@ -288,7 +289,7 @@ export class FeishuStreamingSession {
       elements.push({ tag: "hr" });
       elements.push({
         tag: "markdown",
-        content: `<font color='grey'>${options.note}</font>`,
+        content: `<font color='grey'>${redactFeishuAuditSensitiveText(options.note)}</font>`,
         element_id: "note",
       });
     }
@@ -303,7 +304,10 @@ export class FeishuStreamingSession {
     };
     if (options?.header) {
       cardJson.header = {
-        title: { tag: "plain_text", content: options.header.title },
+        title: {
+          tag: "plain_text",
+          content: redactFeishuAuditSensitiveText(options.header.title),
+        },
         template: resolveFeishuCardTemplate(options.header.template) ?? "blue",
       };
     }
@@ -417,6 +421,7 @@ export class FeishuStreamingSession {
     if (!this.state) {
       return false;
     }
+    const safeText = redactFeishuAuditSensitiveText(text);
     const apiBase = resolveApiBase(this.creds.domain);
     this.state.sequence += 1;
     try {
@@ -433,7 +438,7 @@ export class FeishuStreamingSession {
             "User-Agent": getFeishuUserAgent(),
           },
           body: JSON.stringify({
-            content: text,
+            content: safeText,
             sequence: this.state.sequence,
             uuid: `s_${this.state.cardId}_${this.state.sequence}`,
           }),
@@ -467,6 +472,7 @@ export class FeishuStreamingSession {
     if (!this.state) {
       return false;
     }
+    const safeText = redactFeishuAuditSensitiveText(text);
     const apiBase = resolveApiBase(this.creds.domain);
     this.state.sequence += 1;
     try {
@@ -483,7 +489,7 @@ export class FeishuStreamingSession {
             "User-Agent": getFeishuUserAgent(),
           },
           body: JSON.stringify({
-            element: JSON.stringify({ tag: "markdown", content: text, element_id: "content" }),
+            element: JSON.stringify({ tag: "markdown", content: safeText, element_id: "content" }),
             sequence: this.state.sequence,
             uuid: `r_${this.state.cardId}_${this.state.sequence}`,
           }),
@@ -596,7 +602,7 @@ export class FeishuStreamingSession {
           "User-Agent": getFeishuUserAgent(),
         },
         body: JSON.stringify({
-          content: `<font color='grey'>${note}</font>`,
+          content: `<font color='grey'>${redactFeishuAuditSensitiveText(note)}</font>`,
           sequence: this.state.sequence,
           uuid: `n_${this.state.cardId}_${this.state.sequence}`,
         }),
@@ -673,7 +679,12 @@ export class FeishuStreamingSession {
         },
         body: JSON.stringify({
           settings: JSON.stringify({
-            config: { streaming_mode: false, summary: { content: truncateSummary(acceptedText) } },
+            config: {
+              streaming_mode: false,
+              summary: {
+                content: truncateSummary(redactFeishuAuditSensitiveText(acceptedText)),
+              },
+            },
           }),
           sequence: this.state.sequence,
           uuid: `c_${this.state.cardId}_${this.state.sequence}`,


### PR DESCRIPTION
## Summary
- Redact Feishu audit-sensitive contact identifiers at outbound message boundaries before sending text, cards, edited cards, and streaming Card Kit updates.
- Cover email addresses, mainland China mobile numbers, 95xxx service numbers, and 400/800 hotline formats.
- Add regression coverage for post messages, interactive cards, edited messages, structured/markdown cards, and streaming card update/replace/note/summary payloads.

## Real behavior proof

- Behavior or issue addressed: Feishu final replies containing contact identifiers can be rejected by Feishu audit code 230028, which leaves users seeing the misleading no-visible-content fallback instead of the generated answer.
- Real environment tested: macOS local OpenClaw gateway with a real Feishu account and the Feishu plugin loaded from the installed runtime path under `/Users/bytedance/.openclaw/npm/projects/.../@openclaw/feishu/dist/index.js`.
- Exact steps or command run after this patch: Applied the same outbound redaction logic from this PR to the installed Feishu plugin runtime, restarted the gateway with `openclaw gateway restart`, then sent a real Feishu delivery using `openclaw agent --agent main --message '东方航空 95530 这封邮件主要讲的是啥内容？' --deliver --reply-channel feishu ... --json`.
- Evidence after fix: Terminal transcript from the real Feishu delivery path:

```text
$ openclaw agent --agent main --message '东方航空 95530 这封邮件主要讲的是啥内容？' --deliver --reply-channel feishu ... --json
{
  "runId": "72bbf949-d61b-4ea4-882a-3db86806332f",
  "status": "ok",
  "deliverySucceeded": true,
  "deliveryStatus": {
    "status": "sent"
  }
}
```

- Observed result after fix: The same service-number prompt delivered successfully through Feishu with `deliverySucceeded: true` and `deliveryStatus.status: sent`; the gateway log for that run did not show Feishu `230028`, `final reply failed`, or the no-visible-content fallback.
- What was not tested: No known gaps.

## Test Plan
- node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-feishu.config.ts
- node scripts/run-tsgo.mjs
- node scripts/run-oxlint.mjs extensions/feishu/src
