### PR TITLE
fix(memory): explain skipped short-term recall hits

### DIFF
--- a/extensions/memory-core/src/memory-events.test.ts
+++ b/extensions/memory-core/src/memory-events.test.ts
@@ -76,6 +76,87 @@ describe("memory host event journal integration", () => {
     expect(promotionEvent.applied).toBe(1);
   });
 
+  it("records skipped recall events for durable memory hits excluded from short-term promotion", async () => {
+    const workspaceDir = await createTempWorkspace("memory-core-skipped-recall-events-");
+    await fs.mkdir(path.join(workspaceDir, "memory", "decisoes"), { recursive: true });
+    await fs.mkdir(path.join(workspaceDir, "memory", "idiomas"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, "MEMORY.md"),
+      "# Memory\n\nAlpha durable note.\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "decisoes", "2026-06.md"),
+      "# Decisoes\n\nAlpha monthly decision.\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "idiomas", "PLANO.md"),
+      "# Plano\n\nAlpha language plan.\n",
+      "utf8",
+    );
+
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "alpha durable memory",
+      results: [
+        {
+          path: "MEMORY.md",
+          startLine: 3,
+          endLine: 3,
+          score: 0.91,
+          snippet: "Alpha durable note.",
+          source: "memory",
+        },
+        {
+          path: "memory/decisoes/2026-06.md",
+          startLine: 3,
+          endLine: 3,
+          score: 0.88,
+          snippet: "Alpha monthly decision.",
+          source: "memory",
+        },
+        {
+          path: "memory/idiomas/PLANO.md",
+          startLine: 3,
+          endLine: 3,
+          score: 0.83,
+          snippet: "Alpha language plan.",
+          source: "memory",
+        },
+      ],
+      nowMs: Date.UTC(2026, 5, 13, 9, 0, 0),
+    });
+
+    const candidates = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: Date.UTC(2026, 5, 13, 9, 5, 0),
+    });
+    const events = await readMemoryHostEvents({ workspaceDir });
+
+    expect(candidates).toEqual([]);
+    expect(events.map((event) => event.type)).toEqual(["memory.recall.skipped"]);
+    const skippedEvent = events[0];
+    if (skippedEvent?.type !== "memory.recall.skipped") {
+      throw new Error("expected skipped recall event");
+    }
+    expect(skippedEvent.query).toBe("alpha durable memory");
+    expect(skippedEvent.reason).toBe("non-short-term-memory-path");
+    expect(skippedEvent.eligibleResultCount).toBe(0);
+    expect(skippedEvent.skippedResultCount).toBe(3);
+    expect(skippedEvent.results.map((result) => result.path)).toEqual([
+      "MEMORY.md",
+      "memory/decisoes/2026-06.md",
+      "memory/idiomas/PLANO.md",
+    ]);
+    expect(
+      skippedEvent.results.every((result) => result.reason === "non-short-term-memory-path"),
+    ).toBe(true);
+  });
+
   it("records dreaming completion events when phase artifacts are written", async () => {
     const workspaceDir = await createTempWorkspace("memory-core-dream-events-");
 

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1355,6 +1355,29 @@ export async function filterLiveShortTermRecallEntries(params: {
   return results.filter((result) => result.exists).map((result) => result.entry);
 }
 
+function buildMemoryRecallSkippedEvent(params: {
+  timestamp: string;
+  query: string;
+  eligibleResultCount: number;
+  skipped: MemorySearchResult[];
+}) {
+  return {
+    type: "memory.recall.skipped" as const,
+    timestamp: params.timestamp,
+    query: params.query,
+    reason: "non-short-term-memory-path" as const,
+    eligibleResultCount: params.eligibleResultCount,
+    skippedResultCount: params.skipped.length,
+    results: params.skipped.map((result) => ({
+      path: normalizeMemoryPath(result.path),
+      startLine: Math.max(1, Math.floor(result.startLine)),
+      endLine: Math.max(1, Math.floor(result.endLine)),
+      score: clampScore(result.score),
+      reason: "non-short-term-memory-path" as const,
+    })),
+  };
+}
+
 export async function recordShortTermRecalls(params: {
   workspaceDir?: string;
   query: string;
@@ -1373,15 +1396,27 @@ export async function recordShortTermRecalls(params: {
   if (!query) {
     return;
   }
-  const relevant = params.results.filter(
-    (result) => result.source === "memory" && isShortTermMemoryPath(result.path),
-  );
-  if (relevant.length === 0) {
+  const memoryResults = params.results.filter((result) => result.source === "memory");
+  const relevant = memoryResults.filter((result) => isShortTermMemoryPath(result.path));
+  const skipped = memoryResults.filter((result) => !isShortTermMemoryPath(result.path));
+  if (relevant.length === 0 && skipped.length === 0) {
     return;
   }
 
   const nowMs = resolveMemoryCoreNowMs(params.nowMs);
   const nowIso = resolveMemoryCoreTimestamp(nowMs);
+  if (relevant.length === 0) {
+    await appendMemoryHostEvent(
+      workspaceDir,
+      buildMemoryRecallSkippedEvent({
+        timestamp: nowIso,
+        query,
+        eligibleResultCount: relevant.length,
+        skipped,
+      }),
+    );
+    return;
+  }
   const signalType = params.signalType ?? "recall";
   const queryHash = hashQuery(query);
   const todayBucket =
@@ -1466,6 +1501,17 @@ export async function recordShortTermRecalls(params: {
         score: clampScore(result.score),
       })),
     });
+    if (skipped.length > 0) {
+      await appendMemoryHostEvent(
+        workspaceDir,
+        buildMemoryRecallSkippedEvent({
+          timestamp: nowIso,
+          query,
+          eligibleResultCount: relevant.length,
+          skipped,
+        }),
+      );
+    }
   });
 }
 

--- a/src/memory-host-sdk/events.ts
+++ b/src/memory-host-sdk/events.ts
@@ -21,6 +21,23 @@ export type MemoryHostRecallRecordedEvent = {
   }>;
 };
 
+/** Event emitted when recall hits are visible but excluded from short-term promotion. */
+export type MemoryHostRecallSkippedEvent = {
+  type: "memory.recall.skipped";
+  timestamp: string;
+  query: string;
+  reason: "non-short-term-memory-path";
+  eligibleResultCount: number;
+  skippedResultCount: number;
+  results: Array<{
+    path: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    reason: "non-short-term-memory-path";
+  }>;
+};
+
 /** Event emitted when deep-dream candidates are promoted into durable memory. */
 export type MemoryHostPromotionAppliedEvent = {
   type: "memory.promotion.applied";
@@ -51,6 +68,7 @@ export type MemoryHostDreamCompletedEvent = {
 /** Append-only memory host event schema stored as JSONL. */
 export type MemoryHostEvent =
   | MemoryHostRecallRecordedEvent
+  | MemoryHostRecallSkippedEvent
   | MemoryHostPromotionAppliedEvent
   | MemoryHostDreamCompletedEvent;
 


### PR DESCRIPTION
## Summary

- Problem: `memory_search` can return `source="memory"` hits from durable paths such as `MEMORY.md` or arbitrary nested `memory/*.md` files, but `recordShortTermRecalls()` silently drops those paths because they are not short-term promotion sources. That makes an intentional eligibility decision look like recall tracking failed.
- Solution: add an additive `memory.recall.skipped` host event for memory hits excluded by `isShortTermMemoryPath()`, including the normalized paths, scores, eligible/skipped counts, and the explicit `non-short-term-memory-path` reason.
- Best-plan comparison against related PRs: #91225 improves light-dreaming diary selection after recall candidates already exist; #92698 protects promotion quality by rejecting placeholder snippets; #89334 and #85899 are docs/operator wording fixes; #88905 keeps shadow-trial scoring report-only. None explains why durable memory hits are absent from the short-term recall store, so this PR adds observability at the recall/promotion boundary instead of competing with those broader changes.
- What did NOT change: `MEMORY.md` and arbitrary durable `memory/*.md` files are still not promotion-eligible short-term sources; short-term recall store schema, promotion thresholds, public memory config, provider routing, Dream Diary selection, and durable memory writes are unchanged.

Fixes #92706

## Root Cause

The short-term promotion owner intentionally filters recall results with `isShortTermMemoryPath()`. Date-based daily notes and `.dreams/session-corpus` paths are eligible, while `MEMORY.md` and general durable memory files are not. Before this patch, when all visible memory hits were filtered out, `recordShortTermRecalls()` returned without writing any event, leaving users unable to distinguish an intentional non-short-term path exclusion from a missing recall-tracking hook.

This is the narrower root-cause fix because it makes the existing eligibility boundary observable without turning durable memory into a strong short-term promotion source or introducing self-reinforcing durable-memory feedback.

## Real behavior proof

- **Behavior or issue addressed:** Durable memory hits returned by recall now produce a diagnostic skipped event while remaining absent from promotion candidates; an eligible daily-note hit still records normally and becomes a short-term promotion candidate.
- **Real environment tested:** Local Linux OpenClaw worktree at `/media/vdc/code/ai/aispace/openclaw-worktrees/issue-92706-local`, branch `fix/92706-memory-recall-source-diagnostics`, commit `c9cbd97760`.
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs extensions/memory-core/src/memory-events.test.ts extensions/memory-core/src/short-term-promotion.test.ts extensions/memory-core/src/tools.recall-tracking.test.ts
./node_modules/.bin/oxfmt --check --threads=1 extensions/memory-core/src/memory-events.test.ts extensions/memory-core/src/short-term-promotion.ts src/memory-host-sdk/events.ts
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --noEmit
git diff --check
node --import tsx --input-type=module - < local skipped-recall proof script
```

- **Evidence after fix:**

```text
Test Files  3 passed (3)
Tests  85 passed (85)
All matched files use the correct format.
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --noEmit passed
git diff --check passed
```

```json
{
  "afterDurableCandidateCount": 0,
  "afterDailyCandidateCount": 1,
  "eventTypes": [
    "memory.recall.skipped",
    "memory.recall.recorded"
  ],
  "skippedEvent": {
    "type": "memory.recall.skipped",
    "timestamp": "2026-06-13T09:00:00.000Z",
    "query": "alpha durable memory",
    "reason": "non-short-term-memory-path",
    "eligibleResultCount": 0,
    "skippedResultCount": 2,
    "results": [
      {
        "path": "MEMORY.md",
        "startLine": 3,
        "endLine": 3,
        "score": 0.91,
        "reason": "non-short-term-memory-path"
      },
      {
        "path": "memory/decisoes/2026-06.md",
        "startLine": 3,
        "endLine": 3,
        "score": 0.88,
        "reason": "non-short-term-memory-path"
      }
    ]
  },
  "dailyCandidatePaths": [
    "memory/2026-06-13.md"
  ],
  "proof": "passed"
}
```

- **Observed result after fix:** Durable `MEMORY.md` and nested durable `memory/decisoes/2026-06.md` hits write a `memory.recall.skipped` event with the explicit non-short-term reason and do not create promotion candidates. A later `memory/2026-06-13.md` daily-note hit still writes `memory.recall.recorded` and produces one promotion candidate.
- **What was not tested:** No external provider, live channel, Desktop, remote memory service, or long-running gateway listener was exercised. The proof is local memory-core behavior over production recall/promotion functions and the host event journal.

## Regression Test Plan

- **Target test file:** `extensions/memory-core/src/memory-events.test.ts`.
- **Scenario locked in:** `recordShortTermRecalls()` receives `source="memory"` hits for `MEMORY.md`, `memory/decisoes/2026-06.md`, and `memory/idiomas/PLANO.md`; no short-term promotion candidates are created, and the event journal contains a single `memory.recall.skipped` event with the excluded paths and reason.
- **Why this is the smallest reliable guardrail:** The test uses the real memory host event journal and real short-term promotion ranking path, so it verifies the user-visible diagnostic without loosening the promotion source contract.

## Merge risk

- **Risk labels considered:** plugin-sdk; session-state; observability; compatibility.
- **Risk explanation:** This adds a new append-only event type to the memory host event union and emits it when memory recall hits are intentionally excluded from short-term promotion. It does not change the short-term recall store schema, ranking math, promotion eligibility, durable memory contents, or public config defaults.
- **Why acceptable:** The new event is additive diagnostics. Existing eligible recall hits still use the original `memory.recall.recorded` path, and mixed eligible/skipped result sets record the eligible path before emitting the skipped diagnostic.
- **Out-of-scope boundary:** This PR does not make `MEMORY.md` or arbitrary `memory/*.md` files eligible for strong short-term promotion, does not add weak-signal policy, does not migrate existing stores, and does not change Dream Diary candidate selection.
