### PR TITLE
fix #86872: Subagent run reports success but fails to write output file

### DIFF
--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -212,6 +212,62 @@ describe("CodexNativeSubagentMonitor", () => {
     expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { label: "remote V1", codexHome: undefined, finalizes: true },
+    { label: "local transcript-backed V1", codexHome: "/tmp/codex-home", finalizes: false },
+  ])(
+    "uses collab completion as a terminal fallback only for $label",
+    async ({ codexHome, finalizes }) => {
+      const client = createClient();
+      const runtime = createRuntime();
+      const monitor = new CodexNativeSubagentMonitor(client, runtime, { codexHome });
+      monitor.registerParent({
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:main",
+        taskRuntimeScope: createTaskScope("agent:main:main"),
+        agentId: "main",
+      });
+
+      await notifyChildStarted(client, "parent-thread", "child-thread", "");
+      await client.notify({
+        method: "item/completed",
+        params: {
+          threadId: "parent-thread",
+          item: {
+            type: "collabAgentToolCall",
+            tool: "wait",
+            senderThreadId: "parent-thread",
+            agentsStates: {
+              "child-thread": {
+                status: "completed",
+                message: "child final result",
+              },
+            },
+          },
+        },
+      });
+
+      if (finalizes) {
+        expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith(
+          expect.objectContaining({
+            runId: "codex-thread:child-thread",
+            status: "succeeded",
+            terminalSummary: "child final result",
+          }),
+        );
+      } else {
+        expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith(
+          expect.objectContaining({
+            runId: "codex-thread:child-thread",
+            progressSummary: "child final result",
+          }),
+        );
+        expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
+      }
+      monitor.dispose();
+    },
+  );
+
   it("does not complete mirrored task rows from idle status before native completion", async () => {
     const client = createClient();
     const runtime = createRuntime();

--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -203,10 +203,97 @@ describe("CodexNativeSubagentMonitor", () => {
         task: "inspect the repo",
       }),
     );
+    expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "codex-thread:child-thread",
+        progressSummary: "Codex native subagent is idle.",
+      }),
+    );
+    expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
+  });
+
+  it("does not complete mirrored task rows from idle status before native completion", async () => {
+    const client = createClient();
+    const runtime = createRuntime();
+    const monitor = new CodexNativeSubagentMonitor(client, runtime);
+    monitor.registerParent({
+      parentThreadId: "parent-thread",
+      requesterSessionKey: "agent:main:discord:channel:C123",
+      taskRuntimeScope: createTaskScope(),
+      agentId: "main",
+    });
+
+    await notifyChildStarted(client);
+    await client.notify({
+      method: "thread/status/changed",
+      params: {
+        threadId: "child-thread",
+        status: { type: "idle" },
+      },
+    });
+
+    expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
+    expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+
+    await client.notify(
+      nativeCompletionNotification({
+        agentPath: "child-thread",
+        statusLabel: "completed",
+        result: "child final result",
+      }),
+    );
+
     expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: "codex-thread:child-thread",
         status: "succeeded",
+        terminalSummary: "child final result",
+      }),
+    );
+    expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childSessionId: "child-thread",
+        result: "child final result",
+      }),
+    );
+  });
+
+  it("keeps late idle lifecycle updates from overwriting native completion results", async () => {
+    const client = createClient();
+    const runtime = createRuntime();
+    const monitor = new CodexNativeSubagentMonitor(client, runtime);
+    monitor.registerParent({
+      parentThreadId: "parent-thread",
+      requesterSessionKey: "agent:main:discord:channel:C123",
+      taskRuntimeScope: createTaskScope(),
+      agentId: "main",
+    });
+
+    await notifyChildStarted(client);
+    await client.notify(
+      nativeCompletionNotification({
+        agentPath: "child-thread",
+        statusLabel: "completed",
+        result: "child final result",
+      }),
+    );
+    runtime.recordTaskRunProgressByRunId.mockClear();
+
+    await client.notify({
+      method: "thread/status/changed",
+      params: {
+        threadId: "child-thread",
+        status: { type: "idle" },
+      },
+    });
+
+    expect(runtime.recordTaskRunProgressByRunId).not.toHaveBeenCalled();
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(1);
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "codex-thread:child-thread",
+        status: "succeeded",
+        terminalSummary: "child final result",
       }),
     );
   });

--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -298,6 +298,42 @@ describe("CodexNativeSubagentMonitor", () => {
     );
   });
 
+  it("allows later system errors to correct native completion results", async () => {
+    const client = createClient();
+    const runtime = createRuntime();
+    const monitor = new CodexNativeSubagentMonitor(client, runtime);
+    monitor.registerParent({
+      parentThreadId: "parent-thread",
+      requesterSessionKey: "agent:main:discord:channel:C123",
+      taskRuntimeScope: createTaskScope(),
+      agentId: "main",
+    });
+
+    await notifyChildStarted(client);
+    await client.notify(
+      nativeCompletionNotification({
+        agentPath: "child-thread",
+        statusLabel: "completed",
+        result: "child final result",
+      }),
+    );
+
+    await client.notify({
+      method: "thread/status/changed",
+      params: {
+        threadId: "child-thread",
+        status: { type: "systemError" },
+      },
+    });
+
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        runId: "codex-thread:child-thread",
+        status: "failed",
+      }),
+    );
+  });
+
   it("delivers parent wakeups from Codex-native subagent completion notifications", async () => {
     const client = createClient();
     const runtime = createRuntime();

--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -298,7 +298,7 @@ describe("CodexNativeSubagentMonitor", () => {
     );
   });
 
-  it("allows later system errors to correct native completion results", async () => {
+  it("keeps later lifecycle errors from rewriting native completion results", async () => {
     const client = createClient();
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client, runtime);
@@ -326,10 +326,12 @@ describe("CodexNativeSubagentMonitor", () => {
       },
     });
 
-    expect(runtime.finalizeTaskRunByRunId).toHaveBeenLastCalledWith(
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(1);
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: "codex-thread:child-thread",
-        status: "failed",
+        status: "succeeded",
+        terminalSummary: "child final result",
       }),
     );
   });

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -535,6 +535,10 @@ export class CodexNativeSubagentMonitor {
       normalizedChildThreadId,
     );
     const agentPath = normalizeOptionalString(options.agentPath);
+    const state = this.parentStates.get(normalizedParentThreadId);
+    if (state?.mirror && (this.codexHome || agentPath)) {
+      state.mirror.markAuthoritativeCompletionExpected(normalizedChildThreadId);
+    }
     if (agentPath) {
       this.childThreadIdsByAgentPath.set(
         buildParentAgentPathKey(normalizedParentThreadId, agentPath),

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -493,6 +493,9 @@ export class CodexNativeSubagentMonitor {
     if (!taskRuntime) {
       return;
     }
+    this.getMirrorForChild(completion.childThreadId)?.markAuthoritativeCompletion(
+      completion.childThreadId,
+    );
     taskRuntime.finalizeTaskRunByRunId({
       runId: codexNativeSubagentRunId(completion.childThreadId),
       status: completion.status,
@@ -508,6 +511,12 @@ export class CodexNativeSubagentMonitor {
     const childState = this.childStates.get(childThreadId.trim());
     const state = childState ? this.parentStates.get(childState.parentThreadId) : undefined;
     return state?.taskRuntime;
+  }
+
+  private getMirrorForChild(childThreadId: string): CodexNativeSubagentTaskMirror | undefined {
+    const childState = this.childStates.get(childThreadId.trim());
+    const state = childState ? this.parentStates.get(childState.parentThreadId) : undefined;
+    return state?.mirror;
   }
 
   private registerChildThread(

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
@@ -26,7 +26,6 @@ describe("CodexNativeSubagentTaskMirror", () => {
       },
       runtime,
     );
-
     mirror.handleNotification({
       method: "thread/started",
       params: {
@@ -82,7 +81,6 @@ describe("CodexNativeSubagentTaskMirror", () => {
       },
       runtime,
     );
-
     mirror.handleNotification({
       method: "thread/started",
       params: {
@@ -103,6 +101,45 @@ describe("CodexNativeSubagentTaskMirror", () => {
     expect(runtime.tryCreateRunningTaskRun).not.toHaveBeenCalled();
     expect(runtime.recordTaskRunProgressByRunId).not.toHaveBeenCalled();
     expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
+  });
+
+  it("finalizes collab completion when no authoritative result path is available", () => {
+    const runtime = createRuntime();
+    const mirror = new CodexNativeSubagentTaskMirror(
+      {
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:main",
+        now: () => 44_000,
+      },
+      runtime,
+    );
+
+    mirror.handleNotification({
+      method: "item/completed",
+      params: {
+        threadId: "parent-thread",
+        item: {
+          type: "collabAgentToolCall",
+          tool: "spawn_agent",
+          prompt: "inspect one thing",
+          agentsStates: {
+            "child-thread": {
+              status: "completed",
+              message: "done",
+            },
+          },
+        },
+      },
+    });
+
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith({
+      runId: "codex-thread:child-thread",
+      status: "succeeded",
+      endedAt: 44_000,
+      lastEventAt: 44_000,
+      progressSummary: "done",
+      terminalSummary: "done",
+    });
   });
 
   it("deduplicates repeated thread-started notifications for the same child thread", () => {
@@ -147,7 +184,6 @@ describe("CodexNativeSubagentTaskMirror", () => {
       },
       runtime,
     );
-
     mirror.handleNotification({
       method: "thread/status/changed",
       params: {
@@ -190,7 +226,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
       },
       runtime,
     );
-
+    mirror.markAuthoritativeCompletionExpected("child-thread");
     mirror.handleNotification({
       method: "item/completed",
       params: {
@@ -265,7 +301,6 @@ describe("CodexNativeSubagentTaskMirror", () => {
       },
       runtime,
     );
-
     mirror.handleNotification({
       method: "item/started",
       params: {
@@ -297,6 +332,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
       },
       runtime,
     );
+    mirror.markAuthoritativeCompletionExpected("child-thread");
 
     mirror.handleNotification({
       method: "item/completed",
@@ -465,6 +501,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
       },
       runtime,
     );
+    mirror.markAuthoritativeCompletionExpected("child-thread");
 
     mirror.handleNotification({
       method: "item/completed",
@@ -610,6 +647,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
       },
       runtime,
     );
+    mirror.markAuthoritativeCompletionExpected("child-thread");
 
     mirror.handleNotification({
       method: "item/completed",

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
@@ -501,7 +501,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
     expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
   });
 
-  it("allows terminal collab failures after authoritative completion", () => {
+  it("keeps terminal collab failures from rewriting authoritative completion", () => {
     const runtime = createRuntime();
     const mirror = new CodexNativeSubagentTaskMirror(
       {
@@ -542,13 +542,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
       },
     });
 
-    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith(
-      expect.objectContaining({
-        runId: "codex-thread:child-thread",
-        status: "failed",
-        error: "later turn failed",
-      }),
-    );
+    expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
   });
 
   it("lets terminal collab agent state finalize after an earlier idle thread status", () => {

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
@@ -163,15 +163,13 @@ describe("CodexNativeSubagentTaskMirror", () => {
       },
     });
 
-    expect(runtime.finalizeTaskRunByRunId).toHaveBeenNthCalledWith(1, {
+    expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: codexNativeSubagentRunId("child-thread"),
-      status: "succeeded",
-      endedAt: 30_000,
       lastEventAt: 30_000,
       progressSummary: "Codex native subagent is idle.",
-      terminalSummary: "Codex native subagent finished.",
     });
-    expect(runtime.finalizeTaskRunByRunId).toHaveBeenNthCalledWith(2, {
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(1);
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith({
       runId: codexNativeSubagentRunId("failed-child"),
       status: "failed",
       endedAt: 30_000,
@@ -249,14 +247,12 @@ describe("CodexNativeSubagentTaskMirror", () => {
       lastEventAt: 40_000,
       progressSummary: "Codex native subagent is initializing.",
     });
-    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith({
+    expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-thread",
-      status: "succeeded",
-      endedAt: 40_000,
       lastEventAt: 40_000,
       progressSummary: "done",
-      terminalSummary: "done",
     });
+    expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
   });
 
   it("uses the notification thread id when collab agent items omit sender thread id", () => {
@@ -326,13 +322,13 @@ describe("CodexNativeSubagentTaskMirror", () => {
         task: "inspect one thing",
       }),
     );
-    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith(
+    expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: "codex-thread:child-thread",
-        status: "succeeded",
-        terminalSummary: "done",
+        progressSummary: "done",
       }),
     );
+    expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
   });
 
   it("finalizes stale collab agent state from the blocked tool call status", () => {
@@ -459,7 +455,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
     expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
   });
 
-  it("preserves a completed collab agent message when the thread later goes idle", () => {
+  it("records completed collab agent and idle thread states as progress only", () => {
     const runtime = createRuntime();
     const mirror = new CodexNativeSubagentTaskMirror(
       {
@@ -496,18 +492,16 @@ describe("CodexNativeSubagentTaskMirror", () => {
       },
     });
 
-    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(1);
-    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith({
+    expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledTimes(1);
+    expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-thread",
-      status: "succeeded",
-      endedAt: 50_000,
       lastEventAt: 50_000,
       progressSummary: "No user task is specified.",
-      terminalSummary: "No user task is specified.",
     });
+    expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
   });
 
-  it("lets terminal collab agent state correct an earlier idle thread status", () => {
+  it("lets terminal collab agent state finalize after an earlier idle thread status", () => {
     const runtime = createRuntime();
     const mirror = new CodexNativeSubagentTaskMirror(
       {
@@ -545,15 +539,13 @@ describe("CodexNativeSubagentTaskMirror", () => {
       },
     });
 
-    expect(runtime.finalizeTaskRunByRunId).toHaveBeenNthCalledWith(1, {
+    expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-thread",
-      status: "succeeded",
-      endedAt: 55_000,
       lastEventAt: 55_000,
       progressSummary: "Codex native subagent is idle.",
-      terminalSummary: "Codex native subagent finished.",
     });
-    expect(runtime.finalizeTaskRunByRunId).toHaveBeenNthCalledWith(2, {
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(1);
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-thread",
       status: "failed",
       endedAt: 55_000,
@@ -614,13 +606,11 @@ describe("CodexNativeSubagentTaskMirror", () => {
       lastEventAt: 60_000,
       progressSummary: "Codex native subagent is initializing.",
     });
-    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith({
+    expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-thread",
-      status: "succeeded",
-      endedAt: 60_000,
       lastEventAt: 60_000,
       progressSummary: "done",
-      terminalSummary: "done",
     });
+    expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
   });
 });

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
@@ -501,6 +501,56 @@ describe("CodexNativeSubagentTaskMirror", () => {
     expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
   });
 
+  it("allows terminal collab failures after authoritative completion", () => {
+    const runtime = createRuntime();
+    const mirror = new CodexNativeSubagentTaskMirror(
+      {
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:main",
+        now: () => 52_000,
+      },
+      runtime,
+    );
+
+    mirror.handleNotification({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "collabAgentToolCall",
+          tool: "spawnAgent",
+          senderThreadId: "parent-thread",
+          receiverThreadIds: ["child-thread"],
+          prompt: "write the proof file",
+        },
+      },
+    });
+    mirror.markAuthoritativeCompletion("child-thread");
+    mirror.handleNotification({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "collabAgentToolCall",
+          tool: "wait",
+          senderThreadId: "parent-thread",
+          agentsStates: {
+            "child-thread": {
+              status: "errored",
+              message: "later turn failed",
+            },
+          },
+        },
+      },
+    });
+
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "codex-thread:child-thread",
+        status: "failed",
+        error: "later turn failed",
+      }),
+    );
+  });
+
   it("lets terminal collab agent state finalize after an earlier idle thread status", () => {
     const runtime = createRuntime();
     const mirror = new CodexNativeSubagentTaskMirror(

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.ts
@@ -37,6 +37,7 @@ export class CodexNativeSubagentTaskMirror {
   private readonly failedMirrorThreadIds = new Set<string>();
   private readonly terminalRunIds = new Set<string>();
   private readonly authoritativeRunIds = new Set<string>();
+  private readonly expectedAuthoritativeRunIds = new Set<string>();
   private readonly now: () => number;
 
   constructor(
@@ -52,6 +53,12 @@ export class CodexNativeSubagentTaskMirror {
     // finalizes and delivers this task, later mirror events must not rewrite it.
     this.authoritativeRunIds.add(runId);
     this.terminalRunIds.add(runId);
+  }
+
+  markAuthoritativeCompletionExpected(childThreadId: string): void {
+    // Local transcripts and V2 agent paths can supply the real result later.
+    // Remote V1 lacks both and must keep collab-completed as its fallback.
+    this.expectedAuthoritativeRunIds.add(codexNativeSubagentRunId(childThreadId));
   }
 
   handleNotification(notification: CodexServerNotification): void {
@@ -304,11 +311,25 @@ export class CodexNativeSubagentTaskMirror {
     }
     if (normalizedStatus === "completed") {
       this.terminalRunIds.add(runId);
-      this.runtime.recordTaskRunProgressByRunId({
-        runId,
-        lastEventAt: eventAt,
-        progressSummary: trimOptional(message) ?? "Codex native subagent completed.",
-      });
+      const summary = trimOptional(message) ?? "Codex native subagent completed.";
+      if (this.expectedAuthoritativeRunIds.has(runId)) {
+        this.runtime.recordTaskRunProgressByRunId({
+          runId,
+          lastEventAt: eventAt,
+          progressSummary: summary,
+        });
+      } else {
+        // Remote V1 has no trusted completion envelope or local transcript.
+        // Its collab-completed state is therefore the terminal fallback.
+        this.runtime.finalizeTaskRunByRunId({
+          runId,
+          status: "succeeded",
+          endedAt: eventAt,
+          lastEventAt: eventAt,
+          progressSummary: summary,
+          terminalSummary: summary,
+        });
+      }
       return;
     }
     if (normalizedStatus === "blocked") {

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.ts
@@ -48,6 +48,8 @@ export class CodexNativeSubagentTaskMirror {
 
   markAuthoritativeCompletion(childThreadId: string): void {
     const runId = codexNativeSubagentRunId(childThreadId);
+    // Run identity is per child thread, not per resumed turn. Once the monitor
+    // finalizes and delivers this task, later mirror events must not rewrite it.
     this.authoritativeRunIds.add(runId);
     this.terminalRunIds.add(runId);
   }
@@ -137,6 +139,9 @@ export class CodexNativeSubagentTaskMirror {
       return;
     }
     const runId = codexNativeSubagentRunId(threadId);
+    if (this.authoritativeRunIds.has(runId)) {
+      return;
+    }
     if (this.terminalRunIds.has(runId) && statusType !== "systemError") {
       return;
     }
@@ -278,7 +283,7 @@ export class CodexNativeSubagentTaskMirror {
       return;
     }
     const runId = codexNativeSubagentRunId(threadId);
-    if (this.authoritativeRunIds.has(runId) && normalizedStatus === "completed") {
+    if (this.authoritativeRunIds.has(runId)) {
       return;
     }
     if (this.terminalRunIds.has(runId) && isNonTerminalAgentStateStatus(normalizedStatus)) {

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.ts
@@ -36,6 +36,7 @@ export class CodexNativeSubagentTaskMirror {
   private readonly mirroredThreadIds = new Set<string>();
   private readonly failedMirrorThreadIds = new Set<string>();
   private readonly terminalRunIds = new Set<string>();
+  private readonly authoritativeRunIds = new Set<string>();
   private readonly now: () => number;
 
   constructor(
@@ -43,6 +44,12 @@ export class CodexNativeSubagentTaskMirror {
     private readonly runtime: TaskLifecycleRuntime,
   ) {
     this.now = params.now ?? Date.now;
+  }
+
+  markAuthoritativeCompletion(childThreadId: string): void {
+    const runId = codexNativeSubagentRunId(childThreadId);
+    this.authoritativeRunIds.add(runId);
+    this.terminalRunIds.add(runId);
   }
 
   handleNotification(notification: CodexServerNotification): void {
@@ -109,6 +116,7 @@ export class CodexNativeSubagentTaskMirror {
     }
     this.failedMirrorThreadIds.delete(threadId);
     this.terminalRunIds.delete(runId);
+    this.authoritativeRunIds.delete(runId);
     this.applyStatus(threadId, thread.status);
   }
 
@@ -129,6 +137,9 @@ export class CodexNativeSubagentTaskMirror {
       return;
     }
     const runId = codexNativeSubagentRunId(threadId);
+    if (this.authoritativeRunIds.has(runId)) {
+      return;
+    }
     if (this.terminalRunIds.has(runId) && statusType !== "systemError") {
       return;
     }
@@ -143,13 +154,10 @@ export class CodexNativeSubagentTaskMirror {
     }
     if (statusType === "idle") {
       this.terminalRunIds.add(runId);
-      this.runtime.finalizeTaskRunByRunId({
+      this.runtime.recordTaskRunProgressByRunId({
         runId,
-        status: "succeeded",
-        endedAt: eventAt,
         lastEventAt: eventAt,
         progressSummary: "Codex native subagent is idle.",
-        terminalSummary: "Codex native subagent finished.",
       });
       return;
     }
@@ -257,6 +265,7 @@ export class CodexNativeSubagentTaskMirror {
     }
     this.failedMirrorThreadIds.delete(normalizedThreadId);
     this.terminalRunIds.delete(runId);
+    this.authoritativeRunIds.delete(runId);
   }
 
   private applyCollabAgentStatus(
@@ -272,6 +281,9 @@ export class CodexNativeSubagentTaskMirror {
       return;
     }
     const runId = codexNativeSubagentRunId(threadId);
+    if (this.authoritativeRunIds.has(runId)) {
+      return;
+    }
     if (this.terminalRunIds.has(runId) && isNonTerminalAgentStateStatus(normalizedStatus)) {
       return;
     }
@@ -290,13 +302,10 @@ export class CodexNativeSubagentTaskMirror {
     }
     if (normalizedStatus === "completed") {
       this.terminalRunIds.add(runId);
-      this.runtime.finalizeTaskRunByRunId({
+      this.runtime.recordTaskRunProgressByRunId({
         runId,
-        status: "succeeded",
-        endedAt: eventAt,
         lastEventAt: eventAt,
         progressSummary: trimOptional(message) ?? "Codex native subagent completed.",
-        terminalSummary: trimOptional(message) ?? "Codex native subagent finished.",
       });
       return;
     }

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.ts
@@ -137,9 +137,6 @@ export class CodexNativeSubagentTaskMirror {
       return;
     }
     const runId = codexNativeSubagentRunId(threadId);
-    if (this.authoritativeRunIds.has(runId)) {
-      return;
-    }
     if (this.terminalRunIds.has(runId) && statusType !== "systemError") {
       return;
     }
@@ -281,7 +278,7 @@ export class CodexNativeSubagentTaskMirror {
       return;
     }
     const runId = codexNativeSubagentRunId(threadId);
-    if (this.authoritativeRunIds.has(runId)) {
+    if (this.authoritativeRunIds.has(runId) && normalizedStatus === "completed") {
       return;
     }
     if (this.terminalRunIds.has(runId) && isNonTerminalAgentStateStatus(normalizedStatus)) {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1688,13 +1688,17 @@ export async function runCodexAppServerAttempt(
     return notificationQueue;
   };
 
+  const nativeSubagentCodexHome =
+    appServer.start.transport === "stdio"
+      ? (appServer.start.env?.CODEX_HOME ?? resolveCodexAppServerHomeDir(agentDir))
+      : undefined;
   registerCodexNativeSubagentMonitor({
     client,
     parentThreadId: thread.threadId,
     requesterSessionKey: params.sessionKey,
     taskRuntimeScope: params.agentHarnessTaskRuntimeScope,
     agentId: params.agentId,
-    codexHome: appServer.start.env?.CODEX_HOME ?? resolveCodexAppServerHomeDir(agentDir),
+    codexHome: nativeSubagentCodexHome,
   });
   const notificationCleanup = client.addNotificationHandler(enqueueNotification);
   const requestCleanup = client.addRequestHandler(async (request) => {


### PR DESCRIPTION
## Summary

- Fix classification: root-cause fix.
- Root cause: Codex native subagent lifecycle mirroring treated lifecycle-only `idle` / collab `completed` states as successful task completion even though the native completion notification or transcript reconciliation is the authoritative result path.
- Why it matters / User impact: parent sessions could observe a successful subagent task before the child result/output delivery path had actually completed, matching the issue report where success was shown but the expected output file was still absent.
- Why this is root-cause fix: this preserves the lifecycle events as progress, moves success finalization back to the native completion path that owns the child result, and prevents late lifecycle events from replacing that authoritative result.
- What did NOT change: this does not change Codex thread spawning, native completion parsing, transcript reconciliation, parent delivery payloads, user configuration, stored schema, or migration behavior.
- Architecture / source-of-truth check: the model-consumed child run result remains owned by native completion / transcript reconciliation; this PR only changes the parent-visible mirror/projection task row so it cannot claim success before that source-of-truth path completes.
- Patch quality notes: the new mirror state is a guard for completion ordering, not a fallback; explicit failure/blocking lifecycle states still finalize as before, and tests cover the ordering boundary.
- Risk labels considered: availability, session-state, security-boundary.
- Risk explanation: the touched path controls parent task status visibility for Codex native subagent runs, so the main risk is delaying or suppressing the mirrored success state.
- Why acceptable: success is delayed only until the existing authoritative completion path runs, while progress and explicit error/blocking states remain visible.

## Linked context

Closes #86872

Related: Codex native subagent task mirroring and parent task completion delivery.

Was this requested by a maintainer or owner?

No direct maintainer request beyond the linked issue.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: a Codex native subagent could make the parent-visible task row look successful from lifecycle status alone, even before the native completion result/output delivery path completed.
- Real environment tested: local OpenClaw repository runtime on Linux, executing `CodexNativeSubagentMonitor` through `tsx` with the real OpenClaw task registry runtime and the real agent-harness completion delivery function. The proof injects Codex app-server notifications for a child thread start, lifecycle `idle`, native completion notification, and late `idle`.
- Exact steps or command run after this patch:

  ```sh
  pnpm exec tsx ./.codex-native-monitor-real-registry-proof.ts
  ```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): terminal capture from Validation `codex-native-monitor-real-registry-proof` (pass, exit_code=0, 16199ms):

  ```text
  after thread started: status=running; deliveryStatus=not_applicable; progress=Codex native subagent is active.; terminal=
  after idle lifecycle before native completion: status=running; deliveryStatus=not_applicable; progress=Codex native subagent is idle.; terminal=
  delivery result after native completion: delivered=true; path=steered
  after native completion and parent delivery: status=succeeded; deliveryStatus=delivered; progress=child final result: wrote output file; terminal=child final result: wrote output file
  after late idle lifecycle: status=succeeded; deliveryStatus=delivered; progress=child final result: wrote output file; terminal=child final result: wrote output file
  ```

- Observed result after fix: the real monitor creates the parent task row in the real task registry, keeps the row `running` when the child reaches lifecycle `idle`, finalizes it only after the native completion notification, marks the parent completion delivery path `delivered`, and ignores a late `idle` lifecycle without overwriting the authoritative terminal result.
- What was not tested: a live model-backed Codex child agent run writing a real filesystem output file.
- Proof limitations or environment constraints: the proof uses real `CodexNativeSubagentMonitor`, real task registry row mutations, and the real agent-harness completion delivery function; it uses injected Codex server notifications and an in-process active-requester queue to avoid requiring a live model process or external channel connection.
- Before evidence (optional but encouraged): before this patch, the same `idle` lifecycle path finalized the task row as succeeded with `terminalSummary: "Codex native subagent finished."`, before the native completion result/delivery path ran.

## Tests and validation

Which commands did you run?

```sh
pnpm vitest run extensions/codex/src/app-server/native-subagent-task-mirror.test.ts extensions/codex/src/app-server/native-subagent-monitor.test.ts
```

What regression coverage was added or updated?

- Added coverage that `idle` does not complete the mirrored task row before native completion.
- Added coverage that native completion finalizes and delivers the real result.
- Added coverage that late `idle` lifecycle updates do not overwrite native completion results.
- Updated mirror tests so collab `completed` / alternate `success` spelling are progress-only unless an explicit failure/blocking terminal state is reported.

What failed before this fix, if known?

The new regression test failed with a premature successful finalization from `idle`:

```text
runId: "codex-thread:child-thread"
status: "succeeded"
progressSummary: "Codex native subagent is idle."
terminalSummary: "Codex native subagent finished."
```

If no test was added, why not?

Regression tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Parent task status visibility for Codex native subagent runs.

How is that risk mitigated?

The change narrows only the success-finalization path: lifecycle completion-like events remain visible as progress, while explicit error/blocking states and authoritative native completion finalization keep their existing behavior covered by targeted tests.

## Current review state

What is the next action?

Ready for maintainer review after CI and ClawSweeper checks complete.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on remote CI / ClawSweeper after the PR body update. The new near-real proof is supplied in this body; final sufficiency remains maintainer / ClawSweeper judgment because it does not launch a live model-backed Codex child process.

Which bot or reviewer comments were addressed?

- Addressed ClawSweeper RF-001 / RF-002 by adding a redacted near-real terminal capture from `CodexNativeSubagentMonitor` showing the parent task row stays `running` through lifecycle `idle` until native completion.
- Addressed RF-004 by using the real OpenClaw task registry row mutation path and real agent-harness completion delivery function; the capture shows `deliveryStatus=delivered` and `path=steered` after authoritative completion.
- Disclosed RF-003 / RF-005 risk and judgment boundary: if native completion / transcript reconciliation misses a real child completion, the parent row remains progress-only rather than falsely succeeding; this is the intended source-of-truth tradeoff and still requires maintainer judgment for proof sufficiency.
