### PR TITLE
fix(markdown-core): treat Infinity chunk limit as unbounded, not 1

### DIFF
--- a/extensions/signal/src/format.chunking.test.ts
+++ b/extensions/signal/src/format.chunking.test.ts
@@ -296,6 +296,16 @@ describe("splitSignalFormattedText", () => {
 });
 
 describe("markdownToSignalTextChunks", () => {
+  it("treats Infinity as unbounded for media captions", () => {
+    const markdown = "Here's **another** photo from today's walk.";
+
+    const chunks = markdownToSignalTextChunks(markdown, Number.POSITIVE_INFINITY);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.text).toBe("Here's another photo from today's walk.");
+    expect(chunks[0]?.styles.map((style) => style.style)).toContain("BOLD");
+  });
+
   describe("link expansion chunk limit", () => {
     it("does not exceed chunk limit after link expansion", () => {
       // Create text that is close to limit, with a link that will expand

--- a/packages/markdown-core/src/render-aware-chunking.test.ts
+++ b/packages/markdown-core/src/render-aware-chunking.test.ts
@@ -84,4 +84,18 @@ describe("renderMarkdownIRChunksWithinLimit", () => {
     expect(chunks.map((chunk) => chunk.source.text)).toEqual(["a", "b", "c"]);
     expect(chunks.every((chunk) => chunk.rendered.length <= 1)).toBe(true);
   });
+
+  it("treats Infinity as no size cap and returns a single chunk", () => {
+    const text = "one two three four five six seven eight nine ten";
+    const ir = markdownToIR(text);
+    const chunks = renderMarkdownIRChunksWithinLimit({
+      ir,
+      limit: Number.POSITIVE_INFINITY,
+      renderChunk: renderEscapedHtml,
+      measureRendered: (rendered) => rendered.length,
+    });
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.source.text).toBe(text);
+  });
 });

--- a/packages/markdown-core/src/render-aware-chunking.ts
+++ b/packages/markdown-core/src/render-aware-chunking.ts
@@ -47,6 +47,13 @@ export function renderMarkdownIRChunksWithinLimit<TRendered>(
     return [];
   }
 
+  // Callers pass Infinity to mean "no size cap" (e.g. a media caption that must not be
+  // split). resolveIntegerOption rejects non-finite values and would fall back to 1,
+  // shattering the text into one chunk per character; emit the whole IR as one chunk.
+  if (options.limit === Number.POSITIVE_INFINITY) {
+    return [{ source: options.ir, rendered: options.renderChunk(options.ir) }];
+  }
+
   const normalizedLimit = resolveIntegerOption(options.limit, 1, { min: 1 });
   const pending = chunkMarkdownIR(options.ir, normalizedLimit);
   const finalized: MarkdownIR[] = [];


### PR DESCRIPTION
## Summary

- Fixes a Signal bug where sending an image **with a caption** delivered only the caption's **first character** (`"Here's another photo…"` arrived as `"H"`).
- Root cause: `renderMarkdownIRChunksWithinLimit` normalized `limit` via `resolveIntegerOption(limit, 1, { min: 1 })`, which rejects non-finite values and falls back to `1`. The Signal media path passes `Number.POSITIVE_INFINITY` to mean "no size cap" and then takes `[0]`, so the caption was split into one chunk per character and only the first survived.
- Fix: emit the whole IR as a single rendered chunk when the limit is `Infinity`. `NaN`/invalid limits keep the existing fallback; finite limits still split unchanged.
- Out of scope: the caption-less `<media:image>` placeholder and the greedy citation-marker strip are separate issues, not touched here.

## Linked context

Closes #92734

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Signal image caption truncated to its first character; after the fix the full caption is delivered.
- Real environment tested: Live OpenClaw `2026.6.1` Signal account (signal-cli daemon), sending to a real Signal recipient. The installed runtime was patched with the identical change in this PR (the `Infinity` chunk-limit path).
- Exact steps or command run after this patch: `openclaw message send --channel signal --account nandemo --target <my-number> --media caption-proof-test.png --message "Caption proof check: this entire sentence must arrive intact, not just C."`
- Evidence after fix (terminal capture / copied live output): real send returned success — `messageId 1781368354040`, `kind: "media"`, `toJid: <my-number>`. Driving the exact shipped runtime function the Signal media path uses, over the same caption:
```
$ node -e 'import("openclaw/dist/format…js").then(m => { const f=m.markdownToSignalTextChunks; ... })'
caption sent: "Caption proof check: this entire sentence must arrive intact, not just C."
BEFORE (limit Infinity): chunks=62  delivered=[0]="C"
AFTER  (patched path)  : chunks=1   delivered=[0]="Caption proof check: this entire sentence must arrive intact, not just C."
```
- Observed result after fix: the message is delivered with the complete caption text ("Caption proof check: this entire sentence must arrive intact, not just C.") instead of the single character "C". The recipient receives the full sentence in Signal.
- What was not tested: other channels' caption paths (Telegram/WhatsApp/etc.) were not re-exercised; the change is in shared markdown-core, and finite-limit chunking is unchanged.
- Proof limitations or environment constraints: proof was produced on a runtime patched identically to this PR diff (the published build cannot run the PR source directly); the gateway does not log the outbound caption text, so evidence is the successful send result plus the shipped chunker's before/after output over the exact caption.

## Tests and validation

- Added a regression test in `render-aware-chunking.test.ts`: an `Infinity` limit returns a single chunk containing the full text; the existing `NaN` fallback test stays green (invalid limits unchanged).
- Validated the edited PR source directly: `limit: Infinity` → 1 chunk full text; `limit: NaN` → per-character fallback (unchanged); `limit: 20` → still splits.

## Risk checklist

- Did user-visible behavior change? Yes — Signal image captions are now delivered in full.
- Did config, environment, or migration behavior change? No.
- Did security, auth, secrets, network, or tool execution behavior change? No.
- Highest-risk area: shared `markdown-core` chunking used by multiple channels.
- Mitigation: change is gated strictly to the `Infinity` ("no cap") sentinel; finite and `NaN` paths are byte-for-byte unchanged and covered by existing tests.

## Current review state

- Next action: maintainer review.
- Waiting on: nothing from author.
- Bot/reviewer comments addressed: added the Real behavior proof section after the proof gate flagged the initial body.
