### PR TITLE
fix #92246: QQ Bot C2C: Media sending (image/file) returns 400 Bad Request

### DIFF
--- a/extensions/qqbot/src/channel.message-adapter.test.ts
+++ b/extensions/qqbot/src/channel.message-adapter.test.ts
@@ -114,4 +114,21 @@ describe("qqbot message adapter", () => {
     expect(proofResults.find((result) => result.capability === "media")?.status).toBe("verified");
     expect(proofResults.find((result) => result.capability === "replyTo")?.status).toBe("verified");
   });
+
+  it("rejects media sends when the QQ outbound layer reports an error", async () => {
+    sendMediaMock.mockResolvedValue({
+      error: "API Error [/v2/users/user-1/files]: Bad Request",
+    });
+
+    const sendMedia = qqbotPlugin.message?.send?.media;
+    expect(sendMedia).toBeDefined();
+    await expect(
+      sendMedia?.({
+        cfg,
+        to: "qqbot:c2c:user-1",
+        text: "image",
+        mediaUrl: "https://example.com/image.png",
+      }),
+    ).rejects.toThrow("API Error [/v2/users/user-1/files]: Bad Request");
+  });
 });

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -135,7 +135,7 @@ async function sendQQBotMedia(params: {
 
 function toQQBotMessageSendResult(result: Awaited<ReturnType<typeof sendQQBotText>>) {
   if (result.meta?.error) {
-    throw new Error(String(result.meta.error));
+    throw new Error(result.meta.error);
   }
   if (!result.messageId || result.receipt.platformMessageIds.length === 0) {
     throw new Error("QQBot send did not return a platform message id");

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -134,6 +134,12 @@ async function sendQQBotMedia(params: {
 }
 
 function toQQBotMessageSendResult(result: Awaited<ReturnType<typeof sendQQBotText>>) {
+  if (result.meta?.error) {
+    throw new Error(String(result.meta.error));
+  }
+  if (!result.messageId || result.receipt.platformMessageIds.length === 0) {
+    throw new Error("QQBot send did not return a platform message id");
+  }
   return {
     messageId: result.messageId,
     receipt: result.receipt,

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -394,7 +394,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expectGuardedDownload("http://93.184.216.34/assets/photo.png");
   });
 
-  it("does not pass URL or fake-IP DNS policy to the QQ upload body", async () => {
+  it("does not pass remote URLs through to the QQ upload body", async () => {
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
@@ -408,20 +408,13 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     );
 
     expectGuardedDownload("https://cdn.example.com/assets/photo.png");
-    expect(client["request"]).toHaveBeenCalledWith(
-      "token-1",
-      "POST",
-      expect.any(String),
-      expect.objectContaining({
-        file_data: MEDIA_BASE64,
-      }),
-      expect.any(Object),
-    );
     expect(client["request"]).not.toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.any(String),
-      expect.objectContaining({ url: expect.any(String) }),
+      expect.objectContaining({
+        url: "https://cdn.example.com/assets/photo.png",
+      }),
       expect.any(Object),
     );
   });

--- a/extensions/qqbot/src/engine/messaging/sender.test.ts
+++ b/extensions/qqbot/src/engine/messaging/sender.test.ts
@@ -1,0 +1,136 @@
+// Qqbot tests cover unified sender behavior.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChunkedMediaApi } from "../api/media-chunked.js";
+import { MediaApi } from "../api/media.js";
+import { MediaFileType, type MessageResponse, type UploadMediaResponse } from "../types.js";
+import { registerAccount, sendMedia } from "./sender.js";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+const readResponseWithLimitMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/response-limit-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/response-limit-runtime")>();
+  return {
+    ...actual,
+    readResponseWithLimit: readResponseWithLimitMock,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  };
+});
+
+const MEDIA_BYTES = Buffer.from("downloaded-media");
+const UPLOAD_RESPONSE: UploadMediaResponse = {
+  file_uuid: "uuid-1",
+  file_info: "file-info-1",
+  ttl: 3600,
+};
+const MESSAGE_RESPONSE: MessageResponse = {
+  id: "msg-1",
+  timestamp: 1781364036672,
+};
+
+const logger = {
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+};
+
+function mockGuardedDownload(): void {
+  fetchWithSsrFGuardMock.mockResolvedValueOnce({
+    response: new Response(MEDIA_BYTES),
+    release: vi.fn(async () => {}),
+  });
+  readResponseWithLimitMock.mockResolvedValueOnce(MEDIA_BYTES);
+}
+
+describe("qqbot unified sender media upload dispatch", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchWithSsrFGuardMock.mockReset();
+    readResponseWithLimitMock.mockReset();
+    logger.info.mockReset();
+    logger.error.mockReset();
+    logger.warn.mockReset();
+    logger.debug.mockReset();
+  });
+
+  it.each([
+    {
+      label: "image",
+      kind: "image" as const,
+      fileType: MediaFileType.IMAGE,
+      fileName: undefined,
+      content: "caption",
+      mediaUrl: "https://cdn.example.com/assets/photo.png",
+    },
+    {
+      label: "file",
+      kind: "file" as const,
+      fileType: MediaFileType.FILE,
+      fileName: "report.pdf",
+      content: undefined,
+      mediaUrl: "https://cdn.example.com/assets/report.pdf",
+    },
+  ])(
+    "uploads C2C URL $label bytes through chunked upload instead of one-shot file_data",
+    async ({ kind, fileType, fileName, content, mediaUrl }) => {
+      mockGuardedDownload();
+      const uploadMediaSpy = vi
+        .spyOn(MediaApi.prototype, "uploadMedia")
+        .mockResolvedValue(UPLOAD_RESPONSE);
+      const uploadChunkedSpy = vi
+        .spyOn(ChunkedMediaApi.prototype, "uploadChunked")
+        .mockResolvedValue(UPLOAD_RESPONSE);
+      const sendMediaMessageSpy = vi
+        .spyOn(MediaApi.prototype, "sendMediaMessage")
+        .mockResolvedValue(MESSAGE_RESPONSE);
+      const appId = `sender-test-${kind}`;
+      const creds = { appId, clientSecret: "client-secret" };
+      registerAccount(appId, { logger });
+
+      const result = await sendMedia({
+        target: { type: "c2c", id: "user-openid" },
+        creds,
+        kind,
+        source: { url: mediaUrl },
+        fileName,
+        content,
+      });
+
+      expect(result).toBe(MESSAGE_RESPONSE);
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
+        url: mediaUrl,
+        maxRedirects: 0,
+        signal: expect.any(AbortSignal),
+      });
+      expect(uploadMediaSpy).not.toHaveBeenCalled();
+      expect(uploadChunkedSpy).toHaveBeenCalledOnce();
+      expect(uploadChunkedSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope: "c2c",
+          targetId: "user-openid",
+          fileType,
+          creds,
+          fileName,
+        }),
+      );
+      const chunkedSource = uploadChunkedSpy.mock.calls[0]?.[0]?.source;
+      expect(chunkedSource).toMatchObject({ kind: "buffer", fileName });
+      expect(chunkedSource?.kind === "buffer" ? chunkedSource.buffer : undefined).toEqual(
+        MEDIA_BYTES,
+      );
+      expect(sendMediaMessageSpy).toHaveBeenCalledWith("c2c", "user-openid", "file-info-1", creds, {
+        msgId: undefined,
+        content: kind === "image" ? content : undefined,
+      });
+    },
+  );
+});

--- a/extensions/qqbot/src/engine/messaging/sender.test.ts
+++ b/extensions/qqbot/src/engine/messaging/sender.test.ts
@@ -1,8 +1,12 @@
 // Qqbot tests cover unified sender behavior.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChunkedMediaApi } from "../api/media-chunked.js";
 import { MediaApi } from "../api/media.js";
 import { MediaFileType, type MessageResponse, type UploadMediaResponse } from "../types.js";
+import type { RawMediaSource } from "./media-source.js";
 import { registerAccount, sendMedia } from "./sender.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
@@ -43,6 +47,16 @@ const logger = {
   debug: vi.fn(),
 };
 
+const tempDirs: string[] = [];
+
+async function createLocalMediaFile(name: string, bytes: Buffer): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "qqbot-sender-test-"));
+  tempDirs.push(dir);
+  const filePath = join(dir, name);
+  await writeFile(filePath, bytes);
+  return filePath;
+}
+
 function mockGuardedDownload(): void {
   fetchWithSsrFGuardMock.mockResolvedValueOnce({
     response: new Response(MEDIA_BYTES),
@@ -60,6 +74,10 @@ describe("qqbot unified sender media upload dispatch", () => {
     logger.error.mockReset();
     logger.warn.mockReset();
     logger.debug.mockReset();
+  });
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
   });
 
   it.each([
@@ -132,6 +150,84 @@ describe("qqbot unified sender media upload dispatch", () => {
         msgId: undefined,
         content: kind === "image" ? content : undefined,
       });
+    },
+  );
+
+  it.each([
+    {
+      label: "base64",
+      source: async (): Promise<RawMediaSource> => ({ base64: MEDIA_BYTES.toString("base64") }),
+      expectedSource: { kind: "buffer" as const, buffer: Buffer.from(MEDIA_BYTES) },
+    },
+    {
+      label: "buffer",
+      source: async (): Promise<RawMediaSource> => ({
+        buffer: Buffer.from(MEDIA_BYTES),
+        fileName: "buffer-proof.png",
+      }),
+      expectedSource: {
+        kind: "buffer" as const,
+        buffer: Buffer.from(MEDIA_BYTES),
+        fileName: "buffer-proof.png",
+      },
+    },
+    {
+      label: "localPath",
+      source: async (): Promise<RawMediaSource> => ({
+        localPath: await createLocalMediaFile("local-proof.png", MEDIA_BYTES),
+      }),
+      expectedSource: { kind: "localPath" as const },
+    },
+  ])(
+    "uploads C2C image $label byte sources through chunked upload instead of one-shot file_data",
+    async ({ source, expectedSource }) => {
+      const uploadMediaSpy = vi
+        .spyOn(MediaApi.prototype, "uploadMedia")
+        .mockResolvedValue(UPLOAD_RESPONSE);
+      const uploadChunkedSpy = vi
+        .spyOn(ChunkedMediaApi.prototype, "uploadChunked")
+        .mockResolvedValue(UPLOAD_RESPONSE);
+      vi.spyOn(MediaApi.prototype, "sendMediaMessage").mockResolvedValue(MESSAGE_RESPONSE);
+      const appId = `sender-test-${expectedSource.kind}`;
+      const creds = { appId, clientSecret: "client-secret" };
+      registerAccount(appId, { logger });
+
+      const result = await sendMedia({
+        target: { type: "c2c", id: "user-openid" },
+        creds,
+        kind: "image",
+        source: await source(),
+        content: "caption",
+      });
+
+      expect(result).toBe(MESSAGE_RESPONSE);
+      expect(uploadMediaSpy).not.toHaveBeenCalled();
+      expect(uploadChunkedSpy).toHaveBeenCalledOnce();
+      expect(uploadChunkedSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope: "c2c",
+          targetId: "user-openid",
+          fileType: MediaFileType.IMAGE,
+          creds,
+        }),
+      );
+      const chunkedSource = uploadChunkedSpy.mock.calls[0]?.[0]?.source;
+      expect(chunkedSource?.kind).toBe(expectedSource.kind);
+      if (expectedSource.kind === "buffer") {
+        expect(chunkedSource).toMatchObject({
+          kind: "buffer",
+          fileName: expectedSource.fileName,
+        });
+        expect(chunkedSource?.kind === "buffer" ? chunkedSource.buffer : undefined).toEqual(
+          expectedSource.buffer,
+        );
+      }
+      if (expectedSource.kind === "localPath") {
+        expect(chunkedSource).toMatchObject({
+          kind: "localPath",
+          size: MEDIA_BYTES.length,
+        });
+      }
     },
   );
 });

--- a/extensions/qqbot/src/engine/messaging/sender.test.ts
+++ b/extensions/qqbot/src/engine/messaging/sender.test.ts
@@ -106,11 +106,12 @@ describe("qqbot unified sender media upload dispatch", () => {
       });
 
       expect(result).toBe(MESSAGE_RESPONSE);
-      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
+      const guardedFetchCall = fetchWithSsrFGuardMock.mock.calls[0]?.[0];
+      expect(guardedFetchCall).toMatchObject({
         url: mediaUrl,
         maxRedirects: 0,
-        signal: expect.any(AbortSignal),
       });
+      expect(guardedFetchCall?.signal).toBeInstanceOf(AbortSignal);
       expect(uploadMediaSpy).not.toHaveBeenCalled();
       expect(uploadChunkedSpy).toHaveBeenCalledOnce();
       expect(uploadChunkedSpy).toHaveBeenCalledWith(

--- a/extensions/qqbot/src/engine/messaging/sender.ts
+++ b/extensions/qqbot/src/engine/messaging/sender.ts
@@ -634,6 +634,10 @@ async function sendMediaInternal(
   }
 }
 
+function requiresC2CChunkedUpload(scope: ChatScope, fileType: MediaFileType): boolean {
+  return scope === "c2c" && (fileType === MediaFileType.IMAGE || fileType === MediaFileType.FILE);
+}
+
 async function dispatchUpload(
   ctx: AccountContext,
   scope: ChatScope,
@@ -648,10 +652,7 @@ async function dispatchUpload(
       const buffer = await downloadDirectUploadUrl(source.url, {
         maxBytes: getMaxUploadSize(fileType),
       });
-      if (
-        scope === "c2c" &&
-        (fileType === MediaFileType.IMAGE || fileType === MediaFileType.FILE)
-      ) {
+      if (requiresC2CChunkedUpload(scope, fileType)) {
         return ctx.chunkedMediaApi.uploadChunked({
           scope,
           targetId,
@@ -677,12 +678,22 @@ async function dispatchUpload(
       });
     }
     case "base64":
+      if (requiresC2CChunkedUpload(scope, fileType)) {
+        return ctx.chunkedMediaApi.uploadChunked({
+          scope,
+          targetId,
+          fileType,
+          source: { kind: "buffer", buffer: Buffer.from(source.data, "base64"), fileName },
+          creds,
+          fileName,
+        });
+      }
       return ctx.mediaApi.uploadMedia(scope, targetId, fileType, creds, {
         fileData: source.data,
         fileName,
       });
     case "localPath":
-      if (source.size >= LARGE_FILE_THRESHOLD) {
+      if (requiresC2CChunkedUpload(scope, fileType) || source.size >= LARGE_FILE_THRESHOLD) {
         return ctx.chunkedMediaApi.uploadChunked({
           scope,
           targetId,
@@ -703,7 +714,10 @@ async function dispatchUpload(
         fileName,
       });
     case "buffer":
-      if (source.buffer.length >= LARGE_FILE_THRESHOLD) {
+      if (
+        requiresC2CChunkedUpload(scope, fileType) ||
+        source.buffer.length >= LARGE_FILE_THRESHOLD
+      ) {
         return ctx.chunkedMediaApi.uploadChunked({
           scope,
           targetId,

--- a/extensions/qqbot/src/engine/messaging/sender.ts
+++ b/extensions/qqbot/src/engine/messaging/sender.ts
@@ -634,18 +634,6 @@ async function sendMediaInternal(
   }
 }
 
-/**
- * Upload a {@link MediaSource} via the one-shot or chunked path, chosen by
- * size + kind.
- *
- * Routing rules (kept here as the single source of truth so callers need
- * not know which endpoint was used):
- *
- * - `url` / `base64`: always one-shot — the server accepts these directly
- *   and the chunked endpoint has no representation for them.
- * - `localPath` / `buffer` with `size >= LARGE_FILE_THRESHOLD`: chunked.
- * - Everything else: one-shot.
- */
 async function dispatchUpload(
   ctx: AccountContext,
   scope: ChatScope,
@@ -660,6 +648,19 @@ async function dispatchUpload(
       const buffer = await downloadDirectUploadUrl(source.url, {
         maxBytes: getMaxUploadSize(fileType),
       });
+      if (
+        scope === "c2c" &&
+        (fileType === MediaFileType.IMAGE || fileType === MediaFileType.FILE)
+      ) {
+        return ctx.chunkedMediaApi.uploadChunked({
+          scope,
+          targetId,
+          fileType,
+          source: { kind: "buffer", buffer, fileName },
+          creds,
+          fileName,
+        });
+      }
       if (buffer.length >= LARGE_FILE_THRESHOLD) {
         return ctx.chunkedMediaApi.uploadChunked({
           scope,


### PR DESCRIPTION
## Summary

- Fix classification: root-cause fix.
- Root cause: QQBot C2C image/file byte sources were routed through the one-shot `/files` `file_data` upload contract, while QQ's C2C image/file path accepts these bytes through the chunked upload contract; the channel adapter also normalized lower-layer QQ upload failures into empty successful receipts.
- Why this is root-cause fix: the unified sender now routes every C2C image/file byte source covered by the issue shape — URL downloads, base64/data sources, buffers, and local files — through the existing `upload_prepare -> COS PUT -> upload_part_finish -> /files` chunked contract before `/messages`, so the failing upload contract is no longer used for C2C image/file delivery. The adapter also preserves the delivery invariant that a successful generic send must include a QQ platform message id.
- Why it matters / User impact: users sending image or file content to QQ private chats no longer get a misleading successful OpenClaw result while QQ rejected the upload with HTTP 400.
- What did NOT change: this PR only changes QQBot C2C image/file upload routing and generic QQBot send error propagation; group media, voice/video routing, public config, schema, migrations, and channel APIs remain unchanged.
- Architecture / source-of-truth check: the source-of-truth boundary is the existing QQBot unified sender dispatch and QQ upload contract selection; no public API/config/schema contract is expanded, and SSRF validation remains at OpenClaw's guarded URL downloader before any QQ upload. Same-contract related open PR scan found no open PR matching QQBot C2C media Bad Request / upload_prepare / image-file Bad Request queries.
- Patch quality notes: the diff is intentionally limited to QQBot sender routing, adapter result normalization, and regression tests; no unrelated refactor or fallback path was added.
- Review focus: the C2C image/file branch in the unified sender, especially the URL/base64/buffer/localPath source routing, and the generic message adapter's error/empty-receipt handling.

## Linked context

Closes #92246

Related #92246

Was this requested by a maintainer or owner? No maintainer request found; this follows the issue report and reproduces the reported C2C image/file failure path.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: QQBot C2C image/file sends through the generic message path returned QQ API HTTP 400 during media upload while OpenClaw could still surface an empty successful receipt.
- Real environment tested: a live QQBot app and a real C2C private-chat target captured from `C2C_MESSAGE_CREATE`; credentials, target openid, token, `file_info`, and COS presigned URLs were redacted.
- Exact steps or command run after this patch:
  1. Start QQBot gateway capture, receive a private C2C message from the tester, and capture the C2C target from the gateway event.
  2. Use the fixed branch's QQBot unified sender to send a URL image to that C2C target.
  3. Use the fixed branch's QQBot unified sender to send a URL file to that C2C target.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

  Live QQBot C2C send proof, redacted:

  ```text
  QQBot live proof runner started {"mode":"send-after","appId":"1904…7531"}
  QQBot live proof: sending fixed-branch C2C URL image via unified sender {"target":"qqbot:c2c:<redacted-c2c-openid>","imageUrl":"https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text.png"}
  [qqbot:chunked-upload] Start: file=file size=90.0KB type=1
  [qqbot:api] >>> POST https://api.sgroup.qq.com/v2/users/<redacted-c2c-openid>/upload_prepare (timeout: 120000ms)
  [qqbot:api] <<< Status: 200 OK | TraceId: 8c4a5a8c29c0f611149737cae1fa84ed
  [qqbot:chunked-upload] prepared: upload_id=upload_1781369239324697480_817037 block=90.0KB parts=1 concurrency=1
  [qqbot:chunked-upload] PUT part 1/1 OK (665ms ETag="c5032c050540994cd223c6b968d41dce" requestId=NmEyZDg5OTdfNjJiNjNlMDlfM2UwYV9hM2U0MDRl)
  [qqbot:api] >>> POST https://api.sgroup.qq.com/v2/users/<redacted-c2c-openid>/upload_part_finish (timeout: 120000ms)
  [qqbot:api] <<< Status: 200 OK | TraceId: 172a96e34f0c05d2311844a610bfc192
  [qqbot:api] >>> POST https://api.sgroup.qq.com/v2/users/<redacted-c2c-openid>/files (timeout: 120000ms)
  [qqbot:api] <<< Status: 200 OK | TraceId: 064738ff19dfd634e6adff4c5f48b794
  [qqbot:api] >>> POST https://api.sgroup.qq.com/v2/users/<redacted-c2c-openid>/messages (timeout: 30000ms)
  [qqbot:api] <<< Status: 200 OK | TraceId: b7b68978da7a43206c606728bc6cd1db
  QQBot live proof: image delivered {"messageId":"ROBOT1.0_SXtbE0cfdw9aiRPIzChuFsts3EWynm.-tswmoKvO4fYxqzrtv9K41PPYD.TG9JA-5knGWIyA0hFu7MXIaP-0tw!!"}

  QQBot live proof: sending fixed-branch C2C URL file via unified sender {"target":"qqbot:c2c:<redacted-c2c-openid>","fileUrl":"https://raw.githubusercontent.com/openclaw/openclaw/main/scripts/codespell-ignore.txt"}
  [qqbot:chunked-upload] Start: file=openclaw-92246-live-proof.txt size=82B type=4
  [qqbot:api] >>> POST https://api.sgroup.qq.com/v2/users/<redacted-c2c-openid>/upload_prepare (timeout: 120000ms)
  [qqbot:api] <<< Status: 200 OK | TraceId: 9e0bef2ab3f2385c224c8cccbee48740
  [qqbot:chunked-upload] PUT part 1/1 OK (354ms ETag="31a040cdd946e9588eebcd0045d2e400" requestId=NmEyZDg5OWRfYzY4ZTI3MDlfNTgyMV8xMmMyZmFhOQ==)
  [qqbot:api] >>> POST https://api.sgroup.qq.com/v2/users/<redacted-c2c-openid>/upload_part_finish (timeout: 120000ms)
  [qqbot:api] <<< Status: 200 OK | TraceId: ba3885e777563e6361a793c15961afe0
  [qqbot:api] >>> POST https://api.sgroup.qq.com/v2/users/<redacted-c2c-openid>/files (timeout: 120000ms)
  [qqbot:api] <<< Status: 200 OK | TraceId: e3cb27e84fd28609eaa569505eac18ad
  [qqbot:api] >>> POST https://api.sgroup.qq.com/v2/users/<redacted-c2c-openid>/messages (timeout: 30000ms)
  [qqbot:api] <<< Status: 200 OK | TraceId: 637a4895101c5ea37e0e21cec1ed997c
  QQBot live proof: file delivered {"messageId":"ROBOT1.0_SXtbE0cfdw9aiRPIzChuFh6tpXoB-GQCtfGhwebmWhkTli-JKMYD81YPMRU9qIDB5knGWIyA0hFu7MXIaP-0tw!!"}
  ```

- Observed result after fix: both live C2C URL image and URL file sends completed the chunked upload sequence and returned non-empty QQ message ids from `/messages`.
- What was not tested: group media sends, voice/video media sends, and QQ client UI screenshot capture from this environment.
- Proof limitations or environment constraints: I could verify the live QQBot API path and returned message ids, but I do not have direct access to the tester's QQ client UI in this coding environment, so I did not attach a QQ client screenshot here. The non-URL C2C byte-source extension is covered by focused sender regressions because the same chunked uploader contract is exercised by the live URL proof.
- Before evidence (optional but encouraged): the issue report shows the previous C2C media upload path failing with `API Error [/v2/users/{openid}/files]: Bad Request` / HTTP 400. The new sender regression failed before the expanded implementation for C2C base64, buffer, and localPath image sources because each still called `MediaApi.uploadMedia` one-shot `file_data`; the adapter regression also failed before the implementation because a lower-layer QQ upload error could resolve as an empty successful receipt.

## Tests and validation

Which commands did you run?

```text
Validation `sender-byte-sources-red` (expected fail before expansion, exit_code=1):
Test Files  1 failed (1)
Tests       3 failed | 2 passed (5)
Failure: C2C image base64, buffer, and localPath sources still called MediaApi.uploadMedia one-shot file_data.

Validation `sender-byte-sources-green` (pass, exit_code=0):
Test Files  1 passed (1)
Tests       5 passed (5)

Validation `qqbot-focused-all-sources` (pass, exit_code=0):
Test Files  3 passed (3)
Tests       27 passed (27)

Validation `extensions-test-typecheck-all-sources` (pass, exit_code=0):
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo

Validation `check-lint-all-sources` (pass, exit_code=0):
node scripts/run-oxlint-shards.mjs --threads=8

Validation `bundled-extension-lint-all-sources` (pass, exit_code=0):
node scripts/run-bundled-extension-oxlint.mjs
```

What regression coverage was added or updated?

- Added sender-level coverage proving C2C URL image/file bytes are fetched through the guarded URL downloader and then uploaded with `ChunkedMediaApi.uploadChunked`, not `MediaApi.uploadMedia` one-shot `file_data`.
- Added sender-level coverage proving C2C base64, buffer, and localPath image byte sources also use `ChunkedMediaApi.uploadChunked` instead of the one-shot `file_data` path.
- Added generic message adapter coverage proving media sends reject when the QQ outbound layer returns an API error.
- Kept low-level media API coverage that remote URLs are not passed through to QQ upload bodies.

What failed before this fix, if known?

- The original sender regression failed before the implementation because C2C URL image/file sends used the one-shot `file_data` upload path.
- The expanded sender regression failed before the follow-up implementation because C2C base64, buffer, and localPath image sources still used the one-shot `file_data` upload path.
- The adapter regression failed before the implementation because a lower-layer QQ upload error could resolve as an empty successful receipt.
- Remote CI `check-lint` and `check-additional-extension-bundled` failed on the no-op `String(...)` conversion in the QQBot channel adapter; the conversion was removed and both corresponding local lint commands now pass.

If no test was added, why not? Regression tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. C2C image/file sends should now succeed via QQ's chunked upload path for URL/base64/buffer/localPath byte sources, and failed QQ media sends now reject instead of returning an empty success.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, network behavior changes narrowly for QQBot C2C image/file sends: bytes now use the existing chunked upload flow. Remote URL fetches still go through the existing SSRF-guarded downloader, local files still go through the existing safe-open path, and this PR does not expose secrets or add config.

What is the highest-risk area?

The highest-risk area is QQBot media upload routing for C2C image/file byte sources.

How is that risk mitigated?

The change is scoped to C2C image/file sources, reuses the existing chunked upload implementation, preserves guarded URL download and safe local-file handling, adds focused regression tests for URL/base64/buffer/localPath sources, passes typecheck/lint, and was verified against a live QQBot C2C target for URL image and URL file delivery.

## Current review state

What is the next action?

Ready for maintainer review after updated CI settles.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on updated CI and maintainer review. A QQ client UI screenshot can be added later if the tester shares one, but live QQBot API proof for image and file delivery is included above.

Which bot or reviewer comments were addressed?

- RF-001 (`status: waiting on author` label): author-side follow-up was completed in this update; the label should be cleared by maintainer/bot once updated checks/review state are accepted.
- RF-002 (P1 source coverage): fixed by routing C2C image/file base64, buffer, and localPath byte sources through chunked upload instead of one-shot `file_data`.
- RF-003 (P1 failing CI checks): fixed by removing the redundant `String(...)` conversion and re-running the two corresponding local lint commands successfully.
- RF-004 (P2 maintainer scope concern): addressed by expanding the PR from URL-only to all reported C2C image/file byte-source shapes while keeping group media/config/schema/API out of scope.
- RF-005 (P2 `sender.ts` source branch): fixed in the unified sender dispatch; new regressions cover URL/base64/buffer/localPath C2C image/file routing through the chunked uploader.
- RF-006 (P3 no-op conversion): fixed in the QQBot channel adapter.
