### PR TITLE
fix(memory-core): preserve keyword-only hybrid results

### DIFF
--- a/extensions/memory-core/src/memory/hybrid.test.ts
+++ b/extensions/memory-core/src/memory/hybrid.test.ts
@@ -5,6 +5,7 @@ import {
   buildFtsQuery,
   mergeHybridResults,
   scoreExactPathTieForTemporalDecay,
+  selectHybridSearchResults,
 } from "./hybrid.js";
 
 describe("memory hybrid helpers", () => {
@@ -78,6 +79,120 @@ describe("memory hybrid helpers", () => {
     expect(b?.score).toBeCloseTo(0.3 * 1);
     expect(b?.vectorScore).toBe(0);
     expect(b?.textScore).toBeCloseTo(1);
+  });
+
+  it("uses spare result capacity for below-threshold keyword-only hits", async () => {
+    const keyword = {
+      id: "keyword",
+      path: "memory/keyword.md",
+      startLine: 3,
+      endLine: 4,
+      source: "memory",
+      snippet: "keyword-only match",
+      textScore: 1,
+    };
+    const merged = await mergeHybridResults({
+      vectorWeight: 0.7,
+      textWeight: 0.3,
+      vector: [
+        {
+          id: "strict",
+          path: "memory/strict.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "strict vector match",
+          vectorScore: 0.9,
+        },
+      ],
+      keyword: [keyword],
+    });
+
+    const selected = selectHybridSearchResults({
+      merged,
+      keyword: [keyword],
+      maxResults: 2,
+      minScore: 0.35,
+    });
+
+    expect(selected.map((entry) => entry.path)).toEqual(["memory/strict.md", "memory/keyword.md"]);
+  });
+
+  it("does not let MMR-ranked keyword-only hits displace strict results", async () => {
+    const keyword = {
+      id: "keyword",
+      path: "memory/keyword-first.md",
+      startLine: 1,
+      endLine: 1,
+      source: "memory",
+      snippet: "unrelated lexical topic",
+      textScore: 1,
+    };
+    const merged = await mergeHybridResults({
+      vectorWeight: 0.7,
+      textWeight: 0.3,
+      mmr: { enabled: true, lambda: 0.2 },
+      vector: [
+        {
+          id: "strict-first",
+          path: "memory/strict-first.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "shared semantic topic",
+          vectorScore: 1,
+        },
+        {
+          id: "strict-later",
+          path: "memory/strict-later.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "shared semantic topic",
+          vectorScore: 0.9,
+        },
+      ],
+      keyword: [keyword],
+    });
+    expect(merged.map((entry) => entry.path)).toEqual([
+      "memory/strict-first.md",
+      "memory/keyword-first.md",
+      "memory/strict-later.md",
+    ]);
+
+    const selected = selectHybridSearchResults({
+      merged,
+      keyword: [keyword],
+      maxResults: 2,
+      minScore: 0.35,
+    });
+
+    expect(selected.map((entry) => entry.path)).toEqual([
+      "memory/strict-first.md",
+      "memory/strict-later.md",
+    ]);
+  });
+
+  it("keeps the relaxed keyword-backed fallback when no result is strict", () => {
+    const overlapping = {
+      path: "memory/overlap.md",
+      startLine: 2,
+      endLine: 3,
+      source: "memory",
+      snippet: "overlapping vector and keyword match",
+      score: 0.2,
+      vectorScore: 0.1,
+      textScore: 0.5,
+    };
+
+    const selected = selectHybridSearchResults({
+      merged: [overlapping],
+      keyword: [overlapping],
+      maxResults: 1,
+      minScore: 0.35,
+    });
+
+    expect(selected).toEqual([overlapping]);
   });
 
   it("keeps null importance neutral and deterministically boosts important entries", async () => {

--- a/extensions/memory-core/src/memory/hybrid.ts
+++ b/extensions/memory-core/src/memory/hybrid.ts
@@ -13,12 +13,27 @@ import {
 type HybridSource = string;
 type ExactPathSpecificity = 0 | 1 | 2 | 3;
 
-type HybridVectorResult = {
+export type HybridSearchResult<TSource extends HybridSource = HybridSource> = {
+  path: string;
+  startLine: number;
+  endLine: number;
+  score: number;
+  vectorScore: number;
+  textScore: number;
+  snippet: string;
+  source: TSource;
+  importance?: number;
+  triggers?: string;
+  projectKey?: string;
+  provenance?: MemoryEntryProvenance;
+};
+
+type HybridVectorResult<TSource extends HybridSource = HybridSource> = {
   id: string;
   path: string;
   startLine: number;
   endLine: number;
-  source: HybridSource;
+  source: TSource;
   snippet: string;
   vectorScore: number;
   importance?: number;
@@ -28,12 +43,12 @@ type HybridVectorResult = {
   provenance?: MemoryEntryProvenance;
 };
 
-type HybridKeywordResult = {
+type HybridKeywordResult<TSource extends HybridSource = HybridSource> = {
   id: string;
   path: string;
   startLine: number;
   endLine: number;
-  source: HybridSource;
+  source: TSource;
   snippet: string;
   textScore: number;
   importance?: number;
@@ -69,9 +84,9 @@ export function scoreExactPathTieForTemporalDecay(contentScore: number): number 
   return (1 + Math.max(0, Math.min(1, contentScore))) / 2;
 }
 
-export async function mergeHybridResults(params: {
-  vector: HybridVectorResult[];
-  keyword: HybridKeywordResult[];
+export async function mergeHybridResults<TSource extends HybridSource>(params: {
+  vector: HybridVectorResult<TSource>[];
+  keyword: HybridKeywordResult<TSource>[];
   vectorWeight: number;
   textWeight: number;
   isNonTextMediaPath?: (path: string) => boolean;
@@ -83,22 +98,7 @@ export async function mergeHybridResults(params: {
   activeProjectKeys?: readonly string[];
   /** Test hook for deterministic time-dependent behavior */
   nowMs?: number;
-}): Promise<
-  Array<{
-    path: string;
-    startLine: number;
-    endLine: number;
-    score: number;
-    vectorScore: number;
-    textScore: number;
-    snippet: string;
-    source: HybridSource;
-    importance?: number;
-    triggers?: string;
-    projectKey?: string;
-    provenance?: MemoryEntryProvenance;
-  }>
-> {
+}): Promise<HybridSearchResult<TSource>[]> {
   const byId = new Map<
     string,
     {
@@ -106,7 +106,7 @@ export async function mergeHybridResults(params: {
       path: string;
       startLine: number;
       endLine: number;
-      source: HybridSource;
+      source: TSource;
       snippet: string;
       vectorScore: number;
       textScore: number;
@@ -316,4 +316,55 @@ export async function mergeHybridResults(params: {
       ...entry
     }) => entry,
   );
+}
+
+type HybridResultRange<TSource extends HybridSource = HybridSource> = Pick<
+  HybridSearchResult<TSource>,
+  "source" | "path" | "startLine" | "endLine"
+>;
+
+function hybridResultRangeKey(entry: HybridResultRange): string {
+  return `${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`;
+}
+
+export function selectHybridSearchResults<TSource extends HybridSource>(params: {
+  merged: HybridSearchResult<TSource>[];
+  keyword: HybridResultRange<TSource>[];
+  maxResults: number;
+  minScore: number;
+}): HybridSearchResult<TSource>[] {
+  const strict = params.merged.filter((entry) => entry.score >= params.minScore);
+  const selected = strict.slice(0, params.maxResults);
+  if (params.keyword.length === 0 || selected.length === params.maxResults) {
+    return selected;
+  }
+
+  const keywordKeys = new Set(params.keyword.map((entry) => hybridResultRangeKey(entry)));
+  if (strict.length === 0) {
+    // Preserve the established all-lexical fallback when every weighted score
+    // is below the configured threshold.
+    return params.merged
+      .filter((entry) => entry.score >= 0 && keywordKeys.has(hybridResultRangeKey(entry)))
+      .slice(0, params.maxResults);
+  }
+
+  // Strict recall owns the result window. MMR-ranked keyword-only hits may use
+  // spare capacity, but must never displace a qualifying result.
+  const seen = new Set(selected.map((entry) => hybridResultRangeKey(entry)));
+  for (const entry of params.merged) {
+    if (selected.length === params.maxResults) {
+      break;
+    }
+    const key = hybridResultRangeKey(entry);
+    if (
+      entry.score < params.minScore &&
+      entry.vectorScore === 0 &&
+      keywordKeys.has(key) &&
+      !seen.has(key)
+    ) {
+      seen.add(key);
+      selected.push(entry);
+    }
+  }
+  return selected;
 }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -58,6 +58,8 @@ import {
   buildFtsQuery,
   mergeHybridResults,
   scoreExactPathTieForTemporalDecay,
+  selectHybridSearchResults,
+  type HybridSearchResult,
 } from "./hybrid.js";
 import { applyImportanceMultiplier } from "./importance.js";
 import { awaitPendingManagerWork, startAsyncSearchSync } from "./manager-async-state.js";
@@ -1446,28 +1448,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         temporalDecay: hybrid.temporalDecay,
         activeProjectKeys: opts?.activeProjectKeys,
       });
-      const strict = merged.filter((entry) => entry.score >= minScore);
-      if (strict.length > 0 || keywordResults.length === 0) {
-        return strict.slice(0, maxResults);
-      }
-
-      // Hybrid defaults can produce keyword-only matches below minScore after
-      // BM25 normalization and textWeight scaling. Preserve FTS-backed lexical
-      // hits when they are the only relevant results.
-      const relaxedMinScore = 0;
-      const keywordKeys = new Set(
-        keywordResults.map(
-          (entry) => `${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`,
-        ),
-      );
-      return this.selectScoredResults(
-        merged.filter((entry) =>
-          keywordKeys.has(`${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`),
-        ),
+      return selectHybridSearchResults({
+        merged,
+        keyword: keywordResults,
         maxResults,
         minScore,
-        relaxedMinScore,
-      );
+      });
     });
   }
 
@@ -1858,7 +1844,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     mmr?: { enabled: boolean; lambda: number };
     temporalDecay?: { enabled: boolean; halfLifeDays: number };
     activeProjectKeys?: readonly string[];
-  }): Promise<MemorySearchResult[]> {
+  }): Promise<HybridSearchResult<MemorySource>[]> {
     return mergeHybridResults({
       vector: params.vector.map((r) => ({
         id: r.id,
@@ -1898,7 +1884,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       temporalDecay: params.temporalDecay,
       activeProjectKeys: params.activeProjectKeys,
       workspaceDir: this.workspaceDir,
-    }).then((entries) => entries.map((entry) => entry as MemorySearchResult));
+    });
   }
 
   async sync(params?: MemorySyncParams): Promise<void> {


### PR DESCRIPTION
## What Problem This Solves

Hybrid memory search can surface a useful, non-overlapping keyword-only FTS hit whose weighted score falls below `minScore`. The manager previously dropped that hit whenever any strict result existed. An earlier repair admitted keyword-only rows before applying `maxResults`, which let a below-threshold lexical row displace a later qualifying result after MMR reordering.

This change lets keyword-only recall use spare result capacity while guaranteeing that it cannot displace a qualifying result.

Fixes #92337.

## Why This Change Was Made

Selection belongs immediately after hybrid ranking. The helper now:

- reserves the result window for all rows meeting `minScore`
- fills only unused slots with FTS-backed rows whose `vectorScore` is `0`
- preserves merged/MMR order within the strict and lexical groups
- retains the established all-lexical fallback when no row is strict

Current project-affinity, MMR, FTS, vector, temporal-decay, and QMD-removal behavior from `main` remains intact.

## User Impact

Memory search can return a useful keyword-only match when strict semantic results leave spare capacity. Qualifying results always retain priority.

Production LOC: `+83/-46` (net `+37`) | Tests: `+115/-0`.

The production growth creates the canonical typed selection owner and removes duplicated manager-side selection policy.

## Evidence

Exact head: `47fdaa391a98d5abd377f2410401a6113cb0e174`

Real `MemoryIndexManager` proof used a temporary SQLite state DB, trigram FTS, and a deterministic local embedding provider. The keyword row's canonical stored embedding was removed after indexing so the final query proves a genuinely FTS-only result:

```json
{
  "database": "temporary SQLite",
  "tokenizer": "trigram",
  "results": [
    {
      "path": "memory/vector.md",
      "score": 0.7,
      "vectorScore": 1,
      "textScore": 0
    },
    {
      "path": "memory/keyword.md",
      "score": 0.3,
      "vectorScore": 0,
      "textScore": 1
    }
  ]
}
```

Validation on the exact head:

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/hybrid.test.ts` - 26 passed
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts -t "preserves keyword-only hybrid hits when minScore exceeds text weight"` - 1 passed, 112 skipped
- real temporary SQLite/trigram/deterministic-embedding manager proof - passed
- changed-file `oxfmt`, `oxlint`, `git diff --check`, extension production `tsgo`, and extension test `tsgo` - passed
- delegated changed Testbox `tbx_01kzsjm6t8jj43p901rsn8gyag` - passed, exit 0
- Testbox Actions run: https://github.com/openclaw/openclaw/actions/runs/31546758585
- isolated Codex autoreview (`gpt-5.6-sol`, high) - clean, no accepted/actionable findings
- local Claw run `20260811T232021-3d9b6a` - no PR-attributable finding; its findings were pre-existing `main` issues outside this strict port

Punchcard-Session: cobalt-lantern-summit-fz

## Risk

The change intentionally broadens hybrid recall only when spare `maxResults` capacity exists. Strict results retain priority, and the previous all-lexical fallback remains unchanged. No config, schema, migration, dependency, protocol, or docs surface changes.
