### PR TITLE
fix(windows): replace cmd handoff with Node.js subprocess for gateway restart

### DIFF
--- a/src/infra/windows-task-restart.test.ts
+++ b/src/infra/windows-task-restart.test.ts
@@ -1,4 +1,4 @@
-// Covers Windows scheduled-task gateway restart script generation.
+// Covers Windows scheduled-task gateway restart via Node.js handoff.
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -37,21 +37,21 @@ let relaunchGatewayScheduledTask: WindowsTaskRestartModule["relaunchGatewaySched
 
 const envSnapshot = captureFullEnv();
 const createdScriptPaths = new Set<string>();
-const createdTmpDirs = new Set<string>();
 
-function decodeCmdPathArg(value: string): string {
-  const trimmed = value.trim();
-  const withoutQuotes =
-    trimmed.startsWith('"') && trimmed.endsWith('"') ? trimmed.slice(1, -1) : trimmed;
-  return withoutQuotes.replace(/\^!/g, "!").replace(/%%/g, "%");
-}
-
-function requireFirstMockCall<T>(mock: { mock: { calls: T[][] } }, label: string): T[] {
-  const call = mock.mock.calls[0];
+function requireCall(mock: { mock: { calls: unknown[][] } }, index: number, label: string) {
+  const call = mock.mock.calls[index];
   if (!call) {
     throw new Error(`expected ${label} call`);
   }
   return call;
+}
+
+function getCreatedScriptPath(): string {
+  const scriptPath = [...createdScriptPaths][0];
+  if (!scriptPath) {
+    throw new Error("expected restart launcher script path");
+  }
+  return scriptPath;
 }
 
 afterEach(() => {
@@ -64,14 +64,6 @@ afterEach(() => {
     }
   }
   createdScriptPaths.clear();
-  for (const tmpDir of createdTmpDirs) {
-    try {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    } catch {
-      // Best-effort cleanup for test temp roots.
-    }
-  }
-  createdTmpDirs.clear();
 });
 
 describe("relaunchGatewayScheduledTask", () => {
@@ -90,12 +82,12 @@ describe("relaunchGatewayScheduledTask", () => {
     });
   });
 
-  it("writes a detached schtasks relaunch helper", () => {
+  it("spawns a detached Node.js handoff launcher", () => {
     const unref = vi.fn();
-    let seenCommandArg = "";
     spawnMock.mockImplementation((_file: string, args: string[]) => {
-      seenCommandArg = args[3];
-      createdScriptPaths.add(decodeCmdPathArg(args[3]));
+      if (args.length === 1 && args[0]?.endsWith(".mjs")) {
+        createdScriptPaths.add(args[0]);
+      }
       return { unref };
     });
 
@@ -103,42 +95,30 @@ describe("relaunchGatewayScheduledTask", () => {
 
     expect(result.ok).toBe(true);
     expect(result.method).toBe("schtasks");
-    expect(result.tried).toContain('schtasks /Run /TN "OpenClaw Gateway (work)"');
-    expect(result.tried).toContain(`cmd.exe /d /s /c ${seenCommandArg}`);
-    const spawnCall = requireFirstMockCall(spawnMock, "restart helper spawn");
-    expect(spawnCall[0]).toBe("cmd.exe");
-    expect(spawnCall[1]).toStrictEqual(["/d", "/s", "/c", seenCommandArg]);
-    expect(spawnCall[2]).toStrictEqual({
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+
+    const endCall = requireCall(spawnMock, 0, "schtasks end");
+    expect(endCall[0]).toBe("cmd.exe");
+
+    const launcherCall = requireCall(spawnMock, 1, "node launcher");
+    expect(launcherCall[0]).toBe(process.execPath);
+    expect(launcherCall[1]).toHaveLength(1);
+    expect((launcherCall[1] as string[])[0]).toContain("openclaw-node-restart-");
+    expect(launcherCall[2]).toStrictEqual({
       detached: true,
       stdio: "ignore",
       windowsHide: true,
     });
-    expect(unref).toHaveBeenCalledOnce();
+    expect(unref).toHaveBeenCalledTimes(2);
 
-    const scriptPath = [...createdScriptPaths][0];
-    if (scriptPath === undefined) {
-      throw new Error("expected restart helper script path");
-    }
-    expect(fs.statSync(scriptPath).isFile()).toBe(true);
-    const script = fs.readFileSync(scriptPath, "utf8");
-    expect(script).toContain("timeout /t 1 /nobreak >nul");
-    expect(script).toContain("gateway-restart.log");
-    expect(script).toContain(
-      'openclaw restart attempt source=windows-task-handoff target="OpenClaw Gateway (work)"',
-    );
-    expect(script).toContain(
-      `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "(Get-ScheduledTask -TaskName 'OpenClaw Gateway (work)' -ErrorAction SilentlyContinue).State" 2>nul | findstr /I /C:"Running" >nul 2>&1`,
-    );
-    expect(script).toContain('schtasks /Run /TN "OpenClaw Gateway (work)" >>');
-    expect(script.indexOf("powershell.exe -NoProfile")).toBeLessThan(
-      script.indexOf('schtasks /Run /TN "OpenClaw Gateway (work)"'),
-    );
-    expect(script).toContain('del "%~f0" >nul 2>&1');
+    expect(fs.readFileSync(getCreatedScriptPath(), "utf8")).toContain("node-handoff");
   });
 
   it("prefers OPENCLAW_WINDOWS_TASK_NAME overrides", () => {
     spawnMock.mockImplementation((_file: string, args: string[]) => {
-      createdScriptPaths.add(decodeCmdPathArg(args[3]));
+      if (args.length === 1 && args[0]?.endsWith(".mjs")) {
+        createdScriptPaths.add(args[0]);
+      }
       return { unref: vi.fn() };
     });
 
@@ -147,30 +127,58 @@ describe("relaunchGatewayScheduledTask", () => {
       OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Gateway (custom)",
     });
 
-    const scriptPath = [...createdScriptPaths][0];
-    const script = fs.readFileSync(scriptPath, "utf8");
-    expect(script).toContain('schtasks /Run /TN "OpenClaw Gateway (custom)" >>');
+    expect(fs.readFileSync(getCreatedScriptPath(), "utf8")).toContain("OpenClaw Gateway (custom)");
   });
 
-  it("escapes custom task names in the PowerShell running-task probe", () => {
+  it("includes stop-wait-start sequence in the launcher script", () => {
     spawnMock.mockImplementation((_file: string, args: string[]) => {
-      createdScriptPaths.add(decodeCmdPathArg(args[3]));
+      if (args.length === 1 && args[0]?.endsWith(".mjs")) {
+        createdScriptPaths.add(args[0]);
+      }
       return { unref: vi.fn() };
     });
 
-    relaunchGatewayScheduledTask({
-      OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Gateway (Bob's work)",
-    });
+    relaunchGatewayScheduledTask({ OPENCLAW_PROFILE: "work" });
 
-    const scriptPath = [...createdScriptPaths][0];
-    const script = fs.readFileSync(scriptPath, "utf8");
-    expect(script).toContain(
-      "-Command \"(Get-ScheduledTask -TaskName 'OpenClaw Gateway (Bob''s work)' -ErrorAction SilentlyContinue).State\"",
-    );
+    const script = fs.readFileSync(getCreatedScriptPath(), "utf8");
+    expect(script).toContain("schtasks");
+    expect(script).toContain("/Run");
+    expect(script).toContain("stopped");
+    expect(script).toContain("openclaw restart finished");
   });
 
-  it("returns failed when the helper cannot be spawned", () => {
-    spawnMock.mockImplementation(() => {
+  it("includes gateway port force-kill fallback in the launcher script", () => {
+    spawnMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.length === 1 && args[0]?.endsWith(".mjs")) {
+        createdScriptPaths.add(args[0]);
+      }
+      return { unref: vi.fn() };
+    });
+
+    relaunchGatewayScheduledTask({ OPENCLAW_PROFILE: "work" });
+
+    const script = fs.readFileSync(getCreatedScriptPath(), "utf8");
+    expect(script).toContain("18789");
+    expect(script).toContain("taskkill");
+  });
+
+  it("includes gateway.cmd fallback in the launcher script", () => {
+    spawnMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.length === 1 && args[0]?.endsWith(".mjs")) {
+        createdScriptPaths.add(args[0]);
+      }
+      return { unref: vi.fn() };
+    });
+
+    relaunchGatewayScheduledTask({ OPENCLAW_PROFILE: "work" });
+
+    const script = fs.readFileSync(getCreatedScriptPath(), "utf8");
+    expect(script).toContain("fallback");
+    expect(script).toContain("gateway.cmd");
+  });
+
+  it("returns failed when the launcher cannot be spawned", () => {
+    spawnMock.mockImplementationOnce(() => {
       throw new Error("spawn failed");
     });
 
@@ -181,57 +189,13 @@ describe("relaunchGatewayScheduledTask", () => {
     expect(result.detail).toContain("spawn failed");
   });
 
-  it("quotes the cmd /c script path when temp paths contain metacharacters", () => {
-    const unref = vi.fn();
-    const metacharTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw&(restart)-"));
-    createdTmpDirs.add(metacharTmpDir);
-    resolvePreferredOpenClawTmpDirMock.mockReturnValue(metacharTmpDir);
-    spawnMock.mockReturnValue({ unref });
+  it("uses windowsHide: true on all spawned processes", () => {
+    spawnMock.mockImplementation(() => ({ unref: vi.fn() }));
 
     relaunchGatewayScheduledTask({ OPENCLAW_PROFILE: "work" });
 
-    expect(spawnMock).toHaveBeenCalledOnce();
-    const spawnCall = requireFirstMockCall(spawnMock, "restart helper spawn");
-    const commandArgs = spawnCall[1];
-    if (!Array.isArray(commandArgs)) {
-      throw new Error("expected cmd.exe argument array");
+    for (const call of spawnMock.mock.calls) {
+      expect(call[2]).toMatchObject({ windowsHide: true });
     }
-    const commandArg = commandArgs[3];
-    if (typeof commandArg !== "string") {
-      throw new Error("expected quoted restart helper path");
-    }
-    expect(spawnCall[0]).toBe("cmd.exe");
-    expect(commandArgs).toStrictEqual(["/d", "/s", "/c", commandArg]);
-    expect(commandArg.startsWith('"')).toBe(true);
-    expect(commandArg.endsWith('"')).toBe(true);
-    expect(commandArg).toContain("&");
-    expect(spawnCall[2]).toStrictEqual({
-      detached: true,
-      stdio: "ignore",
-      windowsHide: true,
-    });
-  });
-
-  it("includes startup fallback", () => {
-    const taskScriptDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-state-"));
-    createdTmpDirs.add(taskScriptDir);
-    const taskScriptPath = path.join(taskScriptDir, "gateway.cmd");
-    fs.writeFileSync(taskScriptPath, "@echo off\r\nrem placeholder\r\n", "utf8");
-    resolveTaskScriptPathMock.mockReturnValue(taskScriptPath);
-
-    spawnMock.mockImplementation((_file: string, args: string[]) => {
-      createdScriptPaths.add(decodeCmdPathArg(args[3]));
-      return { unref: vi.fn() };
-    });
-
-    const result = relaunchGatewayScheduledTask({ OPENCLAW_PROFILE: "work" });
-
-    expect(result.ok).toBe(true);
-    const scriptPath = [...createdScriptPaths][0];
-    const script = fs.readFileSync(scriptPath, "utf8");
-    expect(script).toContain(`schtasks /Query /TN`);
-    expect(script).toContain(":fallback");
-    expect(script).toContain(`start "" /min cmd.exe /d /c`);
-    expect(script).toContain(taskScriptPath);
   });
 });

--- a/src/infra/windows-task-restart.ts
+++ b/src/infra/windows-task-restart.ts
@@ -3,7 +3,6 @@ import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { quoteCmdScriptArg } from "../daemon/cmd-argv.js";
 import { resolveGatewayWindowsTaskName } from "../daemon/constants.js";
 import { renderCmdRestartLogSetup } from "../daemon/restart-logs.js";
 import { resolveTaskScriptPath } from "../daemon/schtasks.js";
@@ -11,12 +10,8 @@ import { formatErrorMessage } from "./errors.js";
 import type { RestartAttempt } from "./restart.types.js";
 import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
 
-const TASK_RESTART_RETRY_LIMIT = 12;
-const TASK_RESTART_RETRY_DELAY_SEC = 1;
-
-function quotePowerShellSingleQuotedLiteral(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
-}
+const TASK_STOP_WAIT_ATTEMPTS = 15;
+const TASK_STOP_WAIT_INTERVAL_MS = 2_000;
 
 function resolveWindowsTaskName(env: NodeJS.ProcessEnv): string {
   const override = env.OPENCLAW_WINDOWS_TASK_NAME?.trim();
@@ -26,49 +21,98 @@ function resolveWindowsTaskName(env: NodeJS.ProcessEnv): string {
   return resolveGatewayWindowsTaskName(env.OPENCLAW_PROFILE);
 }
 
-function buildScheduledTaskRestartScript(params: {
-  quotedLogPath: string;
-  setupLines: string[];
+/**
+ * Launch a Node.js subprocess that waits for the old gateway to stop, then
+ * starts the scheduled task. This avoids the cmd.exe handoff script which:
+ * 1) Shows visible console windows (powershell | findstr)
+ * 2) Has a race condition: "Running" status after gateway exit causes premature cleanup
+ *
+ * The subprocess is detached and self-managing — it exits once the new gateway
+ * is launched or all retries are exhausted.
+ */
+function buildNodeHandoffLauncher(params: {
+  logPath: string;
   taskName: string;
   taskScriptPath?: string;
 }): string {
-  const { quotedLogPath, setupLines, taskName, taskScriptPath } = params;
-  const quotedTaskName = quoteCmdScriptArg(taskName);
-  const queryTaskStateCommand = `(Get-ScheduledTask -TaskName ${quotePowerShellSingleQuotedLiteral(
-    taskName,
-  )} -ErrorAction SilentlyContinue).State`;
-  const quotedQueryTaskStateCommand = quoteCmdScriptArg(queryTaskStateCommand);
-  const lines = [
-    "@echo off",
-    "setlocal",
-    ...setupLines,
-    `>> ${quotedLogPath} 2>&1 echo [%DATE% %TIME%] openclaw restart attempt source=windows-task-handoff target=${quotedTaskName}`,
-    `schtasks /Query /TN ${quotedTaskName} >> ${quotedLogPath} 2>&1`,
-    "if errorlevel 1 goto fallback",
-    "set /a attempts=0",
-    ":retry",
-    `timeout /t ${TASK_RESTART_RETRY_DELAY_SEC} /nobreak >nul`,
-    "set /a attempts+=1",
-    // Avoid racing with another restart path that already started the scheduled task.
-    `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ${quotedQueryTaskStateCommand} 2>nul | findstr /I /C:"Running" >nul 2>&1`,
-    "if not errorlevel 1 goto cleanup",
-    `schtasks /Run /TN ${quotedTaskName} >> ${quotedLogPath} 2>&1`,
-    "if not errorlevel 1 goto cleanup",
-    `if %attempts% GEQ ${TASK_RESTART_RETRY_LIMIT} goto fallback`,
-    "goto retry",
-    ":fallback",
-    `>> ${quotedLogPath} 2>&1 echo [%DATE% %TIME%] openclaw restart fallback source=windows-task-handoff`,
-  ];
-  if (taskScriptPath) {
-    const quotedScript = quoteCmdScriptArg(taskScriptPath);
-    lines.push(`if exist ${quotedScript} (`, `  start "" /min cmd.exe /d /c ${quotedScript}`, ")");
+  const { logPath, taskName, taskScriptPath } = params;
+  return `import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+
+const logPath = ${JSON.stringify(logPath)};
+const taskName = ${JSON.stringify(taskName)};
+const taskScriptPath = ${JSON.stringify(taskScriptPath ?? "")};
+
+function log(message) {
+  try {
+    fs.appendFileSync(logPath, new Date().toISOString() + " " + message + "\\n");
+  } catch {
+    // Best-effort diagnostic logging for a detached restart helper.
   }
-  lines.push(
-    ":cleanup",
-    `>> ${quotedLogPath} 2>&1 echo [%DATE% %TIME%] openclaw restart finished source=windows-task-handoff`,
-    'del "%~f0" >nul 2>&1',
-  );
-  return lines.join("\r\n");
+}
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+let stopped = false;
+log("openclaw restart attempt source=node-handoff target=" + taskName);
+
+for (let attempt = 0; attempt < ${TASK_STOP_WAIT_ATTEMPTS}; attempt += 1) {
+  const result = spawnSync("schtasks", ["/Query", "/TN", taskName, "/FO", "LIST", "/V"], {
+    encoding: "utf8",
+    timeout: 5_000,
+    windowsHide: true,
+  });
+  const output = (result.stdout || "").toLowerCase();
+  if (result.status !== 0 || !output.includes("running")) {
+    stopped = true;
+    break;
+  }
+  sleep(${TASK_STOP_WAIT_INTERVAL_MS});
+}
+
+if (!stopped) {
+  log("task still running, force killing gateway listener");
+  const netstat = spawnSync("netstat", ["-aon"], {
+    encoding: "utf8",
+    timeout: 5_000,
+    windowsHide: true,
+  });
+  for (const line of (netstat.stdout || "").split("\\n")) {
+    if (!line.includes(":18789") || !line.includes("LISTENING")) {
+      continue;
+    }
+    const parts = line.trim().split(/\\s+/);
+    const pid = parts[parts.length - 1];
+    if (pid && /^\\d+$/.test(pid)) {
+      spawnSync("taskkill", ["/F", "/PID", pid], { windowsHide: true });
+    }
+  }
+  sleep(5_000);
+}
+
+log("launching task via schtasks /Run");
+const run = spawnSync("schtasks", ["/Run", "/TN", taskName], {
+  encoding: "utf8",
+  timeout: 10_000,
+  windowsHide: true,
+});
+log("schtasks /Run exit=" + run.status + " out=" + (run.stdout || "").trim());
+
+if (run.status !== 0 && taskScriptPath && fs.existsSync(taskScriptPath)) {
+  log("schtasks /Run failed, trying fallback");
+  const fallback = spawn("cmd.exe", ["/d", "/s", "/c", taskScriptPath], {
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  fallback.unref();
+  log("fallback launched: " + taskScriptPath);
+}
+
+log("openclaw restart finished source=node-handoff");
+`;
 }
 
 export function relaunchGatewayScheduledTask(env: NodeJS.ProcessEnv = process.env): RestartAttempt {
@@ -76,43 +120,47 @@ export function relaunchGatewayScheduledTask(env: NodeJS.ProcessEnv = process.en
   const taskScriptPath = resolveTaskScriptPath(env);
   const scriptPath = path.join(
     resolvePreferredOpenClawTmpDir(),
-    `openclaw-schtasks-restart-${randomUUID()}.cmd`,
+    `openclaw-node-restart-${randomUUID()}.mjs`,
   );
-  const quotedScriptPath = quoteCmdScriptArg(scriptPath);
   const restartLog = renderCmdRestartLogSetup({ ...process.env, ...env });
+  const logPath = restartLog.quotedLogPath.replace(/^"|"$/g, "");
+
   try {
     fs.writeFileSync(
       scriptPath,
-      `${buildScheduledTaskRestartScript({
-        quotedLogPath: restartLog.quotedLogPath,
-        setupLines: restartLog.lines,
-        taskName,
-        taskScriptPath,
-      })}\r\n`,
+      buildNodeHandoffLauncher({ logPath, taskName, taskScriptPath }),
       "utf8",
     );
-    const child = spawn("cmd.exe", ["/d", "/s", "/c", quotedScriptPath], {
+    const endChild = spawn(
+      "cmd.exe",
+      ["/d", "/s", "/c", `schtasks /End /TN "${taskName}"`],
+      { detached: true, stdio: "ignore", windowsHide: true },
+    );
+    endChild.unref();
+
+    const launcher = spawn(process.execPath, [scriptPath], {
       detached: true,
       stdio: "ignore",
       windowsHide: true,
     });
-    child.unref();
+    launcher.unref();
+
     return {
       ok: true,
       method: "schtasks",
-      tried: [`schtasks /Run /TN "${taskName}"`, `cmd.exe /d /s /c ${quotedScriptPath}`],
+      tried: [`node ${scriptPath}`, `schtasks /End /TN "${taskName}"`],
     };
   } catch (err) {
     try {
       fs.unlinkSync(scriptPath);
     } catch {
-      // Best-effort cleanup; keep the original restart failure.
+      // Best-effort cleanup for a helper script that may not have been written.
     }
     return {
       ok: false,
       method: "schtasks",
       detail: formatErrorMessage(err),
-      tried: [`schtasks /Run /TN "${taskName}"`],
+      tried: [`node ${scriptPath}`],
     };
   }
 }


### PR DESCRIPTION
## Problem

On Windows, the `/restart` command (and config-change triggered restarts) frequently fail to relaunch the gateway. The gateway shuts down but never comes back, requiring manual `openclaw gateway restart`.

## Root Cause

Commit `6d26609` (#52487) added a "Running" state check to the cmd.exe handoff script to avoid duplicate `schtasks /Run` calls. However, this introduces a race condition:

1. `/restart` fires → gateway process exits
2. Handoff script spawns and checks `Get-ScheduledTask.State`
3. Windows Task Scheduler still reports **"Running"** due to delayed state updates after process exit
4. Handoff script sees "Running" → assumes another path already restarted → jumps to `cleanup`
5. **No new instance is launched** — gateway stays offline

The cmd script also spawns `powershell.exe | findstr.exe`, which creates **visible console popup windows** even with `windowsHide: true`, because the piped child processes aren't hidden.

## Fix

Replace the cmd.exe handoff script with a **detached Node.js subprocess** that:

1. Writes a temporary `.mjs` restart launcher
2. **`schtasks /End`** — signals the Task Scheduler to stop the old task
3. The launcher **polls** `schtasks /Query` until the task is confirmed NOT running
4. **Force-kills** the process on port 18789 if the task won't stop (timeout fallback)
5. **`schtasks /Run`** — starts the new instance once the old one is confirmed gone
6. **Falls back** to launching `gateway.cmd` directly if `schtasks /Run` fails

### Why Node.js instead of cmd script?

- ✅ **No console popups** — `windowsHide: true` works correctly on Node.js child processes
- ✅ **No race condition** — explicitly waits for task to stop before launching new instance
- ✅ **Better logging** — structured log lines with timestamps
- ✅ **Force-kill fallback** — handles stuck processes that refuse to die

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Windows `/restart` should relaunch the managed `OpenClaw Gateway` Scheduled Task without leaving the gateway offline and without visible `cmd` / `findstr` console popups.
- Real environment tested: Real Windows 10 machine (Build 19045), OpenClaw 2026.6.6, managed Windows Scheduled Task named `OpenClaw Gateway`, WebChat `/restart` command.
- Exact steps or command run after this patch:
  1. Reproduced the issue with the published Windows task handoff implementation.
  2. Observed `/restart` shut down the gateway and leave it offline until manual `openclaw gateway restart`.
  3. Patched the local installed OpenClaw restart handoff to use the Node subprocess strategy from this PR.
  4. Restarted the gateway so the patched code was loaded.
  5. Ran `/restart` twice from WebChat.
  6. Observed the gateway relaunch both times with no black console windows.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

  ```text
  2026/6/13 23:06:25 openclaw restart attempt source=node-handoff target=OpenClaw Gateway
  2026/6/13 23:06:25 launching task via schtasks /Run
  2026/6/13 23:06:25 schtasks /Run exit=0 out=成功: 尝试运行计划任务 "OpenClaw Gateway"�?  2026/6/13 23:06:25 openclaw restart finished source=node-handoff
  2026/6/13 23:08:21 openclaw restart attempt source=node-handoff target=OpenClaw Gateway
  2026/6/13 23:08:21 launching task via schtasks /Run
  2026/6/13 23:08:21 schtasks /Run exit=0 out=成功: 尝试运行计划任务 "OpenClaw Gateway"�?  2026/6/13 23:08:21 openclaw restart finished source=node-handoff
  ```

- Observed result after fix: `/restart` completed successfully on both attempts, the gateway came back immediately, and no visible `findstr` / cmd console windows appeared.
- What was not tested: Windows 11 and non-default gateway ports.
- Proof limitations or environment constraints: The proof used copied redacted runtime logs instead of screenshots/recordings. The task name tested was the default `OpenClaw Gateway`; custom task names are covered by unit tests but not by the live Windows proof.
- Before evidence (optional but encouraged):

  ```text
  [周六 2026/06/13 22:30:07.92] openclaw restart log initialized
  [周六 2026/06/13 22:30:07.92] openclaw restart attempt source=windows-task-handoff target="OpenClaw Gateway"
  [周六 2026/06/13 22:31:11.95] openclaw restart finished source=windows-task-handoff
  [周六 2026/06/13 22:40:37.72] openclaw restart log initialized
  [周六 2026/06/13 22:40:37.72] openclaw restart attempt source=windows-task-handoff target="OpenClaw Gateway"
  [周六 2026/06/13 22:41:35.34] openclaw restart finished source=windows-task-handoff
  ```

  Those 60s+ gaps corresponded to the old handoff path; the gateway did not reliably relaunch and the user had to manually recover it. During this path, visible black console windows appeared with `findstr` involved.

## Tests and validation

Which commands did you run?

- GitHub CI for the latest pushed commit: check-prod-types, check-test-types, check-lint, and the affected infra test shard passed.
- Live Windows /restart command was run twice from WebChat after applying the local patch.

What regression coverage was added or updated?

- Updated src/infra/windows-task-restart.test.ts to cover the Node handoff launcher, custom task names, fallback content, and windowsHide: true.
