### PR TITLE
docs(nodes): add openclaw.json config example to Nodes overview

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -230,15 +230,15 @@ Node-related settings live under `gateway.nodes` and `tools.exec`:
       },
       // Opt into dangerous/privacy-heavy node commands (camera.snap, etc.).
       allowCommands: ["camera.snap", "screen.record"],
-      // Block commands even if platform defaults allow them.
-      denyCommands: [],
+      // Block exact command names even if defaults or allowCommands include them.
+      denyCommands: ["camera.clip"],
     },
   },
   tools: {
     exec: {
       // Default exec host: "node" routes all exec calls to a paired node.
       host: "node",
-      // Security mode for node exec: "allowlist" requires explicit approval.
+      // Security mode for node exec: allow only approved/allowlisted commands.
       security: "allowlist",
       // Pin exec to a specific node (id or name). Omit to allow any node.
       node: "build-node",
@@ -246,6 +246,11 @@ Node-related settings live under `gateway.nodes` and `tools.exec`:
   },
 }
 ```
+
+Use exact node command names. `denyCommands` removes a command even when a
+platform default or `allowCommands` entry would otherwise allow it. See
+[Gateway configuration reference](/gateway/configuration-reference#gateway-field-details)
+for gateway node pairing and command-policy field details.
 
 Per-agent exec node override:
 

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -214,6 +214,54 @@ permission boundary. Dangerous plugin node commands still require explicit
 After a node changes its declared command list, reject the old device pairing
 and approve the new request so the gateway stores the updated command snapshot.
 
+## Config (`openclaw.json`)
+
+Node-related settings live under `gateway.nodes` and `tools.exec`:
+
+```json5
+{
+  gateway: {
+    nodes: {
+      // Auto-approve first-time node pairing from trusted networks (CIDR list).
+      // Disabled when unset. Only applies to first-time role:node requests
+      // with no requested scopes; does not auto-approve upgrades.
+      pairing: {
+        autoApproveCidrs: ["192.168.1.0/24"],
+      },
+      // Opt into dangerous/privacy-heavy node commands (camera.snap, etc.).
+      allowCommands: ["camera.snap", "screen.record"],
+      // Block commands even if platform defaults allow them.
+      denyCommands: [],
+    },
+  },
+  tools: {
+    exec: {
+      // Default exec host: "node" routes all exec calls to a paired node.
+      host: "node",
+      // Security mode for node exec: "allowlist" requires explicit approval.
+      security: "allowlist",
+      // Pin exec to a specific node (id or name). Omit to allow any node.
+      node: "build-node",
+    },
+  },
+}
+```
+
+Per-agent exec node override:
+
+```json5
+{
+  agents: {
+    list: [
+      {
+        id: "main",
+        tools: { exec: { node: "build-node" } },
+      },
+    ],
+  },
+}
+```
+
 ## Screenshots (canvas snapshots)
 
 If the node is showing the Canvas (WebView), `canvas.snapshot` returns `{ format, base64 }`.


### PR DESCRIPTION
## What

Add a `## Config (openclaw.json)` section to the Nodes overview page (`docs/nodes/index.md`) showing a consolidated example of node-related configuration keys.

The page already references `gateway.nodes.allowCommands`, `gateway.nodes.denyCommands`, `gateway.nodes.pairing.autoApproveCidrs`, `tools.exec.host`, `tools.exec.security`, and `tools.exec.node` throughout its prose, but never shows a single example of what the `openclaw.json` looks like. The new section provides a commented json5 snippet covering these settings plus a per-agent exec node override.

## Why

Fixes #92662 — the /nodes page is missing an `openclaw.json` configuration example, making it hard for users to translate the prose references into actual config.

## Changes

- `docs/nodes/index.md`: +48 lines — new `## Config (openclaw.json)` section with two json5 code blocks (gateway.nodes + tools.exec, and per-agent override)

## Real behavior proof

- **Behavior addressed:** The /nodes docs page references node configuration keys but provides no `openclaw.json` example.
- **Environment tested:** macOS, OpenClaw repo at `fix/nodes-docs-config-example` branch
- **Steps run after the patch:** `pnpm build` (builds all docs and runtime), `grep -c` for new config keys in the doc file, `node -e` verification of content presence
- **Evidence after fix:**

```
$ pnpm build 2>&1 | tail -3
[build-all] phase timings: total 91.7s ...
✓ built in 512ms

$ grep -c "autoApproveCidrs\|allowCommands\|tools.exec" docs/nodes/index.md
17

$ node -e "const fs = require('fs'); const c = fs.readFileSync('docs/nodes/index.md','utf8'); console.log('Config section:', c.includes('## Config')); console.log('autoApproveCidrs:', c.includes('autoApproveCidrs')); console.log('allowCommands:', c.includes('camera.snap')); console.log('tools.exec.node:', c.includes('build-node'));"
Config section: true
autoApproveCidrs: true
allowCommands: true
tools.exec.node: true
```

- **Observed result after fix:** The /nodes page now includes a `## Config (openclaw.json)` section with a commented json5 example covering `gateway.nodes.pairing.autoApproveCidrs`, `gateway.nodes.allowCommands`, `gateway.nodes.denyCommands`, `tools.exec.host`, `tools.exec.security`, `tools.exec.node`, and a per-agent override. Build passes cleanly.
- **What was not tested:** No runtime behavior changed (docs-only). The config keys themselves are not validated at runtime by this change.
