### PR TITLE
feat(msteams): respond to channel messages by keyword without an @mention

### DIFF
--- a/extensions/msteams/src/mentions.test.ts
+++ b/extensions/msteams/src/mentions.test.ts
@@ -1,6 +1,11 @@
 // Msteams tests cover mentions plugin behavior.
 import { describe, expect, it } from "vitest";
-import { buildMentionEntities, formatMentionText, parseMentions } from "./mentions.js";
+import {
+  buildMentionEntities,
+  formatMentionText,
+  isMSTeamsKeywordMention,
+  parseMentions,
+} from "./mentions.js";
 
 function requireFirstEntity(result: ReturnType<typeof parseMentions>) {
   const entity = result.entities[0];
@@ -251,5 +256,51 @@ describe("formatMentionText", () => {
     const result = formatMentionText(text, mentions);
 
     expect(result).toBe("Hey <at>John(Test)</at> and <at>Alice.Smith</at>");
+  });
+});
+
+describe("isMSTeamsKeywordMention", () => {
+  const regexes = [/\bradar\b/i];
+  const base = {
+    isDirectMessage: false,
+    alreadyMentioned: false,
+    text: "hey radar, you there?",
+    fromId: "29:user",
+    recipientId: "28:bot",
+    mentionRegexes: regexes,
+  };
+
+  it("treats a keyword match in a channel message as an implicit mention", () => {
+    expect(isMSTeamsKeywordMention(base)).toBe(true);
+  });
+
+  it("is case-insensitive (regex carries the flag)", () => {
+    expect(isMSTeamsKeywordMention({ ...base, text: "RADAR, status?" })).toBe(true);
+  });
+
+  it("does not trigger when the keyword is absent", () => {
+    expect(isMSTeamsKeywordMention({ ...base, text: "the weather is nice today" })).toBe(false);
+  });
+
+  it("does not trigger on the bot's own posts (self-echo guard)", () => {
+    expect(isMSTeamsKeywordMention({ ...base, fromId: "28:bot", recipientId: "28:bot" })).toBe(
+      false,
+    );
+  });
+
+  it("skips direct messages (handled by the normal DM path)", () => {
+    expect(isMSTeamsKeywordMention({ ...base, isDirectMessage: true })).toBe(false);
+  });
+
+  it("skips messages already @mentioned (handled normally)", () => {
+    expect(isMSTeamsKeywordMention({ ...base, alreadyMentioned: true })).toBe(false);
+  });
+
+  it("no-ops when no patterns are configured", () => {
+    expect(isMSTeamsKeywordMention({ ...base, mentionRegexes: [] })).toBe(false);
+  });
+
+  it("no-ops on empty text", () => {
+    expect(isMSTeamsKeywordMention({ ...base, text: undefined })).toBe(false);
   });
 });

--- a/extensions/msteams/src/mentions.ts
+++ b/extensions/msteams/src/mentions.ts
@@ -5,6 +5,7 @@
  * 1. Text containing <at>Name</at> tags
  * 2. entities array with mention metadata
  */
+import { matchesMentionPatterns } from "openclaw/plugin-sdk/channel-inbound";
 
 type MentionEntity = {
   type: "mention";
@@ -111,4 +112,36 @@ export function formatMentionText(text: string, mentions: MentionInfo[]): string
     formatted = formatted.replace(namePattern, `<at>${mention.name}</at>`);
   }
   return formatted;
+}
+
+/**
+ * Whether a channel/group message should be treated as an implicit mention because
+ * its text matches a configured mention pattern (e.g. the agent's name). This lets
+ * the agent answer when named without an `@` — the message-handler ORs the result
+ * into the `wasMentioned` fact so the existing requireMention gate still drops
+ * everything else (no extra model turn).
+ *
+ * Guards, in order: never for DMs or already-@mentioned messages (handled by the
+ * normal path); nothing to match without text or patterns; and never for the bot's
+ * own posts — with RSC the bot also receives its own channel messages, and a reply
+ * that happens to contain the keyword would otherwise re-trigger itself.
+ */
+export function isMSTeamsKeywordMention(params: {
+  isDirectMessage: boolean;
+  alreadyMentioned: boolean;
+  text: string | undefined;
+  fromId: string | undefined;
+  recipientId: string | undefined;
+  mentionRegexes: RegExp[];
+}): boolean {
+  if (params.isDirectMessage || params.alreadyMentioned) {
+    return false;
+  }
+  if (!params.text || params.mentionRegexes.length === 0) {
+    return false;
+  }
+  if (params.fromId && params.fromId === params.recipientId) {
+    return false;
+  }
+  return matchesMentionPatterns(params.text, params.mentionRegexes);
 }

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -2,6 +2,7 @@
 import { formatAllowlistMatchMeta } from "openclaw/plugin-sdk/allow-from";
 import {
   buildChannelInboundEventContext,
+  buildMentionRegexes,
   logInboundDrop,
   resolveInboundMentionDecision,
   resolveInboundSessionEnvelopeContext,
@@ -37,6 +38,7 @@ import {
   type GraphThreadMessage,
 } from "../graph-thread.js";
 import { resolveGraphChatId } from "../graph-upload.js";
+import { isMSTeamsKeywordMention } from "../mentions.js";
 import {
   extractMSTeamsConversationMessageId,
   extractMSTeamsQuoteInfo,
@@ -522,10 +524,26 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       channelConfig,
     });
     const timestamp = parseMSTeamsActivityTimestamp(activity.timestamp);
+    // A non-@mention channel message that matches a configured mention pattern
+    // (e.g. the agent's name) counts as an implicit mention, so the agent answers
+    // when named without an `@`. Non-matching messages fall through to the
+    // requireMention gate below and are dropped before any model turn.
+    const keywordMention = isMSTeamsKeywordMention({
+      isDirectMessage,
+      alreadyMentioned: params.wasMentioned,
+      text,
+      fromId: activity.from?.id,
+      recipientId: activity.recipient?.id,
+      mentionRegexes: buildMentionRegexes(cfg, route.agentId, {
+        provider: "msteams",
+        conversationId,
+        providerPolicy: msteamsCfg?.mentionPatterns,
+      }),
+    });
     const mentionDecision = resolveInboundMentionDecision({
       facts: {
         canDetectMention: true,
-        wasMentioned: params.wasMentioned,
+        wasMentioned: params.wasMentioned || keywordMention,
         implicitMentionKinds: params.implicitMentionKinds,
       },
       policy: {

--- a/src/config/types.msteams.ts
+++ b/src/config/types.msteams.ts
@@ -11,7 +11,7 @@ import type {
   ChannelHealthMonitorConfig,
   ChannelHeartbeatVisibilityConfig,
 } from "./types.channel-health.js";
-import type { DmConfig } from "./types.messages.js";
+import type { DmConfig, MentionPatternsPolicyConfig } from "./types.messages.js";
 import type { SecretInput } from "./types.secrets.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
@@ -163,6 +163,13 @@ export type MSTeamsConfig = {
   mediaAuthAllowHosts?: Array<string>;
   /** Default: require @mention to respond in channels/groups. */
   requireMention?: boolean;
+  /**
+   * Scope the global `messages.groupChat.mentionPatterns` to selected Teams
+   * conversations. A pattern match makes a non-@mention channel message count
+   * as a mention, so the agent answers when named without an @ (e.g. "Radar, …").
+   * Same seam as the Discord/Slack/WhatsApp channels.
+   */
+  mentionPatterns?: MentionPatternsPolicyConfig;
   /** Max group/channel messages to keep as history context (0 disables). */
   historyLimit?: number;
   /** Max DM turns to keep as history context. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -1609,6 +1609,7 @@ export const MSTeamsConfigSchema = z
     mediaAllowHosts: z.array(z.string()).optional(),
     mediaAuthAllowHosts: z.array(z.string()).optional(),
     requireMention: z.boolean().optional(),
+    mentionPatterns: MentionPatternsPolicySchema.optional(),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),


### PR DESCRIPTION
## Summary

The MS Teams channel is the only group-capable channel that ignores `messages.groupChat.mentionPatterns`. Discord, Slack and WhatsApp each expose a per-provider `mentionPatterns` policy that scopes those patterns and treats a text match as an implicit mention — so a user can address the agent by name without an `@`. The msteams handler never wired this, so every non-`@mention` group/channel message is dropped at the `requireMention` gate.

This adds the same seam to msteams (no new concept):

- **config** — `channels.msteams.mentionPatterns` (`MentionPatternsPolicyConfig`), identical in shape to `channels.discord.mentionPatterns` / slack / whatsapp. It scopes the global `messages.groupChat.mentionPatterns` to selected Teams conversations (allow/deny by conversation id).
- **handler** — build the mention regexes (`buildMentionRegexes(cfg, agentId, { provider: "msteams", conversationId, providerPolicy: msteamsCfg?.mentionPatterns })`) and OR a match into the `wasMentioned` fact passed to `resolveInboundMentionDecision`. A matched message dispatches as if `@mentioned`; everything else still hits the existing `requireMention` skip, so there is **no extra model turn** for ordinary channel chatter. `requireMention` semantics are unchanged.
- **self-echo guard** — with RSC `ChannelMessage.Read.Group` the bot also receives its own channel posts; the new `isMSTeamsKeywordMention` helper returns false when `activity.from.id === activity.recipient.id`, so a reply that contains the keyword cannot re-trigger the bot.
- **helper** — `isMSTeamsKeywordMention` in `extensions/msteams/src/mentions.ts` (mirrors Discord's mention-state resolution), unit-tested.

### Config surface note

This adds one config field to an existing channel to reach parity with three sibling channels that already have it; the matching patterns still come from the existing global `messages.groupChat.mentionPatterns`. No default changes, no migration, fully backward-compatible (absent → today's behavior exactly).

## Real behavior proof

**Behavior addressed:** A Microsoft Teams channel message that names the agent (matches a configured mention pattern, e.g. `\bradar\b`) without an `@mention` now gets a reply; a channel message that does not match still gets no reply and triggers no model turn; the bot does not trigger on its own posts.

**Real environment tested:** A live Microsoft Teams deployment (OpenClaw 2026.6.5, native msteams plugin) with the equivalent keyword-mention behavior applied to the installed plugin and `RSC ChannelMessage.Read.Group` consented, exercised by posting real messages in a Teams channel and reading the bot's edge (nginx) and gateway journals over ssh.

**Exact steps or command run after this patch:** Posted three top-level channel messages naming the agent without an `@` ("Radar, can you hear me now?", "RADAR ... who am i", "cool... radar... can you give me latest oil price") and one with no keyword ("The weather today in Little Rock, is sunny and quite nice."), then read the inbound edge and gateway activity:

```
ssh <relay> "grep '/api/messages' /var/log/nginx/access.log | tail -1"
ssh <agent> "journalctl --user -u openclaw-gateway --since '-6 min' | grep -iE 'tool-policy|run agent'"
```

**Evidence after fix:** The inbound non-`@` channel message reaches the bot, and only the keyword messages start an agent turn:

```
# nginx edge — Bot Framework delivered the non-@ channel message, bot accepted (200)
52.112.116.120 - - [13/Jun/2026:02:49:10 +0000] "POST /api/messages HTTP/1.1" 200 0 "-" "Microsoft-SkypeBotApi (Microsoft-BotFramework/3.0)"

# gateway journal — one agent turn per keyword message (03:02:47, 03:04:14, 03:04:35);
# the no-keyword "weather" message posted at 03:03 produced NO turn between them
03:02:47 [agents/tool-policy] tool policy removed 5 tool(s) via tools.profile (coding): ...
03:04:14 [agents/tool-policy] tool policy removed 5 tool(s) via tools.profile (coding): ...
03:04:35 [agents/tool-policy] tool policy removed 5 tool(s) via tools.profile (coding): ...

# the agent's actual channel replies (no @mention was used):
Radar: "Loud and clear, Colton. What do you need?"
Radar: "Loud and clear, Colton — you're Colton Williams, one of the REG admins."
Radar: <latest WTI / Brent crude prices>
```

**Observed result after fix:** All three keyword messages were answered in-channel without an `@mention`; the no-keyword weather message was received by the bot but produced no agent turn and no reply (the `requireMention` skip still fires for non-matches); the bot did not reply to its own keyword-containing replies. `@mention` and DM behavior were unchanged.

**What was not tested:** I exercised the behavior live via the equivalent keyword-mention logic applied to a deployed 2026.6.5 plugin rather than a from-source gateway build of this exact branch; the source on this branch is covered by the added `isMSTeamsKeywordMention` unit cases (match / case-insensitive / no-keyword / self-echo / DM / already-mentioned / empty-patterns / empty-text), which I ran green locally via the repo's scoped vitest helper. I could not run the full local `pnpm check` lanes (oxfmt / tsgo / broad suites) — the toolchain is not fully installed in my checkout. Private/shared-channel RSC variants were not exercised.

Screenshots of the live Teams thread are available on request (repo policy keeps proof images off branches).
