### PR TITLE
fix(state): refuse chmod-less agent database volumes that cannot prove credential privacy

### DIFF
--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -17,6 +17,8 @@ import { requireNodeSqlite } from "../../infra/node-sqlite.js";
 import { resolveSqliteDatabaseFilePaths } from "../../infra/sqlite-files.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
+  enforcePrivateAgentDbFilePermissions,
+  isDefaultProfileAgentDatabaseLocation,
   runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
@@ -89,6 +91,7 @@ function getAuthProfileKysely(db: DatabaseSync) {
 
 function readAuthProfileJsonCellReadOnly(pathname: string, target: "store" | "state"): unknown {
   const sqlite = requireNodeSqlite();
+  enforcePrivateAgentDbFilePermissions(pathname, isDefaultProfileAgentDatabaseLocation(pathname));
   const db = new sqlite.DatabaseSync(pathname, { readOnly: true });
   try {
     // This short-lived reader bypasses the canonical agent DB bootstrap, but it

--- a/src/state/openclaw-agent-db.permissions.test.ts
+++ b/src/state/openclaw-agent-db.permissions.test.ts
@@ -1,0 +1,262 @@
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const chmodFailHook = vi.hoisted(() => ({
+  error: undefined as Error | undefined,
+  silent: false,
+  calls: 0,
+}));
+
+const statModeHook = vi.hoisted(() => ({
+  nonPrivatePaths: new Set<string>(),
+}));
+
+const sqliteHook = vi.hoisted(() => ({
+  instances: [] as Array<{ isOpen: boolean }>,
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const chmodSync: typeof actual.chmodSync = ((target: unknown, mode: unknown) => {
+    chmodFailHook.calls += 1;
+    if (chmodFailHook.error) {
+      throw chmodFailHook.error;
+    }
+    if (chmodFailHook.silent) {
+      return undefined;
+    }
+    return (actual.chmodSync as (...args: unknown[]) => unknown)(target, mode);
+  }) as typeof actual.chmodSync;
+  const statSync: typeof actual.statSync = ((target: unknown, options: unknown) => {
+    const stats = (actual.statSync as (...args: unknown[]) => { mode: number })(target, options);
+    if (statModeHook.nonPrivatePaths.has(String(target))) {
+      stats.mode = (stats.mode & ~0o777) | 0o644;
+    }
+    return stats;
+  }) as typeof actual.statSync;
+  return { ...actual, chmodSync, statSync, default: { ...actual, chmodSync, statSync } };
+});
+
+vi.mock("../infra/node-sqlite.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/node-sqlite.js")>();
+  return {
+    ...actual,
+    requireNodeSqlite: () => {
+      const real = actual.requireNodeSqlite();
+      class TrackedDatabaseSync extends real.DatabaseSync {
+        constructor(...args: ConstructorParameters<typeof real.DatabaseSync>) {
+          super(...args);
+          sqliteHook.instances.push(this);
+        }
+      }
+      return { ...real, DatabaseSync: TrackedDatabaseSync };
+    },
+  };
+});
+
+const fs = await import("node:fs");
+const {
+  closeOpenClawAgentDatabasesForTest,
+  enforcePrivateAgentDbFilePermissions,
+  isDefaultProfileAgentDatabaseLocation,
+  openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
+} = await import("./openclaw-agent-db.js");
+const { closeOpenClawStateDatabaseForTest } = await import("./openclaw-state-db.js");
+const { readPersistedAuthProfileStoreRaw, writePersistedAuthProfileStoreRaw } = await import(
+  "../agents/auth-profiles/sqlite.js"
+);
+
+function chmodError(code: string): Error {
+  const err = new Error(`${code}: chmod failed`) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+function openAgentDb(stateDir: string) {
+  return openOpenClawAgentDatabase({ agentId: "main", env: { OPENCLAW_STATE_DIR: stateDir } });
+}
+
+describe("agent database permission hardening on chmod-less volumes", () => {
+  let stateDir: string | undefined;
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    chmodFailHook.error = undefined;
+    chmodFailHook.silent = false;
+    chmodFailHook.calls = 0;
+    statModeHook.nonPrivatePaths.clear();
+    sqliteHook.instances.length = 0;
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    if (stateDir) {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+      stateDir = undefined;
+    }
+  });
+
+  it("hardens the agent database to private modes when chmod succeeds", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-agent-chmod-"));
+
+    const database = openAgentDb(stateDir);
+
+    expect(database.db.isOpen).toBe(true);
+    expect(fs.statSync(dirname(database.path)).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(database.path).mode & 0o777).toBe(0o600);
+  });
+
+  it("opens when chmod fails but the credential store is already private", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-agent-chmod-"));
+    openAgentDb(stateDir);
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    chmodFailHook.error = chmodError("ENOTSUP");
+
+    const database = openAgentDb(stateDir);
+
+    expect(database.db.isOpen).toBe(true);
+    expect(chmodFailHook.calls).toBeGreaterThan(0);
+  });
+
+  it("refuses when chmod reports success but the store stays world-readable", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-agent-chmod-"));
+    const seed = openAgentDb(stateDir);
+    const agentDir = dirname(seed.path);
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    fs.chmodSync(agentDir, 0o755);
+    chmodFailHook.silent = true;
+
+    expect(() => openAgentDb(stateDir as string)).toThrow(/cannot be made private/);
+    expect(chmodFailHook.calls).toBeGreaterThan(0);
+  });
+
+  const refusalCases = [
+    {
+      name: "refuses when chmod fails and the agent directory is not private",
+      code: "EPERM",
+      win32: false,
+      makeNonPrivate: true,
+      expected: /cannot be made private/,
+    },
+    {
+      name: "refuses with EACCES on a non-private agent directory",
+      code: "EACCES",
+      win32: false,
+      makeNonPrivate: true,
+      expected: /cannot be made private/,
+    },
+    {
+      name: "refuses a relocated agent database on Windows because mode bits cannot prove ACL privacy",
+      code: "ENOTSUP",
+      win32: true,
+      makeNonPrivate: false,
+      expected: /relocated Windows/,
+    },
+  ];
+
+  for (const testCase of refusalCases) {
+    it(testCase.name, () => {
+      stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-agent-chmod-"));
+      const seed = openAgentDb(stateDir);
+      const agentDir = dirname(seed.path);
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      if (testCase.makeNonPrivate) {
+        fs.chmodSync(agentDir, 0o755);
+      }
+      if (testCase.win32) {
+        Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      }
+      chmodFailHook.error = chmodError(testCase.code);
+
+      expect(() => openAgentDb(stateDir as string)).toThrow(testCase.expected);
+    });
+  }
+
+  it("closes the freshly opened handle when the post-open privacy check refuses", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-agent-chmod-"));
+    const dbPath = resolveOpenClawAgentSqlitePath({
+      agentId: "main",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    statModeHook.nonPrivatePaths.add(dbPath);
+
+    expect(() => openAgentDb(stateDir as string)).toThrow(/cannot be made private/);
+
+    expect(sqliteHook.instances.length).toBeGreaterThan(0);
+    expect(sqliteHook.instances.every((db) => !db.isOpen)).toBe(true);
+  });
+
+  it("reads auth profiles from a private store opened read-only", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-agent-chmod-"));
+    const seed = openAgentDb(stateDir);
+    const agentDir = dirname(seed.path);
+    writePersistedAuthProfileStoreRaw({ profiles: { main: { type: "api_key" } } }, agentDir, seed);
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    expect(readPersistedAuthProfileStoreRaw(agentDir)).toEqual({
+      profiles: { main: { type: "api_key" } },
+    });
+  });
+
+  it("refuses read-only auth-profile loads when the credential store stays world-readable", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-agent-chmod-"));
+    const seed = openAgentDb(stateDir);
+    const agentDir = dirname(seed.path);
+    writePersistedAuthProfileStoreRaw({ profiles: {} }, agentDir, seed);
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    fs.chmodSync(seed.path, 0o644);
+    chmodFailHook.silent = true;
+
+    expect(() => readPersistedAuthProfileStoreRaw(agentDir)).toThrow(/cannot be made private/);
+    expect(chmodFailHook.calls).toBeGreaterThan(0);
+  });
+
+  it("trusts the default per-user agent database location on Windows even when chmod cannot harden it", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-agent-chmod-"));
+    const filePath = join(stateDir, "openclaw-agent.sqlite");
+    fs.writeFileSync(filePath, "");
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    chmodFailHook.error = chmodError("ENOTSUP");
+
+    expect(() => enforcePrivateAgentDbFilePermissions(filePath, true)).not.toThrow();
+    expect(chmodFailHook.calls).toBeGreaterThan(0);
+  });
+
+  it("refuses a relocated agent database location on Windows", () => {
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-agent-chmod-"));
+    const filePath = join(stateDir, "openclaw-agent.sqlite");
+    fs.writeFileSync(filePath, "");
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    expect(() => enforcePrivateAgentDbFilePermissions(filePath, false)).toThrow(/relocated Windows/);
+  });
+});
+
+describe("default profile agent database location detection", () => {
+  it("treats the default per-user agent database path as the trusted profile location", () => {
+    const env = { NODE_ENV: "test" } as NodeJS.ProcessEnv;
+    const dbPath = resolveOpenClawAgentSqlitePath({ agentId: "main", env });
+
+    expect(isDefaultProfileAgentDatabaseLocation(dbPath, env)).toBe(true);
+  });
+
+  it("treats a relocated OPENCLAW_STATE_DIR agent database as untrusted", () => {
+    const env = { OPENCLAW_STATE_DIR: join(tmpdir(), "relocated-state") } as NodeJS.ProcessEnv;
+    const dbPath = resolveOpenClawAgentSqlitePath({ agentId: "main", env });
+
+    expect(isDefaultProfileAgentDatabaseLocation(dbPath, env)).toBe(false);
+  });
+
+  it("treats a path outside the default agents root as untrusted", () => {
+    const env = { NODE_ENV: "test" } as NodeJS.ProcessEnv;
+    const outside = join(tmpdir(), "elsewhere", "openclaw-agent.sqlite");
+
+    expect(isDefaultProfileAgentDatabaseLocation(outside, env)).toBe(false);
+  });
+});

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -15,9 +15,11 @@ import {
   configureSqliteConnectionPragmas,
   type SqliteWalMaintenance,
 } from "../infra/sqlite-wal.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "./openclaw-agent-db.generated.js";
 import { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
+import { resolveOpenClawStateSqliteDir } from "./openclaw-state-db.paths.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.generated.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
@@ -37,6 +39,9 @@ export { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
 const OPENCLAW_AGENT_SCHEMA_VERSION = 1;
 const OPENCLAW_AGENT_DB_DIR_MODE = 0o700;
 const OPENCLAW_AGENT_DB_FILE_MODE = 0o600;
+
+const agentDbLog = createSubsystemLogger("state/agent-db");
+const agentDbChmodWarnedTargets = new Set<string>();
 
 /** Open per-agent SQLite database handle plus lifecycle maintenance. */
 export type OpenClawAgentDatabase = {
@@ -70,6 +75,69 @@ function assertSupportedAgentSchemaVersion(db: DatabaseSync, pathname: string): 
   }
 }
 
+function enforcePrivateAgentDbChmodSync(
+  target: string,
+  mode: number,
+  defaultProfileLocation: boolean,
+): void {
+  let chmodFailure: { error: unknown; text: string } | undefined;
+  try {
+    chmodSync(target, mode);
+  } catch (err) {
+    chmodFailure = { error: err, text: String(err) };
+  }
+  if (process.platform === "win32") {
+    if (defaultProfileLocation) {
+      return;
+    }
+    throw new Error(
+      `OpenClaw agent database ${target} stores credentials in a relocated Windows location whose private NTFS ACL cannot be proven (Windows file modes do not reflect ACLs). Keep agent credential storage at the default per-user location instead of relocating it with OPENCLAW_STATE_DIR.`,
+      chmodFailure ? { cause: chmodFailure.error } : undefined,
+    );
+  }
+  const resultingMode = statSync(target).mode & 0o777;
+  if ((resultingMode & 0o077) !== 0) {
+    const reason = chmodFailure?.text ?? "chmod reported success without changing the mode";
+    throw new Error(
+      `OpenClaw agent database ${target} stores credentials and cannot be made private on this volume (mode ${resultingMode.toString(8)}; ${reason}). Move the agent database to a filesystem that enforces private permissions by setting OPENCLAW_STATE_DIR to a local directory.`,
+      chmodFailure ? { cause: chmodFailure.error } : undefined,
+    );
+  }
+  if (!chmodFailure) {
+    return;
+  }
+  if (agentDbChmodWarnedTargets.has(target)) {
+    return;
+  }
+  agentDbChmodWarnedTargets.add(target);
+  agentDbLog.warn(
+    `agent database ${target} is already private; skipped chmod rejected by this volume: ${chmodFailure.text}`,
+  );
+}
+
+export function isDefaultProfileAgentDatabaseLocation(
+  pathname: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (env.OPENCLAW_STATE_DIR?.trim()) {
+    return false;
+  }
+  const agentsRoot = path.resolve(path.dirname(resolveOpenClawStateSqliteDir(env)), "agents");
+  const resolved = path.resolve(pathname);
+  return resolved === agentsRoot || resolved.startsWith(agentsRoot + path.sep);
+}
+
+export function enforcePrivateAgentDbFilePermissions(
+  pathname: string,
+  defaultProfileLocation: boolean,
+): void {
+  for (const candidate of resolveSqliteDatabaseFilePaths(pathname)) {
+    if (existsSync(candidate)) {
+      enforcePrivateAgentDbChmodSync(candidate, OPENCLAW_AGENT_DB_FILE_MODE, defaultProfileLocation);
+    }
+  }
+}
+
 function ensureOpenClawAgentDatabasePermissions(
   pathname: string,
   options: OpenClawAgentDatabaseOptions,
@@ -80,17 +148,14 @@ function ensureOpenClawAgentDatabasePermissions(
     env: options.env,
   });
   const isDefaultAgentDatabase = path.resolve(pathname) === path.resolve(defaultPath);
+  const defaultProfileLocation = isDefaultProfileAgentDatabaseLocation(pathname, options.env);
   const dirExisted = existsSync(dir);
   mkdirSync(dir, { recursive: true, mode: OPENCLAW_AGENT_DB_DIR_MODE });
   // Default agent state is private by contract; custom pre-existing dirs keep caller ownership.
   if (isDefaultAgentDatabase || !dirExisted) {
-    chmodSync(dir, OPENCLAW_AGENT_DB_DIR_MODE);
+    enforcePrivateAgentDbChmodSync(dir, OPENCLAW_AGENT_DB_DIR_MODE, defaultProfileLocation);
   }
-  for (const candidate of resolveSqliteDatabaseFilePaths(pathname)) {
-    if (existsSync(candidate)) {
-      chmodSync(candidate, OPENCLAW_AGENT_DB_FILE_MODE);
-    }
-  }
+  enforcePrivateAgentDbFilePermissions(pathname, defaultProfileLocation);
 }
 
 function readExistingSchemaMeta(db: DatabaseSync): ExistingSchemaMeta | null {
@@ -261,6 +326,7 @@ export function openOpenClawAgentDatabase(
         synchronous: "NORMAL",
       });
       ensureAgentSchema(db, agentId, pathname);
+      ensureOpenClawAgentDatabasePermissions(pathname, databaseOptions);
       return maintenance;
     } catch (err) {
       maintenance?.close();
@@ -268,7 +334,6 @@ export function openOpenClawAgentDatabase(
       throw err;
     }
   })();
-  ensureOpenClawAgentDatabasePermissions(pathname, databaseOptions);
   const database = { agentId, db, path: pathname, walMaintenance };
   cachedDatabases.set(pathname, database);
   registerAgentDatabase({ agentId, path: pathname, env: options.env });


### PR DESCRIPTION
## Summary

The per-agent SQLite database stores credentials (API keys and OAuth tokens under `agents/<agentId>/agent/`). On filesystems that reject `chmod` (Azure Files, NFS without `no_root_squash`, some Docker/SMB volume drivers), `ensureOpenClawAgentDatabasePermissions` called raw `chmodSync` and the agent could not open its database at all: it threw an uncaught `ENOTSUP`/`EPERM` before the handle opened, while the non-secret shared state DB came up fine.

This is the follow-up to #92786, which closed that gap by reusing the shared state DB helper `bestEffortChmodSync`. @vincentkoc closed #92786 because that helper is too permissive for a secret store: it would silently open a world-readable credential store on a chmod-less volume. The canonical paths named were an ACL-aware Windows verify, or a scoped policy that refuses unsafe agent DB locations. This PR implements the scoped fail-closed policy; the shared non-secret state DB is untouched and keeps its best-effort behavior.

For Windows specifically, where file modes cannot represent NTFS ACLs, this implements the scoped option (B) from the review thread: trust only the default per-user profile agent DB location, which is private by the Windows per-user profile ACL, and refuse a relocated `OPENCLAW_STATE_DIR` store, which is where the network-backed/SMB exposure lives. A native ACL-aware verify (option A, for example `icacls`) is a tracked follow-up and would only widen what Windows accepts; POSIX behavior is unchanged either way.

## Fix

New `enforcePrivateAgentDbChmodSync` used for the agent DB directory and sidecar files, replacing the raw `chmodSync` calls. It proves the resulting mode is private after every `chmod` attempt, on both the success and the failure path, before the credential store is trusted:

- POSIX: after attempting `chmod`, OpenClaw reads the resulting mode with `stat` regardless of whether `chmod` reported success or threw. The store is tolerated only when `stat` proves it private (`mode & 0o077 === 0`) for the directory and each existing DB/WAL/SHM target; otherwise it refuses with a scoped, actionable error pointing the operator at a local path via `OPENCLAW_STATE_DIR`. When `chmod` failed but the target is already private the chmod was cosmetic, so OpenClaw warns once and continues.
- Windows (`process.platform === "win32"`): the decision is by location, not by `chmod`. Windows file modes do not reflect NTFS ACLs, so a `chmod` result (success or failure) proves nothing about credential privacy; the prior revision trusted any successful Windows `chmod`, which left a relocated SMB store accepted while it was still group/world accessible. OpenClaw now trusts the default per-user profile agent DB location (private by the Windows per-user profile ACL) and refuses a relocated store, an explicit `OPENCLAW_STATE_DIR` placed outside the default per-user agents root, where the network-backed/SMB exposure lives. A shared helper `isDefaultProfileAgentDatabaseLocation` classifies the location, and both the read-write open path and the read-only loader use it, so a relocated Windows credential store is refused before it is read. This also stops the prior revision from over-refusing the default location when a Windows `chmod` merely failed.

This closes the gap raised in review: a volume can report a successful `chmod` while leaving the mode unchanged. Core CIFS mounted without the Unix extensions documents exactly this; `man mount.cifs` states that attempting to change permissions "will return success but have no effect", and `stat` then reports the mount `file_mode`/`dir_mode` (commonly `0644`/`0755`). Silent-ignore FUSE/bindfs mounts behave the same way. The previous helper only checked the resulting mode inside the `catch` path, so a silent-success volume sailed past the check and opened a `0644` credential DB. Verifying after every attempt refuses that case.

This is deliberately stricter than the sibling `bestEffortChmodSync`, which tolerates `ENOTSUP`/`EOPNOTSUPP`/`EINVAL` unconditionally for the non-secret store. For a credential store the only safe question is whether the secret is private now.

Every secret-bearing open path shares one gate. The read-only auth-profile loader (`readAuthProfileJsonCellReadOnly` in `src/agents/auth-profiles/sqlite.ts`, reached from `loadPersistedAuthProfileStore` -> `readPersistedAuthProfileStoreRaw`) previously opened the same `openclaw-agent.sqlite` with `DatabaseSync(..., { readOnly: true })` with no privacy check, so an existing `0644` credential DB from a chmod-less/silent-success volume was still read and trusted at auth-resolution time. Both the read-write open path and the read-only loader now run the existing DB/WAL/SHM files through one exported helper `enforcePrivateAgentDbFilePermissions`, so a store that cannot be proven private is refused before it is read, not only before it is written.

The post-open permission pass runs inside the same cleanup as schema setup. The refusal can fire on the second (post-open) pass when the agent directory is private but the freshly created DB file is born group/world readable on a chmod-less mount; keeping it inside the cleanup closes the live SQLite handle and WAL maintenance before the error escapes instead of leaking them. This PR is rebased on `main`; the open path now uses the `configureSqliteConnectionPragmas` cleanup added in ea346f4361, with the post-open permission pass moved inside that same `try` so a privacy refusal still releases the handle.

## Verification

- Colocated regression suite `src/state/openclaw-agent-db.permissions.test.ts` (14 cases): chmod success hardens to `0700`/`0600`; chmod fails but store already private opens; chmod reports success but the store stays world-readable refuses (the silent-ignore case); chmod fails on a non-private dir refuses; `EACCES` on a non-private dir refuses; a post-open refusal closes the freshly opened handle (asserts every captured `DatabaseSync` instance reports `!isOpen`); a private store still loads through the read-only auth-profile path; and a silent-success world-readable store refuses on that same read-only path. For the Windows policy: a relocated agent DB on `win32` refuses with the resulting handle released; the default per-user location is trusted on `win32` even when `chmod` cannot harden it; and three `isDefaultProfileAgentDatabaseLocation` cases prove the default per-user path is trusted, a relocated `OPENCLAW_STATE_DIR` store is untrusted, and a path outside the default agents root is untrusted. The post-open case forces the target non-private through the resolved DB path so it is deterministic regardless of the ambient umask. Run with `node scripts/run-vitest.mjs src/state/openclaw-agent-db.permissions.test.ts` -> 14 passed.
- `oxlint` on the changed files -> clean.

## Real behavior proof

Behavior addressed: Opening the per-agent credential database on a volume that does not apply `chmod` now opens only when the store is provably private, and otherwise refuses with a scoped error instead of silently storing credentials with permissive modes. This includes volumes that report a successful `chmod` while leaving the mode unchanged, which previously opened a world-readable credential DB. A refusal that fires after the database handle is already open closes that handle and its WAL maintenance instead of leaking them. The read-only auth-profile load path (`loadPersistedAuthProfileStore` -> `readPersistedAuthProfileStoreRaw`) shares the same gate, so an existing `0644` credential store is refused before it is read, not just before it is written.

Real environment tested: Linux (Node 22.19) running the production entry point `openOpenClawAgentDatabase` against a real temporary state dir. The chmod-less volume is reproduced at the OS layer with an LD_PRELOAD shim over libc chmod(2)/fchmod(2)/fchmodat(2): with `CHMOD_FAIL_CODE=SILENT` the calls return success without changing the mode (the documented CIFS-without-unix-extensions and silent-ignore FUSE behavior); with `ENOTSUP`/`EACCES` they return the matching real errno from the kernel call boundary. Store privacy is varied with the process umask (077 produces a private 0700/0600 store; 022 produces a group/world readable 0644 DB file that only becomes visible to the post-open permission pass). After each run the resulting agent DB file mode is read with `stat`, and open file descriptors are counted from `/proc/self/fd` to show whether the SQLite handle leaked.

Exact steps or command run after this patch: `gcc -shared -fPIC -o chmodfail.so chmodfail.c`; then for each open-path scenario `( umask <077|022>; LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=<SILENT|ENOTSUP|EACCES> node_modules/.bin/tsx drive-agent-db.mts )` where the driver calls the real `openOpenClawAgentDatabase`, prints the resulting DB file mode on success, and on a thrown refusal scans `/proc/self/fd` for any descriptor still pointing at `openclaw-agent.sqlite`. For the read-only path, seed a credential store with `DRIVE_MODE=seed node_modules/.bin/tsx drive-read-auth.mts` (then leave its DB file at `0644`) and load it with `SEED_DIR=<dir> LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=SILENT node_modules/.bin/tsx drive-read-auth.mts`, which calls the real `readPersistedAuthProfileStoreRaw`. For the Windows policy, seed a relocated store the same way, then load it through `drive-read-auth-win32.mts`, which overrides `process.platform` to `win32` before calling the same real `readPersistedAuthProfileStoreRaw`: `SEED_DIR=<dir> WIN32=1 LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=SILENT node_modules/.bin/tsx drive-read-auth-win32.mts`. Each before capture reverts the changed source files to the prior baseline (the open-path/read-path before captures revert to the prior PR head; the Windows before capture reverts both `src/state/openclaw-agent-db.ts` and `src/agents/auth-profiles/sqlite.ts` to `origin/main`, which has no privacy gate); the same shim is used for before and after.

Evidence after fix: redacted live terminal output (non-secret `state/db` best-effort warn lines trimmed).

```
# BEFORE (reviewed head da170353), SILENT volume (chmod returns success, no effect), umask 022
#   -> opens a world/group-readable 0644 credential DB (the reported gap):
$ ( umask 022; LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=SILENT node_modules/.bin/tsx drive-agent-db.mts )
agent DB open: OPENED db.isOpen=true path=<STATE_DIR>/agents/main/agent/openclaw-agent.sqlite
agent DB file mode after open: 0644
agent DB dir mode after open: 0700
OPEN_DB_FDS=3
REAL_EXIT=0

# AFTER (this PR), SILENT volume, umask 022 -> refuses, no leaked descriptors:
$ ( umask 022; LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=SILENT node_modules/.bin/tsx drive-agent-db.mts )
agent DB open: REFUSED - OpenClaw agent database <STATE_DIR>/agents/main/agent/openclaw-agent.sqlite stores credentials and cannot be made private on this volume (mode 644; chmod reported success without changing the mode). Move the agent database to a filesystem that enforces private permissions by setting OPENCLAW_STATE_DIR to a local directory.
OPEN_DB_FDS=0
REAL_EXIT=1

# AFTER (this PR), ENOTSUP volume, private store (umask 077) -> opens:
$ ( umask 077; LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=ENOTSUP node_modules/.bin/tsx drive-agent-db.mts )
agent DB open: OPENED db.isOpen=true path=<STATE_DIR>/agents/main/agent/openclaw-agent.sqlite
agent DB file mode after open: 0600
agent DB dir mode after open: 0700
OPEN_DB_FDS=3
REAL_EXIT=0

# AFTER (this PR), ENOTSUP volume, group/world readable DB file (umask 022) -> post-open refuses, handle closed:
$ ( umask 022; LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=ENOTSUP node_modules/.bin/tsx drive-agent-db.mts )
agent DB open: REFUSED - OpenClaw agent database <STATE_DIR>/agents/main/agent/openclaw-agent.sqlite stores credentials and cannot be made private on this volume (mode 644; Error: ENOTSUP: operation not supported on socket, chmod '<STATE_DIR>/agents/main/agent/openclaw-agent.sqlite'). Move the agent database to a filesystem that enforces private permissions by setting OPENCLAW_STATE_DIR to a local directory.
OPEN_DB_FDS=0
REAL_EXIT=1

# AFTER (this PR), EACCES volume, group/world readable DB file (umask 022) -> refuses (stays loud), handle closed:
$ ( umask 022; LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=EACCES node_modules/.bin/tsx drive-agent-db.mts )
agent DB open: REFUSED - OpenClaw agent database <STATE_DIR>/agents/main/agent/openclaw-agent.sqlite stores credentials and cannot be made private on this volume (mode 644; Error: EACCES: permission denied, chmod '<STATE_DIR>/agents/main/agent/openclaw-agent.sqlite'). Move the agent database to a filesystem that enforces private permissions by setting OPENCLAW_STATE_DIR to a local directory.
OPEN_DB_FDS=0
REAL_EXIT=1

# AFTER (this PR), normal local filesystem (no shim), umask 022 -> opens at 0600 (no regression):
$ ( umask 022; node_modules/.bin/tsx drive-agent-db.mts )
agent DB open: OPENED db.isOpen=true path=<STATE_DIR>/agents/main/agent/openclaw-agent.sqlite
agent DB file mode after open: 0600
agent DB dir mode after open: 0700
OPEN_DB_FDS=3
REAL_EXIT=0

# Read-only auth-profile load path (loadPersistedAuthProfileStore -> readPersistedAuthProfileStoreRaw),
# SILENT volume (chmod returns success, no effect), against the same existing 0644 credential DB.
# BEFORE (prior PR head, open-path fix only) -> the read-only loader trusts the 0644 store:
$ ( SEED_DIR=<STATE_DIR> LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=SILENT node_modules/.bin/tsx drive-read-auth.mts )
credential store file mode before read: 0644
read-only auth load: TRUSTED store (profiles=anthropic)
REAL_EXIT=0

# AFTER (this PR) -> the same read-only loader refuses the 0644 store before opening it:
$ ( SEED_DIR=<STATE_DIR> LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=SILENT node_modules/.bin/tsx drive-read-auth.mts )
credential store file mode before read: 0644
read-only auth load: REFUSED - OpenClaw agent database <STATE_DIR>/agents/main/agent/openclaw-agent.sqlite stores credentials and cannot be made private on this volume (mode 644; chmod reported success without changing the mode). Move the agent database to a filesystem that enforces private permissions by setting OPENCLAW_STATE_DIR to a local directory.
REAL_EXIT=1

# Windows policy (process.platform forced to win32) against a relocated credential store
# on a SILENT volume (chmod returns success, no effect), reading the same existing 0644 DB.
# BEFORE (origin/main, no privacy gate) -> the relocated Windows store is read and trusted:
$ ( SEED_DIR=<STATE_DIR> WIN32=1 LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=SILENT node_modules/.bin/tsx drive-read-auth-win32.mts )
platform=win32; relocated credential store file mode: 0644
read-only auth load: TRUSTED store (profiles=anthropic)
REAL_EXIT=0

# AFTER (this PR) -> the relocated Windows store is refused before it is opened:
$ ( SEED_DIR=<STATE_DIR> WIN32=1 LD_PRELOAD=$PWD/chmodfail.so CHMOD_FAIL_CODE=SILENT node_modules/.bin/tsx drive-read-auth-win32.mts )
platform=win32; relocated credential store file mode: 0644
read-only auth load: REFUSED - OpenClaw agent database <STATE_DIR>/agents/main/agent/openclaw-agent.sqlite stores credentials in a relocated Windows location whose private NTFS ACL cannot be proven (Windows file modes do not reflect ACLs). Keep agent credential storage at the default per-user location instead of relocating it with OPENCLAW_STATE_DIR.
REAL_EXIT=1
```

Observed result after fix: On a volume that does not apply `chmod`, including one that reports `chmod` success while leaving the mode unchanged, the agent DB opens (exit 0) only when the credential store is provably private; when it would be group or world readable it refuses with a scoped, actionable error (exit 1) instead of storing credentials permissively. On the reviewed head da170353 the same SILENT volume opened a 0644 credential DB (exit 0). When the refusal fires after the handle is open, the descriptor count to `openclaw-agent.sqlite` is 0, so the SQLite handle and WAL maintenance are released. A genuine EACCES fault stays loud. On a normal local filesystem the store opens at 0600. The read-only auth-profile loader behaves identically: against the same `0644` store the prior PR head trusted it (exit 0), and this revision refuses it (exit 1) before opening, so a non-private credential store cannot be read either. On Windows the same relocated credential store is refused before it is read (exit 1) where `origin/main` reads and trusts it (exit 0), while the default per-user profile location stays trusted.

What was not tested: A literal Azure Files / NFS / Docker volume, a native Windows SMB mount, or a real CIFS `dynperm` mount end to end. The chmod-less behavior is reproduced at the libc syscall boundary via LD_PRELOAD, matching the documented CIFS-without-unix-extensions contract; `dynperm` (where the client caches a fabricated mode that `stat` reports but the server does not persist) is a CIFS-specific case a mode check cannot defeat and is out of scope. The Windows policy is exercised by overriding `process.platform` to `win32`, both in the regression suite and in the live `drive-read-auth-win32.mts` driver, on Linux: a relocated store is refused before it is read and the default per-user location is trusted. Real NTFS ACL semantics and a native Windows SMB mount were not exercised on Linux; the policy trusts the per-user profile ACL by contract rather than reading the ACL, which a native ACL-aware verify (option A) would add as a follow-up.

Refs: #92786 (closed; this is its canonical follow-up), #91919 (the shared state DB best-effort fix this intentionally does not reuse for the secret store), ea346f4361 (the failed-init cleanup this PR is rebased onto). CIFS contract: https://man7.org/linux/man-pages/man8/mount.cifs.8.html

CC @vincentkoc for the canonical-fix review.


