### PR TITLE
fix(agents): keep larger of adjacent b-sized model tokens

### DIFF
--- a/src/shared/model-param-b.test.ts
+++ b/src/shared/model-param-b.test.ts
@@ -10,6 +10,13 @@ describe("shared/model-param-b", () => {
     expect(inferParamBFromIdOrName("(70b) + m1.5b + qwen-14b")).toBe(70);
   });
 
+  it("keeps the larger of two adjacent b-sized tokens", () => {
+    expect(inferParamBFromIdOrName("8b-70b")).toBe(70);
+    expect(inferParamBFromIdOrName("qwen2-7b-13b")).toBe(13);
+    expect(inferParamBFromIdOrName("7b 13b")).toBe(13);
+    expect(inferParamBFromIdOrName("2b_70b")).toBe(70);
+  });
+
   it("ignores malformed, zero, and non-delimited matches", () => {
     expect(inferParamBFromIdOrName("abc70beta 0b x70b2")).toBeNull();
     expect(inferParamBFromIdOrName("model 0b")).toBeNull();

--- a/src/shared/model-param-b.ts
+++ b/src/shared/model-param-b.ts
@@ -4,7 +4,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 /** Infers the largest `<number>b` parameter-size token from a model id or display name. */
 export function inferParamBFromIdOrName(text: string): number | null {
   const raw = normalizeLowercaseStringOrEmpty(text);
-  const matches = raw.matchAll(/(?:^|[^a-z0-9])[a-z]?(\d+(?:\.\d+)?)b(?:[^a-z0-9]|$)/g);
+  const matches = raw.matchAll(/(?:^|[^a-z0-9])[a-z]?(\d+(?:\.\d+)?)b(?=[^a-z0-9]|$)/g);
   let best: number | null = null;
   for (const match of matches) {
     const numRaw = match[1];


### PR DESCRIPTION
## Summary

`inferParamBFromIdOrName` is contracted to return the largest `<number>b`
parameter-size token in a model id or display name. The regex's trailing
boundary `(?:[^a-z0-9]|$)` is a consuming match, so when two `<num>b` tokens
are separated by a single delimiter the first match consumes that delimiter and
the following token loses the leading boundary required by
`(?:^|[^a-z0-9])`, so it is skipped. The helper then returns the smaller token.

Fix: make the trailing boundary a non-consuming lookahead `(?=[^a-z0-9]|$)` so
adjacent tokens both match. All six pre-existing assertions are unchanged.

Affected callers:
- `src/agents/model-scan.ts:239` builds `inferredParamB` from `${id} ${name}`.
- `src/security/audit-extra.summary.ts:189` flags small models via
  `paramB <= SMALL_MODEL_PARAM_B_MAX`, so an under-reported size can record a
  large model as small.

## Real behavior proof

Behavior addressed: adjacent `<num>b` tokens under-reported the parameter size
(largest token dropped).

Real environment tested: ran the real exported `inferParamBFromIdOrName` via the
colocated Vitest suite (real module resolution, not a copied regex), before and
after the one-character change.

Exact steps or command run after this patch:
`node scripts/run-vitest.mjs src/shared/model-param-b.test.ts`
`node scripts/run-vitest.mjs src/agents/model-scan.test.ts`

Evidence after fix:
- Before fix: `inferParamBFromIdOrName("8b-70b")` returns `8`; the new
  regression test fails (`Received 8` / `Expected 70`).
- After fix: returns `70`; suite passes 3/3.
- `8b-70b -> 70`, `qwen2-7b-13b -> 13`, `7b 13b -> 13`, `2b_70b -> 70`.
- The six existing assertions (`llama-8b mixtral-22b -> 22`,
  `(70b) + m1.5b + qwen-14b -> 70`, the null cases, etc.) still pass.

Observed result after fix:
- `src/shared/model-param-b.test.ts`: 3 passed.
- `src/agents/model-scan.test.ts`: 6 passed.
- oxlint on the changed files: clean (exit 0).

What was not tested: no live model-catalog scan against OpenRouter; the change
is a pure-logic helper covered by the unit suite and its primary caller suite.
