### PR TITLE
fix(diagnostics): keep recovery scheduling out of the stuck-session warning backoff

### DIFF
--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -468,8 +468,9 @@ describe("stuck session diagnostics threshold", () => {
       );
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       vi.advanceTimersByTime(91_000);
+      // One warning emitted (60s); the 90s tick is throttled but still recovers.
       expect(events).toHaveLength(1);
-      expect(recoverStuckSession).toHaveBeenCalledTimes(1);
+      expect(recoverStuckSession).toHaveBeenCalledTimes(2);
 
       vi.advanceTimersByTime(31_000);
     } finally {
@@ -477,7 +478,52 @@ describe("stuck session diagnostics threshold", () => {
     }
 
     expect(events.map((event) => event.ageMs)).toEqual([60_000, 120_000]);
+    // Recovery is requested on every heartbeat tick the session stays stuck,
+    // including the throttled tick at 90s, so it must outpace the warn backoff.
+    expect(recoverStuckSession).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps scheduling recovery for a recovery-eligible stuck session while warnings are throttled", () => {
+    const stuckEvents: DiagnosticEventPayload[] = [];
+    const recoveryRequests: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const unsubscribe = onDiagnosticEvent((event) => {
+      if (event.type === "session.stuck") {
+        stuckEvents.push(event);
+      } else if (event.type === "session.recovery.requested") {
+        recoveryRequests.push(event);
+      }
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+      // First warn tick (60s): emit the stuck warning and request recovery once.
+      vi.advanceTimersByTime(61_000);
+      expect(stuckEvents).toHaveLength(1);
+      expect(recoverStuckSession).toHaveBeenCalledTimes(1);
+
+      // Backoff tick (90s): the next warn age is 120s, so the warning is
+      // throttled. Recovery must still be scheduled because the session is
+      // recovery-eligible — the warning backoff must not gate recovery.
+      vi.advanceTimersByTime(30_000);
+    } finally {
+      unsubscribe();
+    }
+
+    // Warning stays throttled: still only the single 60s warning.
+    expect(stuckEvents).toHaveLength(1);
+    // Recovery was not suppressed by the warning backoff on the 90s tick.
     expect(recoverStuckSession).toHaveBeenCalledTimes(2);
+    expect(recoveryRequests).toHaveLength(2);
   });
 
   it("reports active sessions as stalled instead of stuck when active work stops progressing", () => {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -484,8 +484,8 @@ describe("stuck session diagnostics threshold", () => {
   });
 
   it("keeps scheduling recovery for a recovery-eligible stuck session while warnings are throttled", () => {
-    const stuckEvents: DiagnosticEventPayload[] = [];
-    const recoveryRequests: DiagnosticEventPayload[] = [];
+    const stuckEvents: Array<{ ageMs?: number }> = [];
+    const recoveryRequests: Array<{ ageMs?: number }> = [];
     const recoverStuckSession = vi.fn();
     const unsubscribe = onDiagnosticEvent((event) => {
       if (event.type === "session.stuck") {
@@ -521,9 +521,11 @@ describe("stuck session diagnostics threshold", () => {
 
     // Warning stays throttled: still only the single 60s warning.
     expect(stuckEvents).toHaveLength(1);
+    expect(stuckEvents.map((event) => event.ageMs)).toEqual([60_000]);
     // Recovery was not suppressed by the warning backoff on the 90s tick.
     expect(recoverStuckSession).toHaveBeenCalledTimes(2);
     expect(recoveryRequests).toHaveLength(2);
+    expect(recoveryRequests.map((event) => event.ageMs)).toEqual([60_000, 90_000]);
   });
 
   it("reports active sessions as stalled instead of stuck when active work stops progressing", () => {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1022,15 +1022,23 @@ export function logSessionAttention(
       stuckSessionAbortMs:
         params.abortThresholdMs ?? resolveStalledEmbeddedRunAbortMs(params.thresholdMs),
     });
+  // The warning backoff throttles repeated log lines/events only. It must never
+  // gate recovery: a recovery-eligible session has to return its classification
+  // so the heartbeat can still schedule recovery on every tick.
+  let suppressWarning = false;
   if (classification.eventType === "session.stuck") {
     const nextWarnAgeMs =
       state.lastStuckWarnAgeMs === undefined
         ? params.thresholdMs
         : Math.max(state.lastStuckWarnAgeMs + params.thresholdMs, state.lastStuckWarnAgeMs * 2);
     if (params.ageMs < nextWarnAgeMs) {
-      return undefined;
+      if (!recoveryEligible) {
+        return undefined;
+      }
+      suppressWarning = true;
+    } else {
+      state.lastStuckWarnAgeMs = params.ageMs;
     }
-    state.lastStuckWarnAgeMs = params.ageMs;
   }
   if (classification.eventType === "session.long_running") {
     const nextWarnAgeMs =
@@ -1041,9 +1049,18 @@ export function logSessionAttention(
             state.lastLongRunningWarnAgeMs * 2,
           );
     if (params.ageMs < nextWarnAgeMs) {
-      return undefined;
+      if (!recoveryEligible) {
+        return undefined;
+      }
+      suppressWarning = true;
+    } else {
+      state.lastLongRunningWarnAgeMs = params.ageMs;
     }
-    state.lastLongRunningWarnAgeMs = params.ageMs;
+  }
+  if (suppressWarning) {
+    // Throttled warning, but recovery-eligible: skip the log/event and return
+    // the classification so the heartbeat can drive recovery.
+    return classification;
   }
   const label =
     classification.eventType === "session.stuck"


### PR DESCRIPTION
## What

Diagnostic stuck-session recovery is no longer gated by the warning-backoff
throttle. `logSessionAttention` previously returned `undefined` whenever a
`session.stuck` or `session.long_running` classification fell inside its
exponential warning-backoff window. The heartbeat only schedules recovery from
a returned classification, so throttling the *warning* also throttled
*recovery*: a recovery-eligible lane could sit unrecovered until the next warn
interval (which doubles each time).

This change separates the two concerns. The warning backoff still suppresses
the repeated log line and diagnostic event, but a recovery-eligible
classification is now always returned so the heartbeat can call
`requestStuckSessionRecovery` on every tick. In-flight recovery requests remain
de-duplicated by the recovery coordinator, so this does not add redundant abort
work — it only removes the delay before the first (and each subsequent) recovery
attempt.

## Why

Reported in #92742: a stale active run blocked the `agent:main:direct` lane for
~17 minutes. Diagnostics detected the stuck session, but the same warning
backoff path suppressed the follow-up recovery checks, so the lane was not
released promptly even though the stale work was recoverable.

Root cause (`src/logging/diagnostic.ts`):

- `logSessionAttention` computes `recoveryEligible`, then for `session.stuck`
  and `session.long_running` does `if (params.ageMs < nextWarnAgeMs) return undefined;`
  *before* returning the classification.
- The heartbeat schedules recovery only when `logSessionAttention` returns a
  classification (`classification?.recoveryEligible` / `isActiveAbortRecoveryEligible`),
  so a throttled warning silently throttles recovery too.

## Change

- `src/logging/diagnostic.ts`: within the warning-backoff window, return early
  only when the session is **not** recovery-eligible. When it is recovery-eligible,
  suppress just the warning log + event and still return the classification.
  The `lastStuckWarnAgeMs` / `lastLongRunningWarnAgeMs` markers now advance only
  when a warning is actually emitted, so the backoff cadence is preserved.
- `src/logging/diagnostic.test.ts`: add a regression test proving recovery is
  still scheduled on a throttled tick, and update the existing backoff test
  (which had encoded the old coupling) to assert recovery now runs each tick
  while warnings stay throttled.

Scope is intentionally narrow. The QQ fast-ack / quick-reply path and the
hook-process watchdog mentioned in the issue are separate follow-ups, as the
triage review also noted.

## Real behavior proof

**Behavior or issue addressed:** Recovery-eligible stuck / long-running sessions
were not being recovered while the diagnostic warning backoff was active, so a
blocked lane stayed wedged until the next (exponentially growing) warn interval —
the ~17 minute direct-lane stall reported in #92742.

**Real environment tested:** Local OpenClaw checkout at current `main`
(`45e36a24`), Node v24.14.0, pnpm 11.2.2, macOS arm64. I drove the real
diagnostic runtime — `logSessionAttention` → `requestStuckSessionRecovery`, the
exact calls the 30s diagnostic heartbeat makes (`src/logging/diagnostic.ts`
~L1281–1303) — over a recovery-eligible stuck `agent:main:direct` session, with
the real diagnostic subsystem logger and event bus live. Only the terminal
`recoverStuckSession` side effect is observed (logged) so the lane-release
request is visible.

**Exact steps or command run after this patch:** ran a throwaway `tsx` script
that imports the real `src/logging/diagnostic.ts`, registers a stuck
`agent:main:direct` session, and replays three heartbeat ticks at ageMs = 60s,
90s (inside the warn-backoff window), and 120s — feeding each
`logSessionAttention` result into `requestStuckSessionRecovery` exactly like the
heartbeat loop. Invoked with `node` via `./node_modules/.bin/tsx`.

**Evidence after fix:** copied live terminal output (real `[diagnostic]`
subsystem warn lines, real emitted events, and the real recovery invocations).
On the throttled 90s tick the warn line/event stay suppressed but recovery still
fires:

```
== heartbeat tick: ageMs=60s ==
  [diagnostic] stuck session: sessionId=qq-direct-1 sessionKey=agent:main:direct age=60s reason=stale_session_state recovery=checking
  [event] session.stuck ageMs=60000
  [event] session.recovery.requested ageMs=60000
  [recover] requestStuckSessionRecovery invoked #1 (ageMs=60000)

== heartbeat tick: ageMs=90s ==          # inside warn backoff (next warn age = 120s)
  [event] session.recovery.requested ageMs=90000
  [recover] requestStuckSessionRecovery invoked #2 (ageMs=90000)

== heartbeat tick: ageMs=120s ==
  [diagnostic] stuck session: sessionId=qq-direct-1 ... age=120s recovery=checking
  [event] session.stuck ageMs=120000
  [recover] requestStuckSessionRecovery invoked #3 (ageMs=120000)

TOTAL recovery invocations across the 3 ticks: 3
```

Same script on **unmodified `main`** (fix reverted with `git checkout HEAD~1 -- src/logging/diagnostic.ts`) — the 90s backoff tick drops recovery entirely:

```
== heartbeat tick: ageMs=90s ==
  (no classification returned -> recovery NOT scheduled)
...
TOTAL recovery invocations across the 3 ticks: 2
```

**Observed result after fix:** on the throttled 90s heartbeat tick the
`[diagnostic] stuck session` warn line and `session.stuck` event stay suppressed
(still one warning), but `session.recovery.requested` fires and the
`recoverStuckSession` lane-release request is invoked. Recovery invocations go
from 2 (main, recovery skipped during backoff) to 3 (every tick). With the real
exponential backoff the skipped window keeps doubling, which is what stretched
the reported lane stall to ~17 minutes; the fix releases the lane on the next
~30s heartbeat instead.

Targeted suites (issue acceptance criteria) and repo checks are also green:

```
$ node scripts/run-vitest.mjs src/logging/diagnostic.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
 Test Files  2 passed (2)   Tests  91 passed (91)
$ node scripts/run-vitest.mjs --config test/vitest/vitest.logging.config.ts
 Test Files  29 passed (29) Tests  360 passed (360)
$ pnpm tsgo:core && pnpm tsgo:core:test   # exit 0
```

**What was not tested:** I did not stand up a live QQ gateway to replay the
original end-to-end 17-minute incident (no QQ environment available). The defect
and fix are reproduced at the diagnostic heartbeat level above, exercising the
real `logSessionAttention` → recovery-scheduling control flow that failed.

Fixes #92742
