### PR TITLE
docs(nodes): add openclaw.json example for node exec config

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -153,7 +153,21 @@ Approvals live on the node host at `~/.openclaw/exec-approvals.json`.
 
 ### Point exec at the node
 
-Configure defaults (gateway config):
+Configure defaults in `openclaw.json`:
+
+```json5
+{
+  tools: {
+    exec: {
+      host: "node",
+      security: "allowlist",
+      node: "<id-or-name>",
+    },
+  },
+}
+```
+
+Or via CLI:
 
 ```bash
 openclaw config set tools.exec.host node


### PR DESCRIPTION
The /nodes page showed CLI config commands but was missing the equivalent openclaw.json example.\n\nAdded a json5 block with tools.exec.host/security/node before the existing CLI commands.\n\nCloses #92662