### PR TITLE
fix(slack): emit accurate message_sent hooks

### DIFF
--- a/extensions/slack/src/message-sent-hook.ts
+++ b/extensions/slack/src/message-sent-hook.ts
@@ -1,0 +1,92 @@
+// Slack plugin module implements message_sent hook emission.
+import {
+  buildCanonicalSentMessageHookContext,
+  createInternalHookEvent,
+  fireAndForgetHook,
+  toInternalMessageSentContext,
+  toPluginMessageContext,
+  toPluginMessageSentEvent,
+  triggerInternalHook,
+} from "openclaw/plugin-sdk/hook-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
+
+export type EmitSlackMessageSentHookParams = {
+  sessionKeyForInternalHooks?: string;
+  runId?: string;
+  to: string;
+  accountId?: string | null;
+  content: string;
+  success: boolean;
+  error?: string;
+  messageId?: string;
+  isGroup?: boolean;
+  groupId?: string;
+};
+
+function buildSlackSentHookContext(params: EmitSlackMessageSentHookParams) {
+  return buildCanonicalSentMessageHookContext({
+    to: params.to,
+    content: params.content,
+    success: params.success,
+    error: params.error,
+    channelId: "slack",
+    accountId: params.accountId ?? undefined,
+    conversationId: params.to,
+    sessionKey: params.sessionKeyForInternalHooks,
+    runId: params.runId,
+    messageId: params.messageId,
+    isGroup: params.isGroup,
+    groupId: params.groupId,
+  });
+}
+
+function emitInternalSlackMessageSentHook(params: EmitSlackMessageSentHookParams): void {
+  if (!params.sessionKeyForInternalHooks) {
+    return;
+  }
+  const canonical = buildSlackSentHookContext(params);
+  fireAndForgetHook(
+    triggerInternalHook(
+      createInternalHookEvent(
+        "message",
+        "sent",
+        params.sessionKeyForInternalHooks,
+        toInternalMessageSentContext(canonical),
+      ),
+    ),
+    "slack: message:sent internal hook failed",
+  );
+}
+
+function emitMessageSentHooks(
+  params: EmitSlackMessageSentHookParams & {
+    hookRunner: ReturnType<typeof getGlobalHookRunner>;
+    enabled: boolean;
+  },
+): void {
+  if (!params.enabled && !params.sessionKeyForInternalHooks) {
+    return;
+  }
+  const canonical = buildSlackSentHookContext(params);
+  if (params.enabled) {
+    fireAndForgetHook(
+      Promise.resolve(
+        params.hookRunner!.runMessageSent(
+          toPluginMessageSentEvent(canonical),
+          toPluginMessageContext(canonical),
+        ),
+      ),
+      "slack: message_sent plugin hook failed",
+    );
+  }
+  emitInternalSlackMessageSentHook(params);
+}
+
+export function emitSlackMessageSentHooks(params: EmitSlackMessageSentHookParams): void {
+  const hookRunner = getGlobalHookRunner();
+  emitMessageSentHooks({
+    ...params,
+    hookRunner,
+    enabled: hookRunner?.hasHooks("message_sent") ?? false,
+  });
+}

--- a/extensions/slack/src/message-sent-hook.ts
+++ b/extensions/slack/src/message-sent-hook.ts
@@ -23,8 +23,15 @@ export type EmitSlackMessageSentHookParams = {
   groupId?: string;
 };
 
-function buildSlackSentHookContext(params: EmitSlackMessageSentHookParams) {
-  return buildCanonicalSentMessageHookContext({
+export function emitSlackMessageSentHooks(params: EmitSlackMessageSentHookParams): void {
+  const sessionKey = params.sessionKeyForInternalHooks;
+  const hookRunner = getGlobalHookRunner();
+  const emitPluginHook = hookRunner?.hasHooks("message_sent") ?? false;
+  if (!emitPluginHook && !sessionKey) {
+    return;
+  }
+
+  const canonical = buildCanonicalSentMessageHookContext({
     to: params.to,
     content: params.content,
     success: params.success,
@@ -32,46 +39,17 @@ function buildSlackSentHookContext(params: EmitSlackMessageSentHookParams) {
     channelId: "slack",
     accountId: params.accountId ?? undefined,
     conversationId: params.to,
-    sessionKey: params.sessionKeyForInternalHooks,
+    sessionKey,
     runId: params.runId,
     messageId: params.messageId,
     isGroup: params.isGroup,
     groupId: params.groupId,
   });
-}
 
-function emitInternalSlackMessageSentHook(params: EmitSlackMessageSentHookParams): void {
-  if (!params.sessionKeyForInternalHooks) {
-    return;
-  }
-  const canonical = buildSlackSentHookContext(params);
-  fireAndForgetHook(
-    triggerInternalHook(
-      createInternalHookEvent(
-        "message",
-        "sent",
-        params.sessionKeyForInternalHooks,
-        toInternalMessageSentContext(canonical),
-      ),
-    ),
-    "slack: message:sent internal hook failed",
-  );
-}
-
-function emitMessageSentHooks(
-  params: EmitSlackMessageSentHookParams & {
-    hookRunner: ReturnType<typeof getGlobalHookRunner>;
-    enabled: boolean;
-  },
-): void {
-  if (!params.enabled && !params.sessionKeyForInternalHooks) {
-    return;
-  }
-  const canonical = buildSlackSentHookContext(params);
-  if (params.enabled) {
+  if (emitPluginHook && hookRunner) {
     fireAndForgetHook(
       Promise.resolve(
-        params.hookRunner!.runMessageSent(
+        hookRunner.runMessageSent(
           toPluginMessageSentEvent(canonical),
           toPluginMessageContext(canonical),
         ),
@@ -79,14 +57,18 @@ function emitMessageSentHooks(
       "slack: message_sent plugin hook failed",
     );
   }
-  emitInternalSlackMessageSentHook(params);
-}
 
-export function emitSlackMessageSentHooks(params: EmitSlackMessageSentHookParams): void {
-  const hookRunner = getGlobalHookRunner();
-  emitMessageSentHooks({
-    ...params,
-    hookRunner,
-    enabled: hookRunner?.hasHooks("message_sent") ?? false,
-  });
+  if (sessionKey) {
+    fireAndForgetHook(
+      triggerInternalHook(
+        createInternalHookEvent(
+          "message",
+          "sent",
+          sessionKey,
+          toInternalMessageSentContext(canonical),
+        ),
+      ),
+      "slack: message:sent internal hook failed",
+    );
+  }
 }

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -20,7 +20,8 @@ const startSlackStreamMock = vi.fn(async () => ({
   delivered: true,
   pendingText: "",
 }));
-const stopSlackStreamMock = vi.fn(async () => {});
+const stopSlackStreamMock = vi.fn(async () => ({}) as { messageId?: string });
+const emitSlackMessageSentHooksMock = vi.fn(() => {});
 const reactSlackMessageMock = vi.fn(async () => {});
 const removeSlackReactionMock = vi.fn(async () => {});
 class TestSlackStreamNotDeliveredError extends Error {
@@ -79,6 +80,7 @@ let capturedReplyOptions:
         summary?: string;
       }) => Promise<void> | void;
       onPartialReply?: (payload: { text: string }) => Promise<void> | void;
+      onAgentRunStart?: (runId: string) => void;
     }
   | undefined;
 let capturedStatusReactionOptions: { enabled?: boolean; initialEmoji?: string } | undefined;
@@ -807,6 +809,10 @@ vi.mock("../../streaming.js", () => ({
   stopSlackStream: stopSlackStreamMock,
 }));
 
+vi.mock("../../message-sent-hook.js", () => ({
+  emitSlackMessageSentHooks: emitSlackMessageSentHooksMock,
+}));
+
 vi.mock("../../threading.js", () => ({
   resolveSlackThreadTargets: () => ({
     statusThreadTs: THREAD_TS,
@@ -920,9 +926,11 @@ vi.mock("../reply.runtime.js", () => ({
         isReasoningSnapshot?: boolean;
       }) => Promise<void> | void;
       onPartialReply?: (payload: { text: string }) => Promise<void> | void;
+      onAgentRunStart?: (runId: string) => void;
     };
   }) => {
     capturedReplyOptions = params.replyOptions;
+    params.replyOptions?.onAgentRunStart?.("run-dispatch-1");
     if (mockedReplyOptionEvents.length > 0) {
       for (const entry of mockedReplyOptionEvents) {
         if (entry.kind === "item") {
@@ -1044,12 +1052,14 @@ vi.mock("../reply.runtime.js", () => ({
         summary?: string;
       }) => Promise<void> | void;
       onPartialReply?: (payload: { text: string }) => Promise<void> | void;
+      onAgentRunStart?: (runId: string) => void;
     };
     dispatcher: {
       deliver: (payload: TestReplyPayload, info: { kind: TestReplyDispatchKind }) => Promise<void>;
     };
   }) => {
     capturedReplyOptions = params.replyOptions;
+    params.replyOptions?.onAgentRunStart?.("run-dispatch-1");
     if (mockedReplyOptionEvents.length > 0) {
       for (const entry of mockedReplyOptionEvents) {
         if (entry.kind === "item") {
@@ -1141,6 +1151,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     appendSlackStreamMock.mockReset();
     startSlackStreamMock.mockReset();
     stopSlackStreamMock.mockReset();
+    emitSlackMessageSentHooksMock.mockClear();
     reactSlackMessageMock.mockReset();
     removeSlackReactionMock.mockReset();
     for (const value of Object.values(statusReactionControllerMock)) {
@@ -1173,7 +1184,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       pendingText: "",
     });
     appendSlackStreamMock.mockResolvedValue(undefined);
-    stopSlackStreamMock.mockResolvedValue(undefined);
+    stopSlackStreamMock.mockResolvedValue({});
   });
 
   it("falls back to normal delivery when preview finalize fails", async () => {
@@ -1181,7 +1192,28 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
 
     expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
-    expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT, {
+      sessionKeyForInternalHooks: "agent:agent-1:slack:C123",
+      runId: "run-dispatch-1",
+    });
+    expect(emitSlackMessageSentHooksMock).not.toHaveBeenCalled();
+  });
+
+  it("emits message_sent when a draft preview is finalized in place", async () => {
+    finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(1);
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "preview message_sent", {
+      content: FINAL_REPLY_TEXT,
+      success: true,
+      messageId: "171234.567",
+      sessionKeyForInternalHooks: "agent:agent-1:slack:C123",
+      runId: "run-dispatch-1",
+    });
   });
 
   it("does not create a Slack thread for top-level messages when replyToMode is off", async () => {
@@ -1958,6 +1990,98 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(stopSlackStreamMock).toHaveBeenCalledTimes(1);
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+    expect(emitSlackMessageSentHooksMock).not.toHaveBeenCalled();
+  });
+
+  it("emits message_sent exactly once from the text-stream finalizer", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [{ kind: "final", payload: { text: FINAL_REPLY_TEXT } }];
+    stopSlackStreamMock.mockResolvedValueOnce({ messageId: "171234.568" });
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(stopSlackStreamMock).toHaveBeenCalledTimes(1);
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(1);
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "stream finalizer message_sent", {
+      content: FINAL_REPLY_TEXT,
+      success: true,
+      messageId: "171234.568",
+      sessionKeyForInternalHooks: "agent:agent-1:slack:C123",
+      runId: "run-dispatch-1",
+    });
+  });
+
+  it("emits message_sent with the full native text stream content", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [
+      { kind: "block", payload: { text: "first buffered" } },
+      { kind: "final", payload: { text: "second flushes" } },
+    ];
+    stopSlackStreamMock.mockResolvedValueOnce({ messageId: "171234.569" });
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(startSlackStreamMock).toHaveBeenCalledTimes(1);
+    expect(appendSlackStreamMock).toHaveBeenCalledTimes(1);
+    expect(stopSlackStreamMock).toHaveBeenCalledTimes(1);
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(1);
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "stream finalizer message_sent", {
+      content: "first buffered\nsecond flushes",
+      success: true,
+      messageId: "171234.569",
+      sessionKeyForInternalHooks: "agent:agent-1:slack:C123",
+      runId: "run-dispatch-1",
+    });
+  });
+
+  it("does not emit from the stream finalizer when stop fallback re-enters deliverReplies", async () => {
+    mockedNativeStreaming = true;
+    const session = {
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: false,
+      pendingText: FINAL_REPLY_TEXT,
+    };
+    startSlackStreamMock.mockResolvedValueOnce(session);
+    stopSlackStreamMock.mockRejectedValueOnce(
+      new TestSlackStreamNotDeliveredError(FINAL_REPLY_TEXT, "user_not_found"),
+    );
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+    expect(emitSlackMessageSentHooksMock).not.toHaveBeenCalled();
+  });
+
+  it("does not emit from the stream finalizer when append fallback re-enters deliverReplies", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [
+      { kind: "block", payload: { text: "first buffered" } },
+      { kind: "final", payload: { text: "second flushes" } },
+    ];
+    const session = {
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: false,
+      pendingText: "first buffered",
+    };
+    startSlackStreamMock.mockResolvedValueOnce(session);
+    appendSlackStreamMock.mockImplementationOnce(async () => {
+      session.pendingText += "\nsecond flushes";
+      throw new TestSlackStreamNotDeliveredError(session.pendingText, "user_not_found");
+    });
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, "first buffered\nsecond flushes");
+    expect(stopSlackStreamMock).not.toHaveBeenCalled();
+    expect(emitSlackMessageSentHooksMock).not.toHaveBeenCalled();
   });
 
   it("does not start a text stream for native progress mode when no progress card exists", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -62,6 +62,7 @@ import {
   isSlackInteractiveRepliesEnabled,
 } from "../../interactive-replies.js";
 import { SLACK_TEXT_LIMIT } from "../../limits.js";
+import { emitSlackMessageSentHooks } from "../../message-sent-hook.js";
 import {
   buildSlackProgressDraftBlocks,
   buildSlackProgressStreamCompletionChunks,
@@ -519,6 +520,38 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     ctx: prepared.ctxPayload,
   });
   const sourceRepliesAreToolOnly = sourceReplyDeliveryMode === "message_tool_only";
+  let messageSentRunId: string | undefined;
+  const buildMessageSentHookContext = () => ({
+    sessionKeyForInternalHooks: route.sessionKey,
+    ...(messageSentRunId ? { runId: messageSentRunId } : {}),
+    mirrorIsGroup: prepared.isRoomish,
+    ...(prepared.isRoomish ? { mirrorGroupId: message.channel } : {}),
+  });
+  const buildFinalMessageSentHookContext = () => {
+    const context = buildMessageSentHookContext();
+    return {
+      sessionKeyForInternalHooks: context.sessionKeyForInternalHooks,
+      ...(context.runId ? { runId: context.runId } : {}),
+      isGroup: context.mirrorIsGroup,
+      ...(context.mirrorGroupId ? { groupId: context.mirrorGroupId } : {}),
+    };
+  };
+  const emitSlackFinalMessageSent = (params: {
+    content: string;
+    success: boolean;
+    error?: string;
+    messageId?: string;
+  }) => {
+    emitSlackMessageSentHooks({
+      ...buildFinalMessageSentHookContext(),
+      to: prepared.replyTarget,
+      accountId: account.accountId,
+      content: params.content,
+      success: params.success,
+      ...(params.error ? { error: params.error } : {}),
+      ...(params.messageId ? { messageId: params.messageId } : {}),
+    });
+  };
 
   const reactionMessageTs = prepared.ackReactionMessageTs;
   const messageTs = message.ts ?? message.event_ts;
@@ -703,6 +736,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let usedBlockReplyThreadTs: string | undefined;
   let observedReplyDelivery = false;
   let observedFinalReplyDelivery = false;
+  let streamedContentForSentHook = "";
+  let streamedFinalIncludedForSentHook = false;
+  const appendStreamedContentForSentHook = (text: string) => {
+    streamedContentForSentHook = streamedContentForSentHook
+      ? `${streamedContentForSentHook}\n${text}`
+      : text;
+  };
   const deliveryTracker = createSlackEventDeliveryTracker();
   const resolveDeliveryThreadTs = (params: {
     kind: ReplyDispatchKind;
@@ -754,6 +794,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         replyToMode: replyDeliveryMode,
         ...(slackIdentity ? { identity: slackIdentity } : {}),
         ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
+        ...buildMessageSentHookContext(),
       });
       markSlackStreamFallbackDelivered(session);
       observedReplyDelivery = true;
@@ -807,6 +848,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       replyToMode: replyDeliveryMode,
       ...(slackIdentity ? { identity: slackIdentity } : {}),
       ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
+      ...buildMessageSentHookContext(),
     });
     observedReplyDelivery = true;
     if (params.kind === "final") {
@@ -942,6 +984,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             observedFinalReplyDelivery = true;
           }
         }
+        if (params.kind === "final" && text) {
+          streamedFinalIncludedForSentHook = true;
+        }
+        appendStreamedContentForSentHook(text);
         rememberDeliveredThreadTs(params.kind, streamThreadTs);
         replyPlan.markSent();
         deliveryTracker.markDelivered({
@@ -1009,6 +1055,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           observedFinalReplyDelivery = true;
         }
       }
+      if (params.kind === "final" && text) {
+        streamedFinalIncludedForSentHook = true;
+      }
+      appendStreamedContentForSentHook(text);
       deliveryTracker.markDelivered({
         kind: params.kind,
         payload: params.payload,
@@ -1154,6 +1204,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         observedFinalReplyDelivery = true;
         observedReplyDelivery = true;
         replyPlan.markSent();
+        emitSlackFinalMessageSent({
+          content: trimmedFinalText,
+          success: true,
+          messageId,
+        });
         await deliverNormally({
           payload: buildTtsSupplementMediaPayload(payload),
           kind: info.kind,
@@ -1214,7 +1269,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           draftPreviewCommitted = true;
           observedFinalReplyDelivery = true;
         },
-        onPreviewFinalized: (_preview) => {
+        onPreviewFinalized: (preview) => {
           // The preview edit promotes the draft message into the final answer.
           // Later same-turn payloads must not let fallback cleanup clear it.
           draftPreviewCommitted = true;
@@ -1222,6 +1277,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           const finalThreadTs = usedReplyThreadTs ?? statusThreadTs;
           observedReplyDelivery = true;
           replyPlan.markSent();
+          emitSlackFinalMessageSent({
+            content: trimmedFinalText,
+            success: true,
+            messageId: preview.messageId,
+          });
           deliveryTracker.markDelivered({ kind: info.kind, payload, threadTs: finalThreadTs });
         },
         buildSupplementalPayload: () =>
@@ -1660,6 +1720,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         hasRepliedRef,
         disableBlockStreaming,
         onModelSelected,
+        onAgentRunStart: (runId) => {
+          messageSentRunId = runId;
+        },
         suppressDefaultToolProgressMessages: suppressDefaultToolProgressMessages ? true : undefined,
         onPartialReply: useStreaming
           ? undefined
@@ -1816,15 +1879,29 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       if (completionChunks?.length) {
         nativeProgressCompletionSent = true;
       }
-      await stopSlackStream({
+      const stopResult = await stopSlackStream({
         session: finalStream,
         ...(completionChunks?.length ? { chunks: completionChunks } : {}),
         ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
       });
+      if (streamedFinalIncludedForSentHook && streamedContentForSentHook) {
+        emitSlackFinalMessageSent({
+          content: streamedContentForSentHook,
+          success: true,
+          ...(stopResult?.messageId ? { messageId: stopResult.messageId } : {}),
+        });
+      }
     } catch (err) {
       if (err instanceof SlackStreamNotDeliveredError) {
         streamFallbackDelivered = await deliverPendingStreamFallback(finalStream, err);
       } else {
+        if (streamedFinalIncludedForSentHook && streamedContentForSentHook) {
+          emitSlackFinalMessageSent({
+            content: streamedContentForSentHook,
+            success: false,
+            error: formatSlackError(err),
+          });
+        }
         runtime.error?.(danger(`slack-stream: failed to stop stream: ${formatSlackError(err)}`));
       }
     }

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -6,6 +6,28 @@ vi.mock("../send.js", () => ({
   sendMessageSlack: (...args: unknown[]) => sendMock(...args),
 }));
 
+const triggerInternalHookMock = vi.hoisted(() => vi.fn(async () => {}));
+const messageHookRunner = vi.hoisted(() => ({
+  hasHooks: vi.fn<(name: string) => boolean>(() => false),
+  runMessageSent: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/hook-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/hook-runtime")>();
+  return {
+    ...actual,
+    triggerInternalHook: triggerInternalHookMock,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/plugin-runtime")>();
+  return {
+    ...actual,
+    getGlobalHookRunner: () => messageHookRunner,
+  };
+});
+
 let deliverReplies: typeof import("./replies.js").deliverReplies;
 let createSlackReplyDeliveryPlan: typeof import("./replies.js").createSlackReplyDeliveryPlan;
 let resolveDeliveredSlackReplyThreadTs: typeof import("./replies.js").resolveDeliveredSlackReplyThreadTs;
@@ -385,5 +407,193 @@ describe("deliverReplies reasoning suppression", () => {
     );
 
     expect(sendMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("deliverReplies message_sent hook", () => {
+  beforeAll(async () => {
+    ({ deliverReplies } = await import("./replies.js"));
+  });
+
+  beforeEach(() => {
+    sendMock.mockReset();
+    messageHookRunner.hasHooks.mockReset();
+    messageHookRunner.hasHooks.mockReturnValue(false);
+    messageHookRunner.runMessageSent.mockReset();
+    triggerInternalHookMock.mockReset();
+  });
+
+  it("emits message_sent with the delivered Slack message id after a text reply", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name) => name === "message_sent");
+    sendMock.mockResolvedValue({ messageId: "1700000000.000100", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [{ text: "shipped" }],
+        sessionKeyForInternalHooks: "agent:main:slack:channel:c123",
+        runId: "run-1",
+      }),
+    );
+
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledOnce();
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "C123",
+        content: "shipped",
+        success: true,
+        messageId: "1700000000.000100",
+        sessionKey: "agent:main:slack:channel:c123",
+        runId: "run-1",
+      }),
+      expect.objectContaining({
+        channelId: "slack",
+        conversationId: "C123",
+        messageId: "1700000000.000100",
+        sessionKey: "agent:main:slack:channel:c123",
+        runId: "run-1",
+      }),
+    );
+  });
+
+  it("emits message_sent with success=false when text delivery throws", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name) => name === "message_sent");
+    sendMock.mockRejectedValue(new Error("channel_not_found"));
+
+    await expect(deliverReplies(baseParams({ replies: [{ text: "boom" }] }))).rejects.toThrow(
+      /channel_not_found/,
+    );
+
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledOnce();
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "C123",
+        content: "boom",
+        success: false,
+        error: expect.stringContaining("channel_not_found"),
+      }),
+      expect.objectContaining({ channelId: "slack" }),
+    );
+  });
+
+  it("does not emit the plugin hook when no listener observes message_sent", async () => {
+    sendMock.mockResolvedValue({ messageId: "1700000000.000101", channelId: "C123" });
+
+    await deliverReplies(baseParams({ replies: [{ text: "quiet" }] }));
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(messageHookRunner.runMessageSent).not.toHaveBeenCalled();
+  });
+
+  it("fires the internal message:sent hook when only a session key is supplied", async () => {
+    sendMock.mockResolvedValue({ messageId: "1700000000.000102", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [{ text: "internal" }],
+        sessionKeyForInternalHooks: "agent:main:slack:channel:c123",
+      }),
+    );
+
+    expect(messageHookRunner.runMessageSent).not.toHaveBeenCalled();
+    expect(triggerInternalHookMock).toHaveBeenCalledOnce();
+  });
+
+  it("threads group context into the internal message:sent hook", async () => {
+    sendMock.mockResolvedValue({ messageId: "1700000000.000103", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [{ text: "group reply" }],
+        sessionKeyForInternalHooks: "agent:main:slack:channel:c123",
+        mirrorIsGroup: true,
+        mirrorGroupId: "C123",
+      }),
+    );
+
+    expect(triggerInternalHookMock).toHaveBeenCalledOnce();
+    expect(triggerInternalHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({ isGroup: true, groupId: "C123" }),
+      }),
+    );
+  });
+
+  it("emits message_sent for block-only replies with the delivered Slack id", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name) => name === "message_sent");
+    sendMock.mockResolvedValue({ messageId: "1700000000.000104", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            text: "",
+            channelData: {
+              slack: {
+                blocks: [{ type: "divider" }],
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        messageId: "1700000000.000104",
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("emits message_sent for media replies with the delivered Slack id", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name) => name === "message_sent");
+    sendMock.mockResolvedValue({ messageId: "1700000000.000105", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [{ text: "caption", mediaUrls: ["https://example.com/image.png"] }],
+      }),
+    );
+
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "caption",
+        success: true,
+        messageId: "1700000000.000105",
+      }),
+      expect.objectContaining({ channelId: "slack" }),
+    );
+  });
+
+  it("keeps the caption as message_sent content for multi-media replies", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name) => name === "message_sent");
+    sendMock
+      .mockResolvedValueOnce({ messageId: "1700000000.000106", channelId: "C123" })
+      .mockResolvedValueOnce({ messageId: "1700000000.000107", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            text: "caption",
+            mediaUrls: ["https://example.com/one.png", "https://example.com/two.png"],
+          },
+        ],
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(requireSendCall(0)[1]).toBe("caption");
+    expect(requireSendCall(1)[1]).toBe("");
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledOnce();
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "caption",
+        success: true,
+        messageId: "1700000000.000107",
+      }),
+      expect.objectContaining({ channelId: "slack" }),
+    );
   });
 });

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -596,4 +596,36 @@ describe("deliverReplies message_sent hook", () => {
       expect.objectContaining({ channelId: "slack" }),
     );
   });
+
+  it("uses spoken TTS text as message_sent content for audio-only media replies", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name) => name === "message_sent");
+    sendMock.mockResolvedValue({ messageId: "1700000000.000108", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            mediaUrl: "https://example.com/tts.mp3",
+            audioAsVoice: true,
+            spokenText: "Spoken answer",
+            ttsSupplement: { spokenText: "Spoken answer" },
+          },
+        ],
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledWith(
+      "C123",
+      "",
+      expect.objectContaining({ mediaUrl: "https://example.com/tts.mp3" }),
+    );
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "Spoken answer",
+        success: true,
+        messageId: "1700000000.000108",
+      }),
+      expect.objectContaining({ channelId: "slack" }),
+    );
+  });
 });

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -1,6 +1,7 @@
 // Slack plugin module implements replies behavior.
 import type { MessageMetadata } from "@slack/types";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   chunkMarkdownTextWithMode,
   isSilentReplyText,
@@ -16,8 +17,9 @@ import { createReplyReferencePlanner } from "openclaw/plugin-sdk/reply-reference
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
 import { SLACK_TEXT_LIMIT } from "../limits.js";
+import { emitSlackMessageSentHooks } from "../message-sent-hook.js";
 import { resolveSlackReplyBlocks } from "../reply-blocks.js";
-import { sendMessageSlack, type SlackSendIdentity } from "./send.runtime.js";
+import { sendMessageSlack, type SlackSendIdentity, type SlackSendResult } from "./send.runtime.js";
 
 export function readSlackReplyBlocks(payload: ReplyPayload) {
   return resolveSlackReplyBlocks(payload);
@@ -46,6 +48,10 @@ export async function deliverReplies(params: {
   replyToMode: "off" | "first" | "all" | "batched";
   identity?: SlackSendIdentity;
   metadata?: MessageMetadata;
+  sessionKeyForInternalHooks?: string;
+  runId?: string;
+  mirrorIsGroup?: boolean;
+  mirrorGroupId?: string;
 }) {
   for (const payload of params.replies) {
     if (payload.isReasoning === true) {
@@ -61,6 +67,32 @@ export async function deliverReplies(params: {
     if (!reply.hasContent && !slackBlocks?.length) {
       continue;
     }
+    const emitSent = (content: string, result?: SlackSendResult) => {
+      emitSlackMessageSentHooks({
+        sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
+        runId: params.runId,
+        to: params.target,
+        accountId: params.accountId,
+        content,
+        success: true,
+        messageId: result?.messageId,
+        isGroup: params.mirrorIsGroup,
+        groupId: params.mirrorGroupId,
+      });
+    };
+    const emitFailed = (content: string, error: unknown) => {
+      emitSlackMessageSentHooks({
+        sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
+        runId: params.runId,
+        to: params.target,
+        accountId: params.accountId,
+        content,
+        success: false,
+        error: formatErrorMessage(error),
+        isGroup: params.mirrorIsGroup,
+        groupId: params.mirrorGroupId,
+      });
+    };
 
     if (!reply.hasMedia && slackBlocks?.length) {
       const trimmed = reply.trimmedText;
@@ -70,54 +102,70 @@ export async function deliverReplies(params: {
       if (trimmed && isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
         continue;
       }
-      await sendMessageSlack(params.target, trimmed, {
-        cfg: params.cfg,
-        token: params.token,
-        threadTs,
-        accountId: params.accountId,
-        ...(slackBlocks?.length ? { blocks: slackBlocks } : {}),
-        ...(params.identity ? { identity: params.identity } : {}),
-        ...(params.metadata ? { metadata: params.metadata } : {}),
-      });
+      try {
+        const sent = await sendMessageSlack(params.target, trimmed, {
+          cfg: params.cfg,
+          token: params.token,
+          threadTs,
+          accountId: params.accountId,
+          ...(slackBlocks?.length ? { blocks: slackBlocks } : {}),
+          ...(params.identity ? { identity: params.identity } : {}),
+          ...(params.metadata ? { metadata: params.metadata } : {}),
+        });
+        emitSent(trimmed, sent);
+      } catch (error) {
+        emitFailed(trimmed, error);
+        throw error;
+      }
       params.runtime.log?.(`delivered reply to ${params.target}`);
       continue;
     }
 
-    const delivered = await deliverTextOrMediaReply({
-      payload,
-      text: reply.text,
-      chunkText: !reply.hasMedia
-        ? (value) => {
-            const trimmed = value.trim();
-            if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
-              return [];
+    let contentForSentHook = reply.text;
+    let lastSendResult: SlackSendResult | undefined;
+    let delivered;
+    try {
+      delivered = await deliverTextOrMediaReply({
+        payload,
+        text: reply.text,
+        chunkText: !reply.hasMedia
+          ? (value) => {
+              const trimmed = value.trim();
+              if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
+                return [];
+              }
+              return [trimmed];
             }
-            return [trimmed];
-          }
-        : undefined,
-      sendText: async (trimmed) => {
-        await sendMessageSlack(params.target, trimmed, {
-          cfg: params.cfg,
-          token: params.token,
-          threadTs,
-          accountId: params.accountId,
-          ...(params.identity ? { identity: params.identity } : {}),
-          ...(params.metadata ? { metadata: params.metadata } : {}),
-        });
-      },
-      sendMedia: async ({ mediaUrl, caption }) => {
-        await sendMessageSlack(params.target, caption ?? "", {
-          cfg: params.cfg,
-          token: params.token,
-          mediaUrl,
-          threadTs,
-          accountId: params.accountId,
-          ...(params.identity ? { identity: params.identity } : {}),
-          ...(params.metadata ? { metadata: params.metadata } : {}),
-        });
-      },
-    });
+          : undefined,
+        sendText: async (trimmed) => {
+          contentForSentHook = trimmed;
+          lastSendResult = await sendMessageSlack(params.target, trimmed, {
+            cfg: params.cfg,
+            token: params.token,
+            threadTs,
+            accountId: params.accountId,
+            ...(params.identity ? { identity: params.identity } : {}),
+            ...(params.metadata ? { metadata: params.metadata } : {}),
+          });
+        },
+        sendMedia: async ({ mediaUrl, caption }) => {
+          lastSendResult = await sendMessageSlack(params.target, caption ?? "", {
+            cfg: params.cfg,
+            token: params.token,
+            mediaUrl,
+            threadTs,
+            accountId: params.accountId,
+            ...(params.identity ? { identity: params.identity } : {}),
+            ...(params.metadata ? { metadata: params.metadata } : {}),
+          });
+        },
+      });
+    } catch (error) {
+      emitFailed(contentForSentHook, error);
+      throw error;
+    }
     if (delivered !== "empty") {
+      emitSent(contentForSentHook, lastSendResult);
       params.runtime.log?.(`delivered reply to ${params.target}`);
     }
   }

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -25,6 +25,10 @@ export function readSlackReplyBlocks(payload: ReplyPayload) {
   return resolveSlackReplyBlocks(payload);
 }
 
+function resolveSentHookContent(payload: ReplyPayload, text: string): string {
+  return text || payload.spokenText?.trim() || payload.ttsSupplement?.spokenText?.trim() || "";
+}
+
 export function resolveDeliveredSlackReplyThreadTs(params: {
   replyToMode: "off" | "first" | "all" | "batched";
   payloadReplyToId?: string;
@@ -121,7 +125,7 @@ export async function deliverReplies(params: {
       continue;
     }
 
-    let contentForSentHook = reply.text;
+    let contentForSentHook = resolveSentHookContent(payload, reply.text);
     let lastSendResult: SlackSendResult | undefined;
     let delivered;
     try {

--- a/extensions/slack/src/monitor/send.runtime.ts
+++ b/extensions/slack/src/monitor/send.runtime.ts
@@ -1,2 +1,2 @@
 // Slack plugin module implements send behavior.
-export { sendMessageSlack, type SlackSendIdentity } from "../send.js";
+export { sendMessageSlack, type SlackSendIdentity, type SlackSendResult } from "../send.js";

--- a/extensions/slack/src/streaming.test.ts
+++ b/extensions/slack/src/streaming.test.ts
@@ -13,7 +13,7 @@ import {
 } from "./streaming.js";
 
 type AppendImpl = () => Promise<unknown>;
-type StopImpl = (args?: unknown) => Promise<void>;
+type StopImpl = (args?: unknown) => Promise<unknown>;
 
 function makeSession(params: { appendImpl?: AppendImpl; stopImpl?: StopImpl }): SlackStreamSession {
   return {
@@ -94,7 +94,7 @@ describe("stopSlackStream finalize error handling", () => {
     await appendSlackStream({ session, text: "some text that Slack saw" });
     expect(session.delivered).toBe(true);
 
-    await expect(stopSlackStream({ session })).resolves.toBeUndefined();
+    await expect(stopSlackStream({ session })).resolves.toEqual({});
     expect(session.stopped).toBe(true);
   });
 
@@ -202,7 +202,7 @@ describe("stopSlackStream finalize error handling", () => {
       },
     });
     await appendSlackStream({ session, text: "chars" });
-    await expect(stopSlackStream({ session })).resolves.toBeUndefined();
+    await expect(stopSlackStream({ session })).resolves.toEqual({});
     expect(session.stopped).toBe(true);
   });
 
@@ -239,7 +239,7 @@ describe("stopSlackStream finalize error handling", () => {
       delivered: false,
       pendingText: "",
     };
-    await expect(stopSlackStream({ session })).resolves.toBeUndefined();
+    await expect(stopSlackStream({ session })).resolves.toEqual({});
     expect(stop).not.toHaveBeenCalled();
   });
 
@@ -253,6 +253,40 @@ describe("stopSlackStream finalize error handling", () => {
     await stopSlackStream({ session });
     expect(session.delivered).toBe(true);
     expect(session.pendingText).toBe("");
+  });
+
+  it("returns the finalized message ts as messageId on successful stop()", async () => {
+    const session = makeSession({
+      appendImpl: async () => null,
+      stopImpl: async () => ({ ok: true, ts: "1700000000.500100" }),
+    });
+    await appendSlackStream({ session, text: "short" });
+
+    await expect(stopSlackStream({ session })).resolves.toEqual({
+      messageId: "1700000000.500100",
+    });
+  });
+
+  it("falls back to message.ts when stop omits top-level ts", async () => {
+    const session = makeSession({
+      appendImpl: async () => null,
+      stopImpl: async () => ({ ok: true, message: { ts: "1700000000.500200" } }),
+    });
+    await appendSlackStream({ session, text: "short" });
+
+    await expect(stopSlackStream({ session })).resolves.toEqual({
+      messageId: "1700000000.500200",
+    });
+  });
+
+  it("returns an empty result when stop succeeds without a ts", async () => {
+    const session = makeSession({
+      appendImpl: async () => null,
+      stopImpl: async () => ({ ok: true }),
+    });
+    await appendSlackStream({ session, text: "short" });
+
+    await expect(stopSlackStream({ session })).resolves.toEqual({});
   });
 
   it("converts a start-time flush rejection into a pending-text fallback error", async () => {

--- a/extensions/slack/src/streaming.ts
+++ b/extensions/slack/src/streaming.ts
@@ -79,6 +79,10 @@ type StopSlackStreamParams = {
   metadata?: MessageMetadata;
 };
 
+export type StopSlackStreamResult = {
+  messageId?: string;
+};
+
 /**
  * Thrown when Slack rejects a stream flush/finalize with a recipient-resolution
  * error (see {@link BENIGN_SLACK_FINALIZE_ERROR_CODES}) while text is still
@@ -236,12 +240,14 @@ export async function appendSlackStream(params: AppendSlackStreamParams): Promis
  *
  * All other errors propagate unchanged.
  */
-export async function stopSlackStream(params: StopSlackStreamParams): Promise<void> {
+export async function stopSlackStream(
+  params: StopSlackStreamParams,
+): Promise<StopSlackStreamResult> {
   const { session, text, chunks, metadata } = params;
 
   if (session.stopped) {
     logVerbose("slack-stream: stream already stopped, ignoring duplicate stop");
-    return;
+    return {};
   }
 
   session.stopped = true;
@@ -256,7 +262,7 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
   );
 
   try {
-    await session.streamer.stop(
+    const stopResponse = await session.streamer.stop(
       text || chunks?.length || metadata
         ? {
             ...(text ? { markdown_text: text } : {}),
@@ -267,6 +273,9 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
     );
     session.delivered = true;
     session.pendingText = "";
+    logVerbose("slack-stream: stream stopped");
+    const messageId = readSlackStreamStopMessageId(stopResponse);
+    return messageId ? { messageId } : {};
   } catch (err) {
     if (isBenignSlackFinalizeError(err)) {
       const code = extractSlackErrorCode(err) ?? "unknown";
@@ -279,13 +288,29 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
         logVerbose(
           `slack-stream: finalize rejected by Slack (${code}); prior appends delivered, treating stream as stopped`,
         );
-        return;
+        return {};
       }
     }
     throw err;
   }
+}
 
-  logVerbose("slack-stream: stream stopped");
+function readSlackStreamStopMessageId(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.ts === "string" && record.ts.trim()) {
+    return record.ts;
+  }
+  const message = record.message;
+  if (message && typeof message === "object") {
+    const messageTs = (message as Record<string, unknown>).ts;
+    if (typeof messageTs === "string" && messageTs.trim()) {
+      return messageTs;
+    }
+  }
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix Slack's inbound reply delivery path so `message_sent` hooks observe the actual Slack reply that users see.

- Emit Slack `message_sent` hooks for normal monitor replies, draft-preview finalization, and native Slack text-stream finalization.
- Include Slack delivery identifiers from `sendMessageSlack` / `chat.stopStream` so hook consumers receive the delivered Slack `ts` as `messageId`.
- Preserve accurate hook content for Slack edge cases: multi-media replies keep the caption as the logical sent content, and native text streaming reports the full visible streamed message rather than only the final chunk.

Fixes #78046.

## Why

Slack inbound replies bypass the generic outbound delivery path that already emits `message_sent`. That meant plugins could see Telegram final delivery, but not the equivalent Slack reply delivery. The visible Slack reply still reached users; the missing behavior was the plugin-platform/DX contract after delivery.

This keeps the fix at the Slack channel delivery boundary rather than in a Codex/OpenClaw harness-specific path, so it applies regardless of which runtime produced the reply payload.

## Behavior Addressed

- Slack users continue to receive the same assistant replies.
- Plugins listening for `message_sent` now get success/failure events for Slack monitor replies.
- Successful events include the Slack message timestamp when Slack returns one.
- Session/run correlation is forwarded when available from the Slack reply dispatch context.
- Fallback paths that re-enter normal reply delivery avoid double-emitting.

## Real Behavior Proof

Behavior addressed: Slack `message_sent` hook emission and payload accuracy for monitor reply delivery.

Real environment tested: Local OpenClaw checkout with Slack extension test harnesses and mocked Slack Web API boundaries.

Exact steps or command run after this patch:

- `pnpm test:extension slack`
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/replies.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts`
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/replies.test.ts extensions/slack/src/streaming.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts src/infra/outbound/deliver.test.ts`
- `pnpm tsgo:extensions`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `codex review --base origin/main`

Evidence after fix:

- Slack extension lane passed: 99 files / 1255 tests.
- Focused Slack/infra Vitest passed: 3 Slack files / 113 tests plus 1 infra file / 95 tests.
- Extension typecheck passed.
- Local Codex review reported no actionable correctness issues.

Observed result after fix: Hook tests now cover Slack text replies, delivery failures, internal hook forwarding, group context, block-only replies, media replies, multi-media caption preservation, draft preview finalization, native stream finalization, and native stream fallback no-double-emit behavior.

What was not tested: No live Slack workspace/token end-to-end run was performed. CI results are pending on this PR.

## AI Assistance

AI-assisted change. I reviewed the implementation, reran the OpenClaw PR preflight steps, understand the code being submitted, and addressed the required local Codex review gate before asking for review. No agent transcript is included.
