### PR TITLE
Fix lifecycle timeout cleanup after leader exit

### DIFF
--- a/scripts/e2e/lib/plugin-lifecycle-matrix/measure.mjs
+++ b/scripts/e2e/lib/plugin-lifecycle-matrix/measure.mjs
@@ -72,11 +72,13 @@ function readProcSnapshot() {
         .trim()
         .split(/\s+/u);
       const ppid = Number.parseInt(fields[1] ?? "", 10);
+      const pgrp = Number.parseInt(fields[2] ?? "", 10);
       const userTicks = Number.parseInt(fields[11] ?? "", 10);
       const systemTicks = Number.parseInt(fields[12] ?? "", 10);
       const rssPages = Number.parseInt(fields[21] ?? "", 10);
       if (
         !Number.isFinite(ppid) ||
+        !Number.isFinite(pgrp) ||
         !Number.isFinite(userTicks) ||
         !Number.isFinite(systemTicks) ||
         !Number.isFinite(rssPages)
@@ -85,6 +87,7 @@ function readProcSnapshot() {
       }
       stats.set(pid, {
         ppid,
+        pgrp,
         cpuTicks: userTicks + systemTicks,
         rssBytes: Math.max(0, rssPages) * pageSize,
       });
@@ -117,7 +120,10 @@ function descendantsOf(rootPid, stats) {
 
 function sample(rootPid) {
   const stats = readProcSnapshot();
-  const pids = descendantsOf(rootPid, stats);
+  const groupPids = new Set(
+    [...stats.entries()].filter(([, stat]) => stat.pgrp === rootPid).map(([pid]) => pid),
+  );
+  const pids = new Set([...descendantsOf(rootPid, stats), ...groupPids]);
   let rssBytes = 0;
   let cpuTicks = 0;
   for (const pid of pids) {
@@ -148,6 +154,10 @@ let forwardedParentSignal = null;
 let killTimer;
 let parentSignalTimer;
 let parentSignalPollTimer;
+let childGroupDrainTimer;
+// The leader can exit before descendants in its detached process group.
+// Keep the wrapper alive so timeout cleanup still owns those descendants.
+let childClosedResult = null;
 const updateMetrics = () => {
   if (!child.pid) {
     return;
@@ -157,11 +167,21 @@ const updateMetrics = () => {
   maxCpuTicks = Math.max(maxCpuTicks, current.cpuTicks);
 };
 
+function finishChildClosedResultIfGroupDrained() {
+  if (childClosedResult && !childGroupExists()) {
+    finish(childClosedResult.code, childClosedResult.signal);
+  }
+}
+
 updateMetrics();
 const interval = setInterval(updateMetrics, pollMs);
 const timeoutTimer =
   Number.isFinite(timeoutMs) && timeoutMs > 0
     ? setTimeout(() => {
+        if (childClosedResult && !childGroupExists()) {
+          finish(childClosedResult.code, childClosedResult.signal);
+          return;
+        }
         timedOut = true;
         terminateChildGroup("SIGTERM");
         killTimer = setTimeout(() => {
@@ -214,6 +234,9 @@ function clearRuntimeTimers() {
   }
   if (parentSignalPollTimer) {
     clearInterval(parentSignalPollTimer);
+  }
+  if (childGroupDrainTimer) {
+    clearInterval(childGroupDrainTimer);
   }
 }
 
@@ -327,6 +350,11 @@ child.on("exit", (code, signal) => {
     return;
   }
   if (timedOut && killTimer) {
+    return;
+  }
+  if (childGroupExists()) {
+    childClosedResult = { code, signal };
+    childGroupDrainTimer = setInterval(finishChildClosedResultIfGroupDrained, Math.min(25, pollMs));
     return;
   }
   finish(code, signal);

--- a/test/scripts/plugin-lifecycle-measure.test.ts
+++ b/test/scripts/plugin-lifecycle-measure.test.ts
@@ -220,7 +220,11 @@ describe("plugin lifecycle resource sampler", () => {
             "--",
             "bash",
             "-lc",
-            'bash -c \'trap "" TERM; printf "%s\\n" "$$" >"$PID_FILE"; while :; do sleep 1; done\' & wait',
+            [
+              'bash -c \'trap "" TERM; printf "%s\\n" "$$" >"$PID_FILE"; while :; do sleep 1; done\' &',
+              'while [ ! -s "$PID_FILE" ]; do sleep 0.01; done',
+              "exit 0",
+            ].join("\n"),
           ],
           {
             cwd: process.cwd(),


### PR DESCRIPTION
## Summary

- Keep the plugin lifecycle measurement wrapper alive when the detached process-group leader exits before its descendants.
- Sample both the original descendant tree and same-process-group members so reparented descendants still count toward RSS/CPU ceilings.
- Make the existing stubborn-descendant timeout test exercise the leader-exits-first case that can otherwise surface as status 1 instead of timeout status 124.

## Verification

- `pnpm dlx oxfmt@0.52.0 --check --threads=1 -- scripts/e2e/lib/plugin-lifecycle-matrix/measure.mjs test/scripts/plugin-lifecycle-measure.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean)

## Proof gaps

- Final Linux Testbox reruns for `node scripts/run-vitest.mjs test/scripts/plugin-lifecycle-measure.test.ts --reporter=verbose` were attempted after the final review fixes, but Blacksmith DNS failed before command execution: `tbx_01ktz8y35hcp6t629qkh7ac215`, `tbx_01ktz91vvs0dhvw73d5scsehvz`, `tbx_01ktz9bpv5y5ee32yfsvwrx0ct`, and `tbx_01ktz9k97ck2gv9hk0xj9n9tnx` all stopped with `could not resolve testbox host`.
- Earlier Linux Testbox runs did execute and pass the narrow lifecycle file before the final accounting-review fix; PR CI should be treated as the final Linux proof for this branch.
