### PR TITLE
fix #92453: add session identity to runtime prompt

### DIFF
--- a/src/agents/cli-runner/helpers.system-prompt.test.ts
+++ b/src/agents/cli-runner/helpers.system-prompt.test.ts
@@ -91,4 +91,19 @@ describe("buildCliAgentSystemPrompt", () => {
     expect(prompt).toContain("CLI-only command guidance.");
     expect(prompt).not.toContain("OpenClaw-only command guidance.");
   });
+
+  it("includes session identity in runtime when provided", () => {
+    const prompt = buildCliAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      tools: [],
+      modelDisplay: "test/model",
+      agentId: "main",
+      sessionKey: "agent:main:telegram:direct:peer",
+      sessionId: "session-123",
+    });
+
+    expect(prompt).toContain("agent=main");
+    expect(prompt).toContain("session=agent:main:telegram:direct:peer");
+    expect(prompt).toContain("sessionId=session-123");
+  });
 });

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -128,6 +128,8 @@ export function buildCliAgentSystemPrompt(params: {
   skillsPrompt?: string;
   modelDisplay: string;
   agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
 }) {
   const runtimeWorkspaceDir = params.cwd?.trim() || params.workspaceDir;
   const defaultModelRef = resolveDefaultModelForAgent({
@@ -141,6 +143,8 @@ export function buildCliAgentSystemPrompt(params: {
     workspaceDir: runtimeWorkspaceDir,
     cwd: runtimeWorkspaceDir,
     runtime: {
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
       host: "openclaw",
       os: `${os.type()} ${os.release()}`,
       arch: os.arch(),

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -552,6 +552,8 @@ export async function prepareCliRunContext(
     contextFiles,
     modelDisplay,
     agentId: sessionAgentId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
   });
   const transformedSystemPrompt =
     backendResolved.transformSystemPrompt?.({

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1802,6 +1802,8 @@ export async function runEmbeddedAttempt(
       workspaceDir: effectiveWorkspace,
       cwd: effectiveCwd,
       runtime: {
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
         host: machineName,
         os: `${os.type()} ${os.release()}`,
         arch: os.arch(),

--- a/src/agents/embedded-agent-runner/system-prompt.ts
+++ b/src/agents/embedded-agent-runner/system-prompt.ts
@@ -57,6 +57,8 @@ export function buildEmbeddedSystemPrompt(params: {
   nativeCommandGuidanceLines?: string[];
   runtimeInfo: {
     agentId?: string;
+    sessionKey?: string;
+    sessionId?: string;
     host: string;
     os: string;
     arch: string;

--- a/src/agents/system-prompt-params.test.ts
+++ b/src/agents/system-prompt-params.test.ts
@@ -30,7 +30,7 @@ function buildParams(params: { config?: OpenClawConfig; workspaceDir?: string; c
   });
 }
 
-describe("buildSystemPromptParams repo root", () => {
+describe("buildSystemPromptParams", () => {
   it("detects repo root from workspaceDir", async () => {
     const temp = await makeTempDir("workspace");
     const repoRoot = path.join(temp, "repo");
@@ -104,5 +104,23 @@ describe("buildSystemPromptParams repo root", () => {
     const { runtimeInfo } = buildParams({ workspaceDir });
 
     expect(runtimeInfo.repoRoot).toBeUndefined();
+  });
+
+  it("carries session identity into runtime info", () => {
+    const { runtimeInfo } = buildSystemPromptParams({
+      agentId: "main",
+      runtime: {
+        sessionKey: "agent:main:main",
+        sessionId: "23ae7fce-3c27-4a51-b58e-d800d8ca091f",
+        host: "host",
+        os: "os",
+        arch: "arch",
+        node: "node",
+        model: "model",
+      },
+    });
+
+    expect(runtimeInfo.sessionKey).toBe("agent:main:main");
+    expect(runtimeInfo.sessionId).toBe("23ae7fce-3c27-4a51-b58e-d800d8ca091f");
   });
 });

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -19,6 +19,8 @@ import {
 
 type RuntimeInfoInput = {
   agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
   host: string;
   os: string;
   arch: string;

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1129,11 +1129,13 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain("capabilities= InlineButtons ,voice,inlinebuttons,Voice");
   });
 
-  it("includes agent id in runtime when provided", () => {
+  it("includes agent and session identity in runtime when provided", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
       runtimeInfo: {
         agentId: "work",
+        sessionKey: "agent:main:main",
+        sessionId: "23ae7fce-3c27-4a51-b58e-d800d8ca091f",
         host: "host",
         os: "macOS",
         arch: "arm64",
@@ -1143,6 +1145,8 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("agent=work");
+    expect(prompt).toContain("session=agent:main:main");
+    expect(prompt).toContain("sessionId=23ae7fce-3c27-4a51-b58e-d800d8ca091f");
   });
 
   it("includes reasoning visibility hint", () => {
@@ -1160,6 +1164,8 @@ describe("buildAgentSystemPrompt", () => {
     const line = buildRuntimeLine(
       {
         agentId: "work",
+        sessionKey: "agent:main:subagent:runtime-check",
+        sessionId: "23ae7fce-3c27-4a51-b58e-d800d8ca091f",
         host: "host",
         repoRoot: "/repo",
         os: "macOS",
@@ -1174,6 +1180,8 @@ describe("buildAgentSystemPrompt", () => {
     );
 
     expect(line).toContain("agent=work");
+    expect(line).toContain("session=agent:main:subagent:runtime-check");
+    expect(line).toContain("sessionId=23ae7fce-3c27-4a51-b58e-d800d8ca091f");
     expect(line).toContain("host=host");
     expect(line).toContain("repo=/repo");
     expect(line).toContain("os=macOS (arm64)");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -709,6 +709,8 @@ export function buildAgentSystemPrompt(params: {
   nativeCommandGuidanceLines?: string[];
   runtimeInfo?: {
     agentId?: string;
+    sessionKey?: string;
+    sessionId?: string;
     host?: string;
     os?: string;
     arch?: string;
@@ -1349,6 +1351,8 @@ function buildActiveProcessSessionReferenceLines(
 export function buildRuntimeLine(
   runtimeInfo?: {
     agentId?: string;
+    sessionKey?: string;
+    sessionId?: string;
     host?: string;
     os?: string;
     arch?: string;
@@ -1366,6 +1370,8 @@ export function buildRuntimeLine(
   const normalizedRuntimeCapabilities = normalizePromptCapabilityIds(runtimeCapabilities);
   return `Runtime: ${[
     runtimeInfo?.agentId ? `agent=${runtimeInfo.agentId}` : "",
+    runtimeInfo?.sessionKey ? `session=${sanitizeForPromptLiteral(runtimeInfo.sessionKey)}` : "",
+    runtimeInfo?.sessionId ? `sessionId=${sanitizeForPromptLiteral(runtimeInfo.sessionId)}` : "",
     runtimeInfo?.host ? `host=${runtimeInfo.host}` : "",
     runtimeInfo?.repoRoot ? `repo=${runtimeInfo.repoRoot}` : "",
     runtimeInfo?.os

--- a/src/auto-reply/reply/commands-system-prompt.test.ts
+++ b/src/auto-reply/reply/commands-system-prompt.test.ts
@@ -10,6 +10,7 @@ import {
   ensureSandboxWorkspaceForSession,
   resolveSandboxRuntimeStatus,
 } from "../../agents/sandbox.js";
+import { buildSystemPromptParams } from "../../agents/system-prompt-params.js";
 import { buildAgentSystemPrompt } from "../../agents/system-prompt.js";
 import { resolveReusableWorkspaceSkillSnapshot } from "../../skills/runtime/session-snapshot.js";
 import { resolveCommandsSystemPromptBundle } from "./commands-system-prompt.js";
@@ -229,6 +230,16 @@ describe("resolveCommandsSystemPromptBundle", () => {
       "resolveBootstrapContextForRun",
     );
     expect(bootstrapParams.sessionId).toBe("target-session");
+    const runtimeParams = requireFirstArg(
+      vi.mocked(buildSystemPromptParams),
+      "buildSystemPromptParams",
+    );
+    expect(runtimeParams.runtime).toEqual(
+      expect.objectContaining({
+        sessionKey: "agent:target:telegram:direct:target-session",
+        sessionId: "target-session",
+      }),
+    );
     const toolParams = requireFirstArg(
       vi.mocked(createOpenClawCodingTools),
       "createOpenClawCodingTools",

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -231,6 +231,8 @@ export async function resolveCommandsSystemPromptBundle(
     workspaceDir,
     cwd: process.cwd(),
     runtime: {
+      sessionKey: params.sessionKey,
+      sessionId: targetSessionEntry?.sessionId,
       host: "unknown",
       os: "unknown",
       arch: "unknown",


### PR DESCRIPTION
## Summary

- Problem: The Runtime header told agents their agent id but not their concrete session key or stable session id, so session-aware behaviors had to infer identity.
- Solution: Carry sessionKey/sessionId through the runtime prompt params and render them in the Runtime header.
- What changed: Updated the embedded runner runtimeInfo pipe, prompt renderer types, and prompt regression tests.
- What did NOT change: No provider, channel transport, model routing, or session storage behavior changed.

Fixes #92453

## Real behavior proof

- **Behavior addressed:** Runtime header now exposes both the session key and stable session id when those values are available.
- **Real environment tested:** macOS 26.5 / Darwin 25.5.0 arm64, Node v24.15.0, OpenClaw v2026.6.2, worktree SHA 0b1a27a
- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx -e 'import { buildRuntimeLine } from "./src/agents/system-prompt.ts"; const line = buildRuntimeLine({ agentId: "main", sessionKey: "agent:main:main", sessionId: "23ae7fce-3c27-4a51-b58e-d800d8ca091f", host: "host", os: "Darwin", arch: "arm64", node: process.version, model: "anthropic/test-model" }, "webchat", [], "high"); console.log(line); if (!line.includes("session=agent:main:main") || !line.includes("sessionId=23ae7fce-3c27-4a51-b58e-d800d8ca091f")) process.exit(1);'
  OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/agents/system-prompt.test.ts src/agents/system-prompt-params.test.ts
  OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/test-projects.mjs src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/system-prompt.ts src/agents/system-prompt-params.test.ts src/agents/system-prompt-params.ts src/agents/system-prompt.test.ts src/agents/system-prompt.ts
  node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
  node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo
  ```
- **Evidence after fix:** `Runtime: agent=main | session=agent:main:main | sessionId=23ae7fce-3c27-4a51-b58e-d800d8ca091f | host=host | os=Darwin (arm64) | node=v24.15.0 | model=anthropic/test-model | channel=webchat | capabilities=none | thinking=high`
- **Observed result after fix:** The real prompt renderer includes `session=agent:main:main` and `sessionId=23ae7fce-3c27-4a51-b58e-d800d8ca091f` in the Runtime header instead of only exposing `agent=main`.
- **What was not tested:** did not start a live gateway; this path is a pure system-prompt construction path and was exercised directly through the production renderer.

## Regression Test Plan

- Coverage level: Unit test
- Target test file: src/agents/system-prompt.test.ts; src/agents/system-prompt-params.test.ts
- Scenario locked in: runtime params retain session identity and the Runtime header renders both session key and session id.
- Why this is the smallest reliable guardrail: The tests cover the exact formatter and param assembly functions that lost the session identity.

## Root Cause

- Root cause: `runEmbeddedAttempt` already had `params.sessionKey` and `params.sessionId`, but the runtimeInfo object passed to prompt assembly omitted them and the prompt renderer had no fields to print.
- Missing detection / guardrail: Existing Runtime header tests covered agent id, host, repo, model, and channel details but not session identity.
