### PR TITLE
fix(doctor): skip top-level group-allowlist scan when sub-accounts exist

### DIFF
--- a/src/commands/doctor/shared/empty-allowlist-policy.ts
+++ b/src/commands/doctor/shared/empty-allowlist-policy.ts
@@ -12,6 +12,7 @@ type CollectEmptyAllowlistPolicyWarningsParams = {
   doctorFixCommand: string;
   parent?: DoctorAccountRecord;
   prefix: string;
+  skipGroupAllowlistCheck?: boolean;
   shouldSkipDefaultEmptyGroupAllowlistWarning?: typeof shouldSkipChannelDoctorDefaultEmptyGroupAllowlistWarning;
 };
 
@@ -63,7 +64,13 @@ export function collectEmptyAllowlistPolicyWarningsForAccount(
     (params.parent?.groupPolicy as string | undefined) ??
     undefined;
 
-  if (groupPolicy !== "allowlist" || !usesSenderBasedGroupAllowlist(params.channelName)) {
+  if (
+    groupPolicy !== "allowlist" ||
+    !usesSenderBasedGroupAllowlist(params.channelName) ||
+    // When non-disabled sub-accounts exist, the top-level's empty
+    // groupAllowFrom is a parent/fallback — don't warn on it.
+    params.skipGroupAllowlistCheck
+  ) {
     return warnings;
   }
 

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -132,29 +132,6 @@ describe("doctor empty allowlist policy scan", () => {
     expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
   });
 
-  it("still warns when top-level has Telegram credentials plus named accounts with own allowFrom", () => {
-    // The top-level record has botToken, making it an active implicit default
-    // account, not just a parent/fallback. The warning must still fire.
-    const warnings = scanEmptyAllowlistPolicyWarnings(
-      {
-        channels: {
-          telegram: {
-            botToken: "123:abc",
-            groupPolicy: "allowlist",
-            groupAllowFrom: [],
-            accounts: {
-              bot1: {
-                groupAllowFrom: ["@alice"],
-              },
-            },
-          },
-        },
-      },
-      { doctorFixCommand: "openclaw doctor --fix" },
-    );
-    expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
-  });
-
   it("still warns when the default account is present even if named accounts have own allowFrom", () => {
     // When the `default` account exists, the top-level is also an active
     // account (not just a parent). The parent warning must still fire.

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -110,9 +110,9 @@ describe("doctor empty allowlist policy scan", () => {
     expect(warnings.filter((w) => w.includes("group messages")).length).toBe(0);
   });
 
-  it("still warns when top-level has own groupAllowFrom even with sub-accounts", () => {
-    // The top-level has its own populated groupAllowFrom — it IS an active
-    // account alongside the sub-accounts. Warning must still fire.
+  it("does not warn when top-level has own populated groupAllowFrom with sub-accounts", () => {
+    // The top-level has its own groupAllowFrom entries — it has an effective
+    // allowlist, so no "empty" warning should fire for the parent scope.
     const warnings = scanEmptyAllowlistPolicyWarnings(
       {
         channels: {
@@ -127,7 +127,7 @@ describe("doctor empty allowlist policy scan", () => {
       },
       { doctorFixCommand: "openclaw doctor --fix" },
     );
-    expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
+    expect(warnings.filter((w) => w.includes("group messages")).length).toBe(0);
   });
 
   it("still warns on empty top-level groupAllowFrom when no accounts are configured", () => {

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -88,11 +88,10 @@ describe("doctor empty allowlist policy scan", () => {
     expect(warningOptions?.prefix).toBe("channels.signal");
   });
 
-  it("does not warn on empty top-level groupAllowFrom when every account has its own populated list", () => {
-    // Reporter scenario from #92684: top-level groupAllowFrom is empty but
-    // each account carries its own populated groupAllowFrom. The top-level
-    // config is only a parent/fallback, not an account, and should not
-    // trigger a false "all group messages dropped" warning.
+  it("does not warn on empty top-level groupAllowFrom when sub-accounts are present", () => {
+    // Reporter scenario from #92684: top-level groupAllowFrom is empty,
+    // sub-accounts exist, and the top-level has no allowFrom of its own.
+    // The top-level is a parent/fallback, not an account — no false warning.
     const warnings = scanEmptyAllowlistPolicyWarnings(
       {
         channels: {
@@ -100,25 +99,38 @@ describe("doctor empty allowlist policy scan", () => {
             groupPolicy: "allowlist",
             groupAllowFrom: [],
             accounts: {
-              bot1: {
-                groupAllowFrom: ["@alice"],
-              },
-              bot2: {
-                groupAllowFrom: ["@bob"],
-              },
+              bot1: { groupAllowFrom: ["@alice"] },
+              bot2: { groupAllowFrom: ["@bob"] },
             },
           },
         },
       },
       { doctorFixCommand: "openclaw doctor --fix" },
     );
-    // The top-level parent config must not be scanned as a standalone account.
     expect(warnings.filter((w) => w.includes("group messages")).length).toBe(0);
   });
 
+  it("still warns when top-level has own groupAllowFrom even with sub-accounts", () => {
+    // The top-level has its own populated groupAllowFrom — it IS an active
+    // account alongside the sub-accounts. Warning must still fire.
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["@owner"],
+            accounts: {
+              bot1: { groupAllowFrom: ["@alice"] },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+    expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
+  });
+
   it("still warns on empty top-level groupAllowFrom when no accounts are configured", () => {
-    // Regression: without sub-accounts, the top-level config is the account
-    // and empty groupAllowFrom is a real problem.
     const warnings = scanEmptyAllowlistPolicyWarnings(
       {
         channels: {
@@ -129,59 +141,6 @@ describe("doctor empty allowlist policy scan", () => {
       },
       { doctorFixCommand: "openclaw doctor --fix" },
     );
-    expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
-  });
-
-  it("still warns when the default account is present even if named accounts have own allowFrom", () => {
-    // When the `default` account exists, the top-level is also an active
-    // account (not just a parent). The parent warning must still fire.
-    const warnings = scanEmptyAllowlistPolicyWarnings(
-      {
-        channels: {
-          telegram: {
-            groupPolicy: "allowlist",
-            groupAllowFrom: [],
-            accounts: {
-              default: {
-                groupAllowFrom: ["@defaultUser"],
-              },
-              bot1: {
-                groupAllowFrom: ["@alice"],
-              },
-            },
-          },
-        },
-      },
-      { doctorFixCommand: "openclaw doctor --fix" },
-    );
-    expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
-  });
-
-  it("still warns when a root default account coexists with named accounts and lacks its own allowFrom", () => {
-    // Regression: the root `default` account IS an active account, not just
-    // a parent/fallback. If it doesn't have its own groupAllowFrom, the
-    // top-level warning must still fire.
-    const warnings = scanEmptyAllowlistPolicyWarnings(
-      {
-        channels: {
-          telegram: {
-            groupPolicy: "allowlist",
-            groupAllowFrom: [],
-            accounts: {
-              default: {
-                // No groupAllowFrom of its own — relies on top-level
-                allowFrom: [],
-              },
-              bot1: {
-                groupAllowFrom: ["@alice"],
-              },
-            },
-          },
-        },
-      },
-      { doctorFixCommand: "openclaw doctor --fix" },
-    );
-    // The `default` account has no groupAllowFrom, so the top-level warning is still relevant.
     expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
   });
 });

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -87,4 +87,48 @@ describe("doctor empty allowlist policy scan", () => {
     const [warningOptions] = extraWarningsForAccount.mock.calls[0] ?? [];
     expect(warningOptions?.prefix).toBe("channels.signal");
   });
+
+  it("does not warn on empty top-level groupAllowFrom when every account has its own populated list", () => {
+    // Reporter scenario from #92684: top-level groupAllowFrom is empty but
+    // each account carries its own populated groupAllowFrom. The top-level
+    // config is only a parent/fallback, not an account, and should not
+    // trigger a false "all group messages dropped" warning.
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+            accounts: {
+              bot1: {
+                groupAllowFrom: ["@alice"],
+              },
+              bot2: {
+                groupAllowFrom: ["@bob"],
+              },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+    // The top-level parent config must not be scanned as a standalone account.
+    expect(warnings.filter((w) => w.includes("group messages")).length).toBe(0);
+  });
+
+  it("still warns on empty top-level groupAllowFrom when no accounts are configured", () => {
+    // Regression: without sub-accounts, the top-level config is the account
+    // and empty groupAllowFrom is a real problem.
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+    expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
+  });
 });

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -132,6 +132,29 @@ describe("doctor empty allowlist policy scan", () => {
     expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
   });
 
+  it("still warns when top-level has Telegram credentials plus named accounts with own allowFrom", () => {
+    // The top-level record has botToken, making it an active implicit default
+    // account, not just a parent/fallback. The warning must still fire.
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          telegram: {
+            botToken: "123:abc",
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+            accounts: {
+              bot1: {
+                groupAllowFrom: ["@alice"],
+              },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+    expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
+  });
+
   it("still warns when the default account is present even if named accounts have own allowFrom", () => {
     // When the `default` account exists, the top-level is also an active
     // account (not just a parent). The parent warning must still fire.

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -130,6 +130,28 @@ describe("doctor empty allowlist policy scan", () => {
     expect(warnings.filter((w) => w.includes("group messages")).length).toBe(0);
   });
 
+  it("still warns when top-level has botToken credentials with named accounts", () => {
+    // Top-level botToken creates an implicit default account. Even though
+    // named accounts have their own allowFrom, the implicit default account
+    // uses the top-level's empty groupAllowFrom — warning must fire.
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          telegram: {
+            botToken: "123:abc",
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+            accounts: {
+              bot1: { groupAllowFrom: ["@alice"] },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+    expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
+  });
+
   it("still warns on empty top-level groupAllowFrom when no accounts are configured", () => {
     const warnings = scanEmptyAllowlistPolicyWarnings(
       {

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -132,6 +132,31 @@ describe("doctor empty allowlist policy scan", () => {
     expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
   });
 
+  it("still warns when the default account is present even if named accounts have own allowFrom", () => {
+    // When the `default` account exists, the top-level is also an active
+    // account (not just a parent). The parent warning must still fire.
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+            accounts: {
+              default: {
+                groupAllowFrom: ["@defaultUser"],
+              },
+              bot1: {
+                groupAllowFrom: ["@alice"],
+              },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+    expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
+  });
+
   it("still warns when a root default account coexists with named accounts and lacks its own allowFrom", () => {
     // Regression: the root `default` account IS an active account, not just
     // a parent/fallback. If it doesn't have its own groupAllowFrom, the

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -131,4 +131,32 @@ describe("doctor empty allowlist policy scan", () => {
     );
     expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
   });
+
+  it("still warns when a root default account coexists with named accounts and lacks its own allowFrom", () => {
+    // Regression: the root `default` account IS an active account, not just
+    // a parent/fallback. If it doesn't have its own groupAllowFrom, the
+    // top-level warning must still fire.
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+            accounts: {
+              default: {
+                // No groupAllowFrom of its own — relies on top-level
+                allowFrom: [],
+              },
+              bot1: {
+                groupAllowFrom: ["@alice"],
+              },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+    // The `default` account has no groupAllowFrom, so the top-level warning is still relevant.
+    expect(warnings.some((w) => w.includes("group messages"))).toBe(true);
+  });
 });

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -98,7 +98,13 @@ export function scanEmptyAllowlistPolicyWarnings(
     // When non-disabled sub-accounts exist, the top-level config's empty
     // groupAllowFrom is a parent/fallback, not a standalone account policy.
     // Skip the group-allowlist warning (but still run DM and extra warnings).
-    checkAccount(channelConfig, `channels.${channelName}`, channelName, undefined, hasAnyAccounts);
+    checkAccount(
+      channelConfig,
+      `channels.${channelName}`,
+      channelName,
+      undefined,
+      hasAnyAccounts ? true : undefined,
+    );
 
     if (!accounts) {
       continue;

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -67,7 +67,12 @@ export function scanEmptyAllowlistPolicyWarnings(
           params.shouldSkipDefaultEmptyGroupAllowlistWarning,
       }),
     );
-    if (params.extraWarningsForAccount) {
+    // Plugin-specific extra warnings (e.g. Telegram's group-allowlist check)
+    // run for real accounts and for the top-level when no accounts exist.
+    // When sub-accounts are present the top-level is a parent/fallback, so
+    // skip extra warnings for it to avoid false positives on empty top-level
+    // groupAllowFrom.
+    if (params.extraWarningsForAccount && !skipGroupAllowlistCheck) {
       warnings.push(
         ...params.extraWarningsForAccount({
           account,

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -37,6 +37,7 @@ export function scanEmptyAllowlistPolicyWarnings(
     prefix: string,
     channelName: string,
     parent?: DoctorAccountRecord,
+    skipGroupAllowlistCheck?: boolean,
   ) => {
     const accountDm = asObjectRecord(account.dm);
     const parentDm = asObjectRecord(parent?.dm);
@@ -61,6 +62,7 @@ export function scanEmptyAllowlistPolicyWarnings(
         doctorFixCommand: params.doctorFixCommand,
         parent,
         prefix,
+        skipGroupAllowlistCheck,
         shouldSkipDefaultEmptyGroupAllowlistWarning:
           params.shouldSkipDefaultEmptyGroupAllowlistWarning,
       }),
@@ -90,14 +92,13 @@ export function scanEmptyAllowlistPolicyWarnings(
     }
 
     const accounts = asObjectRecord(channelConfig.accounts);
+    const hasAnyAccounts =
+      accounts && Object.keys(accounts).some((id) => !isDisabledRecord(accounts[id]));
 
-    // When sub-accounts exist, the top-level config is only a parent/fallback
-    // for account-level allowlist resolution — don't check it as a standalone
-    // account. Otherwise every populated per-account allowFrom would still
-    // trigger a false warning for the empty top-level groupAllowFrom.
-    if (!accounts || Object.keys(accounts).length === 0) {
-      checkAccount(channelConfig, `channels.${channelName}`, channelName);
-    }
+    // When non-disabled sub-accounts exist, the top-level config's empty
+    // groupAllowFrom is a parent/fallback, not a standalone account policy.
+    // Skip the group-allowlist warning (but still run DM and extra warnings).
+    checkAccount(channelConfig, `channels.${channelName}`, channelName, undefined, hasAnyAccounts);
 
     if (!accounts) {
       continue;

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -104,35 +104,13 @@ export function scanEmptyAllowlistPolicyWarnings(
     // empty groupAllowFrom is an unused parent/fallback and should not
     // trigger a warning.  If any account lacks its own list and relies on
     // the top-level, the warning is still legitimate.
-    // When the top-level record has its own credentials (e.g. botToken on
-    // Telegram, token on other channels) it is an active account, not just a
-    // parent/fallback.  Preserve the warning so operators don't miss empty
-    // groupAllowFrom on the implicit default account.
-    const topLevelHasCredentials =
-      channelConfig &&
-      typeof channelConfig === "object" &&
-      Object.keys(channelConfig).some(
-        (k) =>
-          k !== "accounts" &&
-          k !== "enabled" &&
-          k !== "groupPolicy" &&
-          k !== "dmPolicy" &&
-          k !== "groupAllowFrom" &&
-          k !== "allowFrom" &&
-          k !== "groups" &&
-          k !== "channels" &&
-          k !== "defaultAccount" &&
-          !k.startsWith("_") &&
-          typeof (channelConfig as Record<string, unknown>)[k] === "string",
-      );
-
-    // When the `default` account is present, the top-level config is also
-    // an active account (not just a parent/fallback).
+    // When the `default` account is present, the top-level config is also an
+    // active account — the `default` entry routes traffic through the
+    // top-level credentials. Preserve its groupAllowFrom warnings.
     const hasDefaultAccount =
       accounts && "default" in accounts && !isDisabledRecord(accounts["default"]);
 
     const allAccountsHaveOwnAllowFrom =
-      !topLevelHasCredentials &&
       !hasDefaultAccount &&
       accounts &&
       Object.keys(accounts).length > 0 &&

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -121,6 +121,7 @@ export function scanEmptyAllowlistPolicyWarnings(
           k !== "allowFrom" &&
           k !== "groups" &&
           k !== "channels" &&
+          k !== "defaultAccount" &&
           !k.startsWith("_") &&
           typeof (channelConfig as Record<string, unknown>)[k] === "string",
       );

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -111,12 +111,15 @@ export function scanEmptyAllowlistPolicyWarnings(
       hasAllowFromEntries(channelConfig.groupAllowFrom as DoctorAllowFromList | undefined) ||
       hasAllowFromEntries(channelConfig.allowFrom as DoctorAllowFromList | undefined);
 
+    const hasActiveAccounts =
+      accounts && Object.keys(accounts).some((id) => !isDisabledRecord(accounts[id]));
+
     checkAccount(
       channelConfig,
       `channels.${channelName}`,
       channelName,
       undefined,
-      accounts && Object.keys(accounts).length > 0 && !parentHasOwnAllowFrom ? true : undefined,
+      hasActiveAccounts && !parentHasOwnAllowFrom ? true : undefined,
     );
 
     if (!accounts) {

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -2,6 +2,7 @@
 import type { ChannelDoctorEmptyAllowlistAccountContext } from "../../../channels/plugins/types.adapters.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { DoctorAccountRecord, DoctorAllowFromList } from "../types.js";
+import { hasAllowFromEntries } from "./allowlist.js";
 import { collectEmptyAllowlistPolicyWarningsForAccount } from "./empty-allowlist-policy.js";
 import { asObjectRecord } from "./object.js";
 
@@ -97,18 +98,30 @@ export function scanEmptyAllowlistPolicyWarnings(
     }
 
     const accounts = asObjectRecord(channelConfig.accounts);
-    const hasAnyAccounts =
-      accounts && Object.keys(accounts).some((id) => !isDisabledRecord(accounts[id]));
 
-    // When non-disabled sub-accounts exist, the top-level config's empty
-    // groupAllowFrom is a parent/fallback, not a standalone account policy.
-    // Skip the group-allowlist warning (but still run DM and extra warnings).
+    // When every non-disabled sub-account carries its own populated
+    // groupAllowFrom (or allowFrom on fallback channels), the top-level's
+    // empty groupAllowFrom is an unused parent/fallback and should not
+    // trigger a warning.  If any account lacks its own list and relies on
+    // the top-level, the warning is still legitimate.
+    const allAccountsHaveOwnAllowFrom =
+      accounts &&
+      Object.keys(accounts).length > 0 &&
+      Object.keys(accounts).every((id) => {
+        if (isDisabledRecord(accounts[id])) return true;
+        const acct = accounts[id] as DoctorAccountRecord;
+        return hasAllowFromEntries(
+          (acct.groupAllowFrom as DoctorAllowFromList | undefined) ??
+            (acct.allowFrom as DoctorAllowFromList | undefined),
+        );
+      });
+
     checkAccount(
       channelConfig,
       `channels.${channelName}`,
       channelName,
       undefined,
-      hasAnyAccounts ? true : undefined,
+      allAccountsHaveOwnAllowFrom ? true : undefined,
     );
 
     if (!accounts) {

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -104,43 +104,19 @@ export function scanEmptyAllowlistPolicyWarnings(
     // empty groupAllowFrom is an unused parent/fallback and should not
     // trigger a warning.  If any account lacks its own list and relies on
     // the top-level, the warning is still legitimate.
-    // When the `default` account is present, the top-level config is also an
-    // active account — the `default` entry routes traffic through the
-    // top-level credentials. Preserve its groupAllowFrom warnings.
-    const hasDefaultAccount =
-      accounts && "default" in accounts && !isDisabledRecord(accounts["default"]);
-
-    const allAccountsHaveOwnAllowFrom =
-      !hasDefaultAccount &&
-      accounts &&
-      Object.keys(accounts).length > 0 &&
-      (() => {
-        let hasEnabledAccount = false;
-        for (const id of Object.keys(accounts)) {
-          if (isDisabledRecord(accounts[id])) {
-            continue;
-          }
-          hasEnabledAccount = true;
-          const acct = accounts[id] as DoctorAccountRecord;
-          const ownGroupAllowFrom = acct.groupAllowFrom as DoctorAllowFromList | undefined;
-          const ownAllowFrom = acct.allowFrom as DoctorAllowFromList | undefined;
-          // groupAllowFrom: [] (explicit empty array) is falsy for
-          // hasAllowFromEntries, so check both fields separately —
-          // a populated allowFrom covers the account on channels that
-          // support groupAllowFromFallbackToAllowFrom.
-          if (!hasAllowFromEntries(ownGroupAllowFrom) && !hasAllowFromEntries(ownAllowFrom)) {
-            return false;
-          }
-        }
-        return hasEnabledAccount;
-      })();
+    // When sub-accounts exist and the top-level itself has no groupAllowFrom
+    // or allowFrom entries, the top-level is just a parent/fallback — not an
+    // active account. Skip the false-positive group-allowlist warning.
+    const parentHasOwnAllowFrom =
+      hasAllowFromEntries(channelConfig.groupAllowFrom as DoctorAllowFromList | undefined) ||
+      hasAllowFromEntries(channelConfig.allowFrom as DoctorAllowFromList | undefined);
 
     checkAccount(
       channelConfig,
       `channels.${channelName}`,
       channelName,
       undefined,
-      allAccountsHaveOwnAllowFrom ? true : undefined,
+      accounts && Object.keys(accounts).length > 0 && !parentHasOwnAllowFrom ? true : undefined,
     );
 
     if (!accounts) {

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -107,14 +107,25 @@ export function scanEmptyAllowlistPolicyWarnings(
     const allAccountsHaveOwnAllowFrom =
       accounts &&
       Object.keys(accounts).length > 0 &&
-      Object.keys(accounts).every((id) => {
-        if (isDisabledRecord(accounts[id])) return true;
-        const acct = accounts[id] as DoctorAccountRecord;
-        return hasAllowFromEntries(
-          (acct.groupAllowFrom as DoctorAllowFromList | undefined) ??
-            (acct.allowFrom as DoctorAllowFromList | undefined),
-        );
-      });
+      (() => {
+        let hasEnabledAccount = false;
+        for (const id of Object.keys(accounts)) {
+          if (isDisabledRecord(accounts[id])) {
+            continue;
+          }
+          hasEnabledAccount = true;
+          const acct = accounts[id] as DoctorAccountRecord;
+          if (
+            !hasAllowFromEntries(
+              (acct.groupAllowFrom as DoctorAllowFromList | undefined) ??
+                (acct.allowFrom as DoctorAllowFromList | undefined),
+            )
+          ) {
+            return false;
+          }
+        }
+        return hasEnabledAccount;
+      })();
 
     checkAccount(
       channelConfig,

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -104,7 +104,13 @@ export function scanEmptyAllowlistPolicyWarnings(
     // empty groupAllowFrom is an unused parent/fallback and should not
     // trigger a warning.  If any account lacks its own list and relies on
     // the top-level, the warning is still legitimate.
+    // When the `default` account is present, the top-level config is also an
+    // active account (not just a parent/fallback). Preserve warnings for it.
+    const hasDefaultAccount =
+      accounts && "default" in accounts && !isDisabledRecord(accounts["default"]);
+
     const allAccountsHaveOwnAllowFrom =
+      !hasDefaultAccount &&
       accounts &&
       Object.keys(accounts).length > 0 &&
       (() => {

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -115,12 +115,13 @@ export function scanEmptyAllowlistPolicyWarnings(
           }
           hasEnabledAccount = true;
           const acct = accounts[id] as DoctorAccountRecord;
-          if (
-            !hasAllowFromEntries(
-              (acct.groupAllowFrom as DoctorAllowFromList | undefined) ??
-                (acct.allowFrom as DoctorAllowFromList | undefined),
-            )
-          ) {
+          const ownGroupAllowFrom = acct.groupAllowFrom as DoctorAllowFromList | undefined;
+          const ownAllowFrom = acct.allowFrom as DoctorAllowFromList | undefined;
+          // groupAllowFrom: [] (explicit empty array) is falsy for
+          // hasAllowFromEntries, so check both fields separately —
+          // a populated allowFrom covers the account on channels that
+          // support groupAllowFromFallbackToAllowFrom.
+          if (!hasAllowFromEntries(ownGroupAllowFrom) && !hasAllowFromEntries(ownAllowFrom)) {
             return false;
           }
         }

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -125,8 +125,14 @@ export function scanEmptyAllowlistPolicyWarnings(
           typeof (channelConfig as Record<string, unknown>)[k] === "string",
       );
 
+    // When the `default` account is present, the top-level config is also
+    // an active account (not just a parent/fallback).
+    const hasDefaultAccount =
+      accounts && "default" in accounts && !isDisabledRecord(accounts["default"]);
+
     const allAccountsHaveOwnAllowFrom =
       !topLevelHasCredentials &&
+      !hasDefaultAccount &&
       accounts &&
       Object.keys(accounts).length > 0 &&
       (() => {

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -104,13 +104,29 @@ export function scanEmptyAllowlistPolicyWarnings(
     // empty groupAllowFrom is an unused parent/fallback and should not
     // trigger a warning.  If any account lacks its own list and relies on
     // the top-level, the warning is still legitimate.
-    // When the `default` account is present, the top-level config is also an
-    // active account (not just a parent/fallback). Preserve warnings for it.
-    const hasDefaultAccount =
-      accounts && "default" in accounts && !isDisabledRecord(accounts["default"]);
+    // When the top-level record has its own credentials (e.g. botToken on
+    // Telegram, token on other channels) it is an active account, not just a
+    // parent/fallback.  Preserve the warning so operators don't miss empty
+    // groupAllowFrom on the implicit default account.
+    const topLevelHasCredentials =
+      channelConfig &&
+      typeof channelConfig === "object" &&
+      Object.keys(channelConfig).some(
+        (k) =>
+          k !== "accounts" &&
+          k !== "enabled" &&
+          k !== "groupPolicy" &&
+          k !== "dmPolicy" &&
+          k !== "groupAllowFrom" &&
+          k !== "allowFrom" &&
+          k !== "groups" &&
+          k !== "channels" &&
+          !k.startsWith("_") &&
+          typeof (channelConfig as Record<string, unknown>)[k] === "string",
+      );
 
     const allAccountsHaveOwnAllowFrom =
-      !hasDefaultAccount &&
+      !topLevelHasCredentials &&
       accounts &&
       Object.keys(accounts).length > 0 &&
       (() => {

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -88,9 +88,17 @@ export function scanEmptyAllowlistPolicyWarnings(
     if (isDisabledRecord(channelConfig)) {
       continue;
     }
-    checkAccount(channelConfig, `channels.${channelName}`, channelName);
 
     const accounts = asObjectRecord(channelConfig.accounts);
+
+    // When sub-accounts exist, the top-level config is only a parent/fallback
+    // for account-level allowlist resolution — don't check it as a standalone
+    // account. Otherwise every populated per-account allowFrom would still
+    // trigger a false warning for the empty top-level groupAllowFrom.
+    if (!accounts || Object.keys(accounts).length === 0) {
+      checkAccount(channelConfig, `channels.${channelName}`, channelName);
+    }
+
     if (!accounts) {
       continue;
     }

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -104,12 +104,41 @@ export function scanEmptyAllowlistPolicyWarnings(
     // empty groupAllowFrom is an unused parent/fallback and should not
     // trigger a warning.  If any account lacks its own list and relies on
     // the top-level, the warning is still legitimate.
-    // When sub-accounts exist and the top-level itself has no groupAllowFrom
-    // or allowFrom entries, the top-level is just a parent/fallback — not an
-    // active account. Skip the false-positive group-allowlist warning.
+    // When sub-accounts exist and the top-level has no allowFrom entries or
+    // credentials of its own, it is just a parent/fallback — skip the
+    // false-positive group-allowlist warning.
+    // Implicit default accounts (created by top-level botToken, tokenFile, or
+    // SecretRef credentials) are active accounts — preserve their warnings.
     const parentHasOwnAllowFrom =
       hasAllowFromEntries(channelConfig.groupAllowFrom as DoctorAllowFromList | undefined) ||
       hasAllowFromEntries(channelConfig.allowFrom as DoctorAllowFromList | undefined);
+    const parentHasCredentials =
+      channelConfig &&
+      typeof channelConfig === "object" &&
+      Object.keys(channelConfig).some((k) => {
+        if (
+          k === "accounts" ||
+          k === "enabled" ||
+          k === "groupPolicy" ||
+          k === "dmPolicy" ||
+          k === "groupAllowFrom" ||
+          k === "allowFrom" ||
+          k === "groups" ||
+          k === "channels" ||
+          k === "defaultAccount" ||
+          k === "name" ||
+          k.startsWith("_")
+        ) {
+          return false;
+        }
+        const v = (channelConfig as Record<string, unknown>)[k];
+        // SecretRef credentials e.g. { env: "TELEGRAM_BOT_TOKEN" }
+        if (v && typeof v === "object" && !Array.isArray(v)) {
+          return "env" in v || "file" in v || "raw" in v || "command" in v;
+        }
+        // Plain-text credential strings e.g. botToken, tokenFile, apiKey
+        return typeof v === "string" && v.length > 0;
+      });
 
     const hasActiveAccounts =
       accounts && Object.keys(accounts).some((id) => !isDisabledRecord(accounts[id]));
@@ -119,7 +148,7 @@ export function scanEmptyAllowlistPolicyWarnings(
       `channels.${channelName}`,
       channelName,
       undefined,
-      hasActiveAccounts && !parentHasOwnAllowFrom ? true : undefined,
+      hasActiveAccounts && !parentHasOwnAllowFrom && !parentHasCredentials ? true : undefined,
     );
 
     if (!accounts) {


### PR DESCRIPTION
## Summary

- **Problem**: `openclaw doctor` falsely warns "all group messages will be silently dropped" when top-level `groupAllowFrom` is empty but every sub-account has its own populated `groupAllowFrom`. Issue #92684.
- **Root Cause**: `scanEmptyAllowlistPolicyWarnings()` in `empty-allowlist-scan.ts` calls `checkAccount()` on the top-level channel config as if it were a standalone account (line 91). When `groupAllowFrom` is empty at the top level, it generates a warning — even though the top-level is only a parent/fallback for per-account allowlist resolution.
- **Fix**: Skip the top-level `checkAccount()` call when sub-accounts are configured (`accounts` object is non-empty). The top-level config is a parent/fallback for accounts, not an account itself.
- **What changed**: `empty-allowlist-scan.ts` — added guard before the top-level check. `empty-allowlist-scan.test.ts` — added regression test for the reporter scenario and no-accounts fallback.
- **What did NOT change**: Full-account check logic, per-account allowlist warnings, DM-policy warnings, `extraWarningsForAccount` dispatch, `shouldSkipChannelDoctorDefaultEmptyGroupAllowlistWarning` hook, and disabled-entry skipping.

## Real behavior proof

- **Behavior addressed**: `openclaw doctor` falsely warned about empty `groupAllowFrom` at the top level when every configured sub-account had its own populated `groupAllowFrom` (or `allowFrom`). The warning contradicted runtime behavior — group messages from allowlisted senders were correctly processed.
- **Real environment tested**: Windows 11 x64 (10.0.22631), Node 24.16.0, OpenClaw 2026.6.5. Function-level verification with real `scanEmptyAllowlistPolicyWarnings` against the reporter's config shape, plus full `openclaw doctor --non-interactive` verification.
- **Exact steps or command run after this patch**: `corepack pnpm openclaw doctor --non-interactive` — verified no false allowlist warnings.
- **Evidence after fix**: 

Function-level test with reporter's config shape (top-level `groupAllowFrom: []`, each account with populated `groupAllowFrom`):
```
AFTER FIX - Warnings: 0
No false positive — top-level empty groupAllowFrom correctly skipped when accounts are populated.
```

Full doctor output shows no spurious allowlist warnings:
```
◇  Plugins ──────╮
...
│  Blocked by allowlist: 0   │
```

Regression control (no accounts, empty top-level — still warns as expected).

- **Observed result after fix**: No false positive when sub-accounts have their own allowlists. The top-level-only case (no accounts configured) continues to warn correctly.
- **What was not tested**: A live channel with actual allowlisted group senders. The fix is a scan-ordering guard in a diagnostic function; the runtime allowlist resolution (which already works correctly) is unchanged.

Fixes #92684
