### PR TITLE
feat(moonshot): add Kimi K2.7 Code support

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1748,7 +1748,7 @@ jobs:
             anthropic) require_any Anthropic ANTHROPIC_API_KEY ANTHROPIC_API_KEY_OLD ANTHROPIC_API_TOKEN ;;
             google) require_any Google GEMINI_API_KEY GOOGLE_API_KEY ;;
             minimax) require_any MiniMax MINIMAX_API_KEY ;;
-            moonshot) require_any Moonshot MOONSHOT_API_KEY ;;
+            moonshot) require_any Moonshot MOONSHOT_API_KEY KIMI_API_KEY ;;
             openai) require_any OpenAI OPENAI_API_KEY ;;
             opencode-go) require_any OpenCode OPENCODE_API_KEY OPENCODE_ZEN_API_KEY ;;
             openrouter) require_any OpenRouter OPENROUTER_API_KEY ;;
@@ -1923,7 +1923,7 @@ jobs:
               anthropic) require_any Anthropic ANTHROPIC_API_KEY ANTHROPIC_API_KEY_OLD ANTHROPIC_API_TOKEN ;;
               google) require_any Google GEMINI_API_KEY GOOGLE_API_KEY ;;
               minimax) require_any MiniMax MINIMAX_API_KEY ;;
-              moonshot) require_any Moonshot MOONSHOT_API_KEY ;;
+              moonshot) require_any Moonshot MOONSHOT_API_KEY KIMI_API_KEY ;;
               openai) require_any OpenAI OPENAI_API_KEY ;;
               opencode-go) require_any OpenCode OPENCODE_API_KEY OPENCODE_ZEN_API_KEY ;;
               openrouter) require_any OpenRouter OPENROUTER_API_KEY ;;

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1748,6 +1748,7 @@ jobs:
             anthropic) require_any Anthropic ANTHROPIC_API_KEY ANTHROPIC_API_KEY_OLD ANTHROPIC_API_TOKEN ;;
             google) require_any Google GEMINI_API_KEY GOOGLE_API_KEY ;;
             minimax) require_any MiniMax MINIMAX_API_KEY ;;
+            moonshot) require_any Moonshot MOONSHOT_API_KEY ;;
             openai) require_any OpenAI OPENAI_API_KEY ;;
             opencode-go) require_any OpenCode OPENCODE_API_KEY OPENCODE_ZEN_API_KEY ;;
             openrouter) require_any OpenRouter OPENROUTER_API_KEY ;;
@@ -1836,7 +1837,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          all_providers=(anthropic google minimax openai opencode-go openrouter xai zai fireworks)
+          all_providers=(anthropic google minimax moonshot openai opencode-go openrouter xai zai fireworks)
 
           normalize_provider() {
             local value="${1,,}"
@@ -1922,6 +1923,7 @@ jobs:
               anthropic) require_any Anthropic ANTHROPIC_API_KEY ANTHROPIC_API_KEY_OLD ANTHROPIC_API_TOKEN ;;
               google) require_any Google GEMINI_API_KEY GOOGLE_API_KEY ;;
               minimax) require_any MiniMax MINIMAX_API_KEY ;;
+              moonshot) require_any Moonshot MOONSHOT_API_KEY ;;
               openai) require_any OpenAI OPENAI_API_KEY ;;
               opencode-go) require_any OpenCode OPENCODE_API_KEY OPENCODE_ZEN_API_KEY ;;
               openrouter) require_any OpenRouter OPENROUTER_API_KEY ;;

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -368,6 +368,7 @@ Kimi K2 model IDs:
 [//]: # "moonshot-kimi-k2-model-refs:start"
 
 - `moonshot/kimi-k2.6`
+- `moonshot/kimi-k2.7-code`
 - `moonshot/kimi-k2.5`
 - `moonshot/kimi-k2-thinking`
 - `moonshot/kimi-k2-thinking-turbo`

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -22,6 +22,7 @@ Moonshot and Kimi Coding are **separate providers**. Keys are not interchangeabl
 | Model ref                         | Name                   | Reasoning | Input       | Context | Max output |
 | --------------------------------- | ---------------------- | --------- | ----------- | ------- | ---------- |
 | `moonshot/kimi-k2.6`              | Kimi K2.6              | No        | text, image | 262,144 | 262,144    |
+| `moonshot/kimi-k2.7-code`         | Kimi K2.7 Code         | Always on | text, image | 262,144 | 262,144    |
 | `moonshot/kimi-k2.5`              | Kimi K2.5              | No        | text, image | 262,144 | 262,144    |
 | `moonshot/kimi-k2-thinking`       | Kimi K2 Thinking       | Yes       | text        | 262,144 | 262,144    |
 | `moonshot/kimi-k2-thinking-turbo` | Kimi K2 Thinking Turbo | Yes       | text        | 262,144 | 262,144    |
@@ -30,10 +31,17 @@ Moonshot and Kimi Coding are **separate providers**. Keys are not interchangeabl
 [//]: # "moonshot-kimi-k2-ids:end"
 
 Bundled cost estimates for current Moonshot-hosted K2 models use Moonshot's
-published pay-as-you-go rates: Kimi K2.6 is $0.16/MTok cache hit,
+published pay-as-you-go rates: Kimi K2.7 Code is $0.19/MTok cache hit,
+$0.95/MTok input, and $4.00/MTok output; Kimi K2.6 is $0.16/MTok cache hit,
 $0.95/MTok input, and $4.00/MTok output; Kimi K2.5 is $0.10/MTok cache hit,
 $0.60/MTok input, and $3.00/MTok output. Other legacy catalog entries keep
 zero-cost placeholders unless you override them in config.
+
+Kimi K2.7 Code always uses native thinking. OpenClaw exposes only the `on`
+thinking state for this model and omits outbound `thinking` and
+`reasoning_effort` controls, as required by Moonshot. OpenClaw also omits
+sampling overrides that K2.7 fixes to provider defaults. Kimi K2.6 remains the
+onboarding default.
 
 ## Getting started
 
@@ -109,6 +117,7 @@ Choose your provider and follow the setup steps.
           models: {
             // moonshot-kimi-k2-aliases:start
             "moonshot/kimi-k2.6": { alias: "Kimi K2.6" },
+            "moonshot/kimi-k2.7-code": { alias: "Kimi K2.7 Code" },
             "moonshot/kimi-k2.5": { alias: "Kimi K2.5" },
             "moonshot/kimi-k2-thinking": { alias: "Kimi K2 Thinking" },
             "moonshot/kimi-k2-thinking-turbo": { alias: "Kimi K2 Thinking Turbo" },
@@ -132,6 +141,15 @@ Choose your provider and follow the setup steps.
                 reasoning: false,
                 input: ["text", "image"],
                 cost: { input: 0.95, output: 4, cacheRead: 0.16, cacheWrite: 0 },
+                contextWindow: 262144,
+                maxTokens: 262144,
+              },
+              {
+                id: "kimi-k2.7-code",
+                name: "Kimi K2.7 Code",
+                reasoning: true,
+                input: ["text", "image"],
+                cost: { input: 0.95, output: 4, cacheRead: 0.19, cacheWrite: 0 },
                 contextWindow: 262144,
                 maxTokens: 262144,
               },
@@ -288,7 +306,13 @@ Config lives under `plugins.entries.moonshot.config.webSearch`:
 
 <AccordionGroup>
   <Accordion title="Native thinking mode">
-    Moonshot Kimi supports binary native thinking:
+    Kimi K2.7 Code always uses native thinking. Moonshot requires clients to
+    omit the `thinking` field for this model, so OpenClaw exposes only `on` and
+    ignores stale `off` settings. K2.7 also fixes `temperature`, `top_p`, `n`,
+    `presence_penalty`, and `frequency_penalty`; OpenClaw omits configured
+    overrides for those fields.
+
+    Other Moonshot Kimi models support binary native thinking:
 
     - `thinking: { type: "enabled" }`
     - `thinking: { type: "disabled" }`
@@ -311,7 +335,7 @@ Config lives under `plugins.entries.moonshot.config.webSearch`:
     }
     ```
 
-    OpenClaw also maps runtime `/think` levels for Moonshot:
+    OpenClaw maps runtime `/think` levels for those models:
 
     | `/think` level       | Moonshot behavior          |
     | -------------------- | -------------------------- |
@@ -319,14 +343,16 @@ Config lives under `plugins.entries.moonshot.config.webSearch`:
     | Any non-off level    | `thinking.type=enabled`    |
 
     <Warning>
-    When Moonshot thinking is enabled, `tool_choice` must be `auto` or `none`. OpenClaw normalizes incompatible `tool_choice` values to `auto` for compatibility.
+    When Moonshot thinking is enabled, `tool_choice` must be `auto` or `none`. OpenClaw normalizes incompatible values to `auto`. This includes Kimi K2.7 Code, whose thinking mode cannot be disabled to preserve a pinned tool choice.
     </Warning>
 
     Kimi K2.6 also accepts an optional `thinking.keep` field that controls
     multi-turn retention of `reasoning_content`. Set it to `"all"` to keep full
     reasoning across turns; omit it (or leave it `null`) to use the server
     default strategy. OpenClaw only forwards `thinking.keep` for
-    `moonshot/kimi-k2.6` and strips it from other models.
+    `moonshot/kimi-k2.6` and strips it from other models. Kimi K2.7 Code
+    preserves full reasoning history by default while OpenClaw omits the entire
+    `thinking` field.
 
     ```json5
     {

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -35,7 +35,7 @@ title: "Thinking levels"
   - Google Gemini maps `/think adaptive` to Gemini's provider-owned dynamic thinking. Gemini 3 requests omit a fixed `thinkingLevel`, while Gemini 2.5 requests send `thinkingBudget: -1`; fixed levels still map to the closest Gemini `thinkingLevel` or budget for that model family.
   - MiniMax M2.x (`minimax/MiniMax-M2*`) on the Anthropic-compatible streaming path defaults to `thinking: { type: "disabled" }` unless you explicitly set thinking in model params or request params. This avoids leaked `reasoning_content` deltas from M2.x's non-native Anthropic stream format. MiniMax-M3 (and M3.x) is exempt: M3 emits proper Anthropic thinking blocks and returns empty content when thinking is disabled, so OpenClaw keeps M3 on the provider's omitted/adaptive thinking path.
   - Z.AI (`zai/*`) only supports binary thinking (`on`/`off`). Any non-`off` level is treated as `on` (mapped to `low`).
-  - Moonshot (`moonshot/*`) maps `/think off` to `thinking: { type: "disabled" }` and any non-`off` level to `thinking: { type: "enabled" }`. When thinking is enabled, Moonshot only accepts `tool_choice` `auto|none`; OpenClaw normalizes incompatible values to `auto`.
+  - Moonshot Kimi K2.7 Code (`moonshot/kimi-k2.7-code`) always thinks. Its profile exposes only `on`, and OpenClaw omits the outbound `thinking` field as required by Moonshot. Other `moonshot/*` models map `/think off` to `thinking: { type: "disabled" }` and any non-`off` level to `thinking: { type: "enabled" }`. When thinking is enabled, Moonshot only accepts `tool_choice` `auto|none`; OpenClaw normalizes incompatible values to `auto`.
 
 ## Resolution order
 

--- a/extensions/moonshot/index.test.ts
+++ b/extensions/moonshot/index.test.ts
@@ -89,4 +89,60 @@ describe("moonshot provider plugin", () => {
       thinking: { type: "disabled" },
     });
   });
+
+  it("keeps Kimi K2.7 Code thinking always on without sending a thinking field", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const capturedStream = createCapturedThinkingConfigStream();
+
+    const wrapped = provider.wrapSimpleCompletionStreamFn?.({
+      provider: "moonshot",
+      modelId: "kimi-k2.7-code",
+      thinkingLevel: "off",
+      streamFn: capturedStream.streamFn,
+    } as never);
+
+    void wrapped?.(
+      {
+        api: "openai-completions",
+        provider: "moonshot",
+        id: "kimi-k2.7-code",
+      } as Model<"openai-completions">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(capturedStream.getCapturedPayload()).toEqual({
+      config: { thinkingConfig: { thinkingBudget: -1 } },
+    });
+    expect(
+      provider.wrapSimpleCompletionStreamFn?.({
+        provider: "moonshot",
+        modelId: "kimi-k2.6",
+        streamFn: capturedStream.streamFn,
+      } as never),
+    ).toBe(capturedStream.streamFn);
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "moonshot",
+        modelId: "kimi-k2.7-code",
+        reasoning: true,
+      } as never),
+    ).toEqual({
+      levels: [{ id: "low", label: "on" }],
+      defaultLevel: "low",
+      preserveWhenCatalogReasoningFalse: true,
+    });
+    expect(
+      provider.isModernModelRef?.({
+        provider: "moonshot",
+        modelId: "kimi-k2.7-code",
+      }),
+    ).toBe(true);
+    expect(
+      provider.isModernModelRef?.({
+        provider: "moonshot",
+        modelId: "kimi-k2.6",
+      }),
+    ).toBe(false);
+  });
 });

--- a/extensions/moonshot/index.ts
+++ b/extensions/moonshot/index.ts
@@ -10,9 +10,11 @@ import {
   MOONSHOT_DEFAULT_MODEL_REF,
 } from "./onboard.js";
 import { buildMoonshotProvider } from "./provider-catalog.js";
+import { KIMI_K2_7_CODE_MODEL_ID, resolveThinkingProfile } from "./provider-policy-api.js";
 import { createKimiWebSearchProvider } from "./src/kimi-web-search-provider.js";
 
 const PROVIDER_ID = "moonshot";
+const moonshotThinkingStreamHooks = MOONSHOT_THINKING_STREAM_HOOKS;
 
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
@@ -67,14 +69,13 @@ export default defineSingleProviderPluginEntry({
       sanitizeToolCallIds: false,
       dropReasoningFromHistory: false,
     }),
-    ...MOONSHOT_THINKING_STREAM_HOOKS,
-    resolveThinkingProfile: () => ({
-      levels: [
-        { id: "off", label: "off" },
-        { id: "low", label: "on" },
-      ],
-      defaultLevel: "off",
-    }),
+    ...moonshotThinkingStreamHooks,
+    wrapSimpleCompletionStreamFn: (ctx) =>
+      ctx.modelId.trim().toLowerCase() === KIMI_K2_7_CODE_MODEL_ID
+        ? moonshotThinkingStreamHooks.wrapStreamFn?.(ctx)
+        : ctx.streamFn,
+    resolveThinkingProfile,
+    isModernModelRef: ({ modelId }) => modelId.trim().toLowerCase() === KIMI_K2_7_CODE_MODEL_ID,
   },
   register(api) {
     api.registerMediaUnderstandingProvider(moonshotMediaUnderstandingProvider);

--- a/extensions/moonshot/moonshot.live.test.ts
+++ b/extensions/moonshot/moonshot.live.test.ts
@@ -11,7 +11,7 @@ import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-env";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
-import { buildMoonshotProvider } from "./provider-catalog.js";
+import { buildMoonshotProvider, MOONSHOT_CN_BASE_URL } from "./provider-catalog.js";
 import { createKimiWebSearchProvider } from "./src/kimi-web-search-provider.js";
 
 const KIMI_SEARCH_KEY =
@@ -33,16 +33,30 @@ function isTransientKimiSearchError(error: unknown): boolean {
   return message.includes("timeout") || message.includes("aborted");
 }
 
-function isKimiAuthDrift(error: unknown): boolean {
+function isMoonshotAuthDrift(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
   }
   const message = error.message.toLowerCase();
   return (
-    message.includes("kimi api error (401)") &&
-    (message.includes("incorrect api key") || message.includes("incorrect_api_key"))
+    message.includes("401") &&
+    (message.includes("incorrect api key") ||
+      message.includes("incorrect_api_key") ||
+      message.includes("invalid authentication") ||
+      message.includes("invalid_authentication_error"))
   );
 }
+
+describe("moonshot live auth drift detection", () => {
+  it.each([
+    ["401 Incorrect API key provided", true],
+    ["401 invalid_authentication_error: Invalid Authentication", true],
+    ["401 Permission denied", false],
+    ["400 Incorrect API key provided", false],
+  ])("classifies %s", (message, expected) => {
+    expect(isMoonshotAuthDrift(new Error(message))).toBe(expected);
+  });
+});
 
 describeLive("moonshot plugin live", () => {
   it("runs Kimi web search through the provider tool", async () => {
@@ -65,7 +79,7 @@ describeLive("moonshot plugin live", () => {
         break;
       } catch (error) {
         lastError = error;
-        if (isKimiAuthDrift(error)) {
+        if (isMoonshotAuthDrift(error)) {
           console.warn("[moonshot:live] skip Kimi web search: auth drift");
           return;
         }
@@ -85,18 +99,19 @@ describeLive("moonshot plugin live", () => {
   }, 180_000);
 });
 
-function resolveKimiK27CodeModel(): Model<"openai-completions"> {
+function resolveKimiK27CodeModels(): Model<"openai-completions">[] {
   const provider = buildMoonshotProvider();
   const model = provider.models.find((entry) => entry.id === "kimi-k2.7-code");
   if (!model) {
     throw new Error("Moonshot catalog does not include kimi-k2.7-code");
   }
-  return {
+  const defaultModel = {
     provider: "moonshot",
     baseUrl: provider.baseUrl,
     ...model,
     api: "openai-completions",
   } as Model<"openai-completions">;
+  return [defaultModel, { ...defaultModel, baseUrl: MOONSHOT_CN_BASE_URL }];
 }
 
 function createNoopTool(): Tool {
@@ -139,92 +154,111 @@ describeModelLive("moonshot K2.7 Code live", () => {
       throw new Error("Moonshot provider did not register a stream wrapper");
     }
 
-    const model = resolveKimiK27CodeModel();
     const tool = createNoopTool();
     const firstUser = {
       role: "user" as const,
       content: "Call the noop tool with {}. Do not answer directly.",
       timestamp: Date.now(),
     };
-    let firstPayload: Record<string, unknown> | undefined;
-    const first = await collectDoneMessage(
-      wrappedStream(
-        model,
-        { messages: [firstUser], tools: [tool] },
-        {
+
+    const runScenario = async (model: Model<"openai-completions">) => {
+      let firstPayload: Record<string, unknown> | undefined;
+      const first = await collectDoneMessage(
+        wrappedStream(
+          model,
+          { messages: [firstUser], tools: [tool] },
+          {
+            apiKey: MOONSHOT_API_KEY,
+            maxTokens: 16_000,
+            temperature: 0,
+            onPayload: (payload) => {
+              firstPayload = payload as Record<string, unknown>;
+            },
+          },
+        ) as AsyncIterable<{
+          type: string;
+          message?: AssistantMessage;
+          error?: AssistantMessage;
+        }>,
+      );
+
+      expect(firstPayload).toBeDefined();
+      expect(firstPayload).not.toHaveProperty("thinking");
+      expect(firstPayload).not.toHaveProperty("reasoning_effort");
+      expect(firstPayload).not.toHaveProperty("temperature");
+      const reasoning = first.content.find((block) => block.type === "thinking");
+      if (!reasoning || reasoning.type !== "thinking" || reasoning.thinking.length === 0) {
+        throw new Error("Moonshot K2.7 Code did not return captured reasoning");
+      }
+      const toolCall = first.content.find((block) => block.type === "toolCall");
+      if (!toolCall || toolCall.type !== "toolCall") {
+        throw new Error(`Moonshot K2.7 Code did not call noop: ${first.stopReason}`);
+      }
+      expect(toolCall.name).toBe("noop");
+
+      let secondPayload: Record<string, unknown> | undefined;
+      const replayContext: Context = {
+        messages: [
+          firstUser,
+          first,
+          {
+            role: "toolResult",
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+            timestamp: Date.now(),
+          },
+          {
+            role: "user",
+            content: "Reply with exactly: ok",
+            timestamp: Date.now(),
+          },
+        ],
+        tools: [tool],
+      };
+      const second = await collectDoneMessage(
+        wrappedStream(model, replayContext, {
           apiKey: MOONSHOT_API_KEY,
           maxTokens: 16_000,
           temperature: 0,
           onPayload: (payload) => {
-            firstPayload = payload as Record<string, unknown>;
+            secondPayload = payload as Record<string, unknown>;
           },
-        },
-      ) as AsyncIterable<{
-        type: string;
-        message?: AssistantMessage;
-        error?: AssistantMessage;
-      }>,
-    );
+        }) as AsyncIterable<{
+          type: string;
+          message?: AssistantMessage;
+          error?: AssistantMessage;
+        }>,
+      );
 
-    expect(firstPayload).toBeDefined();
-    expect(firstPayload).not.toHaveProperty("thinking");
-    expect(firstPayload).not.toHaveProperty("reasoning_effort");
-    expect(firstPayload).not.toHaveProperty("temperature");
-    const reasoning = first.content.find((block) => block.type === "thinking");
-    if (!reasoning || reasoning.type !== "thinking" || reasoning.thinking.length === 0) {
-      throw new Error("Moonshot K2.7 Code did not return captured reasoning");
-    }
-    const toolCall = first.content.find((block) => block.type === "toolCall");
-    if (!toolCall || toolCall.type !== "toolCall") {
-      throw new Error(`Moonshot K2.7 Code did not call noop: ${first.stopReason}`);
-    }
-    expect(toolCall.name).toBe("noop");
-
-    let secondPayload: Record<string, unknown> | undefined;
-    const replayContext: Context = {
-      messages: [
-        firstUser,
-        first,
-        {
-          role: "toolResult",
-          toolCallId: toolCall.id,
-          toolName: toolCall.name,
-          content: [{ type: "text", text: "ok" }],
-          isError: false,
-          timestamp: Date.now(),
-        },
-        {
-          role: "user",
-          content: "Reply with exactly: ok",
-          timestamp: Date.now(),
-        },
-      ],
-      tools: [tool],
+      expect(secondPayload).toBeDefined();
+      expect(secondPayload).not.toHaveProperty("thinking");
+      expect(secondPayload).not.toHaveProperty("reasoning_effort");
+      expect(secondPayload).not.toHaveProperty("temperature");
+      const text = second.content
+        .filter((block) => block.type === "text")
+        .map((block) => block.text.trim())
+        .join(" ");
+      expect(text).toMatch(/^ok[.!]?$/i);
     };
-    const second = await collectDoneMessage(
-      wrappedStream(model, replayContext, {
-        apiKey: MOONSHOT_API_KEY,
-        maxTokens: 16_000,
-        temperature: 0,
-        onPayload: (payload) => {
-          secondPayload = payload as Record<string, unknown>;
-        },
-      }) as AsyncIterable<{
-        type: string;
-        message?: AssistantMessage;
-        error?: AssistantMessage;
-      }>,
-    );
 
-    expect(secondPayload).toBeDefined();
-    expect(secondPayload).not.toHaveProperty("thinking");
-    expect(secondPayload).not.toHaveProperty("reasoning_effort");
-    expect(secondPayload).not.toHaveProperty("temperature");
-    const text = second.content
-      .filter((block) => block.type === "text")
-      .map((block) => block.text.trim())
-      .join(" ");
-    expect(text).toMatch(/^ok[.!]?$/i);
+    let lastAuthError: unknown;
+    for (const model of resolveKimiK27CodeModels()) {
+      try {
+        await runScenario(model);
+        return;
+      } catch (error) {
+        if (!isMoonshotAuthDrift(error)) {
+          throw error;
+        }
+        lastAuthError = error;
+      }
+    }
+    throw toLintErrorObject(
+      lastAuthError,
+      "Moonshot K2.7 Code rejected the API key in both regions",
+    );
   }, 180_000);
 });
 

--- a/extensions/moonshot/moonshot.live.test.ts
+++ b/extensions/moonshot/moonshot.live.test.ts
@@ -108,10 +108,13 @@ function createNoopTool(): Tool {
 }
 
 async function collectDoneMessage(
-  stream: AsyncIterable<{ type: string; message?: AssistantMessage }>,
+  stream: AsyncIterable<{ type: string; message?: AssistantMessage; error?: AssistantMessage }>,
 ): Promise<AssistantMessage> {
   let doneMessage: AssistantMessage | undefined;
   for await (const event of stream) {
+    if (event.type === "error") {
+      throw new Error(event.error?.errorMessage || "Moonshot K2.7 live request failed");
+    }
     if (event.type === "done") {
       doneMessage = event.message;
     }
@@ -156,7 +159,11 @@ describeModelLive("moonshot K2.7 Code live", () => {
             firstPayload = payload as Record<string, unknown>;
           },
         },
-      ) as AsyncIterable<{ type: string; message?: AssistantMessage }>,
+      ) as AsyncIterable<{
+        type: string;
+        message?: AssistantMessage;
+        error?: AssistantMessage;
+      }>,
     );
 
     expect(firstPayload).toBeDefined();
@@ -202,7 +209,11 @@ describeModelLive("moonshot K2.7 Code live", () => {
         onPayload: (payload) => {
           secondPayload = payload as Record<string, unknown>;
         },
-      }) as AsyncIterable<{ type: string; message?: AssistantMessage }>,
+      }) as AsyncIterable<{
+        type: string;
+        message?: AssistantMessage;
+        error?: AssistantMessage;
+      }>,
     );
 
     expect(secondPayload).toBeDefined();

--- a/extensions/moonshot/moonshot.live.test.ts
+++ b/extensions/moonshot/moonshot.live.test.ts
@@ -1,11 +1,25 @@
 // Moonshot tests cover moonshot plugin behavior.
+import {
+  streamSimple,
+  type AssistantMessage,
+  type Context,
+  type Model,
+  type Tool,
+} from "openclaw/plugin-sdk/llm";
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-env";
+import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+import { buildMoonshotProvider } from "./provider-catalog.js";
 import { createKimiWebSearchProvider } from "./src/kimi-web-search-provider.js";
 
 const KIMI_SEARCH_KEY =
   process.env.KIMI_API_KEY?.trim() || process.env.MOONSHOT_API_KEY?.trim() || "";
+const MOONSHOT_API_KEY = process.env.MOONSHOT_API_KEY?.trim() || "";
 const describeLive = isLiveTestEnabled() && KIMI_SEARCH_KEY.length > 0 ? describe : describe.skip;
+const describeModelLive =
+  isLiveTestEnabled() && MOONSHOT_API_KEY.length > 0 ? describe : describe.skip;
 const KIMI_LIVE_SEARCH_TIMEOUT_SECONDS = 60;
 
 function isTransientKimiSearchError(error: unknown): boolean {
@@ -68,6 +82,138 @@ describeLive("moonshot plugin live", () => {
     expect(typeof result?.content).toBe("string");
     expect((result!.content as string).length).toBeGreaterThan(20);
     expect(Array.isArray(result?.citations)).toBe(true);
+  }, 180_000);
+});
+
+function resolveKimiK27CodeModel(): Model<"openai-completions"> {
+  const provider = buildMoonshotProvider();
+  const model = provider.models.find((entry) => entry.id === "kimi-k2.7-code");
+  if (!model) {
+    throw new Error("Moonshot catalog does not include kimi-k2.7-code");
+  }
+  return {
+    provider: "moonshot",
+    baseUrl: provider.baseUrl,
+    ...model,
+    api: "openai-completions",
+  } as Model<"openai-completions">;
+}
+
+function createNoopTool(): Tool {
+  return {
+    name: "noop",
+    description: "Return ok.",
+    parameters: Type.Object({}, { additionalProperties: false }),
+  };
+}
+
+async function collectDoneMessage(
+  stream: AsyncIterable<{ type: string; message?: AssistantMessage }>,
+): Promise<AssistantMessage> {
+  let doneMessage: AssistantMessage | undefined;
+  for await (const event of stream) {
+    if (event.type === "done") {
+      doneMessage = event.message;
+    }
+  }
+  if (!doneMessage) {
+    throw new Error("Moonshot K2.7 live stream ended without a done message");
+  }
+  return doneMessage;
+}
+
+describeModelLive("moonshot K2.7 Code live", () => {
+  it("omits thinking controls and completes a replayed tool turn", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const wrappedStream = provider.wrapStreamFn?.({
+      provider: "moonshot",
+      modelId: "kimi-k2.7-code",
+      thinkingLevel: "off",
+      extraParams: { thinking: { type: "disabled", keep: "all" } },
+      streamFn: streamSimple,
+    } as never);
+    if (!wrappedStream) {
+      throw new Error("Moonshot provider did not register a stream wrapper");
+    }
+
+    const model = resolveKimiK27CodeModel();
+    const tool = createNoopTool();
+    const firstUser = {
+      role: "user" as const,
+      content: "Call the noop tool with {}. Do not answer directly.",
+      timestamp: Date.now(),
+    };
+    let firstPayload: Record<string, unknown> | undefined;
+    const first = await collectDoneMessage(
+      wrappedStream(
+        model,
+        { messages: [firstUser], tools: [tool] },
+        {
+          apiKey: MOONSHOT_API_KEY,
+          maxTokens: 16_000,
+          temperature: 0,
+          onPayload: (payload) => {
+            firstPayload = payload as Record<string, unknown>;
+          },
+        },
+      ) as AsyncIterable<{ type: string; message?: AssistantMessage }>,
+    );
+
+    expect(firstPayload).toBeDefined();
+    expect(firstPayload).not.toHaveProperty("thinking");
+    expect(firstPayload).not.toHaveProperty("reasoning_effort");
+    expect(firstPayload).not.toHaveProperty("temperature");
+    const reasoning = first.content.find((block) => block.type === "thinking");
+    if (!reasoning || reasoning.type !== "thinking" || reasoning.thinking.length === 0) {
+      throw new Error("Moonshot K2.7 Code did not return captured reasoning");
+    }
+    const toolCall = first.content.find((block) => block.type === "toolCall");
+    if (!toolCall || toolCall.type !== "toolCall") {
+      throw new Error(`Moonshot K2.7 Code did not call noop: ${first.stopReason}`);
+    }
+    expect(toolCall.name).toBe("noop");
+
+    let secondPayload: Record<string, unknown> | undefined;
+    const replayContext: Context = {
+      messages: [
+        firstUser,
+        first,
+        {
+          role: "toolResult",
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+          timestamp: Date.now(),
+        },
+        {
+          role: "user",
+          content: "Reply with exactly: ok",
+          timestamp: Date.now(),
+        },
+      ],
+      tools: [tool],
+    };
+    const second = await collectDoneMessage(
+      wrappedStream(model, replayContext, {
+        apiKey: MOONSHOT_API_KEY,
+        maxTokens: 16_000,
+        temperature: 0,
+        onPayload: (payload) => {
+          secondPayload = payload as Record<string, unknown>;
+        },
+      }) as AsyncIterable<{ type: string; message?: AssistantMessage }>,
+    );
+
+    expect(secondPayload).toBeDefined();
+    expect(secondPayload).not.toHaveProperty("thinking");
+    expect(secondPayload).not.toHaveProperty("reasoning_effort");
+    expect(secondPayload).not.toHaveProperty("temperature");
+    const text = second.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text.trim())
+      .join(" ");
+    expect(text).toMatch(/^ok[.!]?$/i);
   }, 180_000);
 });
 

--- a/extensions/moonshot/openclaw.plugin.json
+++ b/extensions/moonshot/openclaw.plugin.json
@@ -64,6 +64,20 @@
             }
           },
           {
+            "id": "kimi-k2.7-code",
+            "name": "Kimi K2.7 Code",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 262144,
+            "cost": {
+              "input": 0.95,
+              "output": 4,
+              "cacheRead": 0.19,
+              "cacheWrite": 0
+            }
+          },
+          {
             "id": "kimi-k2.5",
             "name": "Kimi K2.5",
             "input": ["text", "image"],

--- a/extensions/moonshot/provider-catalog.test.ts
+++ b/extensions/moonshot/provider-catalog.test.ts
@@ -41,6 +41,7 @@ describe("moonshot provider catalog", () => {
     expect(provider.api).toBe("openai-completions");
     expect(provider.models.map((model) => model.id)).toEqual([
       "kimi-k2.6",
+      "kimi-k2.7-code",
       "kimi-k2.5",
       "kimi-k2-thinking",
       "kimi-k2-thinking-turbo",
@@ -51,6 +52,18 @@ describe("moonshot provider catalog", () => {
       output: 4,
       cacheRead: 0.16,
       cacheWrite: 0,
+    });
+    expect(requireMoonshotModel(provider, "kimi-k2.7-code")).toMatchObject({
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 262144,
+      maxTokens: 262144,
+      cost: {
+        input: 0.95,
+        output: 4,
+        cacheRead: 0.19,
+        cacheWrite: 0,
+      },
     });
     expect(requireMoonshotModel(provider, "kimi-k2.5").cost).toEqual({
       input: 0.6,

--- a/extensions/moonshot/provider-policy-api.ts
+++ b/extensions/moonshot/provider-policy-api.ts
@@ -1,0 +1,21 @@
+// Moonshot policy module exposes model-specific thinking controls before runtime registration.
+import type { ProviderDefaultThinkingPolicyContext } from "openclaw/plugin-sdk/core";
+
+export const KIMI_K2_7_CODE_MODEL_ID = "kimi-k2.7-code";
+
+export function resolveThinkingProfile(context: ProviderDefaultThinkingPolicyContext) {
+  if (context.modelId.trim().toLowerCase() === KIMI_K2_7_CODE_MODEL_ID) {
+    return {
+      levels: [{ id: "low" as const, label: "on" }],
+      defaultLevel: "low" as const,
+      preserveWhenCatalogReasoningFalse: true,
+    };
+  }
+  return {
+    levels: [
+      { id: "off" as const, label: "off" },
+      { id: "low" as const, label: "on" },
+    ],
+    defaultLevel: "off" as const,
+  };
+}

--- a/scripts/plan-release-workflow-matrix.mjs
+++ b/scripts/plan-release-workflow-matrix.mjs
@@ -103,6 +103,11 @@ const LIVE_MODEL_PROVIDERS = [
     profiles: "stable full",
   },
   {
+    provider_label: "Moonshot",
+    providers: "moonshot",
+    profiles: "full",
+  },
+  {
     provider_label: "OpenAI",
     providers: "openai",
     profiles: "beta minimum stable full",

--- a/src/agents/embedded-agent-runner-extraparams-moonshot.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams-moonshot.test.ts
@@ -178,4 +178,47 @@ describe("applyExtraParamsToAgent Moonshot", () => {
 
     expect(payload.thinking).toEqual({ type: "disabled" });
   });
+
+  it("omits thinking controls and broadens pinned tool choice for kimi-k2.7-code", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "moonshot",
+      modelId: "kimi-k2.7-code",
+      thinkingLevel: "off",
+      payload: {
+        model: "kimi-k2.7-code",
+      },
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "moonshot/kimi-k2.7-code": {
+                params: {
+                  thinking: { type: "disabled", keep: "all" },
+                  extra_body: {
+                    thinking: { type: "disabled", keep: "all" },
+                    reasoning_effort: "low",
+                    tool_choice: { type: "tool", name: "read" },
+                    temperature: 0,
+                    top_p: 0.5,
+                    n: 2,
+                    presence_penalty: 1,
+                    frequency_penalty: 1,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(payload).not.toHaveProperty("thinking");
+    expect(payload).not.toHaveProperty("reasoning_effort");
+    expect(payload.tool_choice).toBe("auto");
+    expect(payload).not.toHaveProperty("temperature");
+    expect(payload).not.toHaveProperty("top_p");
+    expect(payload).not.toHaveProperty("n");
+    expect(payload).not.toHaveProperty("presence_penalty");
+    expect(payload).not.toHaveProperty("frequency_penalty");
+  });
 });

--- a/src/agents/live-model-filter.test.ts
+++ b/src/agents/live-model-filter.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+  listPrioritizedHighSignalLiveModelRefs,
   resolveHighSignalLiveModelLimit,
   shouldExcludeProviderFromDefaultHighSignalLiveSweep,
 } from "./live-model-filter.js";
@@ -108,5 +109,14 @@ describe("resolveHighSignalLiveModelLimit", () => {
         defaultLimit: 5,
       }),
     ).toBe(0);
+  });
+});
+
+describe("live model priorities", () => {
+  it("includes the always-thinking Moonshot K2.7 Code route", () => {
+    expect(listPrioritizedHighSignalLiveModelRefs()).toContainEqual({
+      provider: "moonshot",
+      id: "kimi-k2.7-code",
+    });
   });
 });

--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -21,6 +21,7 @@ const HIGH_SIGNAL_LIVE_MODEL_PRIORITY = [
   "anthropic/claude-opus-4-7",
   "google/gemini-3.1-pro-preview",
   "google/gemini-3-flash-preview",
+  "moonshot/kimi-k2.7-code",
   "anthropic/claude-opus-4-6",
   "deepseek/deepseek-v4-flash",
   "deepseek/deepseek-v4-pro",

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -658,6 +658,7 @@ describe("isPrioritizedHighSignalLiveModelRef", () => {
       { provider: "anthropic", id: "claude-opus-4-7" },
       { provider: "google", id: "gemini-3.1-pro-preview" },
       { provider: "google", id: "gemini-3-flash-preview" },
+      { provider: "moonshot", id: "kimi-k2.7-code" },
       { provider: "anthropic", id: "claude-opus-4-6" },
       { provider: "deepseek", id: "deepseek-v4-flash" },
       { provider: "deepseek", id: "deepseek-v4-pro" },

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -10056,6 +10056,15 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
     maxTokens: 32_000,
   } satisfies Model<"openai-completions">;
 
+  const staleKimiK27Model = {
+    ...customKimiProxyModel,
+    id: "kimi-k2.7-code",
+    name: "Kimi K2.7 Code",
+    provider: "moonshot",
+    baseUrl: "https://api.moonshot.ai/v1",
+    reasoning: false,
+  } satisfies Model<"openai-completions">;
+
   const customQwenReasoningModel = {
     id: "Qwen3.6-35B-A3B",
     name: "Qwen3.6 35B",
@@ -10312,6 +10321,17 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
   it("preserves reasoning_content replay for custom Kimi K2 proxy routes", () => {
     const assistant = getAssistantMessage(
       buildReplayParams(customKimiProxyModel, "reasoning_content"),
+    );
+
+    expect(assistant.reasoning_content).toBe("Need to answer politely.");
+    expect(assistant).not.toHaveProperty("reasoning_details");
+    expect(assistant).not.toHaveProperty("reasoning");
+    expect(assistant).not.toHaveProperty("reasoning_text");
+  });
+
+  it("preserves Kimi K2.7 reasoning_content replay with stale reasoning metadata", () => {
+    const assistant = getAssistantMessage(
+      buildReplayParams(staleKimiK27Model, "reasoning_content"),
     );
 
     expect(assistant.reasoning_content).toBe("Need to answer politely.");

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3947,6 +3947,7 @@ const REASONING_CONTENT_REPLAY_MODEL_IDS = new Set([
   "kimi-for-coding",
   "kimi-k2.5",
   "kimi-k2.6",
+  "kimi-k2.7-code",
   "kimi-k2-thinking",
   "kimi-k2-thinking-turbo",
   "mimo-v2-pro",

--- a/src/agents/simple-completion-transport.test.ts
+++ b/src/agents/simple-completion-transport.test.ts
@@ -1,12 +1,15 @@
 // Simple completion transport tests cover provider-specific stream alias
 // selection before the generic completion helper invokes the LLM layer.
 import type { Model } from "openclaw/plugin-sdk/llm";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { registerApiProvider, unregisterApiProviders } from "../llm/api-registry.js";
+import { createMoonshotThinkingWrapper } from "../llm/providers/stream-wrappers/moonshot-thinking.js";
 
 const createAnthropicVertexStreamFnForModel = vi.fn();
 const ensureCustomApiRegistered = vi.fn();
 const resolveProviderStreamFn = vi.fn();
+const wrapProviderSimpleCompletionStreamFn = vi.fn();
 const buildTransportAwareSimpleStreamFn = vi.fn();
 const createOpenClawTransportStreamFnForModel = vi.fn();
 const createTransportAwareStreamFnForModel = vi.fn();
@@ -41,10 +44,12 @@ vi.mock("../plugins/provider-runtime.js", async () => {
   return {
     ...actual,
     resolveProviderStreamFn,
+    wrapProviderSimpleCompletionStreamFn,
   };
 });
 
 let prepareModelForSimpleCompletion: typeof import("./simple-completion-transport.js").prepareModelForSimpleCompletion;
+const SIMPLE_COMPLETION_SOURCE_ID = "test:simple-completion-transport";
 
 describe("prepareModelForSimpleCompletion", () => {
   beforeAll(async () => {
@@ -57,6 +62,7 @@ describe("prepareModelForSimpleCompletion", () => {
     createAnthropicVertexStreamFnForModel.mockReset();
     ensureCustomApiRegistered.mockReset();
     resolveProviderStreamFn.mockReset();
+    wrapProviderSimpleCompletionStreamFn.mockReset();
     buildTransportAwareSimpleStreamFn.mockReset();
     createOpenClawTransportStreamFnForModel.mockReset();
     createTransportAwareStreamFnForModel.mockReset();
@@ -65,12 +71,74 @@ describe("prepareModelForSimpleCompletion", () => {
     prepareGoogleSimpleCompletionModel.mockReset();
     createAnthropicVertexStreamFnForModel.mockReturnValue("vertex-stream");
     resolveProviderStreamFn.mockReturnValue("ollama-stream");
+    wrapProviderSimpleCompletionStreamFn.mockReturnValue(undefined);
     buildTransportAwareSimpleStreamFn.mockReturnValue(undefined);
     createOpenClawTransportStreamFnForModel.mockReturnValue(undefined);
     createTransportAwareStreamFnForModel.mockReturnValue(undefined);
     prepareTransportAwareSimpleModel.mockImplementation((model) => model);
     resolveTransportAwareSimpleApi.mockReturnValue(undefined);
     prepareGoogleSimpleCompletionModel.mockImplementation((model) => model);
+  });
+
+  afterEach(() => {
+    unregisterApiProviders(SIMPLE_COMPLETION_SOURCE_ID);
+  });
+
+  it("routes provider-owned simple-completion wrappers through an internal API alias", () => {
+    const sourceApi = "moonshot-simple-source";
+    const sourceResult = { source: true };
+    let capturedApi: string | undefined;
+    registerApiProvider(
+      {
+        api: sourceApi,
+        stream: () => sourceResult as never,
+        streamSimple: (runtimeModel) => {
+          capturedApi = runtimeModel.api;
+          return sourceResult as never;
+        },
+      },
+      SIMPLE_COMPLETION_SOURCE_ID,
+    );
+    wrapProviderSimpleCompletionStreamFn.mockImplementationOnce(({ context }) =>
+      createMoonshotThinkingWrapper(context.streamFn),
+    );
+    const model: Model = {
+      id: "kimi-k2.7-code",
+      name: "Kimi K2.7 Code",
+      api: sourceApi,
+      provider: "moonshot",
+      baseUrl: "https://api.moonshot.ai/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0.95, output: 4, cacheRead: 0.19, cacheWrite: 0 },
+      contextWindow: 262_144,
+      maxTokens: 262_144,
+    };
+
+    const result = prepareModelForSimpleCompletion({ model });
+
+    expect(wrapProviderSimpleCompletionStreamFn).toHaveBeenCalledTimes(1);
+    expect(wrapProviderSimpleCompletionStreamFn.mock.results[0]?.value).toBeTypeOf("function");
+    expect(result.api).toBe(
+      "openclaw-provider-simple:moonshot:kimi-k2.7-code:moonshot-simple-source:https%3A%2F%2Fapi.moonshot.ai%2Fv1",
+    );
+    expect(wrapProviderSimpleCompletionStreamFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "moonshot",
+        context: expect.objectContaining({
+          provider: "moonshot",
+          modelId: "kimi-k2.7-code",
+          model,
+          streamFn: expect.any(Function),
+        }),
+      }),
+    );
+    const registeredStream = ensureCustomApiRegistered.mock.calls.at(-1)?.[1];
+    expect(registeredStream).toBeTypeOf("function");
+    const stream = registeredStream(result, { messages: [] }, {});
+    expect(stream).toBe(sourceResult);
+    expect(stream).not.toBeInstanceOf(Promise);
+    expect(capturedApi).toBe(sourceApi);
   });
 
   it("registers the configured Ollama transport and keeps the original api", () => {

--- a/src/agents/simple-completion-transport.ts
+++ b/src/agents/simple-completion-transport.ts
@@ -6,6 +6,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getApiProvider } from "../llm/api-registry.js";
 import type { Api, Model } from "../llm/types.js";
+import { wrapProviderSimpleCompletionStreamFn } from "../plugins/provider-runtime.js";
 import { createAnthropicVertexStreamFnForModel } from "./anthropic-vertex-stream.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
 import { prepareGoogleSimpleCompletionModel } from "./google-simple-completion-stream.js";
@@ -16,6 +17,9 @@ import {
   prepareTransportAwareSimpleModel,
   resolveTransportAwareSimpleApi,
 } from "./provider-transport-stream.js";
+import type { StreamFn } from "./runtime/index.js";
+
+const PROVIDER_SIMPLE_COMPLETION_API_PREFIX = "openclaw-provider-simple:";
 
 function resolveAnthropicVertexSimpleApi(baseUrl?: string): Api {
   const suffix = baseUrl?.trim() ? encodeURIComponent(baseUrl.trim()) : "default";
@@ -54,6 +58,45 @@ function normalizeCodexResponsesBaseUrlForOpenAISdk(baseUrl?: string): string {
   return `${normalized}/codex`;
 }
 
+function resolveProviderSimpleCompletionApi(model: Model): Api {
+  const parts = [model.provider, model.id, model.api, model.baseUrl || "default"];
+  return `${PROVIDER_SIMPLE_COMPLETION_API_PREFIX}${parts
+    .map((part) => encodeURIComponent(part))
+    .join(":")}`;
+}
+
+function applyProviderSimpleCompletionWrapper(model: Model, cfg?: OpenClawConfig): Model {
+  if (model.api.startsWith(PROVIDER_SIMPLE_COMPLETION_API_PREFIX)) {
+    return model;
+  }
+  const sourceProvider = getApiProvider(model.api);
+  if (!sourceProvider) {
+    return model;
+  }
+
+  const sourceApi = model.api;
+  const sourceStreamFn: StreamFn = (runtimeModel, context, options) =>
+    sourceProvider.streamSimple({ ...runtimeModel, api: sourceApi }, context, options);
+  const streamFn = wrapProviderSimpleCompletionStreamFn({
+    provider: model.provider,
+    config: cfg,
+    context: {
+      config: cfg,
+      provider: model.provider,
+      modelId: model.id,
+      model,
+      streamFn: sourceStreamFn,
+    },
+  });
+  if (!streamFn) {
+    return model;
+  }
+
+  const api = resolveProviderSimpleCompletionApi(model);
+  ensureCustomApiRegistered(api, streamFn);
+  return { ...model, api };
+}
+
 function prepareCodexSimpleTransportModel<TApi extends Api>(
   model: Model<TApi>,
   cfg?: OpenClawConfig,
@@ -88,12 +131,12 @@ export function prepareModelForSimpleCompletion<TApi extends Api>(params: {
   const { model, cfg } = params;
   // Only provider-owned custom APIs need runtime stream registration here.
   if (!getApiProvider(model.api) && registerProviderStreamForModel({ model, cfg })) {
-    return model;
+    return applyProviderSimpleCompletionWrapper(model, cfg);
   }
 
   const codexTransportModel = prepareCodexSimpleTransportModel(model, cfg);
   if (codexTransportModel) {
-    return codexTransportModel;
+    return applyProviderSimpleCompletionWrapper(codexTransportModel, cfg);
   }
 
   const transportAwareModel = prepareTransportAwareSimpleModel(model, { cfg });
@@ -101,19 +144,19 @@ export function prepareModelForSimpleCompletion<TApi extends Api>(params: {
     const streamFn = buildTransportAwareSimpleStreamFn(model, { cfg });
     if (streamFn) {
       ensureCustomApiRegistered(transportAwareModel.api, streamFn);
-      return transportAwareModel;
+      return applyProviderSimpleCompletionWrapper(transportAwareModel, cfg);
     }
   }
 
   if (model.api === "google-generative-ai") {
-    return prepareGoogleSimpleCompletionModel(model);
+    return applyProviderSimpleCompletionWrapper(prepareGoogleSimpleCompletionModel(model), cfg);
   }
 
   if (model.provider === "anthropic-vertex") {
     const api = resolveAnthropicVertexSimpleApi(model.baseUrl);
     ensureCustomApiRegistered(api, createAnthropicVertexStreamFnForModel(model));
-    return { ...model, api };
+    return applyProviderSimpleCompletionWrapper({ ...model, api }, cfg);
   }
 
-  return model;
+  return applyProviderSimpleCompletionWrapper(model, cfg);
 }

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -398,6 +398,7 @@ describe("resolveTranscriptPolicy", () => {
   it.each([
     "kimi-for-coding",
     "moonshotai/kimi-k2.6",
+    "moonshot/kimi-k2.7-code",
     "kimi-k2-thinking",
     "hf:moonshotai/kimi-k2-thinking",
     "xiaomi/mimo-v2.6-pro",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -186,6 +186,7 @@ const REASONING_CONTENT_REPLAY_MODEL_IDS = new Set([
   "kimi-for-coding",
   "kimi-k2.5",
   "kimi-k2.6",
+  "kimi-k2.7-code",
   "kimi-k2-thinking",
   "kimi-k2-thinking-turbo",
   "mimo-v2-pro",

--- a/src/commands/models/list.provider-index-catalog.test.ts
+++ b/src/commands/models/list.provider-index-catalog.test.ts
@@ -12,7 +12,7 @@ describe("loadProviderIndexCatalogRowsForList", () => {
         cfg: baseConfig,
         providerFilter: "moonshot",
       }).map((row) => row.ref),
-    ).toEqual(["moonshot/kimi-k2.6"]);
+    ).toEqual(["moonshot/kimi-k2.6", "moonshot/kimi-k2.7-code"]);
   });
 
   it("returns all enabled provider-index preview rows without a provider filter", () => {
@@ -23,6 +23,7 @@ describe("loadProviderIndexCatalogRowsForList", () => {
       "deepseek/deepseek-chat",
       "deepseek/deepseek-reasoner",
       "moonshot/kimi-k2.6",
+      "moonshot/kimi-k2.7-code",
     ]);
   });
 

--- a/src/llm/providers/stream-wrappers/moonshot-thinking.ts
+++ b/src/llm/providers/stream-wrappers/moonshot-thinking.ts
@@ -3,11 +3,18 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import type { StreamFn } from "../../../agents/runtime/index.js";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
 import { createLazyImportLoader } from "../../../shared/lazy-promise.js";
-import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 
 type MoonshotThinkingType = "enabled" | "disabled";
 type MoonshotThinkingKeep = "all";
 const MOONSHOT_THINKING_KEEP_MODEL_ID = "kimi-k2.6";
+const MOONSHOT_ALWAYS_THINKING_MODEL_ID = "kimi-k2.7-code";
+const MOONSHOT_FIXED_SAMPLING_FIELDS = [
+  "temperature",
+  "top_p",
+  "n",
+  "presence_penalty",
+  "frequency_penalty",
+] as const;
 const llmRuntimeLoader = createLazyImportLoader(() => import("openclaw/plugin-sdk/llm"));
 
 async function loadDefaultStreamFn(): Promise<StreamFn> {
@@ -68,6 +75,32 @@ function isPinnedToolChoice(toolChoice: unknown): boolean {
   return typeValue === "tool" || typeValue === "function";
 }
 
+function asPayloadRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function sanitizeKimiK27Payload(payloadObj: Record<string, unknown>): void {
+  delete payloadObj.thinking;
+  delete payloadObj.reasoning_effort;
+  delete payloadObj.reasoningEffort;
+  for (const field of MOONSHOT_FIXED_SAMPLING_FIELDS) {
+    delete payloadObj[field];
+  }
+  if (!isMoonshotToolChoiceCompatible(payloadObj.tool_choice)) {
+    payloadObj.tool_choice = "auto";
+  }
+}
+
+function sanitizeKimiK27AfterCaller(
+  value: unknown,
+  fallbackPayload: Record<string, unknown>,
+): unknown {
+  sanitizeKimiK27Payload(asPayloadRecord(value) ?? fallbackPayload);
+  return value;
+}
+
 /** @deprecated Moonshot provider-owned stream helper; do not use from third-party plugins. */
 export function resolveMoonshotThinkingType(params: {
   configuredThinking: unknown;
@@ -96,39 +129,79 @@ export function createMoonshotThinkingWrapper(
   thinkingType?: MoonshotThinkingType,
   thinkingKeep?: MoonshotThinkingKeep,
 ): StreamFn {
+  const wrap =
+    (underlying: StreamFn): StreamFn =>
+    (model, context, options) => {
+      const modelId = model.id.trim().toLowerCase();
+      const isKimiK27 = modelId === MOONSHOT_ALWAYS_THINKING_MODEL_ID;
+      const streamModel = isKimiK27 ? { ...model, reasoning: true } : model;
+      const streamOptions = isKimiK27 ? { ...options, reasoning: "low" as const } : options;
+      const originalOnPayload = streamOptions?.onPayload;
+      return underlying(streamModel, context, {
+        ...streamOptions,
+        onPayload(payload, payloadModel) {
+          const payloadObj = asPayloadRecord(payload);
+          if (!payloadObj) {
+            return originalOnPayload?.(payload, payloadModel);
+          }
+          const payloadModelId =
+            typeof payloadObj.model === "string" ? payloadObj.model.trim().toLowerCase() : modelId;
+          let effectiveThinkingType = normalizeMoonshotThinkingType(payloadObj.thinking);
+
+          if (thinkingType) {
+            payloadObj.thinking = { type: thinkingType };
+            effectiveThinkingType = thinkingType;
+          }
+
+          if (payloadModelId === MOONSHOT_ALWAYS_THINKING_MODEL_ID) {
+            // K2.7 Code always reasons, preserves reasoning, and fixes sampling.
+            // Reapply constraints after caller hooks so extra_body cannot restore them.
+            sanitizeKimiK27Payload(payloadObj);
+            const result = originalOnPayload?.(payload, payloadModel);
+            if (result && typeof (result as Promise<unknown>).then === "function") {
+              return Promise.resolve(result).then((resolved) =>
+                sanitizeKimiK27AfterCaller(resolved, payloadObj),
+              );
+            }
+            return sanitizeKimiK27AfterCaller(result, payloadObj);
+          }
+
+          if (
+            effectiveThinkingType === "enabled" &&
+            !isMoonshotToolChoiceCompatible(payloadObj.tool_choice)
+          ) {
+            if (payloadObj.tool_choice === "required") {
+              payloadObj.tool_choice = "auto";
+            } else if (isPinnedToolChoice(payloadObj.tool_choice)) {
+              payloadObj.thinking = { type: "disabled" };
+              effectiveThinkingType = "disabled";
+            }
+          }
+
+          // thinking.keep is only valid on kimi-k2.6 when thinking is enabled. Gate
+          // by the final payload.model and final type so stray config never leaks.
+          const isKeepCapableModel = payloadModelId === MOONSHOT_THINKING_KEEP_MODEL_ID;
+          if (payloadObj.thinking && typeof payloadObj.thinking === "object") {
+            const thinkingObj = payloadObj.thinking as Record<string, unknown>;
+            if (
+              isKeepCapableModel &&
+              effectiveThinkingType === "enabled" &&
+              thinkingKeep === "all"
+            ) {
+              thinkingObj.keep = "all";
+            } else if ("keep" in thinkingObj) {
+              delete thinkingObj.keep;
+            }
+          }
+          return originalOnPayload?.(payload, payloadModel);
+        },
+      });
+    };
+  if (baseStreamFn) {
+    return wrap(baseStreamFn);
+  }
   return async (model, context, options) => {
-    const underlying = baseStreamFn ?? (await loadDefaultStreamFn());
-    return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
-      let effectiveThinkingType = normalizeMoonshotThinkingType(payloadObj.thinking);
-
-      if (thinkingType) {
-        payloadObj.thinking = { type: thinkingType };
-        effectiveThinkingType = thinkingType;
-      }
-
-      if (
-        effectiveThinkingType === "enabled" &&
-        !isMoonshotToolChoiceCompatible(payloadObj.tool_choice)
-      ) {
-        if (payloadObj.tool_choice === "required") {
-          payloadObj.tool_choice = "auto";
-        } else if (isPinnedToolChoice(payloadObj.tool_choice)) {
-          payloadObj.thinking = { type: "disabled" };
-          effectiveThinkingType = "disabled";
-        }
-      }
-
-      // thinking.keep is only valid on kimi-k2.6 when thinking is enabled. Gate
-      // by the final payload.model and final type so stray config never leaks.
-      const isKeepCapableModel = payloadObj.model === MOONSHOT_THINKING_KEEP_MODEL_ID;
-      if (payloadObj.thinking && typeof payloadObj.thinking === "object") {
-        const thinkingObj = payloadObj.thinking as Record<string, unknown>;
-        if (isKeepCapableModel && effectiveThinkingType === "enabled" && thinkingKeep === "all") {
-          thinkingObj.keep = "all";
-        } else if ("keep" in thinkingObj) {
-          delete thinkingObj.keep;
-        }
-      }
-    });
+    const underlying = await loadDefaultStreamFn();
+    return wrap(underlying)(model, context, options);
   };
 }

--- a/src/model-catalog/provider-index/normalize.test.ts
+++ b/src/model-catalog/provider-index/normalize.test.ts
@@ -149,6 +149,15 @@ describe("OpenClaw provider index", () => {
       (model) => model.id === "kimi-k2.6",
     );
     expect(kimi?.status).toBe("preview");
+    const kimiCode = index.providers.moonshot?.previewCatalog?.models.find(
+      (model) => model.id === "kimi-k2.7-code",
+    );
+    expect(kimiCode).toMatchObject({
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 262144,
+      status: "preview",
+    });
     expect(index.providers.deepseek?.plugin.id).toBe("deepseek");
     const deepseekChat = index.providers.deepseek?.previewCatalog?.models.find(
       (model) => model.id === "deepseek-chat",

--- a/src/model-catalog/provider-index/openclaw-provider-index.ts
+++ b/src/model-catalog/provider-index/openclaw-provider-index.ts
@@ -29,6 +29,13 @@ export const OPENCLAW_PROVIDER_INDEX = {
             input: ["text", "image"],
             contextWindow: 262144,
           },
+          {
+            id: "kimi-k2.7-code",
+            name: "Kimi K2.7 Code",
+            reasoning: true,
+            input: ["text", "image"],
+            contextWindow: 262144,
+          },
         ],
       },
     },

--- a/src/plugin-sdk/provider-stream.test.ts
+++ b/src/plugin-sdk/provider-stream.test.ts
@@ -62,6 +62,37 @@ function expectDefaultThinkingBudget(payload: Record<string, unknown>) {
   expect(thinkingConfig.thinkingBudget).toBe(-1);
 }
 
+describe("createMoonshotThinkingWrapper", () => {
+  it("sanitizes K2.7 after an async caller replaces the payload", async () => {
+    let finalPayload: Record<string, unknown> | undefined;
+    const baseStreamFn: StreamFn = async (model, _context, options) => {
+      const payload = { model: model.id };
+      const replacement = await options?.onPayload?.(payload, model);
+      finalPayload = requireRecord(replacement ?? payload, "final payload");
+      return {} as never;
+    };
+    const wrapped = createMoonshotThinkingWrapper(baseStreamFn, "disabled", "all");
+
+    await wrapped({ api: "openai-completions", id: "kimi-k2.7-code" } as never, {} as never, {
+      onPayload: async () => ({
+        model: "kimi-k2.7-code",
+        thinking: { type: "disabled" },
+        reasoning_effort: "low",
+        temperature: 0,
+        top_p: 0.5,
+        tool_choice: "required",
+      }),
+    });
+
+    const payload = requirePayload(finalPayload);
+    expect(payload).not.toHaveProperty("thinking");
+    expect(payload).not.toHaveProperty("reasoning_effort");
+    expect(payload).not.toHaveProperty("temperature");
+    expect(payload).not.toHaveProperty("top_p");
+    expect(payload.tool_choice).toBe("auto");
+  });
+});
+
 describe("composeProviderStreamWrappers", () => {
   it("re-exports the shared wrapper composer", () => {
     expect(composeProviderStreamWrappers).toBe(composeProviderStreamWrappersShared);
@@ -109,11 +140,15 @@ describe("buildProviderStreamFamilyHooks", () => {
   it("covers the stream family matrix", async () => {
     let capturedPayload: Record<string, unknown> | undefined;
     let capturedModelId: string | undefined;
+    let capturedModelReasoning: boolean | undefined;
     let capturedHeaders: Record<string, string> | undefined;
+    let capturedReasoning: string | undefined;
     let payloadSeed: Record<string, unknown> | undefined;
 
     const baseStreamFn: StreamFn = (model, _context, options) => {
       capturedModelId = model.id;
+      capturedModelReasoning = model.reasoning;
+      capturedReasoning = options?.reasoning;
       const payload = {
         model: model.id,
         config: { thinkingConfig: { thinkingBudget: -1 } },
@@ -257,6 +292,33 @@ describe("buildProviderStreamFamilyHooks", () => {
     );
     expect(moonshotToolChoiceThinking.type).toBe("disabled");
     expect(moonshotToolChoiceThinking).not.toHaveProperty("keep");
+
+    payloadSeed = {
+      tool_choice: { type: "tool", name: "read" },
+      temperature: 0,
+      top_p: 0.5,
+      n: 2,
+      presence_penalty: 1,
+      frequency_penalty: 1,
+      reasoning_effort: "low",
+    };
+    await moonshotKeepStream(
+      { api: "openai-completions", id: "kimi-k2.7-code", reasoning: false } as never,
+      {} as never,
+      {},
+    );
+    const moonshotK27Payload = requirePayload(capturedPayload);
+    expectDefaultThinkingBudget(moonshotK27Payload);
+    expect(moonshotK27Payload).not.toHaveProperty("thinking");
+    expect(moonshotK27Payload).not.toHaveProperty("reasoning_effort");
+    expect(moonshotK27Payload.tool_choice).toBe("auto");
+    expect(moonshotK27Payload).not.toHaveProperty("temperature");
+    expect(moonshotK27Payload).not.toHaveProperty("top_p");
+    expect(moonshotK27Payload).not.toHaveProperty("n");
+    expect(moonshotK27Payload).not.toHaveProperty("presence_penalty");
+    expect(moonshotK27Payload).not.toHaveProperty("frequency_penalty");
+    expect(capturedReasoning).toBe("low");
+    expect(capturedModelReasoning).toBe(true);
 
     const openAiHooks = OPENAI_RESPONSES_STREAM_HOOKS;
     void requireStreamFn(

--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -448,3 +448,18 @@ export function wrapProviderStreamFn(params: {
     ensureProviderRuntimePluginHandle(params).plugin?.wrapStreamFn?.(params.context) ?? undefined
   );
 }
+
+export function wrapProviderSimpleCompletionStreamFn(params: {
+  provider: string;
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
+  context: ProviderWrapStreamFnContext;
+}) {
+  return (
+    ensureProviderRuntimePluginHandle(params).plugin?.wrapSimpleCompletionStreamFn?.(
+      params.context,
+    ) ?? undefined
+  );
+}

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -58,6 +58,21 @@ describe("provider public artifacts", () => {
     ).toBe("adaptive");
   });
 
+  it("loads Moonshot Kimi K2.7 thinking policy before runtime registration", () => {
+    const surface = resolveBundledProviderPolicySurface("moonshot");
+
+    expect(
+      surface?.resolveThinkingProfile?.({
+        provider: "moonshot",
+        modelId: "kimi-k2.7-code",
+      }),
+    ).toEqual({
+      levels: [{ id: "low", label: "on" }],
+      defaultLevel: "low",
+      preserveWhenCatalogReasoningFalse: true,
+    });
+  });
+
   it("resolves multi-provider policy artifacts by manifest-owned provider id", async () => {
     const bundledPluginsDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-provider-policy-"));
     const pluginDir = path.join(bundledPluginsDir, "openai");

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -94,6 +94,7 @@ let resolveProviderRuntimePlugin: typeof import("./provider-runtime.js").resolve
 let providerRuntimeTesting: typeof import("./provider-runtime.js").testing;
 let runProviderDynamicModel: typeof import("./provider-runtime.js").runProviderDynamicModel;
 let validateProviderReplayTurnsWithPlugin: typeof import("./provider-runtime.js").validateProviderReplayTurnsWithPlugin;
+let wrapProviderSimpleCompletionStreamFn: typeof import("./provider-runtime.js").wrapProviderSimpleCompletionStreamFn;
 let wrapProviderStreamFn: typeof import("./provider-runtime.js").wrapProviderStreamFn;
 let createEmptyPluginRegistry: typeof import("./registry.js").createEmptyPluginRegistry;
 let resetPluginRuntimeStateForTest: typeof import("./runtime.js").resetPluginRuntimeStateForTest;
@@ -358,6 +359,7 @@ describe("provider-runtime", () => {
       testing: providerRuntimeTesting,
       runProviderDynamicModel,
       validateProviderReplayTurnsWithPlugin,
+      wrapProviderSimpleCompletionStreamFn,
       wrapProviderStreamFn,
     } = await import("./provider-runtime.js"));
     ({ createEmptyPluginRegistry } = await import("./registry.js"));
@@ -1621,6 +1623,28 @@ describe("provider-runtime", () => {
         provider: "azure-openai-responses",
         context: createDemoResolvedModelContext({
           provider: "azure-openai-responses",
+          streamFn: wrappedStreamFn,
+        }),
+      }),
+    ).toBe(wrappedStreamFn);
+  });
+
+  it("resolves opt-in simple-completion stream wrappers", () => {
+    const wrappedStreamFn = vi.fn();
+    resolvePluginProvidersMock.mockReturnValue([
+      {
+        id: "moonshot",
+        label: "Moonshot",
+        auth: [],
+        wrapSimpleCompletionStreamFn: ({ streamFn }) => streamFn ?? wrappedStreamFn,
+      },
+    ]);
+
+    expect(
+      wrapProviderSimpleCompletionStreamFn({
+        provider: "moonshot",
+        context: createDemoResolvedModelContext({
+          provider: "moonshot",
           streamFn: wrappedStreamFn,
         }),
       }),

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -33,6 +33,7 @@ import {
   resolveProviderHookPlugin,
   resolveProviderPluginsForHooks,
   resolveProviderRuntimePlugin,
+  wrapProviderSimpleCompletionStreamFn,
   type ProviderRuntimePluginHandle,
   wrapProviderStreamFn,
 } from "./provider-hook-runtime.js";
@@ -166,6 +167,7 @@ export {
   resolveProviderExtraParamsForTransport,
   resolveProviderFollowupFallbackRoute,
   resolveProviderRuntimePlugin,
+  wrapProviderSimpleCompletionStreamFn,
   wrapProviderStreamFn,
 };
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1478,6 +1478,13 @@ export type ProviderPlugin = {
    */
   wrapStreamFn?: (ctx: ProviderWrapStreamFnContext) => StreamFn | null | undefined;
   /**
+   * Provider-owned wrapper for direct `completeSimple` callers.
+   *
+   * Opt in only when the provider must enforce the same wire contract outside
+   * the embedded agent runtime.
+   */
+  wrapSimpleCompletionStreamFn?: (ctx: ProviderWrapStreamFnContext) => StreamFn | null | undefined;
+  /**
    * Provider-owned native transport turn identity.
    *
    * Use this when a provider wants generic transports to attach provider-native

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -761,6 +761,9 @@ describe("package artifact reuse", () => {
     expect(retryHelper).toContain("OPENCLAW_LIVE_COMMAND_RATE_LIMIT_RETRY_DELAY_SECONDS:-60");
     expect(retryHelper).toContain("Rate limit reached");
     expect(retryHelper).toContain("tokens per min");
+    expect(
+      workflow.match(/moonshot\) require_any Moonshot MOONSHOT_API_KEY KIMI_API_KEY ;;/gu),
+    ).toHaveLength(2);
   });
 
   it("runs Docker live harnesses from trusted helper scripts", () => {

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -67,6 +67,7 @@ const PROFILE_EXPECTATIONS = [
       "anthropic",
       "google",
       "minimax",
+      "moonshot",
       "openai",
       "opencode-go",
       "openrouter",
@@ -130,6 +131,7 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
       "openai",
     ]);
     expect(plan.liveModels.omitted.map((entry) => entry.id)).toEqual([
+      "moonshot",
       "opencode-go",
       "openrouter",
       "xai",
@@ -147,7 +149,7 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
     });
 
     expect(plan.liveModels.count).toBe(0);
-    expect(plan.liveModels.omitted).toHaveLength(9);
+    expect(plan.liveModels.omitted).toHaveLength(10);
     expect(plan.liveModels.omitted[0]?.reason).toBe(
       "Docker live model matrix disabled by input selection",
     );


### PR DESCRIPTION
## Summary

- add `moonshot/kimi-k2.7-code` with current Moonshot catalog metadata, pricing, multimodal input, and 256K context/output limits
- enforce K2.7's always-on reasoning wire contract across embedded-agent and direct simple-completion paths
- preserve reasoning/tool replay, expose model/thinking policy, document setup, and add exact live Moonshot coverage

## Verification

- `node scripts/run-vitest.mjs ...` (changed surface: 481 tests; model-list follow-up: 56 tests; post-rebase smoke: 21 tests)
- `pnpm build`
- `pnpm docs:check-mdx`
- `pnpm docs:check-links` (4,473 links, 0 broken)
- Testbox `check:changed`: `tbx_01ktz2wwe9sr856mvw581rr6xd` ([run](https://github.com/openclaw/openclaw/actions/runs/27449106539))
- fresh Codex autoreview: clean, no accepted/actionable findings
- live Moonshot E2E: [run 27451021589](https://github.com/openclaw/openclaw/actions/runs/27451021589), `extensions/moonshot/moonshot.live.test.ts` passed all 6 tests, including the K2.7 replayed tool-turn scenario

## Release Note

Moonshot: add Kimi K2.7 Code support with always-on reasoning, multimodal catalog metadata, replay compatibility, and live validation.
