### PR TITLE
feat(cli): add --file option to image generate command (fixes #91734)

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -1930,6 +1930,42 @@ describe("capability cli", () => {
     expect(mocks.generateImage).not.toHaveBeenCalled();
   });
 
+  it("forwards --file from image generate to runImageGenerate", async () => {
+    const inputPath = path.join(os.tmpdir(), `openclaw-image-gen-input-${Date.now()}.png`);
+    await fs.writeFile(inputPath, Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
+
+    mocks.generateImage.mockResolvedValue({
+      provider: "openai",
+      model: "gpt-image-1",
+      attempts: [],
+      images: [],
+    });
+
+    try {
+      await runRegisteredCli({
+        register: registerCapabilityCli as (program: Command) => void,
+        argv: [
+          "capability",
+          "image",
+          "generate",
+          "--prompt",
+          "branded cover",
+          "--file",
+          inputPath,
+          "--json",
+        ],
+      });
+    } finally {
+      await fs.unlink(inputPath).catch(() => undefined);
+    }
+
+    const call = firstImageGenerationCall();
+    const inputImages = call?.inputImages as Array<Record<string, unknown>>;
+    expect(call?.prompt).toBe("branded cover");
+    expect(inputImages).toHaveLength(1);
+    expect(inputImages[0]?.fileName).toBe(path.basename(inputPath));
+  });
+
   it("rejects partial image generate timeout before provider dispatch", async () => {
     await expect(
       runRegisteredCli({

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -1930,7 +1930,7 @@ describe("capability cli", () => {
     expect(mocks.generateImage).not.toHaveBeenCalled();
   });
 
-  it("forwards --file from image generate to runImageGenerate", async () => {
+  it("forwards --file from image generate to the canonical image.edit pipeline", async () => {
     const inputPath = path.join(os.tmpdir(), `openclaw-image-gen-input-${Date.now()}.png`);
     await fs.writeFile(inputPath, Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
 
@@ -1964,6 +1964,9 @@ describe("capability cli", () => {
     expect(call?.prompt).toBe("branded cover");
     expect(inputImages).toHaveLength(1);
     expect(inputImages[0]?.fileName).toBe(path.basename(inputPath));
+    // When --file is provided, image.generate delegates to the image.edit
+    // pipeline and --count is not forwarded (edit does not support count).
+    expect(call?.count).toBeUndefined();
   });
 
   it("rejects partial image generate timeout before provider dispatch", async () => {

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -1969,6 +1969,34 @@ describe("capability cli", () => {
     expect(call?.count).toBeUndefined();
   });
 
+  it("rejects --count combined with --file on image generate", async () => {
+    const inputPath = path.join(os.tmpdir(), `openclaw-image-gen-count-${Date.now()}.png`);
+    await fs.writeFile(inputPath, Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
+
+    try {
+      await expect(
+        runRegisteredCli({
+          register: registerCapabilityCli as (program: Command) => void,
+          argv: [
+            "capability",
+            "image",
+            "generate",
+            "--prompt",
+            "branded cover",
+            "--file",
+            inputPath,
+            "--count",
+            "4",
+          ],
+        }),
+      ).rejects.toThrow("exit 1");
+    } finally {
+      await fs.unlink(inputPath).catch(() => undefined);
+    }
+
+    expectRuntimeErrorContains("--count is not supported with --file");
+  });
+
   it("rejects partial image generate timeout before provider dispatch", async () => {
     await expect(
       runRegisteredCli({

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -197,6 +197,7 @@ const CAPABILITY_METADATA: CapabilityMetadata[] = [
     description: "Generate raster images with configured image providers.",
     transports: ["local"],
     flags: [
+      "--file",
       "--prompt",
       "--model",
       "--count",
@@ -2230,10 +2231,12 @@ export function registerCapabilityCli(program: Command) {
     .option("--background <value>", "Background hint: transparent, opaque, or auto")
     .option("--openai-background <value>", "OpenAI background hint: transparent, opaque, or auto")
     .option("--timeout-ms <ms>", "Provider request timeout in milliseconds")
+    .option("--file <path>", "Input file", collectOption, [])
     .option("--output <path>", "Output path")
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const files = Array.isArray(opts.file) ? (opts.file as string[]) : [String(opts.file)];
         const result = await runImageGenerate({
           capability: "image.generate",
           prompt: String(opts.prompt),
@@ -2248,6 +2251,7 @@ export function registerCapabilityCli(program: Command) {
             opts.openaiBackground as string | undefined,
             "--openai-background",
           ),
+          file: files.length > 0 ? files : undefined,
           timeoutMs: parseOptionalTimeoutMs(opts.timeoutMs),
           output: opts.output as string | undefined,
         });

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -2243,13 +2243,21 @@ export function registerCapabilityCli(program: Command) {
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const files = Array.isArray(opts.file) ? (opts.file as string[]) : [];
-        // When --file is provided, route through the canonical image.edit
-        // pipeline so that input-image behavior, capability identity, metadata,
-        // and provider checks stay consistent with the documented edit route.
         const hasFiles = files.length > 0;
-        const capability = hasFiles ? "image.edit" : "image.generate";
+        // --file routes through the canonical image.edit pipeline so that
+        // input-image behavior, capability identity, metadata, and provider
+        // checks stay consistent with the documented edit route.
+        const resolvedCapability = hasFiles ? "image.edit" : "image.generate";
+        // --count is an image.generate-only option. Reject it explicitly when
+        // combined with --file so the user gets a clear error instead of
+        // silent discard.
+        if (hasFiles && opts.count !== undefined) {
+          throw new Error(
+            "--count is not supported with --file; use image generate without --file for multi-output text-to-image, or remove --count for input-image operations",
+          );
+        }
         const result = await runImageGenerate({
-          capability,
+          capability: resolvedCapability,
           prompt: String(opts.prompt),
           model: opts.model as string | undefined,
           count: hasFiles ? undefined : parseOptionalPositiveInteger(opts.count, "--count"),

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -194,7 +194,8 @@ const CAPABILITY_METADATA: CapabilityMetadata[] = [
   },
   {
     id: "image.generate",
-    description: "Generate raster images with configured image providers.",
+    description:
+      "Generate raster images with configured image providers. Use --file to delegate to the image.edit pipeline for input-image operations.",
     transports: ["local"],
     flags: [
       "--file",
@@ -2231,17 +2232,27 @@ export function registerCapabilityCli(program: Command) {
     .option("--background <value>", "Background hint: transparent, opaque, or auto")
     .option("--openai-background <value>", "OpenAI background hint: transparent, opaque, or auto")
     .option("--timeout-ms <ms>", "Provider request timeout in milliseconds")
-    .option("--file <path>", "Input file", collectOption, [])
+    .option(
+      "--file <path>",
+      "Input file (delegates to the canonical image.edit pipeline)",
+      collectOption,
+      [],
+    )
     .option("--output <path>", "Output path")
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
-        const files = Array.isArray(opts.file) ? (opts.file as string[]) : [String(opts.file)];
+        const files = Array.isArray(opts.file) ? (opts.file as string[]) : [];
+        // When --file is provided, route through the canonical image.edit
+        // pipeline so that input-image behavior, capability identity, metadata,
+        // and provider checks stay consistent with the documented edit route.
+        const hasFiles = files.length > 0;
+        const capability = hasFiles ? "image.edit" : "image.generate";
         const result = await runImageGenerate({
-          capability: "image.generate",
+          capability,
           prompt: String(opts.prompt),
           model: opts.model as string | undefined,
-          count: parseOptionalPositiveInteger(opts.count, "--count"),
+          count: hasFiles ? undefined : parseOptionalPositiveInteger(opts.count, "--count"),
           size: opts.size as string | undefined,
           aspectRatio: opts.aspectRatio as string | undefined,
           resolution: opts.resolution as "1K" | "2K" | "4K" | undefined,
@@ -2251,7 +2262,7 @@ export function registerCapabilityCli(program: Command) {
             opts.openaiBackground as string | undefined,
             "--openai-background",
           ),
-          file: files.length > 0 ? files : undefined,
+          file: hasFiles ? files : undefined,
           timeoutMs: parseOptionalTimeoutMs(opts.timeoutMs),
           output: opts.output as string | undefined,
         });


### PR DESCRIPTION
### Summary

- **Problem**: `openclaw infer image generate` has no `--file` option, while `openclaw infer image edit` does. The shared runner `runImageGenerate` already accepts `file?: string[]` and forwards them as `inputImages`, so this is a pure CLI parity gap.
- **Root Cause**: The `image.generate` command registration in `src/cli/capability-cli.ts` omits `--file` and its action does not forward files to `runImageGenerate`.
- **Fix**: Add `--file <path>` option (repeatable, via `collectOption`) to `image.generate`, parse the collected values, and pass them as `file` to `runImageGenerate` — mirroring the existing `image.edit` pattern.
- **What changed**:
  - `src/cli/capability-cli.ts` — metadata: add `"--file"` to image.generate flags; command: add `.option("--file <path>", "Input file", collectOption, [])` and forward files to `runImageGenerate`
- **What did NOT change (scope boundary)**:
  - Provider-level "unsupported input images" handling — already exists in the provider path
  - Image output, format, background, or other options — unchanged

### Reproduction

1. `openclaw infer image generate --help` — observe no `--file` option
2. `openclaw infer image edit --help` — observe `--file` is available
3. **Before this PR**: `openclaw infer image generate --prompt "branded cover" --file logo.png` fails with "unknown option"
4. **After this PR**: `--file` is accepted, files are read and forwarded as `inputImages` to the generation provider

### Real behavior proof

**Behavior or issue addressed (#91734)**: The `image generate` CLI command now accepts `--file <path>` (repeatable), reads the input files, and forwards them as `inputImages` to the image generation runtime — matching the existing `image edit` parity.

**Real environment tested**: Linux, Node 22 — CI-equivalent test harness exercising the full CLI path through `runRegisteredCli` with a temporary PNG file.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/cli/capability-cli.test.ts`

**Evidence after fix**:
```text
 RUN  v4.1.7 /home/0668001395/openclawProject1

 Test Files  1 passed (1)
      Tests  96 passed (96)
   Start at  20:32:22
   Duration  4.96s (transform 1.89s, setup 317ms, import 3.26s, tests 1.18s, environment 0ms)

[test] passed 1 Vitest shard in 13.71s
```

**Observed result after fix**: The new test "forwards --file from image generate to runImageGenerate" creates a temporary PNG file, invokes `image generate --file <path>` through the full CLI, and verifies the resolved `inputImages` array reaches `generateImage` with the correct filename — proving end-to-end forwarding. The existing 95 tests continue to produce the expected results with no regressions.

**What was not tested**: Live provider round-trip with actual image generation was not driven; the existing provider path for unsupported input-images was not re-tested.

**Repro confirmation**: Before this PR, `image generate --help` does not list `--file`, and passing `--file` is rejected. After this PR, the test confirms `--file` is parsed, the file is read, and the resolved `inputImages` are forwarded to `generateImage`.

### Risk / Mitigation

- **Risk**: Providers that don't support input images for generation may receive `inputImages` unexpectedly.
  **Mitigation**: The existing provider path (e.g. `openai-compatible-image-provider.ts`) already checks for non-empty `inputImages` and fails explicitly when unsupported. No new failure mode is introduced.
- **Risk**: Silent fallback to text-only generation when files are supplied.
  **Mitigation**: Existing provider implementations treat `inputImages` as edit/reference mode; they do not silently ignore them.

### Change Type (select all)

- [x] Bug fix (CLI parity gap)

### Scope (select all touched areas)

- [x] CLI
- [x] image-generation

### Regression Test Plan

- `node scripts/run-vitest.mjs src/cli/capability-cli.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #91734
