### PR TITLE
fix(memory): guard against missing agentIds in wiki artifact clone and sort

### DIFF
--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -305,7 +305,7 @@ function cloneMemoryPublicArtifact(
 ): MemoryPluginPublicArtifact {
   return {
     ...artifact,
-    agentIds: [...artifact.agentIds],
+    agentIds: Array.isArray(artifact.agentIds) ? [...artifact.agentIds] : [],
   };
 }
 
@@ -331,7 +331,9 @@ export async function listActiveMemoryPublicArtifacts(params: {
     if (contentTypeOrder !== 0) {
       return contentTypeOrder;
     }
-    const agentOrder = left.agentIds.join("\0").localeCompare(right.agentIds.join("\0"));
+    const agentOrder = (left.agentIds ?? [])
+      .join("\0")
+      .localeCompare((right.agentIds ?? []).join("\0"));
     if (agentOrder !== 0) {
       return agentOrder;
     }


### PR DESCRIPTION
## Summary

`cloneMemoryPublicArtifact` crashed with `artifact.agentIds is not iterable` when the artifact had no `agentIds` field. The sort comparator had the same bug. All `wiki_*` tools threw `artifact.agentIds is not iterable`.

## Fix

- `cloneMemoryPublicArtifact`: `Array.isArray(artifact.agentIds) ? [...artifact.agentIds] : []`
- Sort comparator: `left.agentIds.join()` → `(left.agentIds ?? []).join()` (same for right)

## Files changed
- `src/plugins/memory-state.ts` — 2 guards (+4/-2)

## Real behavior proof

**Behavior addressed:** Undefined `agentIds` on memory public artifacts caused `TypeError: artifact.agentIds is not iterable` crashing all wiki tools.

**Real environment tested:** Local OpenClaw checkout at PR head, macOS/Darwin arm64, Node v22.22.0.

**Before-fix repro (source-level):**
```js
const artifact = { name: "test", contentType: "text" }; // no agentIds
cloneMemoryPublicArtifact(artifact); // → TypeError: artifact.agentIds is not iterable
```

**After-fix behavior (source-level):**
```js
cloneMemoryPublicArtifact({ name: "test", contentType: "text" }); 
// → { name: "test", contentType: "text", agentIds: [] }
```

**Exact steps run after this patch:**
```
node scripts/run-vitest.mjs src/plugins/memory-state.test.ts
```
All 14 tests pass.

Closes #92207