### PR TITLE
feat(control-ui): add right-click Reply in Dashboard webchat

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -504,6 +504,111 @@
   height: 14px;
 }
 
+/* Reply preview bar above composer */
+.chat-reply-preview {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  margin-bottom: 4px;
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.chat-reply-preview__icon {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.chat-reply-preview__icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.chat-reply-preview__label {
+  font-weight: 600;
+  flex-shrink: 0;
+  color: var(--accent);
+}
+
+.chat-reply-preview__text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fg);
+}
+
+.chat-reply-preview__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.chat-reply-preview__dismiss:hover {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+}
+
+.chat-reply-preview__dismiss svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2px;
+}
+
+/* Right-click reply context menu */
+.chat-reply-context-menu {
+  position: fixed;
+  z-index: 9999;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  min-width: 160px;
+}
+
+.chat-reply-context-menu button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: none;
+  color: var(--fg);
+  font-size: 13px;
+  cursor: pointer;
+  border-radius: 6px;
+  text-align: left;
+}
+
+.chat-reply-context-menu button:hover {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.chat-reply-context-menu button svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
 /* Compose input row - horizontal layout */
 .chat-compose__row {
   display: flex;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -593,14 +593,15 @@
   border: none;
   background: none;
   color: var(--fg);
-  font-size: 13px;
   cursor: pointer;
   border-radius: 6px;
   text-align: left;
 }
 
-.chat-reply-context-menu button:hover {
+.chat-reply-context-menu button:hover,
+.chat-reply-context-menu button:focus-visible {
   background: color-mix(in srgb, var(--accent) 12%, transparent);
+  outline: none;
 }
 
 .chat-reply-context-menu button svg {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -2445,6 +2445,59 @@ describe("handleSendChat", () => {
     expect(userMessage.role).toBe("user");
   });
 
+  it("escapes reply sender labels and clears reply state after chat.send is acknowledged", async () => {
+    const sent = createDeferred<unknown>();
+    const request = vi.fn((method: string) => {
+      if (method === "chat.send") {
+        return sent.promise;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "continue",
+      chatReplyTarget: {
+        messageId: "reply-source-1",
+        text: "quoted body",
+        senderLabel: "A *B* [C]",
+      },
+    });
+
+    const send = handleSendChat(host);
+    await Promise.resolve();
+
+    expect(host.chatReplyTarget?.messageId).toBe("reply-source-1");
+    expect(host.chatQueue[0]?.text).toBe("> **A \\*B\\* \\[C\\]:** quoted body\n\ncontinue");
+
+    sent.resolve({ runId: host.chatQueue[0]?.sendRunId, status: "started" });
+    await send;
+
+    expect(host.chatReplyTarget).toBeNull();
+  });
+
+  it("keeps reply state when chat.send fails before acceptance", async () => {
+    const request = vi.fn((method: string) => {
+      if (method === "chat.send") {
+        return Promise.resolve({ runId: "run-failed", status: "error" });
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "retry this",
+      chatReplyTarget: {
+        messageId: "reply-source-2",
+        text: "quoted body",
+        senderLabel: "User",
+      },
+    });
+
+    await handleSendChat(host);
+
+    expect(host.chatReplyTarget?.messageId).toBe("reply-source-2");
+    expect(host.chatMessage).toBe("retry this");
+  });
+
   it("routes queued Skill Workshop revisions through the proposal request RPC", async () => {
     const sent = createDeferred<unknown>();
     const request = vi.fn((method: string) => {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1989,7 +1989,7 @@ function prependReplyQuote(
 }
 
 function escapeMarkdownInline(value: string): string {
-  return value.replace(/([\\`*_{}\[\]()#+\-.!|>])/g, "\\$1");
+  return value.replace(/([\\`*_{}[\]()#+\-.!|>])/g, "\\$1");
 }
 
 // ── Slash Command Dispatch ──

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -137,6 +137,8 @@ export type ChatHost = ChatInputHistoryState & {
   tab?: string;
   /** Callback for slash-command side effects that need app-level access. */
   onSlashAction?: (action: string) => void | Promise<void>;
+  /** Selected message to reply to (right-click / keyboard shortcut). */
+  chatReplyTarget?: { messageId: string; text: string; senderLabel?: string | null } | null;
 };
 
 type ChatAgentsListSnapshot = Partial<Omit<AgentsListResult, "agents">> & {
@@ -1872,11 +1874,14 @@ export async function handleSendChat(
     }
   }
 
+  const replyTarget = host.chatReplyTarget;
+  const effectiveMessage = replyTarget ? prependReplyQuote(message, replyTarget) : message;
+
   const refreshSessions = shouldInterpretChatCommands && isChatResetCommand(message);
   const submitKey = chatSubmitKey(
     host,
     "message",
-    message,
+    effectiveMessage,
     attachmentsToSend,
     skillWorkshopRevision,
   );
@@ -1896,7 +1901,7 @@ export async function handleSendChat(
     const waitingForModel = modelSwitchReady !== true;
     const queued = enqueuePendingSendMessage(
       host,
-      message,
+      effectiveMessage,
       hasAttachments ? attachmentsToSend : undefined,
       refreshSessions,
       submittedAtMs,
@@ -1906,6 +1911,8 @@ export async function handleSendChat(
     if (!queued) {
       return;
     }
+    // Quote is captured in the queue; safe to clear the transient reply target.
+    host.chatReplyTarget = null;
 
     if (modelSwitchReady !== true && !(await modelSwitchReady)) {
       if (host.sessionKey === submittedSessionKey) {
@@ -1943,7 +1950,7 @@ export async function handleSendChat(
       return;
     }
 
-    await sendChatMessageNow(host, message, {
+    await sendChatMessageNow(host, effectiveMessage, {
       queueItemId: queued.id,
       previousDraft: cleared.previousDraft,
       restoreDraft: Boolean(messageOverride && opts?.restoreDraft),
@@ -1958,6 +1965,22 @@ export async function handleSendChat(
 
 function shouldQueueLocalSlashCommand(name: string): boolean {
   return !["stop", "export-session", "steer", "redirect", "new"].includes(name);
+}
+
+function prependReplyQuote(
+  message: string,
+  replyTarget: NonNullable<ChatHost["chatReplyTarget"]>,
+): string {
+  const label = replyTarget.senderLabel ?? "User";
+  const text = replyTarget.text.trim();
+  if (!text.includes("\n")) {
+    return `> **${label}:** ${text}\n\n${message}`;
+  }
+  const quoted = text
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+  return `> **${label}:**\n${quoted}\n\n${message}`;
 }
 
 // ── Slash Command Dispatch ──
@@ -2068,6 +2091,7 @@ async function clearChatHistory(host: ChatHost) {
     host.chatMessages = [];
     clearCachedChatMessagesForSession(host, host.sessionKey);
     host.chatSideResult = null;
+    host.chatReplyTarget = null;
     reconcileChatRunLifecycle(host as unknown as Parameters<typeof reconcileChatRunLifecycle>[0], {
       outcome: hadActiveRun ? "interrupted" : undefined,
       sessionStatus: "killed",

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1911,9 +1911,6 @@ export async function handleSendChat(
     if (!queued) {
       return;
     }
-    // Quote is captured in the queue; safe to clear the transient reply target.
-    host.chatReplyTarget = null;
-
     if (modelSwitchReady !== true && !(await modelSwitchReady)) {
       if (host.sessionKey === submittedSessionKey) {
         cancelPendingSendBeforeRequest(host, queued, {
@@ -1950,7 +1947,7 @@ export async function handleSendChat(
       return;
     }
 
-    await sendChatMessageNow(host, effectiveMessage, {
+    const accepted = await sendChatMessageNow(host, effectiveMessage, {
       queueItemId: queued.id,
       previousDraft: cleared.previousDraft,
       restoreDraft: Boolean(messageOverride && opts?.restoreDraft),
@@ -1960,6 +1957,14 @@ export async function handleSendChat(
       refreshSessions,
       submittedAtMs,
     });
+    if (
+      accepted &&
+      replyTarget &&
+      host.chatReplyTarget?.messageId === replyTarget.messageId &&
+      host.sessionKey === submittedSessionKey
+    ) {
+      host.chatReplyTarget = null;
+    }
   });
 }
 
@@ -1971,7 +1976,7 @@ function prependReplyQuote(
   message: string,
   replyTarget: NonNullable<ChatHost["chatReplyTarget"]>,
 ): string {
-  const label = replyTarget.senderLabel ?? "User";
+  const label = escapeMarkdownInline(replyTarget.senderLabel ?? "User");
   const text = replyTarget.text.trim();
   if (!text.includes("\n")) {
     return `> **${label}:** ${text}\n\n${message}`;
@@ -1981,6 +1986,10 @@ function prependReplyQuote(
     .map((line) => `> ${line}`)
     .join("\n");
   return `> **${label}:**\n${quoted}\n\n${message}`;
+}
+
+function escapeMarkdownInline(value: string): string {
+  return value.replace(/([\\`*_{}\[\]()#+\-.!|>])/g, "\\$1");
 }
 
 // ── Slash Command Dispatch ──

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -169,6 +169,7 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
   chatSessionState.reconnectResumeSessionId = null;
   state.chatMessage = "";
   state.chatAttachments = [];
+  state.chatReplyTarget = null;
   state.chatMessages = restoreChatMessagesForSession(state, sessionKey);
   state.chatToolMessages = [];
   state.activityEntries = [];

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -3851,6 +3851,15 @@ export function renderApp(state: AppViewState) {
                   onDismissSideResult: () => {
                     state.chatSideResult = null;
                   },
+                  replyTarget: state.chatReplyTarget ?? null,
+                  onClearReply: () => {
+                    state.chatReplyTarget = null;
+                    requestHostUpdate?.();
+                  },
+                  onSetReply: (target) => {
+                    state.chatReplyTarget = target;
+                    requestHostUpdate?.();
+                  },
                   onNewSession: () => void createChatSession(state, { source: "user" }),
                   onClearHistory: runUiTask(async () => {
                     if (!state.client || !state.connected) {
@@ -3867,6 +3876,7 @@ export function renderApp(state: AppViewState) {
                         sessionKey: state.sessionKey,
                       });
                       state.chatSideResult = null;
+                      state.chatReplyTarget = null;
                       reconcileChatRunLifecycle(
                         state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0],
                         {

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -101,6 +101,7 @@ export type AppViewState = {
   chatSending: boolean;
   chatMessage: string;
   chatAttachments: ChatAttachment[];
+  chatReplyTarget?: { messageId: string; text: string; senderLabel?: string | null } | null;
   chatMessages: unknown[];
   chatToolMessages: unknown[];
   activityEntries: ActivityEntry[];

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -320,6 +320,11 @@ export class OpenClawApp extends LitElement {
   @state() chatQueueBySession: Record<string, ChatQueueItem[]> = {};
   @state() chatMessagesBySession: ChatMessageCache = new Map();
   @state() chatAttachments: ChatAttachment[] = [];
+  @state() chatReplyTarget: {
+    messageId: string;
+    text: string;
+    senderLabel?: string | null;
+  } | null = null;
   @state() realtimeTalkActive = false;
   @state() realtimeTalkStatus: RealtimeTalkStatus = "idle";
   @state() realtimeTalkDetail: string | null = null;

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1772,7 +1772,7 @@ function renderGroupedMessage(
   const duplicateCount = Math.max(1, Math.floor(opts.duplicateCount ?? 1));
 
   return html`
-    <div class="${bubbleClasses}">
+    <div class="${bubbleClasses}" data-message-text=${extractedText || nothing}>
       ${renderReplyPill(normalizedMessage.replyTarget)}
       ${hasActions
         ? html`<div class="chat-bubble-actions">

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1772,7 +1772,11 @@ function renderGroupedMessage(
   const duplicateCount = Math.max(1, Math.floor(opts.duplicateCount ?? 1));
 
   return html`
-    <div class="${bubbleClasses}" data-message-text=${extractedText || nothing}>
+    <div
+      class="${bubbleClasses}"
+      data-message-id=${messageKey}
+      data-message-text=${extractedText || nothing}
+    >
       ${renderReplyPill(normalizedMessage.replyTarget)}
       ${hasActions
         ? html`<div class="chat-bubble-actions">

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -4426,6 +4426,7 @@ describe("right-click Reply", () => {
     group.className = "chat-group";
     const bubble = document.createElement("div");
     bubble.className = "chat-bubble";
+    bubble.dataset.messageId = "msg-stable-1";
     bubble.dataset.messageText = "hello world";
     const sender = document.createElement("span");
     sender.className = "chat-sender-name";
@@ -4443,8 +4444,71 @@ describe("right-click Reply", () => {
 
     expect(onSetReply).toHaveBeenCalledTimes(1);
     const target = onSetReply.mock.calls[0][0];
+    expect(target.messageId).toBe("msg-stable-1");
     expect(target.text).toBe("hello world");
     expect(target.senderLabel).toBe("User");
+  });
+
+  it("keeps the native context menu when Reply is unavailable", () => {
+    const container = renderChatView();
+    const section = container.querySelector<HTMLElement>(".card.chat");
+    expect(section).not.toBeNull();
+
+    const group = document.createElement("div");
+    group.className = "chat-group";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble streaming";
+    bubble.dataset.messageText = "still streaming";
+    group.appendChild(bubble);
+    section!.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    bubble.dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(false);
+    expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
+  });
+
+  it("dismisses the reply context menu with Escape after delayed listeners register", () => {
+    const onSetReply = vi.fn();
+    const frameCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallbacks.push(callback);
+        return frameCallbacks.length;
+      }),
+    );
+    const container = renderChatView({ onSetReply });
+    const section = container.querySelector<HTMLElement>(".card.chat");
+    expect(section).not.toBeNull();
+
+    const group = document.createElement("div");
+    group.className = "chat-group";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    bubble.dataset.messageText = "hello world";
+    group.appendChild(bubble);
+    section!.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    for (const callback of frameCallbacks.splice(0)) {
+      callback(0);
+    }
+
+    const menu = document.querySelector<HTMLElement>(".chat-reply-context-menu");
+    expect(menu).not.toBeNull();
+    expect(menu!.getAttribute("role")).toBe("menu");
+    expect(menu!.getAttribute("aria-label")).toBe("Message actions");
+    const button = menu!.querySelector<HTMLButtonElement>("button");
+    expect(button?.getAttribute("role")).toBe("menuitem");
+    expect(document.activeElement).toBe(button);
+
+    const evt = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
+    document.dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(true);
+    expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
   });
 
   it("renders reply preview bar with quote text and dismiss button", () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -4413,3 +4413,124 @@ describe("chat session controls", () => {
     expect(thinkingSelect.title).toContain("Adaptive");
   });
 });
+
+describe("right-click Reply", () => {
+  it("opens context menu and calls onSetReply when Reply is selected", () => {
+    const onSetReply = vi.fn();
+    const container = renderChatView({ onSetReply });
+    const section = container.querySelector<HTMLElement>(".card.chat");
+    expect(section).not.toBeNull();
+
+    // Create a real chat bubble inside a group with the data-message-text attribute
+    const group = document.createElement("div");
+    group.className = "chat-group";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    bubble.dataset.messageText = "hello world";
+    const sender = document.createElement("span");
+    sender.className = "chat-sender-name";
+    sender.textContent = "User";
+    group.appendChild(sender);
+    group.appendChild(bubble);
+    section!.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    bubble.dispatchEvent(evt);
+
+    const menu = document.querySelector(".chat-reply-context-menu");
+    expect(menu).not.toBeNull();
+    menu!.querySelector("button")!.click();
+
+    expect(onSetReply).toHaveBeenCalledTimes(1);
+    const target = onSetReply.mock.calls[0][0];
+    expect(target.text).toBe("hello world");
+    expect(target.senderLabel).toBe("User");
+  });
+
+  it("renders reply preview bar with quote text and dismiss button", () => {
+    const container = renderChatView({
+      replyTarget: {
+        messageId: "msg-1",
+        text: "quoted message",
+        senderLabel: "User",
+      },
+    });
+
+    const preview = container.querySelector(".chat-reply-preview");
+    expect(preview).not.toBeNull();
+    expect(preview!.textContent).toContain("quoted message");
+    expect(preview!.textContent).toContain("User");
+
+    const dismiss = preview!.querySelector<HTMLButtonElement>(".chat-reply-preview__dismiss");
+    expect(dismiss).not.toBeNull();
+  });
+
+  it("calls onClearReply when dismiss button is clicked", () => {
+    const onClearReply = vi.fn();
+    const container = renderChatView({
+      replyTarget: {
+        messageId: "msg-1",
+        text: "quoted",
+        senderLabel: "User",
+      },
+      onClearReply,
+    });
+
+    container.querySelector<HTMLButtonElement>(".chat-reply-preview__dismiss")!.click();
+    expect(onClearReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears reply target on Escape when no other handler intercepted", () => {
+    const onClearReply = vi.fn();
+    const container = renderChatView({
+      replyTarget: {
+        messageId: "msg-1",
+        text: "quoted",
+        senderLabel: "User",
+      },
+      onClearReply,
+    });
+
+    const section = container.querySelector<HTMLElement>(".card.chat");
+    const evt = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    section!.dispatchEvent(evt);
+
+    expect(onClearReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not clear reply target when Escape is already defaultPrevented", () => {
+    const onClearReply = vi.fn();
+    const container = renderChatView({
+      replyTarget: {
+        messageId: "msg-1",
+        text: "quoted",
+        senderLabel: "User",
+      },
+      onClearReply,
+    });
+
+    const section = container.querySelector<HTMLElement>(".card.chat");
+    const evt = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(evt, "defaultPrevented", { value: true });
+    section!.dispatchEvent(evt);
+
+    expect(onClearReply).not.toHaveBeenCalled();
+  });
+
+  it("does not open Reply menu when onSetReply is absent", () => {
+    renderChatView({
+      messages: [{ role: "user", content: "hello", timestamp: 1 }],
+    });
+
+    // Without onSetReply, the handler returns early and no menu is created
+    expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
+  });
+});

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -2030,14 +2030,58 @@ function renderSlashMenu(
   `;
 }
 
+let activeReplyContextMenu: HTMLElement | null = null;
+let contextMenuDocumentClickHandler: ((e: MouseEvent) => void) | null = null;
 let contextMenuKeydownHandler: ((e: KeyboardEvent) => void) | null = null;
 
 function removeReplyContextMenu() {
+  activeReplyContextMenu?.remove();
+  activeReplyContextMenu = null;
   document.querySelector(".chat-reply-context-menu")?.remove();
+  if (contextMenuDocumentClickHandler) {
+    document.removeEventListener("click", contextMenuDocumentClickHandler);
+    contextMenuDocumentClickHandler = null;
+  }
   if (contextMenuKeydownHandler) {
     document.removeEventListener("keydown", contextMenuKeydownHandler);
     contextMenuKeydownHandler = null;
   }
+}
+
+function stableReplyMessageId(senderLabel: string | undefined, text: string): string {
+  const source = `${senderLabel ?? ""}\n${text}`;
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < source.length; index += 1) {
+    hash ^= source.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `reply:${(hash >>> 0).toString(16)}`;
+}
+
+function createReplyContextMenuButton(onClick: () => void): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.setAttribute("role", "menuitem");
+  button.setAttribute("aria-label", "Reply to message");
+
+  const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  icon.setAttribute("viewBox", "0 0 24 24");
+  icon.setAttribute("width", "16");
+  icon.setAttribute("height", "16");
+  icon.setAttribute("fill", "currentColor");
+  icon.setAttribute("stroke", "none");
+  icon.setAttribute("aria-hidden", "true");
+  icon.setAttribute("focusable", "false");
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("d", "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z");
+  icon.appendChild(path);
+
+  const label = document.createElement("span");
+  label.textContent = "Reply";
+
+  button.append(icon, label);
+  button.addEventListener("click", onClick);
+  return button;
 }
 
 export function renderChat(props: ChatProps) {
@@ -2099,7 +2143,6 @@ export function renderChat(props: ChatProps) {
   };
   const handleChatContextMenu = (e: MouseEvent, p: ChatProps) => {
     const bubble = (e.target as HTMLElement).closest(".chat-bubble");
-    // Always suppress native menu on chat bubbles; we show our own Reply menu.
     if (!bubble) {
       return;
     }
@@ -2125,20 +2168,23 @@ export function renderChat(props: ChatProps) {
     }
     e.preventDefault();
     e.stopPropagation();
-    const messageId = `msg-${Date.now()}`;
+    const messageId =
+      (bubble as HTMLElement).dataset.messageId?.trim() || stableReplyMessageId(senderLabel, text);
     removeReplyContextMenu();
     const menu = document.createElement("div");
     menu.className = "chat-reply-context-menu";
     menu.setAttribute("role", "menu");
-    menu.innerHTML = `<button type="button" role="menuitem"><svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" stroke="none"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg> Reply</button>`;
+    menu.setAttribute("aria-label", "Message actions");
     menu.style.left = `${e.clientX}px`;
     menu.style.top = `${e.clientY}px`;
-    menu.querySelector("button")?.addEventListener("click", () => {
+    const button = createReplyContextMenuButton(() => {
       p.onSetReply?.({ messageId, text, senderLabel });
       removeReplyContextMenu();
       composerTextarea?.focus();
     });
+    menu.append(button);
     document.body.appendChild(menu);
+    activeReplyContextMenu = menu;
     // Clamp menu position within the viewport
     const menuRect = menu.getBoundingClientRect();
     let left = e.clientX;
@@ -2151,15 +2197,26 @@ export function renderChat(props: ChatProps) {
     }
     menu.style.left = `${Math.max(0, left)}px`;
     menu.style.top = `${Math.max(0, top)}px`;
-    menu.querySelector<HTMLButtonElement>("button")?.focus();
+    button.focus();
     requestAnimationFrame(() => {
-      document.addEventListener("click", removeReplyContextMenu, { once: true });
-      const handleKeydown = (ev: KeyboardEvent) => {
-        if (ev.key === "Escape") {
+      if (!menu.isConnected || activeReplyContextMenu !== menu) {
+        return;
+      }
+      contextMenuDocumentClickHandler = (ev: MouseEvent) => {
+        if (!menu.contains(ev.target as Node | null)) {
           removeReplyContextMenu();
         }
       };
+      const handleKeydown = (ev: KeyboardEvent) => {
+        if (ev.key === "Escape") {
+          ev.preventDefault();
+          ev.stopPropagation();
+          removeReplyContextMenu();
+          composerTextarea?.focus();
+        }
+      };
       contextMenuKeydownHandler = handleKeydown;
+      document.addEventListener("click", contextMenuDocumentClickHandler);
       document.addEventListener("keydown", handleKeydown);
     });
   };

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -203,6 +203,12 @@ export type ChatProps = {
   onChatScroll?: (event: Event) => void;
   basePath?: string;
   composerControls?: TemplateResult | typeof nothing | ReturnType<typeof guard>;
+  /** Selected message to reply to (set via right-click or keyboard shortcut). */
+  replyTarget?: { messageId: string; text: string; senderLabel?: string | null } | null;
+  /** Clear the current reply target. */
+  onClearReply?: () => void;
+  /** Set the reply target from a message element. */
+  onSetReply?: (target: { messageId: string; text: string; senderLabel?: string | null }) => void;
   sessionWorkspace?: {
     collapsed: boolean;
     sessionKey: string;
@@ -2024,6 +2030,16 @@ function renderSlashMenu(
   `;
 }
 
+let contextMenuKeydownHandler: ((e: KeyboardEvent) => void) | null = null;
+
+function removeReplyContextMenu() {
+  document.querySelector(".chat-reply-context-menu")?.remove();
+  if (contextMenuKeydownHandler) {
+    document.removeEventListener("keydown", contextMenuKeydownHandler);
+    contextMenuKeydownHandler = null;
+  }
+}
+
 export function renderChat(props: ChatProps) {
   const canCompose = props.connected;
   const isBusy = props.sending || props.stream !== null;
@@ -2081,6 +2097,72 @@ export function renderChat(props: ChatProps) {
       setTimeout(() => btn.classList.remove("copied"), 1500);
     });
   };
+  const handleChatContextMenu = (e: MouseEvent, p: ChatProps) => {
+    const bubble = (e.target as HTMLElement).closest(".chat-bubble");
+    // Always suppress native menu on chat bubbles; we show our own Reply menu.
+    if (!bubble) {
+      return;
+    }
+    if (typeof p.onSetReply !== "function") {
+      return;
+    }
+    const group = bubble.closest(".chat-group");
+    if (!group) {
+      return;
+    }
+    // Skip streaming messages and reading indicators
+    if (
+      group.querySelector(".chat-reading-indicator") ||
+      group.querySelector(".chat-bubble.streaming")
+    ) {
+      return;
+    }
+    const senderEl = group.querySelector(".chat-sender-name");
+    const senderLabel = senderEl?.textContent?.trim() ?? undefined;
+    const text = (bubble as HTMLElement).dataset.messageText?.trim().slice(0, 500) ?? "";
+    if (!text) {
+      return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+    const messageId = `msg-${Date.now()}`;
+    removeReplyContextMenu();
+    const menu = document.createElement("div");
+    menu.className = "chat-reply-context-menu";
+    menu.setAttribute("role", "menu");
+    menu.innerHTML = `<button type="button" role="menuitem"><svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" stroke="none"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg> Reply</button>`;
+    menu.style.left = `${e.clientX}px`;
+    menu.style.top = `${e.clientY}px`;
+    menu.querySelector("button")?.addEventListener("click", () => {
+      p.onSetReply?.({ messageId, text, senderLabel });
+      removeReplyContextMenu();
+      composerTextarea?.focus();
+    });
+    document.body.appendChild(menu);
+    // Clamp menu position within the viewport
+    const menuRect = menu.getBoundingClientRect();
+    let left = e.clientX;
+    let top = e.clientY;
+    if (left + menuRect.width > window.innerWidth) {
+      left = window.innerWidth - menuRect.width - 8;
+    }
+    if (top + menuRect.height > window.innerHeight) {
+      top = window.innerHeight - menuRect.height - 8;
+    }
+    menu.style.left = `${Math.max(0, left)}px`;
+    menu.style.top = `${Math.max(0, top)}px`;
+    menu.querySelector<HTMLButtonElement>("button")?.focus();
+    requestAnimationFrame(() => {
+      document.addEventListener("click", removeReplyContextMenu, { once: true });
+      const handleKeydown = (ev: KeyboardEvent) => {
+        if (ev.key === "Escape") {
+          removeReplyContextMenu();
+        }
+      };
+      contextMenuKeydownHandler = handleKeydown;
+      document.addEventListener("keydown", handleKeydown);
+    });
+  };
   const handleChatThreadScroll = (event: Event) => {
     maybeExpandChatHistoryRenderWindow(event, requestUpdate);
     props.onChatScroll?.(event);
@@ -2126,6 +2208,7 @@ export function renderChat(props: ChatProps) {
       })}
       @scroll=${handleChatThreadScroll}
       @click=${handleCodeBlockCopy}
+      @contextmenu=${(e: MouseEvent) => handleChatContextMenu(e, props)}
     >
       <div class="chat-thread-inner">
         ${showLoadingSkeleton
@@ -2533,6 +2616,30 @@ export function renderChat(props: ChatProps) {
       @click=${(event: MouseEvent) => focusComposerFromChrome(event, props.connected)}
     >
       ${renderSlashMenu(requestUpdate, props, visibleDraft)} ${renderAttachmentPreview(props)}
+      ${props.replyTarget
+        ? html`
+            <div class="chat-reply-preview">
+              <span class="chat-reply-preview__icon">${icons.messageSquare}</span>
+              <span class="chat-reply-preview__label"
+                >Replying to ${props.replyTarget.senderLabel ?? "message"}</span
+              >
+              <span class="chat-reply-preview__text"
+                >${props.replyTarget.text.slice(0, 120)}${props.replyTarget.text.length > 120
+                  ? "…"
+                  : ""}</span
+              >
+              <button
+                type="button"
+                class="chat-reply-preview__dismiss"
+                @click=${() => props.onClearReply?.()}
+                aria-label="Cancel reply"
+                title="Cancel reply"
+              >
+                ${icons.x}
+              </button>
+            </div>
+          `
+        : nothing}
       <div class="agent-chat__composer-status-stack">
         ${renderFallbackIndicator(props.fallbackStatus)}
         ${renderCompactionIndicator(props.compactionStatus)}
@@ -2709,6 +2816,12 @@ export function renderChat(props: ChatProps) {
       class="card chat"
       @drop=${(e: DragEvent) => handleDrop(e, props)}
       @dragover=${(e: DragEvent) => e.preventDefault()}
+      @keydown=${(e: KeyboardEvent) => {
+        if (e.key === "Escape" && props.replyTarget && !e.defaultPrevented) {
+          e.preventDefault();
+          props.onClearReply?.();
+        }
+      }}
     >
       ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
       ${


### PR DESCRIPTION
## Summary

- Adds right-click Reply to messages in the Dashboard / Control UI webchat
- Right-click any chat bubble → "Reply" option → reply preview bar appears above the composer → type reply → message auto-prepended with Markdown blockquote
- Click ✕ on the preview bar or press Escape to cancel the reply

### How it works

Three new optional props on `ChatProps` (`replyTarget`, `onSetReply`, `onClearReply`) wired through `app-render.ts` into `renderChat`. A `@state() chatReplyTarget` on the app class holds the transient reply target. On send, `handleSendChat` reads the target, prepends a Markdown blockquote via `prependReplyQuote`, and clears the state.

### Quote format (what the model receives)

| Quoted message | Your reply | Sent to model |
|---|---|---|
| `hello world` | `got it` | `> **User:** hello world`<br><br>`got it` |
| `line one`<br>`line two` | `ok` | `> **User:**`<br>`> line one`<br>`> line two`<br><br>`ok` |

## Linked context

Closes #16896

## Real behavior proof

- **Behavior or issue addressed:** Users previously had to manually copy-paste messages to reference them. Now right-click → Reply sets a reply target with a visual preview, and the message is automatically quoted on send.
- **Real environment tested:** OpenClaw dev build (vite), WSL2 Ubuntu 22.04 on Windows 11, Chromium
- **Exact steps or command run after this patch:**
  1. `cd ui && pnpm dev`
  2. Right-click a chat bubble → context menu shows speech-bubble icon + "Reply"
  3. Click "Reply" → preview bar appears above composer with sender name, quoted text, and visible ✕
  4. Type a response and send
  5. Sent message includes `> **User:** ...` Markdown blockquote
  6. Click ✕ or press Escape → preview bar dismissed, plain send unaffected
- **Evidence after fix:**

<img alt="Right-click context menu with Reply option" src="https://github.com/user-attachments/assets/f40f7887-1dda-4910-9d31-3aa868a6a99e" />

<img alt="Reply preview bar above composer with dismiss button" src="https://github.com/user-attachments/assets/ec500ad9-31ef-4fe8-94df-bdff2d432235" />

<img alt="Sent message showing Markdown blockquote" src="https://github.com/user-attachments/assets/c1abe121-62e8-432b-83e6-041fa5a1693e" />

- **Observed result after fix:** Right-click reply works end-to-end. Context menu shows proper icon. Preview bar appears with sender name, quoted text, and visible dismiss button. Quoted message is prepended with correct Markdown format on send. Dismiss clears the state. Plain send without reply target is unaffected.
- **What was not tested:** Long message truncation in preview (>120 chars), interaction with slash commands while reply target is active, queueing behavior when chat is busy
- **Before evidence:** Before this change, the Control UI had no reply affordance — users had to manually copy text and paste with `>` prefix.

## Files changed

```
ui/src/ui/app-chat.ts        — prependReplyQuote + queue ordering fix
ui/src/ui/app-render.ts      — wire replyTarget/onSetReply/onClearReply into renderChat
ui/src/ui/app-view-state.ts  — add chatReplyTarget to AppViewState type
ui/src/ui/app.ts             — add @state() chatReplyTarget to OpenClawApp
ui/src/ui/views/chat.ts      — context-menu handler, reply preview bar, ChatProps additions
ui/src/styles/chat/layout.css — reply preview bar + context menu styles
```

## Risk checklist

- **User-visible behavior change:** Yes — new right-click Reply in Control UI
- **Config / migration / security / network:** No changes
- **Highest-risk area:** `bubble.textContent` extraction for quote text; mitigated by `.trim().slice(0, 500)`
- **Risk mitigation:** Reply target is transient state only, cleared on send or dismiss. No persistence.
