### PR TITLE
docs: add /nodes openclaw.json example (AI-assisted)

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -205,6 +205,30 @@ Dangerous or privacy-heavy commands such as `camera.snap`, `camera.clip`, and
 `gateway.nodes.allowCommands`. `gateway.nodes.denyCommands` always wins over
 defaults and extra allowlist entries.
 
+Example Gateway config (`~/.openclaw/openclaw.json`) for enabling selected
+high-risk node commands:
+
+```json5
+{
+  gateway: {
+    nodes: {
+      // Add only the high-risk commands this Gateway should expose.
+      allowCommands: ["camera.snap", "screen.record"],
+      // Keep exact denials for commands that must stay unavailable.
+      denyCommands: ["camera.clip"],
+    },
+  },
+}
+```
+
+Use exact node command names. `denyCommands` is also exact-match and removes a
+command even when a platform default or `allowCommands` entry would otherwise
+allow it. If your config was generated with high-risk commands in
+`denyCommands`, remove the same command there before adding it to
+`allowCommands`.
+See [Gateway configuration reference](/gateway/configuration-reference#gateway-field-details)
+for the complete `gateway.nodes` field list.
+
 Plugin-owned node commands can add a Gateway node-invoke policy. That policy
 runs after the allowlist check and before forwarding to the node, so raw
 `node.invoke`, CLI helpers, and dedicated agent tools share the same plugin


### PR DESCRIPTION
## Summary

- Adds an AI-assisted docs clarification to `/nodes` with a compact `~/.openclaw/openclaw.json` example for `gateway.nodes.allowCommands` and `gateway.nodes.denyCommands`.
- Keeps the example next to the existing node command-policy explanation so the config shape is tied to the node command safety model, not presented as generic setup boilerplate.
- Calls out that `denyCommands` uses exact command names and overrides defaults or explicit allow entries.
- What did NOT change: runtime behavior, config schema, Gateway command policy, node pairing behavior, and the full configuration reference.
- Review focus: whether the example belongs in the command-policy section and whether the allow/deny wording matches current node command semantics.

## Linked context

Closes #92662

Requested by the issue reporter via docs feedback for `https://docs.openclaw.ai/nodes`.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `/nodes` now includes a direct `openclaw.json` example for configuring selected high-risk node commands.
- Real environment tested: OpenClaw source checkout on branch `docs/nodes-openclaw-json-example`, based on `upstream/main` at `4c23d1d597`.
- Exact steps or command run after this patch: `pnpm docs:list`; `git diff --check upstream/main...HEAD`; `DOCS_I18N_GLOSSARY_BASE=upstream/main pnpm check:docs`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `docs/nodes/index.md` now contains the JSON5 example under Command policy; `pnpm check:docs` completed with `Summary: 0 error(s)`, `Docs MDX check passed (677 files, 7778ms)`, and `broken_links=0`.
- Observed result after fix: the docs page source has the requested `~/.openclaw/openclaw.json` example and the docs validation suite passes against the upstream main base.
- What was not tested: hosted Mintlify deployment rendering after merge.
- Proof limitations or environment constraints: docs-only change; no Gateway runtime behavior was changed or exercised.
- Before evidence (optional but encouraged): current `/nodes` source had `gateway.nodes.allowCommands` / `gateway.nodes.denyCommands` prose but no direct `openclaw.json` or JSON5 example on the reported page.

## Tests and validation

- `pnpm docs:list`
- `git diff --check upstream/main...HEAD`
- `DOCS_I18N_GLOSSARY_BASE=upstream/main pnpm check:docs`

No regression test was added because this is a docs-only clarification. The docs validation path covers formatting, markdownlint, MDX parsing, i18n glossary checks against the PR base, and internal links.

## Risk checklist

Did user-visible behavior change? `No`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area?

Docs accuracy for node command allow/deny policy.

How is that risk mitigated?

The example is anchored to the existing `/nodes` Command policy section, uses the current `gateway.nodes.*` config keys, and explicitly states that `denyCommands` overrides defaults and `allowCommands`.

## Current review state

Next action: maintainer review.

Waiting on: CI and reviewer feedback.

Bot/reviewer comments addressed: none yet.
