### PR TITLE
docs(gateway): add uptime monitoring guidance to health check docs (fixes #55768)

### DIFF
--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -42,6 +42,21 @@ health commands above for live connectivity checks.
 - `channels.<provider>.accounts.<accountId>.healthMonitor.enabled`: multi-account override that wins over the channel-level setting.
 - These per-channel overrides apply to the built-in channel monitors that expose them today: Discord, Google Chat, iMessage, Microsoft Teams, Signal, Slack, Telegram, and WhatsApp.
 
+## Uptime monitoring
+
+External uptime monitoring services should use the dedicated `/health` endpoint, not `/v1/chat/completions`.
+
+- **DO use:** `GET /health` — instant response, no session created, no LLM call, returns `{"ok":true,"status":"live"}`
+- **DON'T use:** `/v1/chat/completions` for health checks — each request creates a full agent session with skill snapshot, context assembly, and LLM calls
+
+When no `x-openclaw-session-key` header or `user` field is provided, `/v1/chat/completions` generates a new random session for each request. Monitoring services that ping every 15 minutes create ~96 sessions/day, each consuming 4–22KB. Over time this causes session store bloat and can lead to context window overflow.
+
+### Monitoring service setup examples
+
+- **BetterStack:** Set health check URL to `https://<your-gateway-host>:<port>/health`
+- **UptimeRobot:** Add a new HTTP monitor with URL `https://<your-gateway-host>:<port>/health`
+- **Generic:** Any HTTP GET to `/health` returns 200 with `{"ok":true}` when the gateway is healthy
+
 ## When something fails
 
 - `logged out` or status 409–515 → relink with `openclaw channels logout` then `openclaw channels login`.


### PR DESCRIPTION
## What

Adds uptime monitoring best practices to the gateway health check documentation, explaining that monitoring services should use `GET /health` instead of `/v1/chat/completions` to avoid session store bloat.

Fixes #55768

## Why

External uptime monitoring services hitting `/v1/chat/completions` create full agent sessions (with skill snapshot, context assembly, and LLM calls) for each ping. When no `x-openclaw-session-key` header or `user` field is provided, the gateway generates a new random UUID session per request. Monitoring at ~15-minute intervals creates ~96 sessions/day, each consuming 4–22KB, causing session store bloat and potential context window overflow.

## How

Adds a new "Uptime monitoring" section to `docs/gateway/health.md` that:
- Clearly states DO use `/health` and DON'T use `/v1/chat/completions` for monitoring
- Explains the session creation mechanism and bloat impact
- Provides setup examples for BetterStack, UptimeRobot, and generic monitors

## Real behavior proof

- **Behavior addressed:** Uptime monitoring services using `/v1/chat/completions` instead of `/health` create unnecessary agent sessions, causing session store bloat
- **Environment tested:** macOS arm64, OpenClaw local build from `upstream/main` (492b9173)
- **Steps run after the patch:** `pnpm build` completed successfully with the docs change; verified the new section renders correctly in `docs/gateway/health.md`
- **Evidence after fix:**

```
$ pnpm build 2>&1 | tail -3
[build-all] phase timings: total 87.0s; slowest tsdown 81.6s; ui:build 1.33s
$ git diff --stat
 docs/gateway/health.md | 15 +++++++++++++++
 1 file changed, 15 insertions(+)
$ grep -c "Uptime monitoring" docs/gateway/health.md
1
```

- **Observed result after fix:** The health check documentation now includes clear guidance directing monitoring services to use the dedicated `/health` endpoint, with concrete setup examples for popular monitoring tools
- **What was not tested:** This is a documentation-only change; no runtime behavior was modified. The `/health` endpoint itself was not tested (it already works correctly per the existing code at `src/gateway/server-http.ts:160`)
