### PR TITLE
feat(usage): ship built-in /usage full footer

### DIFF
--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -95,7 +95,6 @@ empty (so a `when` guard or a `|fallback` keeps the piece clean).
 | `usage.input_tokens` / `usage.output_tokens` / `usage.cache_hit_pct`                | turn aggregate                         |
 | `usage.last.input_tokens` / `usage.last.output_tokens` / `usage.last.cache_hit_pct` | final model call only                  |
 | `cost.turn_usd`                                                                     | estimated turn cost                    |
-| `timing.duration_ms`                                                                | wall-clock ms                          |
 | `identity.name` / `identity.emoji`                                                  | agent name / chosen emoji              |
 
 (Provider rate-limit windows are **not** in this contract.)

--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -32,8 +32,13 @@ title: "Usage tracking"
 
 ## Custom `/usage full` footer
 
-`messages.usageTemplate` customizes the per-response `/usage full` footer. The
-value is a JSON file path (supports `~`) or an inline object:
+`/usage full` shows a built-in compact footer with model, reasoning, fast/slow,
+context window, final-call tokens, cache, and cost when those fields are
+available. No template file is required.
+
+`messages.usageTemplate` is only for advanced custom layouts. The value is a
+JSON file path (supports `~`) or an inline object, and it replaces the built-in
+footer when valid:
 
 ```json
 {
@@ -43,35 +48,30 @@ value is a JSON file path (supports `~`) or an inline object:
 }
 ```
 
-Set it to the string `"default"` to use OpenClaw's built-in footer as-is:
-
-```json
-{ "messages": { "usageTemplate": "default" } }
-```
-
-When unset, the legacy single-line footer is used; `"default"` opts into the
-richer built-in footer (model, reasoning, fast/slow, context-window bar, last-call
-tokens, cache, cost).
-
-Your template is **merged over that built-in footer**, the same way other config
-objects layer over defaults: nested objects (`scales`, `aliases`) extend
-key-by-key, while an `output.surfaces.<channel>` piece list replaces that
-channel's default. So a template only needs to contain what it adds or changes —
-start from `"default"` and override just the pieces you want. A missing,
-unreadable, or invalid template falls back to the built-in line.
+Missing, unreadable, invalid, or empty templates fall back to the built-in
+footer.
 
 ### Shape
 
 ```jsonc
 {
   "schema": "openclaw.usageBar.v1",
-  "scales":  { "<name>": "low→high glyphs" },   // string (1 glyph/char) or array
+  "scales": { "<name>": "low-to-high glyphs" }, // string (1 glyph/char) or array
   "aliases": { "<table>": { "<value>": "<label>" } },
   "output": {
-    "sep": "",                                  // joins surviving pieces
-    "default":  [ /* pieces */ ],               // fallback for any surface
-    "surfaces": { "discord": [ /* pieces */ ], "telegram": [ /* pieces */ ] }
-  }
+    "sep": "", // joins surviving pieces
+    "default": [
+      /* pieces */
+    ], // fallback for any surface
+    "surfaces": {
+      "discord": [
+        /* pieces */
+      ],
+      "telegram": [
+        /* pieces */
+      ],
+    },
+  },
 }
 ```
 
@@ -79,47 +79,47 @@ Each surface is an ordered list of **pieces**; the engine renders each, drops
 empties, and joins survivors with `sep`. A surface with no entry uses
 `output.default`.
 
-### Contract — the `{paths}` you can read
+### Contract Paths
 
 A piece reads values from the per-turn contract by dot-path. Absent values are
 empty (so a `when` guard or a `|fallback` keeps the piece clean).
 
-| Path | Meaning |
-| --- | --- |
-| `surface` | channel id (`discord`/`telegram`/…) |
-| `model.provider` · `model.display_name` | provider id · model id |
-| `model.reasoning` | effort (`off`…`xhigh`) |
-| `model.is_fallback` · `model.is_override` | bool — fallback used · model pinned |
-| `state.fast_mode` | bool — fast vs slow |
-| `context.max_tokens` · `context.pct_used` | window budget · 0–100 used |
-| `usage.input_tokens` · `usage.output_tokens` · `usage.cache_hit_pct` | turn aggregate |
-| `usage.last.input_tokens` · `usage.last.output_tokens` · `usage.last.cache_hit_pct` | final model call only |
-| `cost.turn_usd` | estimated turn cost |
-| `timing.duration_ms` | wall-clock ms |
-| `identity.name` · `identity.emoji` | agent name · chosen emoji |
+| Path                                                                                | Meaning                                |
+| ----------------------------------------------------------------------------------- | -------------------------------------- |
+| `surface`                                                                           | channel id (`discord`/`telegram`/etc.) |
+| `model.provider` / `model.display_name`                                             | provider id / model id                 |
+| `model.reasoning`                                                                   | effort (`off` through `xhigh`)         |
+| `model.is_fallback` / `model.is_override`                                           | bool: fallback used / model pinned     |
+| `state.fast_mode`                                                                   | bool: fast vs slow                     |
+| `context.max_tokens` / `context.pct_used`                                           | window budget / 0-100 used             |
+| `usage.input_tokens` / `usage.output_tokens` / `usage.cache_hit_pct`                | turn aggregate                         |
+| `usage.last.input_tokens` / `usage.last.output_tokens` / `usage.last.cache_hit_pct` | final model call only                  |
+| `cost.turn_usd`                                                                     | estimated turn cost                    |
+| `timing.duration_ms`                                                                | wall-clock ms                          |
+| `identity.name` / `identity.emoji`                                                  | agent name / chosen emoji              |
 
 (Provider rate-limit windows are **not** in this contract.)
 
-### Verbs — `{path|verb:arg|fallback}`
+### Verbs
 
-Pipe a value through verbs left→right; a non-verb segment is the fallback.
+Pipe a value through verbs left to right; a non-verb segment is the fallback.
 
-| Verb | Effect | Example |
-| --- | --- | --- |
-| `num` | compact count | `272000 → 272k` |
-| `fixed:N` | N decimals (default 2) | `0.0377` |
-| `dur` | seconds → duration | `14820 → 4h07m` |
-| `pct` | append `%` | `96 → 96%` |
-| `inv` | `100 − x` | for used→remaining |
-| `alias:TABLE` | lookup in `aliases`, echo if unlisted | `medium → 🌗` |
-| `meter:W:SCALE` | W-cell glyph bar over a 0–100 value | `[⣿⣿⠐⠐⠐]` (`meter:1` = one glyph) |
+| Verb            | Effect                                | Example                           |
+| --------------- | ------------------------------------- | --------------------------------- |
+| `num`           | compact count                         | `272000 -> 272k`                  |
+| `fixed:N`       | N decimals (default 2)                | `0.0377`                          |
+| `dur`           | seconds to duration                   | `14820 -> 4h07m`                  |
+| `pct`           | append `%`                            | `96 -> 96%`                       |
+| `inv`           | `100 - x`                             | for used to remaining             |
+| `alias:TABLE`   | lookup in `aliases`, echo if unlisted | `medium -> 🌗`                    |
+| `meter:W:SCALE` | W-cell glyph bar over a 0-100 value   | `[⣿⣿⠐⠐⠐]` (`meter:1` = one glyph) |
 
 ### Piece forms
 
-- `{ "text": "📚 {context.max_tokens|num}" }` — literal + interpolation.
-- `{ "when": "<path>", "text": … }` — render only if the path is truthy.
-- `{ "map": "<path>", "cases": { "true": "⚡", "false": "🐌", "_default": "?" } }` — value→glyph.
-- `{ "each": "limits.windows", "item": "{label}", "item_scales": ["weather"] }` — iterate an array; `*` in `item` selects the per-item scale.
+- `{ "text": "📚 {context.max_tokens|num}" }`: literal + interpolation.
+- `{ "when": "<path>", "text": "..." }`: render only if the path is truthy.
+- `{ "map": "<path>", "cases": { "true": "⚡", "false": "🐌" } }`: value to glyph.
+- `{ "each": "limits.windows", "item": "{label}" }`: iterate an array.
 
 ### Example
 
@@ -134,11 +134,13 @@ Pipe a value through verbs left→right; a non-verb segment is the fallback.
         { "text": "{model.display_name}" },
         { "when": "model.reasoning", "text": " {model.reasoning|alias:reasoning}" },
         { "map": "state.fast_mode", "cases": { "true": " ⚡", "false": " 🐌" } },
-        { "when": "context.max_tokens",
-          "text": " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}" }
-      ]
-    }
-  }
+        {
+          "when": "context.max_tokens",
+          "text": " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
+        },
+      ],
+    },
+  },
 }
 ```
 

--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -48,8 +48,87 @@ footer when valid:
 }
 ```
 
-Missing, unreadable, invalid, or empty templates fall back to the built-in
-footer.
+Missing or empty templates fall back to the built-in footer quietly. Unreadable
+or invalid configured templates also fall back to the built-in footer and emit an
+operator warning.
+
+Start custom templates from the built-in shape, then edit the parts you want to
+change:
+
+```jsonc
+{
+  "schema": "openclaw.usageBar.v1",
+  "scales": {
+    "braille": "⠐⡀⡄⡆⡇⣇⣧⣷⣿",
+    "block": "░▏▎▍▌▋▊▉█",
+    "shade": "░▒▓█",
+    "moon": "🌑🌘🌗🌖🌕",
+    "level": "▁▂▃▄▅▆▇█",
+    "weather": ["🥶", "☁️", "🌥", "⛅️", "🌤", "☀️"],
+    "plants": ["🪾", "🍂", "🌱", "☘️", "🍀", "🌿"],
+    "moons6": ["🌑", "🌚", "🌘", "🌗", "🌖", "🌝"],
+  },
+  "aliases": {
+    "models": {
+      "claude-opus-4-6": "opus46",
+      "claude-opus-4-8": "opus48",
+      "claude-sonnet-4-6": "sonnet46",
+      "claude-haiku-4-5": "haiku45",
+      "gpt-5.5": "gpt5.5",
+    },
+    "reasoning": {
+      "off": "🌑",
+      "minimal": "🌚",
+      "low": "🌘",
+      "medium": "🌗",
+      "high": "🌕",
+      "xhigh": "🌝",
+    },
+  },
+  "output": {
+    "sep": "",
+    "default": [
+      { "text": "{model.provider}{identity.emoji|🤖} {model.display_name|alias:models}" },
+      { "map": "model.is_fallback", "cases": { "true": " 🔄" } },
+      { "map": "model.is_override", "cases": { "true": " 📌" } },
+      { "when": "model.reasoning", "text": " {model.reasoning|alias:reasoning}" },
+      { "map": "state.fast_mode", "cases": { "true": " ⚡", "false": " 🐌" } },
+      {
+        "when": "context.max_tokens",
+        "text": " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
+      },
+      {
+        "when": "usage.has_split_tokens",
+        "text": " ↕️ {usage.input_tokens|num|?}/{usage.output_tokens|num|?}",
+      },
+      { "when": "usage.has_total_only_tokens", "text": " ↕️ {usage.total_tokens|num}" },
+      { "when": "usage.cache_hit_pct", "text": " 🗄 {usage.cache_hit_pct|pct}" },
+      { "when": "cost.turn_usd", "text": " 💰{cost.turn_usd|fixed:4}" },
+    ],
+    "surfaces": {
+      "discord": [
+        { "text": "-# -\n" },
+        { "text": "-# {model.provider}{identity.emoji|🤖} {model.display_name|alias:models}" },
+        { "map": "model.is_fallback", "cases": { "true": "🔄" } },
+        { "map": "model.is_override", "cases": { "true": "📌" } },
+        { "when": "model.reasoning", "text": " {model.reasoning|alias:reasoning}" },
+        { "map": "state.fast_mode", "cases": { "true": " ⚡️", "false": " 🐌" } },
+        {
+          "when": "context.max_tokens",
+          "text": " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
+        },
+        {
+          "when": "usage.has_split_tokens",
+          "text": " ↕️ {usage.input_tokens|num|?}/{usage.output_tokens|num|?}",
+        },
+        { "when": "usage.has_total_only_tokens", "text": " ↕️ {usage.total_tokens|num}" },
+        { "when": "usage.cache_hit_pct", "text": " 🗄 {usage.cache_hit_pct|pct}" },
+        { "when": "cost.turn_usd", "text": " 💰{cost.turn_usd|fixed:4}" },
+      ],
+    },
+  },
+}
+```
 
 ### Shape
 
@@ -92,7 +171,8 @@ empty (so a `when` guard or a `|fallback` keeps the piece clean).
 | `model.is_fallback` / `model.is_override`                                           | bool: fallback used / model pinned     |
 | `state.fast_mode`                                                                   | bool: fast vs slow                     |
 | `context.max_tokens` / `context.pct_used`                                           | window budget / 0-100 used             |
-| `usage.input_tokens` / `usage.output_tokens` / `usage.cache_hit_pct`                | turn aggregate                         |
+| `usage.input_tokens` / `usage.output_tokens` / `usage.total_tokens`                 | turn aggregate                         |
+| `usage.has_split_tokens` / `usage.has_total_only_tokens` / `usage.cache_hit_pct`    | token display guards and cache percent |
 | `usage.last.input_tokens` / `usage.last.output_tokens` / `usage.last.cache_hit_pct` | final model call only                  |
 | `cost.turn_usd`                                                                     | estimated turn cost                    |
 | `identity.name` / `identity.emoji`                                                  | agent name / chosen emoji              |

--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -32,8 +32,8 @@ title: "Usage tracking"
 
 ## Custom `/usage full` footer
 
-Set `messages.usageTemplate` to customize the per-response `/usage full`
-footer. The value can be an inline template object or a JSON file path:
+`messages.usageTemplate` customizes the per-response `/usage full` footer. The
+value is a JSON file path (supports `~`) or an inline object:
 
 ```json
 {
@@ -43,9 +43,106 @@ footer. The value can be an inline template object or a JSON file path:
 }
 ```
 
-Templates read the `openclaw.usageLine.v1` contract and can use `scales`,
-`aliases`, and `output.surfaces` to render channel-specific footers. Missing,
-unreadable, invalid, or empty templates fall back to the built-in usage line.
+Set it to the string `"default"` to use OpenClaw's built-in footer as-is:
+
+```json
+{ "messages": { "usageTemplate": "default" } }
+```
+
+When unset, the legacy single-line footer is used; `"default"` opts into the
+richer built-in footer (model, reasoning, fast/slow, context-window bar, last-call
+tokens, cache, cost).
+
+Your template is **merged over that built-in footer**, the same way other config
+objects layer over defaults: nested objects (`scales`, `aliases`) extend
+key-by-key, while an `output.surfaces.<channel>` piece list replaces that
+channel's default. So a template only needs to contain what it adds or changes —
+start from `"default"` and override just the pieces you want. A missing,
+unreadable, or invalid template falls back to the built-in line.
+
+### Shape
+
+```jsonc
+{
+  "schema": "openclaw.usageBar.v1",
+  "scales":  { "<name>": "low→high glyphs" },   // string (1 glyph/char) or array
+  "aliases": { "<table>": { "<value>": "<label>" } },
+  "output": {
+    "sep": "",                                  // joins surviving pieces
+    "default":  [ /* pieces */ ],               // fallback for any surface
+    "surfaces": { "discord": [ /* pieces */ ], "telegram": [ /* pieces */ ] }
+  }
+}
+```
+
+Each surface is an ordered list of **pieces**; the engine renders each, drops
+empties, and joins survivors with `sep`. A surface with no entry uses
+`output.default`.
+
+### Contract — the `{paths}` you can read
+
+A piece reads values from the per-turn contract by dot-path. Absent values are
+empty (so a `when` guard or a `|fallback` keeps the piece clean).
+
+| Path | Meaning |
+| --- | --- |
+| `surface` | channel id (`discord`/`telegram`/…) |
+| `model.provider` · `model.display_name` | provider id · model id |
+| `model.reasoning` | effort (`off`…`xhigh`) |
+| `model.is_fallback` · `model.is_override` | bool — fallback used · model pinned |
+| `state.fast_mode` | bool — fast vs slow |
+| `context.max_tokens` · `context.pct_used` | window budget · 0–100 used |
+| `usage.input_tokens` · `usage.output_tokens` · `usage.cache_hit_pct` | turn aggregate |
+| `usage.last.input_tokens` · `usage.last.output_tokens` · `usage.last.cache_hit_pct` | final model call only |
+| `cost.turn_usd` | estimated turn cost |
+| `timing.duration_ms` | wall-clock ms |
+| `identity.name` · `identity.emoji` | agent name · chosen emoji |
+
+(Provider rate-limit windows are **not** in this contract.)
+
+### Verbs — `{path|verb:arg|fallback}`
+
+Pipe a value through verbs left→right; a non-verb segment is the fallback.
+
+| Verb | Effect | Example |
+| --- | --- | --- |
+| `num` | compact count | `272000 → 272k` |
+| `fixed:N` | N decimals (default 2) | `0.0377` |
+| `dur` | seconds → duration | `14820 → 4h07m` |
+| `pct` | append `%` | `96 → 96%` |
+| `inv` | `100 − x` | for used→remaining |
+| `alias:TABLE` | lookup in `aliases`, echo if unlisted | `medium → 🌗` |
+| `meter:W:SCALE` | W-cell glyph bar over a 0–100 value | `[⣿⣿⠐⠐⠐]` (`meter:1` = one glyph) |
+
+### Piece forms
+
+- `{ "text": "📚 {context.max_tokens|num}" }` — literal + interpolation.
+- `{ "when": "<path>", "text": … }` — render only if the path is truthy.
+- `{ "map": "<path>", "cases": { "true": "⚡", "false": "🐌", "_default": "?" } }` — value→glyph.
+- `{ "each": "limits.windows", "item": "{label}", "item_scales": ["weather"] }` — iterate an array; `*` in `item` selects the per-item scale.
+
+### Example
+
+```jsonc
+{
+  "schema": "openclaw.usageBar.v1",
+  "scales": { "braille": "⠐⡀⡄⡆⡇⣇⣧⣷⣿" },
+  "aliases": { "reasoning": { "medium": "🌗", "high": "🌕" } },
+  "output": {
+    "surfaces": {
+      "discord": [
+        { "text": "{model.display_name}" },
+        { "when": "model.reasoning", "text": " {model.reasoning|alias:reasoning}" },
+        { "map": "state.fast_mode", "cases": { "true": " ⚡", "false": " 🐌" } },
+        { "when": "context.max_tokens",
+          "text": " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}" }
+      ]
+    }
+  }
+}
+```
+
+renders e.g. `claude-sonnet-4-6 🌗 🐌 | 📚 [⣿⣿⣿⣿⣧]272k`.
 
 ## Providers + credentials
 

--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -33,8 +33,8 @@ title: "Usage tracking"
 ## Custom `/usage full` footer
 
 `/usage full` shows a built-in compact footer with model, reasoning, fast/slow,
-context window, final-call tokens, cache, and cost when those fields are
-available. No template file is required.
+context window, turn tokens, cache, and cost when those fields are available. No
+template file is required.
 
 `messages.usageTemplate` is only for advanced custom layouts. The value is a
 JSON file path (supports `~`) or an inline object, and it replaces the built-in

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2707,6 +2707,28 @@ describe("runReplyAgent response usage footer", () => {
     expect(text).not.toContain("· session ");
   });
 
+  it("keeps partial token counts in the built-in full footer", async () => {
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude",
+          usage: { output: 125 },
+        },
+      },
+    });
+
+    const res = await createRun({
+      responseUsage: "full",
+      sessionKey: "agent:main:whatsapp:dm:+1000",
+    });
+    const payload = Array.isArray(res) ? res[0] : res;
+    const text = payload?.text ?? "";
+    expect(text).toContain("↕️ ?/125");
+    expect(text).not.toContain("Usage:");
+  });
+
   it("shows configured costs for aws-sdk providers when responseUsage=full", async () => {
     runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "ok" }],

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2744,11 +2744,21 @@ describe("runReplyAgent response usage footer", () => {
     const res = await createRun({
       responseUsage: "full",
       sessionKey: "agent:main:whatsapp:dm:+1000",
+      config: {
+        models: {
+          providers: {
+            anthropic: {
+              models: [{ id: "claude", cost: { input: 3, output: 15 } }],
+            },
+          },
+        },
+      },
     });
     const payload = Array.isArray(res) ? res[0] : res;
     const text = payload?.text ?? "";
     expect(text).toContain("↕️ 1.3k");
     expect(text).not.toContain("↕️ ?/?");
+    expect(text).not.toContain("💰");
     expect(text).not.toContain("Usage:");
   });
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2729,6 +2729,29 @@ describe("runReplyAgent response usage footer", () => {
     expect(text).not.toContain("Usage:");
   });
 
+  it("shows aggregate-only token totals in the built-in full footer", async () => {
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude",
+          usage: { total: 1250 },
+        },
+      },
+    });
+
+    const res = await createRun({
+      responseUsage: "full",
+      sessionKey: "agent:main:whatsapp:dm:+1000",
+    });
+    const payload = Array.isArray(res) ? res[0] : res;
+    const text = payload?.text ?? "";
+    expect(text).toContain("↕️ 1.3k");
+    expect(text).not.toContain("↕️ ?/?");
+    expect(text).not.toContain("Usage:");
+  });
+
   it("shows configured costs for aws-sdk providers when responseUsage=full", async () => {
     runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "ok" }],

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2642,7 +2642,7 @@ describe("runReplyAgent response usage footer", () => {
     });
   }
 
-  it("appends session key when responseUsage=full", async () => {
+  it("uses the built-in compact footer when responseUsage=full", async () => {
     runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "ok" }],
       meta: {
@@ -2658,9 +2658,11 @@ describe("runReplyAgent response usage footer", () => {
     const res = await createRun({ responseUsage: "full", sessionKey });
     const payload = Array.isArray(res) ? res[0] : res;
     const text = payload?.text ?? "";
-    expect(text).toContain("Usage:");
-    expect(text).toContain("cache 4 cached / 2 new");
-    expect(text).toContain(`· session \`${sessionKey}\``);
+    expect(text).toContain("anthropic🤖 claude 🌘 🐌");
+    expect(text).toContain("↕️ 12/3");
+    expect(text).toContain("🗄 22%");
+    expect(text).not.toContain("Usage:");
+    expect(text).not.toContain("· session ");
   });
 
   it("does not append session key when responseUsage=tokens", async () => {
@@ -2747,10 +2749,12 @@ describe("runReplyAgent response usage footer", () => {
     const payload = Array.isArray(res) ? res[0] : res;
     const text = payload?.text ?? "";
 
-    expect(text).toContain("Usage: 1.0k in / 2.0k out");
-    expect(text).toContain("cache 500 cached / 2.0k new");
-    expect(text).toContain("est $0.04");
-    expect(text).toContain(`· session \`${sessionKey}\``);
+    expect(text).toContain("amazon-bedrock🤖 us.anthropic.claude-sonnet-4-6 🌘 🐌");
+    expect(text).toContain("↕️ 1.0k/2.0k");
+    expect(text).toContain("🗄 14%");
+    expect(text).toContain("💰0.0406");
+    expect(text).not.toContain("Usage:");
+    expect(text).not.toContain("· session ");
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1738,6 +1738,12 @@ export async function runReplyAgent(params: {
     }
 
     const usage = runResult.meta?.agentMeta?.usage;
+    const hasBillableUsageBuckets =
+      usage &&
+      (usage.input !== undefined ||
+        usage.output !== undefined ||
+        usage.cacheRead !== undefined ||
+        usage.cacheWrite !== undefined);
     const promptTokens = runResult.meta?.agentMeta?.promptTokens;
     const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
     const providerUsed =
@@ -1773,7 +1779,7 @@ export async function runReplyAgent(params: {
           followupRun.run.provider && followupRun.run.model
             ? `${followupRun.run.provider}/${followupRun.run.model}`
             : undefined,
-        turnUsd: usage
+        turnUsd: hasBillableUsageBuckets
           ? estimateUsageCost({
               usage,
               cost: resolveModelCostConfig({
@@ -2130,7 +2136,9 @@ export async function runReplyAgent(params: {
         model: modelUsed,
         config: cfg,
       });
-      const costUsd = estimateUsageCost({ usage, cost: costConfig });
+      const costUsd = hasBillableUsageBuckets
+        ? estimateUsageCost({ usage, cost: costConfig })
+        : undefined;
       emitTrustedDiagnosticEvent({
         type: "model.usage",
         ...(runResult.diagnosticTrace

--- a/src/auto-reply/usage-bar/contract.ts
+++ b/src/auto-reply/usage-bar/contract.ts
@@ -11,6 +11,12 @@ export function buildUsageContract(
   const cacheRead = usage.cacheRead;
   const cacheWrite = usage.cacheWrite;
   const total = usage.total;
+  const hasTokens =
+    input !== undefined ||
+    output !== undefined ||
+    cacheRead !== undefined ||
+    cacheWrite !== undefined ||
+    total !== undefined;
 
   const promptTotal = (cacheRead ?? 0) + (cacheWrite ?? 0) + (input ?? 0);
   const cacheHitPct =
@@ -70,6 +76,7 @@ export function buildUsageContract(
       cache_write_tokens: cacheWrite,
       total_tokens: total,
       cache_hit_pct: cacheHitPct,
+      has_tokens: hasTokens,
       last: last
         ? {
             input_tokens: last.input,

--- a/src/auto-reply/usage-bar/contract.ts
+++ b/src/auto-reply/usage-bar/contract.ts
@@ -11,12 +11,10 @@ export function buildUsageContract(
   const cacheRead = usage.cacheRead;
   const cacheWrite = usage.cacheWrite;
   const total = usage.total;
+  const hasSplitTokens = input !== undefined || output !== undefined;
+  const hasTotalOnlyTokens = !hasSplitTokens && total !== undefined;
   const hasTokens =
-    input !== undefined ||
-    output !== undefined ||
-    cacheRead !== undefined ||
-    cacheWrite !== undefined ||
-    total !== undefined;
+    hasSplitTokens || cacheRead !== undefined || cacheWrite !== undefined || total !== undefined;
 
   const promptTotal = (cacheRead ?? 0) + (cacheWrite ?? 0) + (input ?? 0);
   const cacheHitPct =
@@ -77,6 +75,8 @@ export function buildUsageContract(
       total_tokens: total,
       cache_hit_pct: cacheHitPct,
       has_tokens: hasTokens,
+      has_split_tokens: hasSplitTokens,
+      has_total_only_tokens: hasTotalOnlyTokens,
       last: last
         ? {
             input_tokens: last.input,

--- a/src/auto-reply/usage-bar/default-template.ts
+++ b/src/auto-reply/usage-bar/default-template.ts
@@ -1,36 +1,7 @@
 import type { UsageBarTemplate } from "./translator.js";
 
-/**
- * Built-in `/usage full` footer template, used when `messages.usageTemplate` is
- * set to the sentinel string `"default"`. Opt-in and intentionally undocumented
- * in the config schema/help for now — a path or inline object still overrides.
- *
- * It is the same `openclaw.usageBar.v1` DSL a user template uses, kept in source
- * (rather than a shipped JSON) so the default stays in lockstep with the engine.
- *
- * DSL recap (see translator.ts for the full verb set):
- *   - Each surface in `output.surfaces` is an ordered piece list; the engine
- *     renders each piece, drops empties, and joins survivors with `output.sep`.
- *   - `{path|verb:arg|fallback}` resolves `path` against the contract, applies
- *     verbs left→right, and uses `fallback` when the value is absent.
- *   - Verbs: num (compact count) · fixed:N (decimals) · dur (seconds→4h07m/5.2d)
- *     · pct · inv (100−x) · alias:TABLE (lookup in `aliases`, echo if unlisted)
- *     · meter:W:SCALE (glyph bar — used for the 📚 context-window bar).
- *   - `{ when }` shows a piece only if a path is truthy; `{ map, cases }` maps a
- *     value to a glyph; `{ each, item }` iterates an array.
- *
- * Contract paths used below (built by buildUsageContract in contract.ts):
- *   model.{provider,display_name,reasoning,is_fallback,is_override}
- *   identity.emoji · state.fast_mode · context.{pct_used,max_tokens}
- *   usage.last.{input_tokens,output_tokens,cache_hit_pct} · cost.turn_usd
- *
- * `when` guards wrap the optional segments so an absent field drops the whole
- * piece (no dangling separators or empty glyphs).
- */
 export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
   schema: "openclaw.usageBar.v1",
-  // Full glyph-ramp palette shipped by default; a user template can add more
-  // or override by name. Each is low→high (string = one glyph per char).
   scales: {
     braille: "⠐⡀⡄⡆⡇⣇⣧⣷⣿",
     block: "░▏▎▍▌▋▊▉█",
@@ -53,10 +24,8 @@ export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
   },
   output: {
     sep: "",
-    // Surfaces without an explicit entry (telegram, web, …) fall back to this.
-    // The engine reads `output.default`, NOT `output.surfaces.default`.
     default: [
-      { text: "{model.display_name|alias:models}" },
+      { text: "{model.provider}{identity.emoji|🤖} {model.display_name|alias:models}" },
       { map: "model.is_fallback", cases: { true: " 🔄" } },
       { map: "model.is_override", cases: { true: " 📌" } },
       { when: "model.reasoning", text: " {model.reasoning|alias:reasoning}" },
@@ -65,6 +34,12 @@ export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
         when: "context.max_tokens",
         text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
       },
+      {
+        when: "usage.last",
+        text: " ↕️ {usage.last.input_tokens|num}/{usage.last.output_tokens|num}",
+      },
+      { when: "usage.last.cache_hit_pct", text: " 🗄 {usage.last.cache_hit_pct|pct}" },
+      { when: "cost.turn_usd", text: " 💰{cost.turn_usd|fixed:4}" },
     ],
     surfaces: {
       discord: [

--- a/src/auto-reply/usage-bar/default-template.ts
+++ b/src/auto-reply/usage-bar/default-template.ts
@@ -35,8 +35,8 @@ export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
         text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
       },
       {
-        when: "usage.input_tokens",
-        text: " ↕️ {usage.input_tokens|num}/{usage.output_tokens|num}",
+        when: "usage.has_tokens",
+        text: " ↕️ {usage.input_tokens|num|?}/{usage.output_tokens|num|?}",
       },
       { when: "usage.cache_hit_pct", text: " 🗄 {usage.cache_hit_pct|pct}" },
       { when: "cost.turn_usd", text: " 💰{cost.turn_usd|fixed:4}" },
@@ -54,8 +54,8 @@ export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
           text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
         },
         {
-          when: "usage.input_tokens",
-          text: " ↕️ {usage.input_tokens|num}/{usage.output_tokens|num}",
+          when: "usage.has_tokens",
+          text: " ↕️ {usage.input_tokens|num|?}/{usage.output_tokens|num|?}",
         },
         { when: "usage.cache_hit_pct", text: " 🗄 {usage.cache_hit_pct|pct}" },
         { when: "cost.turn_usd", text: " 💰{cost.turn_usd|fixed:4}" },

--- a/src/auto-reply/usage-bar/default-template.ts
+++ b/src/auto-reply/usage-bar/default-template.ts
@@ -1,0 +1,81 @@
+import type { UsageBarTemplate } from "./translator.js";
+
+/**
+ * Built-in `/usage full` footer template, used when `messages.usageTemplate` is
+ * set to the sentinel string `"default"`. Opt-in and intentionally undocumented
+ * in the config schema/help for now — a path or inline object still overrides.
+ *
+ * It is the same `openclaw.usageBar.v1` DSL a user template uses, kept in source
+ * (rather than a shipped JSON) so the default stays in lockstep with the engine.
+ *
+ * DSL recap (see translator.ts for the full verb set):
+ *   - Each surface in `output.surfaces` is an ordered piece list; the engine
+ *     renders each piece, drops empties, and joins survivors with `output.sep`.
+ *   - `{path|verb:arg|fallback}` resolves `path` against the contract, applies
+ *     verbs left→right, and uses `fallback` when the value is absent.
+ *   - Verbs: num (compact count) · fixed:N (decimals) · dur (seconds→4h07m/5.2d)
+ *     · pct · inv (100−x) · alias:TABLE (lookup in `aliases`, echo if unlisted)
+ *     · meter:W:SCALE (glyph bar — used for the 📚 context-window bar).
+ *   - `{ when }` shows a piece only if a path is truthy; `{ map, cases }` maps a
+ *     value to a glyph; `{ each, item }` iterates an array.
+ *
+ * Contract paths used below (built by buildUsageContract in contract.ts):
+ *   model.{provider,display_name,reasoning,is_fallback,is_override}
+ *   identity.emoji · state.fast_mode · context.{pct_used,max_tokens}
+ *   usage.last.{input_tokens,output_tokens,cache_hit_pct} · cost.turn_usd
+ *
+ * `when` guards wrap the optional segments so an absent field drops the whole
+ * piece (no dangling separators or empty glyphs).
+ */
+export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
+  schema: "openclaw.usageBar.v1",
+  scales: {
+    braille: "⠐⡀⡄⡆⡇⣇⣧⣷⣿",
+  },
+  aliases: {
+    models: {
+      "claude-opus-4-6": "opus46",
+      "claude-opus-4-8": "opus48",
+      "claude-sonnet-4-6": "sonnet46",
+      "claude-haiku-4-5": "haiku45",
+      "gpt-5.5": "gpt5.5",
+    },
+    reasoning: { off: "🌑", minimal: "🌚", low: "🌘", medium: "🌗", high: "🌕", xhigh: "🌝" },
+  },
+  output: {
+    sep: "",
+    // Surfaces without an explicit entry (telegram, web, …) fall back to this.
+    // The engine reads `output.default`, NOT `output.surfaces.default`.
+    default: [
+      { text: "{model.display_name|alias:models}" },
+      { map: "model.is_fallback", cases: { true: " 🔄" } },
+      { map: "model.is_override", cases: { true: " 📌" } },
+      { when: "model.reasoning", text: " {model.reasoning|alias:reasoning}" },
+      { map: "state.fast_mode", cases: { true: " ⚡", false: " 🐌" } },
+      {
+        when: "context.max_tokens",
+        text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
+      },
+    ],
+    surfaces: {
+      discord: [
+        { text: "-# -\n" },
+        { text: "-# {model.provider}{identity.emoji|🤖} {model.display_name|alias:models}" },
+        { map: "model.is_fallback", cases: { true: "🔄" } },
+        { map: "model.is_override", cases: { true: "📌" } },
+        { when: "model.reasoning", text: " {model.reasoning|alias:reasoning}" },
+        { map: "state.fast_mode", cases: { true: " ⚡️", false: " 🐌" } },
+        {
+          when: "context.max_tokens",
+          text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
+        },
+        {
+          when: "usage.last",
+          text: " ↕️ {usage.last.input_tokens|num}/{usage.last.output_tokens|num}",
+        },
+        { when: "usage.last.cache_hit_pct", text: " 🗄 {usage.last.cache_hit_pct|pct}" },
+        { when: "cost.turn_usd", text: " 💰{cost.turn_usd|fixed:4}" },
+      ],
+    },
+  },
+};

--- a/src/auto-reply/usage-bar/default-template.ts
+++ b/src/auto-reply/usage-bar/default-template.ts
@@ -35,9 +35,10 @@ export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
         text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
       },
       {
-        when: "usage.has_tokens",
+        when: "usage.has_split_tokens",
         text: " ↕️ {usage.input_tokens|num|?}/{usage.output_tokens|num|?}",
       },
+      { when: "usage.has_total_only_tokens", text: " ↕️ {usage.total_tokens|num}" },
       { when: "usage.cache_hit_pct", text: " 🗄 {usage.cache_hit_pct|pct}" },
       { when: "cost.turn_usd", text: " 💰{cost.turn_usd|fixed:4}" },
     ],
@@ -54,9 +55,10 @@ export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
           text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
         },
         {
-          when: "usage.has_tokens",
+          when: "usage.has_split_tokens",
           text: " ↕️ {usage.input_tokens|num|?}/{usage.output_tokens|num|?}",
         },
+        { when: "usage.has_total_only_tokens", text: " ↕️ {usage.total_tokens|num}" },
         { when: "usage.cache_hit_pct", text: " 🗄 {usage.cache_hit_pct|pct}" },
         { when: "cost.turn_usd", text: " 💰{cost.turn_usd|fixed:4}" },
       ],

--- a/src/auto-reply/usage-bar/default-template.ts
+++ b/src/auto-reply/usage-bar/default-template.ts
@@ -35,10 +35,10 @@ export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
         text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
       },
       {
-        when: "usage.last",
-        text: " ↕️ {usage.last.input_tokens|num}/{usage.last.output_tokens|num}",
+        when: "usage.input_tokens",
+        text: " ↕️ {usage.input_tokens|num}/{usage.output_tokens|num}",
       },
-      { when: "usage.last.cache_hit_pct", text: " 🗄 {usage.last.cache_hit_pct|pct}" },
+      { when: "usage.cache_hit_pct", text: " 🗄 {usage.cache_hit_pct|pct}" },
       { when: "cost.turn_usd", text: " 💰{cost.turn_usd|fixed:4}" },
     ],
     surfaces: {
@@ -54,10 +54,10 @@ export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
           text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
         },
         {
-          when: "usage.last",
-          text: " ↕️ {usage.last.input_tokens|num}/{usage.last.output_tokens|num}",
+          when: "usage.input_tokens",
+          text: " ↕️ {usage.input_tokens|num}/{usage.output_tokens|num}",
         },
-        { when: "usage.last.cache_hit_pct", text: " 🗄 {usage.last.cache_hit_pct|pct}" },
+        { when: "usage.cache_hit_pct", text: " 🗄 {usage.cache_hit_pct|pct}" },
         { when: "cost.turn_usd", text: " 💰{cost.turn_usd|fixed:4}" },
       ],
     },

--- a/src/auto-reply/usage-bar/default-template.ts
+++ b/src/auto-reply/usage-bar/default-template.ts
@@ -29,8 +29,17 @@ import type { UsageBarTemplate } from "./translator.js";
  */
 export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
   schema: "openclaw.usageBar.v1",
+  // Full glyph-ramp palette shipped by default; a user template can add more
+  // or override by name. Each is low→high (string = one glyph per char).
   scales: {
     braille: "⠐⡀⡄⡆⡇⣇⣧⣷⣿",
+    block: "░▏▎▍▌▋▊▉█",
+    shade: "░▒▓█",
+    moon: "🌑🌘🌗🌖🌕",
+    level: "▁▂▃▄▅▆▇█",
+    weather: ["🥶", "☁️", "🌥", "⛅️", "🌤", "☀️"],
+    plants: ["🪾", "🍂", "🌱", "☘️", "🍀", "🌿"],
+    moons6: ["🌑", "🌚", "🌘", "🌗", "🌖", "🌝"],
   },
   aliases: {
     models: {

--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -2,10 +2,11 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_USAGE_BAR_TEMPLATE } from "./default-template.js";
 import { clearUsageBarTemplateCacheForTest, loadUsageBarTemplate } from "./template.js";
 
 const tplA = { segments: [{ text: "A" }] };
-const tplB = { output: { lines: [] } };
+const tplB = { output: { default: [{ text: "B" }] } };
 
 let dir: string | undefined;
 
@@ -25,36 +26,16 @@ function tmpFile(name: string, contents: string): string {
 }
 
 describe("loadUsageBarTemplate", () => {
-  it("returns undefined when unset", () => {
-    expect(loadUsageBarTemplate(undefined)).toBeUndefined();
+  it("returns the built-in template when unset", () => {
+    expect(loadUsageBarTemplate(undefined)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
   });
 
-  it('resolves the "default" sentinel to the built-in usable template', () => {
-    const tpl = loadUsageBarTemplate("default");
-    expect(tpl).toBeDefined();
-    expect((tpl as { output?: unknown }).output).toBeDefined();
+  it("returns an inline template object when usable", () => {
+    expect(loadUsageBarTemplate(tplA)).toBe(tplA);
   });
 
-  it("merges an inline override over the default (vocab extends, surfaces replace)", () => {
-    const merged = loadUsageBarTemplate({
-      scales: { mine: "ab" },
-      output: { surfaces: { discord: [{ text: "X" }] } },
-    }) as {
-      scales: Record<string, unknown>;
-      output: { surfaces: Record<string, unknown>; default?: unknown };
-    };
-    // added scale, and the default palette is still present
-    expect(merged.scales.mine).toBe("ab");
-    expect(merged.scales.braille).toBeDefined();
-    // the overridden channel is replaced; the default fallback survives
-    expect(merged.output.surfaces.discord).toEqual([{ text: "X" }]);
-    expect(merged.output.default).toBeDefined();
-  });
-
-  it("does not mutate the shared default when merging an override", () => {
-    loadUsageBarTemplate({ scales: { mine: "ab" } });
-    const bare = loadUsageBarTemplate("default") as { scales: Record<string, unknown> };
-    expect(bare.scales.mine).toBeUndefined();
+  it("falls back to the built-in template for an unusable inline object", () => {
+    expect(loadUsageBarTemplate({ nope: true })).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
   });
 
   it("loads and parses a template file", () => {
@@ -62,22 +43,22 @@ describe("loadUsageBarTemplate", () => {
     expect(loadUsageBarTemplate(path)).toMatchObject(tplA);
   });
 
-  it("falls back (undefined) for invalid JSON", () => {
+  it("falls back to the built-in template for invalid JSON", () => {
     const path = tmpFile("bad.json", "{ not json");
-    expect(loadUsageBarTemplate(path)).toBeUndefined();
+    expect(loadUsageBarTemplate(path)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
   });
 
   it("reloads a path after an initial miss", () => {
     dir = mkdtempSync(join(tmpdir(), "usage-template-"));
     const missing = join(dir, "missing.json");
-    expect(loadUsageBarTemplate(missing)).toBeUndefined();
+    expect(loadUsageBarTemplate(missing)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
     writeFileSync(missing, JSON.stringify(tplB));
     expect(loadUsageBarTemplate(missing)).toMatchObject(tplB);
   });
 
   it("reloads a path after invalid JSON is fixed", () => {
     const path = tmpFile("bad.json", "{ not json");
-    expect(loadUsageBarTemplate(path)).toBeUndefined();
+    expect(loadUsageBarTemplate(path)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
     writeFileSync(path, JSON.stringify(tplB));
     expect(loadUsageBarTemplate(path)).toMatchObject(tplB);
   });

--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -34,6 +34,12 @@ describe("loadUsageBarTemplate", () => {
     expect(loadUsageBarTemplate(undefined)).toBeUndefined();
   });
 
+  it('resolves the "default" sentinel to the built-in usable template', () => {
+    const tpl = loadUsageBarTemplate("default");
+    expect(tpl).toBeDefined();
+    expect((tpl as { output?: unknown }).output).toBeDefined();
+  });
+
   it("loads and parses a template file", () => {
     const path = tmpFile("t.json", JSON.stringify(tplA));
     expect(loadUsageBarTemplate(path)).toMatchObject(tplA);

--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -1,9 +1,15 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_USAGE_BAR_TEMPLATE } from "./default-template.js";
 import { clearUsageBarTemplateCacheForTest, loadUsageBarTemplate } from "./template.js";
+
+const warnSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ warn: warnSpy }),
+}));
 
 const tplA = { segments: [{ text: "A" }] };
 const tplB = { output: { default: [{ text: "B" }] } };
@@ -12,6 +18,7 @@ let dir: string | undefined;
 
 afterEach(() => {
   clearUsageBarTemplateCacheForTest();
+  warnSpy.mockClear();
   if (dir) {
     rmSync(dir, { recursive: true, force: true });
     dir = undefined;
@@ -36,8 +43,17 @@ describe("loadUsageBarTemplate", () => {
 
   it("falls back to the built-in template for an unusable inline object", () => {
     expect(loadUsageBarTemplate({ nope: true })).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]).toMatchObject([
+      "configured usage template could not be used; using built-in footer",
+      { source: "inline", reason: "unsupported-shape" },
+    ]);
+  });
+
+  it("falls back quietly for an empty inline template", () => {
     expect(loadUsageBarTemplate({ output: {} })).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
     expect(loadUsageBarTemplate({ output: { default: [] } })).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("loads and parses a template file", () => {
@@ -48,17 +64,24 @@ describe("loadUsageBarTemplate", () => {
   it("falls back to the built-in template for invalid JSON", () => {
     const path = tmpFile("bad.json", "{ not json");
     expect(loadUsageBarTemplate(path)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]).toMatchObject([
+      "configured usage template could not be used; using built-in footer",
+      { source: "file", reason: "invalid-json", path },
+    ]);
   });
 
   it("falls back to the built-in template for an empty template file", () => {
     const path = tmpFile("empty.json", JSON.stringify({ output: { default: [] } }));
     expect(loadUsageBarTemplate(path)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("reloads a path after an initial miss", () => {
     dir = mkdtempSync(join(tmpdir(), "usage-template-"));
     const missing = join(dir, "missing.json");
     expect(loadUsageBarTemplate(missing)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
+    expect(warnSpy).not.toHaveBeenCalled();
     writeFileSync(missing, JSON.stringify(tplB));
     expect(loadUsageBarTemplate(missing)).toMatchObject(tplB);
   });
@@ -66,6 +89,7 @@ describe("loadUsageBarTemplate", () => {
   it("reloads a path after invalid JSON is fixed", () => {
     const path = tmpFile("bad.json", "{ not json");
     expect(loadUsageBarTemplate(path)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
     writeFileSync(path, JSON.stringify(tplB));
     expect(loadUsageBarTemplate(path)).toMatchObject(tplB);
   });

--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -36,6 +36,8 @@ describe("loadUsageBarTemplate", () => {
 
   it("falls back to the built-in template for an unusable inline object", () => {
     expect(loadUsageBarTemplate({ nope: true })).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
+    expect(loadUsageBarTemplate({ output: {} })).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
+    expect(loadUsageBarTemplate({ output: { default: [] } })).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
   });
 
   it("loads and parses a template file", () => {
@@ -45,6 +47,11 @@ describe("loadUsageBarTemplate", () => {
 
   it("falls back to the built-in template for invalid JSON", () => {
     const path = tmpFile("bad.json", "{ not json");
+    expect(loadUsageBarTemplate(path)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
+  });
+
+  it("falls back to the built-in template for an empty template file", () => {
+    const path = tmpFile("empty.json", JSON.stringify({ output: { default: [] } }));
     expect(loadUsageBarTemplate(path)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
   });
 

--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -25,12 +25,7 @@ function tmpFile(name: string, contents: string): string {
 }
 
 describe("loadUsageBarTemplate", () => {
-  it("returns an inline template object when usable", () => {
-    expect(loadUsageBarTemplate(tplA as Record<string, unknown>)).toBe(tplA);
-  });
-
-  it("returns undefined for an unusable inline object or when unset", () => {
-    expect(loadUsageBarTemplate({ nope: true })).toBeUndefined();
+  it("returns undefined when unset", () => {
     expect(loadUsageBarTemplate(undefined)).toBeUndefined();
   });
 
@@ -38,6 +33,28 @@ describe("loadUsageBarTemplate", () => {
     const tpl = loadUsageBarTemplate("default");
     expect(tpl).toBeDefined();
     expect((tpl as { output?: unknown }).output).toBeDefined();
+  });
+
+  it("merges an inline override over the default (vocab extends, surfaces replace)", () => {
+    const merged = loadUsageBarTemplate({
+      scales: { mine: "ab" },
+      output: { surfaces: { discord: [{ text: "X" }] } },
+    }) as {
+      scales: Record<string, unknown>;
+      output: { surfaces: Record<string, unknown>; default?: unknown };
+    };
+    // added scale, and the default palette is still present
+    expect(merged.scales.mine).toBe("ab");
+    expect(merged.scales.braille).toBeDefined();
+    // the overridden channel is replaced; the default fallback survives
+    expect(merged.output.surfaces.discord).toEqual([{ text: "X" }]);
+    expect(merged.output.default).toBeDefined();
+  });
+
+  it("does not mutate the shared default when merging an override", () => {
+    loadUsageBarTemplate({ scales: { mine: "ab" } });
+    const bare = loadUsageBarTemplate("default") as { scales: Record<string, unknown> };
+    expect(bare.scales.mine).toBeUndefined();
   });
 
   it("loads and parses a template file", () => {

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -6,9 +6,6 @@ import type { UsageBarTemplate } from "./translator.js";
 
 export type UsageTemplateConfig = string | Record<string, unknown> | undefined;
 
-/** Sentinel value of `messages.usageTemplate` that selects the built-in default. */
-const DEFAULT_SENTINEL = "default";
-
 type CacheEntry = { template: UsageBarTemplate | undefined; watcher?: FSWatcher };
 const fileCache = new Map<string, CacheEntry>();
 
@@ -26,24 +23,12 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-/**
- * Deep-merge a user override OVER the built-in default, like other openclaw
- * config objects: nested objects are merged key-by-key (so `scales`/`aliases`
- * extend rather than replace), while arrays and scalars from the override win
- * (a `output.surfaces.<channel>` piece-list replaces that channel's default).
- * Never mutates `base` — each level is cloned.
- */
-function mergeTemplate(
-  base: Record<string, unknown>,
-  override: Record<string, unknown>,
-): UsageBarTemplate {
-  const out: Record<string, unknown> = { ...base };
-  for (const [key, value] of Object.entries(override)) {
-    const prev = out[key];
-    out[key] =
-      isPlainObject(prev) && isPlainObject(value) ? mergeTemplate(prev, value) : value;
+function isUsableTemplate(value: unknown): value is UsageBarTemplate {
+  if (!isPlainObject(value)) {
+    return false;
   }
-  return out;
+  const hasOutput = typeof value.output === "object" && value.output !== null;
+  return hasOutput || Array.isArray(value.segments);
 }
 
 function readTemplateFile(path: string): UsageBarTemplate | undefined {
@@ -55,7 +40,7 @@ function readTemplateFile(path: string): UsageBarTemplate | undefined {
   }
   try {
     const parsed: unknown = JSON.parse(raw);
-    return isPlainObject(parsed) ? parsed : undefined;
+    return isUsableTemplate(parsed) ? parsed : undefined;
   } catch {
     return undefined;
   }
@@ -80,30 +65,20 @@ function cacheTemplateFile(path: string): UsageBarTemplate | undefined {
   return entry.template;
 }
 
-export function loadUsageBarTemplate(
-  configured: UsageTemplateConfig,
-): UsageBarTemplate | undefined {
+export function loadUsageBarTemplate(configured: UsageTemplateConfig): UsageBarTemplate {
   if (!configured) {
-    return undefined;
-  }
-  // The bare default, no override.
-  if (configured === DEFAULT_SENTINEL) {
     return DEFAULT_USAGE_BAR_TEMPLATE;
   }
-  // Inline override object → merged over the default.
   if (typeof configured === "object") {
-    return isPlainObject(configured)
-      ? mergeTemplate(DEFAULT_USAGE_BAR_TEMPLATE, configured)
-      : undefined;
+    return isUsableTemplate(configured) ? configured : DEFAULT_USAGE_BAR_TEMPLATE;
   }
-  // File path → parsed override merged over the default. A missing/invalid file
-  // yields no override (undefined), so the caller falls back to the built-in line.
   const path = expandPath(configured);
   const cached = fileCache.get(path);
-  const override = cached
-    ? (cached.template ?? (cached.watcher ? undefined : cacheTemplateFile(path)))
-    : cacheTemplateFile(path);
-  return override ? mergeTemplate(DEFAULT_USAGE_BAR_TEMPLATE, override) : undefined;
+  return (
+    (cached
+      ? (cached.template ?? (cached.watcher ? undefined : cacheTemplateFile(path)))
+      : cacheTemplateFile(path)) ?? DEFAULT_USAGE_BAR_TEMPLATE
+  );
 }
 
 export function clearUsageBarTemplateCacheForTest(): void {

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -1,9 +1,13 @@
 import { type FSWatcher, readFileSync, watch } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, resolve } from "node:path";
+import { DEFAULT_USAGE_BAR_TEMPLATE } from "./default-template.js";
 import type { UsageBarTemplate } from "./translator.js";
 
 export type UsageTemplateConfig = string | Record<string, unknown> | undefined;
+
+/** Sentinel value of `messages.usageTemplate` that selects the built-in default. */
+const DEFAULT_SENTINEL = "default";
 
 type CacheEntry = { template: UsageBarTemplate | undefined; watcher?: FSWatcher };
 const fileCache = new Map<string, CacheEntry>();
@@ -69,6 +73,9 @@ export function loadUsageBarTemplate(
   }
   if (typeof configured === "object") {
     return isUsableTemplate(configured) ? configured : undefined;
+  }
+  if (configured === DEFAULT_SENTINEL) {
+    return DEFAULT_USAGE_BAR_TEMPLATE;
   }
   const path = expandPath(configured);
   const cached = fileCache.get(path);

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -1,6 +1,7 @@
 import { type FSWatcher, readFileSync, watch } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, resolve } from "node:path";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { DEFAULT_USAGE_BAR_TEMPLATE } from "./default-template.js";
 import type { UsageBarTemplate } from "./translator.js";
 
@@ -8,6 +9,8 @@ export type UsageTemplateConfig = string | Record<string, unknown> | undefined;
 
 type CacheEntry = { template: UsageBarTemplate | undefined; watcher?: FSWatcher };
 const fileCache = new Map<string, CacheEntry>();
+const warnedTemplateOverrides = new Set<string>();
+const usageTemplateLog = createSubsystemLogger("usage-template");
 
 function expandPath(p: string): string {
   if (p === "~") {
@@ -41,6 +44,20 @@ function hasOutputPieces(output: unknown): boolean {
   );
 }
 
+function isEmptyTemplate(value: unknown): boolean {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+  if (Object.keys(value).length === 0) {
+    return true;
+  }
+  if ("segments" in value && Array.isArray(value.segments)) {
+    return value.segments.length === 0;
+  }
+  const output = value.output;
+  return isPlainObject(output) && !hasOutputPieces(output);
+}
+
 function isUsableTemplate(value: unknown): value is UsageBarTemplate {
   if (!isPlainObject(value)) {
     return false;
@@ -55,27 +72,68 @@ function isUsableTemplate(value: unknown): value is UsageBarTemplate {
   );
 }
 
-function readTemplateFile(path: string): UsageBarTemplate | undefined {
+type InvalidTemplateReason = "invalid-json" | "unreadable" | "unsupported-shape";
+type TemplateReadResult = { template?: UsageBarTemplate; reason?: InvalidTemplateReason };
+
+function getErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return undefined;
+  }
+  const code = error.code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function warnInvalidUsageTemplate(source: "inline" | "file", reason: string, path?: string): void {
+  const key = `${source}:${reason}:${path ?? ""}`;
+  if (warnedTemplateOverrides.has(key)) {
+    return;
+  }
+  warnedTemplateOverrides.add(key);
+  usageTemplateLog.warn("configured usage template could not be used; using built-in footer", {
+    source,
+    reason,
+    ...(path ? { path } : {}),
+  });
+}
+
+function parseTemplate(value: unknown): TemplateReadResult {
+  if (isUsableTemplate(value)) {
+    return { template: value };
+  }
+  return isEmptyTemplate(value) ? {} : { reason: "unsupported-shape" };
+}
+
+function readTemplateFile(path: string): TemplateReadResult {
   let raw: string;
   try {
     raw = readFileSync(path, "utf8");
-  } catch {
-    return undefined;
+  } catch (error) {
+    return getErrorCode(error) === "ENOENT" ? {} : { reason: "unreadable" };
+  }
+  if (raw.trim().length === 0) {
+    return {};
   }
   try {
-    const parsed: unknown = JSON.parse(raw);
-    return isUsableTemplate(parsed) ? parsed : undefined;
+    return parseTemplate(JSON.parse(raw));
   } catch {
-    return undefined;
+    return { reason: "invalid-json" };
   }
 }
 
 function cacheTemplateFile(path: string): UsageBarTemplate | undefined {
-  const entry: CacheEntry = { template: readTemplateFile(path) };
+  const result = readTemplateFile(path);
+  if (result.reason) {
+    warnInvalidUsageTemplate("file", result.reason, path);
+  }
+  const entry: CacheEntry = { template: result.template };
   if (entry.template) {
     try {
       const watcher = watch(path, { persistent: false }, () => {
-        entry.template = readTemplateFile(path);
+        const next = readTemplateFile(path);
+        if (next.reason) {
+          warnInvalidUsageTemplate("file", next.reason, path);
+        }
+        entry.template = next.template;
       });
       watcher.on("error", () => {
         watcher.close();
@@ -94,7 +152,11 @@ export function loadUsageBarTemplate(configured: UsageTemplateConfig): UsageBarT
     return DEFAULT_USAGE_BAR_TEMPLATE;
   }
   if (typeof configured === "object") {
-    return isUsableTemplate(configured) ? configured : DEFAULT_USAGE_BAR_TEMPLATE;
+    const result = parseTemplate(configured);
+    if (result.reason) {
+      warnInvalidUsageTemplate("inline", result.reason);
+    }
+    return result.template ?? DEFAULT_USAGE_BAR_TEMPLATE;
   }
   const path = expandPath(configured);
   const cached = fileCache.get(path);
@@ -110,4 +172,5 @@ export function clearUsageBarTemplateCacheForTest(): void {
     entry.watcher?.close();
   }
   fileCache.clear();
+  warnedTemplateOverrides.clear();
 }

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -23,12 +23,36 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function hasPieces(value: unknown): boolean {
+  return Array.isArray(value) && value.some(isPlainObject);
+}
+
+function hasOutputPieces(output: unknown): boolean {
+  if (!isPlainObject(output)) {
+    return false;
+  }
+  if (hasPieces(output.default)) {
+    return true;
+  }
+  const surfaces = output.surfaces;
+  return (
+    isPlainObject(surfaces) &&
+    Object.values(surfaces).some((surfacePieces) => hasPieces(surfacePieces))
+  );
+}
+
 function isUsableTemplate(value: unknown): value is UsageBarTemplate {
   if (!isPlainObject(value)) {
     return false;
   }
-  const hasOutput = typeof value.output === "object" && value.output !== null;
-  return hasOutput || Array.isArray(value.segments);
+  if (hasOutputPieces(value.output) || hasPieces(value.segments)) {
+    return true;
+  }
+  const surfaces = value.surfaces;
+  return (
+    isPlainObject(surfaces) &&
+    Object.values(surfaces).some((surface) => isPlainObject(surface) && hasPieces(surface.segments))
+  );
 }
 
 function readTemplateFile(path: string): UsageBarTemplate | undefined {

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -22,13 +22,28 @@ function expandPath(p: string): string {
   return isAbsolute(p) ? p : resolve(p);
 }
 
-function isUsableTemplate(value: unknown): value is UsageBarTemplate {
-  if (typeof value !== "object" || value === null) {
-    return false;
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Deep-merge a user override OVER the built-in default, like other openclaw
+ * config objects: nested objects are merged key-by-key (so `scales`/`aliases`
+ * extend rather than replace), while arrays and scalars from the override win
+ * (a `output.surfaces.<channel>` piece-list replaces that channel's default).
+ * Never mutates `base` — each level is cloned.
+ */
+function mergeTemplate(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>,
+): UsageBarTemplate {
+  const out: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    const prev = out[key];
+    out[key] =
+      isPlainObject(prev) && isPlainObject(value) ? mergeTemplate(prev, value) : value;
   }
-  const obj = value as Record<string, unknown>;
-  const hasOutput = typeof obj.output === "object" && obj.output !== null;
-  return hasOutput || Array.isArray(obj.segments);
+  return out;
 }
 
 function readTemplateFile(path: string): UsageBarTemplate | undefined {
@@ -40,7 +55,7 @@ function readTemplateFile(path: string): UsageBarTemplate | undefined {
   }
   try {
     const parsed: unknown = JSON.parse(raw);
-    return isUsableTemplate(parsed) ? parsed : undefined;
+    return isPlainObject(parsed) ? parsed : undefined;
   } catch {
     return undefined;
   }
@@ -71,18 +86,24 @@ export function loadUsageBarTemplate(
   if (!configured) {
     return undefined;
   }
-  if (typeof configured === "object") {
-    return isUsableTemplate(configured) ? configured : undefined;
-  }
+  // The bare default, no override.
   if (configured === DEFAULT_SENTINEL) {
     return DEFAULT_USAGE_BAR_TEMPLATE;
   }
+  // Inline override object → merged over the default.
+  if (typeof configured === "object") {
+    return isPlainObject(configured)
+      ? mergeTemplate(DEFAULT_USAGE_BAR_TEMPLATE, configured)
+      : undefined;
+  }
+  // File path → parsed override merged over the default. A missing/invalid file
+  // yields no override (undefined), so the caller falls back to the built-in line.
   const path = expandPath(configured);
   const cached = fileCache.get(path);
-  if (cached) {
-    return cached.template ?? (cached.watcher ? undefined : cacheTemplateFile(path));
-  }
-  return cacheTemplateFile(path);
+  const override = cached
+    ? (cached.template ?? (cached.watcher ? undefined : cacheTemplateFile(path)))
+    : cacheTemplateFile(path);
+  return override ? mergeTemplate(DEFAULT_USAGE_BAR_TEMPLATE, override) : undefined;
 }
 
 export function clearUsageBarTemplateCacheForTest(): void {


### PR DESCRIPTION
## Summary

- Ship a built-in compact `/usage full` footer; users no longer need a JSON file for the pretty default.
- Keep `messages.usageTemplate` as the advanced override path only. Inline/file templates replace the built-in when valid.
- Remove the `"default"` sentinel and merge-over-default behavior. Strings are paths again.
- Fall back to the built-in footer for unset, missing, invalid, or empty templates; explicit broken overrides emit an operator warning.
- Document the template DSL and include the built-in footer as the custom-template starter block.
- Preserve partial and total-only token reporting without inventing unknown split counts or false `$0.0000` costs.

## Real behavior proof

Behavior addressed: `/usage full` shows the built-in compact footer without any `messages.usageTemplate` JSON file.

Real environment tested: Real Telegram bot-to-bot group with a temp OpenClaw gateway started from this PR head, repo `mock-openai`, and a temp config that did not include `messages.usageTemplate`.

Exact steps or command run after this patch: Started `scripts/e2e/mock-openai-server.mjs`; started `pnpm openclaw gateway --port 19947` with temp state/config; sent `/usage full`; sent `@{sut} Please answer with OPENCLAW_E2E_OK only.` through `~/.codex/skills/custom/telegram-e2e-bot-to-bot/scripts/probe.mjs`.

Evidence after fix: Copied live output from the Telegram probe:

```text
/usage full -> ⚙️ Usage footer: full.
@{sut} Please answer with OPENCLAW_E2E_OK only. -> OPENCLAW_E2E_OK
openai🤖 gpt5.5 🌑 🐌 | 📚 [⠐⠐⠐⠐⠐]128k ↕️ 11/7 🗄 0% 💰0.0000
```

Observed result after fix: Actual output showed the default footer in Telegram with no template file configured; mock OpenAI saw 1 request; command RTT 2437 ms; model-turn RTT 2536 ms.

What was not tested: No Telegram Desktop video artifact. Custom template replacement, broken-template warnings, empty-template fallback, partial token counts, total-only token counts, and total-only cost suppression are covered by focused tests, not by the live Telegram probe.

## Verification

- `pnpm exec oxfmt --check src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/usage-bar/contract.ts src/auto-reply/usage-bar/default-template.ts src/auto-reply/usage-bar/template.ts src/auto-reply/usage-bar/template.test.ts docs/concepts/usage-tracking.md`
- `pnpm docs:list`
- `pnpm check:docs`
- `git diff --check`
- `node scripts/run-vitest.mjs src/auto-reply/usage-bar/template.test.ts src/auto-reply/usage-bar/translator.test.ts test/vitest-scoped-config.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- Telegram bot-to-bot proof described above
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean: no accepted/actionable findings
