### PR TITLE
docs(sessions_spawn): add delegation usage guidance to tool description

### DIFF
--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -53,7 +53,11 @@ export function describeSessionsSpawnTool(options?: {
     "Subagents inherit parent workspace.",
     "Native subagents get task in first visible `[Subagent Task]` message.",
     'Native only: `context="fork"` only when child needs current transcript; else omit or `isolated`.',
-    "Use for fresh child-session work.",
+    "Delegation guidance:",
+    "- Delegate: sidecar/parallel work, bounded subtasks, long reads, web searches, large file processing, debugging in remote workspaces, multi-step batch commands.",
+    "- Do NOT delegate: trivial 1-step lookups, work that must happen in sequence with immediate main-thread consumption, single-line edits, quick glace-and-decide reads.",
+    "- After delegating: advance other non-dependent work in parallel; do not idle-wait on child completion.",
+    "- Parallel: split independent subtasks across multiple sub-agents when they share no outputs.",
   ];
   if (options?.acpAvailable === false) {
     return baseDescription.join(" ");


### PR DESCRIPTION
## Summary

The `sessions_spawn` tool description was purely mechanical with no guidance on **when** agents should delegate vs. handle work directly. This caused agents to bypass sub-agent delegation even when AGENTS.md explicitly requested it.

## Fix

Added compact delegation usage guidance directly in `describeSessionsSpawnTool`:
- **Delegate**: sidecar/parallel work, bounded subtasks, long reads, web searches, large file processing, debugging in remote workspaces, multi-step batch commands
- **Do NOT delegate**: trivial 1-step lookups, sequential work, single-line edits, quick glance-and-decide reads
- **After delegating**: advance other non-dependent work in parallel; do not idle-wait on child completion
- **Parallel**: split independent subtasks across multiple sub-agents when they share no outputs

Follows the pattern used by Codex `spawn_agent` tool which embeds delegation decision guidance in the tool definition.

## Files changed
- `src/agents/tool-description-presets.ts` — 4 new guidance lines (+5/-1)

## Real behavior proof

**Behavior addressed:** `sessions_spawn` tool description was pure mechanics; agents ignored even explicit AGENTS.md delegation rules. The fix adds delegation decision guidance directly in the model-visible tool description.

**Real environment tested:** Local OpenClaw checkout at PR head, macOS/Darwin arm64, Node v22.22.0, pnpm from repository toolchain.

**Exact steps run after this patch:**
```
node scripts/run-vitest.mjs src/agents/tools/sessions-spawn-tool.test.ts
```
All 53 sessions_spawn tool tests pass.

Closes #91814