### PR TITLE
ci: gate secret scanning remediation approval

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -29,3 +29,5 @@ paths:
       - 'constant expression "false" in condition'
       # actionlint's built-in runner label allowlist lags Blacksmith additions.
       - 'label "blacksmith-16vcpu-[^"]+" is unknown\.'
+      # actionlint may lag newly supported GitHub webhook names.
+      - 'unknown Webhook event "secret_scanning_alert"\.'

--- a/.github/workflows/secret-scanning-remediation.yml
+++ b/.github/workflows/secret-scanning-remediation.yml
@@ -1,0 +1,67 @@
+name: Secret Scanning Remediation
+
+on:
+  secret_scanning_alert:
+    types: [created, reopened]
+  workflow_dispatch:
+    inputs:
+      alert_number:
+        description: Secret scanning alert number to process
+        required: true
+
+permissions: {}
+
+concurrency:
+  group: secret-scanning-remediation-${{ github.event.alert.number || inputs.alert_number }}
+  cancel-in-progress: false
+
+jobs:
+  secret-scanning-plan:
+    if: github.event_name == 'workflow_dispatch' || github.event.alert.resolution == null
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      security-events: read
+    outputs:
+      remediation-action: ${{ steps.plan.outputs.remediation-action }}
+      remediation-summary: ${{ steps.plan.outputs.remediation-summary }}
+    steps:
+      - name: Check out trusted workflow scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Plan secret scanning remediation
+        id: plan
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPENCLAW_SECRET_SCAN_ALERT_NUMBER: ${{ github.event.alert.number || inputs.alert_number }}
+          OPENCLAW_SECRET_SCAN_MODE: plan
+        run: node scripts/github/secret-scanning-remediation.mjs
+
+  secret-scanning-remediate:
+    if: needs.secret-scanning-plan.outputs.remediation-action == 'approval-required'
+    needs: secret-scanning-plan
+    environment: secret-remediation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      security-events: write
+    steps:
+      - name: Check out trusted workflow scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Apply approved secret scanning remediation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPENCLAW_SECRET_SCAN_ALERT_NUMBER: ${{ github.event.alert.number || inputs.alert_number }}
+          OPENCLAW_SECRET_SCAN_MODE: remediate
+        run: node scripts/github/secret-scanning-remediation.mjs

--- a/scripts/github/secret-scanning-remediation.mjs
+++ b/scripts/github/secret-scanning-remediation.mjs
@@ -1,0 +1,614 @@
+#!/usr/bin/env node
+
+// GitHub secret-scanning remediation workflow helper.
+//
+// Definition:
+//   plan: fetches a secret-scanning alert with hide_secret=true, classifies
+//   locations, and emits sanitized workflow outputs for environment approval.
+//   remediate: after protected-environment approval, redacts supported body
+//   locations or deletes/recreates supported issue comments, then resolves the
+//   alert. Commit and review-comment locations stay manual.
+//
+// Parameters:
+//   --mode <plan|remediate> or OPENCLAW_SECRET_SCAN_MODE.
+//   --alert <number> or OPENCLAW_SECRET_SCAN_ALERT_NUMBER / event payload.
+//   GITHUB_TOKEN and GITHUB_REPOSITORY are required for API calls.
+//
+// Outputs:
+//   plan writes remediation-action and remediation-summary to GITHUB_OUTPUT.
+//   stdout contains sanitized status only; never plaintext body or secrets.
+//
+// Examples:
+//   OPENCLAW_SECRET_SCAN_MODE=plan node scripts/github/secret-scanning-remediation.mjs
+//   node scripts/github/secret-scanning-remediation.mjs --mode remediate --alert 123
+
+import fs from "node:fs";
+import process from "node:process";
+
+export const supportedLocationTypes = new Set(["issue_body", "pull_request_body", "issue_comment"]);
+
+const apiBaseUrl = process.env.OPENCLAW_SECRET_SCAN_API_BASE_URL || "https://api.github.com";
+const redactionPrefix = "[REDACTED ";
+
+function usage() {
+  return `Usage:
+  node scripts/github/secret-scanning-remediation.mjs --mode <plan|remediate> [--alert <number>]
+
+Description:
+  Plans and performs approved OpenClaw secret-scanning remediation. The plan
+  phase never reads plaintext secrets and never changes GitHub content. The
+  remediate phase is intended to run only behind the secret-remediation
+  protected environment approval gate.
+
+Options:
+  --mode <plan|remediate>  Required unless OPENCLAW_SECRET_SCAN_MODE is set.
+  --alert <number>         Alert number; otherwise read from env or event JSON.
+  -h, --help               Show this help.
+
+Outputs:
+  plan: GitHub Actions outputs remediation-action and remediation-summary.
+  remediate: sanitized JSON status on stdout and private alert resolution.
+
+Examples:
+  node scripts/github/secret-scanning-remediation.mjs --mode plan --alert 123
+  OPENCLAW_SECRET_SCAN_MODE=remediate node scripts/github/secret-scanning-remediation.mjs
+`;
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArgs(argv) {
+  const args = {
+    alertNumber: null,
+    mode: process.env.OPENCLAW_SECRET_SCAN_MODE || null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "-h" || arg === "--help") {
+      return { ...args, help: true };
+    }
+    if (arg === "--mode") {
+      args.mode = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+    if (arg === "--alert") {
+      args.alertNumber = Number(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    fail(`Unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+function normalizeApiUrl(urlOrPath) {
+  if (!urlOrPath) {
+    fail("Missing API URL");
+  }
+  if (urlOrPath.startsWith("https://")) {
+    return urlOrPath;
+  }
+  if (urlOrPath.startsWith("/")) {
+    return `${apiBaseUrl}${urlOrPath}`;
+  }
+  return `${apiBaseUrl}/${urlOrPath}`;
+}
+
+function apiPathForLog(url) {
+  return String(url).replace(apiBaseUrl, "");
+}
+
+async function requestJson(urlOrPath, init = {}, env = process.env) {
+  const url = normalizeApiUrl(urlOrPath);
+  const token = env.GITHUB_TOKEN;
+  if (!token) {
+    fail("GITHUB_TOKEN is required");
+  }
+
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...init.headers,
+    },
+  });
+  if (!response.ok) {
+    fail(
+      `GitHub API request failed: ${response.status} ${response.statusText} ${apiPathForLog(url)}`,
+    );
+  }
+  if (response.status === 204) {
+    return null;
+  }
+  return response.json();
+}
+
+async function paginateJson(urlOrPath, env = process.env) {
+  const items = [];
+  let nextUrl = normalizeApiUrl(urlOrPath);
+  while (nextUrl) {
+    const response = await fetch(nextUrl, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!response.ok) {
+      fail(
+        `GitHub API request failed: ${response.status} ${response.statusText} ${apiPathForLog(nextUrl)}`,
+      );
+    }
+    const page = await response.json();
+    items.push(...(Array.isArray(page) ? page : [page]));
+    const linkHeader = response.headers.get("link") || "";
+    nextUrl = linkHeader.match(/<([^>]+)>;\s*rel="next"/)?.[1] ?? null;
+  }
+  return items;
+}
+
+function parseEventPayload(env = process.env) {
+  const eventPath = env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    return {};
+  }
+  return JSON.parse(fs.readFileSync(eventPath, "utf8"));
+}
+
+function resolveAlertNumber(args, env = process.env) {
+  if (Number.isInteger(args.alertNumber) && args.alertNumber > 0) {
+    return args.alertNumber;
+  }
+  const payload = parseEventPayload(env);
+  const value =
+    env.OPENCLAW_SECRET_SCAN_ALERT_NUMBER ||
+    env.SECRET_SCANNING_ALERT_NUMBER ||
+    payload?.alert?.number ||
+    payload?.number;
+  const number = Number(value);
+  if (!Number.isInteger(number) || number <= 0) {
+    fail("Unable to determine secret scanning alert number");
+  }
+  return number;
+}
+
+function normalizeLogin(login) {
+  return typeof login === "string" && login.length > 0 && !login.endsWith("[bot]") ? login : null;
+}
+
+function extractIssueNumberFromHtmlUrl(htmlUrl) {
+  const match = String(htmlUrl || "").match(/\/(?:issues|pull)\/(\d+)/u);
+  return match ? Number(match[1]) : null;
+}
+
+function targetSummary(target) {
+  const author = target.author ? `author=@${target.author}` : "author=unknown";
+  return `${target.locationType}:${target.operation}:${author}`;
+}
+
+function outputValue(value) {
+  return String(value)
+    .replace(/[\r\n]/gu, " ")
+    .slice(0, 1024);
+}
+
+function setGithubOutput(name, value, env = process.env) {
+  if (!env.GITHUB_OUTPUT) {
+    return;
+  }
+  fs.appendFileSync(env.GITHUB_OUTPUT, `${name}=${outputValue(value)}\n`);
+}
+
+function redactionMarker(secretType) {
+  return `${redactionPrefix}${String(secretType || "Secret")}]`;
+}
+
+function isAlreadyRedacted(value) {
+  return String(value).includes(redactionPrefix);
+}
+
+export function redactLocationRange(body, details, secretType) {
+  const startLine = Number(details.start_line);
+  const endLine = Number(details.end_line);
+  const startColumn = Number(details.start_column);
+  const endColumn = Number(details.end_column);
+  if (
+    !Number.isInteger(startLine) ||
+    !Number.isInteger(endLine) ||
+    !Number.isInteger(startColumn) ||
+    !Number.isInteger(endColumn) ||
+    startLine <= 0 ||
+    endLine < startLine ||
+    startColumn <= 0 ||
+    endColumn <= 0
+  ) {
+    return { changed: false, reason: "invalid_location_range", text: body };
+  }
+
+  const lines = String(body ?? "").split("\n");
+  if (startLine > lines.length || endLine > lines.length) {
+    return { changed: false, reason: "location_out_of_range", text: body };
+  }
+
+  const startIndex = startColumn - 1;
+  const endIndex = endColumn - 1;
+  const firstLine = lines[startLine - 1] ?? "";
+  const lastLine = lines[endLine - 1] ?? "";
+  if (startIndex > firstLine.length || endIndex > lastLine.length) {
+    return { changed: false, reason: "column_out_of_range", text: body };
+  }
+
+  const selected =
+    startLine === endLine
+      ? firstLine.slice(startIndex, endIndex)
+      : [
+          firstLine.slice(startIndex),
+          ...lines.slice(startLine, endLine - 1),
+          lastLine.slice(0, endIndex),
+        ].join("\n");
+  if (selected.length === 0) {
+    return { changed: false, reason: "empty_location_range", text: body };
+  }
+  if (isAlreadyRedacted(selected)) {
+    return { changed: false, reason: "already_redacted", text: body };
+  }
+
+  const marker = redactionMarker(secretType);
+  if (startLine === endLine) {
+    lines[startLine - 1] = `${firstLine.slice(0, startIndex)}${marker}${firstLine.slice(endIndex)}`;
+  } else {
+    lines.splice(
+      startLine - 1,
+      endLine - startLine + 1,
+      `${firstLine.slice(0, startIndex)}${marker}${lastLine.slice(endIndex)}`,
+    );
+  }
+  return { changed: true, text: lines.join("\n") };
+}
+
+function rangeStart(details) {
+  return {
+    column: Number(details.start_column),
+    line: Number(details.start_line),
+  };
+}
+
+function compareRangeDescending(left, right) {
+  const leftStart = rangeStart(left);
+  const rightStart = rangeStart(right);
+  return rightStart.line - leftStart.line || rightStart.column - leftStart.column;
+}
+
+export function redactLocationRanges(body, detailsList, secretType) {
+  let text = String(body ?? "");
+  let changed = false;
+  let alreadyRedacted = 0;
+  const sortedDetails = detailsList.toSorted(compareRangeDescending);
+
+  for (const details of sortedDetails) {
+    const redaction = redactLocationRange(text, details, secretType);
+    if (!redaction.changed) {
+      if (redaction.reason === "already_redacted") {
+        alreadyRedacted += 1;
+        continue;
+      }
+      return {
+        changed: false,
+        ok: false,
+        reason: redaction.reason,
+        text: body,
+      };
+    }
+    changed = true;
+    text = redaction.text;
+  }
+
+  return {
+    changed,
+    ok: true,
+    reason: changed ? undefined : alreadyRedacted > 0 ? "already_redacted" : "empty_locations",
+    text,
+  };
+}
+
+async function fetchAlert(alertNumber, env) {
+  const repository = env.GITHUB_REPOSITORY;
+  if (!repository) {
+    fail("GITHUB_REPOSITORY is required");
+  }
+  return requestJson(
+    `/repos/${repository}/secret-scanning/alerts/${alertNumber}?hide_secret=true`,
+    {},
+    env,
+  );
+}
+
+async function fetchLocations(alertNumber, env) {
+  return paginateJson(
+    `/repos/${env.GITHUB_REPOSITORY}/secret-scanning/alerts/${alertNumber}/locations?per_page=100`,
+    env,
+  );
+}
+
+async function classifyLocation(location, env) {
+  const details = location.details ?? {};
+  if (location.type === "issue_body") {
+    const issue = await requestJson(details.issue_body_url || details.issue_url, {}, env);
+    return {
+      author: normalizeLogin(issue?.user?.login),
+      bodyEndpoint: `/repos/${env.GITHUB_REPOSITORY}/issues/${issue.number}`,
+      locationType: location.type,
+      operation: "patch_body",
+      details,
+    };
+  }
+  if (location.type === "pull_request_body") {
+    const pullRequest = await requestJson(
+      details.pull_request_body_url || details.pull_request_url,
+      {},
+      env,
+    );
+    return {
+      author: normalizeLogin(pullRequest?.user?.login),
+      bodyEndpoint: `/repos/${env.GITHUB_REPOSITORY}/pulls/${pullRequest.number}`,
+      locationType: location.type,
+      operation: "patch_body",
+      details,
+    };
+  }
+  if (location.type === "issue_comment") {
+    const comment = await requestJson(details.issue_comment_url, {}, env);
+    return {
+      author: normalizeLogin(comment?.user?.login),
+      commentDeleteEndpoint: `/repos/${env.GITHUB_REPOSITORY}/issues/comments/${comment.id}`,
+      commentId: comment.id,
+      issueNumber: extractIssueNumberFromHtmlUrl(comment?.html_url),
+      locationType: location.type,
+      operation: "delete_recreate_comment",
+      details,
+    };
+  }
+  return {
+    locationType: location.type,
+    operation: location.type === "commit" ? "manual_rotate_commit" : "manual_review",
+    unsupported: true,
+  };
+}
+
+export async function buildRemediationPlan({ alertNumber, env = process.env }) {
+  const alert = await fetchAlert(alertNumber, env);
+  if (alert.state !== "open") {
+    return {
+      action: "none",
+      reason: `alert_state_${alert.state}`,
+      summary: `No remediation needed; alert state is ${alert.state}.`,
+      targets: [],
+    };
+  }
+
+  const locations = await fetchLocations(alertNumber, env);
+  const targets = [];
+  for (const location of locations) {
+    targets.push(await classifyLocation(location, env));
+  }
+  if (targets.length === 0) {
+    return {
+      action: "manual",
+      reason: "no_locations",
+      summary: "No alert locations returned; maintainer review required.",
+      targets,
+    };
+  }
+
+  const unsupportedTargets = targets.filter((target) => target.unsupported);
+  if (unsupportedTargets.length > 0) {
+    return {
+      action: "manual",
+      reason: "unsupported_location",
+      summary: `Manual remediation required for ${unsupportedTargets
+        .map((target) => target.locationType)
+        .toSorted()
+        .join(", ")}.`,
+      targets,
+    };
+  }
+
+  return {
+    action: "approval-required",
+    reason: "supported_locations",
+    summary: `Maintainer approval required for ${targets.map(targetSummary).join("; ")}`,
+    targets,
+  };
+}
+
+function groupTargets(targets, keyForTarget) {
+  const groups = new Map();
+  for (const target of targets) {
+    const key = keyForTarget(target);
+    if (!key) {
+      continue;
+    }
+    if (!groups.has(key)) {
+      groups.set(key, []);
+    }
+    groups.get(key).push(target);
+  }
+  return [...groups.values()];
+}
+
+async function patchBodyTargets({ targets, alert, env }) {
+  const target = targets[0];
+  const resource = await requestJson(target.bodyEndpoint, {}, env);
+  const redaction = redactLocationRanges(
+    resource?.body ?? "",
+    targets.map((item) => item.details),
+    alert.secret_type_display_name,
+  );
+  if (!redaction.ok || !redaction.changed) {
+    return {
+      changed: false,
+      locationType: target.locationType,
+      operation: target.operation,
+      reason: redaction.reason,
+    };
+  }
+  await requestJson(
+    target.bodyEndpoint,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ body: redaction.text }),
+    },
+    env,
+  );
+  return { changed: true, locationType: target.locationType, operation: target.operation };
+}
+
+function replacementCommentBody({ author, originalBody }) {
+  const attribution = author ? ` by @${author}` : "";
+  return [
+    `> **Note:** The original comment${attribution} was removed because it contained sensitive credentials. The redacted content is preserved below.`,
+    "",
+    "---",
+    "",
+    originalBody,
+  ].join("\n");
+}
+
+async function remediateIssueCommentTargets({ targets, alert, env }) {
+  const target = targets[0];
+  if (!target.issueNumber) {
+    return {
+      changed: false,
+      locationType: target.locationType,
+      operation: target.operation,
+      reason: "missing_issue_number",
+    };
+  }
+  const comment = await requestJson(
+    `/repos/${env.GITHUB_REPOSITORY}/issues/comments/${target.commentId}`,
+    {},
+    env,
+  );
+  const redaction = redactLocationRanges(
+    comment?.body ?? "",
+    targets.map((item) => item.details),
+    alert.secret_type_display_name,
+  );
+  if (!redaction.ok || !redaction.changed) {
+    return {
+      changed: false,
+      locationType: target.locationType,
+      operation: target.operation,
+      reason: redaction.reason,
+    };
+  }
+  await requestJson(target.commentDeleteEndpoint, { method: "DELETE" }, env);
+  await requestJson(
+    `/repos/${env.GITHUB_REPOSITORY}/issues/${target.issueNumber}/comments`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        body: replacementCommentBody({
+          author: target.author,
+          originalBody: redaction.text,
+        }),
+      }),
+    },
+    env,
+  );
+  return { changed: true, locationType: target.locationType, operation: target.operation };
+}
+
+function isSuccessfulRemediationResult(result) {
+  return result.changed === true || result.reason === "already_redacted";
+}
+
+async function resolveAlert(alertNumber, results, env) {
+  const changedCount = results.filter((result) => result.changed).length;
+  const resolutionComment =
+    changedCount > 0
+      ? "Approved maintainer remediation completed; exposed credentials must be considered compromised and rotated."
+      : "Approved maintainer remediation found no remaining plaintext at the current location; credentials must still be considered compromised and rotated.";
+  await requestJson(
+    `/repos/${env.GITHUB_REPOSITORY}/secret-scanning/alerts/${alertNumber}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        state: "resolved",
+        resolution: "revoked",
+        resolution_comment: resolutionComment,
+      }),
+    },
+    env,
+  );
+}
+
+export async function remediateAlert({ alertNumber, env = process.env }) {
+  const plan = await buildRemediationPlan({ alertNumber, env });
+  if (plan.action !== "approval-required") {
+    return { ok: true, skipped: true, reason: plan.reason, results: [] };
+  }
+
+  const alert = await fetchAlert(alertNumber, env);
+  const results = [];
+  for (const targets of groupTargets(
+    plan.targets.filter((target) => target.operation === "patch_body"),
+    (target) => target.bodyEndpoint,
+  )) {
+    results.push(await patchBodyTargets({ targets, alert, env }));
+  }
+  for (const targets of groupTargets(
+    plan.targets.filter((target) => target.operation === "delete_recreate_comment"),
+    (target) => String(target.commentId),
+  )) {
+    results.push(await remediateIssueCommentTargets({ targets, alert, env }));
+  }
+  const failedResult = results.find((result) => !isSuccessfulRemediationResult(result));
+  if (failedResult) {
+    fail(
+      `Secret scanning remediation incomplete for ${failedResult.locationType}: ${failedResult.reason}`,
+    );
+  }
+  await resolveAlert(alertNumber, results, env);
+  return { ok: true, skipped: false, results };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  if (args.mode !== "plan" && args.mode !== "remediate") {
+    fail("--mode must be plan or remediate");
+  }
+  const alertNumber = resolveAlertNumber(args);
+
+  if (args.mode === "plan") {
+    const plan = await buildRemediationPlan({ alertNumber });
+    setGithubOutput("remediation-action", plan.action);
+    setGithubOutput("remediation-summary", plan.summary);
+    console.log(
+      JSON.stringify({ action: plan.action, reason: plan.reason, summary: plan.summary }),
+    );
+    return;
+  }
+
+  const result = await remediateAlert({ alertNumber });
+  console.log(JSON.stringify(result));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/test/scripts/secret-scanning-remediation-workflow.test.ts
+++ b/test/scripts/secret-scanning-remediation-workflow.test.ts
@@ -1,0 +1,90 @@
+// Secret Scanning Remediation Workflow tests cover the approval-gated workflow shape.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const WORKFLOW = ".github/workflows/secret-scanning-remediation.yml";
+
+type WorkflowStep = {
+  env?: Record<string, string>;
+  id?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, string | boolean>;
+};
+
+type WorkflowJob = {
+  environment?: string;
+  if?: string;
+  needs?: string;
+  outputs?: Record<string, string>;
+  permissions?: Record<string, string>;
+  steps?: WorkflowStep[];
+};
+
+type Workflow = {
+  jobs?: Record<string, WorkflowJob>;
+  permissions?: Record<string, string>;
+};
+
+function readWorkflow(): Workflow {
+  return parse(readFileSync(WORKFLOW, "utf8")) as Workflow;
+}
+
+describe("secret scanning remediation workflow", () => {
+  it("uses a private plan job before the protected remediation job", () => {
+    const parsed = readWorkflow();
+    const plan = parsed.jobs?.["secret-scanning-plan"];
+    const remediate = parsed.jobs?.["secret-scanning-remediate"];
+
+    expect(parsed.permissions).toEqual({});
+    expect(plan?.permissions).toEqual({
+      contents: "read",
+      "security-events": "read",
+    });
+    expect(plan?.outputs?.["remediation-action"]).toBe(
+      "${{ steps.plan.outputs.remediation-action }}",
+    );
+    expect(remediate?.needs).toBe("secret-scanning-plan");
+    expect(remediate?.if).toBe(
+      "needs.secret-scanning-plan.outputs.remediation-action == 'approval-required'",
+    );
+    expect(remediate?.environment).toBe("secret-remediation");
+  });
+
+  it("checks out trusted default-branch scripts instead of the alert commit", () => {
+    const jobs = readWorkflow().jobs ?? {};
+    for (const job of Object.values(jobs)) {
+      const checkout = job.steps?.[0];
+      expect(checkout?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd");
+      expect(checkout?.with?.ref).toBe("${{ github.event.repository.default_branch }}");
+      expect(checkout?.with?.["persist-credentials"]).toBe(false);
+    }
+  });
+
+  it("does not post public comments from the plan job", () => {
+    const parsed = readWorkflow();
+    const plan = parsed.jobs?.["secret-scanning-plan"];
+    const planSteps = parsed.jobs?.["secret-scanning-plan"]?.steps ?? [];
+
+    expect(plan?.permissions).not.toHaveProperty("issues");
+    expect(plan?.permissions).not.toHaveProperty("pull-requests");
+    expect(planSteps.at(-1)?.env?.OPENCLAW_SECRET_SCAN_MODE).toBe("plan");
+    expect(planSteps.at(-1)?.run).toBe("node scripts/github/secret-scanning-remediation.mjs");
+  });
+
+  it("grants write permissions only after environment approval", () => {
+    const remediate = readWorkflow().jobs?.["secret-scanning-remediate"];
+    const steps = remediate?.steps ?? [];
+
+    expect(remediate?.permissions).toEqual({
+      contents: "read",
+      issues: "write",
+      "pull-requests": "write",
+      "security-events": "write",
+    });
+    expect(steps.at(-1)?.env?.OPENCLAW_SECRET_SCAN_MODE).toBe("remediate");
+    expect(steps.at(-1)?.run).toBe("node scripts/github/secret-scanning-remediation.mjs");
+  });
+});

--- a/test/scripts/secret-scanning-remediation.test.ts
+++ b/test/scripts/secret-scanning-remediation.test.ts
@@ -1,0 +1,281 @@
+// Secret Scanning Remediation tests cover the approval-gated alert workflow helper.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildRemediationPlan,
+  redactLocationRange,
+  redactLocationRanges,
+  remediateAlert,
+} from "../../scripts/github/secret-scanning-remediation.mjs";
+
+type RequestRecord = { body?: string; method: string; url: string };
+
+function jsonResponse(value: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(value), {
+    headers: { "content-type": "application/json" },
+    status: 200,
+    ...init,
+  });
+}
+
+function testEnv() {
+  return {
+    GITHUB_REPOSITORY: "openclaw/openclaw",
+    GITHUB_TOKEN: "test-token",
+    OPENCLAW_SECRET_SCAN_API_BASE_URL: "https://api.test",
+  };
+}
+
+function installFetch(routes: Record<string, (request: Request) => Response>) {
+  const requests: RequestRecord[] = [];
+  vi.stubGlobal("fetch", async (url: string | URL | Request, init?: RequestInit) => {
+    const request = new Request(url, init);
+    requests.push({
+      body: init?.body ? String(init.body) : undefined,
+      method: request.method,
+      url: request.url,
+    });
+    const parsed = new URL(request.url);
+    const handler = routes[`${request.method} ${parsed.pathname}${parsed.search}`];
+    if (!handler) {
+      return jsonResponse(
+        { message: `Unhandled ${request.method} ${parsed.pathname}` },
+        { status: 404 },
+      );
+    }
+    return handler(request);
+  });
+  return requests;
+}
+
+describe("secret scanning remediation script", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("redacts the exact alert range without exposing the original secret", () => {
+    const result = redactLocationRange(
+      "key: abcdefghijklmnopqrstuvwxyz\n",
+      {
+        end_column: 32,
+        end_line: 1,
+        start_column: 6,
+        start_line: 1,
+      },
+      "Example Token",
+    );
+
+    expect(result).toMatchObject({ changed: true });
+    expect(result.text).toBe("key: [REDACTED Example Token]\n");
+    expect(result.text).not.toContain("abcdefghijklmnopqrstuvwxyz");
+  });
+
+  it("applies multiple redactions against the original coordinates", () => {
+    const result = redactLocationRanges(
+      "tokens: alpha beta\n",
+      [
+        { end_column: 14, end_line: 1, start_column: 9, start_line: 1 },
+        { end_column: 19, end_line: 1, start_column: 15, start_line: 1 },
+      ],
+      "Example Token",
+    );
+
+    expect(result).toMatchObject({ changed: true, ok: true });
+    expect(result.text).toBe("tokens: [REDACTED Example Token] [REDACTED Example Token]\n");
+    expect(result.text).not.toContain("alpha");
+    expect(result.text).not.toContain("beta");
+  });
+
+  it("plans supported body remediation without changing GitHub content", async () => {
+    const requests = installFetch({
+      "GET /repos/openclaw/openclaw/secret-scanning/alerts/7?hide_secret=true": () =>
+        jsonResponse({
+          number: 7,
+          secret_type_display_name: "Discord Bot Token",
+          state: "open",
+        }),
+      "GET /repos/openclaw/openclaw/secret-scanning/alerts/7/locations?per_page=100": () =>
+        jsonResponse([
+          {
+            details: {
+              end_column: 15,
+              end_line: 2,
+              issue_url: "/repos/openclaw/openclaw/issues/55",
+              start_column: 8,
+              start_line: 2,
+            },
+            type: "issue_body",
+          },
+        ]),
+      "GET /repos/openclaw/openclaw/issues/55": () =>
+        jsonResponse({ number: 55, user: { login: "reporter" } }),
+    });
+
+    const plan = await buildRemediationPlan({ alertNumber: 7, env: testEnv() });
+
+    expect(plan.action).toBe("approval-required");
+    expect(plan.summary).toContain("issue_body:patch_body:author=@reporter");
+    expect(requests.map((request) => request.method)).toEqual(["GET", "GET", "GET"]);
+  });
+
+  it("keeps commit alerts in manual handling instead of public notification", async () => {
+    installFetch({
+      "GET /repos/openclaw/openclaw/secret-scanning/alerts/8?hide_secret=true": () =>
+        jsonResponse({
+          number: 8,
+          secret_type_display_name: "Cloud Secret",
+          state: "open",
+        }),
+      "GET /repos/openclaw/openclaw/secret-scanning/alerts/8/locations?per_page=100": () =>
+        jsonResponse([{ details: { path: "src/example.ts" }, type: "commit" }]),
+    });
+
+    const plan = await buildRemediationPlan({ alertNumber: 8, env: testEnv() });
+
+    expect(plan).toMatchObject({
+      action: "manual",
+      reason: "unsupported_location",
+    });
+    expect(plan.summary).toContain("Manual remediation required");
+  });
+
+  it("patches body content and resolves the alert only during remediation", async () => {
+    const requests = installFetch({
+      "GET /repos/openclaw/openclaw/secret-scanning/alerts/9?hide_secret=true": () =>
+        jsonResponse({
+          number: 9,
+          secret_type_display_name: "Discord Bot Token",
+          state: "open",
+        }),
+      "GET /repos/openclaw/openclaw/secret-scanning/alerts/9/locations?per_page=100": () =>
+        jsonResponse([
+          {
+            details: {
+              end_column: 17,
+              end_line: 1,
+              issue_url: "/repos/openclaw/openclaw/issues/91",
+              start_column: 8,
+              start_line: 1,
+            },
+            type: "issue_body",
+          },
+        ]),
+      "GET /repos/openclaw/openclaw/issues/91": () =>
+        jsonResponse({ body: "token: plaintext\n", number: 91, user: { login: "reporter" } }),
+      "PATCH /repos/openclaw/openclaw/issues/91": () => jsonResponse({ number: 91 }),
+      "PATCH /repos/openclaw/openclaw/secret-scanning/alerts/9": () =>
+        jsonResponse({ number: 9, state: "resolved" }),
+    });
+
+    const result = await remediateAlert({ alertNumber: 9, env: testEnv() });
+
+    expect(result.skipped).toBe(false);
+    const patchBody =
+      requests.find((request) => request.method === "PATCH" && request.url.endsWith("/issues/91"))
+        ?.body ?? "";
+    expect(patchBody).toContain("[REDACTED Discord Bot Token]");
+    expect(patchBody).not.toContain("plaintext");
+    expect(requests.some((request) => request.url.endsWith("/issues/91/comments"))).toBe(false);
+  });
+
+  it("deletes and recreates issue comments once after applying all matching locations", async () => {
+    const requests = installFetch({
+      "GET /repos/openclaw/openclaw/secret-scanning/alerts/10?hide_secret=true": () =>
+        jsonResponse({
+          number: 10,
+          secret_type_display_name: "API Key",
+          state: "open",
+        }),
+      "GET /repos/openclaw/openclaw/secret-scanning/alerts/10/locations?per_page=100": () =>
+        jsonResponse([
+          {
+            details: {
+              end_column: 15,
+              end_line: 1,
+              issue_comment_url: "/repos/openclaw/openclaw/issues/comments/2001",
+              start_column: 6,
+              start_line: 1,
+            },
+            type: "issue_comment",
+          },
+          {
+            details: {
+              end_column: 24,
+              end_line: 1,
+              issue_comment_url: "/repos/openclaw/openclaw/issues/comments/2001",
+              start_column: 16,
+              start_line: 1,
+            },
+            type: "issue_comment",
+          },
+        ]),
+      "GET /repos/openclaw/openclaw/issues/comments/2001": () =>
+        jsonResponse({
+          body: "key: secret123 other456\ncontext",
+          html_url: "https://github.com/openclaw/openclaw/issues/77#issuecomment-2001",
+          id: 2001,
+          user: { login: "reporter" },
+        }),
+      "DELETE /repos/openclaw/openclaw/issues/comments/2001": () =>
+        new Response(null, { status: 204 }),
+      "POST /repos/openclaw/openclaw/issues/77/comments": () =>
+        jsonResponse({
+          html_url: "https://github.com/openclaw/openclaw/issues/77#issuecomment-3001",
+        }),
+      "PATCH /repos/openclaw/openclaw/secret-scanning/alerts/10": () =>
+        jsonResponse({ number: 10, state: "resolved" }),
+    });
+
+    const result = await remediateAlert({ alertNumber: 10, env: testEnv() });
+
+    expect(result.results).toMatchObject([
+      { changed: true, locationType: "issue_comment", operation: "delete_recreate_comment" },
+    ]);
+    expect(
+      requests.some(
+        (request) => request.method === "PATCH" && request.url.includes("/comments/2001"),
+      ),
+    ).toBe(false);
+    expect(requests.filter((request) => request.method === "DELETE")).toHaveLength(1);
+    expect(requests.filter((request) => request.method === "POST")).toHaveLength(1);
+    const replacement = requests.find((request) => request.method === "POST")?.body ?? "";
+    expect(replacement).toContain("[REDACTED API Key]");
+    expect(replacement).not.toContain("secret123");
+    expect(replacement).not.toContain("other456");
+  });
+
+  it("does not resolve alerts when a supported location cannot be fully redacted", async () => {
+    const requests = installFetch({
+      "GET /repos/openclaw/openclaw/secret-scanning/alerts/11?hide_secret=true": () =>
+        jsonResponse({
+          number: 11,
+          secret_type_display_name: "API Key",
+          state: "open",
+        }),
+      "GET /repos/openclaw/openclaw/secret-scanning/alerts/11/locations?per_page=100": () =>
+        jsonResponse([
+          {
+            details: {
+              end_column: 99,
+              end_line: 1,
+              issue_url: "/repos/openclaw/openclaw/issues/111",
+              start_column: 80,
+              start_line: 1,
+            },
+            type: "issue_body",
+          },
+        ]),
+      "GET /repos/openclaw/openclaw/issues/111": () =>
+        jsonResponse({ body: "key: short\n", number: 111, user: { login: "reporter" } }),
+    });
+
+    await expect(remediateAlert({ alertNumber: 11, env: testEnv() })).rejects.toThrow(
+      /remediation incomplete/,
+    );
+
+    expect(
+      requests.some((request) =>
+        request.url.endsWith("/repos/openclaw/openclaw/secret-scanning/alerts/11"),
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the public secret-scanning nudge approach from #71370 with a protected-environment remediation flow.
- Add a `secret_scanning_alert` workflow that first runs a read-only sanitized plan job, then waits on the `secret-remediation` environment before changing issue/PR content.
- Add a GitHub helper that redacts supported issue/PR body locations, deletes and recreates supported issue comments after approval, leaves commit/review-comment locations manual, and refuses to resolve alerts when remediation is incomplete.
- Add focused tests for planning, environment-gated workflow shape, multi-location redaction, comment delete/recreate, and failure-to-resolve behavior.

## Verification

- `node scripts/github/secret-scanning-remediation.mjs --help`
- `node --check scripts/github/secret-scanning-remediation.mjs`
- `/data/code/openclaw/openclaw/node_modules/.bin/oxfmt --write --threads=1 scripts/github/secret-scanning-remediation.mjs test/scripts/secret-scanning-remediation.test.ts test/scripts/secret-scanning-remediation-workflow.test.ts`
- `/data/code/openclaw/openclaw/node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.scripts.json --report-unused-disable-directives-severity error --threads=1 scripts/github/secret-scanning-remediation.mjs test/scripts/secret-scanning-remediation.test.ts test/scripts/secret-scanning-remediation-workflow.test.ts`
- `node scripts/run-vitest.mjs test/scripts/secret-scanning-remediation.test.ts test/scripts/secret-scanning-remediation-workflow.test.ts test/scripts/secret-scanning-maintainer.test.ts`
- `PATH=/data/code/openclaw/openclaw/node_modules/.bin:$PATH node scripts/check-workflows.mjs`
- `GITHUB_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=openclaw/openclaw OPENCLAW_SECRET_SCAN_MODE=plan node scripts/github/secret-scanning-remediation.mjs --alert 95` -> `manual` for `commit`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

## Manual acceptance

1. Create repository environment `secret-remediation`.
2. Set required reviewer to `steipete` for the first rollout.
3. Leave prevent self-review disabled for the first rollout so a manually dispatched maintainer run can be approved by the same maintainer.
4. Use `workflow_dispatch` with a non-production test alert or an open alert whose location is known to be manual-only.
5. Confirm the plan job does not write issue/PR comments and the remediation job waits for environment approval.
6. Confirm commit-type alerts remain manual and supported body/comment locations are remediated only after approval.

## Real behavior proof

- Behavior addressed: Secret scanning alerts now route through a private plan plus protected environment approval before content-changing remediation.
- Real environment tested: OpenClaw repository checkout with GitHub API read access; live alert #95 checked only in read-only plan mode.
- Exact steps or command run after this patch: `GITHUB_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=openclaw/openclaw OPENCLAW_SECRET_SCAN_MODE=plan node scripts/github/secret-scanning-remediation.mjs --alert 95`
- Evidence after fix: The helper returned `manual` for the commit-type alert and did not modify GitHub content.
- Observed result after fix: Unsupported commit locations are not auto-remediated and do not enter destructive cleanup.
- What was not tested: A live approval that patches a real issue/PR body or deletes/recreates a real comment; this should be done with the `secret-remediation` environment configured and a controlled test alert.
