### PR TITLE
fix(codex): honor migrated ChatGPT auth profiles

### DIFF
--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -300,6 +300,53 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
+  it("clears inherited API-key env vars when the migrated ChatGPT Codex profile is subscription auth", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const startOptions = createStartOptions({
+      env: { EXISTING: "1" },
+      clearEnv: ["FOO"],
+    });
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:chatgpt-default",
+        credential: {
+          type: "oauth",
+          provider: "openai",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 24 * 60 * 60_000,
+          accountId: "account-123",
+        },
+      });
+
+      await expect(
+        bridgeCodexAppServerStartOptions({
+          startOptions,
+          agentDir,
+          config: {
+            auth: {
+              order: {
+                openai: ["openai:chatgpt-default"],
+              },
+            },
+          },
+        }),
+      ).resolves.toEqual({
+        ...startOptions,
+        env: {
+          EXISTING: "1",
+          CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
+        },
+        clearEnv: ["FOO", "CODEX_API_KEY", "OPENAI_API_KEY"],
+      });
+      expect(startOptions.clearEnv).toEqual(["FOO"]);
+      await expectPathMissing(path.join(agentDir, "harness-auth"));
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("clears an inherited OpenAI API key for an explicit Codex OAuth profile", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const startOptions = createStartOptions({ clearEnv: ["FOO"] });
@@ -651,6 +698,47 @@ describe("bridgeCodexAppServerStartOptions", () => {
         type: "chatgptAuthTokens",
         accessToken: "default-access-token",
         chatgptAccountId: "account-default",
+        chatgptPlanType: null,
+      });
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("applies a migrated ChatGPT Codex OAuth profile when no profile id is explicit", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:chatgpt-default",
+        credential: {
+          type: "oauth",
+          provider: "openai",
+          access: "chatgpt-access-token",
+          refresh: "chatgpt-refresh-token",
+          expires: Date.now() + 24 * 60 * 60_000,
+          accountId: "account-chatgpt-default",
+          email: "codex-chatgpt@example.test",
+        },
+      });
+
+      await applyCodexAppServerAuthProfile({
+        client: { request } as never,
+        agentDir,
+        config: {
+          auth: {
+            order: {
+              openai: ["openai:chatgpt-default"],
+            },
+          },
+        },
+      });
+
+      expect(request).toHaveBeenCalledWith("account/login/start", {
+        type: "chatgptAuthTokens",
+        accessToken: "chatgpt-access-token",
+        chatgptAccountId: "account-chatgpt-default",
         chatgptPlanType: null,
       });
     } finally {

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -641,10 +641,14 @@ function shouldClearOpenAiApiKeyForCodexAuthProfile(params: {
   authProfileId?: string;
   config?: AuthProfileOrderConfig;
 }): boolean {
-  const profileId = params.authProfileId?.trim();
-  const credential = profileId
-    ? params.store.profiles[profileId]
-    : params.store.profiles[OPENAI_CODEX_DEFAULT_PROFILE_ID];
+  const profileId =
+    params.authProfileId?.trim() ||
+    resolveCodexAppServerAuthProfileId({
+      store: params.store,
+      config: params.config,
+    }) ||
+    OPENAI_CODEX_DEFAULT_PROFILE_ID;
+  const credential = params.store.profiles[profileId];
   return isCodexSubscriptionCredential(credential, params.config);
 }
 


### PR DESCRIPTION
## Summary
- Resolve implicit Codex app-server auth profile handling through the same auth-order path used for login.
- Preserve API-key env clearing for migrated `openai:chatgpt-default` OAuth profiles.
- Add regression coverage for launching with the migrated profile shape from #92458.

## Issue
Fixes #92458

## Real behavior proof

- Behavior or issue addressed: A migrated `openai:chatgpt-default` OAuth profile selected through auth order should be treated as the implicit Codex app-server auth profile, so inherited `CODEX_API_KEY` / `OPENAI_API_KEY` values are cleared before stdio launch.
- Real environment tested: Local OpenClaw checkout at PR head `d8e56cfe85afbe962d33967f590831590790d199` on macOS, Node v24.15.0, using the real auth profile store and Codex app-server auth bridge modules.
- Exact steps or command run after this patch: Ran a `node --import tsx --input-type=module` terminal command that created a temp OpenClaw state dir, upserted an `openai:chatgpt-default` OAuth profile, configured `auth.order.openai = ["openai:chatgpt-default"]`, and called `resolveCodexAppServerAuthProfileId` plus `bridgeCodexAppServerStartOptions` with inherited API key env vars present.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from the command above:

```json
{
  "resolvedProfileId": "openai:chatgpt-default",
  "clearEnv": [
    "FOO",
    "CODEX_API_KEY",
    "OPENAI_API_KEY"
  ],
  "codexHomeIsIsolated": true,
  "inheritedApiKeysCleared": true
}
```

- Observed result after fix: The migrated ChatGPT profile resolved as the implicit app-server auth profile, and the bridged stdio launch options cleared both inherited API key env vars while keeping the isolated Codex home behavior.
- What was not tested: Live OpenAI/ChatGPT network authentication was not exercised; the proof is limited to the local auth profile resolution and launch environment path that caused #92458.
- Proof limitations or environment constraints: The command uses redacted local test credentials and does not contact OpenAI.
- Before evidence (optional but encouraged): Before this patch, the implicit env-clearing path only checked `openai:default`, so the same migrated-profile setup could leave inherited API key env vars available to the app-server launch.

## Tests and validation

- `pnpm exec vitest run extensions/codex/src/app-server/auth-bridge.test.ts` - 45 tests passed.
- `pnpm exec oxlint extensions/codex/src/app-server/auth-bridge.ts extensions/codex/src/app-server/auth-bridge.test.ts` - passed.
- `pnpm exec oxfmt --write extensions/codex/src/app-server/auth-bridge.ts extensions/codex/src/app-server/auth-bridge.test.ts && git diff --check` - passed.
