### PR TITLE
perf(gateway): drop watcher awaitWriteFinish polling

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -744,6 +744,27 @@ describe("startGatewayConfigReloader", () => {
     vi.restoreAllMocks();
   });
 
+  it("watches config changes without awaitWriteFinish polling", async () => {
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValue(makeSnapshot());
+
+    const { reloader } = createReloaderHarness(readSnapshot);
+    const watchOptions = vi.mocked(chokidar.watch).mock.calls[0]?.[1] as
+      | { awaitWriteFinish?: unknown; ignoreInitial?: boolean; usePolling?: boolean }
+      | undefined;
+
+    expect(watchOptions).toEqual(
+      expect.objectContaining({
+        ignoreInitial: true,
+        usePolling: Boolean(process.env.VITEST),
+      }),
+    );
+    expect(watchOptions).not.toHaveProperty("awaitWriteFinish");
+
+    await reloader.stop();
+  });
+
   it("retries missing snapshots and reloads once config file reappears", async () => {
     const readSnapshot = vi
       .fn<() => Promise<ConfigFileSnapshot>>()

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -860,28 +860,46 @@ describe("startGatewayConfigReloader", () => {
     }
   });
 
-  it("skips invalid external config edits without recovery", async () => {
-    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
-      makeSnapshot({
-        valid: false,
-        raw: "{ gateway: { mode: 123 } }",
-        issues: [{ path: "gateway.mode", message: "Expected string" }],
-        hash: "bad-1",
-      }),
-    );
+  it("retries invalid external config edits before applying a stable snapshot", async () => {
+    const acceptedSnapshot = makeSnapshot({
+      config: {
+        gateway: { reload: { debounceMs: 0 } },
+        hooks: { enabled: true },
+      },
+      hash: "good-1",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          valid: false,
+          raw: "{ gateway: { mode: 123 } }",
+          issues: [{ path: "gateway.mode", message: "Expected string" }],
+          hash: "bad-1",
+        }),
+      )
+      .mockResolvedValueOnce(acceptedSnapshot);
     const promoteSnapshot = vi.fn(async (_snapshot: ConfigFileSnapshot, _reason: string) => true);
     const { watcher, onHotReload, onRestart, log, reloader } = createReloaderHarness(readSnapshot, {
       promoteSnapshot,
     });
 
     watcher.emit("change");
-    await vi.runAllTimersAsync();
+    await vi.runOnlyPendingTimersAsync();
 
     expect(readSnapshot).toHaveBeenCalledTimes(1);
     expect(onHotReload).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      "config reload retry (1/2): config file is not valid yet: gateway.mode: Expected string",
+    );
+
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(readSnapshot).toHaveBeenCalledTimes(2);
+    expect(onHotReload).toHaveBeenCalledTimes(1);
     expect(onRestart).not.toHaveBeenCalled();
-    expect(promoteSnapshot).not.toHaveBeenCalled();
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(promoteSnapshot).toHaveBeenCalledWith(acceptedSnapshot, "valid-config");
+    expect(log.warn).not.toHaveBeenCalledWith(
       "config reload skipped (invalid config): gateway.mode: Expected string",
     );
 
@@ -918,7 +936,7 @@ describe("startGatewayConfigReloader", () => {
     });
     const readSnapshot = vi
       .fn<() => Promise<ConfigFileSnapshot>>()
-      .mockResolvedValueOnce(invalidSnapshot);
+      .mockResolvedValue(invalidSnapshot);
     const promoteSnapshot = vi.fn(async (_snapshot: ConfigFileSnapshot, _reason: string) => true);
     const previousConfig: OpenClawConfig = {
       ...activeConfig,
@@ -939,10 +957,16 @@ describe("startGatewayConfigReloader", () => {
     watcher.emit("change");
     await vi.runAllTimersAsync();
 
-    expect(readSnapshot).toHaveBeenCalledTimes(1);
+    expect(readSnapshot).toHaveBeenCalledTimes(3);
     expect(onRestart).not.toHaveBeenCalled();
     expect(onHotReload).not.toHaveBeenCalled();
     expect(promoteSnapshot).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      "config reload retry (1/2): config file is not valid yet: plugins.entries.lossless-claw.config.cacheAwareCompaction: invalid config: must NOT have additional properties",
+    );
+    expect(log.info).toHaveBeenCalledWith(
+      "config reload retry (2/2): config file is not valid yet: plugins.entries.lossless-claw.config.cacheAwareCompaction: invalid config: must NOT have additional properties",
+    );
     expect(
       log.warn.mock.calls.some(([message]) =>
         message.includes(

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -32,6 +32,8 @@ export {
 export type { ChannelKind, GatewayReloadPlan } from "./config-reload-plan.js";
 const MISSING_CONFIG_RETRY_DELAY_MS = 150;
 const MISSING_CONFIG_MAX_RETRIES = 2;
+const INVALID_CONFIG_RETRY_DELAY_MS = 150;
+const INVALID_CONFIG_MAX_RETRIES = 2;
 
 // Watcher 'error' events (for example EMFILE/ENOSPC inotify exhaustion) close
 // the chokidar watcher. Re-create it with bounded backoff so a transient fault
@@ -125,6 +127,7 @@ export function startGatewayConfigReloader(opts: {
   let stopped = false;
   let restartQueued = false;
   let missingConfigRetries = 0;
+  let invalidConfigRetries = 0;
   let pendingInProcessConfig: {
     config: OpenClawConfig;
     compareConfig: OpenClawConfig;
@@ -175,6 +178,7 @@ export function startGatewayConfigReloader(opts: {
       missingConfigRetries = 0;
       return false;
     }
+    invalidConfigRetries = 0;
     if (missingConfigRetries < MISSING_CONFIG_MAX_RETRIES) {
       missingConfigRetries += 1;
       opts.log.info(
@@ -189,9 +193,18 @@ export function startGatewayConfigReloader(opts: {
 
   const handleInvalidSnapshot = (snapshot: ConfigFileSnapshot): boolean => {
     if (snapshot.valid) {
+      invalidConfigRetries = 0;
       return false;
     }
     const issues = formatConfigIssueLines(snapshot.issues, "").join(", ");
+    if (invalidConfigRetries < INVALID_CONFIG_MAX_RETRIES) {
+      invalidConfigRetries += 1;
+      opts.log.info(
+        `config reload retry (${invalidConfigRetries}/${INVALID_CONFIG_MAX_RETRIES}): config file is not valid yet: ${issues}`,
+      );
+      scheduleAfter(INVALID_CONFIG_RETRY_DELAY_MS);
+      return true;
+    }
     opts.log.warn(`config reload skipped (invalid config): ${issues}`);
     return true;
   };
@@ -385,6 +398,7 @@ export function startGatewayConfigReloader(opts: {
   };
 
   const scheduleFromWatcher = () => {
+    invalidConfigRetries = 0;
     schedule();
   };
 

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -414,7 +414,6 @@ export function startGatewayConfigReloader(opts: {
     }
     const next = chokidar.watch(opts.watchPath, {
       ignoreInitial: true,
-      awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
       usePolling: Boolean(process.env.VITEST),
     });
     next.on("add", scheduleFromWatcher);

--- a/src/skills/runtime/refresh.test.ts
+++ b/src/skills/runtime/refresh.test.ts
@@ -64,7 +64,15 @@ describe("ensureSkillsWatcher", () => {
 
       // Each unique directory gets its own watcher (one path argument per call).
       const calls = watchMock.mock.calls as unknown as Array<
-        [string, { depth?: number; followSymlinks?: boolean; ignored?: unknown }]
+        [
+          string,
+          {
+            awaitWriteFinish?: unknown;
+            depth?: number;
+            followSymlinks?: boolean;
+            ignored?: unknown;
+          },
+        ]
       >;
       expect(calls.length).toBeGreaterThan(0);
       const targets = calls.map((call) => call[0]);
@@ -73,6 +81,7 @@ describe("ensureSkillsWatcher", () => {
 
       expect(typeof opts.ignored).toBe("function");
       expect(opts.followSymlinks).toBe(false);
+      expect(opts).not.toHaveProperty("awaitWriteFinish");
       const posix = (p: string) => p.replaceAll("\\", "/");
       expect(targets).toContain(workspaceSkillsRoot);
       expect(targets).toContain(posix(path.join(workspaceDir, ".agents", "skills")));

--- a/src/skills/runtime/refresh.test.ts
+++ b/src/skills/runtime/refresh.test.ts
@@ -191,6 +191,48 @@ describe("ensureSkillsWatcher", () => {
     }
   });
 
+  it("waits for polling SKILL.md file events to stabilize before refreshing", async () => {
+    vi.useFakeTimers();
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-watch-polling-stable-"));
+    const skillDir = path.join(workspaceDir, "skills", "demo");
+    const skillFile = path.join(skillDir, "SKILL.md");
+    const previousPolling = process.env.CHOKIDAR_USEPOLLING;
+    const seen: SkillsChangeEvent[] = [];
+    try {
+      process.env.CHOKIDAR_USEPOLLING = "true";
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(skillFile, "---\nname: demo\ndescription: Demo\n---\n");
+      refreshModule.registerSkillsChangeListener((change) => {
+        seen.push(change);
+      });
+      refreshModule.ensureSkillsWatcher({
+        workspaceDir,
+        config: { skills: { load: { watchDebounceMs: 10 } } },
+      });
+
+      createdWatchers[0]?.emit("change", skillFile);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(10);
+      expect(seen).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(seen).toEqual([
+        {
+          workspaceDir,
+          reason: "watch",
+          changedPath: skillFile,
+        },
+      ]);
+    } finally {
+      if (previousPolling === undefined) {
+        delete process.env.CHOKIDAR_USEPOLLING;
+      } else {
+        process.env.CHOKIDAR_USEPOLLING = previousPolling;
+      }
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps grouped skill folders within the watcher traversal depth", async () => {
     vi.useFakeTimers();
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-watch-depth-"));

--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -517,10 +517,6 @@ function createSkillsPathWatcher(target: WatchTarget, debounceMs: number): Skill
     // Skill root precedence and grouped discovery use the same bounded depth,
     // so watcher invalidation must observe that whole decision surface.
     depth: target.depth,
-    awaitWriteFinish: {
-      stabilityThreshold: debounceMs,
-      pollInterval: 100,
-    },
     ignored: (watchPath, stats) => shouldIgnoreSkillsWatchPath(watchPath, stats, { usePolling }),
   });
 

--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -548,17 +548,24 @@ function createSkillsPathWatcher(target: WatchTarget, debounceMs: number): Skill
       }
     }, debounceMs);
   };
-  const scheduleRawSkillFile = (changedPath: string) => {
+  const scheduleStableSkillFile = (changedPath: string) => {
     void waitForStableSkillFile(changedPath, debounceMs)
       .catch((err: unknown) => {
         log.warn(`skills watcher stability check failed (${changedPath}): ${String(err)}`);
       })
       .then(() => schedule(changedPath));
   };
+  const schedulePolledSkillFile = (changedPath: string) => {
+    if (usePolling && isSkillFileWatchPath(changedPath)) {
+      scheduleStableSkillFile(changedPath);
+      return;
+    }
+    schedule(changedPath);
+  };
 
   watcher.on("addDir", (p) => schedule(p));
-  watcher.on("add", (p) => schedule(p));
-  watcher.on("change", (p) => schedule(p));
+  watcher.on("add", schedulePolledSkillFile);
+  watcher.on("change", schedulePolledSkillFile);
   watcher.on("unlink", (p) => schedule(p));
   watcher.on("unlinkDir", (p) => schedule(p));
   watcher.on("raw", (_eventName, rawPath, details) => {
@@ -575,7 +582,7 @@ function createSkillsPathWatcher(target: WatchTarget, debounceMs: number): Skill
       if (usePolling) {
         return;
       }
-      scheduleRawSkillFile(changedPath);
+      scheduleStableSkillFile(changedPath);
     }
   });
   watcher.on("error", (err) => {


### PR DESCRIPTION
## Summary

- Problem: #87256 reports high idle CPU on macOS gateway and points at the Gateway config reload watcher plus skills runtime watcher using Chokidar `awaitWriteFinish` polling.
- Solution: Remove `awaitWriteFinish` from those two watcher constructors, keep OpenClaw's debounce layers, and preserve change-time write stability with bounded invalid-config retry plus polling-mode `SKILL.md` stabilization.
- What changed: `src/gateway/config-reload.ts`, `src/skills/runtime/refresh.ts`, and focused regression coverage in `src/gateway/config-reload.test.ts` and `src/skills/runtime/refresh.test.ts`.
- What did NOT change: No new public config/env switch, no watched path expansion, no channel/provider behavior change, and no skills discovery precedence or depth change.

Fixes #87256

## Real behavior proof

- **Behavior addressed:** Gateway config reload and skills runtime watchers no longer enable Chokidar `awaitWriteFinish`; a real macOS OpenClaw gateway can start, sit idle, and still observe config/skills watcher events while the PR keeps change-time stability for invalid config snapshots and polling `SKILL.md` events.
- **Real environment tested:** macOS 26.5 arm64, Node v24.15.0, pnpm 11.2.2, OpenClaw 2026.6.2, worktree SHA `0c3516b2d8bf`, isolated OpenClaw home/state/config directories outside the repository, channels skipped with `OPENCLAW_SKIP_CHANNELS=1`.
- **Exact steps or command run after this patch:**
  ```bash
  # Run the gateway with isolated OpenClaw home/state/config directories outside the repository.
  OPENCLAW_HOME=<isolated-openclaw-home> \
    OPENCLAW_STATE_DIR=<isolated-openclaw-state-dir> \
    OPENCLAW_CONFIG_PATH=<isolated-openclaw-home>/.openclaw/openclaw.json \
    OPENCLAW_SKIP_CHANNELS=1 \
    OPENCLAW_GATEWAY_PORT=19010 \
    pnpm gateway:dev

  ps -p <gateway-runtime-pid> -o pid,ppid,%cpu,%mem,etime,command
  sample <gateway-runtime-pid> 5 -file <sample-output-file>
  # Checked the sample output for awaitWriteFinish, stat/lstat, opendir, open NOCANCEL, uv_fs, and chokidar frames.

  # Edited the isolated openclaw.json to add gateway.reload.debounceMs=211.

  # Run a one-off proof script outside the repository that imports the production skills refresh modules,
  # calls ensureSkillsWatcher(), writes a temporary SKILL.md under an isolated workspace, and prints observed events.
  node --import tsx <skills-watcher-live-proof-script-outside-repo>

  node scripts/run-vitest.mjs src/gateway/config-reload.test.ts src/skills/runtime/refresh.test.ts
  node scripts/run-vitest.mjs src/auto-reply/reply/session-updates.test.ts
  pnpm check:test-types
  pnpm exec oxlint --deny=warn --ignore-path=.oxlintignore src/gateway/config-reload.ts src/gateway/config-reload.test.ts src/skills/runtime/refresh.ts src/skills/runtime/refresh.test.ts
  git diff --check
  ```
- **Evidence after fix:** Real gateway startup and idle process sampling on macOS, with local paths redacted from the pasted log:
  ```text
  gateway real proof rerun
  worktree sha: 0c3516b2d8bf
  root pid: 14844
  sample pid: 14857
  2026-06-14T00:49:09.498+08:00 Dev config ready: [isolated OpenClaw home]/.openclaw/openclaw.json
  2026-06-14T00:49:09.503+08:00 Dev workspace ready: [isolated OpenClaw home]/.openclaw/workspace-dev
  2026-06-14T00:49:09.509+08:00 [gateway] loading configuration…
  2026-06-14T00:49:09.538+08:00 [gateway] resolving authentication…
  2026-06-14T00:49:10.321+08:00 [gateway] http server listening (9 plugins: acpx, bonjour, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 0.8s)
  2026-06-14T00:49:10.323+08:00 [gateway] ready

  Process tree
    PID  PPID  %CPU %MEM ELAPSED COMMAND
  14844 14836   0.0  0.8   00:02 pnpm gateway:dev
  14857 14856   0.0  0.6   00:02 node scripts/run-node.mjs --dev gateway

  Idle ps samples for PID 14857
  sample 00:49:10
    PID  PPID  %CPU %MEM ELAPSED COMMAND
  14857 14856   0.0  0.6   00:02 node scripts/run-node.mjs --dev gateway
  sample 00:49:15
    PID  PPID  %CPU %MEM ELAPSED COMMAND
  14857 14856   0.0  0.6   00:07 node scripts/run-node.mjs --dev gateway
  sample 00:49:20
    PID  PPID  %CPU %MEM ELAPSED COMMAND
  14857 14856   0.0  0.6   00:12 node scripts/run-node.mjs --dev gateway
  sample 00:49:25
    PID  PPID  %CPU %MEM ELAPSED COMMAND
  14857 14856   0.0  0.6   00:17 node scripts/run-node.mjs --dev gateway

  sample 14857 5 -file <sample-output-file>
  Sampling process 14857 for 5 seconds with 1 millisecond of run time between samples
  Sampling completed, processing symbols...

  Focused sample grep for awaitWriteFinish/stat/lstat/opendir/open/uv_fs/chokidar frames
  no matching frames
  ```

  Real config watcher event after editing the isolated config file:
  ```text
  2026-06-14T00:49:10.323+08:00 [gateway] ready
  2026-06-14T00:49:10.726+08:00 [gateway/channels] skipping channel start (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)
  2026-06-14T00:49:20.887+08:00 [gateway] agent runtime plugins pre-warmed in 84ms
  2026-06-14T00:49:36.396+08:00 [reload] config change detected; evaluating reload (gateway.reload)
  ```

  Real skills watcher event using the production `ensureSkillsWatcher` path and a live filesystem change under a temporary workspace outside the repository:
  ```text
  real skills watcher live proof
  worktree sha: 0c3516b2d8bf
  workspace: [temporary workspace outside the repository]
  initial version: 0
  final version: 1781369387824
  events observed: 1
  {"workspaceDir":"[temporary workspace outside the repository]","reason":"watch","changedPath":"[temporary workspace outside the repository]/skills/live-watch-proof"}
  ```

  Regression and static-check commands also passed:
  ```text
  node scripts/run-vitest.mjs src/gateway/config-reload.test.ts src/skills/runtime/refresh.test.ts
  [test] passed 2 Vitest shards in 10.01s

  node scripts/run-vitest.mjs src/auto-reply/reply/session-updates.test.ts
  [test] passed 1 Vitest shard in 3.02s

  pnpm check:test-types
  $ pnpm tsgo:test
  $ pnpm tsgo:core:test && pnpm tsgo:extensions:test
  $ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
  $ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo

  pnpm exec oxlint --deny=warn --ignore-path=.oxlintignore src/gateway/config-reload.ts src/gateway/config-reload.test.ts src/skills/runtime/refresh.ts src/skills/runtime/refresh.test.ts
  [no output]

  git diff --check
  [no output]
  ```
- **Observed result after fix:** The PR branch ran a real macOS gateway with channels skipped, stayed at 0.0% CPU after warmup in the sampled gateway runtime process, produced no sampled `awaitWriteFinish`/filesystem polling frames in the focused `sample` grep, detected an actual config-file change through the config watcher, and observed an actual skills-directory change through the production skills watcher path. Focused tests also now lock in bounded invalid-config retry and polling-mode `SKILL.md` stabilization so the removed Chokidar option does not remove change-time write stability.
- **What was not tested:** I did not reproduce the reporter's exact Intel macOS 26.4.1 LaunchAgent/global npm setup. The parent commit also did not reproduce the reported 60-93% idle CPU in my isolated macOS 26.5 arm64 dev setup, so this proof does not claim a same-machine before/after CPU drop for that original environment.

## Regression Test Plan

- Coverage level: Unit tests plus real macOS runtime/function proof.
- Target test file: `src/gateway/config-reload.test.ts`, `src/skills/runtime/refresh.test.ts`, `src/auto-reply/reply/session-updates.test.ts`.
- Scenario locked in: Config watcher options preserve `ignoreInitial` and test polling without `awaitWriteFinish`; invalid external config snapshots get a bounded retry before reload is skipped; skills watcher options preserve bounded depth, symlink behavior, and ignore filtering without `awaitWriteFinish`; polling-mode `SKILL.md` file events wait for stability before refreshing; existing session update behavior remains covered.
- Why this is the smallest reliable guardrail: The code change removes dependency-level Chokidar write-finish polling while adding narrow tests for the two retained change-time stability paths that ClawSweeper flagged.

## Root Cause

- Root cause: The two watcher surfaces named in #87256 enabled Chokidar `awaitWriteFinish`, which adds a dependency-level file-size stability gate and can use repeated `stat` checks during pending writes even though OpenClaw already debounces config reload and skills refresh work above Chokidar. Removing it outright also removed two change-time stability guarantees: invalid external config edits were skipped without retry, and polling-mode `SKILL.md` changes refreshed immediately while a file could still be mid-write.
- Missing detection / guardrail: Existing tests covered reload/refresh behavior but did not assert that the gateway and skills watcher options avoid dependency-level `awaitWriteFinish` polling while preserving bounded invalid-config retry and polling-mode `SKILL.md` stabilization.
