### PR TITLE
fix #86039: skip disabled bundled setup fallbacks

### DIFF
--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -847,6 +847,60 @@ describe("bundled channel entry shape guards", () => {
       delete testGlobal["__bundledSetupOnlyPluginLoaded"];
     }
   });
+  it("skips disabled bundled setup plugins before loading setup entries", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-disabled-bundled-setup-"));
+    const previousBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+    const pluginDir = path.join(root, "dist", "extensions", "alpha");
+    const testGlobal = globalThis as typeof globalThis & {
+      __disabledBundledSetupLoads?: number;
+    };
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "setup-entry.js"),
+      [
+        "export default {",
+        "  kind: 'bundled-channel-setup-entry',",
+        "  loadSetupPlugin() {",
+        '    globalThis["__disabledBundledSetupLoads"] = (globalThis["__disabledBundledSetupLoads"] ?? 0) + 1;',
+        "    return { id: 'alpha', meta: { label: 'Alpha' } };",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    mockAlphaDistExtensionRuntime();
+
+    try {
+      process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = path.join(root, "dist", "extensions");
+
+      const bundled = await importFreshModule<typeof import("./bundled.js")>(
+        import.meta.url,
+        "./bundled.js?scope=disabled-bundled-setup",
+      );
+
+      expect(
+        bundled.listBundledChannelSetupPlugins({
+          config: {
+            channels: { alpha: { enabled: false } },
+            plugins: { entries: { alpha: { enabled: false } } },
+          } as never,
+        }),
+      ).toStrictEqual([]);
+      expect(testGlobal["__disabledBundledSetupLoads"]).toBeUndefined();
+
+      expect(bundled.listBundledChannelSetupPlugins().map((plugin) => plugin.id)).toEqual([
+        "alpha",
+      ]);
+      expect(testGlobal["__disabledBundledSetupLoads"]).toBe(1);
+    } finally {
+      restoreBundledPluginsDir(previousBundledPluginsDir);
+      fs.rmSync(root, { recursive: true, force: true });
+      delete testGlobal["__disabledBundledSetupLoads"];
+    }
+  });
+
   it("swallows and caches bundled plugin and setup load failures", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-load-failure-"));
     const previousBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -497,6 +497,21 @@ function shouldIncludeBundledChannelSetupFeatureForConfig(params: {
   return !hasExplicitChannelDisable;
 }
 
+function listBundledChannelSetupPluginIdsForRoot(
+  rootScope: BundledChannelRootScope,
+  options: { config?: OpenClawConfig } = {},
+): readonly ChannelId[] {
+  return listBundledChannelMetadata(rootScope)
+    .filter((metadata) =>
+      shouldIncludeBundledChannelSetupFeatureForConfig({
+        metadata,
+        config: options.config,
+      }),
+    )
+    .map((metadata) => metadata.manifest.id)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
 function listBundledChannelPluginIdsForSetupFeature(
   rootScope: BundledChannelRootScope,
   feature: keyof NonNullable<BundledChannelSetupEntryRuntimeContract["features"]>,
@@ -513,17 +528,7 @@ function listBundledChannelPluginIdsForSetupFeature(
     )
     .map((metadata) => metadata.manifest.id)
     .toSorted((left, right) => left.localeCompare(right));
-  return hinted.length > 0
-    ? hinted
-    : listBundledChannelMetadata(rootScope)
-        .filter((metadata) =>
-          shouldIncludeBundledChannelSetupFeatureForConfig({
-            metadata,
-            config: options.config,
-          }),
-        )
-        .map((metadata) => metadata.manifest.id)
-        .toSorted((left, right) => left.localeCompare(right));
+  return hinted.length > 0 ? hinted : listBundledChannelSetupPluginIdsForRoot(rootScope, options);
 }
 
 export function listBundledChannelPluginIds(): readonly ChannelId[] {
@@ -808,9 +813,11 @@ export function listBundledChannelPlugins(): readonly ChannelPlugin[] {
   });
 }
 
-export function listBundledChannelSetupPlugins(): readonly ChannelPlugin[] {
+export function listBundledChannelSetupPlugins(
+  options: { config?: OpenClawConfig } = {},
+): readonly ChannelPlugin[] {
   const { rootScope, loadContext } = resolveActiveBundledChannelLoadScope();
-  return listBundledChannelPluginIdsForRoot(rootScope).flatMap((id) => {
+  return listBundledChannelSetupPluginIdsForRoot(rootScope, options).flatMap((id) => {
     const plugin = getBundledChannelSetupPluginForRoot(id, rootScope, loadContext);
     return plugin ? [plugin] : [];
   });

--- a/src/channels/plugins/setup-registry.ts
+++ b/src/channels/plugins/setup-registry.ts
@@ -4,6 +4,7 @@
  * Resolves loaded or bundled setup plugins for onboarding flows.
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   getActivePluginChannelRegistry,
   requireActivePluginRegistry,
@@ -16,6 +17,10 @@ import type { ChannelId } from "./types.public.js";
 type ChannelSetupPluginView = {
   sorted: ChannelPlugin[];
   byId: Map<string, ChannelPlugin>;
+};
+
+type ChannelSetupPluginOptions = {
+  config?: OpenClawConfig;
 };
 
 function dedupeSetupPlugins(plugins: readonly ChannelPlugin[]): ChannelPlugin[] {
@@ -47,14 +52,18 @@ function sortChannelSetupPlugins(plugins: readonly ChannelPlugin[]): ChannelPlug
   });
 }
 
-function resolveChannelSetupPlugins(): ChannelSetupPluginView {
+function resolveChannelSetupPlugins(
+  options: ChannelSetupPluginOptions = {},
+): ChannelSetupPluginView {
   const registry = requireActivePluginRegistry();
 
   const registryPlugins = (registry.channelSetups ?? []).map((entry) => entry.plugin);
   // Before the registry has setup plugins, bundled setup plugins provide the
   // onboarding catalog so first-run setup can still render.
   const sorted = sortChannelSetupPlugins(
-    registryPlugins.length > 0 ? registryPlugins : listBundledChannelSetupPlugins(),
+    registryPlugins.length > 0
+      ? registryPlugins
+      : listBundledChannelSetupPlugins({ config: options.config }),
   );
   const byId = new Map<string, ChannelPlugin>();
   for (const plugin of sorted) {
@@ -70,8 +79,8 @@ function resolveChannelSetupPlugins(): ChannelSetupPluginView {
 /**
  * Lists setup-capable channel plugins, falling back to bundled setup metadata.
  */
-export function listChannelSetupPlugins(): ChannelPlugin[] {
-  return resolveChannelSetupPlugins().sorted.slice();
+export function listChannelSetupPlugins(options: ChannelSetupPluginOptions = {}): ChannelPlugin[] {
+  return resolveChannelSetupPlugins(options).sorted.slice();
 }
 
 /**

--- a/src/flows/channel-setup.status.test.ts
+++ b/src/flows/channel-setup.status.test.ts
@@ -1,5 +1,5 @@
 // Channel setup status tests cover status text and docs link rendering.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import {
   makeCatalogEntry,
@@ -89,6 +89,7 @@ let noteChannelStatus: ChannelSetupStatusModule["noteChannelStatus"];
 let noteChannelPrimer: ChannelSetupStatusModule["noteChannelPrimer"];
 let resolveChannelSelectionNoteLines: ChannelSetupStatusModule["resolveChannelSelectionNoteLines"];
 let resolveChannelSetupSelectionContributions: ChannelSetupStatusModule["resolveChannelSetupSelectionContributions"];
+let previousOpenClawLocale: string | undefined;
 
 function requireFirstMockCall<const Calls extends readonly unknown[][]>(
   calls: Calls,
@@ -104,6 +105,7 @@ function requireFirstMockCall<const Calls extends readonly unknown[][]>(
 describe("resolveChannelSetupSelectionContributions", () => {
   beforeEach(async () => {
     vi.resetModules();
+    previousOpenClawLocale = process.env.OPENCLAW_LOCALE;
     process.env.OPENCLAW_LOCALE = "en";
     vi.clearAllMocks();
     listChatChannels.mockReturnValue([
@@ -125,6 +127,14 @@ describe("resolveChannelSetupSelectionContributions", () => {
       resolveChannelSelectionNoteLines,
       resolveChannelSetupSelectionContributions,
     } = await import("./channel-setup.status.js"));
+  });
+
+  afterEach(() => {
+    if (previousOpenClawLocale === undefined) {
+      delete process.env.OPENCLAW_LOCALE;
+    } else {
+      process.env.OPENCLAW_LOCALE = previousOpenClawLocale;
+    }
   });
 
   it("sorts channels alphabetically by picker label", () => {

--- a/src/flows/channel-setup.status.test.ts
+++ b/src/flows/channel-setup.status.test.ts
@@ -104,6 +104,7 @@ function requireFirstMockCall<const Calls extends readonly unknown[][]>(
 describe("resolveChannelSetupSelectionContributions", () => {
   beforeEach(async () => {
     vi.resetModules();
+    process.env.OPENCLAW_LOCALE = "en";
     vi.clearAllMocks();
     listChatChannels.mockReturnValue([
       makeMeta("discord", "Discord"),

--- a/src/flows/channel-setup.status.test.ts
+++ b/src/flows/channel-setup.status.test.ts
@@ -14,6 +14,9 @@ type FormatChannelPrimerLine = typeof import("../channels/registry.js").formatCh
 type FormatChannelSelectionLine =
   typeof import("../channels/registry.js").formatChannelSelectionLine;
 type IsChannelConfigured = typeof import("../config/channel-configured.js").isChannelConfigured;
+type ListChannelSetupPlugins =
+  typeof import("../channels/plugins/setup-registry.js").listChannelSetupPlugins;
+type ChannelSetupStatusModule = typeof import("./channel-setup.status.js");
 type NoteChannelPrimerChannels = Parameters<
   typeof import("./channel-setup.status.js").noteChannelPrimer
 >[1];
@@ -35,6 +38,12 @@ const formatChannelSelectionLine = vi.hoisted(() =>
   vi.fn<FormatChannelSelectionLine>((meta) => `${meta.label} — ${meta.blurb}`),
 );
 const isChannelConfigured = vi.hoisted(() => vi.fn<IsChannelConfigured>(() => false));
+const listChannelSetupPlugins = vi.hoisted(() => vi.fn<ListChannelSetupPlugins>(() => []));
+
+vi.mock("../channels/plugins/setup-registry.js", () => ({
+  listChannelSetupPlugins: (...args: Parameters<ListChannelSetupPlugins>) =>
+    listChannelSetupPlugins(...args),
+}));
 
 vi.mock("../channels/chat-meta.js", () => ({
   listChatChannels: () => listChatChannels(),
@@ -75,13 +84,11 @@ vi.mock("../plugins/bundled-sources.js", () => ({
   findBundledPluginSourceInMap: () => undefined,
 }));
 
-import {
-  collectChannelStatus,
-  noteChannelPrimer,
-  noteChannelStatus,
-  resolveChannelSelectionNoteLines,
-  resolveChannelSetupSelectionContributions,
-} from "./channel-setup.status.js";
+let collectChannelStatus: ChannelSetupStatusModule["collectChannelStatus"];
+let noteChannelStatus: ChannelSetupStatusModule["noteChannelStatus"];
+let noteChannelPrimer: ChannelSetupStatusModule["noteChannelPrimer"];
+let resolveChannelSelectionNoteLines: ChannelSetupStatusModule["resolveChannelSelectionNoteLines"];
+let resolveChannelSetupSelectionContributions: ChannelSetupStatusModule["resolveChannelSetupSelectionContributions"];
 
 function requireFirstMockCall<const Calls extends readonly unknown[][]>(
   calls: Calls,
@@ -95,7 +102,8 @@ function requireFirstMockCall<const Calls extends readonly unknown[][]>(
 }
 
 describe("resolveChannelSetupSelectionContributions", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     vi.clearAllMocks();
     listChatChannels.mockReturnValue([
       makeMeta("discord", "Discord"),
@@ -107,6 +115,15 @@ describe("resolveChannelSetupSelectionContributions", () => {
     );
     formatChannelSelectionLine.mockImplementation((meta) => `${meta.label} — ${meta.blurb}`);
     isChannelConfigured.mockReturnValue(false);
+    listChannelSetupPlugins.mockReset();
+    listChannelSetupPlugins.mockReturnValue([]);
+    ({
+      collectChannelStatus,
+      noteChannelStatus,
+      noteChannelPrimer,
+      resolveChannelSelectionNoteLines,
+      resolveChannelSetupSelectionContributions,
+    } = await import("./channel-setup.status.js"));
   });
 
   it("sorts channels alphabetically by picker label", () => {
@@ -236,6 +253,20 @@ describe("resolveChannelSetupSelectionContributions", () => {
       value: "bad\u001B[31m\nid",
       label: "bad\\nid",
     });
+  });
+
+  it("passes config into fallback setup plugin discovery", async () => {
+    const cfg = {
+      channels: { irc: { enabled: false } },
+      plugins: { entries: { irc: { enabled: false } } },
+    };
+
+    await collectChannelStatus({
+      cfg: cfg as never,
+      accountOverrides: {},
+    });
+
+    expect(listChannelSetupPlugins).toHaveBeenCalledWith({ config: cfg });
   });
 
   it("sanitizes channel labels in status note lines", async () => {

--- a/src/flows/channel-setup.status.ts
+++ b/src/flows/channel-setup.status.ts
@@ -343,7 +343,8 @@ export async function collectChannelStatus(params: {
   installedPlugins?: ChannelSetupPlugin[];
   resolveAdapter?: (channel: ChannelChoice) => ChannelSetupWizardAdapter | undefined;
 }): Promise<ChannelStatusSummary> {
-  const installedPlugins = params.installedPlugins ?? listChannelSetupPlugins();
+  const installedPlugins =
+    params.installedPlugins ?? listChannelSetupPlugins({ config: params.cfg });
   const workspaceDir = resolveAgentWorkspaceDir(params.cfg, resolveDefaultAgentId(params.cfg));
   const { installedCatalogEntries, installableCatalogEntries } = resolveChannelSetupEntries({
     cfg: params.cfg,


### PR DESCRIPTION
## Summary

- Problem: Disabled bundled channels could still be considered by setup fallback discovery, so doctor/status paths could try to load missing generated setup modules and emit noisy bundled-channel warnings.
- Solution: Thread config into bundled setup fallback discovery and filter explicitly disabled channel/plugin entries before loading setup entries.
- What changed: Updated bundled setup enumeration, setup registry fallback discovery, channel status collection, and focused regression coverage.
- What did NOT change: Runtime bundled channel enumeration for normal active channels, channel transport behavior, setup feature-specific filtering semantics, config schema/defaults, or workspace catalog lookup behavior.

Fixes #86039

## Architecture / source-of-truth boundary

- **Source-of-truth boundary:** This uses the existing OpenClaw config disable contract (`channels.<id>.enabled=false` and `plugins.entries.<id>.enabled=false`) and the existing bundled setup inclusion logic; it does not add a new public config key, schema field, default, protocol, or migration.
- **Canonical owner:** `src/channels/plugins/bundled.ts` owns bundled setup metadata enumeration, and `src/channels/plugins/setup-registry.ts` owns the active-registry-or-bundled setup fallback boundary. The fix passes config into that owner boundary so disabled bundled setup entries are skipped before generated setup modules are loaded.
- **Out of scope:** Active runtime bundled channel loading, channel transport/message delivery, channel pairing, workspace catalog lookup guards, Windows packaging, and generated module build output are intentionally unchanged.
- **Related open PR scan:** Read-only searches for `86039`, `"disabled bundled" "setup"`, and `"bundled channel setup"` found this PR plus #62657 (`fix(channel): guard setup catalog lookups`). #62657 is a maintainer PR about workspace catalog lookup guards in `src/commands/channel-setup/**` and does not cover #86039's config-disabled bundled setup entry filtering before generated module loading.

## Real behavior proof

- **Behavior or issue addressed:** `openclaw doctor` should continue cleanly without disabled bundled channel setup warnings when `channels.<id>.enabled=false` and `plugins.entries.<id>.enabled=false` are set for bundled channels such as imessage, irc, mattermost, and signal.
- **Behavior addressed:** `openclaw doctor` should continue cleanly without disabled bundled channel setup warnings when `channels.<id>.enabled=false` and `plugins.entries.<id>.enabled=false` are set for bundled channels such as imessage, irc, mattermost, and signal.
- **Why it matters / User impact:** Users who disable bundled channels should not see noisy missing-generated-module warnings on every doctor/status path, especially in incomplete local builds where disabled channels are intentionally not usable.
- **Real environment tested:** Linux x86_64, Node v22.22.0, OpenClaw source checkout `d369c2d0f1143f9f22812a278c76c2184cb0778b`.
- **Exact steps or command run after this patch:**
  ```bash
  OPENCLAW_LOCALE=en \
  OPENCLAW_STATE_DIR=/media/vdc/code/ai/aispace/openclaw-pr-86166-evidence/state-d369c2d0 \
  OPENCLAW_CONFIG_PATH=/media/vdc/code/ai/aispace/openclaw-pr-86166-evidence/state-d369c2d0/openclaw.json \
  env -C /media/vdc/code/ai/aispace/openclaw-worktrees/pr-86166 \
    node scripts/run-node.mjs --dev doctor --non-interactive
  ```
- **Evidence after fix:** OpenClaw doctor terminal output excerpt:
  ```text
  ◇  Plugins ──────╮
  │                │
  │  Loaded: 72    │
  │  Imported: 0   │
  │  Disabled: 59  │
  │  Errors: 0     │
  │                │
  ├────────────────╯
  ```

  Disabled-channel warning checks from the captured doctor output:
  ```text
  failed to load bundled channel irc: False
  failed to load bundled channel setup entry irc: False
  failed to load bundled channel imessage: False
  failed to load bundled channel setup entry imessage: False
  failed to load bundled channel mattermost: False
  failed to load bundled channel setup entry mattermost: False
  failed to load bundled channel signal: False
  failed to load bundled channel setup entry signal: False
  Doctor complete: True
  Plugin errors zero: True
  ```
- **Observed result after fix:** The real doctor run completed and did not emit the disabled bundled-channel warning strings for imessage, irc, mattermost, or signal.
- **What was not tested:** A packaged Windows incomplete-build install was not available in this Linux environment.

## Fix classification

- **Fix classification:** Root-cause runtime bug fix with a narrow test-isolation cleanup.
- **Maintainer-ready confidence:** High. The runtime change is limited to config-aware setup fallback discovery, the follow-up test commit restores the status suite locale after forcing English defaults, and current-head proof covers the real doctor behavior, focused regressions, dependency checks, and build-artifacts checks relevant to this change.
- **Why this is root-cause fix:** The warning came from setup fallback discovery enumerating disabled bundled setup entries before loading generated setup modules. Passing the existing config into that discovery path skips explicitly disabled entries before module loading, so the warning source is removed instead of filtered after logging.
- **Patch quality notes:** The diff stays within the bundled setup discovery/status path and tests. The added test phrase "fallback setup plugin discovery" describes the existing fallback discovery surface under test; it does not add a new runtime fallback branch.
- **Target test file:** `src/flows/channel-setup.status.test.ts`; `src/channels/plugins/bundled.shape-guard.test.ts`.

## Merge risk

- **Risk labels considered:** compatibility, message-delivery.
- **Risk explanation:** Compatibility risk is limited to setup/status fallback discovery now honoring existing `channels.<id>.enabled=false` and `plugins.entries.<id>.enabled=false` config before loading setup entries. The message-delivery signal is from channel setup/status files, but this PR does not change channel transport, outbound delivery, inbound delivery, pairing, or active runtime channel enumeration.
- **Why acceptable:** The changed behavior matches the user's explicit disabled config and only prevents disabled setup entries from being loaded for setup/status discovery. Active bundled channel loading remains unchanged, and current-head doctor proof plus focused and broad channel tests cover the intended boundary.

## Regression Test Plan

- Coverage level: Real local doctor run, focused channel setup/status regression tests, full channels shard, dependency check shard, build-artifacts build/smoke checks, and whitespace diff gates.
- Target test file: `src/flows/channel-setup.status.test.ts`; `src/channels/plugins/bundled.shape-guard.test.ts`.
- Scenario locked in: Disabled bundled setup plugins are filtered using config before generated setup entries are loaded, channel status passes config into fallback setup plugin discovery, and the status test suite restores `OPENCLAW_LOCALE` after forcing English defaults.
- Why this is the smallest reliable guardrail: It covers the exact fallback boundary that emitted disabled-channel setup warnings and the test isolation cleanup without changing active channel loading.
- Commands run after current head `d369c2d0f1143f9f22812a278c76c2184cb0778b`:
  ```bash
  OPENCLAW_LOCALE=en LANG=C.UTF-8 node scripts/run-vitest.mjs \
    src/flows/channel-setup.status.test.ts \
    src/channels/plugins/bundled.shape-guard.test.ts \
    --reporter=dot --pool=forks --no-file-parallelism

  git diff --check origin/main...HEAD
  git diff --cached --check

  if pnpm run --silent 2>/dev/null | grep -q '^  deadcode:dependencies$'; then
    pnpm deadcode:dependencies
    pnpm deadcode:unused-files
    pnpm deadcode:report:ci:ts-unused
  else
    pnpm deadcode:ci
  fi

  NODE_OPTIONS=--max-old-space-size=8192 pnpm build:ci-artifacts
  node openclaw.mjs --help
  node openclaw.mjs status --json --timeout 1
  pnpm test:build:singleton
  pnpm test:startup:memory
  NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test:channels
  ```
- Results:
  ```text
  focused unit-fast shard: Test Files 1 passed; Tests 13 passed
  focused channels shard: Test Files 1 passed; Tests 25 passed
  git diff --check origin/main...HEAD: passed with no output
  git diff --cached --check: passed with no output
  check-dependencies shard: passed
  pnpm build:ci-artifacts: passed
  build-artifacts smoke commands: passed
  pnpm test:channels: Test Files 70 passed; Tests 651 passed
  ```

## Review findings addressed

- Real behavior proof request: Addressed with a local `openclaw doctor --non-interactive` run on current head using config that disables imessage, irc, mattermost, and signal in both `channels` and `plugins.entries`. The captured output shows doctor completed, plugin errors were zero, and the disabled bundled-channel warning strings were absent.
- RF-001/RF-002: The previous `check-dependencies` and `build-artifacts` failures were rechecked on current head `d369c2d0f1143f9f22812a278c76c2184cb0778b`. The dependency shard passed locally, the build-artifacts build and smoke commands passed locally, and the full channels shard passed locally. Remote checks should be judged only on this new pushed head, not on older head `af97dfe15bbc38c4c229b31c99c415926407f5e2`.
- Prior locale isolation cleanup remains covered: `src/flows/channel-setup.status.test.ts` saves the prior `OPENCLAW_LOCALE` value before forcing English defaults and restores it in `afterEach`, so later Vitest suites do not inherit English from this suite.

## Root Cause

- Root cause: Broad setup fallback discovery listed every bundled setup plugin without the user's config, while the disabled-channel filter was only applied to feature-specific setup helpers.
- Missing detection / guardrail: There was no regression proving disabled bundled channels are skipped before setup-entry loading in fallback setup discovery, and the added status test initially forced `OPENCLAW_LOCALE=en` without restoring the previous value.
