### PR TITLE
fix(mcp): reject blocked stdio env keys at save time instead of flooding journal

### DIFF
--- a/src/config/mcp-config.test.ts
+++ b/src/config/mcp-config.test.ts
@@ -209,4 +209,23 @@ describe("config mcp config", () => {
       });
     });
   });
+
+  it("rejects blocked stdio env keys at save time", async () => {
+    await withMcpConfigHome({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "my_server",
+        server: {
+          command: "/path/to/python",
+          args: ["server.py"],
+          env: { PYTHONPATH: "/workspace", PYTHONUNBUFFERED: "1" },
+        },
+      });
+
+      expect(setResult.ok).toBe(false);
+      if (!setResult.ok) {
+        expect(setResult.error).toContain("blocked stdio keys");
+        expect(setResult.error).toContain("PYTHONPATH");
+      }
+    });
+  });
 });

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -1,3 +1,4 @@
+import { resolveStdioMcpServerLaunchConfig } from "../agents/mcp-stdio.js";
 // Normalizes MCP server config for runtime launch and validation.
 import { isRecord } from "../utils.js";
 import { readSourceConfigSnapshot } from "./io.js";
@@ -208,6 +209,27 @@ export async function setConfiguredMcpServer(params: {
   const next = structuredClone(loaded.config);
   const servers = normalizeConfiguredMcpServers(next.mcp?.servers);
   servers[name] = canonicalizeConfiguredMcpServer(params.server);
+
+  // Reject blocked stdio env keys at save time to avoid per-spawn journal floods.
+  const rawEnv =
+    isRecord(params.server) && isRecord(params.server.env)
+      ? (params.server.env as Record<string, unknown>)
+      : undefined;
+  if (rawEnv && Object.keys(rawEnv).length > 0) {
+    const resolved = resolveStdioMcpServerLaunchConfig(params.server);
+    if (resolved.ok) {
+      const safeEnvKeys = resolved.config.env ? Object.keys(resolved.config.env) : [];
+      const blockedKeys = Object.keys(rawEnv).filter((k) => !safeEnvKeys.includes(k));
+      if (blockedKeys.length > 0) {
+        return {
+          ok: false,
+          path: "",
+          error: `MCP server env contains blocked stdio keys: ${blockedKeys.map((k) => `"${k}"`).join(", ")}. These are dropped at spawn for startup safety. Remove them from the env config and use a wrapper script if needed.`,
+        };
+      }
+    }
+  }
+
   next.mcp = {
     ...next.mcp,
     servers,


### PR DESCRIPTION
## Summary

`openclaw mcp set` silently wrote blocked env keys (e.g. `PYTHONPATH`). Every subsequent MCP operation (`probe`, `doctor`, `status`, spawn) emitted a warning, flooding the gateway journal.

## Fix

- `setConfiguredMcpServer` now runs `resolveStdioMcpServerLaunchConfig` before saving to detect blocked env keys
- If any keys would be dropped at spawn, the save is rejected with a clear error listing the blocked keys
- Added regression test

## Files changed
- `src/config/mcp-config.ts` — blocked-env pre-save check
- `src/config/mcp-config.test.ts` — new test

## Testing

```
node scripts/run-vitest.mjs src/config/mcp-config.test.ts
```

All 6 tests pass (5 existing + 1 new).

Closes #92474