### PR TITLE
#92589: fix(internal-runtime-context): wrap prompt-preface runtime context body in delimiters

### DIFF
--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -219,7 +219,9 @@ describe("runtime context prompt submission", () => {
         "OpenClaw runtime event.",
         "This context is runtime-generated, not user-authored. Keep internal details private.",
         "",
+        "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
         "internal event",
+        "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
       ].join("\n"),
     });
   });
@@ -242,7 +244,9 @@ describe("runtime context prompt submission", () => {
         "OpenClaw runtime event.",
         "This context is runtime-generated, not user-authored. Keep internal details private.",
         "",
+        "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
         "internal event",
+        "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
       ].join("\n"),
     });
   });
@@ -339,7 +343,9 @@ describe("runtime context prompt submission", () => {
         "OpenClaw runtime context for the immediately preceding user message.",
         "This context is runtime-generated, not user-authored. Keep internal details private.",
         "",
+        "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
         "secret runtime context",
+        "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
       ].join("\n"),
       display: false,
       details: { source: "openclaw-runtime-context" },

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -3,6 +3,8 @@
  */
 import {
   extractInternalRuntimeContext,
+  INTERNAL_RUNTIME_CONTEXT_BEGIN,
+  INTERNAL_RUNTIME_CONTEXT_END,
   OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER,
   OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
   OPENCLAW_RUNTIME_CONTEXT_NOTICE,
@@ -153,13 +155,18 @@ function buildRuntimeContextMessageContent(params: {
   runtimeContext: string;
   kind: "next-turn" | "runtime-event";
 }): string {
+  // Wrap the runtime context body in delimited internal-context markers so
+  // stripInternalRuntimeContext can fully remove the block when it leaks
+  // into user-visible surfaces (e.g. Feishu streaming cards, #92589).
   return [
     params.kind === "runtime-event"
       ? OPENCLAW_RUNTIME_EVENT_HEADER
       : OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER,
     OPENCLAW_RUNTIME_CONTEXT_NOTICE,
     "",
+    INTERNAL_RUNTIME_CONTEXT_BEGIN,
     params.runtimeContext,
+    INTERNAL_RUNTIME_CONTEXT_END,
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary

Wrap the runtime context body in `buildRuntimeContextMessageContent` with `INTERNAL_RUNTIME_CONTEXT_BEGIN` / `END` delimiters so `stripInternalRuntimeContext` can fully remove leaked runtime context from user-visible surfaces.

## Root Cause

`buildRuntimeContextMessageContent` (in `runtime-context-prompt.ts`) constructs hidden runtime context prompt blocks using the "prompt preface" format. When the model echoes this context back in its reply, `stripInternalRuntimeContext` strips the header and notice lines via `stripRuntimeContextPromptPreface`, but the **body** (containing sensitive data like `<relevant-memories>`, `Sender (untrusted metadata)`, `Conversation info`) was not wrapped in delimiters that `stripDelimitedBlock` handles. The body leaked through into Feishu streaming cards.

**Fix**: Wrap the runtime context body in `<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>` / `<<<END_OPENCLAW_INTERNAL_CONTEXT>>>` delimiters (3 lines added). `stripInternalRuntimeContext` already processes delimited blocks first, so the entire context block is removed.

## Real behavior proof

Behavior or issue addressed: When a runtime context block (containing `<relevant-memories>`, `Sender (untrusted metadata)`, `Conversation info`, system timestamps) is echoed in a reply, `stripInternalRuntimeContext` now completely removes the entire block instead of leaving the context body visible.

Real environment tested: Linux x64, kernel 4.19.112-2.el8, Node.js v24.13.1, tsx v4.22.3, openclaw at a0f80950ed on top of origin/main (6cf06e8e7e).

Exact steps or command run after this patch:
1. Checkout `fix/issue-92589-*` branch in openclaw workspace
2. Build runtime context with sensitive metadata via production `buildRuntimeContextSystemContext`
3. Run: `npx tsx scripts/repro-92589.mjs`
4. Verify `stripInternalRuntimeContext` removes all sensitive data from a simulated leaked reply

Evidence after fix:

```
========================================================================
Real behavior proof — #92589
========================================================================

Built runtime context (delimiters now wrap the body):
---
OpenClaw runtime context for the immediately preceding user message.
This context is runtime-generated, not user-authored. Keep internal details private.

<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>
Sender (untrusted metadata):
{"open_id": "ou_abc123", "name": "Alice"}
Conversation info (untrusted metadata):
{"chat_id": "oc_xyz789", "message_id": "om_456"}
<relevant-memories>
Memory: Bob uses Python for backend work.
</relevant-memories>
<<<END_OPENCLAW_INTERNAL_CONTEXT>>>
---

Contains BEGIN delimiter: ✅ YES
Contains END delimiter:   ✅ YES

After stripInternalRuntimeContext (simulated leaked reply):
---
Here is my analysis of the data:

Would you like me to proceed further?
---

All sensitive data stripped: ✅ YES
Actual reply text preserved: ✅ YES
========================================================================
```

Observed result after fix: All sensitive runtime context data (`<relevant-memories>`, `Sender (untrusted metadata)`, `Conversation info`, user `open_id`, context header) is completely removed. The actual user-visible reply text is preserved intact. Fix adds 3 lines: `INTERNAL_RUNTIME_CONTEXT_BEGIN`, the existing body, `INTERNAL_RUNTIME_CONTEXT_END`.

What was not tested: Live Feishu gateway with streaming cards (requires API keys and real channel setup). Verified via production-import tsx execution and existing test suite.

## Regression Test Plan

- [x] `runtime-context-prompt.test.ts` — 21/21
- [x] `replay-history.test.ts` — passed
- [x] `sanitizeuserfacingtext.test.ts` — 142/142
- [x] `internal-runtime-context.test.ts` — 5/5
- [x] No changes to stripping logic

---

*AI-assisted: built with Claude Code*
