### PR TITLE
docs(config): correct maxConcurrent default in agent-defaults type comments (AI-assisted)

### DIFF
--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -455,7 +455,7 @@ export type AgentDefaultsConfig = {
      */
     includeReasoning?: boolean;
   };
-  /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
+  /** Max concurrent agent runs across all conversations. Default: 4. */
   maxConcurrent?: number;
   /** Sub-agent defaults (spawned via sessions_spawn). */
   subagents?: {
@@ -463,7 +463,7 @@ export type AgentDefaultsConfig = {
     delegationMode?: SubagentDelegationMode;
     /** Default allowlist of target agent ids for sessions_spawn. Use "*" to allow any configured target. */
     allowAgents?: string[];
-    /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 1. */
+    /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 8. */
     maxConcurrent?: number;
     /** Maximum depth allowed for sessions_spawn chains. Default behavior: 1 (no nested spawns). */
     maxSpawnDepth?: number;


### PR DESCRIPTION
## Summary

The JSDoc on `AgentDefaultsConfig.maxConcurrent` and `subagents.maxConcurrent` in `src/config/types.agent-defaults.ts` says `Default: 1`, but the resolvers default to **4** and **8**:

- `src/config/agent-limits.ts:5` — `export const DEFAULT_AGENT_MAX_CONCURRENT = 4;`
- `src/config/agent-limits.ts:7` — `export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;`

The user-facing docs already say 4 (`docs/gateway/config-agents.md:469`), so the inline type comment was the only place that disagreed — misleading for anyone reasoning about concurrency straight from the type definition.

This is a comment-only change that aligns the type doc with the resolver, the repo's own test, and the docs. No behavior or default changes.

> AI-assisted (Claude + Codex). Comment-only, no behavior change.

## Diff

```diff
-  /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
+  /** Max concurrent agent runs across all conversations. Default: 4. */
   maxConcurrent?: number;
...
-    /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 1. */
+    /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 8. */
     maxConcurrent?: number;
```

## Real behavior proof

This is a comment-only documentation correctness fix — there is no runtime code path to exercise, so there is no human-run runtime proof to show. Requesting `proof: override` per CONTRIBUTING, since the proof gate does not apply to a doc-comment change.

The authoritative defaults the comment now matches are pinned by the codebase itself:

- `resolveAgentMaxConcurrent({})` returns `DEFAULT_AGENT_MAX_CONCURRENT` (4); `resolveSubagentMaxConcurrent({})` returns `DEFAULT_SUBAGENT_MAX_CONCURRENT` (8) — no override path.
- `src/config/config.agent-concurrency-defaults.test.ts:16-17` asserts exactly those two equalities, and `:54-55` asserts the resolved config carries the same 4/8.
- `docs/gateway/config-agents.md:469` already documents "Default: 4."

What was not tested: nothing at runtime — no code path changed. The 4/8 values were verified by reading the resolver constants, the existing test that pins them, and the user docs, all on a fresh `main` checkout.

## Risk checklist

- User-visible behavior change? **No.**
- Config/environment/migration change? **No.**
- Security/auth/secrets/network/tool-exec change? **No.**
- Highest-risk area: none — two comment lines; resolver and test unchanged.
