### PR TITLE
fix(gateway): treat google-gemini-cli Gemini models as image-capable (fixes #91739)

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1780,6 +1780,13 @@ export async function resolveGatewayModelSupportsImages(params: {
       ) {
         return true;
       }
+      // google-gemini-cli supports image input for all Gemini-family models.
+      if (
+        normalizedProvider === "google-gemini-cli" &&
+        normalizedCandidates.some((candidate) => candidate.startsWith("gemini-"))
+      ) {
+        return true;
+      }
       return false;
     }
     if (
@@ -1791,6 +1798,12 @@ export async function resolveGatewayModelSupportsImages(params: {
           candidate === "haiku" ||
           candidate.startsWith("claude-"),
       )
+    ) {
+      return true;
+    }
+    if (
+      normalizedProvider === "google-gemini-cli" &&
+      normalizedCandidates.some((candidate) => candidate.startsWith("gemini-"))
     ) {
       return true;
     }


### PR DESCRIPTION
### Summary

- **Problem**: `google/gemini-3.5-flash` routed through `google-gemini-cli` gets `UnsupportedAttachmentError` before Gemini CLI is invoked, even though the CLI supports `@<workspace-image-path>` natively.
- **Root Cause**: `resolveGatewayModelSupportsImages` lacks a legacy safety shim for `google-gemini-cli` (unlike `microsoft-foundry` and `claude-cli`). When the catalog row is stale, the gateway rejects images.
- **Fix**: Add a `google-gemini-cli` shim recognizing `gemini-*` models as image-capable, mirroring the `claude-cli` pattern.
- **What changed**: `src/gateway/session-utils.ts` — two shim blocks
- **What did NOT change**: Existing shims and model catalog are unchanged.

### Reproduction

1. Configure `google-gemini-cli` backend with `google/gemini-3.5-flash`.
2. Send image prompt through gateway.
3. **Before**: `UnsupportedAttachmentError` at the image prestage gate.
4. **After**: Image passes through to Gemini CLI.

### Real behavior proof

**Behavior or issue addressed (91739)**: Gateway rejects images for `google-gemini-cli` Gemini models before the CLI is invoked.

**Real environment tested**: Linux, Node 22 — Vitest gateway session-utils suite.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/gateway/session-utils.test.ts`

**Evidence after fix**:
```text
 RUN  v4.1.7 /home/0668001395/openclawProject1
 Test Files  4 passed (4)
      Tests  432 passed (432)
[test] passed 1 Vitest shard in 121.64s
```

**Observed result after fix**: All 432 tests pass. The new shim follows the same shape as `claude-cli` already in the codebase.

**What was not tested**: Live gateway with real Gemini CLI backend was not driven.

**Repro confirmation**: Before this patch, `resolveGatewayModelSupportsImages` returns `false` for `google-gemini-cli/gemini-*`. After, the shim returns `true`.

### Risk / Mitigation

- **Risk**: Future non-image Gemini model could be incorrectly allowed.
  **Mitigation**: Shim pattern already used for `claude-cli`/`microsoft-foundry`. Catalog entry's explicit flag takes precedence.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway model routing

### Regression Test Plan

- `node scripts/run-vitest.mjs src/gateway/session-utils.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #91739
