### PR TITLE
feat(providers): add GLM-5.2 support

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -420,6 +420,7 @@ jobs:
               add_suite live-cache
 
               add_profile_suite native-live-src-agents "stable full"
+              add_profile_suite native-live-src-agents-zai-coding "stable full"
               add_profile_suite native-live-src-gateway-core "beta minimum stable full"
               add_profile_suite native-live-src-gateway-profiles-anthropic "stable full"
               add_profile_suite native-live-src-gateway-profiles-anthropic-smoke "stable"
@@ -1954,6 +1955,12 @@ jobs:
             label: Native live agents
             command: node .release-harness/scripts/test-live-shard.mjs native-live-src-agents
             timeout_minutes: 60
+            profile_env_only: false
+            profiles: stable full
+          - suite_id: native-live-src-agents-zai-coding
+            label: Native live Z.AI Coding Plan
+            command: ZAI_CODING_LIVE_TEST=1 node .release-harness/scripts/test-live-shard.mjs native-live-src-agents-zai-coding
+            timeout_minutes: 15
             profile_env_only: false
             profiles: stable full
           - suite_id: native-live-src-gateway-core

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -182,7 +182,10 @@ Interactive onboarding behavior with reference mode:
 ### Non-interactive Z.AI endpoint choices
 
 <Note>
-`--auth-choice zai-api-key` auto-detects the best Z.AI endpoint for your key (prefers the general API with `zai/glm-5.1`). If you specifically want the GLM Coding Plan endpoints, pick `zai-coding-global` or `zai-coding-cn`.
+`--auth-choice zai-api-key` auto-detects the best Z.AI endpoint and model for
+your key. Coding Plan endpoints prefer `zai/glm-5.2`; general API endpoints use
+`zai/glm-5.1`. To force a Coding Plan endpoint, pick `zai-coding-global` or
+`zai-coding-cn`.
 </Note>
 
 ```bash

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -264,7 +264,7 @@ Gemini CLI JSON replies are parsed from `response`; usage falls back to `stats`,
 
 - Provider: `zai`
 - Auth: `ZAI_API_KEY`
-- Example model: `zai/glm-5.1`
+- Example model: `zai/glm-5.2`
 - CLI: `openclaw onboard --auth-choice zai-api-key`
   - Model refs use the canonical `zai/*` provider ID.
   - `zai-api-key` auto-detects the matching Z.AI endpoint; `zai-coding-global`, `zai-coding-cn`, `zai-global`, and `zai-cn` force a specific surface

--- a/docs/help/testing-live.md
+++ b/docs/help/testing-live.md
@@ -73,7 +73,7 @@ Live tests are split into two layers so we can isolate failures:
   - `pnpm test:live` (or `OPENCLAW_LIVE_TEST=1` if invoking Vitest directly)
 - Set `OPENCLAW_LIVE_MODELS=modern`, `small`, or `all` (alias for modern) to actually run this suite; otherwise it skips to keep `pnpm test:live` focused on gateway smoke
 - How to select models:
-  - `OPENCLAW_LIVE_MODELS=modern` to run the modern allowlist (Opus/Sonnet 4.6+, GPT-5.2 + Codex, Gemini 3, DeepSeek V4, GLM 4.7, MiniMax M3, Grok 4.3)
+  - `OPENCLAW_LIVE_MODELS=modern` to run the modern allowlist (Opus/Sonnet 4.6+, GPT-5.2 + Codex, Gemini 3, DeepSeek V4, GLM 5.1, MiniMax M3, Grok 4.3)
   - `OPENCLAW_LIVE_MODELS=small` to run the constrained small-model allowlist (Qwen 8B/9B local-compatible routes, Ollama Gemma, OpenRouter Qwen/GLM, and Z.AI GLM)
   - `OPENCLAW_LIVE_MODELS=all` is an alias for the modern allowlist
   - or `OPENCLAW_LIVE_MODELS="openai/gpt-5.5,anthropic/claude-opus-4-6,..."` (comma allowlist)
@@ -357,6 +357,9 @@ Narrow, explicit allowlists are fastest and least flaky:
 - Tool calling across several providers:
   - `OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.5,anthropic/claude-opus-4-6,google/gemini-3-flash-preview,deepseek/deepseek-v4-flash,zai/glm-5.1,minimax/MiniMax-M3" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
 
+- Z.AI Coding Plan GLM-5.2 direct smoke:
+  - `ZAI_CODING_LIVE_TEST=1 pnpm test:live src/agents/zai.live.test.ts`
+
 - Google focus (Gemini API key + Antigravity):
   - Gemini (API key): `OPENCLAW_LIVE_GATEWAY_MODELS="google/gemini-3-flash-preview" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
   - Antigravity (OAuth): `OPENCLAW_LIVE_GATEWAY_MODELS="google-antigravity/claude-opus-4-6-thinking,google-antigravity/gemini-3-pro-high" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
@@ -388,7 +391,7 @@ This is the "common models" run we expect to keep working:
 - Google (Gemini API): `google/gemini-3.1-pro-preview` and `google/gemini-3-flash-preview` (avoid older Gemini 2.x models)
 - Google (Antigravity): `google-antigravity/claude-opus-4-6-thinking` and `google-antigravity/gemini-3-flash`
 - DeepSeek: `deepseek/deepseek-v4-flash` and `deepseek/deepseek-v4-pro`
-- Z.AI (GLM): `zai/glm-5.1`
+- Z.AI (GLM): `zai/glm-5.1` (general API) or `zai/glm-5.2` (Coding Plan)
 - MiniMax: `minimax/MiniMax-M3`
 
 Run gateway smoke with tools + image:
@@ -402,7 +405,7 @@ Pick at least one per provider family:
 - Anthropic: `anthropic/claude-opus-4-6` (or `anthropic/claude-sonnet-4-6`)
 - Google: `google/gemini-3-flash-preview` (or `google/gemini-3.1-pro-preview`)
 - DeepSeek: `deepseek/deepseek-v4-flash`
-- Z.AI (GLM): `zai/glm-5.1`
+- Z.AI (GLM): `zai/glm-5.1` (general API) or `zai/glm-5.2` (Coding Plan)
 - MiniMax: `minimax/MiniMax-M3`
 
 Optional additional coverage (nice to have):

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -19,7 +19,7 @@ OpenClaw uses the `zai` provider with a Z.AI API key.
 ## GLM models
 
 GLM is a model family, not a separate provider. In OpenClaw, GLM models use
-refs such as `zai/glm-5.1`: provider `zai`, model id `glm-5.1`.
+refs such as `zai/glm-5.2`: provider `zai`, model id `glm-5.2`.
 
 ## Getting started
 
@@ -85,12 +85,12 @@ you want to force a specific Coding Plan or general API surface.
   models: {
     providers: {
       zai: {
-        // Example value. Onboarding writes the matching baseUrl for your endpoint.
-        baseUrl: "https://api.z.ai/api/paas/v4",
+        // GLM-5.2 uses the Coding Plan endpoint.
+        baseUrl: "https://api.z.ai/api/coding/paas/v4",
       },
     },
   },
-  agents: { defaults: { model: { primary: "zai/glm-5.1" } } },
+  agents: { defaults: { model: { primary: "zai/glm-5.2" } } },
 }
 ```
 
@@ -105,28 +105,31 @@ openclaw models list --all --provider zai
 
 The manifest-backed catalog currently includes:
 
-| Model ref            | Notes         |
-| -------------------- | ------------- |
-| `zai/glm-5.1`        | Default model |
-| `zai/glm-5`          |               |
-| `zai/glm-5-turbo`    |               |
-| `zai/glm-5v-turbo`   |               |
-| `zai/glm-4.7`        |               |
-| `zai/glm-4.7-flash`  |               |
-| `zai/glm-4.7-flashx` |               |
-| `zai/glm-4.6`        |               |
-| `zai/glm-4.6v`       |               |
-| `zai/glm-4.5`        |               |
-| `zai/glm-4.5-air`    |               |
-| `zai/glm-4.5-flash`  |               |
-| `zai/glm-4.5v`       |               |
+| Model ref            | Notes                           |
+| -------------------- | ------------------------------- |
+| `zai/glm-5.2`        | Coding Plan default; 1M context |
+| `zai/glm-5.1`        | General API default             |
+| `zai/glm-5`          |                                 |
+| `zai/glm-5-turbo`    |                                 |
+| `zai/glm-5v-turbo`   |                                 |
+| `zai/glm-4.7`        |                                 |
+| `zai/glm-4.7-flash`  |                                 |
+| `zai/glm-4.7-flashx` |                                 |
+| `zai/glm-4.6`        |                                 |
+| `zai/glm-4.6v`       |                                 |
+| `zai/glm-4.5`        |                                 |
+| `zai/glm-4.5-air`    |                                 |
+| `zai/glm-4.5-flash`  |                                 |
+| `zai/glm-4.5v`       |                                 |
 
 <Tip>
 GLM models are available as `zai/<model>` (example: `zai/glm-5`).
 </Tip>
 
 <Note>
-The default bundled model ref is `zai/glm-5.1`. GLM versions and availability
+Coding Plan setup defaults to `zai/glm-5.2`; general API setup keeps
+`zai/glm-5.1`. Endpoint auto-detection falls back to `glm-5.1` or `glm-4.7`
+when the selected plan does not expose GLM-5.2. GLM versions and availability
 can change; run `openclaw models list --all --provider zai` to see the catalog
 known to your installed version.
 </Note>
@@ -173,7 +176,7 @@ known to your installed version.
       agents: {
         defaults: {
           models: {
-            "zai/glm-5.1": {
+            "zai/glm-5.2": {
               params: { preserveThinking: true },
             },
           },

--- a/extensions/zai/detect.test.ts
+++ b/extensions/zai/detect.test.ts
@@ -39,10 +39,7 @@ describe("detectZaiEndpoint", () => {
       },
       {
         responses: {
-          "https://api.z.ai/api/paas/v4/chat/completions::glm-5.1": {
-            status: 404,
-            body: { error: { message: "not found" } },
-          },
+          "https://api.z.ai/api/paas/v4/chat/completions::glm-5.1": { status: 404 },
           "https://open.bigmodel.cn/api/paas/v4/chat/completions::glm-5.1": { status: 200 },
         },
         expected: { endpoint: "cn", modelId: "glm-5.1" },
@@ -51,13 +48,17 @@ describe("detectZaiEndpoint", () => {
         responses: {
           "https://api.z.ai/api/paas/v4/chat/completions::glm-5.1": { status: 404 },
           "https://open.bigmodel.cn/api/paas/v4/chat/completions::glm-5.1": { status: 404 },
-          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5.1": { status: 200 },
+          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5.2": { status: 200 },
         },
-        expected: { endpoint: "coding-global", modelId: "glm-5.1" },
+        expected: { endpoint: "coding-global", modelId: "glm-5.2" },
       },
       {
         endpoint: "coding-global",
         responses: {
+          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5.2": {
+            status: 404,
+            body: { error: { message: "glm-5.2 unavailable" } },
+          },
           "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5.1": {
             status: 404,
             body: { error: { message: "glm-5.1 unavailable" } },
@@ -67,8 +68,45 @@ describe("detectZaiEndpoint", () => {
         expected: { endpoint: "coding-global", modelId: "glm-4.7" },
       },
       {
+        endpoint: "coding-global",
+        responses: {
+          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5.2": {
+            status: 400,
+            body: { code: 1311, msg: "model not included in the current plan" },
+          },
+          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5.1": {
+            status: 400,
+            body: { code: 1211, msg: "model does not exist" },
+          },
+          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-4.7": { status: 200 },
+        },
+        expected: { endpoint: "coding-global", modelId: "glm-4.7" },
+      },
+      {
+        endpoint: "coding-global",
+        responses: {
+          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5.2": {
+            status: 429,
+            body: { error: { message: "rate limited" } },
+          },
+        },
+        expected: null,
+      },
+      {
         endpoint: "coding-cn",
         responses: {
+          "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5.2": {
+            status: 200,
+          },
+        },
+        expected: { endpoint: "coding-cn", modelId: "glm-5.2" },
+      },
+      {
+        endpoint: "coding-cn",
+        responses: {
+          "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5.2": {
+            status: 404,
+          },
           "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5.1": {
             status: 200,
           },
@@ -78,6 +116,10 @@ describe("detectZaiEndpoint", () => {
       {
         endpoint: "coding-cn",
         responses: {
+          "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5.2": {
+            status: 404,
+            body: { error: { message: "glm-5.2 unavailable" } },
+          },
           "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5.1": {
             status: 404,
             body: { error: { message: "glm-5.1 unavailable" } },
@@ -92,8 +134,12 @@ describe("detectZaiEndpoint", () => {
         responses: {
           "https://api.z.ai/api/paas/v4/chat/completions::glm-5.1": { status: 401 },
           "https://open.bigmodel.cn/api/paas/v4/chat/completions::glm-5.1": { status: 401 },
+          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5.2": { status: 401 },
           "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5.1": { status: 401 },
           "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-4.7": { status: 401 },
+          "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5.2": {
+            status: 401,
+          },
           "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5.1": {
             status: 401,
           },

--- a/extensions/zai/detect.ts
+++ b/extensions/zai/detect.ts
@@ -3,6 +3,7 @@ import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   ZAI_CN_BASE_URL,
   ZAI_CODING_CN_BASE_URL,
+  ZAI_CODING_DEFAULT_MODEL_ID,
   ZAI_CODING_GLOBAL_BASE_URL,
   ZAI_DEFAULT_MODEL_ID,
   ZAI_GLOBAL_BASE_URL,
@@ -28,6 +29,32 @@ type ProbeResult =
       errorCode?: string;
       errorMessage?: string;
     };
+
+type ProbeCandidate = ZaiDetectedEndpoint & {
+  fallback?: boolean;
+};
+
+const UNSUPPORTED_MODEL_ERROR_CODES = new Set(["1211", "1311"]);
+
+function isUnsupportedModelResult(result: ProbeResult): boolean {
+  if (result.ok) {
+    return false;
+  }
+  if (result.status === 404) {
+    return true;
+  }
+  if (result.errorCode && UNSUPPORTED_MODEL_ERROR_CODES.has(result.errorCode)) {
+    return true;
+  }
+  if (result.status !== 400) {
+    return false;
+  }
+  const detail = `${result.errorCode ?? ""} ${result.errorMessage ?? ""}`.toLowerCase();
+  return (
+    /\bmodel\b.*\b(not found|unavailable|unsupported|does not exist)\b/.test(detail) ||
+    /模型.*(不存在|不支持|不可用)/.test(detail)
+  );
+}
 
 async function fetchWithTimeoutLocal(
   fetchFn: typeof fetch,
@@ -81,10 +108,11 @@ async function probeZaiChatCompletions(params: {
     try {
       const json = (await res.json()) as {
         error?: { code?: unknown; message?: unknown };
+        code?: unknown;
         msg?: unknown;
         message?: unknown;
       };
-      const code = json?.error?.code;
+      const code = json?.error?.code ?? json?.code;
       const msg = json?.error?.message ?? json?.msg ?? json?.message;
       if (typeof code === "string") {
         errorCode = code;
@@ -117,7 +145,7 @@ export async function detectZaiEndpoint(params: {
 
   const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 5_000);
   const probeCandidates = (() => {
-    const general = [
+    const general: ProbeCandidate[] = [
       {
         endpoint: "global" as const,
         baseUrl: ZAI_GLOBAL_BASE_URL,
@@ -131,32 +159,48 @@ export async function detectZaiEndpoint(params: {
         note: "Verified GLM-5.1 on cn endpoint.",
       },
     ];
-    const codingGlm51 = [
+    const codingModels: ProbeCandidate[] = [
       {
         endpoint: "coding-global" as const,
         baseUrl: ZAI_CODING_GLOBAL_BASE_URL,
-        modelId: ZAI_DEFAULT_MODEL_ID,
-        note: "Verified GLM-5.1 on coding-global endpoint.",
+        modelId: ZAI_CODING_DEFAULT_MODEL_ID,
+        note: "Verified GLM-5.2 on coding-global endpoint.",
+      },
+      {
+        endpoint: "coding-global" as const,
+        baseUrl: ZAI_CODING_GLOBAL_BASE_URL,
+        modelId: "glm-5.1",
+        note: "Verified GLM-5.1 on coding-global endpoint; GLM-5.2 is unavailable.",
+        fallback: true,
       },
       {
         endpoint: "coding-cn" as const,
         baseUrl: ZAI_CODING_CN_BASE_URL,
-        modelId: ZAI_DEFAULT_MODEL_ID,
-        note: "Verified GLM-5.1 on coding-cn endpoint.",
+        modelId: ZAI_CODING_DEFAULT_MODEL_ID,
+        note: "Verified GLM-5.2 on coding-cn endpoint.",
+      },
+      {
+        endpoint: "coding-cn" as const,
+        baseUrl: ZAI_CODING_CN_BASE_URL,
+        modelId: "glm-5.1",
+        note: "Verified GLM-5.1 on coding-cn endpoint; GLM-5.2 is unavailable.",
+        fallback: true,
       },
     ];
-    const codingFallback = [
+    const codingFallback: ProbeCandidate[] = [
       {
         endpoint: "coding-global" as const,
         baseUrl: ZAI_CODING_GLOBAL_BASE_URL,
         modelId: "glm-4.7",
-        note: "Coding Plan endpoint verified, but this key/plan does not expose GLM-5.1 there. Defaulting to GLM-4.7.",
+        note: "Coding Plan endpoint verified, but this key/plan does not expose GLM-5.2 or GLM-5.1 there. Defaulting to GLM-4.7.",
+        fallback: true,
       },
       {
         endpoint: "coding-cn" as const,
         baseUrl: ZAI_CODING_CN_BASE_URL,
         modelId: "glm-4.7",
-        note: "Coding Plan CN endpoint verified, but this key/plan does not expose GLM-5.1 there. Defaulting to GLM-4.7.",
+        note: "Coding Plan CN endpoint verified, but this key/plan does not expose GLM-5.2 or GLM-5.1 there. Defaulting to GLM-4.7.",
+        fallback: true,
       },
     ];
 
@@ -167,20 +211,28 @@ export async function detectZaiEndpoint(params: {
         return general.filter((candidate) => candidate.endpoint === "cn");
       case "coding-global":
         return [
-          ...codingGlm51.filter((candidate) => candidate.endpoint === "coding-global"),
+          ...codingModels.filter((candidate) => candidate.endpoint === "coding-global"),
           ...codingFallback.filter((candidate) => candidate.endpoint === "coding-global"),
         ];
       case "coding-cn":
         return [
-          ...codingGlm51.filter((candidate) => candidate.endpoint === "coding-cn"),
+          ...codingModels.filter((candidate) => candidate.endpoint === "coding-cn"),
           ...codingFallback.filter((candidate) => candidate.endpoint === "coding-cn"),
         ];
       default:
-        return [...general, ...codingGlm51, ...codingFallback];
+        return [...general, ...codingModels, ...codingFallback];
     }
   })();
 
+  const resultsByEndpoint = new Map<ZaiEndpointId, ProbeResult[]>();
   for (const candidate of probeCandidates) {
+    const priorResults = resultsByEndpoint.get(candidate.endpoint) ?? [];
+    if (
+      candidate.fallback &&
+      (priorResults.length === 0 || !priorResults.every(isUnsupportedModelResult))
+    ) {
+      continue;
+    }
     const result = await probeZaiChatCompletions({
       baseUrl: candidate.baseUrl,
       apiKey: params.apiKey,
@@ -189,8 +241,14 @@ export async function detectZaiEndpoint(params: {
       fetchFn: params.fetchFn,
     });
     if (result.ok) {
-      return candidate;
+      return {
+        endpoint: candidate.endpoint,
+        baseUrl: candidate.baseUrl,
+        modelId: candidate.modelId,
+        note: candidate.note,
+      };
     }
+    resultsByEndpoint.set(candidate.endpoint, [...priorResults, result]);
   }
 
   return null;

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -89,8 +89,21 @@ describe("zai provider plugin", () => {
 
     const cases = [
       {
-        modelId: "glm-5.1",
+        modelId: "glm-5.2",
+        providerBaseUrl: "https://api.z.ai/api/coding/paas/v4",
         expected: {
+          baseUrl: "https://api.z.ai/api/coding/paas/v4",
+          input: ["text"],
+          reasoning: true,
+          contextWindow: 1_000_000,
+          maxTokens: 131_072,
+        },
+      },
+      {
+        modelId: "glm-5.1",
+        providerBaseUrl: "https://api.z.ai/api/paas/v4",
+        expected: {
+          baseUrl: "https://api.z.ai/api/paas/v4",
           input: ["text"],
           reasoning: true,
           contextWindow: 202800,
@@ -99,7 +112,9 @@ describe("zai provider plugin", () => {
       },
       {
         modelId: "glm-5v-turbo",
+        providerBaseUrl: "https://api.z.ai/api/paas/v4",
         expected: {
+          baseUrl: "https://api.z.ai/api/paas/v4",
           input: ["text", "image"],
           reasoning: true,
           contextWindow: 202800,
@@ -115,14 +130,34 @@ describe("zai provider plugin", () => {
         modelRegistry: {
           find: (_provider: string, modelId: string) => (modelId === "glm-4.7" ? template : null),
         },
+        providerConfig: { baseUrl: testCase.providerBaseUrl },
       } as never) as Record<string, unknown> | undefined;
       expectModelFields(resolved, {
         provider: "zai",
         api: "openai-completions",
-        baseUrl: "https://api.z.ai/api/paas/v4",
         id: testCase.modelId,
         ...testCase.expected,
       });
+    }
+  });
+
+  it("keeps selected Coding Plan and proxy endpoints for dynamic GLM-5 models", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const template = createGlm47Template();
+
+    for (const baseUrl of [
+      "https://open.bigmodel.cn/api/coding/paas/v4",
+      "https://proxy.example.test/zai",
+    ]) {
+      const resolved = provider.resolveDynamicModel?.({
+        provider: "zai",
+        modelId: "glm-5.2",
+        modelRegistry: {
+          find: (_provider: string, modelId: string) => (modelId === "glm-4.7" ? template : null),
+        },
+        providerConfig: { baseUrl },
+      } as never) as Record<string, unknown> | undefined;
+      expect(resolved?.baseUrl).toBe(baseUrl);
     }
   });
 

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -35,7 +35,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { detectZaiEndpoint, type ZaiEndpointId } from "./detect.js";
 import { zaiMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { buildZaiModelDefinition } from "./model-definitions.js";
-import { applyZaiConfig, applyZaiProviderConfig, ZAI_DEFAULT_MODEL_REF } from "./onboard.js";
+import { applyZaiConfig, applyZaiProviderConfig, resolveZaiModelId } from "./onboard.js";
 
 const PROVIDER_ID = "zai";
 const GLM5_TEMPLATE_MODEL_ID = "glm-4.7";
@@ -104,6 +104,7 @@ function resolveGlm5ForwardCompatModel(
     ...template,
     id: def.id,
     name: def.name,
+    baseUrl: ctx.providerConfig?.baseUrl ?? template?.baseUrl,
     api: "openai-completions",
     provider: PROVIDER_ID,
     reasoning: def.reasoning,
@@ -112,10 +113,6 @@ function resolveGlm5ForwardCompatModel(
     contextWindow: def.contextWindow,
     maxTokens: def.maxTokens,
   } as ProviderRuntimeModel);
-}
-
-function resolveZaiDefaultModel(modelIdOverride?: string): string {
-  return modelIdOverride ? `zai/${modelIdOverride}` : ZAI_DEFAULT_MODEL_REF;
 }
 
 function isTrueParam(value: unknown): boolean {
@@ -222,6 +219,10 @@ async function runZaiApiKeyAuth(
   const detected = await detectZaiEndpoint({ apiKey, ...(endpoint ? { endpoint } : {}) });
   const modelIdOverride = detected?.modelId;
   const nextEndpoint = detected?.endpoint ?? endpoint ?? (await promptForZaiEndpoint(ctx));
+  const preset = {
+    ...(nextEndpoint ? { endpoint: nextEndpoint } : {}),
+    ...(modelIdOverride ? { modelId: modelIdOverride } : {}),
+  };
   return {
     profiles: [
       {
@@ -234,11 +235,8 @@ async function runZaiApiKeyAuth(
         ),
       },
     ],
-    configPatch: applyZaiProviderConfig(ctx.config, {
-      ...(nextEndpoint ? { endpoint: nextEndpoint } : {}),
-      ...(modelIdOverride ? { modelId: modelIdOverride } : {}),
-    }),
-    defaultModel: resolveZaiDefaultModel(modelIdOverride),
+    configPatch: applyZaiProviderConfig(ctx.config, preset),
+    defaultModel: `zai/${resolveZaiModelId(preset)}`,
     ...(detected?.note ? { notes: [detected.note] } : {}),
   };
 }

--- a/extensions/zai/model-definitions.test.ts
+++ b/extensions/zai/model-definitions.test.ts
@@ -32,6 +32,17 @@ function expectZaiModelFields(expected: ExpectedZaiModelFields) {
 }
 
 describe("zai model definitions", () => {
+  it("uses official GLM-5.2 Coding Plan metadata", () => {
+    expectZaiModelFields({
+      id: "glm-5.2",
+      reasoning: true,
+      input: ["text"],
+      contextWindow: 1_000_000,
+      maxTokens: 131_072,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    });
+  });
+
   it("uses current OpenClaw metadata for the new GLM-5.1 model", () => {
     expectZaiModelFields({
       id: "glm-5.1",

--- a/extensions/zai/model-definitions.ts
+++ b/extensions/zai/model-definitions.ts
@@ -8,6 +8,7 @@ export const ZAI_CODING_CN_BASE_URL = "https://open.bigmodel.cn/api/coding/paas/
 export const ZAI_GLOBAL_BASE_URL = "https://api.z.ai/api/paas/v4";
 export const ZAI_CN_BASE_URL = "https://open.bigmodel.cn/api/paas/v4";
 export const ZAI_DEFAULT_MODEL_ID = "glm-5.1";
+export const ZAI_CODING_DEFAULT_MODEL_ID = "glm-5.2";
 export const ZAI_DEFAULT_MODEL_REF = `zai/${ZAI_DEFAULT_MODEL_ID}`;
 
 const ZAI_MANIFEST_CATALOG = manifest.modelCatalog.providers.zai;

--- a/extensions/zai/onboard.test.ts
+++ b/extensions/zai/onboard.test.ts
@@ -1,8 +1,16 @@
 // Zai tests cover onboard plugin behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { AuthStorage, ModelRegistry } from "openclaw/plugin-sdk/agent-sessions";
 import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
 import { expectProviderOnboardPreservesPrimary } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it } from "vitest";
-import { ZAI_CODING_CN_BASE_URL, ZAI_GLOBAL_BASE_URL } from "./model-definitions.js";
+import {
+  ZAI_CODING_CN_BASE_URL,
+  ZAI_CODING_GLOBAL_BASE_URL,
+  ZAI_GLOBAL_BASE_URL,
+} from "./model-definitions.js";
 import { applyZaiConfig, applyZaiProviderConfig } from "./onboard.js";
 
 describe("zai onboard", () => {
@@ -21,6 +29,7 @@ describe("zai onboard", () => {
     expect(defaultCfg.models?.providers?.zai?.api).toBe("openai-completions");
     const ids = defaultCfg.models?.providers?.zai?.models?.map((m) => m.id);
     expect(ids).toEqual([
+      "glm-5.2",
       "glm-5.1",
       "glm-5",
       "glm-5-turbo",
@@ -35,6 +44,56 @@ describe("zai onboard", () => {
       "glm-4.5-flash",
       "glm-4.5v",
     ]);
+    expect(
+      defaultCfg.models?.providers?.zai?.models?.find((model) => model.id === "glm-5.2"),
+    ).toMatchObject({
+      contextWindow: 1_000_000,
+      maxTokens: 131_072,
+    });
+    expect(
+      defaultCfg.models?.providers?.zai?.models?.find((model) => model.id === "glm-5.2"),
+    ).not.toHaveProperty("baseUrl");
+  });
+
+  it("resolves GLM-5.2 through the selected Coding Plan or custom endpoint", async () => {
+    for (const [name, cfg, expectedBaseUrl] of [
+      ["coding-cn", applyZaiConfig({}, { endpoint: "coding-cn" }), ZAI_CODING_CN_BASE_URL],
+      [
+        "custom",
+        applyZaiConfig({
+          models: {
+            providers: {
+              zai: {
+                baseUrl: "https://proxy.example.test/zai",
+                api: "openai-completions",
+                models: [],
+              },
+            },
+          },
+        }),
+        "https://proxy.example.test/zai",
+      ],
+    ] as const) {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), `openclaw-zai-${name}-`));
+      try {
+        const modelsPath = path.join(dir, "models.json");
+        await fs.writeFile(
+          modelsPath,
+          JSON.stringify({
+            ...cfg.models,
+            providers: {
+              ...cfg.models?.providers,
+              zai: { ...cfg.models?.providers?.zai, apiKey: "test-key" },
+            },
+          }),
+        );
+        const registry = ModelRegistry.create(AuthStorage.inMemory(), modelsPath);
+        expect(registry.getError()).toBeUndefined();
+        expect(registry.find("zai", "glm-5.2")?.baseUrl).toBe(expectedBaseUrl);
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    }
   });
 
   it("supports CN endpoint for supported coding models", () => {
@@ -45,6 +104,28 @@ describe("zai onboard", () => {
       expect(cfg.models?.providers?.zai?.baseUrl).toBe(ZAI_CODING_CN_BASE_URL);
       expect(resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model)).toBe(`zai/${modelId}`);
     }
+  });
+
+  it("defaults Coding Plan endpoints to GLM-5.2 without changing the general API default", () => {
+    const codingCfg = applyZaiConfig({}, { endpoint: "coding-global" });
+    const existingCodingCfg = applyZaiConfig({
+      models: {
+        providers: {
+          zai: {
+            baseUrl: `${ZAI_CODING_GLOBAL_BASE_URL}/`,
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      },
+    });
+
+    expect(resolveAgentModelPrimaryValue(defaultCfg.agents?.defaults?.model)).toBe("zai/glm-5.1");
+    expect(codingCfg.models?.providers?.zai?.baseUrl).toBe(ZAI_CODING_GLOBAL_BASE_URL);
+    expect(resolveAgentModelPrimaryValue(codingCfg.agents?.defaults?.model)).toBe("zai/glm-5.2");
+    expect(resolveAgentModelPrimaryValue(existingCodingCfg.agents?.defaults?.model)).toBe(
+      "zai/glm-5.2",
+    );
   });
 
   it("does not overwrite existing primary model in provider-only mode", () => {

--- a/extensions/zai/onboard.ts
+++ b/extensions/zai/onboard.ts
@@ -7,6 +7,9 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import {
   buildZaiCatalogModels,
   resolveZaiBaseUrl,
+  ZAI_CODING_CN_BASE_URL,
+  ZAI_CODING_DEFAULT_MODEL_ID,
+  ZAI_CODING_GLOBAL_BASE_URL,
   ZAI_DEFAULT_MODEL_ID,
 } from "./model-definitions.js";
 
@@ -18,17 +21,35 @@ function resolveZaiPresetBaseUrl(cfg: OpenClawConfig, endpoint?: string): string
   return endpoint ? resolveZaiBaseUrl(endpoint) : existingBaseUrl || resolveZaiBaseUrl();
 }
 
+export function resolveZaiModelId(params?: {
+  endpoint?: string;
+  modelId?: string;
+  baseUrl?: string;
+}): string {
+  const explicitModelId = normalizeOptionalString(params?.modelId);
+  if (explicitModelId) {
+    return explicitModelId;
+  }
+  const baseUrl = normalizeOptionalString(params?.baseUrl)?.replace(/\/+$/, "");
+  const usesCodingEndpoint =
+    params?.endpoint?.startsWith("coding-") ||
+    baseUrl === ZAI_CODING_GLOBAL_BASE_URL ||
+    baseUrl === ZAI_CODING_CN_BASE_URL;
+  return usesCodingEndpoint ? ZAI_CODING_DEFAULT_MODEL_ID : ZAI_DEFAULT_MODEL_ID;
+}
+
 function applyZaiPreset(
   cfg: OpenClawConfig,
   params?: { endpoint?: string; modelId?: string },
   primaryModelRef?: string,
 ): OpenClawConfig {
-  const modelId = normalizeOptionalString(params?.modelId) ?? ZAI_DEFAULT_MODEL_ID;
+  const baseUrl = resolveZaiPresetBaseUrl(cfg, params?.endpoint);
+  const modelId = resolveZaiModelId({ ...params, baseUrl });
   const modelRef = `zai/${modelId}`;
   return applyProviderConfigWithModelCatalogPreset(cfg, {
     providerId: "zai",
     api: "openai-completions",
-    baseUrl: resolveZaiPresetBaseUrl(cfg, params?.endpoint),
+    baseUrl,
     catalogModels: buildZaiCatalogModels(),
     aliases: [{ modelRef, alias: "GLM" }],
     primaryModelRef,
@@ -46,7 +67,8 @@ export function applyZaiConfig(
   cfg: OpenClawConfig,
   params?: { endpoint?: string; modelId?: string },
 ): OpenClawConfig {
-  const modelId = normalizeOptionalString(params?.modelId) ?? ZAI_DEFAULT_MODEL_ID;
+  const baseUrl = resolveZaiPresetBaseUrl(cfg, params?.endpoint);
+  const modelId = resolveZaiModelId({ ...params, baseUrl });
   const modelRef = modelId === ZAI_DEFAULT_MODEL_ID ? ZAI_DEFAULT_MODEL_REF : `zai/${modelId}`;
   return applyZaiPreset(cfg, params, modelRef);
 }

--- a/extensions/zai/openclaw.plugin.json
+++ b/extensions/zai/openclaw.plugin.json
@@ -34,6 +34,20 @@
         "api": "openai-completions",
         "models": [
           {
+            "id": "glm-5.2",
+            "name": "GLM-5.2",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
             "id": "glm-5.1",
             "name": "GLM-5.1",
             "reasoning": true,

--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -36,6 +36,7 @@ const SKIPPED_ASSERTION_STATUSES = new Set(["disabled", "pending", "skipped", "t
 /** Live-test shards included in release validation. */
 export const RELEASE_LIVE_TEST_SHARDS = Object.freeze([
   "native-live-src-agents",
+  "native-live-src-agents-zai-coding",
   "native-live-src-gateway-core",
   "native-live-src-gateway-profiles",
   "native-live-src-gateway-backends",
@@ -245,6 +246,8 @@ export function selectLiveShardFiles(shard, files = collectAllLiveTestFiles()) {
   switch (shard) {
     case "native-live-src-agents":
       return files.filter((file) => file.startsWith("src/agents/"));
+    case "native-live-src-agents-zai-coding":
+      return files.filter((file) => file === "src/agents/zai.live.test.ts");
     case "native-live-src-gateway":
       return files.filter(
         (file) => file.startsWith("src/gateway/") || file.startsWith("src/crestodian/"),

--- a/src/agents/zai.live.test.ts
+++ b/src/agents/zai.live.test.ts
@@ -2,6 +2,7 @@
 // credentials and live-test flags are enabled.
 import { completeSimple, type Model } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
+import { isTruthyEnvValue } from "../infra/env.js";
 import {
   createSingleUserPromptMessage,
   extractNonEmptyAssistantText,
@@ -10,22 +11,29 @@ import {
 
 const ZAI_KEY = process.env.ZAI_API_KEY ?? process.env.Z_AI_API_KEY ?? "";
 const LIVE = isLiveTestEnabled(["ZAI_LIVE_TEST"]);
+const CODING_LIVE = isTruthyEnvValue(process.env.ZAI_CODING_LIVE_TEST);
 const ZAI_LIVE_TIMEOUT_MS = 45_000;
+const ZAI_GLOBAL_BASE_URL = "https://api.z.ai/api/paas/v4";
+const ZAI_CODING_GLOBAL_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
 
-const describeLive = LIVE && ZAI_KEY ? describe : describe.skip;
+const describeLive = LIVE && !CODING_LIVE && ZAI_KEY ? describe : describe.skip;
+const describeCodingLive = CODING_LIVE && ZAI_KEY ? describe : describe.skip;
 
-async function expectModelReturnsAssistantText(modelId: "glm-5-turbo" | "glm-5.1") {
+async function expectModelReturnsAssistantText(
+  modelId: "glm-5.2" | "glm-5-turbo" | "glm-5.1",
+  baseUrl = ZAI_GLOBAL_BASE_URL,
+) {
   const model: Model<"openai-completions"> = {
     id: modelId,
     name: modelId,
     api: "openai-completions",
     provider: "zai",
-    baseUrl: "https://api.z.ai/api/paas/v4",
+    baseUrl,
     reasoning: true,
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 202_800,
-    maxTokens: 131_100,
+    contextWindow: modelId === "glm-5.2" ? 1_000_000 : 202_800,
+    maxTokens: modelId === "glm-5.2" ? 131_072 : 131_100,
   };
   const res = await completeSimple(
     model,
@@ -37,6 +45,16 @@ async function expectModelReturnsAssistantText(modelId: "glm-5-turbo" | "glm-5.1
   const text = extractNonEmptyAssistantText(res.content);
   expect(text.length).toBeGreaterThan(0);
 }
+
+describeCodingLive("zai Coding Plan live", () => {
+  it(
+    "glm-5.2 returns assistant text through the Coding Plan endpoint",
+    async () => {
+      await expectModelReturnsAssistantText("glm-5.2", ZAI_CODING_GLOBAL_BASE_URL);
+    },
+    ZAI_LIVE_TIMEOUT_MS,
+  );
+});
 
 describeLive("zai live", () => {
   it(

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -599,6 +599,10 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain(
       "command: node .release-harness/scripts/test-live-shard.mjs native-live-src-agents",
     );
+    expect(workflow).toContain("suite_id: native-live-src-agents-zai-coding");
+    expect(workflow).toContain(
+      "command: ZAI_CODING_LIVE_TEST=1 node .release-harness/scripts/test-live-shard.mjs native-live-src-agents-zai-coding",
+    );
     expect(workflow).toContain("OPENCLAW_LIVE_COMMAND: ${{ matrix.command }}");
     expect(workflow).toContain("live_suite_filter:");
     expect(workflow).toContain("validate_live_suite_filter:");

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -46,7 +46,10 @@ describe("scripts/test-live-shard", () => {
 
     expect(allFiles.length).toBeGreaterThan(0);
     expect([...new Set(selectedFiles)].toSorted((a, b) => a.localeCompare(b))).toEqual(allFiles);
-    expect(duplicateFiles).toEqual(["extensions/music-generation-providers.live.test.ts"]);
+    expect(duplicateFiles).toEqual([
+      "src/agents/zai.live.test.ts",
+      "extensions/music-generation-providers.live.test.ts",
+    ]);
     expect(musicProviderFanout).toEqual([
       "native-live-extensions-media-music-google",
       "native-live-extensions-media-music-minimax",
@@ -80,6 +83,9 @@ describe("scripts/test-live-shard", () => {
   });
 
   it("keeps slow gateway backend and media-capable extension files in their own shards", () => {
+    expect(selectLiveShardFiles("native-live-src-agents-zai-coding", allFiles)).toEqual([
+      "src/agents/zai.live.test.ts",
+    ]);
     expect(selectLiveShardFiles("native-live-src-gateway-backends", allFiles)).toEqual([
       "src/gateway/gateway-acp-bind.live.test.ts",
       "src/gateway/gateway-cli-backend.live.test.ts",


### PR DESCRIPTION
## Summary

- Add GLM-5.2 metadata and make it the default for Z.AI Coding Plan endpoints while preserving GLM-5.1 for the general API.
- Probe Coding Plan endpoints in order: GLM-5.2, GLM-5.1, then GLM-4.7, with downgrade only after a definitive unsupported-model response.
- Preserve global, CN, and custom/proxy endpoint selection through onboarding and runtime model resolution.
- Document the Coding Plan endpoint/default distinction and add a dedicated secret-backed GLM-5.2 live test.
- Out of scope: speculative GLM-5.2 rows for third-party providers that do not currently publish the model.

## Linked context

No matching open issue or implementation PR found in exact GitHub/Gitcrawl searches for `GLM-5.2`, `glm-5.2`, and Z.AI Coding Plan combinations. The only PR search hit was unrelated and did not touch Z.AI model support.

Provider research on June 13, 2026 found GLM-5.2 documented only for the direct Z.AI Coding Plan endpoint. OpenRouter, OpenCode Go, Ollama, Together, NVIDIA, DeepInfra, and Fireworks did not publish a GLM-5.2 model entry, so this PR avoids speculative provider aliases.

Official references:

- https://docs.z.ai/guides/develop/openclaw
- https://docs.z.ai/devpack/overview
- https://docs.z.ai/devpack/tool/others
- https://docs.z.ai/api-reference/llm/chat-completion
- https://docs.z.ai/guides/overview/pricing

## Real behavior proof

- Behavior or issue addressed: OpenClaw lacked GLM-5.2 catalog, onboarding, endpoint detection, and dedicated live-test support.
- Real environment tested: macOS source checkout, Node/pnpm repo toolchain; secret-backed remote proof pending on this exact PR head.
- Exact steps or command run after this patch: `pnpm test extensions/zai`; `pnpm test src/agents/model-catalog.test.ts src/commands/models/list.provider-catalog.test.ts`; `node scripts/test-live.mjs -- src/agents/zai.live.test.ts`; `pnpm build`; `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local`.
- Evidence after fix: 27 Z.AI provider tests passed; 73 catalog/list tests passed; live harness selected the dedicated file and skipped all 3 tests without credentials; full build passed; autoreview reported no accepted/actionable findings.
- Observed result after fix: Coding Plan defaults to GLM-5.2, general API stays on GLM-5.1, definitive unsupported-model responses fall back safely, and runtime registry tests preserve CN/custom endpoints.
- What was not tested: authenticated GLM-5.2 completion before PR creation.
- Proof limitations or environment constraints: two pre-PR Blacksmith Testbox attempts failed during host DNS setup before the test command ran; exact-head secret-backed proof will run after PR creation.

## Tests and validation

- `pnpm exec oxfmt --check <touched files>`
- `pnpm format:docs:check`
- `pnpm test extensions/zai`
- `pnpm test src/agents/model-catalog.test.ts src/commands/models/list.provider-catalog.test.ts`
- `node scripts/test-live.mjs -- src/agents/zai.live.test.ts`
- `pnpm build`
- `git diff --check`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local` (clean)

Regression coverage includes endpoint probe ordering, transient-error behavior, Z.AI unsupported-model codes, Coding Plan defaults, trailing-slash handling, general API isolation, CN/custom runtime routing, model metadata, and live-test gating.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `Yes` - Coding Plan onboarding now defaults to GLM-5.2; general API behavior remains unchanged.

Did security, auth, secrets, network, or tool execution behavior change? `No` auth storage change; endpoint probing now adds GLM-5.2 before existing fallbacks.

Highest risk: selecting the wrong endpoint or downgrading on a transient provider failure. Mitigation: provider-level URL precedence, real registry tests for CN/custom URLs, and fallback only after definitive unsupported-model responses.

## Current review state

Next action: exact-head CI plus secret-backed GLM-5.2 completion proof, then land if green.

Fresh autoreview is clean. No unresolved reviewer findings.
