### PR TITLE
feat(gateway): make the default node.invoke timeout configurable

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -214,6 +214,20 @@ permission boundary. Dangerous plugin node commands still require explicit
 After a node changes its declared command list, reject the old device pairing
 and approve the new request so the gateway stores the updated command snapshot.
 
+### Invoke timeout
+
+A `node.invoke` call that does not pass its own timeout uses a default of
+**30000 ms**. Raise it for nodes that legitimately run long commands with
+`gateway.nodes.invokeTimeoutMs` (positive integer, milliseconds):
+
+```jsonc
+{ "gateway": { "nodes": { "invokeTimeoutMs": 120000 } } }
+```
+
+Invalid values (zero, negative, non-numeric) fall back to the 30000 ms default.
+A per-call timeout (for example the CLI `--command-timeout`) still overrides this
+default for that call.
+
 ## Screenshots (canvas snapshots)
 
 If the node is showing the Canvas (WebView), `canvas.snapshot` returns `{ format, base64 }`.

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -452,6 +452,13 @@ export type GatewayNodesConfig = {
   allowCommands?: string[];
   /** Commands to deny even if they appear in the defaults or node claims. */
   denyCommands?: string[];
+  /**
+   * Default timeout (ms) for gateway→node `node.invoke` calls that do not
+   * specify their own timeout. Raise this for nodes that legitimately run
+   * long commands. Must be a positive integer; invalid values fall back to
+   * the built-in 30000 default.
+   */
+  invokeTimeoutMs?: number;
 };
 
 export type GatewayToolsConfig = {

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -491,6 +491,73 @@ describe("gateway/node-registry", () => {
     void second.catch(() => {});
   });
 
+  it("uses the configured default invoke timeout when the call omits timeoutMs", async () => {
+    vi.useFakeTimers();
+    const registry = new NodeRegistry({ defaultInvokeTimeoutMs: 5_000 });
+    try {
+      registerNode(registry);
+      let settled = false;
+      const invoke = registry.invoke({ nodeId: "node-1", command: "demo.run" }).then((result) => {
+        settled = true;
+        return result;
+      });
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(settled).toBe(true);
+      await expect(invoke).resolves.toEqual({
+        ok: false,
+        error: { code: "TIMEOUT", message: "node invoke timed out" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls back to the 30s default when the configured invoke timeout is invalid", async () => {
+    vi.useFakeTimers();
+    const registry = new NodeRegistry({ defaultInvokeTimeoutMs: 0 });
+    try {
+      registerNode(registry);
+      let settled = false;
+      const invoke = registry.invoke({ nodeId: "node-1", command: "demo.run" }).then((result) => {
+        settled = true;
+        return result;
+      });
+
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(settled).toBe(true);
+      await expect(invoke).resolves.toEqual({
+        ok: false,
+        error: { code: "TIMEOUT", message: "node invoke timed out" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("lets an explicit call timeoutMs override the configured default", async () => {
+    vi.useFakeTimers();
+    const registry = new NodeRegistry({ defaultInvokeTimeoutMs: 60_000 });
+    try {
+      registerNode(registry);
+      const invoke = registry.invoke({ nodeId: "node-1", command: "demo.run", timeoutMs: 10 });
+
+      await vi.advanceTimersByTimeAsync(10);
+      await expect(invoke).resolves.toEqual({
+        ok: false,
+        error: { code: "TIMEOUT", message: "node invoke timed out" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("sends raw event payload JSON without changing the envelope shape", () => {
     const registry = new NodeRegistry();
     const frames: string[] = [];

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -132,6 +132,22 @@ function normalizeSystemRunTimeoutMs(value: unknown): number | null | undefined 
   return timeoutMs > 0 ? resolveTimerTimeoutMs(timeoutMs, 1) : null;
 }
 
+/** Built-in fallback timeout (ms) for node.invoke calls without an explicit timeout. */
+export const DEFAULT_NODE_INVOKE_TIMEOUT_MS = 30_000;
+
+/**
+ * Normalize a configured default invoke timeout. Returns a positive integer
+ * (capped to the safe timer range) or undefined when the value is unusable, so
+ * callers fall back to {@link DEFAULT_NODE_INVOKE_TIMEOUT_MS}.
+ */
+function normalizeDefaultInvokeTimeoutMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const timeoutMs = Math.trunc(value);
+  return timeoutMs > 0 ? resolveTimerTimeoutMs(timeoutMs, 1) : undefined;
+}
+
 /** Extract system.run event auth metadata from invoke params. */
 function resolvePendingSystemRunEvent(params: {
   command: string;
@@ -177,6 +193,14 @@ export class NodeRegistry {
   private nodesByConn = new Map<string, string>();
   private pendingInvokes = new Map<string, PendingInvoke>();
   private authorizedSystemRunEvents = new Map<string, AuthorizedSystemRunEvent>();
+  private defaultInvokeTimeoutMs: number = DEFAULT_NODE_INVOKE_TIMEOUT_MS;
+
+  constructor(opts?: { defaultInvokeTimeoutMs?: number }) {
+    const configured = normalizeDefaultInvokeTimeoutMs(opts?.defaultInvokeTimeoutMs);
+    if (configured !== undefined) {
+      this.defaultInvokeTimeoutMs = configured;
+    }
+  }
 
   /** Register a websocket client as the current connection for its node id. */
   register(client: GatewayWsClient, opts: { remoteIp?: string | undefined }) {
@@ -469,7 +493,7 @@ export class NodeRegistry {
         ...systemRunEvent,
       });
     }
-    const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 30_000, 0);
+    const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, this.defaultInvokeTimeoutMs, 0);
     return await new Promise<NodeInvokeResult>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pendingInvokes.delete(requestId);

--- a/src/gateway/server-node-session-runtime.ts
+++ b/src/gateway/server-node-session-runtime.ts
@@ -13,8 +13,10 @@ import { hasConnectedTalkNode } from "./server-talk-nodes.js";
 /** Creates node registry/subscription runtime state for a gateway server. */
 export function createGatewayNodeSessionRuntime(params: {
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
+  /** Default node.invoke timeout (ms) from gateway.nodes.invokeTimeoutMs. */
+  defaultInvokeTimeoutMs?: number;
 }) {
-  const nodeRegistry = new NodeRegistry();
+  const nodeRegistry = new NodeRegistry({ defaultInvokeTimeoutMs: params.defaultInvokeTimeoutMs });
   const nodePresenceTimers = new Map<string, ReturnType<typeof setInterval>>();
   const nodeSubscriptions = createNodeSubscriptionManager();
   const sessionEventSubscribers = createSessionEventSubscriberRegistry();

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -938,7 +938,10 @@ export async function startGatewayServer(
     nodeUnsubscribeAll,
     broadcastVoiceWakeChanged,
     hasTalkNodeConnected,
-  } = createGatewayNodeSessionRuntime({ broadcast });
+  } = createGatewayNodeSessionRuntime({
+    broadcast,
+    defaultInvokeTimeoutMs: cfgAtStart.gateway?.nodes?.invokeTimeoutMs,
+  });
   applyGatewayLaneConcurrency(cfgAtStart);
 
   runtimeState = createGatewayServerLiveState({


### PR DESCRIPTION
## Summary

The gateway→node `node.invoke` path used a hardcoded 30-second default timeout for any call that did not pass its own `timeoutMs`. Nodes that legitimately run longer commands were cut off at 30s with a `TIMEOUT` error. This adds a configurable default:

```jsonc
{ "gateway": { "nodes": { "invokeTimeoutMs": 120000 } } }
```

## Behavior

- `NodeRegistry` accepts an optional `defaultInvokeTimeoutMs` and uses it as the fallback timeout when an `invoke` call omits `timeoutMs`.
- Invalid values (zero, negative, non-finite) fall back to the built-in `DEFAULT_NODE_INVOKE_TIMEOUT_MS` (30000), so a misconfiguration can never collapse the timeout to an immediate fire.
- Wired from `gateway.nodes.invokeTimeoutMs` through `createGatewayNodeSessionRuntime` at gateway startup.
- A per-call `timeoutMs` (e.g. the CLI `--command-timeout`) still overrides the configured default for that call.
- **Backward compatible**: with no config set, behavior is unchanged (30s default).
- Documented in `docs/nodes/index.md`.

## Not in this PR (follow-ups)

This is the timeout-configurability slice of the broader long-running-exec work. Two related pieces are deliberately deferred because they are larger and cross-cutting:

- **Task-registry handoff on timeout** — when an invoke times out, hand the still-running work off to the task registry as a tracked task instead of only returning `TIMEOUT`.
- **Node heartbeat** — let an actively-working node send keepalive/progress signals so it is not killed at the timeout. This is a gateway↔node protocol change touching the node client too, so it warrants its own PR.

## Tests

- `src/gateway/node-registry.test.ts`: the configured default is honored when a call omits `timeoutMs`; an invalid configured value falls back to the 30000ms default; a per-call `timeoutMs` overrides the configured default. (Fake timers assert the exact firing boundary.)
- `pnpm check --include-test-types` green; `pnpm check:docs` green (broken_links=0); gateway node-registry + node-session-runtime suites green.

## Real behavior proof

**Behavior or issue addressed:** A `node.invoke` call that omits its own timeout must use the configured `gateway.nodes.invokeTimeoutMs` as its default (instead of the hardcoded 30000ms); an explicit per-call timeout must still override it; and an invalid configured value must fall back to 30000ms rather than collapsing to an immediate timeout.

**Real environment tested:** macOS (Apple Silicon) checkout of this branch, Node v25.9.0. The production `NodeRegistry` and the production `createGatewayNodeSessionRuntime` factory (the same one the gateway server uses at startup) were driven in-process in **real wall-clock time** (no fake timers, no registry test doubles) against a fake node that never responds, and the elapsed time until each invoke resolved with `TIMEOUT` was measured.

**Exact steps or command run after this patch:**

```bash
cd ~/repos/oc-worktrees/impl-prE   # this branch
pnpm exec tsx proof-node-timeout.harness.ts
```

The harness constructs real `NodeRegistry` instances with different configured defaults, registers a fake non-responding node, calls `invoke` (with and without a per-call `timeoutMs`), and prints the measured elapsed time and outcome. It also builds a registry through the real `createGatewayNodeSessionRuntime` factory using a value read from a `gateway.nodes.invokeTimeoutMs`-shaped config object.

**Evidence after fix:**

```text
# Real NodeRegistry, real timers, fake never-responding node

## configured default honored (no per-call timeout)
[config=250ms] {"elapsedMs":254,"ok":false,"errorCode":"TIMEOUT"}
[config=600ms] {"elapsedMs":603,"ok":false,"errorCode":"TIMEOUT"}

## per-call timeout overrides the configured default
[config=5000ms,call=150ms] {"elapsedMs":153,"ok":false,"errorCode":"TIMEOUT"}

## config plumbing: gateway.nodes.invokeTimeoutMs → factory → registry
[cfg.gateway.nodes.invokeTimeoutMs=300ms] {"elapsedMs":302,"ok":false,"errorCode":"TIMEOUT"}

## invalid config falls back to the 30000ms built-in default
[config=0 → fallback] {"waitedMs":403,"resolved":false,"note":"still pending well past 0ms — did not collapse to an immediate timeout"}
```

**Observed result after fix:** Each invoke that omitted a per-call timeout resolved with `TIMEOUT` at the configured default (254ms for 250, 603ms for 600), tracking the configured value within timer overhead. A value supplied through the real `createGatewayNodeSessionRuntime` factory from a `gateway.nodes.invokeTimeoutMs`-shaped config (300) was honored (302ms), proving the config-to-registry plumbing. A per-call `timeoutMs` of 150 overrode a configured default of 5000 (153ms). A configured value of 0 did **not** collapse the timeout — the invoke was still pending at 403ms, confirming the fallback to the 30000ms built-in default rather than an immediate fire.

**What was not tested:** A full live gateway with a real connected node running an actual >30s command end-to-end (the timeout logic and config plumbing are exercised above against the real registry/factory; the node transport is the only stubbed part); the deferred task-registry handoff and heartbeat paths (out of scope for this PR).
