### PR TITLE
fix(status): avoid cumulative usage for context percent

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -222,6 +222,30 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("Context: 3.8m/1.0m");
   });
 
+  it("preserves legacy unknown-freshness totalTokens as context usage", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/test:opus",
+        contextTokens: 1_000_000,
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        totalTokens: 25_000,
+        contextTokens: 1_000_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+      now: 10 * 60_000,
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Context: 25k/1.0m");
+    expect(normalized).not.toContain("Context: ?/1.0m");
+  });
+
   it("uses estimated context budget status when fresh totalTokens are unavailable", () => {
     const text = buildStatusMessage({
       agent: {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -109,6 +109,7 @@ describe("buildStatusMessage", () => {
         inputTokens: 1200,
         outputTokens: 800,
         totalTokens: 16_000,
+        totalTokensFresh: true,
         contextTokens: 32_000,
         thinkingLevel: "low",
         verboseLevel: "on",
@@ -856,6 +857,7 @@ describe("buildStatusMessage", () => {
         channel: "discord",
         groupId: "123",
         totalTokens: 49_000,
+        totalTokensFresh: true,
         contextTokens: 1_048_576,
       },
       sessionKey: "agent:main:main",
@@ -891,6 +893,7 @@ describe("buildStatusMessage", () => {
         sessionId: "ctx1m",
         updatedAt: 0,
         totalTokens: 200_000,
+        totalTokensFresh: true,
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -909,6 +912,7 @@ describe("buildStatusMessage", () => {
         sessionId: "opus47",
         updatedAt: 0,
         totalTokens: 200_000,
+        totalTokensFresh: true,
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -928,6 +932,7 @@ describe("buildStatusMessage", () => {
       modelOverride: "small-model",
       contextTokens: 4_096,
       totalTokens: 1_024,
+      totalTokensFresh: true,
     };
 
     applyModelOverrideToSessionEntry({
@@ -981,6 +986,7 @@ describe("buildStatusMessage", () => {
         fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.7",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
+        totalTokensFresh: true,
         contextTokens: 1_048_576,
       },
       sessionKey: "agent:main:main",
@@ -1113,6 +1119,7 @@ describe("buildStatusMessage", () => {
         fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.7",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
+        totalTokensFresh: true,
         contextTokens: 1_048_576,
       },
       sessionKey: "agent:main:main",
@@ -1157,6 +1164,7 @@ describe("buildStatusMessage", () => {
         fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.7",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
+        totalTokensFresh: true,
         contextTokens: 123_456,
       },
       sessionKey: "agent:main:main",
@@ -1203,6 +1211,7 @@ describe("buildStatusMessage", () => {
         fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.7",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
+        totalTokensFresh: true,
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -1248,6 +1257,7 @@ describe("buildStatusMessage", () => {
         fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.7",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
+        totalTokensFresh: true,
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -1292,6 +1302,7 @@ describe("buildStatusMessage", () => {
         fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.7",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
+        totalTokensFresh: true,
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -1333,6 +1344,7 @@ describe("buildStatusMessage", () => {
         fallbackNoticeActiveModel: "custom-runtime/unknown-fallback-model",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
+        totalTokensFresh: true,
         contextTokens: 128_000,
       },
       sessionKey: "agent:main:main",
@@ -1981,6 +1993,54 @@ describe("buildStatusMessage", () => {
     );
   });
 
+  it("does not let legacy cumulative session totals override fresh transcript context usage", async () => {
+    await withTempHome(
+      async (dir) => {
+        const sessionId = "sess-legacy-cumulative-context";
+        writeTranscriptUsageLog({
+          dir,
+          agentId: "main",
+          sessionId,
+          usage: {
+            input: 10_000,
+            output: 1_000,
+            cacheRead: 26_000,
+            cacheWrite: 0,
+            totalTokens: 36_000,
+          },
+        });
+
+        const text = buildStatusMessage({
+          agent: {
+            model: "anthropic/claude-opus-4-6",
+            contextTokens: 1_000_000,
+          },
+          sessionEntry: {
+            sessionId,
+            updatedAt: 0,
+            inputTokens: 16,
+            outputTokens: 5_100,
+            cacheRead: 2_300_000,
+            cacheWrite: 11_000,
+            totalTokens: 2_300_000,
+            contextTokens: 1_000_000,
+          },
+          sessionKey: "agent:main:main",
+          sessionScope: "per-sender",
+          queue: { mode: "collect", depth: 0 },
+          includeTranscriptUsage: true,
+          modelAuth: "api-key",
+        });
+        const normalized = normalizeTestText(text);
+
+        expect(normalized).toContain("Cache: 100% hit · 2.3m cached, 11k new");
+        expect(normalized).toContain("Context: 36k/1.0m (4%)");
+        expect(normalized).not.toContain("Context: 2.3m/1.0m");
+      },
+      { prefix: "openclaw-status-" },
+    );
+  });
+
   it("reads transcript usage for non-default agents", async () => {
     await withTempHome(
       async (dir) => {
@@ -2237,6 +2297,7 @@ describe("buildStatusMessage", () => {
         sessionId: "sess-runtime-slash-id",
         updatedAt: 0,
         totalTokens: 1205,
+        totalTokensFresh: true,
         model: "google/gemini-2.5-pro",
       },
       sessionKey: "agent:main:main",
@@ -2279,6 +2340,7 @@ describe("buildStatusMessage", () => {
         fallbackNoticeActiveModel: "fake-minimax/FakeMiniMax-M2.5",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
+        totalTokensFresh: true,
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -2314,6 +2376,7 @@ describe("buildStatusMessage", () => {
         updatedAt: 0,
         model: "openai/gpt-4o",
         totalTokens: 49_000,
+        totalTokensFresh: true,
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -2384,6 +2447,7 @@ describe("buildStatusMessage", () => {
         sessionId: "sess-anthropic-qualified-context",
         updatedAt: 0,
         totalTokens: 25_000,
+        totalTokensFresh: true,
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -2408,6 +2472,7 @@ describe("buildStatusMessage", () => {
         sessionId: "sess-openai-chatgpt-cap-context",
         updatedAt: 0,
         totalTokens: 25_000,
+        totalTokensFresh: true,
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -2432,6 +2497,7 @@ describe("buildStatusMessage", () => {
         sessionId: "sess-openai-chatgpt-runtime-cap-context",
         updatedAt: 0,
         totalTokens: 25_000,
+        totalTokensFresh: true,
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -2469,6 +2535,7 @@ describe("buildStatusMessage", () => {
         fallbackNoticeActiveModel: "custom-runtime/unknown-fallback-model",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
+        totalTokensFresh: true,
         contextTokens: 128_000,
       },
       sessionKey: "agent:main:main",

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -632,13 +632,14 @@ export function buildStatusMessage(args: StatusArgs): string {
   let outputTokens = entry?.outputTokens;
   let cacheRead = entry?.cacheRead;
   let cacheWrite = entry?.cacheWrite;
-  const freshTotalTokens =
-    entry?.totalTokensFresh === true ? resolveFreshSessionTotalTokens(entry) : undefined;
+  const freshTotalTokens = resolveFreshSessionTotalTokens(entry);
+  // Undefined freshness is legacy, not stale: keep persisted totals for /status,
+  // but let a fresh transcript prompt snapshot replace them when available.
   const allowTranscriptContextUsage = entry?.totalTokensFresh !== false;
   let totalTokens = freshTotalTokens;
 
-  // Context percentages need a fresh prompt snapshot; cumulative session/cache
-  // usage can still hydrate Tokens/Cache lines but must not become Context.
+  // Explicitly stale session/cache usage can still hydrate Tokens/Cache lines
+  // but must not become Context.
   if (args.includeTranscriptUsage) {
     const logUsage = readUsageFromSessionLog(
       entry?.sessionId,
@@ -655,7 +656,10 @@ export function buildStatusMessage(args: StatusArgs): string {
         allowTranscriptContextUsage &&
         candidate !== undefined &&
         candidate > 0 &&
-        (!totalTokens || totalTokens === 0 || candidate > totalTokens)
+        (entry?.totalTokensFresh !== true ||
+          !totalTokens ||
+          totalTokens === 0 ||
+          candidate > totalTokens)
       ) {
         totalTokens = candidate;
       }

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -293,6 +293,7 @@ const readUsageFromSessionLog = (
       cacheWrite: number;
       promptTokens: number;
       total: number;
+      totalTokensFresh: boolean;
       model?: string;
     }
   | undefined => {
@@ -350,6 +351,7 @@ const readUsageFromSessionLog = (
       cacheWrite,
       promptTokens,
       total,
+      totalTokensFresh: snapshot.totalTokensFresh === true,
       model,
     };
   } catch {
@@ -630,16 +632,13 @@ export function buildStatusMessage(args: StatusArgs): string {
   let outputTokens = entry?.outputTokens;
   let cacheRead = entry?.cacheRead;
   let cacheWrite = entry?.cacheWrite;
-  const freshTotalTokens = resolveFreshSessionTotalTokens(entry);
+  const freshTotalTokens =
+    entry?.totalTokensFresh === true ? resolveFreshSessionTotalTokens(entry) : undefined;
   const allowTranscriptContextUsage = entry?.totalTokensFresh !== false;
-  let totalTokens =
-    freshTotalTokens ??
-    (entry?.totalTokensFresh === false
-      ? undefined
-      : (entry?.totalTokens ?? (entry?.inputTokens ?? 0) + (entry?.outputTokens ?? 0)));
+  let totalTokens = freshTotalTokens;
 
-  // Prefer prompt-size tokens from the session transcript when it looks larger
-  // (cached prompt tokens are often missing from agent meta/store).
+  // Context percentages need a fresh prompt snapshot; cumulative session/cache
+  // usage can still hydrate Tokens/Cache lines but must not become Context.
   if (args.includeTranscriptUsage) {
     const logUsage = readUsageFromSessionLog(
       entry?.sessionId,
@@ -649,9 +648,13 @@ export function buildStatusMessage(args: StatusArgs): string {
       args.sessionStorePath,
     );
     if (logUsage) {
-      const candidate = logUsage.promptTokens || logUsage.total;
+      const candidate = logUsage.totalTokensFresh
+        ? logUsage.promptTokens || logUsage.total
+        : undefined;
       if (
         allowTranscriptContextUsage &&
+        candidate !== undefined &&
+        candidate > 0 &&
         (!totalTokens || totalTokens === 0 || candidate > totalTokens)
       ) {
         totalTokens = candidate;


### PR DESCRIPTION
## Summary

Closes #83526.

Fix the TUI and `/status` Context line so explicitly stale cumulative session/cache totals cannot be used as current prompt occupancy, while legacy sessions with unknown `totalTokensFresh` still show their valid persisted total instead of `?`.

## Problem

The previous repair prevented stale cumulative totals from inflating Context, but it also required `totalTokensFresh === true` before any persisted `totalTokens` could render as Context. Legacy session entries often do not have that freshness flag, so valid unknown-freshness totals regressed to `Context: ?/...`.

## Root Cause

OpenClaw session metadata distinguishes three states:

- `totalTokensFresh: true`: known current/fresh prompt usage.
- `totalTokensFresh: false`: explicitly stale cumulative usage.
- `totalTokensFresh` missing: legacy/unknown freshness, not automatically stale.

The status builder treated the missing flag like stale data, even though the session helper contract only rejects explicit `false`.

## Solution

- Restore `resolveFreshSessionTotalTokens` as the canonical persisted-total gate: explicit `false` is stale; missing freshness is legacy/unknown and remains usable.
- Let a fresh transcript prompt snapshot replace legacy/unknown persisted totals when available, so older cumulative totals do not override better current-context evidence.
- Preserve explicit-fresh persisted totals unless the transcript candidate is larger.
- Add regression coverage for legacy unknown-freshness totals rendering as Context instead of `?`.
- Clarify the status comment around legacy unknown freshness versus explicit stale totals.

## Dependency Contract Proof

- `../codex/codex-rs/protocol/src/protocol.rs:1964` defines `TokenUsage`, and `../codex/codex-rs/protocol/src/protocol.rs:1977` exposes both `total_token_usage` and `last_token_usage` in `TokenUsageInfo`.
- `../codex/codex-rs/protocol/src/protocol.rs:1987` shows `append_last_usage` accumulates total usage separately from the last-turn/current usage.
- `../codex/codex-rs/core/src/session/mod.rs:1171` documents the separate `token_usage_info` path for restored usage, distinct from plain cumulative totals.
- `../codex/codex-rs/core/src/context_manager/history.rs:283` starts context accounting from the most recent model-emitted usage, matching the need to avoid treating cumulative cache/session totals as current prompt occupancy.

## Testing Performed

- `cmd.exe /C pnpm exec oxfmt --check src/status/status-message.ts src/auto-reply/status.test.ts`
  - Passed.
- `cmd.exe /C git diff --check -- src/status/status-message.ts src/auto-reply/status.test.ts`
  - Passed.
- `cmd.exe /C node scripts/run-vitest.mjs src/auto-reply/status.test.ts`
  - Passed: 82 tests.
- `cmd.exe /C node scripts/run-vitest.mjs --config test/vitest/vitest.auto-reply.config.ts src/auto-reply/reply/commands-status.test.ts --testNamePattern "Codex OAuth context|stale persisted"`
  - Passed: 2 tests, 25 skipped by pattern.
- `cmd.exe /C "set PYTHONUTF8=1&&python .agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD"`
  - Passed: autoreview clean, no accepted/actionable findings.

## Release Note

Fixes `/status` and TUI Context reporting for legacy sessions so valid unknown-freshness totals no longer render as unknown, while explicitly stale cumulative totals remain excluded from current context occupancy.

## Real behavior proof

Behavior addressed: `/status` and TUI Context reporting no longer treats missing `totalTokensFresh` as stale, while explicit stale cumulative totals still cannot become the Context numerator.

Real environment tested: Local Windows/WSL OpenClaw source checkout at commit `8ca9ac38ef`, running the patched OpenClaw status formatter through Windows Node with `tsx`; no credentials or live user data were used.

Exact steps or command run after this patch: Created a temporary local driver that imported `buildStatusMessage` from the patched checkout, seeded a redacted legacy session entry with `totalTokens: 25_000`, `contextTokens: 1_000_000`, and no `totalTokensFresh`, then ran `cmd.exe /C node --import tsx .tmp-openclaw-status-proof.ts` and removed the temporary driver.

Evidence after fix: Copied live terminal output from the local OpenClaw checkout:

```text
OpenClaw /status formatter live output (redacted local source checkout)
scenario=legacy-session-totalTokensFresh-omitted totalTokens=25000 contextTokens=1000000
🦞 OpenClaw 2026.6.2 (8ca9ac3)
🧠 Model: anthropic/test:opus · 🔑 api-key
📚 Context: 25k/1.0m (3%) · 🧹 Compactions: 0
🧵 Session: agent:main:main • updated 10m ago
⚙️ Execution: direct · Runtime: OpenClaw Default · Think: off · Fast: off · elevated
🪢 Queue: collect (depth 0)
```

Observed result after fix: The redacted live output shows the legacy unknown-freshness session renders a concrete `Context: 25k/1.0m (3%)` value instead of `Context: ?/1.0m`, while the supplemental regression tests still cover explicit stale totals and fresh transcript replacement.

What was not tested: A live TUI or channel session reproduction, a coverage report, and the full local `commands-status.test.ts` file; the whole-file local run stayed quiet for several minutes and was stopped, so full-lane proof is left to CI on this pushed SHA.
