### PR TITLE
[Bug]: ollama-cloud runtime fails DNS lookup for ai.ollama.com, while ollama/<model>:cloud works

### DIFF
--- a/extensions/ollama/doctor-contract-api.test.ts
+++ b/extensions/ollama/doctor-contract-api.test.ts
@@ -53,7 +53,7 @@ describe("ollama doctor contract", () => {
     const result = normalizeCompatibilityConfig({ cfg: config });
 
     expect(result.changes).toEqual([
-      "Updated models.providers.ollama-cloud.baseUrl from retired https://ai.ollama.com to https://ollama.com.",
+      "Updated models.providers.ollama-cloud.baseUrl from the retired Ollama Cloud endpoint to https://ollama.com.",
     ]);
     expect(readOllamaCloudProvider(result.config)).toEqual({
       baseUrl: "https://ollama.com",
@@ -80,7 +80,7 @@ describe("ollama doctor contract", () => {
     const result = normalizeCompatibilityConfig({ cfg: config });
 
     expect(result.changes).toEqual([
-      "Removed retired models.providers.ollama-cloud.baseURL https://ai.ollama.com/ while preserving models.providers.ollama-cloud.baseUrl.",
+      "Removed retired models.providers.ollama-cloud.baseURL while preserving models.providers.ollama-cloud.baseUrl.",
     ]);
     expect(readOllamaCloudProvider(result.config)).toEqual({
       baseUrl: "https://ollama.com",
@@ -112,7 +112,7 @@ describe("ollama doctor contract", () => {
     const result = normalizeCompatibilityConfig({ cfg: config });
 
     expect(result.changes).toEqual([
-      "Updated models.providers.ollama-cloud.baseURL from retired https://ai.ollama.com/ to https://ollama.com.",
+      "Updated models.providers.ollama-cloud.baseURL from the retired Ollama Cloud endpoint to https://ollama.com.",
     ]);
     expect(readOllamaCloudProvider(result.config)).toEqual({
       baseUrl: "https://ollama.com",
@@ -144,7 +144,7 @@ describe("ollama doctor contract", () => {
     const result = normalizeCompatibilityConfig({ cfg: config });
 
     expect(result.changes).toEqual([
-      "Removed retired models.providers.ollama-cloud.baseURL https://ai.ollama.com/ while preserving models.providers.ollama-cloud.baseUrl.",
+      "Removed retired models.providers.ollama-cloud.baseURL while preserving models.providers.ollama-cloud.baseUrl.",
     ]);
     expect(readOllamaCloudProvider(result.config)).toEqual({
       baseUrl: "https://custom-ollama-cloud.example.test",
@@ -157,5 +157,26 @@ describe("ollama doctor contract", () => {
       api: "ollama",
       models: [],
     });
+  });
+
+  it("does not expose credentials or query parameters from the retired URL", () => {
+    const config = {
+      models: {
+        providers: {
+          "ollama-cloud": {
+            baseUrl: "https://user:password@ai.ollama.com/?token=secret",
+            api: "ollama",
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes.join("\n")).not.toContain("user");
+    expect(result.changes.join("\n")).not.toContain("password");
+    expect(result.changes.join("\n")).not.toContain("secret");
+    expect(readOllamaCloudProvider(result.config)?.baseUrl).toBe("https://ollama.com");
   });
 });

--- a/extensions/ollama/doctor-contract-api.test.ts
+++ b/extensions/ollama/doctor-contract-api.test.ts
@@ -1,0 +1,72 @@
+// Ollama tests cover doctor contract config compatibility.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract-api.js";
+
+function readOllamaCloudProvider(config: OpenClawConfig): Record<string, unknown> | undefined {
+  return config.models?.providers?.["ollama-cloud"] as Record<string, unknown> | undefined;
+}
+
+describe("ollama doctor contract", () => {
+  it("detects retired Ollama Cloud provider endpoints", () => {
+    expect(legacyConfigRules[0]?.match({ baseUrl: "https://ai.ollama.com" })).toBe(true);
+    expect(legacyConfigRules[0]?.match({ baseUrl: "https://ollama.com" })).toBe(false);
+  });
+
+  it("migrates retired Ollama Cloud provider baseUrl to the canonical endpoint", () => {
+    const config = {
+      models: {
+        providers: {
+          "ollama-cloud": {
+            baseUrl: "https://ai.ollama.com",
+            api: "ollama",
+            models: [{ id: "kimi-k2.5:cloud" }],
+          },
+          ollama: {
+            baseUrl: "http://127.0.0.1:11434",
+            api: "ollama",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes).toEqual([
+      "Updated models.providers.ollama-cloud.baseUrl from retired https://ai.ollama.com to https://ollama.com.",
+    ]);
+    expect(readOllamaCloudProvider(result.config)).toEqual({
+      baseUrl: "https://ollama.com",
+      api: "ollama",
+      models: [{ id: "kimi-k2.5:cloud" }],
+    });
+    expect(readOllamaCloudProvider(config)?.baseUrl).toBe("https://ai.ollama.com");
+  });
+
+  it("migrates retired Ollama Cloud provider baseURL aliases to canonical baseUrl", () => {
+    const config = {
+      models: {
+        providers: {
+          "ollama-cloud": {
+            baseURL: "https://ai.ollama.com/",
+            api: "ollama",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes).toEqual([
+      "Updated models.providers.ollama-cloud.baseURL from retired https://ai.ollama.com/ to https://ollama.com.",
+    ]);
+    expect(readOllamaCloudProvider(result.config)).toEqual({
+      baseUrl: "https://ollama.com",
+      api: "ollama",
+    });
+    expect(readOllamaCloudProvider(config)).toEqual({
+      baseURL: "https://ai.ollama.com/",
+      api: "ollama",
+    });
+  });
+});

--- a/extensions/ollama/doctor-contract-api.test.ts
+++ b/extensions/ollama/doctor-contract-api.test.ts
@@ -63,12 +63,44 @@ describe("ollama doctor contract", () => {
     expect(readOllamaCloudProvider(config)?.baseUrl).toBe("https://ai.ollama.com");
   });
 
-  it("migrates retired Ollama Cloud provider baseURL aliases to canonical baseUrl", () => {
+  it("removes retired Ollama Cloud provider baseURL aliases when canonical baseUrl is present", () => {
     const config = {
       models: {
         providers: {
           "ollama-cloud": {
             baseUrl: "https://ollama.com",
+            baseURL: "https://ai.ollama.com/",
+            api: "ollama",
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes).toEqual([
+      "Removed retired models.providers.ollama-cloud.baseURL https://ai.ollama.com/ while preserving models.providers.ollama-cloud.baseUrl.",
+    ]);
+    expect(readOllamaCloudProvider(result.config)).toEqual({
+      baseUrl: "https://ollama.com",
+      api: "ollama",
+      models: [],
+    });
+    expect(readOllamaCloudProvider(config)).toEqual({
+      baseUrl: "https://ollama.com",
+      baseURL: "https://ai.ollama.com/",
+      api: "ollama",
+      models: [],
+    });
+  });
+
+  it("migrates retired Ollama Cloud provider baseURL aliases when canonical baseUrl is blank", () => {
+    const config = {
+      models: {
+        providers: {
+          "ollama-cloud": {
+            baseUrl: " ",
             baseURL: "https://ai.ollama.com/",
             api: "ollama",
             models: [],
@@ -88,7 +120,39 @@ describe("ollama doctor contract", () => {
       models: [],
     });
     expect(readOllamaCloudProvider(config)).toEqual({
-      baseUrl: "https://ollama.com",
+      baseUrl: " ",
+      baseURL: "https://ai.ollama.com/",
+      api: "ollama",
+      models: [],
+    });
+  });
+
+  it("preserves custom canonical baseUrl when removing retired baseURL aliases", () => {
+    const config = {
+      models: {
+        providers: {
+          "ollama-cloud": {
+            baseUrl: "https://custom-ollama-cloud.example.test",
+            baseURL: "https://ai.ollama.com/",
+            api: "ollama",
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes).toEqual([
+      "Removed retired models.providers.ollama-cloud.baseURL https://ai.ollama.com/ while preserving models.providers.ollama-cloud.baseUrl.",
+    ]);
+    expect(readOllamaCloudProvider(result.config)).toEqual({
+      baseUrl: "https://custom-ollama-cloud.example.test",
+      api: "ollama",
+      models: [],
+    });
+    expect(readOllamaCloudProvider(config)).toEqual({
+      baseUrl: "https://custom-ollama-cloud.example.test",
       baseURL: "https://ai.ollama.com/",
       api: "ollama",
       models: [],

--- a/extensions/ollama/doctor-contract-api.test.ts
+++ b/extensions/ollama/doctor-contract-api.test.ts
@@ -3,6 +3,25 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
 import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract-api.js";
 
+type ModelDefinition = NonNullable<
+  NonNullable<OpenClawConfig["models"]>["providers"]
+>[string]["models"][number];
+
+const cloudModel: ModelDefinition = {
+  id: "kimi-k2.5:cloud",
+  name: "Kimi K2.5 Cloud",
+  reasoning: false,
+  input: ["text"],
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+  },
+  contextWindow: 131072,
+  maxTokens: 8192,
+};
+
 function readOllamaCloudProvider(config: OpenClawConfig): Record<string, unknown> | undefined {
   return config.models?.providers?.["ollama-cloud"] as Record<string, unknown> | undefined;
 }
@@ -20,11 +39,12 @@ describe("ollama doctor contract", () => {
           "ollama-cloud": {
             baseUrl: "https://ai.ollama.com",
             api: "ollama",
-            models: [{ id: "kimi-k2.5:cloud" }],
+            models: [cloudModel],
           },
           ollama: {
             baseUrl: "http://127.0.0.1:11434",
             api: "ollama",
+            models: [],
           },
         },
       },
@@ -38,7 +58,7 @@ describe("ollama doctor contract", () => {
     expect(readOllamaCloudProvider(result.config)).toEqual({
       baseUrl: "https://ollama.com",
       api: "ollama",
-      models: [{ id: "kimi-k2.5:cloud" }],
+      models: [cloudModel],
     });
     expect(readOllamaCloudProvider(config)?.baseUrl).toBe("https://ai.ollama.com");
   });
@@ -48,8 +68,10 @@ describe("ollama doctor contract", () => {
       models: {
         providers: {
           "ollama-cloud": {
+            baseUrl: "https://ollama.com",
             baseURL: "https://ai.ollama.com/",
             api: "ollama",
+            models: [],
           },
         },
       },
@@ -63,10 +85,13 @@ describe("ollama doctor contract", () => {
     expect(readOllamaCloudProvider(result.config)).toEqual({
       baseUrl: "https://ollama.com",
       api: "ollama",
+      models: [],
     });
     expect(readOllamaCloudProvider(config)).toEqual({
+      baseUrl: "https://ollama.com",
       baseURL: "https://ai.ollama.com/",
       api: "ollama",
+      models: [],
     });
   });
 });

--- a/extensions/ollama/doctor-contract-api.ts
+++ b/extensions/ollama/doctor-contract-api.ts
@@ -1,0 +1,1 @@
+export { legacyConfigRules, normalizeCompatibilityConfig } from "./src/config-compat.js";

--- a/extensions/ollama/src/config-compat.ts
+++ b/extensions/ollama/src/config-compat.ts
@@ -1,0 +1,89 @@
+// Ollama helper module supports config compat behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { OLLAMA_CLOUD_BASE_URL, OLLAMA_CLOUD_PROVIDER_ID } from "./defaults.js";
+
+type LegacyConfigRule = {
+  path: Array<string | number>;
+  message: string;
+  match: (value: unknown) => boolean;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function isRetiredOllamaCloudBaseUrl(value: unknown): value is string {
+  if (typeof value !== "string" || !value.trim()) {
+    return false;
+  }
+  try {
+    return new URL(value.trim()).hostname.toLowerCase() === "ai.ollama.com";
+  } catch {
+    return false;
+  }
+}
+
+function findRetiredOllamaCloudBaseUrl(
+  provider: unknown,
+): { key: "baseUrl" | "baseURL"; value: string } | null {
+  const record = asRecord(provider);
+  if (!record) {
+    return null;
+  }
+  if (isRetiredOllamaCloudBaseUrl(record.baseUrl)) {
+    return { key: "baseUrl", value: record.baseUrl };
+  }
+  if (isRetiredOllamaCloudBaseUrl(record.baseURL)) {
+    return { key: "baseURL", value: record.baseURL };
+  }
+  return null;
+}
+
+export const legacyConfigRules: LegacyConfigRule[] = [
+  {
+    path: ["models", "providers", OLLAMA_CLOUD_PROVIDER_ID],
+    message:
+      'models.providers.ollama-cloud.baseUrl="https://ai.ollama.com" is retired; use "https://ollama.com". Run "openclaw doctor --fix".',
+    match: (value) => findRetiredOllamaCloudBaseUrl(value) !== null,
+  },
+];
+
+export function migrateOllamaCloudRetiredBaseUrl(config: OpenClawConfig): {
+  config: OpenClawConfig;
+  changes: string[];
+} | null {
+  const provider = config.models?.providers?.[OLLAMA_CLOUD_PROVIDER_ID];
+  const retired = findRetiredOllamaCloudBaseUrl(provider);
+  if (!retired) {
+    return null;
+  }
+
+  const nextConfig = structuredClone(config);
+  const nextModels = asRecord(nextConfig.models) ?? {};
+  nextConfig.models = nextModels as OpenClawConfig["models"];
+  const nextProviders = asRecord(nextModels.providers) ?? {};
+  nextModels.providers = nextProviders;
+  const nextProvider = asRecord(nextProviders[OLLAMA_CLOUD_PROVIDER_ID]) ?? {};
+  nextProviders[OLLAMA_CLOUD_PROVIDER_ID] = nextProvider;
+
+  nextProvider.baseUrl = OLLAMA_CLOUD_BASE_URL;
+  if (retired.key === "baseURL") {
+    delete nextProvider.baseURL;
+  }
+
+  return {
+    config: nextConfig,
+    changes: [
+      `Updated models.providers.ollama-cloud.${retired.key} from retired ${retired.value} to ${OLLAMA_CLOUD_BASE_URL}.`,
+    ],
+  };
+}
+
+export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): {
+  config: OpenClawConfig;
+  changes: string[];
+} {
+  return migrateOllamaCloudRetiredBaseUrl(cfg) ?? { config: cfg, changes: [] };
+}

--- a/extensions/ollama/src/config-compat.ts
+++ b/extensions/ollama/src/config-compat.ts
@@ -25,18 +25,16 @@ function isRetiredOllamaCloudBaseUrl(value: unknown): value is string {
   }
 }
 
-function findRetiredOllamaCloudBaseUrl(
-  provider: unknown,
-): { key: "baseUrl" | "baseURL"; value: string } | null {
+function findRetiredOllamaCloudBaseUrl(provider: unknown): { key: "baseUrl" | "baseURL" } | null {
   const record = asRecord(provider);
   if (!record) {
     return null;
   }
   if (isRetiredOllamaCloudBaseUrl(record.baseUrl)) {
-    return { key: "baseUrl", value: record.baseUrl };
+    return { key: "baseUrl" };
   }
   if (isRetiredOllamaCloudBaseUrl(record.baseURL)) {
-    return { key: "baseURL", value: record.baseURL };
+    return { key: "baseURL" };
   }
   return null;
 }
@@ -79,7 +77,7 @@ export function migrateOllamaCloudRetiredBaseUrl(config: OpenClawConfig): {
     return {
       config: nextConfig,
       changes: [
-        `Removed retired models.providers.ollama-cloud.baseURL ${retired.value} while preserving models.providers.ollama-cloud.baseUrl.`,
+        "Removed retired models.providers.ollama-cloud.baseURL while preserving models.providers.ollama-cloud.baseUrl.",
       ],
     };
   }
@@ -92,7 +90,7 @@ export function migrateOllamaCloudRetiredBaseUrl(config: OpenClawConfig): {
   return {
     config: nextConfig,
     changes: [
-      `Updated models.providers.ollama-cloud.${retired.key} from retired ${retired.value} to ${OLLAMA_CLOUD_BASE_URL}.`,
+      `Updated models.providers.ollama-cloud.${retired.key} from the retired Ollama Cloud endpoint to ${OLLAMA_CLOUD_BASE_URL}.`,
     ],
   };
 }

--- a/extensions/ollama/src/config-compat.ts
+++ b/extensions/ollama/src/config-compat.ts
@@ -68,6 +68,22 @@ export function migrateOllamaCloudRetiredBaseUrl(config: OpenClawConfig): {
   const nextProvider = asRecord(nextProviders[OLLAMA_CLOUD_PROVIDER_ID]) ?? {};
   nextProviders[OLLAMA_CLOUD_PROVIDER_ID] = nextProvider;
 
+  const canonicalBaseUrl = nextProvider.baseUrl;
+  if (
+    retired.key === "baseURL" &&
+    typeof canonicalBaseUrl === "string" &&
+    canonicalBaseUrl.trim() &&
+    !isRetiredOllamaCloudBaseUrl(canonicalBaseUrl)
+  ) {
+    delete nextProvider.baseURL;
+    return {
+      config: nextConfig,
+      changes: [
+        `Removed retired models.providers.ollama-cloud.baseURL ${retired.value} while preserving models.providers.ollama-cloud.baseUrl.`,
+      ],
+    };
+  }
+
   nextProvider.baseUrl = OLLAMA_CLOUD_BASE_URL;
   if (retired.key === "baseURL") {
     delete nextProvider.baseURL;

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -372,7 +372,7 @@ describe("doctor-contract-registry module loader", () => {
       normalizeCompatibilityConfig: ({
         cfg,
       }: {
-        cfg: { models?: { providers?: Record<string, unknown> } };
+        cfg: { models?: { providers?: Record<string, Record<string, unknown>> } };
       }) => ({
         config: {
           ...cfg,
@@ -406,6 +406,7 @@ describe("doctor-contract-registry module loader", () => {
         providers: {
           "ollama-cloud": {
             baseUrl: "https://ai.ollama.com",
+            models: [],
           },
         },
       },
@@ -420,6 +421,7 @@ describe("doctor-contract-registry module loader", () => {
     expect(result.changes).toEqual(["normalized ollama cloud provider endpoint"]);
     expect(result.config.models?.providers?.["ollama-cloud"]).toEqual({
       baseUrl: "https://ollama.com",
+      models: [],
     });
   });
 

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -13,7 +13,9 @@ import {
 const tempDirs: string[] = [];
 const mocks = getRegistryJitiMocks();
 
+let applyPluginDoctorCompatibilityMigrations: typeof import("./doctor-contract-registry.js").applyPluginDoctorCompatibilityMigrations;
 let clearPluginDoctorContractRegistryCache: typeof import("./doctor-contract-registry.js").clearPluginDoctorContractRegistryCache;
+let collectRelevantDoctorPluginIds: typeof import("./doctor-contract-registry.js").collectRelevantDoctorPluginIds;
 let collectRelevantDoctorPluginIdsForTouchedPaths: typeof import("./doctor-contract-registry.js").collectRelevantDoctorPluginIdsForTouchedPaths;
 let listPluginDoctorLegacyConfigRules: typeof import("./doctor-contract-registry.js").listPluginDoctorLegacyConfigRules;
 let listPluginDoctorSessionRouteStateOwners: typeof import("./doctor-contract-registry.js").listPluginDoctorSessionRouteStateOwners;
@@ -43,7 +45,9 @@ describe("doctor-contract-registry module loader", () => {
     resetRegistryJitiMocks();
     vi.resetModules();
     ({
+      applyPluginDoctorCompatibilityMigrations,
       clearPluginDoctorContractRegistryCache,
+      collectRelevantDoctorPluginIds,
       collectRelevantDoctorPluginIdsForTouchedPaths,
       listPluginDoctorLegacyConfigRules,
       listPluginDoctorSessionRouteStateOwners,
@@ -347,6 +351,78 @@ describe("doctor-contract-registry module loader", () => {
     expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(2);
   });
 
+  it("collects model provider ids for doctor compatibility migrations", () => {
+    expect(
+      collectRelevantDoctorPluginIds({
+        models: {
+          providers: {
+            "ollama-cloud": {
+              baseUrl: "https://ai.ollama.com",
+            },
+          },
+        },
+      }),
+    ).toEqual(["ollama-cloud"]);
+  });
+
+  it("loads a plugin doctor contract when scoped by a contributed provider id", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(path.join(pluginRoot, "doctor-contract-api.ts"), "export {};\n", "utf-8");
+    mocks.createJiti.mockImplementation(() => () => ({
+      normalizeCompatibilityConfig: ({
+        cfg,
+      }: {
+        cfg: { models?: { providers?: Record<string, unknown> } };
+      }) => ({
+        config: {
+          ...cfg,
+          models: {
+            ...cfg.models,
+            providers: {
+              ...cfg.models?.providers,
+              "ollama-cloud": {
+                ...cfg.models?.providers?.["ollama-cloud"],
+                baseUrl: "https://ollama.com",
+              },
+            },
+          },
+        },
+        changes: ["normalized ollama cloud provider endpoint"],
+      }),
+    }));
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "ollama",
+          rootDir: pluginRoot,
+          channels: [],
+          providers: ["ollama", "ollama-cloud"],
+        },
+      ],
+      diagnostics: [],
+    });
+    const config = {
+      models: {
+        providers: {
+          "ollama-cloud": {
+            baseUrl: "https://ai.ollama.com",
+          },
+        },
+      },
+    };
+
+    const result = applyPluginDoctorCompatibilityMigrations(config, {
+      config,
+      env: {},
+      pluginIds: ["ollama-cloud"],
+    });
+
+    expect(result.changes).toEqual(["normalized ollama cloud provider endpoint"]);
+    expect(result.config.models?.providers?.["ollama-cloud"]).toEqual({
+      baseUrl: "https://ollama.com",
+    });
+  });
+
   it("narrows touched-path doctor ids for scoped dry-run validation", () => {
     expect(
       collectRelevantDoctorPluginIdsForTouchedPaths({
@@ -360,6 +436,11 @@ describe("doctor-contract-registry module loader", () => {
               "memory-wiki": {},
             },
           },
+          models: {
+            providers: {
+              "ollama-cloud": {},
+            },
+          },
           talk: {
             voiceId: "legacy-voice",
           },
@@ -367,10 +448,11 @@ describe("doctor-contract-registry module loader", () => {
         touchedPaths: [
           ["channels", "discord", "token"],
           ["plugins", "entries", "memory-wiki", "enabled"],
+          ["models", "providers", "ollama-cloud", "baseUrl"],
           ["talk", "voiceId"],
         ],
       }),
-    ).toEqual(["discord", "elevenlabs", "memory-wiki"]);
+    ).toEqual(["discord", "elevenlabs", "memory-wiki", "ollama-cloud"]);
   });
 
   it("falls back to the full doctor-id set when touched paths are too broad", () => {

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -244,6 +244,13 @@ export function collectRelevantDoctorPluginIds(raw: unknown): string[] {
     }
   }
 
+  const modelProviders = asNullableRecord(asNullableRecord(root.models)?.providers);
+  if (modelProviders) {
+    for (const providerId of Object.keys(modelProviders)) {
+      ids.add(providerId);
+    }
+  }
+
   if (hasLegacyElevenLabsTalkFields(root)) {
     ids.add("elevenlabs");
   }
@@ -274,6 +281,13 @@ export function collectRelevantDoctorPluginIdsForTouchedPaths(params: {
     }
     if (first === "plugins") {
       if (second !== "entries" || !third) {
+        return collectRelevantDoctorPluginIds(params.raw);
+      }
+      ids.add(third);
+      continue;
+    }
+    if (first === "models") {
+      if (second !== "providers" || !third) {
         return collectRelevantDoctorPluginIds(params.raw);
       }
       ids.add(third);


### PR DESCRIPTION
## Summary

- Add an Ollama doctor contract that flags retired `models.providers.ollama-cloud.baseUrl` / `baseURL` values pointing at `https://ai.ollama.com`.
- Migrate missing, blank, or retired canonical `baseUrl` values to `https://ollama.com`, while preserving explicit non-retired canonical `baseUrl` values when removing stale `baseURL` aliases.
- Include configured `models.providers` ids in plugin doctor compatibility discovery, so provider-scoped config such as `ollama-cloud` can invoke the owning plugin's doctor normalizer.
- Keep Ollama runtime URL resolution unchanged; legacy config is repaired through `openclaw doctor --fix` instead of silently overriding runtime configuration.

## Linked context

- Fixes #92391.
- Fix classification: root-cause compatibility migration fix.
- Maintainer-ready confidence: High; the patch adds extension-specific contract tests for the Ollama doctor normalizer and registry tests for provider-id doctor discovery.
- Root cause: The doctor compatibility discovery path collected channel ids and plugin entry ids, but not `models.providers` ids, so a saved `models.providers.ollama-cloud.baseUrl` value with the retired `https://ai.ollama.com` host could remain in canonical config and continue to feed the Ollama runtime resolver.
- Why this is root-cause fix: The patch repairs the source of the bad runtime URL by making `ollama-cloud` provider config eligible for plugin doctor migrations, then the Ollama plugin normalizer rewrites the retired endpoint to the canonical endpoint before runtime uses the persisted provider base URL.
- What did NOT change: This only changes doctor compatibility migration and provider-id doctor discovery; it does not change Ollama chat streaming, model discovery, auth handling, default local Ollama endpoints, explicit custom provider endpoints, or unrelated provider behavior.

## Real behavior proof (required for external PRs)

**Behavior addressed**: A legacy `ollama-cloud` provider config with `models.providers.ollama-cloud.baseUrl` set to `https://ai.ollama.com` is repaired by the Ollama doctor compatibility path so the persisted provider base URL becomes `https://ollama.com`.
**Real environment tested**: OpenClaw source checkout at this PR head, running under Node.js 22.22.0 with an isolated temporary `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_HOME`. The temporary config contained a valid `models.providers.ollama-cloud` provider entry using the retired `https://ai.ollama.com` endpoint.
- Real setup used: Same isolated OpenClaw source checkout and temporary config described above.
**Exact steps or command run after this patch**: Ran the OpenClaw doctor config migration path in repair mode against the isolated config, equivalent to `openclaw doctor --fix --non-interactive` for the configuration repair stage, then read the resulting `models.providers.ollama-cloud` provider config.
- Exact post-patch steps or command: Same doctor config migration run described above, followed by reading the repaired `models.providers.ollama-cloud` config.
**Evidence after fix**: Copied terminal output from the OpenClaw doctor config migration run:

```text
Exit code: 0

Legacy config keys detected
- models.providers.ollama-cloud:
  models.providers.ollama-cloud.baseUrl="https://ai.ollama.com" is retired; use "https://ollama.com". Run "openclaw doctor --fix".

Doctor changes
Updated models.providers.ollama-cloud.baseUrl from the retired Ollama Cloud endpoint to https://ollama.com.

shouldWriteConfig=true
ollamaCloudBaseUrl=https://ollama.com
configWrite=applied
configPath=<TEMP_OPENCLAW_SETUP>/openclaw.json

resulting config summary:
models.providers.ollama-cloud.baseUrl=https://ollama.com
models.providers.ollama-cloud.api=ollama
models.providers.ollama-cloud.models[0].id=kimi-k2.5:cloud
models.providers.ollama-cloud.models[0].name=Kimi K2.5 Cloud
```

**Observed result after fix**: The doctor compatibility run detected the retired `https://ai.ollama.com` provider endpoint, reported the Ollama-specific migration, wrote the repaired config, and the resulting `models.providers.ollama-cloud.baseUrl` value was `https://ollama.com`.
- Observed outcome: Same result as above: the persisted `ollama-cloud` provider base URL changed from the retired host to `https://ollama.com`.
**What was not tested**: I did not perform a live authenticated Ollama Cloud chat request because Ollama Cloud account credentials are not available in this environment; this proof validates the OpenClaw setup/config repair path that prevents the retired host from remaining in runtime provider config. Completed local validation covers the migration contract and runtime-adjacent provider behavior, and unit tests below cover the contract and runtime-adjacent provider behavior.

## Tests and validation

- Exact steps or command run after this patch: `node scripts/run-vitest.mjs run extensions/ollama/doctor-contract-api.test.ts extensions/ollama/index.test.ts extensions/ollama/src/provider-base-url.test.ts extensions/ollama/src/stream.test.ts extensions/ollama/provider-discovery.test.ts`
- Observed result after fix: The Ollama contract, provider discovery, provider base URL, and stream tests passed.

```text
Exit code: 0
RUN  v4.1.7 [redacted-local-path]

Test Files  5 passed (5)
Tests  88 passed (88)
```

- Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/plugins/doctor-contract-registry.test.ts src/commands/doctor/shared/channel-legacy-config-migrate.test.ts`
- Observed result after fix: The provider-id doctor discovery tests and compatibility migration bridge tests passed.

```text
Exit code: 0
RUN  v4.1.7 [redacted-local-path]

Test Files  1 passed (1)
Tests  3 passed (3)

RUN  v4.1.7 [redacted-local-path]

Test Files  1 passed (1)
Tests  12 passed (12)
```

- Exact steps or command run after this patch: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- Observed result after fix: The core test type-check shard that failed remotely for `src/plugins/doctor-contract-registry.test.ts` completed successfully with no TypeScript diagnostics.

```text
Exit code: 0
No TypeScript diagnostics were emitted.
```

- Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/plugins/doctor-contract-registry.test.ts`
- Observed result after fix: The doctor contract registry tests passed after aligning the test fixture with the typed provider config shape.

```text
Exit code: 0
RUN  v4.1.7 [redacted-local-path]

Test Files  1 passed (1)
Tests  12 passed (12)
```

- Exact steps or command run after this patch: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- Observed result after fix: The extensions test type-check shard that failed remotely for `extensions/ollama/doctor-contract-api.test.ts` completed successfully with no TypeScript diagnostics.

```text
Exit code: 0
No TypeScript diagnostics were emitted.
```

- Exact steps or command run after this patch: `node scripts/run-vitest.mjs run extensions/ollama/doctor-contract-api.test.ts`
- Observed result after fix: The Ollama doctor contract tests passed, including regression coverage that removes a retired `baseURL` alias while preserving a non-retired custom canonical `baseUrl`.

```text
Exit code: 0
RUN  v4.1.7 [redacted-local-path]

Test Files  1 passed (1)
Tests  5 passed (5)
```

- Exact steps or command run after this patch: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- Observed result after fix: The extensions test type-check shard completed successfully after the mixed-key migration regression was added.

```text
Exit code: 0
No TypeScript diagnostics were emitted.
```

- Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/plugins/doctor-contract-registry.test.ts`
- Observed result after fix: The doctor contract registry tests still passed after the Ollama migration change.

```text
Exit code: 0
RUN  v4.1.7 [redacted-local-path]

Test Files  1 passed (1)
Tests  12 passed (12)
```

## Risk checklist

- Scope boundary: Only doctor compatibility migration and plugin doctor id discovery are changed.
- Runtime behavior: Ollama runtime URL selection remains unchanged after canonical config is repaired.
- Backward compatibility: Existing canonical `https://ollama.com` and local Ollama provider configs are left unchanged.

## Current review state

- PR #92594 is ready for maintainer review after the real behavior proof gate re-runs on this updated body.
