### PR TITLE
fix(doctor): skip parent allowlist phantom accounts

### DIFF
--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -16,14 +16,34 @@ vi.mock("./channel-doctor.js", () => ({
 }));
 
 describe("doctor empty allowlist policy scan", () => {
-  it("scans top-level and account-scoped channel warnings", () => {
+  it("does not warn for a parent group allowlist when every account has entries", () => {
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          signal: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+            accounts: {
+              work: { groupAllowFrom: ["100"] },
+              personal: { groupAllowFrom: ["200"] },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("scans account-scoped warnings with top-level policy fallback", () => {
     const warnings = scanEmptyAllowlistPolicyWarnings(
       {
         channels: {
           signal: {
             dmPolicy: "allowlist",
             accounts: {
-              work: { dmPolicy: "allowlist" },
+              work: {},
             },
           },
         },
@@ -32,7 +52,6 @@ describe("doctor empty allowlist policy scan", () => {
     );
 
     expect(warnings).toEqual([
-      '- channels.signal.dmPolicy is "allowlist" but allowFrom is empty — all DMs will be blocked. Add sender IDs to channels.signal.allowFrom, or run "openclaw doctor --fix" to auto-migrate from pairing store when entries exist.',
       '- channels.signal.accounts.work.dmPolicy is "allowlist" but allowFrom is empty — all DMs will be blocked. Add sender IDs to channels.signal.accounts.work.allowFrom, or run "openclaw doctor --fix" to auto-migrate from pairing store when entries exist.',
     ]);
   });

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -88,19 +88,20 @@ export function scanEmptyAllowlistPolicyWarnings(
     if (isDisabledRecord(channelConfig)) {
       continue;
     }
-    checkAccount(channelConfig, `channels.${channelName}`, channelName);
 
     const accounts = asObjectRecord(channelConfig.accounts);
-    if (!accounts) {
+    const accountEntries = accounts
+      ? Object.entries(accounts).filter(
+          ([, account]) =>
+            Boolean(account && typeof account === "object") && !isDisabledRecord(account),
+        )
+      : [];
+    if (accountEntries.length === 0) {
+      checkAccount(channelConfig, `channels.${channelName}`, channelName);
       continue;
     }
-    for (const [accountId, account] of Object.entries(accounts)) {
-      if (!account || typeof account !== "object") {
-        continue;
-      }
-      if (isDisabledRecord(account)) {
-        continue;
-      }
+
+    for (const [accountId, account] of accountEntries) {
       checkAccount(
         account as DoctorAccountRecord,
         `channels.${channelName}.accounts.${accountId}`,


### PR DESCRIPTION
## Summary

- Fixes a false-positive `openclaw doctor` empty group allowlist warning for multi-account channel configs.
- Treats the top-level channel record as the parent fallback when enabled account records exist, instead of reporting it as a standalone account scope.
- Preserves account-scoped warning behavior when an account inherits an empty allowlist policy from the parent.
- What did NOT change: runtime channel policy resolution, Telegram account merging, config shape, migrations, or channel delivery behavior.
- AI-assisted: yes, Codex helped implement and verify this patch.

## Linked context

Closes #92684

Requested by a queueable ClawSweeper source-repro issue. No maintainer-specific request beyond the issue triage labels.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw doctor` no longer reports an empty top-level `channels.<id>.groupAllowFrom` as a dropped-message risk when every enabled account has its own populated `groupAllowFrom`.
- Real environment tested: local OpenClaw source checkout on branch `fix/92684-doctor-empty-allowlist`, based on `upstream/main` `27e24ca683`.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/commands/doctor/shared/empty-allowlist-scan.test.ts src/commands/doctor/shared/channel-doctor.test.ts extensions/telegram/src/doctor.test.ts`.
- Evidence after fix: the focused scanner regression `does not warn for a parent group allowlist when every account has entries` passed, and the command completed with 3 test files / 37 tests passing.
- Observed result after fix: the reported config shape returns no parent-scope empty group allowlist warning, while the sibling fallback test still reports inherited empty policy risk at `channels.<id>.accounts.<account>`.
- What was not tested: a live Telegram inbound message round trip was not run; the issue is a doctor advisory false positive, and this patch does not change Telegram runtime delivery.
- Proof limitations or environment constraints: direct source `openclaw doctor` CLI proof in the linked worktree attempted to trigger the dev launcher, which tried to reconcile `node_modules`; validation used focused source-level Vitest proof instead.
- Before evidence: the new regression test failed before the fix with `- channels.signal.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty ...`.

## Tests and validation

- `node scripts/run-vitest.mjs src/commands/doctor/shared/empty-allowlist-scan.test.ts src/commands/doctor/shared/channel-doctor.test.ts extensions/telegram/src/doctor.test.ts`
- `node_modules/.bin/oxfmt --check src/commands/doctor/shared/empty-allowlist-scan.ts src/commands/doctor/shared/empty-allowlist-scan.test.ts`
- `node_modules/.bin/oxlint src/commands/doctor/shared/empty-allowlist-scan.ts src/commands/doctor/shared/empty-allowlist-scan.test.ts`
- `git diff --check`

Regression coverage added:

- Added a scanner regression for a parent `groupAllowFrom: []` with all enabled accounts carrying populated `groupAllowFrom` entries.
- Updated the existing scanner test so parent policy fallback is still verified through the account-scoped warning path.

## Risk checklist

Did user-visible behavior change? `Yes` — doctor emits one fewer misleading warning for this multi-account config shape.

Did config, environment, or migration behavior change? `No`.

Did security, auth, secrets, network, or tool execution behavior change? `No`.

What is the highest-risk area?

- Doctor warning coverage for channel configs with both parent and account records.

How is that risk mitigated?

- The scanner still checks top-level channel config when no enabled accounts exist.
- Account records still receive parent fallback context, so inherited empty allowlist policies continue to warn at the account path.
- Adjacent channel doctor hook tests and Telegram doctor tests were run with the focused scanner tests.

## Current review state

Next action: maintainer review / CI.

Still waiting on: GitHub CI after PR creation.

Bot or reviewer comments addressed: none yet.
