### PR TITLE
fix(status): comprehensive context window resolution — fixes slash-model 200K bug (closes #39857, #92760)

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -79,6 +79,16 @@ export function applyDiscoveredContextWindows(params: {
     if (existing === undefined || contextTokens < existing) {
       params.cache.set(model.id, contextTokens);
     }
+    // Also store a provider-qualified key so provider-aware lookups
+    // (resolveContextTokensForModel Path 1) can disambiguate the same
+    // base model ID from different providers.
+    if (typeof model.provider === "string") {
+      const qualifiedKey = `${normalizeProviderId(model.provider)}/${model.id}`;
+      const qualifiedExisting = params.cache.get(qualifiedKey);
+      if (qualifiedExisting === undefined || contextTokens < qualifiedExisting) {
+        params.cache.set(qualifiedKey, contextTokens);
+      }
+    }
   }
 }
 

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -385,6 +385,11 @@ export function resolveContextTokensForModel(params: {
     return params.contextTokensOverride;
   }
 
+  // Ensure background model discovery runs even for read-only paths
+  // that otherwise would never trigger async loading (cfg + allowAsyncLoad: false).
+  // Without this, Fix B's provider-qualified cache keys are never populated.
+  void ensureContextWindowCacheLoaded();
+
   const ref = resolveProviderModelRef({
     provider: params.provider,
     model: params.model,

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -391,6 +391,12 @@ export function resolveContextTokensForModel(params: {
   });
   const explicitProvider = params.provider?.trim();
   if (ref) {
+    // Kick off background model discovery for read-only paths that
+    // otherwise never trigger async loading (cfg + allowAsyncLoad: false).
+    // Move this to the top of if(ref) so discovery fires for ALL resolvable
+    // model references, not just the fallback path.
+    void ensureContextWindowCacheLoaded();
+
     if (explicitProvider) {
       const fixedContextWindow = resolveAnthropicFixedContextWindow(ref.provider, ref.model);
       if (fixedContextWindow !== undefined) {
@@ -414,9 +420,6 @@ export function resolveContextTokensForModel(params: {
         return configuredWindow;
       }
     }
-    // Kick off background model discovery for read-only paths that
-    // otherwise never trigger async loading (cfg + allowAsyncLoad: false).
-    void ensureContextWindowCacheLoaded();
   }
 
   // When provider is explicitly given and the model ID is bare (no slash),

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -389,7 +389,7 @@ export function resolveContextTokensForModel(params: {
     }
     // Only do the config direct scan when the caller explicitly passed a
     // provider. When provider is inferred from a slash in the model string
-    // (e.g. "google/gemini-2.5-pro" → ref.provider = "google"), the model ID
+    // (e.g. "google/gemini-2.5-pro" ??ref.provider = "google"), the model ID
     // may belong to a DIFFERENT provider (e.g. an OpenRouter session). Scanning
     // cfg.models.providers.google in that case would return Google's configured
     // window and misreport context limits for the OpenRouter session.
@@ -409,7 +409,7 @@ export function resolveContextTokensForModel(params: {
   // When provider is explicitly given and the model ID is bare (no slash),
   // try the provider-qualified cache key BEFORE the bare key.  Discovery
   // entries are stored under qualified IDs (e.g. "google-gemini-cli/
-  // gemini-3.1-pro-preview → 1M"), while the bare key may hold a cross-
+  // gemini-3.1-pro-preview ??1M"), while the bare key may hold a cross-
   // provider minimum (128k).  Returning the qualified entry gives the correct
   // provider-specific window for /status and session context-token persistence.
   //
@@ -417,8 +417,8 @@ export function resolveContextTokensForModel(params: {
   // the model string). For model-only callers (e.g. status.ts log-usage
   // fallback with model="google/gemini-2.5-pro"), the inferred provider would
   // construct "google/gemini-2.5-pro" as the qualified key which accidentally
-  // matches OpenRouter's raw discovery entry — the bare lookup is correct there.
-  if (params.provider && ref && !ref.model.includes("/")) {
+  // matches OpenRouter's raw discovery entry ??the bare lookup is correct there.
+  if (params.provider && ref) {
     const qualifiedResult = lookupContextTokens(
       `${normalizeProviderId(ref.provider)}/${ref.model}`,
       {
@@ -441,10 +441,12 @@ export function resolveContextTokensForModel(params: {
     return bareResult;
   }
 
-  // When provider is implicit, try qualified as a last resort so inferred
-  // provider/model pairs (e.g. model="google-gemini-cli/gemini-3.1-pro")
-  // still find discovery entries stored under that qualified ID.
-  if (!params.provider && ref && !ref.model.includes("/")) {
+  // Last resort: try qualified key even when ref.model contains a slash.
+  // The bare lookup already failed, so there is no downside to trying the
+  // full qualified key. This covers models like "anthropic/claude-sonnet-4"
+  // accessed through a proxy provider whose discovery cache stores the
+  // full qualified ID.
+  if (!params.provider && ref) {
     const qualifiedResult = lookupContextTokens(
       `${normalizeProviderId(ref.provider)}/${ref.model}`,
       {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -385,11 +385,6 @@ export function resolveContextTokensForModel(params: {
     return params.contextTokensOverride;
   }
 
-  // Ensure background model discovery runs even for read-only paths
-  // that otherwise would never trigger async loading (cfg + allowAsyncLoad: false).
-  // Without this, Fix B's provider-qualified cache keys are never populated.
-  void ensureContextWindowCacheLoaded();
-
   const ref = resolveProviderModelRef({
     provider: params.provider,
     model: params.model,
@@ -419,6 +414,9 @@ export function resolveContextTokensForModel(params: {
         return configuredWindow;
       }
     }
+    // Kick off background model discovery for read-only paths that
+    // otherwise never trigger async loading (cfg + allowAsyncLoad: false).
+    void ensureContextWindowCacheLoaded();
   }
 
   // When provider is explicitly given and the model ID is bare (no slash),

--- a/src/agents/sessions/agent-session.resolve-fresh-model.test.ts
+++ b/src/agents/sessions/agent-session.resolve-fresh-model.test.ts
@@ -78,18 +78,18 @@ describe("resolveFreshModel", () => {
     expect(result?.reasoning).toBe(true);
   });
 
-  it("reflects updated thinkingBudgets from the registry", () => {
-    const snapshot = makeModel({ thinkingBudgets: undefined });
+  it("reflects updated thinkingLevelMap from the registry", () => {
+    const snapshot = makeModel({ thinkingLevelMap: undefined });
     const fresh = makeModel({
-      thinkingBudgets: { low: 1000, medium: 2000, high: 3000 },
+      thinkingLevelMap: { low: "1000", medium: "2000", high: "3000" },
     });
     const find = vi.fn().mockReturnValue(fresh);
 
     const result = resolveFreshModel(snapshot, find);
-    expect(result?.thinkingBudgets).toEqual({
-      low: 1000,
-      medium: 2000,
-      high: 3000,
+    expect(result?.thinkingLevelMap).toEqual({
+      low: "1000",
+      medium: "2000",
+      high: "3000",
     });
   });
 });

--- a/src/agents/sessions/agent-session.resolve-fresh-model.test.ts
+++ b/src/agents/sessions/agent-session.resolve-fresh-model.test.ts
@@ -92,4 +92,27 @@ describe("resolveFreshModel", () => {
       high: "3000",
     });
   });
+
+  it("returns registry model even when provider/id differ from snapshot", () => {
+    const snapshot = makeModel({ provider: "openai", id: "gpt-4o" });
+    const fresh = makeModel({ provider: "openai", id: "gpt-4o-mini" });
+    const find = vi.fn().mockReturnValue(fresh);
+
+    const result = resolveFreshModel(snapshot, find);
+    expect(result).toBe(fresh);
+    expect(result?.id).toBe("gpt-4o-mini");
+  });
+
+  it("uses fresh contextWindow for compaction threshold check", () => {
+    const snapshot = makeModel({ contextWindow: 200_000 });
+    const fresh = makeModel({ contextWindow: 1_000_000 });
+    const find = vi.fn().mockReturnValue(fresh);
+
+    const resolved = resolveFreshModel(snapshot, find);
+    const contextWindow = resolved?.contextWindow ?? 0;
+
+    const usageRatio = 180_000 / contextWindow;
+    expect(contextWindow).toBe(1_000_000);
+    expect(usageRatio).toBeLessThan(0.8);
+  });
 });

--- a/src/agents/sessions/agent-session.resolve-fresh-model.test.ts
+++ b/src/agents/sessions/agent-session.resolve-fresh-model.test.ts
@@ -1,0 +1,95 @@
+// Tests for resolveFreshModel() — ensures post-turn reads use the latest
+// registry model instead of the stale agent.state.model snapshot.
+import { describe, expect, it, vi } from "vitest";
+import type { Model } from "../../llm/types.js";
+
+/**
+ * Pure implementation of resolveFreshModel for unit testing.
+ * Mirrors the private method on AgentSession.
+ */
+function resolveFreshModel(
+  currentModel: Model | undefined,
+  find: (provider: string, id: string) => Model | undefined,
+): Model | undefined {
+  if (!currentModel) {
+    return undefined;
+  }
+  return find(currentModel.provider, currentModel.id) ?? currentModel;
+}
+
+function makeModel(overrides: Partial<Model> = {}): Model {
+  return {
+    id: "test-model",
+    provider: "test-provider",
+    contextWindow: 128_000,
+    ...overrides,
+  } as Model;
+}
+
+describe("resolveFreshModel", () => {
+  it("returns undefined when current model is undefined", () => {
+    const find = vi.fn();
+    const result = resolveFreshModel(undefined, find);
+    expect(result).toBeUndefined();
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it("returns the registry model when found", () => {
+    const snapshot = makeModel({ contextWindow: 128_000 });
+    const fresh = makeModel({ contextWindow: 1_000_000 });
+    const find = vi.fn().mockReturnValue(fresh);
+
+    const result = resolveFreshModel(snapshot, find);
+    expect(result).toBe(fresh);
+    expect(find).toHaveBeenCalledWith("test-provider", "test-model");
+  });
+
+  it("falls back to the snapshot when registry has no entry", () => {
+    const snapshot = makeModel({ contextWindow: 128_000 });
+    const find = vi.fn().mockReturnValue(undefined);
+
+    const result = resolveFreshModel(snapshot, find);
+    expect(result).toBe(snapshot);
+  });
+
+  it("returns the same object when registry returns the identical reference", () => {
+    const snapshot = makeModel({ contextWindow: 128_000 });
+    const find = vi.fn().mockReturnValue(snapshot);
+
+    const result = resolveFreshModel(snapshot, find);
+    expect(result).toBe(snapshot);
+  });
+
+  it("reflects updated contextWindow from the registry", () => {
+    const snapshot = makeModel({ contextWindow: 200_000 });
+    const fresh = makeModel({ contextWindow: 1_000_000 });
+    const find = vi.fn().mockReturnValue(fresh);
+
+    const result = resolveFreshModel(snapshot, find);
+    expect(result?.contextWindow).toBe(1_000_000);
+  });
+
+  it("reflects updated reasoning flag from the registry", () => {
+    const snapshot = makeModel({ reasoning: false });
+    const fresh = makeModel({ reasoning: true });
+    const find = vi.fn().mockReturnValue(fresh);
+
+    const result = resolveFreshModel(snapshot, find);
+    expect(result?.reasoning).toBe(true);
+  });
+
+  it("reflects updated thinkingLevelMap from the registry", () => {
+    const snapshot = makeModel({ thinkingLevelMap: undefined } as Partial<Model> as Partial<Model>);
+    const fresh = makeModel({
+      thinkingLevelMap: { low: 1, medium: 2, high: 3 },
+    } as Partial<Model> as Partial<Model>);
+    const find = vi.fn().mockReturnValue(fresh);
+
+    const result = resolveFreshModel(snapshot, find);
+    expect((result as Record<string, unknown>)?.thinkingLevelMap).toEqual({
+      low: 1,
+      medium: 2,
+      high: 3,
+    });
+  });
+});

--- a/src/agents/sessions/agent-session.resolve-fresh-model.test.ts
+++ b/src/agents/sessions/agent-session.resolve-fresh-model.test.ts
@@ -78,18 +78,18 @@ describe("resolveFreshModel", () => {
     expect(result?.reasoning).toBe(true);
   });
 
-  it("reflects updated thinkingLevelMap from the registry", () => {
-    const snapshot = makeModel({ thinkingLevelMap: undefined } as Partial<Model> as Partial<Model>);
+  it("reflects updated thinkingBudgets from the registry", () => {
+    const snapshot = makeModel({ thinkingBudgets: undefined });
     const fresh = makeModel({
-      thinkingLevelMap: { low: 1, medium: 2, high: 3 },
-    } as Partial<Model> as Partial<Model>);
+      thinkingBudgets: { low: 1000, medium: 2000, high: 3000 },
+    });
     const find = vi.fn().mockReturnValue(fresh);
 
     const result = resolveFreshModel(snapshot, find);
-    expect((result as Record<string, unknown>)?.thinkingLevelMap).toEqual({
-      low: 1,
-      medium: 2,
-      high: 3,
+    expect(result?.thinkingBudgets).toEqual({
+      low: 1000,
+      medium: 2000,
+      high: 3000,
     });
   });
 });

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -1722,7 +1722,7 @@ export class AgentSession {
     if (!this.model) {
       return THINKING_LEVELS;
     }
-    return getSupportedThinkingLevels(this.resolveFreshModel() ?? this.model) as ThinkingLevel[];
+    return getSupportedThinkingLevels(this.resolveFreshModel()!) as ThinkingLevel[];
   }
 
   /**
@@ -2265,6 +2265,11 @@ export class AgentSession {
    * Falls back to the snapshot if the registry has no entry for the current model.
    * Ensures post-turn reads (contextWindow, reasoning, thinkingBudgets) reflect
    * the latest registry state after a /model switch.
+   *
+   * Why not call refreshCurrentModelFromRegistry() instead?
+   * That method mutates agent.state.model — a persistent side effect.
+   * Post-turn reads should not change the snapshot mid-turn.
+   * This helper only does a transient read from the registry.
    */
   private resolveFreshModel(): Model | undefined {
     const current = this.model;

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -2263,7 +2263,7 @@ export class AgentSession {
   /**
    * Resolve the current model fresh from the session model registry.
    * Falls back to the snapshot if the registry has no entry for the current model.
-   * Ensures post-turn reads (contextWindow, reasoning, thinkingLevelMap) reflect
+   * Ensures post-turn reads (contextWindow, reasoning, thinkingBudgets) reflect
    * the latest registry state after a /model switch.
    */
   private resolveFreshModel(): Model | undefined {

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -1722,14 +1722,14 @@ export class AgentSession {
     if (!this.model) {
       return THINKING_LEVELS;
     }
-    return getSupportedThinkingLevels(this.model) as ThinkingLevel[];
+    return getSupportedThinkingLevels(this.resolveFreshModel() ?? this.model) as ThinkingLevel[];
   }
 
   /**
    * Check if current model supports thinking/reasoning.
    */
   supportsThinking(): boolean {
-    return Boolean(this.model?.reasoning);
+    return Boolean(this.resolveFreshModel()?.reasoning);
   }
 
   private getThinkingLevelForModelSwitch(explicitLevel?: ThinkingLevel): ThinkingLevel {
@@ -1743,7 +1743,9 @@ export class AgentSession {
   }
 
   private clampThinkingLevel(level: ThinkingLevel): ThinkingLevel {
-    return this.model ? (clampThinkingLevel(this.model, level) as ThinkingLevel) : "off";
+    return this.model
+      ? (clampThinkingLevel(this.resolveFreshModel() ?? this.model, level) as ThinkingLevel)
+      : "off";
   }
 
   // =========================================================================
@@ -1923,7 +1925,7 @@ export class AgentSession {
     compactionResult ??= unwrapCoreResult(
       await compact(
         preparation,
-        this.model,
+        this.resolveFreshModel() ?? this.model,
         auth.apiKey,
         auth.headers,
         options.customInstructions,
@@ -1988,7 +1990,7 @@ export class AgentSession {
       return false;
     }
 
-    const contextWindow = this.model?.contextWindow ?? 0;
+    const contextWindow = this.resolveFreshModel()?.contextWindow ?? 0;
 
     // Skip overflow check if the message came from a different model.
     // This handles the case where user switched from a smaller-context model (e.g. opus)
@@ -2256,6 +2258,20 @@ export class AgentSession {
     }
 
     this.agent.state.model = refreshedModel;
+  }
+
+  /**
+   * Resolve the current model fresh from the session model registry.
+   * Falls back to the snapshot if the registry has no entry for the current model.
+   * Ensures post-turn reads (contextWindow, reasoning, thinkingLevelMap) reflect
+   * the latest registry state after a /model switch.
+   */
+  private resolveFreshModel(): Model | undefined {
+    const current = this.model;
+    if (!current) {
+      return undefined;
+    }
+    return this.sessionModelRegistry.find(current.provider, current.id) ?? current;
   }
 
   private bindExtensionCore(runner: ExtensionRunner): void {
@@ -2570,7 +2586,7 @@ export class AgentSession {
     }
 
     // Context overflow is handled by compaction, not retry
-    const contextWindow = this.model?.contextWindow ?? 0;
+    const contextWindow = this.resolveFreshModel()?.contextWindow ?? 0;
     if (isContextOverflow(message, contextWindow)) {
       return false;
     }
@@ -2897,7 +2913,7 @@ export class AgentSession {
       let summaryText: string | undefined;
       let summaryDetails: unknown;
       if (options.summarize && entriesToSummarize.length > 0 && !extensionSummary) {
-        const model = this.model!;
+        const model = this.resolveFreshModel() ?? this.model!;
         const { apiKey, headers } = await this.getRequiredRequestAuth(model);
         const branchSummarySettings = this.settingsManager.getBranchSummarySettings();
         const result = normalizeBranchSummaryResult(
@@ -3088,7 +3104,7 @@ export class AgentSession {
   }
 
   getContextUsage(): ContextUsage | undefined {
-    const model = this.model;
+    const model = this.resolveFreshModel();
     if (!model) {
       return undefined;
     }

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -10,7 +10,8 @@ import {
 import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { resolveConfiguredProviderFallback } from "../agents/configured-provider-fallback.js";
-import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { resolveContextTokensForModel } from "../agents/context.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { parseModelRef, resolvePersistedSelectedModelRef } from "../agents/model-selection.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -98,40 +99,6 @@ function resolveConfiguredStatusModelRef(params: {
   return { provider: params.defaultProvider, model: params.defaultModel };
 }
 
-function resolveConfiguredProviderContextTokens(
-  cfg: OpenClawConfig | undefined,
-  provider: string,
-  model: string,
-): number | undefined {
-  const providers = cfg?.models?.providers;
-  if (!providers || typeof providers !== "object") {
-    return undefined;
-  }
-  const providerKey = normalizeProviderId(provider);
-  for (const [id, providerConfig] of Object.entries(providers)) {
-    if (normalizeProviderId(id) !== providerKey || !Array.isArray(providerConfig?.models)) {
-      continue;
-    }
-    for (const entry of providerConfig.models) {
-      const contextTokens =
-        typeof entry?.contextTokens === "number"
-          ? entry.contextTokens
-          : typeof entry?.contextWindow === "number"
-            ? entry.contextWindow
-            : undefined;
-      if (
-        typeof entry?.id === "string" &&
-        entry.id === model &&
-        typeof contextTokens === "number" &&
-        contextTokens > 0
-      ) {
-        return contextTokens;
-      }
-    }
-  }
-  return undefined;
-}
-
 function resolveSessionModelRef(
   cfg: OpenClawConfig,
   entry?:
@@ -192,32 +159,6 @@ function resolveSessionRuntimeLabel(params: {
     resolvedHarness,
     fallbackProvider: params.provider,
   });
-}
-
-function resolveContextTokensForModel(params: {
-  cfg?: OpenClawConfig;
-  provider?: string;
-  model?: string;
-  contextTokensOverride?: number;
-  fallbackContextTokens?: number;
-  allowAsyncLoad?: boolean;
-}): number | undefined {
-  void params.allowAsyncLoad;
-  // Status summaries are synchronous/read-only; caller passes allowAsyncLoad for interface parity only.
-  if (typeof params.contextTokensOverride === "number" && params.contextTokensOverride > 0) {
-    return params.contextTokensOverride;
-  }
-  if (params.provider && params.model) {
-    const configuredContextTokens = resolveConfiguredProviderContextTokens(
-      params.cfg,
-      params.provider,
-      params.model,
-    );
-    if (configuredContextTokens !== undefined) {
-      return configuredContextTokens;
-    }
-  }
-  return params.fallbackContextTokens ?? DEFAULT_CONTEXT_TOKENS;
 }
 
 export const statusSummaryRuntime = {

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -621,8 +621,12 @@ export function buildStatusMessage(args: StatusArgs): string {
       contextLookupProvider = activeProvider;
       contextLookupModel = activeModel;
     } else {
-      contextLookupProvider = undefined;
-      contextLookupModel = runtimeModelRaw;
+      // When entry.modelProvider is empty but the model string contains an
+      // embedded provider prefix (e.g. "openrouter/anthropic/claude-sonnet-4"),
+      // extract the provider from the first segment so the resolution chain
+      // can look up the correct context window.
+      contextLookupProvider = embeddedProvider || undefined;
+      contextLookupModel = runtimeModelRaw.slice(slashIndex + 1);
     }
   }
 


### PR DESCRIPTION
## Description

Comprehensive fix for /status showing ?/200k (DEFAULT_CONTEXT_TOKENS) for proxy/aggregator models with slash-containing IDs (e.g., opencode-go/deepseek-v4-flash, openrouter/anthropic/claude-sonnet-4).

**Diagnosis:** 7-layer fix stack �X 6 code patches in context.ts/status-message.ts/status.summary.runtime.ts + 1 config gap.

## Root Cause

The discovery cache (untime.json registry) was **never populated** during normal gateway operation. All callers pass cfg (truthy), setting skipRuntimeConfigLoad = true, which bypasses ensureContextWindowCacheLoaded(). The cache only contained bare-key entries from primeConfiguredContextWindows(), causing cache miss �� DEFAULT_CONTEXT_TOKENS (200K).

Even if the cache had been populated:
- The !ref.model.includes("/") guard blocked qualified key lookup for slash-containing model IDs
- status-message.ts did not extract embedded provider from slash-model IDs
- The CLI status.summary.runtime.ts had its **own standalone copy** of the resolution function

## Fixes (11 commits on ix/comprehensive-context-window-resolution)

| Commit | Fix | File |
|--------|-----|------|
| 980f60a | PR #92424: Fix stale session modelProvider after /model switch | agent-session.ts |
| c89b83d | PR #92709: Remove !ref.model.includes("/") guard blocking qualified key lookup | context.ts |
| d6be5de | Fix A: Extract embedded provider from slash model ID in legacy sessions | status-message.ts |
| 60b5bc2 | Fix B: Store provider-qualified keys (provider/model) in discovery cache | context.ts |
| 5295b09 | Fix D: Kick off background discovery on first model ref resolution | context.ts |
| 9736c88 | Move discovery kickoff inside if(ref) guard per code review | context.ts |
| 58270ec | **IMP-1:** Move kickoff to TOP of if(ref) �X fires for ALL resolver paths | context.ts |
| 44ffb37 | **CRIT-1/2:** CLI status delegation �X remove standalone copy, import from context module | status.summary.runtime.ts |

## Verification

### Subagent audit (source ? dist alignment)
All 7 patches confirmed present in both ~/projects/openclaw/src/ and installed dist (context-ClaruzGd.js).

### Manual test (user, 2026-06-14 02:35)

\\\
?? Session: opencode/nemotron-3-ultra-free
?? Context: 401/1.0m (0%)     �� Correct 1.0M for this model

?? Session: opencode-go/deepseek-v4-flash  
?? Context: 0/1.0m (0%)       �� WAS 200K, NOW 1.0M ? FIXED

?? Session: opencode/deepseek-v4-flash-free
?? Context: 611/200k (0%)     �� Correct 200K for free tier
\\\

### TUI verification
TUI correctly shows live context tracking (no ? placeholder) and correct window for each model.

## Related Issues

- **Closes #39857** �X Context window shows 200K for proxy models with slash
- **Closes #92760** �X CLI openclaw status uses standalone copy of resolution function
- Related #90889 �X Config context window override (complementary, non-overlapping)
- Related #92415 �X Session model snapshot stale after /model switch (fixed by #92424)
