### PR TITLE
fix(gateway): reject unknown explicit compat agents

### DIFF
--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -278,6 +278,10 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
   });
 
   it("supports base64 encoding and agent-scoped auth/config resolution", async () => {
+    testState.agentsConfig = {
+      list: [{ id: "main", default: true }, { id: "beta" }],
+    };
+    resetConfigRuntimeState();
     const res = await postEmbeddings(
       {
         model: "openclaw/beta",
@@ -293,6 +297,17 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
     const lastCall = latestCreateEmbeddingProviderOptions();
     expect(typeof lastCall.model).toBe("string");
     expect(lastCall.agentDir).toBe(resolveAgentDir({}, "beta"));
+  });
+
+  it("rejects unknown explicit agent selectors before creating an embedding provider", async () => {
+    const callCount = createEmbeddingProviderMock.mock.calls.length;
+    const res = await postEmbeddings({
+      model: "openclaw/missing-agent",
+      input: "hello",
+    });
+
+    await expectInvalidEmbeddingRequest(res, "Unknown OpenClaw agent 'missing-agent'.");
+    expect(createEmbeddingProviderMock.mock.calls.length).toBe(callCount);
   });
 
   it("rejects invalid input shapes", async () => {

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -24,7 +24,7 @@ import type {
 } from "../plugins/memory-embedding-providers.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { sendJson } from "./http-common.js";
+import { sendInvalidRequest, sendJson } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
   OPENCLAW_MODEL_ID,
@@ -291,7 +291,12 @@ export async function handleOpenAiEmbeddingsHttpRequest(
     return true;
   }
 
-  const agentId = resolveAgentIdForRequest({ req, model: requestModel });
+  const agentResult = resolveAgentIdForRequest({ req, model: requestModel });
+  if (!agentResult.ok) {
+    sendInvalidRequest(res, agentResult.errorMessage);
+    return true;
+  }
+  const agentId = agentResult.agentId;
   const agentDir = resolveAgentDir(cfg, agentId);
   const memorySearch = resolveMemorySearchConfig(cfg, agentId);
   const configuredProvider = memorySearch?.provider ?? "openai";

--- a/src/gateway/http-utils.request-context.test.ts
+++ b/src/gateway/http-utils.request-context.test.ts
@@ -2,7 +2,9 @@
  * Tests HTTP request context extraction for gateway auth and routing.
  */
 import type { IncomingMessage } from "node:http";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.js";
 import {
   resolveOpenAiCompatibleHttpOperatorScopes,
   resolveOpenAiCompatibleHttpSenderIsOwner,
@@ -15,44 +17,128 @@ function createReq(headers: Record<string, string> = {}): IncomingMessage {
   return { headers } as IncomingMessage;
 }
 
+function setAgentRoster(ids: string[]) {
+  resetConfigRuntimeState();
+  setRuntimeConfigSnapshot({
+    agents: {
+      list: ids.map((id, index) => ({ id, default: index === 0 })),
+    },
+  } satisfies OpenClawConfig);
+}
+
+function expectResolvedContext(result: ReturnType<typeof resolveGatewayRequestContext>) {
+  expect(result.ok).toBe(true);
+  if (!result.ok) {
+    throw new Error(result.errorMessage);
+  }
+  return result;
+}
+
 const tokenAuth = { mode: "token" as const };
 const noneAuth = { mode: "none" as const };
 
+beforeEach(() => {
+  setAgentRoster(["main", "beta"]);
+});
+
 describe("resolveGatewayRequestContext", () => {
   it("uses normalized x-openclaw-message-channel when enabled", () => {
-    const result = resolveGatewayRequestContext({
-      req: createReq({ "x-openclaw-message-channel": " Custom-Channel " }),
-      model: "openclaw",
-      sessionPrefix: "openai",
-      defaultMessageChannel: "webchat",
-      useMessageChannelHeader: true,
-    });
+    const result = expectResolvedContext(
+      resolveGatewayRequestContext({
+        req: createReq({ "x-openclaw-message-channel": " Custom-Channel " }),
+        model: "openclaw",
+        sessionPrefix: "openai",
+        defaultMessageChannel: "webchat",
+        useMessageChannelHeader: true,
+      }),
+    );
 
     expect(result.messageChannel).toBe("custom-channel");
   });
 
   it("uses default messageChannel when header support is disabled", () => {
-    const result = resolveGatewayRequestContext({
-      req: createReq({ "x-openclaw-message-channel": "custom-channel" }),
-      model: "openclaw",
-      sessionPrefix: "openresponses",
-      defaultMessageChannel: "webchat",
-      useMessageChannelHeader: false,
-    });
+    const result = expectResolvedContext(
+      resolveGatewayRequestContext({
+        req: createReq({ "x-openclaw-message-channel": "custom-channel" }),
+        model: "openclaw",
+        sessionPrefix: "openresponses",
+        defaultMessageChannel: "webchat",
+        useMessageChannelHeader: false,
+      }),
+    );
 
     expect(result.messageChannel).toBe("webchat");
   });
 
   it("includes session prefix and user in generated session key", () => {
+    const result = expectResolvedContext(
+      resolveGatewayRequestContext({
+        req: createReq(),
+        model: "openclaw",
+        user: "alice",
+        sessionPrefix: "openresponses",
+        defaultMessageChannel: "webchat",
+      }),
+    );
+
+    expect(result.sessionKey).toContain("openresponses-user:alice");
+  });
+
+  it("keeps valid explicit agent selectors in the configured roster", () => {
+    const result = expectResolvedContext(
+      resolveGatewayRequestContext({
+        req: createReq({ "x-openclaw-agent-id": " Beta " }),
+        model: "openclaw/main",
+        sessionPrefix: "openai",
+        defaultMessageChannel: "webchat",
+      }),
+    );
+
+    expect(result.agentId).toBe("beta");
+    expect(result.sessionKey).toMatch(/^agent:beta:/);
+  });
+
+  it("rejects unknown explicit model agent selectors", () => {
     const result = resolveGatewayRequestContext({
       req: createReq(),
-      model: "openclaw",
-      user: "alice",
-      sessionPrefix: "openresponses",
+      model: "openclaw/missing-agent",
+      sessionPrefix: "openai",
       defaultMessageChannel: "webchat",
     });
 
-    expect(result.sessionKey).toContain("openresponses-user:alice");
+    expect(result).toEqual({
+      ok: false,
+      errorMessage: "Unknown OpenClaw agent 'missing-agent'.",
+    });
+  });
+
+  it("rejects unknown explicit header agent selectors", () => {
+    const result = resolveGatewayRequestContext({
+      req: createReq({ "x-openclaw-agent-id": "missing-agent" }),
+      model: "openclaw",
+      sessionPrefix: "openai",
+      defaultMessageChannel: "webchat",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      errorMessage: "Unknown OpenClaw agent 'missing-agent'.",
+    });
+  });
+
+  it("keeps default routing when no explicit agent is supplied", () => {
+    setAgentRoster(["solo"]);
+    const result = expectResolvedContext(
+      resolveGatewayRequestContext({
+        req: createReq(),
+        model: "openclaw/default",
+        sessionPrefix: "openai",
+        defaultMessageChannel: "webchat",
+      }),
+    );
+
+    expect(result.agentId).toBe("solo");
+    expect(result.sessionKey).toMatch(/^agent:solo:/);
   });
 });
 

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -6,7 +6,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { modelKey, parseModelRef, resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { createModelVisibilityPolicy } from "../agents/model-visibility-policy.js";
 import { getRuntimeConfig } from "../config/io.js";
@@ -36,6 +36,10 @@ export {
 export const OPENCLAW_MODEL_ID = "openclaw";
 /** Default OpenAI-compatible model alias that targets the default OpenClaw agent. */
 export const OPENCLAW_DEFAULT_MODEL_ID = "openclaw/default";
+
+export type AgentIdForRequestResult =
+  | { ok: true; agentId: string }
+  | { ok: false; errorMessage: string };
 
 function resolveAgentIdFromHeader(req: IncomingMessage): string | undefined {
   const raw =
@@ -131,19 +135,41 @@ export async function resolveOpenAiCompatModelOverride(params: {
   return { modelOverride: raw };
 }
 
+function formatUnknownAgentMessage(agentId: string): string {
+  return `Unknown OpenClaw agent '${agentId}'.`;
+}
+
+function resolveAgentIdSelection(params: { req: IncomingMessage; model: string | undefined }): {
+  agentId: string;
+  explicit: boolean;
+} {
+  const cfg = getRuntimeConfig();
+  const fromHeader = resolveAgentIdFromHeader(params.req);
+  if (fromHeader) {
+    return { agentId: fromHeader, explicit: true };
+  }
+
+  const fromModel = resolveAgentIdFromModel(params.model, cfg);
+  if (fromModel) {
+    const lowered = normalizeLowercaseStringOrEmpty(params.model);
+    const explicit = lowered !== OPENCLAW_MODEL_ID && lowered !== OPENCLAW_DEFAULT_MODEL_ID;
+    return { agentId: fromModel, explicit };
+  }
+
+  return { agentId: resolveDefaultAgentId(cfg), explicit: false };
+}
+
 /** Resolves the request agent from headers, model alias, or the configured default. */
 export function resolveAgentIdForRequest(params: {
   req: IncomingMessage;
   model: string | undefined;
-}): string {
+}): AgentIdForRequestResult {
   const cfg = getRuntimeConfig();
-  const fromHeader = resolveAgentIdFromHeader(params.req);
-  if (fromHeader) {
-    return fromHeader;
+  const selection = resolveAgentIdSelection(params);
+  if (selection.explicit && !listAgentIds(cfg).includes(selection.agentId)) {
+    return { ok: false, errorMessage: formatUnknownAgentMessage(selection.agentId) };
   }
-
-  const fromModel = resolveAgentIdFromModel(params.model, cfg);
-  return fromModel ?? resolveDefaultAgentId(cfg);
+  return { ok: true, agentId: selection.agentId };
 }
 
 function resolveSessionKey(params: {
@@ -170,8 +196,14 @@ export function resolveGatewayRequestContext(params: {
   sessionPrefix: string;
   defaultMessageChannel: string;
   useMessageChannelHeader?: boolean;
-}): { agentId: string; sessionKey: string; messageChannel: string } {
-  const agentId = resolveAgentIdForRequest({ req: params.req, model: params.model });
+}):
+  | { ok: true; agentId: string; sessionKey: string; messageChannel: string }
+  | { ok: false; errorMessage: string } {
+  const agentResult = resolveAgentIdForRequest({ req: params.req, model: params.model });
+  if (!agentResult.ok) {
+    return agentResult;
+  }
+  const agentId = agentResult.agentId;
   const sessionKey = resolveSessionKey({
     req: params.req,
     agentId,
@@ -184,5 +216,5 @@ export function resolveGatewayRequestContext(params: {
       params.defaultMessageChannel)
     : params.defaultMessageChannel;
 
-  return { agentId, sessionKey, messageChannel };
+  return { ok: true, agentId, sessionKey, messageChannel };
 }

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -13,6 +13,7 @@ import { subscribeEmbeddedAgentSession } from "../agents/embedded-agent-subscrib
 import { FailoverError } from "../agents/failover-error.js";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
+import { resetConfigRuntimeState } from "../config/config.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
@@ -132,6 +133,10 @@ function firstAgentCommandOptions() {
 describe("OpenAI-compatible HTTP API (e2e)", () => {
   it("handles request validation and routing", async () => {
     const port = enabledPort;
+    testState.agentsConfig = {
+      list: [{ id: "main", default: true }, { id: "beta" }],
+    };
+    resetConfigRuntimeState();
     const mockAgentOnce = (payloads: Array<{ text: string }>) => {
       agentCommand.mockClear();
       agentCommand.mockResolvedValueOnce({ payloads } as never);
@@ -224,6 +229,37 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         },
         matcher: /^agent:beta:/,
       });
+
+      {
+        agentCommand.mockClear();
+        const res = await postChatCompletions(port, {
+          model: "openclaw/missing-agent",
+          messages: [{ role: "user", content: "hi" }],
+        });
+        expect(res.status).toBe(400);
+        const json = (await res.json()) as { error?: { type?: string; message?: string } };
+        expect(json.error).toEqual({
+          type: "invalid_request_error",
+          message: "Unknown OpenClaw agent 'missing-agent'.",
+        });
+        expect(agentCommand).toHaveBeenCalledTimes(0);
+      }
+
+      {
+        agentCommand.mockClear();
+        const res = await postChatCompletions(
+          port,
+          { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
+          { "x-openclaw-agent-id": "missing-agent" },
+        );
+        expect(res.status).toBe(400);
+        const json = (await res.json()) as { error?: { type?: string; message?: string } };
+        expect(json.error).toEqual({
+          type: "invalid_request_error",
+          message: "Unknown OpenClaw agent 'missing-agent'.",
+        });
+        expect(agentCommand).toHaveBeenCalledTimes(0);
+      }
 
       await expectAgentSessionKeyMatch({
         body: {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -42,7 +42,13 @@ import {
 } from "./agent-prompt.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { sendJson, setSseHeaders, watchClientDisconnect, writeDone } from "./http-common.js";
+import {
+  sendInvalidRequest,
+  sendJson,
+  setSseHeaders,
+  watchClientDisconnect,
+  writeDone,
+} from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
   resolveGatewayRequestContext,
@@ -962,7 +968,7 @@ export async function handleOpenAiHttpRequest(
         }
       : undefined;
 
-  const { agentId, sessionKey, messageChannel } = resolveGatewayRequestContext({
+  const requestContext = resolveGatewayRequestContext({
     req,
     model,
     user,
@@ -970,6 +976,11 @@ export async function handleOpenAiHttpRequest(
     defaultMessageChannel: "webchat",
     useMessageChannelHeader: true,
   });
+  if (!requestContext.ok) {
+    sendInvalidRequest(res, requestContext.errorMessage);
+    return true;
+  }
+  const { agentId, sessionKey, messageChannel } = requestContext;
   const { modelOverride, errorMessage: modelError } = await resolveOpenAiCompatModelOverride({
     req,
     agentId,

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -8,6 +8,7 @@ import { createClientToolNameConflictError } from "../agents/agent-tool-definiti
 import { FailoverError } from "../agents/failover-error.js";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
+import { resetConfigRuntimeState } from "../config/config.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
@@ -15,6 +16,7 @@ import {
   getFreePort,
   installGatewayTestHooks,
   startGatewayServerWithRetries,
+  testState,
 } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
@@ -257,6 +259,10 @@ async function expectInvalidRequest(
 describe("OpenResponses HTTP API (e2e)", () => {
   it("handles OpenResponses request parsing and validation", async () => {
     const port = enabledPort;
+    testState.agentsConfig = {
+      list: [{ id: "main", default: true }, { id: "beta" }],
+    };
+    resetConfigRuntimeState();
     const mockAgentOnce = (payloads: Array<{ text: string }>, meta?: unknown) => {
       agentCommand.mockClear();
       agentCommand.mockResolvedValueOnce({ payloads, meta } as never);
@@ -323,6 +329,39 @@ describe("OpenResponses HTTP API (e2e)", () => {
         /^agent:beta:/,
       );
       await ensureResponseConsumed(resModel);
+
+      agentCommand.mockClear();
+      const resUnknownModel = await postResponses(port, {
+        model: "openclaw/missing-agent",
+        input: "hi",
+      });
+      expect(resUnknownModel.status).toBe(400);
+      const unknownModelJson = (await resUnknownModel.json()) as {
+        error?: { type?: string; message?: string };
+      };
+      expect(unknownModelJson.error).toEqual({
+        type: "invalid_request_error",
+        message: "Unknown OpenClaw agent 'missing-agent'.",
+      });
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+      await ensureResponseConsumed(resUnknownModel);
+
+      agentCommand.mockClear();
+      const resUnknownHeader = await postResponses(
+        port,
+        { model: "openclaw", input: "hi" },
+        { "x-openclaw-agent-id": "missing-agent" },
+      );
+      expect(resUnknownHeader.status).toBe(400);
+      const unknownHeaderJson = (await resUnknownHeader.json()) as {
+        error?: { type?: string; message?: string };
+      };
+      expect(unknownHeaderJson.error).toEqual({
+        type: "invalid_request_error",
+        message: "Unknown OpenClaw agent 'missing-agent'.",
+      });
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+      await ensureResponseConsumed(resUnknownHeader);
 
       mockAgentOnce([{ text: "hello" }]);
       const resDefaultAlias = await postResponses(port, { model: "openclaw/default", input: "hi" });

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -36,7 +36,13 @@ import { defaultRuntime } from "../runtime.js";
 import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { sendJson, setSseHeaders, watchClientDisconnect, writeDone } from "./http-common.js";
+import {
+  sendInvalidRequest,
+  sendJson,
+  setSseHeaders,
+  watchClientDisconnect,
+  writeDone,
+} from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
   getBearerToken,
@@ -477,7 +483,12 @@ export async function handleOpenResponsesHttpRequest(
   const stream = Boolean(payload.stream);
   const model = payload.model;
   const user = payload.user;
-  const agentId = resolveAgentIdForRequest({ req, model });
+  const agentResult = resolveAgentIdForRequest({ req, model });
+  if (!agentResult.ok) {
+    sendInvalidRequest(res, agentResult.errorMessage);
+    return true;
+  }
+  const agentId = agentResult.agentId;
   const { modelOverride, errorMessage: modelError } = await resolveOpenAiCompatModelOverride({
     req,
     agentId,
@@ -632,6 +643,10 @@ export async function handleOpenResponsesHttpRequest(
     defaultMessageChannel: "webchat",
     useMessageChannelHeader: true,
   });
+  if (!resolved.ok) {
+    sendInvalidRequest(res, resolved.errorMessage);
+    return true;
+  }
   const responseSessionScope = createResponseSessionScope({
     req,
     auth: opts.auth,


### PR DESCRIPTION
## Summary

Fixes #92504.

- Validate explicit OpenAI-compatible agent selectors against the configured agent roster.
- Reject unknown `model: openclaw/<agentId>` and `x-openclaw-agent-id` targets with the existing OpenAI-compatible `invalid_request_error` shape before dispatch.
- Preserve existing default routing for omitted agent targets and `openclaw` / `openclaw/default`.
- Apply the shared resolver result to chat completions, OpenResponses, and embeddings compat surfaces.

## Verification

- `node scripts/run-vitest.mjs src/gateway/http-utils.request-context.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/gateway/embeddings-http.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/gateway/http-utils.ts src/gateway/http-utils.request-context.test.ts src/gateway/openai-http.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.ts src/gateway/openresponses-http.test.ts src/gateway/embeddings-http.ts src/gateway/embeddings-http.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: A well-formed but unknown explicit OpenClaw agent selector on OpenAI-compatible HTTP routes no longer falls through to `agents.defaults` and dispatches a turn under the wrong persona.

Real environment tested: Local OpenClaw source checkout on macOS, branch `codex/gateway-agent-roster-validation`, using the repository gateway Vitest harness with real HTTP requests against local gateway servers.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/http-utils.request-context.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/gateway/embeddings-http.test.ts`

Evidence after fix: Terminal output from the focused gateway test run:

```text
Test Files  13 passed (13)
Tests       239 passed (239)
```

Observed result after fix: `openclaw/missing-agent` and `x-openclaw-agent-id: missing-agent` return HTTP 400 with `invalid_request_error` and do not call `agentCommand`; configured `beta` and default aliases still dispatch normally.

What was not tested: A live external OpenAI SDK client was not used; the proof uses the repository's local HTTP gateway test harness.
