### PR TITLE
test(cron): expand stagger helper edge-case coverage

### DIFF
--- a/src/cron/stagger.test.ts
+++ b/src/cron/stagger.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_TOP_OF_HOUR_STAGGER_MS,
   isRecurringTopOfHourCronExpr,
   normalizeCronStaggerMs,
+  resolveDefaultCronStaggerMs,
   resolveCronStaggerMs,
 } from "./stagger.js";
 
@@ -50,5 +51,76 @@ describe("cron stagger helpers", () => {
     expect(
       resolveCronStaggerMs({ kind: "cron" } as unknown as { kind: "cron"; expr: string }),
     ).toBe(0);
+  });
+
+  it("detects 6-field top-of-hour expressions (second minute hour …)", () => {
+    // second=0, minute=0, hour=* → true
+    expect(isRecurringTopOfHourCronExpr("0 0 * * * *")).toBe(true);
+    // second=0, minute=0, hour=*/6 → true (contains *)
+    expect(isRecurringTopOfHourCronExpr("0 0 */6 * * *")).toBe(true);
+    // second≠0 → false
+    expect(isRecurringTopOfHourCronExpr("1 0 * * * *")).toBe(false);
+    // minute≠0 → false
+    expect(isRecurringTopOfHourCronExpr("0 5 * * * *")).toBe(false);
+    // hour field has no wildcard → false
+    expect(isRecurringTopOfHourCronExpr("0 0 1 * * *")).toBe(false);
+  });
+
+  it("returns false for range-only hour fields, wrong field counts, and empty input", () => {
+    // Range without * in 5-field hour slot → false
+    expect(isRecurringTopOfHourCronExpr("0 0-23 * * *")).toBe(false);
+    // 4 fields → false
+    expect(isRecurringTopOfHourCronExpr("* * * *")).toBe(false);
+    // 7 fields → false
+    expect(isRecurringTopOfHourCronExpr("0 0 * * * * *")).toBe(false);
+    // Empty string → false
+    expect(isRecurringTopOfHourCronExpr("")).toBe(false);
+  });
+
+  it("tolerates extra surrounding and internal whitespace in cron expressions", () => {
+    expect(isRecurringTopOfHourCronExpr("  0   *   *   *   *  ")).toBe(true);
+    expect(isRecurringTopOfHourCronExpr("  15   *   *   *   *  ")).toBe(false);
+  });
+
+  it("normalizes non-numeric and special-value stagger inputs", () => {
+    expect(normalizeCronStaggerMs(undefined)).toBeUndefined();
+    expect(normalizeCronStaggerMs(null)).toBeUndefined();
+    expect(normalizeCronStaggerMs(Infinity)).toBeUndefined();
+    expect(normalizeCronStaggerMs(-Infinity)).toBeUndefined();
+    expect(normalizeCronStaggerMs(NaN)).toBeUndefined();
+    expect(normalizeCronStaggerMs("Infinity")).toBeUndefined();
+    expect(normalizeCronStaggerMs("NaN")).toBeUndefined();
+    // Zero is a valid explicit-disable value
+    expect(normalizeCronStaggerMs(0)).toBe(0);
+    expect(normalizeCronStaggerMs("0")).toBe(0);
+    // Whitespace-padded integer string
+    expect(normalizeCronStaggerMs("  42  ")).toBe(42);
+  });
+
+  it("resolveDefaultCronStaggerMs returns default stagger only for top-of-hour expressions", () => {
+    expect(resolveDefaultCronStaggerMs("0 * * * *")).toBe(DEFAULT_TOP_OF_HOUR_STAGGER_MS);
+    expect(resolveDefaultCronStaggerMs("0 */2 * * *")).toBe(DEFAULT_TOP_OF_HOUR_STAGGER_MS);
+    expect(resolveDefaultCronStaggerMs("15 * * * *")).toBeUndefined();
+    expect(resolveDefaultCronStaggerMs("0 7 * * *")).toBeUndefined();
+    expect(resolveDefaultCronStaggerMs("")).toBeUndefined();
+  });
+
+  it("resolveCronStaggerMs falls through to default when staggerMs is non-finite", () => {
+    // NaN → normalized to undefined → falls through to default
+    expect(resolveCronStaggerMs({ kind: "cron", expr: "0 * * * *", staggerMs: NaN })).toBe(
+      DEFAULT_TOP_OF_HOUR_STAGGER_MS,
+    );
+    // Infinity → normalized to undefined → falls through to default
+    expect(resolveCronStaggerMs({ kind: "cron", expr: "0 * * * *", staggerMs: Infinity })).toBe(
+      DEFAULT_TOP_OF_HOUR_STAGGER_MS,
+    );
+    // String staggerMs (narrow cast) is normalized to a valid number
+    expect(
+      resolveCronStaggerMs({
+        kind: "cron",
+        expr: "0 * * * *",
+        staggerMs: "30000" as unknown as number,
+      }),
+    ).toBe(30_000);
   });
 });


### PR DESCRIPTION
## Summary

Expands `src/cron/stagger.test.ts` from 5 test cases (54 lines) to 11 test cases, covering previously untested paths in all four exported helpers.

**New coverage added:**

| Helper | New cases |
|--------|-----------|
| `isRecurringTopOfHourCronExpr` | 6-field expressions (second/minute/hour semantics); range-only hour fields; wrong field counts (4, 7); empty string; extra surrounding/internal whitespace |
| `normalizeCronStaggerMs` | `undefined`, `null`, `Infinity`, `-Infinity`, `NaN`; string `"Infinity"`, `"NaN"`, `"0"`, `"  42  "` (whitespace-padded) |
| `resolveDefaultCronStaggerMs` | Previously **untested** — now covers top-of-hour true/false and empty string |
| `resolveCronStaggerMs` | `staggerMs: NaN` and `staggerMs: Infinity` fallthrough to default; string `staggerMs` coercion via `normalizeCronStaggerMs` |

## Verification

```
node scripts/run-vitest.mjs src/cron/stagger.test.ts

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Duration  416ms
```

Closes #92467