### PR TITLE
Fix WebChat backscroll during streaming

### DIFF
--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -51,6 +51,7 @@ function createScrollHost(
     chatLastScrollTop: 0,
     chatHasAutoScrolled: false,
     chatUserNearBottom: true,
+    chatFollowLocked: false,
     chatHeaderControlsHidden: false,
     chatNewMessagesBelow: false,
     chatIsProgrammaticScroll: false,
@@ -248,6 +249,62 @@ describe("scheduleChatScroll", () => {
     expect(host.chatNewMessagesBelow).toBe(true);
   });
 
+  it("does not re-stick streaming after a user scrolls slightly up near the bottom", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1540,
+      clientHeight: 400,
+    });
+    host.chatHasAutoScrolled = true;
+    host.chatUserNearBottom = true;
+    host.chatIsProgrammaticScroll = true;
+    host.chatProgrammaticScrollTarget = 1800;
+    host.chatLastScrollTop = 1600;
+
+    handleChatScroll(host, createScrollEvent(2000, 1540, 400));
+
+    expect(host.chatFollowLocked).toBe(true);
+    expect(host.chatUserNearBottom).toBe(false);
+
+    scheduleChatScroll(host);
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(1540);
+    expect(host.chatNewMessagesBelow).toBe(true);
+
+    host.chatIsProgrammaticScroll = false;
+    container.scrollTop = 1600;
+    handleChatScroll(host, createScrollEvent(2000, 1600, 400));
+
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatNewMessagesBelow).toBe(false);
+  });
+
+  it("does not re-stick streaming after a sub-threshold user scroll near the bottom", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1589,
+      clientHeight: 400,
+    });
+    host.chatHasAutoScrolled = true;
+    host.chatUserNearBottom = true;
+    host.chatIsProgrammaticScroll = true;
+    host.chatProgrammaticScrollTarget = 1800;
+    host.chatLastScrollTop = 1600;
+
+    handleChatScroll(host, createScrollEvent(2000, 1589, 400));
+
+    expect(host.chatFollowLocked).toBe(true);
+    expect(host.chatUserNearBottom).toBe(false);
+
+    scheduleChatScroll(host);
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(1589);
+    expect(host.chatNewMessagesBelow).toBe(true);
+  });
+
   it("does NOT scroll automatically when chat auto-scroll is off", async () => {
     const { host, container } = createScrollHost({
       scrollHeight: 2000,
@@ -360,6 +417,7 @@ describe("resetChatScroll", () => {
     const { host } = createScrollHost({});
     host.chatHasAutoScrolled = true;
     host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
     host.chatLastScrollTop = 300;
     host.chatHeaderControlsHidden = true;
 
@@ -367,6 +425,7 @@ describe("resetChatScroll", () => {
 
     expect(host.chatHasAutoScrolled).toBe(false);
     expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
     expect(host.chatLastScrollTop).toBe(0);
     expect(host.chatHeaderControlsHidden).toBe(false);
     expect(host.chatIsProgrammaticScroll).toBe(false);

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -3,6 +3,7 @@ import { normalizeChatAutoScrollMode, type ChatAutoScrollMode } from "./storage.
 
 /** Distance (px) from the bottom within which we consider the user "near bottom". */
 const NEAR_BOTTOM_THRESHOLD = 450;
+const FOLLOW_REACQUIRE_THRESHOLD = 8;
 const HEADER_HIDE_SCROLL_DELTA = 12;
 const HEADER_SHOW_TOP_THRESHOLD = 24;
 
@@ -15,6 +16,7 @@ type ScrollHost = {
   chatLastScrollTop: number;
   chatHasAutoScrolled: boolean;
   chatUserNearBottom: boolean;
+  chatFollowLocked: boolean;
   chatHeaderControlsHidden: boolean;
   chatNewMessagesBelow: boolean;
   chatIsProgrammaticScroll: boolean;
@@ -84,6 +86,7 @@ export function scheduleChatScroll(
         manualScroll ||
         autoScrollMode === "always" ||
         (autoScrollMode === "near-bottom" &&
+          !host.chatFollowLocked &&
           (effectiveForce ||
             host.chatUserNearBottom ||
             distanceFromBottom < NEAR_BOTTOM_THRESHOLD));
@@ -96,6 +99,7 @@ export function scheduleChatScroll(
       if (effectiveForce) {
         host.chatHasAutoScrolled = true;
       }
+      host.chatFollowLocked = false;
       const smoothEnabled =
         smooth &&
         (typeof window === "undefined" ||
@@ -128,6 +132,7 @@ export function scheduleChatScroll(
           manualScroll ||
           autoScrollMode === "always" ||
           (autoScrollMode === "near-bottom" &&
+            !host.chatFollowLocked &&
             (effectiveForce ||
               host.chatUserNearBottom ||
               latestDistanceFromBottom < NEAR_BOTTOM_THRESHOLD));
@@ -207,21 +212,29 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   // Only suppress if scrollTop is still at or above the position we scrolled to;
   // if it dropped below, the user scrolled up during the guard window and we must
   // process the event so streaming stops pinning them back to the bottom.
+  const isUserScrollUp = delta < 0;
+  const isDeliberateScrollUp = delta < -HEADER_HIDE_SCROLL_DELTA;
   if (
     host.chatIsProgrammaticScroll &&
+    !isUserScrollUp &&
     container.scrollTop >= host.chatProgrammaticScrollTarget - container.clientHeight
   ) {
     return;
   }
   const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-  host.chatUserNearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+  if (isUserScrollUp && distanceFromBottom > FOLLOW_REACQUIRE_THRESHOLD) {
+    host.chatFollowLocked = true;
+  } else if (distanceFromBottom <= FOLLOW_REACQUIRE_THRESHOLD) {
+    host.chatFollowLocked = false;
+  }
+  host.chatUserNearBottom = !host.chatFollowLocked && distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
   const hasUsefulScroll = container.scrollHeight - container.clientHeight > NEAR_BOTTOM_THRESHOLD;
 
   if (!hasUsefulScroll || scrollTop <= HEADER_SHOW_TOP_THRESHOLD || host.chatUserNearBottom) {
     host.chatHeaderControlsHidden = false;
   } else if (delta > HEADER_HIDE_SCROLL_DELTA) {
     host.chatHeaderControlsHidden = true;
-  } else if (delta < -HEADER_HIDE_SCROLL_DELTA) {
+  } else if (isDeliberateScrollUp) {
     host.chatHeaderControlsHidden = false;
   }
 
@@ -252,6 +265,7 @@ export function handleActivityScroll(host: ScrollHost, event: Event) {
 export function resetChatScroll(host: ScrollHost) {
   host.chatHasAutoScrolled = false;
   host.chatUserNearBottom = true;
+  host.chatFollowLocked = false;
   host.chatLastScrollTop = 0;
   host.chatHeaderControlsHidden = false;
   host.chatNewMessagesBelow = false;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -697,6 +697,7 @@ export class OpenClawApp extends LitElement {
   chatLastScrollTop = 0;
   chatHasAutoScrolled = false;
   chatUserNearBottom = true;
+  chatFollowLocked = false;
   chatIsProgrammaticScroll = false;
   chatProgrammaticScrollTarget = 0;
   @state() chatNewMessagesBelow = false;


### PR DESCRIPTION
Fixes #92386.

## Summary
- track an explicit WebChat follow lock when the user scrolls upward during streaming
- let upward user input, including sub-12px trackpad/wheel movement, pass through the programmatic-scroll guard instead of being swallowed by a stale target
- keep auto-follow disabled until the user returns to the bottom, while preserving manual/always auto-scroll modes

## Real behavior proof
- Behavior or issue addressed: WebChat no longer snaps a streaming conversation back to the bottom after the user scrolls upward near the bottom while a stale programmatic-scroll target is still active.
- Real environment tested: Local OpenClaw source checkout on macOS, head c824ae32ac8c322f22de7abc2b9284298ee0767e, Node/Vitest through the repository runner.
- Exact steps or command run after this patch: Ran node scripts/run-vitest.mjs ui/src/ui/app-scroll.test.ts, node scripts/run-vitest.mjs ui/src/ui/app-chat.test.ts ui/src/ui/app-scroll.test.ts, pnpm exec oxfmt --check --threads=1 ui/src/ui/app-scroll.ts ui/src/ui/app.ts ui/src/ui/app-scroll.test.ts, git diff --check, and local child-mode pnpm check:changed with OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false.
- Evidence after fix: Terminal output copied from the after-fix local OpenClaw run:

~~~text
[test] starting test/vitest/vitest.ui.config.ts
RUN  v4.1.7 /Users/andy/openclaw-92386-webchat-scroll-preserve
Test Files  1 passed (1)
Tests  30 passed (30)
[test] passed 1 Vitest shard in 927ms

[test] starting test/vitest/vitest.ui.config.ts
RUN  v4.1.7 /Users/andy/openclaw-92386-webchat-scroll-preserve
Test Files  1 passed (1)
Tests  30 passed (30)
[test] starting test/vitest/vitest.unit-ui.config.ts
RUN  v4.1.7 /Users/andy/openclaw-92386-webchat-scroll-preserve
Test Files  1 passed (1)
Tests  86 passed (86)
[test] passed 2 Vitest shards in 2.14s

Checking formatting...
All matched files use the correct format.
git diff --check -> no output
[check:changed] lanes=core, coreTests
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] lint core changed files
runtime-sidecar-loaders: local runtime sidecar loaders look OK.
Import cycle check: 0 runtime value cycle(s).
~~~

- Observed result after fix: The regression records chatFollowLocked=true and chatUserNearBottom=false after an upward scroll with a stale programmatic target, including a sub-threshold movement from scrollTop 1600 to 1589. scheduleChatScroll leaves scrollTop at the user-selected position and sets the new-message indicator, and auto-follow only resumes after returning to the bottom.
- What was not tested: A live browser/gateway WebChat smoke was not run in this local pass.
