### PR TITLE
fix(gateway): preserve active runs during plugin finalization

### DIFF
--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -156,6 +156,7 @@ export function startGatewayEventSubscriptions(params: {
           broadcastToConnIds: params.broadcastToConnIds,
           sessionEventSubscribers: params.sessionEventSubscribers,
           sessionMessageSubscribers: params.sessionMessageSubscribers,
+          chatAbortControllers: params.chatAbortControllers,
         }),
     );
     return transcriptUpdateHandlerPromise;

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatAbortControllerEntry } from "./chat-abort.js";
+
+const sessionRow = vi.hoisted(() => ({
+  key: "agent:main:main",
+  kind: "direct",
+  status: "done",
+  updatedAt: 1,
+}));
+
+vi.mock("../config/io.js", () => ({ getRuntimeConfig: () => ({}) }));
+vi.mock("./chat-display-projection.js", () => ({
+  projectChatDisplayMessage: (message: unknown) => message,
+}));
+vi.mock("./session-utils.js", () => ({
+  attachOpenClawTranscriptMeta: (message: unknown) => message,
+  loadGatewaySessionRow: () => sessionRow,
+  loadSessionEntry: () => ({ entry: undefined, storePath: "" }),
+  readSessionMessageCountAsync: vi.fn(),
+}));
+
+const { createTranscriptUpdateBroadcastHandler } = await import("./server-session-events.js");
+
+function createActiveRun(projectSessionActive: boolean): ChatAbortControllerEntry {
+  return {
+    controller: new AbortController(),
+    sessionId: "sess-main",
+    sessionKey: "agent:main:main",
+    startedAtMs: Date.now(),
+    expiresAtMs: Date.now() + 60_000,
+    projectSessionActive,
+  };
+}
+
+function createHandler(projectSessionActive: boolean) {
+  const broadcastToConnIds = vi.fn();
+  const handler = createTranscriptUpdateBroadcastHandler({
+    broadcastToConnIds,
+    sessionEventSubscribers: { getAll: () => new Set(["conn-1"]) },
+    sessionMessageSubscribers: { get: () => new Set<string>() },
+    chatAbortControllers: new Map([["run-before-finalize", createActiveRun(projectSessionActive)]]),
+  });
+  return { broadcastToConnIds, handler };
+}
+
+async function emitAssistantTranscriptUpdate(projectSessionActive: boolean) {
+  const { broadcastToConnIds, handler } = createHandler(projectSessionActive);
+  handler({
+    sessionFile: "/tmp/sess-main.jsonl",
+    sessionKey: "agent:main:main",
+    message: { role: "assistant", content: [{ type: "text", text: "Final answer" }] },
+    messageId: "message-1",
+    messageSeq: 1,
+  });
+  await vi.waitFor(() => expect(broadcastToConnIds).toHaveBeenCalledTimes(1));
+  return broadcastToConnIds.mock.calls[0]?.[1];
+}
+
+describe("createTranscriptUpdateBroadcastHandler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps transcript snapshots active while plugin finalization delays the terminal event", async () => {
+    // before_agent_finalize hooks run after the assistant transcript write but
+    // before terminal delivery. The active-run registry remains authoritative
+    // during that interval even when the persisted session row says done.
+    await expect(emitAssistantTranscriptUpdate(true)).resolves.toMatchObject({
+      sessionKey: "agent:main:main",
+      hasActiveRun: true,
+      session: { key: "agent:main:main", status: "done", hasActiveRun: true },
+    });
+  });
+
+  it("keeps stale-run recovery when terminal lifecycle has cleared active projection", async () => {
+    await expect(emitAssistantTranscriptUpdate(false)).resolves.toMatchObject({
+      sessionKey: "agent:main:main",
+      hasActiveRun: false,
+      session: { hasActiveRun: false },
+    });
+  });
+});

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -7,12 +7,14 @@ import { getRuntimeConfig } from "../config/io.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { SessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import type { SessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import { projectChatDisplayMessage } from "./chat-display-projection.js";
 import type { GatewayBroadcastToConnIdsFn } from "./server-broadcast-types.js";
 import type {
   SessionEventSubscriberRegistry,
   SessionMessageSubscriberRegistry,
 } from "./server-chat.js";
+import { hasTrackedActiveSessionRun } from "./server-methods/session-active-runs.js";
 import { resolveSessionKeyForTranscriptFile } from "./session-transcript-key.js";
 import {
   attachOpenClawTranscriptMeta,
@@ -49,6 +51,7 @@ function buildGatewaySessionSnapshot(params: {
   label?: string;
   displayName?: string;
   parentSessionKey?: string;
+  hasActiveRun?: boolean;
 }): Record<string, unknown> {
   const { sessionRow } = params;
   if (!sessionRow) {
@@ -60,6 +63,9 @@ function buildGatewaySessionSnapshot(params: {
   const session = params.includeSession ? { ...sessionRow } : undefined;
   if (session && omitUnscopedGlobalGoal) {
     delete session.goal;
+  }
+  if (session && params.hasActiveRun !== undefined) {
+    session.hasActiveRun = params.hasActiveRun;
   }
   return {
     ...(session ? { session } : {}),
@@ -107,6 +113,7 @@ function buildGatewaySessionSnapshot(params: {
     modelProvider: sessionRow.modelProvider,
     model: sessionRow.model,
     status: sessionRow.status,
+    ...(params.hasActiveRun === undefined ? {} : { hasActiveRun: params.hasActiveRun }),
     subagentRunState: sessionRow.subagentRunState,
     hasActiveSubagentRun: sessionRow.hasActiveSubagentRun,
     startedAt: sessionRow.startedAt,
@@ -122,6 +129,7 @@ export function createTranscriptUpdateBroadcastHandler(params: {
   broadcastToConnIds: GatewayBroadcastToConnIdsFn;
   sessionEventSubscribers: SessionEventSubscribers;
   sessionMessageSubscribers: SessionMessageSubscribers;
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>;
 }) {
   let broadcastQueue = Promise.resolve();
   return (update: SessionTranscriptUpdate): void => {
@@ -138,6 +146,7 @@ async function handleTranscriptUpdateBroadcast(
     broadcastToConnIds: GatewayBroadcastToConnIdsFn;
     sessionEventSubscribers: SessionEventSubscribers;
     sessionMessageSubscribers: SessionMessageSubscribers;
+    chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   },
   update: SessionTranscriptUpdate,
 ): Promise<void> {
@@ -176,13 +185,24 @@ async function handleTranscriptUpdateBroadcast(
         )
       : undefined;
   }
+  const sessionRow = loadGatewaySessionRow(sessionKey, {
+    agentId: visibleAgentId,
+    transcriptUsageMaxBytes: 64 * 1024,
+  });
+  const hasActiveRun = sessionRow
+    ? hasTrackedActiveSessionRun({
+        context: params,
+        requestedKey: sessionKey,
+        canonicalKey: sessionRow.key,
+        ...(sessionRow.key === "global" && visibleAgentId ? { agentId: visibleAgentId } : {}),
+        defaultAgentId: normalizeAgentId(resolveDefaultAgentId(getRuntimeConfig())),
+      })
+    : false;
   const sessionSnapshot = buildGatewaySessionSnapshot({
-    sessionRow: loadGatewaySessionRow(sessionKey, {
-      agentId: visibleAgentId,
-      transcriptUsageMaxBytes: 64 * 1024,
-    }),
+    sessionRow,
     agentId: visibleAgentId,
     includeSession: true,
+    hasActiveRun,
   });
   const rawMessage = attachOpenClawTranscriptMeta(update.message, {
     ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -716,6 +716,29 @@ describe("handleGatewayEvent session.message", () => {
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
   });
 
+  it("defers history reload when a session message confirms the chat run is still active", () => {
+    loadChatHistoryMock.mockReset();
+    applySessionsChangedEventMock.mockReset().mockReturnValue({ applied: false });
+    loadSessionsMock.mockReset();
+    const host = createHost();
+    host.sessionKey = "agent:qa:main";
+    host.chatRunId = "run-123";
+
+    handleGatewayEvent(host, {
+      type: "event",
+      event: "session.message",
+      payload: { sessionKey: "agent:qa:main", hasActiveRun: true },
+      seq: 1,
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+    expect(loadSessionsMock).not.toHaveBeenCalled();
+    expect(
+      (host as typeof host & { pendingSessionMessageReloadSessionKey?: string | null })
+        .pendingSessionMessageReloadSessionKey,
+    ).toBe("agent:qa:main");
+  });
+
   it("scopes selected-global session.message refreshes while a chat run is active", async () => {
     loadChatHistoryMock.mockReset();
     applySessionsChangedEventMock.mockReset().mockReturnValue({ applied: false });

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -6,7 +6,8 @@ const loadChatHistoryMock = vi.fn();
 const applySessionsChangedEventMock = vi.fn();
 const clearPendingQueueItemsForRunMock = vi.fn();
 const flushChatQueueForEventMock = vi.fn();
-const handleChatEventMock = vi.fn(() => "idle");
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handleChatEventMock = vi.fn((_state?: any) => "idle");
 const handleSessionOperationEventMock = vi.fn();
 const recordFirstAssistantChatTimingMock = vi.fn();
 

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -6,7 +6,6 @@ const loadChatHistoryMock = vi.fn();
 const applySessionsChangedEventMock = vi.fn();
 const clearPendingQueueItemsForRunMock = vi.fn();
 const flushChatQueueForEventMock = vi.fn();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const handleChatEventMock = vi.fn((_state?: any) => "idle");
 const handleSessionOperationEventMock = vi.fn();
 const recordFirstAssistantChatTimingMock = vi.fn();

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -1179,6 +1179,7 @@ function handleSessionMessageGatewayEvent(
     // Gateway confirms the run is still active (plugin hook window, etc.).
     // Skip reload — the pending chat terminal owns history reconciliation.
     if ((payload as Record<string, unknown> | null)?.hasActiveRun === true) {
+      deferredReloadHost.pendingSessionMessageReloadSessionKey = sessionKey;
       return;
     }
     deferredReloadHost.pendingSessionMessageReloadSessionKey = sessionKey;

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -1176,6 +1176,11 @@ function handleSessionMessageGatewayEvent(
   // chatStream, which delays the user message card from appearing until the
   // first LLM delta arrives.
   if (host.chatRunId) {
+    // Gateway confirms the run is still active (plugin hook window, etc.).
+    // Skip reload — the pending chat terminal owns history reconciliation.
+    if ((payload as Record<string, unknown> | null)?.hasActiveRun === true) {
+      return;
+    }
     deferredReloadHost.pendingSessionMessageReloadSessionKey = sessionKey;
     const refreshStartedAt = Date.now();
     const runIdBeforeRefresh = host.chatRunId;

--- a/ui/src/ui/chat/run-lifecycle.test.ts
+++ b/ui/src/ui/chat/run-lifecycle.test.ts
@@ -33,6 +33,25 @@ function rowActive(host: ReconcileHost): boolean {
 }
 
 describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875)", () => {
+  it("keeps a local run active when the gateway registry overrides a terminal snapshot", () => {
+    const host = makeHost({
+      chatRunId: "run-before-finalize",
+      chatStream: "final answer",
+    });
+
+    expect(
+      reconcileChatRunFromSessionRow(host, {
+        key: "s1",
+        kind: "direct",
+        updatedAt: 1,
+        hasActiveRun: true,
+        status: "done",
+      }),
+    ).toBe(false);
+    expect(host.chatRunId).toBe("run-before-finalize");
+    expect(host.chatStream).toBe("final answer");
+  });
+
   it("suppresses a stale active row after a recent local completion", () => {
     const host = makeHost({
       lastLocalTerminalReconcile: {

--- a/ui/src/ui/chat/run-lifecycle.ts
+++ b/ui/src/ui/chat/run-lifecycle.ts
@@ -296,6 +296,9 @@ export function reconcileChatRunFromSessionRow(
   if (!host.chatRunId && host.chatStream == null) {
     return false;
   }
+  if (row.hasActiveRun === true) {
+    return false;
+  }
   if (isSessionRunActive(row)) {
     return false;
   }

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -655,7 +655,7 @@ describe("loadSessions", () => {
     expect(state.sessionsResult?.count).toBe(2);
   });
 
-  it("uses session list terminal state to clear stale local run tracking", async () => {
+  it("keeps local run tracking while the session list reports an active terminal snapshot", async () => {
     vi.useFakeTimers();
     try {
       const request = vi.fn(async (method: string) => {
@@ -710,18 +710,17 @@ describe("loadSessions", () => {
 
       await loadSessions(state);
 
-      expect(state.chatRunId).toBeNull();
-      expect(state.chatStream).toBeNull();
-      expect(state.chatStreamStartedAt).toBeNull();
-      expect(state.compactionStatus).toBeNull();
-      expect(state.compactionClearTimer).toBeNull();
-      expect(state.fallbackStatus).toBeNull();
-      expect(state.fallbackClearTimer).toBeNull();
-      expect(state.chatRunStatus).toMatchObject({
-        phase: "done",
-        runId: "run-1",
-        sessionKey: "main",
+      expect(state.chatRunId).toBe("run-1");
+      expect(state.chatStream).toBe("Visible answer");
+      expect(state.chatStreamStartedAt).toBe(123);
+      expect(state.compactionStatus).toMatchObject({ phase: "active", runId: "run-1" });
+      expect(state.compactionClearTimer).not.toBeNull();
+      expect(state.fallbackStatus).toMatchObject({
+        selected: "openai/gpt-5.5",
+        active: "anthropic/claude-sonnet-4-6",
       });
+      expect(state.fallbackClearTimer).not.toBeNull();
+      expect(state.chatRunStatus).toBeUndefined();
     } finally {
       vi.useRealTimers();
     }

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1574,6 +1574,49 @@ describe("applySessionsChangedEvent", () => {
     });
   });
 
+  it("keeps the local run active when a transcript snapshot reports plugin finalization pending", () => {
+    const state = {
+      ...createState(async () => undefined, {
+        sessionsResult: {
+          ts: 1,
+          path: "(multiple)",
+          count: 1,
+          defaults: { modelProvider: null, model: null, contextTokens: null },
+          sessions: [
+            {
+              key: "agent:main:main",
+              kind: "direct",
+              updatedAt: 1,
+              hasActiveRun: true,
+              status: "running",
+            },
+          ],
+        },
+      }),
+      sessionKey: "agent:main:main",
+      chatRunId: "run-before-finalize",
+    } as SessionsState & { sessionKey: string; chatRunId: string | null };
+
+    const applied = applySessionsChangedEvent(state, {
+      sessionKey: "agent:main:main",
+      session: {
+        key: "agent:main:main",
+        kind: "direct",
+        updatedAt: 2,
+        status: "done",
+        hasActiveRun: true,
+      },
+      ts: 2,
+    });
+
+    expect(applied).toEqual({ applied: true, change: "updated" });
+    expect(state.chatRunId).toBe("run-before-finalize");
+    expect(state.sessionsResult?.sessions[0]).toMatchObject({
+      status: "done",
+      hasActiveRun: true,
+    });
+  });
+
   it("clears the local chat run when an applied websocket patch makes the current session terminal", () => {
     const requestUpdate = vi.fn();
     const state: SessionsState & {


### PR DESCRIPTION
## Summary

Plugin `before_agent_finalize` hooks run after the assistant transcript can be persisted but before terminal delivery completes. During that hook-controlled interval, the transcript broadcaster built `session.message` snapshots only from the persisted session row. A row already marked `done` could therefore make WebChat reconcile the local run before the delayed chat terminal arrived, allowing history reconciliation and terminal delivery to race.

This fix has two pieces:

- **Gateway**: project the existing Control UI-visible active-run registry (`chatAbortControllers`) into transcript snapshots via `hasActiveRun` in both the top-level payload and nested `session` object
- **WebChat**: skip `session.message` history reload when the gateway reports `hasActiveRun: true` — the pending chat terminal owns history reconciliation

No new state types, timers, pending flags, or deleted recovery paths. The existing stale-run recovery path runs unchanged when `hasActiveRun` is absent or false.

## Plugin hook behavior

While a `before_agent_finalize` hook is awaiting, the chat abort-controller entry remains active. A transcript update emitted in that interval now reports `hasActiveRun: true`, even if the persisted row already says `status: "done"`. WebChat sees `hasActiveRun: true` and skips the history reload, keeping the current run until normal terminal delivery.

After terminal lifecycle handling clears `projectSessionActive`, subsequent transcript snapshots report `hasActiveRun: false` and the existing stale-run recovery path is available.

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-session-events.test.ts src/gateway/session-message-events.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/app-gateway.sessions.node.test.ts`
  - gateway: 72 tests passed
  - UI: 107 tests passed
- `node scripts/run-oxlint.mjs src/gateway/server-session-events.ts src/gateway/server-runtime-subscriptions.ts src/gateway/server-session-events.test.ts ui/src/ui/controllers/sessions.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `git diff --check`

## Real behavior proof

Behavior addressed: WebChat can prematurely reconcile a run while a plugin `before_agent_finalize` hook delays terminal delivery.

Real environment tested: Source-built gateway on macOS with a `before_agent_finalize` hook that inserts a 5-second delay.

Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-session-events.test.ts src/gateway/session-message-events.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/app-gateway.sessions.node.test.ts`

Evidence after fix:

- Before fix: the last conversation turn shows the assistant reply appearing **twice** — once from premature `loadChatHistory` triggered by `session.message`, and again from `chat final` delivering the terminal message.

https://github.com/user-attachments/assets/bd85bd4c-cf8b-4590-b472-13f94a74d650

- After fix: the assistant reply appears only **once**. `session.message` carries `hasActiveRun: true` during the hook window, so WebChat skips the history reload and lets `chat final` deliver the terminal message normally.

https://github.com/user-attachments/assets/77209f1b-22ad-4502-8dd8-cf357cfdafb9

Observed result after fix: No duplicate assistant messages. All 179 focused regression tests pass, including existing stale-run recovery coverage.

What was not tested: No packaged browser E2E or live third-party plugin installation was run.

