### PR TITLE
fix(agents): preserve compatible CLI session runtime pins

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1,6 +1,7 @@
 // Tests agent runner execution setup, command args, and model fallback routing.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OAuthRefreshFailureError } from "../../agents/auth-profiles/oauth-refresh-failure.js";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.js";
 import { FailoverError } from "../../agents/failover-error.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { MissingProviderAuthError } from "../../agents/model-auth.js";
@@ -49,11 +50,57 @@ const GENERIC_RUN_FAILURE_TEXT =
   "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.";
 
 describe("resolveSessionRuntimeOverrideForProvider", () => {
+  afterEach(() => {
+    cliBackendsTesting.resetDepsForTest();
+  });
+
   it("ignores unsupported session runtime pins", () => {
     expect(
       resolveSessionRuntimeOverrideForProvider({
         provider: "openai",
         entry: { agentRuntimeOverride: "unsupported-runtime" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps CLI runtime pins only when the runtime serves the selected provider", () => {
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [],
+      resolvePluginSetupCliBackend: ({ backend, config }) =>
+        backend === "claude-cli" && config
+          ? {
+              pluginId: "anthropic",
+              backend: {
+                id: "claude-cli",
+                modelProvider: "anthropic",
+                config: { command: "claude" },
+                bundleMcp: false,
+              },
+            }
+          : undefined,
+    });
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+        },
+      },
+    };
+
+    expect(
+      resolveSessionRuntimeOverrideForProvider({
+        provider: "anthropic",
+        entry: { agentRuntimeOverride: "claude-cli" },
+        cfg,
+      }),
+    ).toBe("claude-cli");
+    expect(
+      resolveSessionRuntimeOverrideForProvider({
+        provider: "openai",
+        entry: { agentRuntimeOverride: "claude-cli" },
+        cfg,
       }),
     ).toBeUndefined();
   });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -47,7 +47,10 @@ import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-p
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { isMissingProviderAuthError } from "../../agents/model-auth.js";
 import { runWithModelFallback, isFallbackSummaryError } from "../../agents/model-fallback.js";
-import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
+import {
+  isCliRuntimeAliasForProvider,
+  resolveCliRuntimeExecutionProvider,
+} from "../../agents/model-runtime-aliases.js";
 import {
   isCliProvider,
   resolveModelRefFromString,
@@ -1420,6 +1423,7 @@ function emitModelFallbackStepLifecycle(params: {
 export function resolveSessionRuntimeOverrideForProvider(params: {
   provider: string;
   entry?: Pick<SessionEntry, "agentRuntimeOverride">;
+  cfg?: OpenClawConfig;
 }): string | undefined {
   const provider = normalizeLowercaseStringOrEmpty(params.provider);
   const runtime = normalizeLowercaseStringOrEmpty(params.entry?.agentRuntimeOverride);
@@ -1428,6 +1432,9 @@ export function resolveSessionRuntimeOverrideForProvider(params: {
   }
   if (provider === "openai" && runtime === "codex") {
     return "codex";
+  }
+  if (isCliRuntimeAliasForProvider({ provider, runtime, cfg: params.cfg })) {
+    return runtime;
   }
   return undefined;
 }
@@ -2020,6 +2027,7 @@ export async function runAgentTurnWithFallback(params: {
             resolveSessionRuntimeOverrideForProvider({
               provider,
               entry: params.getActiveSessionEntry(),
+              cfg: runtimeConfig,
             }),
           prepareAgentHarnessRuntime: async ({ provider, model, agentHarnessRuntimeOverride }) => {
             await agentTurnTiming.measure("fallback_prepare_harness", () =>
@@ -2104,6 +2112,7 @@ export async function runAgentTurnWithFallback(params: {
                 const resolvedSessionRuntimeOverride = resolveSessionRuntimeOverrideForProvider({
                   provider,
                   entry: params.getActiveSessionEntry(),
+                  cfg: runtimeConfig,
                 });
                 const resolvedSelectedAuthProfile = resolveRunAuthProfile(candidateRun, provider, {
                   config: runtimeConfig,

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   clearMemoryPluginState,
@@ -226,6 +227,7 @@ describe("runMemoryFlushIfNeeded", () => {
 
   afterEach(async () => {
     setAgentRunnerMemoryTestDeps();
+    cliBackendsTesting.resetDepsForTest();
     clearMemoryPluginState();
     await fs.rm(rootDir, { recursive: true, force: true });
   });
@@ -899,6 +901,46 @@ describe("runMemoryFlushIfNeeded", () => {
       followupRun: createTestFollowupRun({ provider: "codex-cli" }),
       sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
       defaultModel: "codex-cli/gpt-5.5",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("skips memory flush for compatible CLI session runtime pins", async () => {
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "claude-cli",
+          modelProvider: "anthropic",
+          pluginId: "anthropic",
+          config: { command: "claude" },
+        },
+      ],
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+      agentRuntimeOverride: "claude-cli",
+    };
+
+    const entry = await runMemoryFlushIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      }),
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-opus-4-6",
       agentCfgContextTokens: 100_000,
       resolvedVerboseLevel: "off",
       sessionEntry,
@@ -1607,6 +1649,61 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey: "main",
       }),
       defaultModel: "gpt-5.5",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("skips preflight compaction for compatible CLI session runtime pins", async () => {
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "claude-cli",
+          modelProvider: "anthropic",
+          pluginId: "anthropic",
+          config: { command: "claude" },
+        },
+      ],
+    });
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 347_000,
+      totalTokensFresh: true,
+      agentRuntimeOverride: "claude-cli",
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: {
+        models: {
+          providers: {
+            anthropic: { models: [{ id: "claude-opus-4-6", contextWindow: 350_000 }] },
+          },
+        },
+        agents: { defaults: { compaction: { memoryFlush: {} } } },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        sessionId: "session",
+        sessionKey: "main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
       sessionEntry,
       sessionStore: { main: sessionEntry },
       sessionKey: "main",

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -12,6 +12,7 @@ import { classifyCompactionReason } from "../../agents/embedded-agent-runner/com
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-plugin.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
+import { isCliRuntimeAliasForProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-routing.js";
 import type { AgentMessage } from "../../agents/runtime/index.js";
@@ -233,6 +234,22 @@ function resolveMemoryFlushRuntimeOverrideForProvider(params: {
     return "codex";
   }
   return undefined;
+}
+
+function followupUsesCliRuntime(params: {
+  cfg: OpenClawConfig;
+  followupRun: FollowupRun;
+  sessionEntry?: Pick<SessionEntry, "agentRuntimeOverride">;
+}): boolean {
+  const provider = params.followupRun.run.provider;
+  if (isCliProvider(provider, params.cfg)) {
+    return true;
+  }
+  return isCliRuntimeAliasForProvider({
+    provider,
+    runtime: params.sessionEntry?.agentRuntimeOverride,
+    cfg: params.cfg,
+  });
 }
 
 function resolveFollowupContextConfigProvider(params: {
@@ -709,7 +726,11 @@ export async function runPreflightCompactionIfNeeded(params: {
     return entry ?? params.sessionEntry;
   }
 
-  const isCli = isCliProvider(params.followupRun.run.provider, params.cfg);
+  const isCli = followupUsesCliRuntime({
+    cfg: params.cfg,
+    followupRun: params.followupRun,
+    sessionEntry: entry,
+  });
   if (params.isHeartbeat || isCli) {
     return entry ?? params.sessionEntry;
   }
@@ -1026,11 +1047,15 @@ export async function runMemoryFlushIfNeeded(params: {
     return sandboxCfg.workspaceAccess === "rw";
   })();
 
-  const isCli = isCliProvider(params.followupRun.run.provider, params.cfg);
-  const canAttemptFlush = memoryFlushWritable && !params.isHeartbeat && !isCli;
   let entry =
     params.sessionEntry ??
     (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
+  const isCli = followupUsesCliRuntime({
+    cfg: params.cfg,
+    followupRun: params.followupRun,
+    sessionEntry: entry,
+  });
+  const canAttemptFlush = memoryFlushWritable && !params.isHeartbeat && !isCli;
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
     cfg: params.cfg,
     provider: resolveFollowupContextConfigProvider({

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -647,6 +647,7 @@ const resolveHarnessSourceVisibleRepliesDefault = (params: {
       const agentHarnessRuntimeOverride = resolveSessionRuntimeOverrideForProvider({
         provider: candidate.provider,
         entry: params.entry,
+        cfg: params.cfg,
       });
       const harness = selectAgentHarness({
         provider: candidate.provider,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -803,6 +803,7 @@ export function createFollowupRunner(params: {
             resolveSessionRuntimeOverrideForProvider({
               provider,
               entry: activeSessionEntry,
+              cfg: runtimeConfig,
             }),
           prepareAgentHarnessRuntime: async ({ provider, model, agentHarnessRuntimeOverride }) => {
             await ensureSelectedAgentHarnessPlugin({
@@ -837,6 +838,7 @@ export function createFollowupRunner(params: {
             const sessionRuntimeOverride = resolveSessionRuntimeOverrideForProvider({
               provider,
               entry: activeSessionEntry,
+              cfg: runtimeConfig,
             });
             const cliExecutionProvider =
               (sessionRuntimeOverride && isCliProvider(sessionRuntimeOverride, runtimeConfig)


### PR DESCRIPTION
## Summary
- Preserve persisted `agentRuntimeOverride` values for CLI runtimes when the runtime is registered to serve the selected provider.
- Keep stale CLI runtime pins isolated: a `claude-cli` session pin still does not leak into unrelated providers such as `openai`.
- Pass runtime config through the reply/follow-up harness override resolver so setup-registered CLI runtime aliases can be validated.

## Real behavior proof
Behavior or issue addressed:
Persisted session runtime pins were only restored for the hard-coded `openai` + `codex` pair. A session pinned to a setup-registered CLI runtime such as `claude-cli` would be dropped even when the selected provider was the matching model provider (`anthropic`). This could force the fallback/restore path away from the CLI runtime that originally owned the session. The fix keeps the existing stale-pin guard by restoring a CLI runtime only when `isCliRuntimeAliasForProvider` confirms that the runtime serves the selected provider.

Real environment tested:
Local OpenClaw checkout on macOS, branch `codex/session-runtime-compat-provider`, Node/Vitest through repository scripts.

Exact steps or command run after this patch:
```sh
node scripts/run-vitest.mjs run src/auto-reply/reply/agent-runner-execution.test.ts -t "resolveSessionRuntimeOverrideForProvider" --reporter verbose
node scripts/run-vitest.mjs run src/auto-reply/reply/agent-runner-execution.test.ts --reporter default
./node_modules/.bin/oxfmt --check --threads=1 src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/followup-runner.ts
node --import tsx --input-type=module --eval "<resolveSessionRuntimeOverrideForProvider live proof>"
```

Evidence after fix:
- Focused Vitest: `2 passed | 188 skipped` for `resolveSessionRuntimeOverrideForProvider`.
- Full related file: `agent-runner-execution.test.ts (190 tests)` passed.
- oxfmt: `All matched files use the correct format.`
- Live proof output:
```json
{
  "anthropic": "claude-cli",
  "openai": null
}
```

Observed result after fix:
With a setup-registered `claude-cli` runtime bound to `anthropic`, `resolveSessionRuntimeOverrideForProvider({ provider: "anthropic", agentRuntimeOverride: "claude-cli" })` now returns `"claude-cli"`; the same persisted runtime pin still returns `undefined` for `provider: "openai"`.

What was not tested:
End-to-end external CLI execution; this patch is limited to runtime override resolution and the reply/follow-up call sites that pass config into it.