### PR TITLE
fix(gateway): use resolveNonNegativeNumber for totalTokens to display 0 instead of ? (fixes #43009)

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -2082,8 +2082,8 @@ export function buildGatewaySessionRow(params: {
     : resolvedModelIdentity;
   const { provider: modelProvider, model } = modelIdentity;
   const totalTokens =
-    resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) ??
-    resolvePositiveNumber(transcriptUsage?.totalTokens);
+    resolveNonNegativeNumber(resolveFreshSessionTotalTokens(entry)) ??
+    resolveNonNegativeNumber(transcriptUsage?.totalTokens);
   const totalTokensFresh =
     typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0
       ? true


### PR DESCRIPTION
## What does this PR do?

Fixes the TUI displaying `tokens ?/200k` instead of `tokens 0/200k (0%)` for new sessions with zero token usage. The `resolvePositiveNumber` helper requires `value > 0`, which filters out the valid `totalTokens = 0` case. Switching to `resolveNonNegativeNumber` (`value >= 0`) allows zero to pass through correctly.

## Related Issue

Fixes #43009

## Type of Change

- [x] Bug fix (non-breaking)

## Changes Made

- `src/gateway/session-utils.ts`: In `buildGatewaySessionRow`, change the two `resolvePositiveNumber` calls for `totalTokens` to `resolveNonNegativeNumber`. The `needsTranscriptTotalTokens` check at line 2041 still correctly uses `resolvePositiveNumber` to decide whether to fetch transcript data.

## How to Test

1. Start OpenClaw TUI with a new session (no prior usage)
2. Observe the token display in the status bar
3. Before fix: shows `?/200k`; after fix: shows `0/200k (0%)`

## Real behavior proof

- **Behavior addressed:** TUI displays `tokens ?/200k` instead of `tokens 0/200k (0%)` for sessions with zero totalTokens because `resolvePositiveNumber(0)` returns `undefined` (requires value > 0). `resolveNonNegativeNumber(0)` correctly returns `0`.
- **Environment tested:** macOS 26.4.1 (arm64), Node 22.22.2, OpenClaw main @ 4e4ea1c1
- **Steps run after the patch:**
  1. Verified `resolveNonNegativeNumber` behavior via inline Node test
  2. Confirmed the fix in `src/gateway/session-utils.ts` via `grep`

- **Evidence after fix:**
```
$ node -e "
function resolvePositiveNumber(v) { return typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : undefined; }
function resolveNonNegativeNumber(v) { return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : undefined; }
console.log('OLD resolvePositiveNumber(0):', resolvePositiveNumber(0));
console.log('NEW resolveNonNegativeNumber(0):', resolveNonNegativeNumber(0));
console.log('resolveNonNegativeNumber(undefined):', resolveNonNegativeNumber(undefined));
console.log('resolveNonNegativeNumber(-1):', resolveNonNegativeNumber(-1));
"
OLD resolvePositiveNumber(0): undefined
NEW resolveNonNegativeNumber(0): 0
resolveNonNegativeNumber(undefined): undefined
resolveNonNegativeNumber(-1): undefined

$ grep -n "resolveNonNegativeNumber.*totalTokens\|resolvePositiveNumber.*totalTokens" src/gateway/session-utils.ts
913:    totalTokens: resolvePositiveNumber(snapshot.totalTokens),
2086:    resolveNonNegativeNumber(transcriptUsage?.totalTokens);
```

- **Observed result after fix:** `resolveNonNegativeNumber(0)` returns `0` (correct), while the old `resolvePositiveNumber(0)` returned `undefined` (the bug). Line 2086 now uses `resolveNonNegativeNumber` for transcript usage. Line 913 (snapshot totalTokens) correctly retains `resolvePositiveNumber`.
- **What was not tested:** Live TUI rendering (no display server available in CI). The fix is a single-function swap verified by logic test and build.