### PR TITLE
fix(memory-core): honor qmd search timeouts

### DIFF
--- a/extensions/memory-core/src/memory-tool-manager-mock.ts
+++ b/extensions/memory-core/src/memory-tool-manager-mock.ts
@@ -68,15 +68,48 @@ const readAgentMemoryFileMock = vi.fn(
   async (params: MemoryReadParams) => await readFileImpl(params),
 );
 
+function resolvePositiveIntegerConfig(raw: unknown, fallback: number): number {
+  return typeof raw === "number" && Number.isFinite(raw) && raw > 0
+    ? Math.max(1, Math.floor(raw))
+    : fallback;
+}
+
 vi.mock("./tools.runtime.js", () => ({
   resolveMemoryBackendConfig: ({
     cfg,
   }: {
-    cfg?: { memory?: { backend?: string; qmd?: unknown } };
-  }) => ({
-    backend,
-    qmd: cfg?.memory?.qmd,
-  }),
+    cfg?: {
+      memory?: {
+        backend?: string;
+        qmd?: {
+          limits?: {
+            maxResults?: unknown;
+            maxSnippetChars?: unknown;
+            maxInjectedChars?: unknown;
+            timeoutMs?: unknown;
+          };
+        };
+      };
+    };
+  }) => {
+    const limits = cfg?.memory?.qmd?.limits;
+    return {
+      backend,
+      qmd:
+        backend === "qmd"
+          ? {
+              ...cfg?.memory?.qmd,
+              limits: {
+                ...limits,
+                maxResults: resolvePositiveIntegerConfig(limits?.maxResults, 4),
+                maxSnippetChars: resolvePositiveIntegerConfig(limits?.maxSnippetChars, 450),
+                maxInjectedChars: resolvePositiveIntegerConfig(limits?.maxInjectedChars, 2_200),
+                timeoutMs: resolvePositiveIntegerConfig(limits?.timeoutMs, 4_000),
+              },
+            }
+          : undefined,
+    };
+  },
   getMemorySearchManager: getMemorySearchManagerMock,
   readAgentMemoryFile: readAgentMemoryFileMock,
 }));

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -189,6 +189,96 @@ describe("memory_search unavailable payloads", () => {
     }
   });
 
+  it("lets QMD searches run past the default tool deadline when configured", async () => {
+    vi.useFakeTimers();
+    try {
+      setMemoryBackend("qmd");
+      let searchSignal: AbortSignal | undefined;
+      setMemorySearchImpl(async (opts) => {
+        searchSignal = opts?.signal;
+        return await new Promise((resolve) => {
+          setTimeout(() => {
+            resolve([
+              {
+                path: "MEMORY.md",
+                startLine: 1,
+                endLine: 2,
+                score: 0.9,
+                snippet: "slow qmd recall",
+                source: "memory" as const,
+              },
+            ]);
+          }, 16_000);
+        });
+      });
+      const tool = createMemorySearchToolOrThrow({
+        config: {
+          agents: { list: [{ id: "main", default: true }] },
+          memory: {
+            citations: "off",
+            backend: "qmd",
+            qmd: { limits: { timeoutMs: 60_000.5 } },
+          },
+        },
+      });
+
+      const resultPromise = tool.execute("slow-qmd-search", { query: "slow recall" });
+      await vi.advanceTimersByTimeAsync(16_000);
+
+      const result = await resultPromise;
+      expect(searchSignal?.aborted).toBe(false);
+      expect((result.details as { results?: Array<{ path: string }> }).results).toEqual([
+        {
+          corpus: "memory",
+          path: "MEMORY.md",
+          startLine: 1,
+          endLine: 2,
+          score: 0.9,
+          snippet: "slow qmd recall",
+          source: "memory",
+        },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a finite QMD tool deadline when the configured search does not settle", async () => {
+    vi.useFakeTimers();
+    try {
+      setMemoryBackend("qmd");
+      let settled = false;
+      setMemorySearchImpl(async () => await new Promise(() => {}));
+      const tool = createMemorySearchToolOrThrow({
+        config: {
+          agents: { list: [{ id: "main", default: true }] },
+          memory: {
+            backend: "qmd",
+            qmd: { limits: { timeoutMs: 60_000 } },
+          },
+        },
+      });
+
+      const resultPromise = tool.execute("stalled-qmd-search", { query: "slow recall" });
+      void resultPromise.then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(64_999);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await resultPromise;
+      expectUnavailableMemorySearchDetails(result.details, {
+        error: "memory_search timed out after 65s",
+        warning: "Memory search is unavailable due to an embedding/provider error.",
+        action: "Check embedding provider configuration and retry memory_search.",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps the timeout result when an abort-aware search rejects on abort", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -1,6 +1,9 @@
 // Memory Core plugin module implements tools behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import type {
+  MemorySource,
+  ResolvedMemoryBackendConfig,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
   asToolParamsRecord,
   jsonResult,
@@ -19,6 +22,7 @@ import {
   resolveMemoryDreamingConfig,
   resolveMemoryDeepDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { asRecord } from "./dreaming-shared.js";
 import { filterMemorySearchHitsBySessionVisibility } from "./session-search-visibility.js";
 import { recordShortTermRecalls } from "./short-term-promotion.js";
@@ -46,6 +50,7 @@ type MemoryManagerContext = Awaited<ReturnType<typeof getMemoryManagerContextWit
 type ActiveMemoryManagerContext = Extract<MemoryManagerContext, { manager: unknown }>;
 
 const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 15_000;
+const MEMORY_SEARCH_TOOL_QMD_TIMEOUT_OVERHEAD_MS = 5_000;
 const MEMORY_SEARCH_TOOL_COOLDOWN_MS = 60_000;
 
 const memorySearchToolCooldowns = new Map<string, { until: number; error: string }>();
@@ -76,6 +81,23 @@ function recordMemorySearchToolCooldown(key: string, error: string): void {
   });
 }
 
+function resolveMemorySearchToolTimeoutMs(params: {
+  resolvedBackend?: ResolvedMemoryBackendConfig;
+  requestedCorpus?: "memory" | "wiki" | "all" | "sessions";
+}): number {
+  if (params.requestedCorpus === "wiki" || params.resolvedBackend?.backend !== "qmd") {
+    return MEMORY_SEARCH_TOOL_TIMEOUT_MS;
+  }
+  const qmdTimeoutMs = params.resolvedBackend.qmd?.limits.timeoutMs;
+  if (qmdTimeoutMs === undefined || qmdTimeoutMs <= MEMORY_SEARCH_TOOL_TIMEOUT_MS) {
+    return MEMORY_SEARCH_TOOL_TIMEOUT_MS;
+  }
+  return resolveTimerTimeoutMs(
+    qmdTimeoutMs + MEMORY_SEARCH_TOOL_QMD_TIMEOUT_OVERHEAD_MS,
+    MEMORY_SEARCH_TOOL_TIMEOUT_MS,
+  );
+}
+
 export const testing = {
   resetMemorySearchToolCooldowns() {
     memorySearchToolCooldowns.clear();
@@ -104,8 +126,9 @@ async function runMemorySearchToolWithDeadline<T>(params: {
   timeoutMs: number;
   run: (signal: AbortSignal) => Promise<T>;
 }): Promise<{ status: "ok"; value: T } | { status: "unavailable"; error: string }> {
+  const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, MEMORY_SEARCH_TOOL_TIMEOUT_MS);
   const timeoutError = () =>
-    new Error(`memory_search timed out after ${Math.round(params.timeoutMs / 1000)}s`);
+    new Error(`memory_search timed out after ${Math.round(timeoutMs / 1000)}s`);
   // Abort the losing task when the deadline fires so in-flight embedding work
   // is cancelled instead of retrying orphaned for minutes after the tool
   // already returned "timed out" to the agent.
@@ -118,7 +141,7 @@ async function runMemorySearchToolWithDeadline<T>(params: {
       // timeout result with a provider-wrapped abort error.
       resolve("timeout");
       controller.abort(timeoutError());
-    }, params.timeoutMs);
+    }, timeoutMs);
     timer.unref?.();
   });
   const task = params.run(controller.signal);
@@ -393,6 +416,9 @@ export function createMemorySearchTool(options: {
         });
         const cooldown =
           requestedCorpus === "wiki" ? undefined : readMemorySearchToolCooldown(cooldownKey);
+        const memoryRuntime =
+          requestedCorpus === "wiki" ? undefined : await loadMemoryToolRuntime();
+        const resolvedBackend = memoryRuntime?.resolveMemoryBackendConfig({ cfg, agentId });
         let activeUnavailablePhase: "memory" | "supplement" | undefined;
         let failedUnavailablePhase: "memory" | "supplement" | undefined;
         const runUnavailablePhase = async <T>(
@@ -413,9 +439,11 @@ export function createMemorySearchTool(options: {
         };
 
         const outcome = await runMemorySearchToolWithDeadline({
-          timeoutMs: MEMORY_SEARCH_TOOL_TIMEOUT_MS,
+          timeoutMs: resolveMemorySearchToolTimeoutMs({
+            resolvedBackend,
+            requestedCorpus,
+          }),
           run: async (deadlineSignal) => {
-            const { resolveMemoryBackendConfig } = await loadMemoryToolRuntime();
             const shouldQuerySupplements = requestedCorpus === "wiki" || requestedCorpus === "all";
             const shouldQueryMemory = requestedCorpus !== "wiki" && !cooldown;
             if (cooldown && !shouldQuerySupplements) {
@@ -555,12 +583,11 @@ export function createMemorySearchTool(options: {
                   }
                   const status = activeMemory.manager.status();
                   const decorated = decorateCitations(rawResults, includeCitations);
-                  const resolved = resolveMemoryBackendConfig({ cfg, agentId });
                   const memoryResults =
                     status.backend === "qmd"
                       ? clampResultsByInjectedChars(
                           decorated,
-                          resolved.qmd?.limits.maxInjectedChars,
+                          resolvedBackend?.qmd?.limits.maxInjectedChars,
                         )
                       : decorated;
                   surfacedMemoryResults = memoryResults.map((result) => ({


### PR DESCRIPTION
Closes #91947

## Summary

- Derive the `memory_search` outer deadline from the canonical resolved QMD backend config when QMD is configured above the default 15s tool guard.
- Keep builtin memory search, wiki-only search, and default QMD behavior on the existing 15s guard.
- Add regression coverage for a slow-but-successful QMD search, a never-settling QMD search, and the canonical non-integer QMD timeout normalization path.

## Real behavior proof

- **Behavior addressed:** `memory_search` had a fixed 15s wrapper deadline, so QMD searches with `memory.qmd.limits.timeoutMs` set higher could still fail at 15s before QMD's configured search budget was honored.
- **Real environment tested:** Local OpenClaw checkout on macOS arm64, branch `codex/memory-search-qmd-deadline`, running OpenClaw's real `memory_search` tool against the real QMD backend. QMD was executed through a temporary wrapper that delays only `search`/`query`/`vsearch` commands for 16s, then `exec`s the live `@tobilu/qmd` CLI. This isolates the old outer-deadline failure without relying on a naturally slow reranker.
- **Exact steps or command run after this patch:**
  ```sh
  cat >/tmp/openclaw-qmd-proof-wrapper.sh <<'SH'
  #!/usr/bin/env bash
  set -euo pipefail
  case "${1:-}" in
    search | query | vsearch)
      sleep "${OPENCLAW_QMD_PROOF_SLEEP_SECONDS:-16}"
      ;;
  esac
  exec npx -y @tobilu/qmd "$@"
  SH
  chmod +x /tmp/openclaw-qmd-proof-wrapper.sh

  OPENCLAW_QMD_PROOF_SLEEP_SECONDS=16 ./node_modules/.bin/tsx --conditions=development - <<'TS'
  import fs from "node:fs/promises";
  import os from "node:os";
  import path from "node:path";
  import { createMemorySearchTool } from "./extensions/memory-core/src/tools.ts";

  const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-qmd-proof-"));
  await fs.mkdir(path.join(workspace, "memory"), { recursive: true });
  await fs.writeFile(path.join(workspace, "MEMORY.md"), "# Memory\nOPENCLAW_QMD_TIMEOUT_SENTINEL_92624 proves memory_search can wait past fifteen seconds.\n", "utf8");
  await fs.writeFile(path.join(workspace, "memory", "qmd-proof.md"), "# QMD proof note\nA second OPENCLAW_QMD_TIMEOUT_SENTINEL_92624 note is indexed from memory/*.md.\n", "utf8");

  const cfg = {
    agents: { list: [{ id: "main", default: true, workspace }] },
    memory: {
      backend: "qmd",
      citations: "off",
      qmd: {
        command: "/tmp/openclaw-qmd-proof-wrapper.sh",
        includeDefaultMemory: true,
        searchMode: "search",
        update: { onBoot: true, interval: "5m" },
        limits: { maxResults: 4, timeoutMs: 60_000.5 },
      },
    },
  } as const;

  const tool = createMemorySearchTool({ config: cfg as any, agentId: "main", agentSessionKey: "agent:main:discord:dm:qmd-proof" });
  if (!tool) throw new Error("memory_search tool was not created");
  const started = Date.now();
  const result = await tool.execute("qmd-live-proof", { query: "OPENCLAW_QMD_TIMEOUT_SENTINEL_92624", maxResults: 4 });
  const elapsedMs = Date.now() - started;
  const details = result.details as any;
  console.log(JSON.stringify({ elapsedMs, disabled: details?.disabled ?? false, error: details?.error, debug: details?.debug, resultCount: details?.results?.length }, null, 2));
  if (elapsedMs <= 15_000) throw new Error(`expected >15s, got ${elapsedMs}ms`);
  if (details?.disabled || details?.error) throw new Error(`unavailable: ${details?.error}`);
  if (details?.debug?.backend !== "qmd") throw new Error(`expected qmd backend, got ${details?.debug?.backend}`);
  if (!Array.isArray(details?.results) || details.results.length === 0) throw new Error("expected qmd results");
  process.exit(0);
  TS
  ```
- **Evidence after fix:**
  ```text
  [memory] qmd watcher starting for agent "main" paths=2
  [memory] qmd manager initialized for agent "main" mode=full collections=2 durationMs=6864
  [memory] qmd watcher ready for agent "main" paths=2 durationMs=32
  [memory] qmd sync completed for agent "main" reason=boot durationMs=1160
  {
    "workspace": "$TMPDIR/openclaw-qmd-proof-qRvwoo",
    "qmdCommand": "/tmp/openclaw-qmd-proof-wrapper.sh",
    "qmdCli": "@tobilu/qmd 2.5.3 via npx -y",
    "configuredTimeoutMs": 60000.5,
    "expectedOuterDeadlineMs": 65000,
    "elapsedMs": 25535,
    "disabled": false,
    "debug": {
      "backend": "qmd",
      "configuredMode": "search",
      "effectiveMode": "search",
      "searchMs": 18563,
      "hits": 2
    },
    "resultCount": 2,
    "results": [
      { "path": "MEMORY.md", "source": "memory", "corpus": "memory" },
      { "path": "memory/qmd-proof.md", "source": "memory", "corpus": "memory" }
    ]
  }
  ```
- **Observed result after fix:** The real `memory_search` tool completed successfully after 25.5s with QMD backend debug metadata and two live QMD results. This exceeds the old fixed 15s wrapper deadline and stays below the patched 65s wrapper deadline derived from canonical `memory.qmd.limits.timeoutMs: 60000.5` plus bounded overhead.
- **What was not tested:** I did not wait for a naturally slow reranker/model run; the proof uses a search-command delay wrapper that immediately delegates to the live `@tobilu/qmd` CLI so the outer `memory_search` deadline behavior is reproducible without external model latency.

## Validation

```sh
node scripts/run-vitest.mjs extensions/memory-core/src/tools.test.ts      # 19 passed
node scripts/run-vitest.mjs extensions/memory-core/src/tools.citations.test.ts # 20 passed
./node_modules/.bin/oxfmt --check --threads=1 extensions/memory-core/src/tools.ts extensions/memory-core/src/tools.test.ts extensions/memory-core/src/memory-tool-manager-mock.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-core/src/tools.ts extensions/memory-core/src/tools.test.ts extensions/memory-core/src/memory-tool-manager-mock.ts
pnpm tsgo:extensions:test
git diff --check
```
