### PR TITLE
fix(memory-core): clarify memory_search tool timeouts

### DIFF
--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -159,6 +159,14 @@ inline batch timeout by default. If the host is simply slow, set
 `agents.defaults.memorySearch.sync.embeddingBatchTimeoutSeconds` and rerun
 `openclaw memory index --force`.
 
+**`memory_search` itself times out?** The tool has a separate hard deadline so a
+slow Gateway or large `memory+sessions` index cannot block the agent turn
+indefinitely. Timeout results are reported as tool-deadline failures rather than
+embedding-provider failures. For slow hosts, set
+`plugins.entries.memory-core.config.tools.memorySearch.timeoutMs` (milliseconds,
+1000-120000). For broad `corpus="all"` searches, OpenClaw returns partial
+results when one corpus finishes before another stalls.
+
 **CJK text not found?** Rebuild the FTS index with
 `openclaw memory index --force`.
 

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -30,6 +30,24 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+      "tools": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "memorySearch": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "timeoutMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 120000,
+                "description": "Hard deadline for the memory_search tool in milliseconds. Increase on slow hosts with large memory/session indexes."
+              }
+            }
+          }
+        }
+      },
       "dreaming": {
         "type": "object",
         "additionalProperties": false,

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -452,7 +452,7 @@ describe("memory tools", () => {
     expect(getMemorySearchManagerMockCalls()).toBe(1);
   });
 
-  it("does not cooldown primary memory when a corpus=all wiki supplement stalls", async () => {
+  it("returns partial primary memory results when a corpus=all wiki supplement stalls", async () => {
     vi.useFakeTimers();
     try {
       let searchCalls = 0;
@@ -481,10 +481,28 @@ describe("memory tools", () => {
       });
       await vi.advanceTimersByTimeAsync(15_000);
       const stalledAllResult = await stalledAllResultPromise;
-      expectUnavailableMemorySearchDetails(stalledAllResult.details, {
+      const stalledDetails = stalledAllResult.details as {
+        results: Array<{ corpus: string; path: string }>;
+        partial?: boolean;
+        error?: string;
+        warning?: string;
+        action?: string;
+        debug?: { partial?: { failedPhase?: string; error?: string } };
+      };
+      expect(stalledDetails.results.map((entry) => [entry.corpus, entry.path])).toEqual([
+        ["memory", "MEMORY.md"],
+      ]);
+      expect(stalledDetails.partial).toBe(true);
+      expect(stalledDetails.error).toBe("memory_search timed out after 15s");
+      expect(stalledDetails.warning).toBe(
+        "Memory search returned partial results because a supplemental corpus did not finish.",
+      );
+      expect(stalledDetails.action).toBe(
+        'Retry with corpus="memory" or corpus="wiki" for a narrower search, or increase plugins.entries.memory-core.config.tools.memorySearch.timeoutMs for slower hosts.',
+      );
+      expect(stalledDetails.debug?.partial).toEqual({
+        failedPhase: "supplement",
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
       });
 
       const memoryResult = await tool.execute("call_memory_after_stalled_wiki", {
@@ -531,8 +549,9 @@ describe("memory tools", () => {
       const stalledAllResult = await stalledAllResultPromise;
       expectUnavailableMemorySearchDetails(stalledAllResult.details, {
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        warning: "Memory search timed out before the tool deadline.",
+        action:
+          "Retry with a narrower corpus/query or after Gateway pressure clears; if this recurs, increase plugins.entries.memory-core.config.tools.memorySearch.timeoutMs.",
       });
 
       const wikiOnlyResult = await tool.execute("call_all_after_stalled_memory", {

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -127,16 +127,21 @@ export function buildMemorySearchUnavailableResult(
 ) {
   const reason = (error ?? "memory search unavailable").trim() || "memory search unavailable";
   const isQuotaError = /insufficient_quota|quota|429/.test(normalizeLowercaseStringOrEmpty(reason));
+  const isToolTimeout = /\bmemory_search timed out after \d+s\b/i.test(reason);
   const warning =
     overrides?.warning ??
     (isQuotaError
       ? "Memory search is unavailable because the embedding provider quota is exhausted."
-      : "Memory search is unavailable due to an embedding/provider error.");
+      : isToolTimeout
+        ? "Memory search timed out before the tool deadline."
+        : "Memory search is unavailable due to an embedding/provider error.");
   const action =
     overrides?.action ??
     (isQuotaError
       ? "Top up or switch embedding provider, then retry memory_search."
-      : "Check embedding provider configuration and retry memory_search.");
+      : isToolTimeout
+        ? "Retry with a narrower corpus/query or after Gateway pressure clears; if this recurs, increase plugins.entries.memory-core.config.tools.memorySearch.timeoutMs."
+        : "Check embedding provider configuration and retry memory_search.");
   return {
     results: [],
     disabled: true,

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -145,8 +145,9 @@ describe("memory_search unavailable payloads", () => {
       const result = await resultPromise;
       expectUnavailableMemorySearchDetails(result.details, {
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        warning: "Memory search timed out before the tool deadline.",
+        action:
+          "Retry with a narrower corpus/query or after Gateway pressure clears; if this recurs, increase plugins.entries.memory-core.config.tools.memorySearch.timeoutMs.",
       });
     } finally {
       vi.useRealTimers();
@@ -171,18 +172,63 @@ describe("memory_search unavailable payloads", () => {
       const result = await resultPromise;
       expectUnavailableMemorySearchDetails(result.details, {
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        warning: "Memory search timed out before the tool deadline.",
+        action:
+          "Retry with a narrower corpus/query or after Gateway pressure clears; if this recurs, increase plugins.entries.memory-core.config.tools.memorySearch.timeoutMs.",
       });
       // The deadline must abort the orphaned search, not just race past it.
       expect(searchSignal?.aborted).toBe(true);
       const cooldownResult = await tool.execute("search-cooldown", { query: "hello again" });
       expectUnavailableMemorySearchDetails(cooldownResult.details, {
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        warning: "Memory search timed out before the tool deadline.",
+        action:
+          "Retry with a narrower corpus/query or after Gateway pressure clears; if this recurs, increase plugins.entries.memory-core.config.tools.memorySearch.timeoutMs.",
       });
       expect(searchCalls).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("honors the configured memory_search tool deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      let searchSignal: AbortSignal | undefined;
+      setMemorySearchImpl(async (opts) => {
+        searchSignal = opts?.signal;
+        return await new Promise(() => {});
+      });
+      const tool = createMemorySearchToolOrThrow({
+        config: {
+          agents: { list: [{ id: "main", default: true }] },
+          plugins: {
+            entries: {
+              "memory-core": {
+                config: {
+                  tools: {
+                    memorySearch: {
+                      timeoutMs: 5_000,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const resultPromise = tool.execute("configured-timeout", { query: "hello" });
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      const result = await resultPromise;
+      expectUnavailableMemorySearchDetails(result.details, {
+        error: "memory_search timed out after 5s",
+        warning: "Memory search timed out before the tool deadline.",
+        action:
+          "Retry with a narrower corpus/query or after Gateway pressure clears; if this recurs, increase plugins.entries.memory-core.config.tools.memorySearch.timeoutMs.",
+      });
+      expect(searchSignal?.aborted).toBe(true);
     } finally {
       vi.useRealTimers();
     }
@@ -209,8 +255,9 @@ describe("memory_search unavailable payloads", () => {
       const result = await resultPromise;
       expectUnavailableMemorySearchDetails(result.details, {
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        warning: "Memory search timed out before the tool deadline.",
+        action:
+          "Retry with a narrower corpus/query or after Gateway pressure clears; if this recurs, increase plugins.entries.memory-core.config.tools.memorySearch.timeoutMs.",
       });
     } finally {
       vi.useRealTimers();

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -44,7 +44,9 @@ type MemorySearchToolResult =
   | (MemorySearchResult & { corpus: MemorySource })
   | MemoryCorpusSearchResult;
 
-const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 15_000;
+const DEFAULT_MEMORY_SEARCH_TOOL_TIMEOUT_MS = 15_000;
+const MIN_MEMORY_SEARCH_TOOL_TIMEOUT_MS = 1_000;
+const MAX_MEMORY_SEARCH_TOOL_TIMEOUT_MS = 120_000;
 const MEMORY_SEARCH_TOOL_COOLDOWN_MS = 60_000;
 
 const memorySearchToolCooldowns = new Map<string, { until: number; error: string }>();
@@ -80,6 +82,23 @@ export const testing = {
     memorySearchToolCooldowns.clear();
   },
 } as const;
+
+function clampMemorySearchToolTimeoutMs(value: number): number {
+  return Math.min(
+    MAX_MEMORY_SEARCH_TOOL_TIMEOUT_MS,
+    Math.max(MIN_MEMORY_SEARCH_TOOL_TIMEOUT_MS, Math.round(value)),
+  );
+}
+
+function resolveMemorySearchToolTimeoutMs(cfg: OpenClawConfig): number {
+  const pluginConfig = resolveMemoryCorePluginConfig(cfg);
+  const toolsConfig = asRecord(pluginConfig?.tools);
+  const memorySearchConfig = asRecord(toolsConfig?.memorySearch);
+  const timeoutMs = memorySearchConfig?.timeoutMs;
+  return typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? clampMemorySearchToolTimeoutMs(timeoutMs)
+    : DEFAULT_MEMORY_SEARCH_TOOL_TIMEOUT_MS;
+}
 
 async function runMemorySearchToolWithDeadline<T>(params: {
   timeoutMs: number;
@@ -183,6 +202,59 @@ function mergeMemorySearchCorpusResults(params: {
   }
 
   return sortMemorySearchToolResults(selected).slice(0, params.maxResults);
+}
+
+function buildPartialMemorySearchCorpusResult(params: {
+  memoryResults: MemorySearchToolResult[];
+  maxResults: number;
+  provider?: string;
+  model?: string;
+  fallback: unknown;
+  citations: unknown;
+  mode?: string;
+  debug?:
+    | {
+        backend: string;
+        configuredMode?: string;
+        effectiveMode?: string;
+        fallback?: string;
+        searchMs: number;
+        hits: number;
+      }
+    | undefined;
+  error: string;
+  failedPhase: "memory" | "supplement";
+}) {
+  const warning =
+    params.failedPhase === "supplement"
+      ? "Memory search returned partial results because a supplemental corpus did not finish."
+      : "Memory search returned partial results because the primary memory corpus did not finish.";
+  const action =
+    'Retry with corpus="memory" or corpus="wiki" for a narrower search, or increase plugins.entries.memory-core.config.tools.memorySearch.timeoutMs for slower hosts.';
+  return jsonResult({
+    results: mergeMemorySearchCorpusResults({
+      memoryResults: params.memoryResults,
+      supplementResults: [],
+      maxResults: params.maxResults,
+      balanceCorpora: false,
+    }),
+    provider: params.provider,
+    model: params.model,
+    fallback: params.fallback,
+    citations: params.citations,
+    mode: params.mode,
+    partial: true,
+    error: params.error,
+    warning,
+    action,
+    debug: {
+      ...(params.debug ?? {}),
+      partial: {
+        failedPhase: params.failedPhase,
+        error: params.error,
+      },
+    },
+  });
 }
 
 function isClosedMemoryStoreError(error: unknown): boolean {
@@ -375,6 +447,27 @@ export function createMemorySearchTool(options: {
           requestedCorpus === "wiki" ? undefined : readMemorySearchToolCooldown(cooldownKey);
         let activeUnavailablePhase: "memory" | "supplement" | undefined;
         let failedUnavailablePhase: "memory" | "supplement" | undefined;
+        let partialAllCorpusResult:
+          | {
+              memoryResults: MemorySearchToolResult[];
+              maxResults: number;
+              provider?: string;
+              model?: string;
+              fallback: unknown;
+              citations: unknown;
+              mode?: string;
+              debug?:
+                | {
+                    backend: string;
+                    configuredMode?: string;
+                    effectiveMode?: string;
+                    fallback?: string;
+                    searchMs: number;
+                    hits: number;
+                  }
+                | undefined;
+            }
+          | undefined;
         const runUnavailablePhase = async <T>(
           phase: "memory" | "supplement",
           task: () => Promise<T>,
@@ -393,7 +486,7 @@ export function createMemorySearchTool(options: {
         };
 
         const outcome = await runMemorySearchToolWithDeadline({
-          timeoutMs: MEMORY_SEARCH_TOOL_TIMEOUT_MS,
+          timeoutMs: resolveMemorySearchToolTimeoutMs(cfg),
           run: async (deadlineSignal) => {
             const { resolveMemoryBackendConfig } = await loadMemoryToolRuntime();
             const shouldQuerySupplements = requestedCorpus === "wiki" || requestedCorpus === "all";
@@ -555,6 +648,18 @@ export function createMemorySearchTool(options: {
                   buildPausedMemoryIndexUnavailableResult(pausedIndexIdentityReason),
                 );
               }
+              if (requestedCorpus === "all" && surfacedMemoryResults.length > 0) {
+                partialAllCorpusResult = {
+                  memoryResults: surfacedMemoryResults,
+                  maxResults: Math.max(1, maxResults ?? 10),
+                  provider,
+                  model,
+                  fallback,
+                  citations: citationsMode,
+                  mode: searchMode,
+                  debug: searchDebug,
+                };
+              }
             }
             const supplementResults = shouldQuerySupplements
               ? await runUnavailablePhase(
@@ -590,6 +695,17 @@ export function createMemorySearchTool(options: {
         });
         if (outcome.status === "unavailable") {
           const unavailablePhase = failedUnavailablePhase ?? activeUnavailablePhase;
+          if (
+            requestedCorpus === "all" &&
+            unavailablePhase === "supplement" &&
+            partialAllCorpusResult
+          ) {
+            return buildPartialMemorySearchCorpusResult({
+              ...partialAllCorpusResult,
+              error: outcome.error,
+              failedPhase: unavailablePhase,
+            });
+          }
           const shouldRecordCooldown =
             requestedCorpus !== "wiki" &&
             (requestedCorpus !== "all" || unavailablePhase === "memory");


### PR DESCRIPTION
## Summary

Fixes the `memory_search` tool timeout path so tool-deadline failures are no longer reported as embedding-provider failures, and makes the deadline configurable for slower hosts / larger indexes.

What changed:
- add `plugins.entries.memory-core.config.tools.memorySearch.timeoutMs` (1000-120000 ms) for the `memory_search` tool hard deadline;
- classify `memory_search timed out after ...` as a tool deadline failure instead of an embedding/provider error;
- return partial primary-memory results for `corpus="all"` when the supplemental/wiki corpus stalls after memory hits are already available;
- document the new timeout knob and partial-result behavior.

## Relationship to adjacent work

This is adjacent to, but not a duplicate of:

- #91958 / #91947 — QMD-specific deadline alignment. This PR uses an explicit memory-core tool timeout config and also fixes timeout classification plus partial `corpus="all"` results.
- #77899 — supplement failure isolation inside `searchMemoryCorpusSupplements`. This PR handles the outer tool deadline path, including partial primary-memory results when the supplement phase misses the deadline.
- #75951 — embedding-provider error hints. This PR prevents tool-deadline failures from being mislabeled as embedding-provider failures.
- #91862 / #91778 — provider/index-metadata diagnostics. This PR addresses the separate tool-deadline failure surface.

## Behavior addressed

`memory_search` could hit the hardcoded 15s tool deadline and surface:

```text
Memory search is unavailable due to an embedding/provider error.
```

That message is misleading when the embedding provider is healthy and the failure is the wrapper deadline. Broad `corpus="all"` searches could also discard usable primary memory results if the supplemental/wiki phase stalled.

## Real setup tested

Isolated source checkout on current `origin/main`. I did not use any live user Gateway/runtime/config for proof.

## Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/src/tools.test.ts extensions/memory-core/src/tools.citations.test.ts extensions/memory-core/src/config.test.ts
corepack pnpm exec oxfmt --check extensions/memory-core/src/tools.ts extensions/memory-core/src/tools.shared.ts extensions/memory-core/src/tools.test.ts extensions/memory-core/src/tools.citations.test.ts extensions/memory-core/openclaw.plugin.json docs/concepts/memory-search.md
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --noEmit
```

## Evidence after fix

- Targeted Vitest: 3 files, 36 tests passed.
- Formatting check passed for touched files.
- Extension type gate passed.

## Observed result after fix

- Timeout tests now report `Memory search timed out before the tool deadline.` instead of the generic embedding/provider warning.
- A configured `tools.memorySearch.timeoutMs: 5000` produces `memory_search timed out after 5s` and aborts the active search signal.
- `corpus="all"` returns `partial: true` and primary memory hits when the supplemental corpus stalls after primary memory hits are available.

## What was not tested

Live Gateway behavior on a production/user instance was intentionally not tested.
