### PR TITLE
fix: reject unvalidated voice media streams

### DIFF
--- a/extensions/voice-call/src/media-stream.test.ts
+++ b/extensions/voice-call/src/media-stream.test.ts
@@ -199,6 +199,39 @@ describe("MediaStreamHandler security hardening", () => {
     expect((error as Error).cause).toBeInstanceOf(SyntaxError);
   });
 
+  it("rejects start frames when no stream acceptance validator is configured", async () => {
+    const createSession = vi.fn(() => createStubSession());
+    const handler = new MediaStreamHandler({
+      transcriptionProvider: {
+        createSession,
+        id: "openai",
+        label: "OpenAI",
+        isConfigured: () => true,
+      },
+      providerConfig: {},
+    });
+    const server = await startWsServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          streamSid: "MZ-unvalidated",
+          start: { callSid: "CA-unvalidated" },
+        }),
+      );
+
+      const closed = await waitForClose(ws);
+
+      expect(closed.code).toBe(1008);
+      expect(closed.reason).toBe("Unauthorized stream");
+      expect(createSession).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
   it("emits common Talk events for telephony STT/TTS sessions", async () => {
     let callbacks: RealtimeTranscriptionSessionCreateRequest | undefined;
     const sentAudio: Buffer[] = [];

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -45,7 +45,7 @@ export interface MediaStreamConfig {
   maxConnections?: number;
   /** Optional trusted resolver for the source IP used by pending-connection guards. */
   resolveClientIp?: (request: IncomingMessage) => string | undefined;
-  /** Validate whether to accept a media stream for the given call ID */
+  /** Validate whether to accept a media stream for the given call ID. Missing validator rejects. */
   shouldAcceptStream?: (params: { callId: string; streamSid: string; token?: string }) => boolean;
   /** Callback when transcript is received */
   onTranscript?: (callId: string, transcript: string) => void;
@@ -321,10 +321,13 @@ export class MediaStreamHandler {
       ws.close(1008, "Missing callSid");
       return null;
     }
-    if (
-      this.config.shouldAcceptStream &&
-      !this.config.shouldAcceptStream({ callId: callSid, streamSid, token: effectiveToken })
-    ) {
+    if (!this.config.shouldAcceptStream) {
+      console.warn("[MediaStream] Rejecting stream without an acceptance validator");
+      ws.close(1008, "Unauthorized stream");
+      return null;
+    }
+
+    if (!this.config.shouldAcceptStream({ callId: callSid, streamSid, token: effectiveToken })) {
       console.warn(`[MediaStream] Rejecting stream for unknown call: ${callSid}`);
       ws.close(1008, "Unknown call");
       return null;


### PR DESCRIPTION
## Summary

- Make voice-call media streams fail closed when no stream acceptance validator is configured.
- Close unvalidated `start` frames with WebSocket policy violation before creating STT/TTS session state.
- Add regression coverage for the missing-validator path.

## Verification

- `node scripts/run-vitest.mjs extensions/voice-call/src/media-stream.test.ts`
- `node scripts/run-vitest.mjs extensions/voice-call/src/media-stream.test.ts extensions/voice-call/src/webhook.test.ts extensions/voice-call/src/webhook-security.test.ts`
- `node_modules/oxfmt/bin/oxfmt --check --threads=1 extensions/voice-call/src/media-stream.ts extensions/voice-call/src/media-stream.test.ts`
- `node_modules/oxlint/bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/voice-call/src/media-stream.ts extensions/voice-call/src/media-stream.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --no-web-search`
- Remote Linux dev-box: `corepack pnpm install --frozen-lockfile && node scripts/run-vitest.mjs extensions/voice-call/src/media-stream.test.ts extensions/voice-call/src/webhook.test.ts extensions/voice-call/src/webhook-security.test.ts` (86 tests passed)
