### PR TITLE
fix(plugins): load dreaming engine when memory slot plugin omitted from allowlist

### DIFF
--- a/src/plugins/config-activation-shared.ts
+++ b/src/plugins/config-activation-shared.ts
@@ -25,7 +25,8 @@ export type PluginActivationCause =
   | "enabled-by-effective-config"
   | "bundled-channel-configured"
   | "bundled-default-enablement"
-  | "bundled-disabled-by-default";
+  | "bundled-disabled-by-default"
+  | "dreaming-engine-sidecar";
 
 export type PluginActivationStateLike = {
   enabled: boolean;
@@ -70,6 +71,7 @@ export const PLUGIN_ACTIVATION_REASON_BY_CAUSE: Record<PluginActivationCause, st
   "bundled-channel-configured": "channel configured",
   "bundled-default-enablement": "bundled default enablement",
   "bundled-disabled-by-default": "bundled (disabled by default)",
+  "dreaming-engine-sidecar": "dreaming engine sidecar",
 };
 
 export function resolvePluginActivationReason(
@@ -134,6 +136,7 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
   activationSource?: PluginActivationConfigSourceLike<TRootConfig>;
   autoEnabledReason?: string;
   allowBundledChannelExplicitBypassesAllowlist?: boolean;
+  dreamingEngineId?: string | null;
   isBundledChannelEnabledByChannelConfig: (
     rootConfig: TRootConfig | undefined,
     pluginId: string,
@@ -222,6 +225,21 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
       explicitlyEnabled: true,
       source: "explicit",
       cause: explicitSelection.cause,
+    };
+  }
+  // The dreaming engine is a runtime dependency of the selected memory-slot plugin.
+  // When dreaming is enabled it must activate even if a restrictive `plugins.allow`
+  // omits it, otherwise dreaming sweeps silently never run. Placed after the deny,
+  // disabled-in-config, and workspace-default-off gates so an explicit opt-out still
+  // wins, and scoped to the resolved dreaming engine id so it cannot widen any other
+  // allowlist decision.
+  if (params.dreamingEngineId != null && params.id === params.dreamingEngineId) {
+    return {
+      enabled: true,
+      activated: true,
+      explicitlyEnabled: false,
+      source: "auto",
+      cause: "dreaming-engine-sidecar",
     };
   }
   if (params.config.allow.length > 0 && !explicitlyAllowed) {

--- a/src/plugins/config-activation-shared.ts
+++ b/src/plugins/config-activation-shared.ts
@@ -229,11 +229,17 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
   }
   // The dreaming engine is a runtime dependency of the selected memory-slot plugin.
   // When dreaming is enabled it must activate even if a restrictive `plugins.allow`
-  // omits it, otherwise dreaming sweeps silently never run. Placed after the deny,
-  // disabled-in-config, and workspace-default-off gates so an explicit opt-out still
-  // wins, and scoped to the resolved dreaming engine id so it cannot widen any other
-  // allowlist decision.
-  if (params.dreamingEngineId != null && params.id === params.dreamingEngineId) {
+  // omits it, otherwise dreaming sweeps silently never run. Denylist and
+  // `entries.<id>.enabled: false` still win (those gates return above). Scoped to the
+  // bundled resolved dreaming engine id, and only when the plugin would otherwise be
+  // rejected by the allowlist gate below, so no other activation decision changes.
+  if (
+    params.dreamingEngineId != null &&
+    params.id === params.dreamingEngineId &&
+    params.origin === "bundled" &&
+    params.config.allow.length > 0 &&
+    !explicitlyAllowed
+  ) {
     return {
       enabled: true,
       activated: true,

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -1,9 +1,15 @@
 /** Normalizes plugin config and resolves effective enablement, slots, and activation sources. */
 import {
+  normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  DEFAULT_MEMORY_DREAMING_PLUGIN_ID,
+  resolveMemoryDreamingConfig,
+  resolveMemoryDreamingPluginConfig,
+} from "../memory-host-sdk/dreaming.js";
 import {
   createEffectiveEnableStateResolver,
   createPluginEnableStateResolver,
@@ -156,6 +162,31 @@ export function isTestDefaultMemorySlotDisabled(
   return true;
 }
 
+/**
+ * Resolves the dreaming sidecar engine id for a config: the bundled dreaming engine
+ * (memory-core) when dreaming is enabled and a different plugin holds the memory slot,
+ * otherwise null. Shared by the loader fast-path guards and the activation decision so
+ * every registry surface agrees on when the sidecar must load.
+ */
+export function resolveDreamingSidecarEngineId(params: {
+  cfg: OpenClawConfig;
+  memorySlot: string | null | undefined;
+}): string | null {
+  const normalizedMemorySlot = normalizeLowercaseStringOrEmpty(params.memorySlot);
+  if (
+    !normalizedMemorySlot ||
+    normalizedMemorySlot === "none" ||
+    normalizedMemorySlot === DEFAULT_MEMORY_DREAMING_PLUGIN_ID
+  ) {
+    return null;
+  }
+  const dreamingConfig = resolveMemoryDreamingConfig({
+    pluginConfig: resolveMemoryDreamingPluginConfig(params.cfg),
+    cfg: params.cfg,
+  });
+  return dreamingConfig.enabled ? DEFAULT_MEMORY_DREAMING_PLUGIN_ID : null;
+}
+
 export function resolvePluginActivationState(params: {
   id: string;
   origin: PluginOrigin;
@@ -164,7 +195,6 @@ export function resolvePluginActivationState(params: {
   enabledByDefault?: boolean;
   activationSource?: PluginActivationConfigSource;
   autoEnabledReason?: string;
-  dreamingEngineId?: string | null;
 }): PluginActivationState {
   return toPluginActivationState(
     resolvePluginActivationDecisionShared({
@@ -176,6 +206,12 @@ export function resolvePluginActivationState(params: {
           plugins: params.config,
         }),
       allowBundledChannelExplicitBypassesAllowlist: true,
+      dreamingEngineId: params.rootConfig
+        ? resolveDreamingSidecarEngineId({
+            cfg: params.rootConfig,
+            memorySlot: params.config.slots.memory,
+          })
+        : null,
       isBundledChannelEnabledByChannelConfig,
     }),
   );
@@ -195,7 +231,6 @@ type EffectiveActivationParams = {
   rootConfig?: OpenClawConfig;
   enabledByDefault?: boolean;
   activationSource?: PluginActivationConfigSource;
-  dreamingEngineId?: string | null;
 };
 
 export const resolveEffectiveEnableState =
@@ -211,7 +246,6 @@ export function resolveEffectivePluginActivationState(params: {
   enabledByDefault?: EffectiveActivationParams["enabledByDefault"];
   activationSource?: EffectiveActivationParams["activationSource"];
   autoEnabledReason?: string;
-  dreamingEngineId?: string | null;
 }): PluginActivationState {
   return resolvePluginActivationState(params);
 }

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -164,6 +164,7 @@ export function resolvePluginActivationState(params: {
   enabledByDefault?: boolean;
   activationSource?: PluginActivationConfigSource;
   autoEnabledReason?: string;
+  dreamingEngineId?: string | null;
 }): PluginActivationState {
   return toPluginActivationState(
     resolvePluginActivationDecisionShared({
@@ -194,6 +195,7 @@ type EffectiveActivationParams = {
   rootConfig?: OpenClawConfig;
   enabledByDefault?: boolean;
   activationSource?: PluginActivationConfigSource;
+  dreamingEngineId?: string | null;
 };
 
 export const resolveEffectiveEnableState =
@@ -209,6 +211,7 @@ export function resolveEffectivePluginActivationState(params: {
   enabledByDefault?: EffectiveActivationParams["enabledByDefault"];
   activationSource?: EffectiveActivationParams["activationSource"];
   autoEnabledReason?: string;
+  dreamingEngineId?: string | null;
 }): PluginActivationState {
   return resolvePluginActivationState(params);
 }

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -7884,6 +7884,74 @@ module.exports = {
         },
       },
       {
+        label:
+          "loads dreaming engine when a restrictive allowlist omits it but dreaming is enabled",
+        loadRegistry: () => {
+          const bundledDir = makeTempDir();
+          const memoryCoreDir = path.join(bundledDir, "memory-core");
+          const memoryLanceDir = path.join(bundledDir, "memory-lancedb");
+          mkdirSafe(memoryCoreDir);
+          mkdirSafe(memoryLanceDir);
+          writePlugin({
+            id: "memory-core",
+            dir: memoryCoreDir,
+            filename: "index.cjs",
+            body: memoryPluginBody("memory-core"),
+          });
+          writePlugin({
+            id: "memory-lancedb",
+            dir: memoryLanceDir,
+            filename: "index.cjs",
+            body: memoryPluginBody("memory-lancedb"),
+          });
+          const openSchema = { type: "object", additionalProperties: true };
+          fs.writeFileSync(
+            path.join(memoryCoreDir, "openclaw.plugin.json"),
+            JSON.stringify(
+              { id: "memory-core", kind: "memory", configSchema: EMPTY_PLUGIN_SCHEMA },
+              null,
+              2,
+            ),
+            "utf-8",
+          );
+          fs.writeFileSync(
+            path.join(memoryLanceDir, "openclaw.plugin.json"),
+            JSON.stringify(
+              { id: "memory-lancedb", kind: "memory", configSchema: openSchema },
+              null,
+              2,
+            ),
+            "utf-8",
+          );
+          process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+
+          // Restrictive allowlist that omits the dreaming engine (memory-core) while a
+          // third-party plugin holds the memory slot with dreaming enabled. Without the
+          // sidecar exemption memory-core is rejected as "not-in-allowlist" and dreaming
+          // sweeps silently never run.
+          return loadOpenClawPlugins({
+            cache: false,
+            config: {
+              plugins: {
+                allow: ["memory-lancedb"],
+                slots: { memory: "memory-lancedb" },
+                entries: {
+                  "memory-lancedb": { enabled: true, config: { dreaming: { enabled: true } } },
+                },
+              },
+            },
+          });
+        },
+        assert: (registry: ReturnType<typeof loadOpenClawPlugins>) => {
+          const core = registry.plugins.find((entry) => entry.id === "memory-core");
+          const lance = registry.plugins.find((entry) => entry.id === "memory-lancedb");
+          expect(core?.status).toBe("loaded");
+          expect(lance?.status).toBe("loaded");
+          expect(lance?.memorySlotSelected).toBe(true);
+          expect(core?.memorySlotSelected).not.toBe(true);
+        },
+      },
+      {
         label: "excludes dreaming engine when dreaming is disabled and it is not the slot",
         loadRegistry: () => {
           const bundledDir = makeTempDir();

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2,7 +2,6 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import {
   clearAgentHarnesses,
   listRegisteredAgentHarnesses,
@@ -16,11 +15,6 @@ import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import {
-  DEFAULT_MEMORY_DREAMING_PLUGIN_ID,
-  resolveMemoryDreamingConfig,
-  resolveMemoryDreamingPluginConfig,
-} from "../memory-host-sdk/dreaming.js";
 import {
   clearDetachedTaskLifecycleRuntimeRegistration,
   getDetachedTaskLifecycleRuntimeRegistration,
@@ -46,6 +40,7 @@ import {
   applyTestPluginDefaults,
   createPluginActivationSource,
   normalizePluginsConfig,
+  resolveDreamingSidecarEngineId,
   resolveEffectiveEnableState,
   resolveEffectivePluginActivationState,
   resolveMemorySlotDecision,
@@ -248,25 +243,6 @@ const CLI_METADATA_ENTRY_BASENAMES = [
   "cli-metadata.mjs",
   "cli-metadata.cjs",
 ] as const;
-
-function resolveDreamingSidecarEngineId(params: {
-  cfg: OpenClawConfig;
-  memorySlot: string | null | undefined;
-}): string | null {
-  const normalizedMemorySlot = normalizeLowercaseStringOrEmpty(params.memorySlot);
-  if (
-    !normalizedMemorySlot ||
-    normalizedMemorySlot === "none" ||
-    normalizedMemorySlot === DEFAULT_MEMORY_DREAMING_PLUGIN_ID
-  ) {
-    return null;
-  }
-  const dreamingConfig = resolveMemoryDreamingConfig({
-    pluginConfig: resolveMemoryDreamingPluginConfig(params.cfg),
-    cfg: params.cfg,
-  });
-  return dreamingConfig.enabled ? DEFAULT_MEMORY_DREAMING_PLUGIN_ID : null;
-}
 
 export class PluginLoadFailureError extends Error {
   readonly pluginIds: string[];
@@ -2005,7 +1981,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         rootConfig: cfg,
         enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
         activationSource,
-        dreamingEngineId,
         autoEnabledReason: formatAutoEnabledActivationReason(autoEnabledReasons[pluginId]),
       });
       const existingOrigin = seenIds.get(pluginId);
@@ -2047,7 +2022,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         rootConfig: cfg,
         enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
         activationSource,
-        dreamingEngineId,
       });
       const entry = normalized.entries[pluginId];
       const record = createPluginRecord({
@@ -2967,7 +2941,6 @@ export async function loadOpenClawPluginCliRegistry(
       rootConfig: cfg,
       enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
       activationSource,
-      dreamingEngineId,
       autoEnabledReason: formatAutoEnabledActivationReason(autoEnabledReasons[pluginId]),
     });
     const existingOrigin = seenIds.get(pluginId);
@@ -3009,7 +2982,6 @@ export async function loadOpenClawPluginCliRegistry(
       rootConfig: cfg,
       enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
       activationSource,
-      dreamingEngineId,
     });
     const entry = normalized.entries[pluginId];
     const record = createPluginRecord({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2005,6 +2005,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         rootConfig: cfg,
         enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
         activationSource,
+        dreamingEngineId,
         autoEnabledReason: formatAutoEnabledActivationReason(autoEnabledReasons[pluginId]),
       });
       const existingOrigin = seenIds.get(pluginId);
@@ -2046,6 +2047,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         rootConfig: cfg,
         enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
         activationSource,
+        dreamingEngineId,
       });
       const entry = normalized.entries[pluginId];
       const record = createPluginRecord({
@@ -2965,6 +2967,7 @@ export async function loadOpenClawPluginCliRegistry(
       rootConfig: cfg,
       enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
       activationSource,
+      dreamingEngineId,
       autoEnabledReason: formatAutoEnabledActivationReason(autoEnabledReasons[pluginId]),
     });
     const existingOrigin = seenIds.get(pluginId);
@@ -3006,6 +3009,7 @@ export async function loadOpenClawPluginCliRegistry(
       rootConfig: cfg,
       enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
       activationSource,
+      dreamingEngineId,
     });
     const entry = normalized.entries[pluginId];
     const record = createPluginRecord({


### PR DESCRIPTION
## Summary

- **Problem:** When a third-party Dreaming-compatible memory plugin holds the memory slot and `plugins.allow` is restrictive (omitting `memory-core`, the default dreaming engine), the dreaming engine is rejected as `not-in-allowlist` and never loads, so dreaming sweeps silently never run.
- **Why now:** Reported in #92536 with a source-level repro; affects any user who locks down `plugins.allow` while running dreaming on a non-default memory plugin.
- **Intended outcome:** The bundled dreaming engine activates as a sidecar of the selected memory slot even under a restrictive allowlist — on every registry surface (gateway loader, CLI plugin registry, installed-plugin index, `openclaw plugins list`) — while denylist and `entries.<id>.enabled: false` still win.
- **Out of scope:** No new config/default surface, no change to how dreaming is configured, no gateway-startup changes (that path already includes the dreaming ids unconditionally via `resolveGatewayStartupDreamingPluginIds`).
- **Reviewer focus:** The exemption guard in `resolvePluginActivationDecisionShared` (scoped to bundled origin + restrictive allowlist), and the central derivation of the sidecar id in `resolvePluginActivationState` (`src/plugins/config-state.ts`) instead of per-caller threading.

How it works: `resolveDreamingSidecarEngineId` (moved from `loader.ts` to `config-state.ts`) resolves the bundled dreaming engine id (`memory-core`) only when dreaming is enabled and a different plugin holds the memory slot. `resolvePluginActivationState` passes it to the shared activation decision, which exempts exactly that plugin from the `not-in-allowlist` rejection — only when it is bundled and would otherwise be rejected. The loader's existing memory-slot guards (`pluginId !== dreamingEngineId`) keep `memory-core` from claiming the slot, so it loads strictly as the sidecar.

## Linked context

Closes #92536

Was this requested by a maintainer or owner? No — found via issue triage.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `memory-core` (the dreaming engine) is wrongly disabled (`not-in-allowlist`) when a restrictive `plugins.allow` omits it while a third-party plugin holds the memory slot with dreaming enabled, so dreaming sweeps never run.
- Real environment tested: Real `openclaw` CLI built from this branch (`pnpm build`, then `pnpm openclaw`), Node 25 on macOS, real bundled `memory-core` and `memory-lancedb` extensions from `dist/extensions`, isolated state via `OPENCLAW_STATE_DIR=/tmp/openclaw-proof-state` and `OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-state/openclaw.json`. No mocks, no test runner.
- Exact steps or command run after this patch:
  ```bash
  cat /tmp/openclaw-proof-state/openclaw.json
  # {
  #   "plugins": {
  #     "allow": ["memory-lancedb"],
  #     "slots": { "memory": "memory-lancedb" },
  #     "entries": {
  #       "memory-lancedb": { "enabled": true, "config": { "dreaming": { "enabled": true } } }
  #     }
  #   }
  # }
  pnpm build
  OPENCLAW_STATE_DIR=/tmp/openclaw-proof-state \
  OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-state/openclaw.json \
    pnpm openclaw plugins list
  OPENCLAW_STATE_DIR=/tmp/openclaw-proof-state \
  OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-state/openclaw.json \
    pnpm openclaw plugins inspect memory-core
  ```
- Evidence after fix (copied live CLI output):
  ```text
  Plugins (2/133 enabled)
  │ @openclaw/   │ memory-  │ openclaw │ enabled  │ stock:memory-core/index.js    │ 2026.6.2 │
  │ memory-core  │ core     │          │          │                               │          │
  │ Memory       │ memory-  │ openclaw │ enabled  │ stock:memory-lancedb/index.js │ 2026.6.2 │
  │ LanceDB      │ lancedb  │          │          │                               │          │

  $ openclaw plugins inspect memory-core
  @openclaw/memory-core
  id: memory-core
  Status: loaded
  Origin: bundled
  Commands: dreaming
  ```
- Observed result after fix: With the restrictive allowlist still omitting `memory-core`, the real CLI reports `memory-core` enabled/loaded as the dreaming sidecar (its `dreaming` command is registered) while `memory-lancedb` remains the selected memory slot. Enabled count goes from 1/133 to 2/133, with no other plugin's status changing.
- What was not tested: A live gateway sweep with a real third-party (non-bundled) Dreaming-compatible memory plugin and an LLM credential; `memory-lancedb` (bundled) stood in for the third-party plugin — it exercises the identical activation path (memory slot holder ≠ dreaming engine, dreaming engine omitted from `plugins.allow`).
- Proof limitations or environment constraints: No third-party memory plugin install or LLM API key locally, so the scheduled sweep execution itself was not observed end-to-end. The sweep scheduling depended on the activation layer proven above: the gateway-startup path already includes the dreaming ids unconditionally (`resolveGatewayStartupDreamingPluginIds`, `src/plugins/gateway-startup-plugin-ids.ts`) and only failed because the loader never enabled `memory-core`.
- Before evidence (optional but encouraged): Same config, same commands on unpatched `main` (8d9ce35):
  ```text
  Plugins (1/133 enabled)
  │ @openclaw/   │ memory-  │ openclaw │ disabled │ stock:memory-core/index.js    │ 2026.6.2 │
  │ memory-core  │ core     │          │          │                               │          │

  $ openclaw plugins inspect memory-core
  Status: disabled
  ```

## Tests and validation

Commands run:
- `node scripts/run-vitest.mjs src/plugins/loader.test.ts` → 160 passed
- `node scripts/run-vitest.mjs src/plugins/channel-plugin-ids.test.ts` → 144 passed
- `pnpm tsgo:core` and `pnpm tsgo:core:test` → no errors
- `pnpm check:import-cycles` → 0 runtime value cycles (config-state now imports memory-host-sdk/dreaming)
- `node scripts/run-oxlint.mjs` on changed files → no findings; `oxfmt` clean; `git diff --check` clean

Regression coverage added: a characterization scenario in `src/plugins/loader.test.ts` ("loads dreaming engine when a restrictive allowlist omits it but dreaming is enabled") that fails on `main` (`expected 'disabled' to be 'loaded'`) and passes with this fix.

What failed before: that scenario, plus the real CLI behavior shown in "Before evidence" above.

Note: `codex review` could not run locally (Codex CLI usage limit); substituted with the typecheck/lint/cycle checks above and the review feedback addressed below.

## Risk checklist

- Did user-visible behavior change? Yes — the dreaming engine now activates (and `openclaw plugins list` reports it enabled) for configs that previously silently skipped it. No change when `memory-core` is denied, disabled via `entries`, dreaming is off, the slot is the default engine, or no restrictive allowlist is set.
- Did config, environment, or migration behavior change? No — no new config keys, defaults, or migrations.
- Did security, auth, secrets, network, or tool execution behavior change? No.
- What is the highest-risk area? Loosening the allowlist gate for one plugin id. 
- How is that risk mitigated? The exemption requires all of: the id equals the centrally resolved dreaming engine id (only ever bundled `memory-core`, only when dreaming is enabled and a different plugin holds the memory slot), `origin === "bundled"`, and a restrictive allowlist that would otherwise reject it. Denylist, `entries.<id>.enabled: false`, and the workspace default-off gate all return before the exemption.

## Current review state

What is the next action? Maintainer review.

What is still waiting on author, maintainer, CI, or external proof? Nothing on the author. `CI / security-fast` fails on a pre-existing production-dependency advisory (esbuild, GHSA-gv7w-rqvm-qjhr) in the shared lockfile — this PR touches only `src/plugins/{config-activation-shared,config-state,loader,loader.test}.ts` and no dependency files, so that failure is unrelated and maintainer-owned.

Which bot or reviewer comments were addressed? All three Copilot comments: the origin/allowlist scoping (fixed in 455c9253), the comment wording (reworded in 455c9253), and the env-var restore (already handled by the file's global `afterEach` via `resetPluginLoaderTestStateForTest`, see inline reply). ClawSweeper's first review failed on bot-side Codex execution; re-review requested.
