### PR TITLE
feat(slack): update assistant thread status text per tool during execution (refs #33413)

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -125,6 +125,34 @@ const SLACK_REASONING_TAG_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking
 const SLACK_REASONING_LABEL_PREFIX_RE = /^\s*(?:>\s*)?Reasoning:\s*/iu;
 const SLACK_THINKING_LABEL_PREFIX_RE = /^\s*(?:>\s*)?Thinking\.{0,3}(?=\s*(?:\n|_))/iu;
 
+const SLACK_TOOL_STATUS_LABELS: Record<string, string> = {
+  exec: "Running command…",
+  shell: "Running command…",
+  terminal: "Running command…",
+  web_search: "Searching the web…",
+  web_fetch: "Fetching URL…",
+  Read: "Reading files…",
+  read_file: "Reading files…",
+  write_file: "Writing files…",
+  search_files: "Searching files…",
+  memory_search: "Checking memory…",
+  tts: "Converting to speech…",
+  message: "Sending message…",
+  browser_navigate: "Opening browser…",
+  browser_click: "Interacting with page…",
+  browser_type: "Typing…",
+  browser_snapshot: "Reading page…",
+  browser_scroll: "Scrolling…",
+  image_generate: "Generating image…",
+};
+
+function resolveSlackToolStatusLabel(toolName: string | null | undefined): string | undefined {
+  if (!toolName) {
+    return undefined;
+  }
+  return SLACK_TOOL_STATUS_LABELS[toolName] ?? undefined;
+}
+
 function resolveSlackMessageTimestampMs(message: SlackMessageEvent): number | undefined {
   const ts = message.event_ts ?? message.ts;
   return resolveSlackTimestampMs(ts);
@@ -1683,6 +1711,16 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         onToolStart: async (payload) => {
           if (statusReactionsEnabled) {
             await statusReactions.setTool(payload.name);
+          }
+          if (didSetStatus) {
+            const toolStatus = resolveSlackToolStatusLabel(payload.name);
+            if (toolStatus) {
+              await ctx.setSlackThreadStatus({
+                channelId: message.channel,
+                threadTs: statusThreadTs,
+                status: toolStatus,
+              });
+            }
           }
           await pushPreviewToolProgress(
             buildChannelProgressDraftLineForEntry(


### PR DESCRIPTION
## Summary

Updates the Slack `assistant.threads.setStatus` text dynamically during agent loop execution to reflect which tool is currently running, instead of the static "is typing..." message.

Refs #33413

## What changed

- Added `SLACK_TOOL_STATUS_LABELS` mapping table in `dispatch.ts` with human-readable labels for common tools:
  - `exec`/`shell`/`terminal` → "Running command…"
  - `web_search` → "Searching the web…"
  - `web_fetch` → "Fetching URL…"
  - `Read`/`read_file` → "Reading files…"
  - `write_file` → "Writing files…"
  - `search_files` → "Searching files…"
  - `memory_search` → "Checking memory…"
  - `tts` → "Converting to speech…"
  - `message` → "Sending message…"
  - `browser_*` → Various browser action labels
  - `image_generate` → "Generating image…"
- Added `resolveSlackToolStatusLabel()` lookup function
- In the `onToolStart` handler, when `didSetStatus` is true (i.e., the typing indicator was started), calls `ctx.setSlackThreadStatus` with the tool-specific label

## How it works

1. `typing.start` sets the initial "is typing..." status (unchanged)
2. When a tool starts executing, `onToolStart` fires and:
   - Updates emoji reactions via `statusReactions.setTool` (unchanged)
   - **NEW:** Updates the `assistant.threads.setStatus` text to a tool-specific label
3. `typing.stop` clears the status (unchanged)
4. Unknown tools fall through gracefully — no status update, the "is typing..." remains

## Architecture notes

Per #33413's analysis: `before_tool_call` plugin hook, `setSlackThreadStatus`, and `onToolStart` are all connected now. The fix uses the existing `onToolStart` callback (already wired in `dispatch.ts:1683`) which fires before every tool execution with the tool name, avoiding the need for new hooks or cross-module wiring.

## Testing

- All 98 Slack extension test files pass (1234 tests)
- `dispatch.preview-fallback.test.ts` (61 tests) — passes
- `dispatch.streaming.test.ts` (26 tests) — passes
- Full `pnpm build` succeeds
- `check-lint` passes

## Real behavior proof

**Behavior addressed:**
Slack assistant thread status shows "is typing..." throughout the entire agent run regardless of which tool is executing. Users have no visibility into what the agent is doing during long multi-tool runs.

**Environment tested:**
macOS 26.4.1, Node 24, OpenClaw main (6c88811b), pnpm build + vitest

**Steps run after the patch:**
```
node scripts/run-vitest.mjs run extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
node scripts/run-vitest.mjs run extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
node scripts/run-vitest.mjs run extensions/slack/src/
pnpm build
```

**Evidence after fix:**
```
✓ extension-slack  extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts (61 tests) 7492ms
✓ extension-slack  extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts (26 tests) 7ms
Test Files  98 passed (98)
Tests  1234 passed (1234)
```
node -e verification confirms:
- `SLACK_TOOL_STATUS_LABELS` mapping is present
- `resolveSlackToolStatusLabel(payload.name)` is called in `onToolStart`
- `setSlackThreadStatus` receives `status: toolStatus` with `channelId` and `threadTs`

**Observed result after fix:**
When a tool starts, `onToolStart` calls `ctx.setSlackThreadStatus` with a tool-specific label (e.g., "Running command…" for `exec`), replacing the generic "is typing..." text. Unknown tools retain the default status without errors.

**What was not tested:**
Live Slack API interaction (requires a running Slack app with assistant threads enabled). The fix uses the existing `setSlackThreadStatus` wrapper which already handles errors gracefully via try/catch + verbose logging.
