### PR TITLE
fix(agents): catch malformed image blocks in sanitizeContentBlocksImages

### DIFF
--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -181,7 +181,6 @@ describe("tool image sanitizing", () => {
   it("screenshot-shaped tool result with malformed image produces text fallback", async () => {
     const result = {
       content: [
-        { type: "text" as const, text: "screenshot metadata" },
         {
           type: "image" as const,
           data: undefined as unknown as string,

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -7,7 +7,11 @@ import {
   createTinyJpegBuffer,
 } from "../../test/helpers/image-fixtures.js";
 import { getImageMetadata } from "../media/image-ops.js";
-import { sanitizeContentBlocksImages, sanitizeImageBlocks } from "./tool-images.js";
+import {
+  sanitizeContentBlocksImages,
+  sanitizeImageBlocks,
+  sanitizeToolResultImages,
+} from "./tool-images.js";
 
 describe("tool image sanitizing", () => {
   const getImageBlock = (
@@ -115,6 +119,84 @@ describe("tool image sanitizing", () => {
     const image = getImageBlock(out);
     expect(image.mimeType).toBe("image/jpeg");
     expect(image.data).toBe(jpeg.toString("base64"));
+  });
+
+  it("preserves data and mimeType on no-resize path", async () => {
+    const png = createSolidPngBuffer(10, 10, { r: 0, g: 0, b: 255 });
+    const base64 = png.toString("base64");
+
+    const blocks = [{ type: "image" as const, data: base64, mimeType: "image/png" }];
+    const out = await sanitizeContentBlocksImages(blocks, "test");
+    expect(out).toHaveLength(1);
+    const image = getImageBlock(out);
+    expect(typeof image.data).toBe("string");
+    expect(image.data.length).toBeGreaterThan(0);
+    expect(typeof image.mimeType).toBe("string");
+    expect(image.mimeType).toBe("image/png");
+  });
+
+  it("preserves data and mimeType on resize path", async () => {
+    const png = createSolidPngBuffer(2600, 400, { r: 255, g: 0, b: 0 });
+    const base64 = png.toString("base64");
+
+    const blocks = [{ type: "image" as const, data: base64, mimeType: "image/png" }];
+    const out = await sanitizeContentBlocksImages(blocks, "test");
+    expect(out).toHaveLength(1);
+    const image = getImageBlock(out);
+    expect(typeof image.data).toBe("string");
+    expect(image.data.length).toBeGreaterThan(0);
+    expect(typeof image.mimeType).toBe("string");
+  }, 20_000);
+
+  it("converts image blocks with missing data/mimeType to text", async () => {
+    const blocks = [
+      {
+        type: "image" as const,
+        data: undefined as unknown as string,
+        mimeType: undefined as unknown as string,
+      },
+    ];
+    const out = await sanitizeContentBlocksImages(blocks, "browser:screenshot");
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("text");
+    expect((out[0] as { type: "text"; text: string }).text).toContain("missing data or mimeType");
+  });
+
+  it("screenshot-shaped tool result round-trips with valid image block", async () => {
+    const png = createSolidPngBuffer(100, 100, { r: 0, g: 128, b: 0 });
+    const base64 = png.toString("base64");
+
+    const result = {
+      content: [{ type: "image" as const, data: base64, mimeType: "image/png" }],
+      details: { path: "/tmp/screenshot.png" },
+    };
+    const sanitized = await sanitizeToolResultImages(result, "browser:screenshot");
+    const imageBlock = sanitized.content.find((b) => b.type === "image");
+    expect(imageBlock).toBeDefined();
+    expect(typeof (imageBlock as { data: string }).data).toBe("string");
+    expect((imageBlock as { data: string }).data.length).toBeGreaterThan(0);
+    expect(typeof (imageBlock as { mimeType: string }).mimeType).toBe("string");
+  });
+
+  it("screenshot-shaped tool result with malformed image produces text fallback", async () => {
+    const result = {
+      content: [
+        { type: "text" as const, text: "screenshot metadata" },
+        {
+          type: "image" as const,
+          data: undefined as unknown as string,
+          mimeType: undefined as unknown as string,
+        },
+      ],
+      details: {},
+    };
+    const sanitized = await sanitizeToolResultImages(result, "browser:screenshot");
+    const imageBlocks = sanitized.content.filter((b) => b.type === "image");
+    expect(imageBlocks).toHaveLength(0);
+    const textFallback = sanitized.content.find(
+      (b) => b.type === "text" && (b as { text: string }).text.includes("missing data or mimeType"),
+    );
+    expect(textFallback).toBeDefined();
   });
 
   it("drops malformed image base64 payloads", async () => {

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -34,12 +34,17 @@ const MAX_IMAGE_DIMENSION_PX = DEFAULT_IMAGE_MAX_DIMENSION_PX;
 const MAX_IMAGE_BYTES = DEFAULT_IMAGE_MAX_BYTES;
 const log = createSubsystemLogger("agents/tool-images");
 
+function isImageTypeBlock(block: unknown): block is Record<string, unknown> & { type: "image" } {
+  return (
+    Boolean(block) && typeof block === "object" && (block as { type?: unknown }).type === "image"
+  );
+}
+
 function isImageBlock(block: unknown): block is ImageContentBlock {
-  if (!block || typeof block !== "object") {
+  if (!isImageTypeBlock(block)) {
     return false;
   }
-  const rec = block as Record<string, unknown>;
-  return rec.type === "image" && typeof rec.data === "string" && typeof rec.mimeType === "string";
+  return typeof block.data === "string" && typeof block.mimeType === "string";
 }
 
 function isTextBlock(block: unknown): block is TextContentBlock {
@@ -310,11 +315,7 @@ export async function sanitizeContentBlocksImages(
   const out: ToolContentBlock[] = [];
   for (const block of blocks) {
     if (!isImageBlock(block)) {
-      if (
-        block &&
-        typeof block === "object" &&
-        (block as unknown as Record<string, unknown>).type === "image"
-      ) {
+      if (isImageTypeBlock(block)) {
         out.push({
           type: "text",
           text: `[${label}] omitted image payload: missing data or mimeType`,
@@ -389,7 +390,7 @@ export async function sanitizeToolResultImages(
   opts: ImageSanitizationLimits = {},
 ): Promise<AgentToolResult<unknown>> {
   const content = Array.isArray(result.content) ? result.content : [];
-  if (!content.some((b) => isImageBlock(b) || isTextBlock(b))) {
+  if (!content.some((block) => isImageTypeBlock(block) || isTextBlock(block))) {
     return result;
   }
 

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -310,6 +310,17 @@ export async function sanitizeContentBlocksImages(
   const out: ToolContentBlock[] = [];
   for (const block of blocks) {
     if (!isImageBlock(block)) {
+      if (
+        block &&
+        typeof block === "object" &&
+        (block as unknown as Record<string, unknown>).type === "image"
+      ) {
+        out.push({
+          type: "text",
+          text: `[${label}] omitted image payload: missing data or mimeType`,
+        } satisfies TextContentBlock);
+        continue;
+      }
       out.push(block);
       continue;
     }


### PR DESCRIPTION
## Problem
`sanitizeContentBlocksImages` gates image processing on `isImageBlock()`, which requires both `data` and `mimeType` to be valid strings. When a block is `type: "image"` but `data`/`mimeType` is undefined (or otherwise non-string), the guard returns false and the `!isImageBlock` branch pushes the block through **unchanged** — leaking a malformed image block onto the MCP wire, where the SDK's zod `ImageContentSchema` (`data: Base64Schema`, `mimeType: z.string()`) rejects the entire tool result.

In practice this breaks **every** `browser` tool screenshot (basic, jpeg, and fullPage): the call fails with an `invalid_union` validation error on `content[1]` rather than returning the image.

## Fix
In the `!isImageBlock(block)` branch, detect blocks that claim `type: "image"` but fail the string checks, and convert them to a text fallback (`"[<label>] omitted image payload: missing data or mimeType"`) instead of passing a malformed image block through. Valid image blocks are unaffected.

## Tests
5 new tests in `tool-images.test.ts`:
- no-resize path: a small PNG round-trips with `data` + `mimeType` present
- resize path: an oversized PNG round-trips with `data` + `mimeType` present
- malformed block (`{type:"image", data:undefined, mimeType:undefined}`) → text fallback
- full screenshot-shaped `AgentToolResult` round-trips, preserving the valid image
- malformed tool result via `sanitizeToolResultImages` → converted to text fallback

`pnpm check` and `pnpm build` pass; all tests green.
