### PR TITLE
Honor WhatsApp configured ACP bindings

### DIFF
--- a/docs/channels/broadcast-groups.md
+++ b/docs/channels/broadcast-groups.md
@@ -161,17 +161,20 @@ Control how agents process messages:
   <Step title="Incoming message arrives">
     A WhatsApp group or DM message arrives.
   </Step>
-  <Step title="Broadcast check">
-    System checks if peer ID is in `broadcast`.
+  <Step title="Route and admission">
+    OpenClaw applies channel allowlists, group activation rules, and configured ACP binding ownership.
   </Step>
-  <Step title="If in broadcast list">
+  <Step title="Broadcast check">
+    If no configured ACP binding owns the route, OpenClaw checks whether the peer ID is in `broadcast`.
+  </Step>
+  <Step title="If broadcast applies">
     - All listed agents process the message.
     - Each agent has its own session key and isolated context.
     - Agents process in parallel (default) or sequentially.
 
   </Step>
-  <Step title="If not in broadcast list">
-    Normal routing applies (first matching binding).
+  <Step title="If broadcast does not apply">
+    OpenClaw dispatches the ordinary route or the configured ACP session route selected during routing.
   </Step>
 </Steps>
 
@@ -322,7 +325,7 @@ Broadcast groups work alongside existing routing:
 - `GROUP_B`: agent1 AND agent2 respond (broadcast).
 
 <Note>
-**Precedence:** `broadcast` takes priority over `bindings`.
+**Precedence:** `broadcast` takes priority over ordinary route bindings. Configured ACP bindings (`bindings[].type="acp"`) are exclusive: when one matches, OpenClaw dispatches to the configured ACP session instead of fan-out broadcast.
 </Note>
 
 ## Troubleshooting
@@ -343,9 +346,9 @@ Broadcast groups work alongside existing routing:
 
   </Accordion>
   <Accordion title="Only one agent responding">
-    **Cause:** Peer ID might be in `bindings` but not `broadcast`.
+    **Cause:** Peer ID might be in ordinary route bindings but not `broadcast`, or it might match an exclusive configured ACP binding.
 
-    **Fix:** Add to broadcast config or remove from bindings.
+    **Fix:** Add ordinary route-bound peers to broadcast config, or remove/change the configured ACP binding if fan-out broadcast is desired.
 
   </Accordion>
   <Accordion title="Performance issues">

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -319,6 +319,40 @@ content and identifiers.
   </Tab>
 </Tabs>
 
+## Configured ACP bindings
+
+WhatsApp supports persistent ACP bindings with top-level `bindings[]` entries:
+
+```json5
+{
+  bindings: [
+    {
+      type: "acp",
+      agentId: "codex",
+      match: {
+        channel: "whatsapp",
+        accountId: "work",
+        peer: { kind: "direct", id: "+15555550123" },
+      },
+    },
+    {
+      type: "acp",
+      agentId: "codex",
+      match: {
+        channel: "whatsapp",
+        accountId: "work",
+        peer: { kind: "group", id: "120363424282127706@g.us" },
+      },
+    },
+  ],
+}
+```
+
+- Direct chats match E.164 numbers such as `+15555550123`.
+- Groups match WhatsApp group JIDs such as `120363424282127706@g.us`.
+- Group allowlists, sender policy, and mention or activation gating run before OpenClaw ensures the configured ACP session exists.
+- A matched configured ACP binding owns the route. WhatsApp broadcast groups do not fan out that turn to ordinary WhatsApp sessions.
+
 ## Personal-number and self-chat behavior
 
 When the linked self number is also present in `allowFrom`, WhatsApp self-chat safeguards activate:

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -130,6 +130,8 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 }
 ```
 
+- Top-level `bindings[]` entries with `type: "acp"` configure persistent ACP bindings for WhatsApp DMs and groups. Use an E.164 direct number or WhatsApp group JID in `match.peer.id`. Field semantics are shared in [ACP Agents](/tools/acp-agents#persistent-channel-bindings).
+
 <Accordion title="Multi-account WhatsApp">
 
 ```json5

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -336,6 +336,7 @@ top-level `bindings[]` entries.
 - **Discord channel/thread:** `match.channel="discord"` + `match.peer.id="<channelOrThreadId>"`
 - **Slack channel/DM:** `match.channel="slack"` + `match.peer.id="<channelId|channel:<channelId>|#<channelId>|userId|user:<userId>|slack:<userId>|<@userId>>"`. Prefer stable Slack ids; channel bindings also match replies inside that channel's threads.
 - **Telegram forum topic:** `match.channel="telegram"` + `match.peer.id="<chatId>:topic:<topicId>"`
+- **WhatsApp DM/group:** `match.channel="whatsapp"` + `match.peer.id="<E.164|group JID>"`. Use E.164 numbers such as `+15555550123` for direct chats and WhatsApp group JIDs such as `120363424282127706@g.us` for groups.
 - **iMessage DM/group:** `match.channel="imessage"` + `match.peer.id="<handle|chat_id:*|chat_guid:*|chat_identifier:*>"`. Prefer `chat_id:*` for stable group bindings.
 
 </ParamField>
@@ -453,8 +454,9 @@ Use `agents.list[].runtime` to define ACP defaults once per agent:
 
 ### Behavior
 
-- OpenClaw ensures the configured ACP session exists before use.
-- Messages in that channel or topic route to the configured ACP session.
+- OpenClaw ensures the configured ACP session exists after channel-specific admission and before use.
+- Messages in that channel, topic, or chat route to the configured ACP session.
+- Configured ACP bindings own their session route. Channel broadcast fan-out does not replace the configured ACP session for a matched binding.
 - In bound conversations, `/new` and `/reset` reset the same ACP session key in place.
 - Temporary runtime bindings (for example created by thread-focus flows) still apply where present.
 - For cross-agent ACP spawns without an explicit `cwd`, OpenClaw inherits the target agent workspace from agent config.

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.acp-bindings.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.acp-bindings.test.ts
@@ -1,16 +1,30 @@
 // Whatsapp tests cover inbound configured ACP binding route materialization.
+import type { ConfiguredBindingRouteResult } from "openclaw/plugin-sdk/conversation-binding-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const processMessageMock = vi.fn();
-const maybeBroadcastMessageMock = vi.fn();
-const resolveConfiguredBindingRouteMock = vi.fn();
-const ensureConfiguredBindingRouteReadyMock = vi.fn();
-const resolveAgentRouteMock = vi.fn();
+const processMessageMock = vi.hoisted(() => vi.fn());
+const maybeBroadcastMessageMock = vi.hoisted(() => vi.fn());
+const resolveConfiguredBindingRouteMock = vi.hoisted(() => vi.fn());
+const ensureConfiguredBindingRouteReadyMock = vi.hoisted(() => vi.fn());
+const resolveAgentRouteMock = vi.hoisted(() => vi.fn());
+const applyGroupGatingMock = vi.hoisted(() => vi.fn());
+const updateLastRouteInBackgroundMock = vi.hoisted(() => vi.fn());
+const transcribeFirstAudioMock = vi.hoisted(() => vi.fn());
+const maybeSendAckReactionMock = vi.hoisted(() => vi.fn());
+const createStatusReactionControllerMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/conversation-binding-runtime", () => ({
   resolveConfiguredBindingRoute: (...args: unknown[]) => resolveConfiguredBindingRouteMock(...args),
   ensureConfiguredBindingRouteReady: (...args: unknown[]) =>
     ensureConfiguredBindingRouteReadyMock(...args),
+}));
+
+vi.mock("./audio-preflight.runtime.js", () => ({
+  transcribeFirstAudio: (...args: unknown[]) => transcribeFirstAudioMock(...args),
+}));
+
+vi.mock("./ack-reaction.js", () => ({
+  maybeSendAckReaction: (...args: unknown[]) => maybeSendAckReactionMock(...args),
 }));
 
 vi.mock("openclaw/plugin-sdk/routing", async (importOriginal) => {
@@ -44,12 +58,21 @@ vi.mock("./broadcast.js", () => ({
   maybeBroadcastMessage: (...args: unknown[]) => maybeBroadcastMessageMock(...args),
 }));
 
+vi.mock("./group-gating.js", () => ({
+  applyGroupGating: (...args: unknown[]) => applyGroupGatingMock(...args),
+}));
+
 vi.mock("./last-route.js", () => ({
-  updateLastRouteInBackground: () => {},
+  updateLastRouteInBackground: (...args: unknown[]) => updateLastRouteInBackgroundMock(...args),
 }));
 
 vi.mock("./process-message.js", () => ({
   processMessage: (...args: unknown[]) => processMessageMock(...args),
+}));
+
+vi.mock("./status-reaction.js", () => ({
+  createWhatsAppStatusReactionController: (...args: unknown[]) =>
+    createStatusReactionControllerMock(...args),
 }));
 
 import { createTestWebInboundMessage } from "../../inbound/test-message.test-helper.js";
@@ -66,15 +89,17 @@ const baseRoute = {
 };
 
 const boundSessionKey = "agent:sandboxed-agent:acp:binding:whatsapp:work:abc123";
+const directConversationId = "+15551234567";
+const groupConversationId = "120363001234567890@g.us";
 
 const configuredBindingRecord = {
-  bindingId: "config:acp:whatsapp:work:+15551234567",
+  bindingId: `config:acp:whatsapp:work:${directConversationId}`,
   targetSessionKey: boundSessionKey,
   targetKind: "session",
   conversation: {
     channel: "whatsapp",
     accountId: "work",
-    conversationId: "+15551234567",
+    conversationId: directConversationId,
   },
   status: "active",
   boundAt: 0,
@@ -96,7 +121,7 @@ const configuredBindingResolution = {
   conversation: {
     channel: "whatsapp",
     accountId: "work",
-    conversationId: "+15551234567",
+    conversationId: directConversationId,
   },
   compiledBinding: {
     channel: "whatsapp",
@@ -107,15 +132,15 @@ const configuredBindingResolution = {
       match: {
         channel: "whatsapp",
         accountId: "work",
-        peer: { kind: "direct", id: "+15551234567" },
+        peer: { kind: "direct", id: directConversationId },
       },
     },
-    bindingConversationId: "+15551234567",
-    target: { conversationId: "+15551234567" },
+    bindingConversationId: directConversationId,
+    target: { conversationId: directConversationId },
     agentId: "sandboxed-agent",
     provider: {
-      compileConfiguredBinding: () => ({ conversationId: "+15551234567" }),
-      matchInboundConversation: () => ({ conversationId: "+15551234567" }),
+      compileConfiguredBinding: () => ({ conversationId: directConversationId }),
+      matchInboundConversation: () => ({ conversationId: directConversationId }),
     },
     targetFactory: {
       driverId: "acp",
@@ -130,28 +155,113 @@ const configuredBindingResolution = {
   statefulTarget: configuredStatefulTarget,
 } as const;
 
-function createHandler(warn = vi.fn()) {
+const configuredGroupBindingRecord = {
+  ...configuredBindingRecord,
+  bindingId: `config:acp:whatsapp:work:${groupConversationId}`,
+  conversation: {
+    channel: "whatsapp",
+    accountId: "work",
+    conversationId: groupConversationId,
+  },
+} as const;
+
+const configuredGroupBindingResolution = {
+  ...configuredBindingResolution,
+  conversation: {
+    channel: "whatsapp",
+    accountId: "work",
+    conversationId: groupConversationId,
+  },
+  compiledBinding: {
+    ...configuredBindingResolution.compiledBinding,
+    binding: {
+      ...configuredBindingResolution.compiledBinding.binding,
+      match: {
+        channel: "whatsapp",
+        accountId: "work",
+        peer: { kind: "group", id: groupConversationId },
+      },
+    },
+    bindingConversationId: groupConversationId,
+    target: { conversationId: groupConversationId },
+    provider: {
+      compileConfiguredBinding: () => ({ conversationId: groupConversationId }),
+      matchInboundConversation: () => ({ conversationId: groupConversationId }),
+    },
+    targetFactory: {
+      driverId: "acp",
+      materialize: () => ({
+        record: configuredGroupBindingRecord,
+        statefulTarget: configuredStatefulTarget,
+      }),
+    },
+  },
+  match: { conversationId: groupConversationId },
+  record: configuredGroupBindingRecord,
+} as const;
+
+type ConfiguredBindingResolution = NonNullable<ConfiguredBindingRouteResult["bindingResolution"]>;
+
+function resolvedConfiguredRoute(
+  bindingResolution: ConfiguredBindingResolution = configuredBindingResolution,
+) {
+  return ({ route }: { route: typeof baseRoute }) => ({
+    bindingResolution,
+    boundSessionKey,
+    boundAgentId: "sandboxed-agent",
+    route: {
+      ...route,
+      agentId: "sandboxed-agent",
+      sessionKey: boundSessionKey,
+      matchedBy: "binding.channel",
+    },
+  });
+}
+
+function createCfg(): Record<string, unknown> {
+  return {
+    bindings: [
+      {
+        type: "acp",
+        agentId: "sandboxed-agent",
+        match: {
+          channel: "whatsapp",
+          accountId: "work",
+          peer: { kind: "direct", id: "+15551234567" },
+        },
+      },
+    ],
+  };
+}
+
+function createGroupCfg(): Record<string, unknown> {
+  return {
+    bindings: [
+      {
+        type: "acp",
+        agentId: "sandboxed-agent",
+        match: {
+          channel: "whatsapp",
+          accountId: "work",
+          peer: { kind: "group", id: "120363001234567890@g.us" },
+        },
+      },
+    ],
+  };
+}
+
+function createHandler(warn = vi.fn(), cfg: Record<string, unknown> = createCfg()) {
+  const groupHistories = new Map();
   return {
     warn,
+    groupHistories,
     handler: createWebOnMessageHandler({
-      cfg: {
-        bindings: [
-          {
-            type: "acp",
-            agentId: "sandboxed-agent",
-            match: {
-              channel: "whatsapp",
-              accountId: "work",
-              peer: { kind: "direct", id: "+15551234567" },
-            },
-          },
-        ],
-      } as never,
+      cfg: cfg as never,
       verbose: false,
       connectionId: "conn-1",
       maxMediaBytes: 1024 * 1024,
       groupHistoryLimit: 20,
-      groupHistories: new Map(),
+      groupHistories,
       groupMemberNames: new Map(),
       echoTracker: {
         has: () => false,
@@ -185,28 +295,60 @@ function createMessage() {
   });
 }
 
+function createGroupMessage() {
+  return createTestWebInboundMessage({
+    accountId: "work",
+    chatType: "group",
+    from: "120363001234567890@g.us",
+    conversationId: "120363001234567890@g.us",
+    platform: {
+      chatJid: "120363001234567890@g.us",
+      recipientJid: "15559876543@s.whatsapp.net",
+    },
+  });
+}
+
+function createGroupAudioMessage() {
+  return createTestWebInboundMessage({
+    accountId: "work",
+    chatType: "group",
+    from: "120363001234567890@g.us",
+    conversationId: "120363001234567890@g.us",
+    payload: {
+      body: "<media:audio>",
+      media: {
+        type: "audio/ogg; codecs=opus",
+        path: "/tmp/voice.ogg",
+      },
+    },
+    platform: {
+      chatJid: "120363001234567890@g.us",
+      recipientJid: "15559876543@s.whatsapp.net",
+    },
+  });
+}
+
 describe("createWebOnMessageHandler configured ACP bindings", () => {
   beforeEach(() => {
     processMessageMock.mockReset();
     processMessageMock.mockResolvedValue(true);
     maybeBroadcastMessageMock.mockReset();
     maybeBroadcastMessageMock.mockResolvedValue(false);
+    applyGroupGatingMock.mockReset();
+    applyGroupGatingMock.mockResolvedValue({ shouldProcess: true });
+    updateLastRouteInBackgroundMock.mockReset();
+    transcribeFirstAudioMock.mockReset();
+    transcribeFirstAudioMock.mockResolvedValue("agent please handle this");
+    maybeSendAckReactionMock.mockReset();
+    maybeSendAckReactionMock.mockResolvedValue(null);
+    createStatusReactionControllerMock.mockReset();
+    createStatusReactionControllerMock.mockResolvedValue(null);
     resolveAgentRouteMock.mockReset();
     resolveAgentRouteMock.mockReturnValue(baseRoute);
     ensureConfiguredBindingRouteReadyMock.mockReset();
     ensureConfiguredBindingRouteReadyMock.mockResolvedValue({ ok: true });
     resolveConfiguredBindingRouteMock.mockReset();
-    resolveConfiguredBindingRouteMock.mockImplementation(({ route }) => ({
-      bindingResolution: configuredBindingResolution,
-      boundSessionKey,
-      boundAgentId: "sandboxed-agent",
-      route: {
-        ...route,
-        agentId: "sandboxed-agent",
-        sessionKey: boundSessionKey,
-        matchedBy: "binding.channel",
-      },
-    }));
+    resolveConfiguredBindingRouteMock.mockImplementation(resolvedConfiguredRoute());
   });
 
   it("rewrites matching WhatsApp inbound turns to the configured ACP session key", async () => {
@@ -272,5 +414,174 @@ describe("createWebOnMessageHandler configured ACP bindings", () => {
         }),
       }),
     );
+  });
+
+  it("skips broadcast fan-out for configured ACP binding routes", async () => {
+    const { handler } = createHandler(vi.fn(), {
+      ...createCfg(),
+      broadcast: {
+        "+15551234567": ["ordinary-agent"],
+      },
+    });
+
+    await handler(createMessage());
+
+    expect(maybeBroadcastMessageMock).not.toHaveBeenCalled();
+    expect(processMessageMock).toHaveBeenCalledTimes(1);
+    expect(processMessageMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        route: expect.objectContaining({
+          sessionKey: boundSessionKey,
+          matchedBy: "binding.channel",
+        }),
+      }),
+    );
+  });
+
+  it("waits for group admission before ensuring a configured ACP binding target", async () => {
+    resolveConfiguredBindingRouteMock.mockImplementationOnce(
+      resolvedConfiguredRoute(configuredGroupBindingResolution),
+    );
+    const pendingEntry = {
+      sender: "Alice",
+      body: "ambient group message",
+    };
+    applyGroupGatingMock.mockImplementationOnce(
+      async (params: { groupHistories: Map<string, unknown[]>; groupHistoryKey: string }) => {
+        params.groupHistories.set(params.groupHistoryKey, [pendingEntry]);
+        return { shouldProcess: false };
+      },
+    );
+    const { handler, groupHistories } = createHandler(vi.fn(), createGroupCfg());
+
+    await handler(createGroupMessage());
+
+    expect(applyGroupGatingMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "sandboxed-agent",
+        sessionKey: boundSessionKey,
+      }),
+    );
+    expect(ensureConfiguredBindingRouteReadyMock).not.toHaveBeenCalled();
+    expect(updateLastRouteInBackgroundMock).not.toHaveBeenCalled();
+    expect(maybeBroadcastMessageMock).not.toHaveBeenCalled();
+    expect(processMessageMock).not.toHaveBeenCalled();
+    expect(groupHistories.get("group-key")).toEqual([pendingEntry]);
+  });
+
+  it("does not record configured ACP group routes when readiness fails", async () => {
+    resolveConfiguredBindingRouteMock.mockImplementationOnce(
+      resolvedConfiguredRoute(configuredGroupBindingResolution),
+    );
+    const { handler, warn } = createHandler(vi.fn(), createGroupCfg());
+    ensureConfiguredBindingRouteReadyMock.mockResolvedValueOnce({
+      ok: false,
+      error: "acpx backend unavailable",
+    });
+
+    await handler(createGroupMessage());
+
+    expect(applyGroupGatingMock).toHaveBeenCalledTimes(1);
+    expect(ensureConfiguredBindingRouteReadyMock).toHaveBeenCalledTimes(1);
+    expect(updateLastRouteInBackgroundMock).not.toHaveBeenCalled();
+    expect(maybeBroadcastMessageMock).not.toHaveBeenCalled();
+    expect(processMessageMock).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "whatsapp: configured ACP binding unavailable for conversation 120363001234567890@g.us: acpx backend unavailable",
+    );
+  });
+
+  it("removes preflight ack when configured ACP readiness fails after group audio mention gating", async () => {
+    const ackReaction = {
+      ackReactionPromise: Promise.resolve(true),
+      ackReactionValue: "👀",
+      remove: vi.fn(async () => undefined),
+    };
+    resolveConfiguredBindingRouteMock.mockImplementationOnce(
+      resolvedConfiguredRoute(configuredGroupBindingResolution),
+    );
+    applyGroupGatingMock
+      .mockResolvedValueOnce({ shouldProcess: false, needsMentionText: true })
+      .mockResolvedValueOnce({ shouldProcess: true });
+    maybeSendAckReactionMock.mockResolvedValueOnce(ackReaction);
+    ensureConfiguredBindingRouteReadyMock.mockResolvedValueOnce({
+      ok: false,
+      error: "acpx backend unavailable",
+    });
+    const { handler } = createHandler(vi.fn(), createGroupCfg());
+
+    await handler(createGroupAudioMessage());
+
+    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(ensureConfiguredBindingRouteReadyMock).toHaveBeenCalledTimes(1);
+    expect(ackReaction.remove).toHaveBeenCalledTimes(1);
+    expect(maybeBroadcastMessageMock).not.toHaveBeenCalled();
+    expect(processMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("clears preflight status reaction when configured ACP readiness fails after group audio mention gating", async () => {
+    const statusReactionController = {
+      setQueued: vi.fn(async () => undefined),
+      setThinking: vi.fn(async () => undefined),
+      setTool: vi.fn(async () => undefined),
+      setCompacting: vi.fn(async () => undefined),
+      cancelPending: vi.fn(),
+      setDone: vi.fn(async () => undefined),
+      setError: vi.fn(async () => undefined),
+      clear: vi.fn(async () => undefined),
+      restoreInitial: vi.fn(async () => undefined),
+    };
+    resolveConfiguredBindingRouteMock.mockImplementationOnce(
+      resolvedConfiguredRoute(configuredGroupBindingResolution),
+    );
+    applyGroupGatingMock
+      .mockResolvedValueOnce({ shouldProcess: false, needsMentionText: true })
+      .mockResolvedValueOnce({ shouldProcess: true });
+    createStatusReactionControllerMock.mockResolvedValueOnce(statusReactionController);
+    ensureConfiguredBindingRouteReadyMock.mockResolvedValueOnce({
+      ok: false,
+      error: "acpx backend unavailable",
+    });
+    const { handler } = createHandler(vi.fn(), {
+      ...createGroupCfg(),
+      messages: {
+        statusReactions: { enabled: true },
+      },
+    });
+
+    await handler(createGroupAudioMessage());
+
+    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.setQueued).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.cancelPending).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.clear).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.restoreInitial).not.toHaveBeenCalled();
+    expect(maybeSendAckReactionMock).not.toHaveBeenCalled();
+    expect(maybeBroadcastMessageMock).not.toHaveBeenCalled();
+    expect(processMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("records configured ACP group routes after admission and readiness", async () => {
+    resolveConfiguredBindingRouteMock.mockImplementationOnce(
+      resolvedConfiguredRoute(configuredGroupBindingResolution),
+    );
+    const { handler } = createHandler(vi.fn(), createGroupCfg());
+
+    await handler(createGroupMessage());
+
+    expect(updateLastRouteInBackgroundMock).toHaveBeenCalledTimes(1);
+    expect(updateLastRouteInBackgroundMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storeAgentId: "sandboxed-agent",
+        sessionKey: boundSessionKey,
+        channel: "whatsapp",
+        to: "120363001234567890@g.us",
+        accountId: "work",
+      }),
+    );
+    expect(ensureConfiguredBindingRouteReadyMock.mock.invocationCallOrder[0]).toBeLessThan(
+      updateLastRouteInBackgroundMock.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(processMessageMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.acp-bindings.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.acp-bindings.test.ts
@@ -1,0 +1,255 @@
+// Whatsapp tests cover inbound configured ACP binding route materialization.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const processMessageMock = vi.fn();
+const maybeBroadcastMessageMock = vi.fn();
+const resolveConfiguredBindingRouteMock = vi.fn();
+const ensureConfiguredBindingRouteReadyMock = vi.fn();
+const resolveAgentRouteMock = vi.fn();
+
+vi.mock("openclaw/plugin-sdk/conversation-binding-runtime", () => ({
+  resolveConfiguredBindingRoute: (...args: unknown[]) => resolveConfiguredBindingRouteMock(...args),
+  ensureConfiguredBindingRouteReady: (...args: unknown[]) =>
+    ensureConfiguredBindingRouteReadyMock(...args),
+}));
+
+vi.mock("openclaw/plugin-sdk/routing", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/routing")>();
+  return {
+    ...actual,
+    buildGroupHistoryKey: () => "group-key",
+    resolveAgentRoute: (...args: unknown[]) => resolveAgentRouteMock(...args),
+  };
+});
+
+vi.mock("../../accounts.js", () => ({
+  resolveWhatsAppAccount: () => ({
+    accountId: "work",
+    authDir: "/tmp/whatsapp-auth",
+    mentionPatterns: [],
+    selfChatMode: false,
+  }),
+}));
+
+vi.mock("../../group-session-key.js", () => ({
+  resolveWhatsAppGroupSessionRoute: (route: unknown) => route,
+}));
+
+vi.mock("../../identity.js", () => ({
+  getPrimaryIdentityId: () => "+15551234567",
+  getSenderIdentity: () => ({ e164: "+15551234567", name: "Alice" }),
+}));
+
+vi.mock("./broadcast.js", () => ({
+  maybeBroadcastMessage: (...args: unknown[]) => maybeBroadcastMessageMock(...args),
+}));
+
+vi.mock("./last-route.js", () => ({
+  updateLastRouteInBackground: () => {},
+}));
+
+vi.mock("./process-message.js", () => ({
+  processMessage: (...args: unknown[]) => processMessageMock(...args),
+}));
+
+import { createTestWebInboundMessage } from "../../inbound/test-message.test-helper.js";
+import { createWebOnMessageHandler } from "./on-message.js";
+
+const baseRoute = {
+  agentId: "sandboxed-agent",
+  accountId: "work",
+  channel: "whatsapp",
+  sessionKey: "agent:sandboxed-agent:whatsapp:direct:+15551234567",
+  mainSessionKey: "agent:sandboxed-agent:main",
+  matchedBy: "binding.agent",
+  lastRoutePolicy: "bound",
+};
+
+const boundSessionKey = "agent:sandboxed-agent:acp:binding:whatsapp:work:abc123";
+
+const configuredBindingRecord = {
+  bindingId: "config:acp:whatsapp:work:+15551234567",
+  targetSessionKey: boundSessionKey,
+  targetKind: "session",
+  conversation: {
+    channel: "whatsapp",
+    accountId: "work",
+    conversationId: "+15551234567",
+  },
+  status: "active",
+  boundAt: 0,
+  metadata: {
+    source: "config",
+    mode: "oneshot",
+    agentId: "sandboxed-agent",
+  },
+} as const;
+
+const configuredStatefulTarget = {
+  kind: "stateful",
+  driverId: "acp",
+  sessionKey: boundSessionKey,
+  agentId: "sandboxed-agent",
+} as const;
+
+const configuredBindingResolution = {
+  conversation: {
+    channel: "whatsapp",
+    accountId: "work",
+    conversationId: "+15551234567",
+  },
+  compiledBinding: {
+    channel: "whatsapp",
+    accountPattern: "work",
+    binding: {
+      type: "acp",
+      agentId: "sandboxed-agent",
+      match: {
+        channel: "whatsapp",
+        accountId: "work",
+        peer: { kind: "direct", id: "+15551234567" },
+      },
+    },
+    bindingConversationId: "+15551234567",
+    target: { conversationId: "+15551234567" },
+    agentId: "sandboxed-agent",
+    provider: {
+      compileConfiguredBinding: () => ({ conversationId: "+15551234567" }),
+      matchInboundConversation: () => ({ conversationId: "+15551234567" }),
+    },
+    targetFactory: {
+      driverId: "acp",
+      materialize: () => ({
+        record: configuredBindingRecord,
+        statefulTarget: configuredStatefulTarget,
+      }),
+    },
+  },
+  match: { conversationId: "+15551234567" },
+  record: configuredBindingRecord,
+  statefulTarget: configuredStatefulTarget,
+} as const;
+
+function createHandler(warn = vi.fn()) {
+  return {
+    warn,
+    handler: createWebOnMessageHandler({
+      cfg: {
+        bindings: [
+          {
+            type: "acp",
+            agentId: "sandboxed-agent",
+            match: {
+              channel: "whatsapp",
+              accountId: "work",
+              peer: { kind: "direct", id: "+15551234567" },
+            },
+          },
+        ],
+      } as never,
+      verbose: false,
+      connectionId: "conn-1",
+      maxMediaBytes: 1024 * 1024,
+      groupHistoryLimit: 20,
+      groupHistories: new Map(),
+      groupMemberNames: new Map(),
+      echoTracker: {
+        has: () => false,
+        forget: () => {},
+        rememberText: () => {},
+        buildCombinedKey: ({ combinedBody }: { combinedBody: string }) => combinedBody,
+      },
+      backgroundTasks: new Set(),
+      replyResolver: vi.fn() as never,
+      replyLogger: {
+        info: () => {},
+        warn,
+        debug: () => {},
+        error: () => {},
+      } as never,
+      baseMentionConfig: {} as never,
+      account: { authDir: "/tmp/whatsapp-auth", accountId: "work" },
+    }),
+  };
+}
+
+function createMessage() {
+  return createTestWebInboundMessage({
+    accountId: "work",
+    from: "15551234567@s.whatsapp.net",
+    conversationId: "15551234567@s.whatsapp.net",
+    platform: {
+      chatJid: "15551234567@s.whatsapp.net",
+      recipientJid: "15559876543@s.whatsapp.net",
+    },
+  });
+}
+
+describe("createWebOnMessageHandler configured ACP bindings", () => {
+  beforeEach(() => {
+    processMessageMock.mockReset();
+    processMessageMock.mockResolvedValue(true);
+    maybeBroadcastMessageMock.mockReset();
+    maybeBroadcastMessageMock.mockResolvedValue(false);
+    resolveAgentRouteMock.mockReset();
+    resolveAgentRouteMock.mockReturnValue(baseRoute);
+    ensureConfiguredBindingRouteReadyMock.mockReset();
+    ensureConfiguredBindingRouteReadyMock.mockResolvedValue({ ok: true });
+    resolveConfiguredBindingRouteMock.mockReset();
+    resolveConfiguredBindingRouteMock.mockImplementation(({ route }) => ({
+      bindingResolution: configuredBindingResolution,
+      boundSessionKey,
+      boundAgentId: "sandboxed-agent",
+      route: {
+        ...route,
+        agentId: "sandboxed-agent",
+        sessionKey: boundSessionKey,
+        matchedBy: "binding.channel",
+      },
+    }));
+  });
+
+  it("rewrites matching WhatsApp inbound turns to the configured ACP session key", async () => {
+    const { handler } = createHandler();
+
+    await handler(createMessage());
+
+    expect(resolveConfiguredBindingRouteMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "whatsapp",
+        accountId: "work",
+        conversationId: "+15551234567",
+        route: baseRoute,
+      }),
+    );
+    expect(ensureConfiguredBindingRouteReadyMock).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      bindingResolution: configuredBindingResolution,
+    });
+    expect(processMessageMock).toHaveBeenCalledTimes(1);
+    expect(processMessageMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        route: expect.objectContaining({
+          sessionKey: boundSessionKey,
+          matchedBy: "binding.channel",
+        }),
+      }),
+    );
+  });
+
+  it("drops the inbound turn instead of falling back when ACP binding readiness fails", async () => {
+    const { handler, warn } = createHandler();
+    ensureConfiguredBindingRouteReadyMock.mockResolvedValueOnce({
+      ok: false,
+      error: "acpx backend unavailable",
+    });
+
+    await handler(createMessage());
+
+    expect(processMessageMock).not.toHaveBeenCalled();
+    expect(maybeBroadcastMessageMock).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "whatsapp: configured ACP binding unavailable for conversation +15551234567: acpx backend unavailable",
+    );
+  });
+});

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.acp-bindings.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.acp-bindings.test.ts
@@ -252,4 +252,25 @@ describe("createWebOnMessageHandler configured ACP bindings", () => {
       "whatsapp: configured ACP binding unavailable for conversation +15551234567: acpx backend unavailable",
     );
   });
+
+  it("keeps the ordinary WhatsApp route when no configured ACP binding matches", async () => {
+    const { handler } = createHandler();
+    resolveConfiguredBindingRouteMock.mockImplementationOnce(({ route }) => ({
+      bindingResolution: null,
+      route,
+    }));
+
+    await handler(createMessage());
+
+    expect(ensureConfiguredBindingRouteReadyMock).not.toHaveBeenCalled();
+    expect(processMessageMock).toHaveBeenCalledTimes(1);
+    expect(processMessageMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        route: expect.objectContaining({
+          sessionKey: baseRoute.sessionKey,
+          matchedBy: baseRoute.matchedBy,
+        }),
+      }),
+    );
+  });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -1,6 +1,10 @@
 // Whatsapp plugin module implements on message behavior.
 import type { AckReactionHandle } from "openclaw/plugin-sdk/channel-feedback";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  ensureConfiguredBindingRouteReady,
+  resolveConfiguredBindingRoute,
+} from "openclaw/plugin-sdk/conversation-binding-runtime";
 import type { getReplyFromConfig } from "openclaw/plugin-sdk/reply-runtime";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
@@ -138,20 +142,13 @@ export function createWebOnMessageHandler(params: {
         id: peerId,
       },
     });
-    const route =
+    const baseConversationRoute =
       msg.chatType === "group" ? resolveWhatsAppGroupSessionRoute(baseRoute) : baseRoute;
-    const groupHistoryKey =
-      msg.chatType === "group"
-        ? buildGroupHistoryKey({
-            channel: "whatsapp",
-            accountId: route.accountId,
-            peerKind: "group",
-            peerId,
-          })
-        : route.sessionKey;
+    const routeAccountId =
+      baseConversationRoute.accountId ?? msg.accountId ?? params.account.accountId ?? "default";
     const account = resolveWhatsAppAccount({
       cfg,
-      accountId: route.accountId ?? msg.accountId ?? params.account.accountId,
+      accountId: routeAccountId,
     });
     const baseMentionConfig = buildMentionConfig(cfg);
 
@@ -166,6 +163,36 @@ export function createWebOnMessageHandler(params: {
       params.echoTracker.forget(msg.payload.body);
       return;
     }
+
+    const configuredRoute = resolveConfiguredBindingRoute({
+      cfg,
+      route: baseConversationRoute,
+      channel: "whatsapp",
+      accountId: routeAccountId,
+      conversationId: peerId,
+    });
+    const route = configuredRoute.route;
+    if (configuredRoute.bindingResolution) {
+      const ensured = await ensureConfiguredBindingRouteReady({
+        cfg,
+        bindingResolution: configuredRoute.bindingResolution,
+      });
+      if (!ensured.ok) {
+        params.replyLogger.warn(
+          `whatsapp: configured ACP binding unavailable for conversation ${configuredRoute.bindingResolution.record.conversation.conversationId}: ${ensured.error}`,
+        );
+        return;
+      }
+    }
+    const groupHistoryKey =
+      msg.chatType === "group"
+        ? buildGroupHistoryKey({
+            channel: "whatsapp",
+            accountId: route.accountId,
+            peerKind: "group",
+            peerId,
+          })
+        : route.sessionKey;
 
     // Preflight audio transcription: run once before broadcast fan-out so all
     // agents share the same transcript instead of each making a separate STT call.

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -171,19 +171,9 @@ export function createWebOnMessageHandler(params: {
       accountId: routeAccountId,
       conversationId: peerId,
     });
+    // Bound route facts intentionally feed group activation/mention policy.
+    // Side-effectful ACP readiness still waits until the group turn is admitted.
     const route = configuredRoute.route;
-    if (configuredRoute.bindingResolution) {
-      const ensured = await ensureConfiguredBindingRouteReady({
-        cfg,
-        bindingResolution: configuredRoute.bindingResolution,
-      });
-      if (!ensured.ok) {
-        params.replyLogger.warn(
-          `whatsapp: configured ACP binding unavailable for conversation ${configuredRoute.bindingResolution.record.conversation.conversationId}: ${ensured.error}`,
-        );
-        return;
-      }
-    }
     const groupHistoryKey =
       msg.chatType === "group"
         ? buildGroupHistoryKey({
@@ -209,6 +199,24 @@ export function createWebOnMessageHandler(params: {
     let ackAlreadySent = false;
     let ackReaction: AckReactionHandle | null = null;
     let statusReactionController: StatusReactionController | null = null;
+    let recordAcceptedConfiguredGroupRoute: (() => void) | null = null;
+    const clearPreDispatchReaction = async () => {
+      try {
+        if (statusReactionController) {
+          statusReactionController.cancelPending();
+          await statusReactionController.clear();
+          return;
+        }
+        if (ackReaction && (await ackReaction.ackReactionPromise)) {
+          await ackReaction.remove();
+        }
+      } catch (err) {
+        params.replyLogger.warn(
+          { error: String(err) },
+          "whatsapp: failed to clear pre-dispatch reaction after configured ACP readiness failure",
+        );
+      }
+    };
     const runAudioPreflightOnce = async () => {
       if (
         preflightAudioTranscript !== undefined ||
@@ -288,17 +296,25 @@ export function createWebOnMessageHandler(params: {
         OriginatingChannel: "whatsapp",
         OriginatingTo: conversationId,
       } satisfies MsgContext;
-      updateLastRouteInBackground({
-        cfg,
-        backgroundTasks: params.backgroundTasks,
-        storeAgentId: route.agentId,
-        sessionKey: route.sessionKey,
-        channel: "whatsapp",
-        to: conversationId,
-        accountId: route.accountId,
-        ctx: metaCtx,
-        warn: params.replyLogger.warn.bind(params.replyLogger),
-      });
+      const recordGroupRoute = () =>
+        updateLastRouteInBackground({
+          cfg,
+          backgroundTasks: params.backgroundTasks,
+          storeAgentId: route.agentId,
+          sessionKey: route.sessionKey,
+          channel: "whatsapp",
+          to: conversationId,
+          accountId: route.accountId,
+          ctx: metaCtx,
+          warn: params.replyLogger.warn.bind(params.replyLogger),
+        });
+      // Configured ACP group routes are session-owned only after admission and
+      // readiness; ordinary routes keep the existing early group last-route update.
+      if (configuredRoute.bindingResolution) {
+        recordAcceptedConfiguredGroupRoute = recordGroupRoute;
+      } else {
+        recordGroupRoute();
+      }
 
       let gating = await applyGroupGating({
         cfg,
@@ -350,12 +366,26 @@ export function createWebOnMessageHandler(params: {
       }
     }
 
+    if (configuredRoute.bindingResolution) {
+      const ensured = await ensureConfiguredBindingRouteReady({
+        cfg,
+        bindingResolution: configuredRoute.bindingResolution,
+      });
+      if (!ensured.ok) {
+        params.replyLogger.warn(
+          `whatsapp: configured ACP binding unavailable for conversation ${configuredRoute.bindingResolution.record.conversation.conversationId}: ${ensured.error}`,
+        );
+        await clearPreDispatchReaction();
+        return;
+      }
+    }
+    recordAcceptedConfiguredGroupRoute?.();
+
     await runAudioPreflightOnce();
 
-    // Broadcast groups: when we'd reply anyway, run multiple agents.
-    // Does not bypass group mention/activation gating above.
     if (
-      await maybeBroadcastMessage({
+      !configuredRoute.bindingResolution &&
+      (await maybeBroadcastMessage({
         cfg,
         msg,
         peerId,
@@ -370,7 +400,7 @@ export function createWebOnMessageHandler(params: {
         ...(ackReaction && msg.chatType !== "group" ? { ackReaction } : {}),
         ...(statusReactionController && msg.chatType !== "group" ? { ackAlreadySent: true } : {}),
         processMessage: (m, r, k, opts) => processForRoute(cfg, m, r, k, opts),
-      })
+      }))
     ) {
       return;
     }

--- a/extensions/whatsapp/src/channel.acp-bindings.test.ts
+++ b/extensions/whatsapp/src/channel.acp-bindings.test.ts
@@ -1,0 +1,104 @@
+// Whatsapp tests cover configured ACP binding support.
+import { resolveConfiguredAcpBindingRecord } from "openclaw/plugin-sdk/acp-binding-resolve-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  createEmptyPluginRegistry,
+  createTestRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { whatsappPlugin } from "./channel.js";
+
+function createCfg(
+  peerId: string,
+  accountId = "work",
+  peerKind: "direct" | "group" = "direct",
+): OpenClawConfig {
+  return {
+    agents: {
+      list: [
+        {
+          id: "sandboxed-agent",
+          runtime: {
+            type: "acp",
+            acp: {
+              agent: "codex",
+              backend: "acpx",
+              cwd: "/workspace/sandboxed-agent",
+              mode: "oneshot",
+            },
+          },
+        },
+      ],
+    },
+    bindings: [
+      {
+        type: "acp",
+        agentId: "sandboxed-agent",
+        match: {
+          channel: "whatsapp",
+          accountId,
+          peer: {
+            kind: peerKind,
+            id: peerId,
+          },
+        },
+      },
+    ],
+  } as OpenClawConfig;
+}
+
+describe("WhatsApp configured ACP bindings", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "whatsapp",
+          source: "test",
+          plugin: whatsappPlugin,
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("materializes direct WhatsApp ACP bindings from inbound JIDs", () => {
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg: createCfg("+15551234567"),
+      channel: "whatsapp",
+      accountId: "work",
+      conversationId: "15551234567@s.whatsapp.net",
+    });
+
+    expect(resolved?.spec.channel).toBe("whatsapp");
+    expect(resolved?.spec.accountId).toBe("work");
+    expect(resolved?.spec.conversationId).toBe("+15551234567");
+    expect(resolved?.spec.agentId).toBe("sandboxed-agent");
+    expect(resolved?.spec.mode).toBe("oneshot");
+    expect(resolved?.spec.backend).toBe("acpx");
+    expect(resolved?.record.conversation.conversationId).toBe("+15551234567");
+    expect(resolved?.record.targetSessionKey).toContain(
+      "agent:sandboxed-agent:acp:binding:whatsapp:work:",
+    );
+  });
+
+  it("normalizes WhatsApp group JIDs for configured ACP binding lookup", () => {
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg: createCfg("120363001234567890@g.us", "work", "group"),
+      channel: "whatsapp",
+      accountId: "work",
+      conversationId: "whatsapp:group:120363001234567890@g.us",
+    });
+
+    expect(resolved?.spec.conversationId).toBe("120363001234567890@g.us");
+    expect(resolved?.record.conversation.conversationId).toBe("120363001234567890@g.us");
+    expect(resolved?.record.targetSessionKey).toContain(
+      "agent:sandboxed-agent:acp:binding:whatsapp:work:",
+    );
+  });
+});

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -108,6 +108,25 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
         stripRegexes: ({ ctx }) => resolveWhatsAppMentionStripRegexes(ctx),
       },
       commands: whatsappCommandPolicy,
+      bindings: {
+        compileConfiguredBinding: ({ conversationId }) => {
+          const normalized = normalizeWhatsAppTarget(conversationId);
+          return normalized ? { conversationId: normalized } : null;
+        },
+        matchInboundConversation: ({ compiledBinding, conversationId, parentConversationId }) => {
+          const normalizedConversationId = normalizeWhatsAppTarget(conversationId);
+          if (normalizedConversationId === compiledBinding.conversationId) {
+            return { conversationId: compiledBinding.conversationId, matchPriority: 2 };
+          }
+          const normalizedParentConversationId = parentConversationId
+            ? normalizeWhatsAppTarget(parentConversationId)
+            : null;
+          if (normalizedParentConversationId === compiledBinding.conversationId) {
+            return { conversationId: compiledBinding.conversationId, matchPriority: 1 };
+          }
+          return null;
+        },
+      },
       agentPrompt: {
         reactionGuidance: ({ cfg, accountId }) => {
           const level = resolveWhatsAppAgentReactionGuidance({

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -113,16 +113,10 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
           const normalized = normalizeWhatsAppTarget(conversationId);
           return normalized ? { conversationId: normalized } : null;
         },
-        matchInboundConversation: ({ compiledBinding, conversationId, parentConversationId }) => {
+        matchInboundConversation: ({ compiledBinding, conversationId }) => {
           const normalizedConversationId = normalizeWhatsAppTarget(conversationId);
           if (normalizedConversationId === compiledBinding.conversationId) {
             return { conversationId: compiledBinding.conversationId, matchPriority: 2 };
-          }
-          const normalizedParentConversationId = parentConversationId
-            ? normalizeWhatsAppTarget(parentConversationId)
-            : null;
-          if (normalizedParentConversationId === compiledBinding.conversationId) {
-            return { conversationId: compiledBinding.conversationId, matchPriority: 1 };
           }
           return null;
         },


### PR DESCRIPTION
Fixes #92449.

## Summary
- add WhatsApp configured-binding compile/match support using the channel target normalizer
- rewrite matching WhatsApp inbound routes to the configured ACP binding session before dispatch
- fail closed with a clear warning when the configured ACP binding target cannot be readied

## Real behavior proof
- Behavior or issue addressed: A WhatsApp direct conversation with a type=acp configured binding now materializes the configured ACP binding and dispatches with the agent:sandboxed-agent:acp:binding:whatsapp:work:<hash> session key instead of continuing on the ordinary local WhatsApp route.
- Real environment tested: Local OpenClaw source checkout on macOS, head 355976522aeaefced9dfb2937aa5616b9970c8ac, WhatsApp extension tests running through the repository runner.
- Exact steps or command run after this patch: Ran node scripts/run-vitest.mjs extensions/whatsapp/src/channel.acp-bindings.test.ts extensions/whatsapp/src/auto-reply/monitor/on-message.acp-bindings.test.ts extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts, then ran pnpm exec oxfmt --check --threads=1 extensions/whatsapp/src/channel.ts extensions/whatsapp/src/auto-reply/monitor/on-message.ts extensions/whatsapp/src/channel.acp-bindings.test.ts extensions/whatsapp/src/auto-reply/monitor/on-message.acp-bindings.test.ts, git diff --check, and local child-mode pnpm check:changed.
- Evidence after fix: Terminal output copied from the after-fix local OpenClaw run:

~~~text
[test] starting test/vitest/vitest.extension-whatsapp.config.ts
RUN  v4.1.7 /Users/andy/openclaw-92449-whatsapp-acp-binding
Test Files  4 passed (4)
Tests  60 passed (60)
[test] passed 1 Vitest shard in 6.07s
Checking formatting...
All matched files use the correct format.
git diff --check -> no output
[check:changed] lanes=extensions, extensionTests
[check:changed] typecheck extensions
[check:changed] typecheck extension tests
[check:changed] lint extensions
runtime-sidecar-loaders: local runtime sidecar loaders look OK.
Import cycle check: 0 runtime value cycle(s).
~~~

- Observed result after fix: The real WhatsApp plugin resolver materialized a configured ACP binding from inbound JID 15551234567@s.whatsapp.net to +15551234567, producing a target session key containing agent:sandboxed-agent:acp:binding:whatsapp:work:. The inbound handler regression dispatched the matching turn with that bound ACP session key and, when readiness returned acpx backend unavailable, dropped the turn before broadcast/processMessage instead of falling back to the ordinary local route.
- What was not tested: Live WhatsApp-to-ACP/acpx isolation proof was not run in this local pass; the route materialization and fail-closed behavior were validated in the source-level WhatsApp runtime path.


## Additional targeted packaged runtime proof

- Behavior or issue addressed: targeted configured WhatsApp ACP binding route materialization and readiness-failure drop/no local fallback.
- Real environment tested: isolated PR-head checkout on macOS at `255f37a60080669a9073ee4323cfa8d022df8ee0`, built by `pnpm openclaw qa whatsapp --help` as OpenClaw `2026.6.2 (255f37a)`.
- Exact proof marker: `PR92513-PACKAGED-WHATSAPP-ACP-ROUTE-PROOF-20260613`.
- Exact packaged-runtime command: `node --import tsx -e <script importing src/routing/resolve-route.ts and src/channels/plugins/binding-routing.ts>`. The script used the normal bundled WhatsApp channel plugin registry, not a mocked WhatsApp binding adapter.
- Evidence after fix:

~~~json
{
  "marker": "PR92513-PACKAGED-WHATSAPP-ACP-ROUTE-PROOF-20260613",
  "base": {
    "sessionKey": "agent:sandboxed-agent:whatsapp:work:direct:+15551234567",
    "matchedBy": "default"
  },
  "configured": {
    "matched": true,
    "sessionKey": "agent:sandboxed-agent:acp:binding:whatsapp:work:cfe01dba0e30db71",
    "matchedBy": "binding.channel",
    "boundSessionKey": "agent:sandboxed-agent:acp:binding:whatsapp:work:cfe01dba0e30db71",
    "recordTargetSessionKey": "agent:sandboxed-agent:acp:binding:whatsapp:work:cfe01dba0e30db71",
    "conversationId": "+15551234567",
    "driverId": "acp"
  },
  "ready": {
    "ok": false,
    "error": "ACP runtime backend is not configured. Install and enable the acpx runtime plugin."
  },
  "dispatchDecision": "drop_without_local_fallback_or_broadcast"
}
~~~

- Focused dispatch regression command: `node scripts/run-vitest.mjs extensions/whatsapp/src/channel.acp-bindings.test.ts extensions/whatsapp/src/auto-reply/monitor/on-message.acp-bindings.test.ts`.
- Focused dispatch regression result: `2 passed (2)` test files, `11 passed (11)` tests.
- Observed result after fix: the packaged PR-head route resolver normalized inbound WhatsApp JID `15551234567@s.whatsapp.net` to `+15551234567`, matched the configured ACP binding, rewrote the route from ordinary WhatsApp session `agent:sandboxed-agent:whatsapp:work:direct:+15551234567` to configured ACP session `agent:sandboxed-agent:acp:binding:whatsapp:work:cfe01dba0e30db71`, marked the route as `binding.channel`, and returned a real ACP readiness failure. The PR dispatch branch returns on that readiness failure before broadcast/local `processMessage`, which is covered by the focused dispatch tests above.
- What was not tested in this targeted pass: live-device WhatsApp credentials were not available in this environment; mcaxtr separately posted broad WhatsApp QA proof with `35 passed / 0 failed` on this same head in https://github.com/openclaw/openclaw/pull/92513#issuecomment-4699651503.
