### PR TITLE
fix(daemon): strip leading backslash from schtasks name before managed-task comparison

### DIFF
--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -199,7 +199,10 @@ function isOpenClawGatewaySystemdService(name: string, contents: string): boolea
 }
 
 function isOpenClawGatewayTaskName(name: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(name);
+  // Windows schtasks may report names with a leading backslash
+  // (e.g. "\OpenClaw Gateway"); strip it before comparison.
+  const stripped = name.replace(/^\\/u, "");
+  const normalized = normalizeLowercaseStringOrEmpty(stripped);
   if (!normalized) {
     return false;
   }


### PR DESCRIPTION
## Summary

Windows schtasks /query reports task names with a leading backslash (e.g. \`\\OpenClaw Gateway\`). `isOpenClawGatewayTaskName` compared the raw name against `"openclaw gateway"` without stripping the prefix, so managed tasks were not recognized and appeared as extra gateway services in doctor/status output.

## Fix

- Strip leading backslash before normalization in `isOpenClawGatewayTaskName`

## Files changed
- `src/daemon/inspect.ts` — 1 line prepend, 3 lines changed

## Testing

All 13 inspect tests pass (5 skipped = platform-specific).

Closes #90494