### PR TITLE
Add Telegram voice STT telemetry and cron payload audit

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -5872,6 +5872,7 @@ public struct CronJob: Codable, Sendable {
     public let sessiontarget: AnyCodable
     public let wakemode: AnyCodable
     public let payload: AnyCodable
+    public let audit: [String: AnyCodable]?
     public let delivery: AnyCodable?
     public let failurealert: AnyCodable?
     public let state: [String: AnyCodable]
@@ -5890,6 +5891,7 @@ public struct CronJob: Codable, Sendable {
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
         payload: AnyCodable,
+        audit: [String: AnyCodable]?,
         delivery: AnyCodable?,
         failurealert: AnyCodable?,
         state: [String: AnyCodable])
@@ -5907,6 +5909,7 @@ public struct CronJob: Codable, Sendable {
         self.sessiontarget = sessiontarget
         self.wakemode = wakemode
         self.payload = payload
+        self.audit = audit
         self.delivery = delivery
         self.failurealert = failurealert
         self.state = state
@@ -5926,6 +5929,7 @@ public struct CronJob: Codable, Sendable {
         case sessiontarget = "sessionTarget"
         case wakemode = "wakeMode"
         case payload
+        case audit
         case delivery
         case failurealert = "failureAlert"
         case state

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -934,11 +934,7 @@ export const registerTelegramHandlers = ({
           continue;
         }
         if (media) {
-          allMedia.push({
-            path: media.path,
-            contentType: media.contentType,
-            stickerMetadata: media.stickerMetadata,
-          });
+          allMedia.push(media);
         } else {
           skippedCount++;
         }
@@ -1190,13 +1186,7 @@ export const registerTelegramHandlers = ({
             maxBytes: mediaMaxBytes,
             ...mediaRuntimeOptions,
           });
-          mediaRef = media
-            ? {
-                path: media.path,
-                ...(media.contentType ? { contentType: media.contentType } : {}),
-                ...(media.stickerMetadata ? { stickerMetadata: media.stickerMetadata } : {}),
-              }
-            : undefined;
+          mediaRef = media ?? undefined;
         } catch (err) {
           logger.warn(
             { chatId: ctx.message.chat.id, error: String(err) },
@@ -2023,15 +2013,7 @@ export const registerTelegramHandlers = ({
       return;
     }
 
-    const allMedia = media
-      ? [
-          {
-            path: media.path,
-            contentType: media.contentType,
-            stickerMetadata: media.stickerMetadata,
-          },
-        ]
-      : [];
+    const allMedia: TelegramMediaRef[] = media ? [media] : [];
     const conversationKey = buildTelegramInboundDebounceConversationKey({
       chatId,
       threadId: resolvedThreadId ?? dmThreadId,

--- a/extensions/telegram/src/bot-message-context.audio-transcript.test-support.ts
+++ b/extensions/telegram/src/bot-message-context.audio-transcript.test-support.ts
@@ -1,13 +1,17 @@
 // Telegram plugin module implements bot message context.audio transcript support behavior.
+import { createHash } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const transcribeFirstAudioMock = vi.fn();
+const transcribeFirstAudioWithTelemetryMock = vi.fn();
 const DEFAULT_MODEL = "anthropic/claude-opus-4-5";
 const DEFAULT_WORKSPACE = "/tmp/openclaw";
 const DEFAULT_MENTION_PATTERN = "\\bbot\\b";
 
 vi.mock("./media-understanding.runtime.js", () => ({
   transcribeFirstAudio: (...args: unknown[]) => transcribeFirstAudioMock(...args),
+  transcribeFirstAudioWithTelemetry: (...args: unknown[]) =>
+    transcribeFirstAudioWithTelemetryMock(...args),
 }));
 
 const { buildTelegramMessageContextForTest } =
@@ -22,6 +26,8 @@ async function buildGroupVoiceContext(params: {
   firstName: string;
   fileId: string;
   mediaPath: string;
+  mediaSize?: number;
+  mimeType?: string;
   groupDisableAudioPreflight?: boolean;
   topicDisableAudioPreflight?: boolean;
 }) {
@@ -43,9 +49,26 @@ async function buildGroupVoiceContext(params: {
       date: params.date,
       text: undefined,
       from: { id: params.fromId, first_name: params.firstName },
-      voice: { file_id: params.fileId },
+      voice: {
+        file_id: params.fileId,
+        file_unique_id: `${params.fileId}-unique`,
+        duration: 7,
+        mime_type: params.mimeType ?? "audio/ogg",
+      },
     },
-    allMedia: [{ path: params.mediaPath, contentType: "audio/ogg" }],
+    allMedia: [
+      {
+        path: params.mediaPath,
+        contentType: params.mimeType ?? "audio/ogg",
+        size: params.mediaSize ?? 4096,
+        mediaKind: "voice",
+        telegramFileId: params.fileId,
+        telegramFileUniqueId: `${params.fileId}-unique`,
+        telegramFilePath: `voice/${params.fileId}.ogg`,
+        telegramMimeType: params.mimeType ?? "audio/ogg",
+        durationSeconds: 7,
+      },
+    ],
     options: { forceWasMentioned: true },
     cfg: {
       agents: { defaults: { model: DEFAULT_MODEL, workspace: DEFAULT_WORKSPACE } },
@@ -59,6 +82,30 @@ async function buildGroupVoiceContext(params: {
       topicConfig,
     }),
   });
+}
+
+function transcriptHash(transcript: string): string {
+  return createHash("sha256").update(transcript).digest("hex");
+}
+
+function successfulPreflightResult(transcript: string) {
+  return {
+    transcript,
+    telemetry: {
+      status: "success",
+      provider: "openai",
+      model: "whisper-1",
+      baseUrl: "https://stt.example.test/v1",
+      durationMs: 24,
+      transcript: {
+        length: transcript.length,
+        sha256: transcriptHash(transcript),
+        trusted: false,
+        truncated: false,
+        enteredAgentContext: false,
+      },
+    },
+  };
 }
 
 function expectTranscriptRendered(
@@ -81,10 +128,13 @@ function expectAudioPlaceholderRendered(ctx: Awaited<ReturnType<typeof buildGrou
 describe("buildTelegramMessageContext audio transcript body", () => {
   beforeEach(() => {
     transcribeFirstAudioMock.mockReset();
+    transcribeFirstAudioWithTelemetryMock.mockReset();
   });
 
   it("uses preflight transcript as BodyForAgent for mention-gated group voice messages", async () => {
-    transcribeFirstAudioMock.mockResolvedValueOnce("hey bot please help");
+    transcribeFirstAudioWithTelemetryMock.mockResolvedValueOnce(
+      successfulPreflightResult("hey bot please help"),
+    );
 
     const ctx = await buildGroupVoiceContext({
       messageId: 1,
@@ -97,7 +147,7 @@ describe("buildTelegramMessageContext audio transcript body", () => {
       mediaPath: "/tmp/voice.ogg",
     });
 
-    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(transcribeFirstAudioWithTelemetryMock).toHaveBeenCalledTimes(1);
     expectTranscriptRendered(ctx, "hey bot please help");
   });
 
@@ -117,11 +167,14 @@ describe("buildTelegramMessageContext audio transcript body", () => {
     });
 
     expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
+    expect(transcribeFirstAudioWithTelemetryMock).not.toHaveBeenCalled();
     expectAudioPlaceholderRendered(ctx);
   });
 
   it("uses topic disableAudioPreflight=false to override group disableAudioPreflight=true", async () => {
-    transcribeFirstAudioMock.mockResolvedValueOnce("topic override transcript");
+    transcribeFirstAudioWithTelemetryMock.mockResolvedValueOnce(
+      successfulPreflightResult("topic override transcript"),
+    );
 
     const ctx = await buildGroupVoiceContext({
       messageId: 3,
@@ -136,7 +189,7 @@ describe("buildTelegramMessageContext audio transcript body", () => {
       topicDisableAudioPreflight: false,
     });
 
-    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(transcribeFirstAudioWithTelemetryMock).toHaveBeenCalledTimes(1);
     expectTranscriptRendered(ctx, "topic override transcript");
   });
 
@@ -157,6 +210,177 @@ describe("buildTelegramMessageContext audio transcript body", () => {
     });
 
     expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
+    expect(transcribeFirstAudioWithTelemetryMock).not.toHaveBeenCalled();
     expectAudioPlaceholderRendered(ctx);
+  });
+
+  it("surfaces per-message voice STT handoff telemetry in agent context", async () => {
+    const transcript = "hey bot please help";
+    transcribeFirstAudioWithTelemetryMock.mockResolvedValueOnce(
+      successfulPreflightResult(transcript),
+    );
+
+    const ctx = await buildGroupVoiceContext({
+      messageId: 5,
+      chatId: -1001234567894,
+      title: "Test Group 5",
+      date: 1700000400,
+      fromId: 46,
+      firstName: "Eve",
+      fileId: "voice-5",
+      mediaPath: "/tmp/voice5.ogg",
+      mediaSize: 8192,
+    });
+
+    const ctxPayload = ctx?.ctxPayload as
+      | {
+          TelegramVoiceSttTelemetry?: unknown;
+          UntrustedStructuredContext?: Array<{ type?: string; payload?: unknown }>;
+        }
+      | undefined;
+    const handoff = ctxPayload?.UntrustedStructuredContext?.find(
+      (entry) => entry.type === "telegram_voice_stt_handoff",
+    )?.payload as Record<string, unknown> | undefined;
+
+    expectTranscriptRendered(ctx, transcript);
+    expect(handoff).toMatchObject({
+      media: {
+        kind: "voice",
+        fileId: "voice-5",
+        fileUniqueId: "voice-5-unique",
+        mediaReference: "voice/voice-5.ogg",
+        durationSeconds: 7,
+      },
+      download: {
+        bytes: 8192,
+        mime: "audio/ogg",
+        path: "/tmp/voice5.ogg",
+      },
+      stt: {
+        provider: "openai",
+        model: "whisper-1",
+        baseUrl: "https://stt.example.test/v1",
+        status: "success",
+      },
+      transcript: {
+        length: transcript.length,
+        sha256: transcriptHash(transcript),
+        trusted: false,
+        truncated: false,
+        enteredAgentContext: true,
+      },
+    });
+    expect(ctxPayload?.TelegramVoiceSttTelemetry).toEqual(handoff);
+  });
+
+  it("surfaces failed voice STT state instead of presenting bad text as speech", async () => {
+    transcribeFirstAudioWithTelemetryMock.mockResolvedValueOnce({
+      transcript: undefined,
+      telemetry: {
+        status: "timeout",
+        durationMs: 30_001,
+        errorClass: "TimeoutError",
+        transcript: {
+          length: 0,
+          trusted: false,
+          truncated: false,
+          enteredAgentContext: false,
+        },
+      },
+    });
+
+    const ctx = await buildGroupVoiceContext({
+      messageId: 6,
+      chatId: -1001234567895,
+      title: "Test Group 6",
+      date: 1700000500,
+      fromId: 47,
+      firstName: "Frank",
+      fileId: "voice-6",
+      mediaPath: "/tmp/voice6.ogg",
+    });
+
+    const ctxPayload = ctx?.ctxPayload as
+      | {
+          BodyForAgent?: string;
+          TelegramVoiceSttTelemetry?: unknown;
+          UntrustedStructuredContext?: Array<{ type?: string; payload?: unknown }>;
+        }
+      | undefined;
+    const handoff = ctxPayload?.UntrustedStructuredContext?.find(
+      (entry) => entry.type === "telegram_voice_stt_handoff",
+    )?.payload as Record<string, unknown> | undefined;
+
+    expect(ctxPayload?.BodyForAgent).toContain("Audio transcript unavailable");
+    expect(ctxPayload?.BodyForAgent).toContain("timeout");
+    expect(ctxPayload?.BodyForAgent).not.toContain("[Audio transcript (machine-generated");
+    expect(handoff).toMatchObject({
+      stt: {
+        status: "timeout",
+        errorClass: "TimeoutError",
+      },
+      transcript: {
+        length: 0,
+        trusted: false,
+        truncated: false,
+        enteredAgentContext: false,
+      },
+    });
+    expect(ctxPayload?.TelegramVoiceSttTelemetry).toEqual(handoff);
+  });
+
+  it("labels truncated voice STT transcripts in body and telemetry", async () => {
+    const transcript = "partial voice text";
+    transcribeFirstAudioWithTelemetryMock.mockResolvedValueOnce({
+      transcript,
+      telemetry: {
+        status: "truncated",
+        provider: "openai",
+        model: "whisper-1",
+        durationMs: 88,
+        transcript: {
+          length: transcript.length,
+          sha256: transcriptHash(transcript),
+          trusted: false,
+          truncated: true,
+          enteredAgentContext: false,
+        },
+      },
+    });
+
+    const ctx = await buildGroupVoiceContext({
+      messageId: 7,
+      chatId: -1001234567896,
+      title: "Test Group 7",
+      date: 1700000600,
+      fromId: 48,
+      firstName: "Grace",
+      fileId: "voice-7",
+      mediaPath: "/tmp/voice7.ogg",
+    });
+
+    const ctxPayload = ctx?.ctxPayload as
+      | {
+          BodyForAgent?: string;
+          UntrustedStructuredContext?: Array<{ type?: string; payload?: unknown }>;
+        }
+      | undefined;
+    const handoff = ctxPayload?.UntrustedStructuredContext?.find(
+      (entry) => entry.type === "telegram_voice_stt_handoff",
+    )?.payload as Record<string, unknown> | undefined;
+
+    expect(ctxPayload?.BodyForAgent).toContain("machine-generated, untrusted, truncated");
+    expect(handoff).toMatchObject({
+      stt: {
+        status: "truncated",
+      },
+      transcript: {
+        length: transcript.length,
+        sha256: transcriptHash(transcript),
+        trusted: false,
+        truncated: true,
+        enteredAgentContext: true,
+      },
+    });
   });
 });

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -32,6 +32,7 @@ import type {
   TelegramLogger,
   TelegramMediaRef,
   TelegramMessageContextOptions,
+  TelegramVoiceSttTelemetry,
 } from "./bot-message-context.types.js";
 import {
   buildSenderLabel,
@@ -49,6 +50,10 @@ import { resolveTelegramCommandIngressAuthorization } from "./ingress.js";
 
 type StickerVisionRuntime = typeof import("./sticker-vision.runtime.js");
 type MediaUnderstandingRuntime = typeof import("./media-understanding.runtime.js");
+type AudioPreflightRuntimeResult = Awaited<
+  ReturnType<MediaUnderstandingRuntime["transcribeFirstAudioWithTelemetry"]>
+>;
+type AudioPreflightRuntimeTelemetry = NonNullable<AudioPreflightRuntimeResult>["telemetry"];
 
 let stickerVisionRuntimePromise: Promise<StickerVisionRuntime> | undefined;
 let mediaUnderstandingRuntimePromise: Promise<MediaUnderstandingRuntime> | undefined;
@@ -73,12 +78,31 @@ export type TelegramInboundBodyResult = {
   shouldBypassMention: boolean;
   hasControlCommand: boolean;
   audioTranscribedMediaIndex?: number;
+  audioPreflightTelemetry?: TelegramVoiceSttTelemetry;
   stickerCacheHit: boolean;
   locationData?: NormalizedLocation;
 };
 
-function formatAudioTranscriptForAgent(transcript: string): string {
-  return `[Audio transcript (machine-generated, untrusted)]: ${JSON.stringify(transcript)}`;
+function formatAudioTranscriptForAgent(
+  transcript: string,
+  telemetry?: TelegramVoiceSttTelemetry,
+): string {
+  const labels = ["machine-generated", telemetry?.transcript.trusted ? "trusted" : "untrusted"];
+  if (telemetry?.transcript.truncated) {
+    labels.push("truncated");
+  }
+  return `[Audio transcript (${labels.join(", ")})]: ${JSON.stringify(transcript)}`;
+}
+
+function formatAudioTranscriptUnavailableForAgent(
+  telemetry?: TelegramVoiceSttTelemetry,
+): string {
+  const status = telemetry?.stt.status ?? "missing";
+  const errorClass = telemetry?.stt.errorClass ? `/${telemetry.stt.errorClass}` : "";
+  return (
+    `[Audio transcript unavailable: ${status}${errorClass}] ` +
+    "Voice message received, but STT did not produce a usable transcript."
+  );
 }
 
 type TelegramSavedMediaKind = "audio" | "document" | "image" | "video";
@@ -95,6 +119,14 @@ function resolveSavedMediaKind(contentType: string | undefined): TelegramSavedMe
     return "video";
   }
   return "document";
+}
+
+function isTelegramAudioMedia(media: TelegramMediaRef): boolean {
+  return (
+    media.contentType?.startsWith("audio/") === true ||
+    media.mediaKind === "voice" ||
+    media.mediaKind === "audio"
+  );
 }
 
 function formatSavedMediaPlaceholder(allMedia: TelegramMediaRef[]): string | undefined {
@@ -117,6 +149,42 @@ function formatSavedMediaPlaceholder(allMedia: TelegramMediaRef[]): string | und
     return `<media:audio> (${allMedia.length} audio attachments)`;
   }
   return `<media:document> (${allMedia.length} attachments)`;
+}
+
+function buildTelegramVoiceSttTelemetry(params: {
+  media?: TelegramMediaRef;
+  preflight: AudioPreflightRuntimeTelemetry;
+}): TelegramVoiceSttTelemetry {
+  const { media, preflight } = params;
+  return {
+    media: {
+      kind: media?.mediaKind,
+      fileId: media?.telegramFileId,
+      fileUniqueId: media?.telegramFileUniqueId,
+      mediaReference: media?.telegramFilePath ?? media?.path,
+      durationSeconds: media?.durationSeconds,
+    },
+    download: {
+      bytes: media?.size,
+      mime: media?.contentType ?? media?.telegramMimeType,
+      path: media?.path,
+    },
+    stt: {
+      status: preflight.status,
+      provider: preflight.provider,
+      model: preflight.model,
+      baseUrl: preflight.baseUrl,
+      durationMs: preflight.durationMs,
+      errorClass: preflight.errorClass,
+    },
+    transcript: {
+      length: preflight.transcript.length,
+      sha256: preflight.transcript.sha256,
+      trusted: preflight.transcript.trusted,
+      truncated: preflight.transcript.truncated,
+      enteredAgentContext: false,
+    },
+  };
 }
 
 async function resolveStickerVisionSupport(params: {
@@ -252,7 +320,7 @@ export async function resolveTelegramInboundBody(params: {
       : placeholder;
     bodyText = `${mediaTag}\n${bodyText}`.trim();
   }
-  const hasAudio = allMedia.some((media) => media.contentType?.startsWith("audio/"));
+  const hasAudio = allMedia.some(isTelegramAudioMedia);
   const disableAudioPreflight =
     (topicConfig?.disableAudioPreflight ??
       (groupConfig as TelegramGroupConfig | undefined)?.disableAudioPreflight) === true;
@@ -260,6 +328,7 @@ export async function resolveTelegramInboundBody(params: {
     !useAccessGroups || !allowForCommands.hasEntries || commandAuthorized;
 
   let preflightTranscript: string | undefined;
+  let audioPreflightTelemetry: TelegramVoiceSttTelemetry | undefined;
   const needsPreflightTranscription =
     hasAudio &&
     !hasUserText &&
@@ -271,7 +340,7 @@ export async function resolveTelegramInboundBody(params: {
 
   if (needsPreflightTranscription) {
     try {
-      const { transcribeFirstAudio } = await loadMediaUnderstandingRuntime();
+      const { transcribeFirstAudioWithTelemetry } = await loadMediaUnderstandingRuntime();
       const tempCtx: MsgContext = {
         Provider: "telegram",
         Surface: "telegram",
@@ -285,11 +354,19 @@ export async function resolveTelegramInboundBody(params: {
             ? (allMedia.map((m) => m.contentType).filter(Boolean) as string[])
             : undefined,
       };
-      preflightTranscript = await transcribeFirstAudio({
+      const preflightResult = await transcribeFirstAudioWithTelemetry({
         ctx: tempCtx,
         cfg,
         agentDir: undefined,
       });
+      preflightTranscript = preflightResult?.transcript;
+      if (preflightResult?.telemetry) {
+        const audioMedia = allMedia.find(isTelegramAudioMedia);
+        audioPreflightTelemetry = buildTelegramVoiceSttTelemetry({
+          media: audioMedia,
+          preflight: preflightResult.telemetry,
+        });
+      }
     } catch (err) {
       logVerbose(`telegram: audio preflight transcription failed: ${String(err)}`);
     }
@@ -297,10 +374,12 @@ export async function resolveTelegramInboundBody(params: {
   const audioTranscribedMediaIndex =
     preflightTranscript === undefined
       ? undefined
-      : allMedia.findIndex((media) => media.contentType?.startsWith("audio/"));
+      : allMedia.findIndex(isTelegramAudioMedia);
 
   if (hasAudio && bodyText === "<media:audio>" && preflightTranscript) {
-    bodyText = formatAudioTranscriptForAgent(preflightTranscript);
+    bodyText = formatAudioTranscriptForAgent(preflightTranscript, audioPreflightTelemetry);
+  } else if (hasAudio && bodyText === "<media:audio>" && audioPreflightTelemetry) {
+    bodyText = formatAudioTranscriptUnavailableForAgent(audioPreflightTelemetry);
   }
 
   const savedMediaPlaceholder = formatSavedMediaPlaceholder(allMedia);
@@ -310,8 +389,10 @@ export async function resolveTelegramInboundBody(params: {
   if (!bodyText && allMedia.length > 0) {
     if (hasAudio) {
       bodyText = preflightTranscript
-        ? formatAudioTranscriptForAgent(preflightTranscript)
-        : "<media:audio>";
+        ? formatAudioTranscriptForAgent(preflightTranscript, audioPreflightTelemetry)
+        : audioPreflightTelemetry
+          ? formatAudioTranscriptUnavailableForAgent(audioPreflightTelemetry)
+          : "<media:audio>";
     } else {
       bodyText = savedMediaPlaceholder ?? "<media:document>";
     }
@@ -438,6 +519,7 @@ export async function resolveTelegramInboundBody(params: {
     ...(audioTranscribedMediaIndex !== undefined && audioTranscribedMediaIndex >= 0
       ? { audioTranscribedMediaIndex }
       : {}),
+    ...(audioPreflightTelemetry ? { audioPreflightTelemetry } : {}),
     stickerCacheHit,
     locationData: locationData ?? undefined,
   };

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -31,6 +31,7 @@ import type {
   TelegramMessageContextOptions,
   TelegramMessageContextSessionRuntimeOverrides,
   TelegramPromptContextEntry,
+  TelegramVoiceSttTelemetry,
 } from "./bot-message-context.types.js";
 import {
   buildGroupLabel,
@@ -154,6 +155,22 @@ function formatReplyChainEntry(entry: TelegramReplyChainEntry, index: number): s
   return `[${labels.join(" ")}]\n${bodyLines.join("\n")}`;
 }
 
+function markTelegramVoiceSttAgentContext(params: {
+  telemetry?: TelegramVoiceSttTelemetry;
+  transcriptEnteredAgentContext: boolean;
+}): TelegramVoiceSttTelemetry | undefined {
+  if (!params.telemetry) {
+    return undefined;
+  }
+  return {
+    ...params.telemetry,
+    transcript: {
+      ...params.telemetry.transcript,
+      enteredAgentContext: params.transcriptEnteredAgentContext,
+    },
+  };
+}
+
 export async function buildTelegramInboundContextPayload(params: {
   cfg: OpenClawConfig;
   primaryCtx: TelegramContext;
@@ -182,6 +199,7 @@ export async function buildTelegramInboundContextPayload(params: {
   effectiveWasMentioned: boolean;
   hasControlCommand: boolean;
   audioTranscribedMediaIndex?: number;
+  audioPreflightTelemetry?: TelegramVoiceSttTelemetry;
   commandAuthorized: boolean;
   locationData?: NormalizedLocation;
   options?: TelegramMessageContextOptions;
@@ -231,6 +249,7 @@ export async function buildTelegramInboundContextPayload(params: {
     effectiveWasMentioned,
     hasControlCommand,
     audioTranscribedMediaIndex,
+    audioPreflightTelemetry,
     commandAuthorized,
     locationData,
     options,
@@ -444,6 +463,23 @@ export async function buildTelegramInboundContextPayload(params: {
   const hasAbortRequest = isAbortRequestText(rawBody, {
     botUsername: normalizeOptionalLowercaseString(primaryCtx.me?.username),
   });
+  const telegramVoiceSttTelemetry = markTelegramVoiceSttAgentContext({
+    telemetry: audioPreflightTelemetry,
+    transcriptEnteredAgentContext:
+      audioTranscribedMediaIndex !== undefined &&
+      bodyText.includes("[Audio transcript") &&
+      !bodyText.includes("Audio transcript unavailable"),
+  });
+  const telegramVoiceSttUntrustedContext = telegramVoiceSttTelemetry
+    ? [
+        {
+          label: "Telegram voice/STT handoff telemetry",
+          type: "telegram_voice_stt_handoff",
+          source: "telegram",
+          payload: telegramVoiceSttTelemetry,
+        },
+      ]
+    : undefined;
   const conversationKind = isGroup ? "group" : "direct";
   const inboundEventKind = classifyChannelInboundEvent({
     conversation: { kind: conversationKind },
@@ -562,6 +598,8 @@ export async function buildTelegramInboundContextPayload(params: {
       WasMentioned: isGroup ? effectiveWasMentioned : undefined,
       Sticker: allMedia[0]?.stickerMetadata,
       StickerMediaIncluded: allMedia[0]?.stickerMetadata ? !stickerCacheHit : undefined,
+      TelegramVoiceSttTelemetry: telegramVoiceSttTelemetry,
+      UntrustedStructuredContext: telegramVoiceSttUntrustedContext,
       ...locationContext,
       IsForum: isForum,
       TopicName: isForum && topicName ? topicName : undefined,

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -525,6 +525,7 @@ export const buildTelegramMessageContext = async ({
     ...(bodyResult.audioTranscribedMediaIndex !== undefined
       ? { audioTranscribedMediaIndex: bodyResult.audioTranscribedMediaIndex }
       : {}),
+    audioPreflightTelemetry: bodyResult.audioPreflightTelemetry,
     locationData: bodyResult.locationData,
     options,
     dmAllowFrom: dmAllow.allowFrom,

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -15,7 +15,53 @@ import type { TelegramReplyChainEntry } from "./message-cache.js";
 export type TelegramMediaRef = {
   path: string;
   contentType?: string;
+  size?: number;
+  mediaKind?: "voice" | "audio" | "video_note" | "video" | "document" | "photo" | "sticker";
+  telegramFileId?: string;
+  telegramFileUniqueId?: string;
+  telegramFilePath?: string;
+  telegramFileName?: string;
+  telegramMimeType?: string;
+  durationSeconds?: number;
   stickerMetadata?: StickerMetadata;
+};
+
+export type TelegramVoiceSttStatus =
+  | "success"
+  | "missing"
+  | "timeout"
+  | "failed"
+  | "truncated"
+  | "disabled";
+
+export type TelegramVoiceSttTelemetry = {
+  media: {
+    kind?: TelegramMediaRef["mediaKind"];
+    fileId?: string;
+    fileUniqueId?: string;
+    mediaReference?: string;
+    durationSeconds?: number;
+  };
+  download: {
+    bytes?: number;
+    mime?: string;
+    path?: string;
+  };
+  stt: {
+    status: TelegramVoiceSttStatus;
+    provider?: string;
+    model?: string;
+    baseUrl?: string;
+    durationMs?: number;
+    errorClass?: string;
+  };
+  transcript: {
+    length: number;
+    sha256?: string;
+    trusted: boolean;
+    truncated: boolean;
+    enteredAgentContext: boolean;
+  };
 };
 
 export type TelegramMessageContextOptions = {

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -85,6 +85,8 @@ interface MediaMetadata {
     | TelegramContext["message"]["voice"];
   fileName?: string;
   mimeType?: string;
+  mediaKind?: "voice" | "audio" | "video_note" | "video" | "document" | "photo" | "sticker";
+  durationSeconds?: number;
 }
 
 function resolveMediaMetadata(msg: TelegramContext["message"]): MediaMetadata {
@@ -107,6 +109,21 @@ function resolveMediaMetadata(msg: TelegramContext["message"]): MediaMetadata {
       msg.video?.mime_type ??
       msg.document?.mime_type ??
       msg.animation?.mime_type,
+    mediaKind: msg.voice
+      ? "voice"
+      : msg.audio
+        ? "audio"
+        : msg.video_note
+          ? "video_note"
+          : msg.video
+            ? "video"
+            : msg.document
+              ? "document"
+              : msg.photo
+                ? "photo"
+                : undefined,
+    durationSeconds:
+      msg.voice?.duration ?? msg.audio?.duration ?? msg.video_note?.duration ?? msg.video?.duration,
   };
 }
 
@@ -275,6 +292,11 @@ async function resolveStickerMedia(params: {
       path: string;
       contentType?: string;
       placeholder: string;
+      size?: number;
+      mediaKind?: "sticker";
+      telegramFileId?: string;
+      telegramFileUniqueId?: string;
+      telegramFilePath?: string;
       stickerMetadata?: StickerMetadata;
     }
   | null
@@ -330,6 +352,11 @@ async function resolveStickerMedia(params: {
         path: saved.path,
         contentType: saved.contentType,
         placeholder: "<media:sticker>",
+        size: saved.size,
+        mediaKind: "sticker",
+        telegramFileId: fileId,
+        telegramFileUniqueId: sticker.file_unique_id,
+        telegramFilePath: file.file_path,
         stickerMetadata: {
           emoji,
           setName,
@@ -345,6 +372,11 @@ async function resolveStickerMedia(params: {
       path: saved.path,
       contentType: saved.contentType,
       placeholder: "<media:sticker>",
+      size: saved.size,
+      mediaKind: "sticker",
+      telegramFileId: sticker.file_id,
+      telegramFileUniqueId: sticker.file_unique_id,
+      telegramFilePath: file.file_path,
       stickerMetadata: {
         emoji: sticker.emoji ?? undefined,
         setName: sticker.set_name ?? undefined,
@@ -370,6 +402,14 @@ export async function resolveMedia(params: {
   path: string;
   contentType?: string;
   placeholder: string;
+  size?: number;
+  mediaKind?: MediaMetadata["mediaKind"];
+  telegramFileId?: string;
+  telegramFileUniqueId?: string;
+  telegramFilePath?: string;
+  telegramFileName?: string;
+  telegramMimeType?: string;
+  durationSeconds?: number;
   stickerMetadata?: StickerMetadata;
 } | null> {
   const {
@@ -421,5 +461,17 @@ export async function resolveMedia(params: {
     dangerouslyAllowPrivateNetwork,
   });
   const placeholder = resolveTelegramMediaPlaceholder(msg) ?? "<media:document>";
-  return { path: saved.path, contentType: saved.contentType, placeholder };
+  return {
+    path: saved.path,
+    contentType: saved.contentType,
+    placeholder,
+    size: saved.size,
+    mediaKind: metadata.mediaKind,
+    telegramFileId: m.file_id,
+    telegramFileUniqueId: "file_unique_id" in m ? m.file_unique_id : undefined,
+    telegramFilePath: file.file_path,
+    telegramFileName: metadata.fileName,
+    telegramMimeType: metadata.mimeType,
+    durationSeconds: metadata.durationSeconds,
+  };
 }

--- a/extensions/telegram/src/media-understanding.runtime.ts
+++ b/extensions/telegram/src/media-understanding.runtime.ts
@@ -2,11 +2,14 @@
 import {
   describeImageWithModel as describeImageWithModelImpl,
   transcribeFirstAudio as transcribeFirstAudioImpl,
+  transcribeFirstAudioWithTelemetry as transcribeFirstAudioWithTelemetryImpl,
 } from "openclaw/plugin-sdk/media-runtime";
 
 type DescribeImageWithModel =
   typeof import("openclaw/plugin-sdk/media-runtime").describeImageWithModel;
 type TranscribeFirstAudio = typeof import("openclaw/plugin-sdk/media-runtime").transcribeFirstAudio;
+type TranscribeFirstAudioWithTelemetry =
+  typeof import("openclaw/plugin-sdk/media-runtime").transcribeFirstAudioWithTelemetry;
 
 export async function describeImageWithModel(
   ...args: Parameters<DescribeImageWithModel>
@@ -18,4 +21,10 @@ export async function transcribeFirstAudio(
   ...args: Parameters<TranscribeFirstAudio>
 ): ReturnType<TranscribeFirstAudio> {
   return await transcribeFirstAudioImpl(...args);
+}
+
+export async function transcribeFirstAudioWithTelemetry(
+  ...args: Parameters<TranscribeFirstAudioWithTelemetry>
+): ReturnType<TranscribeFirstAudioWithTelemetry> {
+  return await transcribeFirstAudioWithTelemetryImpl(...args);
 }

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -159,6 +159,29 @@ const CronRunDiagnosticsSchema = Type.Object(
   },
   { additionalProperties: false },
 );
+const CronPayloadAuditExecutionKindSchema = Type.Union([
+  Type.Literal("system-event"),
+  Type.Literal("agent-turn"),
+  Type.Literal("deterministic-command"),
+]);
+const CronPayloadAuditWarningCodeSchema = Type.Literal("hidden-agent-turn-script");
+const CronPayloadAuditWarningSchema = Type.Object(
+  {
+    code: CronPayloadAuditWarningCodeSchema,
+    severity: Type.Literal("warn"),
+    message: Type.String(),
+    recommendation: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+export const CronPayloadAuditSchema = Type.Object(
+  {
+    executionKind: CronPayloadAuditExecutionKindSchema,
+    deterministic: Type.Boolean(),
+    warnings: Type.Array(CronPayloadAuditWarningSchema),
+  },
+  { additionalProperties: false },
+);
 const CronCommonOptionalFields = {
   agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   sessionKey: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
@@ -443,6 +466,7 @@ export const CronJobSchema = Type.Object(
     sessionTarget: CronSessionTargetSchema,
     wakeMode: CronWakeModeSchema,
     payload: CronPayloadSchema,
+    audit: Type.Optional(CronPayloadAuditSchema),
     delivery: Type.Optional(CronDeliverySchema),
     failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
     state: CronJobStateSchema,

--- a/src/cron/cron-protocol-schema.test.ts
+++ b/src/cron/cron-protocol-schema.test.ts
@@ -1,6 +1,6 @@
 // Cron protocol schema tests cover runtime validation for cron protocol payloads.
 import { describe, expect, it } from "vitest";
-import { CronJobStateSchema } from "../../packages/gateway-protocol/src/schema.js";
+import { CronJobSchema, CronJobStateSchema } from "../../packages/gateway-protocol/src/schema.js";
 
 type SchemaLike = {
   properties?: Record<string, unknown>;
@@ -22,5 +22,17 @@ describe("cron protocol schema", () => {
     expect(properties.lastFailureNotificationDelivered).toBeDefined();
     expect(properties.lastFailureNotificationDeliveryStatus).toBeDefined();
     expect(properties.lastFailureNotificationDeliveryError).toBeDefined();
+  });
+
+  it("exposes cron payload audit metadata on listed jobs", () => {
+    const properties = (CronJobSchema as SchemaLike).properties ?? {};
+    const audit = properties.audit as SchemaLike | undefined;
+
+    expect(audit).toBeDefined();
+    expect(audit?.properties).toMatchObject({
+      executionKind: expect.any(Object),
+      deterministic: expect.any(Object),
+      warnings: expect.any(Object),
+    });
   });
 });

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -5,6 +5,7 @@ import {
   validateCronUpdateParams,
 } from "../../packages/gateway-protocol/src/index.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "./normalize.js";
+import { resolveCronPayloadAudit } from "./payload-audit.js";
 import { DEFAULT_TOP_OF_HOUR_STAGGER_MS } from "./stagger.js";
 
 function expectNormalizedAtSchedule(scheduleInput: Record<string, unknown>) {
@@ -416,6 +417,43 @@ describe("normalizeCronJobCreate", () => {
       argv: ["printf", "%s", "  padded value  "],
     });
     expect(validateCronAddParams(normalized)).toBe(true);
+  });
+
+  it("classifies explicit command payloads as deterministic scheduler jobs", () => {
+    const audit = resolveCronPayloadAudit({
+      kind: "command",
+      argv: ["openclaw", "support", "sync", "--json"],
+      cwd: "/srv/openclaw",
+      timeoutSeconds: 60,
+    });
+
+    expect(audit).toEqual({
+      executionKind: "deterministic-command",
+      deterministic: true,
+      warnings: [],
+    });
+  });
+
+  it("warns when a legacy agentTurn payload hides a deterministic script", () => {
+    const audit = resolveCronPayloadAudit({
+      kind: "agentTurn",
+      message: [
+        "Run this exact scheduled job.",
+        "```bash",
+        "node scripts/matt-malory-watchdog.js --json",
+        "```",
+      ].join("\n"),
+    });
+
+    expect(audit.executionKind).toBe("agent-turn");
+    expect(audit.deterministic).toBe(false);
+    expect(audit.warnings).toEqual([
+      expect.objectContaining({
+        code: "hidden-agent-turn-script",
+        severity: "warn",
+      }),
+    ]);
+    expect(audit.warnings[0]?.message).toContain('payload.kind="command"');
   });
 
   it("preserves timeoutSeconds=0 for no-timeout agentTurn payloads", () => {

--- a/src/cron/payload-audit.ts
+++ b/src/cron/payload-audit.ts
@@ -1,25 +1,8 @@
-/** Audit metadata for deterministic command jobs and legacy agentTurn scripts. */
 import type { CronPayload } from "./types.js";
-
-export type CronPayloadAuditExecutionKind =
-  | "system-event"
-  | "agent-turn"
-  | "deterministic-command";
-
-export type CronPayloadAuditWarningCode = "hidden-agent-turn-script";
-
-export type CronPayloadAuditWarning = {
-  code: CronPayloadAuditWarningCode;
-  severity: "warn";
-  message: string;
-  recommendation?: string;
-};
-
-export type CronPayloadAuditMetadata = {
-  executionKind: CronPayloadAuditExecutionKind;
-  deterministic: boolean;
-  warnings: CronPayloadAuditWarning[];
-};
+import type {
+  CronPayloadAuditMetadata,
+  CronPayloadAuditWarning,
+} from "./types-shared.js";
 
 const SCRIPT_BLOCK_RE = /```(?:bash|sh|zsh|shell|js|ts|node|python|py)?\s+[\s\S]*?```/iu;
 const SHELL_COMMAND_RE =

--- a/src/cron/payload-audit.ts
+++ b/src/cron/payload-audit.ts
@@ -1,0 +1,74 @@
+/** Audit metadata for deterministic command jobs and legacy agentTurn scripts. */
+import type { CronPayload } from "./types.js";
+
+export type CronPayloadAuditExecutionKind =
+  | "system-event"
+  | "agent-turn"
+  | "deterministic-command";
+
+export type CronPayloadAuditWarningCode = "hidden-agent-turn-script";
+
+export type CronPayloadAuditWarning = {
+  code: CronPayloadAuditWarningCode;
+  severity: "warn";
+  message: string;
+  recommendation?: string;
+};
+
+export type CronPayloadAuditMetadata = {
+  executionKind: CronPayloadAuditExecutionKind;
+  deterministic: boolean;
+  warnings: CronPayloadAuditWarning[];
+};
+
+const SCRIPT_BLOCK_RE = /```(?:bash|sh|zsh|shell|js|ts|node|python|py)?\s+[\s\S]*?```/iu;
+const SHELL_COMMAND_RE =
+  /(?:^|\n)\s*(?:\$\s*)?(?:bash|sh|zsh|node|python3?|pnpm|npm|bun|openclaw|curl|wget|sqlite3|psql|rsync|scp|ssh)\s+[\w./:-]/iu;
+const EXACT_SCRIPT_LANGUAGE_RE =
+  /\b(?:run|execute|call|invoke)\s+(?:this\s+)?(?:exact|deterministic|scheduled)?\s*(?:script|command|job)\b/iu;
+
+function looksLikeHiddenScript(message: string): boolean {
+  const normalized = message.trim();
+  if (!normalized) {
+    return false;
+  }
+  if (SCRIPT_BLOCK_RE.test(normalized) && SHELL_COMMAND_RE.test(normalized)) {
+    return true;
+  }
+  return EXACT_SCRIPT_LANGUAGE_RE.test(normalized) && SHELL_COMMAND_RE.test(normalized);
+}
+
+function hiddenAgentTurnScriptWarning(): CronPayloadAuditWarning {
+  return {
+    code: "hidden-agent-turn-script",
+    severity: "warn",
+    message:
+      'This scheduled agentTurn appears to hide a deterministic script. Prefer payload.kind="command" with an explicit argv vector for scheduled command jobs.',
+    recommendation:
+      'Convert the job payload to { "kind": "command", "argv": [...] } so scheduler JSON exposes the deterministic command directly.',
+  };
+}
+
+export function resolveCronPayloadAudit(payload: CronPayload): CronPayloadAuditMetadata {
+  if (payload.kind === "command") {
+    return {
+      executionKind: "deterministic-command",
+      deterministic: true,
+      warnings: [],
+    };
+  }
+
+  if (payload.kind === "agentTurn") {
+    return {
+      executionKind: "agent-turn",
+      deterministic: false,
+      warnings: looksLikeHiddenScript(payload.message) ? [hiddenAgentTurnScriptWarning()] : [],
+    };
+  }
+
+  return {
+    executionKind: "system-event",
+    deterministic: false,
+    warnings: [],
+  };
+}

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -6,6 +6,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
+import { resolveCronPayloadAudit } from "../payload-audit.js";
 import {
   coerceFiniteScheduleNumber,
   computeNextRunAtMs,
@@ -783,6 +784,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     sessionTarget: input.sessionTarget,
     wakeMode: input.wakeMode,
     payload: input.payload,
+    audit: resolveCronPayloadAudit(input.payload),
     delivery: resolveInitialCronDelivery(input),
     failureAlert: input.failureAlert,
     state: {
@@ -844,6 +846,7 @@ export function applyJobPatch(
   }
   if (patch.payload) {
     job.payload = mergeCronPayload(job.payload, patch.payload);
+    job.audit = resolveCronPayloadAudit(job.payload);
   }
   if (patch.delivery) {
     job.delivery = mergeCronDelivery(job.delivery, patch.delivery);

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -4,6 +4,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import { normalizeCronJobIdentityFields } from "../normalize-job-identity.js";
 import { normalizeCronJobInput } from "../normalize.js";
+import { resolveCronPayloadAudit } from "../payload-audit.js";
 import { getInvalidPersistedCronJobReason } from "../persisted-shape.js";
 import { tryCronScheduleIdentity } from "../schedule-identity.js";
 import type { CronJob, CronJobState, CronSchedule, CronStoreFile } from "../types.js";
@@ -61,7 +62,7 @@ function bindScheduleColumns(
 }
 
 function stripJobRuntimeFields(job: CronStoreFile["jobs"][number]): Record<string, unknown> {
-  const { state: _state, updatedAtMs: _updatedAtMs, ...rest } = job;
+  const { audit: _audit, state: _state, updatedAtMs: _updatedAtMs, ...rest } = job;
   // job_json stores config shape only; runtime state lives in split columns and
   // state_json so state-only writes never rewrite public job config.
   return { ...rest, state: {} };
@@ -237,6 +238,7 @@ function rowToCronJob(row: CronJobRow): CronJob | null {
     sessionTarget: row.session_target as CronJob["sessionTarget"],
     wakeMode: row.wake_mode as CronJob["wakeMode"],
     payload,
+    audit: resolveCronPayloadAudit(payload),
     ...(delivery ? { delivery } : {}),
     ...(failureAlert !== undefined ? { failureAlert } : {}),
     state: stateFromRow(row),

--- a/src/cron/types-shared.ts
+++ b/src/cron/types-shared.ts
@@ -17,3 +17,24 @@ export type CronJobBase<TSchedule, TSessionTarget, TWakeMode, TPayload, TDeliver
     delivery?: TDelivery;
     failureAlert?: TFailureAlert;
   };
+
+/** Audit metadata for deterministic command jobs and legacy agentTurn scripts. */
+export type CronPayloadAuditExecutionKind =
+  | "system-event"
+  | "agent-turn"
+  | "deterministic-command";
+
+export type CronPayloadAuditWarningCode = "hidden-agent-turn-script";
+
+export type CronPayloadAuditWarning = {
+  code: CronPayloadAuditWarningCode;
+  severity: "warn";
+  message: string;
+  recommendation?: string;
+};
+
+export type CronPayloadAuditMetadata = {
+  executionKind: CronPayloadAuditExecutionKind;
+  deterministic: boolean;
+  warnings: CronPayloadAuditWarning[];
+};

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -3,6 +3,7 @@ import type { FailoverReason } from "../agents/embedded-agent-helpers/types.js";
 import type { EmbeddedAgentExecutionPhase } from "../agents/embedded-agent-runner/execution-phase.js";
 import type { ChannelId } from "../channels/plugins/types.public.js";
 import type { HookExternalContentSource } from "../security/external-content.js";
+import type { CronPayloadAuditMetadata } from "./payload-audit.js";
 import type { CronJobBase } from "./types-shared.js";
 
 /** Supported schedule forms persisted in cron job specs. */
@@ -325,6 +326,7 @@ export type CronJob = CronJobBase<
   CronDelivery,
   CronFailureAlert | false
 > & {
+  audit?: CronPayloadAuditMetadata;
   state: CronJobState;
 };
 

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -3,8 +3,7 @@ import type { FailoverReason } from "../agents/embedded-agent-helpers/types.js";
 import type { EmbeddedAgentExecutionPhase } from "../agents/embedded-agent-runner/execution-phase.js";
 import type { ChannelId } from "../channels/plugins/types.public.js";
 import type { HookExternalContentSource } from "../security/external-content.js";
-import type { CronPayloadAuditMetadata } from "./payload-audit.js";
-import type { CronJobBase } from "./types-shared.js";
+import type { CronJobBase, CronPayloadAuditMetadata } from "./types-shared.js";
 
 /** Supported schedule forms persisted in cron job specs. */
 export type CronSchedule =

--- a/src/media-understanding/audio-preflight.test.ts
+++ b/src/media-understanding/audio-preflight.test.ts
@@ -1,7 +1,8 @@
 // Audio preflight tests cover auto mode, explicit disable, and transcript echo
 // delivery settings.
+import { createHash } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { transcribeFirstAudio } from "./audio-preflight.js";
+import { transcribeFirstAudio, transcribeFirstAudioWithTelemetry } from "./audio-preflight.js";
 
 const runAudioTranscriptionMock = vi.hoisted(() => vi.fn());
 const sendTranscriptEchoMock = vi.hoisted(() => vi.fn());
@@ -99,6 +100,130 @@ describe("transcribeFirstAudio", () => {
       cfg,
       transcript: "hello from dm audio",
       format: "Heard: {transcript}",
+    });
+  });
+
+  it("returns transcript telemetry with provider/model/baseUrl and transcript hash", async () => {
+    const transcript = "voice note transcript";
+    runAudioTranscriptionMock.mockResolvedValueOnce({
+      transcript,
+      attachments: [],
+      output: {
+        kind: "audio.transcription",
+        attachmentIndex: 0,
+        text: transcript,
+        provider: "openai",
+        model: "whisper-1",
+        baseUrl: "https://stt.example.test/v1",
+      },
+      decision: {
+        capability: "audio",
+        outcome: "success",
+        attachments: [
+          {
+            attachmentIndex: 0,
+            attempts: [
+              {
+                type: "provider",
+                provider: "openai",
+                model: "whisper-1",
+                outcome: "success",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await transcribeFirstAudioWithTelemetry({
+      ctx: {
+        Body: "<media:audio>",
+        MediaPath: "/tmp/voice.ogg",
+        MediaType: "audio/ogg",
+      },
+      cfg: {},
+    });
+
+    expect(result?.transcript).toBe(transcript);
+    expect(result?.telemetry).toMatchObject({
+      status: "success",
+      provider: "openai",
+      model: "whisper-1",
+      baseUrl: "https://stt.example.test/v1",
+      transcript: {
+        length: transcript.length,
+        sha256: createHash("sha256").update(transcript).digest("hex"),
+        trusted: false,
+        truncated: false,
+        enteredAgentContext: false,
+      },
+    });
+    expect(result?.telemetry.durationMs).toEqual(expect.any(Number));
+  });
+
+  it("marks truncated preflight transcripts in telemetry", async () => {
+    runAudioTranscriptionMock.mockResolvedValueOnce({
+      transcript: "partial transcript",
+      attachments: [],
+      output: {
+        kind: "audio.transcription",
+        attachmentIndex: 0,
+        text: "partial transcript",
+        provider: "openai",
+        model: "whisper-1",
+        truncated: true,
+      },
+      decision: {
+        capability: "audio",
+        outcome: "success",
+        attachments: [],
+      },
+    });
+
+    const result = await transcribeFirstAudioWithTelemetry({
+      ctx: {
+        Body: "<media:audio>",
+        MediaPath: "/tmp/voice.ogg",
+        MediaType: "audio/ogg",
+      },
+      cfg: {},
+    });
+
+    expect(result?.transcript).toBe("partial transcript");
+    expect(result?.telemetry).toMatchObject({
+      status: "truncated",
+      transcript: {
+        length: "partial transcript".length,
+        trusted: false,
+        truncated: true,
+        enteredAgentContext: false,
+      },
+    });
+  });
+
+  it("returns timeout telemetry when preflight STT throws", async () => {
+    const err = Object.assign(new Error("request timed out"), { name: "TimeoutError" });
+    runAudioTranscriptionMock.mockRejectedValueOnce(err);
+
+    const result = await transcribeFirstAudioWithTelemetry({
+      ctx: {
+        Body: "<media:audio>",
+        MediaPath: "/tmp/voice.ogg",
+        MediaType: "audio/ogg",
+      },
+      cfg: {},
+    });
+
+    expect(result?.transcript).toBeUndefined();
+    expect(result?.telemetry).toMatchObject({
+      status: "timeout",
+      errorClass: "TimeoutError",
+      transcript: {
+        length: 0,
+        trusted: false,
+        truncated: false,
+        enteredAgentContext: false,
+      },
     });
   });
 });

--- a/src/media-understanding/audio-preflight.ts
+++ b/src/media-understanding/audio-preflight.ts
@@ -1,5 +1,6 @@
 // Audio preflight transcribes voice notes before mention checks and optionally
 // echoes the transcript back to the source chat.
+import { createHash } from "node:crypto";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
@@ -8,27 +9,151 @@ import { isAudioAttachment } from "./attachments.js";
 import { runAudioTranscription } from "./audio-transcription-runner.js";
 import { DEFAULT_ECHO_TRANSCRIPT_FORMAT, sendTranscriptEcho } from "./echo-transcript.js";
 import { normalizeMediaAttachments, resolveMediaAttachmentLocalRoots } from "./runner.js";
-import type { MediaUnderstandingProvider } from "./types.js";
+import type {
+  MediaAttachment,
+  MediaUnderstandingDecision,
+  MediaUnderstandingOutput,
+  MediaUnderstandingProvider,
+} from "./types.js";
+
+export type AudioPreflightStatus =
+  | "success"
+  | "missing"
+  | "timeout"
+  | "failed"
+  | "truncated"
+  | "disabled";
+
+export type AudioPreflightTranscriptTelemetry = {
+  length: number;
+  sha256?: string;
+  trusted: boolean;
+  truncated: boolean;
+  enteredAgentContext: boolean;
+};
+
+export type AudioPreflightTelemetry = {
+  status: AudioPreflightStatus;
+  provider?: string;
+  model?: string;
+  baseUrl?: string;
+  durationMs: number;
+  errorClass?: string;
+  transcript: AudioPreflightTranscriptTelemetry;
+};
+
+export type AudioPreflightResult = {
+  transcript?: string;
+  attachments: MediaAttachment[];
+  telemetry: AudioPreflightTelemetry;
+};
+
+type TranscribeFirstAudioParams = {
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  providers?: Record<string, MediaUnderstandingProvider>;
+  activeModel?: ActiveMediaModel;
+};
+
+function hashTranscript(transcript: string): string {
+  return createHash("sha256").update(transcript).digest("hex");
+}
+
+function classifyError(err: unknown): { status: "timeout" | "failed"; errorClass: string } {
+  const name =
+    err && typeof err === "object" && "name" in err && typeof err.name === "string"
+      ? err.name.trim()
+      : "";
+  const message = err instanceof Error ? err.message : String(err);
+  const errorClass = name || (err instanceof Error ? err.constructor.name : "") || "Error";
+  if (/timeout|timed out|abort/i.test(`${errorClass} ${message}`)) {
+    return { status: "timeout", errorClass };
+  }
+  return { status: "failed", errorClass };
+}
+
+function selectedDecisionAttempt(decision?: MediaUnderstandingDecision) {
+  for (const attachment of decision?.attachments ?? []) {
+    if (attachment.chosen) {
+      return attachment.chosen;
+    }
+  }
+  for (const attachment of decision?.attachments ?? []) {
+    const attempt = attachment.attempts.find((entry) => entry.provider || entry.model);
+    if (attempt) {
+      return attempt;
+    }
+  }
+  return undefined;
+}
+
+function resolveMissingErrorClass(decision?: MediaUnderstandingDecision): string | undefined {
+  for (const attachment of decision?.attachments ?? []) {
+    const failed = attachment.attempts.find((entry) => entry.outcome === "failed");
+    if (failed?.reason) {
+      return failed.reason.split(":")[0]?.trim() || failed.reason;
+    }
+    const skipped = attachment.attempts.find((entry) => entry.outcome === "skipped");
+    if (skipped?.reason) {
+      return skipped.reason.split(":")[0]?.trim() || skipped.reason;
+    }
+  }
+  return undefined;
+}
+
+function buildTelemetry(params: {
+  status: AudioPreflightStatus;
+  startedAtMs: number;
+  transcript?: string;
+  output?: MediaUnderstandingOutput;
+  decision?: MediaUnderstandingDecision;
+  errorClass?: string;
+}): AudioPreflightTelemetry {
+  const transcript = params.transcript ?? "";
+  const decisionAttempt = selectedDecisionAttempt(params.decision);
+  const truncated = params.status === "truncated" || params.output?.truncated === true;
+  const provider = params.output?.provider ?? decisionAttempt?.provider;
+  const model = params.output?.model ?? decisionAttempt?.model;
+  return {
+    status: truncated && params.transcript ? "truncated" : params.status,
+    ...(provider ? { provider } : {}),
+    ...(model ? { model } : {}),
+    ...(params.output?.baseUrl ? { baseUrl: params.output.baseUrl } : {}),
+    durationMs: Math.max(0, Date.now() - params.startedAtMs),
+    ...(params.errorClass ? { errorClass: params.errorClass } : {}),
+    transcript: {
+      length: transcript.length,
+      ...(transcript ? { sha256: hashTranscript(transcript) } : {}),
+      trusted: params.output?.trusted === true,
+      truncated,
+      enteredAgentContext: false,
+    },
+  };
+}
 
 /**
  * Transcribes the first audio attachment BEFORE mention checking.
  * This allows voice notes to be processed in group chats with requireMention: true.
  * Returns the transcript or undefined if transcription fails or no audio is found.
  */
-export async function transcribeFirstAudio(params: {
-  ctx: MsgContext;
-  cfg: OpenClawConfig;
-  agentDir?: string;
-  providers?: Record<string, MediaUnderstandingProvider>;
-  activeModel?: ActiveMediaModel;
-}): Promise<string | undefined> {
+export async function transcribeFirstAudio(params: TranscribeFirstAudioParams): Promise<
+  string | undefined
+> {
+  return (await transcribeFirstAudioWithTelemetry(params))?.transcript;
+}
+
+/**
+ * Transcribes the first audio attachment and returns telemetry even when the
+ * transcript is missing, timed out, failed, truncated, or explicitly untrusted.
+ */
+export async function transcribeFirstAudioWithTelemetry(
+  params: TranscribeFirstAudioParams,
+): Promise<AudioPreflightResult | undefined> {
   const { ctx, cfg } = params;
+  const startedAtMs = Date.now();
 
   const audioConfig = cfg.tools?.media?.audio;
-  if (audioConfig?.enabled === false) {
-    return undefined;
-  }
-
   const attachments = normalizeMediaAttachments(ctx);
   if (!attachments || attachments.length === 0) {
     return undefined;
@@ -42,12 +167,22 @@ export async function transcribeFirstAudio(params: {
     return undefined;
   }
 
+  if (audioConfig?.enabled === false) {
+    return {
+      attachments,
+      telemetry: buildTelemetry({
+        status: "disabled",
+        startedAtMs,
+      }),
+    };
+  }
+
   if (shouldLogVerbose()) {
     logVerbose(`audio-preflight: transcribing attachment ${firstAudio.index} for mention check`);
   }
 
   try {
-    const { transcript } = await runAudioTranscription({
+    const { transcript, output, decision } = await runAudioTranscription({
       ctx,
       cfg,
       attachments,
@@ -57,7 +192,16 @@ export async function transcribeFirstAudio(params: {
       localPathRoots: resolveMediaAttachmentLocalRoots({ cfg, ctx }),
     });
     if (!transcript) {
-      return undefined;
+      return {
+        attachments,
+        telemetry: buildTelemetry({
+          status: "missing",
+          startedAtMs,
+          output,
+          decision,
+          errorClass: resolveMissingErrorClass(decision),
+        }),
+      };
     }
 
     if (audioConfig?.echoTranscript) {
@@ -71,6 +215,7 @@ export async function transcribeFirstAudio(params: {
 
     // Mark this attachment as transcribed so the main media pass does not duplicate STT output.
     firstAudio.alreadyTranscribed = true;
+    const status = output?.truncated === true ? "truncated" : "success";
 
     if (shouldLogVerbose()) {
       logVerbose(
@@ -78,12 +223,30 @@ export async function transcribeFirstAudio(params: {
       );
     }
 
-    return transcript;
+    return {
+      transcript,
+      attachments,
+      telemetry: buildTelemetry({
+        status,
+        startedAtMs,
+        transcript,
+        output,
+        decision,
+      }),
+    };
   } catch (err) {
     // Preflight cannot block message handling; mention checks can still run on text-only input.
     if (shouldLogVerbose()) {
       logVerbose(`audio-preflight: transcription failed: ${String(err)}`);
     }
-    return undefined;
+    const { status, errorClass } = classifyError(err);
+    return {
+      attachments,
+      telemetry: buildTelemetry({
+        status,
+        startedAtMs,
+        errorClass,
+      }),
+    };
   }
 }

--- a/src/media-understanding/audio-transcription-runner.ts
+++ b/src/media-understanding/audio-transcription-runner.ts
@@ -9,7 +9,12 @@ import {
   normalizeMediaAttachments,
   runCapability,
 } from "./runner.js";
-import type { MediaAttachment, MediaUnderstandingProvider } from "./types.js";
+import type {
+  MediaAttachment,
+  MediaUnderstandingDecision,
+  MediaUnderstandingOutput,
+  MediaUnderstandingProvider,
+} from "./types.js";
 
 /** Runs the configured audio-understanding pipeline and returns the first transcript output. */
 export async function runAudioTranscription(params: {
@@ -20,7 +25,12 @@ export async function runAudioTranscription(params: {
   providers?: Record<string, MediaUnderstandingProvider>;
   activeModel?: ActiveMediaModel;
   localPathRoots?: readonly string[];
-}): Promise<{ transcript: string | undefined; attachments: MediaAttachment[] }> {
+}): Promise<{
+  transcript: string | undefined;
+  attachments: MediaAttachment[];
+  output?: MediaUnderstandingOutput;
+  decision?: MediaUnderstandingDecision;
+}> {
   const attachments = params.attachments ?? normalizeMediaAttachments(params.ctx);
   if (attachments.length === 0) {
     return { transcript: undefined, attachments };
@@ -44,9 +54,11 @@ export async function runAudioTranscription(params: {
       config: params.cfg.tools?.media?.audio,
       activeModel: params.activeModel,
     });
-    const output = result.outputs.find((entry) => entry.kind === "audio.transcription");
+    const output = result.outputs.find(
+      (entry): entry is MediaUnderstandingOutput => entry.kind === "audio.transcription",
+    );
     const transcript = output?.text?.trim();
-    return { transcript: transcript || undefined, attachments };
+    return { transcript: transcript || undefined, attachments, output, decision: result.decision };
   } finally {
     await cache.cleanup();
   }

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -174,6 +174,7 @@ describe("runCapability auto audio entries", () => {
           provider: "mistral",
           model: "voxtral-mini-latest",
           text: "mistral:mistral-key",
+          trusted: false,
         });
         expect(openAiTranscribe).not.toHaveBeenCalled();
         expect(mistralTranscribe).toHaveBeenCalledTimes(1);
@@ -285,6 +286,7 @@ describe("runCapability auto audio entries", () => {
       provider: "openai",
       model: "gpt-4o-transcribe",
       text: "codex audio",
+      trusted: false,
     });
     expect(seenModel).toBe("gpt-4o-transcribe");
   });

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -106,6 +106,10 @@ function trimOutput(text: string, maxChars?: number): string {
   return trimmed.slice(0, maxChars).trim();
 }
 
+function isOutputTruncated(text: string, maxChars?: number): boolean {
+  return Boolean(maxChars && text.trim().length > maxChars);
+}
+
 function extractSherpaOnnxText(raw: string): { matched: boolean; text: string } {
   const noMatch = { matched: false, text: "" };
   const tryParse = (value: string): { matched: boolean; text: string } => {
@@ -814,12 +818,16 @@ export async function runProviderEntry(params: {
             execute: async (apiKey) => transcribeAudio(buildRequest({ kind: "api-key", apiKey })),
           })
         : await transcribeAudio(buildRequest({ kind: "none" }));
+    const truncated = result.truncated === true || isOutputTruncated(result.text, maxChars);
     return {
       kind: "audio.transcription",
       attachmentIndex: params.attachmentIndex,
       text: trimOutput(result.text, maxChars),
       provider: providerId,
       model: result.model ?? model,
+      ...(baseUrl ? { baseUrl } : {}),
+      ...(truncated ? { truncated } : {}),
+      trusted: result.trusted === true,
     };
   }
 

--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -29,6 +29,9 @@ export type MediaUnderstandingOutput = {
   text: string;
   provider: string;
   model?: string;
+  baseUrl?: string;
+  truncated?: boolean;
+  trusted?: boolean;
 };
 
 type MediaUnderstandingDecisionOutcome =
@@ -111,6 +114,8 @@ export type AudioTranscriptionRequest = {
 export type AudioTranscriptionResult = {
   text: string;
   model?: string;
+  truncated?: boolean;
+  trusted?: boolean;
 };
 
 export type VideoDescriptionRequest = {


### PR DESCRIPTION
## Summary
- add Telegram voice/STT handoff telemetry into inbound context, including download bytes/MIME/path, Telegram file metadata, STT provider/model/base URL, duration, error class, transcript length/hash/trust/truncation, and context-entry marker
- label missing, timed-out, truncated, disabled, and untrusted transcripts instead of silently treating bad or absent STT text as the spoken message
- add computed cron payload audit metadata for deterministic `command` jobs vs script-shaped legacy `agentTurn` jobs

Closes #92500
Closes #92501
Parent: electricsheephq/evaos-support-control#161

## Real behavior proof
- **Behavior or issue addressed:** Scheduled jobs that hide deterministic shell/script work inside `agentTurn` payloads are now detected and surfaced as audit warnings, while explicit `command` jobs are identified as deterministic. This is the OpenClaw-side proof for replacing hidden Matt/Malory agentTurn scripts with manifest-visible deterministic jobs.
- **Real environment tested:** Patched OpenClaw worktree on the local Codex host at `/Volumes/LEXAR/repos/worktrees/openclaw-matt-malory-stt-scheduler`, executing the changed TypeScript runtime module with `tsx` against the real source files on this branch.
- **Exact steps or command run after this patch:** `npx --yes tsx --no-cache --eval ...` imported `./src/cron/payload-audit.ts`, evaluated a script-shaped legacy `agentTurn`, and evaluated an explicit deterministic `command` payload.
- **Evidence after fix:** Terminal output from the patched runtime command:

```console
$ npx --yes tsx --no-cache --eval 'import { resolveCronPayloadAudit } from "./src/cron/payload-audit.ts"; const hidden = resolveCronPayloadAudit({ kind: "agentTurn", message: "Run this exact scheduled job.\n```bash\nnode scripts/matt-malory-watchdog.js --json\n```" }); const command = resolveCronPayloadAudit({ kind: "command", argv: ["openclaw", "support", "sync", "--json"] }); console.log(JSON.stringify({ hidden, command }, null, 2));'
{
  "hidden": {
    "executionKind": "agent-turn",
    "deterministic": false,
    "warnings": [
      {
        "code": "hidden-agent-turn-script",
        "severity": "warn",
        "message": "This scheduled agentTurn appears to hide a deterministic script. Prefer payload.kind=\"command\" with an explicit argv vector for scheduled command jobs.",
        "recommendation": "Convert the job payload to { \"kind\": \"command\", \"argv\": [...] } so scheduler JSON exposes the deterministic command directly."
      }
    ]
  },
  "command": {
    "executionKind": "deterministic-command",
    "deterministic": true,
    "warnings": []
  }
}
```

- **Observed result after fix:** The legacy script-shaped `agentTurn` returned `executionKind: "agent-turn"`, `deterministic: false`, and a `hidden-agent-turn-script` warning. The explicit `command` payload returned `executionKind: "deterministic-command"`, `deterministic: true`, and no warnings.
- **What was not tested:** A live Matt Telegram OGG message and a live Matt VM scheduled-job migration were not triggered from this PR. Those remain Sprint 4 canary acceptance after the platform code is deployed.

## Local validation
- `git diff --check`
- `node --check scripts/run-vitest.mjs`
- real patched-code smoke shown above with `npx --yes tsx --no-cache --eval ...`

## Deferred to GitHub CI
- Dependency-hydrated Vitest/protocol/architecture validation is intentionally delegated to GitHub CI for this large OpenClaw workspace. The clean local worktree does not keep `node_modules` hydrated.
