### PR TITLE
fix(android): queue node events until gateway connect

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -67,7 +67,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 360,
+      "line": 496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -75,7 +75,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1773,
+      "line": 1981,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -83,7 +83,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1775,
+      "line": 1983,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -91,7 +91,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1777,
+      "line": 1985,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -259,7 +259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1054,
+      "line": 1093,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -267,7 +267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1054,
+      "line": 1093,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -13,6 +13,7 @@ import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.GatewayTlsProbeFailure
 import ai.openclaw.app.gateway.GatewayTlsProbeResult
 import ai.openclaw.app.gateway.GatewayUpdateAvailableSummary
+import ai.openclaw.app.gateway.NodeEventSendOutcome
 import ai.openclaw.app.gateway.normalizeGatewayTlsFingerprint
 import ai.openclaw.app.gateway.parseChatSendAck
 import ai.openclaw.app.gateway.probeGatewayTlsFingerprint
@@ -59,6 +60,7 @@ import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -78,6 +80,140 @@ import java.util.Collections
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
+
+private const val MAX_PENDING_NOTIFICATION_EVENTS = 128
+
+internal data class PendingNotificationNodeEvent(
+  val event: String,
+  val payloadJson: String?,
+)
+
+private data class QueuedNotificationNodeEvent(
+  val generation: Long,
+  val event: PendingNotificationNodeEvent,
+)
+
+internal class NotificationNodeEventOutbox(
+  private val capacity: Int = MAX_PENDING_NOTIFICATION_EVENTS,
+  private val isAuthorized: (PendingNotificationNodeEvent) -> Boolean = { true },
+  private val isConnected: () -> Boolean = { true },
+  private val deliveryIntervalMs: () -> Long = { 0L },
+  private val nowEpochMs: () -> Long = System::currentTimeMillis,
+  private val sleep: suspend (Long) -> Unit = { delay(it) },
+  private val invalidateConnection: () -> Unit = {},
+  private val send: suspend (PendingNotificationNodeEvent) -> NodeEventSendOutcome,
+) {
+  private val stateLock = Any()
+  private val generation = AtomicLong()
+  private val lastDeliveryAtMs = AtomicLong(-1L)
+  private val pending = ArrayDeque<QueuedNotificationNodeEvent>(capacity)
+  private val wakeDelivery = Channel<Unit>(Channel.CONFLATED)
+  private var inFlight: QueuedNotificationNodeEvent? = null
+
+  init {
+    require(capacity > 0) { "capacity must be positive" }
+  }
+
+  fun enqueue(event: PendingNotificationNodeEvent) {
+    synchronized(stateLock) {
+      if (pending.size == capacity) pending.removeFirst()
+      pending.addLast(QueuedNotificationNodeEvent(generation = generation.get(), event = event))
+    }
+    wakeDelivery.trySend(Unit)
+  }
+
+  fun clear() {
+    synchronized(stateLock) {
+      clearLocked()
+    }
+    wakeDelivery.trySend(Unit)
+  }
+
+  fun <T> updatePolicy(update: () -> T): T {
+    val result =
+      synchronized(stateLock) {
+        // Admission checks share this lock, so the new policy is visible before the next generation.
+        update().also { clearLocked() }
+      }
+    wakeDelivery.trySend(Unit)
+    return result
+  }
+
+  fun onConnected() {
+    wakeDelivery.trySend(Unit)
+  }
+
+  suspend fun deliver() {
+    while (true) {
+      wakeDelivery.receive()
+      while (true) {
+        val queued = synchronized(stateLock) { pending.firstOrNull() } ?: break
+        if (queued.generation != generation.get() || !isAuthorized(queued.event)) {
+          synchronized(stateLock) {
+            if (pending.firstOrNull() === queued) pending.removeFirst()
+          }
+          continue
+        }
+        if (!isConnected()) break
+        if (!awaitDeliverySlot(queued)) continue
+        val admitted =
+          synchronized(stateLock) {
+            if (
+              pending.firstOrNull() !== queued ||
+              queued.generation != generation.get() ||
+              !isAuthorized(queued.event) ||
+              !isConnected()
+            ) {
+              false
+            } else {
+              pending.removeFirst()
+              inFlight = queued
+              true
+            }
+          }
+        if (!admitted) continue
+
+        val outcome = send(queued.event)
+        synchronized(stateLock) {
+          if (inFlight === queued) inFlight = null
+          if (queued.generation == generation.get() && isAuthorized(queued.event)) {
+            when (outcome) {
+              NodeEventSendOutcome.COMPLETED -> lastDeliveryAtMs.set(nowEpochMs())
+              NodeEventSendOutcome.DISCONNECTED -> {
+                // This outcome is rejected before send, so it is safe to retain for reconnect.
+                if (pending.size == capacity) pending.removeLast()
+                pending.addFirst(queued)
+              }
+              // Ambiguous failures may have reached the gateway: do not retry, but charge their rate slot.
+              NodeEventSendOutcome.FAILED -> lastDeliveryAtMs.set(nowEpochMs())
+            }
+          }
+        }
+        if (outcome == NodeEventSendOutcome.DISCONNECTED) break
+      }
+    }
+  }
+
+  private suspend fun awaitDeliverySlot(queued: QueuedNotificationNodeEvent): Boolean {
+    while (queued.generation == generation.get() && isAuthorized(queued.event)) {
+      val lastDelivery = lastDeliveryAtMs.get()
+      if (lastDelivery < 0L) return true
+      val waitMs = lastDelivery + deliveryIntervalMs().coerceAtLeast(0L) - nowEpochMs()
+      if (waitMs <= 0L) return true
+      // Short slices make policy/gateway invalidation responsive without charging stale quota.
+      sleep(minOf(waitMs, 250L))
+    }
+    return false
+  }
+
+  private fun clearLocked() {
+    // Only an admitted RPC needs transport invalidation; queued payloads have no socket side effect.
+    if (inFlight?.generation == generation.get()) invalidateConnection()
+    generation.incrementAndGet()
+    lastDeliveryAtMs.set(-1L)
+    pending.clear()
+  }
+}
 
 /**
  * Process runtime that owns gateway sessions, node command handlers, capture managers, and UI-facing state.
@@ -591,6 +727,7 @@ class NodeRuntime(
           _nodeConnected.value = true
           nodeStatusText = "Connected"
         }
+        notificationOutbox.onConnected()
         showLocalCanvasOnConnect()
         publishNodePresenceAliveBeacon(NodePresenceAliveBeacon.Trigger.Connect)
         val endpoint = connectedEndpoint
@@ -628,11 +765,46 @@ class NodeRuntime(
       },
     )
 
+  private val notificationOutbox: NotificationNodeEventOutbox by lazy {
+    NotificationNodeEventOutbox(
+      isAuthorized = ::isNotificationEventStillAuthorized,
+      isConnected = nodeSession::isReady,
+      deliveryIntervalMs = ::notificationDeliveryIntervalMs,
+      invalidateConnection = nodeSession::reconnect,
+      send = { pending ->
+        nodeSession.sendNodeEventWithOutcome(event = pending.event, payloadJson = pending.payloadJson)
+      },
+    )
+  }
+
+  private fun notificationDeliveryIntervalMs(): Long {
+    val maxEvents = prefs.notificationForwardingMaxEventsPerMinute.value.coerceAtLeast(1).toLong()
+    return (60_000L + maxEvents - 1L) / maxEvents
+  }
+
+  private fun isNotificationEventStillAuthorized(event: PendingNotificationNodeEvent): Boolean {
+    if (event.event != "notifications.changed") return false
+    if (!DeviceNotificationListenerService.isAccessEnabled(appContext)) return false
+    val payload =
+      runCatching { event.payloadJson?.let(json::parseToJsonElement).asObjectOrNull() }
+        .getOrNull()
+        ?: return false
+    val packageName = payload["packageName"].asStringOrNull()?.trim().orEmpty()
+    if (packageName.isEmpty()) return false
+    val policy = prefs.getNotificationForwardingPolicy(appPackageName = appContext.packageName)
+    val eventSessionKey = payload["sessionKey"].asStringOrNull()?.trim()?.ifEmpty { null }
+    return policy.enabled &&
+      policy.sessionKey == eventSessionKey &&
+      policy.allowsPackage(packageName) &&
+      !policy.isWithinQuietHours(nowEpochMs = System.currentTimeMillis())
+  }
+
   init {
+    scope.launch { notificationOutbox.deliver() }
     DeviceNotificationListenerService.setNodeEventSink { event, payloadJson ->
-      scope.launch {
-        nodeSession.sendNodeEvent(event = event, payloadJson = payloadJson)
-      }
+      notificationOutbox.enqueue(
+        PendingNotificationNodeEvent(event = event, payloadJson = payloadJson),
+      )
     }
   }
 
@@ -1267,29 +1439,60 @@ class NodeRuntime(
   }
 
   fun setNotificationForwardingEnabled(value: Boolean) {
-    prefs.setNotificationForwardingEnabled(value)
+    if (prefs.notificationForwardingEnabled.value == value) return
+    notificationOutbox.updatePolicy { prefs.setNotificationForwardingEnabled(value) }
   }
 
   fun setNotificationForwardingMode(mode: NotificationPackageFilterMode) {
-    prefs.setNotificationForwardingMode(mode)
+    if (prefs.notificationForwardingMode.value == mode) return
+    notificationOutbox.updatePolicy { prefs.setNotificationForwardingMode(mode) }
   }
 
   fun setNotificationForwardingPackages(packages: List<String>) {
-    prefs.setNotificationForwardingPackages(packages)
+    val normalized = packages.map(String::trim).filter(String::isNotEmpty).toSet()
+    if (prefs.notificationForwardingPackages.value == normalized) return
+    notificationOutbox.updatePolicy { prefs.setNotificationForwardingPackages(normalized.toList()) }
   }
 
   fun setNotificationForwardingQuietHours(
     enabled: Boolean,
     start: String,
     end: String,
-  ): Boolean = prefs.setNotificationForwardingQuietHours(enabled = enabled, start = start, end = end)
+  ): Boolean {
+    if (!enabled) {
+      if (!prefs.notificationForwardingQuietHoursEnabled.value) return true
+      return notificationOutbox.updatePolicy {
+        prefs.setNotificationForwardingQuietHours(enabled = false, start = start, end = end)
+      }
+    }
+    val normalizedStart = normalizeLocalHourMinute(start) ?: return false
+    val normalizedEnd = normalizeLocalHourMinute(end) ?: return false
+    val unchanged =
+      prefs.notificationForwardingQuietHoursEnabled.value &&
+        prefs.notificationForwardingQuietStart.value == normalizedStart &&
+        prefs.notificationForwardingQuietEnd.value == normalizedEnd
+    if (unchanged) return true
+    return notificationOutbox.updatePolicy {
+      prefs.setNotificationForwardingQuietHours(
+        enabled = true,
+        start = normalizedStart,
+        end = normalizedEnd,
+      )
+    }
+  }
 
   fun setNotificationForwardingMaxEventsPerMinute(value: Int) {
-    prefs.setNotificationForwardingMaxEventsPerMinute(value)
+    val normalized = value.coerceAtLeast(1)
+    if (prefs.notificationForwardingMaxEventsPerMinute.value == normalized) return
+    notificationOutbox.updatePolicy {
+      prefs.setNotificationForwardingMaxEventsPerMinute(normalized)
+    }
   }
 
   fun setNotificationForwardingSessionKey(value: String?) {
-    prefs.setNotificationForwardingSessionKey(value)
+    val normalized = value?.trim()?.takeIf(String::isNotEmpty)
+    if (prefs.notificationForwardingSessionKey.value == normalized) return
+    notificationOutbox.updatePolicy { prefs.setNotificationForwardingSessionKey(normalized) }
   }
 
   fun setVoiceScreenActive(active: Boolean) {
@@ -1675,6 +1878,8 @@ class NodeRuntime(
     endpoint: GatewayEndpoint,
     auth: GatewayConnectAuth,
   ) {
+    // A user-selected connect target must never inherit notification content from another gateway.
+    notificationOutbox.clear()
     val connectAttemptId = connectAttemptSeq.incrementAndGet()
     _pendingGatewayTrust.value = null
     val tls = connectionManager.resolveTlsParams(endpoint)
@@ -1826,6 +2031,7 @@ class NodeRuntime(
   }
 
   fun disconnect() {
+    notificationOutbox.clear()
     connectAttemptSeq.incrementAndGet()
     stopActiveVoiceSession()
     connectedEndpoint = null

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -778,7 +778,10 @@ class NodeRuntime(
   }
 
   private fun notificationDeliveryIntervalMs(): Long {
-    val maxEvents = prefs.notificationForwardingMaxEventsPerMinute.value.coerceAtLeast(1).toLong()
+    val maxEvents =
+      prefs.notificationForwardingMaxEventsPerMinute.value
+        .coerceAtLeast(1)
+        .toLong()
     return (60_000L + maxEvents - 1L) / maxEvents
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -31,7 +31,7 @@ import okhttp3.WebSocketListener
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Identity advertised during gateway connect; these fields become the device row users approve.
@@ -116,6 +116,14 @@ private data class SelectedConnectAuth(
 private class GatewayConnectFailure(
   val gatewayError: GatewaySession.ErrorShape,
 ) : IllegalStateException(gatewayError.message)
+
+private class GatewayRequestNotEnqueued(message: String) : IllegalStateException(message)
+
+internal enum class NodeEventSendOutcome {
+  COMPLETED,
+  DISCONNECTED,
+  FAILED,
+}
 
 /**
  * WebSocket RPC session that maintains gateway connection lifecycle, auth, events, and node invokes.
@@ -263,22 +271,33 @@ class GatewaySession(
     currentConnection?.closeQuietly()
   }
 
+  private fun readyConnection(): Connection? = currentConnection?.takeIf { it.isReady() }
+
+  internal fun isReady(): Boolean = readyConnection() != null
+
   /** Sends a best-effort node.event and returns false instead of throwing on failure. */
   suspend fun sendNodeEvent(
     event: String,
     payloadJson: String?,
-  ): Boolean {
-    val conn = currentConnection ?: return false
+  ): Boolean = sendNodeEventWithOutcome(event, payloadJson) == NodeEventSendOutcome.COMPLETED
+
+  internal suspend fun sendNodeEventWithOutcome(
+    event: String,
+    payloadJson: String?,
+  ): NodeEventSendOutcome {
+    val conn = readyConnection() ?: return NodeEventSendOutcome.DISCONNECTED
     return try {
       conn.request(
         "node.event",
         buildNodeEventParams(event = event, payloadJson = payloadJson),
         timeoutMs = 8_000,
       )
-      true
+      NodeEventSendOutcome.COMPLETED
+    } catch (_: GatewayRequestNotEnqueued) {
+      NodeEventSendOutcome.DISCONNECTED
     } catch (err: Throwable) {
       Log.w("OpenClawGateway", "node.event failed: ${err::class.java.simpleName}")
-      false
+      NodeEventSendOutcome.FAILED
     }
   }
 
@@ -289,7 +308,7 @@ class GatewaySession(
     timeoutMs: Long = 8_000,
   ): RpcResult {
     val conn =
-      currentConnection
+      readyConnection()
         ?: return RpcResult(
           ok = false,
           payloadJson = null,
@@ -337,7 +356,7 @@ class GatewaySession(
     paramsJson: String?,
     timeoutMs: Long = 15_000,
   ): RpcResult {
-    val conn = currentConnection ?: throw IllegalStateException("not connected")
+    val conn = readyConnection() ?: throw IllegalStateException("not connected")
     val params =
       if (paramsJson.isNullOrBlank()) {
         null
@@ -355,7 +374,7 @@ class GatewaySession(
     timeoutMs: Long = 15_000,
     onError: (ErrorShape) -> Unit = {},
   ) {
-    val conn = currentConnection ?: throw IllegalStateException("not connected")
+    val conn = readyConnection() ?: throw IllegalStateException("not connected")
     val params =
       if (paramsJson.isNullOrBlank()) {
         null
@@ -372,6 +391,18 @@ class GatewaySession(
     val error: ErrorShape?,
   )
 
+  private data class ConnectedGateway(
+    val pluginSurfaceUrls: Map<String, String>,
+    val mainSessionKey: String?,
+    val hello: GatewayHelloSummary,
+  )
+
+  private enum class ConnectionState {
+    CONNECTING,
+    READY,
+    CLOSED,
+  }
+
   private inner class Connection(
     val endpoint: GatewayEndpoint,
     private val token: String?,
@@ -380,9 +411,9 @@ class GatewaySession(
     private val options: GatewayConnectOptions,
     val tls: GatewayTlsParams?,
   ) {
-    private val connectDeferred = CompletableDeferred<Unit>()
+    private val state = AtomicReference(ConnectionState.CONNECTING)
+    private val connectDeferred = CompletableDeferred<ConnectedGateway>()
     private val closedDeferred = CompletableDeferred<Unit>()
-    private val isClosed = AtomicBoolean(false)
     private val connectNonceDeferred = CompletableDeferred<String>()
     private val client: OkHttpClient = buildClient()
     private var socket: WebSocket? = null
@@ -411,15 +442,11 @@ class GatewaySession(
 
     val remoteAddress: String = formatGatewayAuthority(endpoint.host, endpoint.port)
 
-    suspend fun connect() {
+    suspend fun connect(): ConnectedGateway {
       val url = buildGatewayWebSocketUrl(endpoint.host, endpoint.port, tls != null)
       val request = Request.Builder().url(url).build()
       socket = client.newWebSocket(request, Listener())
-      try {
-        connectDeferred.await()
-      } catch (err: Throwable) {
-        throw err
-      }
+      return connectDeferred.await()
     }
 
     suspend fun request(
@@ -477,7 +504,9 @@ class GatewaySession(
       val deferred = CompletableDeferred<RpcResponse>()
       // Registration and the close drain are one lifecycle decision; no waiter may slip between them.
       synchronized(pendingLock) {
-        if (isClosed.get()) throw IllegalStateException("Gateway closed")
+        if (state.get() == ConnectionState.CLOSED) {
+          throw GatewayRequestNotEnqueued("Gateway closed")
+        }
         pending[id] = deferred
       }
       return deferred
@@ -487,7 +516,8 @@ class GatewaySession(
       val jsonString = obj.toString()
       writeLock.withLock {
         if (socket?.send(jsonString) != true) {
-          throw IllegalStateException("gateway send failed")
+          // OkHttp returning false means this frame never entered its outgoing queue.
+          throw GatewayRequestNotEnqueued("gateway send failed")
         }
       }
     }
@@ -506,8 +536,12 @@ class GatewaySession(
 
     suspend fun awaitClose() = closedDeferred.await()
 
+    fun isReady(): Boolean = state.get() == ConnectionState.READY
+
+    fun markReady(): Boolean = state.compareAndSet(ConnectionState.CONNECTING, ConnectionState.READY)
+
     fun closeQuietly() {
-      if (isClosed.compareAndSet(false, true)) {
+      if (state.getAndSet(ConnectionState.CLOSED) != ConnectionState.CLOSED) {
         incomingMessages.close()
         messagePumpJob.cancel()
         if (!connectDeferred.isCompleted) {
@@ -569,7 +603,7 @@ class GatewaySession(
         if (!connectDeferred.isCompleted) {
           connectDeferred.completeExceptionally(t)
         }
-        if (isClosed.compareAndSet(false, true)) {
+        if (state.getAndSet(ConnectionState.CLOSED) != ConnectionState.CLOSED) {
           incomingMessages.close()
           failPending()
           closedDeferred.complete(Unit)
@@ -585,7 +619,7 @@ class GatewaySession(
         if (!connectDeferred.isCompleted) {
           connectDeferred.completeExceptionally(IllegalStateException("Gateway closed: $reason"))
         }
-        if (isClosed.compareAndSet(false, true)) {
+        if (state.getAndSet(ConnectionState.CLOSED) != ConnectionState.CLOSED) {
           incomingMessages.close()
           failPending()
           closedDeferred.complete(Unit)
@@ -641,8 +675,8 @@ class GatewaySession(
         }
         throw GatewayConnectFailure(error)
       }
-      handleConnectSuccess(res, identity.deviceId, selectedAuth.authSource)
-      connectDeferred.complete(Unit)
+      val connected = parseConnectSuccess(res, identity.deviceId, selectedAuth.authSource)
+      connectDeferred.complete(connected)
     }
 
     private fun shouldPersistBootstrapHandoffTokens(authSource: GatewayConnectAuthSource): Boolean {
@@ -694,11 +728,11 @@ class GatewaySession(
       deviceAuthStore.saveToken(deviceId, role, token, scopes)
     }
 
-    private fun handleConnectSuccess(
+    private fun parseConnectSuccess(
       res: RpcResponse,
       deviceId: String,
       authSource: GatewayConnectAuthSource,
-    ) {
+    ): ConnectedGateway {
       val payloadJson = res.payloadJson ?: throw IllegalStateException("connect failed: missing payload")
       val obj = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: throw IllegalStateException("connect failed")
       pendingDeviceTokenRetry = false
@@ -745,21 +779,24 @@ class GatewaySession(
           normalizeCanvasHostUrl(value.asStringOrNull(), endpoint, isTlsConnection = tls != null)
             ?.let { normalized -> surface to normalized }
         } ?: emptyList()
-      pluginSurfaceUrls = normalizedPluginSurfaceUrls.toMap()
+      val nextPluginSurfaceUrls = normalizedPluginSurfaceUrls.toMap()
       val snapshot = obj["snapshot"].asObjectOrNull()
       val sessionDefaults =
         snapshot
           ?.get("sessionDefaults")
           .asObjectOrNull()
-      mainSessionKey = sessionDefaults?.get("mainSessionKey").asStringOrNull()
-      onConnected(
-        GatewayHelloSummary(
-          serverName = serverName,
-          remoteAddress = remoteAddress,
-          serverVersion = serverVersion,
-          mainSessionKey = mainSessionKey,
-          updateAvailable = parseUpdateAvailable(snapshot?.get("updateAvailable").asObjectOrNull()),
-        ),
+      val nextMainSessionKey = sessionDefaults?.get("mainSessionKey").asStringOrNull()
+      return ConnectedGateway(
+        pluginSurfaceUrls = nextPluginSurfaceUrls,
+        mainSessionKey = nextMainSessionKey,
+        hello =
+          GatewayHelloSummary(
+            serverName = serverName,
+            remoteAddress = remoteAddress,
+            serverVersion = serverVersion,
+            mainSessionKey = nextMainSessionKey,
+            updateAvailable = parseUpdateAvailable(snapshot?.get("updateAvailable").asObjectOrNull()),
+          ),
       )
     }
 
@@ -1085,15 +1122,47 @@ class GatewaySession(
           target.options,
           target.tls,
         )
-      currentConnection = conn
+      val shouldConnect =
+        synchronized(lifecycleLock) {
+          if (desired === target) {
+            currentConnection = conn
+            true
+          } else {
+            false
+          }
+        }
+      if (!shouldConnect) {
+        conn.closeQuietly()
+        return@withContext
+      }
       try {
-        conn.connect()
+        val connected = conn.connect()
+        val published =
+          synchronized(lifecycleLock) {
+            if (currentConnection !== conn || desired !== target || !conn.markReady()) {
+              false
+            } else {
+              // Readiness and its metadata must become visible before callbacks flush queued events.
+              pluginSurfaceUrls = connected.pluginSurfaceUrls
+              mainSessionKey = connected.mainSessionKey
+              onConnected(connected.hello)
+              true
+            }
+          }
+        if (!published) {
+          conn.closeQuietly()
+          return@withContext
+        }
         conn.awaitClose()
       } finally {
-        if (currentConnection === conn) {
-          currentConnection = null
-          pluginSurfaceUrls = emptyMap()
-          mainSessionKey = null
+        // Callback failures and cancellation must close this socket before the loop replaces it.
+        conn.closeQuietly()
+        synchronized(lifecycleLock) {
+          if (currentConnection === conn) {
+            currentConnection = null
+            pluginSurfaceUrls = emptyMap()
+            mainSessionKey = null
+          }
         }
       }
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -117,7 +117,9 @@ private class GatewayConnectFailure(
   val gatewayError: GatewaySession.ErrorShape,
 ) : IllegalStateException(gatewayError.message)
 
-private class GatewayRequestNotEnqueued(message: String) : IllegalStateException(message)
+private class GatewayRequestNotEnqueued(
+  message: String,
+) : IllegalStateException(message)
 
 internal enum class NodeEventSendOutcome {
   COMPLETED,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -244,7 +244,10 @@ internal fun gatewayEndpointValidationMessage(
       }
   }
 
-private fun gatewayPort(port: Int, defaultPort: Int): Int? =
+private fun gatewayPort(
+  port: Int,
+  defaultPort: Int,
+): Int? =
   when {
     port == -1 -> defaultPort
     port in 1..65535 -> port

--- a/apps/android/app/src/test/java/ai/openclaw/app/NotificationNodeEventOutboxTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NotificationNodeEventOutboxTest.kt
@@ -1,0 +1,346 @@
+package ai.openclaw.app
+
+import ai.openclaw.app.gateway.NodeEventSendOutcome
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NotificationNodeEventOutboxTest {
+  @Test
+  fun deliverRetainsAcceptedEventsAcrossReconnectAndPreservesOrder() =
+    runBlocking {
+      val attempted = mutableListOf<String>()
+      val delivered = Channel<String>(Channel.UNLIMITED)
+      val firstBlockedAttempt = CompletableDeferred<Unit>()
+      var connected = false
+      val outbox =
+        NotificationNodeEventOutbox(capacity = 2) { pending ->
+          attempted += pending.payloadJson.orEmpty()
+          if (!connected) {
+            firstBlockedAttempt.complete(Unit)
+            NodeEventSendOutcome.DISCONNECTED
+          } else {
+            delivered.send(pending.payloadJson.orEmpty())
+            NodeEventSendOutcome.COMPLETED
+          }
+        }
+      val deliveryJob = launch { outbox.deliver() }
+
+      try {
+        outbox.enqueue(notificationEvent("first"))
+        withTimeout(1_000) { firstBlockedAttempt.await() }
+        outbox.enqueue(notificationEvent("second"))
+
+        connected = true
+        outbox.onConnected()
+
+        val received =
+          listOf(
+            withTimeout(1_000) { delivered.receive() },
+            withTimeout(1_000) { delivered.receive() },
+          )
+        assertEquals(listOf("first", "second"), received)
+        assertEquals(listOf("first", "first", "second"), attempted)
+      } finally {
+        deliveryJob.cancelAndJoin()
+      }
+    }
+
+  @Test
+  fun enqueueDropsOldestBufferedEventAtCapacity() =
+    runBlocking {
+      val delivered = Channel<String>(Channel.UNLIMITED)
+      var connected = false
+      val outbox =
+        NotificationNodeEventOutbox(
+          capacity = 2,
+          isConnected = { connected },
+        ) { pending ->
+          delivered.send(pending.payloadJson.orEmpty())
+          NodeEventSendOutcome.COMPLETED
+        }
+      val deliveryJob = launch { outbox.deliver() }
+
+      outbox.enqueue(notificationEvent("first"))
+      outbox.enqueue(notificationEvent("second"))
+      outbox.enqueue(notificationEvent("third"))
+      connected = true
+      outbox.onConnected()
+
+      try {
+        assertEquals("second", withTimeout(1_000) { delivered.receive() })
+        assertEquals("third", withTimeout(1_000) { delivered.receive() })
+      } finally {
+        deliveryJob.cancelAndJoin()
+      }
+    }
+
+  @Test
+  fun clearDropsCurrentAndBufferedEvents() =
+    runBlocking {
+      val firstAttempt = CompletableDeferred<Unit>()
+      val delivered = Channel<String>(Channel.UNLIMITED)
+      var connected = false
+      val outbox =
+        NotificationNodeEventOutbox { pending ->
+          if (!connected) {
+            firstAttempt.complete(Unit)
+            NodeEventSendOutcome.DISCONNECTED
+          } else {
+            delivered.send(pending.payloadJson.orEmpty())
+            NodeEventSendOutcome.COMPLETED
+          }
+        }
+      val deliveryJob = launch { outbox.deliver() }
+
+      try {
+        outbox.enqueue(notificationEvent("first"))
+        withTimeout(1_000) { firstAttempt.await() }
+        outbox.enqueue(notificationEvent("second"))
+        outbox.clear()
+        connected = true
+        outbox.onConnected()
+
+        assertEquals(null, withTimeoutOrNull(100) { delivered.receive() })
+        outbox.enqueue(notificationEvent("third"))
+        assertEquals("third", withTimeout(1_000) { delivered.receive() })
+      } finally {
+        deliveryJob.cancelAndJoin()
+      }
+    }
+
+  @Test
+  fun ambiguousSendFailureIsNotRetried() =
+    runBlocking {
+      val failedAttempt = CompletableDeferred<Unit>()
+      val delivered = Channel<String>(Channel.UNLIMITED)
+      val attempted = mutableListOf<String>()
+      val outbox =
+        NotificationNodeEventOutbox { pending ->
+          val payload = pending.payloadJson.orEmpty()
+          attempted += payload
+          if (payload == "failed") {
+            failedAttempt.complete(Unit)
+            NodeEventSendOutcome.FAILED
+          } else {
+            delivered.send(payload)
+            NodeEventSendOutcome.COMPLETED
+          }
+        }
+      val deliveryJob = launch { outbox.deliver() }
+
+      try {
+        outbox.enqueue(notificationEvent("failed"))
+        withTimeout(1_000) { failedAttempt.await() }
+        outbox.enqueue(notificationEvent("next"))
+        assertEquals("next", withTimeout(1_000) { delivered.receive() })
+        assertEquals(listOf("failed", "next"), attempted)
+      } finally {
+        deliveryJob.cancelAndJoin()
+      }
+    }
+
+  @Test
+  fun ambiguousSendFailureConsumesDeliverySlot() =
+    runBlocking {
+      val sleepStarted = CompletableDeferred<Long>()
+      val releaseSleep = CompletableDeferred<Unit>()
+      val delivered = Channel<String>(Channel.UNLIMITED)
+      var nowEpochMs = 1_000L
+      val outbox =
+        NotificationNodeEventOutbox(
+          deliveryIntervalMs = { 100L },
+          nowEpochMs = { nowEpochMs },
+          sleep = { delayMs ->
+            sleepStarted.complete(delayMs)
+            releaseSleep.await()
+            nowEpochMs += delayMs
+          },
+        ) { pending ->
+          if (pending.payloadJson == "failed") {
+            NodeEventSendOutcome.FAILED
+          } else {
+            delivered.send(pending.payloadJson.orEmpty())
+            NodeEventSendOutcome.COMPLETED
+          }
+        }
+      val deliveryJob = launch { outbox.deliver() }
+
+      try {
+        outbox.enqueue(notificationEvent("failed"))
+        outbox.enqueue(notificationEvent("next"))
+        assertEquals(100L, withTimeout(1_000) { sleepStarted.await() })
+        assertEquals(null, withTimeoutOrNull(100) { delivered.receive() })
+        releaseSleep.complete(Unit)
+        assertEquals("next", withTimeout(1_000) { delivered.receive() })
+      } finally {
+        deliveryJob.cancelAndJoin()
+      }
+    }
+
+  @Test
+  fun deliveryPacesQueuedEvents() =
+    runBlocking {
+      val sleepStarted = CompletableDeferred<Long>()
+      val releaseSleep = CompletableDeferred<Unit>()
+      val delivered = Channel<String>(Channel.UNLIMITED)
+      var nowEpochMs = 1_000L
+      val outbox =
+        NotificationNodeEventOutbox(
+          deliveryIntervalMs = { 100L },
+          nowEpochMs = { nowEpochMs },
+          sleep = { delayMs ->
+            sleepStarted.complete(delayMs)
+            releaseSleep.await()
+            nowEpochMs += delayMs
+          },
+        ) { pending ->
+          delivered.send(pending.payloadJson.orEmpty())
+          NodeEventSendOutcome.COMPLETED
+        }
+      val deliveryJob = launch { outbox.deliver() }
+
+      try {
+        outbox.enqueue(notificationEvent("first"))
+        outbox.enqueue(notificationEvent("second"))
+        assertEquals("first", withTimeout(1_000) { delivered.receive() })
+        assertEquals(100L, withTimeout(1_000) { sleepStarted.await() })
+        assertEquals(null, withTimeoutOrNull(100) { delivered.receive() })
+        releaseSleep.complete(Unit)
+        assertEquals("second", withTimeout(1_000) { delivered.receive() })
+      } finally {
+        deliveryJob.cancelAndJoin()
+      }
+    }
+
+  @Test
+  fun clearInvalidatesRateWaitWithoutDelayingReplacement() =
+    runBlocking {
+      val sleepStarted = CompletableDeferred<Unit>()
+      val releaseSleep = CompletableDeferred<Unit>()
+      val delivered = Channel<String>(Channel.UNLIMITED)
+      var nowEpochMs = 1_000L
+      val outbox =
+        NotificationNodeEventOutbox(
+          deliveryIntervalMs = { 100L },
+          nowEpochMs = { nowEpochMs },
+          sleep = { delayMs ->
+            sleepStarted.complete(Unit)
+            releaseSleep.await()
+            nowEpochMs += delayMs
+          },
+        ) { pending ->
+          delivered.send(pending.payloadJson.orEmpty())
+          NodeEventSendOutcome.COMPLETED
+        }
+      val deliveryJob = launch { outbox.deliver() }
+
+      try {
+        outbox.enqueue(notificationEvent("first"))
+        assertEquals("first", withTimeout(1_000) { delivered.receive() })
+        outbox.enqueue(notificationEvent("stale"))
+        withTimeout(1_000) { sleepStarted.await() }
+        outbox.clear()
+        outbox.enqueue(notificationEvent("replacement"))
+        releaseSleep.complete(Unit)
+
+        assertEquals("replacement", withTimeout(1_000) { delivered.receive() })
+        assertEquals(null, withTimeoutOrNull(100) { delivered.receive() })
+      } finally {
+        deliveryJob.cancelAndJoin()
+      }
+    }
+
+  @Test
+  fun clearInvalidatesOnlyAnInFlightSend() =
+    runBlocking {
+      val firstSendStarted = CompletableDeferred<Unit>()
+      val finishFirstSend = CompletableDeferred<Unit>()
+      val delivered = Channel<String>(Channel.UNLIMITED)
+      var invalidationCount = 0
+      var firstSend = true
+      val outbox =
+        NotificationNodeEventOutbox(
+          invalidateConnection = { invalidationCount += 1 },
+        ) { pending ->
+          if (firstSend) {
+            firstSend = false
+            firstSendStarted.complete(Unit)
+            finishFirstSend.await()
+            NodeEventSendOutcome.FAILED
+          } else {
+            delivered.send(pending.payloadJson.orEmpty())
+            NodeEventSendOutcome.COMPLETED
+          }
+        }
+      val deliveryJob = launch { outbox.deliver() }
+
+      try {
+        outbox.enqueue(notificationEvent("stale"))
+        withTimeout(1_000) { firstSendStarted.await() }
+        outbox.clear()
+        outbox.enqueue(notificationEvent("replacement"))
+        finishFirstSend.complete(Unit)
+
+        assertEquals("replacement", withTimeout(1_000) { delivered.receive() })
+        assertEquals(1, invalidationCount)
+      } finally {
+        deliveryJob.cancelAndJoin()
+      }
+    }
+
+  @Test
+  fun clearWithOnlyQueuedEventsDoesNotInvalidateConnection() =
+    runBlocking {
+      var invalidationCount = 0
+      val outbox =
+        NotificationNodeEventOutbox(
+          isConnected = { false },
+          invalidateConnection = { invalidationCount += 1 },
+        ) { NodeEventSendOutcome.COMPLETED }
+      val deliveryJob = launch { outbox.deliver() }
+
+      try {
+        outbox.enqueue(notificationEvent("queued"))
+        outbox.clear()
+        assertEquals(0, invalidationCount)
+      } finally {
+        deliveryJob.cancelAndJoin()
+      }
+    }
+
+  @Test
+  fun policyUpdateIsVisibleBeforeNewGenerationCanSend() =
+    runBlocking {
+      var authorized = true
+      val delivered = Channel<String>(Channel.UNLIMITED)
+      val outbox =
+        NotificationNodeEventOutbox(
+          isAuthorized = { authorized },
+        ) { pending ->
+          delivered.send(pending.payloadJson.orEmpty())
+          NodeEventSendOutcome.COMPLETED
+        }
+      val deliveryJob = launch { outbox.deliver() }
+
+      try {
+        outbox.updatePolicy { authorized = false }
+        outbox.enqueue(notificationEvent("blocked"))
+        assertEquals(null, withTimeoutOrNull(100) { delivered.receive() })
+      } finally {
+        deliveryJob.cancelAndJoin()
+      }
+    }
+
+  private fun notificationEvent(payload: String) =
+    PendingNotificationNodeEvent(
+      event = "notifications.changed",
+      payloadJson = payload,
+    )
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -25,7 +25,9 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -856,6 +858,77 @@ class GatewaySessionInvokeTest {
         assertEquals(true, sent)
         assertEquals("agent.request", params["event"]?.jsonPrimitive?.content)
       } finally {
+        shutdownHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun sendNodeEvent_waitsForCompletedConnectHandshake() =
+    runBlocking {
+      val json = testJson()
+      val connected = CompletableDeferred<Unit>()
+      val connectRequestSeen = CompletableDeferred<Unit>()
+      val releaseConnectResponse = CompletableDeferred<Unit>()
+      val nodeEvents = CopyOnWriteArrayList<String>()
+      val eventAfterConnect = CompletableDeferred<Unit>()
+      val lastDisconnect = AtomicReference("")
+      val server =
+        startGatewayServer(json) { webSocket, id, method, frame ->
+          when (method) {
+            "connect" -> {
+              connectRequestSeen.complete(Unit)
+              launch(Dispatchers.Default) {
+                releaseConnectResponse.await()
+                webSocket.send(connectResponseFrame(id))
+              }
+            }
+            "node.event" -> {
+              val event =
+                frame["params"]
+                  ?.jsonObject
+                  ?.get("event")
+                  ?.jsonPrimitive
+                  ?.content
+                  .orEmpty()
+              nodeEvents += event
+              eventAfterConnect.complete(Unit)
+              webSocket.send(
+                """{"type":"res","id":"$id","ok":true,"payload":{"ok":true}}""",
+              )
+              webSocket.close(1000, "done")
+            }
+          }
+        }
+      val harness =
+        createNodeHarness(
+          connected = connected,
+          lastDisconnect = lastDisconnect,
+        ) { GatewaySession.InvokeResult.ok("""{"handled":true}""") }
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        withTimeout(TEST_TIMEOUT_MS) { connectRequestSeen.await() }
+
+        assertFalse(
+          harness.session.sendNodeEvent(
+            event = "notifications.changed",
+            payloadJson = """{"change":"posted","key":"before"}""",
+          ),
+        )
+        assertTrue(nodeEvents.isEmpty())
+
+        releaseConnectResponse.complete(Unit)
+        awaitConnectedOrThrow(connected, lastDisconnect, server)
+        assertTrue(
+          harness.session.sendNodeEvent(
+            event = "notifications.changed",
+            payloadJson = """{"change":"posted","key":"after"}""",
+          ),
+        )
+        withTimeout(TEST_TIMEOUT_MS) { eventAfterConnect.await() }
+        assertEquals(listOf("notifications.changed"), nodeEvents.toList())
+      } finally {
+        releaseConnectResponse.complete(Unit)
         shutdownHarness(harness, server)
       }
     }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -1,5 +1,7 @@
 package ai.openclaw.app.gateway
 
+import ai.openclaw.app.NotificationNodeEventOutbox
+import ai.openclaw.app.PendingNotificationNodeEvent
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -7,12 +9,15 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
@@ -20,6 +25,7 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import okio.ByteString
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -82,6 +88,89 @@ private data class ReconnectServer(
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class GatewaySessionReconnectTest {
+  @Test
+  fun definitelyUnsentNodeEventRemainsQueued() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val connected = CompletableDeferred<Unit>()
+      val rejectedNodeEvent = CompletableDeferred<Unit>()
+      val receivedNodeEvent = CompletableDeferred<Unit>()
+      val receivedNodeEventCount = AtomicInteger()
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          when (method) {
+            "connect" -> webSocket.send(connectResponseFrame(id))
+            "node.event" -> {
+              receivedNodeEventCount.incrementAndGet()
+              receivedNodeEvent.complete(Unit)
+              webSocket.send("""{"type":"res","id":"$id","ok":true,"payload":{}}""")
+            }
+          }
+        }
+      val harness = createReconnectHarness(onConnected = { connected.complete(Unit) })
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connected.await() }
+        val connection = readField<Any>(harness.session, "currentConnection")
+        val socketField = connection.javaClass.getDeclaredField("socket").apply { isAccessible = true }
+        val socket = socketField.get(connection) as WebSocket
+        socketField.set(connection, RejectFirstSendWebSocket(socket) { rejectedNodeEvent.complete(Unit) })
+        val outbox =
+          NotificationNodeEventOutbox {
+            harness.session.sendNodeEventWithOutcome(it.event, it.payloadJson)
+          }
+        val deliveryJob = launch { outbox.deliver() }
+
+        try {
+          outbox.enqueue(PendingNotificationNodeEvent("notifications.changed", "{}"))
+          withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { rejectedNodeEvent.await() }
+          outbox.onConnected()
+          withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { receivedNodeEvent.await() }
+          delay(100)
+          assertEquals(1, receivedNodeEventCount.get())
+        } finally {
+          deliveryJob.cancelAndJoin()
+        }
+      } finally {
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun connectedCallbackFailureClosesSocketBeforeRetry() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val firstClosed = CompletableDeferred<Unit>()
+      val secondConnected = CompletableDeferred<Unit>()
+      val callbackCount = AtomicInteger()
+      val server =
+        startGatewayServer(
+          json = json,
+          onClosed = { firstClosed.complete(Unit) },
+        ) { webSocket, id, method ->
+          if (method == "connect") webSocket.send(connectResponseFrame(id))
+        }
+      val harness =
+        createReconnectHarness(
+          onConnected = {
+            if (callbackCount.incrementAndGet() == 1) {
+              throw IllegalStateException("callback failed")
+            }
+            secondConnected.complete(Unit)
+          },
+        )
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { firstClosed.await() }
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { secondConnected.await() }
+        assertEquals(2, callbackCount.get())
+      } finally {
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
   @Test
   fun staleConnectionDrainCannotCancelReplacementRpc() =
     runBlocking {
@@ -561,4 +650,24 @@ class GatewaySessionReconnectTest {
       }
     return ReconnectServer(server = server, sockets = sockets)
   }
+}
+
+private class RejectFirstSendWebSocket(
+  private val delegate: WebSocket,
+  private val onReject: () -> Unit,
+) : WebSocket by delegate {
+  private var rejectNext = true
+
+  override fun send(text: String): Boolean {
+    if (rejectNext) {
+      rejectNext = false
+      onReject()
+      return false
+    }
+    return delegate.send(text)
+  }
+
+  override fun send(bytes: ByteString): Boolean = delegate.send(bytes)
+
+  override fun request(): Request = delegate.request()
 }


### PR DESCRIPTION
## Summary

Closes #79552.

## What Problem This Solves

Android notification forwarding could call `node.event` while the WebSocket existed but the Gateway handshake was still incomplete. The Gateway requires `connect` to be the first request, so notification-triggered automations could silently miss events during initial connect and reconnect windows.

## Why This Change Was Made

- Make each `GatewaySession.Connection` own its pending RPCs and explicit connecting/ready/closed state; outward RPCs see only a ready connection.
- Queue notification events in one bounded FIFO and wake it only after a completed handshake.
- Retain only events proven not enqueued to OkHttp. Ambiguous post-enqueue failures are dropped to prevent duplicates, while still consuming their configured rate-limit slot.
- Recheck listener access, package policy, quiet hours, and session routing at delivery time.
- Coordinate notification-policy writes with outbox generation rollover so restrictive changes become visible before another RPC can be admitted.
- Close failed/cancelled connecting sockets before retrying.

This replaces the original reconciliation/parallel-ID approach; it does not replay the device's entire active-notification set after reconnect.

## User Impact

Notifications accepted while Android is disconnected or still handshaking are delivered in order after reconnect. The queue is bounded, policy changes purge stale content, and uncertain sends are not replayed as duplicates.

## Evidence

- API 36.1 Android emulator + real local Gateway: stopped the Gateway, waited until the node connection was closed, posted a unique shell notification, then restarted the Gateway. The node completed its handshake at 22:52:10, the Gateway received exactly one `node.event`, returned success in 186 ms, and no duplicate followed.
- Focused Play and third-party unit suites passed for `GatewaySessionInvokeTest`, `GatewaySessionReconnectTest`, `NotificationNodeEventOutboxTest`, and `GatewayBootstrapAuthTest`.
- `:app:ktlintMainSourceSetCheck`, `:app:ktlintTestSourceSetCheck`, and `:app:assemblePlayDebug` passed.
- `node --import tsx scripts/native-app-i18n.ts check` passed.
- Blacksmith Testbox `tbx_01kwjdyehj5p35mb94ercj82x2`: exact-head `pnpm check:changed` passed.
- Fresh Codex autoreview: no accepted/actionable findings.

No screenshot is attached because this is a transport lifecycle fix with no meaningful visual before/after state; the real Gateway transcript is the behavioral proof.
