### PR TITLE
fix: drop retained session fence text after prompt lock reacquire

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -875,6 +875,46 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(2);
   });
 
+  it("uses digest-only fence checks after prompt lock reacquire", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocalDigestFence = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocalDigestFence,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await expect(controller.withSessionWriteLock(() => "warmup")).resolves.toBe("warmup");
+
+    const stableStat = await fs.stat(sessionFile, { bigint: true });
+    const driftedStat = cloneBigIntStatWith(stableStat, {
+      ctimeNs: stableStat.ctimeNs + 1_000_000n,
+    });
+    const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (target, options) => {
+      if (target === sessionFile && options?.bigint === true) {
+        return driftedStat;
+      }
+      throw new Error(`unexpected stat call for ${String(target)}`);
+    });
+    const readFileSpy = vi.spyOn(fs, "readFile").mockImplementation(async (target, options) => {
+      if (target === sessionFile && options === "utf8") {
+        throw Object.assign(new Error("forced readFile failure"), { code: "EIO" });
+      }
+      throw new Error(`unexpected readFile call for ${String(target)}`);
+    });
+
+    try {
+      await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
+    } finally {
+      readFileSpy.mockRestore();
+      statSpy.mockRestore();
+    }
+    expect(controller.hasSessionTakeover()).toBe(false);
+    expect(acquireSessionWriteLockLocalDigestFence).toHaveBeenCalledTimes(3);
+    expect(release).toHaveBeenCalledTimes(3);
+  });
+
   it("trusts owned writes after accepting ctime-only fingerprint drift", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -67,6 +67,20 @@ type SessionFileFenceSnapshot = {
   text?: string;
 };
 
+function compactFenceSnapshotForRetainedLock(
+  snapshot: SessionFileFenceSnapshot | undefined,
+): SessionFileFenceSnapshot | undefined {
+  if (!snapshot?.fingerprint.exists || snapshot.text === undefined) {
+    return snapshot;
+  }
+  return {
+    fingerprint: snapshot.fingerprint,
+    // Keep a stable content check while dropping large transcript text from
+    // long-lived lock-controller closures after prompt lock reacquisition.
+    digest: createHash("sha256").update(snapshot.text).digest("hex"),
+  };
+}
+
 function sameSessionFileFingerprint(
   left: SessionFileFingerprint | undefined,
   right: SessionFileFingerprint,
@@ -797,6 +811,9 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
     const current = await readSessionFileFingerprint(params.lockOptions.sessionFile);
     if (sameSessionFileFingerprint(fenceFingerprint, current)) {
+      fenceSnapshot = compactFenceSnapshotForRetainedLock(fenceSnapshot) ?? {
+        fingerprint: current,
+      };
       return;
     }
 
@@ -822,6 +839,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
       fenceFingerprint = fenceSnapshot.fingerprint;
       fenceGeneration = recordTrustedSessionFileState(sessionFileFenceKey, current);
+      fenceSnapshot = compactFenceSnapshotForRetainedLock(fenceSnapshot) ?? fenceSnapshot;
       return;
     }
 
@@ -840,6 +858,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
       fenceFingerprint = fenceSnapshot.fingerprint;
       fenceGeneration = trustSessionFileState(sessionFileFenceKey, current) ?? fenceGeneration;
+      fenceSnapshot = compactFenceSnapshotForRetainedLock(fenceSnapshot) ?? fenceSnapshot;
       return;
     }
 
@@ -871,7 +890,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     const snapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
     if (!sameSessionFileFingerprint(beforeWrite, snapshot.fingerprint) && fenceActive) {
       fenceFingerprint = snapshot.fingerprint;
-      fenceSnapshot = snapshot;
+      fenceSnapshot = compactFenceSnapshotForRetainedLock(snapshot) ?? snapshot;
     }
   }
 
@@ -882,7 +901,9 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     const ownedWrite = await publishOwnedSessionFileWriteIfChanged(beforeWrite);
     if (ownedWrite && fenceActive) {
       fenceFingerprint = ownedWrite.fingerprint;
-      fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
+      fenceSnapshot = compactFenceSnapshotForRetainedLock(
+        await readSessionFileFenceSnapshot(params.lockOptions.sessionFile),
+      );
       fenceGeneration = ownedWrite.generation;
     }
   }
@@ -1160,6 +1181,8 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     },
     async dispose(): Promise<void> {
       await disposeHeldLockAfterRetainedIdle();
+      fenceSnapshot = undefined;
+      fenceFingerprint = undefined;
     },
   };
 }


### PR DESCRIPTION
## Summary
- compact retained `fenceSnapshot` payloads to `fingerprint + digest` once the session write lock is reacquired
- keep full `fenceSnapshot.text` only during the released prompt window where rewrite detection needs it
- clear retained fence snapshot state on `dispose()`
- add regression coverage proving ctime-only drift still passes after reacquire even when `fs.readFile` fails, which requires digest-backed (not text-backed) retained snapshots

## Root cause context
Heap retainer traces from 2026-06-13 showed 1MB transcript/tool payload strings retained as:
`string -> Object.text -> context:fenceSnapshot -> closure:releaseForPrompt/withSessionWriteLock`.

`readSessionFileFenceSnapshot()` intentionally reads full session file text (up to 8MB), but that text was staying in long-lived lock-controller closures after prompt lock reacquisition.

## Verification
- `pnpm test src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`
  - `Test Files 1 passed`
  - `Tests 54 passed`

## Related context
- https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1897
