### PR TITLE
fix: dedupe cleaned assistant transcript entries for session-memory

### DIFF
--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -551,6 +551,56 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("user: External follow-up");
   });
 
+  it("deduplicates cleaned assistant messages that point to the raw thinking transcript entry", async () => {
+    const sessionContent = [
+      JSON.stringify({
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        message: { role: "user", content: "What happened?" },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "assistant-raw-1",
+        parentId: "user-1",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "private reasoning" },
+            { type: "text", text: "Here is the answer." },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "assistant-clean-1",
+        parentId: "assistant-raw-1",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Here is the answer." }],
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "user-2",
+        parentId: "assistant-clean-1",
+        message: { role: "user", content: "Thanks" },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "assistant-2",
+        parentId: "user-2",
+        message: { role: "assistant", content: "You're welcome" },
+      }),
+    ].join("\n");
+    const memoryContent = await readSessionTranscript({ sessionContent });
+
+    expect(memoryContent).toContain("user: What happened?");
+    expect(memoryContent?.match(/assistant: Here is the answer\./g)).toHaveLength(1);
+    expect(memoryContent).toContain("user: Thanks");
+    expect(memoryContent).toContain("assistant: You're welcome");
+  });
+
   it("filters out command messages starting with /", async () => {
     const sessionContent = createMockSessionContent([
       { role: "user", content: "/help" },

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -31,9 +31,15 @@ export async function getRecentSessionContent(
     const lines = content.trim().split("\n");
 
     const allMessages: string[] = [];
+    const messageIndex = new Map<string, { role: "user" | "assistant"; text?: string }>();
     for (const line of lines) {
       try {
-        const entry = JSON.parse(line);
+        const entry = JSON.parse(line) as {
+          type?: unknown;
+          id?: unknown;
+          parentId?: unknown;
+          message?: unknown;
+        };
         if (entry.type === "message" && entry.message) {
           const msg = entry.message as {
             role?: unknown;
@@ -41,14 +47,37 @@ export async function getRecentSessionContent(
             provenance?: unknown;
           };
           const role = msg.role;
-          if ((role === "user" || role === "assistant") && "content" in msg && msg.content) {
-            if (role === "user" && hasInterSessionUserProvenance(msg)) {
-              continue;
+          if (role !== "user" && role !== "assistant") {
+            continue;
+          }
+          if (!("content" in msg) || !msg.content) {
+            continue;
+          }
+          if (role === "user" && hasInterSessionUserProvenance(msg)) {
+            continue;
+          }
+
+          const text = extractTextMessageContent(msg.content);
+          const entryId = typeof entry.id === "string" ? entry.id : undefined;
+          const parentMessage =
+            typeof entry.parentId === "string" ? messageIndex.get(entry.parentId) : undefined;
+          if (
+            role === "assistant" &&
+            text &&
+            parentMessage?.role === "assistant" &&
+            parentMessage.text === text
+          ) {
+            if (entryId) {
+              messageIndex.set(entryId, { role, text });
             }
-            const text = extractTextMessageContent(msg.content);
-            if (text && !text.startsWith("/")) {
-              allMessages.push(`${role}: ${text}`);
-            }
+            continue;
+          }
+
+          if (entryId) {
+            messageIndex.set(entryId, { role, ...(text ? { text } : {}) });
+          }
+          if (text && !text.startsWith("/")) {
+            allMessages.push(`${role}: ${text}`);
           }
         }
       } catch {


### PR DESCRIPTION
## Summary
- skip assistant transcript entries when they are cleaned text-only children of a raw assistant thinking entry with the same extracted text
- preserve legitimate repeated assistant replies that come from different conversation turns
- add a regression test covering the raw+cleaned thinking transcript shape from #92563

## Testing
- node --import tsx /tmp/issue-92563-check.mjs

Closes #92563