### PR TITLE
fix(agents): inherit materialized runtime tools

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -35,7 +35,11 @@ import { createAgentToolsSandboxContext } from "./test-helpers/agent-tools-sandb
 import { stubTool } from "./test-helpers/fast-tool-stubs.js";
 import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge.js";
 import { buildEmptyExplicitToolAllowlistError } from "./tool-allowlist-guard.js";
-import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY, normalizeToolName } from "./tool-policy.js";
+import {
+  DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
+  normalizeToolName,
+  replaceWithEffectiveToolAllowlist,
+} from "./tool-policy.js";
 import { replaceWithEffectiveCronCreatorToolAllowlist } from "./tools/cron-tool.js";
 import { getGatewayToolCallerIdentity } from "./tools/gateway-caller-context.js";
 
@@ -1095,6 +1099,30 @@ describe("createOpenClawCodingTools", () => {
     expectListIncludes(inheritedAllow, ["read", "sessions_spawn"]);
     expect(inheritedAllow?.includes("exec")).toBe(false);
     expect(inheritedAllow?.includes("process")).toBe(false);
+  });
+
+  it("lets embedded attempts refresh a caller-owned spawned-session tool surface", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+    const inheritedToolAllowlistRef: string[] = [];
+
+    createOpenClawCodingTools({
+      config: { tools: { allow: ["read", "sessions_spawn"] } },
+      inheritedToolAllowlistRef,
+    });
+
+    expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
+    const inheritedAllow = latestCreateOpenClawToolsOptions().inheritedToolAllowlist;
+    expect(inheritedAllow).toBe(inheritedToolAllowlistRef);
+    expect(inheritedAllow).toEqual(["read", "sessions_spawn"]);
+
+    replaceWithEffectiveToolAllowlist(inheritedToolAllowlistRef, [
+      stubTool("read"),
+      stubTool("sessions_spawn"),
+      stubTool("probe__search"),
+    ]);
+
+    expect(inheritedAllow).toEqual(["read", "sessions_spawn", "probe__search"]);
   });
 
   it("passes group-restricted tool surface to cron-created agent turns", () => {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -403,6 +403,8 @@ type OpenClawCodingToolsOptions = {
   runtimeToolAllowlist?: string[];
   /** Mutable cron creator cap ref for callers that append final runtime tools later. */
   cronCreatorToolAllowlistRef?: CronCreatorToolAllowlistEntry[];
+  /** Mutable spawned-child cap ref for callers that append final runtime tools later. */
+  inheritedToolAllowlistRef?: string[];
   /** If true, the model has native vision capability */
   modelHasVision?: boolean;
   /** Mutable model-context generation used to expire screenshot coordinate frames. */
@@ -825,7 +827,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   const inheritedToolDenylist = [...pluginToolDenylist];
   // Passed by reference to sessions_spawn and populated after the final policy
   // pass so child sessions inherit the actual parent tool surface.
-  const inheritedToolAllowlist: string[] = [];
+  const inheritedToolAllowlist = options?.inheritedToolAllowlistRef ?? [];
   const toolPolicyInheritanceSources = capabilityProfile.policy.inheritancePolicies;
   const shouldInheritEffectiveToolAllowlist =
     toolPolicyInheritanceSources.some(hasRestrictiveAllowPolicy);

--- a/src/agents/embedded-agent-runner/effective-tool-policy.test.ts
+++ b/src/agents/embedded-agent-runner/effective-tool-policy.test.ts
@@ -152,6 +152,37 @@ describe("applyFinalEffectiveToolPolicy", () => {
     expect(filtered.map((tool) => tool.name)).toEqual(["mcp__bundle__fs_read"]);
   });
 
+  it("intersects overlapping configured and inherited MCP globs", async () => {
+    const agentId = `bundled-glob-intersection-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const sessionKey = `agent:${agentId}:subagent:limited`;
+    const storePath = createSessionStorePath("openclaw-bundled-glob-intersection", agentId);
+    await writeSessionEntries(storePath, {
+      [sessionKey]: {
+        sessionId: "limited-session",
+        updatedAt: Date.now(),
+        spawnDepth: 1,
+        subagentRole: "orchestrator",
+        subagentControlScope: "children",
+        inheritedToolAllow: ["*__search"],
+      },
+    });
+    const tools = [makeTool("probe__search"), makeTool("probe__delete"), makeTool("other__search")];
+    for (const tool of tools) {
+      setPluginToolMeta(tool, { pluginId: "bundle-mcp", optional: false });
+    }
+
+    const filtered = applyFinalPolicy({
+      bundledTools: tools,
+      config: {
+        session: { store: storePath },
+        tools: { allow: ["probe__*"] },
+      },
+      sessionKey,
+    });
+
+    expect(filtered.map((tool) => tool.name)).toEqual(["probe__search"]);
+  });
+
   it("applies channel-normalized per-sender policy to bundled tools", () => {
     // Teams normalizes to msteams in policy keys, which must happen before
     // sender-specific deny rules are applied.

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   getOrCreateSessionMcpRuntime: vi.fn(),
   materializeBundleMcpToolsForRun: vi.fn(),
   applyFinalEffectiveToolPolicy: vi.fn(),
+  normalizeAgentRuntimeTools: vi.fn(({ tools }: { tools: unknown[] }) => tools),
 }));
 
 vi.mock("../../agent-bundle-lsp-runtime.js", () => ({
@@ -17,7 +18,7 @@ vi.mock("../../agent-bundle-mcp-tools.js", () => ({
 }));
 
 vi.mock("../../runtime-plan/tools.js", () => ({
-  normalizeAgentRuntimeTools: vi.fn(() => []),
+  normalizeAgentRuntimeTools: mocks.normalizeAgentRuntimeTools,
 }));
 
 vi.mock("../effective-tool-policy.js", () => ({
@@ -31,6 +32,16 @@ vi.mock("./attempt-tool-construction-plan.js", () => ({
 }));
 
 import { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
+
+function makeTool(name: string) {
+  return {
+    name,
+    label: name,
+    description: `${name} tool`,
+    parameters: { type: "object", properties: {} },
+    execute: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+  };
+}
 
 describe("prepareEmbeddedAttemptBundleTools", () => {
   beforeEach(() => {
@@ -82,5 +93,67 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
     await expect(prepareEmbeddedAttemptBundleTools(input)).rejects.toThrow("bundle policy failed");
     expect(disposeMcp).toHaveBeenCalledOnce();
     expect(disposeLsp).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes spawned-child inheritance from the final materialized tool surface", async () => {
+    const inheritedToolAllowlist = ["read", "sessions_spawn"];
+    const allowedMcpTool = makeTool("probe__search");
+    const blockedMcpTool = makeTool("probe__delete");
+    const quarantinedMcpTool = {
+      ...makeTool("probe__quarantined"),
+      parameters: { type: "array", items: { type: "number" } },
+    };
+    const allowedLspTool = makeTool("lsp_hover_typescript");
+    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
+      tools: [allowedMcpTool, blockedMcpTool, quarantinedMcpTool],
+      dispose: vi.fn(async () => {}),
+    });
+    mocks.createBundleLspToolRuntime.mockResolvedValue({
+      tools: [allowedLspTool],
+      dispose: vi.fn(async () => {}),
+    });
+    mocks.applyFinalEffectiveToolPolicy.mockImplementation(
+      ({ bundledTools }: { bundledTools: Array<{ name: string }> }) =>
+        bundledTools.filter((tool) => tool.name !== "probe__delete"),
+    );
+
+    const input = {
+      agentDir: "/tmp/agent",
+      attempt: {
+        config: {},
+        model: {},
+        modelId: "model",
+        provider: "provider",
+        runId: "run",
+        runtimePlan: {},
+        sessionId: "session",
+      },
+      effectiveWorkspace: "/tmp/workspace",
+      getCurrentAttemptPluginMetadataSnapshot: () => undefined,
+      getProviderRuntimeHandle: () => undefined,
+      isRawModelRun: false,
+      preparedToolBase: {
+        cronCreatorToolAllowlist: [],
+        effectiveToolsAllow: undefined,
+        inheritedToolAllowlist,
+        localModelLeanPreserveToolNames: [],
+        runtimeCapabilityProfile: {},
+        toolsEnabled: true,
+        toolsRaw: [makeTool("read"), makeTool("sessions_spawn")],
+      },
+      sessionAgentId: "main",
+    } as unknown as Parameters<typeof prepareEmbeddedAttemptBundleTools>[0];
+
+    await prepareEmbeddedAttemptBundleTools(input);
+
+    expect(inheritedToolAllowlist).toEqual([
+      "read",
+      "sessions_spawn",
+      "probe__search",
+      "lsp_hover_typescript",
+    ]);
+    expect(inheritedToolAllowlist).not.toContain("probe__delete");
+    expect(inheritedToolAllowlist).not.toContain("probe__quarantined");
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
@@ -95,7 +95,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
     expect(disposeLsp).toHaveBeenCalledOnce();
   });
 
-  it("refreshes spawned-child inheritance from the final materialized tool surface", async () => {
+  it("keeps core tools while adding final materialized tools to spawned-child inheritance", async () => {
     const inheritedToolAllowlist = ["read", "sessions_spawn"];
     const allowedMcpTool = makeTool("probe__search");
     const blockedMcpTool = makeTool("probe__delete");
@@ -145,8 +145,14 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
       sessionAgentId: "main",
     } as unknown as Parameters<typeof prepareEmbeddedAttemptBundleTools>[0];
 
-    await prepareEmbeddedAttemptBundleTools(input);
+    const prepared = await prepareEmbeddedAttemptBundleTools(input);
 
+    expect(prepared.uncompactedEffectiveTools.map((tool) => tool.name)).toEqual([
+      "read",
+      "sessions_spawn",
+      "probe__search",
+      "lsp_hover_typescript",
+    ]);
     expect(inheritedToolAllowlist).toEqual([
       "read",
       "sessions_spawn",

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -6,6 +6,7 @@ import {
 } from "../../agent-bundle-mcp-tools.js";
 import { filterLocalModelLeanTools } from "../../local-model-lean.js";
 import { normalizeAgentRuntimeTools } from "../../runtime-plan/tools.js";
+import { replaceWithEffectiveToolAllowlist } from "../../tool-policy.js";
 import { filterRuntimeCompatibleTools } from "../../tool-schema-projection.js";
 import { logRuntimeToolSchemaQuarantine } from "../../tool-schema-quarantine.js";
 import { replaceWithEffectiveCronCreatorToolAllowlist } from "../../tools/cron-tool.js";
@@ -36,6 +37,7 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
   const {
     cronCreatorToolAllowlist,
     effectiveToolsAllow,
+    inheritedToolAllowlist,
     localModelLeanPreserveToolNames,
     runtimeCapabilityProfile,
     toolsEnabled,
@@ -195,6 +197,11 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
       );
     }
     const schemaProjection = filterRuntimeCompatibleTools(projectedTools);
+    if (inheritedToolAllowlist) {
+      // Core tools are built before MCP/LSP runtimes. Refresh the shared ref
+      // from the exact model-visible surface so spawned children inherit those tools too.
+      replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, schemaProjection.tools);
+    }
     logRuntimeToolSchemaQuarantine({
       diagnostics: schemaProjection.diagnostics,
       tools: projectedTools,

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -43,7 +43,7 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
     toolsEnabled,
     toolsRaw,
   } = params.preparedToolBase;
-  const tools = normalizeAgentRuntimeTools({
+  const normalizedCoreTools = normalizeAgentRuntimeTools({
     runtimePlan: params.attempt.runtimePlan,
     tools: toolsEnabled ? toolsRaw : [],
     provider: params.attempt.provider,
@@ -101,7 +101,7 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
     ? await materializeBundleMcpToolsForRun({
         runtime: bundleMcpSessionRuntime,
         reservedToolNames: [
-          ...tools.map((tool) => tool.name),
+          ...normalizedCoreTools.map((tool) => tool.name),
           ...(clientTools?.map((tool) => tool.function.name) ?? []),
         ],
       })
@@ -121,7 +121,7 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
           cfg: params.attempt.config,
           manifestRegistry: bundleManifestRegistry,
           reservedToolNames: [
-            ...tools.map((tool) => tool.name),
+            ...normalizedCoreTools.map((tool) => tool.name),
             ...(clientTools?.map((tool) => tool.function.name) ?? []),
             ...(bundleMcpRuntime?.tools.map((tool) => tool.name) ?? []),
           ],
@@ -182,8 +182,9 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
               }),
           })
         : filteredBundledTools;
-    const projectedTools = filterLocalModelLeanTools({
-      tools: [...tools, ...normalizedBundledTools],
+    const combinedModelVisibleTools = [...normalizedCoreTools, ...normalizedBundledTools];
+    const projectedModelVisibleTools = filterLocalModelLeanTools({
+      tools: combinedModelVisibleTools,
       config: params.attempt.config,
       agentId: params.sessionAgentId,
       preserveToolNames: localModelLeanPreserveToolNames,
@@ -192,19 +193,19 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
       // Cron is built before bundled tools; refresh its cap against the complete surface.
       replaceWithEffectiveCronCreatorToolAllowlist(
         cronCreatorToolAllowlist,
-        projectedTools,
+        projectedModelVisibleTools,
         (tool) => getPluginToolMeta(tool),
       );
     }
-    const schemaProjection = filterRuntimeCompatibleTools(projectedTools);
+    const schemaProjection = filterRuntimeCompatibleTools(projectedModelVisibleTools);
     if (inheritedToolAllowlist) {
-      // Core tools are built before MCP/LSP runtimes. Refresh the shared ref
-      // from the exact model-visible surface so spawned children inherit those tools too.
+      // This projection contains both normalized core tools and late MCP/LSP tools.
+      // Refreshing from it also drops anything removed by lean or schema filtering.
       replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, schemaProjection.tools);
     }
     logRuntimeToolSchemaQuarantine({
       diagnostics: schemaProjection.diagnostics,
-      tools: projectedTools,
+      tools: projectedModelVisibleTools,
       runId: params.attempt.runId,
       agentId: params.sessionAgentId,
       sessionKey: params.attempt.sessionKey,
@@ -214,7 +215,7 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
       bundleLspRuntime,
       bundleMcpRuntime,
       clientTools,
-      tools,
+      tools: normalizedCoreTools,
       uncompactedEffectiveTools: [...schemaProjection.tools],
     };
   } catch (error) {

--- a/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
@@ -14,6 +14,7 @@ import {
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { supportsModelTools } from "../../model-tool-support.js";
 import type { SandboxContext } from "../../sandbox/types.js";
+import { hasRestrictiveAllowPolicy } from "../../tool-policy.js";
 import { isAgentToolRestartSafe } from "../../tool-replay-safety.js";
 import { resolveAgentToolSearchRuntimeConfig } from "../../tool-search-runtime-config.js";
 import {
@@ -171,6 +172,11 @@ export function prepareEmbeddedAttemptToolBase(params: {
     runtimeToolAllowlist: effectiveToolsAllow,
     runtimePluginToolGrant: attempt.runtimePluginToolGrant,
   });
+  const inheritedToolAllowlist = runtimeCapabilityProfile.policy.inheritancePolicies.some(
+    hasRestrictiveAllowPolicy,
+  )
+    ? []
+    : undefined;
   const localModelLeanEnabled = isLocalModelLeanEnabled({
     config: attempt.config,
     agentId: params.sessionAgentId,
@@ -299,6 +305,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
           forceHeartbeatTool: attempt.forceHeartbeatTool,
           runtimeToolAllowlist: effectiveToolsAllow,
           cronCreatorToolAllowlistRef: cronCreatorToolAllowlist,
+          inheritedToolAllowlistRef: inheritedToolAllowlist,
           authProfileStore: attempt.authProfileStore,
           recordToolPrepStage: params.markCoreToolStage,
           onToolOutcome: attempt.onToolOutcome,
@@ -329,6 +336,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
     computerContextEpoch,
     cronCreatorToolAllowlist,
     effectiveToolsAllow,
+    inheritedToolAllowlist,
     localModelLeanEnabled,
     localModelLeanPreserveToolNames,
     replaySafetyOptions,

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -71,7 +71,7 @@ export function hasRestrictiveAllowPolicy(policy?: { allow?: string[] }): boolea
 /** Replaces an allowlist with the normalized names of an effective tool array. */
 export function replaceWithEffectiveToolAllowlist(
   target: string[],
-  tools: Array<{ name: string }>,
+  tools: readonly { name: string }[],
 ): void {
   target.length = 0;
   const seen = new Set<string>();


### PR DESCRIPTION
## Summary

- Keep spawned-child tool inheritance capped to the parent's actual final tool surface when MCP/LSP tools materialize after core tools are constructed.
- Share a mutable inherited allowlist reference with embedded attempt preparation, then refresh it only after final policy filtering, runtime normalization, local-model filtering, and schema compatibility checks.
- Preserve existing unrestricted behavior and cover overlapping allow globs, policy-denied runtime tools, schema-quarantined runtime tools, and retention of permitted core tools.

Refs #85030

## What Problem This Solves

`sessions_spawn` is constructed before bundle MCP/LSP runtimes are materialized. When a parent had a restrictive inherited tool policy, the captured child allowlist therefore contained only the earlier core tool surface and silently omitted otherwise-authorized runtime tools.

This change does not carry broad selectors such as `bundle-mcp` into child state. Instead, it refreshes the shared cap from concrete tool names on the final model-visible surface. That surface is explicitly assembled from normalized core tools plus normalized bundled tools before lean and schema filtering. This preserves intersections between configured and inherited globs and cannot reintroduce tools removed by later deny or schema-quarantine layers.

## Evidence

- Exact head `80bd9ed7951efa17c5e008cb7e16af6b126d7090`, rebased onto `aaacee8166cda8eb9972441444d36ca7dfe8679f`.
- `node scripts/run-vitest.mjs src/agents/tool-policy.test.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/agents/embedded-agent-runner/effective-tool-policy.test.ts src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts src/agents/tools/sessions-spawn-tool.test.ts --reporter=dot` (7 files, 228 tests passed on the exact head).
- The bundle preparation regression asserts both the final model-visible tool list and the shared spawned-child cap contain `read`, `sessions_spawn`, an allowed MCP tool, and an LSP tool, while denied and schema-quarantined runtime tools remain absent.
- `git range-diff 5a81e9fa811500950f8306a428f0dc77df217b21...4ef93c69971fb426130c7c6e143a7bb7da174166 upstream/main..HEAD` (both commits are patch-equivalent to the prior exact head).
- `git diff --check upstream/main...HEAD`.
- On patch-equivalent head `4ef93c69971fb426130c7c6e143a7bb7da174166`: `pnpm format:check -- <7 changed files>`, `node scripts/run-oxlint.mjs <7 changed files>`, `pnpm tsgo:core`, and `pnpm build` (full CLI, plugin SDK, runtime, and Control UI build passed).
- `pnpm exec tsx test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts` (real stdio MCP server through the production materialization and invocation path; `ok: true` on patch-equivalent head `4ef93c69971fb426130c7c6e143a7bb7da174166`).

The stdio MCP probe materialized and invoked `dockerProbe__docker_probe`; coding and messaging profiles exposed all three probe/resource tools, while minimal and explicit deny policies exposed zero.

A fresh external branch autoreview was not rerun after the rebase because the local safety policy blocked exporting unpublished workspace code to an external review service. The rebased commits are patch-equivalent to the previously clean-reviewed versions, and GitHub CI and repository review automation are rerunning on the exact head.

`corepack pnpm test:docker:cron-mcp-cleanup` previously completed the branch build and package-tarball integrity check. The container phase cannot start on this host because no Docker CLI is installed, so it is not reported as a passing Docker run.

## Review Notes

The first review iteration identified two selector-based risks: broad-selector deny bypass and loss of overlapping glob intersections. The implementation was replaced with concrete post-materialization allowlist refresh. A later review identified refresh before schema quarantine; the refresh now uses `schemaProjection.tools`.

A follow-up review raised possible loss of permitted core tools. The final surface already combined core and bundled tools, and the existing regression retained both. The data flow is now named explicitly as `normalizedCoreTools + normalizedBundledTools -> combinedModelVisibleTools -> lean/schema projection`, and the test separately asserts the complete returned surface and the shared child cap.
