### PR TITLE
Memory/QMD: isolate mcporter sidecars per agent

### DIFF
--- a/docs/concepts/memory-qmd.md
+++ b/docs/concepts/memory-qmd.md
@@ -92,6 +92,30 @@ The first search may be slow - QMD auto-downloads GGUF models (~2 GB) for
 reranking and query expansion on the first `qmd query` run.
 </Info>
 
+## MCPorter integration
+
+When `memory.qmd.mcporter.enabled` is `true`, OpenClaw routes QMD searches
+through [MCPorter](https://github.com/openclaw/mcporter) instead of spawning a
+new `qmd` process for every search. This keeps the QMD MCP server warm and
+eliminates cold-start overhead on large models.
+
+OpenClaw discovers your existing mcporter configuration in the same order
+mcporter itself uses:
+
+1. `MCPORTER_CONFIG` environment variable, if set.
+2. `<workspaceDir>/config/mcporter.json` (project-scoped).
+3. `$XDG_CONFIG_HOME/mcporter/mcporter.json` (falls back to `~/.mcporter/mcporter.json`).
+
+If your existing `qmd` server entry has any custom material -- environment
+variables, auth headers, relative paths, or `logging.daemon.enabled` -- OpenClaw
+treats it as **external** and routes the daemon through your original mcporter
+config. Otherwise OpenClaw generates a per-agent config under
+`~/.openclaw/agents/<id>/qmd/mcporter/mcporter.json` with the default QMD
+stdio shape (`command: "qmd", args: ["mcp"]`).
+
+The per-agent generated config is rewritten only when its contents actually
+change, so repeated searches do not thrash the filesystem.
+
 ## Search performance and compatibility
 
 OpenClaw keeps the QMD search path compatible with both current and older QMD

--- a/docs/concepts/memory-qmd.md
+++ b/docs/concepts/memory-qmd.md
@@ -92,30 +92,6 @@ The first search may be slow - QMD auto-downloads GGUF models (~2 GB) for
 reranking and query expansion on the first `qmd query` run.
 </Info>
 
-## MCPorter integration
-
-When `memory.qmd.mcporter.enabled` is `true`, OpenClaw routes QMD searches
-through [MCPorter](https://github.com/openclaw/mcporter) instead of spawning a
-new `qmd` process for every search. This keeps the QMD MCP server warm and
-eliminates cold-start overhead on large models.
-
-OpenClaw discovers your existing mcporter configuration in the same order
-mcporter itself uses:
-
-1. `MCPORTER_CONFIG` environment variable, if set.
-2. `<workspaceDir>/config/mcporter.json` (project-scoped).
-3. `$XDG_CONFIG_HOME/mcporter/mcporter.json` (falls back to `~/.mcporter/mcporter.json`).
-
-If your existing `qmd` server entry has any custom material -- environment
-variables, auth headers, relative paths, or `logging.daemon.enabled` -- OpenClaw
-treats it as **external** and routes the daemon through your original mcporter
-config. Otherwise OpenClaw generates a per-agent config under
-`~/.openclaw/agents/<id>/qmd/mcporter/mcporter.json` with the default QMD
-stdio shape (`command: "qmd", args: ["mcp"]`).
-
-The per-agent generated config is rewritten only when its contents actually
-change, so repeated searches do not thrash the filesystem.
-
 ## Search performance and compatibility
 
 OpenClaw keeps the QMD search path compatible with both current and older QMD

--- a/extensions/memory-core/src/memory/qmd-command-client.ts
+++ b/extensions/memory-core/src/memory/qmd-command-client.ts
@@ -1,8 +1,5 @@
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import {
-  createSubsystemLogger,
-  resolveGlobalSingleton,
-} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   parseQmdQueryJson,
   resolveCliSpawnInvocation,
@@ -16,15 +13,11 @@ import type {
 import { addTimerTimeoutGraceMs } from "openclaw/plugin-sdk/number-runtime";
 import { asRecord } from "../dreaming-shared.js";
 import { asQmdAbortError, parseFailedQmdSearchJson } from "./qmd-command-errors.js";
+import { QmdMcporterClient } from "./qmd-mcporter-client.js";
+import { parseMcporterResponseJson } from "./qmd-mcporter-config.js";
 import type { MemorySearchDeadlineAction } from "./search-deadline.js";
 
 const log = createSubsystemLogger("memory");
-const MCPORTER_STATE_KEY = Symbol.for("openclaw.mcporterState");
-
-type McporterState = {
-  coldStartWarned: boolean;
-  daemonStart: Promise<void> | null;
-};
 
 type BuiltinQmdMcpTool = "query" | "search" | "vector_search" | "deep_search";
 
@@ -60,13 +53,6 @@ export function resolveQmdMcporterSearchProcessTimeoutMs(timeoutMs: number): num
   return Math.max(addTimerTimeoutGraceMs(timeoutMs, 2_000) ?? 1, 5_000);
 }
 
-function getMcporterState(): McporterState {
-  return resolveGlobalSingleton<McporterState>(MCPORTER_STATE_KEY, () => ({
-    coldStartWarned: false,
-    daemonStart: null,
-  }));
-}
-
 async function runInQmdCommandPhase<T>(
   report: QmdCommandPhaseReporter | undefined,
   task: () => Promise<T>,
@@ -81,13 +67,25 @@ async function runInQmdCommandPhase<T>(
 
 export class QmdCommandClient {
   private qmdMcpToolVersion: "v2" | "v1" | null = null;
+  private readonly mcporter: QmdMcporterClient;
 
   constructor(
     private readonly qmd: ResolvedQmdConfig,
     private readonly env: NodeJS.ProcessEnv,
     private readonly workspaceDir: string,
     private readonly maxOutputChars: number,
-  ) {}
+    qmdDir: string,
+    mcporterEnv: NodeJS.ProcessEnv,
+  ) {
+    this.mcporter = new QmdMcporterClient({
+      qmd,
+      qmdEnv: env,
+      mcporterEnv,
+      qmdDir,
+      workspaceDir,
+      maxOutputChars,
+    });
+  }
 
   async run(
     args: string[],
@@ -149,7 +147,7 @@ export class QmdCommandClient {
     if (params.signal?.aborted) {
       throw asQmdAbortError(params.signal);
     }
-    await this.ensureMcporterDaemonStarted(params.mcporter);
+    await this.mcporter.ensureDaemonStarted(params.mcporter);
 
     const effectiveTool =
       params.tool === "query" && this.qmdMcpToolVersion === "v1"
@@ -189,7 +187,7 @@ export class QmdCommandClient {
     let result: { stdout: string };
     try {
       result = await runInQmdCommandPhase(params.reportCommandPhase, async () =>
-        this.runMcporter(
+        this.mcporter.run(
           [
             "call",
             selector,
@@ -317,58 +315,10 @@ export class QmdCommandClient {
     }
   }
 
-  private async ensureMcporterDaemonStarted(mcporter: ResolvedQmdMcporterConfig): Promise<void> {
-    if (!mcporter.enabled) {
-      return;
-    }
-    const state = getMcporterState();
-    if (!mcporter.startDaemon) {
-      if (!state.coldStartWarned) {
-        state.coldStartWarned = true;
-        log.warn(
-          "mcporter qmd bridge enabled but startDaemon=false; each query may cold-start QMD MCP. Consider setting memory.qmd.mcporter.startDaemon=true to keep it warm.",
-        );
-      }
-      return;
-    }
-    if (!state.daemonStart) {
-      state.daemonStart = (async () => {
-        try {
-          await this.runMcporter(["daemon", "start"], { timeoutMs: 10_000 });
-        } catch (err) {
-          log.warn(`mcporter daemon start failed: ${String(err)}`);
-          state.daemonStart = null;
-        }
-      })();
-    }
-    await state.daemonStart;
-  }
-
-  private async runMcporter(
-    args: string[],
-    opts?: { timeoutMs?: number; signal?: AbortSignal },
-  ): Promise<{ stdout: string; stderr: string }> {
-    const spawnInvocation = resolveCliSpawnInvocation({
-      command: "mcporter",
-      args,
-      env: this.env,
-      packageName: "mcporter",
-    });
-    return await runCliCommand({
-      commandSummary: `${spawnInvocation.command} ${spawnInvocation.argv.join(" ")}`,
-      spawnInvocation,
-      env: this.env,
-      cwd: this.workspaceDir,
-      timeoutMs: opts?.timeoutMs,
-      maxOutputChars: this.maxOutputChars,
-      signal: opts?.signal,
-    });
-  }
-
   private parseMcporterResults(stdout: string): QmdQueryResult[] {
     let parsedUnknown: unknown;
     try {
-      parsedUnknown = JSON.parse(stdout);
+      parsedUnknown = parseMcporterResponseJson(stdout);
     } catch {
       throw new Error("qmd mcporter returned non-JSON stdout", {
         cause: new Error("mcporter stdout was not valid JSON"),

--- a/extensions/memory-core/src/memory/qmd-manager-base.ts
+++ b/extensions/memory-core/src/memory/qmd-manager-base.ts
@@ -132,11 +132,18 @@ export abstract class QmdManagerBase {
       XDG_CACHE_HOME: this.xdgCacheHome,
       NO_COLOR: "1",
     };
+    const mcporterEnv = {
+      ...process.env,
+      PATH: buildQmdProcessPath(process.env.PATH),
+      NO_COLOR: "1",
+    };
     this.commands = new QmdCommandClient(
       this.qmd,
       this.env,
       this.workspaceDir,
       this.maxQmdOutputChars,
+      this.qmdDir,
+      mcporterEnv,
     );
     this.collectionController = new QmdCollectionController(
       this.qmd,

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3982,17 +3982,19 @@ describe("QmdMemoryManager", () => {
     const commandClient = (
       manager as object as {
         commands: {
-          runMcporter: (
-            args: string[],
-            opts?: { timeoutMs?: number; signal?: AbortSignal },
-          ) => Promise<{ stdout: string; stderr: string }>;
+          mcporter: {
+            run: (
+              args: string[],
+              opts?: { timeoutMs?: number; signal?: AbortSignal },
+            ) => Promise<{ stdout: string; stderr: string }>;
+          };
         };
       }
     ).commands;
-    const originalRunMcporter = commandClient.runMcporter.bind(commandClient);
+    const originalRunMcporter = commandClient.mcporter.run.bind(commandClient.mcporter);
     let injectTimeoutOnce = true;
     const runMcporterSpy = vi
-      .spyOn(commandClient, "runMcporter")
+      .spyOn(commandClient.mcporter, "run")
       .mockImplementation(async (...args) => {
         if (injectTimeoutOnce) {
           injectTimeoutOnce = false;
@@ -4123,10 +4125,19 @@ describe("QmdMemoryManager", () => {
     });
   });
 
-  it("passes manager-scoped XDG env to mcporter commands", async () => {
-    configureQmd({
-      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-    });
+  it("passes agent-scoped QMD env through generated mcporter config", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       if (isMcporterCommand(cmd) && args[0] === "call") {
@@ -4144,12 +4155,29 @@ describe("QmdMemoryManager", () => {
     const searchCall = requireValue(mcporterCall, "mcporter search call missing");
     const spawnOpts = searchCall[2] as { env?: NodeJS.ProcessEnv } | undefined;
     const normalizePath = (value?: string) => value?.replace(/\\/g, "/");
-    expect(normalizePath(spawnOpts?.env?.XDG_CONFIG_HOME)).toContain("/agents/main/qmd/xdg-config");
-    expect(normalizePath(spawnOpts?.env?.QMD_CONFIG_DIR)).toContain(
+    expect(spawnOpts?.env?.XDG_CONFIG_HOME).toBeUndefined();
+    expect(spawnOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
+    expect(spawnOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
+    expect(spawnOpts?.env?.MCPORTER_CONFIG).toBeUndefined();
+    expect(spawnOpts?.env?.PATH?.split(path.delimiter)).toContain(path.dirname(process.execPath));
+
+    const args = searchCall[1] as string[];
+    const configPath = requireValue(
+      args[args.indexOf("--config") + 1],
+      "mcporter config path missing",
+    );
+    const config = JSON.parse(await fs.readFile(configPath, "utf8")) as {
+      mcpServers?: { qmd?: { env?: NodeJS.ProcessEnv } };
+    };
+    expect(normalizePath(config.mcpServers?.qmd?.env?.XDG_CONFIG_HOME)).toContain(
+      "/agents/main/qmd/xdg-config",
+    );
+    expect(normalizePath(config.mcpServers?.qmd?.env?.QMD_CONFIG_DIR)).toContain(
       "/agents/main/qmd/xdg-config/qmd",
     );
-    expect(normalizePath(spawnOpts?.env?.XDG_CACHE_HOME)).toContain("/agents/main/qmd/xdg-cache");
-    expect(spawnOpts?.env?.PATH?.split(path.delimiter)).toContain(path.dirname(process.execPath));
+    expect(normalizePath(config.mcpServers?.qmd?.env?.XDG_CACHE_HOME)).toContain(
+      "/agents/main/qmd/xdg-cache",
+    );
 
     await manager.close();
   });
@@ -6447,6 +6475,285 @@ describe("QmdMemoryManager", () => {
     const pathOnly = parseShownQmdCollection("Collection: x\n  Path:  /some/path\n");
     expect(pathOnly.path).toBe("/some/path");
     expect(pathOnly.pattern).toBeUndefined();
+  });
+
+  it("reads project config when MCPORTER_CONFIG is unset", async () => {
+    delete process.env.MCPORTER_CONFIG;
+    delete process.env.XDG_CONFIG_HOME;
+
+    const projectConfigDir = path.join(workspaceDir, "config");
+    await fs.mkdir(projectConfigDir, { recursive: true });
+    const projectMcporterConfig = path.join(projectConfigDir, "mcporter.json");
+    await fs.writeFile(
+      projectMcporterConfig,
+      JSON.stringify({
+        mcpServers: {
+          qmd: {
+            command: "qmd",
+            args: ["mcp"],
+            env: { PROJECT_KEEP: "1" },
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "qmd",
+            source: "user",
+            command: "qmd",
+            args: ["mcp"],
+            env: { PROJECT_KEEP: "1" },
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    const callOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(args).not.toContain("--config");
+    expect(callOpts?.env?.MCPORTER_CONFIG).toBeUndefined();
+    expect(callOpts?.env?.XDG_CONFIG_HOME).toBeUndefined();
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+
+    await manager.close();
+  });
+
+  it("preserves MCPORTER_CONFIG precedence over project config", async () => {
+    const userMcporterConfig = path.join(tmpRoot, "user-mcporter.json");
+    await fs.writeFile(
+      userMcporterConfig,
+      JSON.stringify({
+        mcpServers: {
+          qmd: {
+            command: "qmd",
+            args: ["mcp"],
+            env: { USER_KEEP: "1" },
+          },
+        },
+      }),
+      "utf8",
+    );
+    process.env.MCPORTER_CONFIG = userMcporterConfig;
+    process.env.XDG_CONFIG_HOME = path.join(tmpRoot, "user-xdg-config");
+
+    const projectConfigDir = path.join(workspaceDir, "config");
+    await fs.mkdir(projectConfigDir, { recursive: true });
+    const projectMcporterConfig = path.join(projectConfigDir, "mcporter.json");
+    await fs.writeFile(
+      projectMcporterConfig,
+      JSON.stringify({
+        mcpServers: {
+          qmd: {
+            command: "qmd",
+            args: ["mcp"],
+            env: { PROJECT_KEEP: "1" },
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    let configCallCount = 0;
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        configCallCount += 1;
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "qmd",
+            source: { kind: "local", path: userMcporterConfig },
+            command: "qmd",
+            args: ["mcp"],
+            env: { USER_KEEP: "1" },
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    expect(configCallCount).toBe(1);
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    const callOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(args).not.toContain("--config");
+    expect(callOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
+    expect(callOpts?.env?.XDG_CONFIG_HOME).toBe(path.join(tmpRoot, "user-xdg-config"));
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+
+    await manager.close();
+  });
+
+  it("does not use an imported editor config as MCPORTER_CONFIG", async () => {
+    const editorConfig = path.join(tmpRoot, "editor-mcp.json");
+    await fs.writeFile(editorConfig, JSON.stringify({ mcpServers: { qmd: {} } }), "utf8");
+    process.env.XDG_CONFIG_HOME = path.join(tmpRoot, "user-xdg-config");
+
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "qmd",
+            source: { kind: "import", path: editorConfig, importKind: "claude" },
+            command: "qmd",
+            args: ["mcp"],
+            env: { IMPORT_KEEP: "1" },
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    const callOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(args).not.toContain("--config");
+    expect(callOpts?.env?.MCPORTER_CONFIG).toBeUndefined();
+    expect(callOpts?.env?.XDG_CONFIG_HOME).toBe(path.join(tmpRoot, "user-xdg-config"));
+
+    await manager.close();
+  });
+
+  it("does not rewrite unchanged generated mcporter config on repeated searches", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: true },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "daemon") {
+        emitAndClose(child, "stdout", "");
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("one", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    const configPath = requireValue(args[args.indexOf("--config") + 1], "config path missing");
+    const firstContents = await fs.readFile(configPath, "utf8");
+    const stableTimestamp = new Date("2026-01-02T03:04:05.123Z");
+    await fs.utimes(configPath, stableTimestamp, stableTimestamp);
+    const beforeSecondSearch = await fs.stat(configPath);
+
+    await manager.search("two", { sessionKey: "agent:main:slack:dm:u123" });
+
+    expect(await fs.readFile(configPath, "utf8")).toBe(firstContents);
+    expect((await fs.stat(configPath)).mtimeMs).toBe(beforeSecondSearch.mtimeMs);
+    const daemonStarts = spawnMock.mock.calls.filter(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "daemon",
+    );
+    expect(daemonStarts).toHaveLength(1);
+
+    await manager.close();
   });
 
   it("parseListedQmdCollections accepts uppercase bare collection names", () => {

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -269,6 +269,8 @@ const spawnMock = mockedSpawn as unknown as Mock;
 const originalPath = process.env.PATH;
 const originalPathExt = process.env.PATHEXT;
 const originalWindowsPath = process.env.Path;
+const originalMcporterConfig = process.env.MCPORTER_CONFIG;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
 const originalQmdStateDir = process.env.OPENCLAW_STATE_DIR;
 
 function expectedQmdProvenance(originClass: "agent" | "untrusted") {
@@ -1208,6 +1210,16 @@ describe("QmdMemoryManager", () => {
       delete process.env.Path;
     } else {
       process.env.Path = originalWindowsPath;
+    }
+    if (originalMcporterConfig === undefined) {
+      delete process.env.MCPORTER_CONFIG;
+    } else {
+      process.env.MCPORTER_CONFIG = originalMcporterConfig;
+    }
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
     }
     delete (globalThis as Record<PropertyKey, unknown>)[MCPORTER_STATE_KEY];
     delete (globalThis as Record<PropertyKey, unknown>)[QMD_EMBED_QUEUE_KEY];

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -6662,6 +6662,115 @@ describe("QmdMemoryManager", () => {
 
   it.each([
     {
+      name: "bare baseUrl",
+      remoteDefinition: { baseUrl: "https://bare.example/mcp" },
+    },
+    {
+      name: "opaque URL path and non-auth query data",
+      remoteDefinition: { baseUrl: "https://opaque.example/private/workspace?tenant=internal" },
+    },
+    {
+      name: "canonical unauthenticated HTTP transport with policy",
+      remoteDefinition: {
+        baseUrl: "https://policy.example/mcp",
+        transport: "http",
+        description: "operator-selected endpoint",
+        headers: { Accept: "application/json, text/event-stream" },
+        httpFetch: "node-http1",
+        allowedTools: ["query"],
+      },
+    },
+    {
+      name: "mixed command and remote endpoint",
+      remoteDefinition: {
+        command: "qmd",
+        args: ["mcp"],
+        baseUrl: "https://mixed.example/private?tenant=internal",
+      },
+    },
+    {
+      name: "base_url alias",
+      remoteDefinition: { base_url: "https://base-snake.example/mcp" },
+    },
+    {
+      name: "url alias",
+      remoteDefinition: { url: "https://url.example/mcp" },
+    },
+    {
+      name: "serverUrl alias",
+      remoteDefinition: { serverUrl: "https://server-camel.example/mcp" },
+    },
+    {
+      name: "server_url alias",
+      remoteDefinition: { server_url: "https://server-snake.example/mcp" },
+    },
+  ])(
+    "keeps an unauthenticated remote MCPorter server using $name external config",
+    async ({ remoteDefinition }) => {
+      const userMcporterConfig = path.join(tmpRoot, "remote-mcporter.json");
+      await fs.writeFile(
+        userMcporterConfig,
+        JSON.stringify({ mcpServers: { qmd: remoteDefinition } }),
+        "utf8",
+      );
+      process.env.MCPORTER_CONFIG = userMcporterConfig;
+
+      cfg = {
+        ...cfg,
+        memory: {
+          backend: "qmd",
+          qmd: {
+            includeDefaultMemory: false,
+            update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+            paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+            mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+          },
+        },
+      } as OpenClawConfig;
+
+      spawnMock.mockImplementation((cmd: string, args: string[]) => {
+        const child = createMockChild({ autoClose: false });
+        if (isMcporterCommand(cmd) && args[0] === "config") {
+          emitAndClose(
+            child,
+            "stdout",
+            JSON.stringify({
+              name: "qmd",
+              source: { kind: "local", path: userMcporterConfig },
+              ...remoteDefinition,
+            }),
+          );
+          return child;
+        }
+        if (isMcporterCommand(cmd) && args[0] === "call") {
+          emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+          return child;
+        }
+        emitAndClose(child, "stdout", "[]");
+        return child;
+      });
+
+      const { manager } = await createManager();
+      await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+      const mcporterCall = spawnMock.mock.calls.find(
+        (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+      );
+      const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ??
+        []) as string[];
+      const callOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+      expect(args).not.toContain("--config");
+      expect(callOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
+      await expect(
+        fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+
+      await manager.close();
+    },
+  );
+
+  it.each([
+    {
       name: "command failure",
       configValue: "path",
       emitConfigResult: (child: ReturnType<typeof createMockChild>) =>

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4137,7 +4137,9 @@ describe("QmdMemoryManager", () => {
     });
   });
 
-  it("passes agent-scoped QMD env through generated mcporter config", async () => {
+  it("treats empty MCPORTER_CONFIG as implicit for agent-scoped generated config", async () => {
+    process.env.MCPORTER_CONFIG = "";
+
     cfg = {
       ...cfg,
       memory: {
@@ -6657,6 +6659,100 @@ describe("QmdMemoryManager", () => {
 
     await manager.close();
   });
+
+  it.each([
+    {
+      name: "command failure",
+      configValue: "path",
+      emitConfigResult: (child: ReturnType<typeof createMockChild>) =>
+        emitAndClose(child, "stderr", "config file not found", 1),
+      expectedError: /mcporter server "qmd" is not configured or could not be read/,
+    },
+    {
+      name: "whitespace-only explicit config command failure",
+      configValue: "whitespace",
+      emitConfigResult: (child: ReturnType<typeof createMockChild>) =>
+        emitAndClose(child, "stderr", "config file not found", 1),
+      expectedError: /mcporter server "qmd" is not configured or could not be read/,
+    },
+    {
+      name: "invalid JSON",
+      configValue: "path",
+      emitConfigResult: (child: ReturnType<typeof createMockChild>) =>
+        emitAndClose(child, "stdout", "{"),
+      expectedError: /mcporter server "qmd" returned invalid JSON/,
+    },
+    {
+      name: "non-record JSON",
+      configValue: "path",
+      emitConfigResult: (child: ReturnType<typeof createMockChild>) =>
+        emitAndClose(child, "stdout", JSON.stringify([])),
+      expectedError: /mcporter server "qmd" returned an invalid JSON definition/,
+    },
+    {
+      name: "unsupported definition",
+      configValue: "path",
+      emitConfigResult: (child: ReturnType<typeof createMockChild>) =>
+        emitAndClose(child, "stdout", JSON.stringify({ name: "qmd", source: "user" })),
+      expectedError: /mcporter server "qmd" returned an unsupported definition/,
+    },
+  ])(
+    "rejects $name for explicit MCPORTER_CONFIG instead of generating fallback qmd config",
+    async ({ configValue, emitConfigResult, expectedError }) => {
+      const explicitMcporterConfig =
+        configValue === "whitespace" ? "   " : path.join(tmpRoot, "missing-user-mcporter.json");
+      process.env.MCPORTER_CONFIG = explicitMcporterConfig;
+      delete process.env.XDG_CONFIG_HOME;
+
+      cfg = {
+        ...cfg,
+        memory: {
+          backend: "qmd",
+          qmd: {
+            includeDefaultMemory: false,
+            update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+            paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+            mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+          },
+        },
+      } as OpenClawConfig;
+
+      spawnMock.mockImplementation((cmd: string, args: string[]) => {
+        const child = createMockChild({ autoClose: false });
+        if (isMcporterCommand(cmd) && args[0] === "config") {
+          emitConfigResult(child);
+          return child;
+        }
+        if (isMcporterCommand(cmd) && args[0] === "call") {
+          emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+          return child;
+        }
+        emitAndClose(child, "stdout", "[]");
+        return child;
+      });
+
+      const { manager } = await createManager();
+      await expect(
+        manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" }),
+      ).rejects.toThrow(expectedError);
+
+      const configProbe = spawnMock.mock.calls.find(
+        (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "config",
+      );
+      const probeOpts = configProbe?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+      expect(probeOpts?.env?.MCPORTER_CONFIG).toBe(explicitMcporterConfig);
+      expect(
+        spawnMock.mock.calls.some(
+          (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+        ),
+      ).toBe(false);
+      await expect(
+        fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+
+      await manager.close();
+    },
+  );
 
   it("does not use an imported editor config as MCPORTER_CONFIG", async () => {
     const editorConfig = path.join(tmpRoot, "editor-mcp.json");

--- a/extensions/memory-core/src/memory/qmd-mcporter-client.ts
+++ b/extensions/memory-core/src/memory/qmd-mcporter-client.ts
@@ -1,0 +1,384 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import {
+  createSubsystemLogger,
+  resolveGlobalSingleton,
+} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import {
+  resolveCliSpawnInvocation,
+  runCliCommand,
+} from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
+import {
+  isFileMissingError,
+  type ResolvedQmdConfig,
+  type ResolvedQmdMcporterConfig,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { asRecord } from "../dreaming-shared.js";
+import {
+  extractMcporterSourcePath,
+  hasMcporterRemoteAuthMaterial,
+  hasMcporterStdioLifecycleOrLogging,
+  hasMcporterStdioUserOwnedMaterial,
+  isGeneratedMcporterQmdStdioServer,
+  parseMcporterResponseJson,
+  readRawMcporterEntry,
+  type ConfiguredMcporterServer,
+  type McporterConfigMode,
+  type McporterEnvMode,
+  type RawMcporterEntry,
+} from "./qmd-mcporter-config.js";
+
+const log = createSubsystemLogger("memory");
+const MCPORTER_STATE_KEY = Symbol.for("openclaw.mcporterState");
+
+type McporterState = {
+  coldStartWarned: boolean;
+  daemonStarts: Map<string, Promise<void>>;
+};
+
+function getMcporterState(): McporterState {
+  return resolveGlobalSingleton<McporterState>(MCPORTER_STATE_KEY, () => ({
+    coldStartWarned: false,
+    daemonStarts: new Map(),
+  }));
+}
+
+export class QmdMcporterClient {
+  private readonly mcporterConfigPath: string;
+  private readonly mcporterEnv: NodeJS.ProcessEnv;
+  private externalMcporterConfigPath: string | null = null;
+  private mcporterConfigMode: Promise<McporterConfigMode> | null = null;
+
+  constructor(
+    private readonly params: {
+      qmd: ResolvedQmdConfig;
+      qmdEnv: NodeJS.ProcessEnv;
+      mcporterEnv: NodeJS.ProcessEnv;
+      qmdDir: string;
+      workspaceDir: string;
+      maxOutputChars: number;
+    },
+  ) {
+    this.mcporterConfigPath = path.join(this.params.qmdDir, "mcporter", "mcporter.json");
+    this.mcporterEnv = this.params.mcporterEnv;
+  }
+
+  private get qmd(): ResolvedQmdConfig {
+    return this.params.qmd;
+  }
+  private get env(): NodeJS.ProcessEnv {
+    return this.params.qmdEnv;
+  }
+  private get workspaceDir(): string {
+    return this.params.workspaceDir;
+  }
+  private get maxQmdOutputChars(): number {
+    return this.params.maxOutputChars;
+  }
+
+  async ensureDaemonStarted(mcporter: ResolvedQmdMcporterConfig): Promise<void> {
+    if (!mcporter.enabled) {
+      return;
+    }
+    const configMode = await this.ensureMcporterConfig();
+    const state = getMcporterState();
+    if (!mcporter.startDaemon) {
+      if (!state.coldStartWarned) {
+        state.coldStartWarned = true;
+        log.warn(
+          "mcporter qmd bridge enabled but startDaemon=false; each query may cold-start QMD MCP. Consider setting memory.qmd.mcporter.startDaemon=true to keep it warm.",
+        );
+      }
+      return;
+    }
+    const daemonKey = this.mcporterDaemonKey(configMode);
+    let daemonStart = state.daemonStarts.get(daemonKey);
+    if (!daemonStart) {
+      daemonStart = (async () => {
+        try {
+          await this.runMcporterCommand(["daemon", "start"], {
+            envMode: configMode,
+            includeGeneratedConfig: configMode === "generated",
+            timeoutMs: 10_000,
+          });
+        } catch (err) {
+          log.warn(`mcporter daemon start failed: ${String(err)}`);
+          // Allow future searches to retry daemon start on transient failures.
+          state.daemonStarts.delete(daemonKey);
+        }
+      })();
+      state.daemonStarts.set(daemonKey, daemonStart);
+    }
+    await daemonStart;
+  }
+
+  private async ensureMcporterConfig(): Promise<McporterConfigMode> {
+    if (!this.mcporterConfigMode) {
+      this.mcporterConfigMode = this.resolveMcporterConfigMode().catch((err: unknown) => {
+        this.mcporterConfigMode = null;
+        throw err;
+      });
+    }
+    return await this.mcporterConfigMode;
+  }
+
+  private async resolveMcporterConfigMode(): Promise<McporterConfigMode> {
+    await fs.mkdir(path.dirname(this.mcporterConfigPath), { recursive: true });
+    const configured = await this.resolveConfiguredMcporterServer();
+    if (configured?.mode === "external") {
+      return "external";
+    }
+    const server = configured?.server ?? this.buildDefaultMcporterQmdServer();
+    const config = {
+      imports: [],
+      mcpServers: {
+        [this.qmd.mcporter.serverName]: server,
+      },
+    };
+    await this.writeMcporterConfigIfChanged(`${JSON.stringify(config, null, 2)}\n`);
+    return "generated";
+  }
+
+  private async writeMcporterConfigIfChanged(contents: string): Promise<void> {
+    try {
+      if ((await fs.readFile(this.mcporterConfigPath, "utf8")) === contents) {
+        return;
+      }
+    } catch (err) {
+      if (!isFileMissingError(err)) {
+        throw err;
+      }
+    }
+    await fs.writeFile(this.mcporterConfigPath, contents, "utf8");
+  }
+
+  private buildDefaultMcporterQmdServer(): Record<string, unknown> {
+    const server: Record<string, unknown> = {
+      command: this.qmd.command,
+      args: ["mcp"],
+      env: this.buildMcporterQmdEnv(),
+    };
+    // Only keep the QMD MCP server warm when the resolved config enables daemon management.
+    if (this.qmd.mcporter.startDaemon) {
+      server.lifecycle = { mode: "keep-alive", idleTimeoutMs: 300_000 };
+    }
+    return server;
+  }
+
+  private async resolveConfiguredMcporterServer(): Promise<ConfiguredMcporterServer | null> {
+    const serverName = this.qmd.mcporter.serverName;
+    let result: { stdout: string; stderr: string };
+    try {
+      result = await this.runMcporterCommand(["config", "get", serverName, "--json"], {
+        envMode: "discovery",
+        includeGeneratedConfig: false,
+        timeoutMs: 5_000,
+      });
+    } catch (err) {
+      if (serverName === "qmd") {
+        return null;
+      }
+      throw new Error(
+        `mcporter server "${serverName}" is not configured or could not be read: ${formatErrorMessage(
+          err,
+        )}`,
+        { cause: err },
+      );
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = parseMcporterResponseJson(result.stdout);
+    } catch (err) {
+      if (serverName === "qmd") {
+        return null;
+      }
+      throw new Error(`mcporter server "${serverName}" returned invalid JSON`, { cause: err });
+    }
+    const serialized = asRecord(parsed);
+    if (!serialized) {
+      if (serverName === "qmd") {
+        return null;
+      }
+      throw new Error(`mcporter server "${serverName}" returned an invalid JSON definition`);
+    }
+
+    const rawEntry = await readRawMcporterEntry(
+      serverName,
+      this.mcporterEnv,
+      this.workspaceDir,
+      extractMcporterSourcePath(serialized),
+    );
+    const source = asRecord(serialized.source);
+    // Imported editor entries point at their native config format, not an
+    // MCPorter config file. Only `local` sources are safe MCPORTER_CONFIG values.
+    this.externalMcporterConfigPath =
+      source?.kind === "local" ? (extractMcporterSourcePath(serialized) ?? null) : null;
+    const server = this.toMcporterRawServerEntry(serialized, rawEntry);
+    if (!server) {
+      if (serverName === "qmd") {
+        return null;
+      }
+      throw new Error(`mcporter server "${serverName}" returned an unsupported definition`);
+    }
+    return server;
+  }
+
+  private toMcporterRawServerEntry(
+    serialized: Record<string, unknown>,
+    rawEntry: RawMcporterEntry | null,
+  ): ConfiguredMcporterServer | null {
+    const server: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(serialized)) {
+      if (key === "name" || key === "source" || value === undefined) {
+        continue;
+      }
+      server[key] = value;
+    }
+
+    if (server.command !== undefined && server.command !== null) {
+      // mcporter accepts stdio commands as strings, arrays, or executable
+      // objects. We can only regenerate the string form, so preserve anything
+      // else as external and let mcporter handle the invocation directly.
+      if (typeof server.command !== "string" || server.command.length === 0) {
+        return { mode: "external" };
+      }
+      if (
+        !isGeneratedMcporterQmdStdioServer(server) ||
+        hasMcporterStdioUserOwnedMaterial(server) ||
+        (rawEntry !== null && hasMcporterStdioLifecycleOrLogging(rawEntry))
+      ) {
+        return { mode: "external" };
+      }
+      return { mode: "generated", server: this.toGeneratedMcporterStdioServer(server) };
+    }
+
+    const hasRemoteEndpoint =
+      typeof server.baseUrl === "string" ||
+      typeof server.base_url === "string" ||
+      typeof server.url === "string" ||
+      typeof server.serverUrl === "string" ||
+      typeof server.server_url === "string";
+    if (hasRemoteEndpoint) {
+      // The generated per-agent config is persisted under OpenClaw state. Do not
+      // copy remote auth material from a user's mcporter config into that file;
+      // keep using the original mcporter config for authenticated remotes.
+      if (
+        hasMcporterRemoteAuthMaterial(server) ||
+        (rawEntry !== null && hasMcporterStdioLifecycleOrLogging(rawEntry))
+      ) {
+        return { mode: "external" };
+      }
+      return { mode: "generated", server };
+    }
+
+    return null;
+  }
+
+  private toGeneratedMcporterStdioServer(server: Record<string, unknown>): Record<string, unknown> {
+    return {
+      ...server,
+      env: this.buildMcporterQmdEnv(),
+    };
+  }
+
+  private buildMcporterQmdEnv(): Record<string, string> {
+    const keys = [
+      "PATH",
+      "XDG_CONFIG_HOME",
+      "QMD_CONFIG_DIR",
+      "XDG_CACHE_HOME",
+      "QMD_EMBED_MODEL",
+      "QMD_RERANK_MODEL",
+      "QMD_GENERATE_MODEL",
+      "QMD_LLAMA_GPU",
+      "QMD_EMBED_CONTEXT_SIZE",
+      "QMD_RERANK_CONTEXT_SIZE",
+      "QMD_EXPAND_CONTEXT_SIZE",
+      "NO_COLOR",
+    ];
+    const env: Record<string, string> = {};
+    for (const key of keys) {
+      const value = this.env[key];
+      if (typeof value === "string" && value.length > 0) {
+        env[key] = value;
+      }
+    }
+    return env;
+  }
+
+  private buildMcporterProcessEnv(mode: McporterEnvMode): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...this.mcporterEnv };
+    if (mode === "generated") {
+      // Generated sidecars must not inherit the user's MCPorter/QMD discovery
+      // state. Discovery and external modes start from the user's environment.
+      delete env.XDG_CONFIG_HOME;
+      delete env.QMD_CONFIG_DIR;
+      delete env.XDG_CACHE_HOME;
+      delete env.MCPORTER_CONFIG;
+    }
+    if (mode === "external" && this.externalMcporterConfigPath) {
+      // Point mcporter at the exact user/project config that defined the
+      // external server, so calls do not fall back to agent-scoped dirs.
+      env.MCPORTER_CONFIG = this.externalMcporterConfigPath;
+    }
+    return env;
+  }
+
+  private mcporterDaemonKey(configMode: McporterConfigMode): string {
+    if (configMode === "generated") {
+      return this.mcporterConfigPath;
+    }
+    return [
+      "external",
+      this.qmd.mcporter.serverName,
+      this.mcporterEnv.MCPORTER_CONFIG ?? "",
+      this.mcporterEnv.XDG_CONFIG_HOME ?? "",
+      this.workspaceDir,
+    ].join(":");
+  }
+
+  private async runMcporterCommand(
+    args: string[],
+    opts?: {
+      envMode?: McporterEnvMode;
+      includeGeneratedConfig?: boolean;
+      timeoutMs?: number;
+      signal?: AbortSignal;
+    },
+  ): Promise<{ stdout: string; stderr: string }> {
+    const mcporterArgs =
+      opts?.includeGeneratedConfig === false
+        ? args
+        : [...args, "--config", this.mcporterConfigPath];
+    const env = this.buildMcporterProcessEnv(opts?.envMode ?? "generated");
+    const spawnInvocation = resolveCliSpawnInvocation({
+      command: "mcporter",
+      args: mcporterArgs,
+      env,
+      packageName: "mcporter",
+    });
+    return await runCliCommand({
+      commandSummary: `${spawnInvocation.command} ${spawnInvocation.argv.join(" ")}`,
+      spawnInvocation,
+      env,
+      cwd: this.workspaceDir,
+      timeoutMs: opts?.timeoutMs,
+      maxOutputChars: this.maxQmdOutputChars,
+      signal: opts?.signal,
+    });
+  }
+
+  async run(
+    args: string[],
+    opts?: { timeoutMs?: number; signal?: AbortSignal },
+  ): Promise<{ stdout: string; stderr: string }> {
+    const configMode = await this.ensureMcporterConfig();
+    return await this.runMcporterCommand(args, {
+      ...opts,
+      envMode: configMode,
+      includeGeneratedConfig: configMode === "generated",
+    });
+  }
+}

--- a/extensions/memory-core/src/memory/qmd-mcporter-client.ts
+++ b/extensions/memory-core/src/memory/qmd-mcporter-client.ts
@@ -17,7 +17,6 @@ import {
 import { asRecord } from "../dreaming-shared.js";
 import {
   extractMcporterSourcePath,
-  hasMcporterRemoteAuthMaterial,
   hasMcporterStdioLifecycleOrLogging,
   hasMcporterStdioUserOwnedMaterial,
   isGeneratedMcporterQmdStdioServer,
@@ -124,11 +123,11 @@ export class QmdMcporterClient {
   }
 
   private async resolveMcporterConfigMode(): Promise<McporterConfigMode> {
-    await fs.mkdir(path.dirname(this.mcporterConfigPath), { recursive: true });
     const configured = await this.resolveConfiguredMcporterServer();
     if (configured?.mode === "external") {
       return "external";
     }
+    await fs.mkdir(path.dirname(this.mcporterConfigPath), { recursive: true });
     const server = configured?.server ?? this.buildDefaultMcporterQmdServer();
     const config = {
       imports: [],
@@ -243,6 +242,19 @@ export class QmdMcporterClient {
       server[key] = value;
     }
 
+    const hasRemoteEndpoint =
+      server.transport === "http" ||
+      typeof server.baseUrl === "string" ||
+      typeof server.base_url === "string" ||
+      typeof server.url === "string" ||
+      typeof server.serverUrl === "string" ||
+      typeof server.server_url === "string";
+    if (hasRemoteEndpoint) {
+      // Remote transport is always operator-owned, even without recognizable auth.
+      // Keep its endpoint and policy in the original config instead of agent state.
+      return { mode: "external" };
+    }
+
     if (server.command !== undefined && server.command !== null) {
       // mcporter accepts stdio commands as strings, arrays, or executable
       // objects. We can only regenerate the string form, so preserve anything
@@ -258,25 +270,6 @@ export class QmdMcporterClient {
         return { mode: "external" };
       }
       return { mode: "generated", server: this.toGeneratedMcporterStdioServer(server) };
-    }
-
-    const hasRemoteEndpoint =
-      typeof server.baseUrl === "string" ||
-      typeof server.base_url === "string" ||
-      typeof server.url === "string" ||
-      typeof server.serverUrl === "string" ||
-      typeof server.server_url === "string";
-    if (hasRemoteEndpoint) {
-      // The generated per-agent config is persisted under OpenClaw state. Do not
-      // copy remote auth material from a user's mcporter config into that file;
-      // keep using the original mcporter config for authenticated remotes.
-      if (
-        hasMcporterRemoteAuthMaterial(server) ||
-        (rawEntry !== null && hasMcporterStdioLifecycleOrLogging(rawEntry))
-      ) {
-        return { mode: "external" };
-      }
-      return { mode: "generated", server };
     }
 
     return null;

--- a/extensions/memory-core/src/memory/qmd-mcporter-client.ts
+++ b/extensions/memory-core/src/memory/qmd-mcporter-client.ts
@@ -168,6 +168,12 @@ export class QmdMcporterClient {
 
   private async resolveConfiguredMcporterServer(): Promise<ConfiguredMcporterServer | null> {
     const serverName = this.qmd.mcporter.serverName;
+    const explicitMcporterConfig = this.mcporterEnv.MCPORTER_CONFIG;
+    // An explicit config is authoritative. Only implicit default QMD discovery may
+    // fall back to a generated sidecar, or user configuration failures are hidden.
+    const canUseGeneratedFallback =
+      serverName === "qmd" &&
+      (explicitMcporterConfig === undefined || explicitMcporterConfig === "");
     let result: { stdout: string; stderr: string };
     try {
       result = await this.runMcporterCommand(["config", "get", serverName, "--json"], {
@@ -176,7 +182,7 @@ export class QmdMcporterClient {
         timeoutMs: 5_000,
       });
     } catch (err) {
-      if (serverName === "qmd") {
+      if (canUseGeneratedFallback) {
         return null;
       }
       throw new Error(
@@ -191,14 +197,14 @@ export class QmdMcporterClient {
     try {
       parsed = parseMcporterResponseJson(result.stdout);
     } catch (err) {
-      if (serverName === "qmd") {
+      if (canUseGeneratedFallback) {
         return null;
       }
       throw new Error(`mcporter server "${serverName}" returned invalid JSON`, { cause: err });
     }
     const serialized = asRecord(parsed);
     if (!serialized) {
-      if (serverName === "qmd") {
+      if (canUseGeneratedFallback) {
         return null;
       }
       throw new Error(`mcporter server "${serverName}" returned an invalid JSON definition`);
@@ -217,7 +223,7 @@ export class QmdMcporterClient {
       source?.kind === "local" ? (extractMcporterSourcePath(serialized) ?? null) : null;
     const server = this.toMcporterRawServerEntry(serialized, rawEntry);
     if (!server) {
-      if (serverName === "qmd") {
+      if (canUseGeneratedFallback) {
         return null;
       }
       throw new Error(`mcporter server "${serverName}" returned an unsupported definition`);

--- a/extensions/memory-core/src/memory/qmd-mcporter-config.ts
+++ b/extensions/memory-core/src/memory/qmd-mcporter-config.ts
@@ -1,0 +1,455 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { isFileMissingError } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { asRecord } from "../dreaming-shared.js";
+
+export type McporterConfigMode = "generated" | "external";
+export type McporterEnvMode = "discovery" | McporterConfigMode;
+
+export type ConfiguredMcporterServer =
+  | { mode: "generated"; server: Record<string, unknown> }
+  | { mode: "external" };
+
+export type RawMcporterEntry = {
+  lifecycle?: unknown;
+  logging?: unknown;
+  cwd?: unknown;
+  path?: unknown;
+};
+
+const MCPORTER_REMOTE_AUTH_KEYS = new Set(
+  [
+    "auth",
+    "authProvider",
+    "authProviderEnv",
+    "bearerToken",
+    "bearerTokenEnv",
+    "oauth",
+    "oauthClientId",
+    "oauthClientSecret",
+    "oauthClientSecretEnv",
+    "refresh",
+    "refreshToken",
+    "refreshTokenEnv",
+    "tokenCacheDir",
+  ].map(normalizeMcporterConfigKey),
+);
+
+type JsonExtractionResult = { found: true; value: unknown } | { found: false };
+
+function normalizeMcporterConfigKey(key: string): string {
+  return key.toLowerCase().replace(/[_-]/g, "");
+}
+
+function isMcporterAuthLikeKey(key: string): boolean {
+  const normalized = normalizeMcporterConfigKey(key);
+  return (
+    MCPORTER_REMOTE_AUTH_KEYS.has(normalized) ||
+    normalized.includes("apikey") ||
+    normalized.includes("auth") ||
+    normalized.includes("bearer") ||
+    normalized.includes("credential") ||
+    normalized.includes("header") ||
+    normalized.includes("jwt") ||
+    normalized.includes("password") ||
+    normalized.includes("passwd") ||
+    normalized.includes("secret") ||
+    normalized.includes("signature") ||
+    normalized.includes("token") ||
+    normalized === "key" ||
+    normalized === "pwd" ||
+    normalized === "sig"
+  );
+}
+
+function hasMcporterHeaderAuthMaterial(value: unknown): boolean {
+  const headers = asRecord(value);
+  if (!headers) {
+    return true;
+  }
+  for (const [key, headerValue] of Object.entries(headers)) {
+    const normalized = normalizeMcporterConfigKey(key);
+    if (
+      normalized === "accept" &&
+      typeof headerValue === "string" &&
+      hasRequiredMcporterAcceptTokens(headerValue)
+    ) {
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+function hasRequiredMcporterAcceptTokens(value: string): boolean {
+  const lower = value.toLowerCase();
+  return lower.includes("application/json") && lower.includes("text/event-stream");
+}
+
+export function hasMcporterRemoteAuthMaterial(server: Record<string, unknown>): boolean {
+  if (hasMcporterRemoteUrlCredentials(server)) {
+    return true;
+  }
+  return Object.entries(server).some(([key, value]) => {
+    if (normalizeMcporterConfigKey(key) === "env") {
+      return true;
+    }
+    if (normalizeMcporterConfigKey(key) === "headers") {
+      return hasMcporterHeaderAuthMaterial(value);
+    }
+    return isMcporterAuthLikeKey(key);
+  });
+}
+
+export function hasMcporterStdioUserOwnedMaterial(server: Record<string, unknown>): boolean {
+  return Object.entries(server).some(([key, value]) => {
+    const normalizedKey = normalizeMcporterConfigKey(key);
+    if (normalizedKey === "env") {
+      return true;
+    }
+    if (normalizedKey === "command") {
+      return hasMcporterAuthLikeText(value);
+    }
+    if (normalizedKey === "args") {
+      return hasMcporterAuthLikeArgs(value);
+    }
+    return isMcporterAuthLikeKey(key);
+  });
+}
+
+export function isGeneratedMcporterQmdStdioServer(server: Record<string, unknown>): boolean {
+  if (!isQmdExecutableCommand(server.command)) {
+    return false;
+  }
+  const args = server.args;
+  return Array.isArray(args) && args.length === 1 && args[0] === "mcp";
+}
+
+function isQmdExecutableCommand(command: unknown): boolean {
+  if (typeof command !== "string" || command.length === 0) {
+    return false;
+  }
+  const normalized = command.replace(/\\/g, "/");
+  const commandName = normalized.split("/").findLast(Boolean) ?? normalized;
+  return normalizeMcporterConfigKey(commandName) === "qmd";
+}
+
+function hasMcporterAuthLikeArgs(value: unknown): boolean {
+  return Array.isArray(value) && value.some((entry) => hasMcporterAuthLikeText(entry));
+}
+
+function hasMcporterAuthLikeText(value: unknown): boolean {
+  return typeof value === "string" && isMcporterAuthLikeKey(value);
+}
+
+function hasMcporterRemoteUrlCredentials(server: Record<string, unknown>): boolean {
+  for (const key of ["baseUrl", "base_url", "url", "serverUrl", "server_url"]) {
+    const value = server[key];
+    if (typeof value !== "string" || value.length === 0) {
+      continue;
+    }
+    try {
+      const parsed = new URL(value);
+      if (parsed.username.length > 0 || parsed.password.length > 0) {
+        return true;
+      }
+      for (const queryKey of parsed.searchParams.keys()) {
+        if (isMcporterAuthLikeKey(queryKey)) {
+          return true;
+        }
+      }
+    } catch {
+      if (/^[a-z][a-z0-9+.-]*:\/\/[^/?#@]+@/i.test(value)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function parseMcporterResponseJson(stdout: string): unknown {
+  const trimmed = stdout.trim();
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch (err) {
+    const payload = extractLastJsonValue(trimmed);
+    if (payload.found) {
+      return payload.value;
+    }
+    throw err;
+  }
+}
+
+// Scan stdout for the last syntactically valid top-level JSON value.
+// mcporter/daemon log lines can themselves be valid JSON objects; the actual
+// response is the final top-level value in the stream, so a preceding log
+// line must not shadow it. We walk the text at root depth and parse each
+// complete top-level value, keeping the last one that successfully parses.
+function extractLastJsonValue(raw: string): JsonExtractionResult {
+  let lastResult: JsonExtractionResult = { found: false };
+  let i = 0;
+  const len = raw.length;
+  while (i < len) {
+    const ch = raw[i];
+    if (ch !== "{" && ch !== "[") {
+      i += 1;
+      continue;
+    }
+    const opening = ch;
+    const closing = opening === "{" ? "}" : "]";
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    let closed = -1;
+    for (let index = i; index < len; index += 1) {
+      const c = raw[index];
+      if (c === undefined) {
+        break;
+      }
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+        if (c === "\\") {
+          escaped = true;
+        } else if (c === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (c === '"') {
+        inString = true;
+        continue;
+      }
+      if (c === opening) {
+        depth += 1;
+      } else if (c === closing) {
+        depth -= 1;
+        if (depth === 0) {
+          closed = index;
+          break;
+        }
+      }
+    }
+    if (closed === -1) {
+      // Unbalanced; no more complete top-level values to find.
+      return lastResult;
+    }
+    try {
+      lastResult = {
+        found: true,
+        value: JSON.parse(raw.slice(i, closed + 1)) as unknown,
+      };
+    } catch {
+      // Skip this malformed candidate and look for the next top-level value.
+    }
+    i = closed + 1;
+  }
+  return lastResult;
+}
+
+function expandMcporterHome(input: string): string {
+  if (!input.startsWith("~")) {
+    return input;
+  }
+  const home = os.homedir();
+  if (input === "~") {
+    return home;
+  }
+  if (input.startsWith("~/") || input.startsWith("~\\")) {
+    return path.join(home, input.slice(2));
+  }
+  return input;
+}
+
+function resolveMcporterConfigCandidates(env: NodeJS.ProcessEnv, workspaceDir: string): string[] {
+  // Match mcporter's config discovery precedence (mcporter source:
+  // src/config/path-discovery.ts): explicit override -> project -> XDG/home ->
+  // legacy home fallback. Workspace config wins over user-level definitions.
+  const candidates: string[] = [];
+
+  const explicitConfig = env.MCPORTER_CONFIG;
+  if (explicitConfig && explicitConfig.trim().length > 0) {
+    candidates.push(path.resolve(expandMcporterHome(explicitConfig.trim())));
+  }
+
+  const projectConfigDir = path.resolve(workspaceDir, "config");
+  candidates.push(path.join(projectConfigDir, "mcporter.json"));
+  candidates.push(path.join(projectConfigDir, "mcporter.jsonc"));
+
+  const xdgConfigHome = env.XDG_CONFIG_HOME;
+  if (xdgConfigHome && xdgConfigHome.trim().length > 0) {
+    const resolved = expandMcporterHome(xdgConfigHome.trim());
+    if (path.isAbsolute(resolved)) {
+      candidates.push(path.join(resolved, "mcporter", "mcporter.json"));
+      candidates.push(path.join(resolved, "mcporter", "mcporter.jsonc"));
+    }
+  }
+
+  candidates.push(path.join(os.homedir(), ".mcporter", "mcporter.json"));
+  candidates.push(path.join(os.homedir(), ".mcporter", "mcporter.jsonc"));
+
+  return candidates;
+}
+
+export function extractMcporterSourcePath(serialized: Record<string, unknown>): string | undefined {
+  const source = serialized.source;
+  if (!source || typeof source !== "object" || Array.isArray(source)) {
+    return undefined;
+  }
+  const sourceRecord = source as Record<string, unknown>;
+  if (typeof sourceRecord.path === "string") {
+    return sourceRecord.path;
+  }
+  return undefined;
+}
+
+// String-aware JSONC comment and trailing-comma stripper. Walks the source
+// respecting string boundaries so URLs containing "//" and similar tokens
+// are not mistaken for line comments. Used only for the read-only probe of
+// raw mcporter entries; mcporter itself is the source of truth for runtime
+// config loading.
+function stripJsoncCommentsAndTrailingCommas(text: string): string {
+  let out = "";
+  let i = 0;
+  const len = text.length;
+  while (i < len) {
+    const ch = text[i];
+    if (ch === '"') {
+      // Copy the entire string literal verbatim, honoring backslash escapes.
+      let j = i + 1;
+      while (j < len) {
+        if (text[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (text[j] === '"') {
+          j += 1;
+          break;
+        }
+        j += 1;
+      }
+      out += text.slice(i, j);
+      i = j;
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "/") {
+      const newline = text.indexOf("\n", i);
+      i = newline === -1 ? len : newline;
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "*") {
+      const close = text.indexOf("*/", i + 2);
+      i = close === -1 ? len : close + 2;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  // Strip trailing commas before closing brackets/braces. The preceding
+  // comment pass already removed any "//" inside string values, so the
+  // remaining "," characters only appear in structural positions.
+  return out.replace(/,(\s*[}\]])/g, "$1");
+}
+
+async function readRawMcporterEntryFromFile(
+  serverName: string,
+  filePath: string,
+): Promise<RawMcporterEntry | null> {
+  let text: string;
+  try {
+    text = await fs.readFile(filePath, "utf8");
+  } catch (err) {
+    if (isFileMissingError(err)) {
+      return null;
+    }
+    throw err;
+  }
+  // Try strict JSON first; only fall back to JSONC cleanup for ".jsonc" files
+  // that need comment/trailing-comma removal. The cleanup is string-aware so
+  // URLs containing "//" inside string values are not mistaken for comments.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch {
+    if (!filePath.endsWith(".jsonc")) {
+      return null;
+    }
+    try {
+      parsed = JSON.parse(stripJsoncCommentsAndTrailingCommas(text)) as unknown;
+    } catch {
+      return null;
+    }
+  }
+  const record = asRecord(parsed);
+  const servers = record ? asRecord(record.mcpServers) : null;
+  const entry = servers ? asRecord(servers[serverName]) : null;
+  if (entry) {
+    return entry as RawMcporterEntry;
+  }
+  return null;
+}
+
+export async function readRawMcporterEntry(
+  serverName: string,
+  env: NodeJS.ProcessEnv,
+  workspaceDir: string,
+  sourcePath?: string,
+): Promise<RawMcporterEntry | null> {
+  // Prefer the file mcporter actually reported via source.path; it is the
+  // authoritative layer for this server. Fall back to enumerating layers in
+  // mcporter's documented precedence order.
+  if (sourcePath) {
+    const resolved = path.resolve(expandMcporterHome(sourcePath.trim()));
+    const entry = await readRawMcporterEntryFromFile(serverName, resolved);
+    if (entry) {
+      return entry;
+    }
+  }
+
+  for (const candidate of resolveMcporterConfigCandidates(env, workspaceDir)) {
+    const entry = await readRawMcporterEntryFromFile(serverName, candidate);
+    if (entry) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+export function hasMcporterStdioLifecycleOrLogging(server: RawMcporterEntry): boolean {
+  if (server.lifecycle !== undefined) {
+    return true;
+  }
+  const logging =
+    typeof server.logging === "object" && server.logging !== null
+      ? (server.logging as Record<string, unknown>)
+      : null;
+  if (logging) {
+    // Detect top-level logging.enabled (mcporter legacy shape) and nested
+    // logging.daemon.enabled (mcporter current shape: src/config-schema.ts:39-49).
+    if (logging.enabled === true) {
+      return true;
+    }
+    const daemon =
+      typeof logging.daemon === "object" && logging.daemon !== null
+        ? (logging.daemon as Record<string, unknown>)
+        : null;
+    if (daemon?.enabled === true) {
+      return true;
+    }
+  }
+  // A user-set cwd or path is context-dependent and must not be copied into
+  // the per-agent generated config under OpenClaw state, where it would
+  // resolve against a different working directory. Check the raw entry so
+  // mcporter's normalized default cwd (added to "config get --json" output)
+  // does not force every bare qmd server into external mode.
+  if (typeof server.cwd === "string" && server.cwd.length > 0) {
+    return true;
+  }
+  if (typeof server.path === "string" && server.path.length > 0) {
+    return true;
+  }
+  return false;
+}

--- a/extensions/memory-core/src/memory/qmd-mcporter-config.ts
+++ b/extensions/memory-core/src/memory/qmd-mcporter-config.ts
@@ -18,7 +18,7 @@ export type RawMcporterEntry = {
   path?: unknown;
 };
 
-const MCPORTER_REMOTE_AUTH_KEYS = new Set(
+const MCPORTER_AUTH_KEYS = new Set(
   [
     "auth",
     "authProvider",
@@ -45,7 +45,7 @@ function normalizeMcporterConfigKey(key: string): string {
 function isMcporterAuthLikeKey(key: string): boolean {
   const normalized = normalizeMcporterConfigKey(key);
   return (
-    MCPORTER_REMOTE_AUTH_KEYS.has(normalized) ||
+    MCPORTER_AUTH_KEYS.has(normalized) ||
     normalized.includes("apikey") ||
     normalized.includes("auth") ||
     normalized.includes("bearer") ||
@@ -61,45 +61,6 @@ function isMcporterAuthLikeKey(key: string): boolean {
     normalized === "pwd" ||
     normalized === "sig"
   );
-}
-
-function hasMcporterHeaderAuthMaterial(value: unknown): boolean {
-  const headers = asRecord(value);
-  if (!headers) {
-    return true;
-  }
-  for (const [key, headerValue] of Object.entries(headers)) {
-    const normalized = normalizeMcporterConfigKey(key);
-    if (
-      normalized === "accept" &&
-      typeof headerValue === "string" &&
-      hasRequiredMcporterAcceptTokens(headerValue)
-    ) {
-      continue;
-    }
-    return true;
-  }
-  return false;
-}
-
-function hasRequiredMcporterAcceptTokens(value: string): boolean {
-  const lower = value.toLowerCase();
-  return lower.includes("application/json") && lower.includes("text/event-stream");
-}
-
-export function hasMcporterRemoteAuthMaterial(server: Record<string, unknown>): boolean {
-  if (hasMcporterRemoteUrlCredentials(server)) {
-    return true;
-  }
-  return Object.entries(server).some(([key, value]) => {
-    if (normalizeMcporterConfigKey(key) === "env") {
-      return true;
-    }
-    if (normalizeMcporterConfigKey(key) === "headers") {
-      return hasMcporterHeaderAuthMaterial(value);
-    }
-    return isMcporterAuthLikeKey(key);
-  });
 }
 
 export function hasMcporterStdioUserOwnedMaterial(server: Record<string, unknown>): boolean {
@@ -141,31 +102,6 @@ function hasMcporterAuthLikeArgs(value: unknown): boolean {
 
 function hasMcporterAuthLikeText(value: unknown): boolean {
   return typeof value === "string" && isMcporterAuthLikeKey(value);
-}
-
-function hasMcporterRemoteUrlCredentials(server: Record<string, unknown>): boolean {
-  for (const key of ["baseUrl", "base_url", "url", "serverUrl", "server_url"]) {
-    const value = server[key];
-    if (typeof value !== "string" || value.length === 0) {
-      continue;
-    }
-    try {
-      const parsed = new URL(value);
-      if (parsed.username.length > 0 || parsed.password.length > 0) {
-        return true;
-      }
-      for (const queryKey of parsed.searchParams.keys()) {
-        if (isMcporterAuthLikeKey(queryKey)) {
-          return true;
-        }
-      }
-    } catch {
-      if (/^[a-z][a-z0-9+.-]*:\/\/[^/?#@]+@/i.test(value)) {
-        return true;
-      }
-    }
-  }
-  return false;
 }
 
 export function parseMcporterResponseJson(stdout: string): unknown {


### PR DESCRIPTION
## What Problem This Solves

QMD memory searches that bridge through MCPorter need generated sidecar configuration and daemon identity scoped to each OpenClaw agent. User-owned MCPorter definitions—especially every remote/HTTP endpoint and stdio definitions containing authentication, lifecycle, logging, relative paths, or other operator-controlled behavior—must remain external and must not be copied into agent state.

This refresh publishes the technically solvable repairs from the latest review. It does **not** claim merge readiness: the supported product/configuration contract for enabling MCPorter remains a maintainer decision.

## Exact Revision

- Pinned `upstream/main`: `6f94e7b23d0db23a13864dabd0bd6a75f3cb31b6`
- Final PR head: `1f4ecaf4c2f78911a34a8d159159ba2c4dd0fc08`
- The repair commit contains the prior exact head `6b6e12d2ec85fce2c5b0c4b51e33127918adcae0`; the pinned base was intentionally not moved merely because `main` advanced.

## Technical Changes

- Generated QMD/MCPorter state remains agent-scoped, including configuration paths, XDG/QMD state, and daemon identity.
- Bare generated QMD stdio definitions may use an OpenClaw-generated per-agent configuration.
- Every remote/HTTP definition is now external and operator-owned, regardless of recognized auth or lifecycle fields. Classification checks canonical `transport: "http"`, every MCPorter URL alias, and mixed command-plus-endpoint records before the stdio-generated path.
- External discovery returns before creating the agent MCPorter directory, so endpoint, policy, path/query data, headers, and other operator material are never copied into agent state.
- The obsolete remote-secret blacklist was removed; exact local `source.path` routing remains authoritative for external calls.
- An explicit `MCPORTER_CONFIG` is authoritative. Discovery failures fail closed instead of silently generating a sidecar and deleting the explicit setting.
- Fallback matches MCPorter's exact configuration semantics: only an absent or exactly empty `MCPORTER_CONFIG` is implicit; whitespace-only values remain explicit.
- The invalid operator instruction for retired `memory.qmd.mcporter.*` configuration is absent on the final head. Current `main` already contained that documentation removal, so this PR has no documentation diff.

MCPorter dependency behavior was checked directly against the sibling source, including `src/config-schema.ts`, `src/config-normalize.ts`, `src/config/imports/external.ts`, and `src/cli/config/render.ts`. Those contracts establish canonical HTTP serialization and the accepted `baseUrl`, `base_url`, `url`, `serverUrl`, and `server_url` shapes.

## Evidence

### Exact-Head Focused Proof

Commands run from the isolated Linux worktree on final head `1f4ecaf4c2f78911a34a8d159159ba2c4dd0fc08`:

```sh
node scripts/run-vitest.mjs extensions/memory-core/src/memory/qmd-manager.test.ts
pnpm exec oxfmt --check \
  extensions/memory-core/src/memory/qmd-manager.test.ts \
  extensions/memory-core/src/memory/qmd-mcporter-client.ts \
  extensions/memory-core/src/memory/qmd-mcporter-config.ts
git diff 6f94e7b23d0db23a13864dabd0bd6a75f3cb31b6...HEAD --check
```

Observed:

- Full focused manager suite: **182/182 passed**.
- Formatting and diff checks passed.
- Before the repair, five remote URL-shape regressions failed because calls contained generated `--config` state.
- Independent review then found a mixed `{ command, args, baseUrl }` ordering bypass; its regression failed on the intermediate head for the same reason.
- After moving HTTP/endpoint classification before stdio, all eight remote cases passed: canonical `transport: "http"`, bare and opaque URLs, rich unauthenticated policy, the mixed record, and all endpoint aliases.
- Every case proves no `--config`, exact external `MCPORTER_CONFIG` source routing, and `ENOENT` for the entire agent MCPorter directory.
- Independent post-amend review returned **clean**, with no remaining technical finding for this boundary.

Repair delta from prior head `6b6e12d2ec85fce2c5b0c4b51e33127918adcae0`:

- Production: `+16/-87` (net `-71`)
- Tests: `+109/-0`

Final PR surface against the pinned base:

- Production: `+800/-69` (net `+731`)
- Tests: `+538/-14` (net `+524`)
- Total: `+1338/-83` across 5 files

The positive overall production delta implements agent isolation, while the latest security/ownership repair is net-negative. The overall capability remains unreachable through canonical configuration pending the maintainer decision below.

### Real Linux Attempt and Blocking Product Contract

A temp-only real-binary attempt was run using:

- QMD `2.1.0 (bab86d5)`
- MCPorter `0.10.2`
- isolated `HOME`, `OPENCLAW_STATE_DIR`, and XDG config/cache/state directories under `/tmp`

The first supported enablement step failed:

```sh
pnpm openclaw config set memory.qmd.mcporter.enabled true --strict-json
```

Observed result:

```text
exit 1
Error: Config validation failed: memory.qmd: Unrecognized key: "mcporter"
```

Because strict canonical validation rejected the setting, the run stopped before indexing, search, generated sidecar creation, or daemon startup. No test-only cast or internal mutation was used to bypass the product contract. The temporary root was removed by the cleanup trap and verified absent.

Therefore a real two-agent search/daemon-isolation trace cannot honestly be supplied from the supported CLI on this head. Native Windows `.cmd`-shim behavior also remains unverified.

## Remaining Maintainer Product Decision

Before merge, maintainers must choose one of these directions:

1. Restore a supported MCPorter configuration contract, including approved schema/type/resolver behavior and any required doctor migration, then complete real Linux two-agent and native Windows proof; or
2. Keep MCPorter retired from canonical QMD configuration and remove the unreachable sidecar feature work from this PR.

Until that decision is made and implemented, this PR remains open but **not merge-ready**.
