### PR TITLE
feat(ui): show derived titles in session picker instead of raw session keys (fixes #81117)

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -487,10 +487,51 @@ describe("resolveSessionDisplayName", () => {
   it("does not prefix non-typed sessions with labels", () => {
     expect(
       resolveSessionDisplayName(
-        "agent:main:imessage:direct:+19257864429",
-        row({ key: "agent:main:imessage:direct:+19257864429", label: "Tyler" }),
+        "agent:main:imessage:direct:+192****4429",
+        row({ key: "agent:main:imessage:direct:+192****4429", label: "Tyler" }),
       ),
     ).toBe("Tyler");
+  });
+
+  // ── derivedTitle fallback ──────────────────────────
+
+  it("uses derivedTitle when label and displayName are absent", () => {
+    expect(
+      resolveSessionDisplayName("mykey", row({ key: "mykey", derivedTitle: "Help with Docker" })),
+    ).toBe("Help with Docker");
+  });
+
+  it("ignores derivedTitle when label is present", () => {
+    expect(
+      resolveSessionDisplayName(
+        "mykey",
+        row({ key: "mykey", label: "Custom Label", derivedTitle: "Help with Docker" }),
+      ),
+    ).toBe("Custom Label");
+  });
+
+  it("ignores derivedTitle when displayName is present", () => {
+    expect(
+      resolveSessionDisplayName(
+        "mykey",
+        row({ key: "mykey", displayName: "My Chat", derivedTitle: "Help with Docker" }),
+      ),
+    ).toBe("My Chat");
+  });
+
+  it("ignores derivedTitle that matches key", () => {
+    expect(
+      resolveSessionDisplayName("mykey", row({ key: "mykey", derivedTitle: "mykey" })),
+    ).toBe("mykey");
+  });
+
+  it("prefixes derivedTitle for typed sessions", () => {
+    expect(
+      resolveSessionDisplayName(
+        "agent:main:cron:abc-123",
+        row({ key: "agent:main:cron:abc-123", derivedTitle: "Daily Briefing" }),
+      ),
+    ).toBe("Cron: Daily Briefing");
   });
 });
 

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -287,6 +287,7 @@ function createChatSessionPickerRequestParams(
     includeGlobal: overrides.includeGlobal,
     includeUnknown: overrides.includeUnknown,
     configuredAgentsOnly: overrides.configuredAgentsOnly,
+    includeDerivedTitles: true,
     limit: overrides.limit,
   };
   const activeAgentSession = parseAgentSessionKey(state.sessionKey);

--- a/ui/src/ui/session-display.ts
+++ b/ui/src/ui/session-display.ts
@@ -100,6 +100,10 @@ export function resolveSessionDisplayName(
   if (displayName && displayName !== key) {
     return applyTypedPrefix(displayName);
   }
+  const derivedTitle = normalizeOptionalString(row?.derivedTitle) ?? "";
+  if (derivedTitle && derivedTitle !== key) {
+    return applyTypedPrefix(derivedTitle);
+  }
   return fallbackName;
 }
 

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -428,6 +428,7 @@ export type GatewaySessionRow = {
   kind: "cron" | "direct" | "group" | "global" | "unknown";
   label?: string;
   displayName?: string;
+  derivedTitle?: string;
   surface?: string;
   subject?: string;
   room?: string;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -2332,6 +2332,7 @@ describe("chat session controls", () => {
       includeUnknown: true,
       limit: 50,
       search: "telegram",
+      includeDerivedTitles: true,
     });
     expect(loadSessionsMock).not.toHaveBeenCalled();
   });
@@ -2397,6 +2398,7 @@ describe("chat session controls", () => {
       includeUnknown: true,
       limit: 50,
       search: "tele",
+      includeDerivedTitles: true,
     });
   });
 
@@ -2544,6 +2546,7 @@ describe("chat session controls", () => {
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
+      includeDerivedTitles: true,
     });
   });
 
@@ -2589,6 +2592,7 @@ describe("chat session controls", () => {
       includeUnknown: true,
       limit: 50,
       search: "tele",
+      includeDerivedTitles: true,
     });
 
     input!.value = "telegram";
@@ -2601,6 +2605,7 @@ describe("chat session controls", () => {
       includeUnknown: true,
       limit: 50,
       search: "telegram",
+      includeDerivedTitles: true,
     });
 
     resolveTelegram(
@@ -2689,6 +2694,7 @@ describe("chat session controls", () => {
       limit: 50,
       offset: 50,
       search: "telegram",
+      includeDerivedTitles: true,
     });
   });
 
@@ -2768,6 +2774,7 @@ describe("chat session controls", () => {
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
+      includeDerivedTitles: true,
     });
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "main",
@@ -2776,6 +2783,7 @@ describe("chat session controls", () => {
       includeUnknown: true,
       limit: 50,
       offset: 2,
+      includeDerivedTitles: true,
     });
     expect(request.mock.calls.some(([, params]) => params?.offset === 50)).toBe(false);
   });
@@ -2824,6 +2832,7 @@ describe("chat session controls", () => {
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
+      includeDerivedTitles: true,
     });
     expect(request.mock.calls.some(([, params]) => Object.hasOwn(params ?? {}, "agentId"))).toBe(
       false,
@@ -2904,6 +2913,7 @@ describe("chat session controls", () => {
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
+      includeDerivedTitles: true,
     });
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "ops",
@@ -2911,6 +2921,7 @@ describe("chat session controls", () => {
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
+      includeDerivedTitles: true,
     });
   });
 


### PR DESCRIPTION
## Summary

The Control UI session picker displays raw session keys (e.g. `agent:main:dashboard:uuid`), making it hard to identify sessions. The Gateway `sessions.list` RPC already supports `includeDerivedTitles`, which generates readable titles from conversation content. The TUI already uses this (`src/tui/tui-command-handlers.ts:253`). This PR wires it into the Control UI.

**Changes:**
- `ui/src/ui/types.ts`: Add `derivedTitle?: string` to `GatewaySessionRow`
- `ui/src/ui/session-display.ts`: Use `derivedTitle` as fallback in `resolveSessionDisplayName` (after `label` and `displayName`)
- `ui/src/ui/chat/session-controls.ts`: Pass `includeDerivedTitles: true` in session picker request params
- Tests: 5 new test cases for derivedTitle fallback behavior + updated existing test expectations

Fixes #81117

## Real behavior proof

- **Behavior addressed:** Control UI session picker shows derived titles from conversation content instead of raw session keys
- **Environment tested:** macOS 26.4.1, Node 22, openclaw build from source (upstream/main @ 3429e33f)
- **Steps run after the patch:**
  1. `node scripts/run-vitest.mjs run ui/src/ui/app-render.helpers.node.test.ts` — 76 tests passed
  2. `node scripts/run-vitest.mjs run ui/src/ui/views/chat.test.ts` — 103 tests passed
  3. `pnpm build` — succeeded (70.6s)
  4. Verified `includeDerivedTitles` wired in session picker request params

- **Evidence after fix:**

```
$ grep -n 'includeDerivedTitles\|derivedTitle' ui/src/ui/chat/session-controls.ts ui/src/ui/session-display.ts ui/src/ui/types.ts
ui/src/ui/chat/session-controls.ts:290:    includeDerivedTitles: true,
ui/src/ui/session-display.ts:103:  const derivedTitle = normalizeOptionalString(row?.derivedTitle) ?? "";
ui/src/ui/session-display.ts:104:  if (derivedTitle && derivedTitle !== key) {
ui/src/ui/session-display.ts:105:    return applyTypedPrefix(derivedTitle);
ui/src/ui/types.ts:431:  derivedTitle?: string;

$ node scripts/run-vitest.mjs run ui/src/ui/app-render.helpers.node.test.ts
 ✓  ui  ui/src/ui/app-render.helpers.node.test.ts (76 tests) 9ms
 Test Files  1 passed (1)
      Tests  76 passed (76)

$ node scripts/run-vitest.mjs run ui/src/ui/views/chat.test.ts
 ✓  unit-ui  ui/src/ui/views/chat.test.ts (103 tests) 1131ms
 Test Files  1 passed (1)
      Tests  103 passed (103)
```

- **Observed result after fix:** All 179 tests pass. The session picker now requests derived titles from the Gateway, and `resolveSessionDisplayName` falls back to `derivedTitle` when `label` and `displayName` are absent.
- **What was not tested:** Live Control UI rendering (requires running gateway + browser). The tests verify the request params and display name resolution logic.
