### PR TITLE
fix(doctor): pass --deep flag to memory embedding probe (fixes #92582)

### DIFF
--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -255,6 +255,24 @@ describe("probeGatewayMemoryStatus", () => {
     });
   });
 
+  it("sends probe: true when deep is requested", async () => {
+    callGateway.mockResolvedValue({ embedding: { ok: true, checked: true } });
+
+    await expect(probeGatewayMemoryStatus({ cfg, deep: true })).resolves.toEqual({
+      checked: true,
+      ready: true,
+      error: undefined,
+      skipped: false,
+    });
+
+    expect(callGateway).toHaveBeenCalledWith({
+      method: "doctor.memory.status",
+      params: { probe: true },
+      timeoutMs: 8_000,
+      config: cfg,
+    });
+  });
+
   it("keeps non-timeout gateway errors as explicit failures", async () => {
     callGateway.mockRejectedValue(new Error("gateway closed (1006): no close reason"));
 

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -139,17 +139,18 @@ export async function checkGatewayHealth(params: {
   return { healthOk, authenticated: false, status };
 }
 
-/** Probes gateway memory readiness without forcing deep embedding checks. */
+/** Probes gateway memory readiness; passes deep=true when --deep is active. */
 export async function probeGatewayMemoryStatus(params: {
   cfg: OpenClawConfig;
   timeoutMs?: number;
+  deep?: boolean;
 }): Promise<GatewayMemoryProbe> {
   const timeoutMs =
     typeof params.timeoutMs === "number" && params.timeoutMs > 0 ? params.timeoutMs : 8_000;
   try {
     const payload = await callGateway<DoctorMemoryStatusPayload>({
       method: "doctor.memory.status",
-      params: { probe: false },
+      params: { probe: params.deep === true },
       timeoutMs,
       config: params.cfg,
     });

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -839,6 +839,7 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
     ? await probeGatewayMemoryStatus({
         cfg: ctx.cfg,
         timeoutMs: ctx.options.nonInteractive === true ? 3000 : 10_000,
+        deep: ctx.options.deep === true,
       })
     : { checked: false, ready: false, skipped: healthOk };
 }


### PR DESCRIPTION
## fix(doctor): pass --deep flag to memory embedding probe (fixes #92582)

`openclaw doctor` reports local embeddings as "not confirmed ready" even when `openclaw memory status --deep` confirms the full memory stack is healthy.

### Root Cause

`probeGatewayMemoryStatus` in `src/commands/doctor-gateway-health.ts:152` hardcoded `params: { probe: false }`, so the gateway's `shouldProbeMemoryEmbeddings()` always returned false. The `--deep` flag was never forwarded from the doctor flow to the gateway memory status handler.

### Fix

- Added `deep?: boolean` parameter to `probeGatewayMemoryStatus`
- Changed `params: { probe: false }` → `params: { probe: params.deep === true }`
- Pass `deep: ctx.options.deep === true` from `doctor-health-contributions.ts`

### Files Changed

- `src/commands/doctor-gateway-health.ts` — accept and forward `deep` param
- `src/flows/doctor-health-contributions.ts` — pass `ctx.options.deep` to probe
- `src/commands/doctor-gateway-health.test.ts` — add test for `deep: true` path

## Real behavior proof

- **Behavior addressed:** `openclaw doctor --deep` falsely warns "local embeddings are not confirmed ready" because the memory embedding probe is never triggered
- **Environment tested:** macOS, Node v25.8.2, OpenClaw main branch
- **Steps run after the patch:**
  1. `node scripts/run-vitest.mjs run src/commands/doctor-gateway-health.test.ts` — 11 tests pass
  2. `node scripts/run-vitest.mjs run src/flows/doctor-health-contributions.test.ts` — 34 tests pass
  3. Verified the fix by inspecting the changed code path
- **Evidence after fix:**
```
$ node -e "const fs = require('fs'); const src = fs.readFileSync('src/commands/doctor-gateway-health.ts','utf8'); console.log('deep param present:', src.includes('deep?: boolean')); console.log('probe forwarded:', src.includes('params.deep === true'));"
deep param present: true
probe forwarded: true

$ grep -n "deep" src/commands/doctor-gateway-health.ts
143:  deep?: boolean;
152:      params: { probe: params.deep === true },

$ grep -n "deep" src/flows/doctor-health-contributions.ts
842:        deep: ctx.options.deep === true,
```
- **Observed result after fix:** The `probeGatewayMemoryStatus` function now forwards the `deep` flag to the gateway. When `--deep` is active, the gateway runs the live embedding availability check (`shouldProbeMemoryEmbeddings` returns true), and the doctor correctly reports readiness instead of emitting a false warning.
- **What was not tested:** Live end-to-end `openclaw doctor --deep` with a real local embedding model — verified at code and test level only.
