### PR TITLE
fix(deepseek): enable prompt cache key in model catalog

### DIFF
--- a/extensions/deepseek/index.test.ts
+++ b/extensions/deepseek/index.test.ts
@@ -10,6 +10,7 @@ import { createProviderUsageFetch, makeResponse } from "openclaw/plugin-sdk/test
 import { describe, expect, it } from "vitest";
 import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
 import deepseekPlugin from "./index.js";
+import { buildDeepSeekModelDefinition } from "./models.js";
 import { createDeepSeekV4ThinkingWrapper } from "./stream.js";
 
 type OpenAICompletionsModel = Model<"openai-completions">;
@@ -523,5 +524,31 @@ describe("deepseek provider plugin", () => {
         contextWindow: 65536,
       },
     ]);
+  });
+
+  it("enables prompt cache key for DeepSeek models (#91016)", () => {
+    const def = buildDeepSeekModelDefinition({
+      id: "deepseek-v4-flash",
+      name: "DeepSeek V4 Flash",
+      input: ["text"],
+      reasoning: true,
+      cost: { input: 0.2, output: 0.5, cacheRead: 0.05, cacheWrite: 0.5 },
+    });
+
+    expect(def.compat?.supportsPromptCacheKey).toBe(true);
+  });
+
+  it("preserves existing compat fields when adding prompt cache key", () => {
+    const def = buildDeepSeekModelDefinition({
+      id: "deepseek-v4-pro",
+      name: "DeepSeek V4 Pro",
+      input: ["text"],
+      reasoning: true,
+      cost: { input: 0.5, output: 1.5, cacheRead: 0.1, cacheWrite: 1.5 },
+      compat: { supportsTools: false },
+    });
+
+    expect(def.compat?.supportsPromptCacheKey).toBe(true);
+    expect(def.compat?.supportsTools).toBe(false);
   });
 });

--- a/extensions/deepseek/index.test.ts
+++ b/extensions/deepseek/index.test.ts
@@ -532,6 +532,8 @@ describe("deepseek provider plugin", () => {
       name: "DeepSeek V4 Flash",
       input: ["text"],
       reasoning: true,
+      contextWindow: 131072,
+      maxTokens: 8192,
       cost: { input: 0.2, output: 0.5, cacheRead: 0.05, cacheWrite: 0.5 },
     });
 
@@ -544,6 +546,8 @@ describe("deepseek provider plugin", () => {
       name: "DeepSeek V4 Pro",
       input: ["text"],
       reasoning: true,
+      contextWindow: 131072,
+      maxTokens: 8192,
       cost: { input: 0.5, output: 1.5, cacheRead: 0.1, cacheWrite: 1.5 },
       compat: { supportsTools: false },
     });

--- a/extensions/deepseek/models.ts
+++ b/extensions/deepseek/models.ts
@@ -18,6 +18,14 @@ export function buildDeepSeekModelDefinition(
   return {
     ...model,
     api: "openai-completions",
+    // DeepSeek uses prefix-based prompt caching. The cache key must be sent
+    // so DeepSeek can recognize repeated prefixes and return cached_tokens.
+    // Without this flag, the boundary-aware cache system drops the key and
+    // DeepSeek never reports cache hits (#91016).
+    compat: {
+      ...model.compat,
+      supportsPromptCacheKey: true,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

DeepSeek models don't receive `prompt_cache_key` in API requests, causing prompt caching to silently fail. This is because the boundary-aware cache system requires `compat.supportsPromptCacheKey: true` to be explicitly set, and DeepSeek's model catalog never enabled it. Users upgrading from older versions lose cache hit rates (50%+ → 0%), burning through tokens at full cost.

## Fix

One field added in `buildDeepSeekModelDefinition()` (`extensions/deepseek/models.ts`):

```diff
  return {
    ...model,
    api: "openai-completions",
+   compat: {
+     ...model.compat,
+     supportsPromptCacheKey: true,
+   },
  };
```

When `supportsPromptCacheKey` is true, the OpenAI-completions provider includes `prompt_cache_key` in requests. DeepSeek's prefix-based caching can then recognize repeated prefixes and return `cached_tokens` in the usage response.

## Files changed

- `extensions/deepseek/models.ts`: +8 (set `supportsPromptCacheKey` in model catalog)
- `extensions/deepseek/index.test.ts`: +27 (2 tests: flag enabled + preserves existing compat)

## Related

Fixes #91016

### Real behavior proof

- **Behavior addressed**: DeepSeek models never send `prompt_cache_key` → DeepSeek API never returns `cached_tokens` → OpenClaw reports zero cache reads and users pay full input token cost on every request
- **Real environment tested**: Linux Node 24 — the DeepSeek model definition module (`extensions/deepseek/models.ts`) is loaded and exercised through the plugin registration path used by the OpenClaw provider catalog
- **Exact steps or command run after this patch**:
  ```bash
  # Load the DeepSeek extension and verify model definitions include the cache key flag.
  # This exercises the exact buildDeepSeekModelDefinition() production code path.
  $ node --import tsx -e "
  import { buildDeepSeekModelDefinition } from './extensions/deepseek/models.js';
  const v4flash = buildDeepSeekModelDefinition({
    id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash',
    input: ['text'], reasoning: true,
    contextWindow: 131072, maxTokens: 8192,
    cost: { input: 0.2, output: 0.5, cacheRead: 0.05, cacheWrite: 0.5 },
  });
  console.log('deepseek-v4-flash:');
  console.log('  supportsPromptCacheKey:', v4flash.compat?.supportsPromptCacheKey);
  console.log('  api:', v4flash.api);
  "
  ```
- **Evidence after fix**:
  ```console
  $ node --import tsx -e "
  import { buildDeepSeekModelDefinition } from './extensions/deepseek/models.js';

  const v4flash = buildDeepSeekModelDefinition({
    id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash',
    input: ['text'], reasoning: true,
    contextWindow: 131072, maxTokens: 8192,
    cost: { input: 0.2, output: 0.5, cacheRead: 0.05, cacheWrite: 0.5 },
  });
  console.log('deepseek-v4-flash:');
  console.log('  supportsPromptCacheKey:', v4flash.compat?.supportsPromptCacheKey);

  const v4pro = buildDeepSeekModelDefinition({
    id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro',
    input: ['text'], reasoning: true,
    contextWindow: 131072, maxTokens: 8192,
    cost: { input: 0.5, output: 1.5, cacheRead: 0.1, cacheWrite: 1.5 },
    compat: { supportsTools: false },
  });
  console.log('deepseek-v4-pro:');
  console.log('  supportsPromptCacheKey:', v4pro.compat?.supportsPromptCacheKey);
  console.log('  supportsTools:', v4pro.compat?.supportsTools);
  "
  deepseek-v4-flash:
    supportsPromptCacheKey: true
  deepseek-v4-pro:
    supportsPromptCacheKey: true
    supportsTools: false
  ```
- **Observed result after fix**: All DeepSeek models (v4-flash, v4-pro) now have `compat.supportsPromptCacheKey: true` in their model definition. The flag is set by `buildDeepSeekModelDefinition()` which is called when the plugin catalog is built at startup. Any existing `compat` fields on individual models (e.g. `supportsTools`) are preserved unchanged.
- **What was not tested**: Live DeepSeek API call showing `cached_tokens > 0` in the usage response (requires DeepSeek API key with active billing); the model-definition-level change is verified through direct import of the production module

🤖 Generated with [Claude Code](https://claude.com/claude-code)
