### PR TITLE
 [AI] fix(tools): warn when tool availability contains malformed empty allOf/anyOf

### DIFF
--- a/src/tools/planner.test.ts
+++ b/src/tools/planner.test.ts
@@ -1,5 +1,5 @@
 // Verifies tool planner filtering, ordering, and unsupported-tool reporting.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ToolPlanContractError } from "./diagnostics.js";
 import { formatToolExecutorRef } from "./execution.js";
 import { buildToolPlan } from "./planner.js";
@@ -98,6 +98,8 @@ describe("buildToolPlan", () => {
   });
 
   it("hides descriptors with malformed empty allOf availability", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
     const plan = buildToolPlan({
       descriptors: [descriptor("malformed", { availability: { allOf: [] } })],
     });
@@ -111,6 +113,15 @@ describe("buildToolPlan", () => {
         message: "Empty availability allOf group",
       },
     ]);
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("malformed"),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("unsupported-signal"),
+    );
+
+    warn.mockRestore();
   });
 
   it("keeps protocol conversion separate from executor refs and model normalization", () => {

--- a/src/tools/planner.ts
+++ b/src/tools/planner.ts
@@ -49,6 +49,13 @@ export function buildToolPlan(options: BuildToolPlanOptions): ToolPlan {
       ...evaluateToolAvailability({ descriptor, context: options.availability }),
     ];
     if (diagnostics.length > 0) {
+      for (const diagnostic of diagnostics) {
+        if (diagnostic.reason === "unsupported-signal") {
+          console.warn(
+            `[tool-planner] ${descriptor.name}: ${diagnostic.reason} — ${diagnostic.message}`,
+          );
+        }
+      }
       hidden.push({ descriptor, diagnostics });
       continue;
     }


### PR DESCRIPTION
## Summary

`buildToolPlan` silently adds tools with malformed empty `allOf`/`anyOf` availability to the hidden plan with `"unsupported-signal"` diagnostics. These diagnostics are returned but never surfaced — no log, no warning, no error. Plugin authors see their tools quietly disappear with no actionable signal.

Now `buildToolPlan` emits `console.warn` for each `unsupported-signal` diagnostic, naming the affected tool and the reason. Runtime conditions (missing env, disabled plugin, model mismatch) remain silent — only authoring errors produce warnings.

- Problem: Empty `allOf`/`anyOf` in tool availability silently hides tools with no actionable error
- Solution: `console.warn` for each `unsupported-signal` diagnostic in `buildToolPlan`
- What changed: `src/tools/planner.ts` (+8 lines), `src/tools/planner.test.ts` (+11 lines)
- What did NOT change: Tool plan behavior (tools still hidden), runtime condition diagnostics, descriptor API

## Change Type

- [x] Bug fix

## Scope

- [x] Tools / developer experience

## Linked Issue

- Refs #92361

## Motivation

Issue #92361 reports that empty `allOf`/`anyOf` arrays in `ToolAvailabilityExpression` produce `"unsupported-signal"` diagnostics that are never surfaced to callers. The code in `buildToolPlan` correctly identifies the malformed descriptor and marks it hidden, but the diagnostic is never logged or emitted. Plugin and tool authors waste time debugging why their tools never appear in the plan.

The fix adds `console.warn` for `unsupported-signal` diagnostics, giving developers immediate feedback at gateway startup. Runtime conditions (missing env, disabled plugin, context mismatch) deliberately remain silent since those are normal operational states, not authoring errors.

## Changes

**File**: `src/tools/planner.ts`

In `buildToolPlan`, before pushing a descriptor with diagnostics to `hidden`, iterate the diagnostics. When `diagnostic.reason === "unsupported-signal"`, emit `console.warn` with the tool name, reason, and message.

**Test**: `src/tools/planner.test.ts`

Updated the existing "hides descriptors with malformed empty allOf availability" test to also verify `console.warn` was called with the tool name and `unsupported-signal` reason.

## Real Behavior Proof

- Behavior addressed: Empty `allOf`/`anyOf` tool availability silently hides tools with no log or warning
- Real environment tested: Linux (RHEL), Node.js 22.22, local checkout on branch `fix/tool-availability-empty-log-92361` at commit `96e1c76f`
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/tools/planner.test.ts --run --reporter=verbose
```

- Evidence after fix:

```console
 ✓ hides descriptors with malformed empty allOf availability 5ms
   (includes console.warn spy verification for tool name + unsupported-signal reason)

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

- Observed result after fix: `buildToolPlan` now emits `console.warn("[tool-planner] malformed: unsupported-signal — Empty availability allOf group")` when a descriptor has malformed availability. The tool is still hidden (behavior unchanged), but developers now see the warning at gateway startup. Runtime conditions like missing env vars or disabled plugins remain silent.
- What was not tested: Live gateway startup with a malformed tool descriptor. The fix is verified through the `planner.test.ts` unit test which spys on `console.warn`.

## Risks

- **Low risk**: Only adds `console.warn`; does not change tool plan visibility or runtime behavior
- **No new logging framework**: Uses `console.warn` directly (standard Node.js, no dependency)
- **Selective**: Only `unsupported-signal` diagnostics produce warnings; runtime conditions (env-missing, plugin-disabled, context-mismatch) are deliberately excluded
- **No config/default surface changes**: No new config keys, env vars, or defaults introduced

## User-visible / Behavior Changes

Tool and plugin authors who accidentally use empty `allOf`/`anyOf` in their tool descriptors will now see a warning at gateway startup. Tool behavior is unchanged — malformed descriptors are still hidden.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Human Verification

- Verified scenarios: Empty allOf produces console.warn with tool name and reason (test)
- Edge cases checked: Existing tests pass (no breakage), unsupported-signal detection preserved
- What you did NOT verify: Live gateway warning output

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Human confirmed understanding of code changes**: Yes

---

Refs #92361