### PR TITLE
fix: require admin for HTTP session kills

### DIFF
--- a/src/gateway/session-kill-http.test.ts
+++ b/src/gateway/session-kill-http.test.ts
@@ -15,14 +15,14 @@ const REQUESTER_WRITE_HEADERS = {
   "x-openclaw-scopes": "operator.write",
   "x-openclaw-requester-session-key": "agent:main:main",
 };
+const REQUESTER_ADMIN_HEADERS = {
+  "x-openclaw-scopes": "operator.admin",
+  "x-openclaw-requester-session-key": "agent:other:main",
+};
 
 let cfg: Record<string, unknown> = {};
 const authMock = vi.fn(async (): Promise<GatewayAuthResult> => ({ ok: true }));
-const isLocalDirectRequestMock = vi.fn(() => true);
 const loadSessionEntryMock = vi.fn();
-const getLatestSubagentRunByChildSessionKeyMock = vi.fn();
-const resolveSubagentControllerMock = vi.fn();
-const killControlledSubagentRunMock = vi.fn();
 const killSubagentRunAdminMock = vi.fn();
 
 vi.mock("../config/config.js", () => ({
@@ -35,21 +35,14 @@ vi.mock("../config/io.js", () => ({
 
 vi.mock("./auth.js", () => ({
   authorizeHttpGatewayConnect: authMock,
-  isLocalDirectRequest: isLocalDirectRequestMock,
 }));
 
 vi.mock("./session-utils.js", () => ({
   loadSessionEntry: loadSessionEntryMock,
 }));
 
-vi.mock("../agents/subagent-registry.js", () => ({
-  getLatestSubagentRunByChildSessionKey: getLatestSubagentRunByChildSessionKeyMock,
-}));
-
 vi.mock("../agents/subagent-control.js", () => ({
-  killControlledSubagentRun: killControlledSubagentRunMock,
   killSubagentRunAdmin: killSubagentRunAdminMock,
-  resolveSubagentController: resolveSubagentControllerMock,
 }));
 
 const { handleSessionKillHttpRequest } = await import("./session-kill-http.js");
@@ -93,13 +86,7 @@ beforeEach(() => {
   cfg = {};
   authMock.mockReset();
   authMock.mockResolvedValue({ ok: true, method: "token" });
-  isLocalDirectRequestMock.mockReset();
-  isLocalDirectRequestMock.mockReturnValue(true);
   loadSessionEntryMock.mockReset();
-  getLatestSubagentRunByChildSessionKeyMock.mockReset();
-  resolveSubagentControllerMock.mockReset();
-  resolveSubagentControllerMock.mockReturnValue({ controllerSessionKey: "agent:main:main" });
-  killControlledSubagentRunMock.mockReset();
   killSubagentRunAdminMock.mockReset();
 });
 
@@ -134,23 +121,12 @@ function mockWorkerSession() {
   });
 }
 
-function allowRemoteRequesterKill() {
-  isLocalDirectRequestMock.mockReturnValue(false);
-  allowTrustedProxyAuth();
-  mockWorkerSession();
-}
-
 async function expectForbiddenMissingScope(response: Response, message: string) {
   expect(response.status).toBe(403);
   expectErrorResponse(await response.json(), {
     type: "forbidden",
     message,
   });
-}
-
-async function expectRequesterKillResponse(response: Response, killed: boolean) {
-  expect(response.status).toBe(200);
-  await expect(response.json()).resolves.toEqual({ ok: true, killed });
 }
 
 function expectErrorResponse(body: unknown, expected: { type: string; message?: string }) {
@@ -210,7 +186,6 @@ describe("POST /sessions/:sessionKey/kill", () => {
       expect(authMock).not.toHaveBeenCalled();
       expect(loadSessionEntryMock).not.toHaveBeenCalled();
       expect(killSubagentRunAdminMock).not.toHaveBeenCalled();
-      expect(killControlledSubagentRunMock).not.toHaveBeenCalled();
     },
   );
 
@@ -261,8 +236,7 @@ describe("POST /sessions/:sessionKey/kill", () => {
     expect(killSubagentRunAdminMock).not.toHaveBeenCalled();
   });
 
-  it("rejects remote bearer-auth kills without requester ownership", async () => {
-    isLocalDirectRequestMock.mockReturnValue(false);
+  it("rejects bearer-auth kills without a trusted admin scope surface", async () => {
     mockWorkerSession();
 
     const response = await postWorkerKill();
@@ -271,63 +245,29 @@ describe("POST /sessions/:sessionKey/kill", () => {
     expect(killSubagentRunAdminMock).not.toHaveBeenCalled();
   });
 
-  it("rejects remote kills without requester ownership or an authorized token", async () => {
-    isLocalDirectRequestMock.mockReturnValue(false);
-    authMock.mockResolvedValueOnce({ ok: true });
+  it("rejects trusted-proxy requester-session kills without admin scope", async () => {
+    allowTrustedProxyAuth();
+    const response = await postWorkerKill("", REQUESTER_WRITE_HEADERS);
+    await expectForbiddenMissingScope(response, "missing scope: operator.admin");
+    expect(loadSessionEntryMock).not.toHaveBeenCalled();
+    expect(killSubagentRunAdminMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the admin kill path even when the requester session header is present", async () => {
+    allowTrustedProxyAuth();
     mockWorkerSession();
+    killSubagentRunAdminMock.mockResolvedValue({ found: true, killed: true });
 
-    const response = await postWorkerKill("", {
-      authorization: "",
-    });
-    expect(response.status).toBe(403);
-    expect(killSubagentRunAdminMock).not.toHaveBeenCalled();
-  });
-
-  it("uses requester ownership checks when a requester session header is provided without admin bypass", async () => {
-    allowRemoteRequesterKill();
-    getLatestSubagentRunByChildSessionKeyMock.mockReturnValue({
-      runId: "run-1",
-      childSessionKey: WORKER_SESSION_KEY,
-    });
-    killControlledSubagentRunMock.mockResolvedValue({ status: "ok" });
-
-    const response = await postWorkerKill("", REQUESTER_WRITE_HEADERS);
-    await expectRequesterKillResponse(response, true);
-    expect(resolveSubagentControllerMock).toHaveBeenCalledWith({
+    const response = await postWorkerKill("", REQUESTER_ADMIN_HEADERS);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, killed: true });
+    expect(killSubagentRunAdminMock).toHaveBeenCalledWith({
       cfg,
-      agentSessionKey: "agent:main:main",
+      sessionKey: WORKER_SESSION_KEY,
     });
-    expect(getLatestSubagentRunByChildSessionKeyMock).toHaveBeenCalledWith(WORKER_SESSION_KEY);
-    expect(killSubagentRunAdminMock).not.toHaveBeenCalled();
   });
 
-  it("uses the newest child-session row for requester-owned kills when stale rows still exist", async () => {
-    allowRemoteRequesterKill();
-    getLatestSubagentRunByChildSessionKeyMock.mockReturnValue({
-      runId: "run-current-ended",
-      childSessionKey: WORKER_SESSION_KEY,
-      endedAt: Date.now() - 1,
-    });
-    killControlledSubagentRunMock.mockResolvedValue({ status: "done" });
-
-    const response = await postWorkerKill("", REQUESTER_WRITE_HEADERS);
-    await expectRequesterKillResponse(response, false);
-    expect(killControlledSubagentRunMock).toHaveBeenCalledTimes(1);
-    const killCall = killControlledSubagentRunMock.mock.calls.at(0)?.[0] as
-      | {
-          cfg?: unknown;
-          controller?: { controllerSessionKey?: string };
-          entry?: { runId?: string; childSessionKey?: string };
-        }
-      | undefined;
-    expect(killCall?.cfg).toBe(cfg);
-    expect(killCall?.controller?.controllerSessionKey).toBe("agent:main:main");
-    expect(killCall?.entry?.runId).toBe("run-current-ended");
-    expect(killCall?.entry?.childSessionKey).toBe(WORKER_SESSION_KEY);
-  });
-
-  it("rejects bearer-auth requester kills without a trusted write scope surface", async () => {
-    isLocalDirectRequestMock.mockReturnValue(false);
+  it("rejects bearer-auth requester kills without a trusted admin scope surface", async () => {
     const response = await post(
       "/sessions/agent%3Amain%3Asubagent%3Aworker/kill",
       TEST_GATEWAY_TOKEN,
@@ -336,10 +276,9 @@ describe("POST /sessions/:sessionKey/kill", () => {
     expect(response.status).toBe(403);
     expectErrorResponse(await response.json(), {
       type: "forbidden",
-      message: "missing scope: operator.write",
+      message: "missing scope: operator.admin",
     });
     expect(loadSessionEntryMock).not.toHaveBeenCalled();
     expect(killSubagentRunAdminMock).not.toHaveBeenCalled();
-    expect(killControlledSubagentRunMock).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/session-kill-http.ts
+++ b/src/gateway/session-kill-http.ts
@@ -1,16 +1,10 @@
 // Gateway HTTP session kill handler.
-// Allows local admins or owning parent sessions to stop subagent runs.
+// Stops subagent runs through the admin-scoped HTTP control surface.
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import {
-  killControlledSubagentRun,
-  killSubagentRunAdmin,
-  resolveSubagentController,
-} from "../agents/subagent-control.js";
-import { getLatestSubagentRunByChildSessionKey } from "../agents/subagent-registry.js";
+import { killSubagentRunAdmin } from "../agents/subagent-control.js";
 import { getRuntimeConfig } from "../config/io.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
-import { isLocalDirectRequest, type ResolvedGatewayAuth } from "./auth.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
 import {
   sendInvalidRequest,
   sendJson,
@@ -23,8 +17,6 @@ import {
 } from "./http-utils.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import { loadSessionEntry } from "./session-utils.js";
-
-const REQUESTER_SESSION_KEY_HEADER = "x-openclaw-requester-session-key";
 
 type SessionKeyPathResolution =
   | { matched: false }
@@ -86,30 +78,8 @@ export async function handleSessionKillHttpRequest(
     return true;
   }
 
-  const trustedProxies = opts.trustedProxies ?? cfg.gateway?.trustedProxies;
-  const allowRealIpFallback = opts.allowRealIpFallback ?? cfg.gateway?.allowRealIpFallback;
-  const requesterSessionKey = normalizeOptionalString(
-    req.headers[REQUESTER_SESSION_KEY_HEADER]?.toString(),
-  );
-  const allowLocalAdminKill = isLocalDirectRequest(req, trustedProxies, allowRealIpFallback);
   const requestedScopes = resolveTrustedHttpOperatorScopes(req, requestAuth);
-
-  // Remote browser requests must prove parent-session ownership; local direct
-  // operator requests can perform the stronger admin kill path.
-  if (!requesterSessionKey && !allowLocalAdminKill) {
-    sendJson(res, 403, {
-      ok: false,
-      error: {
-        type: "forbidden",
-        message: "Session kills require a local admin request or requester session ownership.",
-      },
-    });
-    return true;
-  }
-
-  const requiredOperatorMethod =
-    requesterSessionKey && !allowLocalAdminKill ? "sessions.abort" : "sessions.delete";
-  const scopeAuth = authorizeOperatorScopesForMethod(requiredOperatorMethod, requestedScopes);
+  const scopeAuth = authorizeOperatorScopesForMethod("sessions.delete", requestedScopes);
   if (!scopeAuth.allowed) {
     sendMissingScopeForbidden(res, scopeAuth.missingScope);
     return true;
@@ -127,38 +97,14 @@ export async function handleSessionKillHttpRequest(
     return true;
   }
 
-  let killed = false;
-  if (!allowLocalAdminKill && requesterSessionKey) {
-    const runEntry = getLatestSubagentRunByChildSessionKey(canonicalKey);
-    if (runEntry) {
-      const result = await killControlledSubagentRun({
-        cfg,
-        controller: resolveSubagentController({ cfg, agentSessionKey: requesterSessionKey }),
-        entry: runEntry,
-      });
-      if (result.status === "forbidden") {
-        sendJson(res, 403, {
-          ok: false,
-          error: {
-            type: "forbidden",
-            message: result.error,
-          },
-        });
-        return true;
-      }
-      killed = result.status === "ok";
-    }
-  } else {
-    const result = await killSubagentRunAdmin({
-      cfg,
-      sessionKey: canonicalKey,
-    });
-    killed = result.killed;
-  }
+  const result = await killSubagentRunAdmin({
+    cfg,
+    sessionKey: canonicalKey,
+  });
 
   sendJson(res, 200, {
     ok: true,
-    killed,
+    killed: result.killed,
   });
   return true;
 }


### PR DESCRIPTION
## Summary

- Fixes the HTTP session-kill authorization path so `POST /sessions/:sessionKey/kill` no longer treats client-declared `x-openclaw-requester-session-key` as parent-session ownership proof.
- Requires the existing `sessions.delete` / `operator.admin` scope before session lookup, then always routes authorized requests through the established admin kill helper.
- Removes the stale requester-owned HTTP kill branch; admin-scoped local and trusted HTTP kill behavior stays intact.
- Intentionally out of scope: adding a new non-admin HTTP kill capability. The current HTTP auth result has no authenticated session-key binding to make that ownership claim trustworthy.

## Linked context

Maintainer-requested security sweep. No linked issue.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: trusted HTTP callers with only `operator.write` can no longer spoof `x-openclaw-requester-session-key` to kill a child session owned by another requester.
- Real environment tested: local OpenClaw checkout exercising the gateway HTTP handler through its HTTP-server regression test.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/session-kill-http.test.ts`
- Evidence after fix: `[test] passed 1 Vitest shard`; `Test Files 4 passed (4)`; `Tests 52 passed (52)`.
- Observed result after fix: trusted-proxy requester-session kill with `operator.write` returns `403` / `missing scope: operator.admin`; admin-scoped requests still return `200` and call `killSubagentRunAdmin` with the canonical session key.
- What was not tested: a live remote gateway/devbox run.
- Proof limitations or environment constraints: remote devbox execution from this workstation was blocked before repo commands ran because the local SSH signing agent refused signing; PR CI is the broad remote gate.
- Before evidence: the removed regression expected write-scoped requester-session HTTP kills to succeed through `killControlledSubagentRun`.

## Tests and validation

- `node scripts/run-vitest.mjs src/gateway/session-kill-http.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> `autoreview clean: no accepted/actionable findings reported`

Regression coverage now asserts that the spoofable requester header is rejected without `operator.admin`, and that admin-scoped requests ignore the requester header and use the admin kill path.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Non-admin HTTP requester-session kills are no longer accepted.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. HTTP session kills now require the admin session-delete scope.

What is the highest-risk area?

Remote clients that were relying on the previous write-scoped requester-session HTTP kill path now need an admin-scoped caller or a future session-bound HTTP proof mechanism.

How is that risk mitigated?

The removed path had no trustworthy HTTP binding between the caller and the declared requester session key. The admin path remains available and covered, and the direct local/admin Control UI behavior remains intact.

## Current review state

Next action: CI, review, then land if green.

Waiting on: GitHub CI. Remote devbox proof is blocked by local SSH signing on this workstation; focused local regression proof and autoreview are complete.

Reviewer comments addressed: none yet.
