### PR TITLE
#92523: Bug: Orphaned TaskFlows in `waiting` status permanently block agent heartbeats (requests-in-flight deadlock)

### DIFF
--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -704,7 +704,7 @@ export async function tasksMaintenanceCommand(
 
   runtime.log(
     info(
-      `Tasks maintenance (${opts.apply ? "applied" : "preview"}): tasks ${taskMaintenance.reconciled} reconcile · ${taskMaintenance.recovered} recovered · ${taskMaintenance.cleanupStamped} cleanup stamp · ${taskMaintenance.pruned} prune; task-flows ${flowMaintenance.reconciled} reconcile · ${flowMaintenance.pruned} prune`,
+      `Tasks maintenance (${opts.apply ? "applied" : "preview"}): tasks ${taskMaintenance.reconciled} reconcile · ${taskMaintenance.recovered} recovered · ${taskMaintenance.cleanupStamped} cleanup stamp · ${taskMaintenance.pruned} prune; task-flows ${flowMaintenance.reconciled} reconcile · ${flowMaintenance.pruned} prune · ${flowMaintenance.expired} expired`,
     ),
   );
   runtime.log(

--- a/src/tasks/task-flow-registry.maintenance.test.ts
+++ b/src/tasks/task-flow-registry.maintenance.test.ts
@@ -99,11 +99,13 @@ describe("task-flow-registry maintenance", () => {
       expect(previewTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 1,
         pruned: 0,
+        expired: 0,
       });
 
       expect(await runTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 1,
         pruned: 0,
+        expired: 0,
       });
       const storedFlow = getTaskFlowById(flow.flowId);
       if (!storedFlow) {
@@ -131,11 +133,13 @@ describe("task-flow-registry maintenance", () => {
       expect(previewTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 0,
         pruned: 1,
+        expired: 0,
       });
 
       expect(await runTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 0,
         pruned: 1,
+        expired: 0,
       });
       expect(getTaskFlowById(oldFlow.flowId)).toBeUndefined();
     });
@@ -157,11 +161,13 @@ describe("task-flow-registry maintenance", () => {
       expect(previewTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 1,
         pruned: 0,
+        expired: 0,
       });
 
       expect(await runTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 1,
         pruned: 0,
+        expired: 0,
       });
       const storedFlow = getTaskFlowById(flow.flowId);
       if (!storedFlow) {
@@ -212,11 +218,13 @@ describe("task-flow-registry maintenance", () => {
       expect(previewTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 0,
         pruned: 0,
+        expired: 0,
       });
 
       expect(await runTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 0,
         pruned: 0,
+        expired: 0,
       });
       const storedFlow = getTaskFlowById(flow.flowId);
       if (!storedFlow) {
@@ -267,15 +275,144 @@ describe("task-flow-registry maintenance", () => {
       expect(previewTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 0,
         pruned: 25,
+        expired: 0,
       });
 
       expect(await runTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 0,
         pruned: 25,
+        expired: 0,
       });
 
       const remainingFlowIds = new Set(listTaskFlowRecords().map((flow) => flow.flowId));
       expect(remainingFlowIds).toEqual(new Set([fresh.flowId, running.flowId]));
+    });
+  });
+
+  it("expires waiting flows older than 5 minutes", async () => {
+    await withTaskFlowMaintenanceStateDir(async () => {
+      const now = Date.now();
+      const stuckFlow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Waiting for approval",
+        status: "waiting",
+        createdAt: now - 6 * 60_000,
+        updatedAt: now - 6 * 60_000,
+      });
+
+      expect(previewTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        pruned: 0,
+        expired: 1,
+      });
+
+      expect(await runTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        pruned: 0,
+        expired: 1,
+      });
+      const storedFlow = getTaskFlowById(stuckFlow.flowId);
+      if (!storedFlow) {
+        throw new Error("Expected expired waiting flow to remain registered");
+      }
+      expect(storedFlow.flowId).toBe(stuckFlow.flowId);
+      expect(storedFlow.status).toBe("lost");
+    });
+  });
+
+  it("does not expire waiting flows younger than 5 minutes", async () => {
+    await withTaskFlowMaintenanceStateDir(async () => {
+      const now = Date.now();
+      createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Waiting for approval — fresh",
+        status: "waiting",
+        createdAt: now - 2 * 60_000,
+        updatedAt: now - 2 * 60_000,
+      });
+
+      expect(previewTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        pruned: 0,
+        expired: 0,
+      });
+
+      expect(await runTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        pruned: 0,
+        expired: 0,
+      });
+    });
+  });
+
+  it("does not expire non-waiting flows", async () => {
+    await withTaskFlowMaintenanceStateDir(async () => {
+      const now = Date.now();
+      createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Running flow",
+        status: "running",
+        createdAt: now - 10 * 60_000,
+        updatedAt: now - 10 * 60_000,
+      });
+
+      expect(previewTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        pruned: 0,
+        expired: 0,
+      });
+
+      expect(await runTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        pruned: 0,
+        expired: 0,
+      });
+    });
+  });
+
+  it("expires multiple stuck waiting flows from different sessions", async () => {
+    await withTaskFlowMaintenanceStateDir(async () => {
+      const now = Date.now();
+      for (let index = 0; index < 10; index += 1) {
+        createManagedTaskFlow({
+          ownerKey: `agent:main:${index}`,
+          controllerId: "tests/task-flow-maintenance",
+          goal: `Waiting flow ${index}`,
+          status: "waiting",
+          createdAt: now - 10 * 60_000 - index * 1000,
+          updatedAt: now - 10 * 60_000 - index * 1000,
+        });
+      }
+
+      const freshWaiting = createManagedTaskFlow({
+        ownerKey: "agent:main:fresh",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Fresh waiting flow",
+        status: "waiting",
+        createdAt: now - 2 * 60_000,
+        updatedAt: now - 2 * 60_000,
+      });
+
+      expect(previewTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        pruned: 0,
+        expired: 10,
+      });
+
+      expect(await runTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        pruned: 0,
+        expired: 10,
+      });
+
+      const storedFreshFlow = getTaskFlowById(freshWaiting.flowId);
+      if (!storedFreshFlow) {
+        throw new Error("Expected fresh waiting flow to remain registered");
+      }
+      expect(storedFreshFlow.status).toBe("waiting");
     });
   });
 });

--- a/src/tasks/task-flow-registry.maintenance.ts
+++ b/src/tasks/task-flow-registry.maintenance.ts
@@ -15,10 +15,14 @@ import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 
 const TASK_FLOW_RETENTION_MS = 7 * 24 * 60 * 60_000;
 
+/** Maximum time a flow may remain in `waiting` status before it is expired. */
+const WAITING_FLOW_EXPIRY_MS = 5 * 60_000;
+
 /** Counts task-flow registry maintenance actions without exposing individual records. */
 export type TaskFlowRegistryMaintenanceSummary = {
   reconciled: number;
   pruned: number;
+  expired: number;
 };
 
 function isTerminalFlow(flow: TaskFlowRecord): boolean {
@@ -49,6 +53,43 @@ function shouldPruneFlow(flow: TaskFlowRecord, now: number): boolean {
     return false;
   }
   return now - resolveTerminalAt(flow) >= TASK_FLOW_RETENTION_MS;
+}
+
+function shouldExpireWaitingFlow(flow: TaskFlowRecord, now: number): boolean {
+  if (flow.status !== "waiting") {
+    return false;
+  }
+  return now - flow.updatedAt >= WAITING_FLOW_EXPIRY_MS;
+}
+
+function expireWaitingFlow(flow: TaskFlowRecord, now: number): boolean {
+  let current = flow;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const endedAt = Math.max(now, current.updatedAt);
+    const result = updateFlowRecordByIdExpectedRevision({
+      flowId: current.flowId,
+      expectedRevision: current.revision,
+      patch: {
+        status: "lost",
+        blockedTaskId: null,
+        blockedSummary: null,
+        waitJson: null,
+        endedAt,
+        updatedAt: endedAt,
+      },
+    });
+    if (result.applied) {
+      return true;
+    }
+    if (result.reason === "not_found" || !result.current) {
+      return false;
+    }
+    current = result.current;
+    if (!shouldExpireWaitingFlow(current, now)) {
+      return false;
+    }
+  }
+  return false;
 }
 
 function shouldFinalizeCancelledFlow(flow: TaskFlowRecord): boolean {
@@ -133,9 +174,14 @@ export function previewTaskFlowRegistryMaintenance(): TaskFlowRegistryMaintenanc
   const now = Date.now();
   let reconciled = 0;
   let pruned = 0;
+  let expired = 0;
   for (const flow of listTaskFlowRecords()) {
     if (shouldRepairTerminalMirroredFlowTimestamp(flow)) {
       reconciled += 1;
+      continue;
+    }
+    if (shouldExpireWaitingFlow(flow, now)) {
+      expired += 1;
       continue;
     }
     if (shouldFinalizeCancelledFlow(flow)) {
@@ -146,13 +192,14 @@ export function previewTaskFlowRegistryMaintenance(): TaskFlowRegistryMaintenanc
       pruned += 1;
     }
   }
-  return { reconciled, pruned };
+  return { reconciled, pruned, expired };
 }
 
 export async function runTaskFlowRegistryMaintenance(): Promise<TaskFlowRegistryMaintenanceSummary> {
   const now = Date.now();
   let reconciled = 0;
   let pruned = 0;
+  let expired = 0;
   for (const flow of listTaskFlowRecords()) {
     const current = getTaskFlowById(flow.flowId);
     if (!current) {
@@ -161,6 +208,12 @@ export async function runTaskFlowRegistryMaintenance(): Promise<TaskFlowRegistry
     if (shouldRepairTerminalMirroredFlowTimestamp(current)) {
       if (repairTerminalMirroredFlowTimestamp(current)) {
         reconciled += 1;
+      }
+      continue;
+    }
+    if (shouldExpireWaitingFlow(current, now)) {
+      if (expireWaitingFlow(current, now)) {
+        expired += 1;
       }
       continue;
     }
@@ -174,5 +227,5 @@ export async function runTaskFlowRegistryMaintenance(): Promise<TaskFlowRegistry
       pruned += 1;
     }
   }
-  return { reconciled, pruned };
+  return { reconciled, pruned, expired };
 }


### PR DESCRIPTION
## Summary

Expire orphaned TaskFlows stuck in `waiting` status during the task-flow
registry maintenance sweep. Without this, flows whose callback never returns
(display timeout, gateway restart, network failure) stay in `waiting` forever,
causing the gateway to count them as requests-in-flight and permanently skip
heartbeats for the affected session.

## Root Cause

`runTaskFlowRegistryMaintenance` already reconciled cancelled flows, pruned
old terminal flows, and repaired mirrored-flow timestamps — but had no
handling for `waiting` flows. A flow in `waiting` status is only valid while
the callback is expected to arrive. Once the callback is unreachable (device
powered off, gateway restarted, network dropped), the flow becomes orphaned
and should be expired to `lost`.

## Real behavior proof

Behavior addressed: TaskFlows in `waiting` status older than 5 minutes are
now expired to `lost` during the task-flow maintenance sweep, unblocking
sessions whose heartbeats were skipped due to stale in-flight requests.

Real environment tested: Linux 4.19, Node.js v22, tsx

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/tasks/task-flow-registry.maintenance.test.ts
./node_modules/.bin/tsx scripts/repro-92523.mjs
```

Evidence after fix:

- `task-flow-registry.maintenance.test.ts`: 9 tests passed (incl. 4 new expiry tests)
- `scripts/repro-92523.mjs`: 8 assertions, 0 failed

Observed result after fix:

```
=== #92523: Expire orphaned waiting TaskFlows ===

1. Preview shows 1 expired waiting flow:
  ✓ preview.expired === 1 (got 1)
  ✓ preview.reconciled === 0 (got 0)

2. Apply expires the stuck flow:
  ✓ applied.expired === 1 (got 1)

3. Stuck flow transitioned to 'lost':
  ✓ stuck flow still exists in registry
  ✓ stuck flow status is 'lost' (got lost)
  ✓ stuck flow has endedAt timestamp

4. Fresh flow untouched:
  ✓ fresh flow still exists in registry
  ✓ fresh flow status is still 'waiting' (got waiting)

=== Results: 8 passed, 0 failed ===
```

What was not tested: Full gateway integration with real display-based
approval callbacks. The unit tests and repro script exercise the maintenance
module directly with the production store layer.

## Regression Test Plan

- [ ] `node scripts/run-vitest.mjs src/tasks/task-flow-registry.maintenance.test.ts` passes (9/9)
- [ ] New test "expires waiting flows older than 5 minutes" verifies stuck flows → lost
- [ ] New test "does not expire waiting flows younger than 5 minutes" verifies freshness gate
- [ ] Existing maintenance tests pass (reconcile, prune, repair — all include `expired: 0`)
- [ ] Change is minimal: 3 functions added, 1 log line updated

---

*AI-assisted: built with Claude Code*
