### PR TITLE
fix(minimax): show "X% used" instead of "X% left" in usage display

### DIFF
--- a/scripts/repro/issue-92721-minimax-usage-display.mts
+++ b/scripts/repro/issue-92721-minimax-usage-display.mts
@@ -124,7 +124,7 @@ async function main() {
   console.log("MiniMax usage display now correctly shows 'X% used' instead of 'X% left'");
 }
 
-main().catch((err) => {
+main().catch((err: unknown) => {
   console.error(err);
   process.exitCode = 1;
 });

--- a/scripts/repro/issue-92721-minimax-usage-display.mts
+++ b/scripts/repro/issue-92721-minimax-usage-display.mts
@@ -1,0 +1,130 @@
+// Reproduction script for issue #92721
+// Verifies that minimax usage display shows "X% used" instead of "X% left"
+
+import { formatUsageWindowSummary, formatUsageSummaryLine, formatUsageReportLines } from "../../src/infra/provider-usage.format.js";
+import type { ProviderUsageSnapshot, UsageSummary } from "../../src/infra/provider-usage.types.js";
+
+function createMinimaxSnapshot(usedPercent: number): ProviderUsageSnapshot {
+  return {
+    provider: "minimax",
+    displayName: "MiniMax",
+    windows: [
+      {
+        label: "24h",
+        usedPercent,
+        resetAt: Date.now() + 86400000, // 24 hours from now
+      },
+    ],
+  };
+}
+
+function createOtherProviderSnapshot(usedPercent: number): ProviderUsageSnapshot {
+  return {
+    provider: "openai",
+    displayName: "OpenAI",
+    windows: [
+      {
+        label: "24h",
+        usedPercent,
+        resetAt: Date.now() + 86400000,
+      },
+    ],
+  };
+}
+
+async function main() {
+  console.log("=== Reproduction for issue #92721 ===\n");
+
+  // Test 1: MiniMax at 100% used should show "100% used"
+  console.log("Test 1: MiniMax at 100% used");
+  const minimaxFull = createMinimaxSnapshot(100);
+  const minimaxSummary = formatUsageWindowSummary(minimaxFull);
+  console.log(`  Result: ${minimaxSummary}`);
+
+  if (!minimaxSummary?.includes("100% used")) {
+    console.error("  FAIL: Expected '100% used' but got different output");
+    process.exitCode = 1;
+    return;
+  }
+  console.log("  PASS: Shows '100% used'\n");
+
+  // Test 2: MiniMax at 0% used should show "0% used"
+  console.log("Test 2: MiniMax at 0% used");
+  const minimaxEmpty = createMinimaxSnapshot(0);
+  const minimaxEmptySummary = formatUsageWindowSummary(minimaxEmpty);
+  console.log(`  Result: ${minimaxEmptySummary}`);
+
+  if (!minimaxEmptySummary?.includes("0% used")) {
+    console.error("  FAIL: Expected '0% used' but got different output");
+    process.exitCode = 1;
+    return;
+  }
+  console.log("  PASS: Shows '0% used'\n");
+
+  // Test 3: MiniMax at 50% used should show "50% used"
+  console.log("Test 3: MiniMax at 50% used");
+  const minimaxHalf = createMinimaxSnapshot(50);
+  const minimaxHalfSummary = formatUsageWindowSummary(minimaxHalf);
+  console.log(`  Result: ${minimaxHalfSummary}`);
+
+  if (!minimaxHalfSummary?.includes("50% used")) {
+    console.error("  FAIL: Expected '50% used' but got different output");
+    process.exitCode = 1;
+    return;
+  }
+  console.log("  PASS: Shows '50% used'\n");
+
+  // Test 4: Other provider (OpenAI) should still show "X% left"
+  console.log("Test 4: OpenAI at 100% used (should show '0% left')");
+  const openaiFull = createOtherProviderSnapshot(100);
+  const openaiSummary = formatUsageWindowSummary(openaiFull);
+  console.log(`  Result: ${openaiSummary}`);
+
+  if (!openaiSummary?.includes("0% left")) {
+    console.error("  FAIL: Expected '0% left' but got different output");
+    process.exitCode = 1;
+    return;
+  }
+  console.log("  PASS: Shows '0% left' (unchanged behavior)\n");
+
+  // Test 5: formatUsageSummaryLine with MiniMax
+  console.log("Test 5: formatUsageSummaryLine with MiniMax at 75% used");
+  const summary: UsageSummary = {
+    updatedAt: Date.now(),
+    providers: [createMinimaxSnapshot(75)],
+  };
+  const summaryLine = formatUsageSummaryLine(summary);
+  console.log(`  Result: ${summaryLine}`);
+
+  if (!summaryLine?.includes("75% used")) {
+    console.error("  FAIL: Expected '75% used' in summary line");
+    process.exitCode = 1;
+    return;
+  }
+  console.log("  PASS: Shows '75% used' in summary line\n");
+
+  // Test 6: formatUsageReportLines with MiniMax
+  console.log("Test 6: formatUsageReportLines with MiniMax at 25% used");
+  const reportLines = formatUsageReportLines({
+    updatedAt: Date.now(),
+    providers: [createMinimaxSnapshot(25)],
+  });
+  console.log("  Result:");
+  reportLines.forEach(line => console.log(`    ${line}`));
+
+  const hasUsedLine = reportLines.some(line => line.includes("25% used"));
+  if (!hasUsedLine) {
+    console.error("  FAIL: Expected '25% used' in report lines");
+    process.exitCode = 1;
+    return;
+  }
+  console.log("  PASS: Shows '25% used' in report lines\n");
+
+  console.log("=== All tests passed! ===");
+  console.log("MiniMax usage display now correctly shows 'X% used' instead of 'X% left'");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/infra/provider-usage.format.ts
+++ b/src/infra/provider-usage.format.ts
@@ -35,11 +35,19 @@ function formatResetRemaining(targetMs?: number, now?: number): string | null {
   }).format(new Date(targetMs));
 }
 
-function formatWindowShort(window: UsageWindow, now?: number): string {
-  const remaining = clampPercent(100 - window.usedPercent);
+function formatWindowShort(
+  window: UsageWindow,
+  now?: number,
+  opts?: { provider?: string },
+): string {
+  const isMinimax = opts?.provider === "minimax";
+  const percent = isMinimax
+    ? clampPercent(window.usedPercent)
+    : clampPercent(100 - window.usedPercent);
+  const label = isMinimax ? "used" : "left";
   const reset = formatResetRemaining(window.resetAt, now);
   const resetSuffix = reset ? ` ⏱${reset}` : "";
-  return `${remaining.toFixed(0)}% left (${window.label}${resetSuffix})`;
+  return `${percent.toFixed(0)}% ${label} (${window.label}${resetSuffix})`;
 }
 
 /** Formats one provider snapshot into a short usage-window summary. */
@@ -60,11 +68,15 @@ export function formatUsageWindowSummary(
       : snapshot.windows.length;
   const includeResets = opts?.includeResets ?? false;
   const windows = snapshot.windows.slice(0, maxWindows);
+  const isMinimax = snapshot.provider === "minimax";
   const parts = windows.map((window) => {
-    const remaining = clampPercent(100 - window.usedPercent);
+    const percent = isMinimax
+      ? clampPercent(window.usedPercent)
+      : clampPercent(100 - window.usedPercent);
+    const label = isMinimax ? "used" : "left";
     const reset = includeResets ? formatResetRemaining(window.resetAt, now) : null;
     const resetSuffix = reset ? ` ⏱${reset}` : "";
-    return `${window.label} ${remaining.toFixed(0)}% left${resetSuffix}`;
+    return `${window.label} ${percent.toFixed(0)}% ${label}${resetSuffix}`;
   });
   return parts.join(" · ");
 }
@@ -87,7 +99,7 @@ export function formatUsageSummaryLine(
     const window = entry.windows.reduce((best, next) =>
       next.usedPercent > best.usedPercent ? next : best,
     );
-    return `${entry.displayName} ${formatWindowShort(window, opts?.now)}`;
+    return `${entry.displayName} ${formatWindowShort(window, opts?.now, { provider: entry.provider })}`;
   });
   return `📊 Usage: ${parts.join(" · ")}`;
 }
@@ -112,11 +124,15 @@ export function formatUsageReportLines(summary: UsageSummary, opts?: { now?: num
     if (entry.summary?.trim()) {
       lines.push(`    ${entry.summary.trim()}`);
     }
+    const isMinimax = entry.provider === "minimax";
     for (const window of entry.windows) {
-      const remaining = clampPercent(100 - window.usedPercent);
+      const percent = isMinimax
+        ? clampPercent(window.usedPercent)
+        : clampPercent(100 - window.usedPercent);
+      const label = isMinimax ? "used" : "left";
       const reset = formatResetRemaining(window.resetAt, opts?.now);
       const resetSuffix = reset ? ` · resets ${reset}` : "";
-      lines.push(`    ${window.label}: ${remaining.toFixed(0)}% left${resetSuffix}`);
+      lines.push(`    ${window.label}: ${percent.toFixed(0)}% ${label}${resetSuffix}`);
     }
   }
   return lines;


### PR DESCRIPTION
## Summary

Fixes #92721. The MiniMax usage display was showing "X% left" instead of "X% used", which is semantically opposite of what the "Usage:" label should display. The underlying `usedPercent` data represents "consumed" percentage, but the formatters were inverting it with `100 - usedPercent`.

## Changes

- `src/infra/provider-usage.format.ts`: Updated 4 formatter functions to check for MiniMax provider and display "% used" instead of "% left"
  - `formatWindowShort`: Added provider parameter and conditional display logic
  - `formatUsageWindowSummary`: Checks `snapshot.provider === "minimax"` and shows "% used"
  - `formatUsageReportLines`: Checks `entry.provider === "minimax"` and shows "% used"
  - `formatUsageSummaryLine`: Passes provider to `formatWindowShort`

## Real behavior proof

- **Behavior addressed**: MiniMax usage display now correctly shows consumed percentage ("% used") instead of remaining percentage ("% left")
- **Real environment tested**: Linux 4.19.112, Node.js v22.19.0, local OpenClaw checkout
- **Exact steps or command run after this patch**:
  - `node --import tsx scripts/repro/issue-92721-minimax-usage-display.mts`
- **Evidence after fix**: Console output from running the reproduction script showing all 6 test cases pass with the corrected "% used" display for MiniMax provider
  ```
  Test 1: MiniMax at 100% used
    Result: 24h 100% used
    PASS: Shows '100% used'
  
  Test 2: MiniMax at 0% used
    Result: 24h 0% used
    PASS: Shows '0% used'
  
  Test 3: MiniMax at 50% used
    Result: 24h 50% used
    PASS: Shows '50% used'
  
  Test 4: OpenAI at 100% used (should show '0% left')
    Result: 24h 0% left
    PASS: Shows '0% left' (unchanged behavior)
  
  Test 5: formatUsageSummaryLine with MiniMax at 75% used
    Result: 📊 Usage: MiniMax 75% used (24h ⏱23h 59m)
    PASS: Shows '75% used' in summary line
  
  Test 6: formatUsageReportLines with MiniMax at 25% used
    Result:
      Usage:
        MiniMax
          24h: 25% used · resets 1d 0h
    PASS: Shows '25% used' in report lines
  
  === All tests passed! ===
  MiniMax usage display now correctly shows 'X% used' instead of 'X% left'
  ```
- **Observed result after fix**: The reproduction script executed successfully and confirmed that MiniMax provider now displays "% used" (e.g., "100% used", "0% used", "50% used") while other providers like OpenAI continue to show "% left" (e.g., "0% left" when 100% is used). This proves the fix correctly differentiates between providers and displays the semantically correct percentage.
- **What was not tested**: Live API integration with actual MiniMax account (tested with synthetic data only)

## Verification

- `pnpm test src/infra/provider-usage.format.test.ts --run` — 12 passed
- `npx oxlint --import-plugin --config .oxlintrc.json src/infra/provider-usage.format.ts` — clean
- `pnpm build` — passed

AI-assisted: changes were authored with Claude Code; the reproduction script and tests were run locally in this environment.
