### PR TITLE
Fix Codex synthetic usage in status without local OpenAI profiles

### DIFF
--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -957,6 +957,8 @@ describe("buildStatusReply subagent summary", () => {
           OPENAI_API_KEY: undefined,
           OPENAI_OAUTH_TOKEN: undefined,
         },
+        skipSessionCleanup: true,
+        skipHomeCleanup: true,
       },
     );
   });
@@ -1042,6 +1044,8 @@ describe("buildStatusReply subagent summary", () => {
           OPENAI_API_KEY: undefined,
           OPENAI_OAUTH_TOKEN: undefined,
         },
+        skipSessionCleanup: true,
+        skipHomeCleanup: true,
       },
     );
   });
@@ -1066,66 +1070,69 @@ describe("buildStatusReply subagent summary", () => {
       ],
     });
 
-    await withTempHome(async (dir) => {
-      saveStatusTestAuthProfile({ dir, profileId: "work", provider: "openai" });
+    await withTempHome(
+      async (dir) => {
+        saveStatusTestAuthProfile({ dir, profileId: "work", provider: "openai" });
 
-      const text = await buildStatusText({
-        cfg: {
-          ...baseCfg,
-          agents: {
-            defaults: {
-              agentRuntime: { id: "codex" },
+        const text = await buildStatusText({
+          cfg: {
+            ...baseCfg,
+            agents: {
+              defaults: {
+                agentRuntime: { id: "codex" },
+              },
             },
           },
-        },
-        sessionEntry: {
-          sessionId: "sess-status-codex-synthetic-usage",
-          updatedAt: 0,
-          authProfileOverride: "work",
-        },
-        sessionKey: "agent:main:main",
-        parentSessionKey: "agent:main:main",
-        sessionScope: "per-sender",
-        statusChannel: "mobilechat",
-        provider: "openai",
-        model: "gpt-5.5",
-        contextTokens: 32_000,
-        resolvedFastMode: false,
-        resolvedVerboseLevel: "off",
-        resolvedReasoningLevel: "off",
-        resolveDefaultThinkingLevel: async () => undefined,
-        isGroup: false,
-        defaultGroupActivation: () => "mention",
-        modelAuthOverride: "oauth",
-        activeModelAuthOverride: "oauth",
-      });
-
-      const normalized = normalizeTestText(text);
-      expect(normalized).toContain("Model: openai/gpt-5.5");
-      expect(normalized).toContain("Runtime: OpenAI Codex");
-      expect(normalized).toContain("Usage: 5h 91% left");
-      const providerUsageCall = providerUsageMock.loadProviderUsageSummary.mock.calls.find(
-        ([params]) => params?.providers?.includes("openai"),
-      );
-      if (!providerUsageCall) {
-        throw new Error("expected provider usage summary call for synthetic Codex auth");
-      }
-      expect(providerUsageCall[0]).toMatchObject({
-        timeoutMs: 8000,
-        providers: ["openai"],
-        auth: [
-          {
-            ...expectedCodexRuntimeUsageAuth[0],
-            authProfileId: "work",
+          sessionEntry: {
+            sessionId: "sess-status-codex-synthetic-usage",
+            updatedAt: 0,
+            authProfileOverride: "work",
           },
-        ],
-        config: expect.objectContaining({
-          agents: expect.objectContaining({
-            defaults: expect.objectContaining({ agentRuntime: { id: "codex" } }),
+          sessionKey: "agent:main:main",
+          parentSessionKey: "agent:main:main",
+          sessionScope: "per-sender",
+          statusChannel: "mobilechat",
+          provider: "openai",
+          model: "gpt-5.5",
+          contextTokens: 32_000,
+          resolvedFastMode: false,
+          resolvedVerboseLevel: "off",
+          resolvedReasoningLevel: "off",
+          resolveDefaultThinkingLevel: async () => undefined,
+          isGroup: false,
+          defaultGroupActivation: () => "mention",
+          modelAuthOverride: "oauth",
+          activeModelAuthOverride: "oauth",
+        });
+
+        const normalized = normalizeTestText(text);
+        expect(normalized).toContain("Model: openai/gpt-5.5");
+        expect(normalized).toContain("Runtime: OpenAI Codex");
+        expect(normalized).toContain("Usage: 5h 91% left");
+        const providerUsageCall = providerUsageMock.loadProviderUsageSummary.mock.calls.find(
+          ([params]) => params?.providers?.includes("openai"),
+        );
+        if (!providerUsageCall) {
+          throw new Error("expected provider usage summary call for synthetic Codex auth");
+        }
+        expect(providerUsageCall[0]).toMatchObject({
+          timeoutMs: 8000,
+          providers: ["openai"],
+          auth: [
+            {
+              ...expectedCodexRuntimeUsageAuth[0],
+              authProfileId: "work",
+            },
+          ],
+          config: expect.objectContaining({
+            agents: expect.objectContaining({
+              defaults: expect.objectContaining({ agentRuntime: { id: "codex" } }),
+            }),
           }),
-        }),
-      });
-    });
+        });
+      },
+      { skipSessionCleanup: true, skipHomeCleanup: true },
+    );
   });
 
   it("forwards legacy Codex profile providers to Codex synthetic usage", async () => {
@@ -1141,14 +1148,74 @@ describe("buildStatusReply subagent summary", () => {
       ],
     });
 
-    await withTempHome(async (dir) => {
-      saveStatusTestAuthProfile({
-        dir,
-        profileId: "openai-codex:legacy",
-        provider: "openai-codex",
-      });
+    await withTempHome(
+      async (dir) => {
+        saveStatusTestAuthProfile({
+          dir,
+          profileId: "openai-codex:legacy",
+          provider: "openai-codex",
+        });
 
-      await buildStatusText({
+        await buildStatusText({
+          cfg: {
+            ...baseCfg,
+            agents: {
+              defaults: {
+                agentRuntime: { id: "codex" },
+              },
+            },
+          },
+          sessionEntry: {
+            sessionId: "sess-status-codex-legacy-profile",
+            updatedAt: 0,
+            authProfileOverride: "openai-codex:legacy",
+          },
+          sessionKey: "agent:main:main",
+          parentSessionKey: "agent:main:main",
+          sessionScope: "per-sender",
+          statusChannel: "mobilechat",
+          provider: "openai",
+          model: "gpt-5.5",
+          contextTokens: 32_000,
+          resolvedFastMode: false,
+          resolvedVerboseLevel: "off",
+          resolvedReasoningLevel: "off",
+          resolveDefaultThinkingLevel: async () => undefined,
+          isGroup: false,
+          defaultGroupActivation: () => "mention",
+          modelAuthOverride: "oauth",
+          activeModelAuthOverride: "oauth",
+        });
+
+        const providerUsageCall = providerUsageMock.loadProviderUsageSummary.mock.calls.find(
+          ([params]) => params?.providers?.includes("openai"),
+        );
+        expect(providerUsageCall?.[0]?.auth).toEqual([
+          {
+            ...expectedCodexRuntimeUsageAuth[0],
+            authProfileId: "openai-codex:legacy",
+          },
+        ]);
+      },
+      { skipSessionCleanup: true, skipHomeCleanup: true },
+    );
+  });
+
+  it("loads Codex synthetic usage when no local OpenAI profile label exists", async () => {
+    registerStatusCodexHarness();
+    providerUsageMock.loadProviderUsageSummary.mockResolvedValue({
+      updatedAt: Date.now(),
+      providers: [
+        {
+          provider: "openai",
+          displayName: "OpenAI",
+          windows: [{ label: "5h", usedPercent: 16 }],
+        },
+      ],
+    });
+
+    await withTempHome(async () => {
+      const text = await buildStatusText({
         cfg: {
           ...baseCfg,
           agents: {
@@ -1158,9 +1225,8 @@ describe("buildStatusReply subagent summary", () => {
           },
         },
         sessionEntry: {
-          sessionId: "sess-status-codex-legacy-profile",
+          sessionId: "sess-status-codex-no-profile",
           updatedAt: 0,
-          authProfileOverride: "openai-codex:legacy",
         },
         sessionKey: "agent:main:main",
         parentSessionKey: "agent:main:main",
@@ -1175,19 +1241,13 @@ describe("buildStatusReply subagent summary", () => {
         resolveDefaultThinkingLevel: async () => undefined,
         isGroup: false,
         defaultGroupActivation: () => "mention",
-        modelAuthOverride: "oauth",
-        activeModelAuthOverride: "oauth",
       });
 
+      expect(normalizeTestText(text)).toContain("Usage: 5h 84% left");
       const providerUsageCall = providerUsageMock.loadProviderUsageSummary.mock.calls.find(
         ([params]) => params?.providers?.includes("openai"),
       );
-      expect(providerUsageCall?.[0]?.auth).toEqual([
-        {
-          ...expectedCodexRuntimeUsageAuth[0],
-          authProfileId: "openai-codex:legacy",
-        },
-      ]);
+      expect(providerUsageCall?.[0]?.auth).toEqual(expectedCodexRuntimeUsageAuth);
     });
   });
 
@@ -1204,49 +1264,52 @@ describe("buildStatusReply subagent summary", () => {
       ],
     });
 
-    await withTempHome(async (dir) => {
-      saveStatusTestAuthProfiles({
-        dir,
-        profiles: [
-          { profileId: "openai:status", provider: "openai" },
-          { profileId: "anthropic:work", provider: "anthropic" },
-        ],
-      });
+    await withTempHome(
+      async (dir) => {
+        saveStatusTestAuthProfiles({
+          dir,
+          profiles: [
+            { profileId: "openai:status", provider: "openai" },
+            { profileId: "anthropic:work", provider: "anthropic" },
+          ],
+        });
 
-      await buildStatusText({
-        cfg: {
-          ...baseCfg,
-          agents: {
-            defaults: {
-              agentRuntime: { id: "codex" },
+        await buildStatusText({
+          cfg: {
+            ...baseCfg,
+            agents: {
+              defaults: {
+                agentRuntime: { id: "codex" },
+              },
             },
           },
-        },
-        sessionEntry: {
-          sessionId: "sess-status-codex-stale-profile",
-          updatedAt: 0,
-          authProfileOverride: "anthropic:work",
-        },
-        sessionKey: "agent:main:main",
-        parentSessionKey: "agent:main:main",
-        sessionScope: "per-sender",
-        statusChannel: "mobilechat",
-        provider: "openai",
-        model: "gpt-5.5",
-        contextTokens: 32_000,
-        resolvedFastMode: false,
-        resolvedVerboseLevel: "off",
-        resolvedReasoningLevel: "off",
-        resolveDefaultThinkingLevel: async () => undefined,
-        isGroup: false,
-        defaultGroupActivation: () => "mention",
-      });
+          sessionEntry: {
+            sessionId: "sess-status-codex-stale-profile",
+            updatedAt: 0,
+            authProfileOverride: "anthropic:work",
+          },
+          sessionKey: "agent:main:main",
+          parentSessionKey: "agent:main:main",
+          sessionScope: "per-sender",
+          statusChannel: "mobilechat",
+          provider: "openai",
+          model: "gpt-5.5",
+          contextTokens: 32_000,
+          resolvedFastMode: false,
+          resolvedVerboseLevel: "off",
+          resolvedReasoningLevel: "off",
+          resolveDefaultThinkingLevel: async () => undefined,
+          isGroup: false,
+          defaultGroupActivation: () => "mention",
+        });
 
-      const providerUsageCall = providerUsageMock.loadProviderUsageSummary.mock.calls.find(
-        ([params]) => params?.providers?.includes("openai"),
-      );
-      expect(providerUsageCall?.[0]?.auth).toEqual(expectedCodexRuntimeUsageAuth);
-    });
+        const providerUsageCall = providerUsageMock.loadProviderUsageSummary.mock.calls.find(
+          ([params]) => params?.providers?.includes("openai"),
+        );
+        expect(providerUsageCall?.[0]?.auth).toEqual(expectedCodexRuntimeUsageAuth);
+      },
+      { skipSessionCleanup: true, skipHomeCleanup: true },
+    );
   });
 
   it("uses active fallback provider usage for legacy fallback notices", async () => {
@@ -1751,7 +1814,7 @@ describe("buildStatusReply subagent summary", () => {
         expect(normalized).toContain("oauth (openai:status)");
         expect(normalized).not.toContain("api-key (openai:backup)");
       },
-      { env: { OPENAI_API_KEY: undefined } },
+      { env: { OPENAI_API_KEY: undefined }, skipSessionCleanup: true, skipHomeCleanup: true },
     );
   });
 

--- a/src/commands/status-runtime-shared.test.ts
+++ b/src/commands/status-runtime-shared.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   getDaemonStatusSummary: vi.fn(),
   getNodeDaemonStatusSummary: vi.fn(),
   resolveReadOnlyChannelPluginsForConfig: vi.fn(),
+  resolveModelAuthLabel: vi.fn(),
 }));
 
 vi.mock("../channels/plugins/read-only.js", () => ({
@@ -26,6 +27,10 @@ vi.mock("../channels/plugins/read-only.js", () => ({
 
 vi.mock("../infra/provider-usage.js", () => ({
   loadProviderUsageSummary: mocks.loadProviderUsageSummary,
+}));
+
+vi.mock("../agents/model-auth-label.js", () => ({
+  resolveModelAuthLabel: mocks.resolveModelAuthLabel,
 }));
 
 vi.mock("../security/audit.runtime.js", () => ({
@@ -45,6 +50,8 @@ function requireProviderUsageCall(): {
   timeoutMs?: number;
   config?: unknown;
   agentDir?: string;
+  providers?: string[];
+  auth?: Array<Record<string, unknown>>;
 } {
   const call = mocks.loadProviderUsageSummary.mock.calls[0];
   if (!call) {
@@ -58,6 +65,8 @@ function requireProviderUsageCall(): {
     timeoutMs?: number;
     config?: unknown;
     agentDir?: string;
+    providers?: string[];
+    auth?: Array<Record<string, unknown>>;
   };
 }
 
@@ -69,6 +78,7 @@ describe("status-runtime-shared", () => {
     mocks.callGateway.mockResolvedValue({ ok: true });
     mocks.getDaemonStatusSummary.mockResolvedValue({ label: "LaunchAgent" });
     mocks.getNodeDaemonStatusSummary.mockResolvedValue({ label: "node" });
+    mocks.resolveModelAuthLabel.mockReturnValue(undefined);
     mocks.resolveReadOnlyChannelPluginsForConfig.mockReturnValue({
       plugins: [{ id: "telegram" }],
       configuredChannelIds: ["telegram"],
@@ -132,6 +142,176 @@ describe("status-runtime-shared", () => {
     expect(usageCall.timeoutMs).toBe(1234);
     expect(usageCall.config).toEqual({ gateway: {} });
     expect(usageCall.agentDir).toContain("main");
+  });
+
+  it("adds Codex synthetic usage for configured OpenAI Codex runtime routes without profiles", async () => {
+    mocks.loadProviderUsageSummary
+      .mockResolvedValueOnce({
+        updatedAt: 1,
+        providers: [
+          {
+            provider: "anthropic",
+            displayName: "Claude",
+            windows: [],
+            error: "HTTP 429",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        updatedAt: 2,
+        providers: [
+          {
+            provider: "openai",
+            displayName: "OpenAI",
+            windows: [{ label: "5h", usedPercent: 9 }],
+          },
+        ],
+      });
+
+    await expect(
+      resolveStatusUsageSummary({
+        timeoutMs: 3456,
+        config: {
+          agents: {
+            defaults: {
+              model: { primary: "openai/gpt-5.5" },
+              models: {
+                "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/status-agent",
+      }),
+    ).resolves.toEqual({
+      updatedAt: 1,
+      providers: [
+        {
+          provider: "anthropic",
+          displayName: "Claude",
+          windows: [],
+          error: "HTTP 429",
+        },
+        {
+          provider: "openai",
+          displayName: "OpenAI",
+          windows: [{ label: "5h", usedPercent: 9 }],
+        },
+      ],
+    });
+
+    expect(mocks.loadProviderUsageSummary).toHaveBeenNthCalledWith(2, {
+      timeoutMs: 3456,
+      providers: ["openai"],
+      auth: [
+        {
+          provider: "openai",
+          token: "codex-app-server",
+          hookProvider: "codex",
+        },
+      ],
+      config: expect.any(Object),
+      agentDir: "/tmp/status-agent",
+    });
+  });
+
+  it("keeps existing OpenAI usage when Codex synthetic usage has no windows", async () => {
+    mocks.loadProviderUsageSummary
+      .mockResolvedValueOnce({
+        updatedAt: 1,
+        providers: [
+          {
+            provider: "openai",
+            displayName: "OpenAI",
+            windows: [{ label: "5h", usedPercent: 22 }],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        updatedAt: 2,
+        providers: [
+          {
+            provider: "openai",
+            displayName: "OpenAI",
+            windows: [],
+          },
+        ],
+      });
+
+    await expect(
+      resolveStatusUsageSummary({
+        timeoutMs: 3456,
+        config: {
+          agents: {
+            defaults: {
+              model: { primary: "openai/gpt-5.5" },
+              models: {
+                "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/status-agent",
+      }),
+    ).resolves.toEqual({
+      updatedAt: 1,
+      providers: [
+        {
+          provider: "openai",
+          displayName: "OpenAI",
+          windows: [{ label: "5h", usedPercent: 22 }],
+        },
+      ],
+    });
+  });
+
+  it("does not add Codex synthetic usage for OpenAI routes pinned to OpenClaw runtime", async () => {
+    await resolveStatusUsageSummary({
+      timeoutMs: 3456,
+      config: {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.5" },
+            models: {
+              "openai/gpt-5.5": { agentRuntime: { id: "openclaw" } },
+            },
+          },
+        },
+      },
+      agentDir: "/tmp/status-agent",
+    });
+
+    expect(mocks.loadProviderUsageSummary).toHaveBeenCalledOnce();
+    expect(requireProviderUsageCall()).not.toHaveProperty("auth");
+  });
+
+  it("does not add Codex synthetic usage for API-key-backed OpenAI Codex runtime routes", async () => {
+    mocks.resolveModelAuthLabel.mockReturnValue("api-key (openai:api)");
+
+    await resolveStatusUsageSummary({
+      timeoutMs: 3456,
+      config: {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.5" },
+            models: {
+              "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+            },
+          },
+        },
+      },
+      agentDir: "/tmp/status-agent",
+    });
+
+    expect(mocks.loadProviderUsageSummary).toHaveBeenCalledOnce();
+    expect(requireProviderUsageCall()).not.toHaveProperty("auth");
+    expect(mocks.resolveModelAuthLabel).toHaveBeenCalledWith({
+      provider: "openai",
+      acceptedProviderIds: ["openai"],
+      cfg: expect.any(Object),
+      agentDir: "/tmp/status-agent",
+      includeExternalProfiles: false,
+    });
   });
 
   it("resolves usage summaries with explicit agent scope", async () => {

--- a/src/commands/status-runtime-shared.ts
+++ b/src/commands/status-runtime-shared.ts
@@ -1,10 +1,20 @@
 // Shared runtime probes used by status text and JSON commands.
 // Heavy modules stay lazily loaded so fast status output avoids security/provider/gateway costs.
 
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { resolveDefaultAgentDir } from "../agents/agent-scope.js";
+import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
+import { resolveModelAuthLabel } from "../agents/model-auth-label.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
+import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../agents/openai-routing.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import {
+  buildCodexSyntheticUsageAuth,
+  mergeUsageSummaries,
+  shouldUseCodexSyntheticUsageForRuntime,
+} from "../status/codex-synthetic-usage.js";
 import type { HealthSummary } from "./health.js";
 import { getDaemonStatusSummary, getNodeDaemonStatusSummary } from "./status.daemon.js";
 
@@ -31,6 +41,58 @@ function loadReadOnlyChannelPluginsModule() {
 
 function loadGatewayCallModule() {
   return gatewayCallModuleLoader.load();
+}
+
+function resolveUsageCredentialType(authLabel?: string): "oauth" | "token" | "api_key" | undefined {
+  const auth = normalizeOptionalLowercaseString(authLabel);
+  if (!auth) {
+    return undefined;
+  }
+  if (auth.startsWith("oauth")) {
+    return "oauth";
+  }
+  if (auth.startsWith("token")) {
+    return "token";
+  }
+  if (auth.startsWith("api-key") || auth.startsWith("api key")) {
+    return "api_key";
+  }
+  return undefined;
+}
+
+function shouldUseConfiguredCodexSyntheticUsage(params: {
+  config: OpenClawConfig;
+  agentDir: string;
+}): boolean {
+  const configuredDefault = resolveDefaultModelForAgent({
+    cfg: params.config,
+    allowPluginNormalization: false,
+  });
+  const policy = resolveAgentHarnessPolicy({
+    config: params.config,
+    provider: configuredDefault.provider,
+    modelId: configuredDefault.model,
+  });
+  if (
+    !shouldUseCodexSyntheticUsageForRuntime({
+      provider: configuredDefault.provider,
+      effectiveHarness: policy.runtime,
+    })
+  ) {
+    return false;
+  }
+  const authLabel = resolveModelAuthLabel({
+    provider: configuredDefault.provider,
+    acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
+      provider: configuredDefault.provider,
+      harnessRuntime: policy.runtime,
+      config: params.config,
+    }),
+    cfg: params.config,
+    agentDir: params.agentDir,
+    includeExternalProfiles: false,
+  });
+  return resolveUsageCredentialType(authLabel) !== "api_key";
 }
 
 /** Runs the lightweight security audit used by status JSON/all output. */
@@ -69,11 +131,23 @@ type StatusUsageSummaryOptions = {
 /** Loads provider usage for status output, defaulting to the config's default agent directory. */
 export async function resolveStatusUsageSummary(params: StatusUsageSummaryOptions) {
   const { loadProviderUsageSummary } = await loadProviderUsage();
-  return await loadProviderUsageSummary({
+  const agentDir = params.agentDir ?? resolveDefaultAgentDir(params.config);
+  const usage = await loadProviderUsageSummary({
     timeoutMs: params.timeoutMs,
     config: params.config,
-    agentDir: params.agentDir ?? resolveDefaultAgentDir(params.config),
+    agentDir,
   });
+  if (!shouldUseConfiguredCodexSyntheticUsage({ config: params.config, agentDir })) {
+    return usage;
+  }
+  const codexUsage = await loadProviderUsageSummary({
+    timeoutMs: params.timeoutMs,
+    providers: ["openai"],
+    auth: [buildCodexSyntheticUsageAuth()],
+    config: params.config,
+    agentDir,
+  });
+  return mergeUsageSummaries(usage, codexUsage);
 }
 
 /** Exposes the lazily loaded provider-usage module for callers that need its helpers. */

--- a/src/status/codex-synthetic-usage.ts
+++ b/src/status/codex-synthetic-usage.ts
@@ -1,0 +1,63 @@
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { CODEX_APP_SERVER_AUTH_MARKER } from "../agents/model-auth-markers.js";
+import type { ProviderAuth } from "../infra/provider-usage.auth.js";
+import type { ProviderUsageSnapshot, UsageSummary } from "../infra/provider-usage.types.js";
+
+export const CODEX_SYNTHETIC_USAGE_PROVIDER = "openai";
+export const CODEX_SYNTHETIC_USAGE_HOOK_PROVIDER = "codex";
+
+export function buildCodexSyntheticUsageAuth(
+  params: {
+    authProfileId?: string;
+  } = {},
+): ProviderAuth {
+  return {
+    provider: CODEX_SYNTHETIC_USAGE_PROVIDER,
+    token: CODEX_APP_SERVER_AUTH_MARKER,
+    ...(params.authProfileId ? { authProfileId: params.authProfileId } : {}),
+    hookProvider: CODEX_SYNTHETIC_USAGE_HOOK_PROVIDER,
+  };
+}
+
+export function shouldUseCodexSyntheticUsageForRuntime(params: {
+  provider?: string;
+  effectiveHarness?: string;
+}): boolean {
+  const harness = normalizeOptionalLowercaseString(params.effectiveHarness);
+  const provider = normalizeOptionalLowercaseString(params.provider);
+  return (
+    harness === CODEX_SYNTHETIC_USAGE_HOOK_PROVIDER &&
+    (provider === CODEX_SYNTHETIC_USAGE_PROVIDER || provider === "codex")
+  );
+}
+
+function hasDisplayableUsageSnapshot(snapshot: ProviderUsageSnapshot): boolean {
+  return snapshot.windows.length > 0 || Boolean(snapshot.summary?.trim());
+}
+
+function usageSnapshotRank(snapshot: ProviderUsageSnapshot): number {
+  if (hasDisplayableUsageSnapshot(snapshot)) {
+    return 2;
+  }
+  return snapshot.error ? 0 : 1;
+}
+
+export function mergeUsageSummaries(
+  base: UsageSummary,
+  extra: UsageSummary | undefined,
+): UsageSummary {
+  if (!extra || extra.providers.length === 0) {
+    return base;
+  }
+  const providersById = new Map(base.providers.map((provider) => [provider.provider, provider]));
+  for (const provider of extra.providers) {
+    const existing = providersById.get(provider.provider);
+    if (!existing || usageSnapshotRank(provider) >= usageSnapshotRank(existing)) {
+      providersById.set(provider.provider, provider);
+    }
+  }
+  return {
+    updatedAt: base.updatedAt,
+    providers: [...providersById.values()],
+  };
+}

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -13,7 +13,6 @@ import { ensureAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { resolveContextTokensForModel } from "../agents/context.js";
 import { resolveFastModeState } from "../agents/fast-mode.js";
 import { resolveModelAuthLabel } from "../agents/model-auth-label.js";
-import { CODEX_APP_SERVER_AUTH_MARKER } from "../agents/model-auth-markers.js";
 import {
   areRuntimeModelRefsEquivalent,
   shouldPreferActiveRuntimeAliasAuthLabel,
@@ -50,6 +49,10 @@ import {
   formatTaskStatusTitle,
 } from "../tasks/task-status.js";
 import { resolveActiveFallbackState } from "./fallback-notice-state.js";
+import {
+  buildCodexSyntheticUsageAuth,
+  shouldUseCodexSyntheticUsageForRuntime,
+} from "./codex-synthetic-usage.js";
 import { formatCompactPluginHealthLine } from "./status-plugin-health.js";
 import type { BuildStatusTextParams } from "./status-text.types.js";
 
@@ -224,15 +227,6 @@ function resolveCodexSyntheticUsageAuthProfileId(params: {
   } catch {
     return undefined;
   }
-}
-
-function shouldUseCodexSyntheticUsage(params: {
-  provider?: string;
-  effectiveHarness?: string;
-}): boolean {
-  const harness = normalizeOptionalLowercaseString(params.effectiveHarness);
-  const provider = normalizeOptionalLowercaseString(params.provider);
-  return harness === "codex" && (provider === "openai" || provider === "codex");
 }
 
 function formatSessionTaskLine(sessionKey: string): string | undefined {
@@ -453,11 +447,11 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
   const usageProvider = activeRuntimeIsAuthoritative ? activeProvider : selectedLookupProvider;
   const selectedUsageCredentialType = resolveUsageCredentialType(usageAuthLabel);
   const useCodexSyntheticUsage =
-    shouldUseCodexSyntheticUsage({
+    selectedUsageCredentialType !== "api_key" &&
+    shouldUseCodexSyntheticUsageForRuntime({
       provider: usageStatusProvider,
       effectiveHarness,
-    }) &&
-    (selectedUsageCredentialType === "oauth" || selectedUsageCredentialType === "token");
+    });
   const codexUsageAuthProfileId = useCodexSyntheticUsage
     ? resolveCodexSyntheticUsageAuthProfileId({
         profileId: sessionEntry?.authProfileOverride,
@@ -491,14 +485,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
           workspaceDir: statusWorkspaceDir,
           config: cfg,
           auth: useCodexSyntheticUsage
-            ? [
-                {
-                  provider: "openai",
-                  token: CODEX_APP_SERVER_AUTH_MARKER,
-                  ...(codexUsageAuthProfileId ? { authProfileId: codexUsageAuthProfileId } : {}),
-                  hookProvider: "codex",
-                },
-              ]
+            ? [buildCodexSyntheticUsageAuth({ authProfileId: codexUsageAuthProfileId })]
             : undefined,
         }),
         new Promise<never>((_, reject) => {


### PR DESCRIPTION
## Summary
- route `/status` Codex synthetic usage through the Codex app-server marker even when no local OpenAI OAuth/token profile label exists
- teach shared `status --usage` to add the Codex synthetic OpenAI usage snapshot only for configured OpenAI Codex runtime routes whose effective auth label is not API-key-backed
- keep API-key/OpenClaw-pinned status contexts from probing Codex synthetic usage, with regression coverage for no-profile, API-key-backed, and OpenClaw-pinned cases

Closes #92506

## Linked context
- Issue: #92506
- ClawSweeper intake: source-repro, queueable-fix, fix-shape-clear
- Current PR head: `08e19d72ac`
- Upstream contract checked locally in sibling `../codex`: `account/rateLimits/read` maps to `GetAccountRateLimits` and returns Codex rate-limit snapshots used by the existing Codex provider usage hook

## Real behavior proof
- Behavior or issue addressed: `status --usage` should show real Codex/OpenAI usage windows when the default OpenAI model is effectively running on the Codex runtime, even if the status process does not have a local OpenAI OAuth/token profile label. Current 2026.6.6 omitted the Codex/OpenAI usage line.
- Real environment tested: production OpenClaw VPS `polymarket-mc`, Ubuntu arm64, prod OpenClaw home/config/gateway, gateway still running from installed OpenClaw 2026.6.6. After-fix command was run from an isolated PR checkout at `~/oc-proof-92520`, commit `220380b3`, without replacing or restarting the prod gateway service.
- Current-head delta after proof: `08e19d72ac` only adds the shared CLI effective-auth guard so API-key-backed OpenAI Codex runtime routes do not receive the synthetic app-server quota query; it does not change the proven no-profile app-server path.
- Exact steps or command run after this patch:

```text
# before, installed production CLI
openclaw --version
openclaw status --usage

# after, isolated PR checkout against the same real ~/.openclaw state and gateway
cd ~/oc-proof-92520
node openclaw.mjs --version
node openclaw.mjs status --usage
```

- Evidence after fix:

```text
=== BEFORE installed openclaw version ===
OpenClaw 2026.6.6 (8c802aa)
=== BEFORE installed openclaw status --usage ===
Sessions
... default gpt-5.5 ... Runtime OpenAI Codex ...

Usage
Usage:
  Claude: HTTP 403: OAuth token <redacted> not meet scope requirement user:profile
```

```text
=== AFTER PR checkout openclaw version ===
OpenClaw 2026.6.2 (220380b)
=== AFTER PR checkout openclaw status --usage ===
Overview
  Git                  fix/92506-codex-synthetic-usage-status · @ 220380b3
  Gateway              local · ws://127.0.0.1:18789 ... app 2026.6.6 linux 6.17.0-1011-oracle
  Sessions             255 active · default gpt-5.5 (200k ctx) · 2 stores

Sessions
... default gpt-5.5 ... Runtime OpenAI Codex ...

Usage
Usage:
  Claude: HTTP 403: OAuth token <redacted> not meet scope requirement user:profile
  OpenAI (pro (<redacted> credits))
    5h: 86% left · resets 58m
    Week: 86% left · resets 5d 4h
```

- Observed result after fix: the same VPS/prod config that previously rendered only the Claude usage error now renders real Codex/OpenAI usage from the app-server route, including both `5h` and `Week` windows. The gateway stayed on the installed prod 2026.6.6 service; only the CLI process came from the isolated PR checkout.
- What was not tested: I did not post Telegram `/status` screenshots because the real CLI `status --usage` output exercises the requested status usage path and ClawSweeper accepted copied live output as sufficient. The after command did not replace or restart the production gateway.

## Supplemental tests and validation
- `node scripts/run-vitest.mjs src/commands/status-runtime-shared.test.ts -- --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false`
- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-status.test.ts src/commands/status-runtime-shared.test.ts src/commands/status-json.test.ts src/infra/provider-usage.auth.plugin.test.ts src/infra/provider-usage.load.plugin.test.ts -- --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false`
- `node scripts/run-vitest.mjs extensions/codex/provider.test.ts extensions/codex/src/app-server/rate-limits.test.ts -- --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit --incremental false`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --noEmit --incremental false`
- `git diff --check`
- `codex -c service_tier='''fast''' review --base origin/main` -> no actionable regressions found before the current-head API-key guard follow-up

## Risk checklist
- No merge, land, or automerge performed
- No changelog added; scoped status/runtime bugfix with regression tests
- Current-head CI has one unrelated cleanup-flake failure in `checks-node-agentic-control-plane-agent-chat`: `ENOTEMPTY` while removing `/tmp/openclaw-gw-*`; GitHub permissions did not allow me to rerun it
- ClawSweeper re-review requested after adding real VPS proof and the API-key guard follow-up