### PR TITLE
Suppress failed tool progress in Discord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Discord failed tool progress:** keep failed item and command-output details out of streaming drafts while preserving the final user-facing tool-error fallback for both immediate and queued runs. (#92517) Thanks @davefano.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Discord failed tool progress:** keep failed item and command-output details out of streaming drafts while preserving the final user-facing tool-error fallback for both immediate and queued runs. (#92517) Thanks @davefano.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -139,11 +139,13 @@ type DispatchInboundParams = {
     onItemEvent?: (payload: {
       itemId?: string;
       kind?: string;
+      phase?: string;
+      status?: string;
       progressText?: string;
       summary?: string;
       title?: string;
       name?: string;
-    }) => Promise<void> | void;
+    }) => Promise<false | void> | false | void;
     onVerboseProgressVisibility?: (isActive: () => boolean) => void;
     onPlanUpdate?: (payload: {
       phase?: string;
@@ -155,8 +157,9 @@ type DispatchInboundParams = {
       phase?: string;
       name?: string;
       title?: string;
+      status?: string;
       exitCode?: number | null;
-    }) => Promise<void> | void;
+    }) => Promise<false | void> | false | void;
     onPatchSummary?: (payload: {
       phase?: string;
       summary?: string;
@@ -2200,6 +2203,57 @@ describe("processDiscordMessage draft streaming", () => {
     expect(updates).toEqual(["Pinching\n\n🛠️ Exec\n• exec done"]);
     expectProgressSummaryEdit("🛠️ 1 tool call");
     expectFreshFinalText("done");
+  });
+
+  it("declines failed item progress without updating the Discord draft", async () => {
+    const draftStream = createMockDraftStreamForTest();
+    let callbackResult: false | void = undefined;
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      callbackResult = await params?.replyOptions?.onItemEvent?.({
+        itemId: "tool-1",
+        kind: "tool",
+        name: "exec",
+        phase: "end",
+        status: "failed",
+        progressText: "exec failed",
+      });
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { maxLinesPerMessage: 5 },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(callbackResult).toBe(false);
+    expect(draftStream.update).not.toHaveBeenCalled();
+  });
+
+  it("declines failed command output without updating the Discord draft", async () => {
+    const draftStream = createMockDraftStreamForTest();
+    let callbackResult: false | void = undefined;
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      callbackResult = await params?.replyOptions?.onCommandOutput?.({
+        phase: "error",
+        title: "Exec",
+        name: "exec",
+        status: "error",
+        exitCode: 1,
+      });
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { maxLinesPerMessage: 5 },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(callbackResult).toBe(false);
+    expect(draftStream.update).not.toHaveBeenCalled();
   });
 
   it("counts window thinking bursts closed by a tool call when no end event fires", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -93,6 +93,19 @@ function isFallbackOnlyToolWarningFinal(payload: ReplyPayload): boolean {
   return !resolveSendableOutboundReplyParts(payload).hasMedia;
 }
 
+function isFailedProgress(payload: {
+  phase?: string;
+  status?: string;
+  exitCode?: number | null;
+}): boolean {
+  return (
+    payload.phase === "error" ||
+    payload.status === "failed" ||
+    payload.status === "error" ||
+    (typeof payload.exitCode === "number" && payload.exitCode !== 0)
+  );
+}
+
 type DiscordReplySkipReason = "aborted before delivery" | "internal-only payload";
 
 export function formatDiscordReplySkip(params: {
@@ -1143,9 +1156,12 @@ async function processDiscordMessageInner(
           );
         },
         onItemEvent: async (payload) => {
+          if (isFailedProgress(payload)) {
+            return false;
+          }
           if (payload.kind === "preamble") {
             if (shouldYieldDraftProgress()) {
-              return;
+              return undefined;
             }
             if (draftPreview.commentaryProgressEnabled && payload.progressText) {
               // Count only commentary that actually streams to the window draft.
@@ -1154,10 +1170,10 @@ async function processDiscordMessageInner(
                 itemId: payload.itemId,
               });
             }
-            return;
+            return undefined;
           }
           if (shouldYieldDraftProgress()) {
-            return;
+            return undefined;
           }
           await draftPreview.pushToolProgress(
             buildChannelProgressDraftLineForEntry(discordConfig, {
@@ -1174,6 +1190,7 @@ async function processDiscordMessageInner(
               meta: payload.meta,
             }),
           );
+          return undefined;
         },
         onPlanUpdate: async (payload) => {
           if (payload.phase !== "update") {
@@ -1205,11 +1222,14 @@ async function processDiscordMessageInner(
           );
         },
         onCommandOutput: async (payload) => {
+          if (isFailedProgress(payload)) {
+            return false;
+          }
           if (payload.phase !== "end") {
-            return;
+            return undefined;
           }
           if (shouldYieldDraftProgress()) {
-            return;
+            return undefined;
           }
           await draftPreview.pushToolProgress(
             buildChannelProgressDraftLine({
@@ -1223,6 +1243,7 @@ async function processDiscordMessageInner(
               exitCode: payload.exitCode,
             }),
           );
+          return undefined;
         },
         onPatchSummary: async (payload) => {
           if (payload.phase !== "end") {

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -71,6 +71,9 @@ type ReasoningProgressPayload = {
   progressTokens: number;
 };
 
+/** Return false when a channel intentionally keeps a progress event out of user-visible UI. */
+type ProgressCallbackResult = false | void;
+
 /** Reply generation options shared by auto-reply, webchat, channels, and tests. */
 export type GetReplyOptions = {
   /** Override run id for agent events (defaults to random UUID). */
@@ -172,7 +175,7 @@ export type GetReplyOptions = {
     meta?: string;
     approvalId?: string;
     approvalSlug?: string;
-  }) => Promise<void> | void;
+  }) => Promise<ProgressCallbackResult> | ProgressCallbackResult;
   /** In progress mode, classify Claude pre-tool text; true also renders it as commentary. */
   commentaryProgressEnabled?: boolean;
   /** Deliver durable reasoning payloads to channels that own a separate reasoning lane. */
@@ -215,7 +218,7 @@ export type GetReplyOptions = {
     exitCode?: number | null;
     durationMs?: number;
     cwd?: string;
-  }) => Promise<void> | void;
+  }) => Promise<ProgressCallbackResult> | ProgressCallbackResult;
   /** Called when a patch completes with a file summary. */
   onPatchSummary?: (payload: {
     itemId?: string;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -5252,6 +5252,58 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
+  it("keeps tool-error fallbacks eligible when a channel declines failed progress", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const onCommandOutput = vi.fn(async () => false as const);
+    const onItemEvent = vi.fn(async () => false as const);
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      ChatType: "direct",
+      SessionKey: "agent:main:discord:direct:U1",
+    });
+    let receivedOptions: GetReplyOptions | undefined;
+    let commandOutputResult: false | void = undefined;
+    let itemEventResult: false | void = undefined;
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      receivedOptions = opts;
+      commandOutputResult = await opts?.onCommandOutput?.({
+        phase: "end",
+        name: "exec",
+        status: "failed",
+        exitCode: 1,
+      });
+      itemEventResult = await opts?.onItemEvent?.({
+        kind: "tool",
+        phase: "end",
+        name: "exec",
+        status: "failed",
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { onCommandOutput, onItemEvent },
+    });
+
+    expect(onCommandOutput).toHaveBeenCalledTimes(1);
+    expect(onItemEvent).toHaveBeenCalledTimes(1);
+    expect(commandOutputResult).toBe(false);
+    expect(itemEventResult).toBe(false);
+    expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
   it("suppresses terminal tool-error fallbacks in group sessions when verbose progress is visible", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -3294,34 +3294,40 @@ export async function dispatchReplyFromConfig(
           options?.forwardWhenSourceDeliverySuppressed === true)
       );
     };
-    const wrapProgressCallback = <Args extends unknown[]>(
-      callback: ((...args: Args) => Promise<void> | void) | undefined,
+    const wrapProgressCallback = <Args extends unknown[], Result extends false | void>(
+      callback: ((...args: Args) => Promise<Result> | Result) | undefined,
       options?: {
         allowWhenToolSummariesHidden?: boolean;
         forwardWhenSourceDeliverySuppressed?: boolean;
         requiresToolSummaryVisibility?: boolean;
         onForward?: (...args: Args) => Promise<void> | void;
+        onVisible?: (...args: Args) => Promise<void> | void;
         waitForDirectBlockReplyDelivery?: boolean;
       },
-    ): ((...args: Args) => Promise<void>) | undefined => {
+    ): ((...args: Args) => Promise<Result | undefined>) | undefined => {
       if (!callback) {
         return undefined;
       }
       return async (...args: Args) => {
         if (isDispatchOperationAborted()) {
-          return;
+          return undefined;
         }
         markProgress();
         if (options?.waitForDirectBlockReplyDelivery) {
           await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
           if (isDispatchOperationAborted()) {
-            return;
+            return undefined;
           }
         }
         if (shouldForwardProgressCallback(options)) {
           await options?.onForward?.(...args);
-          await callback?.(...args);
+          const result = await callback?.(...args);
+          if (result === false) {
+            return result;
+          }
+          await options?.onVisible?.(...args);
         }
+        return undefined;
       };
     };
 
@@ -3344,7 +3350,7 @@ export async function dispatchReplyFromConfig(
       ? wrapProgressCallback(params.replyOptions?.onItemEvent, {
           ...itemEventForwardingOptions,
           waitForDirectBlockReplyDelivery: true,
-          onForward: (payload) => {
+          onVisible: (payload) => {
             if (hasFailedProgressStatus(payload)) {
               markVisibleToolErrorProgress();
             }
@@ -3366,7 +3372,7 @@ export async function dispatchReplyFromConfig(
           if (deliverStandaloneCommentaryProgress && payload.kind === "preamble") {
             await noteCommentaryProgress(payload);
           }
-          await forwardItemEvent?.(payload);
+          return await forwardItemEvent?.(payload);
         }
       : undefined;
     // Let draft-rendering channels yield their ephemeral commentary lines while
@@ -3438,7 +3444,7 @@ export async function dispatchReplyFromConfig(
                     forwardWhenSourceDeliverySuppressed: true,
                     requiresToolSummaryVisibility: true,
                     waitForDirectBlockReplyDelivery: true,
-                    onForward: (payload) => {
+                    onVisible: (payload) => {
                       if (hasFailedProgressStatus(payload)) {
                         markVisibleToolErrorProgress();
                       }

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -3663,6 +3663,53 @@ describe("createFollowupRunner progress forwarding", () => {
     expect(onCommandOutput).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps queued tool-error fallbacks when the channel declines failed progress", async () => {
+    const onCommandOutput = vi.fn(async () => false as const);
+    let completedAfterEvent = false;
+
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (args: {
+        onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
+        suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
+      }) => {
+        const shouldSuppress = args.suppressToolErrorWarnings as () => boolean | undefined;
+        expect(shouldSuppress()).toBeUndefined();
+        await args.onAgentEvent?.({
+          stream: "command_output",
+          data: {
+            phase: "end",
+            name: "exec",
+            status: "failed",
+            exitCode: 1,
+          },
+        });
+        expect(shouldSuppress()).toBeUndefined();
+        completedAfterEvent = true;
+        return { payloads: [], meta: { agentMeta: {} } };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      opts: { onCommandOutput },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "claude",
+    });
+
+    await runner(
+      createQueuedRun({
+        run: {
+          messageProvider: "discord",
+          sourceReplyDeliveryMode: "message_tool_only",
+          verboseLevel: "on",
+        },
+      }),
+    );
+
+    expect(onCommandOutput).toHaveBeenCalledTimes(1);
+    expect(completedAfterEvent).toBe(true);
+  });
+
   it("keeps queued full-verbose tool-error fallbacks available after failed progress", async () => {
     const onCommandOutput = vi.fn(async () => {});
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -186,22 +186,6 @@ function hasFailedFollowupProgressEvent(evt: FollowupAgentEvent): boolean {
   );
 }
 
-function canForwardFailedFollowupProgressEvent(
-  evt: FollowupAgentEvent,
-  opts?: GetReplyOptions,
-): boolean {
-  if (evt.stream === "command_output" || buildCommandOutputFromToolResultEvent(evt)) {
-    return typeof opts?.onCommandOutput === "function";
-  }
-  if (evt.stream !== "item") {
-    return false;
-  }
-  if (evt.data.suppressChannelProgress === true && Boolean(opts?.onToolStart)) {
-    return false;
-  }
-  return typeof opts?.onItemEvent === "function";
-}
-
 async function forwardFollowupProgressEvent(params: {
   evt: FollowupAgentEvent;
   opts?: GetReplyOptions;
@@ -211,13 +195,14 @@ async function forwardFollowupProgressEvent(params: {
   notifyUserAboutCompaction?: boolean;
   currentMessageId?: string;
   onCompactionNoticePayload?: (payload: ReplyPayload) => Promise<void> | void;
-}) {
+}): Promise<boolean> {
   const { evt, opts } = params;
+  let visible = false;
   const emitChannelProgress = params.emitChannelProgress !== false;
   const allowQuietToolLifecycle =
     evt.stream === "tool" && opts?.allowToolLifecycleWhenProgressHidden === true;
   if (!emitChannelProgress && evt.stream !== "compaction" && !allowQuietToolLifecycle) {
-    return;
+    return false;
   }
 
   if (evt.stream === "tool" && evt.data.hideFromChannelProgress !== true) {
@@ -237,8 +222,8 @@ async function forwardFollowupProgressEvent(params: {
       });
     }
     const commandOutput = buildCommandOutputFromToolResultEvent(evt);
-    if (commandOutput) {
-      await opts?.onCommandOutput?.(commandOutput);
+    if (commandOutput && opts?.onCommandOutput) {
+      visible = (await opts.onCommandOutput(commandOutput)) !== false;
     }
   }
 
@@ -249,20 +234,23 @@ async function forwardFollowupProgressEvent(params: {
   const hideItemFromChannelProgress =
     evt.stream === "item" && evt.data.hideFromChannelProgress === true;
   if (evt.stream === "item" && !suppressItemChannelProgress && !hideItemFromChannelProgress) {
-    await opts?.onItemEvent?.({
-      itemId: readStringValue(evt.data.itemId),
-      toolCallId: readStringValue(evt.data.toolCallId),
-      kind: readStringValue(evt.data.kind),
-      title: readStringValue(evt.data.title),
-      name: readStringValue(evt.data.name),
-      phase: readStringValue(evt.data.phase),
-      status: readStringValue(evt.data.status),
-      summary: readStringValue(evt.data.summary),
-      progressText: readStringValue(evt.data.progressText),
-      meta: readStringValue(evt.data.meta),
-      approvalId: readStringValue(evt.data.approvalId),
-      approvalSlug: readStringValue(evt.data.approvalSlug),
-    });
+    if (opts?.onItemEvent) {
+      visible =
+        (await opts.onItemEvent({
+          itemId: readStringValue(evt.data.itemId),
+          toolCallId: readStringValue(evt.data.toolCallId),
+          kind: readStringValue(evt.data.kind),
+          title: readStringValue(evt.data.title),
+          name: readStringValue(evt.data.name),
+          phase: readStringValue(evt.data.phase),
+          status: readStringValue(evt.data.status),
+          summary: readStringValue(evt.data.summary),
+          progressText: readStringValue(evt.data.progressText),
+          meta: readStringValue(evt.data.meta),
+          approvalId: readStringValue(evt.data.approvalId),
+          approvalSlug: readStringValue(evt.data.approvalSlug),
+        })) !== false;
+    }
   }
 
   if (evt.stream === "plan") {
@@ -293,22 +281,23 @@ async function forwardFollowupProgressEvent(params: {
     });
   }
 
-  if (evt.stream === "command_output") {
-    await opts?.onCommandOutput?.({
-      itemId: readStringValue(evt.data.itemId),
-      phase: readStringValue(evt.data.phase),
-      title: readStringValue(evt.data.title),
-      toolCallId: readStringValue(evt.data.toolCallId),
-      name: readStringValue(evt.data.name),
-      output: readStringValue(evt.data.output),
-      status: readStringValue(evt.data.status),
-      exitCode:
-        typeof evt.data.exitCode === "number" || evt.data.exitCode === null
-          ? evt.data.exitCode
-          : undefined,
-      durationMs: typeof evt.data.durationMs === "number" ? evt.data.durationMs : undefined,
-      cwd: readStringValue(evt.data.cwd),
-    });
+  if (evt.stream === "command_output" && opts?.onCommandOutput) {
+    visible =
+      (await opts.onCommandOutput({
+        itemId: readStringValue(evt.data.itemId),
+        phase: readStringValue(evt.data.phase),
+        title: readStringValue(evt.data.title),
+        toolCallId: readStringValue(evt.data.toolCallId),
+        name: readStringValue(evt.data.name),
+        output: readStringValue(evt.data.output),
+        status: readStringValue(evt.data.status),
+        exitCode:
+          typeof evt.data.exitCode === "number" || evt.data.exitCode === null
+            ? evt.data.exitCode
+            : undefined,
+        durationMs: typeof evt.data.durationMs === "number" ? evt.data.durationMs : undefined,
+        cwd: readStringValue(evt.data.cwd),
+      })) !== false;
   }
 
   if (evt.stream === "patch") {
@@ -357,13 +346,14 @@ async function forwardFollowupProgressEvent(params: {
         await opts?.onCompactionEnd?.();
       }
       if (evt.data?.willRetry === true) {
-        return;
+        return visible;
       }
       await sendCompactionUserNotices("end");
     } else if (phase === "end") {
       await sendCompactionUserNotices("incomplete");
     }
   }
+  return visible;
 }
 
 /** Creates the function that drains one queued follow-up run. */
@@ -1358,7 +1348,7 @@ export function createFollowupRunner(params: {
                 onAgentEvent: (evt) => {
                   lifecycleBackstop.note(evt);
                   return enqueueProgressDelivery(async () => {
-                    await forwardFollowupProgressEvent({
+                    const visible = await forwardFollowupProgressEvent({
                       evt,
                       opts: progressOpts,
                       detailMode: toolProgressDetail,
@@ -1371,10 +1361,7 @@ export function createFollowupRunner(params: {
                       onCompactionNoticePayload: (payload) =>
                         sendCompactionNoticePayload(payload, { provider, modelId: model }),
                     });
-                    if (
-                      hasFailedFollowupProgressEvent(evt) &&
-                      canForwardFailedFollowupProgressEvent(evt, progressOpts)
-                    ) {
+                    if (visible && hasFailedFollowupProgressEvent(evt)) {
                       markVisibleToolErrorProgress();
                     }
                   });


### PR DESCRIPTION
## What Problem This Solves

Discord could render failed tool item or command-output progress into its streaming draft. The original channel-local suppression also left a cross-run edge: if a hidden failure was treated as visible by the shared dispatcher, the final user-facing tool-error fallback could be suppressed, especially for queued follow-ups.

## Why This Change Was Made

- Add an explicit progress callback result: returning `false` means the event was intentionally not made user-visible.
- Preserve that result through the shared dispatch wrappers and queued follow-up runner.
- Mark failed progress as visible only after the channel accepts it.
- Have Discord decline failed item and command-output progress before draft rendering.
- Keep one canonical visibility path for immediate and queued runs, deleting the queued runner's callback-presence approximation.

## User Impact

Discord users no longer see internal failed-tool details flash in streaming drafts. The normal final tool-error warning remains eligible when Discord hid that progress, including queued follow-up runs.

## Evidence

- Remote Blacksmith Testbox: 500 focused tests passed across Discord message processing, initial dispatch, and queued follow-ups.
- Remote Blacksmith Testbox: scoped `check:changed` passed, including core/core-test/extension/extension-test typechecks, core and extension lint, import-cycle and runtime guards.
- Fresh autoreview: clean after fixing visibility-result propagation through both command and item adapters.
- `git diff --check`: passed.
- Live Discord QA was attempted through the repository's `qa discord` lane. The source built successfully, but the lane could not acquire transport credentials because `OPENCLAW_QA_CONVEX_SITE_URL` and all direct Discord QA credential fields were absent on the Testbox and local environment. No live result is claimed.
