### PR TITLE
fix(canvas): validate --quality range and --invoke-timeout at the CLI boundary

### DIFF
--- a/extensions/canvas/src/cli.test.ts
+++ b/extensions/canvas/src/cli.test.ts
@@ -1,5 +1,6 @@
 // Canvas tests cover cli plugin behavior.
 import { Command } from "commander";
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { registerNodesCanvasCommands, type CanvasCliDependencies } from "./cli.js";
 
@@ -25,7 +26,8 @@ function createCanvasCliDeps() {
       await action();
     },
     getNodesTheme: () => ({ ok: (value) => value }),
-    parseTimeoutMs: (raw) => (typeof raw === "string" ? Number.parseInt(raw, 10) : undefined),
+    parseTimeoutMs: (raw) =>
+      raw === undefined || raw === null ? undefined : parseStrictPositiveInteger(raw),
     resolveNodeId: async (opts) => opts.node ?? "ios-node",
     buildNodeInvokeParams: ({ nodeId, command, params, timeoutMs }) => ({
       nodeId,
@@ -170,5 +172,50 @@ describe("canvas CLI", () => {
       }),
     ).rejects.toThrow(`${flag} must be a number.`);
     expect(deps.callGatewayCli).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["--quality", "5", "--quality must be between 0 and 1."],
+    ["--quality", "-1", "--quality must be between 0 and 1."],
+    ["--invoke-timeout", "20ms", "--invoke-timeout must be a positive integer (ms)."],
+  ])(
+    "rejects out-of-range or invalid snapshot %s %s before invoking the node (#92487)",
+    async (flag, value, message) => {
+      const program = new Command();
+      program.exitOverride();
+      const nodes = program.command("nodes");
+      const { deps } = createCanvasCliDeps();
+
+      registerNodesCanvasCommands(nodes, deps);
+
+      await expect(
+        program.parseAsync(["nodes", "canvas", "snapshot", "--node", "ios-node", flag, value], {
+          from: "user",
+        }),
+      ).rejects.toThrow(message);
+      expect(deps.callGatewayCli).not.toHaveBeenCalled();
+    },
+  );
+
+  it("accepts boundary --quality values and forwards them to the node (#92487)", async () => {
+    const program = new Command();
+    program.exitOverride();
+    const nodes = program.command("nodes");
+    const { deps } = createCanvasCliDeps();
+
+    registerNodesCanvasCommands(nodes, deps);
+
+    await program.parseAsync(
+      ["nodes", "canvas", "snapshot", "--node", "ios-node", "--quality", "1"],
+      { from: "user" },
+    );
+
+    expect(deps.callGatewayCli).toHaveBeenCalledWith(
+      "node.invoke",
+      expect.anything(),
+      expect.objectContaining({
+        params: expect.objectContaining({ quality: 1 }),
+      }),
+    );
   });
 });

--- a/extensions/canvas/src/cli.ts
+++ b/extensions/canvas/src/cli.ts
@@ -111,13 +111,20 @@ function parseCanvasPositiveIntOption(raw: string | undefined, flag: string): nu
   return parsed;
 }
 
-function parseCanvasFiniteNumberOption(raw: string | undefined, flag: string): number | undefined {
+function parseCanvasFiniteNumberOption(
+  raw: string | undefined,
+  flag: string,
+  bounds?: { min: number; max: number },
+): number | undefined {
   if (!raw) {
     return undefined;
   }
   const parsed = parseStrictFiniteNumber(raw);
   if (parsed === undefined) {
     throw new Error(`${flag} must be a number.`);
+  }
+  if (bounds && (parsed < bounds.min || parsed > bounds.max)) {
+    throw new Error(`${flag} must be between ${bounds.min} and ${bounds.max}.`);
   }
   return parsed;
 }
@@ -245,8 +252,15 @@ async function invokeCanvas(
   command: string,
   params?: Record<string, unknown>,
 ) {
-  const nodeId = await deps.resolveNodeId(opts, normalizeOptionalString(opts.node) ?? "");
+  // Validate the invoke timeout at the CLI boundary so an invalid value fails
+  // before node resolution/invocation instead of being silently dropped.
   const timeoutMs = deps.parseTimeoutMs(opts.invokeTimeout);
+  const hasInvokeTimeout =
+    typeof opts.invokeTimeout === "string" && opts.invokeTimeout.trim() !== "";
+  if (hasInvokeTimeout && timeoutMs === undefined) {
+    throw new Error("--invoke-timeout must be a positive integer (ms).");
+  }
+  const nodeId = await deps.resolveNodeId(opts, normalizeOptionalString(opts.node) ?? "");
   return await deps.callGatewayCli(
     "node.invoke",
     opts,
@@ -278,7 +292,10 @@ export function registerNodesCanvasCommands(nodes: Command, deps: CanvasCliDepen
         await deps.runNodesCommand("canvas snapshot", async () => {
           const format = parseCanvasSnapshotRequestFormat(opts.format);
           const maxWidth = parseCanvasPositiveIntOption(opts.maxWidth, "--max-width");
-          const quality = parseCanvasFiniteNumberOption(opts.quality, "--quality");
+          const quality = parseCanvasFiniteNumberOption(opts.quality, "--quality", {
+            min: 0,
+            max: 1,
+          });
           const raw = await invokeCanvas(deps, opts, "canvas.snapshot", {
             format,
             maxWidth: Number.isFinite(maxWidth) ? maxWidth : undefined,


### PR DESCRIPTION
## Summary

The Canvas node CLI let two numeric options cross the CLI boundary incorrectly:

- `nodes canvas snapshot --quality 5` was **accepted** even though the option is documented `0-1` and the Canvas tool schema bounds `quality` to `0..1`. The bad value reached node resolution / `node.invoke`.
- `--invoke-timeout 20ms` (and any non-integer) was parsed to `undefined` and **silently dropped**, so the command continued with no invoke timeout instead of failing.

This change validates both at the CLI boundary so invalid input fails **before** node resolution/invocation, keeping CLI behavior in sync with the Canvas tool schema.

## Root cause (`extensions/canvas/src/cli.ts`)

- `parseCanvasFiniteNumberOption` parsed any finite number with no range check, so `--quality 5` passed.
- `invokeCanvas` resolved the node first, then called `parseTimeoutMs(opts.invokeTimeout)`, which returns `undefined` for invalid input — and the result was used as "no timeout" with no error.

## What changed

- `parseCanvasFiniteNumberOption` takes an optional `bounds: { min, max }`; the `snapshot --quality` call passes `{ min: 0, max: 1 }` and an out-of-range value throws `--quality must be between 0 and 1.`
- `invokeCanvas` validates `--invoke-timeout` **before** node resolution: a provided-but-invalid value throws `--invoke-timeout must be a positive integer (ms).` instead of being silently dropped. Because this lives in `invokeCanvas`, it covers **every** Canvas subcommand that accepts `--invoke-timeout` (snapshot, present, hide, navigate, eval, a2ui push), not just snapshot.

Net `+20/-3` source, `+48/-1` test.

## Change Type

- [x] Bug fix

## Linked Issue

- Closes #92487

## Evidence

- [x] **Failing before / passing after.** New regression cases assert `--quality 5` and `--quality -1` reject with `--quality must be between 0 and 1.`, `--invoke-timeout 20ms` rejects with `--invoke-timeout must be a positive integer (ms).`, and all reject **before** the gateway call; a boundary `--quality 1` is still forwarded as `quality: 1`. On current `main` these inputs reach the node path, so the new cases fail without this patch. Full file: 13/13 tests pass (Node 22.22.1). The test's `parseTimeoutMs` stub was also made faithful to production `parseStrictPositiveInteger` (it previously used lenient `Number.parseInt`).

## Real behavior proof

Behavior addressed: `nodes canvas snapshot` now rejects out-of-range `--quality` and invalid `--invoke-timeout` at the CLI boundary before node resolution; valid values still pass through.

Real environment tested: local OpenClaw dev gateway (`gateway run --dev --auth none`) on Node 22.22.1 (macOS), Canvas bundled plugin loaded, CLI driven via `scripts/run-node.mjs` against the live gateway.

Exact steps or command run after this patch:

```
$ openclaw nodes canvas snapshot --node test-node --quality 5
$ openclaw nodes canvas snapshot --node test-node --invoke-timeout 20ms
$ openclaw nodes canvas snapshot --node test-node --quality 0.8
```

Evidence after fix: live gateway terminal output captured after this patch (and, for contrast, the same `--quality 5` command on current `main`):

```
# AFTER this patch — invalid input rejected at the CLI boundary:
$ nodes canvas snapshot --node test-node --quality 5
  nodes canvas snapshot failed: --quality must be between 0 and 1.

$ nodes canvas snapshot --node test-node --invoke-timeout 20ms
  nodes canvas snapshot failed: --invoke-timeout must be a positive integer (ms).

$ nodes canvas snapshot --node test-node --quality 0.8
  nodes canvas snapshot failed: unknown node: test-node      (valid quality passes validation, reaches node resolution)

# BEFORE (current main) — out-of-range quality accepted, reached node resolution:
$ nodes canvas snapshot --node test-node --quality 5
  nodes canvas snapshot failed: unknown node: test-node
```

Observed result after fix: out-of-range `--quality` and non-integer `--invoke-timeout` fail before any node/gateway call; in-range `--quality` (including boundary `1`) and valid integer timeouts are unaffected and still reach node resolution.

What was not tested: a snapshot against a real paired node (the validation precedes node resolution, so a real node is not needed to exercise it; the `unknown node` result confirms the request would otherwise have reached resolution).

## Security Impact

None — input validation only. No new permissions, secrets, network calls, or tool-exec surface.

## Compatibility / Migration

Backward compatible. Valid `--quality` (0..1) and valid integer `--invoke-timeout` behave exactly as before; only previously-mis-accepted invalid input now fails fast with a clear message.

## AI assistance

AI-assisted (Claude Code). Verified locally: 13/13 unit tests, oxlint clean, oxfmt clean, extension type-check, plus the live before/after gateway proof above. Author understands the change.
