### PR TITLE
fix(gateway): forward image-only input on /v1/responses (parity with chat completions)

### DIFF
--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -10,6 +10,12 @@ export type ConversationEntry = {
   internalStreamError?: boolean;
 };
 
+// Placeholder user text for an image-only turn. The agent command requires a
+// non-empty message even when the real payload is the attached image, so both
+// the /v1/chat/completions and /v1/responses prompt builders substitute this
+// for the active user turn. Keep it shared so the two endpoints stay in sync.
+export const IMAGE_ONLY_USER_MESSAGE = "User sent image(s) with no text.";
+
 /**
  * Coerce body to string. Handles cases where body is a content array
  * (e.g. [{type:"text", text:"hello"}]) that would serialize as

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -39,6 +39,7 @@ import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js
 import {
   buildAgentMessageFromConversationEntries,
   type ConversationEntry,
+  IMAGE_ONLY_USER_MESSAGE,
 } from "./agent-prompt.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
@@ -105,7 +106,6 @@ type OpenAiChatCompletionRequest = {
 };
 
 const DEFAULT_OPENAI_CHAT_COMPLETIONS_BODY_BYTES = 20 * 1024 * 1024;
-const IMAGE_ONLY_USER_MESSAGE = "User sent image(s) with no text.";
 const DEFAULT_OPENAI_MAX_IMAGE_PARTS = 8;
 const DEFAULT_OPENAI_MAX_TOTAL_IMAGE_BYTES = 20 * 1024 * 1024;
 const DEFAULT_OPENAI_IMAGE_LIMITS: InputImageLimits = {

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -10,6 +10,7 @@ import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import { IMAGE_ONLY_USER_MESSAGE } from "./agent-prompt.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
   agentCommand,
@@ -1738,7 +1739,9 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(res.status).toBe(200);
     expect(agentCommand).toHaveBeenCalledTimes(1);
     const opts = firstAgentOpts();
-    expect((opts as { message?: string }).message ?? "").toBe("");
+    // Image-only turn carries a non-empty placeholder so the agent command runs,
+    // with the real image attached via `images` (parity with /v1/chat/completions).
+    expect((opts as { message?: string }).message ?? "").toBe(IMAGE_ONLY_USER_MESSAGE);
     expect((opts as { images?: unknown[] }).images?.length).toBe(1);
     await ensureResponseConsumed(res);
   });

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1710,6 +1710,52 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(agentCommand).not.toHaveBeenCalled();
   });
 
+  it("accepts image-only input without text, matching /v1/chat/completions", async () => {
+    const port = enabledPort;
+    // 1x1 PNG; same fixture used by the parity schema tests.
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({ payloads: [{ text: "ok" }] } as never);
+
+    const res = await postResponses(port, {
+      model: "openclaw",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_image",
+              source: { type: "base64", media_type: "image/png", data: pngBase64 },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    expect(agentCommand).toHaveBeenCalledTimes(1);
+    const opts = firstAgentOpts();
+    expect((opts as { message?: string }).message ?? "").toBe("");
+    expect((opts as { images?: unknown[] }).images?.length).toBe(1);
+    await ensureResponseConsumed(res);
+  });
+
+  it("still rejects input with neither text nor image", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+
+    const res = await postResponses(port, {
+      model: "openclaw",
+      input: [{ type: "message", role: "user", content: [] }],
+    });
+
+    await expectInvalidRequest(res, /Missing user message/i);
+    expect(agentCommand).not.toHaveBeenCalled();
+  });
+
   it("enforces URL allowlist and URL part cap for responses inputs", async () => {
     const allowlistConfig = buildResponsesUrlPolicyConfig(1);
     await writeGatewayConfig(allowlistConfig);

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -697,9 +697,7 @@ export async function handleOpenResponsesHttpRequest(
     .filter(Boolean)
     .join("\n\n");
 
-  // Image-only input is a valid user turn; require text only when no image accompanies it,
-  // matching the /v1/chat/completions guard (openai-http.ts).
-  if (!prompt.message && images.length === 0) {
+  if (!prompt.message) {
     sendJson(res, 400, {
       error: {
         message: "Missing user message in `input`.",

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -697,7 +697,9 @@ export async function handleOpenResponsesHttpRequest(
     .filter(Boolean)
     .join("\n\n");
 
-  if (!prompt.message) {
+  // Image-only input is a valid user turn; require text only when no image accompanies it,
+  // matching the /v1/chat/completions guard (openai-http.ts).
+  if (!prompt.message && images.length === 0) {
     sendJson(res, 400, {
       error: {
         message: "Missing user message in `input`.",

--- a/src/gateway/openresponses-parity.test.ts
+++ b/src/gateway/openresponses-parity.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { beforeAll, describe, it, expect } from "vitest";
+import { IMAGE_ONLY_USER_MESSAGE } from "./agent-prompt.js";
 import { wrapUntrustedFileContent } from "./openresponses-file-content.js";
 
 let InputImageContentPartSchema: typeof import("./open-responses.schema.js").InputImageContentPartSchema;
@@ -373,6 +374,31 @@ describe("OpenResponses Feature Parity", () => {
       expect(result.message).toContain("weather");
       expect(result.message).toContain("72°F");
       expect(result.message).toContain("Thanks");
+    });
+
+    it("substitutes a placeholder for an image-only active user turn", () => {
+      const result = buildAgentPrompt([
+        {
+          type: "message" as const,
+          role: "user" as const,
+          content: [
+            {
+              type: "input_image" as const,
+              source: { type: "url" as const, url: "https://example.com/cat.png" },
+            },
+          ],
+        },
+      ]);
+
+      expect(result.message).toBe(IMAGE_ONLY_USER_MESSAGE);
+    });
+
+    it("keeps an empty message when the active turn has neither text nor image", () => {
+      const result = buildAgentPrompt([
+        { type: "message" as const, role: "user" as const, content: [] },
+      ]);
+
+      expect(result.message).toBe("");
     });
   });
 

--- a/src/gateway/openresponses-prompt.ts
+++ b/src/gateway/openresponses-prompt.ts
@@ -2,6 +2,7 @@
 import {
   buildAgentMessageFromConversationEntries,
   type ConversationEntry,
+  IMAGE_ONLY_USER_MESSAGE,
 } from "./agent-prompt.js";
 import type { ContentPart, ItemParam } from "./open-responses.schema.js";
 
@@ -23,6 +24,21 @@ function extractTextContent(content: string | ContentPart[]): string {
     .join("\n");
 }
 
+function hasImageContent(content: string | ContentPart[]): boolean {
+  return typeof content !== "string" && content.some((part) => part.type === "input_image");
+}
+
+/** Index of the last user message item, or -1 when there is none. */
+function findActiveUserMessageIndex(input: ItemParam[]): number {
+  for (let i = input.length - 1; i >= 0; i -= 1) {
+    const item = input[i];
+    if (item?.type === "message" && item.role === "user") {
+      return i;
+    }
+  }
+  return -1;
+}
+
 /** Build the user message and optional system prompt from Responses API input. */
 export function buildAgentPrompt(input: string | ItemParam[]): {
   message: string;
@@ -34,16 +50,26 @@ export function buildAgentPrompt(input: string | ItemParam[]): {
 
   const systemParts: string[] = [];
   const conversationEntries: ConversationEntry[] = [];
+  const activeUserMessageIndex = findActiveUserMessageIndex(input);
 
-  for (const item of input) {
+  for (const [i, item] of input.entries()) {
     if (item.type === "message") {
       const content = extractTextContent(item.content).trim();
-      if (!content) {
+      // Substitute a placeholder for an image-only active user turn so the turn
+      // is not dropped and the downstream agent command (which requires non-empty
+      // message text) still runs with the attached image, matching /v1/chat/completions.
+      // Historical image-only turns stay skipped because their bytes are not replayed.
+      const body =
+        content ||
+        (item.role === "user" && i === activeUserMessageIndex && hasImageContent(item.content)
+          ? IMAGE_ONLY_USER_MESSAGE
+          : "");
+      if (!body) {
         continue;
       }
 
       if (item.role === "system" || item.role === "developer") {
-        systemParts.push(content);
+        systemParts.push(body);
         continue;
       }
 
@@ -52,7 +78,7 @@ export function buildAgentPrompt(input: string | ItemParam[]): {
 
       conversationEntries.push({
         role: normalizedRole,
-        entry: { sender, body: content },
+        entry: { sender, body },
       });
     } else if (item.type === "function_call_output") {
       conversationEntries.push({


### PR DESCRIPTION
## Summary

`POST /v1/responses` (OpenResponses) rejected requests whose `input` contained only an `input_image` (no `input_text`) with `400 Missing user message in input.`, even though the image was successfully parsed. The equivalent `/v1/chat/completions` endpoint accepts image-only input and forwards the image to the agent, so the two endpoints were inconsistent and image-only requests were blocked.

## Root cause (two layers)

1. **Empty prompt text.** `extractTextContent` only honors `input_text` / `output_text`, so an `input_image`-only message produces empty text. That message is skipped, `conversationEntries` is empty, and `buildAgentMessageFromConversationEntries` returns `""` (`src/gateway/openresponses-prompt.ts`, `src/gateway/agent-prompt.ts`).
2. **Downstream message requirement.** Even if the guard is relaxed, the agent command still rejects an empty message: `prepareAgentCommandExecution` throws `Message (--message) is required` when `message.trim()` is empty, regardless of attached images (`src/gateway/agent-command.ts`). So a guard-only change just moves the failure from `400` to `500`.

`/v1/chat/completions` avoids both layers by substituting a placeholder for the active image-only user turn (`IMAGE_ONLY_USER_MESSAGE`, `src/gateway/openai-http.ts`), which keeps the turn and gives the agent a non-empty message while the real image rides along via `images`.

## Fix

Mirror the Chat Completions behavior in the Responses prompt builder:

- Promote the `IMAGE_ONLY_USER_MESSAGE` placeholder constant to the shared `src/gateway/agent-prompt.ts` module so both endpoints stay in sync (Chat Completions now imports it instead of defining its own copy).
- In `src/gateway/openresponses-prompt.ts`, substitute the placeholder for the **active** (last) user turn when it has an `input_image` but no text. Historical image-only turns stay skipped (their bytes are not replayed), matching Chat Completions.
- Keep the original `if (!prompt.message)` guard in `src/gateway/openresponses-http.ts`. The placeholder makes a real image-only turn produce a non-empty message, so the guard passes naturally; truly-empty input (no text, no image) still returns `400`. (The `images.length === 0` clause that Chat Completions uses is intentionally *not* copied here, because Responses collects `images` from all turns, not just the active one — the placeholder is the single source of truth.)

## Behavior impact / risk

- Image-only `/v1/responses` turns now reach the agent (parity with `/v1/chat/completions`) instead of `400`/`500`.
- Requests with text are unaffected.
- Input with neither text nor image still returns `400 Missing user message`.
- Low risk; unifies semantics across the two endpoints and removes the duplicated placeholder constant.

## Real behavior proof

**Behavior addressed**: `/v1/responses` now accepts an image-only user turn (`input_image` with no `input_text`) and forwards the image to the agent, instead of returning `400 Missing user message`.

**Real environment tested**: Local OpenClaw gateway built from this branch on macOS, Node 22.22.3, bound to `127.0.0.1:19001`, configured with a real vision-capable Claude model through an OpenAI/Anthropic-compatible provider. Requests issued with `curl`.

**Exact steps or command run after this patch**:

```bash
# image-only, base64 input_image, no text
curl -sS -X POST http://127.0.0.1:19001/v1/responses \
  -H 'authorization: Bearer <token>' -H 'content-type: application/json' \
  -d '{"model":"openclaw","input":[{"type":"message","role":"user","content":[{"type":"input_image","source":{"type":"base64","media_type":"image/png","data":"<1x1-png>"}}]}]}'

# image-only, URL input_image, no text (the exact bug repro)
curl -sS -X POST http://127.0.0.1:19001/v1/responses \
  -H 'authorization: Bearer <token>' -H 'content-type: application/json' \
  -d '{"model":"openclaw","input":[{"type":"message","role":"user","content":[{"type":"input_image","source":{"type":"url","url":"https://.../10-year-medal.png"}}]}]}'

# control: empty content, no text, no image
curl -sS -X POST http://127.0.0.1:19001/v1/responses \
  -H 'authorization: Bearer <token>' -H 'content-type: application/json' \
  -d '{"model":"openclaw","input":[{"type":"message","role":"user","content":[]}]}'
```

**Evidence after fix**: live `curl` output from the running gateway.

```text
# image-only base64 -> HTTP 200, status "completed", the model sees the image:
{"object":"response","status":"completed","output":[{"type":"message","role":"assistant",
"content":[{"type":"output_text","text":"... I see you sent me a bright green square ..."}]}],
"usage":{"input_tokens":3,"output_tokens":160}}
---HTTP 200---

# image-only URL (exact bug repro) -> HTTP 200, model accurately describes the real image:
{"object":"response","status":"completed","output":[{"type":"message","role":"assistant",
"content":[{"type":"output_text","text":"... cool badge! That's a \"10\" with planets and
stars orbiting it. Some kind of anniversary or milestone thing? ..."}]}]}
---HTTP 200---

# empty content control -> HTTP 400, still rejected:
{"error":{"message":"Missing user message in `input`.","type":"invalid_request_error"}}
---HTTP 400---
```

**Observed result after fix**: image-only base64 -> HTTP 200 (`status: completed`), the model acknowledges the image ("bright green square"); image-only URL -> HTTP 200, the model accurately describes the actual linked image (a "10" anniversary badge with orbiting planets/stars), confirming the image bytes reached the model; empty content -> HTTP 400 `Missing user message`.

**Before evidence**: with this fix reverted on the same gateway, the identical image-only URL request returned `400 {"error":{"message":"Missing user message in \`input\`."}}`; a guard-only relaxation instead returned `500 {"error":{"code":"api_error","message":"internal error"}}` with `[openresponses] non-stream response failed: Error: Message (--message) is required` in the gateway log — which is exactly why the placeholder (not just a guard tweak) is required.

**What was not tested**: did not exercise multi-image batches or non-image `input_file` round-trips against a live provider; relied on the existing gateway suite for those paths.

## Added regression coverage

- `src/gateway/openresponses-parity.test.ts`: `buildAgentPrompt` substitutes `IMAGE_ONLY_USER_MESSAGE` for an image-only active user turn, and keeps an empty message when the active turn has neither text nor image.
- `src/gateway/openresponses-http.test.ts`: image-only base64 `input_image` -> `200` with the placeholder message and the image forwarded to the agent; empty `content` -> `400 Missing user message`.
