### PR TITLE
fix(macos): defer isOverflowing mutation to break SwiftUI render loop (fixes #43480)

### DIFF
--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
@@ -92,7 +92,14 @@ extension VoiceWakeOverlayController {
 
         let contentHeight = ceil(used.height + (textInset.height * 2))
         let total = contentHeight + self.verticalPadding * 2
-        self.model.isOverflowing = total > self.maxHeight
+        // Defer the overflow state mutation to break the SwiftUI onChange → measuredHeight →
+        // isOverflowing → re-render → onChange synchronous render loop (fixes #43480).
+        let overflowing = total > self.maxHeight
+        if self.model.isOverflowing != overflowing {
+            DispatchQueue.main.async { [weak self] in
+                self?.model.isOverflowing = overflowing
+            }
+        }
         return max(self.minHeight, min(total, self.maxHeight))
     }
 

--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
@@ -95,10 +95,9 @@ extension VoiceWakeOverlayController {
         // Defer the overflow state mutation to break the SwiftUI onChange → measuredHeight →
         // isOverflowing → re-render → onChange synchronous render loop (fixes #43480).
         let overflowing = total > self.maxHeight
-        if self.model.isOverflowing != overflowing {
-            DispatchQueue.main.async { [weak self] in
-                self?.model.isOverflowing = overflowing
-            }
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.model.isOverflowing != overflowing else { return }
+            self.model.isOverflowing = overflowing
         }
         return max(self.minHeight, min(total, self.maxHeight))
     }


### PR DESCRIPTION
## Summary

Defer the `isOverflowing` state mutation in `measuredHeight()` via `DispatchQueue.main.async` with an equality guard. This breaks the synchronous SwiftUI render loop that causes the macOS app to pinwheel at 100% CPU.

## Root Cause

`measuredHeight()` in `VoiceWakeOverlayController+Window.swift` mutated `model.isOverflowing` synchronously during a SwiftUI view update cycle:

```
onChange(of: attributed) → updateWindowFrame() → targetFrame() → measuredHeight()
  → sets isOverflowing → invalidates view → re-render → onChange fires again → repeat
```

The SwiftUI warning logs confirm this:
```
Modifying state during view update, this will cause undefined behavior.
onChange(of: AnyTextLayoutCollection) action tried to update multiple times per frame.
```

## Fix

- **Equality guard**: only update `isOverflowing` when the value actually changes
- **Deferred mutation**: use `DispatchQueue.main.async` to set `isOverflowing` on the next run loop iteration, breaking the synchronous cycle
- The frame calculation (`targetFrame`) remains synchronous so the window size is correct immediately
- 1 file changed, +8 −1

Fixes #43480

## Real behavior proof

- **Behavior addressed:** macOS app pinwheels due to infinite SwiftUI render loop when VoiceWakeOverlay attributed text changes trigger onChange → updateWindowFrame → measuredHeight → isOverflowing mutation → re-render → onChange cycle
- **Environment tested:** macOS 26.4.1 (Sequoia), Swift 6.2, arm64
- **Steps run after the patch:**
```
cd apps/macos && swift build 2>&1 | tail -5
swift test --filter VoiceWakeOverlay 2>&1 | grep -E "passed|failed"
```
- **Evidence after fix:**
```
Build complete! (10.27s)
✔ Test run with 10 tests in 3 suites passed after 0.668 seconds.
```
- **Observed result after fix:** `swift build` compiles without errors or warnings. All 10 VoiceWakeOverlay tests pass. The deferred mutation via `DispatchQueue.main.async` with equality guard breaks the synchronous render loop.
- **What was not tested:** Live macOS app interaction (menu bar click, voice wake trigger). The render loop is a SwiftUI runtime behavior that requires an active NSApplication run loop to reproduce.
