### PR TITLE
fix(memory): keep memory_search in transient qmd mode

### DIFF
--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -29,6 +29,7 @@ type MemoryToolOptions = {
   agentId?: string;
   agentSessionKey?: string;
   sandboxed?: boolean;
+  oneShotCliRun?: boolean;
 };
 
 let memoryToolsModulePromise: Promise<MemoryToolsModule> | undefined;
@@ -154,6 +155,7 @@ function resolveMemoryToolOptions(ctx: OpenClawPluginToolContext): MemoryToolOpt
     agentId: ctx.agentId,
     agentSessionKey: ctx.sessionKey,
     sandboxed: ctx.sandboxed,
+    oneShotCliRun: ctx.oneShotCliRun,
   };
 }
 

--- a/extensions/memory-core/src/memory-tool-manager-mock.ts
+++ b/extensions/memory-core/src/memory-tool-manager-mock.ts
@@ -141,6 +141,10 @@ export function getMemorySyncMockCalls(): number {
   return stubManager.sync.mock.calls.length;
 }
 
+export function getMemoryCloseMockCalls(): number {
+  return stubManager.close.mock.calls.length;
+}
+
 export function getMemorySearchManagerMockConfigs(): unknown[] {
   return getMemorySearchManagerMock.mock.calls.map(([params]) => params.cfg);
 }

--- a/extensions/memory-core/src/memory-tool-manager-mock.ts
+++ b/extensions/memory-core/src/memory-tool-manager-mock.ts
@@ -26,7 +26,7 @@ let workspaceDir = "/workspace";
 let customStatus: Record<string, unknown> | undefined;
 let searchImpl: SearchImpl = async () => [];
 let getManagerImpl:
-  | ((params: { cfg?: unknown; agentId?: string }) => Promise<{
+  | ((params: { cfg?: unknown; agentId?: string; purpose?: string }) => Promise<{
       manager?: unknown;
       error?: string;
     }>)
@@ -60,8 +60,9 @@ const stubManager = {
   close: vi.fn(),
 };
 
-const getMemorySearchManagerMock = vi.fn(async (params: { cfg?: unknown; agentId?: string }) =>
-  getManagerImpl ? await getManagerImpl(params) : { manager: stubManager },
+const getMemorySearchManagerMock = vi.fn(
+  async (params: { cfg?: unknown; agentId?: string; purpose?: string }) =>
+    getManagerImpl ? await getManagerImpl(params) : { manager: stubManager },
 );
 const readAgentMemoryFileMock = vi.fn(
   async (params: MemoryReadParams) => await readFileImpl(params),
@@ -97,7 +98,7 @@ export function setMemorySearchImpl(next: SearchImpl): void {
 }
 
 export function setMemorySearchManagerImpl(
-  next: (params: { cfg?: unknown; agentId?: string }) => Promise<{
+  next: (params: { cfg?: unknown; agentId?: string; purpose?: string }) => Promise<{
     manager?: unknown;
     error?: string;
   }>,
@@ -144,7 +145,11 @@ export function getMemorySearchManagerMockConfigs(): unknown[] {
   return getMemorySearchManagerMock.mock.calls.map(([params]) => params.cfg);
 }
 
-export function getMemorySearchManagerMockParams(): Array<{ cfg?: unknown; agentId?: string }> {
+export function getMemorySearchManagerMockParams(): Array<{
+  cfg?: unknown;
+  agentId?: string;
+  purpose?: string;
+}> {
   return getMemorySearchManagerMock.mock.calls.map(([params]) => params);
 }
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -797,6 +797,59 @@ describe("QmdMemoryManager", () => {
     await manager?.close();
   });
 
+  it("preserves blocking boot update freshness for one-shot CLI mode", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: {
+            interval: "5m",
+            debounceMs: 60_000,
+            onBoot: true,
+            waitForBootSync: true,
+          },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const updateSpawned = createDeferred<void>();
+    let releaseUpdate: (() => void) | null = null;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "update") {
+        const child = createMockChild({ autoClose: false });
+        releaseUpdate = () => child.closeWith(0);
+        updateSpawned.resolve();
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const createPromise = createManager({ mode: "cli" });
+    await updateSpawned.promise;
+    let created = false;
+    void createPromise.then(() => {
+      created = true;
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(created).toBe(false);
+    expect(watchMock).not.toHaveBeenCalled();
+
+    (releaseUpdate as (() => void) | null)?.();
+    const { manager } = await createPromise;
+    const updateCalls = spawnMock.mock.calls
+      .map((call: unknown[]) => call[1] as string[])
+      .filter((args: string[]) => args[0] === "update" || args[0] === "embed");
+    expect(updateCalls).toStrictEqual([["update"]]);
+    expect(watchMock).not.toHaveBeenCalled();
+
+    await manager?.close();
+  });
+
   it("keeps one-shot CLI searches from scheduling session-start updates", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -497,6 +497,11 @@ export class QmdMemoryManager implements MemorySearchManager {
 
     await this.ensureCollections();
     if (mode === "cli") {
+      if (this.qmd.update.onBoot && this.qmd.update.waitForBootSync) {
+        await this.runUpdate("boot:cli", true).catch((err: unknown) => {
+          log.warn(`qmd cli boot update failed: ${String(err)}`);
+        });
+      }
       log.info(
         `qmd manager initialized for agent "${this.agentId}" mode=cli collections=${this.qmd.collections.length} durationMs=${Date.now() - startTime}`,
       );

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -164,13 +164,34 @@ describe("memory tools", () => {
     });
   });
 
-  it("uses one-shot CLI memory manager mode for memory_search", async () => {
+  it("uses default memory manager mode for shared memory_search", async () => {
     setMemoryBackend("qmd");
     const tool = createMemorySearchToolOrThrow({
       config: asOpenClawConfig({
         memory: { backend: "qmd", qmd: { command: "qmd" } },
         agents: { list: [{ id: "main", default: true }] },
       }),
+    });
+
+    await tool.execute("call_default_purpose", { query: "contact phrase" });
+
+    expect(getMemorySearchManagerMockParams()).toEqual([
+      expect.objectContaining({
+        agentId: "main",
+        purpose: undefined,
+      }),
+    ]);
+    expect(getMemoryCloseMockCalls()).toBe(0);
+  });
+
+  it("uses one-shot CLI memory manager mode for explicit local CLI memory_search", async () => {
+    setMemoryBackend("qmd");
+    const tool = createMemorySearchToolOrThrow({
+      config: asOpenClawConfig({
+        memory: { backend: "qmd", qmd: { command: "qmd" } },
+        agents: { list: [{ id: "main", default: true }] },
+      }),
+      oneShotCliRun: true,
     });
 
     await tool.execute("call_cli_purpose", { query: "contact phrase" });

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -7,6 +7,7 @@ import {
 import { readMemoryHostEvents } from "openclaw/plugin-sdk/memory-host-events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  getMemoryCloseMockCalls,
   getMemorySearchManagerMockCalls,
   getMemorySearchManagerMockParams,
   getReadAgentMemoryFileMockCalls,
@@ -180,6 +181,7 @@ describe("memory tools", () => {
         purpose: "cli",
       }),
     ]);
+    expect(getMemoryCloseMockCalls()).toBe(1);
   });
 
   it("returns disabled details when memory_get fails", async () => {

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -8,6 +8,7 @@ import { readMemoryHostEvents } from "openclaw/plugin-sdk/memory-host-events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getMemorySearchManagerMockCalls,
+  getMemorySearchManagerMockParams,
   getReadAgentMemoryFileMockCalls,
   resetMemoryToolMockState,
   setMemoryBackend,
@@ -160,6 +161,25 @@ describe("memory tools", () => {
       warning: "Memory search is unavailable because the embedding provider quota is exhausted.",
       action: "Top up or switch embedding provider, then retry memory_search.",
     });
+  });
+
+  it("uses one-shot CLI memory manager mode for memory_search", async () => {
+    setMemoryBackend("qmd");
+    const tool = createMemorySearchToolOrThrow({
+      config: asOpenClawConfig({
+        memory: { backend: "qmd", qmd: { command: "qmd" } },
+        agents: { list: [{ id: "main", default: true }] },
+      }),
+    });
+
+    await tool.execute("call_cli_purpose", { query: "contact phrase" });
+
+    expect(getMemorySearchManagerMockParams()).toEqual([
+      expect.objectContaining({
+        agentId: "main",
+        purpose: "cli",
+      }),
+    ]);
   });
 
   it("returns disabled details when memory_get fails", async () => {

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -20,6 +20,7 @@ type MemoryToolOptions = {
   getConfig?: () => OpenClawConfig | undefined;
   agentId?: string;
   agentSessionKey?: string;
+  oneShotCliRun?: boolean;
 };
 
 let memoryToolRuntimePromise: Promise<MemoryToolRuntime> | null = null;

--- a/extensions/memory-core/src/tools.test-helpers.ts
+++ b/extensions/memory-core/src/tools.test-helpers.ts
@@ -15,11 +15,13 @@ export function createMemorySearchToolOrThrow(params?: {
   config?: OpenClawConfig;
   agentId?: string;
   agentSessionKey?: string;
+  oneShotCliRun?: boolean;
 }) {
   const tool = createMemorySearchTool({
     config: params?.config ?? createDefaultMemoryToolConfig(),
     ...(params?.agentId ? { agentId: params.agentId } : {}),
     ...(params?.agentSessionKey ? { agentSessionKey: params.agentSessionKey } : {}),
+    ...(params?.oneShotCliRun ? { oneShotCliRun: params.oneShotCliRun } : {}),
   });
   if (!tool) {
     throw new Error("tool missing");

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -259,6 +259,54 @@ describe("memory_search unavailable payloads", () => {
     expect(searchCalls).toBe(2);
     expect(getMemorySearchManagerMockCalls()).toBe(2);
     expect(getMemorySearchManagerMockParams()).toEqual([
+      expect.objectContaining({ purpose: undefined }),
+      expect.objectContaining({ purpose: undefined }),
+    ]);
+    expect(getMemoryCloseMockCalls()).toBe(0);
+  });
+
+  it("re-resolves and closes one-shot CLI managers when a cached sqlite handle was closed", async () => {
+    let searchCalls = 0;
+    setMemorySearchImpl(async () => {
+      searchCalls += 1;
+      if (searchCalls === 1) {
+        throw new Error("database is not open");
+      }
+      return [
+        {
+          path: "MEMORY.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.9,
+          snippet: "Thread-hidden codename: ORBIT-22.",
+          source: "memory" as const,
+        },
+      ];
+    });
+
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+      },
+      oneShotCliRun: true,
+    });
+    const result = await tool.execute("closed-db-cli", { query: "hidden thread codename" });
+
+    expect((result.details as { results?: Array<{ path: string }> }).results).toEqual([
+      {
+        corpus: "memory",
+        path: "MEMORY.md",
+        startLine: 1,
+        endLine: 1,
+        score: 0.9,
+        snippet: "Thread-hidden codename: ORBIT-22.",
+        source: "memory",
+      },
+    ]);
+    expect(searchCalls).toBe(2);
+    expect(getMemorySearchManagerMockCalls()).toBe(2);
+    expect(getMemorySearchManagerMockParams()).toEqual([
       expect.objectContaining({ purpose: "cli" }),
       expect.objectContaining({ purpose: "cli" }),
     ]);

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -1,6 +1,7 @@
 // Memory Core tests cover tools plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  getMemoryCloseMockCalls,
   getMemorySearchManagerMockCalls,
   getMemorySearchManagerMockConfigs,
   getMemorySearchManagerMockParams,
@@ -257,6 +258,11 @@ describe("memory_search unavailable payloads", () => {
     ]);
     expect(searchCalls).toBe(2);
     expect(getMemorySearchManagerMockCalls()).toBe(2);
+    expect(getMemorySearchManagerMockParams()).toEqual([
+      expect.objectContaining({ purpose: "cli" }),
+      expect.objectContaining({ purpose: "cli" }),
+    ]);
+    expect(getMemoryCloseMockCalls()).toBe(1);
   });
 
   it("forces a sync and retries once when the first search has zero hits", async () => {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -32,7 +32,6 @@ import {
   buildMemorySearchUnavailableResult,
   createMemoryTool,
   getMemoryCorpusSupplementResult,
-  getMemoryManagerContext,
   getMemoryManagerContextWithPurpose,
   loadMemoryToolRuntime,
   MemoryGetSchema,
@@ -43,6 +42,8 @@ import {
 type MemorySearchToolResult =
   | (MemorySearchResult & { corpus: MemorySource })
   | MemoryCorpusSearchResult;
+type MemoryManagerContext = Awaited<ReturnType<typeof getMemoryManagerContextWithPurpose>>;
+type ActiveMemoryManagerContext = Extract<MemoryManagerContext, { manager: unknown }>;
 
 const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 15_000;
 const MEMORY_SEARCH_TOOL_COOLDOWN_MS = 60_000;
@@ -80,6 +81,24 @@ export const testing = {
     memorySearchToolCooldowns.clear();
   },
 } as const;
+
+function isActiveMemoryManagerContext(
+  context: MemoryManagerContext | null,
+): context is ActiveMemoryManagerContext {
+  return context !== null && "manager" in context;
+}
+
+async function closeMemoryManagers(
+  managers: Iterable<ActiveMemoryManagerContext["manager"]>,
+): Promise<void> {
+  for (const manager of managers) {
+    try {
+      await manager.close?.();
+    } catch {
+      // Search results should not be hidden by best-effort transient cleanup.
+    }
+  }
+}
 
 async function runMemorySearchToolWithDeadline<T>(params: {
   timeoutMs: number;
@@ -401,196 +420,216 @@ export function createMemorySearchTool(options: {
             if (cooldown && !shouldQuerySupplements) {
               return jsonResult(buildMemorySearchUnavailableResult(cooldown.error));
             }
-            const memory = shouldQueryMemory
-              ? await runUnavailablePhase(
-                  "memory",
-                  async () =>
-                    await getMemoryManagerContextWithPurpose({
-                      cfg,
-                      agentId,
-                      purpose: "cli",
-                    }),
-                )
-              : null;
-            if (shouldQueryMemory && memory && "error" in memory && !shouldQuerySupplements) {
-              recordMemorySearchToolCooldown(
-                cooldownKey,
-                memory.error ?? "memory search unavailable",
-              );
-              return jsonResult(buildMemorySearchUnavailableResult(memory.error));
-            }
-
-            const citationsMode = resolveMemoryCitationsMode(cfg);
-            const includeCitations = shouldIncludeCitations({
-              mode: citationsMode,
-              sessionKey: options.agentSessionKey,
-            });
-            const pluginConfig = resolveMemoryCorePluginConfig(cfg);
-            const dreamingEnabled = resolveMemoryDreamingConfig({
-              pluginConfig,
-              cfg,
-            }).enabled;
-            const dreaming = resolveMemoryDeepDreamingConfig({
-              pluginConfig,
-              cfg,
-            });
-            const searchStartedAt = Date.now();
-            let rawResults: MemorySearchResult[] = [];
-            let surfacedMemoryResults: Array<MemorySearchResult & { corpus: MemorySource }> = [];
-            let provider: string | undefined;
-            let model: string | undefined;
-            let fallback: unknown;
-            let searchMode: string | undefined;
-            let pausedIndexIdentityReason: string | undefined;
-            let searchDebug:
-              | {
-                  backend: string;
-                  configuredMode?: string;
-                  effectiveMode?: string;
-                  fallback?: string;
-                  searchMs: number;
-                  hits: number;
-                }
-              | undefined;
-            if (shouldQueryMemory && memory && !("error" in memory)) {
-              await runUnavailablePhase("memory", async () => {
-                let activeMemory = memory;
-                const runtimeDebug: MemorySearchRuntimeDebug[] = [];
-                const qmdSearchModeOverride = resolveActiveMemoryQmdSearchModeOverride(
-                  cfg,
-                  options.agentSessionKey,
+            const memoryManagersToClose = new Set<ActiveMemoryManagerContext["manager"]>();
+            const trackMemoryManager = (context: MemoryManagerContext): MemoryManagerContext => {
+              if (isActiveMemoryManagerContext(context)) {
+                memoryManagersToClose.add(context.manager);
+              }
+              return context;
+            };
+            try {
+              const memory = shouldQueryMemory
+                ? await runUnavailablePhase("memory", async () =>
+                    trackMemoryManager(
+                      await getMemoryManagerContextWithPurpose({
+                        cfg,
+                        agentId,
+                        purpose: "cli",
+                      }),
+                    ),
+                  )
+                : null;
+              if (shouldQueryMemory && memory && "error" in memory && !shouldQuerySupplements) {
+                recordMemorySearchToolCooldown(
+                  cooldownKey,
+                  memory.error ?? "memory search unavailable",
                 );
-                const searchSources: MemorySource[] | undefined =
-                  requestedCorpus === "sessions"
-                    ? (["sessions"] as MemorySource[])
-                    : requestedCorpus === "memory"
-                      ? (["memory"] as MemorySource[])
-                      : undefined;
-                const searchOptions = {
-                  maxResults,
-                  minScore,
-                  sessionKey: options.agentSessionKey,
-                  qmdSearchModeOverride,
-                  signal: deadlineSignal,
-                  onDebug: (debug: MemorySearchRuntimeDebug) => {
-                    runtimeDebug.push(debug);
-                  },
-                  ...(searchSources ? { sources: searchSources } : {}),
-                };
-                try {
-                  rawResults = await activeMemory.manager.search(query, searchOptions);
-                } catch (error) {
-                  if (!isClosedMemoryStoreError(error)) {
-                    throw error;
+                return jsonResult(buildMemorySearchUnavailableResult(memory.error));
+              }
+
+              const citationsMode = resolveMemoryCitationsMode(cfg);
+              const includeCitations = shouldIncludeCitations({
+                mode: citationsMode,
+                sessionKey: options.agentSessionKey,
+              });
+              const pluginConfig = resolveMemoryCorePluginConfig(cfg);
+              const dreamingEnabled = resolveMemoryDreamingConfig({
+                pluginConfig,
+                cfg,
+              }).enabled;
+              const dreaming = resolveMemoryDeepDreamingConfig({
+                pluginConfig,
+                cfg,
+              });
+              const searchStartedAt = Date.now();
+              let rawResults: MemorySearchResult[] = [];
+              let surfacedMemoryResults: Array<MemorySearchResult & { corpus: MemorySource }> = [];
+              let provider: string | undefined;
+              let model: string | undefined;
+              let fallback: unknown;
+              let searchMode: string | undefined;
+              let pausedIndexIdentityReason: string | undefined;
+              let searchDebug:
+                | {
+                    backend: string;
+                    configuredMode?: string;
+                    effectiveMode?: string;
+                    fallback?: string;
+                    searchMs: number;
+                    hits: number;
                   }
-                  const refreshed = await getMemoryManagerContext({ cfg, agentId });
-                  if ("error" in refreshed) {
-                    throw error;
-                  }
-                  activeMemory = refreshed;
-                  rawResults = await activeMemory.manager.search(query, searchOptions);
-                }
-                const statusBeforeRetry = activeMemory.manager.status();
-                pausedIndexIdentityReason =
-                  resolvePausedMemoryIndexIdentityReason(statusBeforeRetry);
-                if (pausedIndexIdentityReason) {
-                  return;
-                }
-                if (rawResults.length === 0 && activeMemory.manager.sync) {
-                  await activeMemory.manager.sync({ reason: "search", force: true });
-                  rawResults = await activeMemory.manager.search(query, searchOptions);
-                  pausedIndexIdentityReason = resolvePausedMemoryIndexIdentityReason(
-                    activeMemory.manager.status(),
+                | undefined;
+              if (shouldQueryMemory && memory && !("error" in memory)) {
+                await runUnavailablePhase("memory", async () => {
+                  let activeMemory = memory;
+                  const runtimeDebug: MemorySearchRuntimeDebug[] = [];
+                  const qmdSearchModeOverride = resolveActiveMemoryQmdSearchModeOverride(
+                    cfg,
+                    options.agentSessionKey,
                   );
+                  const searchSources: MemorySource[] | undefined =
+                    requestedCorpus === "sessions"
+                      ? (["sessions"] as MemorySource[])
+                      : requestedCorpus === "memory"
+                        ? (["memory"] as MemorySource[])
+                        : undefined;
+                  const searchOptions = {
+                    maxResults,
+                    minScore,
+                    sessionKey: options.agentSessionKey,
+                    qmdSearchModeOverride,
+                    signal: deadlineSignal,
+                    onDebug: (debug: MemorySearchRuntimeDebug) => {
+                      runtimeDebug.push(debug);
+                    },
+                    ...(searchSources ? { sources: searchSources } : {}),
+                  };
+                  try {
+                    rawResults = await activeMemory.manager.search(query, searchOptions);
+                  } catch (error) {
+                    if (!isClosedMemoryStoreError(error)) {
+                      throw error;
+                    }
+                    const refreshed = trackMemoryManager(
+                      await getMemoryManagerContextWithPurpose({
+                        cfg,
+                        agentId,
+                        purpose: "cli",
+                      }),
+                    );
+                    if ("error" in refreshed) {
+                      throw error;
+                    }
+                    activeMemory = refreshed;
+                    rawResults = await activeMemory.manager.search(query, searchOptions);
+                  }
+                  const statusBeforeRetry = activeMemory.manager.status();
+                  pausedIndexIdentityReason =
+                    resolvePausedMemoryIndexIdentityReason(statusBeforeRetry);
                   if (pausedIndexIdentityReason) {
                     return;
                   }
-                }
-                rawResults = await filterMemorySearchHitsBySessionVisibility({
-                  cfg,
-                  agentId,
-                  requesterSessionKey: options.agentSessionKey,
-                  sandboxed: options.sandboxed === true,
-                  hits: rawResults,
-                });
-                if (requestedCorpus === "sessions") {
-                  rawResults = rawResults.filter((hit) => hit.source === "sessions");
-                } else if (requestedCorpus === "memory") {
-                  rawResults = rawResults.filter((hit) => hit.source === "memory");
-                }
-                const status = activeMemory.manager.status();
-                const decorated = decorateCitations(rawResults, includeCitations);
-                const resolved = resolveMemoryBackendConfig({ cfg, agentId });
-                const memoryResults =
-                  status.backend === "qmd"
-                    ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
-                    : decorated;
-                surfacedMemoryResults = memoryResults.map((result) => ({
-                  ...result,
-                  corpus: result.source,
-                }));
-                if (dreamingEnabled) {
-                  queueShortTermRecallTracking({
-                    workspaceDir: status.workspaceDir,
-                    query,
-                    rawResults,
-                    surfacedResults: memoryResults,
-                    timezone: dreaming.timezone,
+                  if (rawResults.length === 0 && activeMemory.manager.sync) {
+                    await activeMemory.manager.sync({ reason: "search", force: true });
+                    rawResults = await activeMemory.manager.search(query, searchOptions);
+                    pausedIndexIdentityReason = resolvePausedMemoryIndexIdentityReason(
+                      activeMemory.manager.status(),
+                    );
+                    if (pausedIndexIdentityReason) {
+                      return;
+                    }
+                  }
+                  rawResults = await filterMemorySearchHitsBySessionVisibility({
+                    cfg,
+                    agentId,
+                    requesterSessionKey: options.agentSessionKey,
+                    sandboxed: options.sandboxed === true,
+                    hits: rawResults,
                   });
-                }
-                provider = status.provider;
-                model = status.model;
-                fallback = status.fallback;
-                const latestDebug = runtimeDebug.at(-1);
-                searchMode = latestDebug?.effectiveMode;
-                searchDebug = {
-                  backend: status.backend,
-                  configuredMode: latestDebug?.configuredMode,
-                  effectiveMode:
+                  if (requestedCorpus === "sessions") {
+                    rawResults = rawResults.filter((hit) => hit.source === "sessions");
+                  } else if (requestedCorpus === "memory") {
+                    rawResults = rawResults.filter((hit) => hit.source === "memory");
+                  }
+                  const status = activeMemory.manager.status();
+                  const decorated = decorateCitations(rawResults, includeCitations);
+                  const resolved = resolveMemoryBackendConfig({ cfg, agentId });
+                  const memoryResults =
                     status.backend === "qmd"
-                      ? (latestDebug?.effectiveMode ?? latestDebug?.configuredMode)
-                      : "n/a",
-                  fallback: latestDebug?.fallback,
-                  searchMs: Math.max(0, Date.now() - searchStartedAt),
-                  hits: rawResults.length,
-                };
-              });
-              if (pausedIndexIdentityReason) {
-                return jsonResult(
-                  buildPausedMemoryIndexUnavailableResult(pausedIndexIdentityReason),
-                );
-              }
-            }
-            const supplementResults = shouldQuerySupplements
-              ? await runUnavailablePhase(
-                  "supplement",
-                  async () =>
-                    await searchMemoryCorpusSupplements({
+                      ? clampResultsByInjectedChars(
+                          decorated,
+                          resolved.qmd?.limits.maxInjectedChars,
+                        )
+                      : decorated;
+                  surfacedMemoryResults = memoryResults.map((result) => ({
+                    ...result,
+                    corpus: result.source,
+                  }));
+                  if (dreamingEnabled) {
+                    queueShortTermRecallTracking({
+                      workspaceDir: status.workspaceDir,
                       query,
-                      maxResults,
-                      agentSessionKey: options.agentSessionKey,
-                      corpus: requestedCorpus,
-                    }),
-                )
-              : [];
-            // Wiki and memory scores use incomparable scales, so corpus=all first
-            // balances candidate selection and then backfills any unused slots.
-            const effectiveMax = Math.max(1, maxResults ?? 10);
-            const results = mergeMemorySearchCorpusResults({
-              memoryResults: surfacedMemoryResults,
-              supplementResults,
-              maxResults: effectiveMax,
-              balanceCorpora: requestedCorpus === "all",
-            });
-            return jsonResult({
-              results,
-              provider,
-              model,
-              fallback,
-              citations: citationsMode,
-              mode: searchMode,
-              debug: searchDebug,
-            });
+                      rawResults,
+                      surfacedResults: memoryResults,
+                      timezone: dreaming.timezone,
+                    });
+                  }
+                  provider = status.provider;
+                  model = status.model;
+                  fallback = status.fallback;
+                  const latestDebug = runtimeDebug.at(-1);
+                  searchMode = latestDebug?.effectiveMode;
+                  searchDebug = {
+                    backend: status.backend,
+                    configuredMode: latestDebug?.configuredMode,
+                    effectiveMode:
+                      status.backend === "qmd"
+                        ? (latestDebug?.effectiveMode ?? latestDebug?.configuredMode)
+                        : "n/a",
+                    fallback: latestDebug?.fallback,
+                    searchMs: Math.max(0, Date.now() - searchStartedAt),
+                    hits: rawResults.length,
+                  };
+                });
+                if (pausedIndexIdentityReason) {
+                  return jsonResult(
+                    buildPausedMemoryIndexUnavailableResult(pausedIndexIdentityReason),
+                  );
+                }
+              }
+              const supplementResults = shouldQuerySupplements
+                ? await runUnavailablePhase(
+                    "supplement",
+                    async () =>
+                      await searchMemoryCorpusSupplements({
+                        query,
+                        maxResults,
+                        agentSessionKey: options.agentSessionKey,
+                        corpus: requestedCorpus,
+                      }),
+                  )
+                : [];
+              // Wiki and memory scores use incomparable scales, so corpus=all first
+              // balances candidate selection and then backfills any unused slots.
+              const effectiveMax = Math.max(1, maxResults ?? 10);
+              const results = mergeMemorySearchCorpusResults({
+                memoryResults: surfacedMemoryResults,
+                supplementResults,
+                maxResults: effectiveMax,
+                balanceCorpora: requestedCorpus === "all",
+              });
+              return jsonResult({
+                results,
+                provider,
+                model,
+                fallback,
+                citations: citationsMode,
+                mode: searchMode,
+                debug: searchDebug,
+              });
+            } finally {
+              await closeMemoryManagers(memoryManagersToClose);
+            }
           },
         });
         if (outcome.status === "unavailable") {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -365,6 +365,7 @@ export function createMemorySearchTool(options: {
   agentId?: string;
   agentSessionKey?: string;
   sandboxed?: boolean;
+  oneShotCliRun?: boolean;
 }) {
   return createMemoryTool({
     options,
@@ -420,9 +421,10 @@ export function createMemorySearchTool(options: {
             if (cooldown && !shouldQuerySupplements) {
               return jsonResult(buildMemorySearchUnavailableResult(cooldown.error));
             }
+            const memoryManagerPurpose = options.oneShotCliRun ? "cli" : undefined;
             const memoryManagersToClose = new Set<ActiveMemoryManagerContext["manager"]>();
             const trackMemoryManager = (context: MemoryManagerContext): MemoryManagerContext => {
-              if (isActiveMemoryManagerContext(context)) {
+              if (memoryManagerPurpose === "cli" && isActiveMemoryManagerContext(context)) {
                 memoryManagersToClose.add(context.manager);
               }
               return context;
@@ -434,7 +436,7 @@ export function createMemorySearchTool(options: {
                       await getMemoryManagerContextWithPurpose({
                         cfg,
                         agentId,
-                        purpose: "cli",
+                        purpose: memoryManagerPurpose,
                       }),
                     ),
                   )
@@ -514,7 +516,7 @@ export function createMemorySearchTool(options: {
                       await getMemoryManagerContextWithPurpose({
                         cfg,
                         agentId,
-                        purpose: "cli",
+                        purpose: memoryManagerPurpose,
                       }),
                     );
                     if ("error" in refreshed) {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -404,7 +404,12 @@ export function createMemorySearchTool(options: {
             const memory = shouldQueryMemory
               ? await runUnavailablePhase(
                   "memory",
-                  async () => await getMemoryManagerContext({ cfg, agentId }),
+                  async () =>
+                    await getMemoryManagerContextWithPurpose({
+                      cfg,
+                      agentId,
+                      purpose: "cli",
+                    }),
                 )
               : null;
             if (shouldQueryMemory && memory && "error" in memory && !shouldQuerySupplements) {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -428,6 +428,11 @@ export function createOpenClawCodingTools(options?: {
   runSessionKey?: string;
   /** Ephemeral session UUID — regenerated on /new and /reset. */
   sessionId?: string;
+  /**
+   * Explicit one-shot local CLI runs should not keep plugin-owned process
+   * resources alive after emitting their result.
+   */
+  oneShotCliRun?: boolean;
   /** Stable run identifier for this agent invocation. */
   runId?: string;
   /** Diagnostic trace context for hook/log correlation during this run. */
@@ -939,6 +944,7 @@ export function createOpenClawCodingTools(options?: {
             fsPolicy,
             requesterSenderId: options?.senderId,
             sessionId: options?.sessionId,
+            oneShotCliRun: options?.oneShotCliRun,
             sandboxBrowserBridgeUrl: sandbox?.browser?.bridgeUrl,
             allowHostBrowserControl: sandbox ? sandbox.browserAllowHostControl : true,
             sandboxed: Boolean(sandbox),
@@ -1052,6 +1058,7 @@ export function createOpenClawCodingTools(options?: {
           senderIsOwner: options?.senderIsOwner,
           authProfileStore: options?.authProfileStore,
           sessionId: options?.sessionId,
+          oneShotCliRun: options?.oneShotCliRun,
           inheritedToolAllowlist,
           inheritedToolDenylist,
           onYield: options?.onYield,

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -126,6 +126,8 @@ export type RunCliAgentParams = {
    * alive after the JSON response is emitted.
    */
   cleanupBundleMcpOnRunEnd?: boolean;
+  /** Mark explicit one-shot local CLI runs so plugin tools can release resources promptly. */
+  oneShotCliRun?: boolean;
 };
 
 /** Backend config after MCP, skill, env, and cleanup preparation. */

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -643,6 +643,7 @@ export function runAgentAttempt(params: {
         toolsAllow: params.opts.toolsAllow,
         cleanupBundleMcpOnRunEnd: params.opts.cleanupBundleMcpOnRunEnd,
         cleanupCliLiveSessionOnRunEnd: params.opts.cleanupCliLiveSessionOnRunEnd,
+        oneShotCliRun: params.opts.oneShotCliRun,
         ...(mutableCliSessionStore
           ? {
               onBeforeFreshCliSessionRetry: async (retry) => {
@@ -746,6 +747,7 @@ export function runAgentAttempt(params: {
     agentDir: params.agentDir,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
     cleanupBundleMcpOnRunEnd: params.opts.cleanupBundleMcpOnRunEnd,
+    oneShotCliRun: params.opts.oneShotCliRun,
     modelRun: params.opts.modelRun,
     promptMode: params.opts.promptMode,
     disableTools: params.opts.modelRun === true,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -135,6 +135,8 @@ export type AgentCommandOpts = {
   cleanupBundleMcpOnRunEnd?: boolean;
   /** Force long-lived CLI live session teardown when a one-shot local run completes. */
   cleanupCliLiveSessionOnRunEnd?: boolean;
+  /** Mark explicit one-shot local CLI runs so plugin tools can release resources promptly. */
+  oneShotCliRun?: boolean;
   /** Internal local CLI callers can annotate result metadata before JSON/text output. */
   resultMetaOverrides?: AgentCommandResultMetaOverrides;
   /** Called when the actual run model is selected, including fallback retries. */

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -96,8 +96,8 @@ import { isFallbackSummaryError, runWithModelFallback } from "../model-fallback.
 import { supportsModelTools } from "../model-tool-support.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import { wrapStreamFnTextTransforms } from "../plugin-text-transforms.js";
-import { applyPreparedRuntimeAuthToModel } from "../provider-request-config.js";
 import { resolveAgentPromptSurfaceForSessionKey } from "../prompt-surface.js";
+import { applyPreparedRuntimeAuthToModel } from "../provider-request-config.js";
 import { registerProviderStreamForModel } from "../provider-stream.js";
 import { collectRuntimeChannelCapabilities } from "../runtime-capabilities.js";
 import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
@@ -845,6 +845,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
           : undefined,
       sessionId: params.sessionId,
       runId: params.runId,
+      oneShotCliRun: params.oneShotCliRun,
       groupId: params.groupId,
       groupChannel: params.groupChannel,
       groupSpace: params.groupSpace,

--- a/src/agents/embedded-agent-runner/compact.types.ts
+++ b/src/agents/embedded-agent-runner/compact.types.ts
@@ -102,6 +102,8 @@ export type CompactEmbeddedAgentSessionParams = {
   }) => void | Promise<void>;
   /** Allow runtime plugins for this compaction to late-bind the gateway subagent. */
   allowGatewaySubagentBinding?: boolean;
+  /** Mark explicit one-shot local CLI runs so plugin tools can release resources promptly. */
+  oneShotCliRun?: boolean;
 };
 
 export type CompactionMessageMetrics = {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1238,6 +1238,7 @@ export async function runEmbeddedAttempt(
                 : undefined,
             sessionId: params.sessionId,
             runId: params.runId,
+            oneShotCliRun: params.oneShotCliRun,
             toolSearchCatalogRef,
             agentDir,
             cwd: effectiveCwd,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -257,4 +257,6 @@ export type RunEmbeddedAgentParams = {
    * exit promptly after emitting the final JSON result.
    */
   cleanupBundleMcpOnRunEnd?: boolean;
+  /** Mark explicit one-shot local CLI runs so plugin tools can release resources promptly. */
+  oneShotCliRun?: boolean;
 };

--- a/src/agents/openclaw-tools.plugin-context.ts
+++ b/src/agents/openclaw-tools.plugin-context.ts
@@ -27,6 +27,11 @@ export type OpenClawPluginToolOptions = {
   requesterSenderId?: string | null;
   requesterAgentIdOverride?: string;
   sessionId?: string;
+  /**
+   * Explicit one-shot local CLI runs should not keep plugin-owned process
+   * resources alive after emitting their result.
+   */
+  oneShotCliRun?: boolean;
   sandboxBrowserBridgeUrl?: string;
   allowHostBrowserControl?: boolean;
   sandboxed?: boolean;
@@ -91,6 +96,7 @@ export function resolveOpenClawPluginToolInputs(params: {
       deliveryContext,
       requesterSenderId: options?.requesterSenderId ?? undefined,
       sandboxed: options?.sandboxed,
+      oneShotCliRun: options?.oneShotCliRun,
     },
     allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
   };

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -165,6 +165,11 @@ export function createOpenClawTools(
     /** Ephemeral session UUID — regenerated on /new and /reset. */
     sessionId?: string;
     /**
+     * Explicit one-shot local CLI runs should not keep plugin-owned process
+     * resources alive after emitting their result.
+     */
+    oneShotCliRun?: boolean;
+    /**
      * Workspace directory to pass to spawned subagents for inheritance.
      * Defaults to workspaceDir. Use this to pass the actual agent workspace when the
      * session itself is running in a copied-workspace sandbox (`ro` or `none`) so

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -1694,6 +1694,7 @@ describe("agentCliCommand", () => {
       );
       expect(localOpts.cleanupBundleMcpOnRunEnd).toBe(true);
       expect(localOpts.cleanupCliLiveSessionOnRunEnd).toBe(true);
+      expect(localOpts.oneShotCliRun).toBe(true);
       expect(localOpts).not.toHaveProperty("resultMetaOverrides");
       expect(runtime.log).toHaveBeenCalledWith("local");
     });
@@ -1789,6 +1790,7 @@ describe("agentCliCommand", () => {
       );
       expect(fallbackOpts.cleanupBundleMcpOnRunEnd).toBe(true);
       expect(fallbackOpts.cleanupCliLiveSessionOnRunEnd).toBe(true);
+      expect(fallbackOpts.oneShotCliRun).toBe(false);
     });
   });
 });

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -842,6 +842,7 @@ export async function agentCliCommand(
     replyAccountId: gatewayDispatchOpts.replyAccount,
     cleanupBundleMcpOnRunEnd: true,
     cleanupCliLiveSessionOnRunEnd: true,
+    oneShotCliRun: dispatchOpts.local === true,
     abortSignal: signalBridge.signal,
   };
   try {

--- a/src/plugins/tool-types.ts
+++ b/src/plugins/tool-types.ts
@@ -47,6 +47,11 @@ export type OpenClawPluginToolContext = {
   /** Trusted sender id from inbound context (runtime-provided, not tool args). */
   requesterSenderId?: string;
   sandboxed?: boolean;
+  /**
+   * True for explicit one-shot local CLI runs that must release plugin-owned
+   * process resources before the command exits.
+   */
+  oneShotCliRun?: boolean;
 };
 
 export type OpenClawPluginToolFactory = (


### PR DESCRIPTION
## Summary

- Route `memory_search` through the existing transient QMD manager mode (`purpose: "cli"`) instead of the default/full manager.
- Keep QMD memory search from starting full-manager lifecycle resources such as watchers, boot updates, and embed/update timers during one-shot agent turns.
- Add focused regression coverage proving `memory_search` requests the transient manager mode; existing QMD manager coverage proves that mode does not start watchers or background updates.

Fixes #92464

## Real behavior proof

**Behavior addressed:** `openclaw agent --local --json` can complete the assistant turn and print JSON, but a memory-heavy `memory_search` path can leave the CLI process waiting on QMD full-manager lifecycle cleanup. The fix makes the memory search tool use QMD's existing one-shot CLI manager mode, which performs searches without opening the full background lifecycle.

**Real environment tested:** Local OpenClaw checkout at PR head `42d7eb4a52`, macOS/Darwin, Node from the repository toolchain, pnpm 11.2.2. The packaged OpenClaw extension build/profile was run from this checkout, and the memory-core/QMD runtime shard was executed against the real extension-memory Vitest project. The local host did not have the external `qmd` binary installed, so the original 10,000-entry Docker/OpenAI-provider repro was not rerun.

**Exact steps or command run after this patch:**

```bash
corepack pnpm@11.2.2 --dir . test extensions/memory-core/src/tools.citations.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts
corepack pnpm@11.2.2 --dir . test extensions/memory-core/src/tools.citations.test.ts
node scripts/run-oxlint.mjs extensions/memory-core/src/tools.ts extensions/memory-core/src/tools.citations.test.ts extensions/memory-core/src/memory-tool-manager-mock.ts
corepack pnpm@11.2.2 --dir . exec oxfmt --check extensions/memory-core/src/tools.ts extensions/memory-core/src/tools.citations.test.ts extensions/memory-core/src/memory-tool-manager-mock.ts
git diff --check
corepack pnpm@11.2.2 --dir . test extensions/memory-core
corepack pnpm@11.2.2 --dir . tsgo:test:extensions
corepack pnpm@11.2.2 --dir . test:extensions:memory
```

**Evidence after fix:**

```text
corepack pnpm@11.2.2 --dir . test extensions/memory-core/src/tools.citations.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts
[test] starting test/vitest/vitest.extension-memory.config.ts
Test Files  2 passed (2)
Tests  145 passed (145)
[test] passed 1 Vitest shard in 7.14s

corepack pnpm@11.2.2 --dir . test extensions/memory-core
Test Files  64 passed (64)
Tests  895 passed (895)
[test] passed 1 Vitest shard in 35.89s

corepack pnpm@11.2.2 --dir . test:extensions:memory
[extension-memory] memory-core: ok 334.3 MB
[extension-memory] report: /var/folders/sl/5dkd3zq12dv65j6jx57zq1hc0000gn/T/openclaw-extension-memory.json
{
  "baselineMb": 45.328125,
  "combinedMb": 652.21875,
  "counts": { "totalEntries": 120, "ok": 120, "fail": 0, "timeout": 0 }
}
```

**Observed result after fix:** `memory_search` now asks the memory runtime for `purpose: "cli"`; the QMD manager's existing one-shot CLI mode initializes without file watchers, boot updates, or embed/update timers. The changed memory-core extension builds and loads successfully, and all 120 extension-memory profile entries completed with zero failures and zero timeouts.

**What was not tested:** I did not run the original Docker image with 10,000 imported entries and external OpenAI credentials. The local proof covers the source-level lifecycle bug that made `memory_search` select the full QMD manager instead of the one-shot manager.
