### PR TITLE
fix: allow session write lock re-entry for same-process abort race

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -683,6 +683,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       timeoutMs: params.lockOptions.timeoutMs,
       staleMs: params.lockOptions.staleMs,
       maxHoldMs: params.lockOptions.maxHoldMs,
+      allowReentrant: true,
     });
 
   let heldLock: SessionLock | undefined = await acquireLock();


### PR DESCRIPTION
## Problem

When the user presses the stop button mid-response, the session write lock release is fire-and-forget (non-blocking). If a new message arrives before the async release completes, the same process cannot reclaim its own lock because `allowReentrant` defaults to `false` and `respectMaxHold` is disabled for same-process holders.

This causes every subsequent message to fail with `SessionWriteLockTimeoutError` for the full `maxHoldMs` window (~17 minutes by default), forcing the user to start a new session.

Fixes #90309

## Root Cause

The session write lock (`session-write-lock.ts`) does not allow re-entrant acquires by default. When an embedded attempt aborts via the stop button:

1. `releaseEmbeddedAttemptSessionLockForAbort` fires `releaseHeldLockWithFence` asynchronously (intentionally non-blocking to not delay abort propagation)
2. A new message arrives and a new embedded attempt starts
3. The new attempt calls `acquireSessionWriteLock` which tries to acquire the file lock
4. The old lock file still exists (release hasn't completed yet)
5. Same PID -> `heldByThisProcess=true` -> `respectMaxHold=false` -> stale recovery skipped
6. New attempt can't acquire -> `SessionWriteLockTimeoutError` for ~17 minutes

## Fix

Pass `allowReentrant: true` to `acquireSessionWriteLock` in `createEmbeddedAttemptSessionLockController`. This allows the same process to acquire its own lock even while the previous async release is still in flight. The lock controller's `withSessionWriteLock` already serializes actual write access, so concurrent re-entrant acquires do not risk overlapping transcript writes.

## References

- Issue #90309: Stop-button abort retains session write lock for maxHoldMs (~17 min)
- Issue #89868 (related): Stop-button abort doesn't cancel auto-compaction LLM call
- PR #89886 (related): Fixed auto-compaction abort signal propagation