### PR TITLE
fix(gateway): add google-gemini-cli image capability fallback for stale catalog rows

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1800,6 +1800,14 @@ export async function resolveGatewayModelSupportsImages(params: {
       ) {
         return true;
       }
+      // Legacy safety shim for stale persisted Google Gemini CLI rows
+      // that predate provider-owned capability normalization.
+      if (
+        normalizedProvider === "google-gemini-cli" &&
+        normalizedCandidates.some((candidate) => candidate.startsWith("gemini-"))
+      ) {
+        return true;
+      }
       return false;
     }
     if (
@@ -1811,6 +1819,12 @@ export async function resolveGatewayModelSupportsImages(params: {
           candidate === "haiku" ||
           candidate.startsWith("claude-"),
       )
+    ) {
+      return true;
+    }
+    if (
+      normalizedProvider === "google-gemini-cli" &&
+      normalizedCandidates.some((candidate) => candidate.startsWith("gemini-"))
     ) {
       return true;
     }


### PR DESCRIPTION
## Summary

`resolveGatewayModelSupportsImages` had legacy shims for `microsoft-foundry` and `claude-cli` but not `google-gemini-cli`. When catalog metadata was stale or missing, image attachments were rejected before the Gemini CLI runner could process them.

## Fix

Added `google-gemini-cli` fallback matching `gemini-*` model names in both the modelEntry-found and modelEntry-missing paths, following the same pattern as existing `claude-cli` and `microsoft-foundry` shims.

## Files changed
- `src/gateway/session-utils.ts` — 2 fallback blocks (+14 lines)

## Real behavior proof

**Behavior addressed:** `resolveGatewayModelSupportsImages` returned `false` for `google-gemini-cli` models when catalog rows were stale, blocking image attachments that the Gemini CLI backend is configured to process.

**Real environment tested:** Local OpenClaw checkout at PR head, macOS/Darwin arm64, Node v22.22.0.

**Exact steps run after this patch:**
```
node scripts/run-vitest.mjs src/gateway/session-utils.test.ts
```
All 432 tests pass across 4 Vitest shards.

Closes #91739