### PR TITLE
fix(dreaming): increase narrative timeout from 60s to 120s for ARM devices (fixes #92494)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -979,7 +979,7 @@ describe("generateAndAppendDreamNarrative", () => {
     });
 
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(60_000);
+    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(120_000);
     expectLogIncludes(logger.warn, "narrative session cleanup failed for rem phase");
   });
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -95,10 +95,13 @@ const NARRATIVE_SYSTEM_PROMPT = [
 // many minutes after the reports have already been written. The previous 15 s
 // limit was empirically too tight for warm-gateway runs across light, REM, and
 // deep phases — even unblocked LLM calls hit it on the first sweep after a
-// restart. 60 s gives realistic latency headroom while still capping the
-// worst case at one minute, well below the multi-minute stall the original
-// comment warned against.
-const NARRATIVE_TIMEOUT_MS = 60_000;
+// restart. 60 s was still too tight for ARM devices with 600+ skills where
+// cold-loading tool definitions takes ~57 s on the first narrative phase,
+// leaving almost no headroom for the LLM call itself. 120 s gives realistic
+// latency headroom for resource-constrained environments while still capping
+// the worst case at two minutes, well below the multi-minute stall the
+// original comment warned against.
+const NARRATIVE_TIMEOUT_MS = 120_000;
 const NARRATIVE_MESSAGE_FETCH_LIMIT = 5;
 // A completed run can reach the session reader before the final assistant text
 // is visible, so retry briefly before falling back to synthetic diary text.


### PR DESCRIPTION
## What does this PR do?

Increases `NARRATIVE_TIMEOUT_MS` in the dreaming narrative generator from 60s to 120s. ARM devices with 600+ skills need ~57s just for cold-loading tool definitions on the first narrative phase, leaving almost no headroom within the 60s timeout for the actual LLM call.

## Related Issue

Fixes #92494

## Type of Change

- [x] Bug fix (non-breaking)

## Changes Made

- `extensions/memory-core/src/dreaming-narrative.ts`: Increased `NARRATIVE_TIMEOUT_MS` from `60_000` to `120_000`, updated comment to document ARM cold-load scenario
- `extensions/memory-core/src/dreaming-narrative.test.ts`: Updated timeout assertion from `60_000` to `120_000`

## How to Test

1. On an ARM device with 600+ skills, trigger a dreaming cron run
2. Observe that the light narrative phase completes within the new 120s timeout
3. Verify that stalled subagents are still cleaned up within 2 minutes

## Real behavior proof

**Behavior or issue addressed:**
ARM devices with 600+ skills experience consistent narrative timeouts during dreaming light phase because cold-loading tool definitions takes ~57s, leaving only ~3s headroom within the 60s `NARRATIVE_TIMEOUT_MS` limit for the actual LLM call. The timeout was previously increased from 15s to 60s but is still insufficient for resource-constrained environments.

**Real environment tested:**
macOS 26.4.1, Node v22, OpenClaw dev build from upstream/main (7190fc4d)

**Exact steps or command run after the patch:**
```
pnpm build
node -e "const fs = require('fs'); const src = fs.readFileSync('extensions/memory-core/src/dreaming-narrative.ts','utf8'); const m = src.match(/NARRATIVE_TIMEOUT_MS\s*=\s*(\d[\d_]*\d)/); console.log('NARRATIVE_TIMEOUT_MS =', m ? m[1] : 'NOT FOUND');"
```

**Evidence after fix:**
```
$ node -e "const fs = require('fs'); const src = fs.readFileSync('extensions/memory-core/src/dreaming-narrative.ts','utf8'); const m = src.match(/NARRATIVE_TIMEOUT_MS\s*=\s*(\d[\d_]*\d)/); console.log('NARRATIVE_TIMEOUT_MS =', m ? m[1] : 'NOT FOUND');"
NARRATIVE_TIMEOUT_MS = 120_000

$ grep -n "NARRATIVE_TIMEOUT_MS" extensions/memory-core/src/dreaming-narrative.ts
104:const NARRATIVE_TIMEOUT_MS = 120_000;
957:            timeoutMs: NARRATIVE_TIMEOUT_MS,
```

**Observed result after fix:**
Build succeeds. The narrative timeout constant is now 120_000ms (120s), doubling the previous 60s limit. The comment documents the ARM cold-load scenario. Test file assertion updated to match.

**What was not tested:**
- Live dreaming cron run on ARM device (requires ARM hardware with 600+ skills)
- Actual subagent timeout behavior with the new limit (requires full dreaming pipeline)
