### PR TITLE
fix(memory): persist metadata after atomic reindex

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -2318,6 +2318,7 @@ export abstract class MemoryManagerSyncOps {
       vectorDims: this.vector.dims,
       vectorDegradedWriteWarningShown: this.vectorDegradedWriteWarningShown,
       vectorReady: this.vectorReady,
+      lastMetaSerialized: this.lastMetaSerialized,
     };
 
     const restoreOriginalState = () => {
@@ -2333,6 +2334,7 @@ export abstract class MemoryManagerSyncOps {
       this.vector.dims = originalState.vectorDims;
       this.vectorDegradedWriteWarningShown = originalState.vectorDegradedWriteWarningShown;
       this.vectorReady = originalDbClosed ? null : originalState.vectorReady;
+      this.lastMetaSerialized = originalState.lastMetaSerialized;
     };
 
     this.db = tempDb;
@@ -2575,7 +2577,12 @@ export abstract class MemoryManagerSyncOps {
   protected writeMeta(meta: MemoryIndexMeta) {
     const value = JSON.stringify(meta);
     if (this.lastMetaSerialized === value) {
-      return;
+      const row = this.db.prepare(`SELECT value FROM meta WHERE key = ?`).get(META_KEY) as
+        | { value: string }
+        | undefined;
+      if (row?.value === value) {
+        return;
+      }
     }
     this.db
       .prepare(

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -105,6 +105,18 @@ describe("memory manager FTS-only reindex", () => {
     }
   }
 
+  function countMetaRows(): number {
+    const db = new DatabaseSync(indexPath);
+    try {
+      const row = db
+        .prepare(`SELECT COUNT(*) as c FROM meta WHERE key = 'memory_index_meta_v1'`)
+        .get() as { c: number } | undefined;
+      return row?.c ?? 0;
+    } finally {
+      db.close();
+    }
+  }
+
   function writeExistingMeta(memoryManager: MemoryIndexManager, model: string): void {
     const metaWriter = memoryManager as unknown as {
       writeMeta(meta: MemoryIndexMeta): void;
@@ -130,6 +142,19 @@ describe("memory manager FTS-only reindex", () => {
     const secondStatus = memoryManager.status();
     expect(secondStatus.chunks).toBeGreaterThan(0);
     expect(countChunksContaining("Alpha topic")).toBeGreaterThan(0);
+  });
+
+  it("writes unchanged metadata into the fresh database during safe reindex", async () => {
+    const memoryManager = await createManager({ provider: "none", vectorEnabled: false });
+
+    await memoryManager.sync({ force: true });
+    expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+    expect(countMetaRows()).toBe(1);
+
+    await memoryManager.sync({ force: true });
+
+    expect(countMetaRows()).toBe(1);
+    expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
   });
 
   it("syncs explicit provider-none memory without resolving an embedding provider", async () => {


### PR DESCRIPTION
## Summary
- make memory index metadata writes verify the row still exists before skipping an unchanged serialized meta write
- restore the cached serialized metadata value when a safe reindex fails and returns to the original database
- add a regression covering a forced safe reindex that rebuilds into a fresh SQLite database with unchanged metadata

## Real behavior proof

- Behavior or issue addressed: forced safe/atomic memory reindex into a fresh SQLite DB must preserve the `meta` row keyed by `memory_index_meta_v1`, so later memory status/search does not report `index metadata is missing` after unchanged metadata rebuilds.
- Real environment tested: local OpenClaw source checkout on this PR branch using `node scripts/run-node.mjs`, with an isolated throwaway `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, and workspace under `/tmp/openclaw-memory-proof-R2nluo`; memory config used `provider: "none"` and `store.vector.enabled: false` for deliberate FTS-only recall. No shared OpenClaw config was changed and no running gateway was restarted.
- Exact steps or command run after this patch: created a temp `openclaw.json` and workspace containing `MEMORY.md` plus one `memory/2026-06-12.md`; ran `node scripts/run-node.mjs memory index --agent main --force --verbose` twice; inspected `/tmp/openclaw-memory-proof-R2nluo/state/memory/main.sqlite` with `node:sqlite`; ran `node scripts/run-node.mjs memory status --agent main --json`; ran `node scripts/run-node.mjs memory search --agent main --json "safe reindex metadata"`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
Memory Index (main)
Provider: none (requested: none)
Model: none
Sources: memory (MEMORY.md + /tmp/openclaw-memory-proof-R2nluo/workspace/memory/*.md)

[memory] sync: indexing memory files
Memory index updated (main).
Memory Index (main)
Provider: none (requested: none)
Model: none
Sources: memory (MEMORY.md + /tmp/openclaw-memory-proof-R2nluo/workspace/memory/*.md)

[memory] sync: indexing memory files
Memory index updated (main).
index path: /tmp/openclaw-memory-proof-R2nluo/state/memory/main.sqlite
{"metaRows":1,"chunkRows":2,"chunksVecTablePresent":false,"identity":{"model":"fts-only","provider":"none","providerKey":"b2f409223dd1bd19cedee3332de54748a5f323765d4cdcbbb29295199cfde125","sources":["memory"],"scopeHash":"e861c1d291b583b9f4bf96233b72b9e6984cc92320671a0805e1063946e4b1a1","chunkTokens":400,"chunkOverlap":80,"ftsTokenizer":"unicode61"}}
```

`memory status --agent main --json` included:

```json
"chunks": 2,
"dirty": false,
"dbPath": "/tmp/openclaw-memory-proof-R2nluo/state/memory/main.sqlite",
"provider": "none",
"vector": { "enabled": false },
"custom": { "indexIdentity": { "status": "valid" } }
```

`memory search --agent main --json "safe reindex metadata"` returned:

```json
{
  "results": [
    {
      "path": "MEMORY.md",
      "score": 0.680002999991,
      "snippet": "# Memory\n\n- Alpha topic: safe reindex metadata should persist after an unchanged rebuild.\n",
      "source": "memory"
    }
  ]
}
```

- Observed result after fix: the second forced reindex, which reuses unchanged metadata, leaves exactly one `meta` row for `memory_index_meta_v1`; status reports the index identity as valid; real CLI memory search returns the indexed memory instead of failing with missing metadata.
- What was not tested: the already-running shared/global gateway manager refreshing a stale in-memory manager after an external on-disk repair; remote Gemini/vector embedding reindex; the captured production database itself.
- Proof limitations or environment constraints: proof intentionally used an isolated local OpenClaw setup and FTS-only provider-none config to avoid changing shared config, credentials, production memory files, or restarting the gateway.

## Tests and validation
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts`
- `./node_modules/.bin/oxfmt --check extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts`
- `git diff --check`
- isolated local source CLI proof documented above

## Notes
- `pnpm install --frozen-lockfile` was needed because this worktree was missing `node_modules`.
- Autoreview was attempted with `.agents/skills/autoreview/scripts/autoreview --mode local`, but the helper could not run because the `codex` executable is not installed in this environment.

## Current review state
- Not claiming land-ready until the Real behavior proof check re-runs against this updated PR body and maintainers accept the isolated proof scope.
