### PR TITLE
fix(ui): reflow composer beside workspace rail

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -19,6 +19,17 @@
   box-shadow: none !important;
 }
 
+.chat-workbench__main {
+  grid-column: 1;
+  grid-row: 1;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
 /* Chat header - fixed at top, transparent */
 .chat-header {
   display: flex;

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -41,6 +41,8 @@
 }
 
 .chat-workspace-rail {
+  grid-column: 2;
+  grid-row: 1;
   display: flex;
   flex-direction: column;
   min-width: 0;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -908,6 +908,15 @@ describe("chat composer workbench", () => {
     expect(
       container.querySelector(".agent-chat__composer-controls .test-composer-control"),
     ).not.toBeNull();
+    const workbench = container.querySelector(".chat-workbench");
+    const main = container.querySelector(".chat-workbench__main");
+    const rail = container.querySelector(".chat-workspace-rail");
+    expect(main?.parentElement).toBe(workbench);
+    expect(rail?.parentElement).toBe(workbench);
+    expect(Array.from(workbench?.children ?? []).map((child) => child.className)).toEqual([
+      "chat-workspace-rail",
+      "chat-workbench__main",
+    ]);
     expect(container.querySelector(".chat-workspace-rail__path")?.textContent?.trim()).toBe(
       "/workspace",
     );

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -2063,107 +2063,115 @@ export function renderChat(props: ChatProps) {
       @dragover=${(e: DragEvent) => e.preventDefault()}
     >
       ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
-      ${props.error
-        ? html`
-            <div class="callout danger callout--dismissible" role="alert">
-              <span class="callout__content">${props.error}</span>
-              ${props.onDismissError
-                ? html`
-                    <button
-                      class="callout__dismiss"
-                      type="button"
-                      @click=${props.onDismissError}
-                      aria-label="Dismiss error"
-                      title="Dismiss error"
-                    >
-                      ${icons.x}
-                    </button>
-                  `
-                : nothing}
-            </div>
-          `
-        : nothing}
-      ${props.focusMode && props.onToggleFocusMode
-        ? html`
-            <button
-              class="chat-focus-exit"
-              type="button"
-              @click=${props.onToggleFocusMode}
-              aria-label="Exit focus mode"
-              title="Exit focus mode"
-            >
-              ${icons.x}
-            </button>
-          `
-        : nothing}
+      ${
+        props.error
+          ? html`
+              <div class="callout danger callout--dismissible" role="alert">
+                <span class="callout__content">${props.error}</span>
+                ${props.onDismissError
+                  ? html`
+                      <button
+                        class="callout__dismiss"
+                        type="button"
+                        @click=${props.onDismissError}
+                        aria-label="Dismiss error"
+                        title="Dismiss error"
+                      >
+                        ${icons.x}
+                      </button>
+                    `
+                  : nothing}
+              </div>
+            `
+          : nothing
+      }
+      ${
+        props.focusMode && props.onToggleFocusMode
+          ? html`
+              <button
+                class="chat-focus-exit"
+                type="button"
+                @click=${props.onToggleFocusMode}
+                aria-label="Exit focus mode"
+                title="Exit focus mode"
+              >
+                ${icons.x}
+              </button>
+            `
+          : nothing
+      }
       ${renderSearchBar(requestUpdate)} ${renderPinnedSection(props, pinned, requestUpdate)}
 
       <div
-        class="chat-workbench ${props.workspaceFiles?.collapsed
-          ? "chat-workbench--workspace-collapsed"
-          : ""}"
+        class="chat-workbench ${
+          props.workspaceFiles?.collapsed ? "chat-workbench--workspace-collapsed" : ""
+        }"
       >
-        <div class="chat-split-container ${sidebarOpen ? "chat-split-container--open" : ""}">
-          <div
-            class="chat-main"
-            style="flex: ${sidebarOpen ? `0 0 ${splitRatio * 100}%` : "1 1 100%"}"
-          >
-            ${thread}
+        ${renderWorkspaceFileRail(props.workspaceFiles)}
+        <div class="chat-workbench__main">
+          <div class="chat-split-container ${sidebarOpen ? "chat-split-container--open" : ""}">
+            <div
+              class="chat-main"
+              style="flex: ${sidebarOpen ? `0 0 ${splitRatio * 100}%` : "1 1 100%"}"
+            >
+              ${thread}
+            </div>
+
+            ${
+              sidebarOpen
+                ? html`
+                    <resizable-divider
+                      .splitRatio=${splitRatio}
+                      .label=${t("nav.resize")}
+                      @resize=${(e: CustomEvent) => props.onSplitRatioChange?.(e.detail.splitRatio)}
+                    ></resizable-divider>
+                    <div class="chat-sidebar" @click=${handleCodeBlockCopy}>
+                      ${renderMarkdownSidebar({
+                        content: props.sidebarContent ?? null,
+                        error: props.sidebarError ?? null,
+                        canvasPluginSurfaceUrl: props.canvasPluginSurfaceUrl,
+                        embedSandboxMode: props.embedSandboxMode ?? "scripts",
+                        allowExternalEmbedUrls: props.allowExternalEmbedUrls ?? false,
+                        onClose: props.onCloseSidebar!,
+                        onViewRawText: () => {
+                          if (!props.onOpenSidebar) {
+                            return;
+                          }
+                          const rawContent = buildRawSidebarContent(props.sidebarContent);
+                          if (rawContent) {
+                            props.onOpenSidebar(rawContent);
+                          }
+                        },
+                      })}
+                    </div>
+                  `
+                : nothing
+            }
           </div>
 
-          ${sidebarOpen
-            ? html`
-                <resizable-divider
-                  .splitRatio=${splitRatio}
-                  .label=${t("nav.resize")}
-                  @resize=${(e: CustomEvent) => props.onSplitRatioChange?.(e.detail.splitRatio)}
-                ></resizable-divider>
-                <div class="chat-sidebar" @click=${handleCodeBlockCopy}>
-                  ${renderMarkdownSidebar({
-                    content: props.sidebarContent ?? null,
-                    error: props.sidebarError ?? null,
-                    canvasPluginSurfaceUrl: props.canvasPluginSurfaceUrl,
-                    embedSandboxMode: props.embedSandboxMode ?? "scripts",
-                    allowExternalEmbedUrls: props.allowExternalEmbedUrls ?? false,
-                    onClose: props.onCloseSidebar!,
-                    onViewRawText: () => {
-                      if (!props.onOpenSidebar) {
-                        return;
-                      }
-                      const rawContent = buildRawSidebarContent(props.sidebarContent);
-                      if (rawContent) {
-                        props.onOpenSidebar(rawContent);
-                      }
-                    },
-                  })}
-                </div>
-              `
-            : nothing}
-        </div>
-        ${renderWorkspaceFileRail(props.workspaceFiles)}
-      </div>
+          ${renderChatQueue({
+            queue: props.queue,
+            canAbort: showAbortableUi,
+            onQueueRetry: props.onQueueRetry,
+            onQueueSteer: props.onQueueSteer,
+            onQueueRemove: props.onQueueRemove,
+          })}
+          ${renderSideResult(props.sideResult, props.onDismissSideResult)}
+          ${
+            props.showNewMessages
+              ? html`
+                  <button class="chat-new-messages" type="button" @click=${props.onScrollToBottom}>
+                    ${icons.arrowDown} New messages
+                  </button>
+                `
+              : nothing
+          }
 
-      ${renderChatQueue({
-        queue: props.queue,
-        canAbort: showAbortableUi,
-        onQueueRetry: props.onQueueRetry,
-        onQueueSteer: props.onQueueSteer,
-        onQueueRemove: props.onQueueRemove,
-      })}
-      ${renderSideResult(props.sideResult, props.onDismissSideResult)}
-      ${props.showNewMessages
-        ? html`
-            <button class="chat-new-messages" type="button" @click=${props.onScrollToBottom}>
-              ${icons.arrowDown} New messages
-            </button>
-          `
-        : nothing}
-
-      <!-- Input bar -->
-      <div
-        class="agent-chat__input"
-        @click=${(event: MouseEvent) => focusComposerFromChrome(event, props.connected)}
-      >
+          <!-- Input bar -->
+          <div
+            class="agent-chat__input"
+            @click=${(event: MouseEvent) => focusComposerFromChrome(event, props.connected)}
+          >
         ${renderSlashMenu(requestUpdate, props, visibleDraft)} ${renderAttachmentPreview(props)}
         <div class="agent-chat__composer-status-stack">
           ${renderFallbackIndicator(props.fallbackStatus)}
@@ -2185,21 +2193,23 @@ export function renderChat(props: ChatProps) {
         />
 
         ${renderRealtimeTalkOptions(props)}
-        ${props.realtimeTalkActive || props.realtimeTalkDetail || props.realtimeTalkTranscript
-          ? html`
-              <div class="agent-chat__stt-interim agent-chat__talk-status">
-                ${props.realtimeTalkDetail ??
-                ((props.realtimeTalkConversation?.length ?? 0) === 0
-                  ? props.realtimeTalkTranscript
-                  : null) ??
-                (props.realtimeTalkStatus === "thinking"
-                  ? "Asking OpenClaw..."
-                  : props.realtimeTalkStatus === "connecting"
-                    ? "Connecting Talk..."
-                    : "Talk live")}
-              </div>
-            `
-          : nothing}
+        ${
+          props.realtimeTalkActive || props.realtimeTalkDetail || props.realtimeTalkTranscript
+            ? html`
+                <div class="agent-chat__stt-interim agent-chat__talk-status">
+                  ${props.realtimeTalkDetail ??
+                  ((props.realtimeTalkConversation?.length ?? 0) === 0
+                    ? props.realtimeTalkTranscript
+                    : null) ??
+                  (props.realtimeTalkStatus === "thinking"
+                    ? "Asking OpenClaw..."
+                    : props.realtimeTalkStatus === "connecting"
+                      ? "Connecting Talk..."
+                      : "Talk live")}
+                </div>
+              `
+            : nothing
+        }
 
         <div class="agent-chat__composer-combobox">
           <textarea
@@ -2247,54 +2257,60 @@ export function renderChat(props: ChatProps) {
               <span class="agent-chat__control-label">${t("chat.composer.attachFile")}</span>
             </button>
 
-            ${props.onToggleRealtimeTalk
-              ? html`
-                  <button
-                    class="agent-chat__input-btn ${props.realtimeTalkActive
-                      ? "agent-chat__input-btn--talk"
-                      : ""}"
-                    @click=${props.onToggleRealtimeTalk}
-                    title=${props.realtimeTalkActive
-                      ? t("chat.composer.stopTalk")
-                      : t("chat.composer.startTalk")}
-                    aria-label=${props.realtimeTalkActive
-                      ? t("chat.composer.stopTalk")
-                      : t("chat.composer.startTalk")}
-                    ?disabled=${!props.connected}
-                  >
-                    ${props.realtimeTalkActive ? icons.volume2 : icons.radio}
-                    <span class="agent-chat__control-label"
-                      >${props.realtimeTalkActive
+            ${
+              props.onToggleRealtimeTalk
+                ? html`
+                    <button
+                      class="agent-chat__input-btn ${props.realtimeTalkActive
+                        ? "agent-chat__input-btn--talk"
+                        : ""}"
+                      @click=${props.onToggleRealtimeTalk}
+                      title=${props.realtimeTalkActive
                         ? t("chat.composer.stopTalk")
-                        : t("chat.composer.startTalk")}</span
+                        : t("chat.composer.startTalk")}
+                      aria-label=${props.realtimeTalkActive
+                        ? t("chat.composer.stopTalk")
+                        : t("chat.composer.startTalk")}
+                      ?disabled=${!props.connected}
                     >
-                  </button>
-                `
-              : nothing}
-            ${props.onToggleRealtimeTalkOptions
-              ? html`
-                  <button
-                    class="agent-chat__input-btn ${props.realtimeTalkOptionsOpen
-                      ? "agent-chat__input-btn--talk"
-                      : ""}"
-                    @click=${props.onToggleRealtimeTalkOptions}
-                    title="Talk settings"
-                    aria-label="Talk settings"
-                    aria-expanded=${props.realtimeTalkOptionsOpen ? "true" : "false"}
-                    ?disabled=${!props.connected || props.realtimeTalkActive}
-                  >
-                    ${icons.settings}
-                    <span class="agent-chat__control-label">Talk settings</span>
-                  </button>
-                `
-              : nothing}
+                      ${props.realtimeTalkActive ? icons.volume2 : icons.radio}
+                      <span class="agent-chat__control-label"
+                        >${props.realtimeTalkActive
+                          ? t("chat.composer.stopTalk")
+                          : t("chat.composer.startTalk")}</span
+                      >
+                    </button>
+                  `
+                : nothing
+            }
+            ${
+              props.onToggleRealtimeTalkOptions
+                ? html`
+                    <button
+                      class="agent-chat__input-btn ${props.realtimeTalkOptionsOpen
+                        ? "agent-chat__input-btn--talk"
+                        : ""}"
+                      @click=${props.onToggleRealtimeTalkOptions}
+                      title="Talk settings"
+                      aria-label="Talk settings"
+                      aria-expanded=${props.realtimeTalkOptionsOpen ? "true" : "false"}
+                      ?disabled=${!props.connected || props.realtimeTalkActive}
+                    >
+                      ${icons.settings}
+                      <span class="agent-chat__control-label">Talk settings</span>
+                    </button>
+                  `
+                : nothing
+            }
             ${tokens ? html`<span class="agent-chat__token-count">${tokens}</span>` : nothing}
             ${renderChatRunStatusIndicator(composerRunStatus)}
           </div>
 
-          ${composerControls && composerControls !== nothing
-            ? html`<div class="agent-chat__composer-controls">${composerControls}</div>`
-            : nothing}
+          ${
+            composerControls && composerControls !== nothing
+              ? html`<div class="agent-chat__composer-controls">${composerControls}</div>`
+              : nothing
+          }
           ${renderChatRunControls({
             canAbort: showAbortableUi,
             connected: props.connected,
@@ -2309,6 +2325,7 @@ export function renderChat(props: ChatProps) {
             onStoreDraft: () => {},
             showSecondary: false,
           })}
+        </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

- Reflow the chat composer inside the main chat column when the right Workspace Files rail is open.
- Keep Workspace Files as a first-level `chat-workbench` grid child, placed in the right column while appearing before the main column in DOM order.
- Add focused DOM coverage so the rail cannot regress back inside the main flex column.

This is intentionally scoped to the existing workspace rail layout. Follow-up work can change what the rail shows without mixing in this layout fix.

## Before / After Proof

Before: the composer extends under the Workspace Files rail.

![Before: composer extends under Workspace Files rail](https://github.com/Solvely-Colin/openclaw/releases/download/proof-92802-workspace-rail-reflow-20260613-1911/before.gif)

After: the composer reflows beside the Workspace Files rail.

![After: composer stays beside Workspace Files rail](https://github.com/Solvely-Colin/openclaw/releases/download/proof-92802-workspace-rail-reflow-20260613-1911/after.gif)

Proof assets are hosted as GitHub release assets on the fork, not committed to this branch:

- Before GIF: https://github.com/Solvely-Colin/openclaw/releases/download/proof-92802-workspace-rail-reflow-20260613-1911/before.gif
- After GIF: https://github.com/Solvely-Colin/openclaw/releases/download/proof-92802-workspace-rail-reflow-20260613-1911/after.gif
- Before metrics: https://github.com/Solvely-Colin/openclaw/releases/download/proof-92802-workspace-rail-reflow-20260613-1911/before-proof.json
- After metrics: https://github.com/Solvely-Colin/openclaw/releases/download/proof-92802-workspace-rail-reflow-20260613-1911/after-proof.json

## Real behavior proof

Behavior addressed: Opening the existing right Workspace Files rail left the chat composer outside the workbench grid, so the composer extended under the rail instead of reflowing beside it.

Real environment tested: Local OpenClaw Control UI rendered in Chromium at a 1440x900 desktop viewport, using the repo Control UI app and deterministic gateway data so the same expanded Workspace Files rail state could be compared before and after the patch.

Exact steps or command run after this patch: Captured a baseline by reversing `git diff origin/main`, opening the local Control UI in Chromium, expanding Workspace Files, and recording the viewport. Then reapplied this patch, opened the same local Control UI state, and recorded the viewport again. The resulting GIFs and JSON metrics are linked above. Verification commands run after the final patch are listed below.

Evidence after fix: After recording linked artifact: https://github.com/Solvely-Colin/openclaw/releases/download/proof-92802-workspace-rail-reflow-20260613-1911/after.gif. After metrics linked artifact: https://github.com/Solvely-Colin/openclaw/releases/download/proof-92802-workspace-rail-reflow-20260613-1911/after-proof.json. The after metrics report `input.right: 1122`, `rail.x: 1140`, `inputExtendsIntoRailColumn: false`, and `railBeforeMainInDom: true`. The before metrics reported `input.right: 1402`, `rail.x: 1140`, and `inputExtendsIntoRailColumn: true`.

Observed result after fix: With the rail expanded, the composer sits fully in the main column, the rail occupies the right grid column through the composer height, and the rail appears before the main column in DOM order while staying visually on the right.

What was not tested: A packaged macOS app build was not recaptured for this PR body update; this proof used the local Control UI browser scenario to drive the layout deterministically.

## Verification

- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui-workspace-rail-reflow.tsbuildinfo`
- `node scripts/ui.js build`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 ui/src/ui/views/chat.ts ui/src/ui/views/chat.test.ts ui/src/styles/chat/sidebar.css ui/src/styles/chat/layout.css`

