### PR TITLE
fix(logging): prune stale non-idle diagnostic session states after fallback TTL (fixes #91697)

### DIFF
--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -58,6 +58,8 @@ export function pruneDiagnosticSessionStates(now = Date.now(), force = false): v
     const isIdle = state.state === "idle";
     if (isIdle && state.queueDepth <= 0 && ageMs > SESSION_STATE_TTL_MS) {
       diagnosticSessionStates.delete(key);
+    } else if (!isIdle && ageMs > SESSION_STATE_TTL_MS * 2) {
+      diagnosticSessionStates.delete(key);
     }
   }
 

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -184,6 +184,36 @@ describe("diagnostic session state pruning", () => {
     expect(getDiagnosticSessionStateCountForTest()).toBe(2000);
   });
 
+  it("evicts stale non-idle session states after the fallback TTL", () => {
+    const now = Date.now();
+    diagnosticSessionStates.set("ghost-1", {
+      sessionId: "ghost-1",
+      lastActivity: now,
+      generation: 0,
+      state: "processing",
+      queueDepth: 0,
+    });
+    diagnosticSessionStates.set("idle-1", {
+      sessionId: "idle-1",
+      lastActivity: now,
+      generation: 0,
+      state: "idle",
+      queueDepth: 0,
+    });
+    expect(getDiagnosticSessionStateCountForTest()).toBe(2);
+
+    // Advance past idle TTL (30 min) but not past fallback TTL (60 min)
+    pruneDiagnosticSessionStates(now + 31 * 60 * 1000, true);
+    // idle-1 should be evicted (idle + stale), ghost-1 should survive (non-idle, not past 2x TTL)
+    expect(getDiagnosticSessionStateCountForTest()).toBe(1);
+    expect(diagnosticSessionStates.has("ghost-1")).toBe(true);
+
+    // Advance past fallback TTL (60 min)
+    pruneDiagnosticSessionStates(now + 61 * 60 * 1000, true);
+    // ghost-1 should now be evicted by the fallback condition
+    expect(getDiagnosticSessionStateCountForTest()).toBe(0);
+  });
+
   it("reuses keyed session state when later looked up by sessionId", () => {
     const keyed = getDiagnosticSessionState({
       sessionId: "s1",


### PR DESCRIPTION
### Summary

- **Problem**: `pruneDiagnosticSessionStates()` in `src/logging/diagnostic-session-state.ts` only deletes entries where `state === "idle"` AND `queueDepth <= 0` AND `age > 30 min`. Entries that never transition back to idle after failed stuck-session recovery accumulate indefinitely in the `diagnosticSessionStates` Map, holding activity snapshots and queue metadata in V8 heap.
- **Root Cause**: When `requestStuckSessionRecovery()` fails (session already closed, generation check fails, exception), `applyRecoveryOutcomeToDiagnosticState()` receives `{ status: "failed" }`. The `recoveryOutcomeMutatesSessionState` guard returns false for "failed" outcomes, so the entry stays at its non-idle state permanently. The prune loop never targets non-idle entries.
- **Fix**: Add a fallback deletion condition after the existing idle gate: any non-idle entry whose `lastActivity` exceeds 2× `SESSION_STATE_TTL_MS` (60 min) is deleted. This gives failed recovery a generous window to retry while preventing indefinite accumulation.
- **What changed**:
  - `src/logging/diagnostic-session-state.ts` — add `else if (!isIdle && ageMs > SESSION_STATE_TTL_MS * 2)` fallback
  - `src/logging/diagnostic.test.ts` — new test verifying two-stage pruning (idle at 30min, non-idle at 60min)
- **What did NOT change (scope boundary)**:
  - The existing idle-prune condition is unchanged
  - The stuck-session recovery logic is unchanged
  - The size-based cap at 2000 entries is unchanged

### Reproduction

1. Create a diagnostic session entry that is stuck in non-idle state (e.g. `"processing"`) due to a failed recovery
2. Wait for the entry's `lastActivity` to exceed 60 minutes (2× TTL)
3. **Before this PR**: the entry survives the prune loop indefinitely because `state !== "idle"`
4. **After this PR**: the entry is cleaned up by the fallback condition once age exceeds 60 min

### Real behavior proof

**Behavior or issue addressed (91697)**: Ghost diagnostic session state entries stuck in non-idle state after failed recovery accumulate in the process-level Map until the 2000-entry FIFO cap is hit.

**Real environment tested**: Linux, Node 22 — fake-timer test fixture exercising `pruneDiagnosticSessionStates` with idle and non-idle entries.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts`

**Evidence after fix**:
```text
 RUN  v4.1.7 /home/0668001395/openclawProject1

 Test Files  1 passed (1)
      Tests  69 passed (69)
   Start at  10:52:10
   Duration  3.23s

[test] passed 1 Vitest shard in 11.86s
```

**Observed result after fix**: The new `evicts stale non-idle session states after the fallback TTL` test case confirms: after 31 minutes only the idle stale entry is evicted and the non-idle ghost entry survives; after 61 minutes the fallback condition evicts the non-idle ghost entry. All 68 pre-existing diagnostic tests continue to pass without modification.

**What was not tested**: A live gateway with actual failed stuck-session recovery was not driven — that requires a multi-turn embedded agent run with abort triggers. The prune-loop behavior is verified through direct manipulation of the `diagnosticSessionStates` map.

**Repro confirmation**: Before this patch, a non-idle entry with `lastActivity` set 61 minutes in the past survives `pruneDiagnosticSessionStates`. After the patch, the same entry is deleted by the fallback condition.

### Risk / Mitigation

- **Risk**: A legitimate long-running session could stay in non-idle state for over 60 minutes and be incorrectly pruned.
  **Mitigation**: The 2× TTL (60 min) is conservative. A session that is genuinely active will have its `lastActivity` updated regularly by run-progress or tool-started events, keeping `ageMs` well below 60 min. Only entries where all activity has ceased for over an hour are eligible for fallback deletion.
- **Risk**: The fallback could mask a root-cause issue in stuck-session recovery by silently cleaning up entries.
  **Mitigation**: The existing size cap (2000 entries) already provides silent cleanup when the map overflows. This fallback is a gentler mechanism that prevents the cap from being hit in the first place.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] logging / diagnostics

### Regression Test Plan

- `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts`
- The new test case verifies: idle entries evicted at 30min, non-idle ghost entries evicted at 60min

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #91697
