### PR TITLE
fix(ui): define missing --z-dropdown CSS variable for session picker overlay (fixes #92707)

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -120,6 +120,9 @@
   --safe-area-bottom: env(safe-area-inset-bottom, 0px);
   --safe-area-left: env(safe-area-inset-left, 0px);
 
+  /* Z-index layers */
+  --z-dropdown: 100;
+
   color-scheme: dark;
 }
 


### PR DESCRIPTION
## What

Define the missing `--z-dropdown` CSS custom property in the `:root` theme variables. The collapsed sidebar session picker uses `z-index: var(--z-dropdown)` but the variable was never defined, causing the picker to render behind the chat content area.

## Why

`layout.css:809` applies `z-index: var(--z-dropdown)` to `.sidebar-session-select--collapsed .chat-session-picker`. With `--z-dropdown` undefined, the `z-index` resolves to the CSS initial value (`auto`), which means the absolutely-positioned picker has no stacking priority and is painted behind sibling grid areas (the content region).

## How

Add `--z-dropdown: 100` to the `:root` block in `base.css`, positioned above the topbar layer (`z-index: 40`) and tooltip layer (`z-index: 60`).

Fixes #92707

## Real behavior proof

- **Behavior addressed:** Session picker popover rendered behind chat content when sidebar is collapsed and viewport > 1120px, due to undefined `--z-dropdown` CSS variable
- **Environment tested:** macOS 26.4.1, Node v22, OpenClaw workdir at `upstream/main` HEAD
- **Steps run after the patch:**
  1. Verified `--z-dropdown: 100` is defined in `ui/src/styles/base.css:124`
  2. Verified `var(--z-dropdown)` is consumed in `ui/src/styles/layout.css:809`
  3. Ran session view tests: 26 passed
  4. Ran `pnpm build` — UI builds successfully with the variable inlined

- **Evidence after fix:**
```
node -e "const fs=require('fs'); const c=fs.readFileSync('ui/src/styles/base.css','utf8'); const l=fs.readFileSync('ui/src/styles/layout.css','utf8'); console.log('defined:',c.includes('--z-dropdown: 100')); console.log('used:',l.includes('var(--z-dropdown)'));"
defined: true
used: true

ui/src/ui/views/sessions.test.ts (26 tests) 142ms
Test Files  1 passed (1)
Tests  26 passed (26)
```

- **Observed result after fix:** CSS variable is now defined and resolves to `100`, placing the session picker above the topbar (40) and tooltip (60) layers. UI build succeeds with the variable inlined into the compiled CSS.
- **What was not tested:** Visual rendering in a live browser (CSS-only change; z-index layering verified via source inspection and build output)
