### PR TITLE
fix(ui): preserve WebChat backscroll during streaming

### DIFF
--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -232,6 +232,24 @@ describe("scheduleChatScroll", () => {
     expect(container.scrollTop).toBe(container.scrollHeight);
   });
 
+  it("uses force=true on initial load even after a previous follow lock", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 500,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+    host.chatHasAutoScrolled = false;
+
+    scheduleChatScroll(host, true);
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(container.scrollHeight);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatNewMessagesBelow).toBe(false);
+  });
+
   it("sets chatNewMessagesBelow when not scrolling due to user position", async () => {
     const { host } = createScrollHost({
       scrollHeight: 2000,

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -51,6 +51,7 @@ function createScrollHost(
     chatLastScrollTop: 0,
     chatHasAutoScrolled: false,
     chatUserNearBottom: true,
+    chatFollowLocked: false,
     chatHeaderControlsHidden: false,
     chatNewMessagesBelow: false,
     chatIsProgrammaticScroll: false,
@@ -107,10 +108,9 @@ describe("handleChatScroll", () => {
     expect(host.chatUserNearBottom).toBe(false);
   });
 
-  it("sets chatUserNearBottom=false when user scrolled up past one long message (>200px <450px)", () => {
+  it("sets chatUserNearBottom=false when scrolled past the near-bottom threshold", () => {
     const { host } = createScrollHost({});
-    // distanceFromBottom = 2000 - 1250 - 400 = 350 → old threshold would say "near", new says "near"
-    // distanceFromBottom = 2000 - 1100 - 400 = 500 → old threshold would say "not near", new also "not near"
+    // distanceFromBottom = 2000 - 1100 - 400 = 500 → beyond threshold
     const event = createScrollEvent(2000, 1100, 400);
     handleChatScroll(host, event);
     expect(host.chatUserNearBottom).toBe(false);
@@ -248,6 +248,62 @@ describe("scheduleChatScroll", () => {
     expect(host.chatNewMessagesBelow).toBe(true);
   });
 
+  it("does not re-stick streaming after a user scrolls slightly up near the bottom", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1540,
+      clientHeight: 400,
+    });
+    host.chatHasAutoScrolled = true;
+    host.chatUserNearBottom = true;
+    host.chatIsProgrammaticScroll = true;
+    host.chatProgrammaticScrollTarget = 1800;
+    host.chatLastScrollTop = 1600;
+
+    handleChatScroll(host, createScrollEvent(2000, 1540, 400));
+
+    expect(host.chatFollowLocked).toBe(true);
+    expect(host.chatUserNearBottom).toBe(false);
+
+    scheduleChatScroll(host);
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(1540);
+    expect(host.chatNewMessagesBelow).toBe(true);
+
+    host.chatIsProgrammaticScroll = false;
+    container.scrollTop = 1600;
+    handleChatScroll(host, createScrollEvent(2000, 1600, 400));
+
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatNewMessagesBelow).toBe(false);
+  });
+
+  it("does not re-stick streaming after a small user scroll-up near the bottom", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1589,
+      clientHeight: 400,
+    });
+    host.chatHasAutoScrolled = true;
+    host.chatUserNearBottom = true;
+    host.chatIsProgrammaticScroll = true;
+    host.chatProgrammaticScrollTarget = 1800;
+    host.chatLastScrollTop = 1600;
+
+    handleChatScroll(host, createScrollEvent(2000, 1589, 400));
+
+    expect(host.chatFollowLocked).toBe(true);
+    expect(host.chatUserNearBottom).toBe(false);
+
+    scheduleChatScroll(host);
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(1589);
+    expect(host.chatNewMessagesBelow).toBe(true);
+  });
+
   it("does NOT scroll automatically when chat auto-scroll is off", async () => {
     const { host, container } = createScrollHost({
       scrollHeight: 2000,
@@ -360,6 +416,7 @@ describe("resetChatScroll", () => {
     const { host } = createScrollHost({});
     host.chatHasAutoScrolled = true;
     host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
     host.chatLastScrollTop = 300;
     host.chatHeaderControlsHidden = true;
 
@@ -367,6 +424,7 @@ describe("resetChatScroll", () => {
 
     expect(host.chatHasAutoScrolled).toBe(false);
     expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
     expect(host.chatLastScrollTop).toBe(0);
     expect(host.chatHeaderControlsHidden).toBe(false);
     expect(host.chatIsProgrammaticScroll).toBe(false);

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -3,6 +3,7 @@ import { normalizeChatAutoScrollMode, type ChatAutoScrollMode } from "./storage.
 
 /** Distance (px) from the bottom within which we consider the user "near bottom". */
 const NEAR_BOTTOM_THRESHOLD = 450;
+const FOLLOW_REACQUIRE_THRESHOLD = 8;
 const HEADER_HIDE_SCROLL_DELTA = 12;
 const HEADER_SHOW_TOP_THRESHOLD = 24;
 
@@ -15,6 +16,7 @@ type ScrollHost = {
   chatLastScrollTop: number;
   chatHasAutoScrolled: boolean;
   chatUserNearBottom: boolean;
+  chatFollowLocked: boolean;
   chatHeaderControlsHidden: boolean;
   chatNewMessagesBelow: boolean;
   chatIsProgrammaticScroll: boolean;
@@ -84,6 +86,7 @@ export function scheduleChatScroll(
         manualScroll ||
         autoScrollMode === "always" ||
         (autoScrollMode === "near-bottom" &&
+          !host.chatFollowLocked &&
           (effectiveForce ||
             host.chatUserNearBottom ||
             distanceFromBottom < NEAR_BOTTOM_THRESHOLD));
@@ -96,6 +99,7 @@ export function scheduleChatScroll(
       if (effectiveForce) {
         host.chatHasAutoScrolled = true;
       }
+      host.chatFollowLocked = false;
       const smoothEnabled =
         smooth &&
         (typeof window === "undefined" ||
@@ -128,6 +132,7 @@ export function scheduleChatScroll(
           manualScroll ||
           autoScrollMode === "always" ||
           (autoScrollMode === "near-bottom" &&
+            !host.chatFollowLocked &&
             (effectiveForce ||
               host.chatUserNearBottom ||
               latestDistanceFromBottom < NEAR_BOTTOM_THRESHOLD));
@@ -207,21 +212,29 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   // Only suppress if scrollTop is still at or above the position we scrolled to;
   // if it dropped below, the user scrolled up during the guard window and we must
   // process the event so streaming stops pinning them back to the bottom.
+  const isUserScrollUp = delta < 0;
+  const isDeliberateScrollUp = delta < -HEADER_HIDE_SCROLL_DELTA;
   if (
     host.chatIsProgrammaticScroll &&
+    !isUserScrollUp &&
     container.scrollTop >= host.chatProgrammaticScrollTarget - container.clientHeight
   ) {
     return;
   }
   const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-  host.chatUserNearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+  if (isUserScrollUp && distanceFromBottom > FOLLOW_REACQUIRE_THRESHOLD) {
+    host.chatFollowLocked = true;
+  } else if (distanceFromBottom <= FOLLOW_REACQUIRE_THRESHOLD) {
+    host.chatFollowLocked = false;
+  }
+  host.chatUserNearBottom = !host.chatFollowLocked && distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
   const hasUsefulScroll = container.scrollHeight - container.clientHeight > NEAR_BOTTOM_THRESHOLD;
 
   if (!hasUsefulScroll || scrollTop <= HEADER_SHOW_TOP_THRESHOLD || host.chatUserNearBottom) {
     host.chatHeaderControlsHidden = false;
   } else if (delta > HEADER_HIDE_SCROLL_DELTA) {
     host.chatHeaderControlsHidden = true;
-  } else if (delta < -HEADER_HIDE_SCROLL_DELTA) {
+  } else if (isDeliberateScrollUp) {
     host.chatHeaderControlsHidden = false;
   }
 
@@ -252,6 +265,7 @@ export function handleActivityScroll(host: ScrollHost, event: Event) {
 export function resetChatScroll(host: ScrollHost) {
   host.chatHasAutoScrolled = false;
   host.chatUserNearBottom = true;
+  host.chatFollowLocked = false;
   host.chatLastScrollTop = 0;
   host.chatHeaderControlsHidden = false;
   host.chatNewMessagesBelow = false;

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -86,10 +86,9 @@ export function scheduleChatScroll(
         manualScroll ||
         autoScrollMode === "always" ||
         (autoScrollMode === "near-bottom" &&
-          !host.chatFollowLocked &&
           (effectiveForce ||
-            host.chatUserNearBottom ||
-            distanceFromBottom < NEAR_BOTTOM_THRESHOLD));
+            (!host.chatFollowLocked &&
+              (host.chatUserNearBottom || distanceFromBottom < NEAR_BOTTOM_THRESHOLD))));
 
       if (!shouldStick) {
         // User is scrolled up — flag that new content arrived below.
@@ -132,10 +131,9 @@ export function scheduleChatScroll(
           manualScroll ||
           autoScrollMode === "always" ||
           (autoScrollMode === "near-bottom" &&
-            !host.chatFollowLocked &&
             (effectiveForce ||
-              host.chatUserNearBottom ||
-              latestDistanceFromBottom < NEAR_BOTTOM_THRESHOLD));
+              (!host.chatFollowLocked &&
+                (host.chatUserNearBottom || latestDistanceFromBottom < NEAR_BOTTOM_THRESHOLD))));
         if (!shouldStickRetry) {
           return;
         }

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -697,6 +697,7 @@ export class OpenClawApp extends LitElement {
   chatLastScrollTop = 0;
   chatHasAutoScrolled = false;
   chatUserNearBottom = true;
+  chatFollowLocked = false;
   chatIsProgrammaticScroll = false;
   chatProgrammaticScrollTarget = 0;
   @state() chatNewMessagesBelow = false;


### PR DESCRIPTION
## Summary

- Preserves WebChat backscroll when new messages or streaming chunks arrive after the user has scrolled up.
- Adds a follow-lock state that disables near-bottom auto-follow after a user scroll-up until the user returns to the bottom.
- Keeps manual scroll-to-bottom and the `always` auto-scroll mode working as explicit overrides.
- Adds regression coverage for small scroll-up movements during the programmatic scroll guard window.

## Linked context

Closes #92386

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: WebChat should not force-scroll to the bottom when the user has deliberately scrolled up during an active reply or stream.
- Real environment tested: Local OpenClaw checkout at this PR head on macOS, Node 24.15.0, Vite dev server, Playwright Chromium against `http://127.0.0.1:41739/`.
- Exact steps or command run after this patch:

```bash
corepack pnpm@11.2.2 --dir ui exec vite --host 127.0.0.1 --port 41739
node - <<'NODE'
const { chromium } = require('playwright');
// Opens Chromium, imports /src/ui/app-scroll.ts from Vite, creates a real
// scroll container, simulates user scroll-up during streaming, then schedules
// a streaming scroll update and records scroll/follow state.
NODE
```

- Evidence after fix:

```json
{
  "afterUserScroll": {
    "scrollTop": 1540,
    "followLocked": true,
    "userNearBottom": false,
    "newMessagesBelow": false
  },
  "afterStreamingUpdate": {
    "scrollTop": 1540,
    "followLocked": true,
    "userNearBottom": false,
    "newMessagesBelow": true
  },
  "afterReturnToBottom": {
    "scrollTop": 1600,
    "followLocked": false,
    "userNearBottom": true,
    "newMessagesBelow": false
  }
}
```

- Observed result after fix: after the user scrolls from `1600` to `1540`, a streaming update leaves `scrollTop` at `1540` instead of forcing it back to bottom, and marks `newMessagesBelow=true`. Scrolling back to bottom clears the lock and indicator.
- What was not tested: a live gateway-backed chat session with a real model streaming tokens.
- Proof limitations or environment constraints: the browser proof exercises the actual UI scroll module in Chromium with a real DOM scroll container, but uses a synthetic host instead of a live gateway session to avoid needing credentials or live model traffic.
- Before evidence: issue #92386 reports that every new incoming message or streamed reply chunk yanks the WebChat view back to the bottom while the user is reading backscroll.

## Tests and validation

- `node scripts/test-projects.mjs ui/src/ui/app-scroll.test.ts` - passed, 30 tests.
- `node scripts/run-oxlint.mjs ui/src/ui/app-scroll.ts ui/src/ui/app-scroll.test.ts ui/src/ui/app.ts` - passed.
- `corepack pnpm@11.2.2 exec oxfmt --check ui/src/ui/app-scroll.ts ui/src/ui/app-scroll.test.ts ui/src/ui/app.ts` - passed.
- `corepack pnpm@11.2.2 tsgo:test:ui` - passed.
- `corepack pnpm@11.2.2 ui:build` - passed.
- `corepack pnpm@11.2.2 --dir ui test src/ui/chat/chat-avatar.test.ts` - passed, 3 tests.
- `corepack pnpm@11.2.2 --dir ui test src/ui/app-render-usage-tab.test.ts` - passed, 2 tests.
- `corepack pnpm@11.2.2 --dir ui test src/ui/app-polling.node.test.ts` - passed, 1 test.

Full `corepack pnpm@11.2.2 test:ui` currently fails on both this branch and an unmodified current-`upstream/main` worktree with unrelated UI suite-order/timer failures in `app-render-usage-tab` and `app-polling.node`; those files pass in isolation.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. WebChat now preserves backscroll after the user scrolls up during streaming.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Chat auto-scroll ergonomics in Control UI.

How is that risk mitigated?

The change is limited to the chat scroll helper and preserves the explicit manual scroll-to-bottom path plus `chatAutoScroll: "always"`. Regression tests cover initial auto-scroll, manual scroll, auto-scroll-off, always mode, and small user scroll-up during streaming.

## Current review state

What is the next action?

Ready for maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Nothing known from the author side. Full local `test:ui` has a baseline failure on current `upstream/main`, documented above.

Which bot or reviewer comments were addressed?

None yet.
