### PR TITLE
fix: include archived transcript lineage in session usage detail

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1497,6 +1497,53 @@ describe("session cost usage", () => {
     });
   });
 
+  it("shares one in-flight directory listing for hidden batch lineage readers", async () => {
+    const root = await makeSessionCostRoot("cost-cache-batch-lineage-dir-cache");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFiles = ["sess-dir-a", "sess-dir-b", "sess-dir-c"].map((sessionId) =>
+      path.join(sessionsDir, `${sessionId}.jsonl`),
+    );
+    const assistantMessage = (tokens: number) =>
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-05T13:00:00.000Z",
+        message: {
+          role: "assistant",
+          usage: { input: tokens, output: 0, totalTokens: tokens, cost: { total: tokens / 1000 } },
+        },
+      });
+    await Promise.all(
+      sessionFiles.map((sessionFile, index) =>
+        fs.writeFile(sessionFile, assistantMessage(index + 1), "utf-8"),
+      ),
+    );
+
+    await withStateDir(root, async () => {
+      await refreshCostUsageCache({ sessionFiles });
+      const readdirSpy = vi.spyOn(nodeFs.promises, "readdir");
+      try {
+        const result = await loadSessionCostSummariesFromCache({
+          sessions: sessionFiles.map((sessionFile, index) => ({
+            sessionId: `sess-dir-${String.fromCharCode(97 + index)}`,
+            sessionFile,
+          })),
+          agentId: "main",
+          requestRefresh: false,
+        });
+        const lineageDirReads = readdirSpy.mock.calls.filter(([dir]) => {
+          return path.resolve(String(dir)) === path.resolve(sessionsDir);
+        });
+
+        expect(result.cacheStatus.status).toBe("fresh");
+        expect(result.summaries.map((summary) => summary?.totalTokens)).toEqual([1, 2, 3]);
+        expect(lineageDirReads).toHaveLength(1);
+      } finally {
+        readdirSpy.mockRestore();
+      }
+    });
+  });
+
   it("returns a partial summary when a same-stem archive is not yet cached", async () => {
     const root = await makeSessionCostRoot("cost-cache-lineage-partial");
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1395,6 +1395,58 @@ describe("session cost usage", () => {
     });
   });
 
+  it("combines active and archived lineage for hidden batch sessions (#46252)", async () => {
+    const root = await makeSessionCostRoot("cost-cache-batch-lineage");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    // A hidden aggregate session is passed by its active file only; its same-stem
+    // reset archive must still be counted. A second plain session controls that
+    // non-lineage rows are unchanged.
+    const lineageActive = path.join(sessionsDir, "sess-batch-lineage.jsonl");
+    const lineageArchive = path.join(
+      sessionsDir,
+      "sess-batch-lineage.jsonl.reset.2026-02-05T12-30-00.000Z",
+    );
+    const plainFile = path.join(sessionsDir, "sess-batch-plain.jsonl");
+    const assistantMessage = (tokens: number, cost: number, timestamp: string) =>
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          usage: { input: tokens, output: 0, totalTokens: tokens, cost: { total: cost } },
+        },
+      });
+
+    await Promise.all([
+      fs.writeFile(
+        lineageArchive,
+        assistantMessage(12, 0.012, "2026-02-05T12:00:00.000Z"),
+        "utf-8",
+      ),
+      fs.writeFile(lineageActive, assistantMessage(18, 0.018, "2026-02-05T13:00:00.000Z"), "utf-8"),
+      fs.writeFile(plainFile, assistantMessage(5, 0.005, "2026-02-05T14:00:00.000Z"), "utf-8"),
+    ]);
+
+    await withStateDir(root, async () => {
+      await refreshCostUsageCache({ sessionFiles: [lineageActive, lineageArchive, plainFile] });
+      const result = await loadSessionCostSummariesFromCache({
+        sessions: [
+          { sessionId: "sess-batch-lineage", sessionFile: lineageActive },
+          { sessionId: "sess-batch-plain", sessionFile: plainFile },
+        ],
+        agentId: "main",
+        requestRefresh: false,
+      });
+
+      expect(result.cacheStatus.status).toBe("fresh");
+      // Active (18) + reset archive (12) = 30, not the active-file-only 18.
+      expect(result.summaries[0]?.totalTokens).toBe(30);
+      expect(result.summaries[0]?.totalCost).toBeCloseTo(0.03, 8);
+      expect(result.summaries[1]?.totalTokens).toBe(5);
+    });
+  });
+
   it("returns a partial summary when a same-stem archive is not yet cached", async () => {
     const root = await makeSessionCostRoot("cost-cache-lineage-partial");
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1447,6 +1447,56 @@ describe("session cost usage", () => {
     });
   });
 
+  it("uses the explicit sessionFile stem for cached lineage readers", async () => {
+    const root = await makeSessionCostRoot("cost-cache-explicit-stem-lineage");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const topicFile = path.join(sessionsDir, "sess-topic-topic-456.jsonl");
+    const topicArchive = path.join(
+      sessionsDir,
+      "sess-topic-topic-456.jsonl.reset.2026-02-05T12-30-00.000Z",
+    );
+    const canonicalConflict = path.join(sessionsDir, "sess-topic.jsonl");
+    const assistantMessage = (tokens: number, cost: number, timestamp: string) =>
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          usage: { input: tokens, output: 0, totalTokens: tokens, cost: { total: cost } },
+        },
+      });
+
+    await Promise.all([
+      fs.writeFile(topicArchive, assistantMessage(12, 0.012, "2026-02-05T12:00:00.000Z"), "utf-8"),
+      fs.writeFile(topicFile, assistantMessage(18, 0.018, "2026-02-05T13:00:00.000Z"), "utf-8"),
+      fs.writeFile(
+        canonicalConflict,
+        assistantMessage(999, 0.999, "2026-02-05T14:00:00.000Z"),
+        "utf-8",
+      ),
+    ]);
+
+    await withStateDir(root, async () => {
+      await refreshCostUsageCache({ sessionFiles: [topicArchive, topicFile, canonicalConflict] });
+      const single = await loadSessionCostSummaryFromCache({
+        sessionId: "sess-topic",
+        sessionFile: topicFile,
+        requestRefresh: false,
+      });
+      const batch = await loadSessionCostSummariesFromCache({
+        sessions: [{ sessionId: "sess-topic", sessionFile: topicFile }],
+        agentId: "main",
+        requestRefresh: false,
+      });
+
+      expect(single.summary?.sessionFile).toBe(topicFile);
+      expect(single.summary?.totalTokens).toBe(30);
+      expect(batch.summaries[0]?.sessionFile).toBe(topicFile);
+      expect(batch.summaries[0]?.totalTokens).toBe(30);
+    });
+  });
+
   it("returns a partial summary when a same-stem archive is not yet cached", async () => {
     const root = await makeSessionCostRoot("cost-cache-lineage-partial");
     const sessionsDir = path.join(root, "agents", "main", "sessions");
@@ -2398,6 +2448,64 @@ describe("session cost usage", () => {
       expect(timeseries?.points.map((point) => point.totalTokens)).toEqual([12, 18]);
       expect(timeseries?.points.map((point) => point.cumulativeTokens)).toEqual([12, 30]);
       expect(logs?.map((log) => log.content)).toEqual(["archived answer", "active answer"]);
+    });
+  });
+
+  it("uses the explicit sessionFile stem for per-session detail lineage", async () => {
+    const root = await makeSessionCostRoot("session-explicit-stem-lineage");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const topicFile = path.join(sessionsDir, "sess-topic-topic-456.jsonl");
+    const topicArchive = path.join(
+      sessionsDir,
+      "sess-topic-topic-456.jsonl.reset.2026-02-12T10-30-00.000Z",
+    );
+    const canonicalConflict = path.join(sessionsDir, "sess-topic.jsonl");
+    const entry = (timestamp: string, totalTokens: number, content: string): string =>
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          content,
+          usage: {
+            input: totalTokens,
+            output: 0,
+            totalTokens,
+            cost: { total: totalTokens / 1000 },
+          },
+        },
+      });
+
+    await Promise.all([
+      fs.writeFile(topicArchive, entry("2026-02-12T10:00:00.000Z", 12, "topic archive"), "utf-8"),
+      fs.writeFile(topicFile, entry("2026-02-12T11:00:00.000Z", 18, "topic active"), "utf-8"),
+      fs.writeFile(
+        canonicalConflict,
+        entry("2026-02-12T12:00:00.000Z", 999, "canonical conflict"),
+        "utf-8",
+      ),
+    ]);
+
+    await withStateDir(root, async () => {
+      const summary = await loadSessionCostSummary({
+        sessionId: "sess-topic",
+        sessionFile: topicFile,
+      });
+      const timeseries = await loadSessionUsageTimeSeries({
+        sessionId: "sess-topic",
+        sessionFile: topicFile,
+      });
+      const logs = await loadSessionLogs({
+        sessionId: "sess-topic",
+        sessionFile: topicFile,
+      });
+
+      expect(summary?.sessionFile).toBe(topicFile);
+      expect(summary?.totalTokens).toBe(30);
+      expect(timeseries?.points.map((point) => point.totalTokens)).toEqual([12, 18]);
+      expect(logs?.map((log) => log.content)).toEqual(["topic archive", "topic active"]);
     });
   });
 

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1332,6 +1332,158 @@ describe("session cost usage", () => {
     });
   });
 
+  it("combines cached active and archived same-stem session summaries", async () => {
+    const root = await makeSessionCostRoot("cost-cache-session-lineage");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-cache-lineage.jsonl");
+    const archiveFile = path.join(
+      sessionsDir,
+      "sess-cache-lineage.jsonl.deleted.2026-02-05T12-30-00.000Z",
+    );
+
+    await Promise.all([
+      fs.writeFile(
+        archiveFile,
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-02-05T12:00:00.000Z",
+          message: {
+            role: "assistant",
+            usage: {
+              input: 8,
+              output: 4,
+              totalTokens: 12,
+              cost: { total: 0.012 },
+            },
+          },
+        }),
+        "utf-8",
+      ),
+      fs.writeFile(
+        sessionFile,
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-02-05T13:00:00.000Z",
+          message: {
+            role: "assistant",
+            usage: {
+              input: 10,
+              output: 8,
+              totalTokens: 18,
+              cost: { total: 0.018 },
+            },
+          },
+        }),
+        "utf-8",
+      ),
+    ]);
+
+    await withStateDir(root, async () => {
+      await refreshCostUsageCache({ sessionFiles: [sessionFile, archiveFile] });
+      const summary = await loadSessionCostSummaryFromCache({
+        sessionId: "sess-cache-lineage",
+        sessionFile,
+        requestRefresh: false,
+      });
+
+      expect(summary.summary?.sessionFile).toBe(sessionFile);
+      expect(summary.summary?.totalTokens).toBe(30);
+      expect(summary.summary?.totalCost).toBeCloseTo(0.03, 8);
+      expect(summary.cacheStatus.status).toBe("fresh");
+      expect(summary.cacheStatus.cachedFiles).toBe(2);
+    });
+  });
+
+  it("returns a partial summary when a same-stem archive is not yet cached", async () => {
+    const root = await makeSessionCostRoot("cost-cache-lineage-partial");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-cache-partial.jsonl");
+    const archiveFile = path.join(
+      sessionsDir,
+      "sess-cache-partial.jsonl.reset.2026-02-05T12-30-00.000Z",
+    );
+    const message = (timestamp: string, totalTokens: number, cost: number): string =>
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          usage: { input: totalTokens, output: 0, totalTokens, cost: { total: cost } },
+        },
+      });
+    await Promise.all([
+      fs.writeFile(archiveFile, message("2026-02-05T12:00:00.000Z", 12, 0.012), "utf-8"),
+      fs.writeFile(sessionFile, message("2026-02-05T13:00:00.000Z", 18, 0.018), "utf-8"),
+    ]);
+
+    await withStateDir(root, async () => {
+      // Cache only the active transcript; the reset archive stays uncached/stale.
+      await refreshCostUsageCache({ sessionFiles: [sessionFile] });
+      const result = await loadSessionCostSummaryFromCache({
+        sessionId: "sess-cache-partial",
+        sessionFile,
+        requestRefresh: false,
+      });
+
+      // Regression: a stale lineage member used to blank the whole summary; the
+      // cached active spend is now surfaced as a partial result.
+      expect(result.summary).not.toBeNull();
+      expect(result.summary?.totalTokens).toBe(18);
+      expect(result.summary?.sessionFile).toBe(sessionFile);
+      expect(result.cacheStatus.status).toBe("partial");
+      expect(result.cacheStatus.staleFiles).toBe(1);
+    });
+  });
+
+  it("applies the requested range when rebuilding a merged lineage summary", async () => {
+    const root = await makeSessionCostRoot("cost-cache-lineage-range");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-cache-range.jsonl");
+    const archiveFile = path.join(
+      sessionsDir,
+      "sess-cache-range.jsonl.reset.2026-02-05T12-30-00.000Z",
+    );
+    const message = (timestamp: string, totalTokens: number, cost: number): string =>
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          usage: { input: totalTokens, output: 0, totalTokens, cost: { total: cost } },
+        },
+      });
+    await Promise.all([
+      fs.writeFile(archiveFile, message("2026-02-05T12:00:00.000Z", 12, 0.012), "utf-8"),
+      fs.writeFile(sessionFile, message("2026-02-05T13:00:00.000Z", 18, 0.018), "utf-8"),
+    ]);
+
+    await withStateDir(root, async () => {
+      await refreshCostUsageCache({ sessionFiles: [sessionFile, archiveFile] });
+      // Narrow range excludes the 12:00 archive entry; only the 13:00 active entry counts.
+      const narrow = await loadSessionCostSummaryFromCache({
+        sessionId: "sess-cache-range",
+        sessionFile,
+        requestRefresh: false,
+        startMs: Date.parse("2026-02-05T12:45:00.000Z"),
+        endMs: Date.parse("2026-02-05T23:59:00.000Z"),
+      });
+      expect(narrow.summary?.totalTokens).toBe(18);
+
+      // Wide range includes both lineage transcripts.
+      const wide = await loadSessionCostSummaryFromCache({
+        sessionId: "sess-cache-range",
+        sessionFile,
+        requestRefresh: false,
+        startMs: Date.parse("2026-02-05T00:00:00.000Z"),
+        endMs: Date.parse("2026-02-05T23:59:00.000Z"),
+      });
+      expect(wide.summary?.totalTokens).toBe(30);
+    });
+  });
+
   it("respects live usage cache locks even when they are old", async () => {
     const root = await makeSessionCostRoot("cost-cache-stale-lock");
     const sessionsDir = path.join(root, "agents", "main", "sessions");
@@ -2141,6 +2293,154 @@ describe("session cost usage", () => {
       expect(timeseries?.points[0]?.totalTokens).toBe(10);
       expect(logs).toHaveLength(1);
       expect(logs?.[0]?.content).toContain("archived answer");
+    });
+  });
+
+  it("combines active and archived same-stem transcripts for per-session detail queries", async () => {
+    const root = await makeSessionCostRoot("session-active-archive-lineage");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const sessionFile = path.join(sessionsDir, "sess-lineage.jsonl");
+    const archiveFile = path.join(sessionsDir, "sess-lineage.jsonl.reset.2026-02-12T10-30-00.000Z");
+
+    await Promise.all([
+      fs.writeFile(
+        archiveFile,
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-02-12T10:00:00.000Z",
+          message: {
+            role: "assistant",
+            content: "archived answer",
+            usage: { input: 7, output: 5, totalTokens: 12, cost: { total: 0.012 } },
+          },
+        }),
+        "utf-8",
+      ),
+      fs.writeFile(
+        sessionFile,
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-02-12T11:00:00.000Z",
+          message: {
+            role: "assistant",
+            content: "active answer",
+            usage: { input: 10, output: 8, totalTokens: 18, cost: { total: 0.018 } },
+          },
+        }),
+        "utf-8",
+      ),
+    ]);
+
+    await withStateDir(root, async () => {
+      const summary = await loadSessionCostSummary({ sessionId: "sess-lineage" });
+      const timeseries = await loadSessionUsageTimeSeries({ sessionId: "sess-lineage" });
+      const logs = await loadSessionLogs({ sessionId: "sess-lineage" });
+
+      expect(summary?.sessionFile ? await fs.realpath(summary.sessionFile) : undefined).toBe(
+        await fs.realpath(sessionFile),
+      );
+      expect(summary?.totalTokens).toBe(30);
+      expect(summary?.totalCost).toBeCloseTo(0.03, 8);
+      expect(timeseries?.points.map((point) => point.totalTokens)).toEqual([12, 18]);
+      expect(timeseries?.points.map((point) => point.cumulativeTokens)).toEqual([12, 30]);
+      expect(logs?.map((log) => log.content)).toEqual(["archived answer", "active answer"]);
+    });
+  });
+
+  it("excludes non-usage same-stem siblings from per-session lineage totals", async () => {
+    const root = await makeSessionCostRoot("session-lineage-excludes-nonusage");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const sessionFile = path.join(sessionsDir, "sess-exclude.jsonl");
+    const archiveFile = path.join(sessionsDir, "sess-exclude.jsonl.reset.2026-02-12T10-30-00.000Z");
+    const backupFile = path.join(sessionsDir, "sess-exclude.jsonl.bak.2026-02-12T10-45-00.000Z");
+    const checkpointFile = path.join(
+      sessionsDir,
+      "sess-exclude.checkpoint.00000000-0000-4000-8000-000000000000.jsonl",
+    );
+
+    const entry = (timestamp: string, totalTokens: number) =>
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          usage: {
+            input: totalTokens,
+            output: 0,
+            totalTokens,
+            cost: { total: totalTokens / 1000 },
+          },
+        },
+      });
+
+    await Promise.all([
+      fs.writeFile(archiveFile, entry("2026-02-12T10:00:00.000Z", 12), "utf-8"),
+      fs.writeFile(sessionFile, entry("2026-02-12T11:00:00.000Z", 18), "utf-8"),
+      fs.writeFile(backupFile, entry("2026-02-12T11:30:00.000Z", 999), "utf-8"),
+      fs.writeFile(checkpointFile, entry("2026-02-12T12:00:00.000Z", 500), "utf-8"),
+    ]);
+
+    await withStateDir(root, async () => {
+      const summary = await loadSessionCostSummary({ sessionId: "sess-exclude" });
+
+      expect(summary?.sessionFile ? await fs.realpath(summary.sessionFile) : undefined).toBe(
+        await fs.realpath(sessionFile),
+      );
+      expect(summary?.totalTokens).toBe(30);
+      expect(summary?.totalCost).toBeCloseTo(0.03, 8);
+    });
+  });
+
+  it("excludes non-usage same-stem siblings from per-session time-series and logs", async () => {
+    const root = await makeSessionCostRoot("session-lineage-excludes-series");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-series.jsonl");
+    const archiveFile = path.join(sessionsDir, "sess-series.jsonl.reset.2026-02-12T10-30-00.000Z");
+    const backupFile = path.join(sessionsDir, "sess-series.jsonl.bak.2026-02-12T10-45-00.000Z");
+    const checkpointFile = path.join(
+      sessionsDir,
+      "sess-series.checkpoint.00000000-0000-4000-8000-000000000000.jsonl",
+    );
+    const entry = (timestamp: string, totalTokens: number, content: string): string =>
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          content,
+          usage: {
+            input: totalTokens,
+            output: 0,
+            totalTokens,
+            cost: { total: totalTokens / 1000 },
+          },
+        },
+      });
+
+    await Promise.all([
+      fs.writeFile(archiveFile, entry("2026-02-12T10:00:00.000Z", 12, "archived answer"), "utf-8"),
+      fs.writeFile(sessionFile, entry("2026-02-12T11:00:00.000Z", 18, "active answer"), "utf-8"),
+      fs.writeFile(backupFile, entry("2026-02-12T11:30:00.000Z", 999, "backup answer"), "utf-8"),
+      fs.writeFile(
+        checkpointFile,
+        entry("2026-02-12T12:00:00.000Z", 500, "checkpoint answer"),
+        "utf-8",
+      ),
+    ]);
+
+    await withStateDir(root, async () => {
+      const timeseries = await loadSessionUsageTimeSeries({ sessionId: "sess-series" });
+      const logs = await loadSessionLogs({ sessionId: "sess-series" });
+
+      // Only the active + reset transcripts contribute; .bak and checkpoint are ignored.
+      expect(timeseries?.points.map((point) => point.totalTokens)).toEqual([12, 18]);
+      expect(timeseries?.points.map((point) => point.cumulativeTokens)).toEqual([12, 30]);
+      expect(logs?.map((log) => log.content)).toEqual(["archived answer", "active answer"]);
     });
   });
 

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1497,6 +1497,55 @@ describe("session cost usage", () => {
     });
   });
 
+  it("falls back to the current session id when cached lineage metadata is stale", async () => {
+    const root = await makeSessionCostRoot("cost-cache-stale-session-file-lineage");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const staleFile = path.join(sessionsDir, "old-session-id.jsonl");
+    const currentFile = path.join(sessionsDir, "current-session-id.jsonl");
+    const currentArchive = path.join(
+      sessionsDir,
+      "current-session-id.jsonl.reset.2026-02-05T12-30-00.000Z",
+    );
+    const assistantMessage = (tokens: number, cost: number, timestamp: string) =>
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          usage: { input: tokens, output: 0, totalTokens: tokens, cost: { total: cost } },
+        },
+      });
+
+    await Promise.all([
+      fs.writeFile(
+        currentArchive,
+        assistantMessage(12, 0.012, "2026-02-05T12:00:00.000Z"),
+        "utf-8",
+      ),
+      fs.writeFile(currentFile, assistantMessage(18, 0.018, "2026-02-05T13:00:00.000Z"), "utf-8"),
+    ]);
+
+    await withStateDir(root, async () => {
+      await refreshCostUsageCache({ sessionFiles: [currentArchive, currentFile] });
+      const single = await loadSessionCostSummaryFromCache({
+        sessionId: "current-session-id",
+        sessionFile: staleFile,
+        requestRefresh: false,
+      });
+      const batch = await loadSessionCostSummariesFromCache({
+        sessions: [{ sessionId: "current-session-id", sessionFile: staleFile }],
+        agentId: "main",
+        requestRefresh: false,
+      });
+
+      expect(single.summary?.sessionFile).toBe(currentFile);
+      expect(single.summary?.totalTokens).toBe(30);
+      expect(batch.summaries[0]?.sessionFile).toBe(currentFile);
+      expect(batch.summaries[0]?.totalTokens).toBe(30);
+    });
+  });
+
   it("shares one in-flight directory listing for hidden batch lineage readers", async () => {
     const root = await makeSessionCostRoot("cost-cache-batch-lineage-dir-cache");
     const sessionsDir = path.join(root, "agents", "main", "sessions");
@@ -2553,6 +2602,63 @@ describe("session cost usage", () => {
       expect(summary?.totalTokens).toBe(30);
       expect(timeseries?.points.map((point) => point.totalTokens)).toEqual([12, 18]);
       expect(logs?.map((log) => log.content)).toEqual(["topic archive", "topic active"]);
+    });
+  });
+
+  it("falls back to the current session id when per-session detail metadata is stale", async () => {
+    const root = await makeSessionCostRoot("session-stale-session-file-lineage");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const staleFile = path.join(sessionsDir, "old-session-id.jsonl");
+    const currentFile = path.join(sessionsDir, "current-session-id.jsonl");
+    const currentArchive = path.join(
+      sessionsDir,
+      "current-session-id.jsonl.reset.2026-02-12T10-30-00.000Z",
+    );
+    const entry = (timestamp: string, totalTokens: number, content: string): string =>
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          content,
+          usage: {
+            input: totalTokens,
+            output: 0,
+            totalTokens,
+            cost: { total: totalTokens / 1000 },
+          },
+        },
+      });
+
+    await Promise.all([
+      fs.writeFile(
+        currentArchive,
+        entry("2026-02-12T10:00:00.000Z", 12, "current archive"),
+        "utf-8",
+      ),
+      fs.writeFile(currentFile, entry("2026-02-12T11:00:00.000Z", 18, "current active"), "utf-8"),
+    ]);
+
+    await withStateDir(root, async () => {
+      const summary = await loadSessionCostSummary({
+        sessionId: "current-session-id",
+        sessionFile: staleFile,
+      });
+      const timeseries = await loadSessionUsageTimeSeries({
+        sessionId: "current-session-id",
+        sessionFile: staleFile,
+      });
+      const logs = await loadSessionLogs({
+        sessionId: "current-session-id",
+        sessionFile: staleFile,
+      });
+
+      expect(summary?.sessionFile).toBe(currentFile);
+      expect(summary?.totalTokens).toBe(30);
+      expect(timeseries?.points.map((point) => point.totalTokens)).toEqual([12, 18]);
+      expect(logs?.map((log) => log.content)).toEqual(["current archive", "current active"]);
     });
   });
 

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -2058,18 +2058,18 @@ export async function loadSessionCostSummariesFromCache(params: {
   // reset/deleted spend, not just the active file (#46252). Every hidden session
   // for one agent shares a transcripts dir, so list each dir once and index by
   // name rather than running a per-session readdir on this hot aggregate path.
-  const dirNamesCache = new Map<string, string[]>();
+  const dirNamesCache = new Map<string, Promise<string[]>>();
   const readSessionsDirNames = async (sessionsDir: string): Promise<string[]> => {
     const cached = dirNamesCache.get(sessionsDir);
     if (cached) {
       return cached;
     }
-    const names = await fs.promises
+    const namesPromise = fs.promises
       .readdir(sessionsDir, { withFileTypes: true })
       .then((entries) => entries.filter((entry) => entry.isFile()).map((entry) => entry.name))
       .catch(() => [] as string[]);
-    dirNamesCache.set(sessionsDir, names);
-    return names;
+    dirNamesCache.set(sessionsDir, namesPromise);
+    return namesPromise;
   };
   const lineages = await Promise.all(
     params.sessions.map(async (session) => {

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -875,6 +875,30 @@ function buildSessionCostSummaryFromCacheEntry(params: {
   };
 }
 
+function buildSessionCostSummaryFromCacheEntries(params: {
+  entries: UsageCostCacheFileEntry[];
+  sessionId?: string;
+  sessionFile: string;
+  startMs: number;
+  endMs: number;
+}): SessionCostSummary | null {
+  const firstEntry = params.entries[0];
+  if (!firstEntry || params.entries.some((entry) => !entry.transcriptEntries)) {
+    return null;
+  }
+
+  return buildSessionCostSummaryFromCacheEntry({
+    entry: {
+      ...firstEntry,
+      transcriptEntries: params.entries.flatMap((entry) => entry.transcriptEntries ?? []),
+    },
+    sessionId: params.sessionId,
+    sessionFile: params.sessionFile,
+    startMs: params.startMs,
+    endMs: params.endMs,
+  });
+}
+
 const extractCostBreakdown = (usageRaw?: UsageLike | null): CostBreakdown | undefined => {
   if (!usageRaw || typeof usageRaw !== "object") {
     return undefined;
@@ -1242,6 +1266,61 @@ async function scanUsageFile(params: {
   });
 }
 
+type UsageSessionLineageFiles = {
+  sessionFile?: string;
+  files: string[];
+};
+
+function getSessionArchiveTimestamp(fileName: string): number {
+  return (
+    parseSessionArchiveTimestamp(fileName, "deleted") ??
+    parseSessionArchiveTimestamp(fileName, "reset") ??
+    0
+  );
+}
+
+function sortSessionArchiveNamesAscending(a: string, b: string): number {
+  return getSessionArchiveTimestamp(a) - getSessionArchiveTimestamp(b) || a.localeCompare(b);
+}
+
+function sortSessionArchiveNamesDescending(a: string, b: string): number {
+  return getSessionArchiveTimestamp(b) - getSessionArchiveTimestamp(a) || b.localeCompare(a);
+}
+
+function isUsageSessionLineageFileName(fileName: string, sessionId: string): boolean {
+  return (
+    isUsageCountedSessionTranscriptFileName(fileName) &&
+    parseUsageCountedSessionIdFromFileName(fileName) === sessionId
+  );
+}
+
+async function listUsageSessionLineageFileNames(
+  sessionsDir: string,
+  sessionId: string,
+): Promise<string[]> {
+  const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && isUsageSessionLineageFileName(entry.name, sessionId))
+    .map((entry) => entry.name);
+}
+
+function selectUsageSessionFileFromLineageNames(params: {
+  sessionsDir: string;
+  entries: string[];
+  candidate?: string;
+}): string | undefined {
+  const primary = params.entries.find((entry) => isPrimarySessionTranscriptFileName(entry));
+  if (primary) {
+    return path.join(params.sessionsDir, primary);
+  }
+
+  const latestArchive = params.entries
+    .filter((entry) => isSessionArchiveArtifactName(entry))
+    .toSorted(sortSessionArchiveNamesDescending)[0];
+
+  return latestArchive ? path.join(params.sessionsDir, latestArchive) : params.candidate;
+}
+
 export function resolveExistingUsageSessionFile(params: {
   sessionId?: string;
   sessionEntry?: SessionEntry;
@@ -1269,40 +1348,104 @@ export function resolveExistingUsageSessionFile(params: {
     const sessionsDir = candidate
       ? path.dirname(candidate)
       : resolveSessionTranscriptsDirForAgent(params.agentId);
-    const baseFileName = `${sessionId}.jsonl`;
-    const entries = fs.readdirSync(sessionsDir, { withFileTypes: true }).filter((entry) => {
-      return (
-        entry.isFile() &&
-        (entry.name === baseFileName ||
-          entry.name.startsWith(`${baseFileName}.reset.`) ||
-          entry.name.startsWith(`${baseFileName}.deleted.`))
-      );
-    });
+    const entries = fs
+      .readdirSync(sessionsDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && isUsageSessionLineageFileName(entry.name, sessionId))
+      .map((entry) => entry.name);
 
-    const primary = entries.find((entry) => entry.name === baseFileName);
-    if (primary) {
-      return path.join(sessionsDir, primary.name);
-    }
-
-    const latestArchive = entries
-      .filter((entry) => isSessionArchiveArtifactName(entry.name))
-      .map((entry) => entry.name)
-      .toSorted((a, b) => {
-        const tsA =
-          parseSessionArchiveTimestamp(a, "deleted") ??
-          parseSessionArchiveTimestamp(a, "reset") ??
-          0;
-        const tsB =
-          parseSessionArchiveTimestamp(b, "deleted") ??
-          parseSessionArchiveTimestamp(b, "reset") ??
-          0;
-        return tsB - tsA || b.localeCompare(a);
-      })[0];
-
-    return latestArchive ? path.join(sessionsDir, latestArchive) : candidate;
+    return selectUsageSessionFileFromLineageNames({ sessionsDir, entries, candidate });
   } catch {
     return candidate;
   }
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    return (await fs.promises.stat(filePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function resolveExistingUsageSessionFileForLineage(params: {
+  sessionId?: string;
+  sessionEntry?: SessionEntry;
+  sessionFile?: string;
+  agentId?: string;
+}): Promise<string | undefined> {
+  const candidate =
+    params.sessionFile ??
+    (params.sessionId
+      ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
+          agentId: params.agentId,
+        })
+      : undefined);
+
+  if (candidate && (await fileExists(candidate))) {
+    return candidate;
+  }
+
+  const sessionId = params.sessionId?.trim();
+  if (!sessionId) {
+    return candidate;
+  }
+
+  try {
+    const sessionsDir = candidate
+      ? path.dirname(candidate)
+      : resolveSessionTranscriptsDirForAgent(params.agentId);
+    const entries = await listUsageSessionLineageFileNames(sessionsDir, sessionId);
+    return selectUsageSessionFileFromLineageNames({ sessionsDir, entries, candidate });
+  } catch {
+    return candidate;
+  }
+}
+
+async function resolveUsageSessionLineageFiles(params: {
+  sessionId?: string;
+  sessionEntry?: SessionEntry;
+  sessionFile?: string;
+  agentId?: string;
+}): Promise<UsageSessionLineageFiles> {
+  const sessionFile = await resolveExistingUsageSessionFileForLineage(params);
+  if (!sessionFile || !(await fileExists(sessionFile))) {
+    return { sessionFile, files: [] };
+  }
+
+  const sessionId =
+    params.sessionId?.trim() || parseUsageCountedSessionIdFromFileName(path.basename(sessionFile));
+  if (!sessionId) {
+    return { sessionFile, files: [sessionFile] };
+  }
+
+  try {
+    const sessionsDir = path.dirname(sessionFile);
+    const entries = await listUsageSessionLineageFileNames(sessionsDir, sessionId);
+    const primary = entries.find((entry) => isPrimarySessionTranscriptFileName(entry));
+    const archives = entries
+      .filter((entry) => isSessionArchiveArtifactName(entry))
+      .toSorted(sortSessionArchiveNamesAscending);
+
+    if (primary) {
+      return {
+        sessionFile: path.join(sessionsDir, primary),
+        files: [...archives, primary].map((entry) => path.join(sessionsDir, entry)),
+      };
+    }
+
+    const latestArchive = archives.toSorted(sortSessionArchiveNamesDescending)[0];
+    if (latestArchive) {
+      // No active transcript: same-stem reset/deleted archives are alternative
+      // snapshots of one logical session, so the newest is authoritative. Summing
+      // them would double-count overlapping content (see the reset+deleted test).
+      const archiveFile = path.join(sessionsDir, latestArchive);
+      return { sessionFile: archiveFile, files: [archiveFile] };
+    }
+  } catch {
+    // Fall back to the single resolved file below.
+  }
+
+  return { sessionFile, files: [sessionFile] };
 }
 
 export async function loadCostUsageSummary(params?: {
@@ -1709,52 +1852,69 @@ export async function loadSessionCostSummaryFromCache(params: {
 }): Promise<{ summary: SessionCostSummary | null; cacheStatus: UsageCacheStatus }> {
   const cachePath = resolveUsageCostCachePath(params.agentId);
   const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
-  let [cache, stats] = await Promise.all([
-    readUsageCostCache(cachePath),
-    fs.promises.stat(params.sessionFile).catch(() => null),
-  ]);
-  let file = stats
-    ? { filePath: params.sessionFile, size: stats.size, mtimeMs: stats.mtimeMs }
-    : undefined;
-  let entry = cache.files[params.sessionFile];
-  let stale =
-    !file ||
-    !isUsageCostCacheEntryFresh({
-      entry,
-      file,
-      pricingFingerprint,
-      requireSessionSummary: true,
-    });
+  const lineage = await resolveUsageSessionLineageFiles(params);
+  const sessionFile = lineage.sessionFile ?? params.sessionFile;
+  const sessionFiles = lineage.files.length > 0 ? lineage.files : [params.sessionFile];
+  const readCacheState = async (): Promise<{
+    cache: UsageCostCacheFile;
+    entries: UsageCostCacheFileEntry[];
+    cachedFiles: number;
+    staleFiles: number;
+  }> => {
+    const [cache, stats] = await Promise.all([
+      readUsageCostCache(cachePath),
+      Promise.all(
+        sessionFiles.map(async (filePath) => {
+          const stat = await fs.promises.stat(filePath).catch(() => null);
+          return stat ? { filePath, size: stat.size, mtimeMs: stat.mtimeMs } : null;
+        }),
+      ),
+    ]);
+    const filesByPath = new Map(
+      stats
+        .filter((file): file is UsageCostTranscriptFile => Boolean(file))
+        .map((file) => [file.filePath, file]),
+    );
+    const entries: UsageCostCacheFileEntry[] = [];
+    let staleFiles = 0;
+    for (const filePath of sessionFiles) {
+      const file = filesByPath.get(filePath);
+      const entry = cache.files[filePath];
+      const fresh = file
+        ? isUsageCostCacheEntryFresh({
+            entry,
+            file,
+            pricingFingerprint,
+            requireSessionSummary: true,
+          })
+        : false;
+      if (fresh && entry && (sessionFiles.length === 1 || entry.transcriptEntries)) {
+        entries.push(entry);
+      } else {
+        staleFiles += 1;
+      }
+    }
+    return { cache, entries, cachedFiles: entries.length, staleFiles };
+  };
+
+  let cacheState = await readCacheState();
+  let stale = cacheState.staleFiles > 0;
   let refreshRequested = false;
   if (params.requestRefresh !== false && stale) {
     if (params.refreshMode === "sync-when-empty") {
       const result = await refreshCostUsageCache({
         config: params.config,
         agentId: params.agentId,
-        sessionFiles: [params.sessionFile],
+        sessionFiles,
       });
       if (result === "refreshed") {
-        [cache, stats] = await Promise.all([
-          readUsageCostCache(cachePath),
-          fs.promises.stat(params.sessionFile).catch(() => null),
-        ]);
-        file = stats
-          ? { filePath: params.sessionFile, size: stats.size, mtimeMs: stats.mtimeMs }
-          : undefined;
-        entry = cache.files[params.sessionFile];
-        stale =
-          !file ||
-          !isUsageCostCacheEntryFresh({
-            entry,
-            file,
-            pricingFingerprint,
-            requireSessionSummary: true,
-          });
+        cacheState = await readCacheState();
+        stale = cacheState.staleFiles > 0;
       } else {
         requestCostUsageCacheRefresh({
           config: params.config,
           agentId: params.agentId,
-          sessionFiles: [params.sessionFile],
+          sessionFiles,
         });
         refreshRequested = true;
       }
@@ -1762,50 +1922,58 @@ export async function loadSessionCostSummaryFromCache(params: {
       requestCostUsageCacheRefresh({
         config: params.config,
         agentId: params.agentId,
-        sessionFiles: [params.sessionFile],
+        sessionFiles,
       });
       refreshRequested = true;
     }
   }
   const refreshRunning =
     usageCostRefreshes.has(cachePath) || (await isUsageCostCacheRefreshRunning(cachePath));
-  let summary = stale ? null : (entry?.sessionSummary ?? null);
+  const startMs = params.startMs ?? Number.NEGATIVE_INFINITY;
+  const endMs = params.endMs ?? Number.POSITIVE_INFINITY;
+  let summary: SessionCostSummary | null = null;
+  if (!stale) {
+    const singleEntry = cacheState.entries.length === 1 ? cacheState.entries[0] : undefined;
+    summary = singleEntry?.sessionSummary ?? null;
+    if (
+      cacheState.entries.length > 1 ||
+      !summary ||
+      (params.startMs !== undefined &&
+        params.endMs !== undefined &&
+        !isSessionSummaryContainedInRange(summary, params.startMs, params.endMs))
+    ) {
+      summary = buildSessionCostSummaryFromCacheEntries({
+        entries: cacheState.entries,
+        sessionId: params.sessionId,
+        sessionFile,
+        startMs,
+        endMs,
+      });
+    }
+  } else if (cacheState.entries.length > 0) {
+    // Some lineage files are stale (e.g. a just-created reset archive not yet
+    // cached) while others are fresh. Build a partial summary from the cached
+    // entries so a freshly reset session shows its known spend instead of
+    // blanking until the background refresh lands; cacheStatus reports
+    // "partial"/"refreshing" so callers know more is still coming.
+    summary = buildSessionCostSummaryFromCacheEntries({
+      entries: cacheState.entries,
+      sessionId: params.sessionId,
+      sessionFile,
+      startMs,
+      endMs,
+    });
+  }
   if (!summary && params.refreshMode === "sync-when-empty") {
     summary = await loadSessionCostSummary({
       sessionId: params.sessionId,
       sessionEntry: params.sessionEntry,
-      sessionFile: params.sessionFile,
+      sessionFile,
       config: params.config,
       agentId: params.agentId,
       startMs: params.startMs,
       endMs: params.endMs,
     });
-  }
-  if (
-    summary &&
-    params.startMs !== undefined &&
-    params.endMs !== undefined &&
-    !isSessionSummaryContainedInRange(summary, params.startMs, params.endMs)
-  ) {
-    summary = entry
-      ? buildSessionCostSummaryFromCacheEntry({
-          entry,
-          sessionId: params.sessionId,
-          sessionFile: params.sessionFile,
-          startMs: params.startMs,
-          endMs: params.endMs,
-        })
-      : params.refreshMode === "sync-when-empty"
-        ? await loadSessionCostSummary({
-            sessionId: params.sessionId,
-            sessionEntry: params.sessionEntry,
-            sessionFile: params.sessionFile,
-            config: params.config,
-            agentId: params.agentId,
-            startMs: params.startMs,
-            endMs: params.endMs,
-          })
-        : null;
   }
   return {
     summary,
@@ -1817,10 +1985,10 @@ export async function loadSessionCostSummaryFromCache(params: {
             ? "partial"
             : "stale"
         : "fresh",
-      cachedFiles: stale ? 0 : 1,
-      pendingFiles: stale ? 1 : 0,
-      staleFiles: stale ? 1 : 0,
-      refreshedAt: cache.updatedAt || undefined,
+      cachedFiles: cacheState.cachedFiles,
+      pendingFiles: stale ? cacheState.staleFiles : 0,
+      staleFiles: stale ? cacheState.staleFiles : 0,
+      refreshedAt: cacheState.cache.updatedAt || undefined,
     },
   };
 }
@@ -2127,8 +2295,9 @@ export async function loadSessionCostSummary(params: {
   startMs?: number;
   endMs?: number;
 }): Promise<SessionCostSummary | null> {
-  const sessionFile = resolveExistingUsageSessionFile(params);
-  if (!sessionFile || !fs.existsSync(sessionFile)) {
+  const lineage = await resolveUsageSessionLineageFiles(params);
+  const sessionFile = lineage.sessionFile;
+  if (!sessionFile || lineage.files.length === 0) {
     return null;
   }
 
@@ -2154,204 +2323,206 @@ export async function loadSessionCostSummary(params: {
   const modelUsageMap = new Map<string, SessionModelUsage>();
   const errorStopReasons = new Set(["error", "aborted", "timeout"]);
   const latencyValues: number[] = [];
+  // lastUserTimestamp intentionally persists across lineage files: a user turn at
+  // the tail of an archive can pair with the first assistant reply in the active
+  // transcript. The MAX_LATENCY_MS cap below discards those cross-file gaps, so
+  // latency stats stay sane and cost/token totals are unaffected.
   let lastUserTimestamp: number | undefined;
   const MAX_LATENCY_MS = 12 * 60 * 60 * 1000;
   const resolveCost = createUsageCostResolver(params.config);
 
-  await scanTranscriptFile({
-    filePath: sessionFile,
-    config: params.config,
-    resolveCost,
-    onEntry: (entry) => {
-      const ts = entry.timestamp?.getTime();
+  const onEntry = (entry: ParsedTranscriptEntry): void => {
+    const ts = entry.timestamp?.getTime();
 
-      // Filter by date range if specified
-      if (params.startMs !== undefined && ts !== undefined && ts < params.startMs) {
-        return;
-      }
-      if (params.endMs !== undefined && ts !== undefined && ts > params.endMs) {
-        return;
-      }
+    // Filter by date range if specified
+    if (params.startMs !== undefined && ts !== undefined && ts < params.startMs) {
+      return;
+    }
+    if (params.endMs !== undefined && ts !== undefined && ts > params.endMs) {
+      return;
+    }
 
-      if (ts !== undefined) {
-        if (!firstActivity || ts < firstActivity) {
-          firstActivity = ts;
-        }
-        if (!lastActivity || ts > lastActivity) {
-          lastActivity = ts;
-        }
+    if (ts !== undefined) {
+      if (!firstActivity || ts < firstActivity) {
+        firstActivity = ts;
       }
+      if (!lastActivity || ts > lastActivity) {
+        lastActivity = ts;
+      }
+    }
 
-      if (entry.role === "user") {
-        messageCounts.user += 1;
-        messageCounts.total += 1;
-        if (entry.timestamp) {
-          lastUserTimestamp = entry.timestamp.getTime();
-        }
-      }
-      if (entry.role === "assistant") {
-        messageCounts.assistant += 1;
-        messageCounts.total += 1;
-        const tsLocal = entry.timestamp?.getTime();
-        if (tsLocal !== undefined) {
-          const latencyMs =
-            entry.durationMs ??
-            (lastUserTimestamp !== undefined
-              ? Math.max(0, tsLocal - lastUserTimestamp)
-              : undefined);
-          if (
-            latencyMs !== undefined &&
-            Number.isFinite(latencyMs) &&
-            latencyMs <= MAX_LATENCY_MS
-          ) {
-            latencyValues.push(latencyMs);
-            const dayKey = formatDayKey(entry.timestamp ?? new Date(tsLocal));
-            const dailyLatencies = dailyLatencyMap.get(dayKey) ?? [];
-            dailyLatencies.push(latencyMs);
-            dailyLatencyMap.set(dayKey, dailyLatencies);
-          }
-        }
-      }
-
-      if (entry.toolNames.length > 0) {
-        messageCounts.toolCalls += entry.toolNames.length;
-        for (const name of entry.toolNames) {
-          toolUsageMap.set(name, (toolUsageMap.get(name) ?? 0) + 1);
-        }
-      }
-
-      if (entry.toolResultCounts.total > 0) {
-        messageCounts.toolResults += entry.toolResultCounts.total;
-        messageCounts.errors += entry.toolResultCounts.errors;
-      }
-
-      if (entry.stopReason && errorStopReasons.has(entry.stopReason)) {
-        messageCounts.errors += 1;
-      }
-
+    if (entry.role === "user") {
+      messageCounts.user += 1;
+      messageCounts.total += 1;
       if (entry.timestamp) {
-        const dayKey = formatDayKey(entry.timestamp);
-        activityDatesSet.add(dayKey);
-        const daily = dailyMessageMap.get(dayKey) ?? {
-          date: dayKey,
-          total: 0,
-          user: 0,
-          assistant: 0,
-          toolCalls: 0,
-          toolResults: 0,
-          errors: 0,
-        };
-        accumulateMessageCounts(daily, entry, errorStopReasons);
-        dailyMessageMap.set(dayKey, daily);
-
-        // Per-quarter-hour message counts for precise hourly stats (UTC-based)
-        const quarterBucket = getUtcQuarterHourBucketKey(entry.timestamp);
-        const utcQuarterHour = utcQuarterHourMessageMap.get(quarterBucket.key) ?? {
-          date: quarterBucket.date,
-          quarterIndex: quarterBucket.quarterIndex,
-          total: 0,
-          user: 0,
-          assistant: 0,
-          toolCalls: 0,
-          toolResults: 0,
-          errors: 0,
-        };
-        accumulateMessageCounts(utcQuarterHour, entry, errorStopReasons);
-        utcQuarterHourMessageMap.set(quarterBucket.key, utcQuarterHour);
+        lastUserTimestamp = entry.timestamp.getTime();
       }
-
-      if (!entry.usage) {
-        return;
-      }
-
-      applyUsageTotals(totals, entry.usage);
-      if (entry.costBreakdown?.total !== undefined) {
-        applyCostBreakdown(totals, entry.costBreakdown);
-      } else {
-        applyCostTotal(totals, entry.costTotal);
-      }
-
-      if (entry.timestamp) {
-        const dayKey = formatDayKey(entry.timestamp);
-        const entryTokenTotals = computeUsageTokenTotals(entry.usage);
-        // Preserve the legacy dailyBreakdown token basis until daily metrics are
-        // refactored separately. The precise quarter-hour bucket below uses
-        // entryTokenTotals.totalTokens so Usage Mosaic matches session totals.
-        const entryTokens = entryTokenTotals.componentTotal;
-        const entryCost =
-          entry.costBreakdown?.total ??
-          (entry.costBreakdown
-            ? (entry.costBreakdown.input ?? 0) +
-              (entry.costBreakdown.output ?? 0) +
-              (entry.costBreakdown.cacheRead ?? 0) +
-              (entry.costBreakdown.cacheWrite ?? 0)
-            : (entry.costTotal ?? 0));
-
-        const quarterBucket = getUtcQuarterHourBucketKey(entry.timestamp);
-        const utcQuarterHourToken = utcQuarterHourTokenMap.get(quarterBucket.key) ?? {
-          date: quarterBucket.date,
-          quarterIndex: quarterBucket.quarterIndex,
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          totalCost: 0,
-        };
-        utcQuarterHourToken.input += entryTokenTotals.input;
-        utcQuarterHourToken.output += entryTokenTotals.output;
-        utcQuarterHourToken.cacheRead += entryTokenTotals.cacheRead;
-        utcQuarterHourToken.cacheWrite += entryTokenTotals.cacheWrite;
-        utcQuarterHourToken.totalTokens += entryTokenTotals.totalTokens;
-        utcQuarterHourToken.totalCost += entryCost;
-        utcQuarterHourTokenMap.set(quarterBucket.key, utcQuarterHourToken);
-
-        const existing = dailyMap.get(dayKey) ?? { tokens: 0, cost: 0 };
-        dailyMap.set(dayKey, {
-          tokens: existing.tokens + entryTokens,
-          cost: existing.cost + entryCost,
-        });
-
-        if (entry.provider || entry.model) {
-          const modelKey = `${dayKey}::${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
-          const dailyModel =
-            dailyModelUsageMap.get(modelKey) ??
-            ({
-              date: dayKey,
-              provider: entry.provider,
-              model: entry.model,
-              tokens: 0,
-              cost: 0,
-              count: 0,
-            } as SessionDailyModelUsage);
-          dailyModel.tokens += entryTokens;
-          dailyModel.cost += entryCost;
-          dailyModel.count += 1;
-          dailyModelUsageMap.set(modelKey, dailyModel);
+    }
+    if (entry.role === "assistant") {
+      messageCounts.assistant += 1;
+      messageCounts.total += 1;
+      const tsLocal = entry.timestamp?.getTime();
+      if (tsLocal !== undefined) {
+        const latencyMs =
+          entry.durationMs ??
+          (lastUserTimestamp !== undefined ? Math.max(0, tsLocal - lastUserTimestamp) : undefined);
+        if (latencyMs !== undefined && Number.isFinite(latencyMs) && latencyMs <= MAX_LATENCY_MS) {
+          latencyValues.push(latencyMs);
+          const dayKey = formatDayKey(entry.timestamp ?? new Date(tsLocal));
+          const dailyLatencies = dailyLatencyMap.get(dayKey) ?? [];
+          dailyLatencies.push(latencyMs);
+          dailyLatencyMap.set(dayKey, dailyLatencies);
         }
       }
+    }
+
+    if (entry.toolNames.length > 0) {
+      messageCounts.toolCalls += entry.toolNames.length;
+      for (const name of entry.toolNames) {
+        toolUsageMap.set(name, (toolUsageMap.get(name) ?? 0) + 1);
+      }
+    }
+
+    if (entry.toolResultCounts.total > 0) {
+      messageCounts.toolResults += entry.toolResultCounts.total;
+      messageCounts.errors += entry.toolResultCounts.errors;
+    }
+
+    if (entry.stopReason && errorStopReasons.has(entry.stopReason)) {
+      messageCounts.errors += 1;
+    }
+
+    if (entry.timestamp) {
+      const dayKey = formatDayKey(entry.timestamp);
+      activityDatesSet.add(dayKey);
+      const daily = dailyMessageMap.get(dayKey) ?? {
+        date: dayKey,
+        total: 0,
+        user: 0,
+        assistant: 0,
+        toolCalls: 0,
+        toolResults: 0,
+        errors: 0,
+      };
+      accumulateMessageCounts(daily, entry, errorStopReasons);
+      dailyMessageMap.set(dayKey, daily);
+
+      // Per-quarter-hour message counts for precise hourly stats (UTC-based)
+      const quarterBucket = getUtcQuarterHourBucketKey(entry.timestamp);
+      const utcQuarterHour = utcQuarterHourMessageMap.get(quarterBucket.key) ?? {
+        date: quarterBucket.date,
+        quarterIndex: quarterBucket.quarterIndex,
+        total: 0,
+        user: 0,
+        assistant: 0,
+        toolCalls: 0,
+        toolResults: 0,
+        errors: 0,
+      };
+      accumulateMessageCounts(utcQuarterHour, entry, errorStopReasons);
+      utcQuarterHourMessageMap.set(quarterBucket.key, utcQuarterHour);
+    }
+
+    if (!entry.usage) {
+      return;
+    }
+
+    applyUsageTotals(totals, entry.usage);
+    if (entry.costBreakdown?.total !== undefined) {
+      applyCostBreakdown(totals, entry.costBreakdown);
+    } else {
+      applyCostTotal(totals, entry.costTotal);
+    }
+
+    if (entry.timestamp) {
+      const dayKey = formatDayKey(entry.timestamp);
+      const entryTokenTotals = computeUsageTokenTotals(entry.usage);
+      // Preserve the legacy dailyBreakdown token basis until daily metrics are
+      // refactored separately. The precise quarter-hour bucket below uses
+      // entryTokenTotals.totalTokens so Usage Mosaic matches session totals.
+      const entryTokens = entryTokenTotals.componentTotal;
+      const entryCost =
+        entry.costBreakdown?.total ??
+        (entry.costBreakdown
+          ? (entry.costBreakdown.input ?? 0) +
+            (entry.costBreakdown.output ?? 0) +
+            (entry.costBreakdown.cacheRead ?? 0) +
+            (entry.costBreakdown.cacheWrite ?? 0)
+          : (entry.costTotal ?? 0));
+
+      const quarterBucket = getUtcQuarterHourBucketKey(entry.timestamp);
+      const utcQuarterHourToken = utcQuarterHourTokenMap.get(quarterBucket.key) ?? {
+        date: quarterBucket.date,
+        quarterIndex: quarterBucket.quarterIndex,
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        totalCost: 0,
+      };
+      utcQuarterHourToken.input += entryTokenTotals.input;
+      utcQuarterHourToken.output += entryTokenTotals.output;
+      utcQuarterHourToken.cacheRead += entryTokenTotals.cacheRead;
+      utcQuarterHourToken.cacheWrite += entryTokenTotals.cacheWrite;
+      utcQuarterHourToken.totalTokens += entryTokenTotals.totalTokens;
+      utcQuarterHourToken.totalCost += entryCost;
+      utcQuarterHourTokenMap.set(quarterBucket.key, utcQuarterHourToken);
+
+      const existing = dailyMap.get(dayKey) ?? { tokens: 0, cost: 0 };
+      dailyMap.set(dayKey, {
+        tokens: existing.tokens + entryTokens,
+        cost: existing.cost + entryCost,
+      });
 
       if (entry.provider || entry.model) {
-        const key = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
-        const existing =
-          modelUsageMap.get(key) ??
+        const modelKey = `${dayKey}::${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+        const dailyModel =
+          dailyModelUsageMap.get(modelKey) ??
           ({
+            date: dayKey,
             provider: entry.provider,
             model: entry.model,
+            tokens: 0,
+            cost: 0,
             count: 0,
-            totals: emptyTotals(),
-          } as SessionModelUsage);
-        existing.count += 1;
-        applyUsageTotals(existing.totals, entry.usage);
-        if (entry.costBreakdown?.total !== undefined) {
-          applyCostBreakdown(existing.totals, entry.costBreakdown);
-        } else {
-          applyCostTotal(existing.totals, entry.costTotal);
-        }
-        modelUsageMap.set(key, existing);
+          } as SessionDailyModelUsage);
+        dailyModel.tokens += entryTokens;
+        dailyModel.cost += entryCost;
+        dailyModel.count += 1;
+        dailyModelUsageMap.set(modelKey, dailyModel);
       }
-    },
-  });
+    }
+
+    if (entry.provider || entry.model) {
+      const key = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+      const existing =
+        modelUsageMap.get(key) ??
+        ({
+          provider: entry.provider,
+          model: entry.model,
+          count: 0,
+          totals: emptyTotals(),
+        } as SessionModelUsage);
+      existing.count += 1;
+      applyUsageTotals(existing.totals, entry.usage);
+      if (entry.costBreakdown?.total !== undefined) {
+        applyCostBreakdown(existing.totals, entry.costBreakdown);
+      } else {
+        applyCostTotal(existing.totals, entry.costTotal);
+      }
+      modelUsageMap.set(key, existing);
+    }
+  };
+
+  for (const filePath of lineage.files) {
+    await scanTranscriptFile({
+      filePath,
+      config: params.config,
+      resolveCost,
+      onEntry,
+    });
+  }
 
   // Convert daily map to sorted array
   const dailyBreakdown: SessionDailyUsage[] = Array.from(dailyMap.entries())
@@ -2441,8 +2612,8 @@ export async function loadSessionUsageTimeSeries(params: {
   agentId?: string;
   maxPoints?: number;
 }): Promise<SessionUsageTimeSeries | null> {
-  const sessionFile = resolveExistingUsageSessionFile(params);
-  if (!sessionFile || !fs.existsSync(sessionFile)) {
+  const lineage = await resolveUsageSessionLineageFiles(params);
+  if (!lineage.sessionFile || lineage.files.length === 0) {
     return null;
   }
 
@@ -2452,45 +2623,50 @@ export async function loadSessionUsageTimeSeries(params: {
     }
   }
 
-  const points: SessionUsageTimePoint[] = [];
-  let cumulativeTokens = 0;
-  let cumulativeCost = 0;
+  const points: Array<Omit<SessionUsageTimePoint, "cumulativeTokens" | "cumulativeCost">> = [];
   const resolveCost = createUsageCostResolver(params.config);
 
-  await scanUsageFile({
-    filePath: sessionFile,
-    config: params.config,
-    resolveCost,
-    onEntry: (entry) => {
-      const ts = entry.timestamp?.getTime();
-      if (!ts) {
-        return;
-      }
+  const onEntry = (entry: ParsedUsageEntry): void => {
+    const ts = entry.timestamp?.getTime();
+    if (!ts) {
+      return;
+    }
 
-      const { input, output, cacheRead, cacheWrite, totalTokens } = computeUsageTokenTotals(
-        entry.usage,
-      );
-      const cost = entry.costTotal ?? 0;
+    const { input, output, cacheRead, cacheWrite, totalTokens } = computeUsageTokenTotals(
+      entry.usage,
+    );
+    const cost = entry.costTotal ?? 0;
 
-      cumulativeTokens += totalTokens;
-      cumulativeCost += cost;
+    points.push({
+      timestamp: ts,
+      input,
+      output,
+      cacheRead,
+      cacheWrite,
+      totalTokens,
+      cost,
+    });
+  };
 
-      points.push({
-        timestamp: ts,
-        input,
-        output,
-        cacheRead,
-        cacheWrite,
-        totalTokens,
-        cost,
-        cumulativeTokens,
-        cumulativeCost,
-      });
-    },
-  });
+  for (const filePath of lineage.files) {
+    await scanUsageFile({
+      filePath,
+      config: params.config,
+      resolveCost,
+      onEntry,
+    });
+  }
 
-  // Sort by timestamp
-  const sortedPoints = points.toSorted((a, b) => a.timestamp - b.timestamp);
+  // Cumulative totals depend on chronological order across all lineage files,
+  // so sort the merged points before accumulating.
+  const sortedPoints: SessionUsageTimePoint[] = [];
+  let cumulativeTokens = 0;
+  let cumulativeCost = 0;
+  for (const point of points.toSorted((a, b) => a.timestamp - b.timestamp)) {
+    cumulativeTokens += point.totalTokens;
+    cumulativeCost += point.cost;
+    sortedPoints.push({ ...point, cumulativeTokens, cumulativeCost });
+  }
 
   // Optionally downsample if too many points
   const maxPoints = params.maxPoints ?? 100;
@@ -2550,8 +2726,8 @@ export async function loadSessionLogs(params: {
   agentId?: string;
   limit?: number;
 }): Promise<SessionLogEntry[] | null> {
-  const sessionFile = resolveExistingUsageSessionFile(params);
-  if (!sessionFile || !fs.existsSync(sessionFile)) {
+  const lineage = await resolveUsageSessionLineageFiles(params);
+  if (!lineage.sessionFile || lineage.files.length === 0) {
     return null;
   }
 
@@ -2564,137 +2740,139 @@ export async function loadSessionLogs(params: {
   const limit = params.limit ?? 50;
   const resolveCost = createUsageCostResolver(params.config);
 
-  for await (const parsed of readJsonlRecords(sessionFile)) {
-    try {
-      const message = parsed.message as Record<string, unknown> | undefined;
-      if (!message) {
-        continue;
-      }
-
-      const role = message.role as string | undefined;
-      if (role !== "user" && role !== "assistant" && role !== "tool" && role !== "toolResult") {
-        continue;
-      }
-
-      const contentParts: string[] = [];
-      const rawToolName = message.toolName ?? message.tool_name ?? message.name ?? message.tool;
-      const toolName = normalizeOptionalString(rawToolName);
-      if (role === "tool" || role === "toolResult") {
-        contentParts.push(`[Tool: ${toolName ?? "tool"}]`);
-        contentParts.push("[Tool Result]");
-      }
-
-      // Extract content
-      const rawContent = message.content;
-      if (typeof rawContent === "string") {
-        contentParts.push(rawContent);
-      } else if (Array.isArray(rawContent)) {
-        // Handle content blocks (text, tool_use, etc.)
-        const contentText = rawContent
-          .map((block: unknown) => {
-            if (typeof block === "string") {
-              return block;
-            }
-            const b = block as Record<string, unknown>;
-            if (b.type === "text" && typeof b.text === "string") {
-              return b.text;
-            }
-            if (b.type === "tool_use") {
-              const name = typeof b.name === "string" ? b.name : "unknown";
-              return `[Tool: ${name}]`;
-            }
-            if (b.type === "tool_result") {
-              return `[Tool Result]`;
-            }
-            return "";
-          })
-          .filter(Boolean)
-          .join("\n");
-        if (contentText) {
-          contentParts.push(contentText);
+  for (const filePath of lineage.files) {
+    for await (const parsed of readJsonlRecords(filePath)) {
+      try {
+        const message = parsed.message as Record<string, unknown> | undefined;
+        if (!message) {
+          continue;
         }
-      }
 
-      // OpenAI-style tool calls stored outside the content array.
-      const rawToolCalls =
-        message.tool_calls ?? message.toolCalls ?? message.function_call ?? message.functionCall;
-      const toolCalls = Array.isArray(rawToolCalls)
-        ? rawToolCalls
-        : rawToolCalls
-          ? [rawToolCalls]
-          : [];
-      if (toolCalls.length > 0) {
-        for (const call of toolCalls) {
-          const callObj = call as Record<string, unknown>;
-          const directName = typeof callObj.name === "string" ? callObj.name : undefined;
-          const fn = callObj.function as Record<string, unknown> | undefined;
-          const fnName = typeof fn?.name === "string" ? fn.name : undefined;
-          const name = directName ?? fnName ?? "unknown";
-          contentParts.push(`[Tool: ${name}]`);
+        const role = message.role as string | undefined;
+        if (role !== "user" && role !== "assistant" && role !== "tool" && role !== "toolResult") {
+          continue;
         }
-      }
 
-      let content = contentParts.join("\n").trim();
-      if (!content) {
-        continue;
-      }
-      content = stripInboundMetadata(content);
-      if (role === "user") {
-        content = stripMessageIdHints(stripEnvelope(content)).trim();
-      }
-      if (!content) {
-        continue;
-      }
+        const contentParts: string[] = [];
+        const rawToolName = message.toolName ?? message.tool_name ?? message.name ?? message.tool;
+        const toolName = normalizeOptionalString(rawToolName);
+        if (role === "tool" || role === "toolResult") {
+          contentParts.push(`[Tool: ${toolName ?? "tool"}]`);
+          contentParts.push("[Tool Result]");
+        }
 
-      // Truncate very long content
-      const maxLen = 2000;
-      if (content.length > maxLen) {
-        content = content.slice(0, maxLen) + "…";
-      }
-
-      // Get timestamp
-      let timestamp = 0;
-      if (typeof parsed.timestamp === "string") {
-        timestamp = new Date(parsed.timestamp).getTime();
-      } else if (typeof message.timestamp === "number") {
-        timestamp = message.timestamp;
-      }
-
-      // Get usage for assistant messages
-      let tokens: number | undefined;
-      let cost: number | undefined;
-      if (role === "assistant") {
-        const usageRaw = message.usage as Record<string, unknown> | undefined;
-        const usage = normalizeUsage(usageRaw);
-        if (usage) {
-          tokens =
-            usage.total ??
-            (usage.input ?? 0) +
-              (usage.output ?? 0) +
-              (usage.cacheRead ?? 0) +
-              (usage.cacheWrite ?? 0);
-          const breakdown = extractCostBreakdown(usageRaw);
-          if (breakdown?.total !== undefined) {
-            cost = breakdown.total;
-          } else {
-            const costConfig = resolveCost({
-              provider: message.provider as string | undefined,
-              model: message.model as string | undefined,
-            });
-            cost = estimateUsageCost({ usage, cost: costConfig });
+        // Extract content
+        const rawContent = message.content;
+        if (typeof rawContent === "string") {
+          contentParts.push(rawContent);
+        } else if (Array.isArray(rawContent)) {
+          // Handle content blocks (text, tool_use, etc.)
+          const contentText = rawContent
+            .map((block: unknown) => {
+              if (typeof block === "string") {
+                return block;
+              }
+              const b = block as Record<string, unknown>;
+              if (b.type === "text" && typeof b.text === "string") {
+                return b.text;
+              }
+              if (b.type === "tool_use") {
+                const name = typeof b.name === "string" ? b.name : "unknown";
+                return `[Tool: ${name}]`;
+              }
+              if (b.type === "tool_result") {
+                return `[Tool Result]`;
+              }
+              return "";
+            })
+            .filter(Boolean)
+            .join("\n");
+          if (contentText) {
+            contentParts.push(contentText);
           }
         }
-      }
 
-      logs.push({
-        timestamp,
-        role,
-        content,
-        tokens,
-        cost,
-      });
-    } catch {
-      // Ignore malformed lines
+        // OpenAI-style tool calls stored outside the content array.
+        const rawToolCalls =
+          message.tool_calls ?? message.toolCalls ?? message.function_call ?? message.functionCall;
+        const toolCalls = Array.isArray(rawToolCalls)
+          ? rawToolCalls
+          : rawToolCalls
+            ? [rawToolCalls]
+            : [];
+        if (toolCalls.length > 0) {
+          for (const call of toolCalls) {
+            const callObj = call as Record<string, unknown>;
+            const directName = typeof callObj.name === "string" ? callObj.name : undefined;
+            const fn = callObj.function as Record<string, unknown> | undefined;
+            const fnName = typeof fn?.name === "string" ? fn.name : undefined;
+            const name = directName ?? fnName ?? "unknown";
+            contentParts.push(`[Tool: ${name}]`);
+          }
+        }
+
+        let content = contentParts.join("\n").trim();
+        if (!content) {
+          continue;
+        }
+        content = stripInboundMetadata(content);
+        if (role === "user") {
+          content = stripMessageIdHints(stripEnvelope(content)).trim();
+        }
+        if (!content) {
+          continue;
+        }
+
+        // Truncate very long content
+        const maxLen = 2000;
+        if (content.length > maxLen) {
+          content = content.slice(0, maxLen) + "…";
+        }
+
+        // Get timestamp
+        let timestamp = 0;
+        if (typeof parsed.timestamp === "string") {
+          timestamp = new Date(parsed.timestamp).getTime();
+        } else if (typeof message.timestamp === "number") {
+          timestamp = message.timestamp;
+        }
+
+        // Get usage for assistant messages
+        let tokens: number | undefined;
+        let cost: number | undefined;
+        if (role === "assistant") {
+          const usageRaw = message.usage as Record<string, unknown> | undefined;
+          const usage = normalizeUsage(usageRaw);
+          if (usage) {
+            tokens =
+              usage.total ??
+              (usage.input ?? 0) +
+                (usage.output ?? 0) +
+                (usage.cacheRead ?? 0) +
+                (usage.cacheWrite ?? 0);
+            const breakdown = extractCostBreakdown(usageRaw);
+            if (breakdown?.total !== undefined) {
+              cost = breakdown.total;
+            } else {
+              const costConfig = resolveCost({
+                provider: message.provider as string | undefined,
+                model: message.model as string | undefined,
+              });
+              cost = estimateUsageCost({ usage, cost: costConfig });
+            }
+          }
+        }
+
+        logs.push({
+          timestamp,
+          role,
+          content,
+          tokens,
+          cost,
+        });
+      } catch {
+        // Ignore malformed lines
+      }
     }
   }
 

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1301,14 +1301,38 @@ function parseUsageSessionLineageIdFromPath(filePath?: string): string | undefin
   return parseUsageCountedSessionIdFromFileName(path.basename(filePath)) ?? undefined;
 }
 
-async function listUsageSessionLineageFileNames(
-  sessionsDir: string,
-  sessionId: string,
-): Promise<string[]> {
+function filterUsageSessionLineageFileNames(entryNames: string[], sessionId: string): string[] {
+  return entryNames.filter((name) => isUsageSessionLineageFileName(name, sessionId));
+}
+
+function selectUsageSessionLineageFileNames(params: {
+  entryNames: string[];
+  preferredSessionId?: string;
+  fallbackSessionId?: string;
+}): string[] {
+  const preferredSessionId = params.preferredSessionId?.trim();
+  const fallbackSessionId = params.fallbackSessionId?.trim();
+  if (preferredSessionId) {
+    const preferredEntries = filterUsageSessionLineageFileNames(
+      params.entryNames,
+      preferredSessionId,
+    );
+    if (
+      preferredEntries.length > 0 ||
+      !fallbackSessionId ||
+      fallbackSessionId === preferredSessionId
+    ) {
+      return preferredEntries;
+    }
+  }
+  return fallbackSessionId
+    ? filterUsageSessionLineageFileNames(params.entryNames, fallbackSessionId)
+    : [];
+}
+
+async function listSessionFileNames(sessionsDir: string): Promise<string[]> {
   const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
-  return entries
-    .filter((entry) => entry.isFile() && isUsageSessionLineageFileName(entry.name, sessionId))
-    .map((entry) => entry.name);
+  return entries.filter((entry) => entry.isFile()).map((entry) => entry.name);
 }
 
 function selectUsageSessionFileFromLineageNames(params: {
@@ -1346,8 +1370,9 @@ export function resolveExistingUsageSessionFile(params: {
     return candidate;
   }
 
-  const sessionId = parseUsageSessionLineageIdFromPath(candidate) ?? params.sessionId?.trim();
-  if (!sessionId) {
+  const preferredSessionId = parseUsageSessionLineageIdFromPath(candidate);
+  const fallbackSessionId = params.sessionId?.trim();
+  if (!preferredSessionId && !fallbackSessionId) {
     return candidate;
   }
 
@@ -1355,10 +1380,15 @@ export function resolveExistingUsageSessionFile(params: {
     const sessionsDir = candidate
       ? path.dirname(candidate)
       : resolveSessionTranscriptsDirForAgent(params.agentId);
-    const entries = fs
+    const entryNames = fs
       .readdirSync(sessionsDir, { withFileTypes: true })
-      .filter((entry) => entry.isFile() && isUsageSessionLineageFileName(entry.name, sessionId))
+      .filter((entry) => entry.isFile())
       .map((entry) => entry.name);
+    const entries = selectUsageSessionLineageFileNames({
+      entryNames,
+      preferredSessionId,
+      fallbackSessionId,
+    });
 
     return selectUsageSessionFileFromLineageNames({ sessionsDir, entries, candidate });
   } catch {
@@ -1392,8 +1422,9 @@ async function resolveExistingUsageSessionFileForLineage(params: {
     return candidate;
   }
 
-  const sessionId = parseUsageSessionLineageIdFromPath(candidate) ?? params.sessionId?.trim();
-  if (!sessionId) {
+  const preferredSessionId = parseUsageSessionLineageIdFromPath(candidate);
+  const fallbackSessionId = params.sessionId?.trim();
+  if (!preferredSessionId && !fallbackSessionId) {
     return candidate;
   }
 
@@ -1401,7 +1432,11 @@ async function resolveExistingUsageSessionFileForLineage(params: {
     const sessionsDir = candidate
       ? path.dirname(candidate)
       : resolveSessionTranscriptsDirForAgent(params.agentId);
-    const entries = await listUsageSessionLineageFileNames(sessionsDir, sessionId);
+    const entries = selectUsageSessionLineageFileNames({
+      entryNames: await listSessionFileNames(sessionsDir),
+      preferredSessionId,
+      fallbackSessionId,
+    });
     return selectUsageSessionFileFromLineageNames({ sessionsDir, entries, candidate });
   } catch {
     return candidate;
@@ -1445,14 +1480,19 @@ async function resolveUsageSessionLineageFiles(params: {
     return { sessionFile, files: [] };
   }
 
-  const sessionId = parseUsageSessionLineageIdFromPath(sessionFile) ?? params.sessionId?.trim();
-  if (!sessionId) {
+  const preferredSessionId = parseUsageSessionLineageIdFromPath(sessionFile);
+  const fallbackSessionId = params.sessionId?.trim();
+  if (!preferredSessionId && !fallbackSessionId) {
     return { sessionFile, files: [sessionFile] };
   }
 
   try {
     const sessionsDir = path.dirname(sessionFile);
-    const entries = await listUsageSessionLineageFileNames(sessionsDir, sessionId);
+    const entries = selectUsageSessionLineageFileNames({
+      entryNames: await listSessionFileNames(sessionsDir),
+      preferredSessionId,
+      fallbackSessionId,
+    });
     return selectUsageSessionLineageFromNames({
       sessionsDir,
       entryNames: entries,
@@ -2073,15 +2113,17 @@ export async function loadSessionCostSummariesFromCache(params: {
   };
   const lineages = await Promise.all(
     params.sessions.map(async (session) => {
-      const sessionId =
-        parseUsageSessionLineageIdFromPath(session.sessionFile) ?? session.sessionId?.trim();
-      if (!sessionId) {
+      const preferredSessionId = parseUsageSessionLineageIdFromPath(session.sessionFile);
+      const fallbackSessionId = session.sessionId?.trim();
+      if (!preferredSessionId && !fallbackSessionId) {
         return { sessionFile: session.sessionFile, files: [session.sessionFile] };
       }
       const sessionsDir = path.dirname(session.sessionFile);
-      const entryNames = (await readSessionsDirNames(sessionsDir)).filter((name) =>
-        isUsageSessionLineageFileName(name, sessionId),
-      );
+      const entryNames = selectUsageSessionLineageFileNames({
+        entryNames: await readSessionsDirNames(sessionsDir),
+        preferredSessionId,
+        fallbackSessionId,
+      });
       if (entryNames.length === 0) {
         return { sessionFile: session.sessionFile, files: [session.sessionFile] };
       }

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1294,6 +1294,13 @@ function isUsageSessionLineageFileName(fileName: string, sessionId: string): boo
   );
 }
 
+function parseUsageSessionLineageIdFromPath(filePath?: string): string | undefined {
+  if (!filePath) {
+    return undefined;
+  }
+  return parseUsageCountedSessionIdFromFileName(path.basename(filePath)) ?? undefined;
+}
+
 async function listUsageSessionLineageFileNames(
   sessionsDir: string,
   sessionId: string,
@@ -1339,7 +1346,7 @@ export function resolveExistingUsageSessionFile(params: {
     return candidate;
   }
 
-  const sessionId = params.sessionId?.trim();
+  const sessionId = parseUsageSessionLineageIdFromPath(candidate) ?? params.sessionId?.trim();
   if (!sessionId) {
     return candidate;
   }
@@ -1385,7 +1392,7 @@ async function resolveExistingUsageSessionFileForLineage(params: {
     return candidate;
   }
 
-  const sessionId = params.sessionId?.trim();
+  const sessionId = parseUsageSessionLineageIdFromPath(candidate) ?? params.sessionId?.trim();
   if (!sessionId) {
     return candidate;
   }
@@ -1438,8 +1445,7 @@ async function resolveUsageSessionLineageFiles(params: {
     return { sessionFile, files: [] };
   }
 
-  const sessionId =
-    params.sessionId?.trim() || parseUsageCountedSessionIdFromFileName(path.basename(sessionFile));
+  const sessionId = parseUsageSessionLineageIdFromPath(sessionFile) ?? params.sessionId?.trim();
   if (!sessionId) {
     return { sessionFile, files: [sessionFile] };
   }
@@ -2067,7 +2073,8 @@ export async function loadSessionCostSummariesFromCache(params: {
   };
   const lineages = await Promise.all(
     params.sessions.map(async (session) => {
-      const sessionId = session.sessionId?.trim();
+      const sessionId =
+        parseUsageSessionLineageIdFromPath(session.sessionFile) ?? session.sessionId?.trim();
       if (!sessionId) {
         return { sessionFile: session.sessionFile, files: [session.sessionFile] };
       }

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1401,6 +1401,32 @@ async function resolveExistingUsageSessionFileForLineage(params: {
   }
 }
 
+// Select the active+archive lineage for one session from a directory's already
+// listed transcript names. Pure so callers that list the directory once — the
+// per-session resolver and the batched hidden-row reader — share one selection
+// rule: prefer the active file plus same-stem archives oldest-first; with no
+// active file the newest archive is authoritative (summing same-stem archives
+// would double-count overlapping content, see the reset+deleted test).
+function selectUsageSessionLineageFromNames(params: {
+  sessionsDir: string;
+  entryNames: string[];
+  fallbackFile: string;
+}): UsageSessionLineageFiles {
+  const toPath = (name: string) => path.join(params.sessionsDir, name);
+  const primary = params.entryNames.find((entry) => isPrimarySessionTranscriptFileName(entry));
+  const archives = params.entryNames
+    .filter((entry) => isSessionArchiveArtifactName(entry))
+    .toSorted(sortSessionArchiveNamesAscending);
+  if (primary) {
+    return { sessionFile: toPath(primary), files: [...archives, primary].map(toPath) };
+  }
+  const latestArchive = archives.toSorted(sortSessionArchiveNamesDescending)[0];
+  if (latestArchive) {
+    return { sessionFile: toPath(latestArchive), files: [toPath(latestArchive)] };
+  }
+  return { sessionFile: params.fallbackFile, files: [params.fallbackFile] };
+}
+
 async function resolveUsageSessionLineageFiles(params: {
   sessionId?: string;
   sessionEntry?: SessionEntry;
@@ -1421,26 +1447,11 @@ async function resolveUsageSessionLineageFiles(params: {
   try {
     const sessionsDir = path.dirname(sessionFile);
     const entries = await listUsageSessionLineageFileNames(sessionsDir, sessionId);
-    const primary = entries.find((entry) => isPrimarySessionTranscriptFileName(entry));
-    const archives = entries
-      .filter((entry) => isSessionArchiveArtifactName(entry))
-      .toSorted(sortSessionArchiveNamesAscending);
-
-    if (primary) {
-      return {
-        sessionFile: path.join(sessionsDir, primary),
-        files: [...archives, primary].map((entry) => path.join(sessionsDir, entry)),
-      };
-    }
-
-    const latestArchive = archives.toSorted(sortSessionArchiveNamesDescending)[0];
-    if (latestArchive) {
-      // No active transcript: same-stem reset/deleted archives are alternative
-      // snapshots of one logical session, so the newest is authoritative. Summing
-      // them would double-count overlapping content (see the reset+deleted test).
-      const archiveFile = path.join(sessionsDir, latestArchive);
-      return { sessionFile: archiveFile, files: [archiveFile] };
-    }
+    return selectUsageSessionLineageFromNames({
+      sessionsDir,
+      entryNames: entries,
+      fallbackFile: sessionFile,
+    });
   } catch {
     // Fall back to the single resolved file below.
   }
@@ -1839,6 +1850,82 @@ export async function loadCostUsageSummaryFromCache(params: {
   });
 }
 
+// Combine the cached usage entries for one session's active+archive lineage into
+// a single summary. Shared by the per-session reader and the batched hidden-row
+// reader so both apply the same freshness + same-stem combination rule (#46252):
+// a single fresh file uses its stored sessionSummary; multiple lineage files are
+// summed from their transcript entries (oldest archive first); when some lineage
+// files are still uncached the summary is partial and the stale paths are
+// reported so the caller can request a refresh.
+function summarizeSessionLineageFromCache(params: {
+  cache: UsageCostCacheFile;
+  pricingFingerprint: string;
+  sessionId?: string;
+  sessionFile: string;
+  sessionFiles: string[];
+  statsByPath: Map<string, UsageCostTranscriptFile>;
+  startMs?: number;
+  endMs?: number;
+}): { summary: SessionCostSummary | null; cachedFiles: number; staleFilePaths: string[] } {
+  const entries: UsageCostCacheFileEntry[] = [];
+  const staleFilePaths: string[] = [];
+  for (const filePath of params.sessionFiles) {
+    const file = params.statsByPath.get(filePath);
+    const entry = params.cache.files[filePath];
+    const fresh = file
+      ? isUsageCostCacheEntryFresh({
+          entry,
+          file,
+          pricingFingerprint: params.pricingFingerprint,
+          requireSessionSummary: true,
+        })
+      : false;
+    // A multi-file lineage must combine raw transcriptEntries to avoid
+    // double-counting overlapping summaries, so only entries carrying them count
+    // as fresh once there is more than one file in the lineage.
+    if (fresh && entry && (params.sessionFiles.length === 1 || entry.transcriptEntries)) {
+      entries.push(entry);
+    } else {
+      staleFilePaths.push(filePath);
+    }
+  }
+  const startMs = params.startMs ?? Number.NEGATIVE_INFINITY;
+  const endMs = params.endMs ?? Number.POSITIVE_INFINITY;
+  let summary: SessionCostSummary | null = null;
+  if (staleFilePaths.length === 0) {
+    const singleEntry = entries.length === 1 ? entries[0] : undefined;
+    summary = singleEntry?.sessionSummary ?? null;
+    if (
+      entries.length > 1 ||
+      !summary ||
+      (params.startMs !== undefined &&
+        params.endMs !== undefined &&
+        !isSessionSummaryContainedInRange(summary, params.startMs, params.endMs))
+    ) {
+      summary = buildSessionCostSummaryFromCacheEntries({
+        entries,
+        sessionId: params.sessionId,
+        sessionFile: params.sessionFile,
+        startMs,
+        endMs,
+      });
+    }
+  } else if (entries.length > 0) {
+    // Some lineage files are stale (e.g. a just-created reset archive not yet
+    // cached) while others are fresh. Build a partial summary from the cached
+    // entries so a freshly reset session shows its known spend instead of
+    // blanking until the background refresh lands.
+    summary = buildSessionCostSummaryFromCacheEntries({
+      entries,
+      sessionId: params.sessionId,
+      sessionFile: params.sessionFile,
+      startMs,
+      endMs,
+    });
+  }
+  return { summary, cachedFiles: entries.length, staleFilePaths };
+}
+
 export async function loadSessionCostSummaryFromCache(params: {
   sessionId?: string;
   sessionEntry?: SessionEntry;
@@ -1857,7 +1944,7 @@ export async function loadSessionCostSummaryFromCache(params: {
   const sessionFiles = lineage.files.length > 0 ? lineage.files : [params.sessionFile];
   const readCacheState = async (): Promise<{
     cache: UsageCostCacheFile;
-    entries: UsageCostCacheFileEntry[];
+    summary: SessionCostSummary | null;
     cachedFiles: number;
     staleFiles: number;
   }> => {
@@ -1870,31 +1957,22 @@ export async function loadSessionCostSummaryFromCache(params: {
         }),
       ),
     ]);
-    const filesByPath = new Map(
+    const statsByPath = new Map(
       stats
         .filter((file): file is UsageCostTranscriptFile => Boolean(file))
         .map((file) => [file.filePath, file]),
     );
-    const entries: UsageCostCacheFileEntry[] = [];
-    let staleFiles = 0;
-    for (const filePath of sessionFiles) {
-      const file = filesByPath.get(filePath);
-      const entry = cache.files[filePath];
-      const fresh = file
-        ? isUsageCostCacheEntryFresh({
-            entry,
-            file,
-            pricingFingerprint,
-            requireSessionSummary: true,
-          })
-        : false;
-      if (fresh && entry && (sessionFiles.length === 1 || entry.transcriptEntries)) {
-        entries.push(entry);
-      } else {
-        staleFiles += 1;
-      }
-    }
-    return { cache, entries, cachedFiles: entries.length, staleFiles };
+    const { summary, cachedFiles, staleFilePaths } = summarizeSessionLineageFromCache({
+      cache,
+      pricingFingerprint,
+      sessionId: params.sessionId,
+      sessionFile,
+      sessionFiles,
+      statsByPath,
+      startMs: params.startMs,
+      endMs: params.endMs,
+    });
+    return { cache, summary, cachedFiles, staleFiles: staleFilePaths.length };
   };
 
   let cacheState = await readCacheState();
@@ -1929,41 +2007,7 @@ export async function loadSessionCostSummaryFromCache(params: {
   }
   const refreshRunning =
     usageCostRefreshes.has(cachePath) || (await isUsageCostCacheRefreshRunning(cachePath));
-  const startMs = params.startMs ?? Number.NEGATIVE_INFINITY;
-  const endMs = params.endMs ?? Number.POSITIVE_INFINITY;
-  let summary: SessionCostSummary | null = null;
-  if (!stale) {
-    const singleEntry = cacheState.entries.length === 1 ? cacheState.entries[0] : undefined;
-    summary = singleEntry?.sessionSummary ?? null;
-    if (
-      cacheState.entries.length > 1 ||
-      !summary ||
-      (params.startMs !== undefined &&
-        params.endMs !== undefined &&
-        !isSessionSummaryContainedInRange(summary, params.startMs, params.endMs))
-    ) {
-      summary = buildSessionCostSummaryFromCacheEntries({
-        entries: cacheState.entries,
-        sessionId: params.sessionId,
-        sessionFile,
-        startMs,
-        endMs,
-      });
-    }
-  } else if (cacheState.entries.length > 0) {
-    // Some lineage files are stale (e.g. a just-created reset archive not yet
-    // cached) while others are fresh. Build a partial summary from the cached
-    // entries so a freshly reset session shows its known spend instead of
-    // blanking until the background refresh lands; cacheStatus reports
-    // "partial"/"refreshing" so callers know more is still coming.
-    summary = buildSessionCostSummaryFromCacheEntries({
-      entries: cacheState.entries,
-      sessionId: params.sessionId,
-      sessionFile,
-      startMs,
-      endMs,
-    });
-  }
+  let summary = cacheState.summary;
   if (!summary && params.refreshMode === "sync-when-empty") {
     summary = await loadSessionCostSummary({
       sessionId: params.sessionId,
@@ -2003,55 +2047,88 @@ export async function loadSessionCostSummariesFromCache(params: {
 }): Promise<{ summaries: Array<SessionCostSummary | null>; cacheStatus: UsageCacheStatus }> {
   const cachePath = resolveUsageCostCachePath(params.agentId);
   const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
-  const statTasks = params.sessions.map(
-    (session) => async () => await fs.promises.stat(session.sessionFile).catch(() => null),
+
+  // Resolve each session's active+archive lineage so hidden aggregate rows count
+  // reset/deleted spend, not just the active file (#46252). Every hidden session
+  // for one agent shares a transcripts dir, so list each dir once and index by
+  // name rather than running a per-session readdir on this hot aggregate path.
+  const dirNamesCache = new Map<string, string[]>();
+  const readSessionsDirNames = async (sessionsDir: string): Promise<string[]> => {
+    const cached = dirNamesCache.get(sessionsDir);
+    if (cached) {
+      return cached;
+    }
+    const names = await fs.promises
+      .readdir(sessionsDir, { withFileTypes: true })
+      .then((entries) => entries.filter((entry) => entry.isFile()).map((entry) => entry.name))
+      .catch(() => [] as string[]);
+    dirNamesCache.set(sessionsDir, names);
+    return names;
+  };
+  const lineages = await Promise.all(
+    params.sessions.map(async (session) => {
+      const sessionId = session.sessionId?.trim();
+      if (!sessionId) {
+        return { sessionFile: session.sessionFile, files: [session.sessionFile] };
+      }
+      const sessionsDir = path.dirname(session.sessionFile);
+      const entryNames = (await readSessionsDirNames(sessionsDir)).filter((name) =>
+        isUsageSessionLineageFileName(name, sessionId),
+      );
+      if (entryNames.length === 0) {
+        return { sessionFile: session.sessionFile, files: [session.sessionFile] };
+      }
+      return selectUsageSessionLineageFromNames({
+        sessionsDir,
+        entryNames,
+        fallbackFile: session.sessionFile,
+      });
+    }),
   );
-  const statsPromise = runTasksWithConcurrency({
-    tasks: statTasks,
-    limit: USAGE_COST_TRANSCRIPT_STAT_CONCURRENCY,
-  }).then(({ results }) => results);
-  const [cache, stats, refreshRunning] = await Promise.all([
+
+  // Stat the deduped union of all lineage files once so freshness checks reuse a
+  // single stat per file across the active+archive set.
+  const uniqueFiles = [...new Set(lineages.flatMap((lineage) => lineage.files))];
+  const statTasks = uniqueFiles.map((filePath) => async () => {
+    const stat = await fs.promises.stat(filePath).catch(() => null);
+    return stat ? { filePath, size: stat.size, mtimeMs: stat.mtimeMs } : null;
+  });
+  const [cache, statResults, refreshRunning] = await Promise.all([
     readUsageCostCache(cachePath),
-    statsPromise,
+    runTasksWithConcurrency({
+      tasks: statTasks,
+      limit: USAGE_COST_TRANSCRIPT_STAT_CONCURRENCY,
+    }).then(({ results }) => results),
     isUsageCostCacheRefreshRunning(cachePath),
   ]);
+  const statsByPath = new Map(
+    statResults
+      .filter((file): file is UsageCostTranscriptFile => Boolean(file))
+      .map((file) => [file.filePath, file]),
+  );
+
   const staleFiles = new Set<string>();
   let cachedFiles = 0;
   const summaries = params.sessions.map((session, index) => {
-    const stat = stats[index];
-    const file = stat
-      ? { filePath: session.sessionFile, size: stat.size, mtimeMs: stat.mtimeMs }
-      : undefined;
-    const entry = cache.files[session.sessionFile];
-    const stale =
-      !file ||
-      !isUsageCostCacheEntryFresh({
-        entry,
-        file,
-        pricingFingerprint,
-        requireSessionSummary: true,
-      });
-    if (stale) {
-      staleFiles.add(session.sessionFile);
-      return null;
-    }
-    cachedFiles += 1;
-    const summary = entry?.sessionSummary ?? null;
-    if (
-      summary &&
-      params.startMs !== undefined &&
-      params.endMs !== undefined &&
-      !isSessionSummaryContainedInRange(summary, params.startMs, params.endMs)
-    ) {
-      return entry
-        ? buildSessionCostSummaryFromCacheEntry({
-            entry,
-            sessionId: session.sessionId,
-            sessionFile: session.sessionFile,
-            startMs: params.startMs,
-            endMs: params.endMs,
-          })
-        : null;
+    const lineage = lineages[index];
+    const sessionFiles = lineage.files.length > 0 ? lineage.files : [session.sessionFile];
+    const {
+      summary,
+      cachedFiles: lineageCachedFiles,
+      staleFilePaths,
+    } = summarizeSessionLineageFromCache({
+      cache,
+      pricingFingerprint,
+      sessionId: session.sessionId,
+      sessionFile: lineage.sessionFile ?? session.sessionFile,
+      sessionFiles,
+      statsByPath,
+      startMs: params.startMs,
+      endMs: params.endMs,
+    });
+    cachedFiles += lineageCachedFiles;
+    for (const stalePath of staleFilePaths) {
+      staleFiles.add(stalePath);
     }
     return summary;
   });


### PR DESCRIPTION
## Summary

Fixes #46252.

This fixes per-session usage/cost **detail** for sessions that have an active `<id>.jsonl` transcript plus same-stem archives such as `<id>.jsonl.reset.<timestamp>` or `<id>.jsonl.deleted.<timestamp>` (created by `/new` and `/reset`). Global totals already counted these archives, but the per-session detail, time-series, logs, and cache paths each scanned only the active transcript — so a heavy `/new` rotation day showed a fraction of real spend.

The session detail path now:
- aggregates active + reset/deleted lineage files for totals, time-series, logs, and cache-backed summaries
- keeps the active `<id>.jsonl` as the canonical displayed `sessionFile`
- discovers lineage with the existing canonical usage-counted filename contract (`isUsageCountedSessionTranscriptFileName`, `parseUsageCountedSessionIdFromFileName`, `isSessionArchiveArtifactName`, `parseSessionArchiveTimestamp`) instead of broad prefix matching
- excludes non-usage siblings such as `.bak` compaction files and checkpoint artifacts (so they cannot double-count)
- returns a partial summary from the fresh cache entries when a same-stem archive is not yet cached, instead of blanking the panel until the background refresh lands
- keeps the newest same-stem archive authoritative for archive-only sessions (reset/deleted archives are alternative snapshots; summing them would double-count)
- avoids synchronous directory scans in the loader hot path by using async lineage resolution

> Note on diff size: the raw diff is large because `oxfmt` re-indents the three relocated transcript-scan callbacks (`onEntry`) by one level; `git diff -w` shows the real change is ~303/125 in `session-cost-usage.ts`.

Blast radius is limited to `src/infra/session-cost-usage.ts` and focused regression coverage in `src/infra/session-cost-usage.test.ts`. Out of scope: the global aggregation path (already archive-aware on `main`) and the agent-facing `sessions_history` / `chat.history` family readers (separate surface).

## Linked context

Closes #46252

The global daily-spend aggregate is already archive-aware on `main` (landed via #43215, commit `2fe1ff8`, where `loadCostUsageSummary` enumerates `isUsageCountedSessionTranscriptFileName`). This PR closes the matching gap in the **per-session detail** path, which still scanned only the active transcript.

Related #46605 (closed — only the global aggregation landed; per-session detail was never addressed) and #89289 (closed — earlier per-session attempt that used broad prefix matching; this PR uses the canonical usage-counted filename contract the ClawSweeper review asked for). No open PR currently addresses the per-session undercount.

Not requested by a maintainer; issue is labeled `clawsweeper:queueable-fix` / `clawsweeper:fix-shape-clear`.

## Real behavior proof

Behavior addressed: Per-session usage/cost detail now counts the active `<id>.jsonl` transcript together with same-stem `.reset`/`.deleted` archives, keeps the active transcript as the canonical `sessionFile`, and excludes non-usage `.bak`/checkpoint siblings so they do not double-count.

Real environment tested: Local OpenClaw source checkout (macOS, Node 24) running the real production loaders (`loadSessionCostSummary`, `loadSessionUsageTimeSeries`) from `src/infra/session-cost-usage.ts` against a real on-disk session directory laid out exactly like `~/.openclaw/agents/<id>/sessions` — an active `<id>.jsonl`, a same-stem `.jsonl.reset.<ts>`, a same-stem `.jsonl.deleted.<ts>`, and a `.jsonl.bak.<ts>` sibling.

Exact steps or command run after this patch: `node_modules/.bin/tsx /tmp/repro-46252.mjs` — writes the four real transcripts to a temp `OPENCLAW_STATE_DIR`, then calls the unchanged production `loadSessionCostSummary` / `loadSessionUsageTimeSeries` for that session id and prints the resolved totals.

Evidence after fix:

```text
$ node_modules/.bin/tsx /tmp/repro-46252.mjs

issue #46252 — per-session usage detail with reset/deleted archives present

session id: 11111111-2222-4333-8444-555555555555
on-disk transcripts (lineage dir): <id>.jsonl  +  .jsonl.reset.*  +  .jsonl.deleted.*  +  .jsonl.bak.* (excluded)

BEFORE this fix (per-session detail scanned the active <id>.jsonl only):
  totalTokens = 18
  totalCost   = $0.018
  sessionFile = 11111111-2222-4333-8444-555555555555.jsonl

AFTER this fix (active + same-stem reset/deleted archives aggregated):
  totalTokens = 39   (18 active + 12 reset + 9 deleted)
  totalCost   = $0.039   (was $0.018 — a ~2.2x undercount)
  sessionFile = 11111111-2222-4333-8444-555555555555.jsonl   (active transcript stays canonical)
  time-series cumulativeTokens = [12, 21, 39]

.bak sibling excluded (no double-count): YES  (total is 39, not 1038)
```

Observed result after fix: The resolved per-session figure rose from `$0.018` (active transcript alone) to `$0.039` once the same-stem `.reset` and `.deleted` archives were folded in, the canonical `sessionFile` stayed the active `<id>.jsonl`, the cumulative series accumulated in chronological order across all three transcripts (`[12, 21, 39]`), and the huge `.bak` sibling was excluded (total stayed `39`, not `1038`).

What was not tested: The full Gateway RPC + Control-UI dashboard render was not exercised in this run; proof targets the underlying production load path the dashboard consumes. No live channel/provider credential path and no Crabbox/Testbox run.

Proof limitations or environment constraints: The repro drives the real loaders directly rather than through a running gateway/UI; the load/cache path it exercises is exactly what the dashboard's `sessions.usage` consumer calls, so the user-facing figures resolve from the same numbers shown here.

## Tests and validation

- `node scripts/run-vitest.mjs src/infra/session-cost-usage.test.ts` — 57 passed. New coverage: cached active+archive summaries; active+archive per-session detail; exclusion of non-usage same-stem siblings (summary, plus time-series and logs); partial summary when a same-stem archive is uncached (the blank-panel regression); and the `startMs`/`endMs` range rebuild across a merged lineage.
- `node scripts/run-vitest.mjs src/gateway/server-methods/usage.sessions-usage.test.ts` — 34 passed (downstream consumer unaffected).
- `oxfmt --check`, `node scripts/run-oxlint.mjs`, and `git diff --check` — all clean.
- What failed before: the new scenarios — per-session paths scanned only the active `<id>.jsonl` and dropped reset/deleted archive usage; and a stale lineage member blanked the whole summary.

## Risk checklist

Did user-visible behavior change? Yes — per-session cost/usage figures increase to include reset/deleted archive transcripts (correcting an undercount). The reported `sessionFile` is unchanged.

Did config, environment, or migration behavior change? No — no config, schema, default, or storage-shape changes; discovery reads the existing sessions directory only.

Did security, auth, secrets, network, or tool execution behavior change? No — change is confined to backend usage aggregation and tests.

What is the highest-risk area? Lineage discovery picking up unintended same-stem siblings (double-count).

How is that risk mitigated? Discovery is gated by the canonical usage-counted filename contract (not prefix matching), with a regression asserting `.bak`/checkpoint exclusion; archives are ordered by embedded timestamp and cumulative series totals are recomputed in chronological order after merging all lineage files.

## AI assistance disclosure

This PR was implemented with AI assistance (Codex for implementation, Claude for review and the real-behavior repro), with human review of the final diff before submission.

## Out-of-scope follow-ups

- The per-session `sessions.usage` listing now resolves lineage with one `readdir` per row. For sessions directories with very many archives this is O(rows × files); a per-request lineage index (built once during discovery and threaded into each load) would remove the rescan. Deferred to keep this PR scoped to the correctness fix.

## Current review state

Ready for review. Next action: maintainer/owner review of the per-session aggregation approach.

This passed a local Claude+Codex cross-review; resolved findings: the post-`/new` blank-panel regression (now returns a partial summary), formatter compliance, the cross-file latency-pairing boundary (documented + bounded by the 12h cap), and test gaps (range path, time-series/logs sibling exclusion, partial-summary). The archive-only "newest snapshot wins" behavior is kept deliberately (documented) to avoid double-counting overlapping reset/deleted snapshots. Incorporates the ClawSweeper guidance from #89289 to use the canonical usage-counted filename contract instead of broad prefix matching.
