### PR TITLE
Recover memory search from transient missing metadata

### DIFF
--- a/extensions/memory-core/src/memory/manager.metadata-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.metadata-recovery.test.ts
@@ -1,0 +1,216 @@
+// Memory Core tests cover transient index metadata recovery during search.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
+import type { MemoryIndexMeta } from "./manager-reindex-state.js";
+import type { MemoryIndexManager } from "./manager.js";
+import "./test-runtime-mocks.js";
+
+const createEmbeddingProviderMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    requestedProvider: "auto",
+    provider: null,
+    providerUnavailableReason: "No embeddings provider available.",
+  })),
+);
+
+vi.mock("./embeddings.js", () => ({
+  createEmbeddingProvider: createEmbeddingProviderMock,
+  resolveEmbeddingProviderAdapterId: (providerId: string) => providerId,
+  resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
+    providerId === "local" ? "local" : "remote",
+  resolveEmbeddingProviderFallbackModel: () => "fts-only",
+}));
+
+type ManagerInternals = {
+  readMeta: () => MemoryIndexMeta | null;
+  openDatabase: () => unknown;
+  resetVectorState: () => void;
+  ensureSchema: () => void;
+  hasIndexedContent: () => boolean;
+};
+
+function metadataRecoveryStatus(memoryManager: MemoryIndexManager) {
+  return memoryManager.status().custom?.metadataRecovery as
+    | {
+        attempts?: number;
+        successes?: number;
+        failures?: number;
+        lastError?: string;
+      }
+    | undefined;
+}
+
+function indexIdentityStatus(memoryManager: MemoryIndexManager) {
+  return memoryManager.status().custom?.indexIdentity as
+    | {
+        status?: string;
+        reason?: string;
+      }
+    | undefined;
+}
+
+describe("memory manager search metadata recovery", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+  let workspaceDir = "";
+  let indexPath = "";
+  let manager: MemoryIndexManager | null = null;
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-meta-recovery-"));
+  });
+
+  beforeEach(async () => {
+    createEmbeddingProviderMock.mockClear();
+    workspaceDir = path.join(fixtureRoot, `case-${caseId++}`);
+    indexPath = path.join(workspaceDir, "index.sqlite");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, "MEMORY.md"),
+      "Alpha topic\n\nKeep this note for search recovery.",
+    );
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await closeAllMemorySearchManagers();
+  });
+
+  afterAll(async () => {
+    await closeAllMemorySearchManagers();
+    if (fixtureRoot) {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  async function createIndexedFtsOnlyManager(): Promise<MemoryIndexManager> {
+    const cfg = {
+      memory: { backend: "builtin" },
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "auto",
+            model: "",
+            store: { path: indexPath, vector: { enabled: false } },
+            cache: { enabled: false },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    if (!result.manager) {
+      throw new Error(result.error ?? "manager missing");
+    }
+    manager = result.manager as unknown as MemoryIndexManager;
+    await manager.sync({ reason: "test", force: true });
+    expect(indexIdentityStatus(manager)?.status).toBe("valid");
+    return manager;
+  }
+
+  it("reopens sqlite and retries once when search sees transient missing metadata", async () => {
+    const memoryManager = await createIndexedFtsOnlyManager();
+    const internals = memoryManager as unknown as ManagerInternals;
+    const originalReadMeta = internals.readMeta.bind(memoryManager);
+    let missingReads = 1;
+    vi.spyOn(internals, "readMeta").mockImplementation(() =>
+      missingReads-- > 0 ? null : originalReadMeta(),
+    );
+    const openDatabaseSpy = vi.spyOn(internals, "openDatabase");
+    const resetVectorStateSpy = vi.spyOn(internals, "resetVectorState");
+    const ensureSchemaSpy = vi.spyOn(internals, "ensureSchema");
+
+    const results = await memoryManager.search("Alpha topic", { maxResults: 5 });
+
+    expect(results.map((result) => result.path)).toContain("MEMORY.md");
+    expect(openDatabaseSpy).toHaveBeenCalledTimes(1);
+    expect(resetVectorStateSpy).toHaveBeenCalledTimes(1);
+    expect(ensureSchemaSpy).toHaveBeenCalledTimes(1);
+    expect(metadataRecoveryStatus(memoryManager)).toEqual({
+      attempts: 1,
+      successes: 1,
+      failures: 0,
+      lastError: "index metadata is missing",
+    });
+  });
+
+  it("does not retry persistent provider/model/settings mismatches", async () => {
+    const memoryManager = await createIndexedFtsOnlyManager();
+    const internals = memoryManager as unknown as ManagerInternals;
+    const originalMeta = internals.readMeta();
+    if (!originalMeta) {
+      throw new Error("expected indexed metadata");
+    }
+    vi.spyOn(internals, "readMeta").mockReturnValue({
+      ...originalMeta,
+      model: "other-model",
+    });
+    const openDatabaseSpy = vi.spyOn(internals, "openDatabase");
+
+    await expect(memoryManager.search("Alpha topic", { maxResults: 5 })).resolves.toEqual([]);
+
+    expect(openDatabaseSpy).not.toHaveBeenCalled();
+    expect(indexIdentityStatus(memoryManager)).toEqual({
+      status: "mismatched",
+      reason: "index was built for model other-model, expected fts-only",
+    });
+    expect(metadataRecoveryStatus(memoryManager)).toEqual({
+      attempts: 0,
+      successes: 0,
+      failures: 0,
+      lastError: undefined,
+    });
+  });
+
+  it("does not retry non-metadata search failures", async () => {
+    const memoryManager = await createIndexedFtsOnlyManager();
+    const internals = memoryManager as unknown as ManagerInternals;
+    vi.spyOn(internals, "hasIndexedContent").mockImplementation(() => {
+      throw new Error("search storage failed");
+    });
+    const openDatabaseSpy = vi.spyOn(internals, "openDatabase");
+
+    await expect(memoryManager.search("Alpha topic", { maxResults: 5 })).rejects.toThrow(
+      "search storage failed",
+    );
+
+    expect(openDatabaseSpy).not.toHaveBeenCalled();
+    expect(metadataRecoveryStatus(memoryManager)).toEqual({
+      attempts: 0,
+      successes: 0,
+      failures: 0,
+      lastError: undefined,
+    });
+  });
+
+  it("caps missing-metadata recovery at one retry", async () => {
+    const memoryManager = await createIndexedFtsOnlyManager();
+    const internals = memoryManager as unknown as ManagerInternals;
+    vi.spyOn(internals, "readMeta").mockReturnValue(null);
+    const openDatabaseSpy = vi.spyOn(internals, "openDatabase");
+
+    await expect(memoryManager.search("Alpha topic", { maxResults: 5 })).resolves.toEqual([]);
+
+    expect(openDatabaseSpy).toHaveBeenCalledTimes(1);
+    expect(indexIdentityStatus(memoryManager)).toEqual({
+      status: "missing",
+      reason: "index metadata is missing",
+    });
+    expect(metadataRecoveryStatus(memoryManager)).toEqual({
+      attempts: 1,
+      successes: 0,
+      failures: 1,
+      lastError: "index metadata is missing",
+    });
+  });
+});

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -70,6 +70,7 @@ const VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = "chunks_fts";
 const EMBEDDING_CACHE_TABLE = "embedding_cache";
 const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
+const MEMORY_INDEX_METADATA_RECOVERY_DELAY_MS = 500;
 export const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
 const log = createSubsystemLogger("memory");
 type MemoryIndexManagerPurpose = "default" | "status" | "cli";
@@ -290,6 +291,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private readonlyRecoverySuccesses = 0;
   private readonlyRecoveryFailures = 0;
   private readonlyRecoveryLastError?: string;
+  private metadataRecoveryAttempts = 0;
+  private metadataRecoverySuccesses = 0;
+  private metadataRecoveryFailures = 0;
+  private metadataRecoveryLastError?: string;
   private indexIdentityState: MemoryIndexIdentityState = {
     status: "missing",
     reason: "index metadata is missing",
@@ -582,7 +587,97 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return state;
   }
 
+  private isRecoverableMissingIndexMetadata(
+    state: MemoryIndexIdentityState,
+  ): state is Extract<MemoryIndexIdentityState, { status: "missing" }> {
+    return state.status === "missing" && state.reason === "index metadata is missing";
+  }
+
+  private async waitForMetadataRecovery(signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) {
+      throw signal.reason instanceof Error ? signal.reason : new Error("memory search aborted");
+    }
+    await new Promise<void>((resolve, reject) => {
+      let timer: NodeJS.Timeout;
+      const recoverySignal = signal;
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(
+          recoverySignal?.reason instanceof Error
+            ? recoverySignal.reason
+            : new Error("memory search aborted"),
+        );
+      };
+      timer = setTimeout(() => {
+        recoverySignal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, MEMORY_INDEX_METADATA_RECOVERY_DELAY_MS);
+      if (!recoverySignal) {
+        return;
+      }
+      recoverySignal.addEventListener("abort", onAbort, { once: true });
+      void Promise.resolve().then(() => {
+        if (recoverySignal.aborted) {
+          onAbort();
+        }
+      });
+    });
+  }
+
+  private reopenDatabaseForMetadataRecovery(): void {
+    const previousVectorDims = this.vector.dims;
+    try {
+      closeMemoryDatabase(this.db);
+    } catch {}
+    this.db = this.openDatabase();
+    this.resetVectorState();
+    this.ensureSchema();
+    const meta = this.readMeta();
+    this.vector.dims = meta?.vectorDims ?? previousVectorDims;
+  }
+
   async search(
+    query: string,
+    opts?: {
+      maxResults?: number;
+      minScore?: number;
+      sessionKey?: string;
+      qmdSearchModeOverride?: "query" | "search" | "vsearch";
+      onDebug?: (debug: MemorySearchRuntimeDebug) => void;
+      /** When set, only these chunk sources are considered (must be enabled for this manager). */
+      sources?: MemorySource[];
+      /** Caller-owned cancellation; aborts in-flight embedding work when the caller stops waiting. */
+      signal?: AbortSignal;
+    },
+  ): Promise<MemorySearchResult[]> {
+    const result = await this.searchOnce(query, opts);
+    if (!this.isRecoverableMissingIndexMetadata(this.indexIdentityState)) {
+      return result;
+    }
+    const reason = this.indexIdentityState.reason;
+    this.metadataRecoveryAttempts += 1;
+    this.metadataRecoveryLastError = reason;
+    log.warn("memory search metadata missing; reopening sqlite connection after retry delay", {
+      reason,
+    });
+    try {
+      await this.waitForMetadataRecovery(opts?.signal);
+      this.reopenDatabaseForMetadataRecovery();
+      const retryResult = await this.searchOnce(query, opts);
+      const retryIdentityState = this.indexIdentityState as MemoryIndexIdentityState;
+      if (retryIdentityState.status === "valid") {
+        this.metadataRecoverySuccesses += 1;
+      } else {
+        this.metadataRecoveryFailures += 1;
+      }
+      return retryResult;
+    } catch (err) {
+      this.metadataRecoveryFailures += 1;
+      throw err;
+    }
+  }
+
+  private async searchOnce(
     query: string,
     opts?: {
       maxResults?: number;
@@ -1174,6 +1269,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           successes: this.readonlyRecoverySuccesses,
           failures: this.readonlyRecoveryFailures,
           lastError: this.readonlyRecoveryLastError,
+        },
+        metadataRecovery: {
+          attempts: this.metadataRecoveryAttempts,
+          successes: this.metadataRecoverySuccesses,
+          failures: this.metadataRecoveryFailures,
+          lastError: this.metadataRecoveryLastError,
         },
       },
     };


### PR DESCRIPTION
## Summary
- Recover `memory_search` from transient missing index metadata by retrying once after a short delay.
- Reopen the SQLite handle, reset vector state, ensure schema, and rerun the normal search path only for `index metadata is missing`.
- Add metadata recovery diagnostics to memory status and regression coverage for recoverable and non-recoverable cases.

## Root cause
A concurrent memory index rebuild can briefly make a cached SQLite reader observe missing metadata while the WAL/checkpoint state settles. The existing guard correctly fails closed, but it also treats the transient missing read the same as a persistent mismatch.

## Real behavior proof
**Behavior or issue addressed:** `memory_search` can recover from a transient missing index metadata read during a concurrent SQLite WAL/index rebuild without masking persistent identity mismatches.

**Real environment tested:** Local OpenClaw checkout on Linux, temporary workspace under `/tmp`, real `MEMORY.md`, real SQLite memory index, `provider: "none"`, vector search disabled, and the production memory manager search path. No private workspace or credentials were used.

**Exact steps or command run after this patch:** Created a throwaway workspace, wrote `MEMORY.md`, forced a memory sync to build the SQLite index, verified index identity was valid, injected one transient missing metadata read at the manager boundary, called `manager.search("Alpha topic")`, and read memory status after the retry.

**Evidence after fix:** Console output from the local runtime proof:

```json
{
  "beforeIndexIdentity": {
    "status": "valid"
  },
  "injectedTransientMissingMeta": true,
  "reopenedSqliteHandles": 1,
  "resultCount": 1,
  "firstResult": {
    "path": "MEMORY.md",
    "source": "memory",
    "keys": [
      "id",
      "path",
      "startLine",
      "endLine",
      "score",
      "textScore",
      "snippet",
      "source"
    ]
  },
  "afterIndexIdentity": {
    "status": "valid"
  },
  "metadataRecovery": {
    "attempts": 1,
    "successes": 1,
    "failures": 0,
    "lastError": "index metadata is missing"
  }
}
```

**Observed result after fix:** Search returned the indexed `MEMORY.md` result after exactly one SQLite reopen; status stayed `valid`; metadata recovery diagnostics reported `attempts: 1`, `successes: 1`, `failures: 0`, and `lastError: "index metadata is missing"`.

**What was not tested:** No known gaps.

## Validation
- `corepack pnpm exec node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/src/memory/manager.metadata-recovery.test.ts extensions/memory-core/src/memory/manager.readonly-recovery.test.ts extensions/memory-core/src/memory/manager-search.test.ts extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `corepack pnpm format:check -- extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/manager.metadata-recovery.test.ts`
- `git diff --check`