### PR TITLE
fix(canvas): validate CLI numeric options

### DIFF
--- a/extensions/canvas/src/cli.test.ts
+++ b/extensions/canvas/src/cli.test.ts
@@ -1,7 +1,11 @@
 // Canvas tests cover cli plugin behavior.
 import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
-import { registerNodesCanvasCommands, type CanvasCliDependencies } from "./cli.js";
+import {
+  createDefaultCanvasCliDependencies,
+  registerNodesCanvasCommands,
+  type CanvasCliDependencies,
+} from "./cli.js";
 
 function createCanvasCliDeps() {
   const writtenFiles: Array<{ filePath: string; base64: string }> = [];
@@ -45,6 +49,26 @@ function createCanvasCliDeps() {
     shortenHomePath: (filePath) => filePath,
   };
   return { deps, runtime, writtenFiles };
+}
+
+function createCanvasCliDepsWithDefaultParsers() {
+  const baseDeps = createDefaultCanvasCliDependencies();
+  const harness = createCanvasCliDeps();
+  return {
+    ...harness,
+    deps: {
+      ...baseDeps,
+      defaultRuntime: harness.runtime,
+      nodesCallOpts: harness.deps.nodesCallOpts,
+      runNodesCommand: harness.deps.runNodesCommand,
+      getNodesTheme: harness.deps.getNodesTheme,
+      resolveNodeId: harness.deps.resolveNodeId,
+      buildNodeInvokeParams: harness.deps.buildNodeInvokeParams,
+      callGatewayCli: harness.deps.callGatewayCli,
+      writeBase64ToFile: harness.deps.writeBase64ToFile,
+      shortenHomePath: harness.deps.shortenHomePath,
+    },
+  };
 }
 
 describe("canvas CLI", () => {
@@ -135,6 +159,8 @@ describe("canvas CLI", () => {
   it.each([
     ["--max-width", "640px", "--max-width must be a positive integer."],
     ["--quality", "0.8x", "--quality must be a number."],
+    ["--quality", "-0.1", "--quality must be between 0 and 1."],
+    ["--quality", "5", "--quality must be between 0 and 1."],
   ])("rejects partial numeric snapshot %s values", async (flag, value, message) => {
     const program = new Command();
     program.exitOverride();
@@ -148,6 +174,62 @@ describe("canvas CLI", () => {
         from: "user",
       }),
     ).rejects.toThrow(message);
+    expect(deps.callGatewayCli).not.toHaveBeenCalled();
+  });
+
+  it.each(["0", "1"])("accepts snapshot --quality boundary value %s", async (quality) => {
+    const program = new Command();
+    program.exitOverride();
+    const nodes = program.command("nodes");
+    const { deps } = createCanvasCliDeps();
+
+    registerNodesCanvasCommands(nodes, deps);
+
+    await program.parseAsync(
+      ["nodes", "canvas", "snapshot", "--node", "ios-node", "--quality", quality],
+      {
+        from: "user",
+      },
+    );
+    expect(deps.callGatewayCli).toHaveBeenCalledWith(
+      "node.invoke",
+      expect.any(Object),
+      expect.objectContaining({
+        params: expect.objectContaining({
+          quality: Number(quality),
+        }),
+      }),
+    );
+  });
+
+  it.each([
+    ["snapshot"],
+    ["present"],
+    ["hide"],
+    ["navigate", "https://example.com"],
+    ["eval", "1 + 1"],
+    ["a2ui", "push", "--text", "hello"],
+    ["a2ui", "reset"],
+  ])("rejects invalid %s invoke timeouts before invoking the node", async (...args) => {
+    const program = new Command();
+    program.exitOverride();
+    const nodes = program.command("nodes");
+    const { deps } = createCanvasCliDepsWithDefaultParsers();
+    deps.resolveNodeId = vi.fn(async () => {
+      throw new Error("resolveNodeId should not be called");
+    });
+
+    registerNodesCanvasCommands(nodes, deps);
+
+    await expect(
+      program.parseAsync(
+        ["nodes", "canvas", ...args, "--node", "ios-node", "--invoke-timeout", "20ms"],
+        {
+          from: "user",
+        },
+      ),
+    ).rejects.toThrow("--invoke-timeout must be a positive integer.");
+    expect(deps.resolveNodeId).not.toHaveBeenCalled();
     expect(deps.callGatewayCli).not.toHaveBeenCalled();
   });
 

--- a/extensions/canvas/src/cli.ts
+++ b/extensions/canvas/src/cli.ts
@@ -97,7 +97,11 @@ function parseTimeoutMs(raw: unknown): number | undefined {
   if (raw === undefined || raw === null) {
     return undefined;
   }
-  return parseStrictPositiveInteger(raw);
+  const parsed = parseStrictPositiveInteger(raw);
+  if (parsed === undefined) {
+    throw new Error("--invoke-timeout must be a positive integer.");
+  }
+  return parsed;
 }
 
 function parseCanvasPositiveIntOption(raw: string | undefined, flag: string): number | undefined {
@@ -118,6 +122,14 @@ function parseCanvasFiniteNumberOption(raw: string | undefined, flag: string): n
   const parsed = parseStrictFiniteNumber(raw);
   if (parsed === undefined) {
     throw new Error(`${flag} must be a number.`);
+  }
+  return parsed;
+}
+
+function parseCanvasSnapshotQualityOption(raw: string | undefined): number | undefined {
+  const parsed = parseCanvasFiniteNumberOption(raw, "--quality");
+  if (parsed !== undefined && (parsed < 0 || parsed > 1)) {
+    throw new Error("--quality must be between 0 and 1.");
   }
   return parsed;
 }
@@ -245,8 +257,8 @@ async function invokeCanvas(
   command: string,
   params?: Record<string, unknown>,
 ) {
-  const nodeId = await deps.resolveNodeId(opts, normalizeOptionalString(opts.node) ?? "");
   const timeoutMs = deps.parseTimeoutMs(opts.invokeTimeout);
+  const nodeId = await deps.resolveNodeId(opts, normalizeOptionalString(opts.node) ?? "");
   return await deps.callGatewayCli(
     "node.invoke",
     opts,
@@ -278,7 +290,7 @@ export function registerNodesCanvasCommands(nodes: Command, deps: CanvasCliDepen
         await deps.runNodesCommand("canvas snapshot", async () => {
           const format = parseCanvasSnapshotRequestFormat(opts.format);
           const maxWidth = parseCanvasPositiveIntOption(opts.maxWidth, "--max-width");
-          const quality = parseCanvasFiniteNumberOption(opts.quality, "--quality");
+          const quality = parseCanvasSnapshotQualityOption(opts.quality);
           const raw = await invokeCanvas(deps, opts, "canvas.snapshot", {
             format,
             maxWidth: Number.isFinite(maxWidth) ? maxWidth : undefined,


### PR DESCRIPTION
## Summary

This tightens Canvas CLI validation so bad numeric input fails before the command reaches node resolution or the gateway.

The two cases fixed here are:

- `--invoke-timeout 20ms`, which could previously be parsed as invalid and then treated like no invoke timeout was supplied.
- `nodes canvas snapshot --quality 5`, even though the CLI documents `--quality <0-1>` and the Canvas tool schema also bounds quality to `0..1`.

The goal is just to keep the CLI boundary honest and aligned with the Canvas tool contract. This does not change the gateway `node.invoke` schema or add new Canvas behavior.

Review focus: the validation order in `invokeCanvas`, the snapshot quality bounds, and the regression tests proving invalid input does not reach node resolution or gateway invocation.

## Linked context

Closes #92487

Related #92482

This was not specifically requested by a maintainer.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Canvas CLI accepted invalid numeric options. In particular, `--invoke-timeout 20ms` could be treated like no invoke timeout, and `snapshot --quality 5` could pass despite the documented/schema `0..1` range.

- Real environment tested: Local OpenClaw source checkout on macOS after running `pnpm build`, using the built `node openclaw.mjs` launcher.

- Exact steps or command run after this patch:
  ```bash
  node openclaw.mjs nodes canvas snapshot --node ios-node --invoke-timeout 20ms
  node openclaw.mjs nodes canvas snapshot --node ios-node --quality 5
  ```

- Evidence after fix:
  ```text
  nodes canvas snapshot failed: --invoke-timeout must be a positive integer.
  nodes canvas snapshot failed: --quality must be between 0 and 1.
  ```

- Observed result after fix: Both invalid inputs fail at the CLI boundary before a successful node/gateway invocation path.

- What was not tested: I did not run a live paired canvas node or capture a real canvas screenshot, because this change is limited to validation before node invocation.

- Proof limitations or environment constraints: `pnpm check:changed` could not run in this local checkout because the configured Crabbox/Testbox binary failed its basic `--version/--help` sanity check before code checks started.

- Before evidence: Source inspection showed `parseTimeoutMs` returned `undefined` for invalid values and `snapshot --quality` only checked for a finite number, not the documented/schema range.

## Tests and validation

Commands run:

```bash
node scripts/run-vitest.mjs extensions/canvas/src/cli.test.ts
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm test extensions/canvas/src/cli.test.ts extensions/canvas/src/tool.test.ts -- --reporter=verbose
./node_modules/.bin/oxfmt extensions/canvas/src/cli.ts extensions/canvas/src/cli.test.ts --check
node scripts/run-oxlint.mjs extensions/canvas/src/cli.ts extensions/canvas/src/cli.test.ts
pnpm check:test-types
git diff --check
pnpm build
pnpm check:changed
```

`pnpm check:changed` stopped before code checks because the local Crabbox/Testbox binary failed its basic sanity check.

Regression coverage added:

- Invalid `--invoke-timeout` across `snapshot`, `present`, `hide`, `navigate`, `eval`, `a2ui push`, and `a2ui reset`.
- Out-of-range `snapshot --quality` values.
- Accepted `--quality` boundary values `0` and `1`.

## Risk checklist

User-visible behavior changes: yes. Invalid Canvas numeric values now fail immediately instead of being ignored or forwarded deeper into the node path.

Config, environment, or migration changes: no.

Security, auth, secrets, network, or tool execution changes: no.

The main risk is that someone relying on invalid Canvas numeric values will now get a CLI error. That seems acceptable because these values are outside the documented option contract and outside the Canvas tool schema, and the tests cover rejection before node resolution or gateway invocation.

## Current review state

Ready for review. Nothing known is waiting on the author side, and there are no bot or reviewer comments to address yet.
