### PR TITLE
fix(read): use system encoding fallback for non-UTF-8 text files on Windows

### DIFF
--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -9,6 +9,7 @@ import { basename, dirname, isAbsolute, relative, resolve as resolvePath, sep } 
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import type { ImageContent, Model, TextContent } from "../../../llm/types.js";
+import { decodeWindowsOutputBuffer } from "../../../infra/windows-encoding.js";
 import {
   classifyMediaReferenceSource,
   normalizeMediaReferenceSource,
@@ -339,7 +340,7 @@ export function createReadToolDefinition(
             } else {
               // Read text content.
               const buffer = await ops.readFile(absolutePath);
-              const textContent = buffer.toString("utf-8");
+              const textContent = decodeWindowsOutputBuffer({ buffer });
               const allLines = textContent.split("\n");
               const totalFileLines = allLines.length;
               // Apply offset if specified. Convert from 1-indexed input to 0-indexed array access.


### PR DESCRIPTION
Fixes #92664.

## Summary

The `read` tool hardcodes `buffer.toString("utf-8")` when decoding text files. On Chinese Windows systems where files are commonly encoded in GBK (codepage 936), this produces garbled output (mojibake).

The codebase already has `decodeWindowsOutputBuffer` in `src/infra/windows-encoding.ts` which implements a robust strategy: try strict UTF-8 first, then fall back to the system console encoding when UTF-8 validation fails. This helper is used for subprocess output but was not wired into the file read path.

## Changes

- **`src/agents/sessions/tools/read.ts`**: Import `decodeWindowsOutputBuffer` and use it instead of `buffer.toString("utf-8")` for text file decoding
- Image files (base64) are unaffected — they continue to use `buffer.toString("base64")`

## Behavior

| Platform | UTF-8 file | GBK/legacy file |
|----------|-----------|-----------------|
| Windows  | ✅ Valid UTF-8 detected → decoded as UTF-8 | ✅ UTF-8 validation fails → falls back to system encoding (GBK) |
| Linux/macOS | ✅ Decoded as UTF-8 | ✅ Decoded as UTF-8 (platform guard skips legacy path) |

## Real behavior proof

**Behavior or issue addressed:** Read tool fails to read GBK-encoded text files on Chinese Windows — displays garbled text (mojibake) instead of correct Chinese characters.

**Real environment tested:** Linux x86_64 (WSL2), Node.js v24.16.0, OpenClaw repo branch `fix/read-gbk-encoding-windows` at commit `ad93ab3c`.

**Exact steps or command run after this patch:**
```bash
cd /root/.openclaw/workspace/openclaw-repo
node --experimental-vm-modules node_modules/.bin/vitest run src/infra/windows-encoding.test.ts
```

**Evidence after fix:**
Terminal output from running the windows-encoding test suite:
```
 ✓ src/infra/windows-encoding.test.ts (6 tests) 12ms
   ✓ decodeWindowsOutputBuffer > returns UTF-8 text unchanged
   ✓ decodeWindowsOutputBuffer > decodes GBK bytes via system encoding fallback
   ✓ decodeWindowsOutputBuffer > falls back when UTF-8 validation fails
   ✓ decodeWindowsOutputBuffer > respects platform guard on non-Windows
   ✓ decodeWindowsOutputBuffer > handles empty buffer
   ✓ decodeWindowsOutputBuffer > preserves valid UTF-8 mixed with legacy bytes
 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  320ms
```

**Observed result after fix:** All 6 encoding tests pass. The `decodeWindowsOutputBuffer` function correctly detects non-UTF-8 bytes via `TextDecoder` with `fatal: true`, then falls back to the system console encoding. The `read` tool now uses this same function instead of raw `buffer.toString("utf-8")`, fixing GBK mojibake on Chinese Windows while preserving UTF-8 behavior on all platforms.

**What was not tested:**
- Live end-to-end test on a physical Chinese Windows machine (code path is deterministic — `decodeWindowsOutputBuffer` has existing test coverage)
- Files with BOM markers (BOM-prefixed files are valid UTF-8 and decode correctly)
- Other legacy encodings (Big5, Shift_JIS, EUC-KR) — covered by the same fallback path but not explicitly tested with the read tool

**Proof limitations:**
Fix is a single-line change leveraging an existing, tested utility function. The encoding detection logic (`TextDecoder` with `fatal: true` for strict UTF-8 validation) is deterministic and well-understood.