### PR TITLE
fix(telegram): skip IPv4 fallback when user configures explicit network settings (fixes #75574)

### DIFF
--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -680,6 +680,27 @@ describe("resolveTelegramFetch", () => {
     expect(typeof pinnedPolicy?.connect?.lookup).toBe("function");
   });
 
+  it("skips sticky IPv4 fallback when user explicitly configures network settings", async () => {
+    undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
+    const transport = resolveTelegramTransport(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "verbatim",
+      },
+    });
+
+    await expect(
+      transport.sourceFetch("https://api.telegram.org/botTOKEN/getFile"),
+    ).resolves.toEqual({ ok: true });
+    // Only the default dispatcher — no IPv4 fallback or pinned IP attempts
+    expect(transport.dispatcherAttempts).toHaveLength(1);
+    const [defaultAttempt] = transport.dispatcherAttempts as Array<{
+      dispatcherPolicy?: DirectTelegramDispatcherPolicy;
+    }>;
+    expect(defaultAttempt.dispatcherPolicy?.mode).toBe("direct");
+    expect(defaultAttempt.dispatcherPolicy?.connect?.autoSelectFamily).toBe(true);
+  });
+
   it("does not blind-retry when sticky IPv4 fallback is disallowed for explicit proxy paths", async () => {
     const { makeProxyFetch } = await import("./proxy.js");
     const proxyFetch = makeProxyFetch("http://127.0.0.1:7890");

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -635,9 +635,13 @@ export function resolveTelegramTransport(
   });
   const defaultDispatcher = createTelegramDispatcher(defaultDispatcherResolution.policy);
   const shouldBypassEnvProxy = shouldBypassEnvProxyForTelegramApi();
+  const hasExplicitNetworkConfig =
+    dnsDecision.source === "config" &&
+    dnsDecision.value !== "ipv4first";
   const allowStickyFallback =
-    defaultDispatcher.mode === "direct" ||
-    (defaultDispatcher.mode === "env-proxy" && shouldBypassEnvProxy);
+    !hasExplicitNetworkConfig &&
+    (defaultDispatcher.mode === "direct" ||
+      (defaultDispatcher.mode === "env-proxy" && shouldBypassEnvProxy));
   const fallbackDispatcherPolicy = allowStickyFallback
     ? resolveTelegramDispatcherPolicy({
         autoSelectFamily: false,


### PR DESCRIPTION
## Summary

When a user explicitly configures Telegram `network` settings (e.g., `dnsResultOrder: "verbatim"` or `autoSelectFamily: true`), the sticky IPv4 fallback dispatcher should be bypassed — the user's explicit config should take precedence over the automatic fallback behavior.

Previously, `allowStickyFallback` was determined solely by the dispatcher mode, ignoring whether the user had explicitly configured network settings. This meant that even with `dnsResultOrder: "verbatim"` configured, the sticky IPv4 fallback would still activate, potentially overriding the user's intent.

Fix: check `dnsDecision.source === "config"` — when the DNS decision came from user config (not auto-detection) and the config is not `ipv4first`, skip the sticky IPv4 fallback.

Fixes #75574

## Changes

- `extensions/telegram/src/fetch.ts`: add `hasExplicitNetworkConfig` check before enabling sticky IPv4 fallback
- `extensions/telegram/src/fetch.test.ts`: add test verifying sticky IPv4 fallback is skipped when user configures explicit network settings

## Real behavior proof

- **Behavior addressed:** Telegram sticky IPv4 fallback was not respecting explicit user network config, causing IPv6-first or verbatim DNS resolution to be overridden by automatic IPv4 fallback.
- **Environment tested:** macOS 26.4.1, Node.js, OpenClaw local build from `upstream/main` (4e4ea1c1).
- **Steps run after the patch:**
  1. Ran Telegram fetch tests: `extensions/telegram/src/fetch.test.ts` — 41 tests passed
  2. Ran full build: `pnpm build` — completed in 76s
  3. Verified the fix logic with grep showing the explicit config check

- **Evidence after fix:**

```
$ grep -n 'hasExplicitNetworkConfig\|dnsDecision.*source.*config' extensions/telegram/src/fetch.ts
638:  const hasExplicitNetworkConfig =
639:    dnsDecision.source === "config" &&
642:    !hasExplicitNetworkConfig &&

$ pnpm build
✓ built in 506ms
[build-all] phase timings: total 76.5s
```

- **Observed result after fix:** Build passes, all 41 Telegram fetch tests pass, sticky IPv4 fallback correctly bypassed when user configures explicit non-ipv4first network settings.
- **What was not tested:** Live Telegram API calls on IPv6-only hosts (requires platform-specific setup). The fix is verified through unit tests with mocked fetch.
