### PR TITLE
fix(release): tolerate semver build metadata in changelog packaging

### DIFF
--- a/scripts/package-changelog.mjs
+++ b/scripts/package-changelog.mjs
@@ -23,16 +23,19 @@ const PRERELEASE_VERSION_PATTERN =
  * Resolves acceptable changelog headings for a package version.
  */
 export function resolvePackageChangelogVersions(packageVersion) {
-  const match = RELEASE_VERSION_PATTERN.exec(packageVersion);
+  // Semver build metadata (e.g. 2026.6.6+jm) does not change release identity;
+  // changelog sections are keyed by the base version.
+  const baseVersion = packageVersion.split("+", 1)[0];
+  const match = RELEASE_VERSION_PATTERN.exec(baseVersion);
   if (!match) {
     throw new Error(
       `Unsupported OpenClaw package version for changelog packaging: ${packageVersion}`,
     );
   }
-  if (PRERELEASE_VERSION_PATTERN.test(packageVersion)) {
-    return [packageVersion, match[1], UNRELEASED_HEADING];
+  if (PRERELEASE_VERSION_PATTERN.test(baseVersion)) {
+    return [baseVersion, match[1], UNRELEASED_HEADING];
   }
-  return [packageVersion];
+  return [baseVersion];
 }
 
 function splitLines(content) {

--- a/test/scripts/package-changelog.test.ts
+++ b/test/scripts/package-changelog.test.ts
@@ -48,6 +48,12 @@ describe("package-changelog", () => {
       "2026.5.28",
       "Unreleased",
     ]);
+    expect(resolvePackageChangelogVersions("2026.5.28+jm")).toEqual(["2026.5.28"]);
+    expect(resolvePackageChangelogVersions("2026.5.28-beta.1+jm")).toEqual([
+      "2026.5.28-beta.1",
+      "2026.5.28",
+      "Unreleased",
+    ]);
   });
 
   it("extracts only the package version stable release section", () => {


### PR DESCRIPTION
## Summary

`scripts/package-changelog.mjs` rejects valid semver build metadata, so `pnpm pack` of any package with `version: X.Y.Z+suffix` crashes during prepack with `Unsupported OpenClaw package version for changelog packaging`. pnpm 10 preserves build metadata into the packed manifest, and even on pnpm 11 (which strips it at pack time) the working-directory manifest still carries the suffix through the prepack lifecycle, so the crash hits both. Changelog sections are now resolved from the base version, which is correct because build metadata never changes release identity.

## Real behavior proof

Behavior addressed: prepack crash when packing a build with semver build metadata in `package.json`.
Real environment tested: custom-runtime packaging pipeline on Ubuntu (Node 22.22, pnpm 11.2.2), 2026-06-12.
Exact steps or command run after this patch: `pnpm pack` with `version: 2026.6.6+jm`.
Evidence after fix: prepack completes; the packaged CHANGELOG carries the `2026.6.6` release section.
Observed result after fix: tarball builds and installs normally.
What was not tested: nothing material; pure function change covered by unit tests.

## Verification

- Two regression cases added to `test/scripts/package-changelog.test.ts` (`X.Y.Z+meta` and `X.Y.Z-beta.N+meta`); file passes 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
