### PR TITLE
fix(matrix): enforce minimum on numeric CLI options (timeout >= 1, sync-limit >= 0)

### DIFF
--- a/extensions/matrix/src/cli.test.ts
+++ b/extensions/matrix/src/cli.test.ts
@@ -401,6 +401,20 @@ describe("matrix CLI verification commands", () => {
     expect(runMatrixSelfVerificationMock).not.toHaveBeenCalled();
   });
 
+  it("rejects non-positive Matrix self-verification timeout values", async () => {
+    const program = buildProgram();
+
+    await program.parseAsync(["matrix", "verify", "self", "--timeout-ms", "-1"], {
+      from: "user",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      "Self-verification failed: --timeout-ms must be >= 1, got -1",
+    );
+    expect(runMatrixSelfVerificationMock).not.toHaveBeenCalled();
+  });
+
   it("requests Matrix self-verification and prints the follow-up SAS commands", async () => {
     requestMatrixVerificationMock.mockResolvedValue(
       mockMatrixVerificationSummary({

--- a/extensions/matrix/src/cli.ts
+++ b/extensions/matrix/src/cli.ts
@@ -232,7 +232,11 @@ function configureCliLogMode(verbose: boolean): void {
   setMatrixSdkConsoleLogging(verbose);
 }
 
-function parseOptionalInt(value: string | undefined, fieldName: string): number | undefined {
+function parseOptionalInt(
+  value: string | undefined,
+  fieldName: string,
+  opts?: { min?: number },
+): number | undefined {
   const trimmed = value?.trim();
   if (!trimmed) {
     return undefined;
@@ -243,6 +247,9 @@ function parseOptionalInt(value: string | undefined, fieldName: string): number 
   const parsed = parseStrictInteger(trimmed);
   if (parsed === undefined) {
     throw new Error(`${fieldName} must be an integer`);
+  }
+  if (opts?.min !== undefined && parsed < opts.min) {
+    throw new Error(`${fieldName} must be >= ${opts.min}, got ${parsed}`);
   }
   return parsed;
 }
@@ -305,7 +312,9 @@ async function addMatrixAccount(params: {
     accessToken: params.accessToken,
     password: params.password,
     deviceName: params.deviceName,
-    initialSyncLimit: parseOptionalInt(params.initialSyncLimit, "--initial-sync-limit"),
+    initialSyncLimit: parseOptionalInt(params.initialSyncLimit, "--initial-sync-limit", {
+      min: 0,
+    }),
     useEnv: params.useEnv === true,
   };
   const accountId =
@@ -1167,7 +1176,7 @@ async function runMatrixCliSelfVerificationCommand(
       await runMatrixSelfVerification({
         accountId,
         cfg,
-        timeoutMs: parseOptionalInt(options.timeoutMs, "--timeout-ms"),
+        timeoutMs: parseOptionalInt(options.timeoutMs, "--timeout-ms", { min: 1 }),
         onRequested: (summary) => {
           printAccountLabel(accountId);
           printMatrixVerificationSummary(summary);


### PR DESCRIPTION
## Summary

`parseOptionalInt` accepted negative integers. `--timeout-ms` accepted `-1` and `--initial-sync-limit` accepted `-1`, both violating their runtime domain contracts (timeout must be positive, sync-limit must be non-negative).

## Fix

- `parseOptionalInt` gains an optional `min` constraint
- `--timeout-ms` enforces `min: 1`
- `--initial-sync-limit` enforces `min: 0`
- Added regression test for negative timeout

## Files changed
- `extensions/matrix/src/cli.ts` — `parseOptionalInt` min constraint, two call-site updates
- `extensions/matrix/src/cli.test.ts` — new regression test

## Testing

```
node scripts/run-vitest.mjs extensions/matrix/src/cli.test.ts
```

All 52 tests pass (51 existing + 1 new).

Closes #92482