### PR TITLE
#92688: fix(qwen): use DashScope native image format for Qwen vision models

### DIFF
--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -81,6 +81,22 @@ function isImageContentBlock(block: { type: string }): block is ImageContent {
   return block.type === "image";
 }
 
+function isDashScopeEndpoint(model: Model<"openai-completions">): boolean {
+  const provider = model.provider?.toLowerCase() ?? "";
+  const baseUrl = model.baseUrl?.toLowerCase() ?? "";
+  return (
+    provider.includes("dashscope") ||
+    provider === "qwen" ||
+    provider === "qwen-dashscope" ||
+    baseUrl.includes("dashscope.aliyuncs.com")
+  );
+}
+
+type DashScopeImageContentPart = {
+  type: "image";
+  image: string;
+};
+
 export interface OpenAICompletionsOptions extends StreamOptions {
   toolChoice?: "auto" | "none" | "required" | { type: "function"; function: { name: string } };
   reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
@@ -950,6 +966,7 @@ export function convertMessages(
           content: sanitizeSurrogates(msg.content),
         });
       } else {
+        const useDashScopeFormat = isDashScopeEndpoint(model);
         const content: ChatCompletionContentPart[] = msg.content.map(
           (item): ChatCompletionContentPart => {
             if (item.type === "text") {
@@ -957,6 +974,12 @@ export function convertMessages(
                 type: "text",
                 text: sanitizeSurrogates(item.text),
               } satisfies ChatCompletionContentPartText;
+            }
+            if (useDashScopeFormat) {
+              return {
+                type: "image",
+                image: `data:${item.mimeType};base64,${item.data}`,
+              } as unknown as ChatCompletionContentPart;
             }
             return {
               type: "image_url",
@@ -1079,7 +1102,10 @@ export function convertMessages(
       }
       params.push(assistantMsg);
     } else if (msg.role === "toolResult") {
-      const imageBlocks: Array<{ type: "image_url"; image_url: { url: string } }> = [];
+      const useDashScopeFormat = isDashScopeEndpoint(model);
+      const imageBlocks: Array<
+        { type: "image_url"; image_url: { url: string } } | { type: "image"; image: string }
+      > = [];
       let j = i;
 
       for (; j < transformedMessages.length && transformedMessages[j].role === "toolResult"; j++) {
@@ -1108,12 +1134,19 @@ export function convertMessages(
         if (hasImages && model.input.includes("image")) {
           for (const block of toolMsg.content) {
             if (isImageContentBlock(block)) {
-              imageBlocks.push({
-                type: "image_url",
-                image_url: {
-                  url: `data:${block.mimeType};base64,${block.data}`,
-                },
-              });
+              if (useDashScopeFormat) {
+                imageBlocks.push({
+                  type: "image",
+                  image: `data:${block.mimeType};base64,${block.data}`,
+                });
+              } else {
+                imageBlocks.push({
+                  type: "image_url",
+                  image_url: {
+                    url: `data:${block.mimeType};base64,${block.data}`,
+                  },
+                });
+              }
             }
           }
         }
@@ -1137,8 +1170,8 @@ export function convertMessages(
               text: "Attached image(s) from tool result:",
             },
             ...imageBlocks,
-          ],
-        });
+          ] as ChatCompletionContentPart[],
+        } as ChatCompletionMessageParam);
         lastRole = "user";
       } else {
         lastRole = "toolResult";


### PR DESCRIPTION
## Summary

Fix Qwen vision models returning 400 "Unexpected item type in content" on DashScope by converting image content parts from standard OpenAI format (`type: image_url`) to DashScope native format (`type: image`).

## Root Cause

DashScope's OpenAI-compatible chat completions endpoint (`/compatible-mode/v1/chat/completions`) does not support the standard `image_url` content part type for Qwen vision models (qwen3.7-max, qwen3.7-plus, etc.). When the image tool sends multimodal requests, the image is formatted as `{type: "image_url", image_url: {url: "data:..."}}` which DashScope rejects with HTTP 400:

```
400 InternalError.Algo.InvalidParameter: The provided messages input is invalid. 
The error info is [Unexpected item type in content.]
```

The DashScope native multimodal API expects images as `{type: "image", image: "data:..."}` — a flat structure where the image field is a direct data URI string rather than a `{url: ...}` wrapper object. This fix detects DashScope endpoints (by provider name or base URL) and converts the image format accordingly, while preserving standard OpenAI format for all other providers.

## Real behavior proof

### behavior
Detect DashScope endpoints and convert image content parts from OpenAI `image_url` format to DashScope native `image` format.

### environment
- OS: Windows 10 Enterprise LTSC 2019
- Runtime: Node.js v24.14.0
- Setup: OpenClaw workspace with tsx for TypeScript execution

### steps
1. Import `convertMessages` from production code (`src/llm/providers/openai-completions.js`)
2. Construct a Qwen/DashScope model config (provider: "qwen", baseUrl: dashscope.aliyuncs.com)
3. Construct a standard OpenAI model config for comparison
4. Build messages containing both text and image content parts
5. Call `convertMessages` with each model and inspect the content format
6. Verify DashScope models get `type: "image"` while OpenAI models keep `type: "image_url"`

### observedResult

**Reproduction script output (`./node_modules/.bin/tsx scripts/repro-92688.ts`):**
```
======================================================================
Issue #92688 — DashScope Qwen Vision Image Format Fix
======================================================================

--- Test 1: DashScope (qwen) model ---
   Text part: What's in this image?
✅ Image format: type=image (DashScope native format)
   image field starts with: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEA...

--- Test 2: Standard OpenAI model ---
   Text part: What's in this image?
✅ Image format: type=image_url (standard OpenAI format)
   image_url.url starts with: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEA...

--- Test 3: qwen-dashscope provider ---
✅ Image format: type=image (DashScope native format)

--- Test 4: Custom provider with dashscope.aliyuncs.com baseUrl ---
✅ Image format: type=image (DashScope native format by URL detection)

======================================================================
All checks passed — DashScope/Qwen endpoints now receive correct image format.
======================================================================
```

**Production change:**
```typescript
// Detection: provider includes "dashscope", provider is "qwen"/"qwen-dashscope",
// or baseUrl includes "dashscope.aliyuncs.com"
function isDashScopeEndpoint(model: Model<"openai-completions">): boolean {
  const provider = model.provider?.toLowerCase() ?? "";
  const baseUrl = model.baseUrl?.toLowerCase() ?? "";
  return (
    provider.includes("dashscope") ||
    provider === "qwen" ||
    provider === "qwen-dashscope" ||
    baseUrl.includes("dashscope.aliyuncs.com")
  );
}

// In convertMessages(), user message image formatting:
if (useDashScopeFormat) {
  return {
    type: "image",                              // ← DashScope native type
    image: `data:${item.mimeType};base64,${item.data}`,  // ← direct string
  } as unknown as ChatCompletionContentPart;
}
// Standard OpenAI format (unchanged for all other providers):
return {
  type: "image_url",
  image_url: {
    url: `data:${item.mimeType};base64,${item.data}`,
  },
} satisfies ChatCompletionContentPartImage;
```

## Regression Test Plan

- [ ] Run `pnpm test -- --run src/llm/providers/openai-completions.test.ts` — existing OpenAI completions streaming tests pass unchanged
- [ ] Verify DashScope endpoint detection covers: provider "qwen", provider "qwen-dashscope", any provider with URL containing "dashscope.aliyuncs.com"
- [ ] Verify standard OpenAI provider images remain as `image_url` format (no regression)
- [ ] Change is minimal (1 file, 42 insertions, 9 deletions) and does not affect any non-DashScope code path

---

*AI-assisted: built with Claude Code*
