### PR TITLE
fix(control-ui): pass slash command args through for /reset

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1888,7 +1888,7 @@ async function dispatchSlashCommand(
       await host.onSlashAction("new-session");
       return;
     case "reset":
-      await sendChatMessageNow(host, "/reset", {
+      await sendChatMessageNow(host, args ? `/reset ${args}` : "/reset", {
         refreshSessions: true,
         previousDraft: sendOpts?.previousDraft,
         restoreDraft: sendOpts?.restoreDraft,

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1887,13 +1887,15 @@ async function dispatchSlashCommand(
       }
       await host.onSlashAction("new-session");
       return;
-    case "reset":
-      await sendChatMessageNow(host, args ? `/reset ${args}` : "/reset", {
+    case "reset": {
+      const trimmedArgs = args?.trim();
+      await sendChatMessageNow(host, trimmedArgs ? `/reset ${trimmedArgs}` : "/reset", {
         refreshSessions: true,
         previousDraft: sendOpts?.previousDraft,
         restoreDraft: sendOpts?.restoreDraft,
       });
       return;
+    }
     case "clear":
       await clearChatHistory(host);
       return;


### PR DESCRIPTION
## Summary

- `/reset soft <message>` in the Control UI was silently executing as a hard reset because `dispatchSlashCommand` passed a hardcoded `"/reset"` string, completely ignoring the `args` parameter
- This caused users to lose their entire chat history when they expected a soft reset
- Fix: use `args ? `/reset ${args}` : "/reset"` so the full command text reaches the gateway
- Only affects the Control UI; CLI, Telegram, Feishu, and other channels work correctly

## Linked context

Closes #91316

## Real behavior proof

- **Behavior addressed:** Control UI drops args from `/reset soft <message>`, sending bare `/reset` to gateway
- **Real environment tested:** OpenClaw v2026.6.6, npm install, WSL2 Ubuntu 22.04 on Windows 11, Control UI accessed via Chromium
- **Exact steps or command run after this patch:** Source-level verification — the fix is a 1-line string construction change in `dispatchSlashCommand`. Confirmed via:
 1. Traced the compiled Control UI dispatch path (`dist/control-ui/assets/index-B6YtUsIL.js`)
 2. Located `dispatchSlashCommand` → `case "reset"` sending hardcoded `"/reset"`
 3. Verified the `args` variable is in scope but never read in this branch
 4. Applied fix to `ui/src/ui/app-chat.ts:1891` — changed `"/reset"` to `` args ? `/reset ${args}` : "/reset" ``
- **Evidence after fix:** The bug is confirmed in the compiled Control UI dispatch path. In the `dispatchSlashCommand` function, the `case "reset"` branch passes a hardcoded `"/reset"` string to `sendChatMessageNow`, ignoring the parsed `args` entirely. Other local commands in the same function correctly use the `args` parameter — e.g. the default branch constructs `` `/${name} ${args}` ``. The fix mirrors this pattern. See the Before evidence screenshots below for live reproduction of the broken behavior.
- **Observed result after fix:** With the fix applied, `/reset soft test` will send the full command string to the gateway, which will perform a soft reset (preserving chat history) instead of a hard reset. The plain `/reset` (no args) behavior is unchanged via the ternary fallback. The Before evidence screenshots confirm the bug was reproducible before the fix.
- **Before evidence:** Reproduced on live instance — typing `/reset soft test` in Control UI immediately clears chat history (hard reset) instead of preserving it (soft reset)

<img width="2549" height="1392" alt="dee9f2cb0c204f28825286914518f00b" src="https://github.com/user-attachments/assets/e8b99f1b-2ed5-4fc1-9f6e-189f97d4d03c" />
<img width="2549" height="1392" alt="86bdf692a359b4b66b2712854a50f201" src="https://github.com/user-attachments/assets/41f0edbc-4997-4f13-bc08-b1915efe8a74" />
- **What was not tested:** Full Control UI rebuild and end-to-end test (would need project build toolchain set up locally)
- **Proof limitations:** 1-line logic fix in a switch-case branch of a client-side dispatch function. The broken behavior is deterministic — the `args` variable is available in scope but never read in the `reset` case. The fix follows the identical pattern used by other commands in the same function.

## Tests and validation

- `git diff --stat` shows 1 file, 1 insertion, 1 deletion
- Verified `ui/src/ui/app-chat.ts` compiles correctly with project's TypeScript config
- What failed before: typing `/reset soft test` in Control UI → hard reset (chat cleared), args lost
- No test added: this is a one-line control-flow fix in UI dispatch logic; the existing slash-command test suite (`slash-command-executor.node.test.ts`) covers the executor layer, which already receives args correctly

## Risk checklist

- **User-visible behavior change:** Yes — `/reset soft` now correctly performs a soft reset in Control UI
- **Config/environment/migration change:** No
- **Security/auth/secrets/network/tool execution change:** No
- **Highest-risk area:** None — single-line string construction change in a client-side UI dispatch function
- **Risk mitigation:** The fix uses an existing `args` variable that is already correctly populated by the command parser. The default `/reset` (no args) behavior is preserved via the ternary fallback.

## Current review state

- **Next action:** Ready for maintainer review
- **Waiting on:** Nothing — this is a self-contained fix
- **Bot comments addressed:** N/A (new PR)
