### PR TITLE
fix(gateway): reject unknown OpenAI agent selectors

### DIFF
--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -278,21 +278,48 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
   });
 
   it("supports base64 encoding and agent-scoped auth/config resolution", async () => {
-    const res = await postEmbeddings(
-      {
-        model: "openclaw/beta",
-        input: "hello",
-        encoding_format: "base64",
-      },
-      { "x-openclaw-agent-id": "beta" },
-    );
-    expect(res.status).toBe(200);
-    const json = (await res.json()) as { data?: Array<{ embedding?: string }> };
-    expect(typeof json.data?.[0]?.embedding).toBe("string");
-    expect(createEmbeddingProviderMock).toHaveBeenCalled();
-    const lastCall = latestCreateEmbeddingProviderOptions();
-    expect(typeof lastCall.model).toBe("string");
-    expect(lastCall.agentDir).toBe(resolveAgentDir({}, "beta"));
+    try {
+      testState.agentsConfig = { list: [{ id: "main" }, { id: "beta" }] };
+      resetConfigRuntimeState();
+
+      const res = await postEmbeddings(
+        {
+          model: "openclaw/beta",
+          input: "hello",
+          encoding_format: "base64",
+        },
+        { "x-openclaw-agent-id": "beta" },
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { data?: Array<{ embedding?: string }> };
+      expect(typeof json.data?.[0]?.embedding).toBe("string");
+      expect(createEmbeddingProviderMock).toHaveBeenCalled();
+      const lastCall = latestCreateEmbeddingProviderOptions();
+      expect(typeof lastCall.model).toBe("string");
+      expect(lastCall.agentDir).toBe(resolveAgentDir({}, "beta"));
+    } finally {
+      testState.agentsConfig = undefined;
+      resetConfigRuntimeState();
+    }
+  });
+
+  it("rejects explicit unknown agent ids", async () => {
+    try {
+      testState.agentsConfig = { list: [{ id: "main" }, { id: "beta" }] };
+      resetConfigRuntimeState();
+
+      const header = await postEmbeddings(
+        { model: "openclaw/default", input: "hello" },
+        { "x-openclaw-agent-id": "missing-agent" },
+      );
+      await expectInvalidEmbeddingRequest(header, "Unknown agent 'missing-agent'.");
+
+      const model = await postEmbeddings({ model: "openclaw/missing-agent", input: "hello" });
+      await expectInvalidEmbeddingRequest(model, "Unknown agent 'missing-agent'.");
+    } finally {
+      testState.agentsConfig = undefined;
+      resetConfigRuntimeState();
+    }
   });
 
   it("rejects invalid input shapes", async () => {

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -30,6 +30,7 @@ import {
   OPENCLAW_MODEL_ID,
   authorizeOpenAiCompatibleHttpModelOverride,
   getHeader,
+  isUnknownGatewayAgentError,
   resolveAgentIdForRequest,
   resolveAgentIdFromModel,
   resolveOpenAiCompatibleHttpOperatorScopes,
@@ -297,7 +298,18 @@ export async function handleOpenAiEmbeddingsHttpRequest(
     return true;
   }
 
-  const agentId = resolveAgentIdForRequest({ req, model: requestModel });
+  let agentId: string;
+  try {
+    agentId = resolveAgentIdForRequest({ req, model: requestModel });
+  } catch (err) {
+    if (isUnknownGatewayAgentError(err)) {
+      sendJson(res, 400, {
+        error: { message: err.message, type: "invalid_request_error" },
+      });
+      return true;
+    }
+    throw err;
+  }
   const agentDir = resolveAgentDir(cfg, agentId);
   const memorySearch = resolveMemorySearchConfig(cfg, agentId);
   const configuredProvider = memorySearch?.provider ?? "openai";

--- a/src/gateway/http-utils.request-context.test.ts
+++ b/src/gateway/http-utils.request-context.test.ts
@@ -55,6 +55,26 @@ describe("resolveGatewayRequestContext", () => {
 
     expect(result.sessionKey).toContain("openresponses-user:alice");
   });
+
+  it("does not build session state for explicit unknown agent ids", () => {
+    expect(() =>
+      resolveGatewayRequestContext({
+        req: createReq({ "x-openclaw-agent-id": "missing-agent" }),
+        model: "openclaw",
+        sessionPrefix: "openai",
+        defaultMessageChannel: "webchat",
+      }),
+    ).toThrow(/Unknown agent/);
+
+    expect(() =>
+      resolveGatewayRequestContext({
+        req: createReq(),
+        model: "openclaw/missing-agent",
+        sessionPrefix: "openai",
+        defaultMessageChannel: "webchat",
+      }),
+    ).toThrow(/Unknown agent/);
+  });
 });
 
 describe("resolveTrustedHttpOperatorScopes", () => {

--- a/src/gateway/http-utils.request-context.test.ts
+++ b/src/gateway/http-utils.request-context.test.ts
@@ -74,6 +74,15 @@ describe("resolveGatewayRequestContext", () => {
         defaultMessageChannel: "webchat",
       }),
     ).toThrow(/Unknown agent/);
+
+    expect(() =>
+      resolveGatewayRequestContext({
+        req: createReq({ "x-openclaw-agent-id": "!!!" }),
+        model: "openclaw",
+        sessionPrefix: "openai",
+        defaultMessageChannel: "webchat",
+      }),
+    ).toThrow("Unknown agent '!!!'.");
   });
 });
 

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -6,7 +6,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { modelKey, parseModelRef, resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { createModelVisibilityPolicy } from "../agents/model-visibility-policy.js";
 import { getRuntimeConfig } from "../config/io.js";
@@ -37,6 +37,23 @@ export {
 export const OPENCLAW_MODEL_ID = "openclaw";
 /** Default OpenAI-compatible model alias that targets the default OpenClaw agent. */
 export const OPENCLAW_DEFAULT_MODEL_ID = "openclaw/default";
+
+export class UnknownGatewayAgentError extends Error {
+  constructor(readonly agentId: string) {
+    super(`Unknown agent '${agentId}'.`);
+    this.name = "UnknownGatewayAgentError";
+  }
+}
+
+export function isUnknownGatewayAgentError(err: unknown): err is UnknownGatewayAgentError {
+  return err instanceof UnknownGatewayAgentError;
+}
+
+function assertKnownAgentId(agentId: string, cfg = getRuntimeConfig()): void {
+  if (!listAgentIds(cfg).includes(agentId)) {
+    throw new UnknownGatewayAgentError(agentId);
+  }
+}
 
 function resolveAgentIdFromHeader(req: IncomingMessage): string | undefined {
   const raw =
@@ -140,11 +157,17 @@ export function resolveAgentIdForRequest(params: {
   const cfg = getRuntimeConfig();
   const fromHeader = resolveAgentIdFromHeader(params.req);
   if (fromHeader) {
+    assertKnownAgentId(fromHeader, cfg);
     return fromHeader;
   }
 
   const fromModel = resolveAgentIdFromModel(params.model, cfg);
-  return fromModel ?? resolveDefaultAgentId(cfg);
+  if (fromModel) {
+    assertKnownAgentId(fromModel, cfg);
+    return fromModel;
+  }
+
+  return resolveDefaultAgentId(cfg);
 }
 
 function resolveSessionKey(params: {

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -11,7 +11,11 @@ import { modelKey, parseModelRef, resolveDefaultModelForAgent } from "../agents/
 import { createModelVisibilityPolicy } from "../agents/model-visibility-policy.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
-import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-key.js";
+import {
+  buildAgentMainSessionKey,
+  isValidAgentId,
+  normalizeAgentId,
+} from "../routing/session-key.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { getHeader } from "./http-auth-utils.js";
 import { loadGatewayModelCatalog } from "./server-model-catalog.js";
@@ -62,6 +66,9 @@ function resolveAgentIdFromHeader(req: IncomingMessage): string | undefined {
     "";
   if (!raw) {
     return undefined;
+  }
+  if (!isValidAgentId(raw)) {
+    throw new UnknownGatewayAgentError(raw);
   }
   return normalizeAgentId(raw);
 }

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -13,6 +13,7 @@ import { subscribeEmbeddedAgentSession } from "../agents/embedded-agent-subscrib
 import { FailoverError } from "../agents/failover-error.js";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
+import { resetConfigRuntimeState } from "../config/config.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
@@ -187,6 +188,9 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     };
 
     try {
+      testState.agentsConfig = { list: [{ id: "main" }, { id: "beta" }] };
+      resetConfigRuntimeState();
+
       {
         const res = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
           method: "GET",
@@ -232,6 +236,33 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         },
         matcher: /^agent:main:/,
       });
+
+      {
+        agentCommand.mockClear();
+        const res = await postChatCompletions(
+          port,
+          { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
+          { "x-openclaw-agent-id": "missing-agent" },
+        );
+        expect(res.status).toBe(400);
+        const json = (await res.json()) as { error?: { type?: string; message?: string } };
+        expect(json.error?.type).toBe("invalid_request_error");
+        expect(json.error?.message).toBe("Unknown agent 'missing-agent'.");
+        expect(agentCommand).toHaveBeenCalledTimes(0);
+      }
+
+      {
+        agentCommand.mockClear();
+        const res = await postChatCompletions(port, {
+          model: "openclaw/missing-agent",
+          messages: [{ role: "user", content: "hi" }],
+        });
+        expect(res.status).toBe(400);
+        const json = (await res.json()) as { error?: { type?: string; message?: string } };
+        expect(json.error?.type).toBe("invalid_request_error");
+        expect(json.error?.message).toBe("Unknown agent 'missing-agent'.");
+        expect(agentCommand).toHaveBeenCalledTimes(0);
+      }
 
       {
         mockAgentOnce([{ text: "hello" }]);
@@ -1419,7 +1450,8 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         );
       }
     } finally {
-      // shared server
+      testState.agentsConfig = undefined;
+      resetConfigRuntimeState();
     }
   });
 

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -52,6 +52,7 @@ import {
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
   authorizeOpenAiCompatibleHttpModelOverride,
+  isUnknownGatewayAgentError,
   resolveGatewayRequestContext,
   resolveOpenAiCompatModelOverride,
   resolveOpenAiCompatibleHttpOperatorScopes,
@@ -974,14 +975,27 @@ export async function handleOpenAiHttpRequest(
         }
       : undefined;
 
-  const { agentId, sessionKey, messageChannel } = resolveGatewayRequestContext({
-    req,
-    model,
-    user,
-    sessionPrefix: "openai",
-    defaultMessageChannel: "webchat",
-    useMessageChannelHeader: true,
-  });
+  let agentId: string;
+  let sessionKey: string;
+  let messageChannel: string;
+  try {
+    ({ agentId, sessionKey, messageChannel } = resolveGatewayRequestContext({
+      req,
+      model,
+      user,
+      sessionPrefix: "openai",
+      defaultMessageChannel: "webchat",
+      useMessageChannelHeader: true,
+    }));
+  } catch (err) {
+    if (isUnknownGatewayAgentError(err)) {
+      sendJson(res, 400, {
+        error: { message: err.message, type: "invalid_request_error" },
+      });
+      return true;
+    }
+    throw err;
+  }
   const { modelOverride, errorMessage: modelError } = await resolveOpenAiCompatModelOverride({
     req,
     agentId,

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -8,6 +8,7 @@ import { createClientToolNameConflictError } from "../agents/agent-tool-definiti
 import { FailoverError } from "../agents/failover-error.js";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
+import { resetConfigRuntimeState } from "../config/config.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
@@ -15,6 +16,7 @@ import {
   getFreePort,
   installGatewayTestHooks,
   startGatewayServerWithRetries,
+  testState,
 } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
@@ -263,6 +265,9 @@ describe("OpenResponses HTTP API (e2e)", () => {
     };
 
     try {
+      testState.agentsConfig = { list: [{ id: "main" }, { id: "beta" }] };
+      resetConfigRuntimeState();
+
       const resNonPost = await fetch(`http://127.0.0.1:${port}/v1/responses`, {
         method: "GET",
         headers: { authorization: "Bearer secret" },
@@ -332,6 +337,30 @@ describe("OpenResponses HTTP API (e2e)", () => {
         /^agent:main:/,
       );
       await ensureResponseConsumed(resDefaultAlias);
+
+      {
+        agentCommand.mockClear();
+        const res = await postResponses(
+          port,
+          { model: "openclaw", input: "hi" },
+          { "x-openclaw-agent-id": "missing-agent" },
+        );
+        expect(res.status).toBe(400);
+        const json = (await res.json()) as { error?: { type?: string; message?: string } };
+        expect(json.error?.type).toBe("invalid_request_error");
+        expect(json.error?.message).toBe("Unknown agent 'missing-agent'.");
+        expect(agentCommand).toHaveBeenCalledTimes(0);
+      }
+
+      {
+        agentCommand.mockClear();
+        const res = await postResponses(port, { model: "openclaw/missing-agent", input: "hi" });
+        expect(res.status).toBe(400);
+        const json = (await res.json()) as { error?: { type?: string; message?: string } };
+        expect(json.error?.type).toBe("invalid_request_error");
+        expect(json.error?.message).toBe("Unknown agent 'missing-agent'.");
+        expect(agentCommand).toHaveBeenCalledTimes(0);
+      }
 
       mockAgentOnce([{ text: "hello" }]);
       const resChannelHeader = await postResponses(
@@ -818,7 +847,8 @@ describe("OpenResponses HTTP API (e2e)", () => {
       );
       await ensureResponseConsumed(resNoUser);
     } finally {
-      // shared server
+      testState.agentsConfig = undefined;
+      resetConfigRuntimeState();
     }
   });
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -48,6 +48,7 @@ import {
   authorizeOpenAiCompatibleHttpModelOverride,
   getBearerToken,
   getHeader,
+  isUnknownGatewayAgentError,
   resolveAgentIdForRequest,
   resolveGatewayRequestContext,
   resolveOpenAiCompatModelOverride,
@@ -489,7 +490,18 @@ export async function handleOpenResponsesHttpRequest(
   const stream = Boolean(payload.stream);
   const model = payload.model;
   const user = payload.user;
-  const agentId = resolveAgentIdForRequest({ req, model });
+  let agentId: string;
+  try {
+    agentId = resolveAgentIdForRequest({ req, model });
+  } catch (err) {
+    if (isUnknownGatewayAgentError(err)) {
+      sendJson(res, 400, {
+        error: { message: err.message, type: "invalid_request_error" },
+      });
+      return true;
+    }
+    throw err;
+  }
   const { modelOverride, errorMessage: modelError } = await resolveOpenAiCompatModelOverride({
     req,
     agentId,
@@ -636,14 +648,25 @@ export async function handleOpenResponsesHttpRequest(
     });
     return true;
   }
-  const resolved = resolveGatewayRequestContext({
-    req,
-    model,
-    user,
-    sessionPrefix: "openresponses",
-    defaultMessageChannel: "webchat",
-    useMessageChannelHeader: true,
-  });
+  let resolved: ReturnType<typeof resolveGatewayRequestContext>;
+  try {
+    resolved = resolveGatewayRequestContext({
+      req,
+      model,
+      user,
+      sessionPrefix: "openresponses",
+      defaultMessageChannel: "webchat",
+      useMessageChannelHeader: true,
+    });
+  } catch (err) {
+    if (isUnknownGatewayAgentError(err)) {
+      sendJson(res, 400, {
+        error: { message: err.message, type: "invalid_request_error" },
+      });
+      return true;
+    }
+    throw err;
+  }
   const responseSessionScope = createResponseSessionScope({
     req,
     auth: opts.auth,


### PR DESCRIPTION
## Summary

- Fixes explicit OpenAI-compatible agent selector handling for #92504.
- Explicit selector strings now fail closed when the requested agent is not in the configured roster, instead of creating phantom `agent:<id>:` request/session state.
- Default routing stays compatible for clients that omit an explicit selector or use the default alias.
- Review focus: shared selector validation in `http-utils`, plus the HTTP 400 mapping in chat completions, responses, and embeddings.

## Linked context

Which issue does this close?

Closes #92504

Which issues, PRs, or discussions are related?

Related #92504

Was this requested by a maintainer or owner?

No direct maintainer request; this addresses the linked bug report.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenAI-compatible gateway requests that explicitly target an unknown agent now receive a structured request error instead of continuing with phantom agent-scoped state.
- Real environment tested: Local OpenClaw checkout on this PR branch with a separate `openclaw gateway` process, token auth, a configured agent roster (`main`, `beta`), and a local mock OpenAI-compatible provider. The matrix used real HTTP requests against `POST /v1/chat/completions`.
- Exact steps or command run after this patch:
  ```text
  node --import tsx src/entry.ts gateway --port <loopback-port> --bind loopback --auth token --token <redacted>

  POST /v1/chat/completions with:
  - model=openclaw/missing-agent
  - model=openclaw plus x-openclaw-agent-id=missing-agent
  - model=openclaw:missing-agent
  - model=agent:missing-agent
  - model=openclaw/beta
  - model=openclaw/default
  - omitted model

  node scripts/run-vitest.mjs src/gateway/http-utils.request-context.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/gateway/embeddings-http.test.ts && git diff --check
  ```
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  ```text
  OpenClaw live selector matrix proof
  Setup: separate `openclaw gateway` process, token auth, configured agents = main,beta, local mock OpenAI-compatible provider.
  Gateway: http://127.0.0.1:<redacted-loopback-port>
  unknown model selector model=openclaw/missing-agent => HTTP 400 type=invalid_request_error message="Unknown agent 'missing-agent'."
  unknown header selector x-openclaw-agent-id=missing-agent => HTTP 400 type=invalid_request_error message="Unknown agent 'missing-agent'."
  unknown colon selector model=openclaw:missing-agent => HTTP 400 type=invalid_request_error message="Unknown agent 'missing-agent'."
  unknown agent alias selector model=agent:missing-agent => HTTP 400 type=invalid_request_error message="Unknown agent 'missing-agent'."
  configured model selector model=openclaw/beta => HTTP 200 type=ok
  default selector model=openclaw/default => HTTP 200 type=ok
  omitted selector no model => HTTP 200 type=ok
  Result: PASS
  ```

  Focused regression validation also passed:
  ```text
  Test Files 13 passed (13)
  Tests 227 passed (227)
  [test] passed 1 Vitest shard in 95.00s
  ```
- Observed result after fix: Unknown explicit agent selectors return `400 invalid_request_error`; omitted/default selectors and configured agents remain valid.
- What was not tested: No browser UI or mobile app flow was tested; this change is limited to OpenAI-compatible gateway HTTP routing.
- Proof limitations or environment constraints: The live proof used loopback networking and a local mock OpenAI-compatible provider to keep the configured gateway deterministic; no external model provider was contacted.
- Before evidence (optional but encouraged): The new regression test was written first and failed before the fix because `resolveGatewayRequestContext` accepted explicit unknown agent IDs instead of rejecting them.

## Tests and validation

Which commands did you run?

```text
node scripts/run-vitest.mjs src/gateway/http-utils.request-context.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/gateway/embeddings-http.test.ts && git diff --check
```

What regression coverage was added or updated?

- Shared request-context resolver coverage for explicit unknown header/model agent selectors.
- Chat completions HTTP coverage for unknown selector 400 responses and no agent dispatch.
- Responses HTTP coverage for unknown selector 400 responses in both resolver paths.
- Embeddings HTTP coverage for unknown selector 400 responses while preserving configured-agent behavior.

What failed before this fix, if known?

The shared request-context regression failed before the production change because `resolveGatewayRequestContext` accepted explicit unknown agent IDs instead of rejecting them.

If no test was added, why not?

Regression tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Explicit unknown agent selectors now receive HTTP 400 instead of continuing through gateway routing.

Did config, environment, or migration behavior change? (`Yes/No`)

No. Existing configured agent rosters and default selection semantics are unchanged.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No. The change is request validation for already-parsed gateway selector inputs.

What is the highest-risk area?

Compatibility for integrations that accidentally send an unknown explicit agent ID and previously relied on the buggy fallback behavior.

How is that risk mitigated?

The rejection is limited to explicit selectors that do not exist in the configured roster. Omitted/default routing and configured agent IDs continue to work, and all three OpenAI-compatible endpoints now return the same structured request error for the invalid selector case.

## Current review state

What is the next action?

Waiting for CI and ClawSweeper to re-check the updated live configured-gateway proof.

What is still waiting on author, maintainer, CI, or external proof?

CI/proof automation needs to rerun after this PR body update.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's request to add redacted terminal output from a separately started configured gateway showing unknown selectors fail and configured/default/omitted selectors succeed.
