### PR TITLE
fix(mcp): reject unsafe stdio env configs

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -675,7 +675,7 @@ Launches a local child process and communicates over stdin/stdout.
 
 OpenClaw rejects interpreter-startup env keys that can alter how a stdio MCP server starts up before the first RPC, even if they appear in a server's `env` block. Blocked keys include `BASHOPTS`, `FPATH`, `KSH_ENV`, `NODE_OPTIONS`, `NODE_REDIRECT_WARNINGS`, `NODE_REPL_EXTERNAL_MODULE`, `NODE_REPL_HISTORY`, `NODE_V8_COVERAGE`, `PYTHONSTARTUP`, `PYTHONPATH`, `PERL5OPT`, `RUBYOPT`, `SHELLOPTS`, `PS4`, `TCLLIBPATH`, and similar runtime-control variables. Startup rejects these with a configuration error so they cannot inject an implicit prelude, swap the interpreter, enable a debugger, or redirect runtime output against the stdio process. Ordinary credential, proxy, and server-specific env vars (`GITHUB_TOKEN`, `HTTP_PROXY`, custom `*_API_KEY`, etc.) are unaffected.
 
-If your MCP server genuinely needs one of the blocked variables, set it on the gateway host process instead of under the stdio server's `env`.
+If your MCP server genuinely needs one of the blocked variables, set it on the gateway host process instead of under the stdio server's `env`. To clean up a legacy config that already contains blocked stdio env keys, run `openclaw mcp configure <name> --clear-blocked-env`.
 </Warning>
 
 ### SSE / HTTP transport

--- a/src/agents/mcp-config-shared.ts
+++ b/src/agents/mcp-config-shared.ts
@@ -4,43 +4,7 @@
  * MCP transport setup uses these functions to normalize loose JSON config into
  * string records/arrays while dropping unsafe host environment variables.
  */
-import {
-  isDangerousHostEnvVarName,
-  isDangerousHostInheritedEnvVarName,
-  normalizeEnvVarKey,
-} from "../infra/host-env-security.js";
-
-const MCP_EXPLICIT_CREDENTIAL_ENV_KEYS = new Set([
-  // Explicit MCP server credentials are operator-configured auth inputs, not
-  // inherited host config pivots. If policy adds credential keys, add only
-  // direct credentials here; keep loader/search/config pivots blocked.
-  "AMQP_URL",
-  "AWS_ACCESS_KEY_ID",
-  "AWS_SECRET_ACCESS_KEY",
-  "AWS_SECURITY_TOKEN",
-  "AWS_SESSION_TOKEN",
-  "AZURE_CLIENT_ID",
-  "AZURE_CLIENT_SECRET",
-  "DATABASE_URL",
-  "GH_TOKEN",
-  "GITHUB_TOKEN",
-  "GITLAB_TOKEN",
-  "MONGODB_URI",
-  "NODE_AUTH_TOKEN",
-  "NPM_TOKEN",
-  "REDIS_URL",
-]);
-
-function isDangerousMcpStdioEnvVarName(rawKey: string): boolean {
-  if (isDangerousHostEnvVarName(rawKey)) {
-    return true;
-  }
-  const key = normalizeEnvVarKey(rawKey);
-  if (!key || MCP_EXPLICIT_CREDENTIAL_ENV_KEYS.has(key.toUpperCase())) {
-    return false;
-  }
-  return isDangerousHostInheritedEnvVarName(key);
-}
+import { isBlockedMcpStdioEnvVarName } from "../config/mcp-env-policy.js";
 
 /** Returns whether a value is a plain MCP config record. */
 export function isMcpConfigRecord(value: unknown): value is Record<string, unknown> {
@@ -99,7 +63,7 @@ export function toMcpEnvRecord(
   return toMcpFilteredStringRecord(value, {
     ...options,
     preserveEmptyWhenKeysDropped: true,
-    shouldDropKey: (key) => isDangerousMcpStdioEnvVarName(key),
+    shouldDropKey: (key) => isBlockedMcpStdioEnvVarName(key),
   });
 }
 

--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -49,24 +49,26 @@ describe("resolveMcpTransportConfig", () => {
   });
 
   it("drops dangerous env overrides from stdio config", () => {
-    // Stdio env is inherited executable process input. Block loader/shell hook
-    // variables and child-process config pivots while preserving explicit MCP
-    // credentials and ordinary scalar env values.
-    const resolved = resolveMcpTransportConfig("probe", {
-      command: "node",
-      env: {
-        SAFE_VALUE: "ok",
-        PORT: 3000,
-        ENABLED: true,
-        GITHUB_TOKEN: "token",
-        HTTP_PROXY: "http://proxy.example",
-        NODE_OPTIONS: "--require=./evil.js",
-        LD_PRELOAD: "/tmp/pwn.so",
-        BASH_ENV: "/tmp/pwn.sh",
-        ANSIBLE_CONFIG: "/tmp/evil-ansible.cfg",
-        TF_CLI_CONFIG_FILE: "/tmp/evil-terraform.rc",
+    const blockedEnvKeys: string[] = [];
+    const resolved = resolveMcpTransportConfig(
+      "probe",
+      {
+        command: "node",
+        env: {
+          SAFE_VALUE: "ok",
+          PORT: 3000,
+          ENABLED: true,
+          GITHUB_TOKEN: "token",
+          HTTP_PROXY: "http://proxy.example",
+          NODE_OPTIONS: "--require=./evil.js",
+          LD_PRELOAD: "/tmp/pwn.so",
+          BASH_ENV: "/tmp/pwn.sh",
+          ANSIBLE_CONFIG: "/tmp/evil-ansible.cfg",
+          TF_CLI_CONFIG_FILE: "/tmp/evil-terraform.rc",
+        },
       },
-    });
+      { onBlockedStdioEnv: (key) => blockedEnvKeys.push(key) },
+    );
 
     expect(resolved).toEqual({
       kind: "stdio",
@@ -86,21 +88,14 @@ describe("resolveMcpTransportConfig", () => {
       requestTimeoutMs: 60_000,
       supportsParallelToolCalls: false,
     });
-    expect(logWarn).toHaveBeenCalledWith(
-      'bundle-mcp: server "probe": env "NODE_OPTIONS" is blocked for stdio startup safety and was ignored.',
-    );
-    expect(logWarn).toHaveBeenCalledWith(
-      'bundle-mcp: server "probe": env "LD_PRELOAD" is blocked for stdio startup safety and was ignored.',
-    );
-    expect(logWarn).toHaveBeenCalledWith(
-      'bundle-mcp: server "probe": env "BASH_ENV" is blocked for stdio startup safety and was ignored.',
-    );
-    expect(logWarn).toHaveBeenCalledWith(
-      'bundle-mcp: server "probe": env "ANSIBLE_CONFIG" is blocked for stdio startup safety and was ignored.',
-    );
-    expect(logWarn).toHaveBeenCalledWith(
-      'bundle-mcp: server "probe": env "TF_CLI_CONFIG_FILE" is blocked for stdio startup safety and was ignored.',
-    );
+    expect(blockedEnvKeys).toEqual([
+      "NODE_OPTIONS",
+      "LD_PRELOAD",
+      "BASH_ENV",
+      "ANSIBLE_CONFIG",
+      "TF_CLI_CONFIG_FILE",
+    ]);
+    expect(logWarn).not.toHaveBeenCalled();
   });
 
   it("uses an explicit empty stdio env when all configured env keys are blocked", () => {
@@ -126,17 +121,22 @@ describe("resolveMcpTransportConfig", () => {
     });
   });
 
-  it("sanitizes config-controlled names in stdio env warnings", () => {
-    resolveMcpTransportConfig("probe\nWARN forged\u001b[31m", {
-      command: "node",
-      env: {
-        "LD_PRELOAD\nWARN forged\u001b[31m": "/tmp/pwn.so",
-      },
-    });
+  it("reports blocked stdio env keys through callback without logging", () => {
+    const blockedEnvKeys: string[] = [];
 
-    expect(logWarn).toHaveBeenCalledWith(
-      'bundle-mcp: server "probeWARN forged": env "LD_PRELOADWARN forged" is blocked for stdio startup safety and was ignored.',
+    resolveMcpTransportConfig(
+      "probe\nWARN forged\u001b[31m",
+      {
+        command: "node",
+        env: {
+          "LD_PRELOAD\nWARN forged\u001b[31m": "/tmp/pwn.so",
+        },
+      },
+      { onBlockedStdioEnv: (key) => blockedEnvKeys.push(key) },
     );
+
+    expect(blockedEnvKeys).toEqual(["LD_PRELOAD\nWARN forged\u001b[31m"]);
+    expect(logWarn).not.toHaveBeenCalled();
   });
 
   it("resolves SSE config by default", () => {

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -48,6 +48,10 @@ type ResolvedHttpMcpTransportConfig = ResolvedBaseMcpTransportConfig & {
 
 type ResolvedMcpTransportConfig = ResolvedStdioMcpTransportConfig | ResolvedHttpMcpTransportConfig;
 
+type ResolveMcpTransportConfigOptions = {
+  onBlockedStdioEnv?: (key: string) => void;
+};
+
 const DEFAULT_CONNECTION_TIMEOUT_MS = 30_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 
@@ -199,6 +203,7 @@ function resolveHttpTransportConfig(
 export function resolveMcpTransportConfig(
   serverName: string,
   rawServer: unknown,
+  options?: ResolveMcpTransportConfigOptions,
 ): ResolvedMcpTransportConfig | null {
   const logServerName = sanitizeForLog(serverName);
   const requestedTransport = getRequestedTransport(rawServer);
@@ -206,9 +211,7 @@ export function resolveMcpTransportConfig(
   const effectiveTransport = requestedTransport || requestedTransportAlias;
   const stdioLaunch = resolveStdioMcpServerLaunchConfig(rawServer, {
     onDroppedEnv: (key) => {
-      logWarn(
-        `bundle-mcp: server "${logServerName}": env "${sanitizeForLog(key)}" is blocked for stdio startup safety and was ignored.`,
-      );
+      options?.onBlockedStdioEnv?.(key);
     },
   });
   if (stdioLaunch.ok) {

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -368,6 +368,63 @@ describe("mcp cli", () => {
     });
   });
 
+  it("updates and clears legacy blocked stdio env keys", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async (home) => {
+      const workspaceDir = await createWorkspace();
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            mcp: {
+              servers: {
+                docs: {
+                  command: "node",
+                  env: {
+                    PYTHONPATH: "/tmp/mcp-shadow",
+                    PYTHONUNBUFFERED: "1",
+                  },
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      await runMcpCommand(["mcp", "tools", "docs", "--include", "search"]);
+      expect(lastLogLine()).toBe(`Updated MCP tool selection for "docs" in ${configPath}.`);
+
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "show", "docs", "--json"]);
+      expect(JSON.parse(lastLogLine())).toEqual({
+        command: "node",
+        env: {
+          PYTHONPATH: "/tmp/mcp-shadow",
+          PYTHONUNBUFFERED: "1",
+        },
+        toolFilter: { include: ["search"] },
+      });
+
+      await runMcpCommand(["mcp", "configure", "docs", "--clear-blocked-env"]);
+      expect(lastLogLine()).toBe(`Updated MCP server "docs" in ${configPath}.`);
+
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "show", "docs", "--json"]);
+      expect(JSON.parse(lastLogLine())).toEqual({
+        command: "node",
+        env: {
+          PYTHONUNBUFFERED: "1",
+        },
+        toolFilter: { include: ["search"] },
+      });
+    });
+  });
+
   it("rejects legacy blocked stdio env keys before probing MCP configure updates", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async (home) => {
       const workspaceDir = await createWorkspace();

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -116,6 +116,53 @@ describe("mcp cli", () => {
     });
   });
 
+  it("rejects blocked stdio env keys when setting an MCP server", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await expect(
+        runMcpCommand([
+          "mcp",
+          "set",
+          "docs",
+          '{"command":"node","env":{"PYTHONPATH":"/tmp/mcp-shadow","PYTHONUNBUFFERED":"1"}}',
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(lastErrorLine()).toBe(
+        'MCP stdio env key "PYTHONPATH" is blocked by startup safety policy and cannot be saved. Remove it from the server env config.',
+      );
+
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "list", "--json"]);
+      expect(JSON.parse(lastLogLine())).toEqual({});
+    });
+  });
+
+  it("rejects blocked stdio env keys before probing an added MCP server", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await expect(
+        runMcpCommand([
+          "mcp",
+          "add",
+          "docs",
+          "--command",
+          "./missing-mcp",
+          "--env",
+          "PYTHONPATH=/tmp/mcp-shadow",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(lastErrorLine()).toBe(
+        'MCP stdio env key "PYTHONPATH" is blocked by startup safety policy and cannot be saved. Remove it from the server env config.',
+      );
+    });
+  });
+
   it("adds a configured MCP server from flags without replacing operator knobs", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {
       const workspaceDir = await createWorkspace();
@@ -244,6 +291,117 @@ describe("mcp cli", () => {
           supportsParallelToolCalls: false,
         },
       ]);
+    });
+  });
+
+  it("reports legacy blocked stdio env keys in MCP status and doctor", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async (home) => {
+      const workspaceDir = await createWorkspace();
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            mcp: {
+              servers: {
+                docs: {
+                  command: "node",
+                  env: {
+                    PYTHONPATH: "/tmp/mcp-shadow",
+                    PYTHONUNBUFFERED: "1",
+                  },
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      await runMcpCommand(["mcp", "status", "--json"]);
+
+      expect(JSON.parse(lastLogLine()).servers).toEqual([
+        {
+          name: "docs",
+          configured: true,
+          enabled: true,
+          ok: false,
+          transport: "stdio",
+          launch: "node",
+          requestTimeoutMs: 60_000,
+          connectionTimeoutMs: 30_000,
+          supportsParallelToolCalls: false,
+          issues: [
+            {
+              level: "error",
+              message:
+                'MCP stdio env key "PYTHONPATH" is blocked by startup safety policy and ignored at runtime.',
+            },
+          ],
+        },
+      ]);
+
+      mockLog.mockClear();
+      await expect(runMcpCommand(["mcp", "doctor", "--json"])).rejects.toThrow("__exit__:1");
+
+      expect(lastErrorLine()).toBe("MCP doctor found errors.");
+      expect(JSON.parse(lastLogLine())).toMatchObject({
+        ok: false,
+        servers: [
+          {
+            name: "docs",
+            ok: false,
+            issues: [
+              {
+                level: "error",
+                message:
+                  'MCP stdio env key "PYTHONPATH" is blocked by startup safety policy and ignored at runtime.',
+              },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  it("rejects legacy blocked stdio env keys before probing MCP configure updates", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async (home) => {
+      const workspaceDir = await createWorkspace();
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            mcp: {
+              servers: {
+                docs: {
+                  command: "./missing-mcp",
+                  env: {
+                    PYTHONPATH: "/tmp/mcp-shadow",
+                  },
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      await expect(
+        runMcpCommand(["mcp", "configure", "docs", "--timeout", "5", "--probe"]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(lastErrorLine()).toBe(
+        'MCP stdio env key "PYTHONPATH" is blocked by startup safety policy and cannot be saved. Remove it from the server env config.',
+      );
     });
   });
 

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -233,6 +233,23 @@ function failOnBlockedMcpStdioEnv(server: Record<string, unknown>): void {
   }
 }
 
+function clearBlockedMcpStdioEnv(server: Record<string, unknown>): void {
+  const blockedEnvKeys = listBlockedMcpStdioEnvKeys(server);
+  const env = asRecord(server.env);
+  if (blockedEnvKeys.length === 0 || !env) {
+    return;
+  }
+  const nextEnv = { ...env };
+  for (const key of blockedEnvKeys) {
+    delete nextEnv[key];
+  }
+  if (Object.keys(nextEnv).length === 0) {
+    delete server.env;
+  } else {
+    server.env = nextEnv;
+  }
+}
+
 function hasSensitiveKey(name: string): boolean {
   return SENSITIVE_HEADER_NAMES.has(name.trim().toLowerCase()) || SENSITIVE_KEY_PATTERN.test(name);
 }
@@ -1090,6 +1107,7 @@ export function registerMcpCli(program: Command) {
     .option("--include <csv>", "Comma-separated MCP tool names or '*' globs to expose")
     .option("--exclude <csv>", "Comma-separated MCP tool names or '*' globs to hide")
     .option("--clear-tools", "Clear this server's MCP tool filter", false)
+    .option("--clear-blocked-env", "Remove stdio env keys blocked by startup safety policy", false)
     .option("--timeout <seconds>", "Per-request timeout in seconds")
     .option("--connect-timeout <seconds>", "Connection timeout in seconds")
     .option("--clear-timeouts", "Clear request and connection timeout overrides", false)
@@ -1114,6 +1132,7 @@ export function registerMcpCli(program: Command) {
           include?: string;
           exclude?: string;
           clearTools?: boolean;
+          clearBlockedEnv?: boolean;
           timeout?: string;
           connectTimeout?: string;
           clearTimeouts?: boolean;
@@ -1220,7 +1239,12 @@ export function registerMcpCli(program: Command) {
         }
         setOptionalField(next, "clientCert", normalizeStringifiedOptionalString(opts.clientCert));
         setOptionalField(next, "clientKey", normalizeStringifiedOptionalString(opts.clientKey));
-        failOnBlockedMcpStdioEnv(next);
+        if (opts.clearBlockedEnv) {
+          clearBlockedMcpStdioEnv(next);
+        }
+        if (opts.probe) {
+          failOnBlockedMcpStdioEnv(next);
+        }
         if (opts.probe && next.enabled !== false && next.auth !== "oauth") {
           await probeMcpServersOrFail({
             config: loaded.config,

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -29,6 +29,11 @@ import {
   updateConfiguredMcpServer,
   updateConfiguredMcpServerTools,
 } from "../config/mcp-config.js";
+import {
+  formatBlockedMcpStdioEnvDiagnostic,
+  formatBlockedMcpStdioEnvError,
+  listBlockedMcpStdioEnvKeys,
+} from "../config/mcp-env-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { serveOpenClawChannelMcp } from "../mcp/channel-server.js";
@@ -168,6 +173,7 @@ type McpStatusEntry = {
   authStatus?: McpOAuthCredentialsStatus;
   toolFilter?: unknown;
   codex?: unknown;
+  issues?: McpDoctorIssue[];
 };
 
 type McpDoctorIssue = {
@@ -200,6 +206,31 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 function issue(level: McpDoctorIssue["level"], message: string): McpDoctorIssue {
   return { level, message };
+}
+
+function formatMcpIssuePrefix(level: McpDoctorIssue["level"]): string {
+  if (level === "error") {
+    return "!";
+  }
+  if (level === "warning") {
+    return "-";
+  }
+  return "i";
+}
+
+function collectBlockedMcpStdioEnvIssues(server: Record<string, unknown>): McpDoctorIssue[] {
+  const blockedEnvKeys = listBlockedMcpStdioEnvKeys(server);
+  if (blockedEnvKeys.length === 0) {
+    return [];
+  }
+  return [issue("error", formatBlockedMcpStdioEnvDiagnostic(blockedEnvKeys))];
+}
+
+function failOnBlockedMcpStdioEnv(server: Record<string, unknown>): void {
+  const blockedEnvKeys = listBlockedMcpStdioEnvKeys(server);
+  if (blockedEnvKeys.length > 0) {
+    fail(formatBlockedMcpStdioEnvError(blockedEnvKeys));
+  }
 }
 
 function hasSensitiveKey(name: string): boolean {
@@ -312,6 +343,7 @@ async function collectMcpDoctorIssues(params: {
   if (server.enabled === false) {
     issues.push(issue("warning", "server is disabled"));
   }
+  issues.push(...collectBlockedMcpStdioEnvIssues(server));
   if (!disabled) {
     if (!resolved) {
       issues.push(issue("error", "server transport is invalid"));
@@ -441,11 +473,13 @@ async function buildMcpStatusEntries(
     entries.map(async ([name, server]) => {
       const resolved = resolveMcpTransportConfig(name, server);
       const enabled = server.enabled !== false;
+      const issues = collectBlockedMcpStdioEnvIssues(server);
+      const hasErrorIssues = issues.some((issueEntry) => issueEntry.level === "error");
       const entry: McpStatusEntry = {
         name,
         configured: true,
         enabled,
-        ok: enabled && Boolean(resolved),
+        ok: enabled && Boolean(resolved) && !hasErrorIssues,
         transport: resolved?.transportType,
         launch: resolved?.description,
         requestTimeoutMs: resolved?.requestTimeoutMs,
@@ -454,6 +488,9 @@ async function buildMcpStatusEntries(
         toolFilter: server.toolFilter,
         codex: server.codex,
       };
+      if (issues.length > 0) {
+        entry.issues = issues;
+      }
       if (server.auth) {
         entry.auth = server.auth;
       }
@@ -689,6 +726,10 @@ export function registerMcpCli(program: Command) {
         const filters = entry.toolFilter ? " tool-filtered" : "";
         const parallel = entry.supportsParallelToolCalls ? " parallel" : "";
         defaultRuntime.log(`- ${entry.name}: ${transport}${auth}${oauth}${filters}${parallel}`);
+        for (const statusIssue of entry.issues ?? []) {
+          const prefix = formatMcpIssuePrefix(statusIssue.level);
+          defaultRuntime.log(`  ${prefix} ${statusIssue.level}: ${statusIssue.message}`);
+        }
         if (opts.verbose) {
           defaultRuntime.log(`  launch: ${entry.launch ?? "n/a"}`);
           defaultRuntime.log(
@@ -948,6 +989,7 @@ export function registerMcpCli(program: Command) {
             ...(exclude ? { exclude } : {}),
           };
         }
+        failOnBlockedMcpStdioEnv(server);
 
         const loaded = await listConfiguredMcpServers();
         if (!loaded.ok) {
@@ -1178,6 +1220,7 @@ export function registerMcpCli(program: Command) {
         }
         setOptionalField(next, "clientCert", normalizeStringifiedOptionalString(opts.clientCert));
         setOptionalField(next, "clientKey", normalizeStringifiedOptionalString(opts.clientKey));
+        failOnBlockedMcpStdioEnv(next);
         if (opts.probe && next.enabled !== false && next.auth !== "oauth") {
           await probeMcpServersOrFail({
             config: loaded.config,

--- a/src/config/mcp-config.test.ts
+++ b/src/config/mcp-config.test.ts
@@ -7,6 +7,8 @@ import {
   listConfiguredMcpServers,
   setConfiguredMcpServer,
   unsetConfiguredMcpServer,
+  updateConfiguredMcpServer,
+  updateConfiguredMcpServerTools,
 } from "./mcp-config.js";
 
 function validationOk(raw: unknown) {
@@ -123,6 +125,126 @@ describe("config mcp config", () => {
       }
       expect(loaded.path).toBe(configPath);
     });
+  });
+
+  it("rejects blocked stdio env keys before saving MCP config", async () => {
+    await withMcpConfigHome({}, async () => {
+      const blockedResult = await setConfiguredMcpServer({
+        name: "docs",
+        server: {
+          command: "node",
+          env: {
+            PYTHONPATH: "/tmp/mcp-shadow",
+            PYTHONUNBUFFERED: "1",
+          },
+        },
+      });
+
+      expect(blockedResult.ok).toBe(false);
+      if (blockedResult.ok) {
+        throw new Error("expected blocked stdio env config to fail");
+      }
+      expect(blockedResult.error).toBe(
+        'MCP stdio env key "PYTHONPATH" is blocked by startup safety policy and cannot be saved. Remove it from the server env config.',
+      );
+
+      const loadedAfterFailure = await listConfiguredMcpServers();
+      expect(loadedAfterFailure.ok).toBe(true);
+      if (!loadedAfterFailure.ok) {
+        throw new Error("expected MCP config to load");
+      }
+      expect(loadedAfterFailure.mcpServers).not.toHaveProperty("docs");
+
+      const safeResult = await setConfiguredMcpServer({
+        name: "docs",
+        server: {
+          command: "node",
+          env: {
+            PYTHONUNBUFFERED: "1",
+          },
+        },
+      });
+
+      expect(safeResult.ok).toBe(true);
+      const loadedAfterSafeWrite = await listConfiguredMcpServers();
+      expect(loadedAfterSafeWrite.ok).toBe(true);
+      if (!loadedAfterSafeWrite.ok) {
+        throw new Error("expected MCP config to load");
+      }
+      expect(loadedAfterSafeWrite.mcpServers.docs).toEqual({
+        command: "node",
+        env: {
+          PYTHONUNBUFFERED: "1",
+        },
+      });
+    });
+  });
+
+  it("sanitizes blocked stdio env key names in config errors", async () => {
+    await withMcpConfigHome({}, async () => {
+      const unsafeKey = `LD_PRELOAD\nWARN forged${String.fromCharCode(0x1b)}[31m`;
+      const result = await setConfiguredMcpServer({
+        name: "docs",
+        server: {
+          command: "node",
+          env: {
+            [unsafeKey]: "/tmp/pwn.so",
+          },
+        },
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        throw new Error("expected blocked stdio env config to fail");
+      }
+      expect(result.error).toBe(
+        'MCP stdio env key "LD_PRELOADWARN forged" is blocked by startup safety policy and cannot be saved. Remove it from the server env config.',
+      );
+    });
+  });
+
+  it("rejects updates that would keep blocked stdio env keys", async () => {
+    await withMcpConfigHome(
+      {
+        mcp: {
+          servers: {
+            docs: {
+              command: "node",
+              env: {
+                PYTHONPATH: "/tmp/mcp-shadow",
+              },
+            },
+          },
+        },
+      },
+      async () => {
+        const configureResult = await updateConfiguredMcpServer({
+          name: "docs",
+          update: (server) => ({ ...server, timeout: 5 }),
+        });
+
+        expect(configureResult.ok).toBe(false);
+        if (configureResult.ok) {
+          throw new Error("expected blocked stdio env update to fail");
+        }
+        expect(configureResult.error).toBe(
+          'MCP stdio env key "PYTHONPATH" is blocked by startup safety policy and cannot be saved. Remove it from the server env config.',
+        );
+
+        const toolsResult = await updateConfiguredMcpServerTools({
+          name: "docs",
+          tools: { include: ["search"] },
+        });
+
+        expect(toolsResult.ok).toBe(false);
+        if (toolsResult.ok) {
+          throw new Error("expected blocked stdio env tool update to fail");
+        }
+        expect(toolsResult.error).toBe(
+          'MCP stdio env key "PYTHONPATH" is blocked by startup safety policy and cannot be saved. Remove it from the server env config.',
+        );
+      },
+    );
   });
 
   it("accepts SSE MCP configs with headers at the config layer", async () => {

--- a/src/config/mcp-config.test.ts
+++ b/src/config/mcp-config.test.ts
@@ -203,7 +203,7 @@ describe("config mcp config", () => {
     });
   });
 
-  it("rejects updates that would keep blocked stdio env keys", async () => {
+  it("allows unrelated updates when blocked stdio env keys are legacy", async () => {
     await withMcpConfigHome(
       {
         mcp: {
@@ -223,24 +223,70 @@ describe("config mcp config", () => {
           update: (server) => ({ ...server, timeout: 5 }),
         });
 
-        expect(configureResult.ok).toBe(false);
-        if (configureResult.ok) {
-          throw new Error("expected blocked stdio env update to fail");
+        expect(configureResult.ok).toBe(true);
+        if (!configureResult.ok) {
+          throw new Error("expected unrelated MCP config update to succeed");
         }
-        expect(configureResult.error).toBe(
-          'MCP stdio env key "PYTHONPATH" is blocked by startup safety policy and cannot be saved. Remove it from the server env config.',
-        );
+        expect(configureResult.mcpServers.docs).toEqual({
+          command: "node",
+          env: {
+            PYTHONPATH: "/tmp/mcp-shadow",
+          },
+          timeout: 5,
+        });
 
         const toolsResult = await updateConfiguredMcpServerTools({
           name: "docs",
           tools: { include: ["search"] },
         });
 
-        expect(toolsResult.ok).toBe(false);
-        if (toolsResult.ok) {
-          throw new Error("expected blocked stdio env tool update to fail");
+        expect(toolsResult.ok).toBe(true);
+        if (!toolsResult.ok) {
+          throw new Error("expected unrelated MCP tool update to succeed");
         }
-        expect(toolsResult.error).toBe(
+        expect(toolsResult.mcpServers.docs).toEqual({
+          command: "node",
+          env: {
+            PYTHONPATH: "/tmp/mcp-shadow",
+          },
+          timeout: 5,
+          toolFilter: { include: ["search"] },
+        });
+      },
+    );
+  });
+
+  it("rejects updates that introduce blocked stdio env keys", async () => {
+    await withMcpConfigHome(
+      {
+        mcp: {
+          servers: {
+            docs: {
+              command: "node",
+              env: {
+                PYTHONUNBUFFERED: "1",
+              },
+            },
+          },
+        },
+      },
+      async () => {
+        const configureResult = await updateConfiguredMcpServer({
+          name: "docs",
+          update: (server) => ({
+            ...server,
+            env: {
+              ...(server.env as Record<string, unknown>),
+              PYTHONPATH: "/tmp/mcp-shadow",
+            },
+          }),
+        });
+
+        expect(configureResult.ok).toBe(false);
+        if (configureResult.ok) {
+          throw new Error("expected introduced blocked stdio env update to fail");
+        }
+        expect(configureResult.error).toBe(
           'MCP stdio env key "PYTHONPATH" is blocked by startup safety policy and cannot be saved. Remove it from the server env config.',
         );
       },

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -5,6 +5,7 @@ import {
   canonicalizeConfiguredMcpServer,
   normalizeConfiguredMcpServers,
 } from "./mcp-config-normalize.js";
+import { formatBlockedMcpStdioEnvError, listBlockedMcpStdioEnvKeys } from "./mcp-env-policy.js";
 import { replaceConfigFile } from "./mutate.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 import { validateConfigObjectWithPlugins } from "./validation.js";
@@ -46,6 +47,11 @@ function normalizeToolSelectionList(value: readonly string[] | undefined): strin
     new Set(value.map((entry) => entry.trim()).filter((entry) => entry.length > 0)),
   ).toSorted((a, b) => a.localeCompare(b));
   return normalized.length > 0 ? normalized : undefined;
+}
+
+function getBlockedMcpStdioEnvWriteError(server: Record<string, unknown>): string | undefined {
+  const blockedEnvKeys = listBlockedMcpStdioEnvKeys(server);
+  return blockedEnvKeys.length > 0 ? formatBlockedMcpStdioEnvError(blockedEnvKeys) : undefined;
 }
 
 export async function listConfiguredMcpServers(): Promise<ConfigMcpReadResult> {
@@ -107,6 +113,14 @@ export async function updateConfiguredMcpServerTools(params: {
       delete server.toolFilter;
     }
   }
+  const blockedEnvError = getBlockedMcpStdioEnvWriteError(server);
+  if (blockedEnvError) {
+    return {
+      ok: false,
+      path: loaded.path,
+      error: blockedEnvError,
+    };
+  }
   servers[name] = server;
   next.mcp = {
     ...next.mcp,
@@ -160,7 +174,16 @@ export async function updateConfiguredMcpServer(params: {
 
   const next = structuredClone(loaded.config);
   const servers = normalizeConfiguredMcpServers(next.mcp?.servers);
-  servers[name] = canonicalizeConfiguredMcpServer(params.update({ ...servers[name] }));
+  const server = canonicalizeConfiguredMcpServer(params.update({ ...servers[name] }));
+  const blockedEnvError = getBlockedMcpStdioEnvWriteError(server);
+  if (blockedEnvError) {
+    return {
+      ok: false,
+      path: loaded.path,
+      error: blockedEnvError,
+    };
+  }
+  servers[name] = server;
   next.mcp = {
     ...next.mcp,
     servers,
@@ -207,7 +230,16 @@ export async function setConfiguredMcpServer(params: {
 
   const next = structuredClone(loaded.config);
   const servers = normalizeConfiguredMcpServers(next.mcp?.servers);
-  servers[name] = canonicalizeConfiguredMcpServer(params.server);
+  const server = canonicalizeConfiguredMcpServer(params.server);
+  const blockedEnvError = getBlockedMcpStdioEnvWriteError(server);
+  if (blockedEnvError) {
+    return {
+      ok: false,
+      path: loaded.path,
+      error: blockedEnvError,
+    };
+  }
+  servers[name] = server;
   next.mcp = {
     ...next.mcp,
     servers,

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -49,8 +49,19 @@ function normalizeToolSelectionList(value: readonly string[] | undefined): strin
   return normalized.length > 0 ? normalized : undefined;
 }
 
-function getBlockedMcpStdioEnvWriteError(server: Record<string, unknown>): string | undefined {
-  const blockedEnvKeys = listBlockedMcpStdioEnvKeys(server);
+function getBlockedMcpStdioEnvWriteError(
+  server: Record<string, unknown>,
+  previous?: Record<string, unknown>,
+): string | undefined {
+  let blockedEnvKeys = listBlockedMcpStdioEnvKeys(server);
+  if (previous) {
+    const previousBlockedEnvKeys = new Set(listBlockedMcpStdioEnvKeys(previous));
+    const previousEnv = isRecord(previous.env) ? previous.env : {};
+    const serverEnv = isRecord(server.env) ? server.env : {};
+    blockedEnvKeys = blockedEnvKeys.filter(
+      (key) => !previousBlockedEnvKeys.has(key) || !Object.is(previousEnv[key], serverEnv[key]),
+    );
+  }
   return blockedEnvKeys.length > 0 ? formatBlockedMcpStdioEnvError(blockedEnvKeys) : undefined;
 }
 
@@ -98,7 +109,8 @@ export async function updateConfiguredMcpServerTools(params: {
 
   const next = structuredClone(loaded.config);
   const servers = normalizeConfiguredMcpServers(next.mcp?.servers);
-  const server = { ...servers[name] };
+  const previousServer = structuredClone(servers[name]);
+  const server = { ...previousServer };
   if (params.tools === null) {
     delete server.toolFilter;
   } else {
@@ -113,7 +125,7 @@ export async function updateConfiguredMcpServerTools(params: {
       delete server.toolFilter;
     }
   }
-  const blockedEnvError = getBlockedMcpStdioEnvWriteError(server);
+  const blockedEnvError = getBlockedMcpStdioEnvWriteError(server, previousServer);
   if (blockedEnvError) {
     return {
       ok: false,
@@ -174,8 +186,9 @@ export async function updateConfiguredMcpServer(params: {
 
   const next = structuredClone(loaded.config);
   const servers = normalizeConfiguredMcpServers(next.mcp?.servers);
-  const server = canonicalizeConfiguredMcpServer(params.update({ ...servers[name] }));
-  const blockedEnvError = getBlockedMcpStdioEnvWriteError(server);
+  const previousServer = structuredClone(servers[name]);
+  const server = canonicalizeConfiguredMcpServer(params.update(structuredClone(previousServer)));
+  const blockedEnvError = getBlockedMcpStdioEnvWriteError(server, previousServer);
   if (blockedEnvError) {
     return {
       ok: false,

--- a/src/config/mcp-env-policy.ts
+++ b/src/config/mcp-env-policy.ts
@@ -1,0 +1,64 @@
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
+import {
+  isDangerousHostEnvVarName,
+  isDangerousHostInheritedEnvVarName,
+  normalizeEnvVarKey,
+} from "../infra/host-env-security.js";
+
+const MCP_EXPLICIT_CREDENTIAL_ENV_KEYS = new Set([
+  "AMQP_URL",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SECURITY_TOKEN",
+  "AWS_SESSION_TOKEN",
+  "AZURE_CLIENT_ID",
+  "AZURE_CLIENT_SECRET",
+  "DATABASE_URL",
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "GITLAB_TOKEN",
+  "MONGODB_URI",
+  "NODE_AUTH_TOKEN",
+  "NPM_TOKEN",
+  "REDIS_URL",
+]);
+
+export function isBlockedMcpStdioEnvVarName(rawKey: string): boolean {
+  if (isDangerousHostEnvVarName(rawKey)) {
+    return true;
+  }
+  const key = normalizeEnvVarKey(rawKey);
+  if (!key || MCP_EXPLICIT_CREDENTIAL_ENV_KEYS.has(key.toUpperCase())) {
+    return false;
+  }
+  return isDangerousHostInheritedEnvVarName(key);
+}
+
+export function listBlockedMcpStdioEnvKeys(server: Record<string, unknown>): string[] {
+  if (typeof server.command !== "string" || server.command.trim().length === 0) {
+    return [];
+  }
+  if (!server.env || typeof server.env !== "object" || Array.isArray(server.env)) {
+    return [];
+  }
+  return Object.keys(server.env)
+    .filter((key) => isBlockedMcpStdioEnvVarName(key))
+    .toSorted((a, b) => a.localeCompare(b));
+}
+
+function formatBlockedMcpStdioEnvKeys(keys: readonly string[]): string {
+  return keys.map((key) => `"${sanitizeForLog(key)}"`).join(", ");
+}
+
+export function formatBlockedMcpStdioEnvError(keys: readonly string[]): string {
+  const formattedKeys = formatBlockedMcpStdioEnvKeys(keys);
+  const noun = keys.length === 1 ? `key ${formattedKeys} is` : `keys ${formattedKeys} are`;
+  const pronoun = keys.length === 1 ? "it" : "them";
+  return `MCP stdio env ${noun} blocked by startup safety policy and cannot be saved. Remove ${pronoun} from the server env config.`;
+}
+
+export function formatBlockedMcpStdioEnvDiagnostic(keys: readonly string[]): string {
+  const formattedKeys = formatBlockedMcpStdioEnvKeys(keys);
+  const noun = keys.length === 1 ? `key ${formattedKeys} is` : `keys ${formattedKeys} are`;
+  return `MCP stdio env ${noun} blocked by startup safety policy and ignored at runtime.`;
+}


### PR DESCRIPTION
## Summary

- Problem: MCP stdio server config could save startup-sensitive env keys such as `PYTHONPATH`; runtime dropped them later, hiding the bad config and causing repeated warning noise.
- Solution: reject blocked stdio env keys before new config writes/probes, keep runtime filtering fail-closed without warning spam, surface legacy bad configs in `mcp status` / `mcp doctor`, and provide `mcp configure --clear-blocked-env` for supported legacy cleanup.
- What changed: added a shared MCP env policy, wired config write validation, updated MCP CLI add/configure/status/doctor behavior, allowed unrelated legacy config/tool updates, added docs for the cleanup command, and covered the affected config/runtime/CLI paths with regression tests.
- What did NOT change: the startup safety blocklist, HTTP/SSE MCP configs, or safe credential/proxy/server env keys such as `GITHUB_TOKEN`, `HTTP_PROXY`, and `PYTHONUNBUFFERED`.

Fixes #92474

## Real behavior proof

- **Behavior addressed:** `openclaw mcp set` / `openclaw mcp add` could save stdio MCP env keys that runtime policy would ignore, and legacy configs did not show a clear structured status/doctor error or supported cleanup path.
- **Real environment tested:** macOS Darwin 25.5.0, Node via repo toolchain, OpenClaw 2026.6.2, worktree SHA `a76d8f4`.
- **Exact steps or command run after this patch:**
  ```bash
  pnpm docs:list
  pnpm build
  node openclaw.mjs mcp set unsafe '{"command":"node","env":{"PYTHONPATH":"/tmp/mcp-shadow","PYTHONUNBUFFERED":"1"}}'
  node openclaw.mjs mcp add addUnsafe --command ./missing-mcp --env PYTHONPATH=/tmp/mcp-shadow
  node openclaw.mjs mcp list --json
  node openclaw.mjs mcp configure legacy --timeout 5 --probe
  node openclaw.mjs mcp status --json
  node openclaw.mjs mcp doctor --json
  node openclaw.mjs mcp set safe '{"command":"node","env":{"PYTHONUNBUFFERED":"1"}}'
  node openclaw.mjs mcp show safe --json
  node openclaw.mjs mcp tools legacy --include search
  node openclaw.mjs mcp configure legacy --clear-blocked-env
  node openclaw.mjs mcp show legacy --json
  node openclaw.mjs mcp status --json
  node scripts/run-vitest.mjs src/agents/mcp-transport-config.test.ts src/config/mcp-config.test.ts src/cli/mcp-cli.test.ts
  pnpm check:test-types
  git diff --check
  pnpm exec oxlint --deny=warn --ignore-path=.oxlintignore src/agents/mcp-config-shared.ts src/agents/mcp-transport-config.ts src/agents/mcp-transport-config.test.ts src/cli/mcp-cli.ts src/cli/mcp-cli.test.ts src/config/mcp-config.ts src/config/mcp-config.test.ts src/config/mcp-env-policy.ts
  codex -C /Users/zhangguiping/daily_pr_work/openclaw-92474 review --uncommitted
  ```
- **Evidence after fix:**
  ```text
  + node openclaw.mjs --version
  OpenClaw 2026.6.2 (18e70fc)
  + node openclaw.mjs mcp set unsafe '{"command":"node","env":{"PYTHONPATH":"/tmp/mcp-shadow","PYTHONUNBUFFERED":"1"}}'
  MCP stdio env key "PYTHONPATH" is blocked by startup safety policy and cannot be saved. Remove it from the server env config.
  unsafe_set_exit=1
  + node openclaw.mjs mcp add addUnsafe --command ./missing-mcp --env PYTHONPATH=/tmp/mcp-shadow
  MCP stdio env key "PYTHONPATH" is blocked by startup safety policy and cannot be saved. Remove it from the server env config.
  unsafe_add_exit=1
  + node openclaw.mjs mcp list --json
  {}
  + node openclaw.mjs mcp configure legacy --timeout 5 --probe
  MCP stdio env key "PYTHONPATH" is blocked by startup safety policy and cannot be saved. Remove it from the server env config.
  legacy_configure_probe_exit=1
  + node openclaw.mjs mcp status --json
  {
    "servers": [
      {
        "name": "legacy",
        "configured": true,
        "enabled": true,
        "ok": false,
        "transport": "stdio",
        "launch": "node",
        "requestTimeoutMs": 60000,
        "connectionTimeoutMs": 30000,
        "supportsParallelToolCalls": false,
        "issues": [
          {
            "level": "error",
            "message": "MCP stdio env key \"PYTHONPATH\" is blocked by startup safety policy and ignored at runtime."
          }
        ]
      }
    ]
  }
  + node openclaw.mjs mcp doctor --json
  {
    "ok": false,
    "servers": [
      {
        "name": "legacy",
        "ok": false,
        "issues": [
          {
            "level": "error",
            "message": "MCP stdio env key \"PYTHONPATH\" is blocked by startup safety policy and ignored at runtime."
          }
        ]
      }
    ]
  }
  MCP doctor found errors.
  legacy_doctor_exit=1
  + node openclaw.mjs mcp set safe '{"command":"node","env":{"PYTHONUNBUFFERED":"1"}}'
  Saved MCP server "safe" to /Users/zhangguiping/daily_pr_work/proofs/openclaw-issue-92474-evidence/post-rebase-state/openclaw.json.
  + node openclaw.mjs mcp show safe --json
  {
    "command": "node",
    "env": {
      "PYTHONUNBUFFERED": "1"
    }
  }

  + node openclaw.mjs --version
  OpenClaw 2026.6.2 (a76d8f4)
  + node openclaw.mjs mcp tools legacy --include search
  Updated MCP tool selection for "legacy" in /Users/zhangguiping/daily_pr_work/proofs/openclaw-issue-92474-evidence/feedback-final-state/openclaw.json.
  + node openclaw.mjs mcp show legacy --json
  {
    "command": "node",
    "env": {
      "PYTHONPATH": "/tmp/mcp-shadow",
      "PYTHONUNBUFFERED": "1"
    },
    "toolFilter": {
      "include": [
        "search"
      ]
    }
  }
  + node openclaw.mjs mcp configure legacy --clear-blocked-env
  Updated MCP server "legacy" in /Users/zhangguiping/daily_pr_work/proofs/openclaw-issue-92474-evidence/feedback-final-state/openclaw.json.
  + node openclaw.mjs mcp show legacy --json
  {
    "command": "node",
    "env": {
      "PYTHONUNBUFFERED": "1"
    },
    "toolFilter": {
      "include": [
        "search"
      ]
    }
  }
  + node openclaw.mjs mcp status --json
  {
    "servers": [
      {
        "name": "legacy",
        "configured": true,
        "enabled": true,
        "ok": true,
        "transport": "stdio",
        "launch": "node",
        "requestTimeoutMs": 60000,
        "connectionTimeoutMs": 30000,
        "supportsParallelToolCalls": false,
        "toolFilter": {
          "include": [
            "search"
          ]
        }
      }
    ]
  }

  Codex review: The change appears consistent with its intent: it preserves hard rejection of newly introduced blocked stdio env keys at config write time, while allowing unrelated operator updates against legacy blocked keys and adding an explicit cleanup path via `mcp configure --clear-blocked-env`. The updated tests cover the new behaviors, and the touched `set`/`add`/`probe` paths still retain strict blocking semantics.
  ```
- **Observed result after fix:** Blocked stdio env keys now fail before new save/probe, failed writes leave `mcp list --json` empty, legacy blocked configs are visible as status/doctor errors, unrelated legacy tool/config updates are not trapped by pre-existing blocked keys, `--clear-blocked-env` removes legacy blocked keys, and safe env keys still save and round-trip.
- **What was not tested:** A long-running gateway service journal was not separately tailed; the built CLI path and the resolver behavior that previously emitted repeated warnings are covered by the command proof and regression tests.

## Regression Test Plan

- Coverage level: Unit and CLI command tests
- Target test file: `src/config/mcp-config.test.ts`, `src/cli/mcp-cli.test.ts`, `src/agents/mcp-transport-config.test.ts`
- Scenario locked in: blocked stdio env writes are rejected before persistence/probe, legacy blocked configs are diagnosed, unrelated legacy mutations are allowed, `--clear-blocked-env` removes legacy blocked keys, runtime filtering remains fail-closed, and safe env keys still save.
- Why this is the smallest reliable guardrail: these tests cover the write boundary, CLI command behavior, and runtime resolver invariant without depending on external MCP servers or credentials.

## Root Cause

- Root cause: MCP config writes accepted arbitrary stdio `env` keys while runtime launch filtering silently dropped startup-sensitive keys later; the first strict write-boundary fix also treated legacy blocked keys as blockers for unrelated mutations.
- Missing detection / guardrail: the startup safety blocklist existed only at runtime filtering, not at config write/update/probe boundaries or structured MCP status/doctor diagnostics, and legacy cleanup lacked a supported CLI path.