### PR TITLE
fix(telegram): skip IPv4 fallback when user configures non-ipv4first dnsResultOrder (fixes #41671)

### DIFF
--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -680,6 +680,27 @@ describe("resolveTelegramFetch", () => {
     expect(typeof pinnedPolicy?.connect?.lookup).toBe("function");
   });
 
+  it("skips sticky IPv4 fallback when user explicitly configures network settings", async () => {
+    undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
+    const transport = resolveTelegramTransport(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "verbatim",
+      },
+    });
+
+    await expect(
+      transport.sourceFetch("https://api.telegram.org/botTOKEN/getFile"),
+    ).resolves.toEqual({ ok: true });
+    // Only the default dispatcher — no IPv4 fallback or pinned IP attempts
+    expect(transport.dispatcherAttempts).toHaveLength(1);
+    const [defaultAttempt] = transport.dispatcherAttempts as Array<{
+      dispatcherPolicy?: DirectTelegramDispatcherPolicy;
+    }>;
+    expect(defaultAttempt.dispatcherPolicy?.mode).toBe("direct");
+    expect(defaultAttempt.dispatcherPolicy?.connect?.autoSelectFamily).toBe(true);
+  });
+
   it("does not blind-retry when sticky IPv4 fallback is disallowed for explicit proxy paths", async () => {
     const { makeProxyFetch } = await import("./proxy.js");
     const proxyFetch = makeProxyFetch("http://127.0.0.1:7890");

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -635,9 +635,13 @@ export function resolveTelegramTransport(
   });
   const defaultDispatcher = createTelegramDispatcher(defaultDispatcherResolution.policy);
   const shouldBypassEnvProxy = shouldBypassEnvProxyForTelegramApi();
+  const hasExplicitNetworkConfig =
+    dnsDecision.source === "config" &&
+    dnsDecision.value !== "ipv4first";
   const allowStickyFallback =
-    defaultDispatcher.mode === "direct" ||
-    (defaultDispatcher.mode === "env-proxy" && shouldBypassEnvProxy);
+    !hasExplicitNetworkConfig &&
+    (defaultDispatcher.mode === "direct" ||
+      (defaultDispatcher.mode === "env-proxy" && shouldBypassEnvProxy));
   const fallbackDispatcherPolicy = allowStickyFallback
     ? resolveTelegramDispatcherPolicy({
         autoSelectFamily: false,


### PR DESCRIPTION
## Summary

- **Problem:** On hosts where IPv4 to `api.telegram.org` is broken but IPv6 works, Telegram media downloads fail even when `channels.telegram.network.dnsResultOrder` is explicitly set to `"verbatim"`. The sticky IPv4 fallback dispatcher hardcodes `autoSelectFamily=false` + `dnsResultOrder=ipv4first`, overriding the user's IPv6-friendly config.
- **Why it matters:** Users who explicitly configure non-IPv4 network settings (e.g. dual-stack or IPv6-only hosts) cannot receive media through the Telegram bot. The fallback forces the exact wrong direction.
- **What changed:** Skip the sticky IPv4 fallback when the user has explicitly configured `dnsResultOrder` to a non-`ipv4first` value via `channels.telegram.network.dnsResultOrder`. The primary dispatcher already respects the user's config; the fallback was defeating it.

## Changes

- `extensions/telegram/src/fetch.ts`: Added `hasExplicitNetworkConfig` check — when `dnsDecision.source === "config"` and `dnsDecision.value !== "ipv4first"`, the sticky IPv4 fallback is not armed.
- `extensions/telegram/src/fetch.test.ts`: Added test verifying that `dnsResultOrder: "verbatim"` disables the IPv4 fallback dispatcher (only 1 attempt instead of 3).

## Real behavior proof

- **Behavior addressed:** Telegram media download fails on IPv4-broken/IPv6-working hosts when `channels.telegram.network.dnsResultOrder` is set to `"verbatim"`.
- **Environment tested:** macOS arm64, Node.js, OpenClaw repository at commit `e77f0dcc`.
- **Steps run after the patch:**
  1. `node scripts/run-vitest.mjs run extensions/telegram/src/fetch.test.ts`
  2. Verified the new test case "skips sticky IPv4 fallback when user explicitly configures network settings" passes.
  3. Verified all 41 existing tests still pass (no regression).
- **Evidence after fix:**

```
✓  extension-telegram  extensions/telegram/src/fetch.test.ts (41 tests) 155ms
Test Files  1 passed (1)
     Tests  41 passed (41)
```

- **Observed result after fix:** All 41 tests pass. The new test confirms that when `dnsResultOrder: "verbatim"` is configured, the transport has only 1 dispatcher attempt (default), not 3 (default + IPv4 + pinned IP). The IPv4 fallback is correctly skipped.
- **What was not tested:** Live Telegram API testing on an IPv4-broken host. The fix is validated through unit tests that verify the dispatcher structure.
