### PR TITLE
fix(anthropic): cap system prompt cache_control markers to 4-block limit (fixes #92480)

### DIFF
--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -399,4 +399,45 @@ describe("anthropic payload policy", () => {
 
     expect(payload.system).toEqual([textBlock("Stable prefix\nDynamic lab suffix")]);
   });
+
+  it("limits system cache_control markers to 4 blocks (Vertex AI 4-block cap)", () => {
+    const policy = resolveAnthropicPayloadPolicy({
+      provider: "anthropic-vertex",
+      api: "anthropic-messages",
+      baseUrl: "https://us-east5-aiplatform.googleapis.com",
+      cacheRetention: "short",
+      enableCacheControl: true,
+    });
+    // 5 system text blocks — Vertex AI rejects >4 cache_control blocks
+    const payload: TestPayload = {
+      system: [
+        { type: "text", text: "Block 1." },
+        { type: "text", text: "Block 2." },
+        { type: "text", text: "Block 3." },
+        { type: "text", text: "Block 4." },
+        { type: "text", text: "Block 5." },
+      ],
+      messages: [{ role: "user", content: "Hello" }],
+    };
+
+    applyAnthropicPayloadPolicyToParams(payload, policy);
+
+    // Only the first 4 system blocks should have cache_control
+    const system = payload.system as Array<{ cache_control?: unknown }>;
+    expect(system.length).toBe(5);
+    let markerCount = 0;
+    for (const block of system) {
+      if (block.cache_control) {
+        markerCount++;
+      }
+    }
+    expect(markerCount).toBe(4);
+    // The first 4 should have cache_control, the 5th should not
+    expect(system[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(system[1].cache_control).toEqual({ type: "ephemeral" });
+    expect(system[2].cache_control).toEqual({ type: "ephemeral" });
+    expect(system[3].cache_control).toEqual({ type: "ephemeral" });
+    expect(system[4].cache_control).toBeUndefined();
+  });
 });
+

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -81,11 +81,13 @@ export function resolveAnthropicEphemeralCacheControl(
 function applyAnthropicCacheControlToSystem(
   system: unknown,
   cacheControl: AnthropicEphemeralCacheControl,
+  markerBudget: number = ANTHROPIC_CACHE_CONTROL_LIMIT,
 ): void {
   if (!Array.isArray(system)) {
     return;
   }
 
+  let remaining = markerBudget;
   const normalizedBlocks: Array<unknown> = [];
   for (const block of system) {
     if (!block || typeof block !== "object") {
@@ -99,8 +101,9 @@ function applyAnthropicCacheControlToSystem(
     }
     const split = splitSystemPromptCacheBoundary(record.text);
     if (!split) {
-      if (record.cache_control === undefined) {
+      if (record.cache_control === undefined && remaining > 0) {
         record.cache_control = cacheControl;
+        remaining--;
       }
       normalizedBlocks.push(record);
       continue;
@@ -111,8 +114,15 @@ function applyAnthropicCacheControlToSystem(
       normalizedBlocks.push({
         ...rest,
         text: split.stablePrefix,
-        cache_control: existingCacheControl ?? cacheControl,
+        ...(existingCacheControl !== undefined
+          ? { cache_control: existingCacheControl }
+          : remaining > 0
+            ? { cache_control: cacheControl }
+            : {}),
       });
+      if (!existingCacheControl && remaining > 0) {
+        remaining--;
+      }
     }
     if (split.dynamicSuffix) {
       normalizedBlocks.push({


### PR DESCRIPTION
## Summary

Fixes #92480

The `applyAnthropicCacheControlToSystem` function in `src/agents/anthropic-payload-policy.ts` added `cache_control` markers to every system text block without respecting the `ANTHROPIC_CACHE_CONTROL_LIMIT` constant (4). When 5+ system prompt text blocks were present, Vertex AI rejected the request with:

```
400 "A maximum of 4 blocks with cache_control may be provided. Found 5."
```

The message-level marker path (`applyAnthropicCacheControlToMessages`) already respected the limit via `ANTHROPIC_CACHE_CONTROL_LIMIT - usedMarkers` budgeting, but the system prompt path had no such guard.

## Fix

Track a `remaining` marker budget inside `applyAnthropicCacheControlToSystem` and only add `cache_control` while budget remains. The first N blocks (most impactful for caching — typically system prompt, tool descriptions, memory context) are preserved, and excess blocks are left unmarked.

**Changes:**
- `src/agents/anthropic-payload-policy.ts` — added `markerBudget` parameter (defaulting to `ANTHROPIC_CACHE_CONTROL_LIMIT`) and budget tracking to `applyAnthropicCacheControlToSystem`
- `src/agents/anthropic-payload-policy.test.ts` — added test for 5-block system prompt scenario

## Real behavior proof

**Behavior addressed:**
System prompt `cache_control` markers exceeded the 4-block cap on Vertex AI, causing 400 errors for all Anthropic model requests.

**Environment tested:**
macOS arm64, Node 22, local build (`pnpm build`), test suite via `node scripts/run-vitest.mjs run src/agents/anthropic-payload-policy.test.ts`

**Steps run after the patch:**
```
node scripts/run-vitest.mjs run src/agents/anthropic-payload-policy.test.ts
pnpm build
```

**Evidence after fix:**
```
$ node scripts/run-vitest.mjs run src/agents/anthropic-payload-policy.test.ts
 ✓  agents  src/agents/anthropic-payload-policy.test.ts (12 tests) 30ms
 Test Files  1 passed (1)
      Tests  12 passed (12)

$ node -e "
const { applyAnthropicPayloadPolicyToParams, resolveAnthropicPayloadPolicy } = require('./dist/agents/anthropic-payload-policy.js');
const policy = resolveAnthropicPayloadPolicy({ provider: 'anthropic-vertex', api: 'anthropic-messages', baseUrl: 'https://us-east5-aiplatform.googleapis.com', cacheRetention: 'short', enableCacheControl: true });
const payload = { system: [{ type: 'text', text: 'B1' }, { type: 'text', text: 'B2' }, { type: 'text', text: 'B3' }, { type: 'text', text: 'B4' }, { type: 'text', text: 'B5' }], messages: [{ role: 'user', content: 'hi' }] };
applyAnthropicPayloadPolicyToParams(payload, policy);
const markers = payload.system.filter(b => b.cache_control).length;
console.log('cache_control markers on system blocks:', markers);
console.log('Expected: 4, Got:', markers, markers === 4 ? 'PASS' : 'FAIL');
"
cache_control markers on system blocks: 4
Expected: 4, Got: 4 PASS
```

**Observed result after fix:**
Only 4 system blocks receive `cache_control` markers, matching the `ANTHROPIC_CACHE_CONTROL_LIMIT` constant. The 5th block is left without a marker. All 12 existing + new tests pass.

**What was not tested:**
Live Vertex AI API request (no Vertex AI credentials in test environment). The fix is a pure logic change to enforce an existing constant.
