### PR TITLE
Validate ClawHub plugin metadata in PRs

### DIFF
--- a/.github/workflows/plugin-clawhub-validate.yml
+++ b/.github/workflows/plugin-clawhub-validate.yml
@@ -1,0 +1,40 @@
+name: Plugin ClawHub Validate
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    paths:
+      - "extensions/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: plugin-clawhub-validate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  validate_changed_clawhub_plugins:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ${{ github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04' }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Validate changed ClawHub plugin packages
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: ${{ github.sha }}
+        run: pnpm plugins:clawhub:validate-changed -- --base-ref "$BASE_REF" --head-ref "$HEAD_REF"

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -269,7 +269,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[line](/plugins/reference/line)** (`@openclaw/line`) - npm; ClawHub. OpenClaw LINE channel plugin for LINE Bot API chats.
 
-- **[llama-cpp](/plugins/reference/llama-cpp)** (`@openclaw/llama-cpp-provider`) - npm; ClawHub. Local GGUF embeddings through node-llama-cpp.
+- **[llama-cpp](/plugins/reference/llama-cpp)** (`@openclaw/llama-cpp-provider`) - npm; ClawHub: `clawhub:@openclaw/llama-cpp-provider`. Local GGUF embeddings through node-llama-cpp.
 
 - **[lobster](/plugins/reference/lobster)** (`@openclaw/lobster`) - npm; ClawHub. Lobster workflow tool plugin for typed pipelines and resumable approvals.
 

--- a/docs/plugins/reference/llama-cpp.md
+++ b/docs/plugins/reference/llama-cpp.md
@@ -12,7 +12,7 @@ Local GGUF embeddings through node-llama-cpp.
 ## Distribution
 
 - Package: `@openclaw/llama-cpp-provider`
-- Install route: npm; ClawHub
+- Install route: npm; ClawHub: `clawhub:@openclaw/llama-cpp-provider`
 
 ## Surface
 

--- a/extensions/llama-cpp/npm-shrinkwrap.json
+++ b/extensions/llama-cpp/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/llama-cpp-provider",
-  "version": "2026.6.2",
+  "version": "2026.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/llama-cpp-provider",
-      "version": "2026.6.2",
+      "version": "2026.6.6",
       "dependencies": {
         "node-llama-cpp": "3.18.1"
       }

--- a/extensions/llama-cpp/package.json
+++ b/extensions/llama-cpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/llama-cpp-provider",
-  "version": "2026.6.2",
+  "version": "2026.6.6",
   "description": "OpenClaw llama.cpp embedding provider plugin",
   "repository": {
     "type": "git",
@@ -18,15 +18,16 @@
       "./index.ts"
     ],
     "install": {
+      "clawhubSpec": "clawhub:@openclaw/llama-cpp-provider",
       "npmSpec": "@openclaw/llama-cpp-provider",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.6.2"
+      "minHostVersion": ">=2026.6.6"
     },
     "compat": {
-      "pluginApi": ">=2026.6.2"
+      "pluginApi": ">=2026.6.6"
     },
     "build": {
-      "openclawVersion": "2026.6.2"
+      "openclawVersion": "2026.6.6"
     },
     "release": {
       "bundleRuntimeDependencies": false,

--- a/package.json
+++ b/package.json
@@ -1618,6 +1618,7 @@
     "plugins:boundary-report:summary": "node --import tsx scripts/plugin-boundary-report.ts --summary",
     "plugins:assets:build": "node scripts/bundled-plugin-assets.mjs --phase build",
     "plugins:assets:copy": "node scripts/bundled-plugin-assets.mjs --phase copy",
+    "plugins:clawhub:validate-changed": "node --import tsx scripts/validate-changed-clawhub-plugins.ts",
     "plugins:inventory:check": "node scripts/generate-plugin-inventory-doc.mjs --check",
     "plugins:inventory:gen": "node scripts/generate-plugin-inventory-doc.mjs --write",
     "plugins:sync": "node --import tsx scripts/sync-plugin-versions.ts",

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -204,9 +204,10 @@
           "embeddingProviders": ["local"]
         },
         "install": {
+          "clawhubSpec": "clawhub:@openclaw/llama-cpp-provider",
           "npmSpec": "@openclaw/llama-cpp-provider",
           "defaultChoice": "npm",
-          "minHostVersion": ">=2026.6.2"
+          "minHostVersion": ">=2026.6.6"
         }
       }
     },

--- a/scripts/validate-changed-clawhub-plugins.ts
+++ b/scripts/validate-changed-clawhub-plugins.ts
@@ -1,0 +1,599 @@
+#!/usr/bin/env -S node --import tsx
+// Changed ClawHub plugin validation runs a pinned ClawHub CLI for PR-touched packages.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  collectClawHubPublishablePluginPackages,
+  resolveChangedClawHubPublishablePluginPackages,
+  type PublishablePluginPackage,
+} from "./lib/plugin-clawhub-release.ts";
+import { resolveGitCommitSha, type GitRangeSelection } from "./lib/plugin-npm-release.ts";
+
+export const CLAWHUB_VALIDATE_CLI_PACKAGE = "clawhub@0.21.0";
+
+type ChangedClawHubPackageValidatePlanItem = Pick<
+  PublishablePluginPackage,
+  "extensionId" | "packageDir" | "packageName"
+>;
+
+type ChangedClawHubPackageValidatePlanParams = {
+  plugins: PublishablePluginPackage[];
+  changedPaths: readonly string[];
+};
+
+type ParsedValidationResult = {
+  warningCount: number;
+  errorCount: number;
+  blockingWarningKeys: string[];
+};
+
+type ValidateArgs = {
+  baseRef?: string;
+  headRef?: string;
+};
+
+export function createChangedClawHubPackageValidatePlan(
+  params: ChangedClawHubPackageValidatePlanParams,
+): ChangedClawHubPackageValidatePlanItem[] {
+  return resolveChangedClawHubPublishablePluginPackages({
+    plugins: params.plugins,
+    changedPaths: params.changedPaths.filter(isClawHubPluginValidationRelevantPath),
+  }).map((plugin) => ({
+    extensionId: plugin.extensionId,
+    packageDir: plugin.packageDir,
+    packageName: plugin.packageName,
+  }));
+}
+
+export function collectClawHubPluginValidationPathsFromGitRange(params: {
+  rootDir?: string;
+  gitRange: GitRangeSelection;
+}): string[] {
+  const rootDir = resolve(params.rootDir ?? ".");
+  const { baseRef, headRef } = params.gitRange;
+  const baseSha = resolveGitCommitSha(rootDir, baseRef, "baseRef");
+  const headSha = resolveGitCommitSha(rootDir, headRef, "headRef");
+
+  return execFileSync(
+    "git",
+    ["diff", "--name-only", "--diff-filter=ACDMR", baseSha, headSha, "--", "extensions"],
+    {
+      cwd: rootDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  )
+    .split("\n")
+    .map((line) => line.trim().replaceAll("\\", "/"))
+    .filter(Boolean);
+}
+
+export function collectBaselineClawHubPublishablePluginPackages(params: {
+  rootDir?: string;
+  baselineRef: string;
+}): ChangedClawHubPackageValidatePlanItem[] {
+  const rootDir = resolve(params.rootDir ?? ".");
+  const baselineSha = resolveGitCommitSha(rootDir, params.baselineRef, "baselineRef");
+  const paths = execFileSync(
+    "git",
+    ["ls-tree", "-r", "--name-only", baselineSha, "--", "extensions"],
+    {
+      cwd: rootDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  )
+    .split("\n")
+    .map((line) => line.trim().replaceAll("\\", "/"))
+    .filter((path) => /^extensions\/[^/]+\/package\.json$/u.test(path));
+
+  return paths
+    .flatMap((packagePath) =>
+      readBaselineClawHubPublishablePackage({
+        rootDir,
+        baselineSha,
+        packagePath,
+      }),
+    )
+    .toSorted((left, right) => left.packageName.localeCompare(right.packageName));
+}
+
+export function assertNoRemovedClawHubPublishablePackages(params: {
+  currentPlan: readonly ChangedClawHubPackageValidatePlanItem[];
+  baselinePlugins: readonly ChangedClawHubPackageValidatePlanItem[];
+  changedPaths: readonly string[];
+}) {
+  const changedExtensionIds = collectChangedExtensionIdsForClawHubValidation(params.changedPaths);
+  if (changedExtensionIds.size === 0) {
+    return;
+  }
+
+  const currentExtensionIds = new Set(params.currentPlan.map((plugin) => plugin.extensionId));
+  const removedPlugins = params.baselinePlugins.filter(
+    (plugin) =>
+      changedExtensionIds.has(plugin.extensionId) && !currentExtensionIds.has(plugin.extensionId),
+  );
+  if (removedPlugins.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Changed ClawHub-publishable plugin package metadata must remain visible to validation:\n${removedPlugins
+      .map(
+        (plugin) =>
+          `- ${plugin.packageDir}: was ClawHub-publishable at ${plugin.packageName} in the base ref but is no longer publishable in the current head.`,
+      )
+      .join("\n")}`,
+  );
+}
+
+export function buildClawHubPackageValidateCommand(
+  packageDir: string,
+  reportDir: string,
+  repositoryRoot = ".",
+) {
+  const resolvedRepositoryRoot = resolve(repositoryRoot);
+  return {
+    command: "pnpm",
+    args: [
+      "dlx",
+      "--config.minimum-release-age=0",
+      CLAWHUB_VALIDATE_CLI_PACKAGE,
+      "--workdir",
+      resolvedRepositoryRoot,
+      "package",
+      "validate",
+      packageDir,
+      "--json",
+      "--openclaw",
+      resolvedRepositoryRoot,
+      "--out",
+      reportDir,
+    ],
+  };
+}
+
+export function parseClawHubValidationOutput(
+  output: string,
+  packageDir: string,
+): Pick<ParsedValidationResult, "warningCount" | "errorCount"> {
+  const result = parseClawHubValidationReport(output, packageDir);
+  if (result.warningCount > 0 || result.errorCount > 0) {
+    throw new Error(
+      `${packageDir}: ClawHub validation reported ${formatCount(result.warningCount, "warning")} and ${formatCount(result.errorCount, "error")}.`,
+    );
+  }
+
+  return {
+    warningCount: result.warningCount,
+    errorCount: result.errorCount,
+  };
+}
+
+export function parseClawHubValidationReport(
+  output: string,
+  packageDir: string,
+): ParsedValidationResult {
+  const parsed = parseJsonObject(output, packageDir);
+  const rawWarningCount =
+    readNumericCount(parsed, "warningCount") ??
+    readNestedNumericCount(parsed, "summary", "warningCount") ??
+    readArrayCount(parsed, "warnings") ??
+    countDiagnosticsWithSeverity(parsed, "warning");
+  const blockingWarningKeys = collectBlockingWarningKeys(parsed);
+  const warningCount = hasStructuredWarningFindings(parsed)
+    ? blockingWarningKeys.length
+    : rawWarningCount;
+  const explicitErrorCount =
+    readNumericCount(parsed, "errorCount") ??
+    readNestedNumericCount(parsed, "summary", "errorCount") ??
+    readNestedNumericCount(parsed, "summary", "breakageCount") ??
+    readArrayCount(parsed, "errors") ??
+    countDiagnosticsWithSeverity(parsed, "error");
+  const status = readStringField(parsed, "status");
+  const errorCount =
+    status && status !== "pass" ? Math.max(explicitErrorCount, 1) : explicitErrorCount;
+
+  return { warningCount, errorCount, blockingWarningKeys };
+}
+
+function isClawHubPluginValidationRelevantPath(path: string) {
+  const normalized = path.trim().replaceAll("\\", "/");
+  return !normalized.endsWith("/npm-shrinkwrap.json");
+}
+
+export function parseValidateChangedClawHubPluginsArgs(argv: string[]): ValidateArgs {
+  const args: ValidateArgs = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") {
+      continue;
+    }
+    if (arg === "--base-ref") {
+      args.baseRef = readRequiredArgValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--head-ref") {
+      args.headRef = readRequiredArgValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+export function runClawHubPackageValidate(packageDir: string, cwd = ".") {
+  const current = executeClawHubPackageValidate(packageDir, cwd);
+  if (current.warningCount > 0 || current.errorCount > 0) {
+    throw new Error(
+      `${packageDir}: ClawHub validation reported ${formatCount(current.warningCount, "warning")} and ${formatCount(current.errorCount, "error")}.`,
+    );
+  }
+}
+
+function executeClawHubPackageValidate(packageDir: string, cwd = ".") {
+  const reportDir = mkdtempSync(join(tmpdir(), "openclaw-clawhub-validate-"));
+  try {
+    const { command, args } = buildClawHubPackageValidateCommand(packageDir, reportDir, cwd);
+    const result = spawnSync(command, args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    if (result.stdout.trim()) {
+      process.stdout.write(`${result.stdout.trim()}\n`);
+    }
+    if (result.stderr.trim()) {
+      process.stderr.write(`${result.stderr.trim()}\n`);
+    }
+    if (result.error) {
+      throw result.error;
+    }
+    if (result.status !== 0) {
+      throw new Error(
+        `${packageDir}: clawhub package validate failed with exit code ${result.status}.`,
+      );
+    }
+    return parseClawHubValidationReport(result.stdout, packageDir);
+  } finally {
+    rmSync(reportDir, { recursive: true, force: true });
+  }
+}
+
+function runClawHubPackageValidateAgainstBaseline(params: {
+  packageDir: string;
+  cwd: string;
+  baselineRef: string;
+}) {
+  const current = executeClawHubPackageValidate(params.packageDir, params.cwd);
+  if (current.errorCount > 0) {
+    throw new Error(
+      `${params.packageDir}: ClawHub validation reported ${formatCount(current.warningCount, "warning")} and ${formatCount(current.errorCount, "error")}.`,
+    );
+  }
+  if (current.warningCount === 0) {
+    return;
+  }
+
+  const baselineWarnings = new Set(
+    collectBaselineBlockingWarningKeys({
+      packageDir: params.packageDir,
+      cwd: params.cwd,
+      baselineRef: params.baselineRef,
+    }),
+  );
+  if (current.blockingWarningKeys.length === 0) {
+    throw new Error(
+      `${params.packageDir}: ClawHub validation reported ${formatCount(current.warningCount, "warning")} and ${formatCount(current.errorCount, "error")}.`,
+    );
+  }
+  const newWarnings = current.blockingWarningKeys.filter((key) => !baselineWarnings.has(key));
+  if (newWarnings.length > 0) {
+    throw new Error(
+      `${params.packageDir}: ClawHub validation reported ${formatCount(newWarnings.length, "new warning")} and ${formatCount(current.errorCount, "error")}.`,
+    );
+  }
+
+  console.log(
+    `validate-changed-clawhub-plugins: ${params.packageDir} has ${formatCount(current.warningCount, "pre-existing warning")}; no new ClawHub warnings.`,
+  );
+}
+
+function collectBaselineBlockingWarningKeys(params: {
+  packageDir: string;
+  cwd: string;
+  baselineRef: string;
+}) {
+  const rootDir = resolve(params.cwd);
+  const baselineSha = resolveGitCommitSha(rootDir, params.baselineRef, "baselineRef");
+  const tempRoot = mkdtempSync(join(tmpdir(), "openclaw-clawhub-baseline-"));
+  try {
+    const archive = execFileSync(
+      "git",
+      ["archive", "--format=tar", baselineSha, params.packageDir],
+      {
+        cwd: rootDir,
+        encoding: "buffer",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    const tar = spawnSync("tar", ["-xf", "-", "-C", tempRoot], {
+      input: archive,
+      stdio: ["pipe", "ignore", "pipe"],
+    });
+    if (tar.error) {
+      throw tar.error;
+    }
+    if (tar.status !== 0) {
+      throw new Error(`${params.packageDir}: failed to extract baseline package.`);
+    }
+    const baselinePackageDir = join(tempRoot, params.packageDir);
+    return executeClawHubPackageValidate(baselinePackageDir, rootDir).blockingWarningKeys;
+  } catch {
+    return [];
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+export function runValidateChangedClawHubPlugins(argv: string[]) {
+  const { baseRef = "origin/main", headRef = "HEAD" } =
+    parseValidateChangedClawHubPluginsArgs(argv);
+  const rootDir = resolve(".");
+  const gitRange = { baseRef, headRef };
+  const changedPaths = collectClawHubPluginValidationPathsFromGitRange({ rootDir, gitRange });
+  const plan = createChangedClawHubPackageValidatePlan({
+    plugins: collectClawHubPublishablePluginPackages(rootDir),
+    changedPaths,
+  });
+  assertNoRemovedClawHubPublishablePackages({
+    currentPlan: plan,
+    baselinePlugins: collectBaselineClawHubPublishablePluginPackages({
+      rootDir,
+      baselineRef: baseRef,
+    }),
+    changedPaths,
+  });
+
+  if (plan.length === 0) {
+    console.log(
+      `validate-changed-clawhub-plugins: no changed ClawHub-publishable plugin packages between ${baseRef} and ${headRef}.`,
+    );
+    return;
+  }
+
+  for (const plugin of plan) {
+    console.log(
+      `validate-changed-clawhub-plugins: validating ${plugin.packageName} (${plugin.packageDir})`,
+    );
+    runClawHubPackageValidateAgainstBaseline({
+      packageDir: plugin.packageDir,
+      cwd: ".",
+      baselineRef: baseRef,
+    });
+  }
+  console.log(
+    `validate-changed-clawhub-plugins: validated ${formatCount(plan.length, "plugin package")}.`,
+  );
+}
+
+function parseJsonObject(output: string, packageDir: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(output) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Fall through to the contextual error below.
+  }
+  throw new Error(`${packageDir}: ClawHub validation did not return a JSON object.`);
+}
+
+function readBaselineClawHubPublishablePackage(params: {
+  rootDir: string;
+  baselineSha: string;
+  packagePath: string;
+}): ChangedClawHubPackageValidatePlanItem[] {
+  const match = /^extensions\/([^/]+)\/package\.json$/u.exec(params.packagePath);
+  const extensionId = match?.[1];
+  if (!extensionId) {
+    return [];
+  }
+
+  const raw = execFileSync("git", ["show", `${params.baselineSha}:${params.packagePath}`], {
+    cwd: params.rootDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const packageJson = parseJsonRecordOrNull(raw);
+  if (!packageJson) {
+    return [];
+  }
+
+  const openclaw = readRecordField(packageJson, "openclaw");
+  const release = openclaw ? readRecordField(openclaw, "release") : undefined;
+  if (release?.publishToClawHub !== true) {
+    return [];
+  }
+
+  const packageName = readStringField(packageJson, "name")?.trim() || params.packagePath;
+  return [
+    {
+      extensionId,
+      packageDir: `extensions/${extensionId}`,
+      packageName,
+    },
+  ];
+}
+
+function collectChangedExtensionIdsForClawHubValidation(changedPaths: readonly string[]) {
+  return new Set(
+    changedPaths.filter(isClawHubPluginValidationRelevantPath).flatMap((path) => {
+      const match = /^extensions\/([^/]+)\//u.exec(path.trim().replaceAll("\\", "/"));
+      return match?.[1] ? [match[1]] : [];
+    }),
+  );
+}
+
+function parseJsonRecordOrNull(output: string) {
+  try {
+    const parsed = JSON.parse(output) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readRecordField(value: Record<string, unknown>, key: string) {
+  const field = value[key];
+  return field && typeof field === "object" && !Array.isArray(field)
+    ? (field as Record<string, unknown>)
+    : undefined;
+}
+
+function readNumericCount(value: Record<string, unknown>, key: string) {
+  const count = value[key];
+  return typeof count === "number" && Number.isFinite(count) ? count : undefined;
+}
+
+function readNestedNumericCount(value: Record<string, unknown>, parentKey: string, key: string) {
+  const parent = value[parentKey];
+  if (!parent || typeof parent !== "object" || Array.isArray(parent)) {
+    return undefined;
+  }
+  return readNumericCount(parent as Record<string, unknown>, key);
+}
+
+function readArrayCount(value: Record<string, unknown>, key: string) {
+  const items = value[key];
+  return Array.isArray(items) ? items.length : undefined;
+}
+
+function readStringField(value: Record<string, unknown>, key: string) {
+  const field = value[key];
+  return typeof field === "string" ? field : undefined;
+}
+
+function hasStructuredWarningFindings(value: Record<string, unknown>) {
+  return (
+    Array.isArray(value.issues) ||
+    Array.isArray(value.warnings) ||
+    collectDiagnosticWarnings(value).length > 0
+  );
+}
+
+function collectBlockingWarningKeys(value: Record<string, unknown>) {
+  return [...collectIssueLikeWarnings(value), ...collectDiagnosticWarnings(value)].flatMap(
+    (warning) => {
+      if (!warning || typeof warning !== "object" || Array.isArray(warning)) {
+        return ["unknown-issue"];
+      }
+      const record = warning as Record<string, unknown>;
+      return isIgnoredCompatibilityWarning(record) ? [] : [formatWarningKey(record)];
+    },
+  );
+}
+
+function collectIssueLikeWarnings(value: Record<string, unknown>) {
+  return [value.issues, value.warnings].flatMap((items) => (Array.isArray(items) ? items : []));
+}
+
+function collectDiagnosticWarnings(value: Record<string, unknown>) {
+  const diagnostics = value.diagnostics;
+  if (!Array.isArray(diagnostics)) {
+    return [];
+  }
+  return diagnostics.filter((diagnostic) => {
+    if (!diagnostic || typeof diagnostic !== "object" || Array.isArray(diagnostic)) {
+      return false;
+    }
+    return readDiagnosticSeverity(diagnostic) === "warning";
+  });
+}
+
+function formatWarningKey(issue: Record<string, unknown>) {
+  const fields = ["owner", "code", "decision", "issueClass"].map(
+    (field) => `${field}:${readStringField(issue, field) ?? ""}`,
+  );
+  const evidence = issue.evidence;
+  if (Array.isArray(evidence)) {
+    fields.push(
+      `evidence:${evidence
+        .map((item) => String(item))
+        .toSorted()
+        .join("|")}`,
+    );
+  }
+  return fields.join(";");
+}
+
+function isIgnoredCompatibilityWarning(issue: Record<string, unknown>) {
+  const owner = readStringField(issue, "owner");
+  const decision = readStringField(issue, "decision");
+  const issueClass = readStringField(issue, "issueClass");
+  const code = readStringField(issue, "code");
+  return (
+    (owner === "core" && decision === "core-compat-adapter") ||
+    (issueClass === "deprecation-warning" &&
+      (code === "channel-env-vars" || code === "provider-auth-env-vars"))
+  );
+}
+
+function countDiagnosticsWithSeverity(
+  value: Record<string, unknown>,
+  severity: "error" | "warning",
+) {
+  const diagnostics = value.diagnostics ?? value.issues;
+  if (!Array.isArray(diagnostics)) {
+    return 0;
+  }
+  return diagnostics.filter((diagnostic) => {
+    if (!diagnostic || typeof diagnostic !== "object") {
+      return false;
+    }
+    return readDiagnosticSeverity(diagnostic) === severity;
+  }).length;
+}
+
+function readDiagnosticSeverity(diagnostic: object) {
+  return (
+    (diagnostic as { severity?: unknown; level?: unknown }).severity ??
+    (diagnostic as { severity?: unknown; level?: unknown }).level
+  );
+}
+
+function formatCount(count: number, label: string) {
+  return `${count} ${label}${count === 1 ? "" : "s"}`;
+}
+
+function readRequiredArgValue(argv: string[], index: number, flag: string) {
+  const value = argv[index + 1]?.trim();
+  if (!value) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: node --import tsx scripts/validate-changed-clawhub-plugins.ts [--base-ref <ref>] [--head-ref <ref>]
+
+Runs a pinned ClawHub CLI against ClawHub-publishable plugin packages
+changed between the selected git refs.`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  runValidateChangedClawHubPlugins(process.argv.slice(2));
+}

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -50,9 +50,12 @@ describe("official external plugin catalog", () => {
         minHostVersion: ">=2026.5.27",
       },
     );
-    expect(resolveOfficialExternalPluginInstall(expectCatalogEntry("llama-cpp"))?.npmSpec).toBe(
-      "@openclaw/llama-cpp-provider",
-    );
+    expect(resolveOfficialExternalPluginInstall(expectCatalogEntry("llama-cpp"))).toEqual({
+      clawhubSpec: "clawhub:@openclaw/llama-cpp-provider",
+      npmSpec: "@openclaw/llama-cpp-provider",
+      defaultChoice: "npm",
+      minHostVersion: ">=2026.6.6",
+    });
   });
 
   it("allows invalid-config recovery for externalized stock plugins", () => {

--- a/test/plugin-clawhub-release.test.ts
+++ b/test/plugin-clawhub-release.test.ts
@@ -165,6 +165,31 @@ describe("OpenClaw dual-published plugin metadata", () => {
       });
     }
   });
+
+  it("keeps llama.cpp package install metadata aligned with ClawHub validation", () => {
+    const packageJson = JSON.parse(readFileSync("extensions/llama-cpp/package.json", "utf8")) as {
+      version?: string;
+      openclaw?: {
+        compat?: {
+          pluginApi?: string;
+        };
+        build?: {
+          openclawVersion?: string;
+        };
+        install?: unknown;
+      };
+    };
+
+    expect(packageJson.version).toBe("2026.6.6");
+    expect(packageJson.openclaw?.compat?.pluginApi).toBe(">=2026.6.6");
+    expect(packageJson.openclaw?.build?.openclawVersion).toBe("2026.6.6");
+    expect(packageJson.openclaw?.install).toEqual({
+      clawhubSpec: "clawhub:@openclaw/llama-cpp-provider",
+      defaultChoice: "npm",
+      minHostVersion: ">=2026.6.6",
+      npmSpec: "@openclaw/llama-cpp-provider",
+    });
+  });
 });
 
 describe("collectClawHubVersionGateErrors", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -17,6 +17,7 @@ const UPDATE_MIGRATION_WORKFLOW = ".github/workflows/update-migration.yml";
 const CI_CHECK_TESTBOX_WORKFLOW = ".github/workflows/ci-check-testbox.yml";
 const CRABBOX_HYDRATE_WORKFLOW = ".github/workflows/crabbox-hydrate.yml";
 const CRABBOX_CONFIG = ".crabbox.yaml";
+const PLUGIN_CLAWHUB_VALIDATE_WORKFLOW = ".github/workflows/plugin-clawhub-validate.yml";
 const SCHEDULED_LIVE_CHECKS_WORKFLOW = ".github/workflows/openclaw-scheduled-live-checks.yml";
 const TUI_PTY_WORKFLOW = ".github/workflows/tui-pty.yml";
 const CI_HYDRATE_LIVE_AUTH_SCRIPT = "scripts/ci-hydrate-live-auth.sh";
@@ -1667,6 +1668,51 @@ describe("package artifact reuse", () => {
       releaseWorkflow.lastIndexOf("append_release_proof_to_github_release"),
     );
     expect(releaseWorkflow).toContain("finished with ${conclusion} in ${duration_label}");
+  });
+
+  it("runs ClawHub package validation only for plugin PR changes without publish secrets", () => {
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+      scripts?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const validateScript = readFileSync("scripts/validate-changed-clawhub-plugins.ts", "utf8");
+    const workflowText = readFileSync(PLUGIN_CLAWHUB_VALIDATE_WORKFLOW, "utf8");
+    const workflow = readWorkflow(PLUGIN_CLAWHUB_VALIDATE_WORKFLOW);
+    const validateJob = workflowJob(
+      PLUGIN_CLAWHUB_VALIDATE_WORKFLOW,
+      "validate_changed_clawhub_plugins",
+    );
+    const validateStep = workflowStep(validateJob, "Validate changed ClawHub plugin packages");
+
+    expect(packageJson.devDependencies?.clawhub).toBeUndefined();
+    expect(packageJson.scripts?.["plugins:clawhub:validate-changed"]).toBe(
+      "node --import tsx scripts/validate-changed-clawhub-plugins.ts",
+    );
+    expect(validateScript).toContain('CLAWHUB_VALIDATE_CLI_PACKAGE = "clawhub@0.21.0"');
+    expect(validateScript).toContain('"dlx"');
+    expect(workflowText).toContain("name: Plugin ClawHub Validate");
+    expect(workflowText).toContain("pull_request:");
+    expect(workflowText).toContain('      - "extensions/**"');
+    expect(workflowText).not.toContain("CLAWHUB_TOKEN");
+    expect(workflowText).not.toContain("clawhub_token");
+    expect(workflow.env?.FORCE_JAVASCRIPT_ACTIONS_TO_NODE24).toBe("true");
+    expect(validateJob.if).toBe(
+      "github.event_name != 'pull_request' || !github.event.pull_request.draft",
+    );
+    expect(validateJob.permissions).toBeUndefined();
+    expect(workflowStep(validateJob, "Checkout").uses).toBe("actions/checkout@v6");
+    expect(workflowStep(validateJob, "Checkout").with?.["persist-credentials"]).toBe(false);
+    expect(workflowStep(validateJob, "Checkout").with?.["fetch-depth"]).toBe(2);
+    expect(workflowStep(validateJob, "Setup Node environment").uses).toBe(
+      "./.github/actions/setup-node-env",
+    );
+    expect(validateStep.env).toEqual({
+      BASE_REF: "${{ github.event.pull_request.base.sha }}",
+      HEAD_REF: "${{ github.sha }}",
+    });
+    expect(validateStep.run).toBe(
+      'pnpm plugins:clawhub:validate-changed -- --base-ref "$BASE_REF" --head-ref "$HEAD_REF"',
+    );
   });
 
   it("keeps release workflow setup and timeout budgets bounded", () => {

--- a/test/scripts/validate-changed-clawhub-plugins.test.ts
+++ b/test/scripts/validate-changed-clawhub-plugins.test.ts
@@ -1,0 +1,396 @@
+// Changed ClawHub plugin validation tests cover PR-only package validation routing.
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { PublishablePluginPackage } from "../../scripts/lib/plugin-clawhub-release.ts";
+import {
+  assertNoRemovedClawHubPublishablePackages,
+  buildClawHubPackageValidateCommand,
+  CLAWHUB_VALIDATE_CLI_PACKAGE,
+  collectBaselineClawHubPublishablePluginPackages,
+  collectClawHubPluginValidationPathsFromGitRange,
+  createChangedClawHubPackageValidatePlan,
+  parseValidateChangedClawHubPluginsArgs,
+  parseClawHubValidationReport,
+  parseClawHubValidationOutput,
+} from "../../scripts/validate-changed-clawhub-plugins.ts";
+
+const publishablePlugins: PublishablePluginPackage[] = [
+  {
+    extensionId: "discord",
+    packageDir: "extensions/discord",
+    packageName: "@openclaw/discord",
+    version: "2026.6.6",
+    channel: "stable",
+    publishTag: "latest",
+  },
+  {
+    extensionId: "llama-cpp",
+    packageDir: "extensions/llama-cpp",
+    packageName: "@openclaw/llama-cpp-provider",
+    version: "2026.6.6",
+    channel: "stable",
+    publishTag: "latest",
+  },
+  {
+    extensionId: "msteams",
+    packageDir: "extensions/msteams",
+    packageName: "@openclaw/msteams",
+    version: "2026.6.2",
+    channel: "stable",
+    publishTag: "latest",
+  },
+];
+
+describe("createChangedClawHubPackageValidatePlan", () => {
+  it("validates only changed ClawHub-publishable plugin packages", () => {
+    expect(
+      createChangedClawHubPackageValidatePlan({
+        plugins: publishablePlugins,
+        changedPaths: [
+          "extensions/irc/index.ts",
+          "extensions/llama-cpp/package.json",
+          "docs/plugins/reference/llama-cpp.md",
+        ],
+      }),
+    ).toEqual([
+      {
+        extensionId: "llama-cpp",
+        packageDir: "extensions/llama-cpp",
+        packageName: "@openclaw/llama-cpp-provider",
+      },
+    ]);
+  });
+
+  it("ignores generated shrinkwrap-only plugin changes", () => {
+    expect(
+      createChangedClawHubPackageValidatePlan({
+        plugins: publishablePlugins,
+        changedPaths: ["extensions/msteams/npm-shrinkwrap.json"],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("assertNoRemovedClawHubPublishablePackages", () => {
+  it("fails when a changed package was ClawHub-publishable at the base ref but is not in the current plan", () => {
+    expect(() =>
+      assertNoRemovedClawHubPublishablePackages({
+        currentPlan: [],
+        baselinePlugins: [
+          {
+            extensionId: "discord",
+            packageDir: "extensions/discord",
+            packageName: "@openclaw/discord",
+          },
+        ],
+        changedPaths: ["extensions/discord/package.json"],
+      }),
+    ).toThrow("extensions/discord: was ClawHub-publishable at @openclaw/discord");
+  });
+
+  it("allows changed packages that remain visible in the validation plan", () => {
+    expect(() =>
+      assertNoRemovedClawHubPublishablePackages({
+        currentPlan: [
+          {
+            extensionId: "discord",
+            packageDir: "extensions/discord",
+            packageName: "@openclaw/discord",
+          },
+        ],
+        baselinePlugins: [
+          {
+            extensionId: "discord",
+            packageDir: "extensions/discord",
+            packageName: "@openclaw/discord",
+          },
+        ],
+        changedPaths: ["extensions/discord/package.json"],
+      }),
+    ).not.toThrow();
+  });
+
+  it("ignores generated shrinkwrap-only package changes", () => {
+    expect(() =>
+      assertNoRemovedClawHubPublishablePackages({
+        currentPlan: [],
+        baselinePlugins: [
+          {
+            extensionId: "discord",
+            packageDir: "extensions/discord",
+            packageName: "@openclaw/discord",
+          },
+        ],
+        changedPaths: ["extensions/discord/npm-shrinkwrap.json"],
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("collectClawHubPluginValidationPathsFromGitRange", () => {
+  it("includes delete-only changes inside plugin packages", () => {
+    const repoDir = createTempGitRepo();
+    mkdirSync(join(repoDir, "extensions", "llama-cpp"), { recursive: true });
+    writeFileSync(join(repoDir, "package.json"), JSON.stringify({ name: "repo" }));
+    writeFileSync(join(repoDir, "extensions", "llama-cpp", "index.ts"), "export {};\n");
+    commitAll(repoDir, "initial plugin");
+    const baseRef = git(repoDir, ["rev-parse", "HEAD"]);
+
+    rmSync(join(repoDir, "extensions", "llama-cpp", "index.ts"));
+    commitAll(repoDir, "delete plugin entrypoint");
+    const headRef = git(repoDir, ["rev-parse", "HEAD"]);
+
+    try {
+      expect(
+        collectClawHubPluginValidationPathsFromGitRange({
+          rootDir: repoDir,
+          gitRange: { baseRef, headRef },
+        }),
+      ).toEqual(["extensions/llama-cpp/index.ts"]);
+    } finally {
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("collectBaselineClawHubPublishablePluginPackages", () => {
+  it("reads ClawHub-publishable package metadata from the base ref", () => {
+    const repoDir = createTempGitRepo();
+    mkdirSync(join(repoDir, "extensions", "discord"), { recursive: true });
+    writeFileSync(join(repoDir, "package.json"), JSON.stringify({ name: "repo" }));
+    writeFileSync(
+      join(repoDir, "extensions", "discord", "package.json"),
+      JSON.stringify({
+        name: "@openclaw/discord",
+        version: "2026.6.6",
+        openclaw: { release: { publishToClawHub: true } },
+      }),
+    );
+    commitAll(repoDir, "initial plugin");
+    const baseRef = git(repoDir, ["rev-parse", "HEAD"]);
+
+    try {
+      expect(
+        collectBaselineClawHubPublishablePluginPackages({
+          rootDir: repoDir,
+          baselineRef: baseRef,
+        }),
+      ).toEqual([
+        {
+          extensionId: "discord",
+          packageDir: "extensions/discord",
+          packageName: "@openclaw/discord",
+        },
+      ]);
+    } finally {
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("buildClawHubPackageValidateCommand", () => {
+  it("uses the pinned ClawHub CLI outside the root install graph", () => {
+    const repoRoot = resolve("/tmp/openclaw-checkout");
+
+    expect(
+      buildClawHubPackageValidateCommand("extensions/llama-cpp", "/tmp/clawhub-reports", repoRoot),
+    ).toEqual({
+      command: "pnpm",
+      args: [
+        "dlx",
+        "--config.minimum-release-age=0",
+        CLAWHUB_VALIDATE_CLI_PACKAGE,
+        "--workdir",
+        repoRoot,
+        "package",
+        "validate",
+        "extensions/llama-cpp",
+        "--json",
+        "--openclaw",
+        repoRoot,
+        "--out",
+        "/tmp/clawhub-reports",
+      ],
+    });
+  });
+});
+
+describe("parseValidateChangedClawHubPluginsArgs", () => {
+  it("accepts the pnpm script argument separator", () => {
+    expect(
+      parseValidateChangedClawHubPluginsArgs([
+        "--",
+        "--base-ref",
+        "origin/main",
+        "--head-ref",
+        "HEAD",
+      ]),
+    ).toEqual({
+      baseRef: "origin/main",
+      headRef: "HEAD",
+    });
+  });
+});
+
+function createTempGitRepo() {
+  const repoDir = mkdtempSync(join(tmpdir(), "openclaw-clawhub-validate-"));
+  git(repoDir, ["init", "-b", "main"]);
+  return repoDir;
+}
+
+function commitAll(repoDir: string, message: string) {
+  git(repoDir, ["add", "-A"]);
+  git(repoDir, [
+    "-c",
+    "user.name=Test",
+    "-c",
+    "user.email=test@example.com",
+    "commit",
+    "-m",
+    message,
+  ]);
+}
+
+function git(repoDir: string, args: string[]) {
+  return execFileSync("git", args, {
+    cwd: repoDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+describe("parseClawHubValidationOutput", () => {
+  it("accepts a clean validation result", () => {
+    expect(
+      parseClawHubValidationOutput(
+        JSON.stringify({ status: "pass", summary: { warningCount: 0, issueCount: 0 } }),
+        "extensions/llama-cpp",
+      ),
+    ).toEqual({ warningCount: 0, errorCount: 0 });
+  });
+
+  it("fails PR validation on ClawHub summary warnings", () => {
+    expect(() =>
+      parseClawHubValidationOutput(
+        JSON.stringify({ status: "pass", summary: { warningCount: 1, issueCount: 0 } }),
+        "extensions/llama-cpp",
+      ),
+    ).toThrow("extensions/llama-cpp: ClawHub validation reported 1 warning");
+  });
+
+  it("ignores ClawHub core compatibility warnings", () => {
+    expect(
+      parseClawHubValidationOutput(
+        JSON.stringify({
+          status: "pass",
+          summary: { warningCount: 1, issueCount: 1 },
+          issues: [
+            {
+              code: "channel-env-vars",
+              owner: "core",
+              decision: "core-compat-adapter",
+              issueClass: "deprecation-warning",
+            },
+          ],
+        }),
+        "extensions/slack",
+      ),
+    ).toEqual({ warningCount: 0, errorCount: 0 });
+  });
+
+  it("ignores ClawHub core compatibility warnings from warnings arrays", () => {
+    expect(
+      parseClawHubValidationOutput(
+        JSON.stringify({
+          status: "pass",
+          summary: { warningCount: 1, issueCount: 1 },
+          warnings: [
+            {
+              code: "channel-env-vars",
+              owner: "core",
+              decision: "core-compat-adapter",
+              issueClass: "deprecation-warning",
+            },
+          ],
+        }),
+        "extensions/slack",
+      ),
+    ).toEqual({ warningCount: 0, errorCount: 0 });
+  });
+
+  it("keys blocking warnings by code and evidence for baseline comparisons", () => {
+    expect(
+      parseClawHubValidationReport(
+        JSON.stringify({
+          status: "pass",
+          summary: { warningCount: 1, issueCount: 1 },
+          issues: [
+            {
+              code: "package-min-host-version-drift",
+              owner: "plugin",
+              decision: "plugin-upstream-fix",
+              issueClass: "upstream-metadata",
+              evidence: ["buildOpenClawVersion:2026.6.6", "minHostVersion:>=2026.6.2"],
+            },
+          ],
+        }),
+        "extensions/llama-cpp",
+      ),
+    ).toEqual({
+      warningCount: 1,
+      errorCount: 0,
+      blockingWarningKeys: [
+        "owner:plugin;code:package-min-host-version-drift;decision:plugin-upstream-fix;issueClass:upstream-metadata;evidence:buildOpenClawVersion:2026.6.6|minHostVersion:>=2026.6.2",
+      ],
+    });
+  });
+
+  it("keys blocking warnings arrays for baseline comparisons", () => {
+    expect(
+      parseClawHubValidationReport(
+        JSON.stringify({
+          status: "pass",
+          summary: { warningCount: 1, issueCount: 1 },
+          warnings: [
+            {
+              code: "package-install-metadata-incomplete",
+              owner: "plugin",
+              decision: "plugin-upstream-fix",
+              issueClass: "upstream-metadata",
+            },
+          ],
+        }),
+        "extensions/llama-cpp",
+      ),
+    ).toEqual({
+      warningCount: 1,
+      errorCount: 0,
+      blockingWarningKeys: [
+        "owner:plugin;code:package-install-metadata-incomplete;decision:plugin-upstream-fix;issueClass:upstream-metadata",
+      ],
+    });
+  });
+
+  it("fails PR validation on package-owned metadata warnings", () => {
+    expect(() =>
+      parseClawHubValidationOutput(
+        JSON.stringify({
+          status: "pass",
+          summary: { warningCount: 1, issueCount: 1 },
+          issues: [
+            {
+              code: "package-install-metadata-incomplete",
+              owner: "plugin",
+              decision: "plugin-upstream-fix",
+              issueClass: "upstream-metadata",
+            },
+          ],
+        }),
+        "extensions/llama-cpp",
+      ),
+    ).toThrow("extensions/llama-cpp: ClawHub validation reported 1 warning");
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `@openclaw/llama-cpp-provider` ClawHub metadata so `clawhub@0.21.0 package validate extensions/llama-cpp` reports zero warnings.
- Add a PR-only workflow for `extensions/**` changes that validates changed ClawHub-publishable plugin packages.
- Add a tested helper that uses the pinned published CLI via `pnpm dlx clawhub@0.21.0`, baseline-compares existing warnings, ignores generated shrinkwrap-only changes, and avoids root lockfile/plugin shrinkwrap churn.

## Proof

- `node scripts/run-vitest.mjs test/scripts/validate-changed-clawhub-plugins.test.ts test/scripts/package-acceptance-workflow.test.ts test/plugin-clawhub-release.test.ts src/plugins/official-external-plugin-catalog.test.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts` — 130 tests passed.
- `pnpm plugins:clawhub:validate-changed -- --base-ref origin/main --head-ref HEAD` — validated exactly `@openclaw/llama-cpp-provider`; `status: pass`, `warningCount: 0`, `issueCount: 0`.
- Direct pinned ClawHub validation for `extensions/llama-cpp` — `status: pass`, `warningCount: 0`, `issueCount: 0`, target OpenClaw `ok`.
- `pnpm deps:shrinkwrap:changed:check` — passed.
- `pnpm plugins:inventory:check` — passed.
- `pnpm format:check ...` — passed.
- `actionlint .github/workflows/plugin-clawhub-validate.yml && git diff --check` — passed.
- `$autoreview` — clean; no accepted/actionable findings.

## Notes

- No publish, token, or production mutation is part of this change.
- The already-published npm tarball `@openclaw/llama-cpp-provider@2026.6.6` is immutable; this fixes source/staged ClawHub validation for future package validation and publish paths.
