### PR TITLE
fix(agents): resolve context window for proxy models with slash in ID

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -389,7 +389,7 @@ export function resolveContextTokensForModel(params: {
     }
     // Only do the config direct scan when the caller explicitly passed a
     // provider. When provider is inferred from a slash in the model string
-    // (e.g. "google/gemini-2.5-pro" → ref.provider = "google"), the model ID
+    // (e.g. "google/gemini-2.5-pro" ??ref.provider = "google"), the model ID
     // may belong to a DIFFERENT provider (e.g. an OpenRouter session). Scanning
     // cfg.models.providers.google in that case would return Google's configured
     // window and misreport context limits for the OpenRouter session.
@@ -409,7 +409,7 @@ export function resolveContextTokensForModel(params: {
   // When provider is explicitly given and the model ID is bare (no slash),
   // try the provider-qualified cache key BEFORE the bare key.  Discovery
   // entries are stored under qualified IDs (e.g. "google-gemini-cli/
-  // gemini-3.1-pro-preview → 1M"), while the bare key may hold a cross-
+  // gemini-3.1-pro-preview ??1M"), while the bare key may hold a cross-
   // provider minimum (128k).  Returning the qualified entry gives the correct
   // provider-specific window for /status and session context-token persistence.
   //
@@ -417,8 +417,8 @@ export function resolveContextTokensForModel(params: {
   // the model string). For model-only callers (e.g. status.ts log-usage
   // fallback with model="google/gemini-2.5-pro"), the inferred provider would
   // construct "google/gemini-2.5-pro" as the qualified key which accidentally
-  // matches OpenRouter's raw discovery entry — the bare lookup is correct there.
-  if (params.provider && ref && !ref.model.includes("/")) {
+  // matches OpenRouter's raw discovery entry ??the bare lookup is correct there.
+  if (params.provider && ref) {
     const qualifiedResult = lookupContextTokens(
       `${normalizeProviderId(ref.provider)}/${ref.model}`,
       {
@@ -441,10 +441,12 @@ export function resolveContextTokensForModel(params: {
     return bareResult;
   }
 
-  // When provider is implicit, try qualified as a last resort so inferred
-  // provider/model pairs (e.g. model="google-gemini-cli/gemini-3.1-pro")
-  // still find discovery entries stored under that qualified ID.
-  if (!params.provider && ref && !ref.model.includes("/")) {
+  // Last resort: try qualified key even when ref.model contains a slash.
+  // The bare lookup already failed, so there is no downside to trying the
+  // full qualified key. This covers models like "anthropic/claude-sonnet-4"
+  // accessed through a proxy provider whose discovery cache stores the
+  // full qualified ID.
+  if (!params.provider && ref) {
     const qualifiedResult = lookupContextTokens(
       `${normalizeProviderId(ref.provider)}/${ref.model}`,
       {


### PR DESCRIPTION
## Problem

`/status` shows max context = 200K (DEFAULT_CONTEXT_TOKENS) for models accessed through proxy providers like OpenRouter, regardless of the actual model's context window.

## Root Cause

Two guards in `resolveContextTokensForModel()` (src/agents/context.ts) blocked qualified cache key lookup when the model ID contained a slash:

```
// Before: !ref.model.includes("/") blocked OpenRouter models
if (params.provider && ref && !ref.model.includes("/")) { ... }
if (!params.provider && ref && !ref.model.includes("/")) { ... }
```

OpenRouter and similar proxy providers always have slashes in their model IDs (e.g. `anthropic/claude-sonnet-4`), making `ref.model` = `"anthropic/claude-sonnet-4"` which contains "/". The qualified cache key was never constructed, causing a cache miss and fallback to 200K.

## Fix

Removed the `!ref.model.includes("/")` guard from both call sites:

1. **Explicit provider path**: params.provider is explicitly given by the caller, so there is no inference risk
2. **Last resort implicit provider path**: bare key already failed, trying qualified key has no downside

## Related

- **Issue #39857** — Broader issue tracking /status context window over-reporting. This PR addresses one root cause (cache miss for slash-containing model IDs). Complementary to PR #90889 which caps overrides against known model windows.
- **PR #90889** — Cap session context overrides by model window. Independent fix that works alongside this PR to cover the full resolution chain.
- **PR #92424** — Model snapshot stale after /model switch. Separate issue in a different part of the chain.

## Scope

Only `src/agents/context.ts`. No test changes needed (existing tests already cover cache hit/miss paths).
