### PR TITLE
fix(reply): mirror same-channel Slack final replies

### DIFF
--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import {
   testing as replyRunTesting,
   createReplyOperation,
@@ -1276,7 +1277,7 @@ describe("runCliAgent reliability", () => {
     releaseAgentEnd();
   });
 
-  it("persists approved CLI user turns before model execution", async () => {
+  it("persists approved CLI user turns and successful assistant output", async () => {
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({
         reason: "exit",
@@ -1289,7 +1290,7 @@ describe("runCliAgent reliability", () => {
         noOutputTimedOut: false,
       }),
     );
-    const { dir, sessionFile } = createSessionFile();
+    const { dir, sessionFile, storePath } = createSessionFile();
     const onUserMessagePersisted = vi.fn();
 
     try {
@@ -1305,6 +1306,8 @@ describe("runCliAgent reliability", () => {
           sessionFile,
           workspaceDir: dir,
           prompt: "runtime prompt",
+          persistAssistantTranscript: true,
+          storePath,
           userTurnTranscriptRecorder: createCliUserTurnRecorder({
             text: "display prompt",
             sessionFile,
@@ -1316,6 +1319,9 @@ describe("runCliAgent reliability", () => {
       });
 
       expect(result.payloads).toEqual([{ text: "hello from cli" }]);
+      expect(getReplyPayloadMetadata(result.payloads?.[0] ?? {})).toMatchObject({
+        assistantTranscriptOwned: true,
+      });
       expect(onUserMessagePersisted).toHaveBeenCalledOnce();
       expect(onUserMessagePersisted).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1331,7 +1337,180 @@ describe("runCliAgent reliability", () => {
           content: "display prompt",
         }),
       );
+      expect(messages).toContainEqual(
+        expect.objectContaining({
+          role: "assistant",
+          content: [{ type: "text", text: "hello from cli" }],
+          api: "cli",
+          provider: "codex-cli",
+          model: "gpt-5.4",
+          idempotencyKey: "cli-assistant:run-persist-cli",
+        }),
+      );
       expect(JSON.stringify(messages)).not.toContain("runtime prompt");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("lets before_message_write block CLI assistant persistence without delivery fallback", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "before_message_write"),
+      runBeforeMessageWrite: vi.fn(() => ({ block: true })),
+    };
+    setHookRunnerForTest(hookRunner);
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "secret CLI output",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const { dir, sessionFile, storePath } = createSessionFile();
+
+    try {
+      const context = buildPreparedContext({
+        sessionKey: "agent:main:main",
+        runId: "run-blocked-cli",
+      });
+      const result = await runPreparedCliAgent({
+        ...context,
+        params: {
+          ...context.params,
+          agentId: "main",
+          sessionFile,
+          workspaceDir: dir,
+          persistAssistantTranscript: true,
+          storePath,
+        },
+      });
+
+      expect(result.payloads).toEqual([{ text: "secret CLI output" }]);
+      expect(getReplyPayloadMetadata(result.payloads?.[0] ?? {})).toMatchObject({
+        assistantTranscriptOwned: true,
+      });
+      expect(readTranscriptMessages(sessionFile)).toEqual([]);
+      expect(hookRunner.runBeforeMessageWrite).toHaveBeenCalledOnce();
+      expect(
+        callArg(hookRunner.runBeforeMessageWrite, 0, 1, "before_message_write context"),
+      ).toEqual({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not append late CLI output after the session key is rebound", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "late CLI output",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const { dir, sessionFile, storePath } = createSessionFile();
+    const replacementFile = path.join(path.dirname(sessionFile), "s2.jsonl");
+    fs.writeFileSync(
+      replacementFile,
+      `${JSON.stringify({
+        type: "session",
+        version: CURRENT_SESSION_VERSION,
+        id: "s2",
+        timestamp: new Date(0).toISOString(),
+        cwd: dir,
+      })}\n`,
+      "utf-8",
+    );
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId: "s2",
+          sessionFile: replacementFile,
+          updatedAt: Date.now(),
+        },
+      }),
+      "utf-8",
+    );
+
+    try {
+      const context = buildPreparedContext({
+        sessionKey: "agent:main:main",
+        runId: "run-rebound-cli",
+      });
+      const result = await runPreparedCliAgent({
+        ...context,
+        params: {
+          ...context.params,
+          agentId: "main",
+          sessionFile,
+          workspaceDir: dir,
+          persistAssistantTranscript: true,
+          storePath,
+        },
+      });
+
+      expect(result.payloads).toEqual([{ text: "late CLI output" }]);
+      expect(getReplyPayloadMetadata(result.payloads?.[0] ?? {})).toMatchObject({
+        assistantTranscriptOwned: true,
+      });
+      expect(readTranscriptMessages(sessionFile)).toEqual([]);
+      expect(readTranscriptMessages(replacementFile)).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not persist private room-event assistant output", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "private ambient output",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const { dir, sessionFile, storePath } = createSessionFile();
+
+    try {
+      const context = buildPreparedContext({
+        sessionKey: "agent:main:main",
+        runId: "run-private-room-event",
+      });
+      const result = await runPreparedCliAgent({
+        ...context,
+        params: {
+          ...context.params,
+          agentId: "main",
+          sessionFile,
+          workspaceDir: dir,
+          persistAssistantTranscript: true,
+          storePath,
+          currentInboundEventKind: "room_event",
+        },
+      });
+
+      expect(result.payloads).toEqual([{ text: "private ambient output" }]);
+      expect(getReplyPayloadMetadata(result.payloads?.[0] ?? {})).toMatchObject({
+        assistantTranscriptOwned: true,
+      });
+      expect(readTranscriptMessages(sessionFile)).toEqual([]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -656,6 +656,9 @@ describe("runCliAgent spawn path", () => {
       currentMessageId: "reply-message-1",
       senderId: "sender-1",
       senderIsOwner: true,
+      persistAssistantTranscript: true,
+      storePath: "/tmp/sessions.json",
+      currentInboundEventKind: "room_event",
     });
 
     expect(params.messageChannel).toBe("telegram");
@@ -666,6 +669,9 @@ describe("runCliAgent spawn path", () => {
     expect(params.senderId).toBe("sender-1");
     expect(params.senderIsOwner).toBe(true);
     expect(params.cwd).toBe("/tmp/task-repo");
+    expect(params.persistAssistantTranscript).toBe(true);
+    expect(params.storePath).toBe("/tmp/sessions.json");
+    expect(params.currentInboundEventKind).toBe("room_event");
   });
 
   it("forwards static extra system prompt through the compat wrapper", () => {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -1,8 +1,9 @@
 /**
  * Top-level CLI-backed agent runner orchestration.
  */
-import type { ReplyPayload } from "../auto-reply/reply-payload.js";
+import { setReplyPayloadMetadata, type ReplyPayload } from "../auto-reply/reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { appendExactAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { buildAgentHookContextChannelFields } from "../plugins/hook-agent-context.js";
@@ -28,6 +29,7 @@ import {
   runHarnessContextEngineMaintenance,
 } from "./harness/context-engine-lifecycle.js";
 import { buildAgentHookContext } from "./harness/hook-context.js";
+import { runAgentHarnessBeforeMessageWriteHook } from "./harness/hook-helpers.js";
 import { buildAgentHookConversationMessages } from "./harness/hook-history.js";
 import {
   runAgentHarnessLlmInputHook,
@@ -35,6 +37,7 @@ import {
 } from "./harness/lifecycle-hook-helpers.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { SessionManager } from "./sessions/session-manager.js";
+import { buildAssistantMessage, buildUsageWithNoCost } from "./stream-message-shared.js";
 
 const log = createSubsystemLogger("agents/cli-runner");
 
@@ -228,6 +231,62 @@ async function persistApprovedCliUserTurnTranscript(params: RunCliAgentParams): 
     } catch (error) {
       log.warn(`CLI user turn persistence notification failed: ${formatErrorMessage(error)}`);
     }
+  }
+}
+
+async function persistCliAssistantTranscript(params: {
+  runParams: RunCliAgentParams;
+  text: string;
+  modelId: string;
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
+}): Promise<boolean> {
+  const { runParams } = params;
+  if (!runParams.persistAssistantTranscript || !runParams.sessionKey || !params.text) {
+    return false;
+  }
+  if (runParams.currentInboundEventKind === "room_event") {
+    return true;
+  }
+  try {
+    const result = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey: runParams.sessionKey,
+      agentId: runParams.agentId,
+      expectedSessionId: runParams.sessionId,
+      storePath: runParams.storePath,
+      idempotencyKey: `cli-assistant:${runParams.runId}`,
+      config: runParams.config,
+      beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
+      message: buildAssistantMessage({
+        model: {
+          api: "cli",
+          provider: runParams.provider,
+          id: params.modelId,
+        },
+        content: [{ type: "text", text: params.text }],
+        stopReason: "stop",
+        usage: buildUsageWithNoCost({
+          input: params.usage?.input,
+          output: params.usage?.output,
+          cacheRead: params.usage?.cacheRead,
+          cacheWrite: params.usage?.cacheWrite,
+          totalTokens: params.usage?.total,
+        }),
+      }),
+    });
+    if (!result.ok) {
+      log.warn(`CLI assistant transcript persistence skipped: ${result.reason}`);
+      return result.code === "blocked" || result.code === "session-rebound";
+    }
+    return true;
+  } catch (error) {
+    log.warn(`CLI assistant transcript persistence failed: ${formatErrorMessage(error)}`);
+    return false;
   }
 }
 
@@ -594,11 +653,16 @@ export async function runPreparedCliAgent(
     output: Awaited<ReturnType<typeof executePreparedCliRun>>;
     effectiveCliSessionId?: string;
     bindingFlushOk?: boolean;
+    assistantTranscriptOwned?: boolean;
   }): EmbeddedAgentRunResult => {
     const text = resultParams.output.text?.trim();
     const rawText = resultParams.output.rawText?.trim();
     const payloads = text
-      ? [{ text }]
+      ? [
+          resultParams.assistantTranscriptOwned
+            ? setReplyPayloadMetadata({ text }, { assistantTranscriptOwned: true })
+            : { text },
+        ]
       : params.allowEmptyAssistantReplyAsSilent === true
         ? [{ text: SILENT_REPLY_TOKEN }]
         : undefined;
@@ -718,6 +782,12 @@ export async function runPreparedCliAgent(
         assistantText,
         output,
       });
+      const assistantTranscriptOwned = await persistCliAssistantTranscript({
+        runParams: params,
+        text: assistantText,
+        modelId: context.modelId,
+        usage: output.usage,
+      });
       const bindingFlushOk = await isCliBindingFlushed(
         effectiveCliSessionId,
         params.provider,
@@ -732,7 +802,12 @@ export async function runPreparedCliAgent(
         ctx: hookContext,
         hookRunner,
       });
-      return buildCliRunResult({ output, effectiveCliSessionId, bindingFlushOk });
+      return buildCliRunResult({
+        output,
+        effectiveCliSessionId,
+        bindingFlushOk,
+        assistantTranscriptOwned,
+      });
     };
 
     if (hasBeforeAgentRunHooks && hookRunner) {
@@ -880,6 +955,9 @@ export function buildRunClaudeCliAgentParams(params: RunClaudeCliAgentParams): R
     cwd: params.cwd,
     config: params.config,
     prompt: params.prompt,
+    persistAssistantTranscript: params.persistAssistantTranscript,
+    storePath: params.storePath,
+    currentInboundEventKind: params.currentInboundEventKind,
     provider: params.provider ?? "claude-cli",
     model: params.model ?? "opus",
     thinkLevel: params.thinkLevel,

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -46,6 +46,10 @@ export type RunCliAgentParams = {
   suppressNextUserMessagePersistence?: boolean;
   userTurnTranscriptRecorder?: UserTurnTranscriptRecorder;
   onUserMessagePersisted?: (message: PersistedUserTurnMessage) => void | Promise<void>;
+  /** Persist the successful CLI assistant reply into the OpenClaw session transcript. */
+  persistAssistantTranscript?: boolean;
+  /** Session store path used when assistant transcript persistence is enabled. */
+  storePath?: string;
   currentInboundEventKind?: InboundEventKind;
   currentInboundContext?: CurrentInboundPromptContext;
   inputProvenance?: InputProvenance;

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -156,6 +156,8 @@ export function buildTtsSupplementMediaPayload(payload: ReplyPayload): ReplyPayl
 /** WeakMap-backed metadata attached to payload objects without changing wire shape. */
 export type ReplyPayloadMetadata = {
   assistantMessageIndex?: number;
+  /** The runtime owns the transcript decision for this assistant payload. */
+  assistantTranscriptOwned?: boolean;
   /**
    * Internal OpenClaw notices generated after a runtime/provider failure are
    * not assistant source replies. Dispatch may deliver them even when normal

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1967,6 +1967,8 @@ describe("runAgentTurnWithFallback", () => {
       agentId: "agent",
       sessionId: "session",
       suppressNextUserMessagePersistence: false,
+      persistAssistantTranscript: true,
+      storePath: "/tmp/sessions.json",
     });
     const call = requireMockCall(state.runCliAgentMock, 0, "CLI runtime");
     const callParams = requireRecord(call[0], "CLI runtime");
@@ -2019,6 +2021,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("success");
     expectMockCallArgFields(state.runCliAgentMock, 0, "CLI run params", {
       currentInboundEventKind: "room_event",
+      persistAssistantTranscript: false,
       cliSessionId: "existing-cli-session",
       cliSessionBinding: {
         sessionId: "existing-cli-session",

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2194,6 +2194,10 @@ export async function runAgentTurnWithFallback(params: {
                     suppressNextUserMessagePersistence: suppressQueuedUserPersistenceForCandidate,
                     userTurnTranscriptRecorder,
                     onUserMessagePersisted: notifyUserMessagePersisted,
+                    persistAssistantTranscript:
+                      params.followupRun.currentInboundEventKind !== "room_event" &&
+                      params.followupRun.run.suppressTranscriptOnlyAssistantPersistence !== true,
+                    storePath: params.storePath,
                     currentInboundEventKind: params.followupRun.currentInboundEventKind,
                     currentInboundContext: params.followupRun.currentInboundContext,
                     inputProvenance: params.followupRun.run.inputProvenance,

--- a/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
+import { appendUnscheduledReminderNote } from "./agent-runner-reminder-guard.js";
+
+describe("appendUnscheduledReminderNote", () => {
+  it("preserves transcript ownership metadata when appending the guard note", () => {
+    const payload = setReplyPayloadMetadata(
+      { text: "I'll remind you tomorrow." },
+      { assistantTranscriptOwned: true },
+    );
+
+    const [guarded] = appendUnscheduledReminderNote([payload]);
+
+    expect(guarded?.text).toContain("I did not schedule a reminder");
+    expect(getReplyPayloadMetadata(guarded ?? {})).toEqual({
+      assistantTranscriptOwned: true,
+    });
+  });
+});

--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -1,6 +1,7 @@
 /** Detects reminder commitments that were not backed by scheduled cron jobs. */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { loadCronJobsStore, resolveCronJobsStorePath } from "../../cron/store.js";
+import { copyReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 
 const UNSCHEDULED_REMINDER_NOTE =
@@ -60,9 +61,9 @@ export function appendUnscheduledReminderNote(payloads: ReplyPayload[]): ReplyPa
     }
     appended = true;
     const trimmed = payload.text.trimEnd();
-    return {
+    return copyReplyPayloadMetadata(payload, {
       ...payload,
       text: `${trimmed}\n\n${UNSCHEDULED_REMINDER_NOTE}`,
-    };
+    });
   });
 }

--- a/src/auto-reply/reply/commands-reset-hooks.test.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.test.ts
@@ -209,9 +209,16 @@ describe("handleCommands reset hooks", () => {
   });
 
   it("uses gateway session reset for bound ACP sessions", async () => {
+    resetMocks.resetConfiguredBindingTargetInPlace.mockResolvedValue({
+      ok: true,
+      sessionKey: "agent:claude:acp:binding:discord:default:9373ab192b2317f4",
+      sessionId: "session-after-acp-reset",
+      storePath: "/tmp/claude-sessions.json",
+    });
     resetMocks.resolveBoundAcpThreadSessionKey.mockReturnValue(
       "agent:claude:acp:binding:discord:default:9373ab192b2317f4",
     );
+    const onSessionPrepared = vi.fn();
     const params = buildResetParams(
       "/reset",
       {
@@ -224,6 +231,7 @@ describe("handleCommands reset hooks", () => {
         CommandSource: "native",
       },
     );
+    params.opts = { onSessionPrepared } as never;
 
     const result = await maybeHandleResetCommand(params);
 
@@ -245,6 +253,11 @@ describe("handleCommands reset hooks", () => {
     });
     expect(triggerInternalHookMock).not.toHaveBeenCalled();
     expect(params.command.resetHookTriggered).toBe(true);
+    expect(onSessionPrepared).toHaveBeenCalledWith({
+      sessionKey: "agent:claude:acp:binding:discord:default:9373ab192b2317f4",
+      sessionId: "session-after-acp-reset",
+      storePath: "/tmp/claude-sessions.json",
+    });
   });
 
   it("keeps tail dispatch after a bound ACP reset", async () => {

--- a/src/auto-reply/reply/commands-reset.ts
+++ b/src/auto-reply/reply/commands-reset.ts
@@ -9,7 +9,12 @@ import { resolveBoundAcpThreadSessionKey } from "./commands-acp/targets.js";
 import { emitResetCommandHooks, type ResetCommandAction } from "./commands-reset-hooks.js";
 import { parseSoftResetCommand } from "./commands-reset-mode.js";
 import type { CommandHandlerResult, HandleCommandsParams } from "./commands-types.js";
+import type { ReplySessionBinding } from "./get-reply.types.js";
 import { isResetAuthorizedForContext } from "./reset-authorization.js";
+
+type InternalResetCommandOptions = NonNullable<HandleCommandsParams["opts"]> & {
+  onSessionPrepared?: (binding: ReplySessionBinding) => void;
+};
 
 function applyAcpResetTailContext(ctx: HandleCommandsParams["ctx"], resetTail: string): void {
   const mutableCtx = ctx as Record<string, unknown>;
@@ -139,6 +144,13 @@ export async function maybeHandleResetCommand(
       logVerbose(`acp reset failed for ${boundAcpKey}: ${resetResult.error ?? "unknown error"}`);
     }
     if (resetResult.ok) {
+      if (resetResult.sessionId) {
+        (params.opts as InternalResetCommandOptions | undefined)?.onSessionPrepared?.({
+          sessionKey: resetResult.sessionKey ?? boundAcpKey,
+          sessionId: resetResult.sessionId,
+          storePath: resetResult.storePath,
+        });
+      }
       params.command.resetHookTriggered = true;
       if (resetTail) {
         applyAcpResetTailContext(params.ctx, resetTail);

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1271,6 +1271,57 @@ describe("dispatchReplyFromConfig", () => {
     });
   });
 
+  it("mirrors reset acknowledgements into the canonically prepared Slack session", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const sessionKey = "Agent:Main:Slack:Channel:C123";
+    const preparedSessionKey = "agent:main:slack:channel:c123";
+    sessionStoreMocks.currentEntry = {
+      sessionId: "previous-session",
+      updatedAt: Date.now(),
+    };
+    transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "slack",
+        Surface: "slack",
+        OriginatingChannel: "slack",
+        OriginatingTo: "channel:C123",
+        ChatType: "group",
+        SessionKey: sessionKey,
+        MessageSid: "slack-reset-message",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async (_ctx, opts) => {
+        (
+          opts as GetReplyOptions & {
+            onSessionPrepared?: (binding: {
+              sessionKey?: string;
+              sessionId: string;
+              storePath?: string;
+            }) => void;
+          }
+        ).onSessionPrepared?.({
+          sessionKey: preparedSessionKey,
+          sessionId: "new-session",
+          storePath: "/tmp/rotated-sessions.json",
+        });
+        return { text: "✅ New session started." };
+      },
+    });
+
+    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey,
+        expectedSessionId: "new-session",
+        storePath: "/tmp/rotated-sessions.json",
+        text: "✅ New session started.",
+      }),
+    );
+  });
+
   it.each([
     ["embedded", { assistantMessageIndex: 7 }],
     ["CLI", { assistantTranscriptOwned: true }],

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1229,10 +1229,9 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
-  it("mirrors same-channel Slack final replies into the session transcript", async () => {
+  it("mirrors ownerless same-channel Slack finals after successful delivery", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();
-    const cfg = emptyConfig;
     const dispatcher = createDispatcher();
     const ctx = buildTestCtx({
       Provider: "slack",
@@ -1241,102 +1240,116 @@ describe("dispatchReplyFromConfig", () => {
       OriginatingTo: "channel:C123",
       ChatType: "group",
       SessionKey: "agent:main:slack:channel:C123",
+      MessageSid: "slack-message-1",
     });
-
-    const replyResolver = vi.fn(
-      async () => ({ text: "Slack channel reply" }) satisfies ReplyPayload,
-    );
     transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
 
-    const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyOptions: { runId: "slack-run-1" },
+      replyResolver: async () => ({ text: "Slack command reply" }),
+    });
 
     expect(result.queuedFinal).toBe(true);
     expect(mocks.routeReply).not.toHaveBeenCalled();
-    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Slack channel reply" });
     expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith({
       sessionKey: "agent:main:slack:channel:C123",
       agentId: "main",
-      text: "Slack channel reply",
+      text: "Slack command reply",
       mediaUrls: undefined,
-      idempotencyKey: undefined,
+      idempotencyKey: "channel-final:slack-message-1:0",
+      deliveryMirror: {
+        kind: "channel-final",
+        sourceMessageId: "slack-message-1",
+      },
       storePath: "/tmp/mock-sessions.json",
       updateMode: "inline",
-      config: cfg,
+      config: emptyConfig,
+      beforeMessageWrite: expect.any(Function),
     });
   });
 
-  it("mirrors same-channel Slack final replies after dispatcher hook rewrites", async () => {
+  it.each([
+    ["embedded", { assistantMessageIndex: 7 }],
+    ["CLI", { assistantTranscriptOwned: true }],
+  ])("does not mirror %s finals with a runtime transcript owner", async (_name, metadata) => {
     setNoAbort();
-    mocks.routeReply.mockClear();
-    const cfg = emptyConfig;
     const dispatcher = createDispatcher();
-    dispatcher.appendBeforeDeliver?.((payload, info) => {
-      if (info.kind !== "final") {
-        return payload;
-      }
-      return { ...payload, text: "Redacted Slack reply" };
-    });
-    const ctx = buildTestCtx({
-      Provider: "slack",
-      Surface: "slack",
-      OriginatingChannel: "slack",
-      OriginatingTo: "channel:C123",
-      ChatType: "group",
-      SessionKey: "agent:main:slack:channel:C123",
-    });
-
-    const replyResolver = vi.fn(
-      async () => ({ text: "Secret Slack reply" }) satisfies ReplyPayload,
-    );
     transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
 
-    const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "slack",
+        Surface: "slack",
+        OriginatingChannel: "slack",
+        OriginatingTo: "channel:C123",
+        SessionKey: "agent:main:slack:channel:C123",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () =>
+        setReplyPayloadMetadata({ text: "Persisted runtime reply" }, metadata),
+    });
 
     expect(result.queuedFinal).toBe(true);
-    expect(mocks.routeReply).not.toHaveBeenCalled();
-    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Secret Slack reply" });
-    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith({
-      sessionKey: "agent:main:slack:channel:C123",
-      agentId: "main",
-      text: "Redacted Slack reply",
-      mediaUrls: undefined,
-      idempotencyKey: undefined,
-      storePath: "/tmp/mock-sessions.json",
-      updateMode: "inline",
-      config: cfg,
-    });
+    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
 
-  it("does not mirror same-channel Slack final replies stripped by dispatcher hooks", async () => {
+  it("mirrors the delivered ownerless Slack text after dispatcher hook rewrites", async () => {
     setNoAbort();
-    mocks.routeReply.mockClear();
-    const cfg = emptyConfig;
     const dispatcher = createDispatcher();
-    dispatcher.appendBeforeDeliver?.((payload, info) => {
-      if (info.kind !== "final") {
-        return payload;
-      }
-      return { ...payload, text: "", mediaUrl: undefined, mediaUrls: undefined };
-    });
-    const ctx = buildTestCtx({
-      Provider: "slack",
-      Surface: "slack",
-      OriginatingChannel: "slack",
-      OriginatingTo: "channel:C123",
-      ChatType: "group",
-      SessionKey: "agent:main:slack:channel:C123",
-    });
-
-    const replyResolver = vi.fn(
-      async () => ({ text: "Secret Slack reply" }) satisfies ReplyPayload,
+    dispatcher.appendBeforeDeliver?.((payload, info) =>
+      info.kind === "final" ? { ...payload, text: "Redacted Slack reply" } : payload,
     );
     transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
 
-    const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "slack",
+        Surface: "slack",
+        OriginatingChannel: "slack",
+        OriginatingTo: "channel:C123",
+        SessionKey: "agent:main:slack:channel:C123",
+        MessageSid: "slack-message-2",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "Secret Slack reply" }),
+    });
 
-    expect(result.queuedFinal).toBe(true);
-    expect(mocks.routeReply).not.toHaveBeenCalled();
-    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Secret Slack reply" });
+    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Redacted Slack reply",
+        idempotencyKey: "channel-final:slack-message-2:0",
+      }),
+    );
+  });
+
+  it("does not mirror ownerless Slack finals removed by dispatcher hooks", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    dispatcher.appendBeforeDeliver?.((payload, info) =>
+      info.kind === "final"
+        ? { ...payload, text: "", mediaUrl: undefined, mediaUrls: undefined }
+        : payload,
+    );
+    transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "slack",
+        Surface: "slack",
+        OriginatingChannel: "slack",
+        OriginatingTo: "channel:C123",
+        SessionKey: "agent:main:slack:channel:C123",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "Hidden Slack reply" }),
+    });
+
     expect(transcriptMocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
 
@@ -8866,8 +8879,11 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       text: "message tool reply",
       mediaUrls: undefined,
       idempotencyKey: "run-1:internal-source-reply:0",
+      expectedSessionId: "s1",
+      storePath: "/tmp/mock-sessions.json",
       updateMode: "inline",
       config: emptyConfig,
+      beforeMessageWrite: expect.any(Function),
     });
   });
 
@@ -8927,8 +8943,11 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       text: "redacted hook reply",
       mediaUrls: ["https://example.com/redacted.png"],
       idempotencyKey: "run-1:internal-source-reply:rewritten",
+      expectedSessionId: "s1",
+      storePath: "/tmp/mock-sessions.json",
       updateMode: "inline",
       config: emptyConfig,
+      beforeMessageWrite: expect.any(Function),
     });
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1229,6 +1229,115 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
+  it("mirrors same-channel Slack final replies into the session transcript", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "slack",
+      Surface: "slack",
+      OriginatingChannel: "slack",
+      OriginatingTo: "channel:C123",
+      ChatType: "group",
+      SessionKey: "agent:main:slack:channel:C123",
+    });
+
+    const replyResolver = vi.fn(
+      async () => ({ text: "Slack channel reply" }) satisfies ReplyPayload,
+    );
+    transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
+
+    const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(mocks.routeReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Slack channel reply" });
+    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith({
+      sessionKey: "agent:main:slack:channel:C123",
+      agentId: "main",
+      text: "Slack channel reply",
+      mediaUrls: undefined,
+      idempotencyKey: undefined,
+      updateMode: "inline",
+      config: cfg,
+    });
+  });
+
+  it("mirrors same-channel Slack final replies after dispatcher hook rewrites", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    dispatcher.appendBeforeDeliver?.((payload, info) => {
+      if (info.kind !== "final") {
+        return payload;
+      }
+      return { ...payload, text: "Redacted Slack reply" };
+    });
+    const ctx = buildTestCtx({
+      Provider: "slack",
+      Surface: "slack",
+      OriginatingChannel: "slack",
+      OriginatingTo: "channel:C123",
+      ChatType: "group",
+      SessionKey: "agent:main:slack:channel:C123",
+    });
+
+    const replyResolver = vi.fn(
+      async () => ({ text: "Secret Slack reply" }) satisfies ReplyPayload,
+    );
+    transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
+
+    const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(mocks.routeReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Secret Slack reply" });
+    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith({
+      sessionKey: "agent:main:slack:channel:C123",
+      agentId: "main",
+      text: "Redacted Slack reply",
+      mediaUrls: undefined,
+      idempotencyKey: undefined,
+      updateMode: "inline",
+      config: cfg,
+    });
+  });
+
+  it("does not mirror same-channel Slack final replies stripped by dispatcher hooks", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    dispatcher.appendBeforeDeliver?.((payload, info) => {
+      if (info.kind !== "final") {
+        return payload;
+      }
+      return { ...payload, text: "", mediaUrl: undefined, mediaUrls: undefined };
+    });
+    const ctx = buildTestCtx({
+      Provider: "slack",
+      Surface: "slack",
+      OriginatingChannel: "slack",
+      OriginatingTo: "channel:C123",
+      ChatType: "group",
+      SessionKey: "agent:main:slack:channel:C123",
+    });
+
+    const replyResolver = vi.fn(
+      async () => ({ text: "Secret Slack reply" }) satisfies ReplyPayload,
+    );
+    transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
+
+    const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(mocks.routeReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Secret Slack reply" });
+    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
+  });
+
   it("records routed Slack thread id on dispatch-owned reply operations", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1297,6 +1297,37 @@ describe("dispatchReplyFromConfig", () => {
     expect(transcriptMocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
 
+  it("disables routed delivery mirrors for CLI-owned finals", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    mocks.routeReply.mockClear();
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "slack",
+        Surface: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+        SessionKey: "agent:main:telegram:group:999",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () =>
+        setReplyPayloadMetadata(
+          { text: "Persisted routed CLI reply" },
+          { assistantTranscriptOwned: true },
+        ),
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: "Persisted routed CLI reply" },
+        mirror: false,
+      }),
+    );
+  });
+
   it("mirrors the delivered ownerless Slack text after dispatcher hook rewrites", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1259,6 +1259,7 @@ describe("dispatchReplyFromConfig", () => {
       text: "Slack channel reply",
       mediaUrls: undefined,
       idempotencyKey: undefined,
+      storePath: "/tmp/mock-sessions.json",
       updateMode: "inline",
       config: cfg,
     });
@@ -1300,6 +1301,7 @@ describe("dispatchReplyFromConfig", () => {
       text: "Redacted Slack reply",
       mediaUrls: undefined,
       idempotencyKey: undefined,
+      storePath: "/tmp/mock-sessions.json",
       updateMode: "inline",
       config: cfg,
     });

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -43,6 +43,7 @@ import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { shouldSuppressLocalExecApprovalPrompt } from "../../channels/plugins/exec-approval-local.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
+import { normalizeExplicitSessionKey } from "../../config/sessions/explicit-session-key-normalization.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
 import {
   appendAssistantMessageToSessionTranscript,
@@ -142,6 +143,7 @@ import type {
 } from "./dispatch-from-config.types.js";
 import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
 import { withFullRuntimeReplyConfig } from "./get-reply-fast-path.js";
+import type { ReplySessionBinding } from "./get-reply.types.js";
 import { claimInboundDedupe, commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
 import { hasInboundAudio } from "./inbound-media.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
@@ -180,6 +182,7 @@ type TranscriptMirror = SourceReplyTranscriptMirror & {
 };
 type InternalReplyResolverOptions = {
   onSessionMetadataChanges?: (changes: CommandSessionMetadataChange[]) => void;
+  onSessionPrepared?: (binding: ReplySessionBinding) => void;
 };
 
 class DispatchReplyOperationAbortedError extends Error {
@@ -1225,6 +1228,34 @@ export async function dispatchReplyFromConfig(
   const sessionStoreEntry = boundAcpDispatchSessionKey
     ? resolveSessionStoreLookup({ ...ctx, SessionKey: boundAcpDispatchSessionKey }, cfg)
     : initialSessionStoreEntry;
+  let preparedSessionBinding: ReplySessionBinding | undefined =
+    sessionStoreEntry.sessionKey && sessionStoreEntry.entry?.sessionId
+      ? {
+          sessionKey: sessionStoreEntry.sessionKey,
+          sessionId: sessionStoreEntry.entry.sessionId,
+          storePath: sessionStoreEntry.storePath,
+        }
+      : undefined;
+  const sessionKeysMatch = (left?: string, right?: string) =>
+    Boolean(
+      left &&
+      right &&
+      normalizeExplicitSessionKey(left, ctx) === normalizeExplicitSessionKey(right, ctx),
+    );
+  const notePreparedSession = (binding: ReplySessionBinding) => {
+    if (sessionKeysMatch(binding.sessionKey, sessionStoreEntry.sessionKey)) {
+      preparedSessionBinding = binding;
+    }
+  };
+  const resolvePreparedTranscriptBinding = (mirrorSessionKey?: string) => {
+    if (
+      !preparedSessionBinding ||
+      !sessionKeysMatch(mirrorSessionKey, preparedSessionBinding.sessionKey)
+    ) {
+      return undefined;
+    }
+    return preparedSessionBinding;
+  };
   const sessionAgentId = resolveSessionAgentId({
     sessionKey: acpDispatchSessionKey,
     config: cfg,
@@ -2250,14 +2281,16 @@ export async function dispatchReplyFromConfig(
       await flushPendingCommentaryProgress();
       throwIfFinalDeliveryAborted();
       const payloadMetadata = getReplyPayloadMetadata(payload);
+      const sourceReplySessionBinding = resolvePreparedTranscriptBinding(
+        payloadMetadata?.sourceReplyTranscriptMirror?.sessionKey,
+      );
       const sourceReplyTranscriptMirror = payloadMetadata?.sourceReplyTranscriptMirror
         ? {
             ...payloadMetadata.sourceReplyTranscriptMirror,
-            ...(payloadMetadata.sourceReplyTranscriptMirror.sessionKey ===
-              sessionStoreEntry.sessionKey && sessionStoreEntry.entry?.sessionId
-              ? { expectedSessionId: sessionStoreEntry.entry.sessionId }
+            ...(sourceReplySessionBinding
+              ? { expectedSessionId: sourceReplySessionBinding.sessionId }
               : {}),
-            storePath: sessionStoreEntry.storePath,
+            storePath: sourceReplySessionBinding?.storePath ?? sessionStoreEntry.storePath,
           }
         : undefined;
       const hasTranscriptOwner =
@@ -2309,6 +2342,9 @@ export async function dispatchReplyFromConfig(
       const transcriptMirrorSourceId =
         normalizeOptionalString(messageIdForHook) ??
         normalizeOptionalString(params.replyOptions?.runId);
+      const transcriptMirrorSessionBinding = resolvePreparedTranscriptBinding(
+        transcriptMirrorSessionKey,
+      );
       const transcriptMirror =
         sourceReplyTranscriptMirror ??
         (!hasTranscriptOwner &&
@@ -2319,11 +2355,10 @@ export async function dispatchReplyFromConfig(
               {
                 sessionKey: transcriptMirrorSessionKey,
                 agentId: sessionAgentId,
-                ...(transcriptMirrorSessionKey === sessionStoreEntry.sessionKey &&
-                sessionStoreEntry.entry?.sessionId
-                  ? { expectedSessionId: sessionStoreEntry.entry.sessionId }
+                ...(transcriptMirrorSessionBinding
+                  ? { expectedSessionId: transcriptMirrorSessionBinding.sessionId }
                   : {}),
-                storePath: sessionStoreEntry.storePath,
+                storePath: transcriptMirrorSessionBinding?.storePath ?? sessionStoreEntry.storePath,
                 preferText: true,
                 idempotencyKey: transcriptMirrorSourceId
                   ? `channel-final:${transcriptMirrorSourceId}:${options.deliveryId ?? "single"}`
@@ -2795,6 +2830,7 @@ export async function dispatchReplyFromConfig(
             sourceReplyDeliveryMode,
             ...({
               onSessionMetadataChanges: notifySessionMetadataChanges,
+              onSessionPrepared: notePreparedSession,
             } satisfies InternalReplyResolverOptions),
             onObservedReplyDelivery: markObservedReplyDelivery,
             suppressToolErrorWarnings,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -168,6 +168,9 @@ import { resolveRunTypingPolicy } from "./typing-policy.js";
 type SourceReplyTranscriptMirror = NonNullable<
   NonNullable<ReturnType<typeof getReplyPayloadMetadata>>["sourceReplyTranscriptMirror"]
 >;
+type TranscriptMirror = SourceReplyTranscriptMirror & {
+  storePath?: string;
+};
 type InternalReplyResolverOptions = {
   onSessionMetadataChanges?: (changes: CommandSessionMetadataChange[]) => void;
 };
@@ -741,7 +744,7 @@ async function clearPendingFinalDeliveryAfterSuccess(params: {
 }
 
 async function mirrorInternalSourceReplyToTranscript(params: {
-  metadata?: SourceReplyTranscriptMirror;
+  metadata?: TranscriptMirror;
   cfg: OpenClawConfig;
 }): Promise<void> {
   const mirror = params.metadata;
@@ -754,6 +757,7 @@ async function mirrorInternalSourceReplyToTranscript(params: {
     text: mirror.text,
     mediaUrls: mirror.mediaUrls,
     idempotencyKey: mirror.idempotencyKey,
+    ...(mirror.storePath ? { storePath: mirror.storePath } : {}),
     updateMode: "inline",
     config: params.cfg,
   });
@@ -799,9 +803,9 @@ function visibleRecoveryShouldKeepWaiting(outcome: StuckSessionRecoveryOutcome):
 }
 
 function transcriptMirrorForDeliveredPayload(
-  metadata: SourceReplyTranscriptMirror,
+  metadata: TranscriptMirror,
   payload: ReplyPayload,
-): SourceReplyTranscriptMirror | undefined {
+): TranscriptMirror | undefined {
   const sendable = resolveSendableOutboundReplyParts(payload);
   if (!sendable.text && sendable.mediaUrls.length === 0) {
     return undefined;
@@ -815,13 +819,13 @@ function transcriptMirrorForDeliveredPayload(
 
 function captureDeliveredTranscriptMirror(params: {
   dispatcher: ReplyDispatcher;
-  metadata?: SourceReplyTranscriptMirror;
-}): () => SourceReplyTranscriptMirror | undefined {
+  metadata?: TranscriptMirror;
+}): () => TranscriptMirror | undefined {
   if (!params.metadata || !params.dispatcher.appendBeforeDeliver) {
     return () => params.metadata;
   }
   const metadata = params.metadata;
-  let deliveredMetadata: SourceReplyTranscriptMirror | undefined;
+  let deliveredMetadata: TranscriptMirror | undefined;
   let observedFinal = false;
   const { idempotencyKey, sessionKey } = metadata;
   params.dispatcher.appendBeforeDeliver((payload, info) => {
@@ -835,7 +839,10 @@ function captureDeliveredTranscriptMirror(params: {
       payloadMetadata.idempotencyKey === idempotencyKey &&
       payloadMetadata.sessionKey === sessionKey
     ) {
-      deliveredMetadata = transcriptMirrorForDeliveredPayload(payloadMetadata, payload);
+      deliveredMetadata = transcriptMirrorForDeliveredPayload(
+        { ...payloadMetadata, storePath: metadata.storePath },
+        payload,
+      );
     } else if (!payloadMetadata && !idempotencyKey) {
       deliveredMetadata = transcriptMirrorForDeliveredPayload(metadata, payload);
     }
@@ -847,7 +854,7 @@ function captureDeliveredTranscriptMirror(params: {
 async function mirrorTranscriptAfterDispatcherDelivery(params: {
   dispatcher: ReplyDispatcher;
   before: { cancelled: number; failed: number };
-  metadata: () => SourceReplyTranscriptMirror | undefined;
+  metadata: () => TranscriptMirror | undefined;
   cfg: OpenClawConfig;
 }): Promise<void> {
   await params.dispatcher.waitForIdle();
@@ -2251,6 +2258,7 @@ export async function dispatchReplyFromConfig(
               {
                 sessionKey: transcriptMirrorSessionKey,
                 agentId: sessionAgentId,
+                storePath: sessionStoreEntry.storePath,
               },
               normalizedPayload,
             )

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -22,6 +22,7 @@ import {
   resolveInheritedToolPolicyForSession,
   resolveSubagentToolPolicyForSession,
 } from "../../agents/agent-tools.policy.js";
+import { runAgentHarnessBeforeMessageWriteHook } from "../../agents/harness/hook-helpers.js";
 import { selectAgentHarness } from "../../agents/harness/selection.js";
 import {
   buildModelAliasIndex,
@@ -43,7 +44,10 @@ import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { shouldSuppressLocalExecApprovalPrompt } from "../../channels/plugins/exec-approval-local.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
-import { appendAssistantMessageToSessionTranscript } from "../../config/sessions/transcript.js";
+import {
+  appendAssistantMessageToSessionTranscript,
+  type SessionTranscriptDeliveryMirror,
+} from "../../config/sessions/transcript.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
@@ -169,7 +173,10 @@ type SourceReplyTranscriptMirror = NonNullable<
   NonNullable<ReturnType<typeof getReplyPayloadMetadata>>["sourceReplyTranscriptMirror"]
 >;
 type TranscriptMirror = SourceReplyTranscriptMirror & {
+  expectedSessionId?: string;
   storePath?: string;
+  preferText?: boolean;
+  deliveryMirror?: SessionTranscriptDeliveryMirror;
 };
 type InternalReplyResolverOptions = {
   onSessionMetadataChanges?: (changes: CommandSessionMetadataChange[]) => void;
@@ -743,7 +750,7 @@ async function clearPendingFinalDeliveryAfterSuccess(params: {
   });
 }
 
-async function mirrorInternalSourceReplyToTranscript(params: {
+async function mirrorDeliveredReplyToTranscript(params: {
   metadata?: TranscriptMirror;
   cfg: OpenClawConfig;
 }): Promise<void> {
@@ -751,18 +758,27 @@ async function mirrorInternalSourceReplyToTranscript(params: {
   if (!mirror) {
     return;
   }
-  const result = await appendAssistantMessageToSessionTranscript({
-    sessionKey: mirror.sessionKey,
-    agentId: mirror.agentId,
-    text: mirror.text,
-    mediaUrls: mirror.mediaUrls,
-    idempotencyKey: mirror.idempotencyKey,
-    ...(mirror.storePath ? { storePath: mirror.storePath } : {}),
-    updateMode: "inline",
-    config: params.cfg,
-  });
-  if (!result.ok) {
-    logVerbose(`dispatch-from-config: internal source reply mirror skipped: ${result.reason}`);
+  try {
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey: mirror.sessionKey,
+      agentId: mirror.agentId,
+      ...(mirror.expectedSessionId ? { expectedSessionId: mirror.expectedSessionId } : {}),
+      text: mirror.text,
+      mediaUrls: mirror.preferText && mirror.text ? undefined : mirror.mediaUrls,
+      idempotencyKey: mirror.idempotencyKey,
+      ...(mirror.deliveryMirror ? { deliveryMirror: mirror.deliveryMirror } : {}),
+      ...(mirror.storePath ? { storePath: mirror.storePath } : {}),
+      updateMode: "inline",
+      config: params.cfg,
+      beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
+    });
+    if (!result.ok) {
+      logVerbose(`dispatch-from-config: transcript mirror skipped: ${result.reason}`);
+    }
+  } catch (error) {
+    logVerbose(
+      `dispatch-from-config: transcript mirror failed after delivery: ${formatErrorMessage(error)}`,
+    );
   }
 }
 
@@ -840,10 +856,14 @@ function captureDeliveredTranscriptMirror(params: {
       payloadMetadata.sessionKey === sessionKey
     ) {
       deliveredMetadata = transcriptMirrorForDeliveredPayload(
-        { ...payloadMetadata, storePath: metadata.storePath },
+        {
+          ...payloadMetadata,
+          ...(metadata.expectedSessionId ? { expectedSessionId: metadata.expectedSessionId } : {}),
+          storePath: metadata.storePath,
+        },
         payload,
       );
-    } else if (!payloadMetadata && !idempotencyKey) {
+    } else if (!payloadMetadata && (!idempotencyKey || metadata.deliveryMirror)) {
       deliveredMetadata = transcriptMirrorForDeliveredPayload(metadata, payload);
     }
     return payload;
@@ -866,7 +886,7 @@ async function mirrorTranscriptAfterDispatcherDelivery(params: {
   if (!metadata) {
     return;
   }
-  await mirrorInternalSourceReplyToTranscript({
+  await mirrorDeliveredReplyToTranscript({
     metadata,
     cfg: params.cfg,
   });
@@ -2217,7 +2237,7 @@ export async function dispatchReplyFromConfig(
     };
     const sendFinalPayload = async (
       payload: ReplyPayload,
-      options: { abortSignal?: AbortSignal } = {},
+      options: { abortSignal?: AbortSignal; deliveryId?: string } = {},
     ): Promise<{ queuedFinal: boolean; routedFinalCount: number }> => {
       const abortSignal = options.abortSignal ?? getDispatchAbortSignal();
       const throwIfFinalDeliveryAborted = () => {
@@ -2229,8 +2249,20 @@ export async function dispatchReplyFromConfig(
       // Trailing commentary must land ahead of the final answer.
       await flushPendingCommentaryProgress();
       throwIfFinalDeliveryAborted();
-      const sourceReplyTranscriptMirror =
-        getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror;
+      const payloadMetadata = getReplyPayloadMetadata(payload);
+      const sourceReplyTranscriptMirror = payloadMetadata?.sourceReplyTranscriptMirror
+        ? {
+            ...payloadMetadata.sourceReplyTranscriptMirror,
+            ...(payloadMetadata.sourceReplyTranscriptMirror.sessionKey ===
+              sessionStoreEntry.sessionKey && sessionStoreEntry.entry?.sessionId
+              ? { expectedSessionId: sessionStoreEntry.entry.sessionId }
+              : {}),
+            storePath: sessionStoreEntry.storePath,
+          }
+        : undefined;
+      const hasTranscriptOwner =
+        payloadMetadata?.assistantMessageIndex !== undefined ||
+        payloadMetadata?.assistantTranscriptOwned === true;
       const hasVisibleFinalContent = hasOutboundReplyContent(payload, { trimText: true });
       if (hasVisibleFinalContent) {
         markInboundDedupeReplayUnsafe();
@@ -2249,20 +2281,6 @@ export async function dispatchReplyFromConfig(
       throwIfFinalDeliveryAborted();
       const normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
       throwIfFinalDeliveryAborted();
-      const transcriptMirrorSessionKey =
-        acpDispatchSessionKey ?? sessionStoreEntry.sessionKey ?? sessionKey;
-      const transcriptMirror =
-        sourceReplyTranscriptMirror ??
-        (!isInternalWebchatTurn && hasVisibleFinalContent && transcriptMirrorSessionKey
-          ? transcriptMirrorForDeliveredPayload(
-              {
-                sessionKey: transcriptMirrorSessionKey,
-                agentId: sessionAgentId,
-                storePath: sessionStoreEntry.storePath,
-              },
-              normalizedPayload,
-            )
-          : undefined);
       const result = await routeReplyToOriginating(normalizedPayload, {
         abortSignal,
         kind: "final",
@@ -2274,7 +2292,7 @@ export async function dispatchReplyFromConfig(
           );
         }
         if (isRoutedReplyDelivered(result)) {
-          await mirrorInternalSourceReplyToTranscript({
+          await mirrorDeliveredReplyToTranscript({
             metadata: sourceReplyTranscriptMirror,
             cfg,
           });
@@ -2285,6 +2303,40 @@ export async function dispatchReplyFromConfig(
         };
       }
       throwIfFinalDeliveryAborted();
+      const transcriptMirrorSessionKey =
+        acpDispatchSessionKey ?? sessionStoreEntry.sessionKey ?? sessionKey;
+      const transcriptMirrorSourceId =
+        normalizeOptionalString(messageIdForHook) ??
+        normalizeOptionalString(params.replyOptions?.runId);
+      const transcriptMirror =
+        sourceReplyTranscriptMirror ??
+        (!hasTranscriptOwner &&
+        normalizedCurrentSurface === "slack" &&
+        hasVisibleFinalContent &&
+        transcriptMirrorSessionKey
+          ? transcriptMirrorForDeliveredPayload(
+              {
+                sessionKey: transcriptMirrorSessionKey,
+                agentId: sessionAgentId,
+                ...(transcriptMirrorSessionKey === sessionStoreEntry.sessionKey &&
+                sessionStoreEntry.entry?.sessionId
+                  ? { expectedSessionId: sessionStoreEntry.entry.sessionId }
+                  : {}),
+                storePath: sessionStoreEntry.storePath,
+                preferText: true,
+                idempotencyKey: transcriptMirrorSourceId
+                  ? `channel-final:${transcriptMirrorSourceId}:${options.deliveryId ?? "single"}`
+                  : undefined,
+                deliveryMirror: {
+                  kind: "channel-final",
+                  ...(transcriptMirrorSourceId
+                    ? { sourceMessageId: transcriptMirrorSourceId }
+                    : {}),
+                },
+              },
+              normalizedPayload,
+            )
+          : undefined);
       markInboundDedupeReplayUnsafe();
       const finalOutcomeBefore = getDispatcherFinalOutcomeCounts(dispatcher);
       const deliveredTranscriptMirror = captureDeliveredTranscriptMirror({
@@ -2347,7 +2399,10 @@ export async function dispatchReplyFromConfig(
         if (text && !suppressDelivery) {
           const handledReply = await sendFinalPayload(
             { text },
-            { abortSignal: getPreDispatchAbortSignal() },
+            {
+              abortSignal: getPreDispatchAbortSignal(),
+              deliveryId: "before-dispatch",
+            },
           );
           queuedFinal = handledReply.queuedFinal;
           routedFinalCount += handledReply.routedFinalCount;
@@ -3129,7 +3184,7 @@ export async function dispatchReplyFromConfig(
       !sendPolicyDenied &&
       getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression === true &&
       (ctx.InboundEventKind !== "room_event" || explicitCommandTurnCtx);
-    for (const reply of replies) {
+    for (const [replyIndex, reply] of replies.entries()) {
       throwIfDispatchOperationAborted();
       // Suppress reasoning payloads from channel delivery — channels using this
       // generic dispatch path do not have a dedicated reasoning lane.
@@ -3154,7 +3209,7 @@ export async function dispatchReplyFromConfig(
         continue;
       }
       attemptedFinalDelivery = true;
-      const finalReply = await sendFinalPayload(reply);
+      const finalReply = await sendFinalPayload(reply, { deliveryId: String(replyIndex) });
       queuedFinal = finalReply.queuedFinal || queuedFinal;
       routedFinalCount += finalReply.routedFinalCount;
       if (!finalReply.queuedFinal && finalReply.routedFinalCount === 0) {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -798,11 +798,14 @@ function visibleRecoveryShouldKeepWaiting(outcome: StuckSessionRecoveryOutcome):
   );
 }
 
-function sourceReplyTranscriptMirrorForDeliveredPayload(
+function transcriptMirrorForDeliveredPayload(
   metadata: SourceReplyTranscriptMirror,
   payload: ReplyPayload,
-): SourceReplyTranscriptMirror {
+): SourceReplyTranscriptMirror | undefined {
   const sendable = resolveSendableOutboundReplyParts(payload);
+  if (!sendable.text && sendable.mediaUrls.length === 0) {
+    return undefined;
+  }
   return {
     ...metadata,
     text: sendable.text,
@@ -810,35 +813,38 @@ function sourceReplyTranscriptMirrorForDeliveredPayload(
   };
 }
 
-function captureDeliveredSourceReplyTranscriptMirror(params: {
+function captureDeliveredTranscriptMirror(params: {
   dispatcher: ReplyDispatcher;
   metadata?: SourceReplyTranscriptMirror;
 }): () => SourceReplyTranscriptMirror | undefined {
   if (!params.metadata || !params.dispatcher.appendBeforeDeliver) {
     return () => params.metadata;
   }
+  const metadata = params.metadata;
   let deliveredMetadata: SourceReplyTranscriptMirror | undefined;
-  const { idempotencyKey, sessionKey } = params.metadata;
+  let observedFinal = false;
+  const { idempotencyKey, sessionKey } = metadata;
   params.dispatcher.appendBeforeDeliver((payload, info) => {
     if (info.kind !== "final") {
       return payload;
     }
+    observedFinal = true;
     const payloadMetadata = getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror;
-    if (!payloadMetadata) {
-      return payload;
-    }
     if (
+      payloadMetadata &&
       payloadMetadata.idempotencyKey === idempotencyKey &&
       payloadMetadata.sessionKey === sessionKey
     ) {
-      deliveredMetadata = sourceReplyTranscriptMirrorForDeliveredPayload(payloadMetadata, payload);
+      deliveredMetadata = transcriptMirrorForDeliveredPayload(payloadMetadata, payload);
+    } else if (!payloadMetadata && !idempotencyKey) {
+      deliveredMetadata = transcriptMirrorForDeliveredPayload(metadata, payload);
     }
     return payload;
   });
-  return () => deliveredMetadata;
+  return () => (observedFinal ? deliveredMetadata : metadata);
 }
 
-async function mirrorInternalSourceReplyAfterDispatcherDelivery(params: {
+async function mirrorTranscriptAfterDispatcherDelivery(params: {
   dispatcher: ReplyDispatcher;
   before: { cancelled: number; failed: number };
   metadata: () => SourceReplyTranscriptMirror | undefined;
@@ -2236,6 +2242,19 @@ export async function dispatchReplyFromConfig(
       throwIfFinalDeliveryAborted();
       const normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
       throwIfFinalDeliveryAborted();
+      const transcriptMirrorSessionKey =
+        acpDispatchSessionKey ?? sessionStoreEntry.sessionKey ?? sessionKey;
+      const transcriptMirror =
+        sourceReplyTranscriptMirror ??
+        (!isInternalWebchatTurn && hasVisibleFinalContent && transcriptMirrorSessionKey
+          ? transcriptMirrorForDeliveredPayload(
+              {
+                sessionKey: transcriptMirrorSessionKey,
+                agentId: sessionAgentId,
+              },
+              normalizedPayload,
+            )
+          : undefined);
       const result = await routeReplyToOriginating(normalizedPayload, {
         abortSignal,
         kind: "final",
@@ -2260,16 +2279,16 @@ export async function dispatchReplyFromConfig(
       throwIfFinalDeliveryAborted();
       markInboundDedupeReplayUnsafe();
       const finalOutcomeBefore = getDispatcherFinalOutcomeCounts(dispatcher);
-      const deliveredSourceReplyTranscriptMirror = captureDeliveredSourceReplyTranscriptMirror({
+      const deliveredTranscriptMirror = captureDeliveredTranscriptMirror({
         dispatcher,
-        metadata: sourceReplyTranscriptMirror,
+        metadata: transcriptMirror,
       });
       const queuedFinal = dispatcher.sendFinalReply(normalizedPayload);
       if (queuedFinal) {
-        await mirrorInternalSourceReplyAfterDispatcherDelivery({
+        await mirrorTranscriptAfterDispatcherDelivery({
           dispatcher,
           before: finalOutcomeBefore,
-          metadata: deliveredSourceReplyTranscriptMirror,
+          metadata: deliveredTranscriptMirror,
           cfg,
         });
       }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2284,6 +2284,7 @@ export async function dispatchReplyFromConfig(
       const result = await routeReplyToOriginating(normalizedPayload, {
         abortSignal,
         kind: "final",
+        ...(hasTranscriptOwner ? { mirror: false } : {}),
       });
       if (result) {
         if (!result.ok) {

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -1,6 +1,7 @@
 // Tests follow-up reply delivery and route preservation.
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import { resolveFollowupDeliveryPayloads } from "./followup-delivery.js";
 
 vi.mock("../../channels/plugins/index.js", () => ({
@@ -26,6 +27,22 @@ describe("resolveFollowupDeliveryPayloads", () => {
         payloads: [{ text: "HEARTBEAT_OK", mediaUrl: "/tmp/image.png" }],
       }),
     ).toEqual([{ text: "", mediaUrl: "/tmp/image.png" }]);
+  });
+
+  it("preserves transcript ownership when stripping heartbeat text", () => {
+    const payload = setReplyPayloadMetadata(
+      { text: "HEARTBEAT_OK still working" },
+      { assistantTranscriptOwned: true },
+    );
+
+    const [resolved] = resolveFollowupDeliveryPayloads({
+      cfg: baseConfig,
+      payloads: [payload],
+    });
+
+    expect(getReplyPayloadMetadata(resolved ?? {})).toEqual({
+      assistantTranscriptOwned: true,
+    });
   });
 
   it("drops text payloads already sent via messaging tool", () => {

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -2,6 +2,7 @@
 import type { MessagingToolSend } from "../../agents/embedded-agent-messaging.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
+import { copyReplyPayloadMetadata } from "../reply-payload.js";
 import type { OriginatingChannelType } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import {
@@ -60,7 +61,7 @@ export function resolveFollowupDeliveryPayloads(params: {
     if (stripped.shouldSkip && !hasMedia) {
       continue;
     }
-    sanitizedPayloads.push({ ...payload, text: stripped.text });
+    sanitizedPayloads.push(copyReplyPayloadMetadata(payload, { ...payload, text: stripped.text }));
   }
   const replyTaggedPayloads = applyReplyThreading({
     payloads: sanitizedPayloads,

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1132,6 +1132,7 @@ describe("createFollowupRunner runtime config", () => {
     expect(runCliAgentMock).toHaveBeenCalledOnce();
     const call = requireLastMockCallArg(runCliAgentMock, "run cli agent");
     expect(call.currentInboundEventKind).toBe("room_event");
+    expect(call.persistAssistantTranscript).toBe(false);
     expect(call.currentInboundAudio).toBe(true);
     expect(call.suppressNextUserMessagePersistence).toBe(true);
     expect(call.sourceReplyDeliveryMode).toBe("message_tool_only");
@@ -1309,6 +1310,7 @@ describe("createFollowupRunner runtime config", () => {
       typing: createMockTypingController(),
       typingMode: "instant",
       sessionKey: "main",
+      storePath: "/tmp/sessions.json",
       defaultModel: "anthropic/claude-opus-4-7",
     });
 
@@ -1325,6 +1327,8 @@ describe("createFollowupRunner runtime config", () => {
 
     expect(runCliAgentMock).toHaveBeenCalledOnce();
     const mediaCall = requireLastMockCallArg(runCliAgentMock, "run cli agent");
+    expect(mediaCall.persistAssistantTranscript).toBe(true);
+    expect(mediaCall.storePath).toBe("/tmp/sessions.json");
     const recorder = requireRecord(mediaCall.userTurnTranscriptRecorder, "cli user turn recorder");
     expect(recorder.message).toBe(preparedUserTurnMessage);
   });

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -41,6 +41,7 @@ let createMockTypingController: typeof import("./test-helpers.js").createMockTyp
 let createReplyOperationForTest: typeof import("./reply-run-registry.js").createReplyOperation;
 let replyRunTestingForTest: typeof import("./reply-run-registry.js").testing;
 let cliBackendsTestingForTest: typeof import("../../agents/cli-backends.js").testing;
+let setReplyPayloadMetadataForTest: typeof import("../reply-payload.js").setReplyPayloadMetadata;
 const FOLLOWUP_DEBUG = process.env.OPENCLAW_DEBUG_FOLLOWUP_RUNNER_TEST === "1";
 const FOLLOWUP_TEST_QUEUES = new Map<
   string,
@@ -464,6 +465,8 @@ async function loadFreshFollowupRunnerModuleForTest() {
   ({ createMockFollowupRun, createMockTypingController } = await import("./test-helpers.js"));
   ({ createReplyOperation: createReplyOperationForTest, testing: replyRunTestingForTest } =
     await import("./reply-run-registry.js"));
+  ({ setReplyPayloadMetadata: setReplyPayloadMetadataForTest } =
+    await import("../reply-payload.js"));
 }
 
 function setFastFollowupCliBackendDeps(): void {
@@ -1331,6 +1334,55 @@ describe("createFollowupRunner runtime config", () => {
     expect(mediaCall.storePath).toBe("/tmp/sessions.json");
     const recorder = requireRecord(mediaCall.userTurnTranscriptRecorder, "cli user turn recorder");
     expect(recorder.message).toBe(preparedUserTurnMessage);
+  });
+
+  it("disables routed delivery mirrors for CLI-owned followup payloads", async () => {
+    const runtimeConfig: OpenClawConfig = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+          models: {
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    };
+    runCliAgentMock.mockResolvedValueOnce({
+      payloads: [
+        setReplyPayloadMetadataForTest(
+          { text: "persisted CLI followup" },
+          { assistantTranscriptOwned: true },
+        ),
+      ],
+      meta: {},
+    });
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionKey: "main",
+      defaultModel: "anthropic/claude-opus-4-7",
+    });
+
+    await runner(
+      createQueuedRun({
+        originatingChannel: "telegram",
+        originatingTo: "telegram:-100123",
+        run: {
+          config: runtimeConfig,
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+        },
+      }),
+    );
+
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: "persisted CLI followup" },
+        mirror: false,
+      }),
+    );
   });
 
   it("keeps queued CLI tool progress quiet when verbose progress is disabled", async () => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -29,7 +29,10 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
-import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
+import {
+  getReplyPayloadMetadata,
+  markReplyPayloadForSourceSuppressionDelivery,
+} from "../reply-payload.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   clearDroppedCliSessionBinding,
@@ -383,6 +386,10 @@ export function createFollowupRunner(params: {
 
       // Route to originating channel if set, otherwise fall back to dispatcher.
       if (deliveryRoute === "origin" && isRoutableChannel(originatingChannel) && originatingTo) {
+        const payloadMetadata = getReplyPayloadMetadata(payload);
+        const hasTranscriptOwner =
+          payloadMetadata?.assistantMessageIndex !== undefined ||
+          payloadMetadata?.assistantTranscriptOwned === true;
         const result = await routeReply({
           payload,
           channel: originatingChannel,
@@ -395,7 +402,7 @@ export function createFollowupRunner(params: {
           requesterSenderE164: queued.run.senderE164,
           threadId: queued.originatingThreadId,
           cfg: runtimeConfig,
-          mirror: options.mirror,
+          mirror: hasTranscriptOwner ? false : options.mirror,
           replyKind,
           runId: options.runId,
         });

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -931,6 +931,10 @@ export function createFollowupRunner(params: {
                     suppressNextUserMessagePersistence: suppressQueuedUserPersistenceForCandidate,
                     userTurnTranscriptRecorder,
                     onUserMessagePersisted: notifyUserMessagePersisted,
+                    persistAssistantTranscript:
+                      queued.currentInboundEventKind !== "room_event" &&
+                      run.suppressTranscriptOnlyAssistantPersistence !== true,
+                    storePath,
                     currentInboundEventKind: queued.currentInboundEventKind,
                     currentInboundAudio: queued.currentInboundAudio,
                     currentInboundContext: queued.currentInboundContext,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1730,6 +1730,7 @@ describe("runPreparedReply media-only handling", () => {
       async () => await authPromise.then(() => undefined),
     );
     vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({ mode: "interrupt" });
+    const onSessionPrepared = vi.fn();
 
     const runPromise = runPreparedReply(
       baseParams({
@@ -1737,6 +1738,8 @@ describe("runPreparedReply media-only handling", () => {
         sessionId: "session-before-rotation",
         sessionEntry: sessionStore["session-key"],
         sessionStore,
+        storePath: "/tmp/sessions.json",
+        opts: { onSessionPrepared } as never,
       }),
     );
 
@@ -1768,6 +1771,11 @@ describe("runPreparedReply media-only handling", () => {
     await expect(runPromise).resolves.toEqual({ text: "ok" });
     const call = requireLastRunReplyAgentCall();
     expect(call?.followupRun.run.sessionId).toBe("session-after-rotation");
+    expect(onSessionPrepared).toHaveBeenLastCalledWith({
+      sessionKey: "session-key",
+      sessionId: "session-after-rotation",
+      storePath: "/tmp/sessions.json",
+    });
   });
   it("reports still shutting down when a new owner appears after waiting", async () => {
     vi.useFakeTimers();

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -69,6 +69,7 @@ import type { InlineDirectives } from "./directive-handling.js";
 import { isSystemEventProvider } from "./effective-reply-route.js";
 import { shouldUseReplyFastTestRuntime } from "./get-reply-fast-path.js";
 import { resolvePreparedReplyQueueState } from "./get-reply-run-queue.js";
+import type { ReplySessionBinding } from "./get-reply.types.js";
 import {
   buildDirectChatContext,
   buildGroupChatContext,
@@ -119,6 +120,7 @@ type InternalGetReplyOptions = GetReplyOptions & {
    * can differ from abortSignal when dispatch temporarily borrows an active lane.
    */
   queuedFollowupAbortSignal?: AbortSignal;
+  onSessionPrepared?: (binding: ReplySessionBinding) => void;
 };
 
 type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
@@ -940,6 +942,11 @@ export async function runPreparedReply(
           }).existing ?? sessionEntry)
         : sessionEntry;
     const latestSessionId = latestSessionEntry?.sessionId ?? sessionIdFinal;
+    internalOpts?.onSessionPrepared?.({
+      sessionKey,
+      sessionId: latestSessionId,
+      storePath,
+    });
     return {
       sessionEntry: latestSessionEntry,
       sessionId: latestSessionId,
@@ -1330,8 +1337,7 @@ export async function runPreparedReply(
           : {}),
       },
       timeoutMs,
-      runTimeoutOverrideMs:
-        opts?.timeoutOverrideSeconds !== undefined ? timeoutMs : undefined,
+      runTimeoutOverrideMs: opts?.timeoutOverrideSeconds !== undefined ? timeoutMs : undefined,
       blockReplyBreak: resolvedBlockStreamingBreak,
       ownerNumbers: command.ownerList.length > 0 ? command.ownerList : undefined,
       inputProvenance,

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -222,6 +222,34 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expectResolvedTelegramTimezone(mocks.resolveReplyDirectives);
   });
 
+  it("reports the prepared session binding after session bootstrap", async () => {
+    vi.stubEnv("OPENCLAW_ALLOW_SLOW_REPLY_TESTS", "1");
+    mocks.initSessionState.mockResolvedValue(
+      createGetReplySessionState({
+        sessionKey: "agent:main:slack:channel:C123",
+        sessionId: "rotated-session",
+        storePath: "/tmp/custom-sessions.json",
+      }),
+    );
+    const onSessionPrepared = vi.fn();
+
+    await getReplyFromConfig(
+      buildGetReplyCtx({
+        Provider: "slack",
+        Surface: "slack",
+        SessionKey: "agent:main:slack:channel:C123",
+      }),
+      { onSessionPrepared } as never,
+      {} as OpenClawConfig,
+    );
+
+    expect(onSessionPrepared).toHaveBeenCalledWith({
+      sessionKey: "agent:main:slack:channel:C123",
+      sessionId: "rotated-session",
+      storePath: "/tmp/custom-sessions.json",
+    });
+  });
+
   it("marks configs through withFastReplyConfig()", async () => {
     const cfg = withFastReplyConfig({ session: { store: "/tmp/sessions.json" } } as OpenClawConfig);
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -45,6 +45,7 @@ import {
 import { handleInlineActions } from "./get-reply-inline-actions.js";
 import { maybeResolveNativeSlashCommandFastReply } from "./get-reply-native-slash-fast-path.js";
 import { runPreparedReply } from "./get-reply-run.js";
+import type { ReplySessionBinding } from "./get-reply.types.js";
 import { finalizeInboundContext } from "./inbound-context.js";
 import { hasInboundMedia } from "./inbound-media.js";
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
@@ -59,6 +60,10 @@ import {
 import { createTypingController } from "./typing.js";
 
 type ResetCommandAction = "new" | "reset";
+
+type InternalGetReplyOptions = GetReplyOptions & {
+  onSessionPrepared?: (binding: ReplySessionBinding) => void;
+};
 
 function classifyHeartbeatPendingFinalDelivery(text: string, ackMaxChars: number) {
   const stripped = stripHeartbeatToken(text, {
@@ -496,6 +501,11 @@ export async function getReplyFromConfig(
   } = sessionState;
   let { abortedLastRun } = sessionState;
   resolverTimingSessionKey = sessionKey ?? resolverTimingSessionKey;
+  (resolvedOpts as InternalGetReplyOptions | undefined)?.onSessionPrepared?.({
+    sessionKey,
+    sessionId,
+    storePath,
+  });
 
   if (sessionEntry?.pendingFinalDelivery && sessionEntry.pendingFinalDeliveryText) {
     const text = sanitizePendingFinalDeliveryText(sessionEntry.pendingFinalDeliveryText);

--- a/src/auto-reply/reply/get-reply.types.ts
+++ b/src/auto-reply/reply/get-reply.types.ts
@@ -4,6 +4,12 @@ import type { GetReplyOptions } from "../get-reply-options.types.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
 
+export type ReplySessionBinding = {
+  sessionKey?: string;
+  sessionId: string;
+  storePath?: string;
+};
+
 /** Reply resolver signature used by dispatchers and tests for dependency injection. */
 export type GetReplyFromConfig = (
   ctx: MsgContext,

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -14,6 +14,7 @@ import {
   type ChannelRouteTargetInput,
 } from "../../plugin-sdk/channel-route.js";
 import { normalizeOptionalAccountId } from "../../routing/account-id.js";
+import { copyReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 
 /** Removes text payloads already sent by message tools. */
@@ -85,7 +86,8 @@ export function filterMessagingToolMediaDuplicates(params: {
       continue;
     }
 
-    const nextPayload = Object.assign({}, payload, {
+    const nextPayload = copyReplyPayloadMetadata(payload, {
+      ...payload,
       mediaUrl: stripSingle ? undefined : mediaUrl,
       mediaUrls: filteredUrls?.length ? filteredUrls : undefined,
     });

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import {
   filterMessagingToolMediaDuplicates,
   resolveMessagingToolPayloadDedupe,
@@ -108,6 +109,21 @@ describe("filterMessagingToolMediaDuplicates", () => {
       sentMediaUrls: ["file:///tmp/photo%20one.jpg"],
     });
     expect(result).toEqual([{ text: "hello", mediaUrl: undefined, mediaUrls: undefined }]);
+  });
+
+  it("preserves transcript ownership metadata when stripping media", () => {
+    const payload = setReplyPayloadMetadata(
+      { text: "hello", mediaUrl: "file:///tmp/photo.jpg" },
+      { assistantTranscriptOwned: true },
+    );
+    const [result] = filterMessagingToolMediaDuplicates({
+      payloads: [payload],
+      sentMediaUrls: ["file:///tmp/photo.jpg"],
+    });
+
+    expect(getReplyPayloadMetadata(result)).toEqual({
+      assistantTranscriptOwned: true,
+    });
   });
 });
 

--- a/src/channels/plugins/acp-stateful-target-driver.test.ts
+++ b/src/channels/plugins/acp-stateful-target-driver.test.ts
@@ -6,6 +6,8 @@ const resetMocks = vi.hoisted(() => ({
     ok: true as const,
     key: "agent:claude:acp:binding:discord:default:9373ab192b2317f4",
     entry: { sessionId: "next-session", updatedAt: 1 },
+    agentId: "claude",
+    storePath: "/tmp/claude-sessions.json",
   })),
 }));
 const sessionMetaMocks = vi.hoisted(() => ({
@@ -53,7 +55,12 @@ describe("acpStatefulBindingTargetDriver", () => {
           agentId: "claude",
         },
       }),
-    ).resolves.toEqual({ ok: true });
+    ).resolves.toEqual({
+      ok: true,
+      sessionKey: "agent:claude:acp:binding:discord:default:9373ab192b2317f4",
+      sessionId: "next-session",
+      storePath: "/tmp/claude-sessions.json",
+    });
 
     expect(resetMocks.performGatewaySessionReset).toHaveBeenCalledWith({
       key: "agent:claude:acp:binding:discord:default:9373ab192b2317f4",

--- a/src/channels/plugins/acp-stateful-target-driver.ts
+++ b/src/channels/plugins/acp-stateful-target-driver.ts
@@ -125,7 +125,12 @@ async function resetAcpTargetInPlace(params: {
     commandSource: params.commandSource ?? "stateful-target:acp-reset-in-place",
   });
   if (result.ok) {
-    return { ok: true };
+    return {
+      ok: true,
+      sessionKey: result.key,
+      sessionId: result.entry.sessionId,
+      storePath: result.storePath,
+    };
   }
   return {
     ok: false,

--- a/src/channels/plugins/binding-targets.ts
+++ b/src/channels/plugins/binding-targets.ts
@@ -12,6 +12,7 @@ import {
 import {
   getStatefulBindingTargetDriver,
   resolveStatefulBindingTargetBySessionKey,
+  type StatefulBindingTargetResetResult,
 } from "./stateful-target-drivers.js";
 
 /**
@@ -52,7 +53,7 @@ export async function resetConfiguredBindingTargetInPlace(params: {
   sessionKey: string;
   reason: "new" | "reset";
   commandSource?: string;
-}): Promise<{ ok: true } | { ok: false; skipped?: boolean; error?: string }> {
+}): Promise<StatefulBindingTargetResetResult> {
   let resolved = resolveStatefulBindingTargetBySessionKey({
     cfg: params.cfg,
     sessionKey: params.sessionKey,

--- a/src/channels/plugins/stateful-target-drivers.ts
+++ b/src/channels/plugins/stateful-target-drivers.ts
@@ -14,7 +14,7 @@ export type StatefulBindingTargetSessionResult =
   | { ok: true; sessionKey: string }
   | { ok: false; sessionKey: string; error: string };
 export type StatefulBindingTargetResetResult =
-  | { ok: true }
+  | { ok: true; sessionKey?: string; sessionId?: string; storePath?: string }
   | { ok: false; skipped?: boolean; error?: string };
 
 /** Driver contract for lifecycle operations on one stateful target family. */

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -937,6 +937,43 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     ]);
   });
 
+  it("dedupes unkeyed delivery mirrors after before_message_write rewrites", async () => {
+    writeTranscriptStore();
+    const beforeMessageWrite = vi.fn(({ message }: BeforeMessageWriteParams) => ({
+      ...message,
+      content: [{ type: "text" as const, text: "[redacted by hook]" }],
+    }));
+    const append = () =>
+      appendAssistantMessageToSessionTranscript({
+        sessionKey,
+        storePath: fixture.storePath(),
+        text: "secret output",
+        beforeMessageWrite,
+      });
+
+    const first = await append();
+    const replay = await append();
+
+    expect(first.ok).toBe(true);
+    expect(replay.ok).toBe(true);
+    expect(beforeMessageWrite).toHaveBeenCalledTimes(2);
+    if (!first.ok) {
+      throw new Error("expected delivery mirror append to succeed");
+    }
+    const messages = fs
+      .readFileSync(first.sessionFile, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { message?: ExactAssistantMessage })
+      .flatMap((entry) => (entry.message ? [entry.message] : []));
+    expect(messages).toEqual([
+      expect.objectContaining({
+        role: "assistant",
+        content: [{ type: "text", text: "[redacted by hook]" }],
+      }),
+    ]);
+  });
+
   it("reports assistant messages blocked by before_message_write", async () => {
     writeTranscriptStore();
 

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -7,6 +7,7 @@ import { repairToolUseResultPairing } from "../../agents/session-transcript-repa
 import * as transcriptEvents from "../../sessions/transcript-events.js";
 import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { resolveSessionTranscriptPathInDir } from "./paths.js";
+import { updateSessionStoreEntry } from "./store.js";
 import { useTempSessionsFixture } from "./test-helpers.js";
 import { appendSessionTranscriptMessage } from "./transcript-append.js";
 import {
@@ -48,6 +49,11 @@ describe("appendAssistantMessageToSessionTranscript", () => {
   type ExactAssistantMessage = Parameters<
     typeof appendExactAssistantMessageToSessionTranscript
   >[0]["message"];
+  type BeforeMessageWriteParams = Parameters<
+    NonNullable<
+      Parameters<typeof appendExactAssistantMessageToSessionTranscript>[0]["beforeMessageWrite"]
+    >
+  >[0];
   type TranscriptRepairMessage = Parameters<typeof repairToolUseResultPairing>[0][number];
   type TranscriptUpdateEmitterSpy = {
     mock: {
@@ -461,6 +467,46 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     }
   });
 
+  it("idempotently appends identified channel finals while preserving repeated replies", async () => {
+    writeTranscriptStore();
+
+    const first = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Repeated command reply",
+      storePath: fixture.storePath(),
+      idempotencyKey: "channel-final:message-1:0",
+      deliveryMirror: { kind: "channel-final", sourceMessageId: "message-1" },
+    });
+    const replay = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Repeated command reply",
+      storePath: fixture.storePath(),
+      idempotencyKey: "channel-final:message-1:0",
+      deliveryMirror: { kind: "channel-final", sourceMessageId: "message-1" },
+    });
+    const nextTurn = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Repeated command reply",
+      storePath: fixture.storePath(),
+      idempotencyKey: "channel-final:message-2:0",
+      deliveryMirror: { kind: "channel-final", sourceMessageId: "message-2" },
+    });
+
+    expect(first.ok).toBe(true);
+    expect(replay.ok).toBe(true);
+    expect(nextTurn.ok).toBe(true);
+    if (first.ok && replay.ok && nextTurn.ok) {
+      expect(replay.messageId).toBe(first.messageId);
+      expect(nextTurn.messageId).not.toBe(first.messageId);
+      const lines = fs.readFileSync(first.sessionFile, "utf-8").trim().split("\n");
+      expect(lines).toHaveLength(3);
+      expect(JSON.parse(lines[1]).message.openclawDeliveryMirror).toEqual({
+        kind: "channel-final",
+        sourceMessageId: "message-1",
+      });
+    }
+  });
+
   it("dedupes against the latest assistant even when a large user entry follows it", async () => {
     writeTranscriptStore();
 
@@ -850,6 +896,141 @@ describe("appendAssistantMessageToSessionTranscript", () => {
         },
       ]);
     }
+  });
+
+  it("applies before_message_write after idempotency checks and preserves the key", async () => {
+    writeTranscriptStore();
+    const beforeMessageWrite = vi.fn(({ message }: BeforeMessageWriteParams) => ({
+      ...message,
+      content: [{ type: "text" as const, text: "[redacted by hook]" }],
+    }));
+    const append = () =>
+      appendExactAssistantMessageToSessionTranscript({
+        sessionKey,
+        storePath: fixture.storePath(),
+        idempotencyKey: "cli-assistant:redacted",
+        beforeMessageWrite,
+        message: createExactAssistantMessage({ text: "secret output" }),
+      });
+
+    const first = await append();
+    const replay = await append();
+
+    expect(first.ok).toBe(true);
+    expect(replay.ok).toBe(true);
+    expect(beforeMessageWrite).toHaveBeenCalledOnce();
+    if (!first.ok) {
+      throw new Error("expected assistant append to succeed");
+    }
+    const messages = fs
+      .readFileSync(first.sessionFile, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { message?: ExactAssistantMessage })
+      .flatMap((entry) => (entry.message ? [entry.message] : []));
+    expect(messages).toEqual([
+      expect.objectContaining({
+        role: "assistant",
+        content: [{ type: "text", text: "[redacted by hook]" }],
+        idempotencyKey: "cli-assistant:redacted",
+      }),
+    ]);
+  });
+
+  it("reports assistant messages blocked by before_message_write", async () => {
+    writeTranscriptStore();
+
+    const result = await appendExactAssistantMessageToSessionTranscript({
+      agentId: "main",
+      sessionKey,
+      storePath: fixture.storePath(),
+      idempotencyKey: "cli-assistant:blocked",
+      beforeMessageWrite: vi.fn(() => null),
+      message: createExactAssistantMessage({ text: "secret output" }),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "blocked",
+    });
+  });
+
+  it("rejects assistant output after the session key is rebound", async () => {
+    fs.writeFileSync(
+      fixture.storePath(),
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "replacement-session",
+          chatType: "direct",
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      expectedSessionId: sessionId,
+      storePath: fixture.storePath(),
+      message: createExactAssistantMessage({ text: "late output" }),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "session-rebound",
+    });
+    expect(
+      fs.existsSync(
+        resolveSessionTranscriptPathInDir("replacement-session", fixture.sessionsDir()),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a concurrent session rebind before the assistant append", async () => {
+    writeTranscriptStore();
+    let releaseReset = () => {};
+    const resetGate = new Promise<void>((resolve) => {
+      releaseReset = resolve;
+    });
+    let markResetStarted = () => {};
+    const resetStarted = new Promise<void>((resolve) => {
+      markResetStarted = resolve;
+    });
+    const replacementSessionFile = resolveSessionTranscriptPathInDir(
+      "replacement-session",
+      fixture.sessionsDir(),
+    );
+    const reset = updateSessionStoreEntry({
+      storePath: fixture.storePath(),
+      sessionKey,
+      update: async () => {
+        markResetStarted();
+        await resetGate;
+        return {
+          sessionId: "replacement-session",
+          sessionFile: replacementSessionFile,
+        };
+      },
+    });
+    await resetStarted;
+
+    const append = appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      expectedSessionId: sessionId,
+      storePath: fixture.storePath(),
+      message: createExactAssistantMessage({ text: "late output" }),
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    releaseReset();
+
+    await reset;
+    const result = await append;
+    expect(result).toMatchObject({
+      ok: false,
+      code: "session-rebound",
+    });
+    expect(fs.existsSync(replacementSessionFile)).toBe(false);
   });
 
   it("dedupes concurrent exact assistant appends by idempotency key", async () => {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -66,6 +66,30 @@ type AssistantBeforeMessageWrite = (params: {
   sessionKey?: string;
 }) => AgentMessage | null;
 
+function applyBeforeMessageWriteToAssistant(params: {
+  message: Parameters<SessionManager["appendMessage"]>[0];
+  beforeMessageWrite?: AssistantBeforeMessageWrite;
+  explicitIdempotencyKey?: string;
+  agentId?: string;
+  sessionKey: string;
+}): Parameters<SessionManager["appendMessage"]>[0] | undefined {
+  if (!params.beforeMessageWrite) {
+    return params.message;
+  }
+  const nextMessage = params.beforeMessageWrite({
+    message: params.message as AgentMessage,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    sessionKey: params.sessionKey,
+  });
+  if (nextMessage?.role !== "assistant") {
+    return undefined;
+  }
+  return {
+    ...nextMessage,
+    ...(params.explicitIdempotencyKey ? { idempotencyKey: params.explicitIdempotencyKey } : {}),
+  } as Parameters<SessionManager["appendMessage"]>[0];
+}
+
 type AssistantTranscriptText = {
   id?: string;
   text: string;
@@ -319,13 +343,33 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
         const explicitIdempotencyKey =
           params.idempotencyKey ??
           ((params.message as { idempotencyKey?: unknown }).idempotencyKey as string | undefined);
+        const message = {
+          ...params.message,
+          ...(explicitIdempotencyKey ? { idempotencyKey: explicitIdempotencyKey } : {}),
+        } as Parameters<SessionManager["appendMessage"]>[0];
+        const preparedUnkeyedMessage =
+          !explicitIdempotencyKey && params.beforeMessageWrite
+            ? applyBeforeMessageWriteToAssistant({
+                message,
+                beforeMessageWrite: params.beforeMessageWrite,
+                agentId: params.agentId,
+                sessionKey: resolved.normalizedKey,
+              })
+            : message;
+        if (!preparedUnkeyedMessage) {
+          return {
+            ok: false,
+            code: "blocked",
+            reason: "blocked by before_message_write",
+          };
+        }
         const identifiedChannelFinal =
           Boolean(explicitIdempotencyKey) && isChannelFinalDeliveryMirror(params.message);
         const latestEquivalentAssistantId =
           isRedundantDeliveryMirror(params.message) && !identifiedChannelFinal
             ? await findLatestEquivalentAssistantMessageId(
                 sessionFile,
-                params.message,
+                preparedUnkeyedMessage as SessionTranscriptAssistantMessage,
                 params.config,
               )
             : undefined;
@@ -334,10 +378,6 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
         if (latestEquivalentAssistantId) {
           return { ok: true, sessionFile, messageId: latestEquivalentAssistantId };
         }
-        const message = {
-          ...params.message,
-          ...(explicitIdempotencyKey ? { idempotencyKey: explicitIdempotencyKey } : {}),
-        } as Parameters<SessionManager["appendMessage"]>[0];
         const appendedResult = await runWithOwnedSessionTranscriptWritePublication(
           { sessionFile, sessionKey: resolved.normalizedKey },
           async () => {
@@ -348,28 +388,20 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
             });
             return await appendSessionTranscriptMessage({
               transcriptPath: sessionFile,
-              message,
+              message: preparedUnkeyedMessage,
               ...(explicitIdempotencyKey ? { idempotencyLookup: "scan" } : {}),
-              ...(params.beforeMessageWrite
+              ...(explicitIdempotencyKey && params.beforeMessageWrite
                 ? {
                     prepareMessageAfterIdempotencyCheck: (
                       candidate: Parameters<SessionManager["appendMessage"]>[0],
-                    ) => {
-                      const nextMessage = params.beforeMessageWrite?.({
-                        message: candidate as AgentMessage,
-                        ...(params.agentId ? { agentId: params.agentId } : {}),
+                    ) =>
+                      applyBeforeMessageWriteToAssistant({
+                        message: candidate,
+                        beforeMessageWrite: params.beforeMessageWrite,
+                        explicitIdempotencyKey,
+                        agentId: params.agentId,
                         sessionKey: resolved.normalizedKey,
-                      });
-                      if (nextMessage?.role !== "assistant") {
-                        return undefined;
-                      }
-                      return {
-                        ...nextMessage,
-                        ...(explicitIdempotencyKey
-                          ? { idempotencyKey: explicitIdempotencyKey }
-                          : {}),
-                      } as Parameters<SessionManager["appendMessage"]>[0];
-                    },
+                      }),
                   }
                 : {}),
               config: params.config,

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -44,13 +44,27 @@ async function ensureSessionHeader(params: {
 
 export type SessionTranscriptAppendResult =
   | { ok: true; sessionFile: string; messageId: string }
-  | { ok: false; reason: string };
+  | {
+      ok: false;
+      reason: string;
+      code?: "blocked" | "session-rebound";
+    };
 
 export type SessionTranscriptUpdateMode = "inline" | "file-only" | "none";
+export type SessionTranscriptDeliveryMirror = {
+  kind: "channel-final";
+  sourceMessageId?: string;
+};
 
 export type SessionTranscriptAssistantMessage = Parameters<SessionManager["appendMessage"]>[0] & {
   role: "assistant";
 };
+
+type AssistantBeforeMessageWrite = (params: {
+  message: AgentMessage;
+  agentId?: string;
+  sessionKey?: string;
+}) => AgentMessage | null;
 
 type AssistantTranscriptText = {
   id?: string;
@@ -199,13 +213,16 @@ export async function readTailAssistantTextFromSessionTranscript(
 export async function appendAssistantMessageToSessionTranscript(params: {
   agentId?: string;
   sessionKey: string;
+  expectedSessionId?: string;
   text?: string;
   mediaUrls?: string[];
   idempotencyKey?: string;
+  deliveryMirror?: SessionTranscriptDeliveryMirror;
   /** Optional override for store path (mostly for tests). */
   storePath?: string;
   updateMode?: SessionTranscriptUpdateMode;
   config?: OpenClawConfig;
+  beforeMessageWrite?: AssistantBeforeMessageWrite;
 }): Promise<SessionTranscriptAppendResult> {
   const sessionKey = params.sessionKey.trim();
   if (!sessionKey) {
@@ -223,10 +240,12 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   return appendExactAssistantMessageToSessionTranscript({
     agentId: params.agentId,
     sessionKey,
+    ...(params.expectedSessionId ? { expectedSessionId: params.expectedSessionId } : {}),
     storePath: params.storePath,
     idempotencyKey: params.idempotencyKey,
     updateMode: params.updateMode,
     config: params.config,
+    ...(params.beforeMessageWrite ? { beforeMessageWrite: params.beforeMessageWrite } : {}),
     message: {
       role: "assistant" as const,
       content: [{ type: "text", text: mirrorText }],
@@ -249,18 +268,21 @@ export async function appendAssistantMessageToSessionTranscript(params: {
       },
       stopReason: "stop" as const,
       timestamp: Date.now(),
-    },
+      ...(params.deliveryMirror ? { openclawDeliveryMirror: params.deliveryMirror } : {}),
+    } as SessionTranscriptAssistantMessage,
   });
 }
 
 export async function appendExactAssistantMessageToSessionTranscript(params: {
   agentId?: string;
   sessionKey: string;
+  expectedSessionId?: string;
   message: SessionTranscriptAssistantMessage;
   idempotencyKey?: string;
   storePath?: string;
   updateMode?: SessionTranscriptUpdateMode;
   config?: OpenClawConfig;
+  beforeMessageWrite?: AssistantBeforeMessageWrite;
 }): Promise<SessionTranscriptAppendResult> {
   const sessionKey = params.sessionKey.trim();
   if (!sessionKey) {
@@ -274,102 +296,178 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
   const store = loadSessionStore(storePath, { skipCache: true });
   const resolved = resolveSessionStoreEntry({ store, sessionKey });
   const entry = resolved.existing;
+  if (params.expectedSessionId && entry?.sessionId !== params.expectedSessionId) {
+    return {
+      ok: false,
+      code: "session-rebound",
+      reason: `session rebound for sessionKey: ${sessionKey}`,
+    };
+  }
   if (!entry?.sessionId) {
     return { ok: false, reason: `unknown sessionKey: ${sessionKey}` };
   }
 
-  let sessionFile: string;
-  try {
-    const resolvedSessionFile = await resolveAndPersistSessionFile({
-      sessionId: entry.sessionId,
-      sessionKey: resolved.normalizedKey,
-      sessionStore: store,
-      storePath,
-      sessionEntry: entry,
-      agentId: params.agentId,
-      sessionsDir: path.dirname(storePath),
-    });
-    sessionFile = resolvedSessionFile.sessionFile;
-  } catch (err) {
-    return {
-      ok: false,
-      reason: formatErrorMessage(err),
-    };
-  }
-
   let transcriptMarkerUpdatedAt: number | undefined;
-  const result = await runWithOwnedSessionTranscriptWriteLock<SessionTranscriptAppendResult>(
-    { sessionFile, sessionKey: resolved.normalizedKey },
-    async (): Promise<SessionTranscriptAppendResult> => {
-      const explicitIdempotencyKey =
-        params.idempotencyKey ??
-        ((params.message as { idempotencyKey?: unknown }).idempotencyKey as string | undefined);
-      const latestEquivalentAssistantId = isRedundantDeliveryMirror(params.message)
-        ? await findLatestEquivalentAssistantMessageId(sessionFile, params.message, params.config)
-        : undefined;
-      // Delivery mirrors can be replayed after restart; suppress only when the latest assistant text
-      // is exactly the same post-redaction.
-      if (latestEquivalentAssistantId) {
-        return { ok: true, sessionFile, messageId: latestEquivalentAssistantId };
-      }
-      const message = {
-        ...params.message,
-        ...(explicitIdempotencyKey ? { idempotencyKey: explicitIdempotencyKey } : {}),
-      } as Parameters<SessionManager["appendMessage"]>[0];
-      const {
-        messageId,
-        message: appendedMessage,
-        appended,
-      } = await runWithOwnedSessionTranscriptWritePublication(
-        { sessionFile, sessionKey: resolved.normalizedKey },
-        async () => {
-          await ensureSessionHeader({
-            sessionFile,
-            sessionId: entry.sessionId,
-            cwd: entry.spawnedCwd,
-          });
-          return await appendSessionTranscriptMessage({
-            transcriptPath: sessionFile,
-            message,
-            ...(explicitIdempotencyKey ? { idempotencyLookup: "scan" } : {}),
-            config: params.config,
-          });
-        },
-      );
-      if (!appended) {
-        return { ok: true, sessionFile, messageId };
-      }
-      transcriptMarkerUpdatedAt = Date.now();
+  let appendedSessionId = entry.sessionId;
+  const appendToSessionFile = async (
+    currentEntry: SessionEntry,
+    sessionFile: string,
+  ): Promise<SessionTranscriptAppendResult> =>
+    await runWithOwnedSessionTranscriptWriteLock<SessionTranscriptAppendResult>(
+      { sessionFile, sessionKey: resolved.normalizedKey },
+      async (): Promise<SessionTranscriptAppendResult> => {
+        const explicitIdempotencyKey =
+          params.idempotencyKey ??
+          ((params.message as { idempotencyKey?: unknown }).idempotencyKey as string | undefined);
+        const identifiedChannelFinal =
+          Boolean(explicitIdempotencyKey) && isChannelFinalDeliveryMirror(params.message);
+        const latestEquivalentAssistantId =
+          isRedundantDeliveryMirror(params.message) && !identifiedChannelFinal
+            ? await findLatestEquivalentAssistantMessageId(
+                sessionFile,
+                params.message,
+                params.config,
+              )
+            : undefined;
+        // Unidentified delivery mirrors dedupe by latest text. Identified channel finals use their
+        // idempotency key so repeated replies on separate user turns remain distinct.
+        if (latestEquivalentAssistantId) {
+          return { ok: true, sessionFile, messageId: latestEquivalentAssistantId };
+        }
+        const message = {
+          ...params.message,
+          ...(explicitIdempotencyKey ? { idempotencyKey: explicitIdempotencyKey } : {}),
+        } as Parameters<SessionManager["appendMessage"]>[0];
+        const appendedResult = await runWithOwnedSessionTranscriptWritePublication(
+          { sessionFile, sessionKey: resolved.normalizedKey },
+          async () => {
+            await ensureSessionHeader({
+              sessionFile,
+              sessionId: currentEntry.sessionId,
+              cwd: currentEntry.spawnedCwd,
+            });
+            return await appendSessionTranscriptMessage({
+              transcriptPath: sessionFile,
+              message,
+              ...(explicitIdempotencyKey ? { idempotencyLookup: "scan" } : {}),
+              ...(params.beforeMessageWrite
+                ? {
+                    prepareMessageAfterIdempotencyCheck: (
+                      candidate: Parameters<SessionManager["appendMessage"]>[0],
+                    ) => {
+                      const nextMessage = params.beforeMessageWrite?.({
+                        message: candidate as AgentMessage,
+                        ...(params.agentId ? { agentId: params.agentId } : {}),
+                        sessionKey: resolved.normalizedKey,
+                      });
+                      if (nextMessage?.role !== "assistant") {
+                        return undefined;
+                      }
+                      return {
+                        ...nextMessage,
+                        ...(explicitIdempotencyKey
+                          ? { idempotencyKey: explicitIdempotencyKey }
+                          : {}),
+                      } as Parameters<SessionManager["appendMessage"]>[0];
+                    },
+                  }
+                : {}),
+              config: params.config,
+            });
+          },
+        );
+        if (!appendedResult) {
+          return {
+            ok: false,
+            code: "blocked",
+            reason: "blocked by before_message_write",
+          };
+        }
+        const { messageId, message: appendedMessage, appended } = appendedResult;
+        if (!appended) {
+          return { ok: true, sessionFile, messageId };
+        }
+        transcriptMarkerUpdatedAt = Date.now();
 
-      switch (params.updateMode ?? "inline") {
-        case "inline":
-          emitSessionTranscriptUpdate({
-            sessionFile,
-            sessionKey,
-            ...(params.agentId ? { agentId: params.agentId } : {}),
-            message: appendedMessage,
-            messageId,
-          });
-          break;
-        case "file-only":
-          emitSessionTranscriptUpdate({
-            sessionFile,
-            sessionKey,
-            ...(params.agentId ? { agentId: params.agentId } : {}),
-          });
-          break;
-        case "none":
-          break;
-      }
-      return { ok: true, sessionFile, messageId };
-    },
-  );
+        switch (params.updateMode ?? "inline") {
+          case "inline":
+            emitSessionTranscriptUpdate({
+              sessionFile,
+              sessionKey,
+              ...(params.agentId ? { agentId: params.agentId } : {}),
+              message: appendedMessage,
+              messageId,
+            });
+            break;
+          case "file-only":
+            emitSessionTranscriptUpdate({
+              sessionFile,
+              sessionKey,
+              ...(params.agentId ? { agentId: params.agentId } : {}),
+            });
+            break;
+          case "none":
+            break;
+        }
+        return { ok: true, sessionFile, messageId };
+      },
+    );
+
+  let result: SessionTranscriptAppendResult;
+  if (params.expectedSessionId) {
+    result = {
+      ok: false,
+      code: "session-rebound",
+      reason: `session rebound for sessionKey: ${sessionKey}`,
+    };
+    await updateSessionStoreEntry({
+      storePath,
+      sessionKey: resolved.normalizedKey,
+      update: async (currentEntry) => {
+        if (currentEntry.sessionId !== params.expectedSessionId) {
+          return null;
+        }
+        const sessionFile = resolveSessionFilePath(
+          currentEntry.sessionId,
+          currentEntry,
+          resolveSessionFilePathOptions({
+            agentId: params.agentId,
+            storePath,
+          }),
+        );
+        appendedSessionId = currentEntry.sessionId;
+        result = await appendToSessionFile(currentEntry, sessionFile);
+        return currentEntry.sessionFile === sessionFile ? null : { sessionFile };
+      },
+      skipMaintenance: true,
+    });
+  } else {
+    let sessionFile: string;
+    try {
+      const resolvedSessionFile = await resolveAndPersistSessionFile({
+        sessionId: entry.sessionId,
+        sessionKey: resolved.normalizedKey,
+        sessionStore: store,
+        storePath,
+        sessionEntry: entry,
+        agentId: params.agentId,
+        sessionsDir: path.dirname(storePath),
+      });
+      sessionFile = resolvedSessionFile.sessionFile;
+    } catch (err) {
+      return {
+        ok: false,
+        reason: formatErrorMessage(err),
+      };
+    }
+    result = await appendToSessionFile(entry, sessionFile);
+  }
   if (result.ok && transcriptMarkerUpdatedAt !== undefined) {
     await updateSessionStoreEntry({
       storePath,
       sessionKey: resolved.normalizedKey,
       update: (current) =>
-        current.sessionId === entry.sessionId ? { updatedAt: transcriptMarkerUpdatedAt } : null,
+        current.sessionId === appendedSessionId ? { updatedAt: transcriptMarkerUpdatedAt } : null,
     });
   }
   return result;
@@ -377,6 +475,12 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
 
 function isRedundantDeliveryMirror(message: SessionTranscriptAssistantMessage): boolean {
   return message.provider === "openclaw" && message.model === "delivery-mirror";
+}
+
+function isChannelFinalDeliveryMirror(message: SessionTranscriptAssistantMessage): boolean {
+  const marker = (message as { openclawDeliveryMirror?: SessionTranscriptDeliveryMirror })
+    .openclawDeliveryMirror;
+  return isRedundantDeliveryMirror(message) && marker?.kind === "channel-final";
 }
 
 function extractAssistantMessageText(message: SessionTranscriptAssistantMessage): string | null {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -754,7 +754,7 @@ export async function performGatewaySessionReset(params: {
   reason: "new" | "reset";
   commandSource: string;
 }): Promise<
-  | { ok: true; key: string; entry: SessionEntry; agentId: string }
+  | { ok: true; key: string; entry: SessionEntry; agentId: string; storePath: string }
   | { ok: false; error: ReturnType<typeof errorShape> }
 > {
   const resetTarget = (() => {
@@ -1014,5 +1014,11 @@ export async function performGatewaySessionReset(params: {
       reason: "session-reset",
     });
   }
-  return { ok: true, key: target.canonicalKey, entry: next, agentId: target.agentId };
+  return {
+    ok: true,
+    key: target.canonicalKey,
+    entry: next,
+    agentId: target.agentId,
+    storePath,
+  };
 }


### PR DESCRIPTION
## Summary
- Mirror delivered same-channel Slack finals into the owning OpenClaw transcript without duplicating runtime-owned assistant turns.
- Persist successful CLI harness assistant output, preserve delivery-hook rewrites/removals, custom session stores, media/text payloads, and routed-delivery ownership.
- Bind transcript mirroring to the authoritative post-reset/post-queue session identity, including ACP resets and normalized session-key aliases.

## Issue
Fixes #92489

## Real behavior proof

- Behavior addressed: Slack same-channel replies and CLI harness replies now persist exactly one delivered assistant turn in the owning transcript. Reset/session rotation cannot mirror into a stale transcript.
- Real environment tested: Local OpenClaw checkout at PR head `3e6b7a7936bf8089e25cb183b38e07d6f2c423cd` on macOS with Node `v26.3.0`; GitHub CI run `27459816831` on the pushed SHA.
- Exact steps or command run after this patch: Focused and expanded repository test shards via `node scripts/run-vitest.mjs`, `pnpm tsgo:core`, `pnpm tsgo:core:test`, and branch-wide autoreview against `origin/main`.
- Evidence after fix: 813 expanded local tests passed across transcript, CLI runner, auto-reply, reset, ACP binding, and gateway reset surfaces; 303 post-rebase smoke tests passed; both TypeScript lanes passed; GitHub CI, CodeQL, OpenGrep, dependency, lint, type, boundary, and affected test shards passed.
- Observed result after fix: Delivered Slack finals append once; runtime-owned replies do not duplicate; hook-rewritten content is canonical; removed content stays absent; reset acknowledgements use the new session ID/store path; stale-session writes remain rejected.
- What was not tested: No live Slack workspace/API send-and-readback was performed. Blacksmith Testbox `tbx_01ktzwnmdx5v6pc2yhx4pkbymw` hydrated but its hostname failed DNS resolution ([Actions run](https://github.com/openclaw/openclaw/actions/runs/27459830073)); the brokered fallback timed out before lease allocation.

## Verification
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- Expanded touched-surface Vitest run: 813 tests passed.
- Post-rebase smoke run: 303 tests passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output`
- Final autoreview result: no accepted/actionable findings.
- GitHub CI run `27459816831`: passed.
