### PR TITLE
fix #73713: surface nested embedding fetch failures

### DIFF
--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -54,7 +54,7 @@ describe("runCommandWithRuntime", () => {
     );
 
     expect(messages).toHaveLength(1);
-    expect(messages[0]).toContain("fetch failed");
+    expect(messages[0]).toContain("TypeError: fetch failed");
     expect(messages[0]).toContain("invalid onRequestStart method");
     expect(messages[0]).toContain("UND_ERR_INVALID_ARG");
     expect(exits).toEqual([1]);

--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -1,6 +1,7 @@
 // CLI utility tests cover shared command helpers, option parsing, and output formatting.
 import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
+import { runCommandWithRuntime } from "./cli-utils.js";
 import { registerDnsCli } from "./dns-cli.js";
 import { parseByteSize } from "./parse-bytes.js";
 import { parseDurationMs } from "./parse-duration.js";
@@ -30,6 +31,33 @@ describe("waitForever", () => {
     } finally {
       setIntervalSpy.mockRestore();
     }
+  });
+});
+
+describe("runCommandWithRuntime", () => {
+  it("surfaces cause chains and error codes through the default runtime", async () => {
+    const messages: string[] = [];
+    const exits: number[] = [];
+    const cause = Object.assign(new Error("invalid onRequestStart method"), {
+      code: "UND_ERR_INVALID_ARG",
+    });
+    const fetchError = Object.assign(new TypeError("fetch failed"), { cause });
+
+    await runCommandWithRuntime(
+      {
+        error: (message) => messages.push(message),
+        exit: (code) => exits.push(code),
+      },
+      async () => {
+        throw fetchError;
+      },
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("fetch failed");
+    expect(messages[0]).toContain("invalid onRequestStart method");
+    expect(messages[0]).toContain("UND_ERR_INVALID_ARG");
+    expect(exits).toEqual([1]);
   });
 });
 

--- a/src/cli/cli-utils.ts
+++ b/src/cli/cli-utils.ts
@@ -32,6 +32,13 @@ export async function withManager<T>(params: {
   }
 }
 
+function formatCommandRuntimeError(err: unknown): string {
+  if (err instanceof Error) {
+    return formatErrorMessage(new Error(String(err), { cause: err.cause }));
+  }
+  return formatErrorMessage(err);
+}
+
 export async function runCommandWithRuntime(
   runtime: { error: (message: string) => void; exit: (code: number) => void },
   action: () => Promise<void>,
@@ -44,7 +51,7 @@ export async function runCommandWithRuntime(
       onError(err);
       return;
     }
-    runtime.error(formatErrorMessage(err));
+    runtime.error(formatCommandRuntimeError(err));
     runtime.exit(1);
   }
 }

--- a/src/cli/cli-utils.ts
+++ b/src/cli/cli-utils.ts
@@ -44,7 +44,7 @@ export async function runCommandWithRuntime(
       onError(err);
       return;
     }
-    runtime.error(String(err));
+    runtime.error(formatErrorMessage(err));
     runtime.exit(1);
   }
 }

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -86,6 +86,10 @@ export function formatErrorMessage(err: unknown): string {
       seen.add(cause);
       if (cause instanceof Error) {
         appendCauseMessage(cause.message);
+        const code = extractErrorCode(cause);
+        if (code) {
+          appendCauseMessage(code);
+        }
         cause = cause.cause;
       } else if (typeof cause === "string") {
         appendCauseMessage(cause);


### PR DESCRIPTION
## Summary

- Problem: Fixes #73713. `openclaw infer embedding create` routes local embedding failures through the shared CLI runtime, but that runtime printed `String(err)`, so a fetch failure with a nested Node/Undici cause surfaced only as `TypeError: fetch failed`.
- Solution: Use the shared redacting `formatErrorMessage` path for default CLI command failures and include nested error `code` values while walking `.cause` chains.
- What changed: `runCommandWithRuntime` now preserves the existing top-level `Error:` / `TypeError:` prefix while emitting the formatted cause chain, and `formatErrorMessage` preserves nested error codes such as `UND_ERR_INVALID_ARG` alongside the nested message.
- What did NOT change: Provider selection, Voyage request construction, SSRF guard behavior, dispatcher selection, API key lookup, and successful embedding responses are unchanged.
- Why it matters / User impact: When a provider fetch fails, users now see the actionable underlying transport cause instead of a generic top-level `fetch failed`, making Node/Undici dispatcher problems diagnosable from the CLI output.
- Fixes #73713

## Real behavior proof
- **Behavior or issue addressed:** The `infer embedding create` failure path no longer swallows the nested fetch cause/code at the shared CLI runtime boundary used by the embedding command.
- **Real environment tested:** Local source checkout on Linux with Node v22.22.0, using the same `runCommandWithRuntime(defaultRuntime, action)` boundary called by `openclaw infer embedding create`.
- **Exact steps or command run after this patch:**

```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-73713
node --import tsx /media/vdc/code/ai/aispace/openclaw-issue-73713-evidence/cli-error-cause-proof.mts
node scripts/run-vitest.mjs run src/cli/cli-utils.test.ts
node scripts/run-vitest.mjs run src/cli/capability-cli.test.ts src/cli/program/register.agent.test.ts src/cli/program/register.maintenance.test.ts src/cli/program/register.onboard.test.ts src/cli/program/register.setup.test.ts src/cli/program/register.configure.test.ts
pnpm tsgo:core:test
git diff --check
```

- **Evidence after fix:**

```text
CLI error cause proof at 2026-06-13T07:38:51.647Z
command_path=openclaw infer embedding create -> runCommandWithRuntime(defaultRuntime, action)
synthetic_top_error=TypeError: fetch failed
synthetic_cause_message=invalid onRequestStart method
synthetic_cause_code=UND_ERR_INVALID_ARG
runtime_error_message="TypeError: fetch failed | invalid onRequestStart method | UND_ERR_INVALID_ARG"
runtime_exit_codes=[1]
result=passed
```

```text
[test] starting test/vitest/vitest.cli.config.ts

 RUN  v4.1.7 /media/vdc/code/ai/aispace/openclaw-worktrees/issue-73713

 Test Files  1 passed (1)
      Tests  44 passed (44)
```

```text
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
```

```text
Test Files  6 passed (6)
Tests  140 passed (140)
```

- **Observed result after fix:** The default CLI runtime error message preserves the top-level `TypeError: fetch failed`, and also includes the nested `invalid onRequestStart method` and `UND_ERR_INVALID_ARG` code.
- **What was not tested:** No live Voyage API request was sent, no real credential was used, and this local environment was Node v22.22.0 rather than Node 24. The proof targets the error-attribution boundary from the issue: a Node/Undici-style nested fetch failure now reaches CLI output.

## Regression Test Plan
- **Target test file:** `src/cli/cli-utils.test.ts`
- **Scenario locked in:** A `TypeError("fetch failed")` with a nested cause carrying `message: "invalid onRequestStart method"` and `code: "UND_ERR_INVALID_ARG"` must be emitted by `runCommandWithRuntime` with the top-level `TypeError:` prefix, nested message, and nested code present.
- **Why this is the smallest reliable guardrail:** `openclaw infer embedding create` uses this shared runtime wrapper, so this test locks the source CLI error boundary without needing live provider credentials or a network-dependent Node/Undici reproduction.

## Merge risk
- **Risk labels considered:** CLI error formatting, secret redaction, provider diagnostics.
- **Risk explanation:** The change affects default CLI command failure output, so more nested cause detail may appear for other commands. The output still goes through the existing redacting formatter before printing, and custom `onError` handlers are unchanged.
- **Why acceptable:** The patch is small, only changes failure diagnostics, preserves successful command behavior, and improves the shared source-of-truth path instead of adding a Voyage-specific string workaround.

## Root Cause
- **Root cause:** `runCommandWithRuntime` caught default command failures and printed `String(err)`. For `TypeError("fetch failed")`, JavaScript stringification only includes the top-level error, so the source `.cause` chain from Node/Undici was discarded before the CLI output was written.
- **Why this is root-cause fix:** This fixes the root cause because the source invariant is that CLI command failures should preserve the error attribution chain after provider/runtime layers attach it. The bug was caused at the shared CLI error boundary, not in Voyage request construction: the nested transport cause existed on the error object but was dropped by `String(err)`. This patch changes that boundary directly by using the existing redacting formatter and extending the formatter to carry nested error codes while walking `.cause`.
- **Fix classification:** Root cause fix.
- **Maintainer-ready confidence:** High. The diff is limited to three files, the regression covers the exact Node/Undici-style nested fetch failure, and local proof exercises the same shared runtime wrapper used by the embedding CLI.
- **Patch quality notes:** This is not a downstream provider workaround or a catch-all fallback. The shared CLI runtime already owns default command error rendering; the patch preserves diagnostic source information that was already attached to the thrown error.
- **Architecture / source-of-truth check:** `src/cli/cli-utils.ts` is the source boundary for default CLI command failure rendering, and `src/infra/errors.ts` is the shared redacting formatter. Provider transport code remains owned by the memory host SDK and fetch guard layers.
