### PR TITLE
fix(openrouter): strip openrouter/ prefix from model ID in normalizeResolvedModel hook (fixes #92611)

### DIFF
--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -11,6 +11,24 @@ import {
   expectUnifiedModelCatalogProviderRegistration,
 } from "openclaw/plugin-sdk/provider-test-contracts";
 import { describe, expect, it, vi } from "vitest";
+
+const { getOpenRouterModelCapabilitiesMock, loadOpenRouterModelCapabilitiesMock } = vi.hoisted(
+  () => ({
+    getOpenRouterModelCapabilitiesMock: vi.fn(),
+    loadOpenRouterModelCapabilitiesMock: vi.fn(async () => {}),
+  }),
+);
+
+vi.mock("openclaw/plugin-sdk/provider-stream-family", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/provider-stream-family")>();
+  return {
+    ...actual,
+    getOpenRouterModelCapabilities: getOpenRouterModelCapabilitiesMock,
+    loadOpenRouterModelCapabilities: loadOpenRouterModelCapabilitiesMock,
+  };
+});
+
 import openrouterPlugin from "./index.js";
 import {
   buildOpenrouterProvider,
@@ -202,6 +220,59 @@ describe("openrouter provider hooks", () => {
   it("uses the canonical prefixed OpenRouter auto model id", () => {
     expect(buildOpenrouterProvider().models?.map((model) => model.id)).toContain("openrouter/auto");
     expect(buildOpenrouterProvider().models?.map((model) => model.id)).not.toContain("auto");
+  });
+
+  it("normalizes OpenRouter API ids before capability loading and lookup", async () => {
+    getOpenRouterModelCapabilitiesMock.mockReset();
+    loadOpenRouterModelCapabilitiesMock.mockClear();
+    getOpenRouterModelCapabilitiesMock.mockReturnValue({
+      name: "Claude Sonnet 4.6",
+      reasoning: true,
+      input: ["text", "image"],
+      supportsTools: true,
+      cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 64_000,
+    });
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const modelId = "openrouter/anthropic/claude-sonnet-4.6";
+    const context = {
+      provider: "openrouter",
+      modelId,
+      modelRegistry: { find: vi.fn(() => null) },
+    } as never;
+
+    await provider.prepareDynamicModel?.(context);
+    const model = provider.resolveDynamicModel?.(context);
+
+    expect(loadOpenRouterModelCapabilitiesMock).toHaveBeenCalledWith("anthropic/claude-sonnet-4.6");
+    expect(getOpenRouterModelCapabilitiesMock).toHaveBeenCalledWith("anthropic/claude-sonnet-4.6");
+    expect(model).toMatchObject({
+      id: modelId,
+      name: "Claude Sonnet 4.6",
+      reasoning: true,
+      input: ["text", "image"],
+      compat: { supportsTools: true },
+      contextWindow: 200_000,
+      maxTokens: 64_000,
+    });
+  });
+
+  it("keeps native OpenRouter namespace ids for capability lookup", async () => {
+    getOpenRouterModelCapabilitiesMock.mockReset();
+    loadOpenRouterModelCapabilitiesMock.mockClear();
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const context = {
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      modelRegistry: { find: vi.fn(() => null) },
+    } as never;
+
+    await provider.prepareDynamicModel?.(context);
+    provider.resolveDynamicModel?.(context);
+
+    expect(loadOpenRouterModelCapabilitiesMock).toHaveBeenCalledWith("openrouter/auto");
+    expect(getOpenRouterModelCapabilitiesMock).toHaveBeenCalledWith("openrouter/auto");
   });
 
   it("does not include retired stealth models in the bundled catalog", () => {

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -389,6 +389,24 @@ describe("openrouter provider hooks", () => {
       },
     } as never);
     expect(normalizedHunterModel?.reasoning).toBe(false);
+    expect(normalizedHunterModel?.id).toBe("hunter-alpha");
+
+    const normalizedAnthropicModel = provider.normalizeResolvedModel?.({
+      provider: "openrouter",
+      model: {
+        provider: "openrouter",
+        id: "openrouter/anthropic/claude-sonnet-4.6",
+        name: "anthropic/claude-sonnet-4.6",
+        api: "openai-completions",
+        baseUrl: "https://openrouter.ai/api/v1",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200_000,
+        maxTokens: 8192,
+      },
+    } as never);
+    expect(normalizedAnthropicModel?.id).toBe("anthropic/claude-sonnet-4.6");
 
     expect(
       provider.normalizeTransport?.({

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -389,7 +389,7 @@ describe("openrouter provider hooks", () => {
       },
     } as never);
     expect(normalizedHunterModel?.reasoning).toBe(false);
-    expect(normalizedHunterModel?.id).toBe("hunter-alpha");
+    expect(normalizedHunterModel?.id).toBe("openrouter/hunter-alpha");
 
     const normalizedAnthropicModel = provider.normalizeResolvedModel?.({
       provider: "openrouter",
@@ -407,6 +407,43 @@ describe("openrouter provider hooks", () => {
       },
     } as never);
     expect(normalizedAnthropicModel?.id).toBe("anthropic/claude-sonnet-4.6");
+
+    expect(
+      provider.normalizeResolvedModel?.({
+        provider: "openrouter",
+        modelId: "openrouter/auto",
+        model: {
+          provider: "openrouter",
+          id: "openrouter/auto",
+          name: "OpenRouter Auto",
+          api: "openai-completions",
+          baseUrl: "https://openrouter.ai/api/v1",
+          reasoning: false,
+          input: ["text", "image"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200_000,
+          maxTokens: 8192,
+        },
+      } as never),
+    ).toBeUndefined();
+
+    const normalizedDuplicatedAutoModel = provider.normalizeResolvedModel?.({
+      provider: "openrouter",
+      modelId: "openrouter/openrouter/auto",
+      model: {
+        provider: "openrouter",
+        id: "openrouter/openrouter/auto",
+        name: "OpenRouter Auto",
+        api: "openai-completions",
+        baseUrl: "https://openrouter.ai/api/v1",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200_000,
+        maxTokens: 8192,
+      },
+    } as never);
+    expect(normalizedDuplicatedAutoModel?.id).toBe("openrouter/auto");
 
     expect(
       provider.normalizeTransport?.({

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -76,7 +76,8 @@ export default definePluginEntry({
     function buildDynamicOpenRouterModel(
       ctx: ProviderResolveDynamicModelContext,
     ): ProviderRuntimeModel {
-      const capabilities = getOpenRouterModelCapabilities(ctx.modelId);
+      const apiModelId = normalizeOpenRouterApiModelId(ctx.modelId) ?? ctx.modelId;
+      const capabilities = getOpenRouterModelCapabilities(apiModelId);
       return {
         id: ctx.modelId,
         name: capabilities?.name ?? ctx.modelId,
@@ -169,7 +170,9 @@ export default definePluginEntry({
       },
       resolveDynamicModel: (ctx) => buildDynamicOpenRouterModel(ctx),
       prepareDynamicModel: async (ctx) => {
-        await loadOpenRouterModelCapabilities(ctx.modelId);
+        await loadOpenRouterModelCapabilities(
+          normalizeOpenRouterApiModelId(ctx.modelId) ?? ctx.modelId,
+        );
       },
       normalizeConfig: ({ providerConfig }) => {
         const normalizedBaseUrl = normalizeOpenRouterBaseUrl(providerConfig.baseUrl);

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -17,7 +17,7 @@ import {
 } from "openclaw/plugin-sdk/provider-stream-family";
 import { buildOpenRouterImageGenerationProvider } from "./image-generation-provider.js";
 import { openrouterMediaUnderstandingProvider } from "./media-understanding-provider.js";
-import { isOpenRouterMistralModelId } from "./models.js";
+import { isOpenRouterMistralModelId, normalizeOpenRouterModelId } from "./models.js";
 import { buildOpenRouterMusicGenerationProvider } from "./music-generation-provider.js";
 import { createOpenRouterOAuthAuthMethod } from "./oauth.js";
 import { applyOpenrouterConfig, OPENROUTER_DEFAULT_MODEL_REF } from "./onboard.js";
@@ -51,15 +51,18 @@ const OPENROUTER_CACHE_TTL_MODEL_PREFIXES = [
 
 function normalizeOpenRouterResolvedModel<T extends ProviderRuntimeModel>(model: T): T | undefined {
   const normalizedBaseUrl = normalizeOpenRouterBaseUrl(model.baseUrl);
+  const normalizedId = normalizeOpenRouterModelId(model.id);
   const reasoning = isOpenRouterProxyReasoningUnsupportedModel(model.id) ? false : model.reasoning;
   if (
     (!normalizedBaseUrl || normalizedBaseUrl === model.baseUrl) &&
+    (!normalizedId || normalizedId === model.id) &&
     reasoning === model.reasoning
   ) {
     return undefined;
   }
   return {
     ...model,
+    ...(normalizedId ? { id: normalizedId } : {}),
     ...(normalizedBaseUrl ? { baseUrl: normalizedBaseUrl } : {}),
     reasoning,
   };

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -17,7 +17,7 @@ import {
 } from "openclaw/plugin-sdk/provider-stream-family";
 import { buildOpenRouterImageGenerationProvider } from "./image-generation-provider.js";
 import { openrouterMediaUnderstandingProvider } from "./media-understanding-provider.js";
-import { isOpenRouterMistralModelId, normalizeOpenRouterModelId } from "./models.js";
+import { isOpenRouterMistralModelId, normalizeOpenRouterApiModelId } from "./models.js";
 import { buildOpenRouterMusicGenerationProvider } from "./music-generation-provider.js";
 import { createOpenRouterOAuthAuthMethod } from "./oauth.js";
 import { applyOpenrouterConfig, OPENROUTER_DEFAULT_MODEL_REF } from "./onboard.js";
@@ -51,7 +51,7 @@ const OPENROUTER_CACHE_TTL_MODEL_PREFIXES = [
 
 function normalizeOpenRouterResolvedModel<T extends ProviderRuntimeModel>(model: T): T | undefined {
   const normalizedBaseUrl = normalizeOpenRouterBaseUrl(model.baseUrl);
-  const normalizedId = normalizeOpenRouterModelId(model.id);
+  const normalizedId = normalizeOpenRouterApiModelId(model.id);
   const reasoning = isOpenRouterProxyReasoningUnsupportedModel(model.id) ? false : model.reasoning;
   if (
     (!normalizedBaseUrl || normalizedBaseUrl === model.baseUrl) &&

--- a/extensions/openrouter/models.ts
+++ b/extensions/openrouter/models.ts
@@ -12,13 +12,30 @@ const OPENROUTER_MISTRAL_MODEL_PREFIXES = [
   "pixtral-",
   "voxtral-",
 ] as const;
+const OPENROUTER_MODEL_PREFIX = "openrouter/";
 
 export function normalizeOpenRouterModelId(modelId: unknown): string | undefined {
   if (typeof modelId !== "string") {
     return undefined;
   }
   const normalized = normalizeLowercaseStringOrEmpty(modelId);
-  return normalized.startsWith("openrouter/") ? normalized.slice("openrouter/".length) : normalized;
+  return normalized.startsWith(OPENROUTER_MODEL_PREFIX)
+    ? normalized.slice(OPENROUTER_MODEL_PREFIX.length)
+    : normalized;
+}
+
+export function normalizeOpenRouterApiModelId(modelId: unknown): string | undefined {
+  if (typeof modelId !== "string") {
+    return undefined;
+  }
+  const normalized = normalizeLowercaseStringOrEmpty(modelId);
+  if (!normalized.startsWith(OPENROUTER_MODEL_PREFIX)) {
+    return normalized;
+  }
+  const unprefixed = normalized.slice(OPENROUTER_MODEL_PREFIX.length);
+  // `openrouter/` is both a provider qualifier and an upstream namespace.
+  // Strip it only when the remainder is still a namespaced API model id.
+  return unprefixed.includes("/") ? unprefixed : normalized;
 }
 
 export function isOpenRouterMistralModelId(modelId: unknown): boolean {

--- a/extensions/openrouter/openrouter.live.test.ts
+++ b/extensions/openrouter/openrouter.live.test.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
+import { normalizeOpenRouterApiModelId } from "./models.js";
 
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const OPENROUTER_MISTRAL_PROVIDER_PREFIX = "mistralai/";
@@ -91,20 +92,40 @@ describeLive("openrouter plugin live", () => {
     expect(resolved.api).toBe("openai-completions");
     expect(resolved.baseUrl).toBe("https://openrouter.ai/api/v1");
 
-    const normalized = provider.normalizeResolvedModel?.({
-      provider: "openrouter",
-      modelId: resolved.id,
-      model: resolved,
-    });
-    if (!normalized) {
-      throw new Error(`openrouter provider did not normalize ${LIVE_MODEL_ID}`);
-    }
-    expect(normalized.id).toBe(LIVE_MODEL_ID.slice("openrouter/".length));
+    const normalized =
+      provider.normalizeResolvedModel?.({
+        provider: "openrouter",
+        modelId: resolved.id,
+        model: resolved,
+      }) ?? resolved;
+    expect(normalized.id).toBe(normalizeOpenRouterApiModelId(LIVE_MODEL_ID));
 
     const client = new OpenAI({
       apiKey: OPENROUTER_API_KEY,
       baseURL: normalized.baseUrl,
     });
+    const autoResolved = provider.resolveDynamicModel?.({
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      modelRegistry: new ModelRegistryCtor(AuthStorage.inMemory()),
+    });
+    if (!autoResolved) {
+      throw new Error("openrouter provider did not resolve openrouter/auto");
+    }
+    const autoModel =
+      provider.normalizeResolvedModel?.({
+        provider: "openrouter",
+        modelId: autoResolved.id,
+        model: autoResolved,
+      }) ?? autoResolved;
+    expect(autoModel.id).toBe("openrouter/auto");
+    const autoResponse = await client.chat.completions.create({
+      model: autoModel.id,
+      messages: [{ role: "user", content: "Reply with exactly OK." }],
+      max_tokens: 16,
+    });
+    expect(autoResponse.choices[0]?.message?.content?.trim()).toMatch(/^OK[.!]?$/);
+
     const response = await client.chat.completions.create({
       model: normalized.id,
       messages: [{ role: "user", content: "Call get_weather for Paris." }],

--- a/extensions/openrouter/openrouter.live.test.ts
+++ b/extensions/openrouter/openrouter.live.test.ts
@@ -62,6 +62,40 @@ async function completeOpenRouterChat(params: {
   });
 }
 
+async function expectWeatherToolCall(client: OpenAI, model: string): Promise<void> {
+  const response = await client.chat.completions.create({
+    model,
+    messages: [{ role: "user", content: "Call get_weather for Paris." }],
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "get_weather",
+          description: "Get the weather for a city.",
+          parameters: {
+            type: "object",
+            properties: { city: { type: "string" } },
+            required: ["city"],
+            additionalProperties: false,
+          },
+        },
+      },
+    ],
+    tool_choice: {
+      type: "function",
+      function: { name: "get_weather" },
+    },
+    max_tokens: 64,
+  });
+
+  const toolCall = response.choices[0]?.message?.tool_calls?.find(
+    (call) => call.type === "function",
+  );
+  expect(toolCall?.type).toBe("function");
+  expect(toolCall?.function.name).toBe("get_weather");
+  expect(JSON.parse(toolCall?.function.arguments ?? "{}")).toMatchObject({ city: "Paris" });
+}
+
 async function fetchOpenRouterModelIds(): Promise<string[]> {
   const response = await fetch(OPENROUTER_MODELS_URL, {
     headers: { "accept-encoding": "identity" },
@@ -119,44 +153,8 @@ describeLive("openrouter plugin live", () => {
         model: autoResolved,
       }) ?? autoResolved;
     expect(autoModel.id).toBe("openrouter/auto");
-    const autoResponse = await client.chat.completions.create({
-      model: autoModel.id,
-      messages: [{ role: "user", content: "Reply with exactly OK." }],
-      max_tokens: 16,
-    });
-    expect(autoResponse.choices[0]?.message?.content?.trim()).toMatch(/^OK[.!]?$/);
-
-    const response = await client.chat.completions.create({
-      model: normalized.id,
-      messages: [{ role: "user", content: "Call get_weather for Paris." }],
-      tools: [
-        {
-          type: "function",
-          function: {
-            name: "get_weather",
-            description: "Get the weather for a city.",
-            parameters: {
-              type: "object",
-              properties: { city: { type: "string" } },
-              required: ["city"],
-              additionalProperties: false,
-            },
-          },
-        },
-      ],
-      tool_choice: {
-        type: "function",
-        function: { name: "get_weather" },
-      },
-      max_tokens: 64,
-    });
-
-    const toolCall = response.choices[0]?.message?.tool_calls?.find(
-      (call) => call.type === "function",
-    );
-    expect(toolCall?.type).toBe("function");
-    expect(toolCall?.function.name).toBe("get_weather");
-    expect(JSON.parse(toolCall?.function.arguments ?? "{}")).toMatchObject({ city: "Paris" });
+    await expectWeatherToolCall(client, autoModel.id);
+    await expectWeatherToolCall(client, normalized.id);
   }, 30_000);
 });
 

--- a/extensions/openrouter/openrouter.live.test.ts
+++ b/extensions/openrouter/openrouter.live.test.ts
@@ -11,8 +11,12 @@ import plugin from "./index.js";
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const OPENROUTER_MISTRAL_PROVIDER_PREFIX = "mistralai/";
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY ?? "";
-const LIVE_MODEL_ID =
-  process.env.OPENCLAW_LIVE_OPENROUTER_PLUGIN_MODEL?.trim() || "openai/gpt-5.4-nano";
+const LIVE_MODEL_REF =
+  process.env.OPENCLAW_LIVE_OPENROUTER_PLUGIN_MODEL?.trim() ||
+  "openrouter/anthropic/claude-sonnet-4.6";
+const LIVE_MODEL_ID = LIVE_MODEL_REF.startsWith("openrouter/")
+  ? LIVE_MODEL_REF
+  : `openrouter/${LIVE_MODEL_REF}`;
 const LIVE_CACHE_MODEL_ID =
   process.env.OPENCLAW_LIVE_OPENROUTER_CACHE_MODEL?.trim() || "deepseek/deepseek-v3.2";
 const liveEnabled = OPENROUTER_API_KEY.trim().length > 0 && process.env.OPENCLAW_LIVE_TEST === "1";
@@ -69,7 +73,7 @@ async function fetchOpenRouterModelIds(): Promise<string[]> {
 }
 
 describeLive("openrouter plugin live", () => {
-  it("registers an OpenRouter provider that can complete a live request", async () => {
+  it("normalizes a prefixed OpenRouter model and completes a live tool call", async () => {
     const { providers } = await registerOpenRouterPlugin();
     const provider = requireRegisteredProvider(providers, "openrouter");
 
@@ -87,17 +91,51 @@ describeLive("openrouter plugin live", () => {
     expect(resolved.api).toBe("openai-completions");
     expect(resolved.baseUrl).toBe("https://openrouter.ai/api/v1");
 
+    const normalized = provider.normalizeResolvedModel?.({
+      provider: "openrouter",
+      modelId: resolved.id,
+      model: resolved,
+    });
+    if (!normalized) {
+      throw new Error(`openrouter provider did not normalize ${LIVE_MODEL_ID}`);
+    }
+    expect(normalized.id).toBe(LIVE_MODEL_ID.slice("openrouter/".length));
+
     const client = new OpenAI({
       apiKey: OPENROUTER_API_KEY,
-      baseURL: resolved.baseUrl,
+      baseURL: normalized.baseUrl,
     });
     const response = await client.chat.completions.create({
-      model: resolved.id,
-      messages: [{ role: "user", content: "Reply with exactly OK." }],
-      max_tokens: 16,
+      model: normalized.id,
+      messages: [{ role: "user", content: "Call get_weather for Paris." }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "get_weather",
+            description: "Get the weather for a city.",
+            parameters: {
+              type: "object",
+              properties: { city: { type: "string" } },
+              required: ["city"],
+              additionalProperties: false,
+            },
+          },
+        },
+      ],
+      tool_choice: {
+        type: "function",
+        function: { name: "get_weather" },
+      },
+      max_tokens: 64,
     });
 
-    expect(response.choices[0]?.message?.content?.trim()).toMatch(/^OK[.!]?$/);
+    const toolCall = response.choices[0]?.message?.tool_calls?.find(
+      (call) => call.type === "function",
+    );
+    expect(toolCall?.type).toBe("function");
+    expect(toolCall?.function.name).toBe("get_weather");
+    expect(JSON.parse(toolCall?.function.arguments ?? "{}")).toMatchObject({ city: "Paris" });
   }, 30_000);
 });
 

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -3016,6 +3016,52 @@ describe("resolveModel", () => {
     });
   });
 
+  it("uses provider-normalized model ids for OpenRouter transport", () => {
+    const modelId = "openrouter/anthropic/claude-sonnet-4.6";
+    mockDiscoveredModel(discoverModels, {
+      provider: "openrouter",
+      modelId,
+      templateModel: {
+        ...makeModel(modelId),
+        provider: "openrouter",
+        api: "openai-completions",
+        baseUrl: "https://openrouter.ai/api/v1",
+      },
+    });
+    const baseRuntimeHooks = createRuntimeHooks();
+    const normalizeProviderResolvedModelWithPlugin = vi.fn(
+      (params: { context: { model: { id: string } } }) => ({
+        ...params.context.model,
+        id: params.context.model.id.slice("openrouter/".length),
+      }),
+    );
+
+    const result = resolveModel("openrouter", modelId, "/tmp/agent", undefined, {
+      authStorage: { mocked: true } as never,
+      modelRegistry: discoverModels({ mocked: true } as never, "/tmp/agent"),
+      runtimeHooks: {
+        ...baseRuntimeHooks,
+        normalizeProviderResolvedModelWithPlugin,
+      },
+    });
+
+    expect(normalizeProviderResolvedModelWithPlugin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openrouter",
+        context: expect.objectContaining({
+          modelId,
+          model: expect.objectContaining({ id: modelId }),
+        }),
+      }),
+    );
+    expectRecordFields(result.model, {
+      provider: "openrouter",
+      id: "anthropic/claude-sonnet-4.6",
+      api: "openai-completions",
+      baseUrl: "https://openrouter.ai/api/v1",
+    });
+  });
+
   it("matches prefixed Hugging Face ids against discovered registry models", () => {
     mockDiscoveredModel(discoverModels, {
       provider: "huggingface",


### PR DESCRIPTION
## Summary

Fixes #92611.

- Normalize provider-qualified OpenRouter model IDs before transport, so `openrouter/anthropic/claude-sonnet-4.6` reaches the API as `anthropic/claude-sonnet-4.6`.
- Preserve native OpenRouter namespace IDs such as `openrouter/auto`; stripping every `openrouter/` prefix would break valid upstream IDs.
- Use the normalized API ID for capability cache loading and lookup, avoiding fallback text-only/reasoning/token metadata on the repaired path.
- Add core, plugin, and live regressions for both nested provider-qualified IDs and native OpenRouter IDs.

## Verification

- `node scripts/run-vitest.mjs extensions/openrouter/index.test.ts src/agents/embedded-agent-runner/model.test.ts src/llm/providers/openai-completions.test.ts` (178 tests)
- `pnpm tsgo:extensions:test`
- `pnpm build`
- Fresh autoreview: clean, no accepted/actionable findings
- AWS Crabbox `check:changed`: `cbx_8774c1f7dea1`, run `run_b542d858e7f9`
- Live OpenRouter forced tool calls:
  - `openrouter/anthropic/claude-sonnet-4.6`
  - `openrouter/auto`
- Direct provider regression guards:
  - OpenAI Responses `gpt-5.4-mini` forced `get_weather`
  - Anthropic Messages `claude-sonnet-4-6` forced `get_weather`

## Real behavior proof

Behavior addressed: OpenRouter provider-qualified model IDs no longer produce invalid API model IDs or fallback capability metadata.

Real environment tested: Live OpenRouter, OpenAI, and Anthropic APIs from the maintainer checkout; Linux CI-parity checks on AWS Crabbox.

Exact steps or command run after this patch: Ran the focused Vitest command above, live OpenRouter plugin test for both model refs, direct forced-tool API probes, extension typecheck, full build, and remote `check:changed`.

Evidence after fix: Copied live console output:

```text
OpenRouter openrouter/anthropic/claude-sonnet-4.6:
Test Files  1 passed (1)
Tests       1 passed | 2 skipped (3)

OpenRouter openrouter/auto:
Test Files  1 passed (1)
Tests       1 passed | 2 skipped (3)

__OPENROUTER_LIVE_FINAL__:0
OpenAI Responses forced tool call: PASS
Anthropic Messages forced tool call: PASS
```

Observed result after fix: The nested OpenRouter qualifier is removed only where required, native `openrouter/*` API IDs remain intact, and both forms complete real forced tool calls with canonical capability metadata.

What was not tested: No known gaps.

## Release-note context

Release-note context: fixes OpenRouter HTTP 400 failures for provider-qualified model IDs while retaining native OpenRouter routes.
