### PR TITLE
fix #92465: split OpenAI 431 embedding batches

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -126,6 +126,35 @@ describe("memory embedding policy", () => {
     expect(isRetryableMemoryEmbeddingTransportError("embedding validation failed")).toBe(false);
   });
 
+  it("splits OpenAI 431 oversized embedding batches without retrying the same request", async () => {
+    const run = vi.fn(async (items: string[]) => {
+      if (items.length > 1) {
+        throw new Error(
+          "openai embeddings failed: 431 request_headers_too_large: Request Header Fields Too Large",
+        );
+      }
+      return items.map((item) => [item.charCodeAt(0)]);
+    });
+
+    const result = await runMemoryEmbeddingBatchRetryWithSplit({
+      items: ["a", "b", "c", "d"],
+      run,
+      isRetryable: isRetryableMemoryEmbeddingError,
+      isSplittable: isSplittableMemoryEmbeddingTransportError,
+      waitForRetry: async () => {},
+      maxAttempts: 3,
+      baseDelayMs: 500,
+    });
+
+    expect(result).toEqual([[97], [98], [99], [100]]);
+    expect(run.mock.calls.map(([items]) => items.length)).toEqual([4, 2, 1, 1, 2, 1, 1]);
+    expect(isRetryableMemoryEmbeddingError("431 request_headers_too_large")).toBe(false);
+    expect(isSplittableMemoryEmbeddingTransportError("431 request_headers_too_large")).toBe(true);
+    expect(
+      isSplittableMemoryEmbeddingTransportError("embedding validation failed at item 4312"),
+    ).toBe(false);
+  });
+
   it("retries too-many-tokens-per-day errors", async () => {
     let calls = 0;
     const waits: number[] = [];

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -88,7 +88,7 @@ const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
   /(fetch failed|other side closed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|UND_ERR_|socket hang up|socket terminated|network error|read ECONN|timed out|connection (?:reset|refused|aborted|timed out)|EHOSTUNREACH|ENETUNREACH|ECONNABORTED|EAI_AGAIN)/i;
 
 const SPLITTABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
-  /(other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted))/i;
+  /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted))/i;
 
 export function isRetryableMemoryEmbeddingTransportError(message: string): boolean {
   return RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message);


### PR DESCRIPTION
## Summary

- Problem: bulk memory imports using OpenAI-compatible embeddings can fail on `431 request_headers_too_large` before producing usable search results.
- Solution: classify OpenAI 431 oversized embedding failures as batch split signals for the existing memory-core split path.
- What changed: `isSplittableMemoryEmbeddingTransportError` now recognizes `431`, `request_headers_too_large`, and `Request Header Fields Too Large`; the regression proves the existing splitter bisects and preserves result order.
- What did NOT change: no API, config, schema, default model, retry limit, embedding payload shape, cache format, vector schema, or provider request body changed; changing import UX, provider defaults, and endpoint-level outage handling is out of scope.
- Why it matters / User impact: tenant onboarding and large history imports should not require operators to manually split generated memory corpora into 100-entry chunks just to avoid upstream provider request-size failures.
- Fixes #92465

## Real behavior proof

- **Behavior or issue addressed:** Bulk memory indexing with OpenAI-compatible embeddings can encounter a 431 oversized request failure; this patch routes that exact error shape into the production memory embedding batch splitter instead of aborting the import.
- **Real environment tested:** Local Linux source checkout at `/media/vdc/code/ai/aispace/openclaw-worktrees/issue-92465`, isolated `OPENCLAW_STATE_DIR` / `OPENCLAW_CONFIG_PATH`, the real `openclaw memory index --agent main --force --verbose` CLI path via `node --import tsx src/entry.ts`, and a local OpenAI-compatible HTTP `/v1/embeddings` server. The proof corpus contained 1,000 generated memory entries across `MEMORY.md` and `memory/2026-06-13-bulk-import.md`; `remote.batch.enabled` was false so indexing used the synchronous provider `/embeddings` path, not the OpenAI Batch API path.
- **Exact steps or command run after this patch:**

```sh
# Start local OpenAI-compatible /v1/embeddings server that returns 431 when input_count > 4.
PROOF_431_THRESHOLD=4 node /media/vdc/code/ai/aispace/openclaw-issue-92465-evidence/openai-compatible-431-server.mjs

# Run the real memory index CLI against an isolated config and generated 1,000-entry corpus.
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-92465
OPENCLAW_STATE_DIR=/media/vdc/code/ai/aispace/openclaw-issue-92465-evidence/real-openai-compatible-proof/state \
OPENCLAW_CONFIG_PATH=/media/vdc/code/ai/aispace/openclaw-issue-92465-evidence/real-openai-compatible-proof/openclaw.json \
OPENCLAW_HOME=/media/vdc/code/ai/aispace/openclaw-issue-92465-evidence/real-openai-compatible-proof/home \
node --import tsx src/entry.ts memory index --agent main --force --verbose

pnpm vitest run extensions/memory-core/src/memory/manager-embedding-policy.test.ts
git diff --check
```

- **Evidence after fix:**

Real CLI output from `/media/vdc/code/ai/aispace/openclaw-issue-92465-evidence/openai-compatible-memory-index-proof.log`:

```text
Memory Index (main)
Provider: openai-compatible (requested: openai-compatible)
Model: proof-embedding-model
Sources: memory (MEMORY.md + /media/vdc/code/ai/aispace/openclaw-issue-92465-evidence/real-openai-compatible-proof/workspace/memory/*.md)
[memory] sync: indexing memory files
[memory] embeddings: batch start
[memory] embeddings transport failed after retries; splitting batch of 5 into 3 + 2
[memory] embeddings: batch start
[memory] embeddings: batch start
...
Memory index updated (main).
CLI exit status: 0
```

Local OpenAI-compatible provider log from `/media/vdc/code/ai/aispace/openclaw-issue-92465-evidence/openai-compatible-431-server.log`:

```text
ready url=http://127.0.0.1:39013/v1 threshold=4
request=1 path=/v1/embeddings input_count=5 body_bytes=7935 model=proof-embedding-model
request=1 result=431 reason=request_headers_too_large threshold=4
request=2 path=/v1/embeddings input_count=3 body_bytes=4793 model=proof-embedding-model
request=2 result=200 embeddings=3
request=3 path=/v1/embeddings input_count=2 body_bytes=3185 model=proof-embedding-model
request=3 result=200 embeddings=2
...
server_requests 200
server_431 66
server_200 134
cli_split_lines 66
cli_updated True
cli_exit_zero True
```

Regression output remained green:

```text
RUN  v4.1.7 /media/vdc/code/ai/aispace/openclaw-worktrees/issue-92465

Test Files  1 passed (1)
     Tests  14 passed (14)
  Start at  17:31:44
  Duration  828ms (transform 337ms, setup 404ms, import 22ms, tests 152ms, environment 0ms)
```

The regression also covered the pre-fix failure. Before the classifier change, the new test failed with the unsplit 431 error:

```text
FAIL  |extension-memory| ../../extensions/memory-core/src/memory/manager-embedding-policy.test.ts > memory embedding policy > splits OpenAI 431 oversized embedding batches without retrying the same request
Error: openai embeddings failed: 431 request_headers_too_large: Request Header Fields Too Large
```

- **Observed result after fix:** The real OpenAI-compatible memory index run hit 66 synthetic 431 responses on oversized five-input `/v1/embeddings` requests, split each failed batch through the production memory-core splitter into successful three-input and two-input requests, and completed with `Memory index updated (main)` plus CLI exit status 0. The regression also returns vectors in original input order after splitting `["a", "b", "c", "d"]`, and records provider batch sizes `[4, 2, 1, 1, 2, 1, 1]`, proving the original oversized batch is split rather than retried unchanged.
- **What was not tested:** I did not run a paid live OpenAI API import or a Docker daemon-backed 10,000-entry run. The local Docker daemon socket was not accessible in this environment, so the real-behavior proof is local-only proof using a local OpenAI-compatible HTTP endpoint with a dummy local API key and no external credentials or paid calls; it still exercises the real OpenClaw CLI, memory index manager, synchronous provider HTTP `/embeddings` request path, 431 response handling, recursive split, and successful index completion.

## Review findings addressed

- **RF-001:** Fixed by adding redacted real OpenAI-compatible bulk memory index proof from the CLI and provider logs above. The provider log shows `/v1/embeddings` request 1 returning 431 for five inputs, followed by successful three-input and two-input split requests.
- **RF-002:** Fixed by replacing unit-only proof with the real `openclaw memory index --agent main --force --verbose` run above against a 1,000-entry memory corpus and synchronous OpenAI-compatible provider path.
- **RF-003:** Fixed by adding provider-path logs that show 66 oversized 431 responses, 66 CLI split lines, 134 successful 200 responses, and `Memory index updated (main)` with CLI exit status 0.
- **RF-004:** Fixed from contributor side: no code repair was needed after the review; the remaining action was proof, and this body now includes the requested real behavior proof plus the local-only limitation for the unavailable Docker daemon and paid live OpenAI run.

## Regression Test Plan

- **Target test file:** `extensions/memory-core/src/memory/manager-embedding-policy.test.ts`
- **Scenario locked in:** A four-item embedding batch throws `openai embeddings failed: 431 request_headers_too_large: Request Header Fields Too Large` whenever more than one item is sent; the test expects the batch splitter to call sizes `[4, 2, 1, 1, 2, 1, 1]` and return ordered vectors.
- **Why this is the smallest reliable guardrail:** The root behavior lives in the shared memory-core classifier and split helper used by `embedBatchWithRetry`, so this test covers the production decision point without requiring a live OpenAI key or large paid import run.

## Merge risk

- **Risk labels considered:** availability, session-state
- **Risk explanation:** Availability risk is limited to handling one additional oversized-provider error string; session-state risk is limited because the change affects embedding retry/split policy and does not alter memory files, sessions, database schema, cache identity, or search ranking.
- **Why acceptable:** The diff is two files and one source-line classifier change with a focused regression; 431 is not added to the generic retryable regex, so the code does not loop on the same oversized request and existing endpoint-outage behavior stays unchanged.

## Root Cause

- **Root cause:** The memory indexer already owned the correct root behavior in `runMemoryEmbeddingBatchRetryWithSplit`, but the source-of-truth classifier for splittable embedding transport failures did not include OpenAI's 431 oversized-request wording. As a result, large bulk imports failed at the first 431 instead of entering the existing bisection path that manual chunked imports effectively approximated.
- **Why this is root-cause fix:** This fixes the root-cause invariant at the source-of-truth classifier: an oversized embedding batch error must be classified as splittable before the manager decides whether to abort, retry, or bisect. Because the decision now happens at the shared memory embedding policy boundary, every caller using the existing batch splitter handles OpenAI 431 consistently; it is not a downstream special case and does not mask the symptom with a generic retry.
- **Fix classification:** Root cause fix
- **Maintainer-ready confidence:** High: the changed behavior is isolated to splittable embedding batch classification, has a red/green regression, and preserves existing retry boundaries for non-splittable endpoint failures.
- **Patch quality notes:** Related open PR scan from daily-fix did not find an open competing PR or same-contract/canonical PR for #92465; patch-quality risk is acceptable because the public contract surface is unchanged, compatibility/default behavior is unchanged, and the change only maps a provider error string to an already-existing internal split mechanism.
- **Architecture / source-of-truth check:** The source of truth is `extensions/memory-core/src/memory/manager-embedding-policy.ts`, which owns retryable versus splittable embedding failure classification for memory indexing. This patch changes that owner module before downstream `embedBatchWithRetry` fallback behavior, not a CLI string check, provider-specific workaround, schema migration, or persisted record projection.
