### PR TITLE
fix(matrix): validate CLI numeric option ranges

### DIFF
--- a/extensions/matrix/src/cli.test.ts
+++ b/extensions/matrix/src/cli.test.ts
@@ -401,6 +401,20 @@ describe("matrix CLI verification commands", () => {
     expect(runMatrixSelfVerificationMock).not.toHaveBeenCalled();
   });
 
+  it("rejects non-positive Matrix self-verification timeout values", async () => {
+    const program = buildProgram();
+
+    await program.parseAsync(["matrix", "verify", "self", "--timeout-ms", "-1"], {
+      from: "user",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      "Self-verification failed: --timeout-ms must be a positive integer",
+    );
+    expect(runMatrixSelfVerificationMock).not.toHaveBeenCalled();
+  });
+
   it("requests Matrix self-verification and prints the follow-up SAS commands", async () => {
     requestMatrixVerificationMock.mockResolvedValue(
       mockMatrixVerificationSummary({
@@ -1074,6 +1088,34 @@ describe("matrix CLI verification commands", () => {
     expect(console.log).toHaveBeenCalledWith(
       "Bind this account to an agent: openclaw agents bind --agent <id> --bind matrix:ops",
     );
+  });
+
+  it("rejects negative Matrix initial sync limits at the CLI boundary", async () => {
+    const program = buildProgram();
+
+    await program.parseAsync(
+      [
+        "matrix",
+        "account",
+        "add",
+        "--homeserver",
+        "https://matrix.example.org",
+        "--user-id",
+        "@ops:example.org",
+        "--password",
+        "secret",
+        "--initial-sync-limit",
+        "-1",
+      ],
+      { from: "user" },
+    );
+
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      "Account setup failed: --initial-sync-limit must be a non-negative integer",
+    );
+    expect(matrixSetupValidateInputMock).not.toHaveBeenCalled();
+    expect(matrixRuntimeReplaceConfigFileMock).not.toHaveBeenCalled();
   });
 
   it("enables E2EE and bootstraps verification from matrix account add", async () => {

--- a/extensions/matrix/src/cli.ts
+++ b/extensions/matrix/src/cli.ts
@@ -232,7 +232,11 @@ function configureCliLogMode(verbose: boolean): void {
   setMatrixSdkConsoleLogging(verbose);
 }
 
-function parseOptionalInt(value: string | undefined, fieldName: string): number | undefined {
+function parseOptionalInt(
+  value: string | undefined,
+  fieldName: string,
+  opts: { min?: number } = {},
+): number | undefined {
   const trimmed = value?.trim();
   if (!trimmed) {
     return undefined;
@@ -243,6 +247,13 @@ function parseOptionalInt(value: string | undefined, fieldName: string): number 
   const parsed = parseStrictInteger(trimmed);
   if (parsed === undefined) {
     throw new Error(`${fieldName} must be an integer`);
+  }
+  if (opts.min !== undefined && parsed < opts.min) {
+    throw new Error(
+      opts.min === 1
+        ? `${fieldName} must be a positive integer`
+        : `${fieldName} must be a non-negative integer`,
+    );
   }
   return parsed;
 }
@@ -289,6 +300,9 @@ async function addMatrixAccount(params: {
   useEnv?: boolean;
   enableEncryption?: boolean;
 }): Promise<MatrixCliAccountAddResult> {
+  const initialSyncLimit = parseOptionalInt(params.initialSyncLimit, "--initial-sync-limit", {
+    min: 0,
+  });
   const runtime = getMatrixRuntime();
   const cfg = runtime.config.current() as CoreConfig;
   if (!matrixSetupAdapter.applyAccountConfig) {
@@ -305,7 +319,7 @@ async function addMatrixAccount(params: {
     accessToken: params.accessToken,
     password: params.password,
     deviceName: params.deviceName,
-    initialSyncLimit: parseOptionalInt(params.initialSyncLimit, "--initial-sync-limit"),
+    initialSyncLimit,
     useEnv: params.useEnv === true,
   };
   const accountId =
@@ -1159,15 +1173,18 @@ async function runMatrixCliVerificationSummaryCommand(params: {
 async function runMatrixCliSelfVerificationCommand(
   options: MatrixCliSelfVerificationCommandOptions,
 ): Promise<void> {
-  const { accountId, cfg } = resolveMatrixCliAccountContext(options.account);
+  let resolvedAccountId: string | undefined;
   await runMatrixCliCommand({
     verbose: options.verbose === true,
     json: false,
-    run: async () =>
-      await runMatrixSelfVerification({
+    run: async () => {
+      const timeoutMs = parseOptionalInt(options.timeoutMs, "--timeout-ms", { min: 1 });
+      const { accountId, cfg } = resolveMatrixCliAccountContext(options.account);
+      resolvedAccountId = accountId;
+      return await runMatrixSelfVerification({
         accountId,
         cfg,
-        timeoutMs: parseOptionalInt(options.timeoutMs, "--timeout-ms"),
+        timeoutMs,
         onRequested: (summary) => {
           printAccountLabel(accountId);
           printMatrixVerificationSummary(summary);
@@ -1184,7 +1201,8 @@ async function runMatrixCliSelfVerificationCommand(
           console.log("Compare this SAS with the other Matrix client.");
         },
         confirmSas: async () => await promptMatrixVerificationSasMatch(),
-      }),
+      });
+    },
     onText: (summary, verbose) => {
       printMatrixVerificationSummary(summary);
       console.log(`Device verified by owner: ${summary.deviceOwnerVerified ? "yes" : "no"}`);
@@ -1196,6 +1214,7 @@ async function runMatrixCliSelfVerificationCommand(
       console.log("Self-verification complete.");
     },
     onTextError: () => {
+      const accountId = resolvedAccountId ?? options.account;
       printGuidance([
         `Run ${formatMatrixCliCommand("verify self", accountId)} again and accept the request in another verified Matrix client for this account.`,
         `Then run ${formatMatrixCliCommand("verify status --verbose", accountId)} to confirm Cross-signing verified: yes and Signed by owner: yes.`,


### PR DESCRIPTION
## Summary

- Reject out-of-range Matrix CLI numeric options before Matrix setup or verification work starts.
- `matrix verify self --timeout-ms` now requires a positive integer.
- `matrix account add --initial-sync-limit` now rejects negative values while still allowing zero and positive integers.
- Out of scope: changing Matrix verification behavior, account setup behavior, or docs for these already-documented flags.

## Linked context

Fixes #92482

Related: none.

Was this requested by a maintainer or owner? No; this came from local bug reproduction and is linked to the issue above.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: invalid Matrix CLI numeric values were accepted past the CLI boundary.
- Real environment tested: local OpenClaw source checkout on macOS with a temporary `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR`. The Matrix CLI source registration was invoked through Commander so the proof exercised the changed CLI code without touching my real config.
- Exact steps or command run after this patch: ran the Matrix CLI source registration with Commander against two invalid commands: `matrix verify self --timeout-ms -1` and `matrix account add ... --initial-sync-limit -1`, using a temporary config with dummy Matrix values.
- Evidence after fix: copied terminal output from that local run:

```text
verify self:
Self-verification failed: --timeout-ms must be a positive integer
Next steps:
- Run openclaw matrix verify self again and accept the request in another verified Matrix client for this account.
- Then run openclaw matrix verify status --verbose to confirm Cross-signing verified: yes and Signed by owner: yes.
account add:
Account setup failed: --initial-sync-limit must be a non-negative integer
verify_exit=1
account_add_exit=1
```

- Observed result after fix: both invalid values fail immediately with the intended CLI validation errors and exit non-zero. No Matrix network/client work is started.
- What was not tested: a real Matrix homeserver verification flow, because the invalid input should fail before any network behavior.
- Proof limitations or environment constraints: the source-checkout root launcher in this local tree currently hits an unrelated built-dist optional dependency issue, so the proof invokes the Matrix CLI source registration directly with Commander.
- Before evidence: the new regression tests failed before the fix. `--timeout-ms -1` reached the verification path and produced `Cannot read properties of undefined (reading 'id')`; `--initial-sync-limit -1` did not fail at the CLI boundary.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/matrix/src/cli.test.ts -t "rejects non-positive Matrix self-verification timeout values|rejects negative Matrix initial sync limits"`
- `node scripts/run-vitest.mjs extensions/matrix/src/cli.test.ts`
- `./node_modules/.bin/oxfmt extensions/matrix/src/cli.ts extensions/matrix/src/cli.test.ts --check`
- `./node_modules/.bin/tsc -p extensions/matrix/tsconfig.json --noEmit`
- `pnpm lint:extensions`
- `git diff --check`

Regression coverage added for negative `--timeout-ms` and negative `--initial-sync-limit`.

`pnpm check:changed` was attempted, but local `crabbox` failed its basic `--version/--help` sanity checks before reaching code checks.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Invalid negative Matrix CLI values now fail earlier with clearer errors.

Did config, environment, or migration behavior change? (`Yes/No`)

No migration or persisted config shape change. Account setup now rejects an invalid explicit `--initial-sync-limit -1` instead of letting downstream normalization treat it as absent.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No. The real-behavior proof uses dummy local values only; no secrets are required.

What is the highest-risk area?

Rejecting a value that previously slipped through.

How is that risk mitigated?

The accepted ranges match the downstream behavior: verification timeout must be positive; initial sync limit allows zero and positive integers but not negatives. Focused regression tests cover both boundaries.

## Current review state

Ready for review. Nothing is currently waiting on the author.
