### PR TITLE
fix(ui): add CJK font fallback to chat input font stack (fixes #92586)

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -83,7 +83,7 @@
   /* Typography */
   --mono:
     "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
-  --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans CJK SC", "PingFang SC", "Microsoft YaHei", sans-serif;
   --font-display: var(--font-body);
   --control-ui-text-scale: 1;
   --control-ui-text-xs: calc(11px * var(--control-ui-text-scale));

--- a/ui/src/ui/custom-theme.ts
+++ b/ui/src/ui/custom-theme.ts
@@ -9,7 +9,7 @@ const MAX_TWEAKCN_THEME_BYTES = 200_000;
 const MAX_CSS_TOKEN_LENGTH = 240;
 const TWEAKCN_FETCH_TIMEOUT_MS = 10_000;
 const DEFAULT_FONT_BODY =
-  '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans CJK SC", "PingFang SC", "Microsoft YaHei", sans-serif';
 const DEFAULT_MONO =
   '"JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace';
 const FORBIDDEN_CSS_VALUE_PARTS = [


### PR DESCRIPTION
## Summary

Fixes #92586 — adds CJK (Chinese/Japanese/Korean) font fallback to the global body font stack, resolving inconsistent character width rendering in the chat input box on Linux.

**Root cause:** The CSS `font-family` stack (`Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`) has no CJK-specific fonts. On Linux (Chromium), individual CJK characters fall through to different generic fallback fonts, causing visible width inconsistency (e.g., "复" narrower than "制" in "复制").

**Fix:** Add three widely available CJK fonts before the generic `sans-serif` fallback:
- `"Noto Sans CJK SC"` — open source, available on most Linux distributions
- `"PingFang SC"` — macOS system CJK font
- `"Microsoft YaHei"` — Windows system CJK font

These fonts are only used when previous fonts in the stack don't have the required glyphs, so English/Latin text rendering is unaffected.

## Changed files

- `ui/src/styles/base.css` — add CJK fonts to `--font-body` CSS variable
- `ui/src/ui/custom-theme.ts` — add CJK fonts to `DEFAULT_FONT_BODY` constant

## Real behavior proof

**Behavior addressed:** Chinese character width inconsistency in chat input due to missing CJK font fallback in the global font stack.

**Environment tested:** macOS Darwin arm64, Node.js, pnpm build.

**Steps run after the patch:**
```
node -e "const fs = require('fs'); const css = fs.readFileSync('ui/src/styles/base.css', 'utf8'); const m = css.match(/--font-body:([^;]+);/); console.log('CSS --font-body:', m?.[1]?.trim()); const ts = fs.readFileSync('ui/src/ui/custom-theme.ts', 'utf8'); const m2 = ts.match(/DEFAULT_FONT_BODY =\n\s+'([^']+)'/); console.log('TS DEFAULT_FONT_BODY:', m2?.[1]);"
node scripts/run-vitest.mjs run ui/src/ui/custom-theme.test.ts
```

**Evidence after fix:**
```
CSS --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans CJK SC", "PingFang SC", "Microsoft YaHei", sans-serif
TS DEFAULT_FONT_BODY: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans CJK SC", "PingFang SC", "Microsoft YaHei", sans-serif
```

```
✓  ui  ui/src/ui/custom-theme.test.ts (13 tests) 19ms
Test Files  1 passed (1)
Tests  13 passed (13)
```

**Observed result after fix:** Both the CSS variable and TypeScript constant now include CJK font fallback. All 13 existing theme tests pass without modification.

**What was not tested:** Visual rendering on Linux/Chromium — the fix adds standard CJK font names that are widely available. Browser-level rendering verification requires a Linux desktop environment.
