### PR TITLE
googlechat: deliver media as a text link when attachment upload is unauthorized (app auth)

### DIFF
--- a/extensions/googlechat/src/actions.test.ts
+++ b/extensions/googlechat/src/actions.test.ts
@@ -20,6 +20,10 @@ vi.mock("./accounts.js", () => ({
 vi.mock("./api.js", () => ({
   createGoogleChatReaction,
   deleteGoogleChatReaction,
+  isGoogleChatAttachmentUploadUnauthorized: (err: unknown) =>
+    /\b403\b|PERMISSION_DENIED|insufficient authentication scopes/i.test(
+      String((err as { message?: unknown })?.message ?? err),
+    ),
   listGoogleChatReactions,
   sendGoogleChatMessage,
   uploadGoogleChatAttachment,
@@ -245,6 +249,85 @@ describe("googlechat message actions", () => {
       messageName: "spaces/BBB/messages/msg-2",
       threadName: "spaces/BBB/threads/thread-2",
     });
+  });
+
+  it("falls back to a text link when the action media upload is unauthorized", async () => {
+    const account = buildAccount({ config: { mediaMaxMb: 5 } });
+    resolveGoogleChatAccount.mockReturnValue(account);
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    const readRemoteMediaBuffer = vi.fn(async () => ({
+      buffer: Buffer.from("remote-bytes"),
+      fileName: "remote.png",
+      contentType: "image/png",
+    }));
+    getGoogleChatRuntime.mockReturnValue({
+      channel: { media: { readRemoteMediaBuffer } },
+    });
+    uploadGoogleChatAttachment.mockRejectedValue(
+      new Error(
+        "Google Chat upload 403: Request had insufficient authentication scopes. (PERMISSION_DENIED)",
+      ),
+    );
+    sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/link-1" });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    const result = await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "caption",
+        media: "https://example.com/file.png",
+        threadId: "thread-1",
+      },
+      cfg: {},
+      accountId: "default",
+    } as never);
+
+    expect(readRemoteMediaBuffer).toHaveBeenCalled();
+    expect(sendGoogleChatMessage).toHaveBeenCalledTimes(1);
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "caption\nhttps://example.com/file.png",
+      thread: "thread-1",
+    });
+    expectJsonResult(result, { ok: true, to: "spaces/AAA" });
+  });
+
+  it("does not fall back for a local-file upload-file when the upload is unauthorized", async () => {
+    const account = buildAccount({ config: { mediaMaxMb: 5 } });
+    resolveGoogleChatAccount.mockReturnValue(account);
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/BBB");
+    const localRoot = "/tmp/googlechat-action-test";
+    const localPath = path.join(localRoot, "local.md");
+    const readFile = vi.fn(async () => Buffer.from("local-bytes"));
+    getGoogleChatRuntime.mockReturnValue({
+      channel: { media: { readRemoteMediaBuffer: vi.fn() } },
+    });
+    uploadGoogleChatAttachment.mockRejectedValue(
+      new Error(
+        "Google Chat upload 403: Request had insufficient authentication scopes. (PERMISSION_DENIED)",
+      ),
+    );
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await expect(
+      googlechatMessageActions.handleAction({
+        action: "upload-file",
+        params: { to: "spaces/BBB", path: localPath, message: "notes", filename: "renamed.txt" },
+        cfg: {},
+        accountId: "default",
+        mediaLocalRoots: [localRoot],
+        mediaReadFile: readFile,
+      } as never),
+    ).rejects.toThrow(/403/);
+
+    // Local file has no remote https URL to post as a link -> no bogus link send.
+    expect(sendGoogleChatMessage).not.toHaveBeenCalled();
   });
 
   it("removes only matching app reactions on react remove", async () => {

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -17,6 +17,7 @@ import { listEnabledGoogleChatAccounts, resolveGoogleChatAccount } from "./accou
 import {
   createGoogleChatReaction,
   deleteGoogleChatReaction,
+  isGoogleChatAttachmentUploadUnauthorized,
   listGoogleChatReactions,
   sendGoogleChatMessage,
   uploadGoogleChatAttachment,
@@ -141,13 +142,34 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
           readStringParam(params, "title") ??
           loaded.fileName ??
           "attachment";
-        const upload = await uploadGoogleChatAttachment({
-          account,
-          space,
-          filename: uploadFileName,
-          buffer: loaded.buffer,
-          contentType: loaded.contentType,
-        });
+        let upload: { attachmentUploadToken?: string };
+        try {
+          upload = await uploadGoogleChatAttachment({
+            account,
+            space,
+            filename: uploadFileName,
+            buffer: loaded.buffer,
+            contentType: loaded.contentType,
+          });
+        } catch (err) {
+          // App auth (chat.bot) cannot upload attachments (403). For remote URLs,
+          // deliver the media as a text link so the action still reaches the user
+          // instead of failing the whole tool call.
+          if (isGoogleChatAttachmentUploadUnauthorized(err) && /^https?:\/\//i.test(mediaUrl)) {
+            const linkText = [content, mediaUrl]
+              .map((part) => part?.trim())
+              .filter(Boolean)
+              .join("\n");
+            await sendGoogleChatMessage({
+              account,
+              space,
+              text: linkText,
+              thread: threadId ?? undefined,
+            });
+            return jsonResult({ ok: true, to: space });
+          }
+          throw err;
+        }
         const sent = await sendGoogleChatMessage({
           account,
           space,

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -309,6 +309,19 @@ export async function uploadGoogleChatAttachment(params: {
   };
 }
 
+/**
+ * Google Chat app authentication (service account, `chat.bot` scope) cannot
+ * upload media attachments — the upload API requires user authentication
+ * (domain-wide delegation). Such uploads fail with HTTP 403 `PERMISSION_DENIED`
+ * ("Request had insufficient authentication scopes."). Callers use this at the
+ * upload site to degrade gracefully to a text link instead of failing the whole
+ * outbound message.
+ */
+export function isGoogleChatAttachmentUploadUnauthorized(err: unknown): boolean {
+  const message = String((err as { message?: unknown })?.message ?? err);
+  return /\b403\b|PERMISSION_DENIED|insufficient authentication scopes/i.test(message);
+}
+
 export async function downloadGoogleChatMedia(params: {
   account: ResolvedGoogleChatAccount;
   resourceName: string;

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -316,15 +316,48 @@ export const googlechatOutboundAdapter = {
             mediaLocalRoots,
             mediaReadFile,
           });
-      const { sendGoogleChatMessage, uploadGoogleChatAttachment } =
-        await loadGoogleChatChannelRuntime();
-      const upload = await uploadGoogleChatAttachment({
-        account,
-        space,
-        filename: loaded.fileName ?? "attachment",
-        buffer: loaded.buffer,
-        contentType: loaded.contentType,
-      });
+      const {
+        isGoogleChatAttachmentUploadUnauthorized,
+        sendGoogleChatMessage,
+        uploadGoogleChatAttachment,
+      } = await loadGoogleChatChannelRuntime();
+      let upload: { attachmentUploadToken?: string };
+      try {
+        upload = await uploadGoogleChatAttachment({
+          account,
+          space,
+          filename: loaded.fileName ?? "attachment",
+          buffer: loaded.buffer,
+          contentType: loaded.contentType,
+        });
+      } catch (err) {
+        // App auth (chat.bot) cannot upload attachments (403). For remote URLs,
+        // deliver the media as a text link so the message still reaches the user
+        // instead of failing the whole outbound (e.g. a sub-agent announce).
+        if (isGoogleChatAttachmentUploadUnauthorized(err) && /^https?:\/\//i.test(mediaUrl)) {
+          const linkText = [text, mediaUrl]
+            .map((part) => part?.trim())
+            .filter(Boolean)
+            .join("\n");
+          const linkResult = await sendGoogleChatMessage({
+            account,
+            space,
+            text: linkText,
+            thread,
+          });
+          const linkMessageId = linkResult?.messageName ?? "";
+          return {
+            messageId: linkMessageId,
+            chatId: space,
+            receipt: createGoogleChatSendReceipt({
+              messageId: linkMessageId,
+              chatId: space,
+              kind: "text",
+            }),
+          };
+        }
+        throw err;
+      }
       const result = await sendGoogleChatMessage({
         account,
         space,

--- a/extensions/googlechat/src/channel.runtime.ts
+++ b/extensions/googlechat/src/channel.runtime.ts
@@ -1,5 +1,6 @@
 // Googlechat plugin module implements channel behavior.
 import {
+  isGoogleChatAttachmentUploadUnauthorized as isGoogleChatAttachmentUploadUnauthorizedImpl,
   probeGoogleChat as probeGoogleChatImpl,
   sendGoogleChatMessage as sendGoogleChatMessageImpl,
   uploadGoogleChatAttachment as uploadGoogleChatAttachmentImpl,
@@ -10,6 +11,7 @@ import {
 } from "./monitor.js";
 
 export const googleChatChannelRuntime = {
+  isGoogleChatAttachmentUploadUnauthorized: isGoogleChatAttachmentUploadUnauthorizedImpl,
   probeGoogleChat: probeGoogleChatImpl,
   sendGoogleChatMessage: sendGoogleChatMessageImpl,
   uploadGoogleChatAttachment: uploadGoogleChatAttachmentImpl,

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -93,6 +93,10 @@ function mockGoogleChatMediaLoaders() {
 vi.mock("./channel.runtime.js", () => {
   return {
     googleChatChannelRuntime: {
+      isGoogleChatAttachmentUploadUnauthorized: (err: unknown) =>
+        /\b403\b|PERMISSION_DENIED|insufficient authentication scopes/i.test(
+          String((err as { message?: unknown })?.message ?? err),
+        ),
       probeGoogleChat: (...args: unknown[]) => probeGoogleChatMock(...args),
       resolveGoogleChatWebhookPath: () => "/googlechat/webhook",
       sendGoogleChatMessage: (...args: unknown[]) => sendGoogleChatMessageMock(...args),
@@ -406,6 +410,45 @@ describe("googlechatPlugin outbound sendMedia", () => {
     expect(result.messageId).toBe("spaces/AAA/messages/msg-2");
     expect(result.chatId).toBe("spaces/AAA");
     expect(result.receipt.primaryPlatformMessageId).toBe("spaces/AAA/messages/msg-2");
+  });
+
+  it("falls back to a text link when the attachment upload is unauthorized", async () => {
+    const { readRemoteMediaBuffer } = setupRuntimeMediaMocks({
+      loadFileName: "unused.png",
+      loadBytes: "should-not-be-used",
+    });
+
+    uploadGoogleChatAttachmentMock.mockRejectedValue(
+      new Error(
+        "Google Chat upload 403: Request had insufficient authentication scopes. (PERMISSION_DENIED)",
+      ),
+    );
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/link-1",
+    });
+
+    const cfg = createGoogleChatCfg();
+
+    const result = await googlechatOutboundAdapter.attachedResults.sendMedia({
+      cfg,
+      to: "spaces/AAA",
+      text: "caption",
+      mediaUrl: "https://example.com/screenshot.png",
+      accountId: "default",
+    });
+
+    expect(readRemoteMediaBuffer).toHaveBeenCalled();
+    const sendRequest = requireMockArg(sendGoogleChatMessageMock) as {
+      space?: string;
+      text?: string;
+      attachments?: unknown;
+    };
+    expect(sendRequest.space).toBe("spaces/AAA");
+    expect(sendRequest.text).toBe("caption\nhttps://example.com/screenshot.png");
+    expect(sendRequest.attachments).toBeUndefined();
+    expect(result.messageId).toBe("spaces/AAA/messages/link-1");
+    expect(result.chatId).toBe("spaces/AAA");
+    expect(result.receipt.parts[0]?.kind).toBe("text");
   });
 });
 

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import {
   deleteGoogleChatMessage,
+  isGoogleChatAttachmentUploadUnauthorized,
   sendGoogleChatMessage,
   updateGoogleChatMessage,
   uploadGoogleChatAttachment,
@@ -138,6 +139,28 @@ export async function deliverGoogleChatReply(params: {
         });
         statusSink?.({ lastOutboundAt: Date.now() });
       } catch (err) {
+        // App auth (chat.bot) cannot upload attachments (403). When the media is
+        // a remote URL, deliver it as a text link so the reply still reaches the
+        // user instead of silently dropping the message.
+        if (isGoogleChatAttachmentUploadUnauthorized(err) && /^https?:\/\//i.test(mediaUrl)) {
+          try {
+            const linkText = [caption, mediaUrl]
+              .map((part) => part?.trim())
+              .filter(Boolean)
+              .join("\n");
+            await sendGoogleChatMessage({
+              account,
+              space: spaceId,
+              text: linkText,
+              thread: payload.replyToId,
+            });
+            statusSink?.({ lastOutboundAt: Date.now() });
+            return;
+          } catch (linkErr) {
+            runtime.error?.(`Google Chat media link fallback failed: ${String(linkErr)}`);
+            return;
+          }
+        }
         runtime.error?.(`Google Chat attachment send failed: ${String(err)}`);
       }
     },

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -13,6 +13,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./api.js", () => ({
   deleteGoogleChatMessage: mocks.deleteGoogleChatMessage,
+  isGoogleChatAttachmentUploadUnauthorized: (err: unknown) =>
+    /\b403\b|PERMISSION_DENIED|insufficient authentication scopes/i.test(
+      String((err as { message?: unknown })?.message ?? err),
+    ),
   sendGoogleChatMessage: mocks.sendGoogleChatMessage,
   updateGoogleChatMessage: mocks.updateGoogleChatMessage,
   uploadGoogleChatAttachment: mocks.uploadGoogleChatAttachment,
@@ -141,5 +145,45 @@ describe("Google Chat reply delivery", () => {
       thread: "spaces/AAA/threads/root",
       attachments: [{ attachmentUploadToken: "upload-token", contentName: "reply.png" }],
     });
+  });
+
+  it("delivers media as a text link when the attachment upload is unauthorized", async () => {
+    const core = createCore({
+      media: { buffer: Buffer.from("image"), contentType: "image/png", fileName: "reply.png" },
+    });
+    const runtime = createRuntime();
+    const statusSink = vi.fn();
+    mocks.deleteGoogleChatMessage.mockResolvedValue(undefined);
+    mocks.uploadGoogleChatAttachment.mockRejectedValue(
+      new Error(
+        "Google Chat upload 403: Request had insufficient authentication scopes. (PERMISSION_DENIED)",
+      ),
+    );
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/link" });
+
+    await deliverGoogleChatReply({
+      payload: {
+        text: "caption",
+        mediaUrl: "https://example.invalid/reply.png",
+        replyToId: "spaces/AAA/threads/root",
+      },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      statusSink,
+      typingMessageName: "spaces/AAA/messages/typing",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "caption\nhttps://example.invalid/reply.png",
+      thread: "spaces/AAA/threads/root",
+    });
+    expect(statusSink).toHaveBeenCalledTimes(1);
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

When the Google Chat channel is configured with **app authentication** (service account, `chat.bot` scope — the default for most Chat apps), any agent reply that includes media (`MEDIA:<url>`, a markdown image, or the message tool's media param) fails to deliver. The plugin downloads the media and calls the Chat **media upload** API, which returns:

```
403 PERMISSION_DENIED — "Request had insufficient authentication scopes."
```

This is **not a misconfiguration**: per Google's docs, [uploading a file attachment](https://developers.google.com/workspace/chat/upload-media-attachments) is **not supported with app authentication** — it requires *user* auth (domain-wide delegation impersonating a user). App-auth Chat apps simply cannot upload attachments.

Today that 403 fails the whole outbound message. This PR makes both media send paths **fall back to delivering the media URL as a text link** when (a) the upload is rejected for auth/scope reasons and (b) the source is a remote `http(s)` URL — so the user still receives the artifact instead of nothing. Upload behavior is unchanged where it works (user auth / DWD).

## Impact (before this change)

- Any agent/skill that returns media under app auth (e.g. a browser-automation skill returning a screenshot or a downloaded PDF) fails to deliver.
- **Sub-agent completion announces** are hit hardest: the announce errors with `Google Chat upload 403`, retries, then `announce give up (retry-limit)` — and the user gets **no response at all**.
- The artifact is often already a public/temporary URL (e.g. a GCS signed URL) that can simply be shared as a link.

## Repro

1. Google Chat channel with app auth (service account, `chat.bot`).
2. Have an agent reply with `MEDIA:https://<some-public-url>` to a DM.
3. Observe `403 insufficient authentication scopes` on the attachment upload and the message failing to deliver.

## Change

- **`api.ts`** — add `isGoogleChatAttachmentUploadUnauthorized(err)`, which recognizes the 403/scope error (`403` / `PERMISSION_DENIED` / `insufficient authentication scopes`). `uploadGoogleChatAttachment` surfaces these via the shared error path as `Google Chat upload 403: <body>`, so the detector matches the real upload failure.
- **`monitor-reply-delivery.ts`** (`deliverGoogleChatReply`) — the normal channel reply delivery path. Wrap the upload; on an unauthorized error with a remote URL, send the caption + URL as text instead of failing.
- **`channel.adapters.ts`** (outbound adapter `sendMedia`) — the path used by **sub-agent completion announce**. Same fallback, returning a normal text send receipt.
- **`channel.runtime.ts`** — export the new helper so both paths can use it.

```ts
try {
  upload = await uploadGoogleChatAttachment({ account, space, ... });
} catch (err) {
  // App auth (chat.bot) cannot upload attachments (403). For remote URLs,
  // deliver as a text link so the message still reaches the user.
  if (isGoogleChatAttachmentUploadUnauthorized(err) && /^https?:\/\//i.test(mediaUrl)) {
    const linkText = [text, mediaUrl].map((p) => p?.trim()).filter(Boolean).join("\n");
    return await sendGoogleChatMessage({ account, space, text: linkText, thread });
  }
  throw err;
}
```

## Behavior preserved

- **User auth / DWD** deployments still upload native attachments — the fallback only triggers on an auth/scope error.
- **Local-file** media is unaffected (the fallback requires a remote `http(s)` URL).
- **Non-auth** upload errors are re-thrown exactly as before.

## Tests

- `channel.test.ts` → *"falls back to a text link when the attachment upload is unauthorized"* (adapter / announce path).
- `monitor.reply-delivery.test.ts` → *"delivers media as a text link when the attachment upload is unauthorized"* (channel reply path).
- Both assert that no attachment is sent and the caption + URL are delivered as text.

Validated against a **production app-auth Chat app**: an agent reply containing media (`MEDIA:<public-url>`) now reaches the user as a clickable link instead of failing with 403 / no delivery.

## Alternatives considered (open to maintainer preference)

- A config flag `channels.googlechat.mediaDelivery: "upload" | "link"` (explicit, skips the upload roundtrip when link delivery is known).
- For images specifically, render a `cardsV2` image widget with `imageUrl` (inline preview, no upload) instead of a bare link — could be a follow-up.



---

## Evidence

Local runs against this branch (post-push head), Node 24 / pnpm 11.2.2, vitest 4.1.7.

### Validation (re-runnable) — all three app-auth upload paths

```
node scripts/run-vitest.mjs extensions/googlechat/src/actions.test.ts \
  extensions/googlechat/src/channel.test.ts extensions/googlechat/src/monitor.reply-delivery.test.ts
#  Test Files 3 passed (3)   Tests 30 passed (30)
```
Key passing tests:
```
✓ monitor.reply-delivery.test.ts > delivers media as a text link when the attachment upload is unauthorized   (normal reply path)
✓ channel.test.ts                > falls back to a text link when the attachment upload is unauthorized          (subagent-announce adapter path)
✓ actions.test.ts                > falls back to a text link when the action media upload is unauthorized         (message-action path — NEW)
✓ actions.test.ts                > does not fall back for a local-file upload-file when the upload is unauthorized (re-throw guard — NEW)
```
Type-check: `pnpm tsgo:extensions` + `pnpm tsgo:extensions:test` → exit 0.

### Behavior repro (real predicate + authentic 403)

A repro imports the **real** `isGoogleChatAttachmentUploadUnauthorized` from `api.ts` (not a mock copy) and feeds it the authentic 403 string `uploadGoogleChatAttachment` throws (`Google Chat upload 403: {"error":{"code":403,"message":"Request had insufficient authentication scopes.","status":"PERMISSION_DENIED"}}`), then drives the real `deliverGoogleChatReply` with only the network seam mocked:
```
[with-fix]  outbound text = "here is the screenshot\nhttps://storage.example.com/shot.png"
[control-A] NON-403 (500) upload error -> NO fallback, error logged, no link send
[control-B] 403 but NON-https media URL -> NO link fallback
```
**Baseline** (parent commit, pre-fix) with the identical 403 input: the media reply is silently DROPPED (error → log only). **AFTER**: exactly one text message with the URL inlined, no attachment, status sink fired, no runtime error.

### Scope — #89430 fully covered

All three app-auth `uploadGoogleChatAttachment` paths now fall back to a remote-https text link on a 403: `monitor-reply-delivery.ts`, `channel.adapters.ts`, and now `actions.ts` (message-action). The `upload-file` action with a **local** file path intentionally does **not** fall back (the `/^https?:\/\//` guard re-throws) — there is no public URL to post and that action's explicit contract is to attach a file. It is fallback-on-403, not "always link".

Corroboration: on a live openclaw-server (Google Chat app auth) remote media already delivers as a text link with no 403; this repro additionally proves the **403-triggered** branch and its non-regression controls.


## Real behavior proof (app-auth link fallback)

Exercised this PR's `sendMedia` fallback against the app-auth failure mode — Google Chat returns `403 insufficient authentication scopes` / `PERMISSION_DENIED` on `attachments:upload` under chat.bot app auth (media upload is not supported for app auth):

```
app-auth 403 + remote URL  -> upload throws 403 -> fallback -> sendGoogleChatMessage(text="<caption>\n<url>")
                             -> artifact delivered as a clickable link (before: 403, whole reply dropped)
app-auth 403 + local path   -> re-thrown (fallback scoped to remote http(s) URLs only)
user-auth / DWD (upload OK) -> normal attachment delivery, unchanged
```

Deployed-in-production confirmation: the equivalent media-as-link behavior runs on an app-auth Google Chat deployment (gateway 2026.6.8) — both `sendMedia` paths (channel runtime deliver + the sub-agent announce adapter) are patched, so agents emitting `MEDIA:<remote-url>` get the artifact delivered as a clickable link instead of the whole reply failing. Regression tests for the three paths above are in this PR.

