### PR TITLE
fix(sessions): preserve user behavior overrides across daily/idle rollover (#92562) [AI-assisted]

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -974,6 +974,79 @@ describe("initSessionState RawBody", () => {
     expect(store[sessionKey]?.modelOverrideSource).toBe("user");
   });
 
+  it("preserves user-set behavior overrides across an implicit daily stale rollover (#92562)", async () => {
+    // Regression: session-level behavior overrides (/think, /verbose, /reasoning,
+    // /trace, ttsAuto) survive an explicit /new but were dropped after the
+    // automatic daily/idle reset, because the carryover was gated on
+    // resetTriggered while the implicit stale rollover runs with
+    // resetTriggered === false. The model override on this same path was already
+    // fixed (#90119); the behavior overrides must follow suit.
+    const root = await makeCaseDir("openclaw-daily-rollover-behavior-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:discord:channel:daily-rollover-behavior";
+    const existingSessionId = "session-before-daily-reset-behavior";
+    // Stale under the default daily reset (atHour 4): started ~48h ago.
+    const staleStartedAt = Date.now() - 48 * 60 * 60 * 1000;
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: staleStartedAt,
+        sessionStartedAt: staleStartedAt,
+        lastInteractionAt: staleStartedAt,
+        systemSent: true,
+        // User-set behavior overrides (what /think, /verbose, etc. write).
+        thinkingLevel: "medium",
+        verboseLevel: "on",
+        traceLevel: "high",
+        reasoningLevel: "low",
+        ttsAuto: "always",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        // Ordinary message — NOT a reset trigger.
+        RawBody: "hello again",
+        ChatType: "channel",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // The session rolled over implicitly (stale), not via /new.
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false);
+    expect(result.sessionId).not.toBe(existingSessionId);
+    // The user-set behavior overrides must survive the implicit rollover.
+    expect(result.sessionEntry.thinkingLevel).toBe("medium");
+    expect(result.sessionEntry.verboseLevel).toBe("on");
+    expect(result.sessionEntry.traceLevel).toBe("high");
+    expect(result.sessionEntry.reasoningLevel).toBe("low");
+    expect(result.sessionEntry.ttsAuto).toBe("always");
+
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      {
+        thinkingLevel?: string;
+        verboseLevel?: string;
+        traceLevel?: string;
+        reasoningLevel?: string;
+        ttsAuto?: string;
+      }
+    >;
+    expect(store[sessionKey]?.thinkingLevel).toBe("medium");
+    expect(store[sessionKey]?.verboseLevel).toBe("on");
+    expect(store[sessionKey]?.traceLevel).toBe("high");
+    expect(store[sessionKey]?.reasoningLevel).toBe("low");
+    expect(store[sessionKey]?.ttsAuto).toBe("always");
+  });
+
   it("clears an auto-fallback model override on an implicit daily stale rollover (#90119)", async () => {
     // Counterpart: auto-created fallback overrides must still be cleared on a
     // daily rollover so stale sessions return to the configured default.
@@ -1017,6 +1090,58 @@ describe("initSessionState RawBody", () => {
     expect(result.sessionEntry.modelOverride).toBeUndefined();
     expect(result.sessionEntry.providerOverride).toBeUndefined();
     expect(result.sessionEntry.modelOverrideSource).toBeUndefined();
+  });
+
+  it("preserves behavior overrides while clearing an auto-fallback model override on one implicit daily rollover (#92562)", async () => {
+    // Documents the clear/preserve split on a single implicit rollover: a
+    // user-set /think survives (no fallback provenance to filter) while an
+    // auto-fallback model override is dropped back to the configured default.
+    // The two travel separate paths (direct carry vs resolveResetPreservedSelection),
+    // so they must not interfere.
+    const root = await makeCaseDir("openclaw-daily-rollover-mixed-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:discord:channel:daily-rollover-mixed";
+    const existingSessionId = "session-before-daily-reset-mixed";
+    const staleStartedAt = Date.now() - 48 * 60 * 60 * 1000;
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: staleStartedAt,
+        sessionStartedAt: staleStartedAt,
+        lastInteractionAt: staleStartedAt,
+        systemSent: true,
+        // User-set behavior override (must survive).
+        thinkingLevel: "medium",
+        // Auto-fallback model override (must be cleared).
+        providerOverride: "minimax",
+        modelOverride: "m2.7",
+        modelOverrideFallbackOriginProvider: "openai",
+        modelOverrideFallbackOriginModel: "gpt-4o-mini",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "hello again",
+        ChatType: "channel",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false);
+    // Behavior override preserved...
+    expect(result.sessionEntry.thinkingLevel).toBe("medium");
+    // ...while the auto-fallback model override is cleared.
+    expect(result.sessionEntry.modelOverride).toBeUndefined();
+    expect(result.sessionEntry.providerOverride).toBeUndefined();
   });
 
   it("rotates local session state for /new on bound ACP sessions", async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -543,16 +543,20 @@ export async function initSessionState(params: {
       persistedAuthProfileOverrideSource = preservedSelection.authProfileOverrideSource;
       persistedAuthProfileOverrideCompactionCount =
         preservedSelection.authProfileOverrideCompactionCount;
-    }
-    // When a reset trigger (/new, /reset) starts a new session, carry over
-    // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto)
-    // so the user doesn't have to re-enable them every time.
-    if (resetTriggered && entry) {
+      // Behavior overrides carry across ANY new-session mint (explicit /new AND
+      // implicit daily/idle rollover), mirroring the model/auth carry above
+      // (#90119). Any persisted level is safe to forward — user `/think` or a
+      // spawn-applied default (subagent-spawn-thinking.ts) — so unlike model
+      // overrides these need no fallback-provenance filtering (#92562).
       persistedThinking = entry.thinkingLevel;
       persistedVerbose = entry.verboseLevel;
       persistedTrace = entry.traceLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
+    }
+    // When a reset trigger (/new, /reset) starts a new session, also rotate the
+    // underlying CLI conversation and carry forward spawn lineage/label.
+    if (resetTriggered && entry) {
       // Explicit /new and /reset should rotate the underlying CLI conversation too.
       // Keep the model/auth choice, but force the next turn to mint a fresh CLI binding.
       persistedLabel = entry.label;


### PR DESCRIPTION
### Summary

Session-level behavior overrides — `/think`, `/verbose`, `/reasoning`, `/trace`, and auto-TTS — survive an explicit `/new` but were **dropped after the automatic daily/idle session reset**, reverting to defaults with no user action.

Root cause is in `initSessionState` (`src/auto-reply/reply/session.ts`). When a rollover mints a new session, the `else` branch carries **model/auth** overrides unconditionally (the #90119 / #90128 fix) but kept the **behavior** carries gated behind `resetTriggered`. The implicit daily/idle rollover runs with `resetTriggered === false`, so it took that branch and reverted them. This moves the five behavior carries alongside the model/auth preservation so they survive implicit rollover too; the CLI-rotation / spawn-lineage fields stay gated on explicit reset. No auto-fallback provenance filtering is needed for these fields (the model path needs it; these don't).

Surface: `src/auto-reply/reply/session.ts` (one function) + `src/auto-reply/reply/session.test.ts`. No API / schema / config / storage surface change. Refs #92562.

### Verification

- `node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts` -> **108 passed** (the new daily-rollover behavior test fails on unpatched `main`).
- `pnpm oxlint src/auto-reply/reply/session.ts src/auto-reply/reply/session.test.ts` -> clean.
- `oxfmt` (`pnpm format:fix`) -> clean.
- `pnpm tsgo:core` + `pnpm tsgo:core:test` -> exit 0.

### Real behavior proof

**Behavior addressed:** A session-level `/think medium` (and the other behavior overrides) set before the automatic daily/idle reset boundary now persists across the implicit rollover, instead of silently reverting to the default — matching how an explicit `/new` already behaves.

**Real environment tested:** Drove the actual `initSessionState` runtime path against a real on-disk `sessions.json` (a session with `thinkingLevel: "medium"` and a `sessionStartedAt` stale past the daily reset boundary), then sent an ordinary non-`/new` message — the turn that crosses the reset boundary in production. macOS, Node 22, repo `origin/main`.

**Exact steps or command run after this patch:** Seed the store -> call `initSessionState({ ctx: { RawBody: "what's the weather", ChatType: "channel", SessionKey }, cfg, commandAuthorized: true })` -> read back the persisted `sessions.json`. Ran the identical driver against unpatched `origin/main` `session.ts` and against the patched branch.

**Evidence after fix:**
```
BEFORE (origin/main):
  implicit rollover happened : true
  set before reset           : /think = medium
  runtime result after reset : /think = (reverted to default/off)
  persisted to sessions.json : /think = (reverted to default/off)

AFTER (patched):
  implicit rollover happened : true
  set before reset           : /think = medium
  runtime result after reset : /think = medium
  persisted to sessions.json : /think = medium
```

**Observed result after fix:** Both the in-memory session result and the value persisted to `sessions.json` retain `/think = medium` across the implicit daily/idle rollover; before the fix both reverted to default.

**What was not tested:** Not exercised end-to-end through a live channel transport (Discord/Telegram/etc.) or a real wall-clock daily-cron firing — the override-preservation logic lives entirely in `initSessionState` and is independent of the transport, so the boundary was reproduced deterministically via a stale `sessionStartedAt`. The sibling `fastMode` / `elevatedLevel` session fields are intentionally **not** addressed here — they're carried by neither `/new` nor rollover today, so they're out of scope for #92562 (possible follow-up).

---
AI-assisted (Claude). I reviewed and own the final diff. Cross-reviewed with Claude + Codex before submission.
