### PR TITLE
fix(usage): show MiniMax usage as percent used

### DIFF
--- a/src/infra/provider-usage.format.test.ts
+++ b/src/infra/provider-usage.format.test.ts
@@ -94,6 +94,36 @@ describe("provider-usage.format", () => {
     );
   });
 
+  it("formats minimax windows as used percentage instead of remaining quota", () => {
+    const summary: UsageSummary = {
+      updatedAt: now,
+      providers: [
+        {
+          provider: "minimax",
+          displayName: "MiniMax",
+          plan: "API Key",
+          windows: [
+            { label: "24h", usedPercent: 100, resetAt: now + 86_400_000 },
+            { label: "1h", usedPercent: 26, resetAt: now + 86 * 60_000 },
+          ],
+        },
+      ],
+    };
+
+    expect(formatUsageWindowSummary(summary.providers[0], { now, includeResets: true })).toBe(
+      "24h 100% used ⏱1d 0h · 1h 26% used ⏱1h 26m",
+    );
+    expect(formatUsageSummaryLine(summary, { now })).toBe(
+      "📊 Usage: MiniMax 100% used (24h ⏱1d 0h)",
+    );
+    expect(formatUsageReportLines(summary, { now })).toEqual([
+      "Usage:",
+      "  MiniMax (API Key)",
+      "    24h: 100% used · resets 1d 0h",
+      "    1h: 26% used · resets 1h 26m",
+    ]);
+  });
+
   it("formats provider summary text for balance-only providers", () => {
     const summary: UsageSummary = {
       updatedAt: now,

--- a/src/infra/provider-usage.format.ts
+++ b/src/infra/provider-usage.format.ts
@@ -1,6 +1,11 @@
 // Formats provider usage summaries for CLI and status output.
 import { clampPercent } from "./provider-usage.shared.js";
-import type { ProviderUsageSnapshot, UsageSummary, UsageWindow } from "./provider-usage.types.js";
+import type {
+  ProviderUsageSnapshot,
+  UsageProviderId,
+  UsageSummary,
+  UsageWindow,
+} from "./provider-usage.types.js";
 
 // Compact reset times for chat/status lines; long windows fall back to a date.
 function formatResetRemaining(targetMs?: number, now?: number): string | null {
@@ -35,11 +40,19 @@ function formatResetRemaining(targetMs?: number, now?: number): string | null {
   }).format(new Date(targetMs));
 }
 
-function formatWindowShort(window: UsageWindow, now?: number): string {
+function formatWindowPercent(provider: UsageProviderId, window: UsageWindow): string {
+  if (provider === "minimax") {
+    const used = clampPercent(window.usedPercent);
+    return `${used.toFixed(0)}% used`;
+  }
   const remaining = clampPercent(100 - window.usedPercent);
+  return `${remaining.toFixed(0)}% left`;
+}
+
+function formatWindowShort(provider: UsageProviderId, window: UsageWindow, now?: number): string {
   const reset = formatResetRemaining(window.resetAt, now);
   const resetSuffix = reset ? ` ⏱${reset}` : "";
-  return `${remaining.toFixed(0)}% left (${window.label}${resetSuffix})`;
+  return `${formatWindowPercent(provider, window)} (${window.label}${resetSuffix})`;
 }
 
 /** Formats one provider snapshot into a short usage-window summary. */
@@ -61,10 +74,9 @@ export function formatUsageWindowSummary(
   const includeResets = opts?.includeResets ?? false;
   const windows = snapshot.windows.slice(0, maxWindows);
   const parts = windows.map((window) => {
-    const remaining = clampPercent(100 - window.usedPercent);
     const reset = includeResets ? formatResetRemaining(window.resetAt, now) : null;
     const resetSuffix = reset ? ` ⏱${reset}` : "";
-    return `${window.label} ${remaining.toFixed(0)}% left${resetSuffix}`;
+    return `${window.label} ${formatWindowPercent(snapshot.provider, window)}${resetSuffix}`;
   });
   return parts.join(" · ");
 }
@@ -87,7 +99,7 @@ export function formatUsageSummaryLine(
     const window = entry.windows.reduce((best, next) =>
       next.usedPercent > best.usedPercent ? next : best,
     );
-    return `${entry.displayName} ${formatWindowShort(window, opts?.now)}`;
+    return `${entry.displayName} ${formatWindowShort(entry.provider, window, opts?.now)}`;
   });
   return `📊 Usage: ${parts.join(" · ")}`;
 }
@@ -113,10 +125,11 @@ export function formatUsageReportLines(summary: UsageSummary, opts?: { now?: num
       lines.push(`    ${entry.summary.trim()}`);
     }
     for (const window of entry.windows) {
-      const remaining = clampPercent(100 - window.usedPercent);
       const reset = formatResetRemaining(window.resetAt, opts?.now);
       const resetSuffix = reset ? ` · resets ${reset}` : "";
-      lines.push(`    ${window.label}: ${remaining.toFixed(0)}% left${resetSuffix}`);
+      lines.push(
+        `    ${window.label}: ${formatWindowPercent(entry.provider, window)}${resetSuffix}`,
+      );
     }
   }
   return lines;


### PR DESCRIPTION
## Summary
- show MiniMax usage windows as percent used instead of percent left
- keep the existing percent-left wording for other providers
- cover the MiniMax compact/status/report formatting paths

Closes #92721.

## Real behavior proof
After applying this PR locally, I ran the production usage formatter against a MiniMax usage snapshot, not a mocked test assertion:

```bash
pnpm exec tsx -e 'import { formatUsageSummaryLine, formatUsageWindowSummary, formatUsageReportLines } from "./src/infra/provider-usage.format.ts"; const now = Date.UTC(2026, 5, 13, 22, 20, 0); const summary = { providers: [{ provider: "minimax", displayName: "MiniMax", plan: "M3", windows: [{ label: "daily", usedPercent: 32, resetAt: now + 3 * 60 * 60 * 1000 }], summary: "" }] }; console.log(formatUsageSummaryLine(summary, { now })); console.log(formatUsageWindowSummary(summary.providers[0], { now, includeResets: true })); console.log(formatUsageReportLines(summary, { now }).join("\\n"));'\n```\n\nOutput:\n\n```text\n📊 Usage: MiniMax 32% used (daily ⏱3h)\ndaily 32% used ⏱3h\nUsage:\n  MiniMax (M3)\n    daily: 32% used · resets 3h\n```\n\nThis verifies the CLI/status/report formatter now displays MiniMax as `32% used` instead of `68% left`.\n\n## Tests\n- `pnpm format:check src/infra/provider-usage.format.ts src/infra/provider-usage.format.test.ts`\n- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/infra/provider-usage.format.test.ts`\n- `git diff --check`