### PR TITLE
fix(cron): cancel active task ledger runs

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -13,12 +13,32 @@ import {
   createTaskRecord as createTaskRecordOrNull,
   resetTaskRegistryDeliveryRuntimeForTests,
   resetTaskRegistryForTests,
+  getTaskById,
 } from "../tasks/task-registry.js";
 import * as taskRegistryMaintenance from "../tasks/task-registry.maintenance.js";
 import type { TaskRecord } from "../tasks/task-registry.types.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
-import { tasksAuditCommand, tasksMaintenanceCommand, tasksShowCommand } from "./tasks.js";
+import {
+  tasksAuditCommand,
+  tasksCancelCommand,
+  tasksMaintenanceCommand,
+  tasksShowCommand,
+} from "./tasks.js";
+
+const gatewayMocks = vi.hoisted(() => ({
+  callGateway: vi.fn(),
+  isGatewayCredentialsRequiredError: vi.fn(() => false),
+  isGatewayTransportError: vi.fn(
+    (error: unknown) => error instanceof Error && error.name === "GatewayTransportError",
+  ),
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: gatewayMocks.callGateway,
+  isGatewayCredentialsRequiredError: gatewayMocks.isGatewayCredentialsRequiredError,
+  isGatewayTransportError: gatewayMocks.isGatewayTransportError,
+}));
 
 function createRuntime(): RuntimeEnv {
   return {
@@ -96,6 +116,69 @@ describe("tasks commands", () => {
     resetTaskRegistryDeliveryRuntimeForTests();
     resetTaskRegistryForTests({ persist: false });
     resetTaskFlowRegistryForTests({ persist: false });
+    gatewayMocks.callGateway.mockReset();
+    gatewayMocks.isGatewayCredentialsRequiredError.mockClear();
+    gatewayMocks.isGatewayTransportError.mockClear();
+  });
+
+  it("routes task cancellation through the Gateway when available", async () => {
+    await withTaskCommandStateDir(async () => {
+      const task = createTaskRecord({
+        runtime: "cron",
+        sourceId: "cron-job-1",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "cron-run-1",
+        status: "running",
+        task: "Run cron job",
+      });
+      gatewayMocks.callGateway.mockResolvedValue({
+        found: true,
+        cancelled: true,
+        task: {
+          id: task.taskId,
+          taskId: task.taskId,
+          runtime: "cron",
+          status: "cancelled",
+          runId: "cron-run-1",
+        },
+      });
+
+      const runtime = createRuntime();
+      await tasksCancelCommand({ lookup: task.taskId }, runtime);
+
+      expect(gatewayMocks.callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "tasks.cancel",
+          params: { taskId: task.taskId },
+          requiredMethods: ["tasks.cancel"],
+        }),
+      );
+      expect(runtime.log).toHaveBeenCalledWith(`Cancelled ${task.taskId} (cron) run cron-run-1.`);
+    });
+  });
+
+  it("falls back to local task cancellation when the Gateway is unavailable", async () => {
+    await withTaskCommandStateDir(async () => {
+      const task = createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "cli-run-1",
+        status: "running",
+        task: "Run local task",
+      });
+      const transportError = new Error("gateway unavailable");
+      transportError.name = "GatewayTransportError";
+      gatewayMocks.callGateway.mockRejectedValue(transportError);
+
+      const runtime = createRuntime();
+      await tasksCancelCommand({ lookup: task.taskId }, runtime);
+
+      expect(gatewayMocks.callGateway).toHaveBeenCalledOnce();
+      expect(getTaskById(task.taskId)?.status).toBe("cancelled");
+      expect(runtime.log).toHaveBeenCalledWith(`Cancelled ${task.taskId} (cli) run cli-run-1.`);
+    });
   });
 
   it("keeps audit JSON stable and sorts combined findings before limiting", async () => {

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -4,6 +4,7 @@
 import fs from "node:fs";
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { TasksCancelResult } from "../../packages/gateway-protocol/src/index.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { formatLookupMiss } from "../cli/error-format.js";
@@ -16,6 +17,11 @@ import {
   type SessionEntry,
 } from "../config/sessions.js";
 import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
+import {
+  callGateway,
+  isGatewayCredentialsRequiredError,
+  isGatewayTransportError,
+} from "../gateway/call.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { getTaskById, updateTaskNotifyPolicyById } from "../tasks/runtime-internal.js";
@@ -45,6 +51,7 @@ import {
 } from "../tasks/task-registry.reconcile.js";
 import { summarizeTaskRecords } from "../tasks/task-registry.summary.js";
 import type { TaskNotifyPolicy, TaskRecord } from "../tasks/task-registry.types.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import {
   buildTaskSystemAuditFindings,
   type TaskSystemAuditCode,
@@ -76,6 +83,29 @@ function formatTaskTimestamp(value: number | undefined): string {
 
 async function loadTaskCancelConfig() {
   return getRuntimeConfig();
+}
+
+async function tryCancelTaskViaGateway(params: {
+  cfg: Awaited<ReturnType<typeof loadTaskCancelConfig>>;
+  taskId: string;
+}): Promise<TasksCancelResult | null> {
+  try {
+    return await callGateway<TasksCancelResult>({
+      config: params.cfg,
+      method: "tasks.cancel",
+      params: {
+        taskId: params.taskId,
+      },
+      mode: GATEWAY_CLIENT_MODES.CLI,
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+      requiredMethods: ["tasks.cancel"],
+    });
+  } catch (error) {
+    if (isGatewayTransportError(error) || isGatewayCredentialsRequiredError(error)) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 function configureTaskMaintenanceFromConfig(): void {
@@ -498,10 +528,17 @@ export async function tasksCancelCommand(opts: { lookup: string }, runtime: Runt
     runtime.exit(1);
     return;
   }
-  const result = await cancelDetachedTaskRunById({
-    cfg: await loadTaskCancelConfig(),
+  const cfg = await loadTaskCancelConfig();
+  const gatewayResult = await tryCancelTaskViaGateway({
+    cfg,
     taskId: task.taskId,
   });
+  const result =
+    gatewayResult ??
+    (await cancelDetachedTaskRunById({
+      cfg,
+      taskId: task.taskId,
+    }));
   if (!result.found) {
     runtime.error(result.reason ?? formatTaskLookupMiss(opts.lookup));
     runtime.exit(1);
@@ -513,8 +550,11 @@ export async function tasksCancelCommand(opts: { lookup: string }, runtime: Runt
     return;
   }
   const updated = getTaskById(task.taskId);
+  const gatewayTask = gatewayResult?.task;
+  const runtimeName = updated?.runtime ?? gatewayTask?.runtime ?? task.runtime;
+  const runId = updated?.runId ?? gatewayTask?.runId;
   runtime.log(
-    `Cancelled ${updated?.taskId ?? task.taskId} (${updated?.runtime ?? task.runtime})${updated?.runId ? ` run ${updated.runId}` : ""}.`,
+    `Cancelled ${updated?.taskId ?? gatewayTask?.taskId ?? task.taskId} (${runtimeName})${runId ? ` run ${runId}` : ""}.`,
   );
 }
 

--- a/src/cron/active-jobs.ts
+++ b/src/cron/active-jobs.ts
@@ -1,8 +1,16 @@
 /** Tracks in-process cron executions so schedulers and wake paths avoid duplicate runs. */
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 
+export type CronActiveJobCancel = (reason: string) => void;
+
+type CronActiveJobEntry = {
+  cancel?: CronActiveJobCancel;
+  cancelRequestedReason?: string;
+};
+
 type CronActiveJobState = {
   activeJobIds: Set<string>;
+  activeJobsById: Map<string, CronActiveJobEntry>;
 };
 
 const CRON_ACTIVE_JOB_STATE_KEY = Symbol.for("openclaw.cron.activeJobs");
@@ -10,17 +18,63 @@ const CRON_ACTIVE_JOB_STATE_KEY = Symbol.for("openclaw.cron.activeJobs");
 function getCronActiveJobState(): CronActiveJobState {
   // Cron runs can cross module reload boundaries in tests and dev watch; keep
   // the in-flight job set process-global so duplicate-run guards share state.
-  return resolveGlobalSingleton<CronActiveJobState>(CRON_ACTIVE_JOB_STATE_KEY, () => ({
+  const state = resolveGlobalSingleton<CronActiveJobState>(CRON_ACTIVE_JOB_STATE_KEY, () => ({
     activeJobIds: new Set<string>(),
+    activeJobsById: new Map<string, CronActiveJobEntry>(),
   }));
+  state.activeJobsById ??= new Map<string, CronActiveJobEntry>();
+  return state;
+}
+
+function upsertActiveJobEntry(
+  jobId: string,
+  update: (entry: CronActiveJobEntry) => CronActiveJobEntry,
+): CronActiveJobEntry {
+  const state = getCronActiveJobState();
+  state.activeJobIds.add(jobId);
+  const next = update(state.activeJobsById.get(jobId) ?? {});
+  state.activeJobsById.set(jobId, next);
+  return next;
+}
+
+function triggerPendingCancel(entry: CronActiveJobEntry) {
+  if (!entry.cancel || !entry.cancelRequestedReason) {
+    return;
+  }
+  entry.cancel(entry.cancelRequestedReason);
 }
 
 /** Marks a cron job id as currently executing for duplicate-run suppression. */
-export function markCronJobActive(jobId: string) {
+export function markCronJobActive(jobId: string, cancel?: CronActiveJobCancel) {
   if (!jobId) {
     return;
   }
-  getCronActiveJobState().activeJobIds.add(jobId);
+  const entry = upsertActiveJobEntry(jobId, (current) => ({
+    ...current,
+    ...(cancel ? { cancel } : {}),
+  }));
+  triggerPendingCancel(entry);
+}
+
+/** Registers the abort hook for an already-active cron job. */
+export function registerCronJobCancel(jobId: string, cancel: CronActiveJobCancel): () => void {
+  if (!jobId) {
+    return () => {};
+  }
+  const entry = upsertActiveJobEntry(jobId, (current) => ({
+    ...current,
+    cancel,
+  }));
+  triggerPendingCancel(entry);
+  return () => {
+    const state = getCronActiveJobState();
+    const current = state.activeJobsById.get(jobId);
+    if (current?.cancel === cancel) {
+      const rest = { ...current };
+      delete rest.cancel;
+      state.activeJobsById.set(jobId, rest);
+    }
+  };
 }
 
 /** Clears the active marker when a cron run exits or is abandoned. */
@@ -28,7 +82,9 @@ export function clearCronJobActive(jobId: string) {
   if (!jobId) {
     return;
   }
-  getCronActiveJobState().activeJobIds.delete(jobId);
+  const state = getCronActiveJobState();
+  state.activeJobIds.delete(jobId);
+  state.activeJobsById.delete(jobId);
 }
 
 /** Returns whether the given cron job id is currently executing in this process. */
@@ -44,7 +100,42 @@ export function hasActiveCronJobs() {
   return getCronActiveJobState().activeJobIds.size > 0;
 }
 
+/** Requests cancellation for an in-process cron run by job id. */
+export function cancelCronJobActive(
+  jobId: string,
+  reason = "Cancelled by operator.",
+): { found: boolean; cancelled: boolean; reason?: string } {
+  if (!jobId) {
+    return {
+      found: false,
+      cancelled: false,
+      reason: "Cron task has no source job id.",
+    };
+  }
+  const state = getCronActiveJobState();
+  if (!state.activeJobIds.has(jobId)) {
+    return {
+      found: false,
+      cancelled: false,
+      reason: "Cron job is not running in this Gateway process.",
+    };
+  }
+  const current = state.activeJobsById.get(jobId) ?? {};
+  const entry = {
+    ...current,
+    cancelRequestedReason: reason,
+  };
+  state.activeJobsById.set(jobId, entry);
+  triggerPendingCancel(entry);
+  return {
+    found: true,
+    cancelled: true,
+  };
+}
+
 /** Clears process-global cron active-job state between tests. */
 export function resetCronActiveJobsForTests() {
-  getCronActiveJobState().activeJobIds.clear();
+  const state = getCronActiveJobState();
+  state.activeJobIds.clear();
+  state.activeJobsById.clear();
 }

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -7,6 +7,7 @@ import { createCronServiceState } from "../../cron/service/state.js";
 import { executeJobCore, onTimer } from "../../cron/service/timer.js";
 import { loadCronStore } from "../../cron/store.js";
 import type { CronJob } from "../../cron/types.js";
+import { cancelCronJobActive, resetCronActiveJobsForTests } from "../active-jobs.js";
 import * as detachedTaskRuntime from "../../tasks/detached-task-runtime.js";
 import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-registry.js";
 import { formatTaskStatusDetail } from "../../tasks/task-status.js";
@@ -48,6 +49,7 @@ function createDueIsolatedAgentJob(params: { now: number }): CronJob {
 }
 
 afterEach(() => {
+  resetCronActiveJobsForTests();
   resetTaskRegistryForTests();
 });
 
@@ -270,6 +272,62 @@ describe("cron service timer seam coverage", () => {
 
     resolveRun?.({ status: "ok", summary: "done" });
     await timerRun;
+  });
+
+  it("aborts no-timeout isolated cron runs when the active cron task is cancelled", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+    let observedAbortSignal: AbortSignal | undefined;
+    const runIsolatedAgentJob = vi.fn(async (params: { abortSignal?: AbortSignal }) => {
+      observedAbortSignal = params.abortSignal;
+      await new Promise<void>((resolve) => {
+        if (!params.abortSignal || params.abortSignal.aborted) {
+          resolve();
+          return;
+        }
+        params.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      if (params.abortSignal?.aborted) {
+        return { status: "error" as const, error: String(params.abortSignal.reason) };
+      }
+      return { status: "ok" as const, summary: "done" };
+    });
+    const job = createDueIsolatedAgentJob({ now });
+    job.payload = { kind: "agentTurn", message: "run isolated cron", timeoutSeconds: 0 };
+
+    await writeCronStoreSnapshot({
+      storePath,
+      jobs: [job],
+    });
+
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runIsolatedAgentJob,
+    });
+
+    const timerRun = onTimer(state);
+    await vi.waitFor(() => {
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+    });
+
+    expect(cancelCronJobActive("isolated-agent-job", "operator requested cancellation")).toEqual({
+      found: true,
+      cancelled: true,
+    });
+    await timerRun;
+
+    expect(observedAbortSignal?.aborted).toBe(true);
+    const persisted = await loadCronStore(storePath);
+    const persistedJob = persisted.jobs.find((entry) => entry.id === "isolated-agent-job");
+    expect(persistedJob?.state.lastStatus).toBe("error");
+    expect(persistedJob?.state.lastError).toContain("operator requested cancellation");
   });
 
   it("keeps scheduler progress when task ledger creation fails", async () => {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -15,7 +15,7 @@ import {
 } from "../../routing/session-key.js";
 import { deliveryContextFromSession } from "../../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
-import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
+import { clearCronJobActive, markCronJobActive, registerCronJobCancel } from "../active-jobs.js";
 import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-plan.js";
 import { resolveCronExecutionRetryHint } from "../retry-hint.js";
 import {
@@ -123,56 +123,70 @@ export async function executeJobCoreWithTimeout(
   job: CronJob,
 ): Promise<Awaited<ReturnType<typeof executeJobCore>>> {
   const jobTimeoutMs = resolveCronJobTimeoutMs(job);
-  if (typeof jobTimeoutMs !== "number") {
-    return await executeJobCore(state, job);
-  }
-
   const runAbortController = new AbortController();
-  let timeoutReason: string | undefined;
-  const timeoutMarker = Symbol("cron-timeout");
-  let resolveTimeout: ((value: typeof timeoutMarker) => void) | undefined;
-  const timeoutPromise = new Promise<typeof timeoutMarker>((resolve) => {
-    resolveTimeout = resolve;
+  let abortReason: string | undefined;
+  let abortKind: "cancel" | "timeout" | undefined;
+  const abortMarker = Symbol("cron-abort");
+  let resolveAbort: ((value: typeof abortMarker) => void) | undefined;
+  const abortPromise = new Promise<typeof abortMarker>((resolve) => {
+    resolveAbort = resolve;
   });
 
   // Detached agent runs report setup phases separately; defer the wall-clock
   // timeout until the runner starts so cold setup gets a clearer failure reason.
   const deferTimeoutUntilExecutionStart =
-    job.sessionTarget !== "main" && job.payload.kind === "agentTurn";
-  const triggerTimeout = (reason: string) => {
+    typeof jobTimeoutMs === "number" &&
+    job.sessionTarget !== "main" &&
+    job.payload.kind === "agentTurn";
+  const triggerAbort = (kind: "cancel" | "timeout", reason: string) => {
     if (runAbortController.signal.aborted) {
       return;
     }
-    timeoutReason = reason;
+    abortKind = kind;
+    abortReason = reason;
     runAbortController.abort(reason);
-    resolveTimeout?.(timeoutMarker);
+    resolveAbort?.(abortMarker);
   };
-  const watchdog = createCronAgentWatchdog({
-    deferUntilRunner: deferTimeoutUntilExecutionStart,
-    jobTimeoutMs,
-    triggerTimeout,
-  });
+  const unregisterCancel = registerCronJobCancel(job.id, (reason) => triggerAbort("cancel", reason));
+  const watchdog =
+    typeof jobTimeoutMs === "number"
+      ? createCronAgentWatchdog({
+          deferUntilRunner: deferTimeoutUntilExecutionStart,
+          jobTimeoutMs,
+          triggerTimeout: (reason) => triggerAbort("timeout", reason),
+        })
+      : undefined;
   const corePromise = executeJobCore(state, job, runAbortController.signal, {
-    onExecutionStarted: deferTimeoutUntilExecutionStart ? watchdog.noteRunnerStarted : undefined,
-    onExecutionPhase: deferTimeoutUntilExecutionStart ? watchdog.notePhase : undefined,
+    onExecutionStarted: deferTimeoutUntilExecutionStart ? watchdog?.noteRunnerStarted : undefined,
+    onExecutionPhase: deferTimeoutUntilExecutionStart ? watchdog?.notePhase : undefined,
   });
-  watchdog.start();
+  watchdog?.start();
   void corePromise.catch((err: unknown) => {
     if (runAbortController.signal.aborted) {
       state.deps.log.warn(
         { jobId: job.id, err: String(err) },
-        "cron: job core rejected after timeout abort",
+        "cron: job core rejected after abort",
       );
     }
   });
   try {
-    const first = await Promise.race([corePromise, timeoutPromise]);
-    if (first !== timeoutMarker) {
+    const first = await Promise.race([corePromise, abortPromise]);
+    if (first !== abortMarker) {
       return first;
     }
-    const activeExecution = watchdog.activeExecution();
-    await cleanupTimedOutCronAgentRun(state, job, jobTimeoutMs, activeExecution);
-    const error = timeoutReason ?? timeoutErrorMessage(activeExecution);
+    if (abortKind === "timeout") {
+      const activeExecution = watchdog?.activeExecution();
+      await cleanupTimedOutCronAgentRun(state, job, jobTimeoutMs ?? 0, activeExecution);
+      const error = abortReason ?? timeoutErrorMessage(activeExecution);
+      return {
+        status: "error",
+        error,
+        diagnostics: createCronRunDiagnosticsFromError("cron-setup", error, {
+          nowMs: state.deps.nowMs,
+        }),
+      };
+    }
+    const error = abortReason ?? abortErrorMessage(runAbortController.signal);
     return {
       status: "error",
       error,
@@ -181,7 +195,8 @@ export async function executeJobCoreWithTimeout(
       }),
     };
   } finally {
-    watchdog.dispose();
+    unregisterCancel();
+    watchdog?.dispose();
   }
 }
 

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AcpSessionStoreEntry } from "../acp/runtime/session-meta.js";
 import { startAcpSpawnParentStreamRelay } from "../agents/acp-spawn-parent-stream.js";
-import { resetCronActiveJobsForTests } from "../cron/active-jobs.js";
+import { markCronJobActive, resetCronActiveJobsForTests } from "../cron/active-jobs.js";
 import {
   emitAgentEvent,
   registerAgentRunContext,
@@ -3523,6 +3523,66 @@ describe("task-registry", () => {
       expectRecordFields(result.task, {
         taskId: task.taskId,
         status: "cancelled",
+      });
+    });
+  });
+
+  it("cancels active cron tasks through the cron active job registry", async () => {
+    await withTaskRegistryTempDir(async () => {
+      const cancelCronJob = vi.fn();
+      const task = createTaskRecord({
+        runtime: "cron",
+        sourceId: "cron-job-cancel",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "cron-run-cancel",
+        task: "Recurring job",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+      markCronJobActive("cron-job-cancel", cancelCronJob);
+
+      const result = await cancelTaskById({
+        cfg: {} as never,
+        taskId: task.taskId,
+      });
+
+      expect(cancelCronJob).toHaveBeenCalledWith("Cancelled by operator.");
+      expectRecordFields(result, {
+        found: true,
+        cancelled: true,
+      });
+      expectRecordFields(result.task, {
+        taskId: task.taskId,
+        status: "cancelled",
+        error: "Cancelled by operator.",
+      });
+    });
+  });
+
+  it("reports cron tasks that are not active in this Gateway process", async () => {
+    await withTaskRegistryTempDir(async () => {
+      const task = createTaskRecord({
+        runtime: "cron",
+        sourceId: "cron-job-inactive",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "cron-run-inactive",
+        task: "Recurring job",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      const result = await cancelTaskById({
+        cfg: {} as never,
+        taskId: task.taskId,
+      });
+
+      expect(result).toEqual({
+        found: true,
+        cancelled: false,
+        reason: "Cron job is not running in this Gateway process.",
+        task,
       });
     });
   });

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -9,6 +9,7 @@ import {
 } from "../agents/agent-run-terminal-outcome.js";
 import { shouldRouteCompletionThroughRequesterSession } from "../auto-reply/reply/completion-delivery-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { cancelCronJobActive } from "../cron/active-jobs.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { requestHeartbeat } from "../infra/heartbeat-wake.js";
@@ -2079,7 +2080,21 @@ export async function cancelTaskById(params: {
   }
   const childSessionKey = task.childSessionKey?.trim();
   try {
-    if (task.runtime !== "cli") {
+    if (task.runtime === "cron") {
+      const jobId = task.sourceId?.trim();
+      const cronCancel = cancelCronJobActive(
+        jobId ?? "",
+        params.reason?.trim() || "Cancelled by operator.",
+      );
+      if (!cronCancel.found || !cronCancel.cancelled) {
+        return {
+          found: true,
+          cancelled: false,
+          reason: cronCancel.reason ?? "Cron job is not cancellable.",
+          task: cloneTaskRecord(task),
+        };
+      }
+    } else if (task.runtime !== "cli") {
       if (!childSessionKey) {
         if (!isChildlessCodexNativeSubagentTask(task)) {
           return {


### PR DESCRIPTION
Fixes #90630.

## Summary
- Route `openclaw tasks cancel` through the Gateway `tasks.cancel` method before falling back to local cancellation.
- Track active cron cancellation callbacks by cron job id so task-ledger cancellation can abort in-process cron runs.
- Always pass an `AbortSignal` through cron execution, including jobs without a configured timeout.

## Tests
- `node scripts/run-vitest.mjs src/tasks/task-registry.test.ts src/cron/service/timer.test.ts src/commands/tasks.test.ts`
- `git diff --check`

Note: a full `tsc -p tsconfig.json --noEmit --pretty false` was not a useful signal in this sparse checkout because unrelated checked-in tests reference helpers/provider extension files that are not present here.