### PR TITLE
test(models): stabilize plugin auth marker fixtures

### DIFF
--- a/src/agents/model-auth-markers.test.ts
+++ b/src/agents/model-auth-markers.test.ts
@@ -2,9 +2,11 @@
  * Regression coverage for non-secret model-auth marker helpers.
  * Verifies core, plugin, env-var, OAuth, AWS, and secret-ref marker handling.
  */
+import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
 
+const BUNDLED_PLUGINS_DIR = fileURLToPath(new URL("../../extensions/", import.meta.url));
 const PLUGIN_MANIFEST_ENV_KEYS = [
   "OPENCLAW_BUNDLED_PLUGINS_DIR",
   "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
@@ -14,9 +16,12 @@ const PLUGIN_MANIFEST_ENV_KEYS = [
   "OPENCLAW_TEST_MINIMAL_GATEWAY",
 ] as const;
 
-function cleanPluginManifestEnv(): Record<(typeof PLUGIN_MANIFEST_ENV_KEYS)[number], undefined> {
+function cleanPluginManifestEnv(): Record<
+  (typeof PLUGIN_MANIFEST_ENV_KEYS)[number],
+  string | undefined
+> {
   return {
-    OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+    OPENCLAW_BUNDLED_PLUGINS_DIR: BUNDLED_PLUGINS_DIR,
     OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
     OPENCLAW_SKIP_PROVIDERS: undefined,
     OPENCLAW_SKIP_CHANNELS: undefined,
@@ -35,6 +40,7 @@ let listKnownNonSecretApiKeyMarkers: typeof import("./model-auth-markers.js").li
 let resolveOAuthApiKeyMarker: typeof import("./model-auth-markers.js").resolveOAuthApiKeyMarker;
 
 async function loadMarkerModules() {
+  vi.doUnmock("../plugins/manifest-metadata-scan.js");
   vi.doUnmock("../plugins/manifest-registry.js");
   vi.doUnmock("../secrets/provider-env-vars.js");
   vi.resetModules();

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -29,6 +29,19 @@ vi.mock("../plugins/plugin-registry.js", () => ({
   }),
 }));
 
+vi.mock("../plugins/manifest-metadata-scan.js", () => ({
+  listOpenClawPluginManifestMetadata: () => [
+    {
+      pluginDir: "/bundled/anthropic-vertex",
+      origin: "bundled",
+      manifest: {
+        id: "anthropic-vertex",
+        nonSecretAuthMarkers: ["gcp-vertex-credentials"],
+      },
+    },
+  ],
+}));
+
 vi.mock("../plugins/providers.js", () => ({
   resolveOwningPluginIdsForProvider: () => [],
   resolveOwningPluginIdsForProviderRef: () => [],


### PR DESCRIPTION
## Summary

- Mock the current manifest-metadata scan seam in `model-auth.test.ts` so the Vertex ADC marker fixture matches production ownership.
- Make bundled marker discovery deterministic in `model-auth-markers.test.ts` by pointing it at the repository plugin tree.
- Explicitly unmock the scanner before loading the real marker helper, preventing cross-file leakage under the non-isolated Vitest runner.

## Why

Current `main` fails the Vertex ADC marker assertion because the auth test still mocks the retired plugin-registry seam. The marker helper test also depends on implicit bundled-plugin root discovery, which is not stable under the isolated test home.

Runtime behavior is unchanged. `gcp-vertex-credentials` remains provider-owned in `extensions/anthropic-vertex/openclaw.plugin.json`.

## Verification

```bash
node scripts/run-vitest.mjs \
  src/agents/model-auth.test.ts \
  src/agents/model-auth-markers.test.ts \
  extensions/openai/openai-provider.test.ts \
  extensions/anthropic/index.test.ts \
  src/agents/anthropic-transport-stream.test.ts \
  src/llm/providers/openai-responses-shared.test.ts \
  src/llm/providers/openai-completions.test.ts \
  src/llm/providers/openai-chatgpt-responses.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json
pnpm exec oxfmt --check src/agents/model-auth.test.ts src/agents/model-auth-markers.test.ts
git diff --check
```

Results:

- 259 relevant model-auth and official OpenAI/Anthropic tests passed.
- Production and test typechecks passed.
- Fresh forced OpenAI Responses tool call passed with `gpt-5.4-mini`.
- Fresh forced Anthropic Messages tool call passed with `claude-sonnet-4-6`.
- Remote changed gate passed: `run_b6407adeaf8c`.
- Final autoreview found no actionable findings.
