### PR TITLE
fix(agents): cap tool results at LLM boundary

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
@@ -355,6 +355,46 @@ describe("normalizeMessagesForLlmBoundary", () => {
     expect(input[0]).toHaveProperty("details");
   });
 
+  it("bounds provider replay to the latest 24 tool results", () => {
+    const input = Array.from({ length: 30 }, (_, index) => {
+      const toolCallId = `call_${index}`;
+      return [
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: toolCallId, name: "exec", arguments: {} }],
+          timestamp: index * 2,
+        },
+        {
+          role: "toolResult",
+          toolCallId,
+          toolName: "exec",
+          content: [{ type: "text", text: `output ${index}` }],
+          timestamp: index * 2 + 1,
+        },
+      ];
+    }).flat();
+
+    const output = normalizeMessagesForLlmBoundary(
+      input as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
+    ) as unknown as Array<Record<string, unknown>>;
+    const toolResults = output.filter((message) => message.role === "toolResult");
+    const keptIds = toolResults.map((message) => message.toolCallId);
+    const assistantToolCallIds = output.flatMap((message) => {
+      if (message.role !== "assistant" || !Array.isArray(message.content)) {
+        return [];
+      }
+      return message.content.flatMap((block) => {
+        const record = block as { type?: unknown; id?: unknown };
+        return record.type === "toolCall" && typeof record.id === "string" ? [record.id] : [];
+      });
+    });
+
+    expect(toolResults).toHaveLength(24);
+    expect(keptIds).toEqual(Array.from({ length: 24 }, (_, index) => `call_${index + 6}`));
+    expect(assistantToolCallIds).toEqual(keptIds);
+    expect(input.filter((message) => message.role === "toolResult")).toHaveLength(30);
+  });
+
   it("collapses single-text-block user content arrays to plain strings", () => {
     // Both current and historical single-text-block user messages must
     // serialize identically — this is the form-canonicalization half of the

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
@@ -395,6 +395,66 @@ describe("normalizeMessagesForLlmBoundary", () => {
     expect(input.filter((message) => message.role === "toolResult")).toHaveLength(30);
   });
 
+  it("preserves an oversized latest assistant tool-call batch before pruning older results", () => {
+    const historicalBatch = Array.from({ length: 10 }, (_, index) => {
+      const toolCallId = `old_call_${index}`;
+      return [
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: toolCallId, name: "exec", arguments: {} }],
+          timestamp: index * 2,
+        },
+        {
+          role: "toolResult",
+          toolCallId,
+          toolName: "exec",
+          content: [{ type: "text", text: `old output ${index}` }],
+          timestamp: index * 2 + 1,
+        },
+      ];
+    }).flat();
+    const latestCallIds = Array.from({ length: 25 }, (_, index) => `latest_call_${index}`);
+    const latestBatch = [
+      {
+        role: "assistant",
+        content: latestCallIds.map((id) => ({
+          type: "toolCall",
+          id,
+          name: "exec",
+          arguments: {},
+        })),
+        timestamp: 100,
+      },
+      ...latestCallIds.map((toolCallId, index) => ({
+        role: "toolResult",
+        toolCallId,
+        toolName: "exec",
+        content: [{ type: "text", text: `latest output ${index}` }],
+        timestamp: 101 + index,
+      })),
+    ];
+    const input = [...historicalBatch, ...latestBatch];
+
+    const output = normalizeMessagesForLlmBoundary(
+      input as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
+    ) as unknown as Array<Record<string, unknown>>;
+    const keptToolResultIds = output
+      .filter((message) => message.role === "toolResult")
+      .map((message) => message.toolCallId);
+    const keptAssistantToolCallIds = output.flatMap((message) => {
+      if (message.role !== "assistant" || !Array.isArray(message.content)) {
+        return [];
+      }
+      return message.content.flatMap((block) => {
+        const record = block as { type?: unknown; id?: unknown };
+        return record.type === "toolCall" && typeof record.id === "string" ? [record.id] : [];
+      });
+    });
+
+    expect(keptToolResultIds).toEqual(latestCallIds);
+    expect(keptAssistantToolCallIds).toEqual(latestCallIds);
+  });
+
   it("collapses single-text-block user content arrays to plain strings", () => {
     // Both current and historical single-text-block user messages must
     // serialize identically — this is the form-canonicalization half of the

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
@@ -7,6 +7,7 @@ import { INTER_SESSION_PROMPT_PREFIX_BASE } from "../../../sessions/input-proven
 import { stripHistoricalRuntimeContextCustomMessages } from "../../internal-runtime-context.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { stripToolResultDetails } from "../../session-transcript-repair.js";
+import { extractToolResultId } from "../../tool-call-id.js";
 import { normalizeAssistantReplayContent } from "../replay-history.js";
 import { markTranscriptPromptText } from "../tool-result-context-guard.js";
 import type { RuntimeContextCustomMessage } from "./runtime-context-prompt.js";
@@ -36,6 +37,7 @@ const BOUNDARY_CRON_TIME_MARKER = "Current time: ";
  * space(s). Mirrors LEADING_TIMESTAMP_PREFIX_RE in strip-inbound-meta.ts.
  */
 const BOUNDARY_LEADING_ENVELOPE_CAPTURE = /^\[[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*\] */;
+const LLM_BOUNDARY_MAX_TOOL_RESULT_MESSAGES = 24;
 
 export function normalizeMessagesForLlmBoundary(
   messages: AgentMessage[],
@@ -48,7 +50,137 @@ export function normalizeMessagesForLlmBoundary(
     normalized,
     options,
   );
-  return stripHistoricalRuntimeContextCustomMessages(withoutHistoricalInboundMetadata);
+  return pruneExcessToolResultsForProviderBoundary(
+    stripHistoricalRuntimeContextCustomMessages(withoutHistoricalInboundMetadata),
+  );
+}
+
+function pruneExcessToolResultsForProviderBoundary(messages: AgentMessage[]): AgentMessage[] {
+  const toolResultIndexes: number[] = [];
+  for (let index = 0; index < messages.length; index += 1) {
+    if (isBoundaryToolResultMessage(messages[index])) {
+      toolResultIndexes.push(index);
+    }
+  }
+
+  if (toolResultIndexes.length <= LLM_BOUNDARY_MAX_TOOL_RESULT_MESSAGES) {
+    return messages;
+  }
+
+  const keptToolResultIndexes = new Set(
+    toolResultIndexes.slice(-LLM_BOUNDARY_MAX_TOOL_RESULT_MESSAGES),
+  );
+  const droppedToolResultIndexes = new Set(
+    toolResultIndexes.filter((index) => !keptToolResultIndexes.has(index)),
+  );
+  const keptToolResultIds = new Set<string>();
+  const droppedToolResultIds = new Set<string>();
+
+  for (const index of keptToolResultIndexes) {
+    const id = extractBoundaryToolResultId(messages[index]);
+    if (id) {
+      keptToolResultIds.add(id);
+    }
+  }
+  for (const index of droppedToolResultIndexes) {
+    const id = extractBoundaryToolResultId(messages[index]);
+    if (id && !keptToolResultIds.has(id)) {
+      droppedToolResultIds.add(id);
+    }
+  }
+
+  const next: AgentMessage[] = [];
+  let touched = false;
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (droppedToolResultIndexes.has(index)) {
+      touched = true;
+      continue;
+    }
+    if (message?.role === "assistant" && droppedToolResultIds.size > 0) {
+      const pruned = pruneAssistantToolCalls(message, droppedToolResultIds);
+      if (!pruned) {
+        touched = true;
+        continue;
+      }
+      if (pruned !== message) {
+        touched = true;
+      }
+      next.push(pruned);
+      continue;
+    }
+    next.push(message);
+  }
+
+  return touched ? next : messages;
+}
+
+function isBoundaryToolResultMessage(message: AgentMessage | undefined): boolean {
+  return Boolean(message && typeof message === "object" && message.role === "toolResult");
+}
+
+function extractBoundaryToolResultId(message: AgentMessage | undefined): string | null {
+  if (!message || typeof message !== "object" || message.role !== "toolResult") {
+    return null;
+  }
+  return extractToolResultId(message);
+}
+
+function pruneAssistantToolCalls(
+  message: Extract<AgentMessage, { role: "assistant" }>,
+  droppedToolResultIds: Set<string>,
+): AgentMessage | null {
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return message;
+  }
+  if (
+    !content.some((block) => {
+      const id = extractAssistantToolCallBlockId(block);
+      return id ? droppedToolResultIds.has(id) : false;
+    })
+  ) {
+    return message;
+  }
+  const filteredContent = content.filter((block) => {
+    const id = extractAssistantToolCallBlockId(block);
+    if (!id) {
+      return true;
+    }
+    return !droppedToolResultIds.has(id);
+  });
+  if (filteredContent.length === content.length) {
+    return message;
+  }
+  if (filteredContent.length === 0) {
+    return null;
+  }
+  return {
+    ...message,
+    content: filteredContent,
+  } as AgentMessage;
+}
+
+function isAssistantToolCallType(type: unknown): boolean {
+  return (
+    type === "toolCall" ||
+    type === "toolUse" ||
+    type === "functionCall" ||
+    type === "tool_call" ||
+    type === "tool_use" ||
+    type === "function_call"
+  );
+}
+
+function extractAssistantToolCallBlockId(block: unknown): string | null {
+  if (!block || typeof block !== "object") {
+    return null;
+  }
+  const record = block as { type?: unknown; id?: unknown };
+  if (!isAssistantToolCallType(record.type) || typeof record.id !== "string") {
+    return null;
+  }
+  return record.id;
 }
 
 /** Normalizes existing transcript messages as if the current prompt were appended last. */

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
@@ -57,9 +57,16 @@ export function normalizeMessagesForLlmBoundary(
 
 function pruneExcessToolResultsForProviderBoundary(messages: AgentMessage[]): AgentMessage[] {
   const toolResultIndexes: number[] = [];
+  const toolCallAssistantIndexes = new Map<string, number>();
   for (let index = 0; index < messages.length; index += 1) {
-    if (isBoundaryToolResultMessage(messages[index])) {
+    const message = messages[index];
+    if (isBoundaryToolResultMessage(message)) {
       toolResultIndexes.push(index);
+    }
+    if (message?.role === "assistant") {
+      for (const toolCallId of extractAssistantToolCallIds(message)) {
+        toolCallAssistantIndexes.set(toolCallId, index);
+      }
     }
   }
 
@@ -67,9 +74,36 @@ function pruneExcessToolResultsForProviderBoundary(messages: AgentMessage[]): Ag
     return messages;
   }
 
-  const keptToolResultIndexes = new Set(
-    toolResultIndexes.slice(-LLM_BOUNDARY_MAX_TOOL_RESULT_MESSAGES),
+  let latestToolResultAssistantIndex = -1;
+  for (const index of toolResultIndexes) {
+    const id = extractBoundaryToolResultId(messages[index]);
+    if (!id) {
+      continue;
+    }
+    const assistantIndex = toolCallAssistantIndexes.get(id);
+    if (assistantIndex !== undefined && assistantIndex > latestToolResultAssistantIndex) {
+      latestToolResultAssistantIndex = assistantIndex;
+    }
+  }
+
+  const currentBatchToolResultIndexes =
+    latestToolResultAssistantIndex >= 0
+      ? toolResultIndexes.filter((index) => {
+          const id = extractBoundaryToolResultId(messages[index]);
+          return id ? toolCallAssistantIndexes.get(id) === latestToolResultAssistantIndex : false;
+        })
+      : [];
+  const olderToolResultIndexes = toolResultIndexes.filter(
+    (index) => !currentBatchToolResultIndexes.includes(index),
   );
+  const olderToolResultBudget = Math.max(
+    0,
+    LLM_BOUNDARY_MAX_TOOL_RESULT_MESSAGES - currentBatchToolResultIndexes.length,
+  );
+  const keptToolResultIndexes = new Set([
+    ...(olderToolResultBudget > 0 ? olderToolResultIndexes.slice(-olderToolResultBudget) : []),
+    ...currentBatchToolResultIndexes,
+  ]);
   const droppedToolResultIndexes = new Set(
     toolResultIndexes.filter((index) => !keptToolResultIndexes.has(index)),
   );
@@ -170,6 +204,19 @@ function isAssistantToolCallType(type: unknown): boolean {
     type === "tool_use" ||
     type === "function_call"
   );
+}
+
+function extractAssistantToolCallIds(
+  message: Extract<AgentMessage, { role: "assistant" }>,
+): string[] {
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return content.flatMap((block) => {
+    const id = extractAssistantToolCallBlockId(block);
+    return id ? [id] : [];
+  });
 }
 
 function extractAssistantToolCallBlockId(block: unknown): string | null {


### PR DESCRIPTION
## Summary

- Cap provider-boundary replay to the latest 24 `toolResult` messages so histories with 25+ completed tool results do not cross the model boundary intact.
- Drop the matching oldest assistant tool-call blocks when old tool results are omitted, avoiding dangling tool-call/result pairs in the provider-facing replay.
- Add a direct regression with 30 completed tool-call/result pairs proving the boundary keeps only the newest 24 and leaves the persisted input untouched.

Closes #92315.

## Duplicate PR check

- `gh pr list --repo openclaw/openclaw --state open --search "92315" --json number,title,url,headRefName,author` returned no open PRs.
- Closest open overlap found: #87912, but that PR changes text-size truncation of Codex-shaped tool-result blocks in `tool-result-truncation.*`; this PR is a count-based LLM-boundary replay guard in `attempt.llm-boundary.*`.

## Real behavior proof

- Behavior or issue addressed: Histories with 25+ completed tool results should not send all historical `toolResult` messages through the LLM boundary, because that can produce an invalid provider request schema. The boundary should keep the newest tool-result context and avoid dangling assistant tool calls.
- Real environment tested: Local OpenClaw source checkout at `a local OpenClaw checkout`, branch `codex/92315-tool-result-history`, running the actual `normalizeMessagesForLlmBoundary` implementation with `node --import tsx`.
- Exact steps or command run after this patch: Ran a local `node --import tsx` probe that imported `src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts`, built 30 completed assistant tool-call / `toolResult` pairs with public synthetic output, passed them through `normalizeMessagesForLlmBoundary`, and printed sanitized boundary metrics.
- Evidence after fix: Copied terminal output from that OpenClaw source-level boundary probe:

```json
{
  "status": "ok",
  "setup": "OpenClaw source LLM boundary normalizer",
  "inputToolResults": 30,
  "outputToolResults": 24,
  "firstOutputToolResult": "call_6",
  "lastOutputToolResult": "call_29",
  "assistantToolCalls": 24,
  "noDanglingAssistantToolCalls": true,
  "oldestToolResultDropped": true,
  "newestToolResultKept": true
}
```

- Observed result after fix: The real OpenClaw boundary normalizer accepted a 30-tool-result replay and returned a provider-facing history with 24 tool results, keeping the newest result (`call_29`), dropping the oldest result (`call_0`), and preserving tool-call/result pairing for all assistant tool calls that remained.
- What was not tested: I did not run a live provider API call or a Telegram/message-delivery flow. This issue is scoped to source/provider-boundary serialization, so the direct boundary probe plus regression tests cover the changed behavior without requiring transport proof.

## Proof

```bash
pnpm exec oxfmt --check --threads=1 src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
git diff --check
pnpm tsgo:test:src
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
node scripts/test-projects.mjs src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
```

## Risk

- Scope is limited to provider-boundary serialization; persisted session history is not rewritten.
- Main risk is old tool output context being omitted earlier than before when a replay has more than 24 tool results. The guard keeps the newest tool results, matching the current prompt's most relevant execution context.