### PR TITLE
fix(doctor): avoid false-positive legacy cron store warning when store was already migrated (fixes #92683)

### DIFF
--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -578,6 +578,27 @@ describe("maybeRepairLegacyCronStore", () => {
     expectNoteContaining("Cron run logs migrated to SQLite", "Doctor changes");
   });
 
+  it("does not claim legacy store detected when only non-legacy issues exist (#92683)", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCurrentCronStore(storePath, [
+      createCurrentCronJob({
+        id: "notify-job",
+        name: "Notify job",
+        notify: true,
+      }),
+    ]);
+
+    await maybeRepairLegacyCronStore({
+      cfg: createCronConfig(storePath),
+      options: {},
+      prompter: makePrompter(true),
+    });
+
+    expectNoNoteContaining("Legacy cron job storage detected", "Cron");
+    expectNoteContaining("Cron store issues detected", "Cron");
+    expectNoteContaining("1 job still uses legacy", "Cron");
+  });
+
   it("repairs malformed persisted cron ids before list rendering sees them", async () => {
     const storePath = await makeTempStorePath();
     await writeCronStore(storePath, [

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -368,9 +368,13 @@ export async function maybeRepairLegacyCronStore(params: {
     return;
   }
 
+  const noteHeading = legacyStoreDetected
+    ? `Legacy cron job storage detected at ${shortenHomePath(storePath)}.`
+    : `Cron store issues detected at ${shortenHomePath(storePath)}.`;
+
   note(
     [
-      `Legacy cron job storage detected at ${shortenHomePath(storePath)}.`,
+      noteHeading,
       ...previewLines,
       `Repair with ${formatCliCommand("openclaw doctor --fix")} to normalize the store before the next scheduler run.`,
     ].join("\n"),


### PR DESCRIPTION
## Summary

When `openclaw doctor` inspects cron storage and finds non-legacy issues (e.g., `notify: true` webhook fallback, stale dreaming jobs) but no legacy JSON store file exists (already migrated to SQLite), the output unconditionally says **"Legacy cron job storage detected at ..."** — misleading users into thinking the migration is incomplete.

The root cause is at `src/commands/doctor/cron/index.ts:373` where the note heading is hardcoded regardless of whether `legacyStoreDetected` is true.

## Fix

Make the note heading conditional on `legacyStoreDetected`:
- `legacyStoreDetected = true` → "Legacy cron job storage detected at ..."
- `legacyStoreDetected = false` → "Cron store issues detected at ..."

## Real behavior proof

- **Behavior addressed:** Doctor cron check falsely warns about legacy storage when the legacy file was already removed after SQLite migration, but other cron issues (notify fallback, stale dreaming jobs) still exist.
- **Environment tested:** macOS 26.4.1, Node.js, OpenClaw main branch (6862885a)
- **Steps run after the patch:**
  1. Verified the conditional heading logic exists in source
  2. Ran all 26 doctor cron tests including the new test case
  3. Confirmed build passes

- **Evidence after fix:**
```
node -e "const fs = require('fs'); const src = fs.readFileSync('src/commands/doctor/cron/index.ts', 'utf8'); console.log('Has conditional noteHeading:', src.includes('const noteHeading = legacyStoreDetected')); console.log('Has Cron store issues heading:', src.includes('Cron store issues detected at'));"
```
```
Has conditional noteHeading: true
Has Cron store issues heading: true
```
```
grep -n "does not claim legacy store detected" src/commands/doctor/cron/index.test.ts
```
```
581:  it("does not claim legacy store detected when only non-legacy issues exist (#92683)", async () => {
```

- **Observed result after fix:** The doctor now shows "Cron store issues detected" instead of "Legacy cron job storage detected" when no legacy file exists. All 26 tests pass.

- **What was not tested:** Live `openclaw doctor` CLI invocation (requires full OpenClaw setup with cron jobs). The test covers the `maybeRepairLegacyCronStore` function directly.

Fixes #92683
