### PR TITLE
fix(agents): isolate invalid plugin model catalogs [AI-assisted]

### DIFF
--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -26,29 +26,58 @@ function writeModelsJsonWithPluginCatalog(params: {
   pluginRelativePath: string;
   pluginCatalog: unknown;
 }): string {
+  return writeModelsJsonWithPluginCatalogs({
+    root: params.root,
+    pluginCatalogs: [
+      {
+        pluginRelativePath: params.pluginRelativePath,
+        pluginCatalog: params.pluginCatalog,
+      },
+    ],
+  });
+}
+
+function writeModelsJsonWithPluginCatalogs(params: {
+  root: unknown;
+  pluginCatalogs: Array<{
+    pluginRelativePath: string;
+    pluginCatalog: unknown;
+  }>;
+}): string {
   const dir = mkdtempSync(join(tmpdir(), "openclaw-model-registry-"));
   tempDirs.push(dir);
   const file = join(dir, "models.json");
-  const pluginFile = join(dir, params.pluginRelativePath);
-  mkdirSync(dirname(pluginFile), { recursive: true });
   writeFileSync(file, JSON.stringify(params.root, null, 2), "utf-8");
-  writeFileSync(pluginFile, JSON.stringify(params.pluginCatalog, null, 2), "utf-8");
+  for (const pluginCatalog of params.pluginCatalogs) {
+    const pluginFile = join(dir, pluginCatalog.pluginRelativePath);
+    mkdirSync(dirname(pluginFile), { recursive: true });
+    writeFileSync(pluginFile, JSON.stringify(pluginCatalog.pluginCatalog, null, 2), "utf-8");
+  }
   return file;
 }
 
 function pluginOwnerSnapshot(providerId: string, pluginId: string, enabled = true) {
+  return pluginOwnerSnapshotEntries([{ providerId, pluginId, enabled }]);
+}
+
+function pluginOwnerSnapshotEntries(
+  entries: Array<{ providerId: string; pluginId: string; enabled?: boolean }>,
+) {
   // The registry only trusts generated provider shards that are still owned by
   // an enabled plugin in the current metadata snapshot.
   return {
     index: {
-      plugins: [{ pluginId, enabled }],
+      plugins: entries.map((entry) => ({
+        pluginId: entry.pluginId,
+        enabled: entry.enabled ?? true,
+      })),
     },
     normalizePluginId: (id: string) => id,
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),
-      providers: new Map([[providerId, [pluginId]]]),
-      modelCatalogProviders: new Map([[providerId, [pluginId]]]),
+      providers: new Map(entries.map((entry) => [entry.providerId, [entry.pluginId]])),
+      modelCatalogProviders: new Map(entries.map((entry) => [entry.providerId, [entry.pluginId]])),
       cliBackends: new Map(),
       setupProviders: new Map(),
       commandAliases: new Map(),
@@ -143,6 +172,64 @@ describe("ModelRegistry models.json auth", () => {
 
     expect(registry.getError()).toBeUndefined();
     expect(registry.find("zai", "glm-5.1")?.name).toBe("GLM 5.1");
+  });
+
+  it("isolates invalid generated plugin catalog shards from valid models", () => {
+    const modelsPath = writeModelsJsonWithPluginCatalogs({
+      root: {
+        providers: {
+          custom: {
+            baseUrl: "https://models.example/v1",
+            api: "openai-responses",
+            apiKey: "CUSTOM_API_KEY",
+            models: [{ id: "root-model", name: "Root Model" }],
+          },
+        },
+      },
+      pluginCatalogs: [
+        {
+          pluginRelativePath: join("plugins", "google", PLUGIN_MODEL_CATALOG_FILE),
+          pluginCatalog: {
+            generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+            providers: {
+              "google-vertex": {
+                baseUrl: "https://us-central1-aiplatform.googleapis.com/v1",
+                apiKey: "GOOGLE_API_KEY",
+                models: [{ id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro" }],
+              },
+            },
+          },
+        },
+        {
+          pluginRelativePath: join("plugins", "zai", PLUGIN_MODEL_CATALOG_FILE),
+          pluginCatalog: {
+            generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+            providers: {
+              zai: {
+                baseUrl: "https://api.z.ai/api/paas/v4",
+                api: "openai-completions",
+                apiKey: "ZAI_API_KEY",
+                models: [{ id: "glm-5.1", name: "GLM 5.1" }],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const registry = ModelRegistry.create(AuthStorage.inMemory(), modelsPath, {
+      pluginMetadataSnapshot: pluginOwnerSnapshotEntries([
+        { providerId: "google-vertex", pluginId: "google" },
+        { providerId: "zai", pluginId: "zai" },
+      ]),
+    });
+
+    expect(registry.getError()).toContain(
+      'Provider google-vertex, model gemini-3.1-pro-preview: no "api" specified',
+    );
+    expect(registry.find("custom", "root-model")?.name).toBe("Root Model");
+    expect(registry.find("zai", "glm-5.1")?.name).toBe("GLM 5.1");
+    expect(registry.find("google-vertex", "gemini-3.1-pro-preview")).toBeUndefined();
   });
 
   it("preserves model params from generated plugin catalog shards", () => {

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -371,7 +371,7 @@ export class ModelRegistry {
 
     if (error) {
       this.loadError = error;
-      // Keep the prior empty/default registry shape when models.json failed to load.
+      // Plugin catalog failures can return salvaged models; root failures return empty.
     }
 
     let combined = customModels;
@@ -444,6 +444,7 @@ export class ModelRegistry {
       }
 
       const models = this.parseModels(configForUse);
+      const pluginCatalogErrors: string[] = [];
       if (options.includePluginCatalogs !== false) {
         for (const pluginCatalog of listPluginModelCatalogFiles(dirname(modelsJsonPath))) {
           const pluginResult = this.loadCustomModels(pluginCatalog.path, {
@@ -452,13 +453,14 @@ export class ModelRegistry {
             requireGeneratedCatalog: true,
           });
           if (pluginResult.error) {
-            return pluginResult;
+            pluginCatalogErrors.push(pluginResult.error);
+            continue;
           }
           models.push(...pluginResult.models);
         }
       }
 
-      return { models, error: undefined };
+      return { models, error: pluginCatalogErrors.join("\n\n") || undefined };
     } catch (error) {
       if (error instanceof SyntaxError) {
         if (options.requireGeneratedCatalog === true) {

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -21,6 +21,7 @@ import type {
 } from "../../llm/types.js";
 import { registerOAuthProvider, resetOAuthProviders } from "../../llm/utils/oauth/index.js";
 import type { OAuthProviderInterface } from "../../llm/utils/oauth/types.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getAgentDir } from "../config.js";
 import { resolveModelPluginMetadataSnapshot } from "../model-discovery-context.js";
 import {
@@ -37,6 +38,8 @@ import {
   resolveConfigValueUncached,
   resolveHeadersOrThrow,
 } from "./resolve-config-value.js";
+
+const log = createSubsystemLogger("agents/model-registry");
 
 // Schema for OpenRouter routing preferences
 const PercentileCutoffsSchema = Type.Object({
@@ -355,9 +358,7 @@ export class ModelRegistry {
     }
   }
 
-  /**
-   * Get any error from loading models.json (undefined if no error).
-   */
+  /** Get any root or generated plugin catalog load error. */
   getError(): string | undefined {
     return this.loadError;
   }
@@ -371,6 +372,7 @@ export class ModelRegistry {
 
     if (error) {
       this.loadError = error;
+      log.warn(`model catalog load issue: ${error}`);
       // Plugin catalog failures can return salvaged models; root failures return empty.
     }
 


### PR DESCRIPTION
## Summary

- Fixes #92553.
- Keeps custom root models and valid generated plugin catalog shards available when one generated plugin catalog has an invalid provider/model entry.
- Preserves the invalid plugin catalog validation message through `ModelRegistry.getError()` so the bad catalog remains visible instead of being silently ignored.
- Logs partial catalog-load failures through the model-registry subsystem logger.
- Adds a regression test that covers one invalid generated plugin catalog next to valid root and plugin models.

## Verification

- `node scripts/run-vitest.mjs src/agents/sessions/model-registry.test.ts`
- `node node_modules/oxfmt/bin/oxfmt --check src/agents/sessions/model-registry.ts src/agents/sessions/model-registry.test.ts`
- `git diff --check`
- Real `ModelRegistry` CLI probe against a temporary root catalog, invalid generated Google shard, and valid generated ZAI shard.

## Real behavior proof

Behavior addressed: A generated plugin model catalog with an invalid provider entry no longer aborts the entire custom-model load. Valid root models and other valid generated plugin catalog models remain available, and `ModelRegistry.getError()` still exposes the bad catalog validation error.

Real environment tested: Windows source checkout of `openclaw/openclaw`, Node `v24.15.0`, running the real `ModelRegistry` and `AuthStorage` source modules through `tsx` against a temporary agent profile on disk.

Exact steps or command run after this patch: Ran `node --import tsx --input-type=module -` with an inline script that created a temporary `models.json`, a bad generated `plugins/google/catalog.json` missing `api`, and a valid generated `plugins/zai/catalog.json`; then instantiated `ModelRegistry.create(AuthStorage.inMemory(), tempModelsPath, { pluginMetadataSnapshot })` and inspected `getError()`, `find()`, and `getAll()`.

Evidence after fix:
```json
{
  "errorMentionsBadCatalog": true,
  "rootModel": "Root Model",
  "validPluginModel": "GLM 5.1",
  "invalidPluginModelPresent": false,
  "modelCount": 2
}
```

Observed result after fix: The invalid generated `google-vertex` catalog was skipped, the root model and valid `zai` plugin model loaded, and the registry retained the validation error.

What was not tested by the contributor: Full gateway/media-generation runtime behavior, a real user install with an existing stale catalog, full `pnpm check`, and full `pnpm test`.

## Maintainer verification

Verified on rebased head `d2f6316c549a7efe546cabd4528a02223578896f`:

- Focused registry regression: 8 tests passed.
- Related model consumers: 153 tests passed across the registry, embedded model runner, and media understanding.
- Official-provider regression suite: 68 OpenAI Responses/Completions and Anthropic payload/tool tests passed.
- Isolated CLI E2E: `pnpm openclaw models list --all --json` retained the valid custom root model while an invalid generated shard was present.
- Live Anthropic tool roundtrip: `claude-sonnet-4-6` emitted `noop`, accepted the tool result, and completed.
- Live OpenAI tool roundtrip: `gpt-5.4-mini` emitted `noop` through the Responses path, accepted the tool result, and completed.
- AWS Crabbox Docker E2E: `bash scripts/e2e/openai-chat-tools-docker.sh` passed after package build and tarball validation, run `run_e33507c4d2aa`.
- Fresh local and complete-branch autoreviews reported no accepted/actionable findings.

The Azure Crabbox attempt failed during lease allocation with a coordinator HTTP 500 before provisioning; the AWS retry completed successfully.

AI assisted: Yes, this PR was prepared with AI assistance.