### PR TITLE
feat: support /btw in CLI-backed sessions

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-2c783beea6b3cda3d79060739a923f9f39e7e8b5942123dd6b08a09143a587ca  plugin-sdk-api-baseline.json
-0b33af2cffb42abb46682fb71c8f214da220793f13d10a34d332e75ff99e8ce9  plugin-sdk-api-baseline.jsonl
+0cca9891634edbdd08dfcebe0f29b36d7cf2729fd0c2ec3dd4615acef209a7eb  plugin-sdk-api-baseline.json
+2c763baab30411800b8931857e0a61e2710202394c2284f4c98e3e2f4231f88c  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/cli-backend-plugins.md
+++ b/docs/plugins/cli-backend-plugins.md
@@ -197,21 +197,29 @@ only for behavior that really belongs to the backend.
 
 `CliBackendPlugin` can also define:
 
-| Hook                               | Use                                                    |
-| ---------------------------------- | ------------------------------------------------------ |
-| `normalizeConfig(config, context)` | Rewrite legacy user config after merge                 |
-| `resolveExecutionArgs(ctx)`        | Add request-scoped flags such as thinking effort       |
-| `prepareExecution(ctx)`            | Create temporary auth or config bridges before launch  |
-| `transformSystemPrompt(ctx)`       | Apply a final CLI-specific system prompt transform     |
-| `textTransforms`                   | Bidirectional prompt/output replacements               |
-| `defaultAuthProfileId`             | Prefer a specific OpenClaw auth profile                |
-| `authEpochMode`                    | Decide how auth changes invalidate stored CLI sessions |
-| `nativeToolMode`                   | Declare whether the CLI has always-on native tools     |
-| `bundleMcp` / `bundleMcpMode`      | Opt into OpenClaw's loopback MCP tool bridge           |
-| `ownsNativeCompaction`             | Backend owns its own compaction - OpenClaw defers      |
+| Hook                               | Use                                                                         |
+| ---------------------------------- | --------------------------------------------------------------------------- |
+| `normalizeConfig(config, context)` | Rewrite legacy user config after merge                                      |
+| `resolveExecutionArgs(ctx)`        | Add request-scoped flags such as thinking effort or side-question isolation |
+| `prepareExecution(ctx)`            | Create temporary auth or config bridges before launch                       |
+| `transformSystemPrompt(ctx)`       | Apply a final CLI-specific system prompt transform                          |
+| `textTransforms`                   | Bidirectional prompt/output replacements                                    |
+| `defaultAuthProfileId`             | Prefer a specific OpenClaw auth profile                                     |
+| `authEpochMode`                    | Decide how auth changes invalidate stored CLI sessions                      |
+| `nativeToolMode`                   | Declare whether the CLI has always-on native tools                          |
+| `sideQuestionToolMode`             | Declare disabled native tools for `/btw` side questions                     |
+| `bundleMcp` / `bundleMcpMode`      | Opt into OpenClaw's loopback MCP tool bridge                                |
+| `ownsNativeCompaction`             | Backend owns its own compaction - OpenClaw defers                           |
 
 Keep these hooks provider-owned. Do not add CLI-specific branches to core when a
 backend hook can express the behavior.
+
+`ctx.executionMode` is `"agent"` for normal turns and `"side-question"` for
+ephemeral `/btw` calls. Use it when the CLI needs different one-shot flags, such
+as disabling native tools, session persistence, or resume behavior for BTW. If a
+backend normally has `nativeToolMode: "always-on"` but its side-question argv
+reliably disables those tools, also set `sideQuestionToolMode: "disabled"`;
+otherwise OpenClaw fails closed when BTW requires a no-tools CLI run.
 
 ### `ownsNativeCompaction`: opting out of OpenClaw compaction
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -378,7 +378,10 @@ AI CLI backend such as `claude-cli` or `my-cli`.
   (for example normalizing old flag shapes).
 - Use `resolveExecutionArgs` for request-scoped argv rewrites that belong to
   the CLI dialect, such as mapping OpenClaw thinking levels to a native effort
-  flag.
+  flag. The hook receives `ctx.executionMode`; use `"side-question"` to add
+  backend-native isolation flags for ephemeral `/btw` calls. If those flags
+  reliably disable native tools for an otherwise always-on CLI, declare
+  `sideQuestionToolMode: "disabled"` too.
 
 For an end-to-end authoring guide, see
 [CLI backend plugins](/plugins/cli-backend-plugins).

--- a/docs/tools/btw.md
+++ b/docs/tools/btw.md
@@ -42,8 +42,14 @@ app-server thread as an ephemeral side thread. That keeps Codex OAuth and native
 thread behavior intact while still isolating the side answer from the parent
 transcript. Like Codex `/side`, the side thread keeps the current Codex
 permissions and native tool surface, with guardrails that tell the model not to
-treat inherited parent-thread work as active instructions. Non-Codex runtimes
-keep the older direct one-shot path.
+treat inherited parent-thread work as active instructions.
+
+For CLI runtime aliases, BTW uses the owning CLI backend in side-question mode
+instead of falling back to a direct provider call. OpenClaw seeds sanitized
+conversation context into a fresh one-shot CLI invocation, disables OpenClaw MCP
+tool bundling and reusable CLI session state for that invocation, and lets the
+backend add any CLI-native no-resume or no-tools flags it supports. Direct
+non-CLI runtimes keep the direct one-shot path.
 
 ## What it does not do
 

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -34,6 +34,7 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
     bundleMcp: true,
     bundleMcpMode: "claude-config-file",
     nativeToolMode: "always-on",
+    sideQuestionToolMode: "disabled",
     ownsNativeCompaction: true,
     config: {
       command: "claude",

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -150,6 +150,61 @@ describe("resolveClaudeCliExecutionArgs", () => {
       }),
     ).toEqual(["-p", "--effort", "max"]);
   });
+
+  it("forces isolated no-tool one-shot args for side-question execution", () => {
+    expect(
+      resolveClaudeCliExecutionArgs({
+        workspaceDir: "/tmp",
+        provider: "claude-cli",
+        modelId: "claude-opus-4-7",
+        thinkingLevel: "max",
+        useResume: true,
+        executionMode: "side-question",
+        baseArgs: [
+          "-p",
+          "--output-format",
+          "stream-json",
+          "--allowedTools=mcp__openclaw__*",
+          "--allowedTools",
+          "Read",
+          "Grep",
+          "--permission-mode",
+          "bypassPermissions",
+          "--session-id=abc",
+          "--resume",
+          "old-session",
+          "--resume-session-at",
+          "old-message",
+          "--resume-session-at=old-message-equals",
+          "--mcp-config",
+          "/tmp/side-question-mcp.json",
+          "--bare",
+          "--safe-mode",
+          "--strict-mcp-config",
+          "--no-session-persistence",
+          "--max-turns",
+          "4",
+          "--effort",
+          "high",
+        ],
+      }),
+    ).toEqual([
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--safe-mode",
+      "--tools",
+      "",
+      "--disallowedTools",
+      "mcp__*",
+      "--strict-mcp-config",
+      "--no-session-persistence",
+      "--max-turns",
+      "1",
+      "--permission-mode",
+      "default",
+    ]);
+  });
 });
 
 describe("normalizeClaudeBackendConfig", () => {

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -67,8 +67,26 @@ const CLAUDE_LEGACY_SKIP_PERMISSIONS_ARG = "--dangerously-skip-permissions";
 const CLAUDE_PERMISSION_MODE_ARG = "--permission-mode";
 const CLAUDE_SETTING_SOURCES_ARG = "--setting-sources";
 const CLAUDE_EFFORT_ARG = "--effort";
+const CLAUDE_BARE_ARG = "--bare";
+const CLAUDE_SAFE_MODE_ARG = "--safe-mode";
+const CLAUDE_TOOLS_ARG = "--tools";
+const CLAUDE_DISALLOWED_TOOLS_ARG = "--disallowedTools";
+const CLAUDE_MCP_CONFIG_ARG = "--mcp-config";
+const CLAUDE_STRICT_MCP_CONFIG_ARG = "--strict-mcp-config";
+const CLAUDE_NO_SESSION_PERSISTENCE_ARG = "--no-session-persistence";
+const CLAUDE_MAX_TURNS_ARG = "--max-turns";
+const CLAUDE_SESSION_ID_ARG = "--session-id";
+const CLAUDE_RESUME_ARG = "--resume";
+const CLAUDE_RESUME_SESSION_AT_ARG = "--resume-session-at";
+const CLAUDE_RESUME_SHORT_ARG = "-r";
+const CLAUDE_CONTINUE_ARG = "--continue";
+const CLAUDE_CONTINUE_SHORT_ARG = "-c";
+const CLAUDE_FORK_SESSION_ARG = "--fork-session";
 const CLAUDE_SAFE_SETTING_SOURCES = "user";
 const CLAUDE_BYPASS_PERMISSION_MODE = "bypassPermissions";
+const CLAUDE_DEFAULT_PERMISSION_MODE = "default";
+const CLAUDE_NO_TOOLS_VALUE = "";
+const CLAUDE_DENY_MCP_TOOLS_VALUE = "mcp__*";
 
 type ClaudeCliEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
@@ -232,10 +250,89 @@ function stripClaudeEffortArgs(args: readonly string[]): string[] {
   return normalized;
 }
 
+const CLAUDE_SIDE_QUESTION_VARIADIC_VALUE_ARGS = new Set([
+  "--allowedTools",
+  "--allowed-tools",
+  CLAUDE_DISALLOWED_TOOLS_ARG,
+  "--disallowed-tools",
+  CLAUDE_TOOLS_ARG,
+  CLAUDE_MCP_CONFIG_ARG,
+]);
+
+const CLAUDE_SIDE_QUESTION_VALUE_ARGS = new Set([
+  CLAUDE_PERMISSION_MODE_ARG,
+  CLAUDE_SESSION_ID_ARG,
+  CLAUDE_RESUME_ARG,
+  CLAUDE_RESUME_SESSION_AT_ARG,
+  CLAUDE_RESUME_SHORT_ARG,
+  CLAUDE_MAX_TURNS_ARG,
+]);
+
+const CLAUDE_SIDE_QUESTION_BARE_ARGS = new Set([
+  CLAUDE_CONTINUE_ARG,
+  CLAUDE_CONTINUE_SHORT_ARG,
+  CLAUDE_FORK_SESSION_ARG,
+  CLAUDE_BARE_ARG,
+  CLAUDE_SAFE_MODE_ARG,
+  CLAUDE_STRICT_MCP_CONFIG_ARG,
+  CLAUDE_NO_SESSION_PERSISTENCE_ARG,
+]);
+
+function stripClaudeSideQuestionConflictingArgs(args: readonly string[]): string[] {
+  const normalized: string[] = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i] ?? "";
+    const equalsIndex = arg.indexOf("=");
+    const argName = equalsIndex > 0 ? arg.slice(0, equalsIndex) : arg;
+    if (CLAUDE_SIDE_QUESTION_BARE_ARGS.has(argName)) {
+      continue;
+    }
+    if (CLAUDE_SIDE_QUESTION_VARIADIC_VALUE_ARGS.has(argName)) {
+      if (equalsIndex < 0) {
+        while (typeof args[i + 1] === "string" && !args[i + 1]?.startsWith("-")) {
+          i += 1;
+        }
+      }
+      continue;
+    }
+    if (CLAUDE_SIDE_QUESTION_VALUE_ARGS.has(argName)) {
+      if (equalsIndex < 0) {
+        const maybeValue = args[i + 1];
+        if (typeof maybeValue === "string" && !maybeValue.startsWith("-")) {
+          i += 1;
+        }
+      }
+      continue;
+    }
+    normalized.push(arg);
+  }
+  return normalized;
+}
+
+function resolveClaudeCliSideQuestionExecutionArgs(baseArgs: readonly string[]): string[] {
+  return [
+    ...stripClaudeSideQuestionConflictingArgs(stripClaudeEffortArgs(baseArgs)),
+    CLAUDE_SAFE_MODE_ARG,
+    CLAUDE_TOOLS_ARG,
+    CLAUDE_NO_TOOLS_VALUE,
+    CLAUDE_DISALLOWED_TOOLS_ARG,
+    CLAUDE_DENY_MCP_TOOLS_VALUE,
+    CLAUDE_STRICT_MCP_CONFIG_ARG,
+    CLAUDE_NO_SESSION_PERSISTENCE_ARG,
+    CLAUDE_MAX_TURNS_ARG,
+    "1",
+    CLAUDE_PERMISSION_MODE_ARG,
+    CLAUDE_DEFAULT_PERMISSION_MODE,
+  ];
+}
+
 /** Resolve final Claude CLI execution args for one backend invocation. */
 export function resolveClaudeCliExecutionArgs(
   context: CliBackendResolveExecutionArgsContext,
 ): string[] {
+  if (context.executionMode === "side-question") {
+    return resolveClaudeCliSideQuestionExecutionArgs(context.baseArgs);
+  }
   const effort = mapClaudeCliThinkingLevelToEffort(context.thinkingLevel);
   if (!effort) {
     return [...context.baseArgs];

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -1,4 +1,5 @@
 /** Tests BTW side-question execution, session context, auth, and harness routing. */
+import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 
@@ -25,6 +26,8 @@ const listAgentEntriesMock = vi.fn();
 const prepareProviderRuntimeAuthMock = vi.fn();
 const registerProviderStreamForModelMock = vi.fn();
 const resolveEmbeddedAgentStreamFnMock = vi.fn();
+const prepareCliRunContextMock = vi.fn();
+const executePreparedCliRunMock = vi.fn();
 const diagDebugMock = vi.fn();
 
 vi.mock("../llm/stream.js", async () => {
@@ -83,6 +86,7 @@ vi.mock("./model-runtime-aliases.js", () => ({
     provider,
     cfg,
     modelId,
+    authProfileId,
   }: {
     provider?: string;
     cfg?: {
@@ -91,15 +95,40 @@ vi.mock("./model-runtime-aliases.js", () => ({
           models?: Record<string, { agentRuntime?: { id?: string } }>;
         };
       };
+      auth?: {
+        order?: Record<string, string[]>;
+        profiles?: Record<string, { provider?: string }>;
+      };
     };
     modelId?: string;
+    authProfileId?: string;
   }) => {
     const key = provider && modelId ? `${provider}/${modelId}` : undefined;
     const runtime = key
       ? cfg?.agents?.defaults?.models?.[key]?.agentRuntime?.id?.trim()
       : undefined;
+    if ((!runtime || runtime === "auto") && authProfileId?.trim()) {
+      return cfg?.auth?.profiles?.[authProfileId]?.provider === "claude-cli"
+        ? "claude-cli"
+        : undefined;
+    }
+    if (!runtime || runtime === "auto") {
+      for (const profileId of cfg?.auth?.order?.[provider ?? ""] ?? []) {
+        if (cfg?.auth?.profiles?.[profileId]?.provider === "claude-cli") {
+          return "claude-cli";
+        }
+      }
+    }
     return runtime || undefined;
   },
+}));
+
+vi.mock("./cli-runner/prepare.runtime.js", () => ({
+  prepareCliRunContext: (...args: unknown[]) => prepareCliRunContextMock(...args),
+}));
+
+vi.mock("./cli-runner/execute.runtime.js", () => ({
+  executePreparedCliRun: (...args: unknown[]) => executePreparedCliRunMock(...args),
 }));
 
 vi.mock("./embedded-agent-runner/runs.js", () => ({
@@ -421,6 +450,8 @@ describe("runBtwSideQuestion", () => {
     prepareProviderRuntimeAuthMock.mockReset();
     registerProviderStreamForModelMock.mockReset();
     resolveEmbeddedAgentStreamFnMock.mockReset();
+    prepareCliRunContextMock.mockReset();
+    executePreparedCliRunMock.mockReset();
     diagDebugMock.mockReset();
     clearAgentHarnesses();
 
@@ -644,7 +675,135 @@ describe("runBtwSideQuestion", () => {
     expect(streamSimpleMock).toHaveBeenCalledTimes(1);
   });
 
-  it("fails closed instead of using direct provider auth for CLI-runtime alias models", async () => {
+  it("runs CLI-runtime alias BTW as an ephemeral CLI side question", async () => {
+    const cleanup = vi.fn(async () => undefined);
+    prepareCliRunContextMock.mockResolvedValueOnce({
+      prepared: true,
+      preparedBackend: { cleanup },
+    });
+    executePreparedCliRunMock.mockResolvedValueOnce({ text: "CLI side answer." });
+
+    const result = await runSideQuestion({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+            },
+          },
+        },
+      } as never,
+      model: "claude-opus-4-7",
+      sessionKey: DEFAULT_SESSION_KEY,
+    });
+
+    expect(result).toEqual({ text: "CLI side answer." });
+    expect(prepareCliRunContextMock).toHaveBeenCalledTimes(1);
+    const prepareParams = mockArg(prepareCliRunContextMock, 0, 0) as {
+      executionMode?: string;
+      provider?: string;
+      model?: string;
+      disableTools?: boolean;
+      cliSessionId?: string;
+      extraSystemPrompt?: string;
+      prompt?: string;
+    };
+    expect(prepareParams.executionMode).toBe("side-question");
+    expect(prepareParams.provider).toBe("claude-cli");
+    expect(prepareParams.model).toBe("claude-opus-4-7");
+    expect(prepareParams.disableTools).toBe(true);
+    expect(prepareParams.cliSessionId).toBeUndefined();
+    expect(prepareParams.extraSystemPrompt).toContain("Answer only the side question");
+    expect(prepareParams.prompt).toContain("<conversation_history>");
+    expect(prepareParams.prompt).toContain("<btw_side_question>");
+    expect(executePreparedCliRunMock).toHaveBeenCalledWith({
+      prepared: true,
+      preparedBackend: { cleanup },
+    });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(getApiKeyForModelMock).not.toHaveBeenCalled();
+    expect(streamSimpleMock).not.toHaveBeenCalled();
+    expect(registerProviderStreamForModelMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves the explicit no-timeout override for CLI-runtime BTW", async () => {
+    const cleanup = vi.fn(async () => undefined);
+    prepareCliRunContextMock.mockResolvedValueOnce({
+      prepared: true,
+      preparedBackend: { cleanup },
+    });
+    executePreparedCliRunMock.mockResolvedValueOnce({ text: "CLI side answer." });
+
+    await runSideQuestion({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+            },
+          },
+        },
+      } as never,
+      model: "claude-opus-4-7",
+      opts: { timeoutOverrideSeconds: 0 },
+      sessionKey: DEFAULT_SESSION_KEY,
+    });
+
+    const prepareParams = mockArg(prepareCliRunContextMock, 0, 0) as {
+      timeoutMs?: unknown;
+      runTimeoutOverrideMs?: unknown;
+    };
+    expect(prepareParams.timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(prepareParams.runTimeoutOverrideMs).toBe(MAX_TIMER_TIMEOUT_MS);
+  });
+
+  it("runs auth-order-selected CLI BTW through the CLI side-question path", async () => {
+    const cleanup = vi.fn(async () => undefined);
+    prepareCliRunContextMock.mockResolvedValueOnce({
+      prepared: true,
+      preparedBackend: { cleanup },
+    });
+    executePreparedCliRunMock.mockResolvedValueOnce({ text: "CLI auth-order side answer." });
+
+    const result = await runSideQuestion({
+      cfg: {
+        auth: {
+          order: { anthropic: ["anthropic:claude-cli"] },
+          profiles: {
+            "anthropic:claude-cli": { provider: "claude-cli" },
+          },
+        },
+      } as never,
+      model: "claude-opus-4-7",
+      sessionKey: DEFAULT_SESSION_KEY,
+    });
+
+    expect(result).toEqual({ text: "CLI auth-order side answer." });
+    expect(prepareCliRunContextMock).toHaveBeenCalledTimes(1);
+    const prepareParams = mockArg(prepareCliRunContextMock, 0, 0) as {
+      executionMode?: string;
+      provider?: string;
+      disableTools?: boolean;
+    };
+    expect(prepareParams.executionMode).toBe("side-question");
+    expect(prepareParams.provider).toBe("claude-cli");
+    expect(prepareParams.disableTools).toBe(true);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(getApiKeyForModelMock).not.toHaveBeenCalled();
+    expect(streamSimpleMock).not.toHaveBeenCalled();
+  });
+
+  it("does not expose raw CLI BTW output when transformed text is empty", async () => {
+    const cleanup = vi.fn(async () => undefined);
+    prepareCliRunContextMock.mockResolvedValueOnce({
+      prepared: true,
+      preparedBackend: { cleanup },
+    });
+    executePreparedCliRunMock.mockResolvedValueOnce({
+      text: "   ",
+      rawText: "raw untransformed answer",
+    });
+
     await expect(
       runSideQuestion({
         cfg: {
@@ -659,41 +818,19 @@ describe("runBtwSideQuestion", () => {
         model: "claude-opus-4-7",
         sessionKey: DEFAULT_SESSION_KEY,
       }),
-    ).rejects.toThrow(
-      "/btw is not yet supported for claude-cli-backed models. The selected model is routed through claude-cli; OpenClaw will not fall back to direct anthropic auth because that would use a different backend than the active session.",
-    );
-    expect(getApiKeyForModelMock).not.toHaveBeenCalled();
+    ).rejects.toThrow("/btw side question via claude-cli produced no answer");
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
     expect(streamSimpleMock).not.toHaveBeenCalled();
-    expect(registerProviderStreamForModelMock).not.toHaveBeenCalled();
   });
 
-  it("does not let an auto-selected stale Anthropic profile suppress Claude CLI auth for BTW", async () => {
-    const claudeAuthStore = {
-      version: 1 as const,
-      profiles: {
-        "anthropic:api": {
-          type: "api_key" as const,
-          provider: "anthropic",
-          key: "static-key",
-        },
-        "anthropic:claude-cli": {
-          type: "oauth" as const,
-          provider: "claude-cli",
-          access: "claude-cli-access",
-          refresh: "claude-cli-refresh",
-          expires: Date.now() + 60_000,
-        },
-      },
-    };
-    ensureAuthProfileStoreMock.mockReturnValueOnce(claudeAuthStore);
-    getApiKeyForModelMock.mockResolvedValueOnce({
-      apiKey: "claude-cli-access",
-      mode: "oauth",
-      source: "profile:anthropic:claude-cli",
-      profileId: "anthropic:claude-cli",
+  it("does not let an auto-selected stale direct profile suppress auth-order CLI BTW", async () => {
+    const cleanup = vi.fn(async () => undefined);
+    prepareCliRunContextMock.mockResolvedValueOnce({
+      prepared: true,
+      preparedBackend: { cleanup },
     });
-    requireApiKeyMock.mockReturnValueOnce("claude-cli-access");
-    mockDoneAnswer("Claude CLI answer.");
+    executePreparedCliRunMock.mockResolvedValueOnce({ text: "Claude CLI answer." });
 
     const result = await runSideQuestion({
       cfg: {
@@ -712,28 +849,55 @@ describe("runBtwSideQuestion", () => {
     });
 
     expect(result).toEqual({ text: "Claude CLI answer." });
-    expect(ensureAuthProfileStoreMock).toHaveBeenCalledWith(DEFAULT_AGENT_DIR, {
-      externalCliProviderIds: ["claude-cli"],
-      allowKeychainPrompt: false,
+    const prepareParams = mockArg(prepareCliRunContextMock, 0, 0) as {
+      provider?: string;
+      authProfileId?: string;
+      executionMode?: string;
+    };
+    expect(prepareParams.provider).toBe("claude-cli");
+    expect(prepareParams.executionMode).toBe("side-question");
+    expect(prepareParams.authProfileId).toBeUndefined();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(getApiKeyForModelMock).not.toHaveBeenCalled();
+    expect(streamSimpleMock).not.toHaveBeenCalled();
+  });
+
+  it("uses an auto-selected session CLI auth profile for CLI BTW", async () => {
+    const cleanup = vi.fn(async () => undefined);
+    prepareCliRunContextMock.mockResolvedValueOnce({
+      prepared: true,
+      preparedBackend: { cleanup },
     });
-    expect(ensureAuthProfileStoreWithoutExternalProfilesMock).not.toHaveBeenCalled();
-    expectRecordFields(mockArg(getApiKeyForModelMock, 0, 0), {
-      profileId: undefined,
-      store: claudeAuthStore,
+    executePreparedCliRunMock.mockResolvedValueOnce({ text: "Session Claude CLI answer." });
+
+    const result = await runSideQuestion({
+      cfg: {
+        auth: {
+          order: { anthropic: ["anthropic:api"] },
+          profiles: {
+            "anthropic:api": { provider: "anthropic", mode: "api_key" },
+            "anthropic:auto-cli": { provider: "claude-cli", mode: "oauth" },
+          },
+        },
+      } as never,
+      sessionEntry: createSessionEntry({
+        authProfileOverride: "anthropic:auto-cli",
+        authProfileOverrideSource: "auto",
+      }),
     });
-    expectRecordFields(mockArg(prepareProviderRuntimeAuthMock, 0, 0), {
-      provider: "anthropic",
-    });
-    expectRecordFields(
-      (mockArg(prepareProviderRuntimeAuthMock, 0, 0) as { context?: unknown }).context,
-      {
-        profileId: "anthropic:claude-cli",
-        authMode: "oauth",
-      },
-    );
-    expectRecordFields(mockArg(resolveEmbeddedAgentStreamFnMock, 0, 0), {
-      authProfileId: "anthropic:claude-cli",
-    });
+
+    expect(result).toEqual({ text: "Session Claude CLI answer." });
+    const prepareParams = mockArg(prepareCliRunContextMock, 0, 0) as {
+      provider?: string;
+      authProfileId?: string;
+      executionMode?: string;
+    };
+    expect(prepareParams.provider).toBe("claude-cli");
+    expect(prepareParams.executionMode).toBe("side-question");
+    expect(prepareParams.authProfileId).toBe("anthropic:auto-cli");
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(getApiKeyForModelMock).not.toHaveBeenCalled();
+    expect(streamSimpleMock).not.toHaveBeenCalled();
   });
 
   it("loads Claude CLI auth for BTW from persisted auth-store order", async () => {

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 /**
  * Runs `/btw` side questions against the active conversation without resuming
  * or continuing the main task.
@@ -23,6 +24,8 @@ import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.j
 import { resolveExternalCliAuthOverlayScopeFromSelection } from "./auth-profiles/external-cli-auth-selection.js";
 import { resolveSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
 import { readBtwTranscriptMessages, resolveBtwSessionTranscriptPath } from "./btw-transcript.js";
+import { executePreparedCliRun } from "./cli-runner/execute.runtime.js";
+import { prepareCliRunContext } from "./cli-runner/prepare.runtime.js";
 import { EmbeddedBlockChunker, type BlockReplyChunking } from "./embedded-agent-block-chunker.js";
 import { resolveModelWithRegistry } from "./embedded-agent-runner/model.js";
 import { getActiveEmbeddedRunSnapshot } from "./embedded-agent-runner/runs.js";
@@ -38,12 +41,16 @@ import {
   getApiKeyForModel,
   requireApiKey,
 } from "./model-auth.js";
-import { isCliRuntimeAliasForProvider } from "./model-runtime-aliases.js";
+import {
+  isCliRuntimeAliasForProvider,
+  resolveCliRuntimeExecutionProvider,
+} from "./model-runtime-aliases.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "./openai-routing.js";
 import { applyPreparedRuntimeAuthToModel } from "./provider-request-config.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
 import { stripToolResultDetails } from "./session-transcript-repair.js";
+import { resolveAgentTimeoutMs } from "./timeout.js";
 import { sanitizeImageBlocks } from "./tool-images.js";
 
 function collectTextContent(content: Array<{ type?: string; text?: string }>): string {
@@ -102,6 +109,50 @@ function buildBtwQuestionPrompt(question: string, inFlightPrompt?: string): stri
     );
   }
   lines.push("", "<btw_side_question>", question.trim(), "</btw_side_question>");
+  return lines.join("\n");
+}
+
+function collectBtwMessageText(content: Message["content"]): string {
+  if (typeof content === "string") {
+    return content.trim();
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .flatMap((part) => {
+      if (part.type === "text") {
+        return part.text;
+      }
+      if (part.type === "image") {
+        return "[Image content omitted from CLI side-question context.]";
+      }
+      return [];
+    })
+    .join("\n")
+    .trim();
+}
+
+function buildBtwCliPrompt(params: {
+  messages: Message[];
+  question: string;
+  inFlightPrompt?: string;
+}): string {
+  const lines = [
+    "Use this sanitized conversation history as background context only.",
+    "Do not continue, resume, or complete any unfinished task from the conversation.",
+    "",
+    "<conversation_history>",
+  ];
+  for (const message of params.messages) {
+    const text = collectBtwMessageText(message.content);
+    if (!text) {
+      continue;
+    }
+    lines.push(`${message.role === "assistant" ? "Assistant" : "User"}:`, text, "");
+  }
+  lines.push("</conversation_history>", "");
+  lines.push(buildBtwQuestionPrompt(params.question, params.inFlightPrompt));
   return lines.join("\n");
 }
 
@@ -318,6 +369,71 @@ type RunBtwSideQuestionParams = {
   currentChannelId?: string;
 };
 
+async function runCliBtwSideQuestion(params: {
+  cfg: OpenClawConfig;
+  model: string;
+  question: string;
+  sessionId: string;
+  sessionFile: string;
+  sessionEntry: StoredSessionEntry;
+  sessionKey?: string;
+  sessionAgentId: string;
+  workspaceDir: string;
+  cliProvider: string;
+  authProfileId?: string;
+  resolvedThinkLevel?: ThinkLevel;
+  messages: Message[];
+  inFlightPrompt?: string;
+  opts?: GetReplyOptions;
+  messageChannel?: string;
+  messageProvider?: string;
+  currentChannelId?: string;
+}): Promise<ReplyPayload> {
+  const timeoutMs = resolveAgentTimeoutMs({
+    cfg: params.cfg,
+    overrideSeconds: params.opts?.timeoutOverrideSeconds,
+  });
+  const prepared = await prepareCliRunContext({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    sessionEntry: params.sessionEntry,
+    agentId: params.sessionAgentId,
+    trigger: "user",
+    sessionFile: params.sessionFile,
+    workspaceDir: params.workspaceDir,
+    config: params.cfg,
+    prompt: buildBtwCliPrompt({
+      messages: params.messages,
+      question: params.question,
+      inFlightPrompt: params.inFlightPrompt,
+    }),
+    extraSystemPrompt: buildBtwSystemPrompt(),
+    executionMode: "side-question",
+    provider: params.cliProvider,
+    model: params.model,
+    thinkLevel: params.resolvedThinkLevel,
+    disableTools: true,
+    timeoutMs,
+    runTimeoutOverrideMs: timeoutMs,
+    runId: params.opts?.runId ?? `btw-${randomUUID()}`,
+    authProfileId: params.authProfileId,
+    abortSignal: params.opts?.abortSignal,
+    messageChannel: params.messageChannel,
+    messageProvider: params.messageProvider,
+    currentChannelId: params.currentChannelId,
+  });
+  try {
+    const output = await executePreparedCliRun(prepared);
+    const text = output.text.trim();
+    if (!text) {
+      throw new Error(`/btw side question via ${params.cliProvider} produced no answer.`);
+    }
+    return { text };
+  } finally {
+    await prepared.preparedBackend.cleanup?.();
+  }
+}
+
 /** Answers a side question using sanitized session context and no tool execution. */
 export async function runBtwSideQuestion(
   params: RunBtwSideQuestionParams,
@@ -380,26 +496,6 @@ export async function runBtwSideQuestion(
   if (harness.id === "codex") {
     throw new Error(`Selected agent harness "${harness.id}" does not support /btw side questions.`);
   }
-  const fallbackPolicy = resolveAvailableAgentHarnessPolicy({
-    provider: params.provider,
-    modelId: params.model,
-    config: params.cfg,
-    agentId: sessionAgentId,
-    sessionKey: params.sessionKey,
-  });
-  const fallbackRuntime = fallbackPolicy.runtime.trim();
-  if (
-    isCliRuntimeAliasForProvider({
-      runtime: fallbackRuntime,
-      provider: params.provider,
-      cfg: params.cfg,
-    })
-  ) {
-    throw new Error(
-      `/btw is not yet supported for ${fallbackRuntime}-backed models. ` +
-        `The selected model is routed through ${fallbackRuntime}; OpenClaw will not fall back to direct ${params.provider} auth because that would use a different backend than the active session.`,
-    );
-  }
 
   const activeRunSnapshot = getActiveEmbeddedRunSnapshot(sessionId);
   const imageLimits = resolveImageSanitizationLimits(params.cfg);
@@ -426,6 +522,70 @@ export async function runBtwSideQuestion(
   }
   if (messages.length === 0 && !inFlightPrompt?.trim()) {
     throw new Error("No active session context.");
+  }
+
+  const fallbackPolicy = resolveAvailableAgentHarnessPolicy({
+    provider: params.provider,
+    modelId: params.model,
+    config: params.cfg,
+    agentId: sessionAgentId,
+    sessionKey: params.sessionKey,
+  });
+  const fallbackRuntime = fallbackPolicy.runtime.trim();
+  const sessionAuthProfileId = params.sessionEntry.authProfileOverride?.trim() || undefined;
+  const sessionAuthProfileSource = resolveReturnedAuthProfileSource(
+    params.sessionEntry,
+    sessionAuthProfileId,
+  );
+  const cliProviderFromSessionAuth = sessionAuthProfileId
+    ? resolveCliRuntimeExecutionProvider({
+        provider: params.provider,
+        cfg: params.cfg,
+        agentId: sessionAgentId,
+        modelId: params.model,
+        authProfileId: sessionAuthProfileId,
+      })?.trim()
+    : undefined;
+  const cliProviderFromAuthOrder =
+    !sessionAuthProfileId || sessionAuthProfileSource === "auto"
+      ? resolveCliRuntimeExecutionProvider({
+          provider: params.provider,
+          cfg: params.cfg,
+          agentId: sessionAgentId,
+          modelId: params.model,
+        })?.trim()
+      : undefined;
+  const resolvedCliProvider = cliProviderFromSessionAuth ?? cliProviderFromAuthOrder;
+  const cliProvider =
+    resolvedCliProvider ??
+    (isCliRuntimeAliasForProvider({
+      runtime: fallbackRuntime,
+      provider: params.provider,
+      cfg: params.cfg,
+    })
+      ? fallbackRuntime
+      : undefined);
+  if (cliProvider) {
+    return runCliBtwSideQuestion({
+      cfg: params.cfg,
+      model: params.model,
+      question: params.question,
+      sessionId,
+      sessionFile,
+      sessionEntry: params.sessionEntry,
+      sessionKey: params.sessionKey,
+      sessionAgentId,
+      workspaceDir,
+      cliProvider,
+      authProfileId: cliProviderFromSessionAuth ? sessionAuthProfileId : undefined,
+      resolvedThinkLevel: params.resolvedThinkLevel,
+      messages,
+      inFlightPrompt,
+      opts: params.opts,
+      messageChannel: params.messageChannel,
+      messageProvider: params.messageProvider,
+      currentChannelId: params.currentChannelId,
+    });
   }
 
   const { model, authProfileId, authProfileIdSource } = await resolveRuntimeModel({

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -19,6 +19,7 @@ import type {
   CliBundleMcpMode,
   CliBackendPlugin,
   CliBackendNativeToolMode,
+  CliBackendSideQuestionToolMode,
   PluginTextTransforms,
 } from "../plugins/types.js";
 import { mergePluginTextTransforms } from "./plugin-text-transforms.js";
@@ -54,6 +55,7 @@ export type ResolvedCliBackend = {
   prepareExecution?: CliBackendPlugin["prepareExecution"];
   resolveExecutionArgs?: CliBackendPlugin["resolveExecutionArgs"];
   nativeToolMode?: CliBackendNativeToolMode;
+  sideQuestionToolMode?: CliBackendSideQuestionToolMode;
 };
 
 type ResolvedCliBackendLiveTest = {
@@ -89,6 +91,7 @@ type FallbackCliBackendPolicy = {
   prepareExecution?: CliBackendPlugin["prepareExecution"];
   resolveExecutionArgs?: CliBackendPlugin["resolveExecutionArgs"];
   nativeToolMode?: CliBackendNativeToolMode;
+  sideQuestionToolMode?: CliBackendSideQuestionToolMode;
 };
 
 const FALLBACK_CLI_BACKEND_POLICIES: Record<string, FallbackCliBackendPolicy> = {};
@@ -130,6 +133,7 @@ function resolveSetupCliBackendPolicy(provider: string): FallbackCliBackendPolic
     prepareExecution: entry.backend.prepareExecution,
     resolveExecutionArgs: entry.backend.resolveExecutionArgs,
     nativeToolMode: entry.backend.nativeToolMode,
+    sideQuestionToolMode: entry.backend.sideQuestionToolMode,
   };
 }
 
@@ -430,6 +434,7 @@ export function resolveCliBackendConfig(
       prepareExecution: registered.prepareExecution,
       resolveExecutionArgs: registered.resolveExecutionArgs,
       nativeToolMode: registered.nativeToolMode,
+      sideQuestionToolMode: registered.sideQuestionToolMode,
     };
   }
 
@@ -463,6 +468,7 @@ export function resolveCliBackendConfig(
       prepareExecution: fallbackPolicy.prepareExecution,
       resolveExecutionArgs: fallbackPolicy.resolveExecutionArgs,
       nativeToolMode: fallbackPolicy.nativeToolMode,
+      sideQuestionToolMode: fallbackPolicy.sideQuestionToolMode,
     };
   }
   const mergedFallback = fallbackPolicy?.baseConfig
@@ -493,6 +499,7 @@ export function resolveCliBackendConfig(
     prepareExecution: fallbackPolicy?.prepareExecution,
     resolveExecutionArgs: fallbackPolicy?.resolveExecutionArgs,
     nativeToolMode: fallbackPolicy?.nativeToolMode,
+    sideQuestionToolMode: fallbackPolicy?.sideQuestionToolMode,
   };
 }
 

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -143,6 +143,7 @@ function buildPreparedContext(params?: {
   openClawHistoryPrompt?: string;
   provider?: string;
   model?: string;
+  executionMode?: PreparedCliRunContext["params"]["executionMode"];
   allowEmptyAssistantReplyAsSilent?: boolean;
 }): PreparedCliRunContext {
   // Common prepared context fixture for runPreparedCliAgent reliability branches.
@@ -170,6 +171,7 @@ function buildPreparedContext(params?: {
       timeoutMs: 1_000,
       runId: params?.runId ?? "run-2",
       lane: params?.lane,
+      executionMode: params?.executionMode,
       allowEmptyAssistantReplyAsSilent: params?.allowEmptyAssistantReplyAsSilent,
     },
     started: Date.now(),
@@ -370,6 +372,38 @@ describe("runCliAgent reliability", () => {
       reason: "cli:watchdog:stall",
       sessionKey: "agent:main:main",
     });
+  });
+
+  it("does not enqueue watchdog system events for side-question no-output timeouts", async () => {
+    enqueueSystemEventMock.mockClear();
+    requestHeartbeatMock.mockClear();
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "no-output-timeout",
+        exitCode: null,
+        exitSignal: "SIGKILL",
+        durationMs: 200,
+        stdout: "",
+        stderr: "",
+        timedOut: true,
+        noOutputTimedOut: true,
+      }),
+    );
+
+    await expect(
+      executePreparedCliRun(
+        buildPreparedContext({
+          sessionKey: "agent:main:main",
+          cliSessionId: "thread-123",
+          executionMode: "side-question",
+          runId: "run-side-question-timeout",
+        }),
+        "thread-123",
+      ),
+    ).rejects.toThrow("produced no output");
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatMock).not.toHaveBeenCalled();
   });
 
   it("fails with timeout when overall timeout trips", async () => {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -85,6 +85,7 @@ function buildPreparedCliRunContext(params: {
   mcpConfigHash?: string;
   skillsSnapshot?: PreparedCliRunContext["params"]["skillsSnapshot"];
   thinkLevel?: PreparedCliRunContext["params"]["thinkLevel"];
+  executionMode?: PreparedCliRunContext["params"]["executionMode"];
   workspaceDir?: string;
   timeoutMs?: number;
 }): PreparedCliRunContext {
@@ -132,6 +133,7 @@ function buildPreparedCliRunContext(params: {
       provider: params.provider,
       model: params.model,
       thinkLevel: params.thinkLevel,
+      executionMode: params.executionMode,
       timeoutMs: params.timeoutMs ?? 1_000,
       runId: params.runId,
       skillsSnapshot: params.skillsSnapshot,
@@ -466,6 +468,30 @@ describe("runCliAgent spawn path", () => {
     expect(requireArgAfter(input.argv, "--session-id")).not.toBe("");
     expect(input.input).toContain("hi");
     expect(input.argv).not.toContain("hi");
+  });
+
+  it("does not pass a Claude session id for side-question runs", async () => {
+    mockSuccessfulCliRun();
+    const resolveExecutionArgs = vi.fn(({ baseArgs }) => [...baseArgs, "--max-turns", "1"]);
+
+    await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-claude-side-question",
+        executionMode: "side-question",
+        backend: { sessionMode: "none" },
+        resolveExecutionArgs,
+      }),
+    );
+
+    const resolveArgsInput = requireRecord(mockCallArg(resolveExecutionArgs), "resolved args");
+    expect(resolveArgsInput.executionMode).toBe("side-question");
+    expect(resolveArgsInput.useResume).toBe(false);
+    const input = mockCallArg(supervisorSpawnMock) as { argv?: string[]; input?: string };
+    expect(input.argv).not.toContain("--session-id");
+    expect(input.argv).toContain("--max-turns");
+    expect(input.input).toContain("hi");
   });
 
   it("applies backend-owned per-run args before spawning", async () => {
@@ -924,6 +950,61 @@ describe("runCliAgent spawn path", () => {
         { stream: "assistant", text: "Hello", delta: "Hello" },
         { stream: "assistant", text: "Hello world", delta: " world" },
       ]);
+    } finally {
+      stop();
+    }
+  });
+
+  it("suppresses Claude text delta events for side-question runs", async () => {
+    const agentEvents: Array<{ stream: string; text?: string; delta?: string }> = [];
+    const stop = onAgentEvent((evt) => {
+      agentEvents.push({
+        stream: evt.stream,
+        text: typeof evt.data.text === "string" ? evt.data.text : undefined,
+        delta: typeof evt.data.delta === "string" ? evt.data.delta : undefined,
+      });
+    });
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      input.onStdout?.(
+        [
+          JSON.stringify({ type: "init", session_id: "session-123" }),
+          JSON.stringify({
+            type: "stream_event",
+            event: { type: "content_block_delta", delta: { type: "text_delta", text: "Hello" } },
+          }),
+          JSON.stringify({
+            type: "result",
+            session_id: "session-123",
+            result: "Hello",
+          }),
+        ].join("\n") + "\n",
+      );
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    try {
+      const result = await executePreparedCliRun(
+        buildPreparedCliRunContext({
+          provider: "claude-cli",
+          model: "sonnet",
+          runId: "run-claude-side-question-stream-json",
+          executionMode: "side-question",
+          backend: { sessionMode: "none" },
+        }),
+      );
+
+      expect(result.text).toBe("Hello");
+      expect(agentEvents).toEqual([]);
     } finally {
       stop();
     }

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -354,6 +354,7 @@ export async function executePreparedCliRun(
       modelId: context.modelId,
       authProfileId: context.effectiveAuthProfileId,
       thinkingLevel: params.thinkLevel,
+      executionMode: params.executionMode ?? "agent",
       useResume,
       baseArgs: baseArgsWithSkills,
     }) ?? baseArgsWithSkills;
@@ -474,12 +475,16 @@ export async function executePreparedCliRun(
         const outputMode = useResume ? (backend.resumeOutput ?? backend.output) : backend.output;
         const hasJsonlOutput = outputMode === "jsonl";
         let observedCliActivity = false;
+        const emitLiveEvents = params.executionMode !== "side-question";
         const emitCliToolUseStart = (event: {
           toolCallId: string;
           name: string;
           args: Record<string, unknown>;
         }) => {
           observedCliActivity = true;
+          if (!emitLiveEvents) {
+            return;
+          }
           emitAgentEvent({
             runId: params.runId,
             stream: "tool",
@@ -498,6 +503,9 @@ export async function executePreparedCliRun(
           result?: unknown;
         }) => {
           observedCliActivity = true;
+          if (!emitLiveEvents) {
+            return;
+          }
           emitAgentEvent({
             runId: params.runId,
             stream: "tool",
@@ -512,6 +520,9 @@ export async function executePreparedCliRun(
         };
         let commentaryCounter = 0;
         const emitCliCommentaryText = (text: string) => {
+          if (!emitLiveEvents) {
+            return;
+          }
           commentaryCounter += 1;
           const transformedText = applyPluginTextReplacements(
             text,
@@ -555,6 +566,9 @@ export async function executePreparedCliRun(
               if (text || delta) {
                 observedCliActivity = true;
               }
+              if (!emitLiveEvents) {
+                return;
+              }
               emitAgentEvent({
                 runId: params.runId,
                 stream: "assistant",
@@ -572,7 +586,10 @@ export async function executePreparedCliRun(
             },
             onToolUseStart: emitCliToolUseStart,
             onToolResult: emitCliToolResult,
-            onCommentaryText: context.params.emitCommentaryText ? emitCliCommentaryText : undefined,
+            onCommentaryText:
+              emitLiveEvents && context.params.emitCommentaryText
+                ? emitCliCommentaryText
+                : undefined,
             cleanup: async () => {
               try {
                 await fallbackClaudeSkillsPlugin?.cleanup();
@@ -600,6 +617,9 @@ export async function executePreparedCliRun(
                 if (text || delta) {
                   observedCliActivity = true;
                 }
+                if (!emitLiveEvents) {
+                  return;
+                }
                 emitAgentEvent({
                   runId: params.runId,
                   stream: "assistant",
@@ -617,9 +637,10 @@ export async function executePreparedCliRun(
               },
               onToolUseStart: emitCliToolUseStart,
               onToolResult: emitCliToolResult,
-              onCommentaryText: context.params.emitCommentaryText
-                ? emitCliCommentaryText
-                : undefined,
+              onCommentaryText:
+                emitLiveEvents && context.params.emitCommentaryText
+                  ? emitCliCommentaryText
+                  : undefined,
             })
           : null;
         const supervisor = executeDeps.getProcessSupervisor();
@@ -745,7 +766,7 @@ export async function executePreparedCliRun(
               Boolean(context.openClawHistoryPrompt) &&
               Boolean(params.sessionKey) &&
               params.timeoutMs - (Date.now() - context.started) > 0;
-            if (params.sessionKey && !deferWatchdogNoticeForFreshRetry) {
+            if (params.sessionKey && emitLiveEvents && !deferWatchdogNoticeForFreshRetry) {
               const stallNotice = [
                 `CLI agent (${params.provider}) produced no output for ${Math.round(noOutputTimeoutMs / 1000)}s and was terminated.`,
                 "It may have been waiting for interactive input or an approval prompt.",

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
+import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -329,7 +330,9 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       message: { role: "user", content: "prior user text", timestamp: 1 },
     });
     const resolveBootstrapContextForRun = vi.fn(async () => ({
-      bootstrapFiles: [{ path: "AGENTS.md", content: "bootstrap" }],
+      bootstrapFiles: [
+        { name: "AGENTS.md" as const, path: "AGENTS.md", content: "bootstrap", missing: false },
+      ],
       contextFiles: [{ path: "context.md", content: "context" }],
     }));
     const ensureMcpLoopbackServer = vi.fn(createTestMcpLoopbackServer);
@@ -368,7 +371,18 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       getActiveMcpLoopbackRuntime: vi.fn(() => undefined),
       createMcpLoopbackServerConfig: vi.fn(createTestMcpLoopbackServerConfig),
       resolveMcpLoopbackBearerToken: vi.fn(() => "token"),
-      resolveMcpLoopbackScopedTools: vi.fn(() => ({ agentId: "main", tools: [{ name: "exec" }] })),
+      resolveMcpLoopbackScopedTools: vi.fn(() => ({
+        agentId: "main",
+        tools: [
+          {
+            name: "exec",
+            label: "exec",
+            description: "test exec tool",
+            parameters: Type.Object({}, { additionalProperties: false }),
+            execute: vi.fn(async () => ({ content: [], details: { ok: true } })),
+          },
+        ],
+      })),
       resolveOpenClawReferencePaths: vi.fn(async () => ({ docsPath: "docs", sourcePath: "src" })),
     });
 

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -320,6 +320,96 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     ).toBe(false);
   });
 
+  it("prepares side questions without agent-turn context, tools, hooks, or reusable sessions", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    appendTranscriptEntry(sessionFile, {
+      id: "msg-1",
+      parentId: null,
+      timestamp: new Date(1).toISOString(),
+      message: { role: "user", content: "prior user text", timestamp: 1 },
+    });
+    const resolveBootstrapContextForRun = vi.fn(async () => ({
+      bootstrapFiles: [{ path: "AGENTS.md", content: "bootstrap" }],
+      contextFiles: [{ path: "context.md", content: "context" }],
+    }));
+    const ensureMcpLoopbackServer = vi.fn(createTestMcpLoopbackServer);
+    const prepareClaudeCliSkillsPlugin = vi.fn(async () => ({
+      args: ["--plugin-dir", "/tmp/claude-skills"],
+      cleanup: vi.fn(async () => undefined),
+    }));
+    const prepareExecution = vi.fn(async () => undefined);
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: () => undefined,
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "test-cli",
+          pluginId: "test",
+          bundleMcp: true,
+          bundleMcpMode: "claude-config-file",
+          nativeToolMode: "always-on",
+          sideQuestionToolMode: "disabled",
+          prepareExecution,
+          config: {
+            command: "test-cli",
+            args: ["--print"],
+            liveSession: "claude-stdio",
+            sessionMode: "always",
+            output: "jsonl",
+            input: "stdin",
+          },
+        },
+      ],
+    });
+    setCliRunnerPrepareTestDeps({
+      resolveBootstrapContextForRun,
+      ensureMcpLoopbackServer,
+      prepareClaudeCliSkillsPlugin,
+      makeBootstrapWarn: vi.fn(() => () => undefined),
+      getActiveMcpLoopbackRuntime: vi.fn(() => undefined),
+      createMcpLoopbackServerConfig: vi.fn(createTestMcpLoopbackServerConfig),
+      resolveMcpLoopbackBearerToken: vi.fn(() => "token"),
+      resolveMcpLoopbackScopedTools: vi.fn(() => ({ agentId: "main", tools: [{ name: "exec" }] })),
+      resolveOpenClawReferencePaths: vi.fn(async () => ({ docsPath: "docs", sourcePath: "src" })),
+    });
+
+    const context = await prepareCliRunContext({
+      sessionId: "session-test",
+      sessionKey: "agent:main:main",
+      sessionFile,
+      workspaceDir: dir,
+      config: createCliBackendConfig({ bundleMcp: true }),
+      prompt: "side question prompt",
+      executionMode: "side-question",
+      provider: "test-cli",
+      model: "test-model",
+      timeoutMs: 120_000,
+      runId: "run-side-question",
+      extraSystemPrompt: "BTW system prompt",
+      disableTools: true,
+      cliSessionId: "existing-cli-session",
+    });
+
+    expect(resolveBootstrapContextForRun).not.toHaveBeenCalled();
+    expect(ensureMcpLoopbackServer).not.toHaveBeenCalled();
+    expect(prepareClaudeCliSkillsPlugin).not.toHaveBeenCalled();
+    expect(mockGetGlobalHookRunner).not.toHaveBeenCalled();
+    expect(prepareExecution).toHaveBeenCalledWith(
+      expect.objectContaining({ executionMode: "side-question" }),
+    );
+    expect(context.systemPrompt).toBe("BTW system prompt");
+    expect(context.params.prompt).toBe("side question prompt");
+    expect(context.openClawHistoryPrompt).toBeUndefined();
+    expect(context.contextEngine).toBeUndefined();
+    expect(context.contextEngineTurnPrompt).toBeUndefined();
+    expect(context.hadSessionFile).toBe(false);
+    expect(context.claudeSkillsPluginArgs).toEqual([]);
+    expect(context.preparedBackend.backend.sessionMode).toBe("none");
+    expect(context.preparedBackend.backend.liveSession).toBeUndefined();
+    expect(context.bootstrapPromptWarningLines).toEqual([]);
+    expect(context.systemPromptReport.injectedWorkspaceFiles).toEqual([]);
+    expect(context.systemPromptReport.tools.entries).toEqual([]);
+  });
+
   it("applies prompt-build hook context to Claude-style CLI preparation", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -219,6 +219,8 @@ export async function prepareCliRunContext(
   params: RunCliAgentParams,
 ): Promise<PreparedCliRunContext> {
   const started = Date.now();
+  const executionMode = params.executionMode ?? "agent";
+  const isSideQuestion = executionMode === "side-question";
   const workspaceResolution = resolveRunWorkspaceDir({
     workspaceDir: params.workspaceDir,
     sessionKey: params.sessionKey,
@@ -249,7 +251,13 @@ export async function prepareCliRunContext(
       `CLI backend ${backendResolved.id} cannot enforce runtime toolsAllow; use an embedded runtime for restricted tool policy`,
     );
   }
-  if (params.disableTools === true && backendResolved.nativeToolMode === "always-on") {
+  const sideQuestionDisablesNativeTools =
+    isSideQuestion && backendResolved.sideQuestionToolMode === "disabled";
+  if (
+    params.disableTools === true &&
+    backendResolved.nativeToolMode === "always-on" &&
+    !sideQuestionDisablesNativeTools
+  ) {
     throw new Error(
       `CLI backend ${backendResolved.id} cannot run with tools disabled because it exposes native tools`,
     );
@@ -307,20 +315,22 @@ export async function prepareCliRunContext(
     : undefined;
 
   const sessionLabel = params.sessionKey ?? params.sessionId;
-  const { bootstrapFiles, contextFiles } = await prepareDeps.resolveBootstrapContextForRun({
-    workspaceDir,
-    config: params.config,
-    sessionKey: params.sessionKey,
-    sessionId: params.sessionId,
-    agentId: sessionAgentId,
-    contextMode: params.bootstrapContextMode,
-    runKind: params.bootstrapContextRunKind,
-    warn: prepareDeps.makeBootstrapWarn({
-      sessionLabel,
-      workspaceDir,
-      warn: (message) => cliBackendLog.warn(message),
-    }),
-  });
+  const { bootstrapFiles, contextFiles } = isSideQuestion
+    ? { bootstrapFiles: [], contextFiles: [] }
+    : await prepareDeps.resolveBootstrapContextForRun({
+        workspaceDir,
+        config: params.config,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+        agentId: sessionAgentId,
+        contextMode: params.bootstrapContextMode,
+        runKind: params.bootstrapContextRunKind,
+        warn: prepareDeps.makeBootstrapWarn({
+          sessionLabel,
+          workspaceDir,
+          warn: (message) => cliBackendLog.warn(message),
+        }),
+      });
   const bootstrapMaxChars = resolveBootstrapMaxChars(params.config, sessionAgentId);
   const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config, sessionAgentId);
   const bootstrapAnalysis = analyzeBootstrapBudget({
@@ -338,7 +348,8 @@ export async function prepareCliRunContext(
     seenSignatures: params.bootstrapPromptWarningSignaturesSeen,
     previousSignature: params.bootstrapPromptWarningSignature,
   });
-  const bundleMcpEnabled = backendResolved.bundleMcp && params.disableTools !== true;
+  const bundleMcpEnabled =
+    !isSideQuestion && backendResolved.bundleMcp && params.disableTools !== true;
   let mcpLoopbackRuntime = bundleMcpEnabled ? prepareDeps.getActiveMcpLoopbackRuntime() : undefined;
   if (bundleMcpEnabled && !mcpLoopbackRuntime) {
     try {
@@ -385,6 +396,7 @@ export async function prepareCliRunContext(
     provider: params.provider,
     modelId,
     authProfileId: effectiveAuthProfileId,
+    executionMode,
   });
   const skipLocalCredentialEpoch = shouldSkipLocalCliCredentialEpoch({
     authEpochMode: backendResolved.authEpochMode,
@@ -411,10 +423,12 @@ export async function prepareCliRunContext(
           }
         }
       : undefined;
-  const claudeSkillsPlugin = await prepareDeps.prepareClaudeCliSkillsPlugin({
-    backendId: backendResolved.id,
-    skillsSnapshot: params.skillsSnapshot,
-  });
+  const claudeSkillsPlugin = isSideQuestion
+    ? { args: [], cleanup: async () => {} }
+    : await prepareDeps.prepareClaudeCliSkillsPlugin({
+        backendId: backendResolved.id,
+        skillsSnapshot: params.skillsSnapshot,
+      });
   const preparedCleanup =
     preparedBackendCleanup || claudeSkillsPlugin.args.length > 0
       ? async () => {
@@ -429,10 +443,17 @@ export async function prepareCliRunContext(
     ...(preparedBackend.backend.clearEnv ?? []),
     ...(preparedExecution?.clearEnv ?? []),
   ];
+  const sideQuestionBackend = (() => {
+    const { liveSession: _liveSession, ...backend } = preparedBackend.backend;
+    return {
+      ...backend,
+      sessionMode: "none" as const,
+    };
+  })();
   const preparedBackendFinal = {
     ...preparedBackend,
     backend: {
-      ...preparedBackend.backend,
+      ...(isSideQuestion ? sideQuestionBackend : preparedBackend.backend),
       ...(preparedBackendClearEnv.length > 0
         ? { clearEnv: uniqueStrings(preparedBackendClearEnv) }
         : {}),
@@ -460,21 +481,23 @@ export async function prepareCliRunContext(
     bundleMcpEnabled && mcpLoopbackRuntime
       ? hashCliSessionText(JSON.stringify(promptTools.map((tool) => tool.name).toSorted()))
       : undefined;
-  const reusableCliSessionCandidate: CliReusableSession = params.cliSessionBinding
-    ? resolveCliSessionReuse({
-        binding: params.cliSessionBinding,
-        authProfileId: effectiveAuthProfileId,
-        authEpoch,
-        authEpochVersion: CLI_AUTH_EPOCH_VERSION,
-        extraSystemPromptHash,
-        promptToolNamesHash,
-        cwdHash,
-        mcpConfigHash: preparedBackendFinal.mcpConfigHash,
-        mcpResumeHash: preparedBackendFinal.mcpResumeHash,
-      })
-    : params.cliSessionId
-      ? { sessionId: params.cliSessionId }
-      : {};
+  const reusableCliSessionCandidate: CliReusableSession = isSideQuestion
+    ? {}
+    : params.cliSessionBinding
+      ? resolveCliSessionReuse({
+          binding: params.cliSessionBinding,
+          authProfileId: effectiveAuthProfileId,
+          authEpoch,
+          authEpochVersion: CLI_AUTH_EPOCH_VERSION,
+          extraSystemPromptHash,
+          promptToolNamesHash,
+          cwdHash,
+          mcpConfigHash: preparedBackendFinal.mcpConfigHash,
+          mcpResumeHash: preparedBackendFinal.mcpResumeHash,
+        })
+      : params.cliSessionId
+        ? { sessionId: params.cliSessionId }
+        : {};
   const candidateClaudeCliSessionId = reusableCliSessionCandidate.sessionId?.trim() || undefined;
   const hasClaudeCliCandidate =
     candidateClaudeCliSessionId !== undefined && isClaudeCliProvider(params.provider);
@@ -516,19 +539,23 @@ export async function prepareCliRunContext(
     });
     return openClawHistoryMessages;
   };
-  const heartbeatPrompt = resolveHeartbeatPromptForSystemPrompt({
-    config: params.config,
-    agentId: sessionAgentId,
-    defaultAgentId,
-  });
-  const openClawReferences = await prepareDeps.resolveOpenClawReferencePaths({
-    workspaceDir,
-    argv1: process.argv[1],
-    cwd,
-    moduleUrl: import.meta.url,
-  });
+  const heartbeatPrompt = isSideQuestion
+    ? undefined
+    : resolveHeartbeatPromptForSystemPrompt({
+        config: params.config,
+        agentId: sessionAgentId,
+        defaultAgentId,
+      });
+  const openClawReferences = isSideQuestion
+    ? { docsPath: null, sourcePath: null }
+    : await prepareDeps.resolveOpenClawReferencePaths({
+        workspaceDir,
+        argv1: process.argv[1],
+        cwd,
+        moduleUrl: import.meta.url,
+      });
   const systemPromptSkillsPrompt =
-    claudeSkillsPlugin.args.length > 0
+    isSideQuestion || claudeSkillsPlugin.args.length > 0
       ? ""
       : await resolveCliSkillsPrompt({
           skillsSnapshot: params.skillsSnapshot,
@@ -537,117 +564,132 @@ export async function prepareCliRunContext(
           agentId: sessionAgentId,
           sessionKey: params.sessionKey?.trim() || params.sessionId,
         });
-  const runtimeChannel = normalizeMessageChannel(params.messageChannel ?? params.messageProvider);
-  const runtimeCapabilities = collectRuntimeChannelCapabilities({
-    cfg: params.config,
-    channel: runtimeChannel,
-    accountId: params.agentAccountId,
-  });
-  const builtSystemPrompt = buildCliAgentSystemPrompt({
-    workspaceDir,
-    cwd,
-    config: params.config,
-    defaultThinkLevel: params.thinkLevel,
-    extraSystemPrompt,
-    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-    silentReplyPromptMode: params.silentReplyPromptMode,
-    runtimeChannel,
-    runtimeChatType: params.sessionEntry?.chatType,
-    runtimeCapabilities,
-    ownerNumbers: params.ownerNumbers,
-    heartbeatPrompt,
-    docsPath: openClawReferences.docsPath ?? undefined,
-    sourcePath: openClawReferences.sourcePath ?? undefined,
-    skillsPrompt: systemPromptSkillsPrompt,
-    tools: promptTools,
-    contextFiles,
-    modelDisplay,
-    agentId: sessionAgentId,
-    sessionKey: params.sessionKey,
-    sessionId: params.sessionId,
-  });
-  const transformedSystemPrompt =
-    backendResolved.transformSystemPrompt?.({
-      config: params.config,
-      workspaceDir,
-      provider: params.provider,
-      modelId,
-      modelDisplay,
-      agentId: sessionAgentId,
-      systemPrompt: builtSystemPrompt,
-    }) ?? builtSystemPrompt;
-  let systemPrompt = transformedSystemPrompt;
-  let preparedPrompt = params.prompt;
-  const hookRunner = getGlobalHookRunner();
-  try {
-    const hookResult = await resolvePromptBuildHookResult({
-      config: params.config ?? getRuntimeConfig(),
-      prompt: params.prompt,
-      messages: await loadOpenClawHistoryMessages(),
-      hookCtx: {
-        runId: params.runId,
+  const runtimeChannel = isSideQuestion
+    ? undefined
+    : normalizeMessageChannel(params.messageChannel ?? params.messageProvider);
+  const runtimeCapabilities = isSideQuestion
+    ? undefined
+    : collectRuntimeChannelCapabilities({
+        cfg: params.config,
+        channel: runtimeChannel,
+        accountId: params.agentAccountId,
+      });
+  const builtSystemPrompt = isSideQuestion
+    ? extraSystemPrompt
+    : buildCliAgentSystemPrompt({
+        workspaceDir,
+        cwd,
+        config: params.config,
+        defaultThinkLevel: params.thinkLevel,
+        extraSystemPrompt,
+        sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+        silentReplyPromptMode: params.silentReplyPromptMode,
+        runtimeChannel,
+        runtimeChatType: params.sessionEntry?.chatType,
+        runtimeCapabilities,
+        ownerNumbers: params.ownerNumbers,
+        heartbeatPrompt,
+        docsPath: openClawReferences.docsPath ?? undefined,
+        sourcePath: openClawReferences.sourcePath ?? undefined,
+        skillsPrompt: systemPromptSkillsPrompt,
+        tools: promptTools,
+        contextFiles,
+        modelDisplay,
         agentId: sessionAgentId,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
-        workspaceDir,
-        modelProviderId: params.provider,
-        modelId,
-        trigger: params.trigger,
-        ...buildAgentHookContextChannelFields(params),
-      },
-      hookRunner,
-    });
-    if (hookResult.prependContext) {
-      preparedPrompt = `${hookResult.prependContext}\n\n${preparedPrompt}`;
-    }
-    if (hookResult.appendContext) {
-      preparedPrompt = `${preparedPrompt}\n\n${hookResult.appendContext}`;
-    }
-    const hookSystemPrompt = hookResult.systemPrompt?.trim();
-    if (hookSystemPrompt) {
-      systemPrompt = hookSystemPrompt;
-    }
-    systemPrompt =
-      composeSystemPromptWithHookContext({
-        baseSystemPrompt: systemPrompt,
-        prependSystemContext: hookResult.prependSystemContext,
-        appendSystemContext: hookResult.appendSystemContext,
-      }) ?? systemPrompt;
-    const mediaTaskSystemPromptAddition = resolveAttemptMediaTaskSystemPromptAddition({
-      sessionKey: params.sessionKey,
-      trigger: params.trigger,
-    });
-    if (mediaTaskSystemPromptAddition) {
-      systemPrompt = prependSystemPromptAddition({
-        systemPrompt: ensureSystemPromptCacheBoundary(systemPrompt),
-        systemPromptAddition: mediaTaskSystemPromptAddition,
       });
+  const transformedSystemPrompt = !isSideQuestion
+    ? (backendResolved.transformSystemPrompt?.({
+        config: params.config,
+        workspaceDir,
+        provider: params.provider,
+        modelId,
+        modelDisplay,
+        agentId: sessionAgentId,
+        systemPrompt: builtSystemPrompt,
+      }) ?? builtSystemPrompt)
+    : builtSystemPrompt;
+  let systemPrompt = transformedSystemPrompt;
+  let preparedPrompt = params.prompt;
+  if (!isSideQuestion) {
+    const hookRunner = getGlobalHookRunner();
+    try {
+      const hookResult = await resolvePromptBuildHookResult({
+        config: params.config ?? getRuntimeConfig(),
+        prompt: params.prompt,
+        messages: await loadOpenClawHistoryMessages(),
+        hookCtx: {
+          runId: params.runId,
+          agentId: sessionAgentId,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+          workspaceDir,
+          modelProviderId: params.provider,
+          modelId,
+          trigger: params.trigger,
+          ...buildAgentHookContextChannelFields(params),
+        },
+        hookRunner,
+      });
+      if (hookResult.prependContext) {
+        preparedPrompt = `${hookResult.prependContext}\n\n${preparedPrompt}`;
+      }
+      if (hookResult.appendContext) {
+        preparedPrompt = `${preparedPrompt}\n\n${hookResult.appendContext}`;
+      }
+      const hookSystemPrompt = hookResult.systemPrompt?.trim();
+      if (hookSystemPrompt) {
+        systemPrompt = hookSystemPrompt;
+      }
+      systemPrompt =
+        composeSystemPromptWithHookContext({
+          baseSystemPrompt: systemPrompt,
+          prependSystemContext: hookResult.prependSystemContext,
+          appendSystemContext: hookResult.appendSystemContext,
+        }) ?? systemPrompt;
+      const mediaTaskSystemPromptAddition = resolveAttemptMediaTaskSystemPromptAddition({
+        sessionKey: params.sessionKey,
+        trigger: params.trigger,
+      });
+      if (mediaTaskSystemPromptAddition) {
+        systemPrompt = prependSystemPromptAddition({
+          systemPrompt: ensureSystemPromptCacheBoundary(systemPrompt),
+          systemPromptAddition: mediaTaskSystemPromptAddition,
+        });
+      }
+    } catch (error) {
+      cliBackendLog.warn(`cli prompt-build hook preparation failed: ${String(error)}`);
     }
-  } catch (error) {
-    cliBackendLog.warn(`cli prompt-build hook preparation failed: ${String(error)}`);
   }
-  const fullCurrentInboundPrompt = buildCurrentInboundPrompt({
-    context: params.currentInboundContext,
-    prompt: preparedPrompt,
-  });
-  const runCurrentInboundPrompt = buildCurrentInboundPrompt({
-    context: params.currentInboundContext,
-    prompt: preparedPrompt,
-    preferResumableText:
-      params.currentInboundEventKind === "room_event" && Boolean(reusableCliSession.sessionId),
-  });
-  const historyPromptCurrentTurn = annotateInterSessionPromptText(
-    fullCurrentInboundPrompt,
-    params.inputProvenance,
-  );
-  preparedPrompt = annotateInterSessionPromptText(runCurrentInboundPrompt, params.inputProvenance);
+  let historyPromptCurrentTurn = preparedPrompt;
+  if (!isSideQuestion) {
+    const fullCurrentInboundPrompt = buildCurrentInboundPrompt({
+      context: params.currentInboundContext,
+      prompt: preparedPrompt,
+    });
+    const runCurrentInboundPrompt = buildCurrentInboundPrompt({
+      context: params.currentInboundContext,
+      prompt: preparedPrompt,
+      preferResumableText:
+        params.currentInboundEventKind === "room_event" && Boolean(reusableCliSession.sessionId),
+    });
+    historyPromptCurrentTurn = annotateInterSessionPromptText(
+      fullCurrentInboundPrompt,
+      params.inputProvenance,
+    );
+    preparedPrompt = annotateInterSessionPromptText(
+      runCurrentInboundPrompt,
+      params.inputProvenance,
+    );
+  }
   const allowRawTranscriptReseed =
     backendResolved.config.reseedFromRawTranscriptWhenUncompacted === true;
   const rawTranscriptReseedReason = reusableCliSession.sessionId
     ? "session-expired"
     : reusableCliSession.invalidatedReason;
   const shouldPrepareOpenClawHistoryPrompt =
-    !reusableCliSession.sessionId || allowRawTranscriptReseed;
+    !isSideQuestion && (!reusableCliSession.sessionId || allowRawTranscriptReseed);
   const openClawHistoryPrompt = shouldPrepareOpenClawHistoryPrompt
     ? buildCliSessionHistoryPrompt({
         messages: await loadCliSessionReseedMessages({
@@ -671,13 +713,16 @@ export async function prepareCliRunContext(
   // dynamic suffix, not the cached prefix, for marker-free hook overrides — otherwise an idle
   // turn's prefix (O + identity) diverges from an active media turn's prefix (O) and breaks
   // prompt caching. Skip empty prompts and turns with no identity line, which need no boundary.
-  systemPrompt = appendModelIdentitySystemPrompt({
-    systemPrompt:
-      buildModelIdentityPromptLine(modelDisplay) && systemPromptWithReplacements.trim().length > 0
-        ? ensureSystemPromptCacheBoundary(systemPromptWithReplacements)
-        : systemPromptWithReplacements,
-    model: modelDisplay,
-  });
+  systemPrompt = isSideQuestion
+    ? systemPromptWithReplacements
+    : appendModelIdentitySystemPrompt({
+        systemPrompt:
+          buildModelIdentityPromptLine(modelDisplay) &&
+          systemPromptWithReplacements.trim().length > 0
+            ? ensureSystemPromptCacheBoundary(systemPromptWithReplacements)
+            : systemPromptWithReplacements,
+        model: modelDisplay,
+      });
   const systemPromptReport = buildSystemPromptReport({
     source: "run",
     generatedAt: Date.now(),
@@ -706,6 +751,38 @@ export async function prepareCliRunContext(
     },
   });
   const contextEngineConfig = params.config ?? getRuntimeConfig();
+  if (isSideQuestion) {
+    const preparedParams: RunCliAgentParams = {
+      ...params,
+      config: contextEngineConfig,
+      prompt: preparedPrompt,
+    };
+
+    return {
+      params: preparedParams,
+      effectiveAuthProfileId,
+      started,
+      workspaceDir,
+      cwd,
+      backendResolved,
+      preparedBackend: preparedBackendFinal,
+      reusableCliSession,
+      hadSessionFile: false,
+      contextEngineConfig,
+      modelId,
+      normalizedModel,
+      contextWindowInfo,
+      systemPrompt,
+      systemPromptReport,
+      claudeSkillsPluginArgs: claudeSkillsPlugin.args,
+      bootstrapPromptWarningLines: bootstrapPromptWarning.lines,
+      authEpoch,
+      authEpochVersion: CLI_AUTH_EPOCH_VERSION,
+      extraSystemPromptHash,
+      promptToolNamesHash,
+      cwdHash,
+    };
+  }
   try {
     ensureContextEnginesInitialized();
     const { sessionAgentId: contextEngineSessionAgentId } = resolveSessionAgentIds({

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -12,6 +12,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContextEngine } from "../../context-engine/types.js";
 import type { ImageContent } from "../../llm/types.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
+import type { CliBackendExecutionMode } from "../../plugins/cli-backend.types.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
 import type {
   PersistedUserTurnMessage,
@@ -43,6 +44,11 @@ export type RunCliAgentParams = {
   config?: OpenClawConfig;
   prompt: string;
   transcriptPrompt?: string;
+  /**
+   * Execution mode for the generic CLI runner. Side questions are one-shot
+   * background answers and must not reuse or mutate normal agent sessions.
+   */
+  executionMode?: CliBackendExecutionMode;
   suppressNextUserMessagePersistence?: boolean;
   userTurnTranscriptRecorder?: UserTurnTranscriptRecorder;
   onUserMessagePersisted?: (message: PersistedUserTurnMessage) => void | Promise<void>;

--- a/src/plugin-sdk/cli-backend.ts
+++ b/src/plugin-sdk/cli-backend.ts
@@ -4,6 +4,7 @@
 export type { CliBackendConfig } from "../config/types.js";
 export type {
   CliBackendAuthEpochMode,
+  CliBackendExecutionMode,
   CliBackendNormalizeConfigContext,
   CliBackendNativeToolMode,
   CliBackendPlugin,
@@ -11,6 +12,7 @@ export type {
   CliBackendPrepareExecutionContext,
   CliBackendResolveExecutionArgs,
   CliBackendResolveExecutionArgsContext,
+  CliBackendSideQuestionToolMode,
   CliBackendThinkingLevel,
 } from "../plugins/types.js";
 export {

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -27,6 +27,7 @@ export type CliBackendPrepareExecutionContext = {
   provider: string;
   modelId: string;
   authProfileId?: string;
+  executionMode?: CliBackendExecutionMode;
 };
 
 export type CliBackendPreparedExecution = {
@@ -45,6 +46,8 @@ export type CliBackendThinkingLevel =
   | "adaptive"
   | "max";
 
+export type CliBackendExecutionMode = "agent" | "side-question";
+
 export type CliBackendResolveExecutionArgsContext = {
   config?: OpenClawConfig;
   workspaceDir: string;
@@ -52,6 +55,7 @@ export type CliBackendResolveExecutionArgsContext = {
   modelId: string;
   authProfileId?: string;
   thinkingLevel?: CliBackendThinkingLevel;
+  executionMode?: CliBackendExecutionMode;
   useResume: boolean;
   baseArgs: readonly string[];
 };
@@ -63,6 +67,8 @@ export type CliBackendResolveExecutionArgs = (
 export type CliBackendAuthEpochMode = "combined" | "profile-only";
 
 export type CliBackendNativeToolMode = "none" | "always-on";
+
+export type CliBackendSideQuestionToolMode = "disabled";
 
 export type CliBackendNormalizeConfigContext = {
   config?: OpenClawConfig;
@@ -195,4 +201,12 @@ export type CliBackendPlugin = {
    * closed instead of launching a native harness.
    */
   nativeToolMode?: CliBackendNativeToolMode;
+  /**
+   * Side-question native tool behavior.
+   *
+   * Set to `disabled` only when `executionMode: "side-question"` reliably
+   * launches the CLI without native tools, even if normal agent turns expose
+   * backend-owned tools.
+   */
+  sideQuestionToolMode?: CliBackendSideQuestionToolMode;
 };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -191,12 +191,14 @@ export type {
 } from "./conversation-binding.types.js";
 export type {
   CliBackendAuthEpochMode,
+  CliBackendExecutionMode,
   CliBackendNormalizeConfigContext,
   CliBackendNativeToolMode,
   CliBackendPreparedExecution,
   CliBackendPrepareExecutionContext,
   CliBackendResolveExecutionArgs,
   CliBackendResolveExecutionArgsContext,
+  CliBackendSideQuestionToolMode,
   CliBackendThinkingLevel,
   CliBackendPlugin,
   CliBundleMcpMode,

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -5,6 +5,7 @@ import { defaultRuntime } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 
 const agentCommandFromIngressMock = vi.fn();
+const runBtwSideQuestionMock = vi.fn();
 const updateSessionStoreMock = vi.fn();
 const applySessionsPatchToStoreMock = vi.fn();
 const createSessionGoalMock = vi.fn();
@@ -60,6 +61,10 @@ vi.mock("../agents/agent-command.js", () => ({
   agentCommandFromIngress: (...args: unknown[]) => agentCommandFromIngressMock(...args),
 }));
 
+vi.mock("../agents/btw.js", () => ({
+  runBtwSideQuestion: (...args: unknown[]) => runBtwSideQuestionMock(...args),
+}));
+
 vi.mock("../infra/agent-events.js", () => ({
   onAgentEvent: (listener: (evt: unknown) => void) => {
     registeredListener = listener;
@@ -88,6 +93,7 @@ vi.mock("../config/sessions.js", () => ({
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentDir: (_cfg: unknown, agentId: string) => `/tmp/openclaw-agent-${agentId}/agent`,
   resolveAgentWorkspaceDir: (_cfg: unknown, agentId: string) => `/tmp/openclaw-agent-${agentId}`,
   resolveDefaultAgentId: (cfg?: {
     agents?: { list?: Array<{ id?: string; default?: boolean }> };
@@ -216,6 +222,7 @@ describe("EmbeddedTuiBackend", () => {
     vi.useFakeTimers();
     vi.setSystemTime(embeddedEventTimestamp);
     agentCommandFromIngressMock.mockReset();
+    runBtwSideQuestionMock.mockReset();
     updateSessionStoreMock.mockReset();
     updateSessionStoreMock.mockImplementation(
       async (_storePath: string, update: (store: Record<string, unknown>) => unknown) =>
@@ -1654,10 +1661,22 @@ describe("EmbeddedTuiBackend", () => {
 
   it("emits side-result events for local /btw runs", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    agentCommandFromIngressMock.mockResolvedValueOnce({
-      payloads: [{ text: "nothing important" }],
-      meta: {},
+    loadSessionEntryMock.mockReturnValueOnce({
+      cfg: {},
+      canonicalKey: "agent:main:main",
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {
+        "agent:main:main": {
+          sessionId: "session-main",
+          updatedAt: Date.now(),
+        },
+      },
+      entry: {
+        sessionId: "session-main",
+        updatedAt: Date.now(),
+      },
     });
+    runBtwSideQuestionMock.mockResolvedValueOnce({ text: "nothing important" });
 
     const backend = new EmbeddedTuiBackend();
     const events: Array<{ event: string; payload: unknown }> = [];
@@ -1670,9 +1689,26 @@ describe("EmbeddedTuiBackend", () => {
       sessionKey: "agent:main:main",
       message: "/btw what changed?",
       runId: "run-btw-1",
+      timeoutMs: 0,
     });
     await flushMicrotasks();
 
+    await vi.waitFor(() => {
+      expect(runBtwSideQuestionMock).toHaveBeenCalledTimes(1);
+    });
+    expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
+    expect(runBtwSideQuestionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.4",
+        question: "what changed?",
+        sessionKey: "agent:main:main",
+        opts: expect.objectContaining({
+          timeoutOverrideSeconds: 0,
+        }),
+        isNewSession: false,
+      }),
+    );
     expect(events).toEqual([
       {
         event: "chat.side_result",
@@ -1697,10 +1733,22 @@ describe("EmbeddedTuiBackend", () => {
 
   it("emits side-result events for local /side alias runs", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    agentCommandFromIngressMock.mockResolvedValueOnce({
-      payloads: [{ text: "alias answer" }],
-      meta: {},
+    loadSessionEntryMock.mockReturnValueOnce({
+      cfg: {},
+      canonicalKey: "agent:main:main",
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {
+        "agent:main:main": {
+          sessionId: "session-main",
+          updatedAt: Date.now(),
+        },
+      },
+      entry: {
+        sessionId: "session-main",
+        updatedAt: Date.now(),
+      },
     });
+    runBtwSideQuestionMock.mockResolvedValueOnce({ text: "alias answer" });
 
     const backend = new EmbeddedTuiBackend();
     const events: Array<{ event: string; payload: unknown }> = [];
@@ -1716,6 +1764,16 @@ describe("EmbeddedTuiBackend", () => {
     });
     await flushMicrotasks();
 
+    await vi.waitFor(() => {
+      expect(runBtwSideQuestionMock).toHaveBeenCalledTimes(1);
+    });
+    expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
+    expect(runBtwSideQuestionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        question: "what changed?",
+        sessionKey: "agent:main:main",
+      }),
+    );
     expect(events).toEqual([
       {
         event: "chat.side_result",

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -3,10 +3,12 @@ import { randomUUID } from "node:crypto";
 import type { SessionsPatchResult } from "../../packages/gateway-protocol/src/index.js";
 import { agentCommandFromIngress } from "../agents/agent-command.js";
 import {
+  resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../agents/agent-scope.js";
+import { runBtwSideQuestion } from "../agents/btw.js";
 import { ensureContextWindowCacheLoaded } from "../agents/context.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import {
@@ -584,6 +586,62 @@ export class EmbeddedTuiBackend implements TuiBackend {
     return { ok: true as const, key: result.key, entry: result.entry };
   }
 
+  private async runBtwTurn(params: {
+    runId: string;
+    sessionKey: string;
+    agentId?: string;
+    question: string;
+    timeoutMs?: number;
+    controller: AbortController;
+  }) {
+    const loadOptions = params.agentId ? { agentId: params.agentId } : undefined;
+    const { cfg, canonicalKey, storePath, store, entry } = loadSessionEntry(
+      params.sessionKey,
+      loadOptions,
+    );
+    if (!entry?.sessionId) {
+      throw new Error("/btw requires an active session with existing context.");
+    }
+    const sessionAgentId = resolveSessionAgentId({
+      sessionKey: canonicalKey,
+      config: cfg,
+      agentId: params.agentId,
+    });
+    const resolvedModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
+    const timeoutSeconds = timeoutSecondsFromMs(params.timeoutMs);
+    const reply = await runBtwSideQuestion({
+      cfg,
+      agentDir: resolveAgentDir(cfg, sessionAgentId),
+      provider: resolvedModel.provider,
+      model: resolvedModel.model,
+      question: params.question,
+      sessionEntry: entry,
+      sessionStore: store,
+      sessionKey: canonicalKey,
+      storePath,
+      resolvedThinkLevel: "off",
+      resolvedReasoningLevel: "off",
+      opts: {
+        runId: params.runId,
+        abortSignal: params.controller.signal,
+        ...(timeoutSeconds !== undefined ? { timeoutOverrideSeconds: Number(timeoutSeconds) } : {}),
+      },
+      isNewSession: false,
+      messageChannel: INTERNAL_MESSAGE_CHANNEL,
+      messageProvider: INTERNAL_MESSAGE_CHANNEL,
+      currentChannelId: INTERNAL_MESSAGE_CHANNEL,
+    });
+    const text = reply?.text?.trim() ?? "";
+    if (!text) {
+      throw new Error("/btw produced no answer.");
+    }
+    return {
+      sessionKey: canonicalKey,
+      text,
+      isError: reply?.isError === true,
+    };
+  }
+
   async getGatewayStatus() {
     return `local embedded mode${this.runs.size > 0 ? ` (${String(this.runs.size)} active run${this.runs.size === 1 ? "" : "s"})` : ""}`;
   }
@@ -1003,6 +1061,35 @@ export class EmbeddedTuiBackend implements TuiBackend {
           }
           return;
         }
+      }
+      const activeRun = this.runs.get(params.runId);
+      if (activeRun?.isBtw && activeRun.question) {
+        const result = await this.runBtwTurn({
+          runId: params.runId,
+          sessionKey: params.sessionKey,
+          ...(params.agentId ? { agentId: params.agentId } : {}),
+          question: activeRun.question,
+          timeoutMs: params.timeoutMs,
+          controller: params.controller,
+        });
+        const run = this.runs.get(params.runId);
+        if (!run) {
+          return;
+        }
+        if (params.controller.signal.aborted) {
+          this.emitChatAborted(params.runId, run);
+          return;
+        }
+        this.emit("chat.side_result", {
+          kind: "btw",
+          runId: params.runId,
+          sessionKey: result.sessionKey,
+          question: run.question,
+          text: result.text,
+          ...(result.isError ? { isError: true } : {}),
+        });
+        this.emitChatFinal(params.runId, run);
+        return;
       }
       const loadOptions = params.agentId ? { agentId: params.agentId } : undefined;
       const { canonicalKey, entry } = loadSessionEntry(params.sessionKey, loadOptions);

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -8,7 +8,6 @@ import {
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../agents/agent-scope.js";
-import { runBtwSideQuestion } from "../agents/btw.js";
 import { ensureContextWindowCacheLoaded } from "../agents/context.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import {
@@ -609,6 +608,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     });
     const resolvedModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
     const timeoutSeconds = timeoutSecondsFromMs(params.timeoutMs);
+    const { runBtwSideQuestion } = await import("../agents/btw.js");
     const reply = await runBtwSideQuestion({
       cfg,
       agentDir: resolveAgentDir(cfg, sessionAgentId),


### PR DESCRIPTION
## Summary

- Enables `/btw` and `/side` for CLI-runtime sessions instead of failing closed when the selected model uses a CLI backend such as `claude-cli`.
- Adds a side-question execution mode for CLI backends that seeds sanitized session context into a fresh one-shot CLI invocation while disabling OpenClaw MCP bundling, reusable CLI session state, live assistant/tool event emission, and backend session resume behavior.
- Adds Claude CLI side-question argument shaping so conflicting resume/session/tool/MCP flags are stripped before adding isolated no-tool, no-session-persistence, one-turn constraints.
- Routes local embedded chat `/btw` through the side-result path so it is not sent as a normal model-visible prompt.
- Updates plugin SDK/docs to describe the CLI backend side-question contract.

Out of scope: Control UI rendering for live `chat.side_result` events; the Gateway emits the event and history contract correctly, but browser UI consumption remains a separate client-side follow-up.

Reviewers should focus on CLI side-question isolation, Claude CLI argv sanitization, local embedded chat command routing, timeout semantics, and the SDK/docs contract for `sideQuestionToolMode`.

## Linked context

Related #92168
Related #92264
Related #92181
Follow-up to #92226.

Requested by a maintainer in the CLI `/btw` follow-up thread.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `/btw` in Claude CLI-backed OpenClaw sessions should run as an ephemeral side question, emit `chat.side_result`, and avoid polluting normal chat history or the native Claude main session transcript.
- Real environment tested: Local macOS checkout on this branch, isolated `HOME`, OpenClaw built from this patch, real Claude CLI 2.1.177, real Anthropic API-key auth injected via 1Password into the proof subprocess only.
- Exact steps or command run after this patch: Built the branch, then ran two live E2E drivers: one against `EmbeddedTuiBackend` local chat and one against a loopback `openclaw gateway run` using `GatewayChatClient`/`chat.send`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "local_embedded_chat": {
    "ok": true,
    "assistantText": "MAIN_READY_OPENCLAW_BTW_FINAL_EMBED_MAIN_1781352833957\nMAIN_NO_SIDE_MARKER",
    "btwText": "BTW_SEEN_OPENCLAW_BTW_FINAL_EMBED_MAIN_1781352833957_SIDE_OPENCLAW_BTW_FINAL_EMBED_SIDE_1781352833957_6195",
    "historyHasBtwCommand": false,
    "historyHasSideMarker": false,
    "historyHasBtwAnswer": false,
    "claudeFileFacts": [{ "hasMain": true, "hasSide": false }]
  },
  "gateway_chat": {
    "ok": true,
    "assistantText": "MAIN_READY_OPENCLAW_BTW_FINAL_GATEWAY_MAIN_1781352989022\nMAIN_NO_SIDE_MARKER",
    "btwText": "BTW_SEEN_OPENCLAW_BTW_FINAL_GATEWAY_MAIN_1781352989022_SIDE_OPENCLAW_BTW_FINAL_GATEWAY_SIDE_1781352989022_47794",
    "historyHasBtwCommand": false,
    "historyHasSideMarker": false,
    "historyHasBtwAnswer": false,
    "claudeFileFacts": [{ "hasMain": true, "hasSide": false }]
  }
}
```

- Observed result after fix: Both user paths returned the exact `/btw` side answer, emitted the side result separately from normal assistant chat, kept `/btw` text/side marker/side answer out of `chat.history`, and left Claude's native main session JSONL containing the main marker but not the side marker.
- What was not tested: Control UI browser rendering of `chat.side_result`; that client still needs a dedicated live side-result consumer.
- Proof limitations or environment constraints: The proof used API-key Claude CLI auth rather than an interactive Claude subscription login. It still exercised a real Claude CLI binary and real Anthropic-backed model session.
- Before evidence (optional but encouraged): Prior fail-closed behavior rejected CLI-native BTW because `claude-cli` reported always-on native tools and had no side-question no-tools contract. During validation, direct `openclaw agent --local --message "/btw ..."` was also confirmed not to be a valid slash-command user path because it sends literal text as a one-shot agent prompt.

## Tests and validation

- `node scripts/run-vitest.mjs src/tui/embedded-backend.test.ts src/tui/tui-command-handlers.test.ts src/agents/btw.test.ts src/agents/cli-runner/prepare.test.ts src/agents/cli-runner.spawn.test.ts src/agents/cli-runner.reliability.test.ts extensions/anthropic/cli-shared.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:extensions`
- `pnpm build`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings
- Live E2E local embedded chat with real Claude CLI auth/session -> pass
- Live E2E Gateway-backed chat with real Claude CLI auth/session -> pass

Regression coverage added/updated for CLI side-question preparation, Claude side-question argv sanitization, no-tools fail-closed behavior, timeout override `0` semantics, local embedded `/btw` routing, and side-result emission.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. CLI-backed sessions can now use `/btw` instead of receiving the previous fail-closed message.

Did config, environment, or migration behavior change? (`Yes/No`)

No config or migration behavior changes. The plugin SDK CLI backend contract gains optional `executionMode` and `sideQuestionToolMode` fields.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, tool execution posture changes for CLI-backed `/btw`: side-question mode intentionally disables OpenClaw MCP bundling and requires CLI backends with always-on native tools to explicitly declare disabled side-question tools before OpenClaw will run the side question.

What is the highest-risk area?

CLI side-question isolation for native harnesses, especially ensuring side questions do not resume or mutate the normal CLI session and do not expose native tools when the backend cannot disable them.

How is that risk mitigated?

The new side-question mode skips reusable CLI sessions, strips resume/session/tool/MCP args for Claude, disables OpenClaw MCP bundling, suppresses live assistant/tool events, preserves no-timeout semantics through the existing timeout resolver, keeps the previous fail-closed behavior unless the backend declares disabled side-question tools, and is covered by focused unit tests plus live Claude CLI E2E proof.

## Current review state

Next action: CI review.

Waiting on: GitHub CI. `Real behavior proof` may remain non-green per maintainer instruction because live proof is included above.

Bot or reviewer comments addressed: Local autoreview initially found missing `--resume-session-at` stripping and `timeoutOverrideSeconds: 0` handling; both were fixed and autoreview reran clean.
