### PR TITLE
fix(telegram): skip IPv4 fallback when user explicitly configures non-ipv4first dnsResultOrder (fixes #41671)

### DIFF
--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -680,6 +680,27 @@ describe("resolveTelegramFetch", () => {
     expect(typeof pinnedPolicy?.connect?.lookup).toBe("function");
   });
 
+  it("skips sticky IPv4 fallback when user explicitly configures network settings", async () => {
+    undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
+    const transport = resolveTelegramTransport(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "verbatim",
+      },
+    });
+
+    await expect(
+      transport.sourceFetch("https://api.telegram.org/botTOKEN/getFile"),
+    ).resolves.toEqual({ ok: true });
+    // Only the default dispatcher — no IPv4 fallback or pinned IP attempts
+    expect(transport.dispatcherAttempts).toHaveLength(1);
+    const [defaultAttempt] = transport.dispatcherAttempts as Array<{
+      dispatcherPolicy?: DirectTelegramDispatcherPolicy;
+    }>;
+    expect(defaultAttempt.dispatcherPolicy?.mode).toBe("direct");
+    expect(defaultAttempt.dispatcherPolicy?.connect?.autoSelectFamily).toBe(true);
+  });
+
   it("does not blind-retry when sticky IPv4 fallback is disallowed for explicit proxy paths", async () => {
     const { makeProxyFetch } = await import("./proxy.js");
     const proxyFetch = makeProxyFetch("http://127.0.0.1:7890");

--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -701,6 +701,17 @@ describe("resolveTelegramFetch", () => {
     expect(defaultAttempt.dispatcherPolicy?.connect?.autoSelectFamily).toBe(true);
   });
 
+  it("skips sticky IPv4 fallback when the DNS result order env override is verbatim", async () => {
+    vi.stubEnv("OPENCLAW_TELEGRAM_DNS_RESULT_ORDER", "verbatim");
+    undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
+    const transport = resolveTelegramTransport();
+
+    await expect(
+      transport.sourceFetch("https://api.telegram.org/botTOKEN/getFile"),
+    ).resolves.toEqual({ ok: true });
+    expect(transport.dispatcherAttempts).toHaveLength(1);
+  });
+
   it("does not blind-retry when sticky IPv4 fallback is disallowed for explicit proxy paths", async () => {
     const { makeProxyFetch } = await import("./proxy.js");
     const proxyFetch = makeProxyFetch("http://127.0.0.1:7890");

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -635,9 +635,13 @@ export function resolveTelegramTransport(
   });
   const defaultDispatcher = createTelegramDispatcher(defaultDispatcherResolution.policy);
   const shouldBypassEnvProxy = shouldBypassEnvProxyForTelegramApi();
+  const hasExplicitNetworkConfig =
+    dnsDecision.source === "config" &&
+    dnsDecision.value !== "ipv4first";
   const allowStickyFallback =
-    defaultDispatcher.mode === "direct" ||
-    (defaultDispatcher.mode === "env-proxy" && shouldBypassEnvProxy);
+    !hasExplicitNetworkConfig &&
+    (defaultDispatcher.mode === "direct" ||
+      (defaultDispatcher.mode === "env-proxy" && shouldBypassEnvProxy));
   const fallbackDispatcherPolicy = allowStickyFallback
     ? resolveTelegramDispatcherPolicy({
         autoSelectFamily: false,

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -28,6 +28,7 @@ import { normalizeTelegramApiRoot } from "./api-root.js";
 import {
   resolveTelegramAutoSelectFamilyDecision,
   resolveTelegramDnsResultOrderDecision,
+  TELEGRAM_DNS_RESULT_ORDER_ENV,
 } from "./network-config.js";
 import { getProxyUrlFromFetch, makeProxyFetch } from "./proxy.js";
 
@@ -635,11 +636,12 @@ export function resolveTelegramTransport(
   });
   const defaultDispatcher = createTelegramDispatcher(defaultDispatcherResolution.policy);
   const shouldBypassEnvProxy = shouldBypassEnvProxyForTelegramApi();
-  const hasExplicitNetworkConfig =
-    dnsDecision.source === "config" &&
+  const hasExplicitDnsResultOrder =
+    (dnsDecision.source === "config" ||
+      dnsDecision.source === `env:${TELEGRAM_DNS_RESULT_ORDER_ENV}`) &&
     dnsDecision.value !== "ipv4first";
   const allowStickyFallback =
-    !hasExplicitNetworkConfig &&
+    !hasExplicitDnsResultOrder &&
     (defaultDispatcher.mode === "direct" ||
       (defaultDispatcher.mode === "env-proxy" && shouldBypassEnvProxy));
   const fallbackDispatcherPolicy = allowStickyFallback


### PR DESCRIPTION
## Summary

When the user explicitly configures `channels.telegram.network.dnsResultOrder` to a non-`ipv4first` value (e.g. `verbatim`), the sticky IPv4 fallback dispatcher should not be armed. Currently, `resolveTelegramTransport` ignores the user's explicit network config and forces `autoSelectFamily: false` + `dnsResultOrder: "ipv4first"` on the fallback dispatcher, overriding the user's IPv6-friendly config and causing media downloads to fail on hosts where IPv4 is broken but IPv6 works.

Fixes #41671

## Changes

- **`extensions/telegram/src/fetch.ts`**: Added `hasExplicitNetworkConfig` guard that checks `dnsDecision.source === "config" && dnsDecision.value !== "ipv4first"`. When true, `allowStickyFallback` is set to `false`, preventing the sticky IPv4 fallback dispatcher from being armed.
- **`extensions/telegram/src/fetch.test.ts`**: Added test "skips sticky IPv4 fallback when user explicitly configures network settings" that verifies only the default dispatcher is used (no IPv4 fallback or pinned IP attempts) when `dnsResultOrder: "verbatim"` is configured.

## Real behavior proof

- **Behavior addressed:** Telegram media download fails on IPv4-broken/IPv6-working hosts because the runtime IPv4 fallback overrides explicit `channels.telegram.network` config.
- **Environment tested:** macOS 26.4.1, Node.js, OpenClaw local build from `upstream/main` (commit 47759c35).
- **Steps run after the patch:**
  1. Cherry-picked fix onto fresh branch from latest `upstream/main`
  2. Ran `node scripts/run-vitest.mjs run extensions/telegram/src/fetch.test.ts`
  3. Ran `pnpm build`
  4. Verified fix with `grep -n` on changed files

- **Evidence after fix:**

```
$ node scripts/run-vitest.mjs run extensions/telegram/src/fetch.test.ts
 ✓  extension-telegram  extensions/telegram/src/fetch.test.ts (41 tests) 128ms
 Test Files  1 passed (1)
      Tests  41 passed (41)

$ grep -n "hasExplicitNetworkConfig\|allowStickyFallback" extensions/telegram/src/fetch.ts
638:  const hasExplicitNetworkConfig =
641:  const allowStickyFallback =
642:    !hasExplicitNetworkConfig &&

$ grep -n "skips sticky IPv4 fallback when user explicitly" extensions/telegram/src/fetch.test.ts
683:  it("skips sticky IPv4 fallback when user explicitly configures network settings", async () => {

$ pnpm build
[build-all] phase timings: total 74.5s
```

- **Observed result after fix:** All 41 tests pass. Build succeeds. The sticky IPv4 fallback is now correctly skipped when the user explicitly configures `dnsResultOrder` to a non-`ipv4first` value via `channels.telegram.network`.
- **What was not tested:** Live Telegram API call on an IPv4-broken host (requires specific network conditions not available in CI). The test mocks `undiciFetch` to verify dispatcher behavior.
