### PR TITLE
fix(media-understanding): place Qwen/DashScope image prompts in user content (#92688)

### DIFF
--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -884,6 +884,59 @@ describe("describeImageWithModel", () => {
     ]);
   });
 
+  it("places DashScope/Qwen image prompts in user content before images", async () => {
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        api: "openai-completions",
+        provider: "qwen",
+        id: "qwen3.7-max",
+        input: ["text", "image"],
+        baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      })),
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-completions",
+      provider: "qwen",
+      model: "qwen3.7-max",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "qwen dashscope ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "qwen",
+      model: "qwen3.7-max",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "qwen dashscope ok",
+      model: "qwen3.7-max",
+    });
+    const firstCall = requireFirstMockCall(completeMock, "DashScope image completion");
+    const [, context] = firstCall;
+    expect(context.systemPrompt).toBeUndefined();
+    const userMessage = context.messages[0];
+    if (!userMessage) {
+      throw new Error("expected DashScope image completion user message");
+    }
+    expect(userMessage.content).toEqual([
+      { type: "text", text: "Describe the image." },
+      {
+        type: "image",
+        data: Buffer.from("png-bytes").toString("base64"),
+        mimeType: "image/png",
+      },
+    ]);
+  });
+
   it.each([
     {
       name: "direct OpenAI Responses baseUrl",

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -281,12 +281,29 @@ function buildImageContext(
   };
 }
 
+function isDashScopeEndpoint(model: Model): boolean {
+  const provider = model.provider?.toLowerCase() ?? "";
+  const baseUrl = model.baseUrl?.toLowerCase() ?? "";
+  return (
+    provider.includes("dashscope") ||
+    provider === "qwen" ||
+    provider === "qwen-dashscope" ||
+    baseUrl.includes("dashscope.aliyuncs.com")
+  );
+}
+
 function shouldPlaceImagePromptInUserContent(model: Model): boolean {
   // GitHub Copilot models (including Gemini 3.1 Pro Preview) require the
   // prompt text to be in the user message alongside the image. Placing it
   // in a separate system message produces "Request must contain at least
   // one non-empty message" (400).
   if (model.provider === "github-copilot") {
+    return true;
+  }
+  // DashScope/Qwen vision models return 400 "Unexpected item type in content"
+  // when the user message contains only image blocks with no text. The prompt
+  // must be placed in the user content alongside the image.
+  if (isDashScopeEndpoint(model)) {
     return true;
   }
   const capabilities = resolveProviderRequestCapabilities({


### PR DESCRIPTION
Fixes #92688

## Summary

DashScope vision models (qwen3.7-max, qwen3.7-plus) return 400 "Unexpected item type in content" when the image tool sends the prompt in a system message and only image blocks in the user message. The fix adds DashScope/Qwen endpoint detection to `shouldPlaceImagePromptInUserContent` so the prompt text is placed in the user content alongside the image.

## Root Cause

`src/media-understanding/image.ts` builds image context with the prompt in `systemPrompt` by default. Only GitHub Copilot and OpenRouter routes override this to place the prompt in user content. DashScope's OpenAI-compatible endpoint rejects image-only user messages with a 400 schema error.

## Changes

- `src/media-understanding/image.ts`: Added `isDashScopeEndpoint()` helper detecting `qwen`, `qwen-dashscope`, `dashscope` providers and `dashscope.aliyuncs.com` base URLs. Added early return in `shouldPlaceImagePromptInUserContent()` for DashScope endpoints.
- `src/media-understanding/image.test.ts`: Added test verifying DashScope/Qwen image prompts are placed in user content with systemPrompt undefined.

## Real behavior proof

**Behavior or issue addressed:** Qwen vision models fail with 400 "Unexpected item type in content" on DashScope when using the image tool.

**Real environment tested:** Linux 6.6.114.1-microsoft-standard-WSL2 (x64), Node.js v24.16.0, commit 97281d8b on branch fix/qwen-dashscope-vision-prompt-in-user-content.

**Exact steps or command run after this patch:**
```shell
cd /root/.openclaw/workspace/openclaw-repo
grep -A 15 "function isDashScopeEndpoint" src/media-understanding/image.ts
grep -A 5 "DashScope/Qwen" src/media-understanding/image.ts
grep -c "places DashScope" src/media-understanding/image.test.ts
git diff --stat upstream/main
```

**Evidence after fix:**
```text
$ grep -A 15 "function isDashScopeEndpoint" src/media-understanding/image.ts
function isDashScopeEndpoint(model: Model): boolean {
  const provider = model.provider?.toLowerCase() ?? "";
  const baseUrl = model.baseUrl?.toLowerCase() ?? "";
  return (
    provider.includes("dashscope") ||
    provider === "qwen" ||
    provider === "qwen-dashscope" ||
    baseUrl.includes("dashscope.aliyuncs.com")
  );
}

$ grep -A 5 "DashScope/Qwen" src/media-understanding/image.ts
  // DashScope/Qwen vision models return 400 "Unexpected item type in content"
  // when the user message contains only image blocks with no text. The prompt
  // must be placed in the user content alongside the image.
  if (isDashScopeEndpoint(model)) {
    return true;
  }

$ grep -c "places DashScope" src/media-understanding/image.test.ts
1

$ git diff --stat upstream/main
 src/media-understanding/image.test.ts | 53 ++++++++++++++++++++++++++++++++
 src/media-understanding/image.ts      | 17 ++++++++++
 2 files changed, 70 insertions(+)
```

**Observed result after fix:** The `isDashScopeEndpoint` function correctly identifies qwen, qwen-dashscope, and dashscope.aliyuncs.com URLs. `shouldPlaceImagePromptInUserContent` now returns true for these endpoints, causing the prompt to be placed in user content alongside the image blocks instead of in a system message. The test validates that systemPrompt is undefined and user content contains both text and image parts.

**What was not tested:** Live DashScope API call with credentials (requires DashScope account). Only source-level logic verification was performed. The fix follows the same pattern as the existing GitHub Copilot and OpenRouter detections which are well-tested.

**Proof limitations:** No live provider 400 reproduction — the fix is based on source analysis of the payload shape and the reporter's error logs. The DashScope endpoint detection covers common provider/URL patterns but may miss exotic custom configurations.