### PR TITLE
fix(agents): reap prior MCP runtime when a session rebinds its sessionKey

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1376,6 +1376,70 @@ process.on("SIGINT", shutdown);`,
     expect(manager.listSessionIds()).not.toContain("session-a");
   });
 
+  it("reaps the prior runtime when a sessionKey rebinds to a new sessionId", async () => {
+    const disposed: string[] = [];
+    const createRuntime: RuntimeFactory = (params) => ({
+      ...makeRuntime([{ toolName: "bundle_probe", description: "Bundle MCP probe" }]),
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      workspaceDir: params.workspaceDir,
+      configFingerprint: params.configFingerprint ?? "fingerprint",
+      dispose: async () => {
+        disposed.push(params.sessionId);
+      },
+    });
+    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+
+    const rolled = await manager.getOrCreate({
+      sessionId: "session-old",
+      sessionKey: "agent:test:rollover",
+      workspaceDir: "/workspace",
+    });
+    const fresh = await manager.getOrCreate({
+      sessionId: "session-new",
+      sessionKey: "agent:test:rollover",
+      workspaceDir: "/workspace",
+    });
+
+    expect(fresh).not.toBe(rolled);
+    expect(disposed).toEqual(["session-old"]);
+    expect(manager.listSessionIds()).toEqual(["session-new"]);
+    expect(manager.resolveSessionId("agent:test:rollover")).toBe("session-new");
+  });
+
+  it("keeps a still-leased prior runtime alive when its sessionKey rebinds", async () => {
+    const disposed: string[] = [];
+    const createRuntime: RuntimeFactory = (params) => ({
+      ...makeRuntime([{ toolName: "bundle_probe", description: "Bundle MCP probe" }]),
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      workspaceDir: params.workspaceDir,
+      configFingerprint: params.configFingerprint ?? "fingerprint",
+      get activeLeases() {
+        return params.sessionId === "session-busy" ? 1 : 0;
+      },
+      dispose: async () => {
+        disposed.push(params.sessionId);
+      },
+    });
+    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+
+    await manager.getOrCreate({
+      sessionId: "session-busy",
+      sessionKey: "agent:test:busy-rollover",
+      workspaceDir: "/workspace",
+    });
+    await manager.getOrCreate({
+      sessionId: "session-next",
+      sessionKey: "agent:test:busy-rollover",
+      workspaceDir: "/workspace",
+    });
+
+    expect(disposed).toEqual([]);
+    expect(manager.listSessionIds()).toEqual(["session-busy", "session-next"]);
+    expect(manager.resolveSessionId("agent:test:busy-rollover")).toBe("session-next");
+  });
+
   it("peeks existing runtimes and populated catalogs without creating new runtimes", async () => {
     let catalogReady = false;
     const createRuntime: RuntimeFactory = (params) => {

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -945,6 +945,21 @@ function createSessionMcpRuntimeManager(
     idleSweepTimer = undefined;
   };
 
+  const disposeSessionById = async (sessionId: string): Promise<void> => {
+    const inFlight = createInFlight.get(sessionId);
+    createInFlight.delete(sessionId);
+    let runtime = runtimesBySessionId.get(sessionId);
+    if (!runtime && inFlight) {
+      runtime = await inFlight.promise.catch(() => undefined);
+    }
+    runtimesBySessionId.delete(sessionId);
+    idleTtlMsBySessionId.delete(sessionId);
+    forgetSessionKeysForSessionId(sessionId);
+    if (runtime) {
+      await runtime.dispose();
+    }
+  };
+
   return {
     async getOrCreate(params) {
       const idleTtlMs = resolveSessionMcpRuntimeIdleTtlMs(params.cfg);
@@ -956,7 +971,17 @@ function createSessionMcpRuntimeManager(
         ensureIdleSweepTimer();
       }
       if (params.sessionKey) {
+        const previousSessionId = sessionIdBySessionKey.get(params.sessionKey);
         sessionIdBySessionKey.set(params.sessionKey, params.sessionId);
+        // A rolled-over sessionKey strands its prior runtime until the idle TTL; reap the
+        // registered, unleased one now so file-locking MCP servers release before reconnect.
+        // Leave an in-flight prior creation alone so a concurrent same-key getOrCreate keeps it.
+        if (previousSessionId && previousSessionId !== params.sessionId) {
+          const previousRuntime = runtimesBySessionId.get(previousSessionId);
+          if (previousRuntime && (previousRuntime.activeLeases ?? 0) === 0) {
+            await disposeSessionById(previousSessionId);
+          }
+        }
       }
       const { fingerprint: nextFingerprint } = loadSessionMcpConfig({
         workspaceDir: params.workspaceDir,
@@ -1030,20 +1055,7 @@ function createSessionMcpRuntimeManager(
       return sessionId ? runtimesBySessionId.get(sessionId) : undefined;
     },
     async disposeSession(sessionId) {
-      const inFlight = createInFlight.get(sessionId);
-      createInFlight.delete(sessionId);
-      let runtime = runtimesBySessionId.get(sessionId);
-      if (!runtime && inFlight) {
-        runtime = await inFlight.promise.catch(() => undefined);
-      }
-      runtimesBySessionId.delete(sessionId);
-      idleTtlMsBySessionId.delete(sessionId);
-      if (!runtime) {
-        forgetSessionKeysForSessionId(sessionId);
-        return;
-      }
-      forgetSessionKeysForSessionId(sessionId);
-      await runtime.dispose();
+      await disposeSessionById(sessionId);
     },
     async disposeAll() {
       clearIdleSweepTimer();


### PR DESCRIPTION
### Summary

- **Problem**: Issue #92569 reports that MCP servers using exclusive file locks (embedded databases — SQLite, LadybugDB, etc.) fail with lock contention when a session transitions: the previous session's MCP server processes are still alive and holding the lock when the next session spawns fresh ones, so the new session's tool calls fail and the per-server backoff escalates into a self-deepening paused state.
- **Root Cause**: The session MCP runtime manager (`getSessionMcpRuntimeManager`) keys one runtime per `sessionId` and maps each `sessionKey` to exactly one `sessionId`. When a `sessionKey` is rebound to a **new** `sessionId`, `getOrCreate` overwrites the `sessionKey → sessionId` mapping but leaves the prior `sessionId`'s runtime registered and undisposed. Nothing reaps it promptly: for persistent interactive sessions the runtime is intentionally kept warm across turns (`cleanupBundleMcpOnRunEnd` is off), and the explicit session-reset retire path is not on this transition. The orphan therefore lingers until the idle sweep TTL (default 10 minutes), and its stdio MCP child processes keep their exclusive file locks the whole time — so the freshly spawned processes for the new `sessionId` cannot open the database.
- **The rebind happens without any reset**: auto-compaction rotates the transcript and mints a new `sessionId` for the same `sessionKey` (`incrementCompactionCount`'s `newSessionId` path), which is exactly what a long-running session (large context, many turns — the file-lock case in the report) hits. The next turn calls `getOrCreateSessionMcpRuntime` with the same `sessionKey` and the new `sessionId`, stranding the prior runtime.
- **Fix**: Enforce the manager's "one live MCP runtime per `sessionKey`" invariant at the rebind point. When `getOrCreate` rebinds a `sessionKey` to a different `sessionId`, eagerly reap the prior **registered, unleased** runtime instead of waiting for the idle sweep, so file-locking MCP servers release before the new session connects.
- **What changed**:
  - `src/agents/agent-bundle-mcp-runtime.ts` — extract `disposeSessionById` (the existing `disposeSession` method now delegates to it, behavior-preserving), and call it from `getOrCreate` when a `sessionKey` rebinds to a new `sessionId`, gated on the prior runtime being registered and `activeLeases === 0`.
  - Tests added to `agent-bundle-mcp-runtime.test.ts`: the reap-on-rebind case and the still-leased-prior-runtime keep case.
- **What did NOT change (scope boundary)**:
  - The idle sweep, the `retireSessionMcpRuntime` / `retireSessionMcpRuntimeForSessionKey` helpers, and `session-reset-service` are unchanged; the reap runs only on the authoritative `sessionKey` rebind inside `getOrCreate`.
  - An in-flight (not-yet-registered) prior creation is deliberately left alone so a concurrent same-`sessionKey` `getOrCreate` cannot have its pending runtime disposed out from under it.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. A persistent interactive session (e.g. Telegram/Discord) has a file-locking MCP server configured (embedded DB such as SQLite/LadybugDB). The MCP runtime is kept warm across turns, so its child processes hold the DB's exclusive lock.
2. The session runs long enough to trigger auto-compaction, which rotates the transcript and mints a new `sessionId` for the same `sessionKey`.
3. The next turn calls `getOrCreateSessionMcpRuntime` with the same `sessionKey` and the new `sessionId`.
4. **Before this PR**: the manager rebinds the `sessionKey` to the new `sessionId` but leaves the prior `sessionId`'s runtime registered; its MCP child processes keep their exclusive file lock until the idle TTL (default 10 minutes). The new session's freshly spawned processes cannot open the database, tool calls fail, and the per-server backoff escalates.
5. **After this PR**: the rebind reaps the prior registered, unleased runtime; its processes exit and release the lock before the new session connects, so the new session's MCP tools work immediately.

### Real behavior proof

**Behavior addressed (#92569)**: when a `sessionKey` is rebound to a new `sessionId`, the prior MCP runtime is disposed at the rebind instead of lingering until the idle TTL, so a file-locking MCP server's exclusive lock is released before the new session reconnects. An actively-leased prior runtime (in-flight run) is preserved.

**Real environment tested (Linux, Node 22 — Vitest against the production `SessionMcpRuntimeManager`)**: `manager.getOrCreate` driving the real `runtimesBySessionId` / `sessionIdBySessionKey` maps, the `activeLeases` lease guard, and the `dispose` lifecycle, using the manager's own test factory seam (`testing.createSessionMcpRuntimeManager`).

**Exact steps or command run after this patch**: `pnpm test src/agents/agent-bundle-mcp-runtime.test.ts`; `pnpm tsgo:core`; `pnpm exec oxfmt --check` and `node scripts/run-oxlint.mjs` on the changed files.

**Evidence after fix (Vitest output for the touched test file)**:

```text
 agent-bundle-mcp-runtime.test.ts   Tests  35 passed (35)
```

**Observed result after fix**: after a `sessionKey` rebinds from `session-old` to `session-new`, the prior runtime's `dispose()` fires and `listSessionIds()` no longer contains `session-old`, while `resolveSessionId` returns `session-new`. When the prior runtime reports an active lease, it is left alive (no force-kill of an in-flight run) and both runtimes remain registered. With the production change reverted, the reap test fails — the prior runtime is never disposed (`disposed=[]`) — confirming the test exercises the production change rather than the mock.

**What was not tested**: the live gateway round-trip with a real file-locking MCP server (e.g. LadybugDB) under auto-compaction on a deployment. The manager invariant, the rebind reap, and the lease-guard keep are covered deterministically against the production manager; a full gateway round-trip was not driven.

**Repro confirmation**: the reap-on-rebind test fails on current `main` (`disposed=[]`, prior runtime stranded) and passes with the fix.

### Risk / Mitigation

- **Risk**: Reaping a runtime still in use by an in-flight run. **Mitigation**: the reap is gated on `activeLeases === 0`, mirroring the idle sweep's existing invariant; a leased runtime is left to drain and be reaped by the idle sweep.
- **Risk**: Disposing an in-flight prior creation out from under a concurrent same-`sessionKey` `getOrCreate`. **Mitigation**: the reap only targets a runtime already registered in `runtimesBySessionId`; an in-flight-only prior creation is left alone (its own caller keeps it, and the idle sweep reaps it later if it ends up orphaned).
- **Risk**: The `disposeSession` extraction changes teardown behavior. **Mitigation**: `disposeSessionById` is a literal extraction — it always clears the maps and `forgetSessionKeysForSessionId`, then disposes the runtime when present, matching the previous method body; `disposeSession` now delegates to it.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents / runtime
- [x] MCP / tools

### Linked Issue/PR

Refs #92569
