### PR TITLE
fix(docker): seed importer prod deps before offline prune

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ FROM build AS runtime-assets
 ARG OPENCLAW_EXTENSIONS
 ARG OPENCLAW_BUNDLED_PLUGIN_DIR
 # BuildKit cache mounts are not part of cached layers; seed tarballs for the
-# installed prod graph in the same step that runs offline prune.
+# lockfile prod graph in the same step that runs offline prune.
 RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
     pnpm list --prod --depth Infinity --json | node scripts/list-prod-store-packages.mjs | xargs -r pnpm store add && \
     CI=true pnpm prune --prod \

--- a/scripts/list-prod-store-packages.mjs
+++ b/scripts/list-prod-store-packages.mjs
@@ -144,10 +144,21 @@ function addSnapshotClosure(lockfile) {
   }
 }
 
+function addImporterProdDeps(lockfile) {
+  for (const importer of Object.values(lockfile?.importers ?? {})) {
+    for (const deps of [importer.dependencies, importer.optionalDependencies]) {
+      for (const [name, dep] of Object.entries(deps ?? {})) {
+        addSpec(lockfile, packageSpec(name, typeof dep === "string" ? dep : dep?.version));
+      }
+    }
+  }
+}
+
 const lockfile = readLockfile();
 for (const root of roots) {
   visitListNode(lockfile, root);
 }
+addImporterProdDeps(lockfile);
 addSnapshotClosure(lockfile);
 
 process.stdout.write([...specs].toSorted((a, b) => a.localeCompare(b)).join("\n"));

--- a/test/scripts/list-prod-store-packages.test.ts
+++ b/test/scripts/list-prod-store-packages.test.ts
@@ -101,6 +101,47 @@ describe("list-prod-store-packages", () => {
     expect(result.stdout).toBe("source-map-support@0.5.21\nsource-map@0.6.1");
   });
 
+  it("adds prod importer dependencies missing from pnpm list output", () => {
+    const cwd = makeTempRepoRoot(tempDirs, "openclaw-prod-store-packages-");
+    writeFileSync(
+      join(cwd, "pnpm-lock.yaml"),
+      [
+        "lockfileVersion: '10.0'",
+        "",
+        "importers:",
+        "  extensions/bonjour:",
+        "    dependencies:",
+        "      '@homebridge/ciao':",
+        "        specifier: 1.3.9",
+        "        version: 1.3.9",
+        "",
+        "packages:",
+        "  '@homebridge/ciao@1.3.9':",
+        "    resolution: {integrity: sha512-test}",
+        "  source-map-support@0.5.21:",
+        "    resolution: {integrity: sha512-test}",
+        "  source-map@0.6.1:",
+        "    resolution: {integrity: sha512-test}",
+        "",
+        "snapshots:",
+        "  '@homebridge/ciao@1.3.9':",
+        "    dependencies:",
+        "      source-map-support: 0.5.21",
+        "  source-map-support@0.5.21:",
+        "    dependencies:",
+        "      source-map: 0.6.1",
+        "  source-map@0.6.1: {}",
+        "",
+      ].join("\n"),
+    );
+    const result = runListProdStorePackages({ dependencies: {} }, cwd);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(
+      "@homebridge/ciao@1.3.9\nsource-map-support@0.5.21\nsource-map@0.6.1",
+    );
+  });
+
   it("adds target optional dependencies from peer-resolved lockfile snapshots", () => {
     const cwd = makeTempRepoRoot(tempDirs, "openclaw-prod-store-packages-");
     const platformPackages = [


### PR DESCRIPTION
## Summary
- seed Docker offline-prune package list from pnpm-lock importers before walking snapshot closures
- add regression coverage for importer-only prod deps missing from pnpm list output
- update Dockerfile comment to match lockfile-based warmup

## Tests
- git diff --check
- node scripts/run-vitest.mjs run test/scripts/list-prod-store-packages.test.ts
- helper proof: empty pnpm-list input includes @homebridge/ciao@1.3.9, source-map-support@0.5.21, source-map@0.6.1
- PR CI pnpm-store-warmup passed: https://github.com/openclaw/openclaw/actions/runs/27473567635/job/81208715094

## Real behavior proof
After-fix evidence from a real checkout at `/root/repos/openclaw-docker-image-fix`:

```console
$ printf %s '{"dependencies":{}}' | node scripts/list-prod-store-packages.mjs | rg '^(@homebridge/ciao@1\\.3\\.9|source-map-support@0\\.5\\.21|source-map@0\\.6\\.1)$'\n@homebridge/ciao@1.3.9\nsource-map-support@0.5.21\nsource-map@0.6.1\n\n$ node scripts/run-vitest.mjs run test/scripts/list-prod-store-packages.test.ts\nTest Files  1 passed (1)\nTests  7 passed (7)\n```\n\nThe PR CI `pnpm-store-warmup` job also passed after the fix, exercising the repository dependency warmup path used before Docker/release checks.\n\n## Notes\n- Local Docker buildx is unavailable, so Docker Release CI remains the end-to-end confirmation for full image publishing.