### PR TITLE
test(browser): cover action-input CLI request bodies

### DIFF
--- a/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
@@ -72,6 +72,31 @@ describe("browser element commands", () => {
       },
     },
     {
+      name: "click-coords",
+      argv: [
+        "browser",
+        "click-coords",
+        "12.5",
+        "42",
+        "--target-id",
+        "tab-2",
+        "--double",
+        "--button",
+        "middle",
+        "--delay-ms",
+        "25",
+      ],
+      expectedBody: {
+        kind: "clickCoords",
+        x: 12.5,
+        y: 42,
+        targetId: "tab-2",
+        doubleClick: true,
+        button: "middle",
+        delayMs: 25,
+      },
+    },
+    {
       name: "type",
       argv: ["browser", "type", "input-1", "hello", "--submit", "--slowly", "--target-id", "tab-2"],
       expectedBody: {

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
@@ -36,10 +36,106 @@ function createElementProgram(): Command {
   return program;
 }
 
+function getLastActionBody(): Record<string, unknown> | undefined {
+  return (mocks.callBrowserRequest.mock.calls.at(-1)?.[1] as { body?: Record<string, unknown> })
+    ?.body;
+}
+
 describe("browser element commands", () => {
   beforeEach(() => {
     mocks.callBrowserRequest.mockClear();
     getBrowserCliRuntimeCapture().resetRuntimeCapture();
+  });
+
+  it.each([
+    {
+      name: "click",
+      argv: [
+        "browser",
+        "click",
+        " ref-1 ",
+        "--target-id",
+        "tab-1",
+        "--double",
+        "--button",
+        "right",
+        "--modifiers",
+        "Shift, Alt",
+      ],
+      expectedBody: {
+        kind: "click",
+        ref: "ref-1",
+        targetId: "tab-1",
+        doubleClick: true,
+        button: "right",
+        modifiers: ["Shift", "Alt"],
+      },
+    },
+    {
+      name: "type",
+      argv: ["browser", "type", "input-1", "hello", "--submit", "--slowly", "--target-id", "tab-2"],
+      expectedBody: {
+        kind: "type",
+        ref: "input-1",
+        text: "hello",
+        submit: true,
+        slowly: true,
+        targetId: "tab-2",
+      },
+    },
+    {
+      name: "press",
+      argv: ["browser", "press", "Enter", "--target-id", "tab-3"],
+      expectedBody: { kind: "press", key: "Enter", targetId: "tab-3" },
+    },
+    {
+      name: "hover",
+      argv: ["browser", "hover", "node-1", "--target-id", "tab-4"],
+      expectedBody: { kind: "hover", ref: "node-1", targetId: "tab-4" },
+    },
+    {
+      name: "scrollintoview",
+      argv: ["browser", "scrollintoview", "node-2", "--target-id", "tab-5"],
+      expectedBody: { kind: "scrollIntoView", ref: "node-2", targetId: "tab-5" },
+    },
+    {
+      name: "drag",
+      argv: ["browser", "drag", "start-1", "end-1", "--target-id", "tab-6"],
+      expectedBody: {
+        kind: "drag",
+        startRef: "start-1",
+        endRef: "end-1",
+        targetId: "tab-6",
+      },
+    },
+    {
+      name: "select",
+      argv: ["browser", "select", "select-1", "alpha", "beta", "--target-id", "tab-7"],
+      expectedBody: {
+        kind: "select",
+        ref: "select-1",
+        values: ["alpha", "beta"],
+        targetId: "tab-7",
+      },
+    },
+  ])("sends the expected $name action body", async ({ argv, expectedBody }) => {
+    const program = createElementProgram();
+
+    await program.parseAsync(argv, { from: "user" });
+
+    expect(getLastActionBody()).toMatchObject(expectedBody);
+  });
+
+  it("rejects a blank required ref before dispatch", async () => {
+    const program = createElementProgram();
+
+    await expect(program.parseAsync(["browser", "click", "   "], { from: "user" })).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    const capture = getBrowserCliRuntimeCapture();
+    expect(capture.runtimeErrors.join("\n")).toContain("ref is required");
+    expect(mocks.callBrowserRequest).not.toHaveBeenCalled();
   });
 
   it("rejects non-decimal coordinate values before dispatch", async () => {

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
@@ -31,6 +31,10 @@ vi.spyOn(cliCoreApiModule.defaultRuntime, "writeJson").mockImplementation(
 );
 vi.spyOn(cliCoreApiModule.defaultRuntime, "error").mockImplementation(browserCliRuntime.error);
 vi.spyOn(cliCoreApiModule.defaultRuntime, "exit").mockImplementation(browserCliRuntime.exit);
+vi.spyOn(cliCoreApiModule, "resolveExistingUploadPaths").mockResolvedValue({
+  ok: true,
+  paths: ["/tmp/openclaw/uploads/a.pdf", "/tmp/openclaw/uploads/b.pdf"],
+});
 
 const { registerBrowserActionInputCommands } = await import("./register.js");
 
@@ -47,8 +51,49 @@ function getLastRequestOptions(): { timeoutMs?: number } | undefined {
 describe("browser action input file/download commands", () => {
   beforeEach(() => {
     mocks.callBrowserRequest.mockClear();
+    vi.mocked(cliCoreApiModule.resolveExistingUploadPaths).mockClear();
     getBrowserCliRuntimeCapture().resetRuntimeCapture();
     getBrowserCliRuntime().exit.mockImplementation(() => {});
+  });
+
+  it("arms uploads with normalized paths and element targeting options", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "upload",
+        "/tmp/openclaw/uploads/a.pdf",
+        "media://inbound/b",
+        "--input-ref",
+        "file-input",
+        "--element",
+        "input[type=file]",
+        "--target-id",
+        "tab-1",
+        "--timeout-ms",
+        "45000",
+      ],
+      { from: "user" },
+    );
+
+    expect(cliCoreApiModule.resolveExistingUploadPaths).toHaveBeenCalledWith({
+      requestedPaths: ["/tmp/openclaw/uploads/a.pdf", "media://inbound/b"],
+    });
+    const request = mocks.callBrowserRequest.mock.calls.at(-1)?.[1] as
+      | { path?: string; body?: Record<string, unknown> }
+      | undefined;
+    expect(request).toMatchObject({
+      path: "/hooks/file-chooser",
+      body: {
+        paths: ["/tmp/openclaw/uploads/a.pdf", "/tmp/openclaw/uploads/b.pdf"],
+        inputRef: "file-input",
+        element: "input[type=file]",
+        targetId: "tab-1",
+        timeoutMs: 45000,
+      },
+    });
+    expect(getLastRequestOptions()?.timeoutMs).toBeGreaterThan(45000);
   });
 
   it("keeps the outer waitfordownload request open for the advertised default wait", async () => {

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
@@ -36,6 +36,43 @@ function createActionInputProgram(): Command {
   return program;
 }
 
+function getLastActionBody(): Record<string, unknown> | undefined {
+  return (mocks.callBrowserRequest.mock.calls.at(-1)?.[1] as { body?: Record<string, unknown> })
+    ?.body;
+}
+
+describe("browser action input fill command", () => {
+  beforeEach(() => {
+    mocks.callBrowserRequest.mockClear();
+    getBrowserCliRuntimeCapture().resetRuntimeCapture();
+  });
+
+  it("sends normalized fill fields and target id to the act route", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "fill",
+        "--fields",
+        '[{"ref":"name","value":"Ada"},{"ref":"enabled","value":true}]',
+        "--target-id",
+        "tab-1",
+      ],
+      { from: "user" },
+    );
+
+    expect(getLastActionBody()).toMatchObject({
+      kind: "fill",
+      fields: [
+        { ref: "name", type: "text", value: "Ada" },
+        { ref: "enabled", type: "text", value: true },
+      ],
+      targetId: "tab-1",
+    });
+  });
+});
+
 describe("browser action input wait command", () => {
   beforeEach(() => {
     mocks.callBrowserRequest.mockClear();
@@ -97,6 +134,31 @@ describe("browser action input evaluate command", () => {
   beforeEach(() => {
     mocks.callBrowserRequest.mockClear();
     getBrowserCliRuntimeCapture().resetRuntimeCapture();
+  });
+
+  it("sends evaluate function, ref, and target id to the act route", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "evaluate",
+        "--fn",
+        "el => el.textContent",
+        "--ref",
+        "button-1",
+        "--target-id",
+        "tab-2",
+      ],
+      { from: "user" },
+    );
+
+    expect(getLastActionBody()).toMatchObject({
+      kind: "evaluate",
+      fn: "el => el.textContent",
+      ref: "button-1",
+      targetId: "tab-2",
+    });
   });
 
   it("passes timeout-ms through to the evaluate action and outer request", async () => {

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as browserCliResizeModule from "../browser-cli-resize.js";
+import * as browserCliSharedModule from "../browser-cli-shared.js";
 import {
   createBrowserProgram,
   getBrowserCliRuntime,
@@ -10,9 +11,17 @@ import {
 import * as cliCoreApiModule from "../core-api.js";
 
 const mocks = vi.hoisted(() => ({
+  callBrowserRequest: vi.fn<
+    (
+      opts?: unknown,
+      req?: unknown,
+      extra?: { timeoutMs?: number },
+    ) => Promise<Record<string, unknown>>
+  >(async () => ({ url: "https://example.test/landing" })),
   runBrowserResizeWithOutput: vi.fn(async () => {}),
 }));
 
+vi.spyOn(browserCliSharedModule, "callBrowserRequest").mockImplementation(mocks.callBrowserRequest);
 vi.spyOn(browserCliResizeModule, "runBrowserResizeWithOutput").mockImplementation(
   mocks.runBrowserResizeWithOutput,
 );
@@ -34,8 +43,49 @@ function createNavigationProgram(): Command {
 
 describe("browser navigation commands", () => {
   beforeEach(() => {
+    mocks.callBrowserRequest.mockClear();
     mocks.runBrowserResizeWithOutput.mockClear();
     getBrowserCliRuntimeCapture().resetRuntimeCapture();
+  });
+
+  it("sends navigate requests with the URL and target id", async () => {
+    const program = createNavigationProgram();
+
+    await program.parseAsync(
+      ["browser", "navigate", "https://example.test/page", "--target-id", "tab-1"],
+      { from: "user" },
+    );
+
+    const request = mocks.callBrowserRequest.mock.calls.at(-1)?.[1] as
+      | { method?: string; path?: string; body?: Record<string, unknown> }
+      | undefined;
+    const options = mocks.callBrowserRequest.mock.calls.at(-1)?.[2] as
+      | { timeoutMs?: number }
+      | undefined;
+    expect(request).toMatchObject({
+      method: "POST",
+      path: "/navigate",
+      body: { url: "https://example.test/page", targetId: "tab-1" },
+    });
+    expect(options?.timeoutMs).toBe(20000);
+  });
+
+  it("passes normalized resize dimensions and target id to the resize helper", async () => {
+    const program = createNavigationProgram();
+
+    await program.parseAsync(["browser", "resize", "1024", "768", "--target-id", "tab-2"], {
+      from: "user",
+    });
+
+    expect(mocks.runBrowserResizeWithOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        width: 1024,
+        height: 768,
+        targetId: "tab-2",
+        timeoutMs: 20000,
+        successMessage: "resized to 1024x768",
+      }),
+    );
   });
 
   it("rejects non-decimal resize dimensions before dispatch", async () => {


### PR DESCRIPTION
## Summary

Fixes #83877.

## Real Behavior Proof
Behavior addressed: Browser action-input CLI commands now have focused coverage for element request bodies, blank-ref validation, navigate/resize dispatch, fill/evaluate act bodies, and upload hook payloads.
Real environment tested: Local OpenClaw source checkout at ded3a93058 on macOS, using the real source CLI entry point with an isolated temporary HOME/OPENCLAW_HOME/OPENCLAW_STATE_DIR/OPENCLAW_CONFIG_PATH and no Vitest mocks.
Exact steps or command run after this patch: tmpdir=$(mktemp -d); HOME="$tmpdir" OPENCLAW_HOME="$tmpdir" OPENCLAW_STATE_DIR="$tmpdir/state" OPENCLAW_CONFIG_PATH="$tmpdir/openclaw.json" node --import tsx src/entry.ts browser click "   "; code=$?; rm -rf "$tmpdir"; printf 'exit=%s\n' "$code"
Evidence after fix: Real CLI console output was `ref is required` followed by `exit=1`, proving the blank-ref browser click path fails at the CLI validation boundary in a real OpenClaw invocation. Supplemental focused test output: Test Files 4 passed (4); Tests 29 passed (29). oxfmt --check reported all matched files use the correct format. run-oxlint exited 0. git diff --check exited 0.
Observed result after fix: The real CLI rejects the invalid ref before dispatch, and the focused browser action-input tests assert the CLI builds the expected request bodies without any runtime code changes.
What was not tested: Full repository test suite and live browser/Crabbox proof; this PR is unit-level CLI coverage plus a real CLI validation smoke check.

## Changes

- Add table-driven browser element command tests for click/type/press/hover/scroll/drag/select request bodies.
- Cover blank-ref rejection before dispatch for required element refs.
- Add navigate and resize success-path CLI tests.
- Add fill/evaluate request-body coverage and upload hook payload coverage.

## Validation

- tmpdir=$(mktemp -d); HOME="$tmpdir" OPENCLAW_HOME="$tmpdir" OPENCLAW_STATE_DIR="$tmpdir/state" OPENCLAW_CONFIG_PATH="$tmpdir/openclaw.json" node --import tsx src/entry.ts browser click "   "; code=$?; rm -rf "$tmpdir"; printf 'exit=%s\n' "$code"
- OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
- node_modules/.bin/oxfmt --check --threads=1 extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
- node scripts/run-oxlint.mjs extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
- git diff --check -- extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts

## Risks

- Test-only change; no runtime behavior changes.
- Full suite was not run locally.
