### PR TITLE
fix(model-registry): skip invalid plugin catalog shards instead of aborting the whole load

### DIFF
--- a/scripts/repro/issue-92553-model-registry-invalid-catalog.mts
+++ b/scripts/repro/issue-92553-model-registry-invalid-catalog.mts
@@ -1,0 +1,114 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+
+const { ModelRegistry } = await import(
+  path.join(repoRoot, "src/agents/sessions/model-registry.ts")
+);
+const { AuthStorage } = await import(path.join(repoRoot, "src/agents/sessions/auth-storage.ts"));
+const { PLUGIN_MODEL_CATALOG_FILE, PLUGIN_MODEL_CATALOG_GENERATED_BY } = await import(
+  path.join(repoRoot, "src/agents/plugin-model-catalog.ts")
+);
+
+function pluginOwnerSnapshot(providerId: string, pluginId: string) {
+  return {
+    index: {
+      plugins: [{ pluginId, enabled: true }],
+    },
+    normalizePluginId: (id: string) => id,
+    owners: {
+      channels: new Map(),
+      channelConfigs: new Map(),
+      providers: new Map([[providerId, [pluginId]]]),
+      modelCatalogProviders: new Map([[providerId, [pluginId]]]),
+      cliBackends: new Map(),
+      setupProviders: new Map(),
+      commandAliases: new Map(),
+      contracts: new Map(),
+    },
+  };
+}
+
+async function main() {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-repro-92553-"));
+  const modelsJsonPath = path.join(tmpDir, "models.json");
+  const badCatalogDir = path.join(tmpDir, "plugins", "bad");
+  const badCatalogPath = path.join(badCatalogDir, PLUGIN_MODEL_CATALOG_FILE);
+
+  await fs.writeFile(
+    modelsJsonPath,
+    JSON.stringify(
+      {
+        providers: {
+          custom: {
+            baseUrl: "https://models.example/v1",
+            api: "openai-responses",
+            apiKey: "CUSTOM_API_KEY",
+            models: [{ id: "example-model", name: "Example Model" }],
+          },
+        },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+
+  await fs.mkdir(badCatalogDir, { recursive: true });
+  await fs.writeFile(
+    badCatalogPath,
+    JSON.stringify(
+      {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          bad: {
+            baseUrl: "https://bad.example/v1",
+            apiKey: "BAD_API_KEY",
+            models: [{ id: "bad-model" }],
+          },
+        },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+
+  const registry = ModelRegistry.create(
+    AuthStorage.inMemory({
+      custom: { type: "api_key", key: "sk-test" },
+    }),
+    modelsJsonPath,
+    { pluginMetadataSnapshot: pluginOwnerSnapshot("bad", "bad") },
+  );
+
+  const customModel = registry.find("custom", "example-model");
+  const badModel = registry.find("bad", "bad-model");
+
+  console.log("=== Reproduction for issue #92553 ===");
+  console.log(`models.json: ${modelsJsonPath}`);
+  console.log(`bad catalog: ${badCatalogPath}`);
+  console.log(`registry error: ${registry.getError() ?? "none"}`);
+  console.log(`valid model found: ${customModel?.name ?? "not found"}`);
+  console.log(`invalid model found: ${badModel ? "yes (bug)" : "no"}`);
+
+  await fs.rm(tmpDir, { recursive: true, force: true });
+
+  const pass =
+    registry.getError() === undefined && customModel !== undefined && badModel === undefined;
+
+  if (pass) {
+    console.log("PASS: invalid plugin catalog shard does not discard valid root models.");
+    process.exitCode = 0;
+  } else {
+    console.error("FAIL: invalid plugin catalog shard caused ModelRegistry to drop valid models.");
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -225,4 +225,42 @@ describe("ModelRegistry models.json auth", () => {
     expect(registry.getError()).toBeUndefined();
     expect(registry.find("zai", "glm-5.1")).toBeUndefined();
   });
+
+  it("does not let an invalid plugin catalog shard discard valid root models", () => {
+    const modelsPath = writeModelsJsonWithPluginCatalog({
+      root: {
+        providers: {
+          custom: {
+            baseUrl: "https://models.example/v1",
+            api: "openai-responses",
+            apiKey: "CUSTOM_API_KEY",
+            models: [{ id: "example-model", name: "Example Model" }],
+          },
+        },
+      },
+      pluginRelativePath: join("plugins", "bad", PLUGIN_MODEL_CATALOG_FILE),
+      pluginCatalog: {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          bad: {
+            baseUrl: "https://bad.example/v1",
+            apiKey: "BAD_API_KEY",
+            models: [{ id: "bad-model" }],
+          },
+        },
+      },
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({
+        custom: { type: "api_key", key: "sk-test" },
+      }),
+      modelsPath,
+      { pluginMetadataSnapshot: pluginOwnerSnapshot("bad", "bad") },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("custom", "example-model")?.name).toBe("Example Model");
+    expect(registry.find("bad", "bad-model")).toBeUndefined();
+  });
 });

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -451,7 +451,7 @@ export class ModelRegistry {
             requireGeneratedCatalog: true,
           });
           if (pluginResult.error) {
-            return pluginResult;
+            continue;
           }
           models.push(...pluginResult.models);
         }


### PR DESCRIPTION
## Summary

Fixes #92553.

`ModelRegistry.loadCustomModels` returned early when any generated plugin catalog shard failed validation, which discarded every valid model loaded from `models.json` and from all earlier plugin catalogs. A single stale/invalid provider entry in one plugin catalog therefore left the registry empty and caused `Unknown model` errors across the board.

## Changes

- `src/agents/sessions/model-registry.ts`: in the plugin-catalog loop, skip invalid shards (`continue`) instead of propagating the error and dropping already-loaded models.
- `src/agents/sessions/model-registry.test.ts`: add regression test proving a valid root provider survives an invalid generated plugin catalog shard.
- `scripts/repro/issue-92553-model-registry-invalid-catalog.mts`: standalone reproduction script that creates a valid `models.json` plus an invalid catalog shard and asserts the valid model is still registered.

## Real behavior proof

- **Behavior addressed**: a single invalid generated plugin catalog shard no longer causes `ModelRegistry` to discard all valid models.
- **Real environment tested**: Linux 4.19.112, Node 22.19+, OpenClaw repo at `main`.
- **Exact steps or command run after this patch**:
  - `node --import tsx scripts/repro/issue-92553-model-registry-invalid-catalog.mts`
- **Evidence after fix**:
  Terminal output from running the standalone reproduction script against the patched source:
  ```text
  === Reproduction for issue #92553 ===
  registry error: none
  valid model found: Example Model
  invalid model found: no
  PASS: invalid plugin catalog shard does not discard valid root models.
  ```
- **Observed result after fix**: the valid root model is still available via `registry.find(\"custom\", \"example-model\")` and `registry.getError()` is undefined; the invalid shard is ignored. Before the patch, the same script would return an empty registry and the valid model would be lost.
- **What was not tested**: live gateway restart with a real stale `google/catalog.json`; generator-side validation/merging in `ensureOpenClawModelsJson` (suggested fix 3 in the issue) is left as follow-up work.

## Verification

- [x] `node --import tsx scripts/repro/issue-92553-model-registry-invalid-catalog.mts` passes
- [x] `pnpm test src/agents/sessions/model-registry.test.ts --run` passes
- [x] `npx oxlint` on changed files passes
- [x] `npx oxfmt` on changed files passes
- [x] `pnpm build` passes
- [x] `pnpm tsgo` passes