### PR TITLE
test(diffs): add viewerState, toolbar toggle, shadow root, and hydrateProps tests (fixes #83915)

### DIFF
--- a/extensions/diffs/src/viewer-client.test.ts
+++ b/extensions/diffs/src/viewer-client.test.ts
@@ -271,10 +271,11 @@ describe("viewerState initialization", () => {
 
     await hydrateViewer();
 
-    const preloadArg = preloadHighlighterMock.mock.calls[0]?.[0] as { langs: string[] };
-    expect(preloadArg.langs).toContain("typescript");
-    expect(preloadArg.langs).toContain("python");
-    expect(preloadArg.themes).toEqual(["pierre-light", "pierre-dark"]);
+    const preloadArg = preloadHighlighterMock.mock.calls[0]?.[0] as { langs: string[]; themes: string[] } | undefined;
+    expect(preloadArg).toBeDefined();
+    expect(preloadArg!.langs).toContain("typescript");
+    expect(preloadArg!.langs).toContain("python");
+    expect(preloadArg!.themes).toEqual(["pierre-light", "pierre-dark"]);
   });
 });
 

--- a/extensions/diffs/src/viewer-client.test.ts
+++ b/extensions/diffs/src/viewer-client.test.ts
@@ -59,12 +59,13 @@ const viewerPayload = JSON.stringify({
   newFile: { fileName: "a.ts", lang: "text", content: "new" },
 });
 
-function renderCard(): void {
+function renderCard(payloadOverride?: string): void {
+  const payload = payloadOverride ?? viewerPayload;
   document.body.insertAdjacentHTML(
     "beforeend",
     `<section class="oc-diff-card">
       <div data-openclaw-diff-host></div>
-      <script type="application/json" data-openclaw-diff-payload>${viewerPayload}</script>
+      <script type="application/json" data-openclaw-diff-payload>${payload}</script>
     </section>`,
   );
 }
@@ -171,4 +172,291 @@ describe("hydrateViewer", () => {
     expect(document.documentElement.dataset.openclawDiffsError).toBeUndefined();
     warn.mockRestore();
   });
+});
+
+describe("viewerState initialization", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    delete document.documentElement.dataset.openclawDiffsError;
+    delete document.documentElement.dataset.openclawDiffsReady;
+    delete document.body.dataset.theme;
+    vi.clearAllMocks();
+  });
+
+  it("seeds viewerState from firstPayload options and syncs document theme", async () => {
+    const customPayload = JSON.stringify({
+      prerenderedHTML: "<div>diff</div>",
+      options: {
+        theme: { light: "pierre-light", dark: "pierre-dark" },
+        diffStyle: "split",
+        diffIndicators: "bars",
+        disableLineNumbers: false,
+        expandUnchanged: false,
+        themeType: "light",
+        backgroundEnabled: false,
+        overflow: "scroll",
+        unsafeCSS: "",
+      },
+      langs: ["text"],
+      oldFile: { fileName: "a.ts", lang: "text", content: "old" },
+      newFile: { fileName: "a.ts", lang: "text", content: "new" },
+    });
+    renderCard(customPayload);
+    const { hydrateViewer } = await import("./viewer-client.js");
+
+    await hydrateViewer();
+
+    expect(document.body.dataset.theme).toBe("light");
+
+    const opts = fileDiffSetOptionsMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(opts.diffStyle).toBe("split");
+    expect(opts.themeType).toBe("light");
+    expect(opts.overflow).toBe("scroll");
+    expect(opts.disableBackground).toBe(true);
+  });
+
+  it("defaults viewerState to dark/unified/wrap/background when firstPayload uses defaults", async () => {
+    renderCard();
+    const { hydrateViewer } = await import("./viewer-client.js");
+
+    await hydrateViewer();
+
+    expect(document.body.dataset.theme).toBe("dark");
+
+    const opts = fileDiffSetOptionsMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(opts.diffStyle).toBe("unified");
+    expect(opts.themeType).toBe("dark");
+    expect(opts.overflow).toBe("wrap");
+    expect(opts.disableBackground).toBe(false);
+  });
+
+  it("preloadHighlighter receives merged language set from all cards", async () => {
+    const payload1 = JSON.stringify({
+      prerenderedHTML: "<div>diff1</div>",
+      options: {
+        theme: { light: "pierre-light", dark: "pierre-dark" },
+        diffStyle: "unified",
+        diffIndicators: "bars",
+        disableLineNumbers: false,
+        expandUnchanged: false,
+        themeType: "dark",
+        backgroundEnabled: true,
+        overflow: "wrap",
+        unsafeCSS: "",
+      },
+      langs: ["typescript"],
+      oldFile: { fileName: "a.ts", lang: "typescript", content: "old" },
+      newFile: { fileName: "a.ts", lang: "typescript", content: "new" },
+    });
+    const payload2 = JSON.stringify({
+      prerenderedHTML: "<div>diff2</div>",
+      options: {
+        theme: { light: "pierre-light", dark: "pierre-dark" },
+        diffStyle: "unified",
+        diffIndicators: "bars",
+        disableLineNumbers: false,
+        expandUnchanged: false,
+        themeType: "dark",
+        backgroundEnabled: true,
+        overflow: "wrap",
+        unsafeCSS: "",
+      },
+      langs: ["python"],
+      oldFile: { fileName: "b.py", lang: "python", content: "old" },
+      newFile: { fileName: "b.py", lang: "python", content: "new" },
+    });
+    renderCard(payload1);
+    renderCard(payload2);
+    const { hydrateViewer } = await import("./viewer-client.js");
+
+    await hydrateViewer();
+
+    const preloadArg = preloadHighlighterMock.mock.calls[0]?.[0] as { langs: string[] };
+    expect(preloadArg.langs).toContain("typescript");
+    expect(preloadArg.langs).toContain("python");
+    expect(preloadArg.themes).toEqual(["pierre-light", "pierre-dark"]);
+  });
+});
+
+describe("toolbar button toggles", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    delete document.body.dataset.theme;
+    vi.clearAllMocks();
+  });
+
+  it("layout toggle switches between unified and split", async () => {
+    renderCard();
+    const { hydrateViewer } = await import("./viewer-client.js");
+    await hydrateViewer();
+
+    const opts1 = fileDiffSetOptionsMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(opts1.diffStyle).toBe("unified");
+
+    const renderHeaderMetadata = opts1.renderHeaderMetadata as () => HTMLElement;
+    const toolbar = renderHeaderMetadata();
+    const buttons = toolbar.querySelectorAll("button");
+
+    buttons[0].click();
+
+    expect(fileDiffRerenderMock).toHaveBeenCalled();
+
+    const opts2 = fileDiffSetOptionsMock.mock.calls[fileDiffSetOptionsMock.mock.calls.length - 1]?.[0] as Record<string, unknown>;
+    expect(opts2.diffStyle).toBe("split");
+  });
+
+  it("theme toggle switches between dark and light", async () => {
+    renderCard();
+    const { hydrateViewer } = await import("./viewer-client.js");
+    await hydrateViewer();
+
+    const opts1 = fileDiffSetOptionsMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(opts1.themeType).toBe("dark");
+
+    const renderHeaderMetadata = opts1.renderHeaderMetadata as () => HTMLElement;
+    const toolbar = renderHeaderMetadata();
+    const buttons = toolbar.querySelectorAll("button");
+
+    buttons[3].click();
+
+    const lastOpts = fileDiffSetOptionsMock.mock.calls[fileDiffSetOptionsMock.mock.calls.length - 1]?.[0] as Record<string, unknown>;
+    expect(lastOpts.themeType).toBe("light");
+    expect(document.body.dataset.theme).toBe("light");
+  });
+
+  it("wrap toggle switches between wrap and scroll", async () => {
+    renderCard();
+    const { hydrateViewer } = await import("./viewer-client.js");
+    await hydrateViewer();
+
+    const opts1 = fileDiffSetOptionsMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(opts1.overflow).toBe("wrap");
+
+    const renderHeaderMetadata = opts1.renderHeaderMetadata as () => HTMLElement;
+    const toolbar = renderHeaderMetadata();
+    const buttons = toolbar.querySelectorAll("button");
+
+    buttons[1].click();
+
+    const lastOpts = fileDiffSetOptionsMock.mock.calls[fileDiffSetOptionsMock.mock.calls.length - 1]?.[0] as Record<string, unknown>;
+    expect(lastOpts.overflow).toBe("scroll");
+  });
+
+  it("background toggle inverts disableBackground", async () => {
+    renderCard();
+    const { hydrateViewer } = await import("./viewer-client.js");
+    await hydrateViewer();
+
+    const opts1 = fileDiffSetOptionsMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(opts1.disableBackground).toBe(false);
+
+    const renderHeaderMetadata = opts1.renderHeaderMetadata as () => HTMLElement;
+    const toolbar = renderHeaderMetadata();
+    const buttons = toolbar.querySelectorAll("button");
+
+    buttons[2].click();
+
+    const lastOpts = fileDiffSetOptionsMock.mock.calls[fileDiffSetOptionsMock.mock.calls.length - 1]?.[0] as Record<string, unknown>;
+    expect(lastOpts.disableBackground).toBe(true);
+  });
+});
+
+describe("ensureShadowRoot", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("attaches shadow root from template and removes template element", async () => {
+    renderCard();
+    const host = document.querySelector<HTMLElement>("[data-openclaw-diff-host]")!;
+    const template = document.createElement("template");
+    template.setAttribute("shadowrootmode", "open");
+    template.innerHTML = "<div>shadow content</div>";
+    host.append(template);
+
+    const { hydrateViewer } = await import("./viewer-client.js");
+    await hydrateViewer();
+
+    expect(host.shadowRoot).toBeDefined();
+    expect(host.shadowRoot!.querySelector("div")?.textContent).toBe("shadow content");
+    expect(host.querySelector("template")).toBeNull();
+  });
+
+  it("skips shadow root attachment when no template is present", async () => {
+    renderCard();
+    const host = document.querySelector<HTMLElement>("[data-openclaw-diff-host]")!;
+
+    const { hydrateViewer } = await import("./viewer-client.js");
+    await hydrateViewer();
+
+    expect(host.shadowRoot).toBeNull();
+    expect(fileDiffHydrateMock).toHaveBeenCalled();
+  });
+
+  it("skips shadow root when already attached", async () => {
+    renderCard();
+    const host = document.querySelector<HTMLElement>("[data-openclaw-diff-host]")!;
+    host.attachShadow({ mode: "open" });
+    host.shadowRoot!.innerHTML = "<span>existing</span>";
+
+    const template = document.createElement("template");
+    template.setAttribute("shadowrootmode", "open");
+    template.innerHTML = "<div>new content</div>";
+    host.append(template);
+
+    const { hydrateViewer } = await import("./viewer-client.js");
+    await hydrateViewer();
+
+    expect(host.shadowRoot!.querySelector("span")?.textContent).toBe("existing");
+    expect(host.querySelector("template")).not.toBeNull();
+  });
+});
+
+describe("getHydrateProps branching", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("passes fileDiff directly when payload has fileDiff", async () => {
+    const fileDiffPayload = JSON.stringify({
+      prerenderedHTML: "<div>diff</div>",
+      options: {
+        theme: { light: "pierre-light", dark: "pierre-dark" },
+        diffStyle: "unified",
+        diffIndicators: "bars",
+        disableLineNumbers: false,
+        expandUnchanged: false,
+        themeType: "dark",
+        backgroundEnabled: true,
+        overflow: "wrap",
+        unsafeCSS: "",
+      },
+      langs: ["text"],
+      fileDiff: { fileName: "patch.diff", lang: "text", hunks: [] },
+    });
+    renderCard(fileDiffPayload);
+    const { hydrateViewer } = await import("./viewer-client.js");
+
+    await hydrateViewer();
+
+    const hydrateArg = fileDiffHydrateMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(hydrateArg.fileDiff).toEqual({ fileName: "patch.diff", lang: "text", hunks: [] });
+    expect(hydrateArg.oldFile).toBeUndefined();
+    expect(hydrateArg.newFile).toBeUndefined();
+  });
+
+  it("passes oldFile and newFile when payload has them without fileDiff", async () => {
+    renderCard();
+    const { hydrateViewer } = await import("./viewer-client.js");
+
+    await hydrateViewer();
+
+    const hydrateArg = fileDiffHydrateMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(hydrateArg.fileDiff).toBeUndefined();
+    expect(hydrateArg.oldFile).toEqual({ fileName: "a.ts", lang: "text", content: "old" });
+    expect(hydrateArg.newFile).toEqual({ fileName: "a.ts", lang: "text", content: "new" });
+  });
+
 });

--- a/extensions/diffs/src/viewer-client.test.ts
+++ b/extensions/diffs/src/viewer-client.test.ts
@@ -271,7 +271,7 @@ describe("viewerState initialization", () => {
 
     await hydrateViewer();
 
-    const preloadArg = preloadHighlighterMock.mock.calls[0]?.[0] as { langs: string[]; themes: string[] } | undefined;
+    const preloadArg = (preloadHighlighterMock.mock.calls as unknown[][])[0]?.[0] as { langs: string[]; themes: string[] } | undefined;
     expect(preloadArg).toBeDefined();
     expect(preloadArg!.langs).toContain("typescript");
     expect(preloadArg!.langs).toContain("python");


### PR DESCRIPTION
## What does this PR do?

Adds targeted test coverage for `viewer-client.ts` logic that was previously only covered by XSS safety checks and error-handling paths. Exercises viewerState initialization, toolbar button toggle handlers, ensureShadowRoot fallback paths, and getHydrateProps branching.

## Related Issue

Fixes #83915

## Type of Change

- [x] Tests

## Changes Made

- `extensions/diffs/src/viewer-client.test.ts`: Added 12 new test cases across 4 describe blocks:
  - **viewerState initialization** (3 tests): seeds state from firstPayload options, verifies defaults, validates merged language set passed to preloadHighlighter
  - **toolbar button toggles** (4 tests): layout toggle (unified↔split), theme toggle (dark↔light), wrap toggle (wrap↔scroll), background toggle (disableBackground inversion)
  - **ensureShadowRoot** (3 tests): template-clone path, skip when no template, skip when already attached
  - **getHydrateProps branching** (2 tests): fileDiff passthrough vs old/new file extraction

## How to Test

1. `node scripts/run-vitest.mjs run extensions/diffs/src/viewer-client.test.ts` — all 19 tests pass

## Real behavior proof

**Behavior or issue addressed:**
`viewer-client.ts` owns the diff viewer's client-side state machine, toolbar toggle logic, shadow root hydration, and payload branching — all untested beyond source-level XSS pattern checks and error-handling paths.

**Real environment tested:**
macOS, Node v22, vitest 4.1.7 with jsdom environment

**Exact steps or command run after the patch:**
```
node scripts/run-vitest.mjs run extensions/diffs/src/viewer-client.test.ts
```

**Evidence after fix:**
```
 RUN  v4.1.7 /Users/liuhao/.hermes/workdir/openclaw

 ✓  extension-diffs  extensions/diffs/src/viewer-client.test.ts (19 tests) 94ms

 Test Files  1 passed (1)
      Tests  19 passed (19)
   Start at  15:59:08
   Duration  514ms (transform 54ms, setup 220ms, import 15ms, tests 94ms, environment 449ms)

[test] passed 1 Vitest shard in 3.45s
```

**Observed result after fix:**
All 19 tests pass (5 original + 12 new + 2 existing error-handling). New tests verify viewerState seeding, toolbar click handlers dispatch to syncAllControllers, shadow root lifecycle, and hydrateProps branching.

**What was not tested:**
- Live iMessage rendering of diff viewer (requires macOS device)
- Actual `@pierre/diffs` rendering output (mocked in tests)
- DOM rendering in real browser (tests use jsdom)
