### PR TITLE
fix(test-env): exclude browser cache subdirs when staging .gemini into temp home

### DIFF
--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -1,5 +1,6 @@
 // Test environment tests validate shared env setup helpers.
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -275,5 +276,37 @@ describe("installTestEnv", () => {
 
     expect(testEnv.tempHome).toBe(realHome);
     expect(process.env.TEST_PROFILE_ONLY).toBe("from-profile");
+  });
+
+  it("skips excluded cache subdirectories when staging auth dirs", async () => {
+    const { installTestEnv: installLiveTestEnv } = await importFreshModule<
+      typeof import("./test-env.js")
+    >(import.meta.url, "./test-env.js?scope=cache-exclude");
+
+    const realHome = os.homedir();
+    const savedHome = process.env.HOME;
+    const savedLive = process.env.LIVE;
+    const savedOpenclawLive = process.env.OPENCLAW_LIVE_TEST;
+
+    process.env.HOME = realHome;
+    process.env.LIVE = "1";
+    delete process.env.OPENCLAW_LIVE_USE_REAL_HOME;
+    process.env.OPENCLAW_LIVE_TEST_QUIET = "1";
+
+    const testEnv = installLiveTestEnv();
+
+    // .gemini should be staged but large cache dirs should not
+    const geminiDir = path.join(testEnv.tempHome, ".gemini");
+    expect(fs.existsSync(geminiDir)).toBe(true);
+    // These cache dirs must be absent in the temp copy
+    const cacheDirs = ["cache", "Code Cache", "GPUCache", "Service Worker"];
+    for (const cacheDir of cacheDirs) {
+      expect(fs.existsSync(path.join(geminiDir, cacheDir))).toBe(false);
+    }
+
+    process.env.HOME = savedHome;
+    process.env.LIVE = savedLive;
+    process.env.OPENCLAW_LIVE_TEST = savedOpenclawLive;
+    testEnv.cleanup();
   });
 });

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -9,6 +9,25 @@ import JSON5 from "json5";
 type RestoreEntry = { key: string; value: string | undefined };
 
 const LIVE_EXTERNAL_AUTH_DIRS = [".claude/backups", ".gemini", ".minimax"] as const;
+
+/**
+ * Subdirectories to skip when staging external auth dirs into the temp home.
+ * These are typically browser caches or profile data that can be multi-GB.
+ */
+const LIVE_EXTERNAL_AUTH_EXCLUDE_SUBDIRS = [
+  "cache",
+  "Code Cache",
+  "GPUCache",
+  "Service Worker",
+  "IndexedDB",
+  "Session Storage",
+  "Local Storage",
+  "DawnGraphiteCache",
+  "DawnWebGPUCache",
+  "ShaderCache",
+  "GrShaderCache",
+  "Crashpad",
+] as const;
 const LIVE_EXTERNAL_AUTH_FILES = [
   ".claude.json",
   ".claude/.credentials.json",
@@ -249,14 +268,31 @@ function ensureParentDir(targetPath: string): void {
   fs.mkdirSync(path.dirname(targetPath), { recursive: true });
 }
 
-function copyDirIfExists(sourcePath: string, targetPath: string): void {
+function copyDirIfExists(
+  sourcePath: string,
+  targetPath: string,
+  options?: { excludeDirs?: readonly string[] },
+): void {
   if (!fs.existsSync(sourcePath)) {
     return;
   }
+  const excludedDirs = options?.excludeDirs
+    ? new Set(options.excludeDirs.map((d) => d.replace(/\/$|\\$/u, "")))
+    : null;
   fs.mkdirSync(targetPath, { recursive: true });
   fs.cpSync(sourcePath, targetPath, {
     recursive: true,
     force: true,
+    filter: excludedDirs
+      ? (src) => {
+          const rel = path.relative(sourcePath, src);
+          if (!rel) {
+            return true;
+          }
+          const parts = rel.split(path.sep);
+          return !parts.some((part) => excludedDirs.has(part));
+        }
+      : undefined,
   });
 }
 
@@ -408,7 +444,9 @@ function stageLiveTestState(params: {
   copyLiveAuthProfiles(realStateDir, tempStateDir);
 
   for (const authDir of LIVE_EXTERNAL_AUTH_DIRS) {
-    copyDirIfExists(path.join(params.realHome, authDir), path.join(params.tempHome, authDir));
+    copyDirIfExists(path.join(params.realHome, authDir), path.join(params.tempHome, authDir), {
+      excludeDirs: LIVE_EXTERNAL_AUTH_EXCLUDE_SUBDIRS,
+    });
   }
   for (const authFile of LIVE_EXTERNAL_AUTH_FILES) {
     copyFileIfExists(path.join(params.realHome, authFile), path.join(params.tempHome, authFile));


### PR DESCRIPTION
## Summary

`copyDirIfExists` used `fs.cpSync({ recursive: true })` with no filter. When staging `.gemini` into the temp test home, it copied the entire directory including multi-GB browser cache/profile subdirectories, causing ENOSPC in CI.

## Fix

- `copyDirIfExists` gains an `excludeDirs` option that filters matching subdirectories
- Added `LIVE_EXTERNAL_AUTH_EXCLUDE_SUBDIRS` list (cache, Code Cache, GPUCache, Service Worker, IndexedDB, Session Storage, Local Storage, DawnGraphiteCache, DawnWebGPUCache, ShaderCache, GrShaderCache, Crashpad)
- `.gemini` staging now passes the exclude list
- Added regression test

## Files changed
- `test/test-env.ts` — filter option, exclude list, staging update
- `test/test-env.test.ts` — new test, `os` import

## Testing

```
node scripts/run-vitest.mjs test/test-env.test.ts
```

All 5 tests pass (4 existing + 1 new).

Closes #91893