### PR TITLE
fix(session): clear stale auto fallback origins

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -37,8 +37,10 @@ const state = vi.hoisted(() => ({
   ),
   resolveEffectiveModelFallbacksMock: vi.fn().mockReturnValue(undefined),
   hasLegacyAutoFallbackWithoutOriginMock: vi.fn((_entry: unknown) => false),
+  isStaleAutoFallbackOriginOverrideMock: vi.fn((_params: unknown) => false),
   resolveAutoFallbackPrimaryProbeMock: vi.fn((_params: unknown) => undefined as unknown),
   resolveChannelModelOverrideMock: vi.fn((_params: unknown) => null as unknown),
+  applyModelOverrideToSessionEntryMock: vi.fn((_params: unknown) => ({ updated: false })),
   assertLifecycleCurrentMock: vi.fn(),
   emitAgentEventMock: vi.fn(),
   registerAgentRunContextMock: vi.fn(),
@@ -346,7 +348,8 @@ vi.mock("../sessions/level-overrides.js", () => ({
 }));
 
 vi.mock("../sessions/model-overrides.js", () => ({
-  applyModelOverrideToSessionEntry: () => ({ updated: false }),
+  applyModelOverrideToSessionEntry: (params: unknown) =>
+    state.applyModelOverrideToSessionEntryMock(params),
   repairProviderWrappedModelOverride: () => ({ updated: false }),
 }));
 
@@ -384,6 +387,8 @@ vi.mock("./agent-scope.js", () => ({
   hasLegacyAutoFallbackWithoutOrigin: (entry: unknown) =>
     state.hasLegacyAutoFallbackWithoutOriginMock(entry),
   hasSessionAutoModelFallbackProvenance: () => false,
+  isStaleAutoFallbackOriginOverride: (params: unknown) =>
+    state.isStaleAutoFallbackOriginOverrideMock(params),
   listAgentEntries: () => [],
   listAgentIds: () => ["default"],
   markAutoFallbackPrimaryProbe: vi.fn(),
@@ -957,7 +962,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.resolveAgentSkillsFilterMock.mockReturnValue(undefined);
     state.loadManifestModelCatalogMock.mockReturnValue([]);
     state.hasLegacyAutoFallbackWithoutOriginMock.mockReturnValue(false);
+    state.isStaleAutoFallbackOriginOverrideMock.mockReturnValue(false);
     state.resolveAutoFallbackPrimaryProbeMock.mockReturnValue(undefined);
+    state.applyModelOverrideToSessionEntryMock.mockReturnValue({ updated: false });
     state.resolveChannelModelOverrideMock.mockImplementation((params: unknown) => {
       const input = params as {
         cfg?: { channels?: { modelByChannel?: Record<string, Record<string, string>> } };
@@ -1519,6 +1526,88 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     const fallbackParams = mockCallArg(state.runWithModelFallbackMock) as FallbackRunnerParams;
     expect(fallbackParams.provider).toBe("openai");
     expect(fallbackParams.model).toBe("channel-model");
+  });
+
+  it("clears stale auto fallback origin overrides before agent-command model selection", async () => {
+    setupSingleAttemptFallback();
+    state.isStaleAutoFallbackOriginOverrideMock.mockReturnValue(true);
+    state.applyModelOverrideToSessionEntryMock.mockImplementation((params: unknown) => {
+      const entry = (params as { entry: SessionEntry }).entry;
+      delete entry.providerOverride;
+      delete entry.modelOverride;
+      delete entry.modelOverrideSource;
+      delete entry.modelOverrideFallbackOriginProvider;
+      delete entry.modelOverrideFallbackOriginModel;
+      entry.updatedAt = 2;
+      return { updated: true };
+    });
+    state.runtimeConfigMock = {
+      agents: {
+        defaults: {
+          model: "anthropic/claude-opus-4-8",
+        },
+      },
+    };
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-7",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "anthropic",
+      modelOverrideFallbackOriginModel: "claude-haiku-4-5",
+      skillsSnapshot: { prompt: "", skills: [], version: 0 },
+    };
+    const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = sessionStore;
+    state.storePathMock = "/tmp/openclaw-session-store.json";
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("anthropic", "claude-opus-4-8"));
+
+    await runBasicAgentCommand();
+
+    const staleOriginParams = requireRecord(
+      mockCallArg(state.isStaleAutoFallbackOriginOverrideMock),
+      "stale origin params",
+    );
+    expect(staleOriginParams.entry).toEqual(expect.objectContaining({ sessionId: "session-1" }));
+    expectRecordFields(staleOriginParams, {
+      primaryProvider: "anthropic",
+      primaryModel: "claude-opus-4-8",
+    });
+    const applyOverrideParams = requireRecord(
+      mockCallArg(state.applyModelOverrideToSessionEntryMock),
+      "apply model override params",
+    );
+    expect(applyOverrideParams.entry).toEqual(expect.objectContaining({ sessionId: "session-1" }));
+    expectRecordFields(applyOverrideParams, {
+      preserveAuthProfileOverride: true,
+    });
+    expectRecordFields(applyOverrideParams.selection, {
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      isDefault: true,
+    });
+    const cleanupPersist = state.persistSessionEntryMock.mock.calls
+      .map(
+        ([params]) => params as { entry?: SessionEntry; sessionKey?: string; storePath?: string },
+      )
+      .find((params) => params.entry?.updatedAt === 2);
+    expect(cleanupPersist).toEqual(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        storePath: "/tmp/openclaw-session-store.json",
+      }),
+    );
+    expect(cleanupPersist?.entry?.providerOverride).toBeUndefined();
+    expect(cleanupPersist?.entry?.modelOverride).toBeUndefined();
+    expect(cleanupPersist?.entry?.modelOverrideSource).toBeUndefined();
+    expect(cleanupPersist?.entry?.modelOverrideFallbackOriginProvider).toBeUndefined();
+    expect(cleanupPersist?.entry?.modelOverrideFallbackOriginModel).toBeUndefined();
+    const fallbackParams = mockCallArg(state.runWithModelFallbackMock) as FallbackRunnerParams;
+    expect(fallbackParams.provider).toBe("anthropic");
+    expect(fallbackParams.model).toBe("claude-opus-4-8");
+    expect(state.resolveAutoFallbackPrimaryProbeMock).not.toHaveBeenCalled();
   });
 
   it("probes the channel primary when a session is pinned to an auto fallback", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -73,6 +73,7 @@ import {
   entryMatchesAutoFallbackPrimaryProbe,
   hasLegacyAutoFallbackWithoutOrigin,
   hasSessionAutoModelFallbackProvenance,
+  isStaleAutoFallbackOriginOverride,
   listAgentIds,
   markAutoFallbackPrimaryProbe,
   resolveAutoFallbackPrimaryProbe,
@@ -1374,7 +1375,7 @@ async function agentCommandInternal(
       }
     }
 
-    const storedProviderOverride = hasLegacyAutoFallbackOverrideWithoutOrigin
+    let storedProviderOverride = hasLegacyAutoFallbackOverrideWithoutOrigin
       ? undefined
       : sessionEntry?.providerOverride?.trim();
     let storedModelOverride = hasLegacyAutoFallbackOverrideWithoutOrigin
@@ -1416,6 +1417,41 @@ async function agentCommandInternal(
       : null;
     const primaryProvider = normalizedChannelOverride?.provider ?? defaultProvider;
     const primaryModel = normalizedChannelOverride?.model ?? defaultModel;
+    const staleAutoFallbackOriginOverride =
+      !hasExplicitRunOverride &&
+      !hasLegacyAutoFallbackOverrideWithoutOrigin &&
+      hasStoredOverride &&
+      isStaleAutoFallbackOriginOverride({
+        entry: sessionEntry,
+        primaryProvider,
+        primaryModel,
+      });
+    if (
+      staleAutoFallbackOriginOverride &&
+      sessionEntry &&
+      sessionStore &&
+      sessionKey &&
+      !suppressVisibleSessionEffects
+    ) {
+      const { updated } = applyModelOverrideToSessionEntry({
+        entry: sessionEntry,
+        selection: { provider: primaryProvider, model: primaryModel, isDefault: true },
+        preserveAuthProfileOverride: true,
+      });
+      if (updated) {
+        storedModelOverrideSource = undefined;
+        await persistSessionEntry({
+          sessionStore,
+          sessionKey,
+          storePath,
+          entry: sessionEntry,
+        });
+      }
+    }
+    if (staleAutoFallbackOriginOverride) {
+      storedProviderOverride = undefined;
+      storedModelOverride = undefined;
+    }
     const hasEffectiveStoredOverride = Boolean(storedProviderOverride || storedModelOverride);
     if (normalizedChannelOverride && !hasEffectiveStoredOverride) {
       provider = normalizedChannelOverride.provider;
@@ -1435,14 +1471,15 @@ async function agentCommandInternal(
         model = normalizedStored.model;
       }
     }
-    const autoFallbackPrimaryProbe = !hasExplicitRunOverride
-      ? resolveAutoFallbackPrimaryProbe({
-          entry: sessionEntry,
-          sessionKey,
-          primaryProvider,
-          primaryModel,
-        })
-      : undefined;
+    const autoFallbackPrimaryProbe =
+      !hasExplicitRunOverride && !staleAutoFallbackOriginOverride
+        ? resolveAutoFallbackPrimaryProbe({
+            entry: sessionEntry,
+            sessionKey,
+            primaryProvider,
+            primaryModel,
+          })
+        : undefined;
     let autoFallbackPrimaryProbeSessionEntry: SessionEntry | undefined;
     if (autoFallbackPrimaryProbe && sessionEntry) {
       provider = autoFallbackPrimaryProbe.provider;

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -30,6 +30,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "./agent-scope-config.js";
+import { modelKey, normalizeModelRef } from "./model-selection-normalize.js";
 export {
   listAgentEntries,
   listAgentIds,
@@ -116,6 +117,56 @@ export function hasLegacyAutoFallbackWithoutOrigin(
     (!normalizeOptionalString(entry.modelOverrideFallbackOriginProvider) ||
       !normalizeOptionalString(entry.modelOverrideFallbackOriginModel))
   );
+}
+
+function resolveModelRefKey(params: {
+  provider?: string | null;
+  model?: string | null;
+}): string | null {
+  const provider = normalizeOptionalString(params.provider);
+  const model = normalizeOptionalString(params.model);
+  if (!provider || !model) {
+    return null;
+  }
+  const normalized = normalizeModelRef(provider, model);
+  return modelKey(normalized.provider, normalized.model);
+}
+
+/** Detects auto-fallback pins whose recorded primary origin no longer matches the current primary. */
+export function isStaleAutoFallbackOriginOverride(params: {
+  entry:
+    | Pick<
+        SessionEntry,
+        | "modelOverrideSource"
+        | "modelOverrideFallbackOriginProvider"
+        | "modelOverrideFallbackOriginModel"
+      >
+    | null
+    | undefined;
+  primaryProvider?: string | null;
+  primaryModel?: string | null;
+}): boolean {
+  const entry = params.entry;
+  if (!entry) {
+    return false;
+  }
+  const recoveredAutoFallbackOverride =
+    entry.modelOverrideSource === undefined && hasSessionAutoModelFallbackProvenance(entry);
+  if (entry.modelOverrideSource !== "auto" && !recoveredAutoFallbackOverride) {
+    return false;
+  }
+  const primaryKey = resolveModelRefKey({
+    provider: params.primaryProvider,
+    model: params.primaryModel,
+  });
+  if (!primaryKey) {
+    return false;
+  }
+  const originKey = resolveModelRefKey({
+    provider: entry.modelOverrideFallbackOriginProvider,
+    model: entry.modelOverrideFallbackOriginModel,
+  });
+  return originKey !== null && originKey !== primaryKey;
 }
 
 export function resolveAutoFallbackPrimaryProbe(params: {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -54,6 +54,7 @@ import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
 import { createReplyTimingTracker } from "./reply-timing-tracker.js";
 import { initSessionState } from "./session.js";
 import {
+  isStaleAutoFallbackOriginOverride,
   isStaleHeartbeatAutoFallbackOverride,
   resolveStoredModelOverride,
 } from "./stored-model-override.js";
@@ -622,19 +623,30 @@ export async function getReplyFromConfig(
     primaryProvider,
     primaryModel,
   });
+  const staleAutoFallbackOriginOverride = isStaleAutoFallbackOriginOverride({
+    sessionEntry,
+    storedOverride: storedModelOverride,
+    defaultProvider,
+    defaultModel,
+    primaryProvider,
+    primaryModel,
+  });
   const staleLegacyAutoFallbackWithoutOrigin =
     storedModelOverride?.source === "session" && hasLegacyAutoFallbackWithoutOrigin(sessionEntry);
   if (
     storedModelOverride?.model &&
     !hasResolvedHeartbeatModelOverride &&
     !staleHeartbeatAutoFallbackOverride &&
+    !staleAutoFallbackOriginOverride &&
     !staleLegacyAutoFallbackWithoutOrigin
   ) {
     provider = storedModelOverride.provider ?? defaultProvider;
     model = storedModelOverride.model;
   }
   const canApplyAutoFallbackPrimaryProbe =
-    !hasResolvedHeartbeatModelOverride && !staleHeartbeatAutoFallbackOverride;
+    !hasResolvedHeartbeatModelOverride &&
+    !staleHeartbeatAutoFallbackOverride &&
+    !staleAutoFallbackOriginOverride;
   const autoFallbackPrimaryProbe = canApplyAutoFallbackPrimaryProbe
     ? resolveAutoFallbackPrimaryProbe({
         entry: sessionEntry,
@@ -646,6 +658,7 @@ export async function getReplyFromConfig(
   const hasEffectiveSessionModelOverride =
     hasSessionModelOverride &&
     !staleHeartbeatAutoFallbackOverride &&
+    !staleAutoFallbackOriginOverride &&
     !staleLegacyAutoFallbackWithoutOrigin;
   if (
     !hasResolvedHeartbeatModelOverride &&

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1156,6 +1156,30 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("auto");
   });
 
+  it("clears polluted-origin auto-failover overrides on normal turns", async () => {
+    const { state, sessionStore } = await resolveStateWithOverride({
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-7",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "anthropic",
+      modelOverrideFallbackOriginModel: "claude-haiku-4-5",
+      primaryProvider: "anthropic",
+      primaryModel: "claude-opus-4-8",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+    });
+
+    expect(state.provider).toBe("anthropic");
+    expect(state.model).toBe("claude-opus-4-8");
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideRef).toBe("anthropic/claude-opus-4-7");
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginProvider).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginModel).toBeUndefined();
+  });
+
   it("keeps a legacy auto pin when the current selection already matches it", async () => {
     const { state, sessionStore } = await resolveStateWithOverride({
       providerOverride: "openrouter",

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -39,6 +39,7 @@ export {
   type ModelDirectiveSelection,
 } from "./model-selection-directive.js";
 import {
+  isStaleAutoFallbackOriginOverride,
   isStaleHeartbeatAutoFallbackOverride,
   resolveStoredModelOverride,
 } from "./stored-model-override.js";
@@ -206,6 +207,14 @@ export async function createModelSelectionState(params: {
     primaryProvider: params.primaryProvider,
     primaryModel: params.primaryModel,
   });
+  const staleAutoFallbackOriginOverride = isStaleAutoFallbackOriginOverride({
+    sessionEntry,
+    storedOverride: directStoredModelOverride,
+    defaultProvider,
+    defaultModel,
+    primaryProvider: params.primaryProvider,
+    primaryModel: params.primaryModel,
+  });
   const primaryHarnessPolicy = resolveAgentHarnessPolicy({
     provider: primaryProvider,
     modelId: primaryModel,
@@ -236,6 +245,7 @@ export async function createModelSelectionState(params: {
       modelKey(normalizedDirectOverride.provider, normalizedDirectOverride.model);
   const staleDirectStoredOverride =
     staleHeartbeatAutoFallbackOverride ||
+    staleAutoFallbackOriginOverride ||
     staleLegacyOpenAICodexAutoOverride ||
     staleLegacyAutoFallbackWithoutOrigin;
 

--- a/src/auto-reply/reply/stored-model-override.ts
+++ b/src/auto-reply/reply/stored-model-override.ts
@@ -142,3 +142,44 @@ export function isStaleHeartbeatAutoFallbackOverride(params: {
   });
   return storedOverrideKey !== null && storedOverrideKey !== primaryKey;
 }
+
+/** Detects auto-fallback pins whose recorded primary origin no longer matches the current primary. */
+export function isStaleAutoFallbackOriginOverride(params: {
+  sessionEntry?: SessionEntry;
+  storedOverride?: StoredModelOverride | null;
+  defaultProvider: string;
+  defaultModel: string;
+  primaryProvider?: string;
+  primaryModel?: string;
+}): boolean {
+  if (params.storedOverride?.source !== "session") {
+    return false;
+  }
+  const entry = params.sessionEntry;
+  const recoveredAutoFallbackOverride =
+    entry !== undefined &&
+    entry.modelOverrideSource === undefined &&
+    hasSessionAutoModelFallbackProvenance(entry);
+  if (entry?.modelOverrideSource !== "auto" && !recoveredAutoFallbackOverride) {
+    return false;
+  }
+  if (!entry) {
+    return false;
+  }
+
+  const primaryKey = resolveModelRefKey({
+    defaultProvider: params.defaultProvider,
+    overrideProvider: params.primaryProvider ?? params.defaultProvider,
+    overrideModel: params.primaryModel ?? params.defaultModel,
+  });
+  if (!primaryKey) {
+    return false;
+  }
+
+  const originKey = resolveModelRefKey({
+    defaultProvider: params.defaultProvider,
+    overrideProvider: entry.modelOverrideFallbackOriginProvider,
+    overrideModel: entry.modelOverrideFallbackOriginModel,
+  });
+  return originKey !== null && originKey !== primaryKey;
+}

--- a/src/auto-reply/reply/stored-model-override.ts
+++ b/src/auto-reply/reply/stored-model-override.ts
@@ -1,6 +1,9 @@
 // Persists and resolves per-session model override choices.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { hasSessionAutoModelFallbackProvenance } from "../../agents/agent-scope.js";
+import {
+  hasSessionAutoModelFallbackProvenance,
+  isStaleAutoFallbackOriginOverride as isStaleAutoFallbackOriginSessionEntry,
+} from "../../agents/agent-scope.js";
 import {
   modelKey,
   normalizeModelRef,
@@ -155,31 +158,9 @@ export function isStaleAutoFallbackOriginOverride(params: {
   if (params.storedOverride?.source !== "session") {
     return false;
   }
-  const entry = params.sessionEntry;
-  const recoveredAutoFallbackOverride =
-    entry !== undefined &&
-    entry.modelOverrideSource === undefined &&
-    hasSessionAutoModelFallbackProvenance(entry);
-  if (entry?.modelOverrideSource !== "auto" && !recoveredAutoFallbackOverride) {
-    return false;
-  }
-  if (!entry) {
-    return false;
-  }
-
-  const primaryKey = resolveModelRefKey({
-    defaultProvider: params.defaultProvider,
-    overrideProvider: params.primaryProvider ?? params.defaultProvider,
-    overrideModel: params.primaryModel ?? params.defaultModel,
+  return isStaleAutoFallbackOriginSessionEntry({
+    entry: params.sessionEntry,
+    primaryProvider: params.primaryProvider ?? params.defaultProvider,
+    primaryModel: params.primaryModel ?? params.defaultModel,
   });
-  if (!primaryKey) {
-    return false;
-  }
-
-  const originKey = resolveModelRefKey({
-    defaultProvider: params.defaultProvider,
-    overrideProvider: entry.modelOverrideFallbackOriginProvider,
-    overrideModel: entry.modelOverrideFallbackOriginModel,
-  });
-  return originKey !== null && originKey !== primaryKey;
 }


### PR DESCRIPTION
## Summary

- Clear direct session auto-fallback pins when their recorded fallback origin no longer matches the current configured primary.
- Apply the stale-origin check in both early reply model selection and the later model-selection state path so normal turns retry the primary instead of staying pinned to the fallback.
- Add a regression test for the polluted-origin shape from #92776.

Fixes #92776.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec oxfmt --write --threads=1 src/auto-reply/reply/get-reply.ts src/auto-reply/reply/model-selection.test.ts src/auto-reply/reply/model-selection.ts src/auto-reply/reply/stored-model-override.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/model-selection.test.ts`
- `node scripts/run-vitest.mjs src/agents/agent-scope.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/followup-runner.test.ts`
- `node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts`
- `pnpm lint:core`
- `pnpm tsgo:core`

## Real behavior proof

Behavior addressed: Auto-created fallback model pins with polluted `modelOverrideFallbackOriginProvider` / `modelOverrideFallbackOriginModel` no longer keep normal turns on the fallback indefinitely when the current configured primary differs from the stored origin.

Real environment tested: Local OpenClaw source checkout at `b63a5e3df4f062be5206015c4d09673a4ae55eac` on macOS with Node `v24.15.0` and pnpm `11.2.2`, running the production model-selection module through `node --import tsx` against a temporary session-store entry shaped like #92776.

Exact steps or command run after this patch:

```sh
node --import tsx --input-type=module <<'EOF'
import { createModelSelectionState } from "./src/auto-reply/reply/model-selection.ts";

const sessionKey = "agent:main:telegram:direct:real-proof";
const sessionEntry = {
  sessionId: "session-real-proof",
  updatedAt: Date.now(),
  providerOverride: "anthropic",
  modelOverride: "claude-opus-4-7",
  modelOverrideSource: "auto",
  modelOverrideFallbackOriginProvider: "anthropic",
  modelOverrideFallbackOriginModel: "claude-haiku-4-5",
};
const sessionStore = { [sessionKey]: sessionEntry };

const result = await createModelSelectionState({
  cfg: {},
  agentCfg: undefined,
  sessionEntry,
  sessionStore,
  sessionKey,
  defaultProvider: "anthropic",
  defaultModel: "claude-opus-4-8",
  primaryProvider: "anthropic",
  primaryModel: "claude-opus-4-8",
  provider: "anthropic",
  model: "claude-opus-4-7",
  hasModelDirective: false,
});

console.log(JSON.stringify({
  selected: { provider: result.provider, model: result.model },
  resetModelOverride: result.resetModelOverride,
  resetModelOverrideRef: result.resetModelOverrideRef,
  persistedEntry: {
    providerOverride: sessionStore[sessionKey].providerOverride ?? null,
    modelOverride: sessionStore[sessionKey].modelOverride ?? null,
    modelOverrideSource: sessionStore[sessionKey].modelOverrideSource ?? null,
    originProvider: sessionStore[sessionKey].modelOverrideFallbackOriginProvider ?? null,
    originModel: sessionStore[sessionKey].modelOverrideFallbackOriginModel ?? null,
  },
}, null, 2));
EOF
```

Evidence after fix: terminal output from that command:

```json
{
  "selected": {
    "provider": "anthropic",
    "model": "claude-opus-4-8"
  },
  "resetModelOverride": true,
  "resetModelOverrideRef": "anthropic/claude-opus-4-7",
  "persistedEntry": {
    "providerOverride": null,
    "modelOverride": null,
    "modelOverrideSource": null,
    "originProvider": null,
    "originModel": null
  }
}
```

Observed result after fix: The selected model is the current primary `anthropic/claude-opus-4-8`, `resetModelOverride` is true for the stale fallback pin, and the stored override plus fallback-origin fields are cleared from the session entry.

What was not tested: I did not run a live provider-outage reproduction or call a real Anthropic account; this proof exercises the production OpenClaw model-selection path on a local checkout with the persisted session-state shape from #92776.
