### PR TITLE
fix(ios): force stale foreground gateway reconnects

### DIFF
--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -188,6 +188,7 @@ final class NodeAppModel {
     @ObservationIgnored private var backgroundGraceTaskTimer: Task<Void, Never>?
     private var backgroundReconnectSuppressed = false
     private var backgroundReconnectLeaseUntil: Date?
+    @ObservationIgnored private var foregroundGatewayResumeCheckInFlight = false
     private var lastSignificantLocationWakeAt: Date?
     @ObservationIgnored private let watchReplyCoordinator = WatchReplyCoordinator()
     private var watchExecApprovalPromptsByID: [String: ExecApprovalPrompt] = [:]
@@ -214,6 +215,7 @@ final class NodeAppModel {
     private static let watchExecApprovalBridgeStateKey = "watch.execApproval.bridge.state.v1"
     private static let backgroundAliveLastSuccessAtMsKey = "gateway.backgroundAlive.lastSuccessAtMs"
     private static let backgroundAliveLastTriggerKey = "gateway.backgroundAlive.lastTrigger"
+    private static let foregroundResumeHealthTimeoutSeconds = 1
 
     var cameraHUDText: String?
     var cameraHUDKind: CameraHUDKind?
@@ -417,9 +419,7 @@ final class NodeAppModel {
             self.isBackgrounded = false
             self.endBackgroundConnectionGracePeriod(reason: "scene_foreground")
             self.clearBackgroundReconnectSuppression(reason: "scene_foreground")
-            if self.operatorConnected {
-                self.startGatewayHealthMonitor()
-            }
+            var shouldStartGatewayHealthMonitor = self.operatorConnected
             if phase == .active {
                 self.voiceWake.resumeAfterExternalAudioCapture(wasSuspended: self.backgroundVoiceWakeSuspended)
                 self.backgroundVoiceWakeSuspended = false
@@ -444,6 +444,8 @@ final class NodeAppModel {
                 // iOS may suspend network sockets in background without a clean close.
                 // On foreground, force a fresh handshake to avoid "connected but dead" states.
                 if backgroundedFor >= 3.0 {
+                    shouldStartGatewayHealthMonitor = false
+                    self.foregroundGatewayResumeCheckInFlight = true
                     Task { [weak self] in
                         guard let self else { return }
                         let operatorWasConnected = await MainActor.run { self.operatorConnected }
@@ -452,30 +454,25 @@ final class NodeAppModel {
                             let healthy = await (try? self.operatorGateway.request(
                                 method: "health",
                                 paramsJSON: nil,
-                                timeoutSeconds: 2)) != nil
+                                timeoutSeconds: Self.foregroundResumeHealthTimeoutSeconds)) != nil
                             if healthy {
-                                await MainActor.run { self.startGatewayHealthMonitor() }
+                                await MainActor.run {
+                                    self.foregroundGatewayResumeCheckInFlight = false
+                                    self.startGatewayHealthMonitor()
+                                }
                                 return
                             }
                         }
 
-                        await self.operatorGateway.disconnect()
-                        await self.nodeGateway.disconnect()
                         await MainActor.run {
-                            guard !self.isAppleReviewDemoModeEnabled else { return }
-                            self.setOperatorConnected(false)
-                            self.gatewayConnected = false
-                            // Foreground recovery must actively restart the saved gateway config.
-                            // Disconnecting stale sockets alone can leave us idle if the old
-                            // reconnect tasks were suppressed or otherwise got stuck in background.
-                            self.gatewayStatusText = "Reconnecting…"
-                            self.talkMode.updateGatewayConnected(false)
-                            if let cfg = self.activeGatewayConnectConfig {
-                                self.applyGatewayConnectConfig(cfg)
-                            }
+                            self.foregroundGatewayResumeCheckInFlight = false
                         }
+                        await self.restartGatewaySessionsAfterForegroundStaleConnection()
                     }
                 }
+            }
+            if shouldStartGatewayHealthMonitor {
+                self.startGatewayHealthMonitor()
             }
         @unknown default:
             self.isBackgrounded = false
@@ -786,6 +783,12 @@ final class NodeAppModel {
 
     func refreshGatewayOverviewIfConnected() async {
         guard await self.isOperatorConnected() else { return }
+        if self.foregroundGatewayResumeCheckInFlight {
+            GatewayDiagnostics.log("gateway overview refresh deferred reason=foreground_resume_check")
+            try? await Task.sleep(
+                nanoseconds: UInt64(Self.foregroundResumeHealthTimeoutSeconds) * 1_000_000_000)
+            guard await self.isOperatorConnected(), !self.foregroundGatewayResumeCheckInFlight else { return }
+        }
         await self.refreshBrandingFromGateway()
         await self.refreshAgentsFromGateway()
     }
@@ -1986,12 +1989,33 @@ extension NodeAppModel {
     }
 
     func resetGatewaySessionsForForcedReconnect() async {
-        self.nodeGatewayTask?.cancel()
+        let nodeGatewayTask = self.nodeGatewayTask
+        let operatorGatewayTask = self.operatorGatewayTask
+        nodeGatewayTask?.cancel()
         self.nodeGatewayTask = nil
-        self.operatorGatewayTask?.cancel()
+        operatorGatewayTask?.cancel()
         self.operatorGatewayTask = nil
         await self.operatorGateway.disconnect()
         await self.nodeGateway.disconnect()
+        // Foreground recovery reuses the same config immediately after reset.
+        // Wait for canceled loops so their shutdown cleanup cannot clobber the new reconnect state.
+        if let operatorGatewayTask {
+            await operatorGatewayTask.value
+        }
+        if let nodeGatewayTask {
+            await nodeGatewayTask.value
+        }
+    }
+
+    private func restartGatewaySessionsAfterForegroundStaleConnection() async {
+        await self.resetGatewaySessionsForForcedReconnect()
+        guard !self.isAppleReviewDemoModeEnabled else { return }
+        self.setOperatorConnected(false)
+        self.gatewayConnected = false
+        self.gatewayStatusText = "Reconnecting…"
+        self.talkMode.updateGatewayConnected(false)
+        guard let cfg = self.activeGatewayConnectConfig else { return }
+        self.applyGatewayConnectConfig(cfg, forceReconnect: true)
     }
 
     func disconnectGateway() {
@@ -4824,6 +4848,10 @@ extension NodeAppModel {
 
     func _test_hasGatewayLoopTasks() -> (node: Bool, operator: Bool) {
         (self.nodeGatewayTask != nil, self.operatorGatewayTask != nil)
+    }
+
+    func _test_restartGatewaySessionsAfterForegroundStaleConnection() async {
+        await self.restartGatewaySessionsAfterForegroundStaleConnection()
     }
 
     func _test_handleSuccessfulBootstrapGatewayOnboarding() async {

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -356,6 +356,20 @@ import UIKit
         #expect(!appModel._test_hasGatewayLoopTasks().operator)
     }
 
+    @Test @MainActor func foregroundStaleConnectionRestartReappliesActiveGatewayConfig() async {
+        let appModel = NodeAppModel()
+        defer { appModel.disconnectGateway() }
+
+        let config = Self.makeGatewayConnectConfig()
+        appModel.applyGatewayConnectConfig(config)
+        await appModel._test_restartGatewaySessionsAfterForegroundStaleConnection()
+
+        #expect(appModel.gatewayStatusText == "Reconnecting…")
+        #expect(appModel.activeGatewayConnectConfig?.hasSameConnectionInputs(as: config) == true)
+        #expect(appModel._test_hasGatewayLoopTasks().node)
+        #expect(appModel._test_hasGatewayLoopTasks().operator)
+    }
+
     @Test @MainActor func loadLastConnectionReadsSavedValues() {
         let prior = KeychainStore.loadString(service: "ai.openclaw.gateway", account: "lastConnection")
         defer {


### PR DESCRIPTION
## Summary

- Force iOS foreground stale-gateway recovery through the existing gateway-session reset path before reapplying the active config.
- Reapply the active gateway config with `forceReconnect: true` so stale node/operator loop tasks cannot make the same-config guard skip the restart.
- Wait for canceled gateway loop tasks to finish before the forced reconnect starts, preventing old shutdown cleanup from clobbering the new foreground reconnect state.
- Make foreground resume more responsive by avoiding duplicate stale-socket work: the periodic health monitor no longer starts while the foreground resume health probe is in flight, that probe uses a shorter timeout, and gateway overview refreshes defer until the resume decision completes.
- Add focused coverage proving foreground stale recovery preserves the active config and starts fresh node/operator gateway loop tasks.

## Real behavior proof

Behavior addressed: when iOS returns to foreground and gateway health is stale, the app now clears stale gateway sessions, waits for old loop cleanup, and forces a reconnect using the active gateway config. The foreground resume path also avoids stacking the periodic health monitor and overview refresh RPCs on top of the one-shot resume health probe.

Real environment tested: iPhone 17 Pro Simulator through XcodeBuildMCP against local OpenClaw gateway `ws://127.0.0.1:18789`, plus patched build install/launch smoke on Colin's iPhone.

Exact steps or command run after this patch:
- XcodeBuildMCP `test_sim -only-testing:OpenClawTests/GatewayConnectionControllerTests -only-testing:OpenClawTests/NodeAppModelInvokeTests -only-testing:OpenClawTests/AppCoverageTests`
- XcodeBuildMCP `build_run_sim` on the patched app
- Simulator GIF capture: connected Control screen -> Home/background -> foreground/launch -> Control screen remains Gateway Online
- Forced lifecycle check: connected Control screen -> Home/background -> local gateway restart cycle -> foreground app -> Gateway Online
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `git diff --check`

Visual proof:

| Before lifecycle | After patch lifecycle |
| --- | --- |
| ![Before lifecycle](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw-pr-92552/before-connected-lifecycle.gif) | ![After lifecycle](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw-pr-92552/after-connected-lifecycle.gif) |

Forced lifecycle check:

![Forced stale baseline lifecycle](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw-pr-92552/forced-stale-baseline.gif)

Observed result after fix: foreground stale recovery enters `Reconnecting…`, clears the old gateway loop tasks, waits for their shutdown cleanup, and starts fresh node/operator loops using the active gateway config. The simulator lifecycle GIF shows the connected app returning from background with the gateway still Online. The follow-up simulator run also verified the combined foreground-resume path after fixing the simulator boot state.

What was not tested: physical iPhone visual recording was not captured in the PR proof; phone coverage was limited to patched build install/launch smoke.

Full sanitized logs:
- [Before simulator lifecycle log](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw-pr-92552/before-simulator.sanitized.log)
- [After simulator lifecycle log](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw-pr-92552/after-simulator.sanitized.log)
- [Forced lifecycle simulator log](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw-pr-92552/forced-stale-baseline.sanitized.log)
- [Gateway log slice](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw-pr-92552/gateway-log-slice.sanitized.log)

Sanitized simulator/gateway log proof:

```text
2026-06-12T23:15:35.481Z node app model: scene phase=active
2026-06-12T23:15:35.481Z app delegate: scene phase changed=active

2026-06-12T23:25:23.801Z node app model: scene phase=background
2026-06-12T23:25:23.801Z app delegate: scene phase changed=background
2026-06-12T23:25:39.897Z app delegate: scene phase changed=inactive
2026-06-12T23:25:40.126Z node app model: scene phase=active
2026-06-12T23:25:40.126Z app delegate: scene phase changed=active

⇄ res ✓ health 53ms conn=f08c8d0b…fcee id=71886D3F…AD73
⇄ res ✓ health 51ms conn=f08c8d0b…fcee id=389B75F2…C0F5
⇄ res ✓ health 60ms conn=f08c8d0b…fcee id=114CA404…D09E
```

Evidence after fix:
- Focused simulator tests passed: 74 passed, 0 failed.
- Patched simulator build/install/launch succeeded.
- Simulator GIF captured the foreground/background lifecycle returning to Gateway Online.
- Sanitized logs captured the app scene transitions and healthy gateway RPC responses during proof.
- Autoreview reported no accepted/actionable findings on the combined reliability + responsiveness patch.

## Verification

- XcodeBuildMCP `test_sim -only-testing:OpenClawTests/GatewayConnectionControllerTests -only-testing:OpenClawTests/NodeAppModelInvokeTests -only-testing:OpenClawTests/AppCoverageTests` -> 74 passed, 0 failed
- XcodeBuildMCP `build_run_sim` -> succeeded on iPhone 17 Pro Simulator
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings
- `git diff --check`
