### PR TITLE
fix(state): tolerate chmod-less volumes when opening the agent database

### DIFF
--- a/src/state/openclaw-agent-db.permissions.test.ts
+++ b/src/state/openclaw-agent-db.permissions.test.ts
@@ -1,0 +1,90 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const chmodFailHook = vi.hoisted(() => ({
+  error: undefined as Error | undefined,
+  calls: 0,
+  failProbe: true,
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const chmodSync: typeof actual.chmodSync = ((target: unknown, mode: unknown) => {
+    chmodFailHook.calls += 1;
+    const isProbe = String(target).includes(".openclaw-chmod-probe-");
+    if (chmodFailHook.error && (chmodFailHook.failProbe || !isProbe)) {
+      throw chmodFailHook.error;
+    }
+    return (actual.chmodSync as (...args: unknown[]) => unknown)(target, mode);
+  }) as typeof actual.chmodSync;
+  return { ...actual, chmodSync, default: { ...actual, chmodSync } };
+});
+
+const fs = await import("node:fs");
+const { closeOpenClawAgentDatabasesForTest, openOpenClawAgentDatabase } =
+  await import("./openclaw-agent-db.js");
+const { closeOpenClawStateDatabaseForTest } = await import("./openclaw-state-db.js");
+
+function chmodError(code: string): Error {
+  const err = new Error(`${code}: chmod failed`) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+function enotsupError(): Error {
+  return chmodError("ENOTSUP");
+}
+
+describe("agent database permission hardening without chmod support", () => {
+  let stateDir: string | undefined;
+
+  afterEach(() => {
+    chmodFailHook.error = undefined;
+    chmodFailHook.calls = 0;
+    chmodFailHook.failProbe = true;
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    if (stateDir) {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+      stateDir = undefined;
+    }
+  });
+
+  it("opens the agent database when chmodSync throws ENOTSUP", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-agent-chmod-"));
+    chmodFailHook.error = enotsupError();
+
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+
+    expect(database.db.isOpen).toBe(true);
+    expect(chmodFailHook.calls).toBeGreaterThan(0);
+  });
+
+  it("rethrows unexpected chmod errors at open", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-agent-chmod-"));
+    chmodFailHook.error = chmodError("EACCES");
+
+    expect(() =>
+      openOpenClawAgentDatabase({ agentId: "main", env: { OPENCLAW_STATE_DIR: stateDir } }),
+    ).toThrow(/EACCES/);
+  });
+
+  it("opens when the filesystem probe also rejects chmod with EPERM", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-agent-chmod-"));
+    const agentDir = join(stateDir, "agents", "main", "agent");
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.chmodSync(agentDir, 0o755);
+    chmodFailHook.error = chmodError("EPERM");
+
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+
+    expect(database.db.isOpen).toBe(true);
+  });
+});

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -1,5 +1,5 @@
 // OpenClaw agent database stores agent-scoped persisted runtime state.
-import { chmodSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, statSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import {
@@ -17,6 +17,7 @@ import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.generated.js"
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+  bestEffortChmodSync,
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
@@ -95,12 +96,12 @@ function ensureOpenClawAgentDatabasePermissions(
   mkdirSync(dir, { recursive: true, mode: OPENCLAW_AGENT_DB_DIR_MODE });
   // Default agent state is private by contract; custom pre-existing dirs keep caller ownership.
   if (isDefaultAgentDatabase || !dirExisted) {
-    chmodSync(dir, OPENCLAW_AGENT_DB_DIR_MODE);
+    bestEffortChmodSync(dir, OPENCLAW_AGENT_DB_DIR_MODE);
   }
   for (const suffix of OPENCLAW_AGENT_DB_SIDECAR_SUFFIXES) {
     const candidate = `${pathname}${suffix}`;
     if (existsSync(candidate)) {
-      chmodSync(candidate, OPENCLAW_AGENT_DB_FILE_MODE);
+      bestEffortChmodSync(candidate, OPENCLAW_AGENT_DB_FILE_MODE);
     }
   }
 }

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -166,7 +166,7 @@ function canIgnoreChmodError(target: string, code: string | undefined): boolean 
 // it: the database stays usable without the chmod, and crashing at open would
 // take the gateway down on Azure Files/NFS/Docker volumes (#91919). Unexpected
 // chmod failures still throw so credentials-adjacent hardening stays loud.
-function bestEffortChmodSync(target: string, mode: number): void {
+export function bestEffortChmodSync(target: string, mode: number): void {
   try {
     chmodSync(target, mode);
   } catch (err) {


### PR DESCRIPTION
## Summary

`ensureOpenClawAgentDatabasePermissions` in `src/state/openclaw-agent-db.ts` called raw `chmodSync` for the per-agent DB directory and sidecar files. Its sibling, the shared state DB in `src/state/openclaw-state-db.ts`, routes the identical hardening through `bestEffortChmodSync`, which was added in #91919 (commit 13dce48321) to keep the gateway alive on filesystems where `chmod` is unsupported (Azure Files, some Docker volume drivers, NFS without `no_root_squash`, certain k8s PVCs).

That fix only covered the shared state DB. The agent DB still crashed on the same volumes. For the default agent path `isDefaultAgentDatabase` is always true, so `chmodSync` runs on every open. The result on an affected volume: the gateway's shared state DB comes up fine, then the first agent operation (for example loading auth profiles via `openAuthProfileDatabase` -> `openOpenClawAgentDatabase`) hits the raw `chmodSync`, it throws `ENOTSUP`, and the error is uncaught. The agent cannot load auth or run, while the gateway looks healthy, which makes the cause confusing. This is exactly the failure mode #91919 was fixed to support, one layer down.

## Fix

- Export `bestEffortChmodSync` from `openclaw-state-db.ts` (it already encapsulates the tolerate-or-throw policy).
- Use it for both the agent DB directory and the sidecar files in `openclaw-agent-db.ts`.

This preserves fail-closed behavior for ordinary `EPERM` ownership faults on POSIX filesystems: the helper only tolerates the unambiguous unsupported codes (`ENOTSUP`/`EOPNOTSUPP`/`EINVAL`) or a probe-confirmed `EPERM` where the filesystem itself rejects `chmod`. Unexpected codes such as `EACCES` still throw, keeping the private-mode hardening loud.

## Verification

Added a colocated regression test `src/state/openclaw-agent-db.permissions.test.ts`, mirroring the existing `openclaw-state-db.permissions.test.ts` from #91919. Suite status:

- `node scripts/run-vitest.mjs src/state/openclaw-state-db.permissions.test.ts src/state/openclaw-agent-db.permissions.test.ts` -> 10 passed (10). With the source reverted to main, the two agent-DB tolerance cases fail (ENOTSUP, EPERM-probe), confirming the test catches the regression.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` -> exit 0
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json` -> exit 0
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json <changed files>` and `oxfmt --check` -> clean

## Real behavior proof

Behavior addressed: Opening the per-agent SQLite database no longer crashes when the underlying volume rejects chmod (Azure Files, some Docker volume drivers, NFS without no_root_squash, certain k8s PVCs). It tolerates the unsupported errno codes like the shared state DB already does, and still fails closed on a genuine permission fault.

Real environment tested: Linux (Node 22.19) running the real production entry points `openOpenClawAgentDatabase` and the auth-profile reader `readPersistedAuthProfileStoreRaw`, driven through node, against a real temp state dir. The chmod-rejecting volume is reproduced at the OS layer (not in a JS harness): a small LD_PRELOAD shim makes the libc chmod(2)/fchmodat(2) calls return ENOTSUP or EPERM, exactly as those mounts do, so Node receives the real errno from the kernel call boundary.

Exact steps or command run after this patch: gcc -shared -fPIC -o chmodfail.so chmodfail.c ; then LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=ENOTSUP node_modules/.bin/tsx drive-agent-db.mts (the driver calls the real openOpenClawAgentDatabase and then readPersistedAuthProfileStoreRaw on the returned handle). Repeated with CHMOD_FAIL_CODE=EPERM and CHMOD_FAIL_CODE=EACCES, and once with the two source files reverted to origin/main for the before capture.

Evidence after fix: redacted live terminal output. The same LD_PRELOAD volume is used for the before and after captures.

```
# BEFORE (origin/main, raw chmodSync) on an ENOTSUP volume:
$ LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=ENOTSUP node_modules/.bin/tsx drive-agent-db.mts
# simulated volume: chmod() returns ENOTSUP at the libc layer (LD_PRELOAD)
agent DB open: THREW ENOTSUP - ENOTSUP: operation not supported on socket, chmod '.../agents/main/agent'
exit=1

# AFTER (this PR) on the same ENOTSUP volume:
$ LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=ENOTSUP node_modules/.bin/tsx drive-agent-db.mts
[state/db] skipped permission hardening for .../agents/main/agent: ENOTSUP: operation not supported on socket, chmod ...
[state/db] skipped permission hardening for .../agents/main/agent/openclaw-agent.sqlite: ENOTSUP ...
agent DB open: db.isOpen=true path=.../agents/main/agent/openclaw-agent.sqlite
auth profile store load: OK (store=null)
exit=0

# AFTER on an EPERM volume (filesystem probe confirms chmod is rejected):
$ LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=EPERM node_modules/.bin/tsx drive-agent-db.mts
agent DB open: db.isOpen=true path=.../agents/main/agent/openclaw-agent.sqlite
auth profile store load: OK (store=null)
exit=0

# AFTER on an EACCES volume (must stay fail-closed):
$ LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=EACCES node_modules/.bin/tsx drive-agent-db.mts
agent DB open: THREW EACCES - EACCES: permission denied, chmod '.../agents/main/agent'
exit=1
```

Observed result after fix: On the ENOTSUP and EPERM volumes the real openOpenClawAgentDatabase returns an open handle (db.isOpen=true) and the auth-profile read on that handle returns its value instead of crashing (exit 0), whereas the unpatched code threw ENOTSUP before the DB opened (exit 1). On the EACCES volume the patched code still throws (exit 1), so a genuine permission fault stays loud.

What was not tested: A literal cloud Azure Files / NFS / Docker-volume mount end to end (the chmod rejection is reproduced at the libc syscall boundary via LD_PRELOAD); full gateway boot on such a volume.

Refs: #91919 (the shared state DB fix this extends to the agent DB).
