### PR TITLE
fix #92218: memory_search tool disabled with QMD backend

### DIFF
--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -368,6 +368,30 @@ describe("getMemorySearchManager caching", () => {
     expect(searchResults).toHaveLength(1);
   });
 
+  it("returns the qmd startup failure when builtin fallback is unavailable", async () => {
+    const cfg = createQmdCfg("missing-qmd-no-builtin");
+    checkQmdBinaryAvailability.mockResolvedValueOnce({
+      available: false,
+      reason: "binary",
+      error: "spawn qmd ENOENT",
+    });
+    mockMemoryIndexGet.mockRejectedValueOnce(
+      new Error(
+        'Memory search unavailable: embedding provider "openai" is configured but unavailable.',
+      ),
+    );
+
+    const result = await getMemorySearchManager({ cfg, agentId: "missing-qmd-no-builtin" });
+
+    expect(result.manager).toBeNull();
+    expect(result.error).toContain("qmd binary unavailable (qmd): spawn qmd ENOENT");
+    expect(result.error).toContain(
+      'builtin fallback unavailable: Memory search unavailable: embedding provider "openai" is configured but unavailable.',
+    );
+    expect(createQmdManagerMock).not.toHaveBeenCalled();
+    expect(mockMemoryIndexGet).toHaveBeenCalledTimes(1);
+  });
+
   it("treats legacy qmd unavailable results without a reason as binary failures", async () => {
     const cfg = createQmdCfg("missing-qmd-legacy");
     checkQmdBinaryAvailability.mockResolvedValueOnce({

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -262,16 +262,18 @@ export async function getMemorySearchManager(params: {
     }
 
     if (transient) {
-      const { manager } = await createPrimaryQmdManager(
+      const { manager, failureReason } = await createPrimaryQmdManager(
         params.purpose === "cli" ? "cli" : "status",
       );
-      return manager ? { manager } : await getBuiltinMemorySearchManager(params);
+      return manager
+        ? { manager }
+        : await getBuiltinMemorySearchManagerAfterQmdFailure(params, failureReason);
     }
 
     const recentFailure = getActiveQmdManagerOpenFailure(scopeKey, identityKey);
     if (recentFailure) {
       log.debug?.(`qmd memory unavailable; using builtin during cooldown: ${recentFailure.reason}`);
-      return await getBuiltinMemorySearchManager(params);
+      return await getBuiltinMemorySearchManagerAfterQmdFailure(params, recentFailure.reason);
     }
 
     const pending = PENDING_QMD_MANAGER_CREATES.get(scopeKey);
@@ -280,16 +282,14 @@ export async function getMemorySearchManager(params: {
       return await getMemorySearchManager(params);
     }
 
+    let pendingFailureReason: string | undefined;
     const pendingCreate: PendingQmdManagerCreate = {
       identityKey,
       promise: (async () => {
         const created = await createFullQmdManager(identityKey);
         if (!created.entry) {
-          recordQmdManagerOpenFailure(
-            scopeKey,
-            identityKey,
-            created.failureReason ?? "qmd memory unavailable",
-          );
+          pendingFailureReason = created.failureReason ?? "qmd memory unavailable";
+          recordQmdManagerOpenFailure(scopeKey, identityKey, pendingFailureReason);
           return null;
         }
         QMD_MANAGER_CACHE.set(scopeKey, created.entry);
@@ -308,10 +308,33 @@ export async function getMemorySearchManager(params: {
     };
     PENDING_QMD_MANAGER_CREATES.set(scopeKey, pendingCreate);
     const manager = await pendingCreate.promise;
-    return manager ? { manager } : await getBuiltinMemorySearchManager(params);
+    return manager
+      ? { manager }
+      : await getBuiltinMemorySearchManagerAfterQmdFailure(params, pendingFailureReason);
   }
 
   return await getBuiltinMemorySearchManager(params);
+}
+
+async function getBuiltinMemorySearchManagerAfterQmdFailure(
+  params: {
+    cfg: OpenClawConfig;
+    agentId: string;
+    purpose?: MemorySearchManagerPurpose;
+  },
+  qmdFailureReason: string | undefined,
+): Promise<MemorySearchManagerResult> {
+  const fallback = await getBuiltinMemorySearchManager(params);
+  if (fallback.manager || !qmdFailureReason) {
+    return fallback;
+  }
+  const fallbackError = fallback.error?.trim();
+  return {
+    manager: null,
+    error: fallbackError
+      ? `${qmdFailureReason}; builtin fallback unavailable: ${fallbackError}`
+      : qmdFailureReason,
+  };
 }
 
 async function getBuiltinMemorySearchManager(params: {


### PR DESCRIPTION
## Summary

- Problem: Fixes #92218. With `memory.backend: "qmd"`, a QMD startup failure followed by an unavailable builtin fallback reported only the builtin embedding-provider error, making `memory_search` look disabled by missing builtin embeddings instead of showing why QMD could not start.
- Solution: Preserve the QMD manager startup failure when invoking the builtin fallback path, and combine it with the builtin fallback error only when the fallback is also unavailable.
- What changed: `getMemorySearchManager` now threads the QMD failure reason through transient startup, cooldown, and pending full-manager creation failure paths; the regression test covers the QMD-unavailable plus builtin-unavailable case.
- What did NOT change: Successful QMD searches are unchanged, successful builtin fallback remains unchanged, QMD search-mode behavior remains QMD-owned, and no embedding-provider registration behavior was changed.
- Why it matters / User impact: QMD users should not be forced to configure builtin embeddings just to understand or use QMD-backed `memory_search`. When QMD cannot start, the user-facing unavailable result now points at the QMD startup problem instead of hiding it behind an unrelated builtin provider failure.
- Fixes #92218

## Real behavior proof

- **Behavior or issue addressed:** `memory_search` with QMD backend no longer reports only a builtin embedding-provider error when QMD startup fails and builtin fallback is unavailable; the QMD startup reason is preserved. The real QMD `memory_search` route also remains independent from builtin embedding provider registration for BM25 search.
- **Real environment tested:** Local OpenClaw source worktree on Linux using the real memory-core tool/runtime code. The QMD CLI boundary was exercised with a deterministic local `qmd` executable fixture so the proof covers process probing, collection setup, QMD `search`, tool execution, and result decoration without requiring a live external QMD install.
- **Exact steps or command run after this patch:**

```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-92218
node scripts/run-vitest.mjs run extensions/memory-core/src/memory/search-manager.test.ts
node scripts/run-vitest.mjs run extensions/memory-core/src/tools.test.ts
pnpm tsgo:test:extensions
git diff --check
TASK_WORKTREE=/media/vdc/code/ai/aispace/openclaw-worktrees/issue-92218 EVIDENCE_DIR=/media/vdc/code/ai/aispace/openclaw-issue-92218-evidence node --import tsx /media/vdc/code/ai/aispace/openclaw-issue-92218-evidence/qmd-memory-search-proof.mts
```

- **Evidence after fix:**

```text
search-manager.test.ts:
Test Files  1 passed (1)
Tests  35 passed (35)

memory tools test:
Test Files  1 passed (1)
Tests  16 passed (16)

tsgo extensions:
$ pnpm tsgo:extensions:test
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo

qmd memory_search proof:
QMD memory_search proof at 2026-06-13T06:42:31.366Z
worktree=/media/vdc/code/ai/aispace/openclaw-worktrees/issue-92218
workspace=/media/vdc/code/ai/aispace/openclaw-issue-92218-evidence/qmd-proof-tmp/workspace
builtin_embedding_provider=proof-missing-embedding-provider (intentionally unregistered)
memory_search_disabled=false
memory_search_backend=qmd
memory_search_effective_mode=search
memory_search_provider=qmd
memory_search_model=qmd
memory_search_hits=1
memory_search_first_path=memory/2026-06-13.md
memory_search_first_corpus=memory
memory_search_first_snippet="QMD-only proof codename LOBSTER-92218 appears in a memory file.\n\nSource: memory/2026-06-13.md#L2"
fake_qmd_search_args=["search","LOBSTER-92218","--json","-n","4","-c","memory-root-main","-c","memory-dir-main"]
fake_qmd_call_count=5
captured_runtime_stdout_lines=1
result=passed
```

- **Observed result after fix:** The focused regression now receives an unavailable result containing `qmd binary unavailable (qmd): spawn qmd ENOENT` plus `builtin fallback unavailable: Memory search unavailable: embedding provider "openai" is configured but unavailable.` The real tool proof shows `memory_search_disabled=false`, `memory_search_backend=qmd`, and a QMD BM25 hit returned while the builtin embedding provider is intentionally unregistered.
- **What was not tested:** A live third-party QMD installation was not used; the proof uses a deterministic local QMD-compatible executable to avoid external machine state while still exercising the process/tool boundary. No remote embedding providers were tested because the fix is specifically for QMD routing/error attribution when builtin embeddings are absent.

## Review findings addressed

- N/A for new issue-mode PR; no existing review findings were attached to this task.

## Regression Test Plan

- **Target test file:** `extensions/memory-core/src/memory/search-manager.test.ts`
- **Scenario locked in:** QMD is selected as the memory backend, QMD startup fails before a manager is created, and builtin fallback also fails because the configured embedding provider is unavailable. The assertion requires the returned unavailable error to include both the QMD startup failure and the builtin fallback failure.
- **Why this is the smallest reliable guardrail:** The issue is owned by memory search manager selection/error attribution, so the focused unit regression directly exercises the manager boundary without depending on unrelated tool formatting. The separate `extensions/memory-core/src/tools.test.ts` run and local QMD-compatible proof cover the public `memory_search` tool path so the regression is not only a manager-only assertion.

## Merge risk

- **Risk labels considered:** session-state, availability.
- **Risk explanation:** The touched code is in memory search manager selection and cached QMD manager startup state, so a mistake could affect `memory_search` availability or the unavailable reason shown during QMD startup failures. The added `fallback` wording is intentional because the existing code already has a builtin fallback path; this patch only preserves the QMD source failure when that existing fallback cannot be opened.
- **Why acceptable:** The diff is limited to the QMD failure-to-builtin-fallback path. It returns the original builtin fallback result unchanged when fallback succeeds, and it does not change successful QMD manager creation or QMD search execution. The focused regression, full memory search manager test file, tool test file, typecheck, diff check, and QMD-compatible proof all ran after the patch.

## Root Cause

- **Root cause:** `getMemorySearchManager` selected QMD correctly, but when QMD manager creation failed it immediately delegated to `getBuiltinMemorySearchManager`. If that builtin manager also failed because its embedding provider was missing, the builtin error replaced the QMD startup error, so users saw only an embedding-provider failure even though their configured backend was QMD.
- **Why this is root-cause fix:** This fixes the root cause because the source invariant is that `getMemorySearchManager` must preserve the selected backend's startup failure while resolving manager state. The bug was caused at that manager-selection/error-attribution boundary when the QMD failure was discarded before returning an unavailable result. This patch changes that source boundary directly: it carries the original QMD failure through the existing fallback path and only combines messages when both QMD and builtin fallback are unavailable. It does not add a downstream string rewrite, tool-level special case, or provider-specific workaround.
- **Fix classification:** Root cause fix.
- **Maintainer-ready confidence:** High. The patch is small, has a failing-first regression for the exact failure mode, keeps successful fallback behavior unchanged, and has a real tool-path proof showing QMD-backed `memory_search` remains enabled without a registered builtin embedding provider.
- **Patch quality notes:** The patch-quality warnings about `fallback` are expected because this code already owns the QMD-to-builtin fallback path. The patch does not introduce a new silent fallback or mask an error; it makes the existing fallback path report the original QMD startup reason when the fallback cannot serve the request. The `session-state` risk signal comes from QMD manager startup/cache state, and the change is bounded to failure reporting after manager creation fails.
- **Architecture / source-of-truth check:** The source of truth for QMD-vs-builtin memory search manager selection is `extensions/memory-core/src/memory/search-manager.ts`. This patch updates that owner boundary before the tool receives an unavailable manager result; it does not alter `tools.ts` response shaping, QMD query parsing, QMD collection setup, builtin embedding provider resolution, or persisted memory records.
