### PR TITLE
fix(cron): fail closed on repeated unavailable-tool self-debug (#92535) [AI-assisted]

### DIFF
--- a/src/agents/embedded-agent-runner/failure-signal.test.ts
+++ b/src/agents/embedded-agent-runner/failure-signal.test.ts
@@ -38,6 +38,25 @@ describe("resolveEmbeddedRunFailureSignal", () => {
     ).toBe("INVALID_REQUEST");
   });
 
+  it("classifies cron unavailable-tool loop interventions", () => {
+    expect(
+      resolveEmbeddedRunFailureSignal({
+        trigger: "cron",
+        unknownToolLoopIntervention: {
+          toolName: "process",
+          message: 'Tool "process" was requested repeatedly but is not available in this run.',
+        },
+      }),
+    ).toEqual({
+      kind: "unavailable_tool_repeat",
+      source: "tool",
+      toolName: "process",
+      code: "UNAVAILABLE_TOOL_REPEAT",
+      message: 'Tool "process" was requested repeatedly but is not available in this run.',
+      fatalForCron: true,
+    });
+  });
+
   it("does not mark non-cron runs", () => {
     expect(
       resolveEmbeddedRunFailureSignal({
@@ -46,6 +65,15 @@ describe("resolveEmbeddedRunFailureSignal", () => {
           toolName: "exec",
           errorCode: "SYSTEM_RUN_DENIED",
           error: "SYSTEM_RUN_DENIED: approval required",
+        },
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveEmbeddedRunFailureSignal({
+        trigger: "user",
+        unknownToolLoopIntervention: {
+          toolName: "process",
+          message: 'Tool "process" was requested repeatedly but is not available in this run.',
         },
       }),
     ).toBeUndefined();

--- a/src/agents/embedded-agent-runner/failure-signal.ts
+++ b/src/agents/embedded-agent-runner/failure-signal.ts
@@ -12,10 +12,11 @@ import type { EmbeddedRunFailureSignal } from "./types.js";
  * a normal silent completion.
  */
 const FAILURE_SIGNAL_CODES = ["SYSTEM_RUN_DENIED", "INVALID_REQUEST"] as const;
+type ExecutionDeniedFailureSignal = Extract<EmbeddedRunFailureSignal, { kind: "execution_denied" }>;
 
 function resolveFailureSignalCode(
   value: string | undefined,
-): EmbeddedRunFailureSignal["code"] | undefined {
+): ExecutionDeniedFailureSignal["code"] | undefined {
   for (const code of FAILURE_SIGNAL_CODES) {
     if (value === code) {
       return code;
@@ -28,25 +29,46 @@ function resolveFailureSignalCode(
 export function resolveEmbeddedRunFailureSignal(params: {
   trigger?: string | undefined;
   lastToolError?: ToolErrorSummary | undefined;
+  unknownToolLoopIntervention?:
+    | {
+        toolName?: string;
+        message?: string;
+      }
+    | undefined;
 }): EmbeddedRunFailureSignal | undefined {
   if (params.trigger !== "cron") {
     return undefined;
   }
   const lastToolError = params.lastToolError;
-  if (!lastToolError || !isExecLikeToolName(lastToolError.toolName)) {
+  if (lastToolError && isExecLikeToolName(lastToolError.toolName)) {
+    // A concrete exec denial wins when both signals exist; it names the tool
+    // failure the runner observed, while guard metadata only describes a rewrite.
+    const code = resolveFailureSignalCode(normalizeOptionalString(lastToolError.errorCode));
+    if (code) {
+      const message = normalizeOptionalString(lastToolError.error) ?? code;
+      return {
+        kind: "execution_denied",
+        source: "tool",
+        ...(lastToolError.toolName ? { toolName: lastToolError.toolName } : {}),
+        code,
+        message,
+        fatalForCron: true,
+      };
+    }
+  }
+  const unavailableToolName = normalizeOptionalString(params.unknownToolLoopIntervention?.toolName);
+  const unavailableToolMessage = normalizeOptionalString(
+    params.unknownToolLoopIntervention?.message,
+  );
+  if (!unavailableToolName || !unavailableToolMessage) {
     return undefined;
   }
-  const code = resolveFailureSignalCode(normalizeOptionalString(lastToolError.errorCode));
-  if (!code) {
-    return undefined;
-  }
-  const message = normalizeOptionalString(lastToolError.error) ?? code;
   return {
-    kind: "execution_denied",
+    kind: "unavailable_tool_repeat",
     source: "tool",
-    ...(lastToolError.toolName ? { toolName: lastToolError.toolName } : {}),
-    code,
-    message,
+    toolName: unavailableToolName,
+    code: "UNAVAILABLE_TOOL_REPEAT",
+    message: unavailableToolMessage,
     fatalForCron: true,
   };
 }

--- a/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts
@@ -123,19 +123,53 @@ describe("runEmbeddedAgent cron before_agent_reply seam", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
   });
 
+  it("exposes unavailable-tool loop interventions as cron fatal signals", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        unknownToolLoopIntervention: {
+          toolName: "process",
+          message: 'Tool "process" was requested repeatedly but is not available in this run.',
+        },
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      trigger: "cron",
+    });
+
+    expect(result.meta?.failureSignal).toEqual({
+      kind: "unavailable_tool_repeat",
+      source: "tool",
+      toolName: "process",
+      code: "UNAVAILABLE_TOOL_REPEAT",
+      message: 'Tool "process" was requested repeatedly but is not available in this run.',
+      fatalForCron: true,
+    });
+  });
+
   it("does not invoke before_agent_reply for non-cron embedded runs", async () => {
     mockedGlobalHookRunner.hasHooks.mockImplementation(
       (hookName: string) => hookName === "before_agent_reply",
     );
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        unknownToolLoopIntervention: {
+          toolName: "process",
+          message: 'Tool "process" was requested repeatedly but is not available in this run.',
+        },
+      }),
+    );
 
-    await runEmbeddedAgent({
+    const result = await runEmbeddedAgent({
       ...overflowBaseRunParams,
       trigger: "user",
     });
 
     expect(mockedGlobalHookRunner.runBeforeAgentReply).not.toHaveBeenCalled();
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.meta?.failureSignal).toBeUndefined();
   });
 
   it("forwards one-shot model-run flags into the embedded attempt", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3094,6 +3094,7 @@ export async function runEmbeddedAgent(
           const failureSignal = resolveEmbeddedRunFailureSignal({
             trigger: params.trigger,
             lastToolError: attempt.lastToolError,
+            unknownToolLoopIntervention: attempt.unknownToolLoopIntervention,
           });
 
           // Timeout aborts can leave the run without payloads or with only a

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -692,7 +692,7 @@ describe("wrapStreamFnTrimToolCallNames", () => {
   async function invokeWrappedStream(
     baseFn: (...args: never[]) => unknown,
     allowedToolNames?: Set<string>,
-    guardOptions?: { unknownToolThreshold?: number },
+    guardOptions?: Parameters<typeof wrapStreamFnTrimToolCallNames>[2],
   ) {
     return await invokeWrappedTestStream(
       (innerBaseFn) =>
@@ -845,7 +845,8 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     expect(result).toBe(finalMessage);
   });
 
-  it("rewrites repeated unavailable tool calls into plain assistant text after the threshold", async () => {
+  it("records unavailable-tool interventions when result resolves without a done event", async () => {
+    const onUnknownToolLoopIntervention = vi.fn();
     const baseFn = vi.fn(() =>
       createFakeStream({
         events: [],
@@ -857,6 +858,7 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     );
     const wrappedFn = wrapStreamFnTrimToolCallNames(baseFn as never, new Set(["read"]), {
       unknownToolThreshold: 10,
+      onUnknownToolLoopIntervention,
     });
 
     for (let i = 0; i < 10; i += 1) {
@@ -866,6 +868,7 @@ describe("wrapStreamFnTrimToolCallNames", () => {
       expect(message.role).toBe("assistant");
       expectSingleToolCallContent(message.content as unknown[], "exec");
     }
+    expect(onUnknownToolLoopIntervention).not.toHaveBeenCalled();
 
     const blockedStream = await Promise.resolve(wrappedFn({} as never, {} as never, {} as never));
     const blockedResult = (await blockedStream.result()) as {
@@ -875,6 +878,128 @@ describe("wrapStreamFnTrimToolCallNames", () => {
 
     expect(blockedResult.role).toBe("assistant");
     expectSingleTextContent(blockedResult.content, '"exec"');
+    expect(onUnknownToolLoopIntervention).toHaveBeenCalledTimes(1);
+    expect(onUnknownToolLoopIntervention).toHaveBeenCalledWith({
+      toolName: "exec",
+      message: 'Tool "exec" was requested repeatedly but is not available in this run.',
+    });
+  });
+
+  it("clears a recorded unavailable-tool intervention when a later terminal message recovers", async () => {
+    const onUnknownToolLoopIntervention = vi.fn();
+    const blockedMessage = {
+      role: "assistant",
+      content: [{ type: "toolCall", name: " exec ", arguments: { command: "echo retry" } }],
+    };
+    const recoveredMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "Recovered final answer." }],
+    };
+    const baseFn = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        createFakeStream({
+          events: [],
+          resultMessage: {
+            role: "assistant",
+            content: [{ type: "toolCall", name: " exec ", arguments: { command: "echo first" } }],
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        createFakeStream({
+          events: [{ type: "done", reason: "toolUse", message: blockedMessage }],
+          resultMessage: blockedMessage,
+        }),
+      )
+      .mockImplementationOnce(() =>
+        createFakeStream({
+          events: [{ type: "done", reason: "stop", message: recoveredMessage }],
+          resultMessage: recoveredMessage,
+        }),
+      );
+    const wrappedFn = wrapStreamFnTrimToolCallNames(baseFn as never, new Set(["read"]), {
+      unknownToolThreshold: 1,
+      onUnknownToolLoopIntervention,
+    });
+
+    const firstStream = await Promise.resolve(wrappedFn({} as never, {} as never, {} as never));
+    await firstStream.result();
+
+    const blockedStream = await Promise.resolve(wrappedFn({} as never, {} as never, {} as never));
+    for await (const ignoredItem of blockedStream) {
+      void ignoredItem;
+      // drain
+    }
+    const blockedResult = (await blockedStream.result()) as {
+      role: string;
+      content: Array<{ type: string; text?: string }>;
+    };
+    expectSingleTextContent(blockedResult.content, '"exec"');
+
+    const recoveredStream = await Promise.resolve(wrappedFn({} as never, {} as never, {} as never));
+    for await (const ignoredItem of recoveredStream) {
+      void ignoredItem;
+      // drain
+    }
+    const recoveredResult = await recoveredStream.result();
+
+    expect(recoveredResult).toBe(recoveredMessage);
+    expect(onUnknownToolLoopIntervention).toHaveBeenNthCalledWith(1, {
+      toolName: "exec",
+      message: 'Tool "exec" was requested repeatedly but is not available in this run.',
+    });
+    expect(onUnknownToolLoopIntervention).toHaveBeenNthCalledWith(2, undefined);
+    expect(onUnknownToolLoopIntervention).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports unavailable-tool interventions from terminal done messages", async () => {
+    const onUnknownToolLoopIntervention = vi.fn();
+    const finalMessage = {
+      role: "assistant",
+      content: [{ type: "toolCall", name: " exec ", arguments: { command: "echo retry" } }],
+    };
+    const baseFn = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        createFakeStream({
+          events: [],
+          resultMessage: {
+            role: "assistant",
+            content: [{ type: "toolCall", name: " exec ", arguments: { command: "echo first" } }],
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        createFakeStream({
+          events: [{ type: "done", reason: "toolUse", message: finalMessage }],
+          resultMessage: finalMessage,
+        }),
+      );
+    const wrappedFn = wrapStreamFnTrimToolCallNames(baseFn as never, new Set(["read"]), {
+      unknownToolThreshold: 1,
+      onUnknownToolLoopIntervention,
+    });
+
+    const firstStream = await Promise.resolve(wrappedFn({} as never, {} as never, {} as never));
+    await firstStream.result();
+
+    const blockedStream = await Promise.resolve(wrappedFn({} as never, {} as never, {} as never));
+    for await (const ignoredItem of blockedStream) {
+      void ignoredItem;
+      // drain
+    }
+    const blockedResult = (await blockedStream.result()) as {
+      role: string;
+      content: Array<{ type: string; text?: string }>;
+    };
+
+    expectSingleTextContent(blockedResult.content, '"exec"');
+    expect(onUnknownToolLoopIntervention).toHaveBeenCalledTimes(1);
+    expect(onUnknownToolLoopIntervention).toHaveBeenCalledWith({
+      toolName: "exec",
+      message: 'Tool "exec" was requested repeatedly but is not available in this run.',
+    });
   });
 
   it("leaves repeated unavailable tool calls alone when the unknown-tool guard is disabled", async () => {
@@ -924,6 +1049,58 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     expect(partialToolCall.name).toBe("exec");
     expect(messageToolCall.name).toBe("exec");
     expectSingleToolCallContent(result.content, "exec");
+  });
+
+  it("does not report unavailable-tool interventions from non-terminal stream snapshots", async () => {
+    const onUnknownToolLoopIntervention = vi.fn();
+    const streamedMessageToolCall = { type: "toolCall", name: " exec " };
+    const streamedMessage = { role: "assistant", content: [streamedMessageToolCall] };
+    const baseFn = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        createFakeStream({
+          events: [],
+          resultMessage: {
+            role: "assistant",
+            content: [{ type: "toolCall", name: " exec ", arguments: { command: "echo first" } }],
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        createFakeStream({
+          events: [
+            {
+              type: "toolcall_delta",
+              message: streamedMessage,
+            },
+          ],
+          resultMessage: {
+            role: "assistant",
+            content: [{ type: "text", text: "Recovered final answer." }],
+          },
+        }),
+      );
+    const wrappedFn = wrapStreamFnTrimToolCallNames(baseFn as never, new Set(["read"]), {
+      unknownToolThreshold: 1,
+      onUnknownToolLoopIntervention,
+    });
+
+    const firstStream = await Promise.resolve(wrappedFn({} as never, {} as never, {} as never));
+    await firstStream.result();
+
+    const secondStream = await Promise.resolve(wrappedFn({} as never, {} as never, {} as never));
+    for await (const ignoredItem of secondStream) {
+      void ignoredItem;
+      // drain
+    }
+    const secondResult = (await secondStream.result()) as {
+      role: string;
+      content: Array<{ type: string; text?: string; name?: string }>;
+    };
+
+    expectSingleTextContent(streamedMessage.content, '"exec"');
+    expect(secondResult.content).toEqual([{ type: "text", text: "Recovered final answer." }]);
+    expect(onUnknownToolLoopIntervention).not.toHaveBeenCalled();
   });
 
   it("does not reset the unavailable-tool streak on partial-only stream chunks", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
@@ -39,8 +39,24 @@ type UnknownToolLoopGuardState = {
   lastUnknownToolName?: string;
   count: number;
   countedMessages: WeakSet<object>;
+  reportedIntervention?: UnknownToolLoopIntervention;
+  onIntervention?: (intervention: UnknownToolLoopIntervention | undefined) => void;
 };
 type AssistantStream = Awaited<ReturnType<StreamFn>>;
+
+export type UnknownToolLoopIntervention = {
+  toolName: string;
+  message: string;
+};
+
+type UnknownToolLoopGuardOptions = {
+  unknownToolThreshold?: number;
+  onUnknownToolLoopIntervention?: (intervention: UnknownToolLoopIntervention | undefined) => void;
+};
+
+function formatUnknownToolLoopAssistantText(toolName: string): string {
+  return `I can't use the tool "${toolName}" here because it isn't available. I need to stop retrying it and answer without that tool.`;
+}
 
 function resolveCaseInsensitiveAllowedToolName(
   rawName: string,
@@ -780,9 +796,74 @@ function rewriteUnknownToolLoopMessage(message: unknown, toolName: string): void
   (message as { content?: unknown }).content = [
     {
       type: "text",
-      text: `I can't use the tool "${toolName}" here because it isn't available. I need to stop retrying it and answer without that tool.`,
+      text: formatUnknownToolLoopAssistantText(toolName),
     },
   ];
+}
+
+function recordUnknownToolLoopIntervention(
+  state: UnknownToolLoopGuardState,
+  toolName: string,
+): void {
+  const intervention = {
+    toolName,
+    message: `Tool "${toolName}" was requested repeatedly but is not available in this run.`,
+  };
+  state.reportedIntervention = intervention;
+  state.onIntervention?.(intervention);
+}
+
+function clearUnknownToolLoopIntervention(state: UnknownToolLoopGuardState): void {
+  if (!state.reportedIntervention) {
+    return;
+  }
+  delete state.reportedIntervention;
+  state.onIntervention?.(undefined);
+}
+
+function messageKeepsReportedUnknownToolLoopIntervention(
+  message: unknown,
+  state: UnknownToolLoopGuardState,
+): boolean {
+  // Terminal `done` rewrites the shared assistant message in place, then result()
+  // re-checks that already-rewritten text. The formatter-coupled exact match
+  // preserves the real intervention; clearing it would let cron deliver #92535 text.
+  const intervention = state.reportedIntervention;
+  if (!intervention || !message || typeof message !== "object") {
+    return false;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content) || content.length !== 1) {
+    return false;
+  }
+  const item = content[0];
+  return (
+    Boolean(item && typeof item === "object") &&
+    (item as { type?: unknown }).type === "text" &&
+    (item as { text?: unknown }).text === formatUnknownToolLoopAssistantText(intervention.toolName)
+  );
+}
+
+function clearUnknownToolLoopInterventionForMessage(
+  state: UnknownToolLoopGuardState,
+  message: unknown,
+): void {
+  if (messageKeepsReportedUnknownToolLoopIntervention(message, state)) {
+    return;
+  }
+  clearUnknownToolLoopIntervention(state);
+}
+
+function rewriteAndRecordUnknownToolLoopMessage(
+  message: unknown,
+  state: UnknownToolLoopGuardState,
+  toolName: string,
+  recordIntervention: boolean | undefined,
+): void {
+  rewriteUnknownToolLoopMessage(message, toolName);
+  if (recordIntervention === true) {
+    recordUnknownToolLoopIntervention(state, toolName);
+  }
 }
 
 function guardUnknownToolLoopInMessage(
@@ -795,6 +876,7 @@ function guardUnknownToolLoopInMessage(
     resetOnAllowedTool?: boolean;
     resetOnMissingUnknownTool?: boolean;
     rewriteMalformedBlankToolName?: boolean;
+    recordIntervention?: boolean;
   },
 ): boolean {
   const toolCallState = classifyToolCallMessage(message, params.allowedToolNames);
@@ -803,27 +885,42 @@ function guardUnknownToolLoopInMessage(
       state.lastUnknownToolName = undefined;
       state.count = 0;
     }
+    if (params.recordIntervention === true) {
+      clearUnknownToolLoopInterventionForMessage(state, message);
+    }
     return false;
   }
   if (toolCallState.kind === "malformed") {
     if (params.rewriteMalformedBlankToolName === true) {
       rewriteUnknownToolLoopMessage(message, toolCallState.toolName);
+      if (params.recordIntervention === true) {
+        clearUnknownToolLoopInterventionForMessage(state, message);
+      }
       return true;
     }
     if (params.countAttempt && params.resetOnMissingUnknownTool !== false) {
       state.lastUnknownToolName = undefined;
       state.count = 0;
     }
+    if (params.recordIntervention === true) {
+      clearUnknownToolLoopInterventionForMessage(state, message);
+    }
     return false;
   }
   const threshold = params.threshold;
   if (threshold === undefined || threshold <= 0) {
+    if (params.recordIntervention === true) {
+      clearUnknownToolLoopInterventionForMessage(state, message);
+    }
     return false;
   }
   if (toolCallState.kind !== "unknown") {
     if (params.countAttempt && params.resetOnMissingUnknownTool !== false) {
       state.lastUnknownToolName = undefined;
       state.count = 0;
+    }
+    if (params.recordIntervention === true) {
+      clearUnknownToolLoopInterventionForMessage(state, message);
     }
     return false;
   }
@@ -833,7 +930,14 @@ function guardUnknownToolLoopInMessage(
     // Partial stream events can rewrite after the threshold, but only final
     // messages advance the loop counter.
     if (state.lastUnknownToolName === unknownToolName && state.count > threshold) {
-      rewriteUnknownToolLoopMessage(message, unknownToolName);
+      rewriteAndRecordUnknownToolLoopMessage(
+        message,
+        state,
+        unknownToolName,
+        params.recordIntervention,
+      );
+    } else if (params.recordIntervention === true) {
+      clearUnknownToolLoopInterventionForMessage(state, message);
     }
     return false;
   }
@@ -841,7 +945,14 @@ function guardUnknownToolLoopInMessage(
   if (message && typeof message === "object") {
     if (state.countedMessages.has(message)) {
       if (state.lastUnknownToolName === unknownToolName && state.count > threshold) {
-        rewriteUnknownToolLoopMessage(message, unknownToolName);
+        rewriteAndRecordUnknownToolLoopMessage(
+          message,
+          state,
+          unknownToolName,
+          params.recordIntervention,
+        );
+      } else if (params.recordIntervention === true) {
+        clearUnknownToolLoopInterventionForMessage(state, message);
       }
       return true;
     }
@@ -856,7 +967,14 @@ function guardUnknownToolLoopInMessage(
   }
 
   if (state.count > threshold) {
-    rewriteUnknownToolLoopMessage(message, unknownToolName);
+    rewriteAndRecordUnknownToolLoopMessage(
+      message,
+      state,
+      unknownToolName,
+      params.recordIntervention,
+    );
+  } else if (params.recordIntervention === true) {
+    clearUnknownToolLoopInterventionForMessage(state, message);
   }
   return true;
 }
@@ -1080,6 +1198,7 @@ function wrapStreamTrimToolCallNames(
       countAttempt: !streamAttemptAlreadyCounted,
       resetOnAllowedTool: true,
       rewriteMalformedBlankToolName: true,
+      recordIntervention: true,
     });
     return message;
   };
@@ -1087,6 +1206,7 @@ function wrapStreamTrimToolCallNames(
   wrapStreamObjectEvents(stream, (event) => {
     trimWhitespaceFromToolCallNamesInMessage(event.partial, allowedToolNames);
     trimWhitespaceFromToolCallNamesInMessage(event.message, allowedToolNames);
+    const isTerminalDoneEvent = event.type === "done";
     if (event.message && typeof event.message === "object") {
       const countedStreamAttempt = guardUnknownToolLoopInMessage(
         event.message,
@@ -1097,6 +1217,10 @@ function wrapStreamTrimToolCallNames(
           countAttempt: !streamAttemptAlreadyCounted,
           resetOnAllowedTool: true,
           resetOnMissingUnknownTool: false,
+          // Only terminal done/result can own fatal intervention state. Partial
+          // snapshots may still recover, while done and result share the same
+          // formatter-coupled rewrite on the final-message path.
+          recordIntervention: isTerminalDoneEvent,
         },
       );
       streamAttemptAlreadyCounted ||= countedStreamAttempt;
@@ -1115,11 +1239,14 @@ function wrapStreamTrimToolCallNames(
 export function wrapStreamFnTrimToolCallNames(
   baseFn: StreamFn,
   allowedToolNames?: Set<string>,
-  guardOptions?: { unknownToolThreshold?: number },
+  guardOptions?: UnknownToolLoopGuardOptions,
 ): StreamFn {
   const unknownToolGuardState: UnknownToolLoopGuardState = {
     count: 0,
     countedMessages: new WeakSet<object>(),
+    ...(guardOptions?.onUnknownToolLoopIntervention
+      ? { onIntervention: guardOptions.onUnknownToolLoopIntervention }
+      : {}),
   };
   return (model, context, streamOptions) => {
     const maybeStream = baseFn(model, context, streamOptions);

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -415,6 +415,7 @@ import {
   sanitizeOpenAIResponsesReplayForStream,
   sanitizeReplayToolCallIdsForStream,
   shouldApplyReplayToolCallIdSanitizer,
+  type UnknownToolLoopIntervention,
   wrapStreamFnPromoteStandaloneTextToolCalls,
   wrapStreamFnSanitizeMalformedToolCalls,
   wrapStreamFnTrimToolCallNames,
@@ -917,6 +918,7 @@ export async function runEmbeddedAttempt(
   let timedOutDuringCompaction = false;
   let timedOutDuringToolExecution = false;
   let promptError: unknown = null;
+  let unknownToolLoopIntervention: UnknownToolLoopIntervention | undefined;
   let emitDiagnosticRunCompleted:
     | ((
         outcome: "completed" | "aborted" | "blocked" | "error",
@@ -2840,6 +2842,9 @@ export async function runEmbeddedAttempt(
         allowedToolNames,
         {
           unknownToolThreshold: resolveUnknownToolGuardThreshold(clientToolLoopDetection),
+          onUnknownToolLoopIntervention: (intervention) => {
+            unknownToolLoopIntervention = intervention;
+          },
         },
       );
 
@@ -5303,6 +5308,7 @@ export async function runEmbeddedAttempt(
         promptCache,
         contextBudgetStatus,
         compactionCount: getCompactionCount(),
+        unknownToolLoopIntervention,
         compactionTokensAfter: getLastCompactionTokensAfter(),
         // Client tool calls detected (OpenResponses hosted tools).
         // Stay `undefined` (not `[]`) when none were detected so downstream

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -27,6 +27,7 @@ import type { ToolErrorSummary } from "../../tool-error-summary.js";
 import type { NormalizedUsage } from "../../usage.js";
 import type { EmbeddedRunReplayMetadata, EmbeddedRunReplayState } from "../replay-state.js";
 import type { EmbeddedRunLivenessState } from "../types.js";
+import type { UnknownToolLoopIntervention } from "./attempt.tool-call-normalization.js";
 import type { RunEmbeddedAgentParams } from "./params.js";
 import type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js";
 
@@ -194,6 +195,7 @@ export type EmbeddedRunAttemptResult = {
   contextBudgetStatus?: SessionContextBudgetStatus;
   compactionCount?: number;
   compactionTokensAfter?: number;
+  unknownToolLoopIntervention?: UnknownToolLoopIntervention;
   /**
    * Client tool calls detected during this attempt (OpenResponses hosted
    * tools), in the order the underlying LLM emitted them. Field is

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -129,14 +129,23 @@ export type ContextManagementTrace = {
 
 export type EmbeddedRunLivenessState = "working" | "paused" | "blocked" | "abandoned";
 
-export type EmbeddedRunFailureSignal = {
-  kind: "execution_denied";
-  source: "tool";
-  toolName?: string;
-  code: "SYSTEM_RUN_DENIED" | "INVALID_REQUEST";
-  message: string;
-  fatalForCron: true;
-};
+export type EmbeddedRunFailureSignal =
+  | {
+      kind: "execution_denied";
+      source: "tool";
+      toolName?: string;
+      code: "SYSTEM_RUN_DENIED" | "INVALID_REQUEST";
+      message: string;
+      fatalForCron: true;
+    }
+  | {
+      kind: "unavailable_tool_repeat";
+      source: "tool";
+      toolName: string;
+      code: "UNAVAILABLE_TOOL_REPEAT";
+      message: string;
+      fatalForCron: true;
+    };
 
 export type EmbeddedAgentRunMeta = {
   durationMs: number;

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -409,6 +409,37 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.deliveryPayloadHasStructuredContent).toBe(false);
   });
 
+  it("keeps unavailable-tool failure signals fatal over final assistant text", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [{ text: "Working on it..." }],
+      finalAssistantVisibleText:
+        "I can't use the tool \"process\" here because it isn't available.",
+      preferFinalAssistantVisibleText: true,
+      failureSignal: {
+        kind: "unavailable_tool_repeat",
+        source: "tool",
+        toolName: "process",
+        code: "UNAVAILABLE_TOOL_REPEAT",
+        message: 'Tool "process" was requested repeatedly but is not available in this run.',
+        fatalForCron: true,
+      },
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(true);
+    expect(result.embeddedRunError).toBe(
+      'cron classifier: unavailable_tool_repeat failure from process (UNAVAILABLE_TOOL_REPEAT): Tool "process" was requested repeatedly but is not available in this run.',
+    );
+    expect(result.outputText).toBe(
+      'Tool "process" was requested repeatedly but is not available in this run.',
+    );
+    expect(result.deliveryPayloads).toEqual([
+      {
+        text: 'Tool "process" was requested repeatedly but is not available in this run.',
+        isError: true,
+      },
+    ]);
+  });
+
   it("ignores non-fatal failure signal metadata", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [{ text: "ordinary success" }],


### PR DESCRIPTION
## Summary

- Carries repeated unavailable-tool terminal interventions from the embedded runner into cron outcome classification.
- Maps cron-only repeated unavailable-tool rewrites to a fatal `UNAVAILABLE_TOOL_REPEAT` signal instead of treating the canned assistant text as deliverable output.
- Keeps the fix structured and runner-owned rather than adding a delivery text filter.
- Intentionally does not fix replay-from-memory amplification; #80666 is the follow-up surface for memory/dreaming filtering.

## Linked context

Addresses #92535 (primary cron delivery boundary). Memory/dreaming replay amplification is tracked separately, see #80666.

Related #84709, #80666.

#84709 does not cover this case. #84709 fails closed when declared required cron tools are unavailable before model dispatch; in #92535, `exec` was available and the unavailable `process` tool was an undeclared continuation suggested by `exec` output. #84709's success-summary token fallback checks strings such as `exec unavailable`, `tool unavailable`, and `openclaw_dynamic_exec_unavailable`, none of which substring-match the observed canned rewrite: `I can't use the tool "process" here because it isn't available...`. The two changes compose because #84709 treats generic fatal `failureSignal` metadata as fatal, but whichever PR lands second will need to rebase the shared cron outcome-helper/test edits.

The reporter's local candidate was a cron delivery-dispatch text filter. This PR deliberately rejects that layer as the primary fix: a structured `UNAVAILABLE_TOOL_REPEAT` failure signal at outcome classification fails closed before delivery and avoids matching user-visible text by phrase. That follows the repo preference for closed codes over freeform strings.

## Real behavior proof (required for external PRs)

- Behavior addressed: Isolated cron must not classify the unknown-tool guard's canned self-debug rewrite as successful deliverable chat output; a repeated-unavailable-tool loop must fail the cron run closed.
- Real environment tested: Host Node v24.16 process driving the production OpenClaw functions end-to-end — the real unknown-tool guard (`wrapStreamFnTrimToolCallNames`), the real cron failure-signal resolver (`resolveEmbeddedRunFailureSignal`), and the real cron payload-outcome resolver (`resolveCronPayloadOutcome`). Only the looping model turn is stood in for; no live ollama/gateway/Telegram round-trip.
- Exact steps or command run after this patch:
  - Ran `node --import tsx ./.proof-92535.mts` on the patched branch. The script imports the three real production functions above and drives the #92535 `process`-loop payload through them, then prints the delivery decision before and after the new fatal signal. The script is throwaway and was removed after capture, so the PR diff stays the 10 source files.
- Evidence after fix: Ran `node --import tsx ./.proof-92535.mts`; captured console output:

```text
== LEG 1: real unknown-tool guard observes the #92535 process loop ==
guard rewrote terminal assistant message to: [{"type":"text","text":"I can't use the tool \"process\" here because it isn't available. I need to stop retrying it and answer without that tool."}]
recorded runner intervention: {"toolName":"process","message":"Tool \"process\" was requested repeatedly but is not available in this run."}

== LEG 2: real cron failure-signal mapping ==
cron trigger -> failureSignal: {"kind":"unavailable_tool_repeat","source":"tool","toolName":"process","code":"UNAVAILABLE_TOOL_REPEAT","message":"Tool \"process\" was requested repeatedly but is not available in this run.","fatalForCron":true}
user trigger -> failureSignal: undefined

== LEG 3: real cron outcome classification (before vs after the fix's fatal signal) ==
BEFORE deliveryPayloads: [{"text":"I can't use the tool \"process\" here because it isn't available. I need to stop retrying it and answer without that tool."}]
BEFORE hasFatalErrorPayload: false hasFatalStructuredErrorPayload: false
AFTER  deliveryPayloads: [{"text":"Tool \"process\" was requested repeatedly but is not available in this run.","isError":true}]
AFTER  hasFatalErrorPayload: true hasFatalStructuredErrorPayload: false
NOTE: hasFatalStructuredErrorPayload stays false, so run.ts:1117 skip-announce is NOT taken; the run is marked status=error and the isError payload is delivered (same lane as execution_denied, pinned by run.interim-retry.test.ts 'delivers synthesized fatal failure signals').

RESULT: PASS - canned self-debug text is the deliverable BEFORE; AFTER it is replaced by a fatal isError payload and the run is marked failed; non-cron unaffected
```

- Observed result after fix: The real guard rewrote the terminal assistant message to `I can't use the tool "process"...` and recorded a runner intervention for `process`. With `trigger: cron` the real resolver returned a fatal `UNAVAILABLE_TOOL_REPEAT` signal (`fatalForCron: true`); with `trigger: user` it returned nothing. At the real cron outcome classifier, BEFORE the signal the canned self-debug string was the delivered payload with no fatal flags; AFTER the signal the sole delivery payload is an `isError` payload carrying `Tool "process" was requested repeatedly but is not available in this run.` and the run is fatal. **Delivery disposition (explicit):** this is the same lane as the existing `execution_denied`/`SYSTEM_RUN_DENIED` fatal signal — `hasFatalStructuredErrorPayload` stays `false`, so the `run.ts` skip-announce branch is not taken; the cron run is marked `status: error` and the structured error string is delivered to the channel in place of the canned self-debug text (pinned for the existing signal by `src/cron/isolated-agent/run.interim-retry.test.ts` → "delivers synthesized fatal failure signals…", which asserts `deliveryPayloads: [{ text: "SYSTEM_RUN_DENIED: approval required", isError: true }]`). So the fix removes the "internal self-debug treated as a successful answer" failure; it does not by itself suppress the user-topic message entirely. See the open question in Current review state.
- What was not tested: A live Docker gateway plus Telegram cron round-trip (no local Crabbox/Testbox or Telegram credentials available). The looping model turn was stood in for; the guard, failure-signal, and cron-outcome code paths are the real production functions. A maintainer-run `mantis: telegram-visible-proof` would confirm, in Telegram, that the run is marked failed and the delivered message is the structured error rather than the canned self-debug text.
- Before evidence: #92535's live trace shows `exec` returned `Use process`, repeated `Tool process not found`, then `model.completed` with the exact canned rewrite.

## Tests and validation

Regression coverage added (vitest, supplemental to the real-behavior proof above):
- terminal done unavailable-tool intervention recording
- `result()` without a preceding done event
- record-then-clear recovery via `onIntervention(undefined)`
- cron-only fatal signal mapping
- non-cron preservation
- cron payload outcome treating `UNAVAILABLE_TOOL_REPEAT` as fatal over final assistant text

Validation: focused suite (169 cases across the four files) passed; source test type graph passed; `git diff --check` passed; local autoreview clean. Re-verified green after rebasing onto current `origin/main`.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No` — tool dispatch/execution is unchanged. The unknown-tool guard already intercepts and rewrites the repeated unavailable-tool call; this PR only records that intervention as metadata and maps it to a cron-only fatal outcome classification.

Highest-risk area: isolated cron delivery / session-state behavior.

Mitigation: scoped to cron-triggered fatal failure signals; interactive/non-cron unknown-tool recovery is unchanged, and stale intervention metadata is cleared when a later terminal message recovers.

## Current review state

Kept as a draft. Local proof drives the real production pipeline (guard -> failure signal -> cron outcome) and shows that after the fix the cron run is fatal and the canned self-debug text is replaced by a structured `isError` payload, matching the existing `execution_denied` lane.

Open question for maintainers (delivery disposition): this fix makes the run fail closed and stops the internal self-debug text from being announced as a successful answer, but — consistent with the shipped `execution_denied` path — it still delivers the structured error string to the user topic and marks the run `status: error`. It does not route to operator-only / full suppression. Given #92535's note about internal tool names reaching chat recipients, should a `failureSignal` cron fatal (a) deliver the error to the user topic as today (current behavior, consistent across both signals), or (b) suppress to cron-state/failure-alert only (e.g. by also setting the `hasFatalStructuredErrorPayload` skip-announce path)? Option (b) would change the existing `execution_denied` behavior too, so I left it as (a) and am flagging it rather than unilaterally changing the shipped contract.

Remaining proof gap is a live Docker/Telegram cron round-trip, which a maintainer-run `mantis: telegram-visible-proof` (or `workflow_dispatch`) could close. I cannot run that hosted Telegram proof from a fork.

Addressed reviewer feedback:
- done/result invariant comments
- record->clear test
- result-without-done coverage
- repro fidelity check against the #92535 trace
- #84709 sibling analysis
- structured-signal-over-text-filter justification
- real-behavior proof driving the production pipeline (replacing the earlier mock-only evidence)

---

AI-assisted: prepared with Codex (implementation) and Claude (review). The human contributor has reviewed and understands the change and can share session logs on request.
