### PR TITLE
feat: add exec approvals denylist (STOP list) screening

### DIFF
--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -451,11 +451,11 @@ or `security=deny` when you need confinement.
 
 Each denylist entry supports:
 
-| Field     | Meaning                                              |
-| --------- | ---------------------------------------------------- |
-| `pattern` | Glob matched against analyzed segment argv text      |
+| Field     | Meaning                                               |
+| --------- | ----------------------------------------------------- |
+| `pattern` | Glob matched against analyzed segment argv text       |
 | `reason`  | Optional note shown with approval prompts and denials |
-| `id`      | Optional stable identifier for UI/tooling            |
+| `id`      | Optional stable identifier for UI/tooling             |
 
 ## Auto-allow skill CLIs
 

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -401,6 +401,62 @@ Each allowlist entry supports:
 | `lastUsedCommand`  | Last command that matched                                     |
 | `lastResolvedPath` | Last resolved binary path                                     |
 
+## Denylist (STOP list, per agent)
+
+The denylist is the inverse companion to the allowlist: a small STOP list
+that forces an explicit approval for matching commands **even when policy
+would otherwise auto-allow them** (including `security=full` with
+`ask="off"`). It enables a deny-by-exception posture: keep exec permissive,
+but interrupt the handful of commands you always want a human to confirm.
+
+```json
+{
+  "version": 1,
+  "agents": {
+    "*": {
+      "denylist": [
+        { "pattern": "git push*--force*", "reason": "history rewrite" },
+        { "pattern": "launchctl*" },
+        { "pattern": "rm -rf /*" }
+      ]
+    }
+  }
+}
+```
+
+Patterns are globs (`*`, `?`) matched against each analyzed command
+segment's argv text, joined with single spaces. Matching also covers:
+
+- a basename variant of the executable, so `git push --force*` still
+  matches `/usr/bin/git push --force`
+- every part of shell chains (`&&`, `||`, `;`)
+- payloads of POSIX inline shell wrappers such as `bash -c "..."`
+  (up to three nesting levels)
+
+Denylist semantics are intentionally stricter than allowlist semantics:
+
+- A hit always asks again. Durable allow-always trust never clears a hit;
+  approving a denylisted command applies to that invocation only.
+- Hits are excluded from exec auto-review; only a human approval proceeds.
+- If a command cannot be analyzed (for example line continuations) or uses
+  inline wrappers the analyzer cannot screen (`cmd.exe /c`,
+  `powershell -Command`), the command conservatively requires approval
+  while a denylist is configured.
+- Wildcard-agent (`agents.*`) entries merge with per-agent entries.
+
+The denylist is a guardrail against unintended high-risk commands, not a
+sandbox. A determined payload can still hide behind constructs the
+analyzer rejects (which prompt for approval) — use `security=allowlist`
+or `security=deny` when you need confinement.
+
+Each denylist entry supports:
+
+| Field     | Meaning                                              |
+| --------- | ---------------------------------------------------- |
+| `pattern` | Glob matched against analyzed segment argv text      |
+| `reason`  | Optional note shown with approval prompts and denials |
+| `id`      | Optional stable identifier for UI/tooling            |
+
 ## Auto-allow skill CLIs
 
 When **Auto-allow skill CLIs** is enabled, executables referenced by

--- a/src/agents/agent-tools.safe-bins.test.ts
+++ b/src/agents/agent-tools.safe-bins.test.ts
@@ -38,6 +38,7 @@ const { mockExecApprovals, supervisorSpawnMock } = vi.hoisted(() => {
       askFallback: "defaults.askFallback",
     },
     allowlist: [],
+    denylist: [],
     file: {
       version: 1,
       socket: { path: "/tmp/exec-approvals.sock", token: "token" },

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -97,13 +97,25 @@ const recordAllowlistMatchesUseMock = vi.hoisted(() => vi.fn());
 const resolveApprovalDecisionOrUndefinedMock = vi.hoisted(() =>
   vi.fn(async (): Promise<string | null | undefined> => undefined),
 );
+type MockApprovalContext = {
+  approvals: {
+    allowlist: unknown[];
+    denylist?: { id?: string; pattern: string; reason?: string }[];
+    file: { version: number; agents: Record<string, unknown> };
+  };
+  hostSecurity: string;
+  hostAsk: string;
+  askFallback: string;
+};
 const resolveExecHostApprovalContextMock = vi.hoisted(() =>
-  vi.fn(() => ({
-    approvals: { allowlist: [], file: { version: 1, agents: {} } },
-    hostSecurity: "allowlist",
-    hostAsk: "off",
-    askFallback: "deny",
-  })),
+  vi.fn(
+    (): MockApprovalContext => ({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "allowlist",
+      hostAsk: "off",
+      askFallback: "deny",
+    }),
+  ),
 );
 const runExecProcessMock = vi.hoisted(() => vi.fn());
 const sendExecApprovalFollowupResultMock = vi.hoisted(() =>
@@ -778,6 +790,124 @@ describe("processGatewayAllowlist", () => {
     });
 
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
+  });
+
+  function mockDenylistContext(patterns: string[]) {
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: {
+        allowlist: [],
+        denylist: patterns.map((pattern) => ({ pattern })),
+        file: { version: 1, agents: {} },
+      },
+      hostSecurity: "full",
+      hostAsk: "off",
+      askFallback: "deny",
+    });
+  }
+
+  it("requires approval for denylist matches even in yolo mode", async () => {
+    mockDenylistContext(["git push*--force*"]);
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: true,
+      allowlistSatisfied: false,
+      segments: [{ resolution: null, argv: ["git", "push", "--force"] }],
+      segmentAllowlistEntries: [],
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "git push --force",
+      security: "full",
+      ask: "off",
+    });
+
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+  });
+
+  it("keeps denylist matches off the auto-review path", async () => {
+    const warnings: string[] = [];
+    mockDenylistContext(["git push*--force*"]);
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: true,
+      allowlistSatisfied: false,
+      segments: [{ resolution: null, argv: ["git", "push", "--force"] }],
+      segmentAllowlistEntries: [],
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "git push --force",
+      security: "full",
+      ask: "off",
+      autoReview: true,
+      warnings,
+    });
+
+    expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(warnings.some((warning) => warning.includes("git push*--force*"))).toBe(true);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+  });
+
+  it("asks again for denylist matches despite durable allow-always trust", async () => {
+    mockDenylistContext(["git push*--force*"]);
+    hasDurableExecApprovalMock.mockReturnValue(true);
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: true,
+      allowlistSatisfied: false,
+      segments: [{ resolution: null, argv: ["git", "push", "--force"] }],
+      segmentAllowlistEntries: [],
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "git push --force",
+      security: "full",
+      ask: "off",
+    });
+
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+  });
+
+  it("does not require approval for commands that miss the denylist", async () => {
+    mockDenylistContext(["git push*--force*"]);
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: true,
+      allowlistSatisfied: false,
+      segments: [{ resolution: null, argv: ["git", "status"] }],
+      segmentAllowlistEntries: [],
+    });
+
+    await runGatewayAllowlist({
+      command: "git status",
+      security: "full",
+      ask: "off",
+    });
+
+    expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("requires approval for unanalyzable commands when a denylist is configured", async () => {
+    mockDenylistContext(["git push*--force*"]);
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: false,
+      allowlistSatisfied: false,
+      segments: [],
+      segmentAllowlistEntries: [],
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "git push \\\n--force",
+      security: "full",
+      ask: "off",
+    });
+
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
   });
 
   it("does not require suppression edit approval for read-only suppression inspection", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -14,7 +14,9 @@ import {
   resolveExecApprovalAllowedDecisions,
   type ExecSecurity,
   buildEnforcedShellCommand,
+  evaluateExecDenylist,
   evaluateShellAllowlist,
+  formatExecDenylistWarning,
   hasDurableExecApproval,
   persistAllowAlwaysPatterns,
   recordAllowlistMatchesUse,
@@ -424,6 +426,17 @@ export async function processGatewayAllowlist(
       env: params.env,
       segments: allowlistEval.segments,
     }) && !(hostSecurity === "full" && hostAsk === "off");
+  // Denylist hits intentionally have no yolo-mode escape: the STOP list exists
+  // to interrupt auto-allowed commands, and durable trust never clears a hit.
+  const denylistEvaluation = evaluateExecDenylist({
+    denylist: approvals.denylist,
+    segments: allowlistEval.segments,
+    analysisOk,
+    cwd: params.workdir,
+    env: params.env,
+    platform: process.platform,
+  });
+  const requiresDenylistApproval = denylistEvaluation.matched;
   const requiresAsk =
     requiresExecApproval({
       ask: hostAsk,
@@ -435,7 +448,8 @@ export async function processGatewayAllowlist(
     requiresAllowlistPlanApproval ||
     requiresHeredocApproval ||
     requiresInlineEvalApproval ||
-    requiresSecurityAuditSuppressionApproval;
+    requiresSecurityAuditSuppressionApproval ||
+    requiresDenylistApproval;
   if (requiresHeredocApproval) {
     params.warnings.push(
       "Warning: heredoc execution requires reviewer or explicit approval in allowlist mode.",
@@ -451,6 +465,9 @@ export async function processGatewayAllowlist(
       "Warning: security audit suppression changes require explicit approval unless exec is running in yolo mode.",
     );
   }
+  if (requiresDenylistApproval) {
+    params.warnings.push(formatExecDenylistWarning(denylistEvaluation));
+  }
   if (requiresAsk) {
     const [autoReviewSegment] = allowlistEval.segments;
     const autoReviewArgv =
@@ -464,10 +481,13 @@ export async function processGatewayAllowlist(
       params.autoReview === true &&
       hostAsk !== "always" &&
       autoReviewHasBoundCommand &&
-      !requiresSecurityAuditSuppressionApproval;
+      !requiresSecurityAuditSuppressionApproval &&
+      // Denylist hits are reserved for explicit human approval.
+      !requiresDenylistApproval;
     let autoReviewRequiresHumanApproval =
       (params.autoReview === true && hostAsk !== "always" && !autoReviewHasBoundCommand) ||
-      requiresSecurityAuditSuppressionApproval;
+      requiresSecurityAuditSuppressionApproval ||
+      requiresDenylistApproval;
     if (canAutoReviewApprovalMiss) {
       const reviewer = params.autoReviewer ?? defaultExecAutoReviewer;
       const decision = await reviewer({

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -137,6 +137,7 @@ function createExecApprovals(): ExecApprovalsResolved {
       askFallback: "defaults.askFallback",
     },
     allowlist: [],
+    denylist: [],
     file: {
       version: 1,
       socket: { path: "/tmp/exec-approvals.sock", token: "token" },

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -138,6 +138,51 @@ describe("exec approvals node host allowlist check", () => {
   });
 });
 
+describe("exec approvals denylist config", () => {
+  it("merges wildcard denylist entries with agent entries", () => {
+    const resolved = resolveExecApprovalsFromFile({
+      file: {
+        version: 1,
+        agents: {
+          "*": { denylist: [{ pattern: "git push*--force*" }] },
+          main: { denylist: [{ pattern: "launchctl*" }] },
+        },
+      },
+      agentId: "main",
+    });
+    expect(resolved.denylist.map((entry) => entry.pattern)).toEqual([
+      "git push*--force*",
+      "launchctl*",
+    ]);
+  });
+
+  it("resolves an empty denylist when none is configured", () => {
+    const resolved = resolveExecApprovalsFromFile({ file: { version: 1 } });
+    expect(resolved.denylist).toEqual([]);
+  });
+
+  it("drops malformed denylist entries during normalization", () => {
+    const denylist = [
+      { pattern: "  rm -rf /*  " },
+      { pattern: "" },
+      "rm -rf /",
+    ] as unknown as NonNullable<ExecApprovalsAgent["denylist"]>;
+    const normalized = normalizeExecApprovals({
+      version: 1,
+      agents: { main: { denylist } },
+    });
+    expect(normalized.agents?.main?.denylist).toEqual([{ pattern: "rm -rf /*" }]);
+  });
+
+  it("keeps agents without denylist untouched during normalization", () => {
+    const normalized = normalizeExecApprovals({
+      version: 1,
+      agents: { main: { allowlist: [{ pattern: "/bin/hostname" }] } },
+    });
+    expect(normalized.agents?.main?.denylist).toBeUndefined();
+  });
+});
+
 describe("exec approvals default agent migration", () => {
   it("migrates legacy default agent entries to main", () => {
     const file: ExecApprovalsFile = {

--- a/src/infra/exec-approvals-denylist.test.ts
+++ b/src/infra/exec-approvals-denylist.test.ts
@@ -1,0 +1,179 @@
+// Covers exec denylist (STOP-list) screening over analyzed command segments.
+import { describe, expect, it } from "vitest";
+import {
+  analyzeShellCommand,
+  evaluateExecDenylist,
+  sanitizeExecDenylistEntries,
+  type ExecCommandSegment,
+  type ExecDenylistEntry,
+} from "./exec-approvals.js";
+
+function evaluateCommand(command: string, patterns: string[], platform = "linux") {
+  const analysis = analyzeShellCommand({ command, platform });
+  return evaluateExecDenylist({
+    denylist: patterns.map((pattern): ExecDenylistEntry => ({ pattern })),
+    segments: analysis.segments,
+    analysisOk: analysis.ok,
+    platform,
+  });
+}
+
+function syntheticSegment(argv: string[]): ExecCommandSegment {
+  return { raw: argv.join(" "), argv, resolution: null };
+}
+
+describe("sanitizeExecDenylistEntries", () => {
+  it("keeps valid entries and preserves array identity when nothing changes", () => {
+    const entries: ExecDenylistEntry[] = [{ pattern: "git push*--force*", reason: "stop list" }];
+    expect(sanitizeExecDenylistEntries(entries)).toBe(entries);
+  });
+
+  it("drops malformed entries and trims patterns", () => {
+    const sanitized = sanitizeExecDenylistEntries([
+      { pattern: "  git push*  " },
+      { pattern: "   " },
+      { pattern: 42 },
+      "git push*",
+      null,
+      {},
+    ]);
+    expect(sanitized).toEqual([{ pattern: "git push*" }]);
+  });
+
+  it("returns an empty list for non-array input", () => {
+    expect(sanitizeExecDenylistEntries(undefined)).toEqual([]);
+    expect(sanitizeExecDenylistEntries("git push*")).toEqual([]);
+  });
+});
+
+describe("evaluateExecDenylist", () => {
+  it("matches a denylisted command", () => {
+    const evaluation = evaluateCommand("git push --force origin main", ["git push --force*"]);
+    expect(evaluation.matched).toBe(true);
+    expect(evaluation.unanalyzable).toBe(false);
+    expect(evaluation.entry?.pattern).toBe("git push --force*");
+  });
+
+  it("matches flags appearing later in the command", () => {
+    const evaluation = evaluateCommand("git push origin main --force", ["git push*--force*"]);
+    expect(evaluation.matched).toBe(true);
+  });
+
+  it("does not match commands outside the denylist", () => {
+    const evaluation = evaluateCommand("git push origin main", ["git push*--force*"]);
+    expect(evaluation.matched).toBe(false);
+    expect(evaluation.entry).toBeNull();
+  });
+
+  it("matches path-prefixed executables through the basename variant", () => {
+    const evaluation = evaluateCommand("/usr/bin/git push --force", ["git push --force*"]);
+    expect(evaluation.matched).toBe(true);
+  });
+
+  it("matches denylisted parts inside command chains", () => {
+    const evaluation = evaluateCommand("echo ok && git push --force", ["git push*--force*"]);
+    expect(evaluation.matched).toBe(true);
+  });
+
+  it("matches denylisted payloads inside POSIX inline shell wrappers", () => {
+    const evaluation = evaluateCommand(`bash -c "git push --force"`, ["git push*--force*"]);
+    expect(evaluation.matched).toBe(true);
+  });
+
+  it("does not match quoted denylist text passed as data arguments", () => {
+    const evaluation = evaluateCommand(`grep "git push --force" README.md`, ["git push*--force*"]);
+    expect(evaluation.matched).toBe(false);
+  });
+
+  it("treats unanalyzable commands as conservative hits when a denylist exists", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [{ pattern: "git push*--force*" }],
+      segments: [],
+      analysisOk: false,
+      platform: "linux",
+    });
+    expect(evaluation.matched).toBe(true);
+    expect(evaluation.unanalyzable).toBe(true);
+    expect(evaluation.entry).toBeNull();
+  });
+
+  it("never matches when the denylist is empty, even for unanalyzable commands", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [],
+      segments: [],
+      analysisOk: false,
+      platform: "linux",
+    });
+    expect(evaluation.matched).toBe(false);
+    expect(evaluation.unanalyzable).toBe(false);
+  });
+
+  it("never matches when all entries are malformed", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [{ pattern: "   " }] as ExecDenylistEntry[],
+      segments: [],
+      analysisOk: false,
+      platform: "linux",
+    });
+    expect(evaluation.matched).toBe(false);
+  });
+
+  it("treats nested inline wrappers beyond the depth cap as conservative hits", () => {
+    const evaluation = evaluateCommand(`bash -c "bash -c \\"bash -c 'git push --force'\\""`, [
+      "git push*--force*",
+    ]);
+    expect(evaluation.matched).toBe(true);
+  });
+
+  it("treats cmd.exe inline payloads as conservative hits", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [{ pattern: "git push*--force*" }],
+      segments: [syntheticSegment(["cmd.exe", "/c", "git push --force"])],
+      analysisOk: true,
+      platform: "win32",
+    });
+    expect(evaluation.matched).toBe(true);
+    expect(evaluation.unanalyzable).toBe(true);
+  });
+
+  it("treats powershell inline payloads as conservative hits", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [{ pattern: "git push*--force*" }],
+      segments: [syntheticSegment(["pwsh", "-Command", "git push --force"])],
+      analysisOk: true,
+      platform: "linux",
+    });
+    expect(evaluation.matched).toBe(true);
+    expect(evaluation.unanalyzable).toBe(true);
+  });
+
+  it("matches case-insensitively on Windows", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [{ pattern: "git push*--force*" }],
+      segments: [syntheticSegment(["GIT", "push", "--FORCE"])],
+      analysisOk: true,
+      platform: "win32",
+    });
+    expect(evaluation.matched).toBe(true);
+  });
+
+  it("matches case-sensitively on POSIX", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [{ pattern: "git push*--force*" }],
+      segments: [syntheticSegment(["GIT", "push", "--FORCE"])],
+      analysisOk: true,
+      platform: "linux",
+    });
+    expect(evaluation.matched).toBe(false);
+  });
+
+  it("reports the first matching entry for operator-facing messages", () => {
+    const evaluation = evaluateCommand("launchctl kickstart -k system/foo", [
+      "rm -rf*",
+      "launchctl*",
+    ]);
+    expect(evaluation.matched).toBe(true);
+    expect(evaluation.entry?.pattern).toBe("launchctl*");
+    expect(evaluation.matchedText).toContain("launchctl");
+  });
+});

--- a/src/infra/exec-approvals-denylist.ts
+++ b/src/infra/exec-approvals-denylist.ts
@@ -1,0 +1,262 @@
+/**
+ * Exec denylist (STOP-list) screening.
+ *
+ * Denylist entries are glob patterns (`*` and `?`) matched against analyzed
+ * command segments. Any match forces an explicit approval even when
+ * `security=full` and `ask=off` would otherwise auto-allow the command, and
+ * durable allow-always trust never clears a hit. This is a guardrail against
+ * unintended high-risk commands, not a sandbox: adversarial payloads should
+ * still be confined with `security=allowlist` or `security=deny`.
+ */
+import path from "node:path";
+import { analyzeShellCommand, type ExecCommandSegment } from "./exec-approvals-analysis.js";
+import type { ExecDenylistEntry } from "./exec-approvals.types.js";
+import { normalizeExecutableToken } from "./exec-wrapper-resolution.js";
+import { POSIX_INLINE_COMMAND_FLAGS, resolveInlineCommandMatch } from "./shell-inline-command.js";
+import {
+  POSIX_SHELL_WRAPPERS,
+  resolveShellWrapperTransportArgv,
+} from "./shell-wrapper-resolution.js";
+
+const MAX_DENYLIST_INLINE_DEPTH = 3;
+
+const POSIX_SHELL_WRAPPER_NAMES: ReadonlySet<string> = POSIX_SHELL_WRAPPERS;
+
+// Wrapper executables whose inline payloads use parsing semantics this module
+// cannot analyze; segments carrying their inline flags are treated as hits.
+const OPAQUE_INLINE_WRAPPER_TOKENS = new Set(["cmd", "cmd.exe", "powershell", "pwsh"]);
+const OPAQUE_INLINE_FLAG_TOKENS = new Set(["/c", "/k", "-command", "-c", "-encodedcommand"]);
+
+export type ExecDenylistEvaluation = {
+  matched: boolean;
+  entry: ExecDenylistEntry | null;
+  matchedText: string | null;
+  unanalyzable: boolean;
+};
+
+type DenylistMatcher = {
+  entry: ExecDenylistEntry;
+  regex: RegExp;
+};
+
+const NOT_MATCHED: ExecDenylistEvaluation = {
+  matched: false,
+  entry: null,
+  matchedText: null,
+  unanalyzable: false,
+};
+
+const UNANALYZABLE_HIT: ExecDenylistEvaluation = {
+  matched: true,
+  entry: null,
+  matchedText: null,
+  unanalyzable: true,
+};
+
+/** Drops malformed entries; preserves array identity when nothing changes. */
+export function sanitizeExecDenylistEntries(entries: unknown): ExecDenylistEntry[] {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  let changed = false;
+  const sanitized: ExecDenylistEntry[] = [];
+  for (const raw of entries) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      changed = true;
+      continue;
+    }
+    const candidate = raw as { id?: unknown; pattern?: unknown; reason?: unknown };
+    const pattern = typeof candidate.pattern === "string" ? candidate.pattern.trim() : "";
+    if (!pattern) {
+      changed = true;
+      continue;
+    }
+    const id =
+      typeof candidate.id === "string" && candidate.id.trim().length > 0
+        ? candidate.id.trim()
+        : undefined;
+    const reason =
+      typeof candidate.reason === "string" && candidate.reason.trim().length > 0
+        ? candidate.reason.trim()
+        : undefined;
+    if (pattern !== candidate.pattern || id !== candidate.id || reason !== candidate.reason) {
+      changed = true;
+    }
+    sanitized.push({
+      ...(id !== undefined ? { id } : {}),
+      pattern,
+      ...(reason !== undefined ? { reason } : {}),
+    });
+  }
+  return changed ? sanitized : (entries as ExecDenylistEntry[]);
+}
+
+function denylistPatternToRegExp(pattern: string, caseInsensitive: boolean): RegExp {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, "[\\s\\S]*")
+    .replace(/\?/g, "[\\s\\S]");
+  return new RegExp(`^${escaped}$`, caseInsensitive ? "i" : undefined);
+}
+
+function buildDenylistMatchers(
+  entries: readonly ExecDenylistEntry[],
+  caseInsensitive: boolean,
+): DenylistMatcher[] {
+  return entries.map((entry) => ({
+    entry,
+    regex: denylistPatternToRegExp(entry.pattern, caseInsensitive),
+  }));
+}
+
+function addArgvCandidates(out: Set<string>, argv: readonly string[] | undefined): void {
+  if (!argv || argv.length === 0) {
+    return;
+  }
+  const joined = argv.join(" ").trim();
+  if (joined.length > 0) {
+    out.add(joined);
+  }
+  const head = argv[0] ?? "";
+  const base = path.basename(head);
+  if (base.length > 0 && base !== head) {
+    out.add([base, ...argv.slice(1)].join(" ").trim());
+  }
+}
+
+function buildSegmentCandidateTexts(segment: ExecCommandSegment): string[] {
+  const candidates = new Set<string>();
+  addArgvCandidates(candidates, segment.argv);
+  const effectiveArgv = segment.resolution?.effectiveArgv;
+  if (effectiveArgv && effectiveArgv.length > 0) {
+    addArgvCandidates(candidates, effectiveArgv);
+  }
+  return [...candidates];
+}
+
+function hasOpaqueInlinePayload(argv: readonly string[]): boolean {
+  const wrapperToken = normalizeExecutableToken(argv[0] ?? "");
+  if (!OPAQUE_INLINE_WRAPPER_TOKENS.has(wrapperToken)) {
+    return false;
+  }
+  return argv.some((token) => OPAQUE_INLINE_FLAG_TOKENS.has(token.trim().toLowerCase()));
+}
+
+function resolvePosixInlineCommand(argv: string[]): string | null {
+  const transportArgv = resolveShellWrapperTransportArgv(argv) ?? argv;
+  if (!POSIX_SHELL_WRAPPER_NAMES.has(normalizeExecutableToken(transportArgv[0] ?? ""))) {
+    return null;
+  }
+  const match = resolveInlineCommandMatch(transportArgv, POSIX_INLINE_COMMAND_FLAGS, {
+    allowCombinedC: true,
+  });
+  const inline = match.command?.trim();
+  return inline && inline.length > 0 ? inline : null;
+}
+
+function evaluateSegmentsAgainstDenylist(params: {
+  segments: readonly ExecCommandSegment[];
+  matchers: readonly DenylistMatcher[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: string | null;
+  depth: number;
+}): ExecDenylistEvaluation {
+  for (const segment of params.segments) {
+    for (const candidate of buildSegmentCandidateTexts(segment)) {
+      for (const matcher of params.matchers) {
+        if (matcher.regex.test(candidate)) {
+          return {
+            matched: true,
+            entry: matcher.entry,
+            matchedText: candidate,
+            unanalyzable: false,
+          };
+        }
+      }
+    }
+    if (hasOpaqueInlinePayload(segment.argv)) {
+      return UNANALYZABLE_HIT;
+    }
+    const inlineCommand = resolvePosixInlineCommand(segment.argv);
+    if (inlineCommand === null) {
+      continue;
+    }
+    if (params.depth + 1 >= MAX_DENYLIST_INLINE_DEPTH) {
+      return UNANALYZABLE_HIT;
+    }
+    const inlineAnalysis = analyzeShellCommand({
+      command: inlineCommand,
+      cwd: params.cwd,
+      env: params.env,
+      platform: params.platform,
+    });
+    if (!inlineAnalysis.ok || inlineAnalysis.segments.length === 0) {
+      return UNANALYZABLE_HIT;
+    }
+    const inlineEvaluation = evaluateSegmentsAgainstDenylist({
+      segments: inlineAnalysis.segments,
+      matchers: params.matchers,
+      cwd: params.cwd,
+      env: params.env,
+      platform: params.platform,
+      depth: params.depth + 1,
+    });
+    if (inlineEvaluation.matched) {
+      return inlineEvaluation;
+    }
+  }
+  return NOT_MATCHED;
+}
+
+/**
+ * Screens analyzed command segments against the configured denylist.
+ *
+ * Reuses the segments produced by allowlist analysis so screening adds no
+ * extra parsing cost. When the command could not be analyzed and a denylist
+ * is configured, the evaluation conservatively reports a hit because the
+ * command cannot be proven to miss the STOP list.
+ */
+export function evaluateExecDenylist(params: {
+  denylist: readonly ExecDenylistEntry[] | undefined | null;
+  segments: readonly ExecCommandSegment[];
+  analysisOk: boolean;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: string | null;
+}): ExecDenylistEvaluation {
+  const entries = sanitizeExecDenylistEntries(params.denylist);
+  if (entries.length === 0) {
+    return NOT_MATCHED;
+  }
+  if (!params.analysisOk || params.segments.length === 0) {
+    return UNANALYZABLE_HIT;
+  }
+  const caseInsensitive = (params.platform ?? process.platform) === "win32";
+  return evaluateSegmentsAgainstDenylist({
+    segments: params.segments,
+    matchers: buildDenylistMatchers(entries, caseInsensitive),
+    cwd: params.cwd,
+    env: params.env,
+    platform: params.platform,
+    depth: 0,
+  });
+}
+
+/** Operator-facing denial message for denylist screening outcomes. */
+export function formatExecDenylistDeniedMessage(evaluation: ExecDenylistEvaluation): string {
+  if (evaluation.unanalyzable) {
+    return "SYSTEM_RUN_DENIED: denylist screening could not analyze command; approval required";
+  }
+  const reason = evaluation.entry?.reason ? ` (${evaluation.entry.reason})` : "";
+  return `SYSTEM_RUN_DENIED: denylist match (${evaluation.entry?.pattern ?? "unknown"})${reason}; approval required`;
+}
+
+/** Warning line surfaced with approval prompts for denylist screening hits. */
+export function formatExecDenylistWarning(evaluation: ExecDenylistEvaluation): string {
+  if (evaluation.unanalyzable) {
+    return "Warning: command could not be analyzed for denylist screening; explicit approval is required.";
+  }
+  const reason = evaluation.entry?.reason ? ` (${evaluation.entry.reason})` : "";
+  return `Warning: command matches exec denylist entry ${evaluation.entry?.pattern ?? "unknown"}${reason}; explicit approval is required.`;
+}

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -12,14 +12,16 @@ import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import type { CommandExplanationSummary } from "./command-analysis/explain.js";
 import { resolveAllowAlwaysPatternEntries } from "./exec-approvals-allowlist.js";
 import { analyzeShellCommand, type ExecCommandSegment } from "./exec-approvals-analysis.js";
-import type { ExecAllowlistEntry } from "./exec-approvals.types.js";
+import { sanitizeExecDenylistEntries } from "./exec-approvals-denylist.js";
+import type { ExecAllowlistEntry, ExecDenylistEntry } from "./exec-approvals.types.js";
 import { isShellWrapperInvocation } from "./exec-wrapper-resolution.js";
 import { assertNoSymlinkParentsSync } from "./fs-safe-advanced.js";
 import { expandHomePrefix, resolveHomeRelativePath, resolveRequiredHomeDir } from "./home-dir.js";
 import { requestJsonlSocket } from "./jsonl-socket.js";
 export * from "./exec-approvals-analysis.js";
 export * from "./exec-approvals-allowlist.js";
-export type { ExecAllowlistEntry } from "./exec-approvals.types.js";
+export * from "./exec-approvals-denylist.js";
+export type { ExecAllowlistEntry, ExecDenylistEntry } from "./exec-approvals.types.js";
 
 export type ExecHost = "sandbox" | "gateway" | "node";
 export type ExecTarget = "auto" | ExecHost;
@@ -242,6 +244,7 @@ export type ExecApprovalsDefaults = {
 
 export type ExecApprovalsAgent = ExecApprovalsDefaults & {
   allowlist?: ExecAllowlistEntry[];
+  denylist?: ExecDenylistEntry[];
 };
 
 export type ExecApprovalsFile = {
@@ -274,6 +277,7 @@ export type ExecApprovalsResolved = {
     askFallback: string | null;
   };
   allowlist: ExecAllowlistEntry[];
+  denylist: ExecDenylistEntry[];
   file: ExecApprovalsFile;
 };
 
@@ -733,9 +737,12 @@ export function normalizeExecApprovals(file: ExecApprovalsFile): ExecApprovalsFi
     const coerced = coerceAllowlistEntries(agent.allowlist);
     const withIds = ensureAllowlistIds(coerced);
     const allowlist = stripAllowlistCommandText(withIds);
+    const denylist =
+      agent.denylist === undefined ? undefined : sanitizeExecDenylistEntries(agent.denylist);
     const sanitizedPolicy = sanitizeExecApprovalPolicy(agent);
     const agentChanged =
       allowlist !== agent.allowlist ||
+      denylist !== agent.denylist ||
       sanitizedPolicy.security !== agent.security ||
       sanitizedPolicy.ask !== agent.ask ||
       sanitizedPolicy.askFallback !== agent.askFallback;
@@ -743,6 +750,7 @@ export function normalizeExecApprovals(file: ExecApprovalsFile): ExecApprovalsFi
       agents[key] = {
         ...agent,
         allowlist,
+        denylist,
         security: sanitizedPolicy.security,
         ask: sanitizedPolicy.ask,
         askFallback: sanitizedPolicy.askFallback,
@@ -1187,6 +1195,10 @@ export function resolveExecApprovalsFromFile(params: {
     ...(Array.isArray(wildcard.allowlist) ? wildcard.allowlist : []),
     ...(Array.isArray(agent.allowlist) ? agent.allowlist : []),
   ];
+  const denylist = sanitizeExecDenylistEntries([
+    ...(Array.isArray(wildcard.denylist) ? wildcard.denylist : []),
+    ...(Array.isArray(agent.denylist) ? agent.denylist : []),
+  ]);
   return {
     path: params.path ?? resolveExecApprovalsPath(),
     socketPath: expandHomePrefix(
@@ -1201,6 +1213,7 @@ export function resolveExecApprovalsFromFile(params: {
       askFallback: resolvedAgentAskFallback.source,
     },
     allowlist,
+    denylist,
     file,
   };
 }

--- a/src/infra/exec-approvals.types.ts
+++ b/src/infra/exec-approvals.types.ts
@@ -10,3 +10,12 @@ export type ExecAllowlistEntry = {
   lastUsedCommand?: string;
   lastResolvedPath?: string;
 };
+
+// Serialized denylist (STOP-list) entries. Patterns are globs (`*`, `?`)
+// matched against analyzed command segments; any match forces an explicit
+// approval even when policy would otherwise auto-allow the command.
+export type ExecDenylistEntry = {
+  id?: string;
+  pattern: string;
+  reason?: string;
+};

--- a/src/node-host/exec-policy.test.ts
+++ b/src/node-host/exec-policy.test.ts
@@ -166,4 +166,50 @@ describe("evaluateSystemRunPolicy", () => {
     expect(allowed.analysisOk).toBe(true);
     expect(allowed.allowlistSatisfied).toBe(true);
   });
+
+  it("requires approval for denylist hits even when security=full and ask=off", () => {
+    const denied = expectDeniedDecision(
+      evaluateSystemRunPolicy(
+        buildPolicyParams({ security: "full", ask: "off", denylisted: true }),
+      ),
+    );
+    expect(denied.eventReason).toBe("denylist-hit");
+    expect(denied.requiresAsk).toBe(true);
+    expect(denied.errorMessage).toContain("denylist");
+  });
+
+  it("lets an explicit approval decision clear a denylist hit", () => {
+    const allowed = expectAllowedDecision(
+      evaluateSystemRunPolicy(
+        buildPolicyParams({
+          security: "full",
+          ask: "off",
+          denylisted: true,
+          approvalDecision: "allow-once",
+        }),
+      ),
+    );
+    expect(allowed.approvedByAsk).toBe(true);
+  });
+
+  it("does not let durable trust bypass a denylist hit", () => {
+    const denied = expectDeniedDecision(
+      evaluateSystemRunPolicy(
+        buildPolicyParams({
+          security: "full",
+          ask: "off",
+          denylisted: true,
+          durableApprovalSatisfied: true,
+        }),
+      ),
+    );
+    expect(denied.eventReason).toBe("denylist-hit");
+  });
+
+  it("keeps security=deny ahead of denylist hits", () => {
+    const denied = expectDeniedDecision(
+      evaluateSystemRunPolicy(buildPolicyParams({ security: "deny", denylisted: true })),
+    );
+    expect(denied.eventReason).toBe("security=deny");
+  });
 });

--- a/src/node-host/exec-policy.ts
+++ b/src/node-host/exec-policy.ts
@@ -17,7 +17,7 @@ type SystemRunPolicyDecision = {
     }
   | {
       allowed: false;
-      eventReason: "security=deny" | "approval-required" | "allowlist-miss";
+      eventReason: "security=deny" | "denylist-hit" | "approval-required" | "allowlist-miss";
       errorMessage: string;
     }
 );
@@ -58,6 +58,7 @@ export function evaluateSystemRunPolicy(params: {
   analysisOk: boolean;
   allowlistSatisfied: boolean;
   durableApprovalSatisfied?: boolean;
+  denylisted?: boolean;
   approvalDecision: ExecApprovalDecision;
   approved?: boolean;
   isWindows: boolean;
@@ -88,6 +89,23 @@ export function evaluateSystemRunPolicy(params: {
       shellWrapperBlocked,
       windowsShellWrapperBlocked,
       requiresAsk: false,
+      approvalDecision: params.approvalDecision,
+      approvedByAsk,
+    };
+  }
+
+  // Denylist (STOP-list) hits require a fresh explicit approval regardless of
+  // security mode; durable allow-always trust intentionally does not clear them.
+  if (params.denylisted === true && !approvedByAsk) {
+    return {
+      allowed: false,
+      eventReason: "denylist-hit",
+      errorMessage: "SYSTEM_RUN_DENIED: denylist match; approval required",
+      analysisOk,
+      allowlistSatisfied,
+      shellWrapperBlocked,
+      windowsShellWrapperBlocked,
+      requiresAsk: true,
       approvalDecision: params.approvalDecision,
       approvedByAsk,
     };

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -11,6 +11,8 @@ import { detectPolicyInlineEval } from "../infra/command-analysis/policy.js";
 import {
   addDurableCommandApproval,
   commandRequiresSecurityAuditSuppressionApproval,
+  evaluateExecDenylist,
+  formatExecDenylistDeniedMessage,
   hasDurableExecApproval,
   maxAsk,
   minSecurity,
@@ -75,6 +77,7 @@ type SystemRunInvokeResult = {
 
 type SystemRunDeniedReason =
   | "security=deny"
+  | "denylist-hit"
   | "approval-required"
   | "allowlist-miss"
   | "execution-plan-miss"
@@ -192,6 +195,7 @@ function warnWritableTrustedDirOnce(message: string): void {
 function normalizeDeniedReason(reason: string | null | undefined): SystemRunDeniedReason {
   switch (reason) {
     case "security=deny":
+    case "denylist-hit":
     case "approval-required":
     case "allowlist-miss":
     case "execution-plan-miss":
@@ -539,6 +543,14 @@ async function evaluateSystemRunPolicyPhase(
     allowlist: approvals.allowlist,
     commandText: parsed.commandText,
   });
+  const denylistEvaluation = evaluateExecDenylist({
+    denylist: approvals.denylist,
+    segments,
+    analysisOk: allowlistEvaluation.analysisOk,
+    cwd: parsed.cwd,
+    env: parsed.env,
+    platform: process.platform,
+  });
   const inlineEvalExecutableTrusted =
     inlineEvalHit !== null &&
     segmentAllowlistEntries.some((entry) => entry?.source === "allow-always");
@@ -549,6 +561,7 @@ async function evaluateSystemRunPolicyPhase(
     analysisOk,
     allowlistSatisfied,
     durableApprovalSatisfied: durableApprovalSatisfied || inlineEvalExecutableTrusted,
+    denylisted: denylistEvaluation.matched,
     approvalDecision,
     approved: parsed.approved,
     isWindows,
@@ -615,7 +628,9 @@ async function evaluateSystemRunPolicyPhase(
       parsed.approvalPlan !== null &&
       inlineEvalHit === null &&
       !requiresSecurityAuditSuppressionApproval &&
-      policy.eventReason !== "security=deny";
+      policy.eventReason !== "security=deny" &&
+      // Denylist hits are reserved for explicit human approval.
+      policy.eventReason !== "denylist-hit";
     if (canAutoReviewApprovalMiss) {
       const reviewer = await resolveSystemRunAutoReviewer({
         opts,
@@ -651,6 +666,7 @@ async function evaluateSystemRunPolicyPhase(
           analysisOk,
           allowlistSatisfied,
           durableApprovalSatisfied: durableApprovalSatisfied || inlineEvalExecutableTrusted,
+          denylisted: denylistEvaluation.matched,
           approvalDecision,
           approved: true,
           isWindows,
@@ -664,9 +680,13 @@ async function evaluateSystemRunPolicyPhase(
   }
 
   if (!policy.allowed) {
+    const denylistDeniedMessage =
+      policy.eventReason === "denylist-hit"
+        ? formatExecDenylistDeniedMessage(denylistEvaluation)
+        : undefined;
     await sendSystemRunDenied(opts, parsed.execution, {
       reason: policy.eventReason,
-      message: autoReviewDeferredMessage ?? policy.errorMessage,
+      message: autoReviewDeferredMessage ?? denylistDeniedMessage ?? policy.errorMessage,
     });
     return null;
   }


### PR DESCRIPTION
## Summary

Adds an optional per-agent `denylist` to `exec-approvals.json`: a small STOP list that forces an explicit human approval for matching commands even when policy would otherwise auto-allow them (including `security=full` + `ask="off"`).

This enables a deny-by-exception exec posture: keep exec permissive for day-to-day automation, but always interrupt the handful of commands that should never run unattended (`git push --force`, `launchctl ...`, `rm -rf /`, ...).

```json
{
  "version": 1,
  "agents": {
    "*": {
      "denylist": [
        { "pattern": "git push*--force*", "reason": "history rewrite" },
        { "pattern": "launchctl*" }
      ]
    }
  }
}
```

## Behavior

- `agents.<id>.denylist` / `agents.*.denylist` entries are glob patterns (`*`, `?`) matched against each analyzed command segment's argv text (single-space joined), plus a basename variant of the executable so `/usr/bin/git push --force` still matches `git push --force*`.
- Matching reuses the segments already produced by allowlist analysis (no extra parsing cost) and covers shell chains and POSIX inline wrappers (`bash -c "..."`, depth-capped at 3).
- A hit always asks again:
  - excluded from exec auto-review — only a human approval proceeds
  - durable allow-always trust never clears a hit; approving applies to that invocation only
  - no yolo-mode escape (unlike the security-audit-suppression gate — interrupting auto-allowed commands is the feature's purpose)
- Conservative fallbacks: while a denylist is configured, commands the analyzer cannot screen (analysis failures such as line continuations, `cmd.exe /c`, `powershell -Command`, nesting beyond the depth cap) require approval instead of failing open.
- Enforcement points:
  - gateway exec host: `requiresDenylistApproval` joins the pre-execution `requiresAsk` chain (mirrors the security-audit-suppression gate shape), so hits prompt before execution
  - node host: `evaluateSystemRunPolicy` gains a `denylisted` input and a `denylist-hit` deny reason evaluated right after `security=deny`

## Threat model

A guardrail against unintended high-risk commands from an honest agent, not a sandbox. Constructs the analyzer rejects prompt for approval rather than failing open; adversarial confinement still belongs to `security=allowlist` / `security=deny`. Documented in `docs/tools/exec-approvals.md`.

## Not in this PR (follow-ups)

- The node-host preflight (`bash-tools.exec-host-node.ts`) does not yet pre-prompt for denylist hits; the node-host policy still denies server-side with reason `denylist-hit` and an explanatory message, so enforcement is complete. Pre-prompting on the node preflight (mirroring the gateway host) is a natural follow-up.
- Control UI editing for denylist entries (the UI currently edits allowlists only; the file format round-trips safely).

## Tests

- new `src/infra/exec-approvals-denylist.test.ts` (19 tests): glob matching, basename variant, chains, inline wrapper recursion, conservative fallbacks, win32 case folding, entry sanitization
- `src/node-host/exec-policy.test.ts`: denylist-hit precedence, explicit-approval clearing, durable-trust non-bypass, security=deny ordering
- `src/infra/exec-approvals-config.test.ts`: wildcard + agent merge, normalization of malformed entries
- `src/agents/bash-tools.exec-host-gateway.test.ts`: approval required in yolo mode, auto-review exclusion, durable-trust re-ask, denylist miss, unanalyzable command
- `pnpm check --include-test-types` green; exec-related suites green locally (500+ tests across infra/node-host/agents/cli/gateway)

## Real behavior proof

**Behavior or issue addressed:** A configured exec denylist (STOP list) must force an explicit approval for matching commands even when `security=full` + `ask="off"` would auto-allow them, must screen POSIX inline wrapper payloads, must not change behavior for non-matching commands, and an explicit approval decision must clear the hit.

**Real environment tested:** macOS (Apple Silicon) checkout of this branch, Node v25.9.0, isolated `OPENCLAW_STATE_DIR=/tmp/oc-prD-proof-state` containing a real `exec-approvals.json`; the production gateway exec host decision path (`processGatewayAllowlist`, the same function `bash-tools.exec.ts` calls) and the node-host policy chain (`evaluateShellAllowlist` → `evaluateExecDenylist` → `evaluateSystemRunPolicy`) executed in-process against that real config with no test doubles.

**Exact steps or command run after this patch:**

```bash
printf %s '{"version":1,"agents":{"*":{"denylist":[{"pattern":"git push*--force*","reason":"history rewrite"}]}}}' \
  > /tmp/oc-prD-proof-state/exec-approvals.json
cd ~/repos/oc-worktrees/impl-prD   # this branch
OPENCLAW_STATE_DIR=/tmp/oc-prD-proof-state pnpm exec tsx proof-denylist.harness.ts
# control: same harness, denylist removed
printf %s '{"version":1}' > /tmp/oc-prD-proof-control/exec-approvals.json
OPENCLAW_STATE_DIR=/tmp/oc-prD-proof-control pnpm exec tsx proof-denylist.harness.ts
```

The harness calls `processGatewayAllowlist({command, security:"full", ask:"off", ...})` for each command and prints the decision plus pushed warnings, then evaluates the node-host policy for the same commands.

**Evidence after fix:**

Run 1 — denylist configured (`security=full`, `ask=off` resolved from the real file):

```text
# resolved policy: security=full ask=off denylist=[{"pattern":"git push*--force*","reason":"history rewrite"}]

## gateway exec host (security=full, ask=off) — production decision path
[gateway-host] {"command":"git status","outcome":"ALLOWED","result":{}}
[gateway-host] {"command":"git push --force origin main","outcome":"BLOCKED","error":"Exec approval registration failed: GatewayTransportError: gateway closed (1008): unauthorized: gateway token missing (provide gateway auth token)\n..."}
[gateway-host]   warning: Warning: command matches exec denylist entry git push*--force* (history rewrite); explicit approval is required.
[gateway-host] {"command":"bash -c \"git push --force origin main\"","outcome":"BLOCKED","error":"Exec approval registration failed: ..."}
[gateway-host]   warning: Warning: command matches exec denylist entry git push*--force* (history rewrite); explicit approval is required.

## node-host system.run policy (security=full, ask=off)
[node-host] {"command":"git status","approvalDecision":null,"denylistMatched":false,"matchedPattern":null,"allowed":true,"eventReason":null}
[node-host] {"command":"git push --force origin main","approvalDecision":null,"denylistMatched":true,"matchedPattern":"git push*--force*","allowed":false,"eventReason":"denylist-hit"}
[node-host] {"command":"git push --force origin main","approvalDecision":"allow-once","denylistMatched":true,"matchedPattern":"git push*--force*","allowed":true,"eventReason":null}
```

Run 2 — control, denylist removed (`{"version":1}`), same commands:

```text
# resolved policy: security=full ask=off denylist=[]
[gateway-host] {"command":"git status","outcome":"ALLOWED","result":{}}
[gateway-host] {"command":"git push --force origin main","outcome":"ALLOWED","result":{}}
[gateway-host] {"command":"bash -c \"git push --force origin main\"","outcome":"ALLOWED","result":{}}
[node-host] {"command":"git push --force origin main","approvalDecision":null,"denylistMatched":false,...,"allowed":true,"eventReason":null}
```

**Observed result after fix:** With the denylist configured at `security=full`/`ask="off"`, `git status` ran free while `git push --force origin main` and `bash -c "git push --force origin main"` were interrupted: the gateway host surfaced the denylist warning (pattern plus reason) and proceeded to register a real exec approval request — registration fails in the sandbox because no gateway is listening, which blocks the command; in a live deployment this same path raises the approval prompt. The node-host policy denied the matching command with the new `denylist-hit` reason and allowed it once an explicit `allow-once` decision was present. In the control run without a denylist, every command was auto-allowed, so the denylist is the sole deciding factor for the changed behavior.

**What was not tested:** A full live gateway driving a model-initiated agent turn end-to-end (approval prompt UI and resolve round-trip); Windows runtime behavior (`cmd.exe`/PowerShell wrapper payloads are screened conservatively, covered by unit tests only); the node-host preflight pre-prompt (documented follow-up — node-host enforcement itself is shown above).
