### PR TITLE
fix(discord): forward tool-start events for status reactions when verbose is off

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1440,7 +1440,7 @@ describe("createFollowupRunner runtime config", () => {
       }),
     );
 
-    expect(onToolStart).not.toHaveBeenCalled();
+    expect(onToolStart).toHaveBeenCalledTimes(1);
   });
 
   it("bridges queued CLI inter-tool commentary into onItemEvent for live preview", async () => {
@@ -2203,7 +2203,7 @@ describe("createFollowupRunner progress forwarding", () => {
       }),
     );
 
-    expect(onToolStart).not.toHaveBeenCalled();
+    expect(onToolStart).toHaveBeenCalledTimes(1);
     expect(onItemEvent).not.toHaveBeenCalled();
     expect(onCommandOutput).not.toHaveBeenCalled();
     expect(onCompactionStart).not.toHaveBeenCalled();
@@ -2254,7 +2254,7 @@ describe("createFollowupRunner progress forwarding", () => {
       }),
     );
 
-    expect(onToolStart).not.toHaveBeenCalled();
+    expect(onToolStart).toHaveBeenCalledTimes(1);
     expect(onCommandOutput).not.toHaveBeenCalled();
     expect(routeReplyMock).not.toHaveBeenCalled();
   });
@@ -2447,7 +2447,7 @@ describe("createFollowupRunner progress forwarding", () => {
       }),
     );
 
-    expect(onToolStart).not.toHaveBeenCalled();
+    expect(onToolStart).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -132,10 +132,10 @@ async function forwardFollowupProgressEvent(params: {
 }) {
   const { evt, opts } = params;
   const emitChannelProgress = params.emitChannelProgress !== false;
-  if (!emitChannelProgress && evt.stream !== "compaction") {
-    return;
-  }
 
+  // Always forward tool start events for status reaction callbacks, even when
+  // verbose progress is off. Channel handlers gate status reactions and draft
+  // progress internally, so the callback firing is always safe.
   if (evt.stream === "tool") {
     const phase = readStringValue(evt.data.phase) ?? "";
     const name = readStringValue(evt.data.name);
@@ -150,6 +150,10 @@ async function forwardFollowupProgressEvent(params: {
         detailMode: params.detailMode,
       });
     }
+  }
+
+  if (!emitChannelProgress && evt.stream !== "compaction") {
+    return;
   }
 
   const suppressItemChannelProgress =


### PR DESCRIPTION
## Summary

Discord intermediate status reaction emojis (🔧, 🔍, 🛠️, etc.) are never displayed during tool execution when verbose progress is off — the default configuration. Users see only 👀/⏳/⚠️/🧠 but no tool-phase indicators, making the bot appear frozen during multi-step tool chains.

### Root cause

`forwardFollowupProgressEvent` in `src/auto-reply/reply/followup-runner.ts` applied an early return when `emitChannelProgress` was `false` (which is the case whenever `shouldEmitToolResultProgress()` returns `false`, i.e. verbose level is not `"on"` or `"full"`). This early return skipped **all** non-compaction events — including `tool` stream events — so `opts.onToolStart` was never invoked for tool start phases.

Channel handlers (Discord, Slack, etc.) wire `onToolStart` to update status reaction emojis and draft progress. Because the callback never fired in default config, the status reaction controller's `setTool()` was never called, and tool-phase emojis were silently suppressed.

### Fix

Move the `onToolStart` invocation **before** the `emitChannelProgress` early return. Tool start events now always reach the callback, allowing channel handlers to update status reactions regardless of verbose level. The callback itself is safe to fire unconditionally because:

- Status reaction controllers check their own `enabled` flag
- Draft progress handlers check whether draft streaming is active
- The `emitChannelProgress` gate still correctly suppresses item events, plan updates, and other verbose-gated content after the tool event block

Updated 4 existing tests that asserted `onToolStart` was not called when verbose was off — these tests now assert the callback fires once (since status reactions should always update).

## Real behavior proof

- **Behavior addressed:** Discord (and other channels) status reaction emojis for tool execution phases (🔧, 🌐, 💻, etc.) were never displayed when verbose progress was off, the default configuration. Tool start events were filtered by `emitChannelProgress` before reaching `onToolStart`.
- **Environment tested:** macOS 26.4.1, Node.js, OpenClaw dev workdir at commit `eb1b6408` (upstream/main).
- **Steps run after the patch:**
```sh
node scripts/run-vitest.mjs run src/auto-reply/reply/followup-runner.test.ts
node scripts/run-vitest.mjs run src/auto-reply/reply/agent-runner-execution.test.ts
node scripts/run-vitest.mjs run src/auto-reply/reply/dispatch-from-config.test.ts
node scripts/run-vitest.mjs run extensions/discord/src/monitor/message-handler.process.test.ts
node scripts/run-vitest.mjs run src/channels/status-reactions.test.ts
npx oxlint src/auto-reply/reply/followup-runner.ts src/auto-reply/reply/followup-runner.test.ts
```
- **Evidence after fix:**
```
src/auto-reply/reply/followup-runner.ts:135-137: tool start events forwarded before emitChannelProgress gate
followup-runner.test.ts: 74 tests passed
agent-runner-execution.test.ts: 189 tests passed
dispatch-from-config.test.ts: 208 tests passed
message-handler.process.test.ts: 104 tests passed
status-reactions.test.ts: 43 tests passed
oxlint: 0 warnings and 0 errors
```
- **Observed result after fix:** Tool start events now reach `onToolStart` even when verbose is off. The 4 updated tests confirm `onToolStart` fires exactly once per tool start event. All 618 tests across the 5 affected test suites pass. Lint is clean.
- **What was not tested:** Live Discord bot interaction with real tool execution (requires Discord API credentials and a running gateway). The fix was verified at the unit test level by confirming `onToolStart` callback invocation behavior.

Fixes #92715
