### PR TITLE
ci: add process exec CodeQL security shard

### DIFF
--- a/.github/codeql/codeql-process-exec-boundary-critical-security.yml
+++ b/.github/codeql/codeql-process-exec-boundary-critical-security.yml
@@ -1,0 +1,61 @@
+name: openclaw-codeql-process-exec-boundary-critical-security
+
+disable-default-queries: true
+
+queries:
+  - uses: security-extended
+
+query-filters:
+  - include:
+      precision:
+        - high
+        - very-high
+      tags contain: security
+      security-severity: /([7-9]|10)\.(\d)+/
+
+paths:
+  - src/process
+  - src/tui/tui-local-shell.ts
+  - src/tui/tui.ts
+  - src/plugin-sdk/windows-spawn.ts
+  - packages/agent-core/src/harness/env
+  - packages/memory-host-sdk/src/host
+  - extensions/acpx/src
+  - extensions/bonjour/src/advertiser.ts
+  - extensions/browser/src/browser/chrome-mcp.ts
+  - extensions/browser/src/browser/chrome.executables.ts
+  - extensions/browser/src/browser/chrome.ts
+  - extensions/codex/src/app-server/sandbox-exec-server
+  - extensions/codex/src/app-server/transport-stdio.ts
+  - extensions/codex/src/node-cli-sessions.ts
+  - extensions/codex-supervisor/src/json-rpc-client.ts
+  - extensions/file-transfer/src
+  - extensions/google-meet/src
+  - extensions/imessage/src
+  - extensions/memory-core/src/memory/qmd-manager.ts
+  - extensions/memory-wiki/src/obsidian.ts
+  - extensions/microsoft-foundry/cli.ts
+  - extensions/ollama/src/wsl2-crash-loop-check.ts
+  - extensions/qa-lab/src
+  - extensions/signal/src/daemon.ts
+  - extensions/tts-local-cli/speech-provider.ts
+  - extensions/voice-call/src
+  - scripts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,28 @@ on:
       - ".github/actions/**"
       - ".github/codeql/**"
       - ".github/workflows/**"
+      - "extensions/acpx/src/**"
+      - "extensions/bonjour/src/advertiser.ts"
+      - "extensions/browser/src/browser/chrome-mcp.ts"
+      - "extensions/browser/src/browser/chrome.executables.ts"
+      - "extensions/browser/src/browser/chrome.ts"
+      - "extensions/codex/src/app-server/sandbox-exec-server/**"
+      - "extensions/codex/src/app-server/transport-stdio.ts"
+      - "extensions/codex/src/node-cli-sessions.ts"
+      - "extensions/codex-supervisor/src/json-rpc-client.ts"
+      - "extensions/file-transfer/src/**"
+      - "extensions/google-meet/src/**"
+      - "extensions/imessage/src/**"
+      - "extensions/memory-core/src/memory/qmd-manager.ts"
+      - "extensions/memory-wiki/src/obsidian.ts"
+      - "extensions/microsoft-foundry/cli.ts"
+      - "extensions/ollama/src/wsl2-crash-loop-check.ts"
+      - "extensions/qa-lab/src/**"
+      - "extensions/signal/src/daemon.ts"
+      - "extensions/tts-local-cli/speech-provider.ts"
+      - "extensions/voice-call/src/**"
       - "packages/**"
+      - "scripts/**"
       - "src/**"
   push:
     branches:
@@ -67,6 +88,11 @@ jobs:
             runs_on: ubuntu-24.04
             timeout_minutes: 25
             config_file: ./.github/codeql/codeql-mcp-process-tool-boundary-critical-security.yml
+          - language: javascript-typescript
+            category: process-exec-boundary
+            runs_on: ubuntu-24.04
+            timeout_minutes: 25
+            config_file: ./.github/codeql/codeql-process-exec-boundary-critical-security.yml
           - language: javascript-typescript
             category: plugin-trust-boundary
             runs_on: ubuntu-24.04

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -487,7 +487,7 @@ For normal PRs, follow scoped CI/check evidence instead of treating parity as a 
 
 The `CodeQL` workflow is intentionally a narrow first-pass security scanner, not the full repository sweep. Daily, manual, and non-draft pull request guard runs scan Actions workflow code plus the highest-risk JavaScript/TypeScript surfaces with high-confidence security queries filtered to high/critical `security-severity`.
 
-The pull request guard stays light: it only starts for changes under `.github/actions`, `.github/codeql`, `.github/workflows`, `packages`, or `src`, and it runs the same high-confidence security matrix as the scheduled workflow. Android and macOS CodeQL stay out of PR defaults.
+The pull request guard stays light: it only starts for changes under `.github/actions`, `.github/codeql`, `.github/workflows`, `packages`, `scripts`, `src`, or process-owning bundled plugin runtime paths, and it runs the same high-confidence security matrix as the scheduled workflow. Android and macOS CodeQL stay out of PR defaults.
 
 ### Security categories
 
@@ -497,6 +497,7 @@ The pull request guard stays light: it only starts for changes under `.github/ac
 | `/codeql-security-high/channel-runtime-boundary`  | Core channel implementation contracts plus the channel plugin runtime, gateway, Plugin SDK, secrets, audit touchpoints              |
 | `/codeql-security-high/network-ssrf-boundary`     | Core SSRF, IP parsing, network guard, web-fetch, and Plugin SDK SSRF policy surfaces                                                |
 | `/codeql-security-high/mcp-process-tool-boundary` | MCP servers, process execution helpers, outbound delivery, and agent tool-execution gates                                           |
+| `/codeql-security-high/process-exec-boundary`     | Local shell, process spawn helpers, subprocess-owning bundled plugin runtimes, and workflow script glue                             |
 | `/codeql-security-high/plugin-trust-boundary`     | Plugin install, loader, manifest, registry, package-manager install, source-loading, and Plugin SDK package contract trust surfaces |
 
 ### Platform-specific security shards


### PR DESCRIPTION
## Summary
- add a `process-exec-boundary` CodeQL high-security shard for local shell, subprocess helpers, subprocess-owning bundled plugin runtimes, and workflow script glue
- wire the new shard into the existing `CodeQL` security matrix and PR/push path filters
- document the new security category and expanded trigger scope in CI docs

## Why
- supersedes #74437, which added a stale manual-only `local-shell` shard
- current main already covers part of `src/process/**`, but leaves TUI local shell, Plugin SDK/Memory host spawn helpers, key bundled plugin subprocess runtimes, and workflow Node scripts outside the JavaScript/TypeScript security baseline
- keeps the current high/critical `security-severity` CodeQL filter contract instead of adding a broader manual profile

## Verification
- `git diff --check`
- `pnpm docs:list`
- `node scripts/check-workflows.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings
