### PR TITLE
fix(mcp): reject blocked stdio env keys at MCP config write time (fixes #92474)

### DIFF
--- a/src/agents/mcp-config-shared.ts
+++ b/src/agents/mcp-config-shared.ts
@@ -31,7 +31,7 @@ const MCP_EXPLICIT_CREDENTIAL_ENV_KEYS = new Set([
   "REDIS_URL",
 ]);
 
-function isDangerousMcpStdioEnvVarName(rawKey: string): boolean {
+export function isDangerousMcpStdioEnvVarName(rawKey: string): boolean {
   if (isDangerousHostEnvVarName(rawKey)) {
     return true;
   }

--- a/src/config/mcp-config.test.ts
+++ b/src/config/mcp-config.test.ts
@@ -209,4 +209,52 @@ describe("config mcp config", () => {
       });
     });
   });
+
+  it("rejects setConfiguredMcpServer when env contains blocked stdio keys", async () => {
+    await withMcpConfigHome({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "blocked",
+        server: {
+          command: "python",
+          args: ["server.py"],
+          env: { PYTHONPATH: "/tmp/workspace", PYTHONUNBUFFERED: "1" },
+        },
+      });
+
+      expect(setResult.ok).toBe(false);
+      if (setResult.ok) {
+        throw new Error("expected blocked env to fail");
+      }
+      expect(setResult.error).toContain("blocked");
+      expect(setResult.error).toContain("PYTHONPATH");
+    });
+  });
+
+  it("accepts stdio MCP config with clean env keys", async () => {
+    await withMcpConfigHome({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "clean",
+        server: {
+          command: "python",
+          args: ["server.py"],
+          env: { PYTHONUNBUFFERED: "1", NODE_ENV: "production" },
+        },
+      });
+
+      expect(setResult.ok).toBe(true);
+      if (!setResult.ok) {
+        throw new Error(`unexpected rejection: ${setResult.error}`);
+      }
+      const loaded = await listConfiguredMcpServers();
+      expect(loaded.ok).toBe(true);
+      if (!loaded.ok) {
+        throw new Error("expected MCP config to load");
+      }
+      expect(loaded.mcpServers.clean).toEqual({
+        command: "python",
+        args: ["server.py"],
+        env: { PYTHONUNBUFFERED: "1", NODE_ENV: "production" },
+      });
+    });
+  });
 });

--- a/src/config/mcp-config.test.ts
+++ b/src/config/mcp-config.test.ts
@@ -257,4 +257,32 @@ describe("config mcp config", () => {
       });
     });
   });
+
+  it("accepts URL-based MCP config with env keys (not stdio, not validated)", async () => {
+    await withMcpConfigHome({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "remote",
+        server: {
+          url: "https://example.com/mcp",
+          transport: "streamable-http",
+          env: { PYTHONPATH: "/tmp/workspace", NODE_ENV: "production" },
+        },
+      });
+
+      // URL/SSE/HTTP servers are not subject to stdio startup safety checks.
+      expect(setResult.ok).toBe(true);
+      if (!setResult.ok) {
+        throw new Error(`unexpected rejection: ${setResult.error}`);
+      }
+      const loaded = await listConfiguredMcpServers();
+      expect(loaded.ok).toBe(true);
+      if (!loaded.ok) {
+        throw new Error("expected MCP config to load");
+      }
+      expect(loaded.mcpServers.remote).toMatchObject({
+        url: "https://example.com/mcp",
+        transport: "streamable-http",
+      });
+    });
+  });
 });

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -49,8 +49,14 @@ function normalizeToolSelectionList(value: readonly string[] | undefined): strin
   return normalized.length > 0 ? normalized : undefined;
 }
 
-/** Returns blocked env keys found in a server config's env record. */
+/** Returns blocked env keys found in a stdio server config's env record. */
 function findBlockedStdioEnvKeys(server: Record<string, unknown>): string[] {
+  // Only stdio servers (those with a command) are subject to the stdio
+  // startup safety blocklist.  URL/SSE/streamable-HTTP servers that carry
+  // extra env data for other purposes must not be rejected.
+  if (typeof server.command !== "string" || server.command.trim().length === 0) {
+    return [];
+  }
   const env = server.env;
   if (!isRecord(env)) {
     return [];

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -1,4 +1,5 @@
 // Normalizes MCP server config for runtime launch and validation.
+import { isDangerousMcpStdioEnvVarName } from "../agents/mcp-config-shared.js";
 import { isRecord } from "../utils.js";
 import { readSourceConfigSnapshot } from "./io.js";
 import {
@@ -46,6 +47,15 @@ function normalizeToolSelectionList(value: readonly string[] | undefined): strin
     new Set(value.map((entry) => entry.trim()).filter((entry) => entry.length > 0)),
   ).toSorted((a, b) => a.localeCompare(b));
   return normalized.length > 0 ? normalized : undefined;
+}
+
+/** Returns blocked env keys found in a server config's env record. */
+function findBlockedStdioEnvKeys(server: Record<string, unknown>): string[] {
+  const env = server.env;
+  if (!isRecord(env)) {
+    return [];
+  }
+  return Object.keys(env).filter((key) => isDangerousMcpStdioEnvVarName(key));
 }
 
 export async function listConfiguredMcpServers(): Promise<ConfigMcpReadResult> {
@@ -161,6 +171,16 @@ export async function updateConfiguredMcpServer(params: {
   const next = structuredClone(loaded.config);
   const servers = normalizeConfiguredMcpServers(next.mcp?.servers);
   servers[name] = canonicalizeConfiguredMcpServer(params.update({ ...servers[name] }));
+
+  const blockedKeys = findBlockedStdioEnvKeys(servers[name]);
+  if (blockedKeys.length > 0) {
+    return {
+      ok: false,
+      path: loaded.path,
+      error: `MCP server env keys are blocked by stdio startup safety policy: ${blockedKeys.join(", ")}. Remove them from the config or set the values inside the server script.`,
+    };
+  }
+
   next.mcp = {
     ...next.mcp,
     servers,
@@ -208,6 +228,16 @@ export async function setConfiguredMcpServer(params: {
   const next = structuredClone(loaded.config);
   const servers = normalizeConfiguredMcpServers(next.mcp?.servers);
   servers[name] = canonicalizeConfiguredMcpServer(params.server);
+
+  const blockedKeys = findBlockedStdioEnvKeys(servers[name]);
+  if (blockedKeys.length > 0) {
+    return {
+      ok: false,
+      path: loaded.path,
+      error: `MCP server env keys are blocked by stdio startup safety policy: ${blockedKeys.join(", ")}. Remove them from the config or set the values inside the server script.`,
+    };
+  }
+
   next.mcp = {
     ...next.mcp,
     servers,


### PR DESCRIPTION
### Summary

- **Problem**: `openclaw mcp set` silently saves MCP server configs with blocked stdio env keys (e.g. `PYTHONPATH`). At every MCP operation — probe, doctor, status, and each spawn — the runtime resolver drops the key and logs a warning, flooding the gateway journal.
- **Root Cause**: `setConfiguredMcpServer` and `updateConfiguredMcpServer` in `src/config/mcp-config.ts` write arbitrary MCP server `env` entries without validating them against the stdio startup safety blocklist (`isDangerousMcpStdioEnvVarName`). The blocklist check only runs at runtime resolution time (`toMcpEnvRecord` in `src/agents/mcp-config-shared.ts`), producing a per-call warning for every saved blocked key.
- **Fix**: Export `isDangerousMcpStdioEnvVarName` and add a pre-write validation gated to stdio servers (those with a `command` field). URL/SSE/streamable-HTTP servers are not subject to stdio startup safety checks and pass through unchanged. The runtime warning in `mcp-transport-config.ts` is preserved as defense-in-depth for legacy configs.
- **What changed**:
  - `src/agents/mcp-config-shared.ts` — export `isDangerousMcpStdioEnvVarName`
  - `src/config/mcp-config.ts` — add `findBlockedStdioEnvKeys` helper (gated by `command` presence), validate in `setConfiguredMcpServer` and `updateConfiguredMcpServer`
  - `src/config/mcp-config.test.ts` — add rejection (stdio + blocked), acceptance (stdio + clean), and passthrough (URL + blocked) test cases
- **What did NOT change (scope boundary)**:
  - The runtime warning in `mcp-transport-config.ts` is left in place as a defense-in-depth fallback for configs that predate this validation
  - SSE/HTTP MCP configs are not subject to this check (gated by `command` presence)
  - The blocklist itself is unchanged
  - Generic config editors (`config set` / Control UI) continue relying on runtime filtering

### Reproduction

1. Register an MCP server with `PYTHONPATH` in the env block:
   ```bash
   openclaw mcp set my_server '{"command":"/path/to/python","args":["server.py"],"env":{"PYTHONPATH":"/tmp","PYTHONUNBUFFERED":"1"}}'
   ```
2. **Before this PR**: The command succeeds silently. Every subsequent `openclaw mcp probe`, `doctor`, `status`, and each spawn logs a per-resolution warning flooding the gateway journal.
3. **After this PR**: The `mcp set` command fails with: `MCP server env keys are blocked by stdio startup safety policy: PYTHONPATH. Remove them from the config or set the values inside the server script.`

### Real behavior proof

**Behavior or issue addressed (92474)**: MCP configuration commands silently save stdio server env entries that the runtime drops at every resolution, flooding the gateway journal. This fix rejects blocked stdio env keys at `mcp set` / `mcp configure` time so the operator sees the policy immediately.

**Real environment tested**: Linux, Node 22 — patched `openclaw` binary exercising the `mcp set` CLI path end-to-end, plus Vitest suite covering the config helper layer.

**Exact steps or command run after this patch**:
```bash
openclaw mcp set blocked-test '{"command":"echo","args":["hello"],"env":{"PYTHONPATH":"/tmp","PYTHONUNBUFFERED":"1"}}'
openclaw mcp set clean-test '{"command":"echo","args":["hello"],"env":{"PYTHONUNBUFFERED":"1"}}'
node scripts/run-vitest.mjs src/agents/mcp-transport-config.test.ts src/cli/mcp-cli.test.ts src/config/mcp-config.test.ts
```

**Evidence after fix**:
```text
$ openclaw mcp set blocked-test '{"command":"echo","args":["hello"],"env":{"PYTHONPATH":"/tmp","PYTHONUNBUFFERED":"1"}}'
MCP server env keys are blocked by stdio startup safety policy: PYTHONPATH. Remove them from the config or set the values inside the server script.

$ openclaw mcp set clean-test '{"command":"echo","args":["hello"],"env":{"PYTHONUNBUFFERED":"1"}}'
Saved MCP server "clean-test" to ~/.openclaw/openclaw.json.
```

**Observed result after fix**: The patched `openclaw mcp set` CLI rejects `PYTHONPATH` at write time with a policy message naming the blocked key, while accepting safe env keys like `PYTHONUNBUFFERED`. The config helper test suite confirms: stdio servers with blocked keys are rejected, stdio servers with clean keys are saved, and URL-based servers with env data (including blocked key names) pass through without triggering stdio policy.

**What was not tested**: Live `mcp configure` update path was not driven against a running gateway with a pre-existing saved config; the update helper shares the same validation code path as `mcp set`.

**Repro confirmation**: On `origin/main` the `mcp set` command silently saves `PYTHONPATH` in the env block. After this patch the same command exits 1 with the policy error. The three new config-helper test cases validate all three paths: stdio+blocked → reject, stdio+clean → accept, URL+blocked → pass through.

### Risk / Mitigation

- **Risk**: Configs saved under the old silent behavior and later re-saved via `mcp configure` or re-registered via `mcp set` will be rejected.
  **Mitigation**: The error message tells the operator exactly which keys to remove. The runtime warning fallback still protects existing saved configs until they are re-saved.
- **Risk**: The blocklist may contain keys operators intentionally configure (e.g. credential env vars in the allowlist).
  **Mitigation**: The `isDangerousMcpStdioEnvVarName` function has an explicit allowlist (`MCP_EXPLICIT_CREDENTIAL_ENV_KEYS`) that exempts known credential keys. This validation reuses the exact same function so the allowlist is honored.
- **Risk**: URL/SSE/streamable-HTTP servers carrying env data for non-stdio purposes could be falsely rejected.
  **Mitigation**: The validation is gated by `command` presence — only stdio servers trigger the check. URL-based servers with env data pass through.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] MCP configuration
- [x] CLI (mcp set / mcp configure)

### Regression Test Plan

- `node scripts/run-vitest.mjs src/config/mcp-config.test.ts`
- `node scripts/run-vitest.mjs src/agents/mcp-transport-config.test.ts`
- `node scripts/run-vitest.mjs src/cli/mcp-cli.test.ts`

### Review Findings Addressed

- **[P1] Restrict blocked-env validation to stdio servers** — Fixed: `findBlockedStdioEnvKeys` now returns early when `server.command` is absent, allowing URL/SSE/HTTP servers to pass through. Added test coverage for URL-based servers with blocked-key env entries.
- **[P1] Needs real behavior proof** — Fixed: Added redacted terminal output from the patched `openclaw mcp set` CLI showing both the rejection case and the acceptance case.

### Linked Issue/PR

Fixes #92474
