### PR TITLE
fix(stale): exempt ClawSweeper actionable labels from stale lifecycle (fixes #89564)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -68,7 +68,7 @@ jobs:
           days-before-pr-close: 7
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle
+          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
           exempt-pr-labels: maintainer,no-stale,bad-barnacle
           operations-per-run: 2000
           ascending: true
@@ -100,7 +100,7 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           stale-issue-label: stale
-          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle
+          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
           operations-per-run: 2000
           ascending: true
           include-only-assigned: true
@@ -172,7 +172,7 @@ jobs:
           days-before-pr-close: 7
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle
+          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
           exempt-pr-labels: maintainer,no-stale,bad-barnacle
           operations-per-run: 2000
           ascending: true
@@ -203,7 +203,7 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           stale-issue-label: stale
-          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle
+          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
           operations-per-run: 2000
           ascending: true
           include-only-assigned: true
@@ -277,6 +277,9 @@ jobs:
               "security",
               "no-stale",
               "bad-barnacle",
+              "clawsweeper:queueable-fix",
+              "clawsweeper:source-repro",
+              "clawsweeper:fix-shape-clear",
             ]);
             const prExemptLabels = new Set(["maintainer", "no-stale", "bad-barnacle"]);
             const maintainerAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);


### PR DESCRIPTION
## What does this PR do?

Adds ClawSweeper actionable labels (`clawsweeper:queueable-fix`, `clawsweeper:source-repro`, `clawsweeper:fix-shape-clear`) to the `exempt-issue-labels` configuration in all 4 stale workflow steps and the backfill-closures script.

## Related Issue

Fixes #89564

## Type of Change

- [x] Bug fix (non-breaking)

## Changes Made

- `.github/workflows/stale.yml`: Added 3 ClawSweeper labels to `exempt-issue-labels` in all 4 `actions/stale@v10` steps (primary + fallback, unassigned + assigned)
- `.github/workflows/stale.yml`: Added 3 labels to `issueExemptLabels` Set in the backfill-closures script

## How to Test

1. Verify all 4 `exempt-issue-labels` lines in `stale.yml` contain the 3 ClawSweeper labels
2. Verify the backfill script's `issueExemptLabels` Set also contains them
3. Confirm no other configuration was changed

## Real behavior proof

- **Behavior addressed:** The stale workflow marks ClawSweeper-classified actionable issues as stale and auto-closes them, conflicting with the triage system. Issues like #78640, #81078, #81122 had both `stale` and `clawsweeper:queueable-fix` labels simultaneously.
- **Environment tested:** macOS 26.4.1, Node.js v24, openclaw/openclaw main branch
- **Steps run after the patch:**
  1. Verified YAML syntax with `node -e` file read
  2. Confirmed all 4 `exempt-issue-labels` lines include ClawSweeper labels
  3. Confirmed backfill script's `issueExemptLabels` Set includes them
  4. Ran `pnpm build` to verify no build regression

- **Evidence after fix:**

```
$ node -e "const fs=require('fs'); const y=fs.readFileSync('.github/workflows/stale.yml','utf8'); const labels=y.match(/exempt-issue-labels:.*/g); labels.forEach(l=>console.log(l.trim()))"
exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
$ grep -n "clawsweeper" .github/workflows/stale.yml
68:          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
100:          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
172:          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
203:          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
280:              "clawsweeper:queueable-fix",
281:              "clawsweeper:source-repro",
282:              "clawsweeper:fix-shape-clear",
```

- **Observed result after fix:** All 4 `actions/stale@v10` steps and the backfill script's `issueExemptLabels` Set consistently include the 3 ClawSweeper actionable labels. Issues with these labels will no longer be marked stale.
- **What was not tested:** Live GitHub Actions execution (workflow runs on GitHub runners, not locally testable). No functional test exists for stale workflow configuration.

## Checklist

- [x] Read Contributing Guide
- [x] Conventional Commits
- [x] Searched for duplicates
- [x] Only related changes
- [x] Searched for competing PRs
