### PR TITLE
fix(memory): persist metadata during safe reindex

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1876,6 +1876,23 @@ describe("memory index", () => {
 
       expect(manager.status().dirty).toBe(false);
       expect(manager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+      const metaRows = (
+        manager as unknown as {
+          db: {
+            prepare: (sql: string) => {
+              all: (...args: unknown[]) => Array<{ key: string; value: string }>;
+            };
+          };
+        }
+      ).db
+        .prepare("SELECT key, value FROM meta WHERE key = ?")
+        .all("memory_index_meta_v1");
+      expect(metaRows).toHaveLength(1);
+      expect(JSON.parse(metaRows[0]?.value ?? "{}")).toMatchObject({
+        model: "mock-embed",
+        provider: "mock",
+        sources: ["memory"],
+      });
     } finally {
       await manager.close?.();
     }

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -2318,6 +2318,7 @@ export abstract class MemoryManagerSyncOps {
       vectorDims: this.vector.dims,
       vectorDegradedWriteWarningShown: this.vectorDegradedWriteWarningShown,
       vectorReady: this.vectorReady,
+      lastMetaSerialized: this.lastMetaSerialized,
     };
 
     const restoreOriginalState = () => {
@@ -2333,6 +2334,7 @@ export abstract class MemoryManagerSyncOps {
       this.vector.dims = originalState.vectorDims;
       this.vectorDegradedWriteWarningShown = originalState.vectorDegradedWriteWarningShown;
       this.vectorReady = originalDbClosed ? null : originalState.vectorReady;
+      this.lastMetaSerialized = originalState.lastMetaSerialized;
     };
 
     this.db = tempDb;
@@ -2574,7 +2576,14 @@ export abstract class MemoryManagerSyncOps {
 
   protected writeMeta(meta: MemoryIndexMeta) {
     const value = JSON.stringify(meta);
-    if (this.lastMetaSerialized === value) {
+    const activeDbHasMetaValue =
+      this.lastMetaSerialized === value &&
+      (
+        this.db.prepare(`SELECT value FROM meta WHERE key = ?`).get(META_KEY) as
+          | { value: string }
+          | undefined
+      )?.value === value;
+    if (activeDbHasMetaValue) {
       return;
     }
     this.db

--- a/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
+++ b/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
@@ -142,6 +142,34 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
     expect(statusAfter.dirty).toBe(false);
   });
 
+  it("persists one metadata row after repeated safe force reindexes into fresh databases", async () => {
+    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "0");
+    const memoryManager = await createManager({ vectorEnabled: false });
+
+    await memoryManager.sync({ reason: "test", force: true });
+    await memoryManager.sync({ reason: "cli", force: true });
+
+    expect(indexIdentityStatus(memoryManager)).toBe("valid");
+    await memoryManager.close();
+    manager = null;
+
+    const db = new DatabaseSync(indexPath);
+    try {
+      const rows = db
+        .prepare("SELECT value FROM meta WHERE key = ?")
+        .all("memory_index_meta_v1") as Array<{ value: string }>;
+
+      expect(rows).toHaveLength(1);
+      expect(JSON.parse(rows[0]?.value ?? "{}")).toMatchObject({
+        model: "fts-only",
+        provider: "none",
+        sources: ["memory"],
+      });
+    } finally {
+      db.close();
+    }
+  });
+
   it("does not rebuild missing-identity semantic chunks when the provider is unavailable", async () => {
     await seedChunksWithNoMeta("text-embedding-3-small");
     const memoryManager = await createManager({ vectorEnabled: false });


### PR DESCRIPTION
## Summary

Fix memory index metadata writes so safe/atomic reindex cannot publish a fresh SQLite DB without `memory_index_meta_v1` when the in-process serialized metadata cache still matches the new metadata.

- `writeMeta()` now treats `lastMetaSerialized` as a fast path only when the active SQLite handle also contains the same `meta` row.
- Safe reindex now preserves and restores `lastMetaSerialized` with the rest of the original DB state on rollback.
- Added focused regression coverage for repeated safe force reindex into fresh DBs and strengthened the existing safe-force metadata test to assert the physical meta row.

## RCA

The installed 2026.6.1 bundle on this host still has the old cache-only guard:

```js
const value = JSON.stringify(meta);
if (this.lastMetaSerialized === value) return;
```

During safe reindex, `this.db` is swapped to a new temporary SQLite DB before indexing. A cache-only skip can therefore prove only that the prior DB had the serialized metadata, not that the active fresh DB has the `memory_index_meta_v1` row. If the temp DB is then atomically published, chunks/files can exist without index metadata and live memory search reports `index metadata is missing`.

Earlier production RCA captured the host memory DB in that bad shape: chunks/files present with `meta=[]`. A current non-mutating recheck no longer shows that exact bad state, which means the local DB appears to have been repaired since the capture.

## Real behavior proof

Behavior addressed: safe/atomic memory reindex must publish a DB with exactly one `memory_index_meta_v1` row even when the rebuilt metadata is unchanged.

Real environment tested: this worktree on the same OpenClaw host, plus non-mutating inspection of the host's current OpenClaw memory SQLite DB and installed bundled OpenClaw JS.

Exact steps or command run after this patch:

```bash
pnpm install --frozen-lockfile
pnpm oxfmt --write extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 ./node_modules/.bin/vitest run extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts -t "persists one metadata row" --reporter verbose
OPENCLAW_VITEST_MAX_WORKERS=1 ./node_modules/.bin/vitest run extensions/memory-core/src/memory/index.test.ts -t "keeps metadata after unchanged safe force reindex" --reporter verbose
pnpm oxfmt --check extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
node scripts/run-oxlint.mjs extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
git diff --check
```

Evidence after fix:

- New regression passed: `persists one metadata row after repeated safe force reindexes into fresh databases`.
- Strengthened existing safe-force test passed: `keeps metadata after unchanged safe force reindex`.
- Current host DB non-mutating terminal output from a read-only SQLite inspection:

```text
files=31 chunks=1266 meta=1 metaKeys=["memory_index_meta_v1"]
```
- Current installed bundle inspection confirms the shipped runtime still has the cache-only skip, so this source patch addresses the installed-code root cause without mutating the global install.

Observed result after fix: the after-patch terminal output showed repeated forced safe reindexes into fresh databases leave exactly one `memory_index_meta_v1` row, and the host DB inspection output showed the live host memory DB currently has one `memory_index_meta_v1` row alongside existing files/chunks.

What was not tested: I did not install this branch over the global OpenClaw package, mutate the shared memory DB, or restart the running gateway. End-to-end live `memory_search` after-fix proof remains gated on explicit approval to install/restart the local runtime, for example:

```bash
# approval required: mutates global install/runtime and may disrupt the running gateway
pnpm build
# install this build over the host OpenClaw package using the maintainer-approved package/install path
# restart the OpenClaw gateway
# run live memory_search and verify it no longer reports "index metadata is missing"
```

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 ./node_modules/.bin/vitest run extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts -t "persists one metadata row" --reporter verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 ./node_modules/.bin/vitest run extensions/memory-core/src/memory/index.test.ts -t "keeps metadata after unchanged safe force reindex" --reporter verbose`
- `pnpm oxfmt --check extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts`
- `node scripts/run-oxlint.mjs extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts`
- `git diff --check`

Autoreview: attempted `.agents/skills/autoreview/scripts/autoreview --mode local`, but no supported review engine binary (`codex`, `claude`, `droid`, or `copilot`) is installed in this environment.

