### PR TITLE
fix: preserve config-selected subagent model overrides

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
@@ -101,6 +101,27 @@ describe("subagent spawn model + thinking plan", () => {
     expect(plan.resolvedModel).toBe(defaultModelRef);
     expect(plan.initialSessionPatch.model).toBe(defaultModelRef);
     expect(plan.initialSessionPatch.modelOverrideSource).toBe("auto");
+    expect(plan.initialSessionPatch.modelOverrideFallbackOriginProvider).toBeUndefined();
+    expect(plan.initialSessionPatch.modelOverrideFallbackOriginModel).toBeUndefined();
+  });
+
+  it("uses the target default provider for bare configured subagent models", () => {
+    const plan = expectOkPlan(
+      resolveSubagentModelAndThinkingPlan({
+        cfg: createConfig({
+          agents: {
+            defaults: {
+              model: { primary: "openai/gpt-5.5" },
+              subagents: { model: "gpt-5.4" },
+            },
+          },
+        }),
+        targetAgentId: "research",
+      }),
+    );
+    expect(plan.resolvedModel).toBe("gpt-5.4");
+    expect(plan.initialSessionPatch.modelOverrideFallbackOriginProvider).toBe("openai");
+    expect(plan.initialSessionPatch.modelOverrideFallbackOriginModel).toBe("gpt-5.4");
   });
 
   it("can resolve only explicit or configured subagent model selections", () => {
@@ -166,6 +187,8 @@ describe("subagent spawn model + thinking plan", () => {
     expect(plan.resolvedModel).toBe("minimax/MiniMax-M2.7");
     expect(plan.initialSessionPatch.model).toBe("minimax/MiniMax-M2.7");
     expect(plan.initialSessionPatch.modelOverrideSource).toBe("auto");
+    expect(plan.initialSessionPatch.modelOverrideFallbackOriginProvider).toBe("minimax");
+    expect(plan.initialSessionPatch.modelOverrideFallbackOriginModel).toBe("MiniMax-M2.7");
   });
 
   it("prefers target agent primary model over global default", () => {
@@ -189,6 +212,8 @@ describe("subagent spawn model + thinking plan", () => {
     expect(plan.resolvedModel).toBe("opencode/claude");
     expect(plan.initialSessionPatch.model).toBe("opencode/claude");
     expect(plan.initialSessionPatch.modelOverrideSource).toBe("auto");
+    expect(plan.initialSessionPatch.modelOverrideFallbackOriginProvider).toBe("opencode");
+    expect(plan.initialSessionPatch.modelOverrideFallbackOriginModel).toBe("claude");
   });
 
   it("uses config default timeout when agent omits runTimeoutSeconds", () => {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
@@ -86,6 +86,8 @@ describe("subagent spawn model + thinking plan", () => {
     expect(plan.resolvedModel).toBe("minimax/MiniMax-M2.7");
     expect(plan.initialSessionPatch.model).toBe("minimax/MiniMax-M2.7");
     expect(plan.initialSessionPatch.modelOverrideSource).toBe("auto");
+    expect(plan.initialSessionPatch.modelOverrideFallbackOriginProvider).toBe("minimax");
+    expect(plan.initialSessionPatch.modelOverrideFallbackOriginModel).toBe("MiniMax-M2.7");
   });
 
   it("falls back to runtime default model when no model config is set", () => {
@@ -139,6 +141,8 @@ describe("subagent spawn model + thinking plan", () => {
     expect(plan.resolvedModel).toBe("opencode/claude");
     expect(plan.initialSessionPatch.model).toBe("opencode/claude");
     expect(plan.initialSessionPatch.modelOverrideSource).toBe("auto");
+    expect(plan.initialSessionPatch.modelOverrideFallbackOriginProvider).toBe("opencode");
+    expect(plan.initialSessionPatch.modelOverrideFallbackOriginModel).toBe("claude");
   });
 
   it("prefers default subagent model over target agent primary model", () => {

--- a/src/agents/subagent-spawn-plan.ts
+++ b/src/agents/subagent-spawn-plan.ts
@@ -80,6 +80,9 @@ export function resolveSubagentModelAndThinkingPlan(params: {
     };
   }
 
+  const modelOverrideSource = params.modelOverride?.trim() ? "user" : "auto";
+  const resolvedModelRef = splitModelRef(resolvedModel);
+
   return {
     status: "ok" as const,
     resolvedModel,
@@ -89,7 +92,19 @@ export function resolveSubagentModelAndThinkingPlan(params: {
       ...(resolvedModel
         ? {
             model: resolvedModel,
-            modelOverrideSource: params.modelOverride?.trim() ? "user" : "auto",
+            modelOverrideSource,
+            ...(modelOverrideSource === "auto" &&
+            resolvedModelRef.provider &&
+            resolvedModelRef.model
+              ? {
+                  // Auto-selected subagent models are real session overrides, not legacy
+                  // auto-fallback recoveries. Persist self-origin metadata so the child
+                  // run keeps its configured model instead of the legacy cleanup path
+                  // discarding it before first execution.
+                  modelOverrideFallbackOriginProvider: resolvedModelRef.provider,
+                  modelOverrideFallbackOriginModel: resolvedModelRef.model,
+                }
+              : {}),
           }
         : {}),
       ...thinkingPlan.initialSessionPatch,

--- a/src/agents/subagent-spawn-plan.ts
+++ b/src/agents/subagent-spawn-plan.ts
@@ -5,7 +5,11 @@
  */
 import { formatThinkingLevels } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
+import {
+  resolveDefaultModelForAgent,
+  resolveSubagentConfiguredModelSelection,
+  resolveSubagentSpawnModelSelection,
+} from "./model-selection.js";
 import { resolveSubagentThinkingOverride } from "./subagent-spawn-thinking.js";
 
 /** Splits a provider/model ref while preserving model-only refs. */
@@ -81,7 +85,26 @@ export function resolveSubagentModelAndThinkingPlan(params: {
   }
 
   const modelOverrideSource = params.modelOverride?.trim() ? "user" : "auto";
-  const resolvedModelRef = splitModelRef(resolvedModel);
+  const hasConfiguredAutoModel =
+    modelOverrideSource === "auto" &&
+    Boolean(
+      resolveSubagentConfiguredModelSelection({
+        cfg: params.cfg,
+        agentId: params.targetAgentId,
+      }),
+    );
+  const configuredModelRef = hasConfiguredAutoModel ? splitModelRef(resolvedModel) : undefined;
+  const modelOrigin = configuredModelRef?.model
+    ? {
+        provider:
+          configuredModelRef.provider ??
+          resolveDefaultModelForAgent({
+            cfg: params.cfg,
+            agentId: params.targetAgentId,
+          }).provider,
+        model: configuredModelRef.model,
+      }
+    : undefined;
 
   return {
     status: "ok" as const,
@@ -93,16 +116,12 @@ export function resolveSubagentModelAndThinkingPlan(params: {
         ? {
             model: resolvedModel,
             modelOverrideSource,
-            ...(modelOverrideSource === "auto" &&
-            resolvedModelRef.provider &&
-            resolvedModelRef.model
+            ...(modelOrigin
               ? {
-                  // Auto-selected subagent models are real session overrides, not legacy
-                  // auto-fallback recoveries. Persist self-origin metadata so the child
-                  // run keeps its configured model instead of the legacy cleanup path
-                  // discarding it before first execution.
-                  modelOverrideFallbackOriginProvider: resolvedModelRef.provider,
-                  modelOverrideFallbackOriginModel: resolvedModelRef.model,
+                  // Config-selected models are session overrides, not legacy fallback residue.
+                  // Self-origin metadata keeps cleanup from discarding them before first use.
+                  modelOverrideFallbackOriginProvider: modelOrigin.provider,
+                  modelOverrideFallbackOriginModel: modelOrigin.model,
                 }
               : {}),
           }

--- a/src/agents/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagent-spawn.model-session.test.ts
@@ -101,4 +101,49 @@ describe("spawnSubagentDirect runtime model persistence", () => {
       operations.lastIndexOf("store:update"),
     );
   });
+
+  it("persists self-origin metadata for auto-selected subagent models", async () => {
+    const dedicatedUpdateSessionStoreMock = vi.fn();
+    const {
+      resetSubagentRegistryForTests: resetForAutoModelTest,
+      spawnSubagentDirect: spawnWithAutoModel,
+    } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock,
+      getRuntimeConfig: () =>
+        createSubagentSpawnTestConfig(os.tmpdir(), {
+          agents: {
+            defaults: {
+              workspace: os.tmpdir(),
+              subagents: { model: "minimax/MiniMax-M2.7" },
+            },
+          },
+        }),
+      updateSessionStoreMock: dedicatedUpdateSessionStoreMock,
+      pruneLegacyStoreKeysMock,
+      workspaceDir: os.tmpdir(),
+    });
+    resetForAutoModelTest();
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    installSessionStoreCaptureMock(dedicatedUpdateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnWithAutoModel(
+      {
+        task: "test",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "guildchat",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const [, persistedEntry] = Object.entries(persistedStore ?? {})[0] ?? [];
+    expect(persistedEntry?.modelOverrideSource).toBe("auto");
+    expect(persistedEntry?.modelOverrideFallbackOriginProvider).toBe("minimax");
+    expect(persistedEntry?.modelOverrideFallbackOriginModel).toBe("MiniMax-M2.7");
+  });
 });

--- a/src/agents/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagent-spawn.model-session.test.ts
@@ -114,7 +114,8 @@ describe("spawnSubagentDirect runtime model persistence", () => {
           agents: {
             defaults: {
               workspace: os.tmpdir(),
-              subagents: { model: "minimax/MiniMax-M2.7" },
+              model: { primary: "openai/gpt-5.5" },
+              subagents: { model: "gpt-5.4" },
             },
           },
         }),
@@ -143,7 +144,7 @@ describe("spawnSubagentDirect runtime model persistence", () => {
     expect(result.status).toBe("accepted");
     const [, persistedEntry] = Object.entries(persistedStore ?? {})[0] ?? [];
     expect(persistedEntry?.modelOverrideSource).toBe("auto");
-    expect(persistedEntry?.modelOverrideFallbackOriginProvider).toBe("minimax");
-    expect(persistedEntry?.modelOverrideFallbackOriginModel).toBe("MiniMax-M2.7");
+    expect(persistedEntry?.modelOverrideFallbackOriginProvider).toBe("openai");
+    expect(persistedEntry?.modelOverrideFallbackOriginModel).toBe("gpt-5.4");
   });
 });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -348,18 +348,13 @@ function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<S
       entry.model = model;
       entry.modelOverride = model;
       entry.modelOverrideSource = patch.modelOverrideSource === "auto" ? "auto" : "user";
-      if (
-        typeof patch.modelOverrideFallbackOriginProvider === "string" &&
-        patch.modelOverrideFallbackOriginProvider.trim()
-      ) {
-        entry.modelOverrideFallbackOriginProvider =
-          patch.modelOverrideFallbackOriginProvider.trim();
-      }
-      if (
-        typeof patch.modelOverrideFallbackOriginModel === "string" &&
-        patch.modelOverrideFallbackOriginModel.trim()
-      ) {
-        entry.modelOverrideFallbackOriginModel = patch.modelOverrideFallbackOriginModel.trim();
+      const fallbackOriginProvider = normalizeOptionalString(
+        patch.modelOverrideFallbackOriginProvider,
+      );
+      const fallbackOriginModel = normalizeOptionalString(patch.modelOverrideFallbackOriginModel);
+      if (fallbackOriginProvider && fallbackOriginModel) {
+        entry.modelOverrideFallbackOriginProvider = fallbackOriginProvider;
+        entry.modelOverrideFallbackOriginModel = fallbackOriginModel;
       }
       if (provider) {
         entry.modelProvider = provider;

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -348,6 +348,19 @@ function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<S
       entry.model = model;
       entry.modelOverride = model;
       entry.modelOverrideSource = patch.modelOverrideSource === "auto" ? "auto" : "user";
+      if (
+        typeof patch.modelOverrideFallbackOriginProvider === "string" &&
+        patch.modelOverrideFallbackOriginProvider.trim()
+      ) {
+        entry.modelOverrideFallbackOriginProvider =
+          patch.modelOverrideFallbackOriginProvider.trim();
+      }
+      if (
+        typeof patch.modelOverrideFallbackOriginModel === "string" &&
+        patch.modelOverrideFallbackOriginModel.trim()
+      ) {
+        entry.modelOverrideFallbackOriginModel = patch.modelOverrideFallbackOriginModel.trim();
+      }
       if (provider) {
         entry.modelProvider = provider;
         entry.providerOverride = provider;


### PR DESCRIPTION
## Summary
- preserve provenance for configuration-selected subagent model overrides so child execution does not discard them as legacy fallback state
- cover default subagent models, per-agent subagent models, target-agent primary models, and bare configured model IDs
- keep the ordinary global runtime default unpinned so normal model selection remains unchanged

## Verification
- `node scripts/run-vitest.mjs src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts src/agents/subagent-spawn.model-session.test.ts src/agents/agent-scope.test.ts src/agents/subagent-spawn.test.ts src/agents/agent-command.live-model-switch.test.ts src/agents/model-selection.test.ts` (265 tests passed)
- `node scripts/run-oxlint.mjs src/agents/subagent-spawn-plan.ts src/agents/subagent-spawn.ts src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts src/agents/subagent-spawn.model-session.test.ts`
- `pnpm exec oxfmt --write --threads=1 src/agents/subagent-spawn-plan.ts src/agents/subagent-spawn.ts src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts src/agents/subagent-spawn.model-session.test.ts`
- `git diff --check`
- fresh local and full-branch autoreview: no actionable findings

## Real behavior proof

Behavior addressed: A subagent model selected from configuration was persisted as an automatic override without origin metadata, then discarded before child execution as if it were a legacy fallback.

Real environment tested: Live OpenClaw gateway and real OpenAI API. Parent model `openai/gpt-5.5`; configured child models `openai/gpt-5.4` and bare `gpt-5.4`.

Exact steps or command run after this patch: Ran targeted temporary live Vitest probes through `OPENCLAW_LIVE_TEST=1 node scripts/run-vitest.mjs`, starting the real gateway, having GPT-5.5 invoke `sessions_spawn` without a model argument, waiting for the child run, then reading the child registry and assistant transcript. Repeated with bare configured model `gpt-5.4` and target default provider `openai`.

Evidence after fix: Copied live output from the real gateway runs:
```text
[subagent-config-model] {"parentModel":"openai/gpt-5.5","childConfiguredModel":"openai/gpt-5.4","childRunModel":"openai/gpt-5.4","childTranscriptProvider":"openai","childTranscriptModel":"gpt-5.4"}
[subagent-config-bare] {"configuredModel":"gpt-5.4","resolvedModel":"gpt-5.4","transcriptProvider":"openai","transcriptModel":"gpt-5.4"}
```

Observed result after fix: The parent made a real `sessions_spawn` tool call, and both child executions used GPT-5.4 exactly as configured. The qualified-model scenario passed in 48.69 seconds; the bare-model scenario passed in 39.10 seconds.

What was not tested: No Anthropic live call was needed because this change does not alter provider transports, request payloads, tool schemas, or OpenAI/Anthropic tool-call handling. The exercised OpenAI path confirms the existing official tool-call flow remains functional.

Closes #92486
