### PR TITLE
fix(read): decode GBK-encoded files on Windows via existing codepage fallback

### DIFF
--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -4,10 +4,14 @@ import { Buffer } from "node:buffer";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../../../test-utils/env.js";
 import { createReadToolDefinition } from "./read.js";
 import { DEFAULT_MAX_BYTES } from "./truncate.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const ONE_PIXEL_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
@@ -99,5 +103,63 @@ describe("read tool", () => {
     );
 
     expect(textContent(result)).toBe("alpha\n\n[2 more lines in file. Use offset=2 to continue.]");
+  });
+
+  it("decodes GBK-encoded files on Windows instead of returning mojibake", async () => {
+    // "GBK 编码测试" in GBK bytes
+    const gbkBytes = Buffer.from([
+      0x47, 0x42, 0x4b, 0x20, 0xb1, 0xe0, 0xc2, 0xeb, 0xb2, 0xe2, 0xca, 0xd4,
+    ]);
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        detectImageMimeType: async () => null,
+        readFile: async () => gbkBytes,
+      },
+    });
+
+    const windowsEncoding = await import("../../../infra/windows-encoding.js");
+    const original = windowsEncoding.decodeWindowsOutputBuffer;
+    vi.spyOn(windowsEncoding, "decodeWindowsOutputBuffer").mockImplementation((params) =>
+      original({ ...params, platform: "win32", windowsEncoding: "gbk" }),
+    );
+
+    const result = await tool.execute(
+      "call-1",
+      { path: "gbk_test.txt" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toContain("GBK 编码测试");
+  });
+
+  it("decodes valid UTF-8 content unchanged on Windows with GBK codepage", async () => {
+    const utf8Content = "中文测试内容\n第二行";
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        detectImageMimeType: async () => null,
+        readFile: async () => Buffer.from(utf8Content, "utf-8"),
+      },
+    });
+
+    const windowsEncoding = await import("../../../infra/windows-encoding.js");
+    const original = windowsEncoding.decodeWindowsOutputBuffer;
+    vi.spyOn(windowsEncoding, "decodeWindowsOutputBuffer").mockImplementation((params) =>
+      original({ ...params, platform: "win32", windowsEncoding: "gbk" }),
+    );
+
+    const result = await tool.execute(
+      "call-1",
+      { path: "utf8_test.txt" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toContain("中文测试内容");
+    expect(textContent(result)).toContain("第二行");
   });
 });

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -8,6 +8,7 @@ import { access as fsAccess, readFile as fsReadFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, relative, resolve as resolvePath, sep } from "node:path";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import { decodeWindowsOutputBuffer } from "../../../infra/windows-encoding.js";
 import type { ImageContent, Model, TextContent } from "../../../llm/types.js";
 import {
   classifyMediaReferenceSource,
@@ -339,7 +340,7 @@ export function createReadToolDefinition(
             } else {
               // Read text content.
               const buffer = await ops.readFile(absolutePath);
-              const textContent = buffer.toString("utf-8");
+              const textContent = decodeWindowsOutputBuffer({ buffer });
               const allLines = textContent.split("\n");
               const totalFileLines = allLines.length;
               // Apply offset if specified. Convert from 1-indexed input to 0-indexed array access.


### PR DESCRIPTION
## Summary

- Reuse the existing `decodeWindowsOutputBuffer()` in the read tool's text decode path, replacing hard-coded `buffer.toString("utf-8")`
- On Windows with a non-UTF-8 console codepage (e.g. GBK on Chinese Windows), the function tries strict UTF-8 first, then falls back to the system codepage — fixing mojibake for GBK/Big5/Shift_JIS/EUC-KR encoded files
- On non-Windows platforms, behavior is unchanged (`buffer.toString("utf8")`)
- Added regression tests covering both GBK decode and UTF-8 passthrough under simulated Windows codepage

Closes #92664

## Real behavior proof

Runtime decode proof using the patched code path with `platform: "win32"` + `windowsEncoding: "gbk"` to simulate Chinese Windows codepage 936:

```
=== Before fix (hard-coded UTF-8) ===
buffer.toString("utf-8"): GBK �������

=== After fix (decodeWindowsOutputBuffer, simulated win32 + GBK) ===
decodeWindowsOutputBuffer: GBK 编码测试

=== UTF-8 content unchanged ===
decodeWindowsOutputBuffer: 中文测试内容
```

- Behavior addressed: GBK-encoded file content now decodes correctly instead of producing mojibake
- Real environment tested: Node.js v24.15.0 with `decodeWindowsOutputBuffer({ buffer, platform: "win32", windowsEncoding: "gbk" })` simulating Chinese Windows codepage 936
- Exact steps or command run after this patch: `node --import tsx -e "import { decodeWindowsOutputBuffer } from './src/infra/windows-encoding.js'; ..."` with GBK byte buffer `[0x47, 0x42, 0x4b, 0x20, 0xb1, 0xe0, 0xc2, 0xeb, 0xb2, 0xe2, 0xca, 0xd4]`
- Evidence after fix: GBK bytes decode to `"GBK 编码测试"` (correct Chinese text) instead of `"GBK �������"` (mojibake)
- Observed result after fix: Valid UTF-8 content passes through unchanged even with GBK codepage active (strict UTF-8 check succeeds first)
- What was not tested: No real Chinese Windows 11 machine available; codepage detection via `chcp` and end-to-end read tool invocation on Windows were not live-tested

## Verification

- `node scripts/run-vitest.mjs src/agents/sessions/tools/read.test.ts` — 5/5 passed
- `node scripts/run-vitest.mjs src/infra/windows-encoding.test.ts` — 6/6 passed
- `pnpm format:check` — passed

## Test plan

- [x] GBK byte buffer correctly decoded to `"GBK 编码测试"` under simulated Windows + GBK codepage
- [x] Valid UTF-8 Chinese content passes through unchanged under simulated Windows + GBK codepage
- [x] Existing read tool tests (media refs, shell quoting, line limit clamping) still pass
- [x] `windows-encoding.test.ts` GBK/streaming/fallback tests still pass
- [x] Formatting check passes (oxfmt)
- [ ] Ideally verify on real Chinese Windows 11 with GBK-encoded file

🤖 Generated with [Claude Code](https://claude.com/claude-code)