### PR TITLE
fix(docs): pin Windows Hub download links to v2026.6.5

### DIFF
--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -18,11 +18,13 @@ most Linux-compatible Gateway runtime.
 Windows Hub is the native WinUI companion app for Windows 10 20H2+ and Windows 11. It installs without administrator privileges and is published with signed
 x64 and ARM64 installers on OpenClaw releases.
 
-Download the latest stable installer:
+Download the latest stable installer from the [OpenClaw releases page](https://github.com/openclaw/openclaw/releases):
 
-- [OpenClawCompanion-Setup-x64.exe](https://github.com/openclaw/openclaw/releases/latest/download/OpenClawCompanion-Setup-x64.exe)
-- [OpenClawCompanion-Setup-arm64.exe](https://github.com/openclaw/openclaw/releases/latest/download/OpenClawCompanion-Setup-arm64.exe)
-- [Checksums](https://github.com/openclaw/openclaw/releases/latest/download/OpenClawCompanion-SHA256SUMS.txt)
+- [OpenClawCompanion-Setup-x64.exe](https://github.com/openclaw/openclaw/releases/download/v2026.6.5/OpenClawCompanion-Setup-x64.exe)
+- [OpenClawCompanion-Setup-arm64.exe](https://github.com/openclaw/openclaw/releases/download/v2026.6.5/OpenClawCompanion-Setup-arm64.exe)
+- [Checksums](https://github.com/openclaw/openclaw/releases/download/v2026.6.5/OpenClawCompanion-SHA256SUMS.txt)
+
+If a download link above returns a 404, visit the [releases page](https://github.com/openclaw/openclaw/releases) and look for the `OpenClawCompanion-Setup-*` assets on the latest release.
 
 After install, launch **OpenClaw Companion** from the Start menu or the system
 tray. The installer also adds shortcuts for Gateway Setup, Chat, Settings,


### PR DESCRIPTION
## Summary

Fix Windows Hub download links returning 404 on https://docs.openclaw.ai/platforms/windows

Fixes #92470

The Windows Hub companion installers (`OpenClawCompanion-Setup-*`) are promoted to the main OpenClaw release via a manual `workflow_dispatch` from the `openclaw/openclaw-windows-node` repo. The latest release (v2026.6.6) did not receive this promotion, so the `/releases/latest/download/` links resolve to a release without the assets, causing 404 errors.

**Changes:**
- Pin the download links to `v2026.6.5` (the latest release that includes the companion installers)
- Add a fallback note directing users to the releases page when a release is missing the companion assets
- All three links verified working (HTTP 200)

## Real behavior proof

**Behavior addressed**: Changes the Windows Hub download links from using `releases/latest/download/` (which 404s when the latest release lacks the companion assets) to pinning to `v2026.6.5` which has the assets, with a fallback note to the releases page.

**Real setup tested**: Fresh clone of openclaw/openclaw
- **Runtime**: node

**Exact steps or command run after fix**:

```bash
curl -sIL -o /dev/null -w "%{http_code}\n" "https://github.com/openclaw/openclaw/releases/download/v2026.6.5/OpenClawCompanion-Setup-x64.exe"
curl -sIL -o /dev/null -w "%{http_code}\n" "https://github.com/openclaw/openclaw/releases/download/v2026.6.5/OpenClawCompanion-Setup-arm64.exe"
curl -sIL -o /dev/null -w "%{http_code}\n" "https://github.com/openclaw/openclaw/releases/download/v2026.6.5/OpenClawCompanion-SHA256SUMS.txt"
```

**After-fix evidence**:

```
x64: 200
arm64: 200
checksums: 200
```

**Observed result after the fix**: All three Windows Hub download links return HTTP 200. The documentation now pins to a known-good release (v2026.6.5) instead of `latest`, which would 404 when a release lacks the promoted companion assets.

**What was not tested**: The fallback path (user visiting the releases page) is not automated; it depends on the GitHub UI which is outside the scope of this fix.