### PR TITLE
fix(gateway): stop accepting the Control UI token via ?token= query string

### DIFF
--- a/src/gateway/control-ui-assistant-media-query-token.e2e.test.ts
+++ b/src/gateway/control-ui-assistant-media-query-token.e2e.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { installGatewayTestHooks, testState, withGatewayServer } from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const MEDIA_AUTH_TOKEN = "media-auth-gateway-token-1234567890";
+
+// Regression: the assistant-media route must NOT accept the gateway shared secret
+// via the URL query string (?token=...) — tokens in URLs leak through proxy/access
+// logs, browser history, and Referer. Legitimate access is an Authorization: Bearer
+// header (programmatic clients) or the signed, source-scoped mediaTicket (browsers).
+describe("assistant-media auth: query token rejected, header + ticket accepted", () => {
+  test("rejects ?token= even when it is the correct gateway secret", async () => {
+    const stateDir = process.env.OPENCLAW_STATE_DIR;
+    if (!stateDir) {
+      throw new Error("OPENCLAW_STATE_DIR is required for gateway e2e media fixtures");
+    }
+    testState.gatewayAuth = { mode: "token", token: MEDIA_AUTH_TOKEN };
+
+    const mediaDir = path.join(stateDir, "media", "assistant-media-query-token-regression");
+    await fs.mkdir(mediaDir, { recursive: true });
+    const filePath = path.join(mediaDir, "preview.txt");
+    await fs.writeFile(filePath, "assistant media body\n", "utf8");
+
+    await withGatewayServer(
+      async ({ port }) => {
+        const route = `http://127.0.0.1:${port}/__openclaw__/assistant-media`;
+        const sourceParam = encodeURIComponent(filePath);
+
+        // No credential is rejected.
+        const anon = await fetch(`${route}?source=${sourceParam}`);
+        expect(anon.status).toBe(401);
+
+        // The correct gateway secret in the query string is rejected (the fix).
+        const queryToken = await fetch(`${route}?source=${sourceParam}&token=${MEDIA_AUTH_TOKEN}`);
+        expect(queryToken.status).toBe(401);
+
+        // Authorization: Bearer header is the legitimate programmatic path.
+        const header = await fetch(`${route}?source=${sourceParam}`, {
+          headers: { Authorization: `Bearer ${MEDIA_AUTH_TOKEN}` },
+        });
+        expect(header.status).toBe(200);
+        expect(await header.text()).toBe("assistant media body\n");
+
+        // The signed mediaTicket is the legitimate browser path: an authenticated
+        // meta request mints a ticket, which then authorizes the media fetch with
+        // no token in the URL.
+        const meta = await fetch(`${route}?meta=1&source=${sourceParam}`, {
+          headers: { Authorization: `Bearer ${MEDIA_AUTH_TOKEN}` },
+        });
+        expect(meta.status).toBe(200);
+        const payload = (await meta.json()) as { available?: boolean; mediaTicket?: string };
+        expect(payload.available).toBe(true);
+        expect(payload.mediaTicket).toMatch(/^v1\./);
+
+        const ticketed = await fetch(
+          `${route}?source=${sourceParam}&mediaTicket=${encodeURIComponent(payload.mediaTicket ?? "")}`,
+        );
+        expect(ticketed.status).toBe(200);
+        expect(await ticketed.text()).toBe("assistant media body\n");
+      },
+      {
+        serverOptions: {
+          auth: { mode: "token", token: MEDIA_AUTH_TOKEN },
+          controlUiEnabled: true,
+        },
+      },
+    );
+  });
+});

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -426,9 +426,10 @@ describe("handleControlUiHttpRequest", () => {
         const filePath = path.join(tmpRoot, "photo.png");
         await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
         const { res, handled } = await runAssistantMediaRequest({
-          url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+          url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}`,
           method: "GET",
           auth: { mode: "token", token: "test-token", allowTailscale: false },
+          headers: { authorization: "Bearer test-token" },
         });
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
@@ -445,9 +446,10 @@ describe("handleControlUiHttpRequest", () => {
 
     try {
       const { res, handled } = await runAssistantMediaRequest({
-        url: `/__openclaw__/assistant-media?source=${encodeURIComponent(`media://inbound/${id}`)}&token=test-token`,
+        url: `/__openclaw__/assistant-media?source=${encodeURIComponent(`media://inbound/${id}`)}`,
         method: "GET",
         auth: { mode: "token", token: "test-token", allowTailscale: false },
+        headers: { authorization: "Bearer test-token" },
       });
       expect(handled).toBe(true);
       expect(res.statusCode).toBe(200);
@@ -465,9 +467,10 @@ describe("handleControlUiHttpRequest", () => {
 
     try {
       const { res, handled, end } = await runAssistantMediaRequest({
-        url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent(`media://inbound/${id}`)}&token=test-token`,
+        url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent(`media://inbound/${id}`)}`,
         method: "GET",
         auth: { mode: "token", token: "test-token", allowTailscale: false },
+        headers: { authorization: "Bearer test-token" },
       });
       expect(handled).toBe(true);
       expect(res.statusCode).toBe(200);
@@ -490,9 +493,10 @@ describe("handleControlUiHttpRequest", () => {
       const filePath = path.join(tmp, "photo.png");
       await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
       const { res, handled, end } = await runAssistantMediaRequest({
-        url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+        url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}`,
         method: "GET",
         auth: { mode: "token", token: "test-token", allowTailscale: false },
+        headers: { authorization: "Bearer test-token" },
       });
       expectNotFoundResponse({ handled, res, end });
     } finally {
@@ -507,9 +511,10 @@ describe("handleControlUiHttpRequest", () => {
         const filePath = path.join(tmpRoot, "photo.png");
         await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
         const { res, handled, end } = await runAssistantMediaRequest({
-          url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent(filePath)}&token=test-token`,
+          url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent(filePath)}`,
           method: "GET",
           auth: { mode: "token", token: "test-token", allowTailscale: false },
+          headers: { authorization: "Bearer test-token" },
         });
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
@@ -534,9 +539,10 @@ describe("handleControlUiHttpRequest", () => {
           const filePath = path.join(tmpRoot, "photo.png");
           await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
           const { res, handled, end } = await runAssistantMediaRequest({
-            url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent(filePath)}&token=test-token`,
+            url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent(filePath)}`,
             method: "GET",
             auth: { mode: "token", token: "test-token", allowTailscale: false },
+            headers: { authorization: "Bearer test-token" },
           });
           expect(handled).toBe(true);
           expect(res.statusCode).toBe(200);
@@ -637,9 +643,10 @@ describe("handleControlUiHttpRequest", () => {
 
   it("reports assistant local media availability failures with a reason", async () => {
     const { res, handled, end } = await runAssistantMediaRequest({
-      url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent("/Users/test/Documents/private.pdf")}&token=test-token`,
+      url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent("/Users/test/Documents/private.pdf")}`,
       method: "GET",
       auth: { mode: "token", token: "test-token", allowTailscale: false },
+      headers: { authorization: "Bearer test-token" },
     });
     expect(handled).toBe(true);
     expect(res.statusCode).toBe(200);
@@ -716,27 +723,6 @@ describe("handleControlUiHttpRequest", () => {
               headers: {
                 authorization: `Bearer ${operatorToken}`,
               },
-            });
-            expect(handled).toBe(true);
-            expect(res.statusCode).toBe(200);
-          },
-        });
-      },
-    });
-  });
-
-  it("accepts paired operator device tokens in assistant media query auth", async () => {
-    await withPairedOperatorDeviceToken({
-      fn: async (operatorToken) => {
-        await withAllowedAssistantMediaRoot({
-          prefix: "ui-media-device-token-query-",
-          fn: async (tmpRoot) => {
-            const filePath = path.join(tmpRoot, "photo.png");
-            await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
-            const { res, handled } = await runAssistantMediaRequest({
-              url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=${encodeURIComponent(operatorToken)}`,
-              method: "GET",
-              auth: { mode: "token", token: "shared-token", allowTailscale: false },
             });
             expect(handled).toBe(true);
             expect(res.statusCode).toBe(200);

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -266,38 +266,6 @@ function resolveAssistantMediaRoutePath(basePath?: string): string {
   return `${normalizedBasePath}${CONTROL_UI_ASSISTANT_MEDIA_PREFIX}`;
 }
 
-function resolveAssistantMediaAuthToken(req: IncomingMessage): string | undefined {
-  const bearer = getBearerToken(req);
-  if (bearer) {
-    return bearer;
-  }
-  const urlRaw = req.url;
-  if (!urlRaw) {
-    return undefined;
-  }
-  try {
-    const url = new URL(urlRaw, "http://localhost");
-    const token = url.searchParams.get("token")?.trim();
-    return token || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function resolveControlUiReadAuthToken(
-  req: IncomingMessage,
-  opts?: { allowQueryToken?: boolean },
-): string | undefined {
-  const bearer = getBearerToken(req);
-  if (bearer) {
-    return bearer;
-  }
-  if (!opts?.allowQueryToken) {
-    return undefined;
-  }
-  return resolveAssistantMediaAuthToken(req);
-}
-
 async function authorizeControlUiReadRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -306,7 +274,6 @@ async function authorizeControlUiReadRequest(
     trustedProxies?: string[];
     allowRealIpFallback?: boolean;
     rateLimiter?: AuthRateLimiter;
-    allowQueryToken?: boolean;
     requiredOperatorMethod?: string;
   },
 ): Promise<boolean> {
@@ -314,9 +281,11 @@ async function authorizeControlUiReadRequest(
     return true;
   }
 
-  const token = resolveControlUiReadAuthToken(req, {
-    allowQueryToken: opts.allowQueryToken,
-  });
+  // Control UI read auth is header-only: a query-string token (?token=) would
+  // leak the gateway secret through proxy/access logs, browser history, and
+  // Referer. Browser media fetches authenticate with the signed mediaTicket
+  // instead; programmatic clients send Authorization: Bearer.
+  const token = getBearerToken(req);
   const clientIp =
     resolveRequestClientIp(req, opts.trustedProxies, opts.allowRealIpFallback === true) ??
     req.socket?.remoteAddress;
@@ -585,7 +554,6 @@ export async function handleControlUiAssistantMediaRequest(
       trustedProxies: opts?.trustedProxies,
       allowRealIpFallback: opts?.allowRealIpFallback,
       rateLimiter: opts?.rateLimiter,
-      allowQueryToken: true,
     }))
   ) {
     return true;


### PR DESCRIPTION
## Summary

The Control UI assistant-media route (`/__openclaw__/assistant-media`) accepted the gateway shared secret — and paired operator device tokens — from a `?token=` URL query parameter (`allowQueryToken: true` in `src/gateway/control-ui.ts`). Secrets in URLs leak through reverse-proxy/CDN access logs, browser history, and the `Referer` header, and the gateway token is long-lived.

This contradicts the rest of the codebase:
- the hooks endpoint hard-rejects query tokens (`src/gateway/server/hooks-request-handler.ts`), and
- the Control UI itself warns that `?token=` "may appear in server logs" and prefers the URL fragment (`ui/src/ui/app-settings.ts`).

The legitimate browser flow doesn't need it: an authenticated `meta` request mints a signed, source-scoped, short-TTL `mediaTicket`, and the media fetch uses `?mediaTicket=`; programmatic clients send `Authorization: Bearer`. The first-party UI already uses `mediaTicket` exclusively.

### Change
- Delete `resolveAssistantMediaAuthToken` and `resolveControlUiReadAuthToken` and the `allowQueryToken` plumbing; Control UI read auth now resolves the token from `getBearerToken` only (header), or the signed `mediaTicket`. Net `control-ui.ts`: fewer paths.
- Existing media tests moved from `?token=` to `Authorization: Bearer`; the redundant query-auth device-token test removed (its header equivalent already exists).
- New e2e regression asserts a **correct** token in `?token=` is rejected while header + `mediaTicket` still serve media.

## Verification

- `node scripts/run-vitest.mjs src/gateway/control-ui.http.test.ts` → 220 passed
- `node scripts/run-vitest.mjs src/gateway/control-ui-assistant-media-query-token.e2e.test.ts` → 1 passed
- `oxfmt --check` + `oxlint` on changed files → clean; `pnpm tsgo:core` → 0 errors

### Real behavior proof
- Behavior addressed: the Control UI assistant-media route accepted the gateway shared secret (and paired operator device tokens) via the `?token=` URL query string, leaking a long-lived secret into reverse-proxy/CDN access logs, browser history, and the `Referer` header.
- Real environment tested: a real OpenClaw gateway HTTP server booted on loopback TCP via the gateway e2e harness (`withGatewayServer` → `startGatewayServer`); requests issued with real `fetch` against `http://127.0.0.1:<port>`. Node 22.22, Linux (WSL2).
- Exact steps or command run after this patch: drove one probe against a live gateway twice — first with the pre-fix file (`git show origin/main:src/gateway/control-ui.ts`), then with this PR's file — issuing `GET /__openclaw__/assistant-media` five ways via `node scripts/run-vitest.mjs`.
- Evidence after fix: live console output captured from the running gateway (`node` server, real loopback HTTP), before (pre-fix `origin/main`) vs after (this PR):
```text
BEFORE  origin/main src/gateway/control-ui.ts   (real gateway @ 127.0.0.1:62000)
  [1] no credential                    -> HTTP 401
  [2] ?token=<CORRECT gateway secret>  -> HTTP 200   secret-in-URL ACCEPTED  (the leak)
  [3] Authorization: Bearer <token>    -> HTTP 200
  [4] meta=1 (Bearer) -> mediaTicket   -> HTTP 200   available=true  ticket=v1.eyJzY29wZSI...
  [5] ?mediaTicket=<signed ticket>     -> HTTP 200

AFTER   this PR  src/gateway/control-ui.ts       (real gateway @ 127.0.0.1:33000)
  [1] no credential                    -> HTTP 401
  [2] ?token=<CORRECT gateway secret>  -> HTTP 401   secret-in-URL REJECTED  (the fix)
  [3] Authorization: Bearer <token>    -> HTTP 200   body="assistant media body"
  [4] meta=1 (Bearer) -> mediaTicket   -> HTTP 200   available=true  ticket=v1.eyJzY29wZSI...
  [5] ?mediaTicket=<signed ticket>     -> HTTP 200   body="assistant media body"
```
- Observed result after fix: only case [2] changed — a correct gateway secret in `?token=` went from HTTP 200 (accepted, pre-fix) to HTTP 401 (rejected). The legitimate `Authorization: Bearer` header and the signed `mediaTicket` browser path still serve media unchanged. The PR's e2e regression fails on pre-fix code and passes on the fix.
- What was not tested: full `pnpm check` / CI matrix (left to CI); no UI/browser change (the first-party UI already uses `mediaTicket`).
