### PR TITLE
fix(feishu): re-resolve route when dynamic agent binding already exists in runtime config (fixes #42837)

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -417,6 +417,8 @@ This is essential for public bots where you want each user to have their own pri
 
 <Note>
 Dynamic bindings include the normalized Feishu `accountId`, so default and named accounts route each sender to the correct dynamic agent.
+
+If a named account created an unscoped dynamic agent on an older release, that legacy agent still counts toward `maxAgents`. Confirm that it is not used by the default account before removing it, or temporarily increase `maxAgents`; OpenClaw cannot safely infer which account owns ambiguous legacy state.
 </Note>
 
 ### Quick setup

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -416,7 +416,7 @@ Enable `dynamicAgentCreation` to automatically create **isolated agent instances
 This is essential for public bots where you want each user to have their own private AI assistant experience.
 
 <Note>
-**Account limitation**: `dynamicAgentCreation` currently works with the **default Feishu account only**. Named/multi-account setups are not yet fully supported — dynamic bindings are created without `accountId`, so messages to named accounts may still route to `agent:main`. Track progress in [Issue #42837](https://github.com/openclaw/openclaw/issues/42837).
+Dynamic bindings include the normalized Feishu `accountId`, so default and named accounts route each sender to the correct dynamic agent.
 </Note>
 
 ### Quick setup
@@ -471,15 +471,16 @@ Template variables:
 
 `session.dmScope` controls how direct messages are mapped to agent sessions. This is a **global setting** that affects all channels.
 
-| Value                | Behavior                                                  | Best for                                                           |
-| -------------------- | --------------------------------------------------------- | ------------------------------------------------------------------ |
-| `"main"`             | Each user's DM maps to their agent's main session         | Single-user bots where you want `USER.md` / `SOUL.md` to auto-load |
-| `"per-channel-peer"` | Each (channel + user) combination gets a separate session | Public multi-user bots needing stronger isolation                  |
+| Value                        | Behavior                                                            | Best for                                                           |
+| ---------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `"main"`                     | Each user's DM maps to their agent's main session                   | Single-user bots where you want `USER.md` / `SOUL.md` to auto-load |
+| `"per-channel-peer"`         | Each (channel + user) combination gets a separate session           | Public multi-user bots needing stronger isolation                  |
+| `"per-account-channel-peer"` | Each (account + channel + user) combination gets a separate session | Multi-account bots needing account-level session isolation         |
 
 **Tradeoff**: Using `"main"` enables automatic bootstrap file loading (`USER.md`, `SOUL.md`, `MEMORY.md`), but means all DMs across all channels share the same session key pattern. For public multi-user bots where isolation matters more than bootstrap auto-loading, consider `"per-channel-peer"` and manage bootstrap files manually.
 
 <Note>
-`"per-account-channel-peer"` is not recommended with `dynamicAgentCreation` because dynamic bindings are created without `accountId`. Use it only with manual bindings.
+Use `"per-account-channel-peer"` when named Feishu accounts should keep separate sessions for the same sender. Dynamic bindings preserve the account scope.
 </Note>
 
 ```json5

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -447,7 +447,7 @@ Dynamic bindings include the normalized Feishu `accountId`, so default and named
 
 When a new user sends their first DM:
 
-1. The channel generates a unique `agentId`: `feishu-{user_open_id}` for the default account, or `feishu-{account_id}-{user_open_id}` for a named account
+1. The channel generates a unique `agentId`: `feishu-{user_open_id}` for the default account, or a bounded account-prefixed identity digest for a named account
 2. Creates a new workspace at `workspaceTemplate` path
 3. Registers the agent and creates a binding for this user
 4. The workspace helper ensures bootstrap files (`AGENTS.md`, `SOUL.md`, `USER.md`, etc.) on first access
@@ -464,7 +464,7 @@ When a new user sends their first DM:
 
 Template variables:
 
-- `{agentId}` - the generated agent ID (e.g., `feishu-ou_xxxxxx` or `feishu-support-ou_xxxxxx`)
+- `{agentId}` - the generated agent ID (e.g., `feishu-ou_xxxxxx` or `feishu-support-<identity_digest>`)
 - `{userId}` - the sender's Feishu open_id (e.g., `ou_xxxxxx`)
 
 ### Session scope

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -447,7 +447,7 @@ Dynamic bindings include the normalized Feishu `accountId`, so default and named
 
 When a new user sends their first DM:
 
-1. The channel generates a unique `agentId` = `feishu-{user_open_id}`
+1. The channel generates a unique `agentId`: `feishu-{user_open_id}` for the default account, or `feishu-{account_id}-{user_open_id}` for a named account
 2. Creates a new workspace at `workspaceTemplate` path
 3. Registers the agent and creates a binding for this user
 4. The workspace helper ensures bootstrap files (`AGENTS.md`, `SOUL.md`, `USER.md`, etc.) on first access
@@ -464,7 +464,7 @@ When a new user sends their first DM:
 
 Template variables:
 
-- `{agentId}` - the generated agent ID (e.g., `feishu-ou_xxxxxx`)
+- `{agentId}` - the generated agent ID (e.g., `feishu-ou_xxxxxx` or `feishu-support-ou_xxxxxx`)
 - `{userId}` - the sender's Feishu open_id (e.g., `ou_xxxxxx`)
 
 ### Session scope

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1222,7 +1222,7 @@ describe("handleFeishuMessage command authorization", () => {
     expect(ensureNoVisibleReplyFallback).toHaveBeenCalledWith("dispatch-complete-no-visible-reply");
   });
 
-  it("passes disabled config-write policy to dynamic agent creation", async () => {
+  it("uses refreshed config for dynamic agent dispatch", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
     const cfg: ClawdbotConfig = {
@@ -1237,6 +1237,22 @@ describe("handleFeishuMessage command authorization", () => {
         },
       },
     } as ClawdbotConfig;
+    const refreshedCfg = {
+      ...cfg,
+      agents: {
+        list: [
+          {
+            id: "feishu-ou-attacker",
+            workspace: "/tmp/feishu-ou-attacker",
+            agentDir: "/tmp/feishu-ou-attacker/agent",
+          },
+        ],
+      },
+    } as ClawdbotConfig;
+    mockMaybeCreateDynamicAgent.mockResolvedValueOnce({
+      created: false,
+      updatedCfg: refreshedCfg,
+    });
 
     const event: FeishuMessageEvent = {
       sender: {
@@ -1256,12 +1272,17 @@ describe("handleFeishuMessage command authorization", () => {
     await dispatchMessage({ cfg, event });
 
     const dynamicAgentRequest = mockCallArg<{
-      configWritesAllowed?: boolean;
+      accountId?: string;
       senderOpenId?: string;
     }>(mockMaybeCreateDynamicAgent, 0, 0);
     expect(dynamicAgentRequest.senderOpenId).toBe("ou-attacker");
-    expect(dynamicAgentRequest.configWritesAllowed).toBe(false);
-    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(dynamicAgentRequest.accountId).toBe("default");
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: refreshedCfg }),
+    );
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: refreshedCfg }),
+    );
   });
 
   it("blocks open DMs when a restrictive allowlist does not match", async () => {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1337,6 +1337,38 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
   });
 
+  it("reauthorizes current policy before dispatching an existing bound route", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockResolveAgentRoute.mockReturnValue({
+      ...buildDefaultResolveRoute(),
+      matchedBy: "binding.peer",
+    });
+    const cfg = {
+      channels: { feishu: { dmPolicy: "open", allowFrom: ["*"] } },
+    } as ClawdbotConfig;
+    const currentCfg = {
+      channels: { feishu: { dmPolicy: "allowlist", allowFrom: ["ou-admin"] } },
+    } as ClawdbotConfig;
+
+    await dispatchMessage({
+      cfg,
+      currentCfg,
+      event: {
+        sender: { sender_id: { open_id: "ou-attacker" } },
+        message: {
+          message_id: "msg-bound-refreshed-policy-deny",
+          chat_id: "oc-dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    expect(mockFinalizeInboundContext).not.toHaveBeenCalled();
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
   it("issues a pairing challenge before dynamic creation when current policy requires it", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockReadAllowFromStore.mockResolvedValue([]);

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1285,6 +1285,93 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("drops a DM denied by refreshed dynamic-agent policy", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          dynamicAgentCreation: { enabled: true },
+        },
+      },
+    } as ClawdbotConfig;
+    const refreshedCfg = {
+      channels: {
+        feishu: {
+          dmPolicy: "allowlist",
+          allowFrom: ["ou-admin"],
+          dynamicAgentCreation: { enabled: true },
+        },
+      },
+    } as ClawdbotConfig;
+    mockMaybeCreateDynamicAgent.mockResolvedValueOnce({
+      created: false,
+      updatedCfg: refreshedCfg,
+    });
+
+    await dispatchMessage({
+      cfg,
+      event: {
+        sender: { sender_id: { open_id: "ou-attacker" } },
+        message: {
+          message_id: "msg-refreshed-policy-deny",
+          chat_id: "oc-dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    expect(mockMaybeCreateDynamicAgent).toHaveBeenCalledTimes(1);
+    expect(mockFinalizeInboundContext).not.toHaveBeenCalled();
+    expect(mockCreateFeishuReplyDispatcher).not.toHaveBeenCalled();
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("recomputes command authorization against refreshed dynamic-agent config", async () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          dynamicAgentCreation: { enabled: true },
+        },
+      },
+    } as ClawdbotConfig;
+    const refreshedCfg = {
+      ...cfg,
+      commands: { useAccessGroups: true },
+    } as ClawdbotConfig;
+    mockShouldComputeCommandAuthorized.mockImplementation((_body, candidateCfg) => {
+      return candidateCfg === refreshedCfg;
+    });
+    mockMaybeCreateDynamicAgent.mockResolvedValueOnce({
+      created: false,
+      updatedCfg: refreshedCfg,
+    });
+
+    await dispatchMessage({
+      cfg,
+      event: {
+        sender: { sender_id: { open_id: "ou-attacker" } },
+        message: {
+          message_id: "msg-refreshed-command-auth",
+          chat_id: "oc-dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "/status" }),
+        },
+      },
+    });
+
+    expect(mockShouldComputeCommandAuthorized).toHaveBeenCalledWith("/status", refreshedCfg);
+    const context = mockCallArg<{ CommandAuthorized?: boolean }>(mockFinalizeInboundContext, 0, 0);
+    expect(context.CommandAuthorized).toBe(true);
+  });
+
   it("blocks open DMs when a restrictive allowlist does not match", async () => {
     const cfg: ClawdbotConfig = {
       commands: { useAccessGroups: true },

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -455,7 +455,10 @@ describe("handleFeishuMessage ACP routing", () => {
     mockTouchBinding.mockReset();
     mockResolveFeishuReasoningPreviewEnabled.mockReset().mockReturnValue(false);
     mockTranscribeFirstAudio.mockReset().mockResolvedValue(undefined);
-    mockMaybeCreateDynamicAgent.mockReset().mockResolvedValue({ created: false });
+    mockMaybeCreateDynamicAgent.mockReset().mockImplementation(async ({ cfg }) => ({
+      created: false,
+      updatedCfg: cfg,
+    }));
     mockResolveAgentRoute.mockReset().mockReturnValue({
       ...buildDefaultResolveRoute(),
       sessionKey: "agent:main:feishu:direct:ou_sender_1",
@@ -1009,7 +1012,10 @@ describe("handleFeishuMessage command authorization", () => {
     mockResolveBoundConversation.mockReset().mockReturnValue(null);
     mockTouchBinding.mockReset();
     mockTranscribeFirstAudio.mockReset().mockResolvedValue(undefined);
-    mockMaybeCreateDynamicAgent.mockReset().mockResolvedValue({ created: false });
+    mockMaybeCreateDynamicAgent.mockReset().mockImplementation(async ({ cfg }) => ({
+      created: false,
+      updatedCfg: cfg,
+    }));
     mockResolveAgentRoute.mockReturnValue(buildDefaultResolveRoute());
     mockCreateFeishuClient.mockReturnValue({
       contact: {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -989,7 +989,9 @@ describe("handleFeishuMessage command authorization", () => {
     },
   );
   const mockResolveCommandAuthorizedFromAuthorizers = vi.fn(() => false);
-  const mockShouldComputeCommandAuthorized = vi.fn(() => true);
+  const mockShouldComputeCommandAuthorized = vi.fn<
+    PluginRuntime["channel"]["commands"]["shouldComputeCommandAuthorized"]
+  >(() => true);
   const mockReadAllowFromStore = vi.fn().mockResolvedValue([]);
   const mockUpsertPairingRequest = vi.fn().mockResolvedValue({ code: "ABCDEFGH", created: false });
   const mockBuildPairingReply = vi.fn(() => "Pairing response");

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -163,8 +163,13 @@ function buildDefaultResolveRoute(): ResolvedAgentRoute {
     matchedBy: "default",
   };
 }
+let currentRuntimeConfig = {} as ClawdbotConfig;
+
 function createFeishuBotRuntime(overrides: DeepPartial<PluginRuntime> = {}): PluginRuntime {
   return {
+    config: {
+      current: vi.fn(() => currentRuntimeConfig),
+    },
     channel: {
       routing: {
         resolveAgentRoute: resolveAgentRouteMock,
@@ -413,7 +418,11 @@ afterAll(() => {
   vi.resetModules();
 });
 
-async function dispatchMessage(params: { cfg: ClawdbotConfig; event: FeishuMessageEvent }) {
+async function dispatchMessage(params: {
+  cfg: ClawdbotConfig;
+  currentCfg?: ClawdbotConfig;
+  event: FeishuMessageEvent;
+}) {
   const runtime = createRuntimeEnv();
   const feishuConfig = params.cfg.channels?.feishu;
   const cfg =
@@ -429,6 +438,7 @@ async function dispatchMessage(params: { cfg: ClawdbotConfig; event: FeishuMessa
           },
         } as ClawdbotConfig)
       : params.cfg;
+  currentRuntimeConfig = params.currentCfg ?? cfg;
   await handleFeishuMessage({
     cfg,
     event: params.event,
@@ -1306,13 +1316,9 @@ describe("handleFeishuMessage command authorization", () => {
         },
       },
     } as ClawdbotConfig;
-    mockMaybeCreateDynamicAgent.mockResolvedValueOnce({
-      created: false,
-      updatedCfg: refreshedCfg,
-    });
-
     await dispatchMessage({
       cfg,
+      currentCfg: refreshedCfg,
       event: {
         sender: { sender_id: { open_id: "ou-attacker" } },
         message: {
@@ -1325,9 +1331,54 @@ describe("handleFeishuMessage command authorization", () => {
       },
     });
 
-    expect(mockMaybeCreateDynamicAgent).toHaveBeenCalledTimes(1);
+    expect(mockMaybeCreateDynamicAgent).not.toHaveBeenCalled();
     expect(mockFinalizeInboundContext).not.toHaveBeenCalled();
     expect(mockCreateFeishuReplyDispatcher).not.toHaveBeenCalled();
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("issues a pairing challenge before dynamic creation when current policy requires it", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockReadAllowFromStore.mockResolvedValue([]);
+    mockUpsertPairingRequest.mockResolvedValue({ code: "ABCDEFGH", created: true });
+
+    const cfg = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          dynamicAgentCreation: { enabled: true },
+        },
+      },
+    } as ClawdbotConfig;
+    const currentCfg = {
+      channels: {
+        feishu: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          dynamicAgentCreation: { enabled: true },
+        },
+      },
+    } as ClawdbotConfig;
+
+    await dispatchMessage({
+      cfg,
+      currentCfg,
+      event: {
+        sender: { sender_id: { open_id: "ou-attacker" } },
+        message: {
+          message_id: "msg-refreshed-policy-pairing",
+          chat_id: "oc-dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    expect(mockMaybeCreateDynamicAgent).not.toHaveBeenCalled();
+    expect(mockUpsertPairingRequest).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageFeishu).toHaveBeenCalledTimes(1);
     expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
   });
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1,5 +1,4 @@
 // Feishu plugin module implements bot behavior.
-import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-writes";
 import {
   buildChannelInboundEventContext,
   toInboundMediaFacts,
@@ -74,7 +73,6 @@ import {
   type FeishuMessageInfo,
   type ResolvedFeishuAccount,
 } from "./types.js";
-import type { DynamicAgentCreationConfig } from "./types.js";
 
 export { toMessageResourceType } from "./bot-content.js";
 
@@ -833,38 +831,30 @@ export async function handleFeishuMessage(params: {
       parentPeer,
     });
 
-    // Dynamic agent creation for DM users
-    // When enabled, creates a unique agent instance with its own workspace for each DM user.
+    // Refresh a binding written after this request snapshot, or create the DM's
+    // dynamic agent when the current account policy enables it.
     let effectiveCfg = cfg;
     if (!isGroup && route.matchedBy === "default") {
-      const dynamicCfg = feishuCfg?.dynamicAgentCreation as DynamicAgentCreationConfig | undefined;
-      if (dynamicCfg?.enabled) {
-        const runtimeLocal = getFeishuRuntime();
-        const result = await maybeCreateDynamicAgent({
-          cfg,
-          runtime: runtimeLocal,
-          senderOpenId: ctx.senderOpenId,
-          dynamicCfg,
-          configWritesAllowed: resolveChannelConfigWrites({
-            cfg,
-            channelId: "feishu",
-            accountId: account.accountId,
-          }),
-          log: (msg) => log(msg),
+      const runtimeLocal = getFeishuRuntime();
+      const result = await maybeCreateDynamicAgent({
+        cfg,
+        runtime: runtimeLocal,
+        accountId: account.accountId,
+        senderOpenId: ctx.senderOpenId,
+        log: (msg) => log(msg),
+      });
+      if (result.created || result.updatedCfg !== cfg) {
+        effectiveCfg = result.updatedCfg;
+        route = core.channel.routing.resolveAgentRoute({
+          cfg: result.updatedCfg,
+          channel: "feishu",
+          accountId: account.accountId,
+          peer: { kind: "direct", id: ctx.senderOpenId },
         });
-        if (result.created || result.updatedCfg !== cfg) {
-          effectiveCfg = result.updatedCfg;
-          route = core.channel.routing.resolveAgentRoute({
-            cfg: result.updatedCfg,
-            channel: "feishu",
-            accountId: account.accountId,
-            peer: { kind: "direct", id: ctx.senderOpenId },
-          });
-          if (result.created) {
-            log(
-              `feishu[${account.accountId}]: dynamic agent created, new route: ${route.sessionKey}`,
-            );
-          }
+        if (result.created) {
+          log(
+            `feishu[${account.accountId}]: dynamic agent created, new route: ${route.sessionKey}`,
+          );
         }
       }
     }
@@ -1691,19 +1681,19 @@ export async function handleFeishuMessage(params: {
         ctx.mentionedBot,
       );
 
-      const identity = resolveAgentOutboundIdentity(cfg, route.agentId);
-      const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
+      const identity = resolveAgentOutboundIdentity(effectiveCfg, route.agentId);
+      const storePath = core.channel.session.resolveStorePath(effectiveCfg.session?.store, {
         agentId: route.agentId,
       });
       const allowReasoningPreview = resolveFeishuReasoningPreviewEnabled({
-        cfg,
+        cfg: effectiveCfg,
         agentId: route.agentId,
         storePath,
         sessionKey: route.sessionKey,
       });
       const { dispatcher, replyOptions, markDispatchIdle, ensureNoVisibleReplyFallback } =
         createFeishuReplyDispatcher({
-          cfg,
+          cfg: effectiveCfg,
           agentId: route.agentId,
           runtime: runtime as RuntimeEnv,
           chatId: ctx.chatId,
@@ -1772,7 +1762,7 @@ export async function handleFeishuMessage(params: {
                 run: () =>
                   core.channel.reply.dispatchReplyFromConfig({
                     ctx: ctxPayload,
-                    cfg,
+                    cfg: effectiveCfg,
                     dispatcher,
                     replyOptions,
                   }),

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -827,6 +827,23 @@ export async function handleFeishuMessage(params: {
     let effectiveDmIngress = dmIngress;
     let effectiveShouldComputeCommandAuthorized =
       directAuthorization?.shouldComputeCommandAuthorized ?? shouldComputeCommandAuthorized;
+    let effectiveCfg = cfg;
+    if (isDirect) {
+      const currentCfg = getFeishuRuntime().config.current() as ClawdbotConfig;
+      if (currentCfg !== effectiveCfg) {
+        const currentAuthorization = await resolveDirectAuthorization(currentCfg, true);
+        if (currentAuthorization.ingress.ingress.admission !== "dispatch") {
+          await rejectDirectAuthorization(currentAuthorization);
+          return;
+        }
+        effectiveCfg = currentCfg;
+        effectiveDmPolicy = currentAuthorization.dmPolicy;
+        effectiveConfigAllowFrom = currentAuthorization.configAllowFrom;
+        effectiveDmIngress = currentAuthorization.ingress;
+        effectiveShouldComputeCommandAuthorized =
+          currentAuthorization.shouldComputeCommandAuthorized;
+      }
+    }
 
     // In group chats, the session is scoped to the group, but the *speaker* is the sender.
     // Using a group-scoped From causes the agent to treat different users as the same person.
@@ -854,7 +871,7 @@ export async function handleFeishuMessage(params: {
     }
 
     let route = core.channel.routing.resolveAgentRoute({
-      cfg,
+      cfg: effectiveCfg,
       channel: "feishu",
       accountId: account.accountId,
       peer: {
@@ -866,67 +883,44 @@ export async function handleFeishuMessage(params: {
 
     // Refresh a binding written after this request snapshot, or create the DM's
     // dynamic agent when the current account policy enables it.
-    let effectiveCfg = cfg;
     if (!isGroup && route.matchedBy === "default") {
       const runtimeLocal = getFeishuRuntime();
-      const currentCfg = runtimeLocal.config.current() as ClawdbotConfig;
-      if (currentCfg !== effectiveCfg) {
-        const currentAuthorization = await resolveDirectAuthorization(currentCfg, true);
-        if (currentAuthorization.ingress.ingress.admission !== "dispatch") {
-          await rejectDirectAuthorization(currentAuthorization);
+      const result = await maybeCreateDynamicAgent({
+        cfg: effectiveCfg,
+        runtime: runtimeLocal,
+        accountId: account.accountId,
+        senderOpenId: ctx.senderOpenId,
+        canCreateForConfig: async (candidateCfg) => {
+          const authorization = await resolveDirectAuthorization(candidateCfg, false);
+          return authorization.ingress.ingress.admission === "dispatch";
+        },
+        log: (msg) => log(msg),
+      });
+      if (result.created || result.updatedCfg !== effectiveCfg) {
+        const refreshedAuthorization = await resolveDirectAuthorization(result.updatedCfg, false);
+        if (refreshedAuthorization.ingress.ingress.admission !== "dispatch") {
+          log(
+            `feishu[${account.accountId}]: current policy rejected stale DM from ${ctx.senderOpenId} ` +
+              `before adopting refreshed dynamic route (dmPolicy=${refreshedAuthorization.dmPolicy})`,
+          );
           return;
         }
-        effectiveCfg = currentCfg;
-        effectiveDmPolicy = currentAuthorization.dmPolicy;
-        effectiveConfigAllowFrom = currentAuthorization.configAllowFrom;
-        effectiveDmIngress = currentAuthorization.ingress;
+        effectiveCfg = result.updatedCfg;
+        effectiveDmPolicy = refreshedAuthorization.dmPolicy;
+        effectiveConfigAllowFrom = refreshedAuthorization.configAllowFrom;
+        effectiveDmIngress = refreshedAuthorization.ingress;
         effectiveShouldComputeCommandAuthorized =
-          currentAuthorization.shouldComputeCommandAuthorized;
+          refreshedAuthorization.shouldComputeCommandAuthorized;
         route = core.channel.routing.resolveAgentRoute({
-          cfg: currentCfg,
+          cfg: result.updatedCfg,
           channel: "feishu",
           accountId: account.accountId,
           peer: { kind: "direct", id: ctx.senderOpenId },
         });
-      }
-      if (route.matchedBy === "default") {
-        const result = await maybeCreateDynamicAgent({
-          cfg: effectiveCfg,
-          runtime: runtimeLocal,
-          accountId: account.accountId,
-          senderOpenId: ctx.senderOpenId,
-          canCreateForConfig: async (candidateCfg) => {
-            const authorization = await resolveDirectAuthorization(candidateCfg, false);
-            return authorization.ingress.ingress.admission === "dispatch";
-          },
-          log: (msg) => log(msg),
-        });
-        if (result.created || result.updatedCfg !== effectiveCfg) {
-          const refreshedAuthorization = await resolveDirectAuthorization(result.updatedCfg, false);
-          if (refreshedAuthorization.ingress.ingress.admission !== "dispatch") {
-            log(
-              `feishu[${account.accountId}]: current policy rejected stale DM from ${ctx.senderOpenId} ` +
-                `before adopting refreshed dynamic route (dmPolicy=${refreshedAuthorization.dmPolicy})`,
-            );
-            return;
-          }
-          effectiveCfg = result.updatedCfg;
-          effectiveDmPolicy = refreshedAuthorization.dmPolicy;
-          effectiveConfigAllowFrom = refreshedAuthorization.configAllowFrom;
-          effectiveDmIngress = refreshedAuthorization.ingress;
-          effectiveShouldComputeCommandAuthorized =
-            refreshedAuthorization.shouldComputeCommandAuthorized;
-          route = core.channel.routing.resolveAgentRoute({
-            cfg: result.updatedCfg,
-            channel: "feishu",
-            accountId: account.accountId,
-            peer: { kind: "direct", id: ctx.senderOpenId },
-          });
-          if (result.created) {
-            log(
-              `feishu[${account.accountId}]: dynamic agent created, new route: ${route.sessionKey}`,
-            );
-          }
+        if (result.created) {
+          log(
+            `feishu[${account.accountId}]: dynamic agent created, new route: ${route.sessionKey}`,
+          );
         }
       }
     }

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -790,10 +790,10 @@ export async function handleFeishuMessage(params: {
       }
       return;
     }
-
-    const commandAllowFrom = isGroup
-      ? (groupConfig?.allowFrom ?? configAllowFrom)
-      : (dmIngress?.senderAccess.effectiveAllowFrom ?? configAllowFrom);
+    let effectiveDmPolicy = dmPolicy;
+    let effectiveConfigAllowFrom = configAllowFrom;
+    let effectiveDmIngress = dmIngress;
+    let effectiveShouldComputeCommandAuthorized = shouldComputeCommandAuthorized;
 
     // In group chats, the session is scoped to the group, but the *speaker* is the sender.
     // Using a group-scoped From causes the agent to treat different users as the same person.
@@ -844,7 +844,40 @@ export async function handleFeishuMessage(params: {
         log: (msg) => log(msg),
       });
       if (result.created || result.updatedCfg !== cfg) {
+        const refreshedAccount = resolveFeishuRuntimeAccount({
+          cfg: result.updatedCfg,
+          accountId: account.accountId,
+        });
+        const refreshedDmPolicy = refreshedAccount.config.dmPolicy ?? "pairing";
+        const refreshedConfigAllowFrom = refreshedAccount.config.allowFrom ?? [];
+        const refreshedShouldComputeCommandAuthorized =
+          core.channel.commands.shouldComputeCommandAuthorized(commandProbeBody, result.updatedCfg);
+        const refreshedDmIngress = await resolveFeishuDmIngressAccess({
+          cfg: result.updatedCfg,
+          accountId: refreshedAccount.accountId,
+          dmPolicy: refreshedDmPolicy,
+          allowFrom: refreshedConfigAllowFrom,
+          readAllowFromStore: pairing.readAllowFromStore,
+          senderOpenId: ctx.senderOpenId,
+          senderUserId,
+          conversationId: ctx.senderOpenId,
+          mayPair: false,
+          ...(refreshedShouldComputeCommandAuthorized
+            ? { command: { hasControlCommand: true } }
+            : {}),
+        });
+        if (refreshedDmIngress.ingress.admission !== "dispatch") {
+          log(
+            `feishu[${account.accountId}]: current policy rejected stale DM from ${ctx.senderOpenId} ` +
+              `before adopting refreshed dynamic route (dmPolicy=${refreshedDmPolicy})`,
+          );
+          return;
+        }
         effectiveCfg = result.updatedCfg;
+        effectiveDmPolicy = refreshedDmPolicy;
+        effectiveConfigAllowFrom = refreshedConfigAllowFrom;
+        effectiveDmIngress = refreshedDmIngress;
+        effectiveShouldComputeCommandAuthorized = refreshedShouldComputeCommandAuthorized;
         route = core.channel.routing.resolveAgentRoute({
           cfg: result.updatedCfg,
           channel: "feishu",
@@ -858,6 +891,10 @@ export async function handleFeishuMessage(params: {
         }
       }
     }
+
+    const commandAllowFrom = isGroup
+      ? (groupConfig?.allowFrom ?? effectiveConfigAllowFrom)
+      : (effectiveDmIngress?.senderAccess.effectiveAllowFrom ?? effectiveConfigAllowFrom);
 
     const currentConversationId = peerId;
     const parentConversationId = isGroup ? (parentPeer?.id ?? ctx.chatId) : undefined;
@@ -997,15 +1034,18 @@ export async function handleFeishuMessage(params: {
           : audioTranscript;
     const shouldComputeEffectiveCommandAuthorized =
       audioTranscript === undefined
-        ? shouldComputeCommandAuthorized
-        : core.channel.commands.shouldComputeCommandAuthorized(effectiveCommandProbeBody, cfg);
+        ? effectiveShouldComputeCommandAuthorized
+        : core.channel.commands.shouldComputeCommandAuthorized(
+            effectiveCommandProbeBody,
+            effectiveCfg,
+          );
     const commandAuthorized = shouldComputeEffectiveCommandAuthorized
-      ? isDirect && audioTranscript === undefined && dmIngress
-        ? dmIngress.commandAccess.authorized
+      ? isDirect && audioTranscript === undefined && effectiveDmIngress
+        ? effectiveDmIngress.commandAccess.authorized
         : isGroup
           ? (
               await resolveFeishuGroupSenderActivationIngressAccess({
-                cfg,
+                cfg: effectiveCfg,
                 accountId: account.accountId,
                 chatId: ctx.chatId,
                 allowFrom: commandAllowFrom,
@@ -1018,10 +1058,10 @@ export async function handleFeishuMessage(params: {
             ).commandAccess.authorized
           : (
               await resolveFeishuDmIngressAccess({
-                cfg,
+                cfg: effectiveCfg,
                 accountId: account.accountId,
-                dmPolicy,
-                allowFrom: configAllowFrom,
+                dmPolicy: effectiveDmPolicy,
+                allowFrom: effectiveConfigAllowFrom,
                 readAllowFromStore: pairing.readAllowFromStore,
                 senderOpenId: ctx.senderOpenId,
                 senderUserId,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -746,22 +746,44 @@ export async function handleFeishuMessage(params: {
       commandProbeBody,
       cfg,
     );
-    const dmIngress = isDirect
-      ? await resolveFeishuDmIngressAccess({
-          cfg,
-          accountId: account.accountId,
-          dmPolicy,
-          allowFrom: configAllowFrom,
-          readAllowFromStore: pairing.readAllowFromStore,
-          senderOpenId: ctx.senderOpenId,
-          senderUserId,
-          conversationId: ctx.senderOpenId,
-          mayPair: true,
-          ...(shouldComputeCommandAuthorized ? { command: { hasControlCommand: true } } : {}),
-        })
-      : null;
-    if (isDirect && dmIngress?.ingress.admission !== "dispatch") {
-      if (dmIngress?.ingress.admission === "pairing-required") {
+    const resolveDirectAuthorization = async (
+      candidateCfg: ClawdbotConfig,
+      mayPair: boolean,
+      shouldComputeCommand = core.channel.commands.shouldComputeCommandAuthorized(
+        commandProbeBody,
+        candidateCfg,
+      ),
+    ) => {
+      const candidateAccount = resolveFeishuRuntimeAccount({
+        cfg: candidateCfg,
+        accountId: account.accountId,
+      });
+      const candidateDmPolicy = candidateAccount.config.dmPolicy ?? "pairing";
+      const candidateConfigAllowFrom = candidateAccount.config.allowFrom ?? [];
+      const ingress = await resolveFeishuDmIngressAccess({
+        cfg: candidateCfg,
+        accountId: candidateAccount.accountId,
+        dmPolicy: candidateDmPolicy,
+        allowFrom: candidateConfigAllowFrom,
+        readAllowFromStore: pairing.readAllowFromStore,
+        senderOpenId: ctx.senderOpenId,
+        senderUserId,
+        conversationId: ctx.senderOpenId,
+        mayPair,
+        ...(shouldComputeCommand ? { command: { hasControlCommand: true } } : {}),
+      });
+      return {
+        cfg: candidateCfg,
+        dmPolicy: candidateDmPolicy,
+        configAllowFrom: candidateConfigAllowFrom,
+        ingress,
+        shouldComputeCommandAuthorized: shouldComputeCommand,
+      };
+    };
+    const rejectDirectAuthorization = async (
+      authorization: Awaited<ReturnType<typeof resolveDirectAuthorization>>,
+    ) => {
+      if (authorization.ingress.ingress.admission === "pairing-required") {
         await pairing.issueChallenge({
           senderId: ctx.senderOpenId,
           senderIdLine: `Your Feishu user id: ${ctx.senderOpenId}`,
@@ -771,7 +793,7 @@ export async function handleFeishuMessage(params: {
           },
           sendPairingReply: async (text) => {
             await sendMessageFeishu({
-              cfg,
+              cfg: authorization.cfg,
               to: `chat:${ctx.chatId}`,
               text,
               accountId: account.accountId,
@@ -785,15 +807,26 @@ export async function handleFeishuMessage(params: {
         });
       } else {
         log(
-          `feishu[${account.accountId}]: blocked unauthorized sender ${ctx.senderOpenId} (dmPolicy=${dmPolicy})`,
+          `feishu[${account.accountId}]: blocked unauthorized sender ${ctx.senderOpenId} ` +
+            `(dmPolicy=${authorization.dmPolicy})`,
         );
+      }
+    };
+    const directAuthorization = isDirect
+      ? await resolveDirectAuthorization(cfg, true, shouldComputeCommandAuthorized)
+      : null;
+    const dmIngress = directAuthorization?.ingress ?? null;
+    if (isDirect && dmIngress?.ingress.admission !== "dispatch") {
+      if (directAuthorization) {
+        await rejectDirectAuthorization(directAuthorization);
       }
       return;
     }
-    let effectiveDmPolicy = dmPolicy;
-    let effectiveConfigAllowFrom = configAllowFrom;
+    let effectiveDmPolicy = directAuthorization?.dmPolicy ?? dmPolicy;
+    let effectiveConfigAllowFrom = directAuthorization?.configAllowFrom ?? configAllowFrom;
     let effectiveDmIngress = dmIngress;
-    let effectiveShouldComputeCommandAuthorized = shouldComputeCommandAuthorized;
+    let effectiveShouldComputeCommandAuthorized =
+      directAuthorization?.shouldComputeCommandAuthorized ?? shouldComputeCommandAuthorized;
 
     // In group chats, the session is scoped to the group, but the *speaker* is the sender.
     // Using a group-scoped From causes the agent to treat different users as the same person.
@@ -836,58 +869,64 @@ export async function handleFeishuMessage(params: {
     let effectiveCfg = cfg;
     if (!isGroup && route.matchedBy === "default") {
       const runtimeLocal = getFeishuRuntime();
-      const result = await maybeCreateDynamicAgent({
-        cfg,
-        runtime: runtimeLocal,
-        accountId: account.accountId,
-        senderOpenId: ctx.senderOpenId,
-        log: (msg) => log(msg),
-      });
-      if (result.created || result.updatedCfg !== cfg) {
-        const refreshedAccount = resolveFeishuRuntimeAccount({
-          cfg: result.updatedCfg,
-          accountId: account.accountId,
-        });
-        const refreshedDmPolicy = refreshedAccount.config.dmPolicy ?? "pairing";
-        const refreshedConfigAllowFrom = refreshedAccount.config.allowFrom ?? [];
-        const refreshedShouldComputeCommandAuthorized =
-          core.channel.commands.shouldComputeCommandAuthorized(commandProbeBody, result.updatedCfg);
-        const refreshedDmIngress = await resolveFeishuDmIngressAccess({
-          cfg: result.updatedCfg,
-          accountId: refreshedAccount.accountId,
-          dmPolicy: refreshedDmPolicy,
-          allowFrom: refreshedConfigAllowFrom,
-          readAllowFromStore: pairing.readAllowFromStore,
-          senderOpenId: ctx.senderOpenId,
-          senderUserId,
-          conversationId: ctx.senderOpenId,
-          mayPair: false,
-          ...(refreshedShouldComputeCommandAuthorized
-            ? { command: { hasControlCommand: true } }
-            : {}),
-        });
-        if (refreshedDmIngress.ingress.admission !== "dispatch") {
-          log(
-            `feishu[${account.accountId}]: current policy rejected stale DM from ${ctx.senderOpenId} ` +
-              `before adopting refreshed dynamic route (dmPolicy=${refreshedDmPolicy})`,
-          );
+      const currentCfg = runtimeLocal.config.current() as ClawdbotConfig;
+      if (currentCfg !== effectiveCfg) {
+        const currentAuthorization = await resolveDirectAuthorization(currentCfg, true);
+        if (currentAuthorization.ingress.ingress.admission !== "dispatch") {
+          await rejectDirectAuthorization(currentAuthorization);
           return;
         }
-        effectiveCfg = result.updatedCfg;
-        effectiveDmPolicy = refreshedDmPolicy;
-        effectiveConfigAllowFrom = refreshedConfigAllowFrom;
-        effectiveDmIngress = refreshedDmIngress;
-        effectiveShouldComputeCommandAuthorized = refreshedShouldComputeCommandAuthorized;
+        effectiveCfg = currentCfg;
+        effectiveDmPolicy = currentAuthorization.dmPolicy;
+        effectiveConfigAllowFrom = currentAuthorization.configAllowFrom;
+        effectiveDmIngress = currentAuthorization.ingress;
+        effectiveShouldComputeCommandAuthorized =
+          currentAuthorization.shouldComputeCommandAuthorized;
         route = core.channel.routing.resolveAgentRoute({
-          cfg: result.updatedCfg,
+          cfg: currentCfg,
           channel: "feishu",
           accountId: account.accountId,
           peer: { kind: "direct", id: ctx.senderOpenId },
         });
-        if (result.created) {
-          log(
-            `feishu[${account.accountId}]: dynamic agent created, new route: ${route.sessionKey}`,
-          );
+      }
+      if (route.matchedBy === "default") {
+        const result = await maybeCreateDynamicAgent({
+          cfg: effectiveCfg,
+          runtime: runtimeLocal,
+          accountId: account.accountId,
+          senderOpenId: ctx.senderOpenId,
+          canCreateForConfig: async (candidateCfg) => {
+            const authorization = await resolveDirectAuthorization(candidateCfg, false);
+            return authorization.ingress.ingress.admission === "dispatch";
+          },
+          log: (msg) => log(msg),
+        });
+        if (result.created || result.updatedCfg !== effectiveCfg) {
+          const refreshedAuthorization = await resolveDirectAuthorization(result.updatedCfg, false);
+          if (refreshedAuthorization.ingress.ingress.admission !== "dispatch") {
+            log(
+              `feishu[${account.accountId}]: current policy rejected stale DM from ${ctx.senderOpenId} ` +
+                `before adopting refreshed dynamic route (dmPolicy=${refreshedAuthorization.dmPolicy})`,
+            );
+            return;
+          }
+          effectiveCfg = result.updatedCfg;
+          effectiveDmPolicy = refreshedAuthorization.dmPolicy;
+          effectiveConfigAllowFrom = refreshedAuthorization.configAllowFrom;
+          effectiveDmIngress = refreshedAuthorization.ingress;
+          effectiveShouldComputeCommandAuthorized =
+            refreshedAuthorization.shouldComputeCommandAuthorized;
+          route = core.channel.routing.resolveAgentRoute({
+            cfg: result.updatedCfg,
+            channel: "feishu",
+            accountId: account.accountId,
+            peer: { kind: "direct", id: ctx.senderOpenId },
+          });
+          if (result.created) {
+            log(
+              `feishu[${account.accountId}]: dynamic agent created, new route: ${route.sessionKey}`,
+            );
+          }
         }
       }
     }

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1477,8 +1477,8 @@ export async function handleFeishuMessage(params: {
         : undefined;
     const pinnedMainDmOwner = !isGroup
       ? resolvePinnedMainDmOwnerFromAllowlist({
-          dmScope: cfg.session?.dmScope,
-          allowFrom: configAllowFrom,
+          dmScope: effectiveCfg.session?.dmScope,
+          allowFrom: effectiveConfigAllowFrom,
           normalizeEntry: normalizeFeishuAllowEntry,
         })
       : null;

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -864,6 +864,17 @@ export async function handleFeishuMessage(params: {
           log(
             `feishu[${account.accountId}]: dynamic agent created, new route: ${route.sessionKey}`,
           );
+        } else if (result.updatedCfg && result.updatedCfg !== cfg) {
+          // Binding already exists but in-memory cfg may be stale.
+          // Re-resolve with the runtime's current config to pick up
+          // the existing binding.
+          effectiveCfg = result.updatedCfg;
+          route = core.channel.routing.resolveAgentRoute({
+            cfg: result.updatedCfg,
+            channel: "feishu",
+            accountId: account.accountId,
+            peer: { kind: "direct", id: ctx.senderOpenId },
+          });
         }
       }
     }

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -852,22 +852,7 @@ export async function handleFeishuMessage(params: {
           }),
           log: (msg) => log(msg),
         });
-        if (result.created) {
-          effectiveCfg = result.updatedCfg;
-          // Re-resolve route with updated config
-          route = core.channel.routing.resolveAgentRoute({
-            cfg: result.updatedCfg,
-            channel: "feishu",
-            accountId: account.accountId,
-            peer: { kind: "direct", id: ctx.senderOpenId },
-          });
-          log(
-            `feishu[${account.accountId}]: dynamic agent created, new route: ${route.sessionKey}`,
-          );
-        } else if (result.updatedCfg && result.updatedCfg !== cfg) {
-          // Binding already exists but in-memory cfg may be stale.
-          // Re-resolve with the runtime's current config to pick up
-          // the existing binding.
+        if (result.created || result.updatedCfg !== cfg) {
           effectiveCfg = result.updatedCfg;
           route = core.channel.routing.resolveAgentRoute({
             cfg: result.updatedCfg,
@@ -875,6 +860,11 @@ export async function handleFeishuMessage(params: {
             accountId: account.accountId,
             peer: { kind: "direct", id: ctx.senderOpenId },
           });
+          if (result.created) {
+            log(
+              `feishu[${account.accountId}]: dynamic agent created, new route: ${route.sessionKey}`,
+            );
+          }
         }
       }
     }

--- a/extensions/feishu/src/comment-handler.test.ts
+++ b/extensions/feishu/src/comment-handler.test.ts
@@ -326,7 +326,7 @@ describe("handleFeishuCommentEvent", () => {
     expect(deliverCommentThreadTextMock).not.toHaveBeenCalled();
   });
 
-  it("passes disabled config-write policy to dynamic agent creation", async () => {
+  it("passes the resolved account to dynamic agent resolution", async () => {
     const runtime = createTestRuntime({
       resolveAgentRoute: () => buildResolvedRoute("default"),
     });
@@ -357,10 +357,10 @@ describe("handleFeishuCommentEvent", () => {
 
     expect(maybeCreateDynamicAgentMock).toHaveBeenCalledTimes(1);
     const dynamicAgentArgs = mockCallArg(maybeCreateDynamicAgentMock, "maybeCreateDynamicAgent") as
-      | { configWritesAllowed?: boolean; senderOpenId?: string }
+      | { accountId?: string; senderOpenId?: string }
       | undefined;
     expect(dynamicAgentArgs?.senderOpenId).toBe("ou_sender");
-    expect(dynamicAgentArgs?.configWritesAllowed).toBe(false);
+    expect(dynamicAgentArgs?.accountId).toBe("default");
     const dispatchReplyFromConfig = runtime.channel.reply.dispatchReplyFromConfig as ReturnType<
       typeof vi.fn
     >;

--- a/extensions/feishu/src/comment-handler.test.ts
+++ b/extensions/feishu/src/comment-handler.test.ts
@@ -77,6 +77,7 @@ function mockCallArg(mockFn: ReturnType<typeof vi.fn>, label: string, callIndex 
 }
 
 function createTestRuntime(overrides?: {
+  currentCfg?: ClawdbotConfig;
   readAllowFromStore?: () => Promise<unknown[]>;
   upsertPairingRequest?: () => Promise<{ code: string; created: boolean }>;
   resolveAgentRoute?: () => ReturnType<typeof buildResolvedRoute>;
@@ -129,6 +130,9 @@ function createTestRuntime(overrides?: {
   });
 
   return {
+    config: {
+      current: vi.fn(() => overrides?.currentCfg ?? ({} as ClawdbotConfig)),
+    },
     channel: {
       routing: {
         buildAgentSessionKey: vi.fn(
@@ -327,25 +331,27 @@ describe("handleFeishuCommentEvent", () => {
   });
 
   it("passes the resolved account to dynamic agent resolution", async () => {
+    const cfg = buildConfig({
+      channels: {
+        feishu: {
+          enabled: true,
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          configWrites: false,
+          dynamicAgentCreation: {
+            enabled: true,
+          },
+        },
+      },
+    });
     const runtime = createTestRuntime({
+      currentCfg: cfg,
       resolveAgentRoute: () => buildResolvedRoute("default"),
     });
     setFeishuRuntime(runtime);
 
     await handleFeishuCommentEvent({
-      cfg: buildConfig({
-        channels: {
-          feishu: {
-            enabled: true,
-            dmPolicy: "open",
-            allowFrom: ["*"],
-            configWrites: false,
-            dynamicAgentCreation: {
-              enabled: true,
-            },
-          },
-        },
-      }),
+      cfg,
       accountId: "default",
       event: { event_id: "evt_1" },
       botOpenId: "ou_bot",
@@ -368,23 +374,21 @@ describe("handleFeishuCommentEvent", () => {
   });
 
   it("drops a comment denied by refreshed dynamic-agent policy", async () => {
+    const refreshedCfg = buildConfig({
+      channels: {
+        feishu: {
+          enabled: true,
+          dmPolicy: "allowlist",
+          allowFrom: ["ou_admin"],
+        },
+      },
+    });
     const runtime = createTestRuntime({
+      currentCfg: refreshedCfg,
       resolveAgentRoute: () => buildResolvedRoute("default"),
     });
     setFeishuRuntime(runtime);
     const cfg = buildConfig();
-    maybeCreateDynamicAgentMock.mockResolvedValueOnce({
-      created: false,
-      updatedCfg: buildConfig({
-        channels: {
-          feishu: {
-            enabled: true,
-            dmPolicy: "allowlist",
-            allowFrom: ["ou_admin"],
-          },
-        },
-      }),
-    });
 
     await handleFeishuCommentEvent({
       cfg,
@@ -400,8 +404,44 @@ describe("handleFeishuCommentEvent", () => {
     const dispatchReplyFromConfig = runtime.channel.reply.dispatchReplyFromConfig as ReturnType<
       typeof vi.fn
     >;
-    expect(maybeCreateDynamicAgentMock).toHaveBeenCalledTimes(1);
+    expect(maybeCreateDynamicAgentMock).not.toHaveBeenCalled();
     expect(deliverCommentThreadTextMock).not.toHaveBeenCalled();
+    expect(dispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("issues a pairing challenge before dynamic comment-agent creation", async () => {
+    const currentCfg = buildConfig({
+      channels: {
+        feishu: {
+          enabled: true,
+          dmPolicy: "pairing",
+          allowFrom: [],
+          dynamicAgentCreation: { enabled: true },
+        },
+      },
+    });
+    const runtime = createTestRuntime({
+      currentCfg,
+      resolveAgentRoute: () => buildResolvedRoute("default"),
+    });
+    setFeishuRuntime(runtime);
+
+    await handleFeishuCommentEvent({
+      cfg: buildConfig(),
+      accountId: "default",
+      event: { event_id: "evt_1" },
+      botOpenId: "ou_bot",
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+
+    const dispatchReplyFromConfig = runtime.channel.reply.dispatchReplyFromConfig as ReturnType<
+      typeof vi.fn
+    >;
+    expect(maybeCreateDynamicAgentMock).not.toHaveBeenCalled();
+    expect(deliverCommentThreadTextMock).toHaveBeenCalledTimes(1);
     expect(dispatchReplyFromConfig).not.toHaveBeenCalled();
   });
 

--- a/extensions/feishu/src/comment-handler.test.ts
+++ b/extensions/feishu/src/comment-handler.test.ts
@@ -53,6 +53,8 @@ function buildConfig(overrides?: Partial<ClawdbotConfig>): ClawdbotConfig {
   } as ClawdbotConfig;
 }
 
+let currentRuntimeConfig = buildConfig();
+
 function buildResolvedRoute(matchedBy: "binding.channel" | "default" = "binding.channel") {
   return {
     agentId: "main",
@@ -131,7 +133,7 @@ function createTestRuntime(overrides?: {
 
   return {
     config: {
-      current: vi.fn(() => overrides?.currentCfg ?? ({} as ClawdbotConfig)),
+      current: vi.fn(() => overrides?.currentCfg ?? currentRuntimeConfig),
     },
     channel: {
       routing: {
@@ -204,6 +206,7 @@ describe("handleFeishuCommentEvent", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    currentRuntimeConfig = buildConfig();
     maybeCreateDynamicAgentMock.mockImplementation(async ({ cfg }) => ({
       created: false,
       updatedCfg: cfg,

--- a/extensions/feishu/src/comment-handler.test.ts
+++ b/extensions/feishu/src/comment-handler.test.ts
@@ -200,7 +200,10 @@ describe("handleFeishuCommentEvent", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    maybeCreateDynamicAgentMock.mockResolvedValue({ created: false });
+    maybeCreateDynamicAgentMock.mockImplementation(async ({ cfg }) => ({
+      created: false,
+      updatedCfg: cfg,
+    }));
     resolveDriveCommentEventTurnMock.mockResolvedValue({
       eventId: "evt_1",
       messageId: "drive-comment:evt_1",

--- a/extensions/feishu/src/comment-handler.test.ts
+++ b/extensions/feishu/src/comment-handler.test.ts
@@ -367,6 +367,44 @@ describe("handleFeishuCommentEvent", () => {
     expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
 
+  it("drops a comment denied by refreshed dynamic-agent policy", async () => {
+    const runtime = createTestRuntime({
+      resolveAgentRoute: () => buildResolvedRoute("default"),
+    });
+    setFeishuRuntime(runtime);
+    const cfg = buildConfig();
+    maybeCreateDynamicAgentMock.mockResolvedValueOnce({
+      created: false,
+      updatedCfg: buildConfig({
+        channels: {
+          feishu: {
+            enabled: true,
+            dmPolicy: "allowlist",
+            allowFrom: ["ou_admin"],
+          },
+        },
+      }),
+    });
+
+    await handleFeishuCommentEvent({
+      cfg,
+      accountId: "default",
+      event: { event_id: "evt_1" },
+      botOpenId: "ou_bot",
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+
+    const dispatchReplyFromConfig = runtime.channel.reply.dispatchReplyFromConfig as ReturnType<
+      typeof vi.fn
+    >;
+    expect(maybeCreateDynamicAgentMock).toHaveBeenCalledTimes(1);
+    expect(deliverCommentThreadTextMock).not.toHaveBeenCalled();
+    expect(dispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
   it("issues a pairing challenge in the comment thread when dmPolicy=pairing", async () => {
     const runtime = createTestRuntime();
     setFeishuRuntime(runtime);

--- a/extensions/feishu/src/comment-handler.ts
+++ b/extensions/feishu/src/comment-handler.ts
@@ -1,5 +1,4 @@
 // Feishu plugin module implements comment handler behavior.
-import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-writes";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
@@ -19,7 +18,6 @@ import {
 } from "./monitor.comment.js";
 import { resolveFeishuDmIngressAccess } from "./policy.js";
 import { getFeishuRuntime } from "./runtime.js";
-import type { DynamicAgentCreationConfig } from "./types.js";
 
 type HandleFeishuCommentEventParams = {
   cfg: ClawdbotConfig;
@@ -146,36 +144,28 @@ export async function handleFeishuCommentEvent(
     },
   });
   if (route.matchedBy === "default") {
-    const dynamicCfg = feishuCfg?.dynamicAgentCreation as DynamicAgentCreationConfig | undefined;
-    if (dynamicCfg?.enabled) {
-      const dynamicResult = await maybeCreateDynamicAgent({
-        cfg: params.cfg,
-        runtime: core,
-        senderOpenId: turn.senderId,
-        dynamicCfg,
-        configWritesAllowed: resolveChannelConfigWrites({
-          cfg: params.cfg,
-          channelId: "feishu",
-          accountId: account.accountId,
-        }),
-        log: (message) => log(message),
+    const dynamicResult = await maybeCreateDynamicAgent({
+      cfg: params.cfg,
+      runtime: core,
+      accountId: account.accountId,
+      senderOpenId: turn.senderId,
+      log: (message) => log(message),
+    });
+    if (dynamicResult.created || dynamicResult.updatedCfg !== params.cfg) {
+      effectiveCfg = dynamicResult.updatedCfg;
+      route = core.channel.routing.resolveAgentRoute({
+        cfg: dynamicResult.updatedCfg,
+        channel: "feishu",
+        accountId: account.accountId,
+        peer: {
+          kind: "direct",
+          id: turn.senderId,
+        },
       });
-      if (dynamicResult.created || dynamicResult.updatedCfg !== params.cfg) {
-        effectiveCfg = dynamicResult.updatedCfg;
-        route = core.channel.routing.resolveAgentRoute({
-          cfg: dynamicResult.updatedCfg,
-          channel: "feishu",
-          accountId: account.accountId,
-          peer: {
-            kind: "direct",
-            id: turn.senderId,
-          },
-        });
-        if (dynamicResult.created) {
-          log(
-            `feishu[${account.accountId}]: dynamic agent created for comment flow, route=${route.sessionKey}`,
-          );
-        }
+      if (dynamicResult.created) {
+        log(
+          `feishu[${account.accountId}]: dynamic agent created for comment flow, route=${route.sessionKey}`,
+        );
       }
     }
   }

--- a/extensions/feishu/src/comment-handler.ts
+++ b/extensions/feishu/src/comment-handler.ts
@@ -152,6 +152,29 @@ export async function handleFeishuCommentEvent(
       log: (message) => log(message),
     });
     if (dynamicResult.created || dynamicResult.updatedCfg !== params.cfg) {
+      const refreshedAccount = resolveFeishuRuntimeAccount({
+        cfg: dynamicResult.updatedCfg,
+        accountId: account.accountId,
+      });
+      const refreshedDmPolicy = refreshedAccount.config.dmPolicy ?? "pairing";
+      const refreshedDmIngress = await resolveFeishuDmIngressAccess({
+        cfg: dynamicResult.updatedCfg,
+        accountId: refreshedAccount.accountId,
+        dmPolicy: refreshedDmPolicy,
+        allowFrom: refreshedAccount.config.allowFrom ?? [],
+        readAllowFromStore: pairing.readAllowFromStore,
+        senderOpenId: turn.senderId,
+        senderUserId: turn.senderUserId,
+        conversationId: turn.senderId,
+        mayPair: false,
+      });
+      if (refreshedDmIngress.ingress.admission !== "dispatch") {
+        log(
+          `feishu[${account.accountId}]: current policy rejected stale comment sender ${turn.senderId} ` +
+            `before adopting refreshed dynamic route (dmPolicy=${refreshedDmPolicy}, comment=${turn.commentId})`,
+        );
+        return;
+      }
       effectiveCfg = dynamicResult.updatedCfg;
       route = core.channel.routing.resolveAgentRoute({
         cfg: dynamicResult.updatedCfg,

--- a/extensions/feishu/src/comment-handler.ts
+++ b/extensions/feishu/src/comment-handler.ts
@@ -53,7 +53,6 @@ export async function handleFeishuCommentEvent(
   params: HandleFeishuCommentEventParams,
 ): Promise<void> {
   const account = resolveFeishuRuntimeAccount({ cfg: params.cfg, accountId: params.accountId });
-  const feishuCfg = account.config;
   const core = getFeishuRuntime();
   const log = params.runtime?.log ?? console.log;
   const error = params.runtime?.error ?? console.error;
@@ -79,27 +78,35 @@ export async function handleFeishuCommentEvent(
     fileToken: turn.fileToken,
     commentId: turn.commentId,
   });
-  const dmPolicy = feishuCfg?.dmPolicy ?? "pairing";
-  const configAllowFrom = feishuCfg?.allowFrom ?? [];
   const pairing = createChannelPairingController({
     core,
     channel: "feishu",
     accountId: account.accountId,
   });
-  const dmIngress = await resolveFeishuDmIngressAccess({
-    cfg: params.cfg,
-    accountId: account.accountId,
-    dmPolicy,
-    allowFrom: configAllowFrom,
-    readAllowFromStore: pairing.readAllowFromStore,
-    senderOpenId: turn.senderId,
-    senderUserId: turn.senderUserId,
-    conversationId: turn.senderId,
-    mayPair: true,
-  });
-  if (dmIngress.ingress.admission !== "dispatch") {
-    if (dmIngress.ingress.admission === "pairing-required") {
-      const client = createFeishuClient(account);
+  const resolveCommentAuthorization = async (candidateCfg: ClawdbotConfig, mayPair: boolean) => {
+    const candidateAccount = resolveFeishuRuntimeAccount({
+      cfg: candidateCfg,
+      accountId: account.accountId,
+    });
+    const candidateDmPolicy = candidateAccount.config.dmPolicy ?? "pairing";
+    const ingress = await resolveFeishuDmIngressAccess({
+      cfg: candidateCfg,
+      accountId: candidateAccount.accountId,
+      dmPolicy: candidateDmPolicy,
+      allowFrom: candidateAccount.config.allowFrom ?? [],
+      readAllowFromStore: pairing.readAllowFromStore,
+      senderOpenId: turn.senderId,
+      senderUserId: turn.senderUserId,
+      conversationId: turn.senderId,
+      mayPair,
+    });
+    return { account: candidateAccount, cfg: candidateCfg, dmPolicy: candidateDmPolicy, ingress };
+  };
+  const rejectCommentAuthorization = async (
+    authorization: Awaited<ReturnType<typeof resolveCommentAuthorization>>,
+  ) => {
+    if (authorization.ingress.ingress.admission === "pairing-required") {
+      const client = createFeishuClient(authorization.account);
       await pairing.issueChallenge({
         senderId: turn.senderId,
         senderIdLine: `Your Feishu user id: ${turn.senderId}`,
@@ -127,9 +134,13 @@ export async function handleFeishuCommentEvent(
     } else {
       log(
         `feishu[${account.accountId}]: blocked unauthorized comment sender ${turn.senderId} ` +
-          `(dmPolicy=${dmPolicy}, comment=${turn.commentId})`,
+          `(dmPolicy=${authorization.dmPolicy}, comment=${turn.commentId})`,
       );
     }
+  };
+  const commentAuthorization = await resolveCommentAuthorization(params.cfg, true);
+  if (commentAuthorization.ingress.ingress.admission !== "dispatch") {
+    await rejectCommentAuthorization(commentAuthorization);
     return;
   }
 
@@ -144,40 +155,16 @@ export async function handleFeishuCommentEvent(
     },
   });
   if (route.matchedBy === "default") {
-    const dynamicResult = await maybeCreateDynamicAgent({
-      cfg: params.cfg,
-      runtime: core,
-      accountId: account.accountId,
-      senderOpenId: turn.senderId,
-      log: (message) => log(message),
-    });
-    if (dynamicResult.created || dynamicResult.updatedCfg !== params.cfg) {
-      const refreshedAccount = resolveFeishuRuntimeAccount({
-        cfg: dynamicResult.updatedCfg,
-        accountId: account.accountId,
-      });
-      const refreshedDmPolicy = refreshedAccount.config.dmPolicy ?? "pairing";
-      const refreshedDmIngress = await resolveFeishuDmIngressAccess({
-        cfg: dynamicResult.updatedCfg,
-        accountId: refreshedAccount.accountId,
-        dmPolicy: refreshedDmPolicy,
-        allowFrom: refreshedAccount.config.allowFrom ?? [],
-        readAllowFromStore: pairing.readAllowFromStore,
-        senderOpenId: turn.senderId,
-        senderUserId: turn.senderUserId,
-        conversationId: turn.senderId,
-        mayPair: false,
-      });
-      if (refreshedDmIngress.ingress.admission !== "dispatch") {
-        log(
-          `feishu[${account.accountId}]: current policy rejected stale comment sender ${turn.senderId} ` +
-            `before adopting refreshed dynamic route (dmPolicy=${refreshedDmPolicy}, comment=${turn.commentId})`,
-        );
+    const currentCfg = core.config.current() as ClawdbotConfig;
+    if (currentCfg !== effectiveCfg) {
+      const currentAuthorization = await resolveCommentAuthorization(currentCfg, true);
+      if (currentAuthorization.ingress.ingress.admission !== "dispatch") {
+        await rejectCommentAuthorization(currentAuthorization);
         return;
       }
-      effectiveCfg = dynamicResult.updatedCfg;
+      effectiveCfg = currentCfg;
       route = core.channel.routing.resolveAgentRoute({
-        cfg: dynamicResult.updatedCfg,
+        cfg: currentCfg,
         channel: "feishu",
         accountId: account.accountId,
         peer: {
@@ -185,10 +172,46 @@ export async function handleFeishuCommentEvent(
           id: turn.senderId,
         },
       });
-      if (dynamicResult.created) {
-        log(
-          `feishu[${account.accountId}]: dynamic agent created for comment flow, route=${route.sessionKey}`,
+    }
+    if (route.matchedBy === "default") {
+      const dynamicResult = await maybeCreateDynamicAgent({
+        cfg: effectiveCfg,
+        runtime: core,
+        accountId: account.accountId,
+        senderOpenId: turn.senderId,
+        canCreateForConfig: async (candidateCfg) => {
+          const authorization = await resolveCommentAuthorization(candidateCfg, false);
+          return authorization.ingress.ingress.admission === "dispatch";
+        },
+        log: (message) => log(message),
+      });
+      if (dynamicResult.created || dynamicResult.updatedCfg !== effectiveCfg) {
+        const refreshedAuthorization = await resolveCommentAuthorization(
+          dynamicResult.updatedCfg,
+          false,
         );
+        if (refreshedAuthorization.ingress.ingress.admission !== "dispatch") {
+          log(
+            `feishu[${account.accountId}]: current policy rejected stale comment sender ${turn.senderId} ` +
+              `before adopting refreshed dynamic route (dmPolicy=${refreshedAuthorization.dmPolicy}, comment=${turn.commentId})`,
+          );
+          return;
+        }
+        effectiveCfg = dynamicResult.updatedCfg;
+        route = core.channel.routing.resolveAgentRoute({
+          cfg: dynamicResult.updatedCfg,
+          channel: "feishu",
+          accountId: account.accountId,
+          peer: {
+            kind: "direct",
+            id: turn.senderId,
+          },
+        });
+        if (dynamicResult.created) {
+          log(
+            `feishu[${account.accountId}]: dynamic agent created for comment flow, route=${route.sessionKey}`,
+          );
+        }
       }
     }
   }

--- a/extensions/feishu/src/comment-handler.ts
+++ b/extensions/feishu/src/comment-handler.ts
@@ -160,7 +160,7 @@ export async function handleFeishuCommentEvent(
         }),
         log: (message) => log(message),
       });
-      if (dynamicResult.created) {
+      if (dynamicResult.created || dynamicResult.updatedCfg !== params.cfg) {
         effectiveCfg = dynamicResult.updatedCfg;
         route = core.channel.routing.resolveAgentRoute({
           cfg: dynamicResult.updatedCfg,
@@ -171,9 +171,11 @@ export async function handleFeishuCommentEvent(
             id: turn.senderId,
           },
         });
-        log(
-          `feishu[${account.accountId}]: dynamic agent created for comment flow, route=${route.sessionKey}`,
-        );
+        if (dynamicResult.created) {
+          log(
+            `feishu[${account.accountId}]: dynamic agent created for comment flow, route=${route.sessionKey}`,
+          );
+        }
       }
     }
   }

--- a/extensions/feishu/src/comment-handler.ts
+++ b/extensions/feishu/src/comment-handler.ts
@@ -145,8 +145,17 @@ export async function handleFeishuCommentEvent(
   }
 
   let effectiveCfg = params.cfg;
+  const currentCfg = core.config.current() as ClawdbotConfig;
+  if (currentCfg !== effectiveCfg) {
+    const currentAuthorization = await resolveCommentAuthorization(currentCfg, true);
+    if (currentAuthorization.ingress.ingress.admission !== "dispatch") {
+      await rejectCommentAuthorization(currentAuthorization);
+      return;
+    }
+    effectiveCfg = currentCfg;
+  }
   let route = core.channel.routing.resolveAgentRoute({
-    cfg: params.cfg,
+    cfg: effectiveCfg,
     channel: "feishu",
     accountId: account.accountId,
     peer: {
@@ -155,16 +164,32 @@ export async function handleFeishuCommentEvent(
     },
   });
   if (route.matchedBy === "default") {
-    const currentCfg = core.config.current() as ClawdbotConfig;
-    if (currentCfg !== effectiveCfg) {
-      const currentAuthorization = await resolveCommentAuthorization(currentCfg, true);
-      if (currentAuthorization.ingress.ingress.admission !== "dispatch") {
-        await rejectCommentAuthorization(currentAuthorization);
+    const dynamicResult = await maybeCreateDynamicAgent({
+      cfg: effectiveCfg,
+      runtime: core,
+      accountId: account.accountId,
+      senderOpenId: turn.senderId,
+      canCreateForConfig: async (candidateCfg) => {
+        const authorization = await resolveCommentAuthorization(candidateCfg, false);
+        return authorization.ingress.ingress.admission === "dispatch";
+      },
+      log: (message) => log(message),
+    });
+    if (dynamicResult.created || dynamicResult.updatedCfg !== effectiveCfg) {
+      const refreshedAuthorization = await resolveCommentAuthorization(
+        dynamicResult.updatedCfg,
+        false,
+      );
+      if (refreshedAuthorization.ingress.ingress.admission !== "dispatch") {
+        log(
+          `feishu[${account.accountId}]: current policy rejected stale comment sender ${turn.senderId} ` +
+            `before adopting refreshed dynamic route (dmPolicy=${refreshedAuthorization.dmPolicy}, comment=${turn.commentId})`,
+        );
         return;
       }
-      effectiveCfg = currentCfg;
+      effectiveCfg = dynamicResult.updatedCfg;
       route = core.channel.routing.resolveAgentRoute({
-        cfg: currentCfg,
+        cfg: dynamicResult.updatedCfg,
         channel: "feishu",
         accountId: account.accountId,
         peer: {
@@ -172,46 +197,10 @@ export async function handleFeishuCommentEvent(
           id: turn.senderId,
         },
       });
-    }
-    if (route.matchedBy === "default") {
-      const dynamicResult = await maybeCreateDynamicAgent({
-        cfg: effectiveCfg,
-        runtime: core,
-        accountId: account.accountId,
-        senderOpenId: turn.senderId,
-        canCreateForConfig: async (candidateCfg) => {
-          const authorization = await resolveCommentAuthorization(candidateCfg, false);
-          return authorization.ingress.ingress.admission === "dispatch";
-        },
-        log: (message) => log(message),
-      });
-      if (dynamicResult.created || dynamicResult.updatedCfg !== effectiveCfg) {
-        const refreshedAuthorization = await resolveCommentAuthorization(
-          dynamicResult.updatedCfg,
-          false,
+      if (dynamicResult.created) {
+        log(
+          `feishu[${account.accountId}]: dynamic agent created for comment flow, route=${route.sessionKey}`,
         );
-        if (refreshedAuthorization.ingress.ingress.admission !== "dispatch") {
-          log(
-            `feishu[${account.accountId}]: current policy rejected stale comment sender ${turn.senderId} ` +
-              `before adopting refreshed dynamic route (dmPolicy=${refreshedAuthorization.dmPolicy}, comment=${turn.commentId})`,
-          );
-          return;
-        }
-        effectiveCfg = dynamicResult.updatedCfg;
-        route = core.channel.routing.resolveAgentRoute({
-          cfg: dynamicResult.updatedCfg,
-          channel: "feishu",
-          accountId: account.accountId,
-          peer: {
-            kind: "direct",
-            id: turn.senderId,
-          },
-        });
-        if (dynamicResult.created) {
-          log(
-            `feishu[${account.accountId}]: dynamic agent created for comment flow, route=${route.sessionKey}`,
-          );
-        }
       }
     }
   }

--- a/extensions/feishu/src/dynamic-agent.test.ts
+++ b/extensions/feishu/src/dynamic-agent.test.ts
@@ -17,15 +17,28 @@ afterEach(async () => {
 });
 
 function createRuntime(currentCfg?: OpenClawConfig) {
-  const replaceConfigFile = vi.fn(async () => {});
+  let runtimeCfg = structuredClone(currentCfg ?? ({} as OpenClawConfig));
+  const mutateConfigFile = vi.fn(
+    async (params: {
+      mutate: (
+        draft: OpenClawConfig,
+        context: { snapshot: never; previousHash: null },
+      ) => unknown | Promise<unknown>;
+    }) => {
+      const draft = structuredClone(runtimeCfg);
+      const result = await params.mutate(draft, { snapshot: {} as never, previousHash: null });
+      runtimeCfg = draft;
+      return { nextConfig: runtimeCfg, result };
+    },
+  );
   return {
     runtime: {
       config: {
-        replaceConfigFile,
-        current: vi.fn(() => currentCfg ?? ({} as OpenClawConfig)),
+        mutateConfigFile,
+        current: vi.fn(() => runtimeCfg),
       },
     } as unknown as PluginRuntime,
-    replaceConfigFile,
+    mutateConfigFile,
   };
 }
 
@@ -51,7 +64,7 @@ async function pathExists(target: string): Promise<boolean> {
 
 describe("maybeCreateDynamicAgent", () => {
   it("does not persist dynamic agents when config writes are disabled", async () => {
-    const { runtime, replaceConfigFile } = createRuntime();
+    const { runtime, mutateConfigFile } = createRuntime();
     const dynamicCfg = createDynamicConfig();
 
     const result = await maybeCreateDynamicAgent({
@@ -75,13 +88,13 @@ describe("maybeCreateDynamicAgent", () => {
         bindings: [],
       },
     });
-    expect(replaceConfigFile).not.toHaveBeenCalled();
+    expect(mutateConfigFile).not.toHaveBeenCalled();
     expect(await pathExists(path.join(tempRoot, "workspace-feishu-ou_sender"))).toBe(false);
     expect(await pathExists(path.join(tempRoot, "agent-feishu-ou_sender"))).toBe(false);
   });
 
   it("persists a sender agent and direct binding when config writes are allowed", async () => {
-    const { runtime, replaceConfigFile } = createRuntime();
+    const { runtime, mutateConfigFile } = createRuntime();
 
     const result = await maybeCreateDynamicAgent({
       cfg: {
@@ -97,50 +110,53 @@ describe("maybeCreateDynamicAgent", () => {
 
     expect(result.created).toBe(true);
     expect(result.agentId).toBe("feishu-ou_sender");
-    expect(replaceConfigFile).toHaveBeenCalledTimes(1);
-    expect(replaceConfigFile).toHaveBeenCalledWith({
-      nextConfig: {
-        agents: {
-          list: [
-            {
-              id: "feishu-ou_sender",
-              workspace: path.join(tempRoot, "workspace-feishu-ou_sender"),
-              agentDir: path.join(tempRoot, "agent-feishu-ou_sender"),
-            },
-          ],
-        },
-        bindings: [
+    expect(mutateConfigFile).toHaveBeenCalledTimes(1);
+    expect(mutateConfigFile).toHaveBeenCalledWith({
+      base: "runtime",
+      afterWrite: { mode: "auto" },
+      mutate: expect.any(Function),
+    });
+    expect(result.updatedCfg).toEqual({
+      agents: {
+        list: [
           {
-            agentId: "feishu-ou_sender",
-            match: {
-              channel: "feishu",
-              peer: { kind: "direct", id: "ou_sender" },
-            },
+            id: "feishu-ou_sender",
+            workspace: path.join(tempRoot, "workspace-feishu-ou_sender"),
+            agentDir: path.join(tempRoot, "agent-feishu-ou_sender"),
           },
         ],
       },
-      afterWrite: { mode: "auto" },
+      bindings: [
+        {
+          agentId: "feishu-ou_sender",
+          match: {
+            channel: "feishu",
+            peer: { kind: "direct", id: "ou_sender" },
+          },
+        },
+      ],
     });
     expect(await pathExists(path.join(tempRoot, "workspace-feishu-ou_sender"))).toBe(true);
     expect(await pathExists(path.join(tempRoot, "agent-feishu-ou_sender"))).toBe(true);
   });
 
   it("keeps the maxAgents limit before adding a missing binding", async () => {
-    const { runtime, replaceConfigFile } = createRuntime();
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "feishu-ou_sender",
+            workspace: path.join(tempRoot, "existing-workspace"),
+            agentDir: path.join(tempRoot, "existing-agent"),
+          },
+        ],
+      },
+      bindings: [],
+    } as OpenClawConfig;
+    const { runtime, mutateConfigFile } = createRuntime(cfg);
 
     const result = await maybeCreateDynamicAgent({
-      cfg: {
-        agents: {
-          list: [
-            {
-              id: "feishu-ou_sender",
-              workspace: path.join(tempRoot, "existing-workspace"),
-              agentDir: path.join(tempRoot, "existing-agent"),
-            },
-          ],
-        },
-        bindings: [],
-      } as OpenClawConfig,
+      cfg,
       runtime,
       senderOpenId: "ou_sender",
       dynamicCfg: {
@@ -152,7 +168,68 @@ describe("maybeCreateDynamicAgent", () => {
     });
 
     expect(result.created).toBe(false);
-    expect(replaceConfigFile).not.toHaveBeenCalled();
+    expect(mutateConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("preserves concurrent runtime config when creating from a stale request snapshot", async () => {
+    const currentCfg = {
+      agents: {
+        list: [
+          {
+            id: "feishu-ou_existing",
+            workspace: path.join(tempRoot, "existing-workspace"),
+            agentDir: path.join(tempRoot, "existing-agent"),
+          },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "feishu-ou_existing",
+          match: {
+            channel: "feishu",
+            peer: { kind: "direct", id: "ou_existing" },
+          },
+        },
+      ],
+    } as OpenClawConfig;
+    const { runtime, mutateConfigFile } = createRuntime(currentCfg);
+
+    const result = await maybeCreateDynamicAgent({
+      cfg: { agents: { list: [] }, bindings: [] } as OpenClawConfig,
+      runtime,
+      senderOpenId: "ou_sender",
+      dynamicCfg: createDynamicConfig(),
+      configWritesAllowed: true,
+      log: vi.fn(),
+    });
+
+    expect(mutateConfigFile).toHaveBeenCalledWith({
+      base: "runtime",
+      afterWrite: { mode: "auto" },
+      mutate: expect.any(Function),
+    });
+    expect(result.updatedCfg).toEqual({
+      agents: {
+        list: [
+          ...currentCfg.agents!.list!,
+          {
+            id: "feishu-ou_sender",
+            workspace: path.join(tempRoot, "workspace-feishu-ou_sender"),
+            agentDir: path.join(tempRoot, "agent-feishu-ou_sender"),
+          },
+        ],
+      },
+      bindings: [
+        ...currentCfg.bindings!,
+        {
+          agentId: "feishu-ou_sender",
+          match: {
+            channel: "feishu",
+            peer: { kind: "direct", id: "ou_sender" },
+          },
+        },
+      ],
+    });
   });
 
   it("returns runtime current config when binding already exists", async () => {
@@ -176,7 +253,7 @@ describe("maybeCreateDynamicAgent", () => {
         },
       ],
     } as OpenClawConfig;
-    const { runtime, replaceConfigFile } = createRuntime(currentCfg);
+    const { runtime, mutateConfigFile } = createRuntime(currentCfg);
 
     const result = await maybeCreateDynamicAgent({
       cfg: {
@@ -191,7 +268,7 @@ describe("maybeCreateDynamicAgent", () => {
     });
 
     expect(result.created).toBe(false);
-    expect(result.updatedCfg).toBe(currentCfg);
-    expect(replaceConfigFile).not.toHaveBeenCalled();
+    expect(result.updatedCfg).toStrictEqual(currentCfg);
+    expect(mutateConfigFile).not.toHaveBeenCalled();
   });
 });

--- a/extensions/feishu/src/dynamic-agent.test.ts
+++ b/extensions/feishu/src/dynamic-agent.test.ts
@@ -64,47 +64,45 @@ async function pathExists(target: string): Promise<boolean> {
 
 describe("maybeCreateDynamicAgent", () => {
   it("does not persist dynamic agents when config writes are disabled", async () => {
-    const { runtime, mutateConfigFile } = createRuntime();
-    const dynamicCfg = createDynamicConfig();
+    const cfg = {
+      channels: {
+        feishu: {
+          configWrites: false,
+          dynamicAgentCreation: createDynamicConfig(),
+        },
+      },
+      agents: { list: [] },
+      bindings: [],
+    } as OpenClawConfig;
+    const { runtime, mutateConfigFile } = createRuntime(cfg);
 
     const result = await maybeCreateDynamicAgent({
-      cfg: {
-        channels: { feishu: { configWrites: false } },
-        agents: { list: [] },
-        bindings: [],
-      } as OpenClawConfig,
+      cfg,
       runtime,
+      accountId: "default",
       senderOpenId: "ou_sender",
-      dynamicCfg,
-      configWritesAllowed: false,
       log: vi.fn(),
     });
 
-    expect(result).toEqual({
-      created: false,
-      updatedCfg: {
-        channels: { feishu: { configWrites: false } },
-        agents: { list: [] },
-        bindings: [],
-      },
-    });
+    expect(result).toEqual({ created: false, updatedCfg: cfg });
     expect(mutateConfigFile).not.toHaveBeenCalled();
     expect(await pathExists(path.join(tempRoot, "workspace-feishu-ou_sender"))).toBe(false);
     expect(await pathExists(path.join(tempRoot, "agent-feishu-ou_sender"))).toBe(false);
   });
 
   it("persists a sender agent and direct binding when config writes are allowed", async () => {
-    const { runtime, mutateConfigFile } = createRuntime();
+    const cfg = {
+      channels: { feishu: { dynamicAgentCreation: createDynamicConfig() } },
+      agents: { list: [] },
+      bindings: [],
+    } as OpenClawConfig;
+    const { runtime, mutateConfigFile } = createRuntime(cfg);
 
     const result = await maybeCreateDynamicAgent({
-      cfg: {
-        agents: { list: [] },
-        bindings: [],
-      } as OpenClawConfig,
+      cfg,
       runtime,
+      accountId: "default",
       senderOpenId: "ou_sender",
-      dynamicCfg: createDynamicConfig(),
-      configWritesAllowed: true,
       log: vi.fn(),
     });
 
@@ -116,32 +114,36 @@ describe("maybeCreateDynamicAgent", () => {
       afterWrite: { mode: "auto" },
       mutate: expect.any(Function),
     });
-    expect(result.updatedCfg).toEqual({
-      agents: {
-        list: [
-          {
-            id: "feishu-ou_sender",
-            workspace: path.join(tempRoot, "workspace-feishu-ou_sender"),
-            agentDir: path.join(tempRoot, "agent-feishu-ou_sender"),
-          },
-        ],
+    expect(result.updatedCfg.agents?.list).toEqual([
+      {
+        id: "feishu-ou_sender",
+        workspace: path.join(tempRoot, "workspace-feishu-ou_sender"),
+        agentDir: path.join(tempRoot, "agent-feishu-ou_sender"),
       },
-      bindings: [
-        {
-          agentId: "feishu-ou_sender",
-          match: {
-            channel: "feishu",
-            peer: { kind: "direct", id: "ou_sender" },
-          },
+    ]);
+    expect(result.updatedCfg.bindings).toEqual([
+      {
+        agentId: "feishu-ou_sender",
+        match: {
+          channel: "feishu",
+          peer: { kind: "direct", id: "ou_sender" },
         },
-      ],
-    });
+      },
+    ]);
     expect(await pathExists(path.join(tempRoot, "workspace-feishu-ou_sender"))).toBe(true);
     expect(await pathExists(path.join(tempRoot, "agent-feishu-ou_sender"))).toBe(true);
   });
 
-  it("keeps the maxAgents limit before adding a missing binding", async () => {
+  it("uses the current maxAgents limit instead of stale request policy", async () => {
     const cfg = {
+      channels: {
+        feishu: {
+          dynamicAgentCreation: {
+            ...createDynamicConfig(),
+            maxAgents: 1,
+          },
+        },
+      },
       agents: {
         list: [
           {
@@ -156,14 +158,21 @@ describe("maybeCreateDynamicAgent", () => {
     const { runtime, mutateConfigFile } = createRuntime(cfg);
 
     const result = await maybeCreateDynamicAgent({
-      cfg,
+      cfg: {
+        channels: {
+          feishu: {
+            dynamicAgentCreation: {
+              ...createDynamicConfig(),
+              maxAgents: 2,
+            },
+          },
+        },
+        agents: cfg.agents,
+        bindings: [],
+      } as OpenClawConfig,
       runtime,
+      accountId: "default",
       senderOpenId: "ou_sender",
-      dynamicCfg: {
-        ...createDynamicConfig(),
-        maxAgents: 1,
-      },
-      configWritesAllowed: true,
       log: vi.fn(),
     });
 
@@ -173,6 +182,7 @@ describe("maybeCreateDynamicAgent", () => {
 
   it("preserves concurrent runtime config when creating from a stale request snapshot", async () => {
     const currentCfg = {
+      channels: { feishu: { dynamicAgentCreation: createDynamicConfig() } },
       agents: {
         list: [
           {
@@ -197,9 +207,8 @@ describe("maybeCreateDynamicAgent", () => {
     const result = await maybeCreateDynamicAgent({
       cfg: { agents: { list: [] }, bindings: [] } as OpenClawConfig,
       runtime,
+      accountId: "default",
       senderOpenId: "ou_sender",
-      dynamicCfg: createDynamicConfig(),
-      configWritesAllowed: true,
       log: vi.fn(),
     });
 
@@ -208,38 +217,44 @@ describe("maybeCreateDynamicAgent", () => {
       afterWrite: { mode: "auto" },
       mutate: expect.any(Function),
     });
-    expect(result.updatedCfg).toEqual({
-      agents: {
-        list: [
-          ...currentCfg.agents!.list!,
-          {
-            id: "feishu-ou_sender",
-            workspace: path.join(tempRoot, "workspace-feishu-ou_sender"),
-            agentDir: path.join(tempRoot, "agent-feishu-ou_sender"),
-          },
-        ],
+    expect(result.updatedCfg.agents?.list).toEqual([
+      ...currentCfg.agents!.list!,
+      {
+        id: "feishu-ou_sender",
+        workspace: path.join(tempRoot, "workspace-feishu-ou_sender"),
+        agentDir: path.join(tempRoot, "agent-feishu-ou_sender"),
       },
-      bindings: [
-        ...currentCfg.bindings!,
-        {
-          agentId: "feishu-ou_sender",
-          match: {
-            channel: "feishu",
-            peer: { kind: "direct", id: "ou_sender" },
-          },
+    ]);
+    expect(result.updatedCfg.bindings).toEqual([
+      ...currentCfg.bindings!,
+      {
+        agentId: "feishu-ou_sender",
+        match: {
+          channel: "feishu",
+          peer: { kind: "direct", id: "ou_sender" },
         },
-      ],
-    });
+      },
+    ]);
   });
 
   it("returns refreshed runtime config instead of the persisted source config", async () => {
     const currentCfg = {
-      channels: { feishu: { appSecret: "resolved-secret" } },
+      channels: {
+        feishu: {
+          appSecret: "resolved-secret",
+          dynamicAgentCreation: createDynamicConfig(),
+        },
+      },
       agents: { list: [] },
       bindings: [],
     } as OpenClawConfig;
     const persistedCfg = {
-      channels: { feishu: { appSecret: { source: "env", id: "FEISHU_APP_SECRET" } } },
+      channels: {
+        feishu: {
+          appSecret: { source: "env", id: "FEISHU_APP_SECRET" },
+          dynamicAgentCreation: createDynamicConfig(),
+        },
+      },
       agents: { list: [] },
       bindings: [],
     } as OpenClawConfig;
@@ -248,9 +263,8 @@ describe("maybeCreateDynamicAgent", () => {
     const result = await maybeCreateDynamicAgent({
       cfg: currentCfg,
       runtime,
+      accountId: "default",
       senderOpenId: "ou_sender",
-      dynamicCfg: createDynamicConfig(),
-      configWritesAllowed: true,
       log: vi.fn(),
     });
 
@@ -258,8 +272,9 @@ describe("maybeCreateDynamicAgent", () => {
     expect(result.updatedCfg.bindings).toHaveLength(1);
   });
 
-  it("returns runtime current config when binding already exists", async () => {
+  it("returns runtime current binding even when config writes are disabled", async () => {
     const currentCfg = {
+      channels: { feishu: { configWrites: false } },
       agents: {
         list: [
           {
@@ -287,9 +302,8 @@ describe("maybeCreateDynamicAgent", () => {
         bindings: [],
       } as OpenClawConfig,
       runtime,
+      accountId: "default",
       senderOpenId: "ou_sender",
-      dynamicCfg: createDynamicConfig(),
-      configWritesAllowed: true,
       log: vi.fn(),
     });
 

--- a/extensions/feishu/src/dynamic-agent.test.ts
+++ b/extensions/feishu/src/dynamic-agent.test.ts
@@ -232,32 +232,9 @@ describe("maybeCreateDynamicAgent", () => {
 
   it("scopes bindings to the normalized account id", async () => {
     const cfg = {
-      channels: {
-        feishu: {
-          dynamicAgentCreation: {
-            ...createDynamicConfig(),
-            maxAgents: 1,
-          },
-        },
-      },
-      agents: {
-        list: [
-          {
-            id: "feishu-ou_sender",
-            workspace: path.join(tempRoot, "existing-workspace"),
-            agentDir: path.join(tempRoot, "existing-agent"),
-          },
-        ],
-      },
-      bindings: [
-        {
-          agentId: "feishu-ou_sender",
-          match: {
-            channel: "feishu",
-            peer: { kind: "direct", id: "ou_sender" },
-          },
-        },
-      ],
+      channels: { feishu: { dynamicAgentCreation: createDynamicConfig() } },
+      agents: { list: [] },
+      bindings: [],
     } as OpenClawConfig;
     const { runtime } = createRuntime(cfg);
 
@@ -271,10 +248,10 @@ describe("maybeCreateDynamicAgent", () => {
     });
 
     expect(result.created).toBe(true);
+    expect(result.agentId).toBe("feishu-ops-team-ou_sender");
     expect(result.updatedCfg.bindings).toEqual([
-      cfg.bindings?.[0],
       {
-        agentId: "feishu-ou_sender",
+        agentId: "feishu-ops-team-ou_sender",
         match: {
           channel: "feishu",
           accountId: "ops-team",

--- a/extensions/feishu/src/dynamic-agent.test.ts
+++ b/extensions/feishu/src/dynamic-agent.test.ts
@@ -16,12 +16,13 @@ afterEach(async () => {
   await fs.promises.rm(tempRoot, { recursive: true, force: true });
 });
 
-function createRuntime() {
+function createRuntime(currentCfg?: OpenClawConfig) {
   const replaceConfigFile = vi.fn(async () => {});
   return {
     runtime: {
       config: {
         replaceConfigFile,
+        current: vi.fn(() => currentCfg ?? ({} as OpenClawConfig)),
       },
     } as unknown as PluginRuntime,
     replaceConfigFile,
@@ -151,6 +152,46 @@ describe("maybeCreateDynamicAgent", () => {
     });
 
     expect(result.created).toBe(false);
+    expect(replaceConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("returns runtime current config when binding already exists", async () => {
+    const currentCfg = {
+      agents: {
+        list: [
+          {
+            id: "feishu-ou_sender",
+            workspace: path.join(tempRoot, "existing-workspace"),
+            agentDir: path.join(tempRoot, "existing-agent"),
+          },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "feishu-ou_sender",
+          match: {
+            channel: "feishu",
+            peer: { kind: "direct", id: "ou_sender" },
+          },
+        },
+      ],
+    } as OpenClawConfig;
+    const { runtime, replaceConfigFile } = createRuntime(currentCfg);
+
+    const result = await maybeCreateDynamicAgent({
+      cfg: {
+        agents: { list: [] },
+        bindings: [],
+      } as OpenClawConfig,
+      runtime,
+      senderOpenId: "ou_sender",
+      dynamicCfg: createDynamicConfig(),
+      configWritesAllowed: true,
+      log: vi.fn(),
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.updatedCfg).toBe(currentCfg);
     expect(replaceConfigFile).not.toHaveBeenCalled();
   });
 });

--- a/extensions/feishu/src/dynamic-agent.test.ts
+++ b/extensions/feishu/src/dynamic-agent.test.ts
@@ -16,7 +16,11 @@ afterEach(async () => {
   await fs.promises.rm(tempRoot, { recursive: true, force: true });
 });
 
-function createRuntime(currentCfg?: OpenClawConfig, persistedCfg?: OpenClawConfig) {
+function createRuntime(
+  currentCfg?: OpenClawConfig,
+  persistedCfg?: OpenClawConfig,
+  mutationCfg?: OpenClawConfig,
+) {
   let runtimeCfg = structuredClone(currentCfg ?? ({} as OpenClawConfig));
   const commitConfig = vi.fn();
   const mutateConfigFile = vi.fn(
@@ -26,7 +30,7 @@ function createRuntime(currentCfg?: OpenClawConfig, persistedCfg?: OpenClawConfi
         context: { snapshot: never; previousHash: null },
       ) => unknown | Promise<unknown>;
     }) => {
-      const draft = structuredClone(runtimeCfg);
+      const draft = structuredClone(mutationCfg ?? runtimeCfg);
       const result = await params.mutate(draft, { snapshot: {} as never, previousHash: null });
       runtimeCfg = draft;
       commitConfig();
@@ -192,6 +196,38 @@ describe("maybeCreateDynamicAgent", () => {
     expect(result.updatedCfg.bindings).toEqual([]);
     expect(await pathExists(path.join(tempRoot, "workspace-feishu-ou_sender"))).toBe(false);
     expect(await pathExists(path.join(tempRoot, "agent-feishu-ou_sender"))).toBe(false);
+  });
+
+  it("preserves a non-peer route added before the config mutation lock", async () => {
+    const cfg = {
+      channels: { feishu: { dynamicAgentCreation: createDynamicConfig() } },
+      agents: { list: [] },
+      bindings: [],
+    } as OpenClawConfig;
+    const mutationCfg = {
+      ...cfg,
+      bindings: [
+        {
+          agentId: "main",
+          match: { channel: "feishu", accountId: "default" },
+        },
+      ],
+    } as OpenClawConfig;
+    const { runtime, commitConfig, mutateConfigFile } = createRuntime(cfg, undefined, mutationCfg);
+
+    const result = await maybeCreateDynamicAgent({
+      cfg,
+      runtime,
+      accountId: "default",
+      senderOpenId: "ou_sender",
+      canCreateForConfig: async () => true,
+      log: vi.fn(),
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.updatedCfg).toEqual(mutationCfg);
+    expect(mutateConfigFile).toHaveBeenCalledTimes(1);
+    expect(commitConfig).not.toHaveBeenCalled();
   });
 
   it("scopes bindings to the normalized account id", async () => {

--- a/extensions/feishu/src/dynamic-agent.test.ts
+++ b/extensions/feishu/src/dynamic-agent.test.ts
@@ -18,6 +18,7 @@ afterEach(async () => {
 
 function createRuntime(currentCfg?: OpenClawConfig, persistedCfg?: OpenClawConfig) {
   let runtimeCfg = structuredClone(currentCfg ?? ({} as OpenClawConfig));
+  const commitConfig = vi.fn();
   const mutateConfigFile = vi.fn(
     async (params: {
       mutate: (
@@ -28,6 +29,7 @@ function createRuntime(currentCfg?: OpenClawConfig, persistedCfg?: OpenClawConfi
       const draft = structuredClone(runtimeCfg);
       const result = await params.mutate(draft, { snapshot: {} as never, previousHash: null });
       runtimeCfg = draft;
+      commitConfig();
       return { nextConfig: persistedCfg ?? runtimeCfg, result };
     },
   );
@@ -38,6 +40,7 @@ function createRuntime(currentCfg?: OpenClawConfig, persistedCfg?: OpenClawConfi
         current: vi.fn(() => runtimeCfg),
       },
     } as unknown as PluginRuntime,
+    commitConfig,
     mutateConfigFile,
   };
 }
@@ -166,7 +169,7 @@ describe("maybeCreateDynamicAgent", () => {
       agents: { list: [] },
       bindings: [],
     } as OpenClawConfig;
-    const { runtime, mutateConfigFile } = createRuntime(cfg);
+    const { runtime, commitConfig, mutateConfigFile } = createRuntime(cfg);
     const canCreateForConfig = vi
       .fn<(cfg: OpenClawConfig) => Promise<boolean>>()
       .mockResolvedValueOnce(true)
@@ -184,6 +187,7 @@ describe("maybeCreateDynamicAgent", () => {
     expect(result.created).toBe(false);
     expect(canCreateForConfig).toHaveBeenCalledTimes(2);
     expect(mutateConfigFile).toHaveBeenCalledTimes(1);
+    expect(commitConfig).not.toHaveBeenCalled();
     expect(result.updatedCfg.agents?.list).toEqual([]);
     expect(result.updatedCfg.bindings).toEqual([]);
     expect(await pathExists(path.join(tempRoot, "workspace-feishu-ou_sender"))).toBe(false);
@@ -192,7 +196,14 @@ describe("maybeCreateDynamicAgent", () => {
 
   it("scopes bindings to the normalized account id", async () => {
     const cfg = {
-      channels: { feishu: { dynamicAgentCreation: createDynamicConfig() } },
+      channels: {
+        feishu: {
+          dynamicAgentCreation: {
+            ...createDynamicConfig(),
+            maxAgents: 1,
+          },
+        },
+      },
       agents: {
         list: [
           {
@@ -250,7 +261,7 @@ describe("maybeCreateDynamicAgent", () => {
       agents: {
         list: [
           {
-            id: "feishu-ou_sender",
+            id: "feishu-ou_existing",
             workspace: path.join(tempRoot, "existing-workspace"),
             agentDir: path.join(tempRoot, "existing-agent"),
           },

--- a/extensions/feishu/src/dynamic-agent.test.ts
+++ b/extensions/feishu/src/dynamic-agent.test.ts
@@ -248,16 +248,51 @@ describe("maybeCreateDynamicAgent", () => {
     });
 
     expect(result.created).toBe(true);
-    expect(result.agentId).toBe("feishu-ops-team-ou_sender");
+    expect(result.agentId).toMatch(/^feishu-ops-team-[a-f0-9]{32}$/);
     expect(result.updatedCfg.bindings).toEqual([
       {
-        agentId: "feishu-ops-team-ou_sender",
+        agentId: result.agentId,
         match: {
           channel: "feishu",
           accountId: "ops-team",
           peer: { kind: "direct", id: "ou_sender" },
         },
       },
+    ]);
+  });
+
+  it("keeps named-account dynamic agent ids bounded and sender-unique", async () => {
+    const accountId = "a".repeat(64);
+    const cfg = {
+      channels: { feishu: { dynamicAgentCreation: createDynamicConfig() } },
+      agents: { list: [] },
+      bindings: [],
+    } as OpenClawConfig;
+    const { runtime } = createRuntime(cfg);
+
+    const first = await maybeCreateDynamicAgent({
+      cfg,
+      runtime,
+      accountId,
+      senderOpenId: "ou_sender_one_with_a_shared_long_prefix",
+      canCreateForConfig: async () => true,
+      log: vi.fn(),
+    });
+    const second = await maybeCreateDynamicAgent({
+      cfg: first.updatedCfg,
+      runtime,
+      accountId,
+      senderOpenId: "ou_sender_two_with_a_shared_long_prefix",
+      canCreateForConfig: async () => true,
+      log: vi.fn(),
+    });
+
+    expect(first.agentId).toHaveLength(52);
+    expect(second.agentId).toHaveLength(52);
+    expect(first.agentId).not.toBe(second.agentId);
+    expect(second.updatedCfg.agents?.list?.map((agent) => agent.id)).toEqual([
+      first.agentId,
+      second.agentId,
     ]);
   });
 

--- a/extensions/feishu/src/dynamic-agent.test.ts
+++ b/extensions/feishu/src/dynamic-agent.test.ts
@@ -16,7 +16,7 @@ afterEach(async () => {
   await fs.promises.rm(tempRoot, { recursive: true, force: true });
 });
 
-function createRuntime(currentCfg?: OpenClawConfig) {
+function createRuntime(currentCfg?: OpenClawConfig, persistedCfg?: OpenClawConfig) {
   let runtimeCfg = structuredClone(currentCfg ?? ({} as OpenClawConfig));
   const mutateConfigFile = vi.fn(
     async (params: {
@@ -28,7 +28,7 @@ function createRuntime(currentCfg?: OpenClawConfig) {
       const draft = structuredClone(runtimeCfg);
       const result = await params.mutate(draft, { snapshot: {} as never, previousHash: null });
       runtimeCfg = draft;
-      return { nextConfig: runtimeCfg, result };
+      return { nextConfig: persistedCfg ?? runtimeCfg, result };
     },
   );
   return {
@@ -230,6 +230,32 @@ describe("maybeCreateDynamicAgent", () => {
         },
       ],
     });
+  });
+
+  it("returns refreshed runtime config instead of the persisted source config", async () => {
+    const currentCfg = {
+      channels: { feishu: { appSecret: "resolved-secret" } },
+      agents: { list: [] },
+      bindings: [],
+    } as OpenClawConfig;
+    const persistedCfg = {
+      channels: { feishu: { appSecret: { source: "env", id: "FEISHU_APP_SECRET" } } },
+      agents: { list: [] },
+      bindings: [],
+    } as OpenClawConfig;
+    const { runtime } = createRuntime(currentCfg, persistedCfg);
+
+    const result = await maybeCreateDynamicAgent({
+      cfg: currentCfg,
+      runtime,
+      senderOpenId: "ou_sender",
+      dynamicCfg: createDynamicConfig(),
+      configWritesAllowed: true,
+      log: vi.fn(),
+    });
+
+    expect(result.updatedCfg.channels?.feishu?.appSecret).toBe("resolved-secret");
+    expect(result.updatedCfg.bindings).toHaveLength(1);
   });
 
   it("returns runtime current config when binding already exists", async () => {

--- a/extensions/feishu/src/dynamic-agent.test.ts
+++ b/extensions/feishu/src/dynamic-agent.test.ts
@@ -25,10 +25,7 @@ function createRuntime(
   const commitConfig = vi.fn();
   const mutateConfigFile = vi.fn(
     async (params: {
-      mutate: (
-        draft: OpenClawConfig,
-        context: { snapshot: never; previousHash: null },
-      ) => unknown | Promise<unknown>;
+      mutate: (draft: OpenClawConfig, context: { snapshot: never; previousHash: null }) => unknown;
     }) => {
       const draft = structuredClone(mutationCfg ?? runtimeCfg);
       const result = await params.mutate(draft, { snapshot: {} as never, previousHash: null });

--- a/extensions/feishu/src/dynamic-agent.test.ts
+++ b/extensions/feishu/src/dynamic-agent.test.ts
@@ -81,6 +81,7 @@ describe("maybeCreateDynamicAgent", () => {
       runtime,
       accountId: "default",
       senderOpenId: "ou_sender",
+      canCreateForConfig: async () => true,
       log: vi.fn(),
     });
 
@@ -103,6 +104,7 @@ describe("maybeCreateDynamicAgent", () => {
       runtime,
       accountId: "default",
       senderOpenId: "ou_sender",
+      canCreateForConfig: async () => true,
       log: vi.fn(),
     });
 
@@ -126,12 +128,113 @@ describe("maybeCreateDynamicAgent", () => {
         agentId: "feishu-ou_sender",
         match: {
           channel: "feishu",
+          accountId: "default",
           peer: { kind: "direct", id: "ou_sender" },
         },
       },
     ]);
     expect(await pathExists(path.join(tempRoot, "workspace-feishu-ou_sender"))).toBe(true);
     expect(await pathExists(path.join(tempRoot, "agent-feishu-ou_sender"))).toBe(true);
+  });
+
+  it("does not create persistent state when current ingress denies the sender", async () => {
+    const cfg = {
+      channels: { feishu: { dynamicAgentCreation: createDynamicConfig() } },
+      agents: { list: [] },
+      bindings: [],
+    } as OpenClawConfig;
+    const { runtime, mutateConfigFile } = createRuntime(cfg);
+
+    const result = await maybeCreateDynamicAgent({
+      cfg,
+      runtime,
+      accountId: "default",
+      senderOpenId: "ou_sender",
+      canCreateForConfig: async () => false,
+      log: vi.fn(),
+    });
+
+    expect(result).toEqual({ created: false, updatedCfg: cfg });
+    expect(mutateConfigFile).not.toHaveBeenCalled();
+    expect(await pathExists(path.join(tempRoot, "workspace-feishu-ou_sender"))).toBe(false);
+    expect(await pathExists(path.join(tempRoot, "agent-feishu-ou_sender"))).toBe(false);
+  });
+
+  it("rechecks current ingress inside the config mutation lock", async () => {
+    const cfg = {
+      channels: { feishu: { dynamicAgentCreation: createDynamicConfig() } },
+      agents: { list: [] },
+      bindings: [],
+    } as OpenClawConfig;
+    const { runtime, mutateConfigFile } = createRuntime(cfg);
+    const canCreateForConfig = vi
+      .fn<(cfg: OpenClawConfig) => Promise<boolean>>()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    const result = await maybeCreateDynamicAgent({
+      cfg,
+      runtime,
+      accountId: "default",
+      senderOpenId: "ou_sender",
+      canCreateForConfig,
+      log: vi.fn(),
+    });
+
+    expect(result.created).toBe(false);
+    expect(canCreateForConfig).toHaveBeenCalledTimes(2);
+    expect(mutateConfigFile).toHaveBeenCalledTimes(1);
+    expect(result.updatedCfg.agents?.list).toEqual([]);
+    expect(result.updatedCfg.bindings).toEqual([]);
+    expect(await pathExists(path.join(tempRoot, "workspace-feishu-ou_sender"))).toBe(false);
+    expect(await pathExists(path.join(tempRoot, "agent-feishu-ou_sender"))).toBe(false);
+  });
+
+  it("scopes bindings to the normalized account id", async () => {
+    const cfg = {
+      channels: { feishu: { dynamicAgentCreation: createDynamicConfig() } },
+      agents: {
+        list: [
+          {
+            id: "feishu-ou_sender",
+            workspace: path.join(tempRoot, "existing-workspace"),
+            agentDir: path.join(tempRoot, "existing-agent"),
+          },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "feishu-ou_sender",
+          match: {
+            channel: "feishu",
+            peer: { kind: "direct", id: "ou_sender" },
+          },
+        },
+      ],
+    } as OpenClawConfig;
+    const { runtime } = createRuntime(cfg);
+
+    const result = await maybeCreateDynamicAgent({
+      cfg,
+      runtime,
+      accountId: "Ops Team",
+      senderOpenId: "ou_sender",
+      canCreateForConfig: async () => true,
+      log: vi.fn(),
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.updatedCfg.bindings).toEqual([
+      cfg.bindings?.[0],
+      {
+        agentId: "feishu-ou_sender",
+        match: {
+          channel: "feishu",
+          accountId: "ops-team",
+          peer: { kind: "direct", id: "ou_sender" },
+        },
+      },
+    ]);
   });
 
   it("uses the current maxAgents limit instead of stale request policy", async () => {
@@ -173,6 +276,7 @@ describe("maybeCreateDynamicAgent", () => {
       runtime,
       accountId: "default",
       senderOpenId: "ou_sender",
+      canCreateForConfig: async () => true,
       log: vi.fn(),
     });
 
@@ -209,6 +313,7 @@ describe("maybeCreateDynamicAgent", () => {
       runtime,
       accountId: "default",
       senderOpenId: "ou_sender",
+      canCreateForConfig: async () => true,
       log: vi.fn(),
     });
 
@@ -231,6 +336,7 @@ describe("maybeCreateDynamicAgent", () => {
         agentId: "feishu-ou_sender",
         match: {
           channel: "feishu",
+          accountId: "default",
           peer: { kind: "direct", id: "ou_sender" },
         },
       },
@@ -265,6 +371,7 @@ describe("maybeCreateDynamicAgent", () => {
       runtime,
       accountId: "default",
       senderOpenId: "ou_sender",
+      canCreateForConfig: async () => true,
       log: vi.fn(),
     });
 
@@ -304,6 +411,7 @@ describe("maybeCreateDynamicAgent", () => {
       runtime,
       accountId: "default",
       senderOpenId: "ou_sender",
+      canCreateForConfig: async () => true,
       log: vi.fn(),
     });
 

--- a/extensions/feishu/src/dynamic-agent.ts
+++ b/extensions/feishu/src/dynamic-agent.ts
@@ -11,6 +11,20 @@ type MaybeCreateDynamicAgentResult = {
   agentId?: string;
 };
 
+type DynamicAgentMutationResult = {
+  created: boolean;
+  agentId?: string;
+};
+
+function hasDirectBinding(cfg: OpenClawConfig, senderOpenId: string): boolean {
+  return (cfg.bindings ?? []).some(
+    (binding) =>
+      binding.match?.channel === "feishu" &&
+      binding.match?.peer?.kind === "direct" &&
+      binding.match?.peer?.id === senderOpenId,
+  );
+}
+
 /**
  * Check if a dynamic agent should be created for a DM user and create it if needed.
  * This creates a unique agent instance with its own workspace for each DM user.
@@ -30,83 +44,30 @@ export async function maybeCreateDynamicAgent(params: {
     return { created: false, updatedCfg: cfg };
   }
 
-  // Check if there's already a binding for this user
-  // Check both the in-memory cfg (fast path) and the runtime's current config
-  // (which may have been hot-reloaded after a previous config write).
-  const existingBindings = cfg.bindings ?? [];
-  const hasBindingInCfg = existingBindings.some(
-    (b) =>
-      b.match?.channel === "feishu" &&
-      b.match?.peer?.kind === "direct" &&
-      b.match?.peer?.id === senderOpenId,
-  );
-
-  if (hasBindingInCfg) {
+  if (hasDirectBinding(cfg, senderOpenId)) {
     return { created: false, updatedCfg: cfg };
   }
 
-  // Check runtime's current config — it may have the binding from a previous
-  // config write that hot-reloaded after the in-memory cfg was snapshotted.
   const currentCfg = runtime.config.current() as OpenClawConfig;
-  const currentBindings = currentCfg.bindings ?? [];
-  const hasBindingInCurrentCfg = currentBindings.some(
-    (b) =>
-      b.match?.channel === "feishu" &&
-      b.match?.peer?.kind === "direct" &&
-      b.match?.peer?.id === senderOpenId,
-  );
-
-  if (hasBindingInCurrentCfg) {
+  if (hasDirectBinding(currentCfg, senderOpenId)) {
     return { created: false, updatedCfg: currentCfg };
   }
 
-  // Check maxAgents limit if configured
   if (dynamicCfg.maxAgents !== undefined) {
-    const feishuAgentCount = (cfg.agents?.list ?? []).filter((a) =>
+    const feishuAgentCount = (currentCfg.agents?.list ?? []).filter((a) =>
       a.id.startsWith("feishu-"),
     ).length;
     if (feishuAgentCount >= dynamicCfg.maxAgents) {
       log(
         `feishu: maxAgents limit (${dynamicCfg.maxAgents}) reached, not creating agent for ${senderOpenId}`,
       );
-      return { created: false, updatedCfg: cfg };
+      return { created: false, updatedCfg: currentCfg };
     }
   }
 
-  // Use full OpenID as agent ID suffix (OpenID format: ou_xxx is already filesystem-safe)
   const agentId = `feishu-${senderOpenId}`;
-
-  // Check if agent already exists (but binding was missing)
-  const existingAgent = (cfg.agents?.list ?? []).find((a) => a.id === agentId);
-  if (existingAgent) {
-    // Agent exists but binding doesn't - just add the binding
-    log(`feishu: agent "${agentId}" exists, adding missing binding for ${senderOpenId}`);
-
-    const updatedCfg: OpenClawConfig = {
-      ...cfg,
-      bindings: [
-        ...existingBindings,
-        {
-          agentId,
-          match: {
-            channel: "feishu",
-            peer: { kind: "direct", id: senderOpenId },
-          },
-        },
-      ],
-    };
-
-    await runtime.config.replaceConfigFile({
-      nextConfig: updatedCfg,
-      afterWrite: { mode: "auto" },
-    });
-    return { created: true, updatedCfg, agentId };
-  }
-
-  // Resolve path templates with substitutions
   const workspaceTemplate = dynamicCfg.workspaceTemplate ?? "~/.openclaw/workspace-{agentId}";
   const agentDirTemplate = dynamicCfg.agentDirTemplate ?? "~/.openclaw/agents/{agentId}/agent";
-
   const workspace = resolveUserPath(
     workspaceTemplate.replace("{userId}", senderOpenId).replace("{agentId}", agentId),
   );
@@ -114,40 +75,61 @@ export async function maybeCreateDynamicAgent(params: {
     agentDirTemplate.replace("{userId}", senderOpenId).replace("{agentId}", agentId),
   );
 
-  log(`feishu: creating dynamic agent "${agentId}" for user ${senderOpenId}`);
-  log(`  workspace: ${workspace}`);
-  log(`  agentDir: ${agentDir}`);
-
-  // Create directories
-  await fs.promises.mkdir(workspace, { recursive: true });
-  await fs.promises.mkdir(agentDir, { recursive: true });
-
-  // Update configuration with new agent and binding
-  const updatedCfg: OpenClawConfig = {
-    ...cfg,
-    agents: {
-      ...cfg.agents,
-      list: [...(cfg.agents?.list ?? []), { id: agentId, workspace, agentDir }],
-    },
-    bindings: [
-      ...existingBindings,
-      {
-        agentId,
-        match: {
-          channel: "feishu",
-          peer: { kind: "direct", id: senderOpenId },
-        },
-      },
-    ],
-  };
-
-  // Write updated config using PluginRuntime API
-  await runtime.config.replaceConfigFile({
-    nextConfig: updatedCfg,
+  // The config mutation lock owns the final duplicate/limit checks. This keeps
+  // simultaneous DM creations from replacing each other's agents or bindings.
+  const committed = await runtime.config.mutateConfigFile<DynamicAgentMutationResult>({
+    base: "runtime",
     afterWrite: { mode: "auto" },
+    mutate: async (draft) => {
+      if (hasDirectBinding(draft, senderOpenId)) {
+        return { created: false };
+      }
+
+      if (dynamicCfg.maxAgents !== undefined) {
+        const feishuAgentCount = (draft.agents?.list ?? []).filter((agent) =>
+          agent.id.startsWith("feishu-"),
+        ).length;
+        if (feishuAgentCount >= dynamicCfg.maxAgents) {
+          log(
+            `feishu: maxAgents limit (${dynamicCfg.maxAgents}) reached, not creating agent for ${senderOpenId}`,
+          );
+          return { created: false };
+        }
+      }
+
+      if (!(draft.agents?.list ?? []).some((agent) => agent.id === agentId)) {
+        log(`feishu: creating dynamic agent "${agentId}" for user ${senderOpenId}`);
+        log(`  workspace: ${workspace}`);
+        log(`  agentDir: ${agentDir}`);
+        await fs.promises.mkdir(workspace, { recursive: true });
+        await fs.promises.mkdir(agentDir, { recursive: true });
+        draft.agents = {
+          ...draft.agents,
+          list: [...(draft.agents?.list ?? []), { id: agentId, workspace, agentDir }],
+        };
+      } else {
+        log(`feishu: agent "${agentId}" exists, adding missing binding for ${senderOpenId}`);
+      }
+
+      draft.bindings = [
+        ...(draft.bindings ?? []),
+        {
+          agentId,
+          match: {
+            channel: "feishu",
+            peer: { kind: "direct", id: senderOpenId },
+          },
+        },
+      ];
+      return { created: true, agentId };
+    },
   });
 
-  return { created: true, updatedCfg, agentId };
+  return {
+    created: committed.result?.created ?? false,
+    updatedCfg: committed.nextConfig,
+    agentId: committed.result?.agentId,
+  };
 }
 
 /**

--- a/extensions/feishu/src/dynamic-agent.ts
+++ b/extensions/feishu/src/dynamic-agent.ts
@@ -31,16 +31,33 @@ export async function maybeCreateDynamicAgent(params: {
   }
 
   // Check if there's already a binding for this user
+  // Check both the in-memory cfg (fast path) and the runtime's current config
+  // (which may have been hot-reloaded after a previous config write).
   const existingBindings = cfg.bindings ?? [];
-  const hasBinding = existingBindings.some(
+  const hasBindingInCfg = existingBindings.some(
     (b) =>
       b.match?.channel === "feishu" &&
       b.match?.peer?.kind === "direct" &&
       b.match?.peer?.id === senderOpenId,
   );
 
-  if (hasBinding) {
+  if (hasBindingInCfg) {
     return { created: false, updatedCfg: cfg };
+  }
+
+  // Check runtime's current config — it may have the binding from a previous
+  // config write that hot-reloaded after the in-memory cfg was snapshotted.
+  const currentCfg = runtime.config.current() as OpenClawConfig;
+  const currentBindings = currentCfg.bindings ?? [];
+  const hasBindingInCurrentCfg = currentBindings.some(
+    (b) =>
+      b.match?.channel === "feishu" &&
+      b.match?.peer?.kind === "direct" &&
+      b.match?.peer?.id === senderOpenId,
+  );
+
+  if (hasBindingInCurrentCfg) {
+    return { created: false, updatedCfg: currentCfg };
   }
 
   // Check maxAgents limit if configured

--- a/extensions/feishu/src/dynamic-agent.ts
+++ b/extensions/feishu/src/dynamic-agent.ts
@@ -94,7 +94,8 @@ export async function maybeCreateDynamicAgent(params: {
     log(`feishu: config writes disabled, not creating agent for ${senderOpenId}`);
     return { created: false, updatedCfg: currentCfg };
   }
-  const agentId = `feishu-${senderOpenId}`;
+  const agentId =
+    accountId === "default" ? `feishu-${senderOpenId}` : `feishu-${accountId}-${senderOpenId}`;
   const currentAgentExists = (currentCfg.agents?.list ?? []).some((agent) => agent.id === agentId);
   if (!currentAgentExists && isAtDynamicAgentLimit(currentCfg, currentDynamicCfg)) {
     log(

--- a/extensions/feishu/src/dynamic-agent.ts
+++ b/extensions/feishu/src/dynamic-agent.ts
@@ -1,4 +1,5 @@
 // Feishu plugin module implements dynamic agent behavior.
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -62,6 +63,19 @@ function isAtDynamicAgentLimit(
   return feishuAgentCount >= dynamicCfg.maxAgents;
 }
 
+function resolveDynamicAgentId(accountId: string, senderOpenId: string): string {
+  if (accountId === "default") {
+    return `feishu-${senderOpenId}`;
+  }
+  const identityDigest = createHash("sha256")
+    .update(accountId)
+    .update("\0")
+    .update(senderOpenId)
+    .digest("hex")
+    .slice(0, 32);
+  return `feishu-${accountId.slice(0, 12)}-${identityDigest}`;
+}
+
 /**
  * Refresh an existing DM binding or create its dynamic agent when current
  * account policy permits config writes.
@@ -94,8 +108,7 @@ export async function maybeCreateDynamicAgent(params: {
     log(`feishu: config writes disabled, not creating agent for ${senderOpenId}`);
     return { created: false, updatedCfg: currentCfg };
   }
-  const agentId =
-    accountId === "default" ? `feishu-${senderOpenId}` : `feishu-${accountId}-${senderOpenId}`;
+  const agentId = resolveDynamicAgentId(accountId, senderOpenId);
   const currentAgentExists = (currentCfg.agents?.list ?? []).some((agent) => agent.id === agentId);
   if (!currentAgentExists && isAtDynamicAgentLimit(currentCfg, currentDynamicCfg)) {
     log(

--- a/extensions/feishu/src/dynamic-agent.ts
+++ b/extensions/feishu/src/dynamic-agent.ts
@@ -2,7 +2,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-writes";
 import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
+import { resolveFeishuAccount } from "./accounts.js";
 import type { DynamicAgentCreationConfig } from "./types.js";
 
 type MaybeCreateDynamicAgentResult = {
@@ -25,24 +27,40 @@ function hasDirectBinding(cfg: OpenClawConfig, senderOpenId: string): boolean {
   );
 }
 
+function resolveDynamicAgentConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): DynamicAgentCreationConfig | undefined {
+  return resolveFeishuAccount({ cfg, accountId }).config.dynamicAgentCreation as
+    | DynamicAgentCreationConfig
+    | undefined;
+}
+
+function isAtDynamicAgentLimit(
+  cfg: OpenClawConfig,
+  dynamicCfg: DynamicAgentCreationConfig,
+): boolean {
+  if (dynamicCfg.maxAgents === undefined) {
+    return false;
+  }
+  const feishuAgentCount = (cfg.agents?.list ?? []).filter((agent) =>
+    agent.id.startsWith("feishu-"),
+  ).length;
+  return feishuAgentCount >= dynamicCfg.maxAgents;
+}
+
 /**
- * Check if a dynamic agent should be created for a DM user and create it if needed.
- * This creates a unique agent instance with its own workspace for each DM user.
+ * Refresh an existing DM binding or create its dynamic agent when current
+ * account policy permits config writes.
  */
 export async function maybeCreateDynamicAgent(params: {
   cfg: OpenClawConfig;
   runtime: PluginRuntime;
+  accountId: string;
   senderOpenId: string;
-  dynamicCfg: DynamicAgentCreationConfig;
-  configWritesAllowed: boolean;
   log: (msg: string) => void;
 }): Promise<MaybeCreateDynamicAgentResult> {
-  const { cfg, runtime, senderOpenId, dynamicCfg, configWritesAllowed, log } = params;
-
-  if (!configWritesAllowed) {
-    log(`feishu: config writes disabled, not creating agent for ${senderOpenId}`);
-    return { created: false, updatedCfg: cfg };
-  }
+  const { cfg, runtime, accountId, senderOpenId, log } = params;
 
   if (hasDirectBinding(cfg, senderOpenId)) {
     return { created: false, updatedCfg: cfg };
@@ -53,30 +71,25 @@ export async function maybeCreateDynamicAgent(params: {
     return { created: false, updatedCfg: currentCfg };
   }
 
-  if (dynamicCfg.maxAgents !== undefined) {
-    const feishuAgentCount = (currentCfg.agents?.list ?? []).filter((a) =>
-      a.id.startsWith("feishu-"),
-    ).length;
-    if (feishuAgentCount >= dynamicCfg.maxAgents) {
-      log(
-        `feishu: maxAgents limit (${dynamicCfg.maxAgents}) reached, not creating agent for ${senderOpenId}`,
-      );
-      return { created: false, updatedCfg: currentCfg };
-    }
+  const currentDynamicCfg = resolveDynamicAgentConfig(currentCfg, accountId);
+  if (!currentDynamicCfg?.enabled) {
+    return { created: false, updatedCfg: currentCfg };
+  }
+  if (!resolveChannelConfigWrites({ cfg: currentCfg, channelId: "feishu", accountId })) {
+    log(`feishu: config writes disabled, not creating agent for ${senderOpenId}`);
+    return { created: false, updatedCfg: currentCfg };
+  }
+  if (isAtDynamicAgentLimit(currentCfg, currentDynamicCfg)) {
+    log(
+      `feishu: maxAgents limit (${currentDynamicCfg.maxAgents}) reached, not creating agent for ${senderOpenId}`,
+    );
+    return { created: false, updatedCfg: currentCfg };
   }
 
   const agentId = `feishu-${senderOpenId}`;
-  const workspaceTemplate = dynamicCfg.workspaceTemplate ?? "~/.openclaw/workspace-{agentId}";
-  const agentDirTemplate = dynamicCfg.agentDirTemplate ?? "~/.openclaw/agents/{agentId}/agent";
-  const workspace = resolveUserPath(
-    workspaceTemplate.replace("{userId}", senderOpenId).replace("{agentId}", agentId),
-  );
-  const agentDir = resolveUserPath(
-    agentDirTemplate.replace("{userId}", senderOpenId).replace("{agentId}", agentId),
-  );
 
   // The config mutation lock owns the final duplicate/limit checks. This keeps
-  // simultaneous DM creations from replacing each other's agents or bindings.
+  // simultaneous DM creations and policy updates from producing stale writes.
   const committed = await runtime.config.mutateConfigFile<DynamicAgentMutationResult>({
     base: "runtime",
     afterWrite: { mode: "auto" },
@@ -85,19 +98,30 @@ export async function maybeCreateDynamicAgent(params: {
         return { created: false };
       }
 
-      if (dynamicCfg.maxAgents !== undefined) {
-        const feishuAgentCount = (draft.agents?.list ?? []).filter((agent) =>
-          agent.id.startsWith("feishu-"),
-        ).length;
-        if (feishuAgentCount >= dynamicCfg.maxAgents) {
-          log(
-            `feishu: maxAgents limit (${dynamicCfg.maxAgents}) reached, not creating agent for ${senderOpenId}`,
-          );
-          return { created: false };
-        }
+      const dynamicCfg = resolveDynamicAgentConfig(draft, accountId);
+      if (
+        !dynamicCfg?.enabled ||
+        !resolveChannelConfigWrites({ cfg: draft, channelId: "feishu", accountId })
+      ) {
+        return { created: false };
+      }
+      if (isAtDynamicAgentLimit(draft, dynamicCfg)) {
+        log(
+          `feishu: maxAgents limit (${dynamicCfg.maxAgents}) reached, not creating agent for ${senderOpenId}`,
+        );
+        return { created: false };
       }
 
       if (!(draft.agents?.list ?? []).some((agent) => agent.id === agentId)) {
+        const workspaceTemplate = dynamicCfg.workspaceTemplate ?? "~/.openclaw/workspace-{agentId}";
+        const agentDirTemplate =
+          dynamicCfg.agentDirTemplate ?? "~/.openclaw/agents/{agentId}/agent";
+        const workspace = resolveUserPath(
+          workspaceTemplate.replace("{userId}", senderOpenId).replace("{agentId}", agentId),
+        );
+        const agentDir = resolveUserPath(
+          agentDirTemplate.replace("{userId}", senderOpenId).replace("{agentId}", agentId),
+        );
         log(`feishu: creating dynamic agent "${agentId}" for user ${senderOpenId}`);
         log(`  workspace: ${workspace}`);
         log(`  agentDir: ${agentDir}`);

--- a/extensions/feishu/src/dynamic-agent.ts
+++ b/extensions/feishu/src/dynamic-agent.ts
@@ -2,8 +2,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-writes";
+import { normalizeAccountId, resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import type { DynamicAgentCreationConfig } from "./types.js";
@@ -25,14 +25,18 @@ class DynamicAgentMutationSkipped extends Error {
   }
 }
 
-function hasDirectBinding(cfg: OpenClawConfig, accountId: string, senderOpenId: string): boolean {
-  const normalizedAccountId = normalizeAccountId(accountId);
-  return (cfg.bindings ?? []).some(
-    (binding) =>
-      binding.match?.channel === "feishu" &&
-      normalizeAccountId(binding.match?.accountId) === normalizedAccountId &&
-      binding.match?.peer?.kind === "direct" &&
-      binding.match?.peer?.id === senderOpenId,
+function hasDefaultDirectRoute(
+  cfg: OpenClawConfig,
+  accountId: string,
+  senderOpenId: string,
+): boolean {
+  return (
+    resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId,
+      peer: { kind: "direct", id: senderOpenId },
+    }).matchedBy === "default"
   );
 }
 
@@ -73,12 +77,12 @@ export async function maybeCreateDynamicAgent(params: {
   const { cfg, runtime, senderOpenId, canCreateForConfig, log } = params;
   const accountId = normalizeAccountId(params.accountId);
 
-  if (hasDirectBinding(cfg, accountId, senderOpenId)) {
+  if (!hasDefaultDirectRoute(cfg, accountId, senderOpenId)) {
     return { created: false, updatedCfg: cfg };
   }
 
   const currentCfg = runtime.config.current() as OpenClawConfig;
-  if (hasDirectBinding(currentCfg, accountId, senderOpenId)) {
+  if (!hasDefaultDirectRoute(currentCfg, accountId, senderOpenId)) {
     return { created: false, updatedCfg: currentCfg };
   }
 
@@ -110,7 +114,7 @@ export async function maybeCreateDynamicAgent(params: {
       base: "runtime",
       afterWrite: { mode: "auto" },
       mutate: async (draft) => {
-        if (hasDirectBinding(draft, accountId, senderOpenId)) {
+        if (!hasDefaultDirectRoute(draft, accountId, senderOpenId)) {
           throw new DynamicAgentMutationSkipped(draft);
         }
 

--- a/extensions/feishu/src/dynamic-agent.ts
+++ b/extensions/feishu/src/dynamic-agent.ts
@@ -110,6 +110,8 @@ export async function maybeCreateDynamicAgent(params: {
   }
   const agentId = resolveDynamicAgentId(accountId, senderOpenId);
   const currentAgentExists = (currentCfg.agents?.list ?? []).some((agent) => agent.id === agentId);
+  // Legacy unscoped agents are indistinguishable from valid default-account state.
+  // Keep maxAgents as a hard cap instead of auto-rebinding or deleting ambiguous user data.
   if (!currentAgentExists && isAtDynamicAgentLimit(currentCfg, currentDynamicCfg)) {
     log(
       `feishu: maxAgents limit (${currentDynamicCfg.maxAgents}) reached, not creating agent for ${senderOpenId}`,

--- a/extensions/feishu/src/dynamic-agent.ts
+++ b/extensions/feishu/src/dynamic-agent.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-writes";
 import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
@@ -18,10 +19,12 @@ type DynamicAgentMutationResult = {
   agentId?: string;
 };
 
-function hasDirectBinding(cfg: OpenClawConfig, senderOpenId: string): boolean {
+function hasDirectBinding(cfg: OpenClawConfig, accountId: string, senderOpenId: string): boolean {
+  const normalizedAccountId = normalizeAccountId(accountId);
   return (cfg.bindings ?? []).some(
     (binding) =>
       binding.match?.channel === "feishu" &&
+      normalizeAccountId(binding.match?.accountId) === normalizedAccountId &&
       binding.match?.peer?.kind === "direct" &&
       binding.match?.peer?.id === senderOpenId,
   );
@@ -58,16 +61,18 @@ export async function maybeCreateDynamicAgent(params: {
   runtime: PluginRuntime;
   accountId: string;
   senderOpenId: string;
+  canCreateForConfig: (cfg: OpenClawConfig) => Promise<boolean>;
   log: (msg: string) => void;
 }): Promise<MaybeCreateDynamicAgentResult> {
-  const { cfg, runtime, accountId, senderOpenId, log } = params;
+  const { cfg, runtime, senderOpenId, canCreateForConfig, log } = params;
+  const accountId = normalizeAccountId(params.accountId);
 
-  if (hasDirectBinding(cfg, senderOpenId)) {
+  if (hasDirectBinding(cfg, accountId, senderOpenId)) {
     return { created: false, updatedCfg: cfg };
   }
 
   const currentCfg = runtime.config.current() as OpenClawConfig;
-  if (hasDirectBinding(currentCfg, senderOpenId)) {
+  if (hasDirectBinding(currentCfg, accountId, senderOpenId)) {
     return { created: false, updatedCfg: currentCfg };
   }
 
@@ -85,6 +90,9 @@ export async function maybeCreateDynamicAgent(params: {
     );
     return { created: false, updatedCfg: currentCfg };
   }
+  if (!(await canCreateForConfig(currentCfg))) {
+    return { created: false, updatedCfg: currentCfg };
+  }
 
   const agentId = `feishu-${senderOpenId}`;
 
@@ -94,7 +102,7 @@ export async function maybeCreateDynamicAgent(params: {
     base: "runtime",
     afterWrite: { mode: "auto" },
     mutate: async (draft) => {
-      if (hasDirectBinding(draft, senderOpenId)) {
+      if (hasDirectBinding(draft, accountId, senderOpenId)) {
         return { created: false };
       }
 
@@ -109,6 +117,9 @@ export async function maybeCreateDynamicAgent(params: {
         log(
           `feishu: maxAgents limit (${dynamicCfg.maxAgents}) reached, not creating agent for ${senderOpenId}`,
         );
+        return { created: false };
+      }
+      if (!(await canCreateForConfig(draft))) {
         return { created: false };
       }
 
@@ -141,6 +152,7 @@ export async function maybeCreateDynamicAgent(params: {
           agentId,
           match: {
             channel: "feishu",
+            accountId,
             peer: { kind: "direct", id: senderOpenId },
           },
         },

--- a/extensions/feishu/src/dynamic-agent.ts
+++ b/extensions/feishu/src/dynamic-agent.ts
@@ -127,7 +127,7 @@ export async function maybeCreateDynamicAgent(params: {
 
   return {
     created: committed.result?.created ?? false,
-    updatedCfg: committed.nextConfig,
+    updatedCfg: runtime.config.current() as OpenClawConfig,
     agentId: committed.result?.agentId,
   };
 }

--- a/extensions/feishu/src/dynamic-agent.ts
+++ b/extensions/feishu/src/dynamic-agent.ts
@@ -19,6 +19,12 @@ type DynamicAgentMutationResult = {
   agentId?: string;
 };
 
+class DynamicAgentMutationSkipped extends Error {
+  constructor(readonly cfg: OpenClawConfig) {
+    super("dynamic agent mutation skipped");
+  }
+}
+
 function hasDirectBinding(cfg: OpenClawConfig, accountId: string, senderOpenId: string): boolean {
   const normalizedAccountId = normalizeAccountId(accountId);
   return (cfg.bindings ?? []).some(
@@ -84,7 +90,9 @@ export async function maybeCreateDynamicAgent(params: {
     log(`feishu: config writes disabled, not creating agent for ${senderOpenId}`);
     return { created: false, updatedCfg: currentCfg };
   }
-  if (isAtDynamicAgentLimit(currentCfg, currentDynamicCfg)) {
+  const agentId = `feishu-${senderOpenId}`;
+  const currentAgentExists = (currentCfg.agents?.list ?? []).some((agent) => agent.id === agentId);
+  if (!currentAgentExists && isAtDynamicAgentLimit(currentCfg, currentDynamicCfg)) {
     log(
       `feishu: maxAgents limit (${currentDynamicCfg.maxAgents}) reached, not creating agent for ${senderOpenId}`,
     );
@@ -94,72 +102,84 @@ export async function maybeCreateDynamicAgent(params: {
     return { created: false, updatedCfg: currentCfg };
   }
 
-  const agentId = `feishu-${senderOpenId}`;
-
   // The config mutation lock owns the final duplicate/limit checks. This keeps
   // simultaneous DM creations and policy updates from producing stale writes.
-  const committed = await runtime.config.mutateConfigFile<DynamicAgentMutationResult>({
-    base: "runtime",
-    afterWrite: { mode: "auto" },
-    mutate: async (draft) => {
-      if (hasDirectBinding(draft, accountId, senderOpenId)) {
-        return { created: false };
-      }
+  let skippedCfg: OpenClawConfig | undefined;
+  const committed = await runtime.config
+    .mutateConfigFile<DynamicAgentMutationResult>({
+      base: "runtime",
+      afterWrite: { mode: "auto" },
+      mutate: async (draft) => {
+        if (hasDirectBinding(draft, accountId, senderOpenId)) {
+          throw new DynamicAgentMutationSkipped(draft);
+        }
 
-      const dynamicCfg = resolveDynamicAgentConfig(draft, accountId);
-      if (
-        !dynamicCfg?.enabled ||
-        !resolveChannelConfigWrites({ cfg: draft, channelId: "feishu", accountId })
-      ) {
-        return { created: false };
-      }
-      if (isAtDynamicAgentLimit(draft, dynamicCfg)) {
-        log(
-          `feishu: maxAgents limit (${dynamicCfg.maxAgents}) reached, not creating agent for ${senderOpenId}`,
-        );
-        return { created: false };
-      }
-      if (!(await canCreateForConfig(draft))) {
-        return { created: false };
-      }
+        const dynamicCfg = resolveDynamicAgentConfig(draft, accountId);
+        if (
+          !dynamicCfg?.enabled ||
+          !resolveChannelConfigWrites({ cfg: draft, channelId: "feishu", accountId })
+        ) {
+          throw new DynamicAgentMutationSkipped(draft);
+        }
+        const agentExists = (draft.agents?.list ?? []).some((agent) => agent.id === agentId);
+        if (!agentExists && isAtDynamicAgentLimit(draft, dynamicCfg)) {
+          log(
+            `feishu: maxAgents limit (${dynamicCfg.maxAgents}) reached, not creating agent for ${senderOpenId}`,
+          );
+          throw new DynamicAgentMutationSkipped(draft);
+        }
+        if (!(await canCreateForConfig(draft))) {
+          throw new DynamicAgentMutationSkipped(draft);
+        }
 
-      if (!(draft.agents?.list ?? []).some((agent) => agent.id === agentId)) {
-        const workspaceTemplate = dynamicCfg.workspaceTemplate ?? "~/.openclaw/workspace-{agentId}";
-        const agentDirTemplate =
-          dynamicCfg.agentDirTemplate ?? "~/.openclaw/agents/{agentId}/agent";
-        const workspace = resolveUserPath(
-          workspaceTemplate.replace("{userId}", senderOpenId).replace("{agentId}", agentId),
-        );
-        const agentDir = resolveUserPath(
-          agentDirTemplate.replace("{userId}", senderOpenId).replace("{agentId}", agentId),
-        );
-        log(`feishu: creating dynamic agent "${agentId}" for user ${senderOpenId}`);
-        log(`  workspace: ${workspace}`);
-        log(`  agentDir: ${agentDir}`);
-        await fs.promises.mkdir(workspace, { recursive: true });
-        await fs.promises.mkdir(agentDir, { recursive: true });
-        draft.agents = {
-          ...draft.agents,
-          list: [...(draft.agents?.list ?? []), { id: agentId, workspace, agentDir }],
-        };
-      } else {
-        log(`feishu: agent "${agentId}" exists, adding missing binding for ${senderOpenId}`);
-      }
+        if (!agentExists) {
+          const workspaceTemplate =
+            dynamicCfg.workspaceTemplate ?? "~/.openclaw/workspace-{agentId}";
+          const agentDirTemplate =
+            dynamicCfg.agentDirTemplate ?? "~/.openclaw/agents/{agentId}/agent";
+          const workspace = resolveUserPath(
+            workspaceTemplate.replace("{userId}", senderOpenId).replace("{agentId}", agentId),
+          );
+          const agentDir = resolveUserPath(
+            agentDirTemplate.replace("{userId}", senderOpenId).replace("{agentId}", agentId),
+          );
+          log(`feishu: creating dynamic agent "${agentId}" for user ${senderOpenId}`);
+          log(`  workspace: ${workspace}`);
+          log(`  agentDir: ${agentDir}`);
+          await fs.promises.mkdir(workspace, { recursive: true });
+          await fs.promises.mkdir(agentDir, { recursive: true });
+          draft.agents = {
+            ...draft.agents,
+            list: [...(draft.agents?.list ?? []), { id: agentId, workspace, agentDir }],
+          };
+        } else {
+          log(`feishu: agent "${agentId}" exists, adding missing binding for ${senderOpenId}`);
+        }
 
-      draft.bindings = [
-        ...(draft.bindings ?? []),
-        {
-          agentId,
-          match: {
-            channel: "feishu",
-            accountId,
-            peer: { kind: "direct", id: senderOpenId },
+        draft.bindings = [
+          ...(draft.bindings ?? []),
+          {
+            agentId,
+            match: {
+              channel: "feishu",
+              accountId,
+              peer: { kind: "direct", id: senderOpenId },
+            },
           },
-        },
-      ];
-      return { created: true, agentId };
-    },
-  });
+        ];
+        return { created: true, agentId };
+      },
+    })
+    .catch((error: unknown) => {
+      if (error instanceof DynamicAgentMutationSkipped) {
+        skippedCfg = error.cfg;
+        return null;
+      }
+      throw error;
+    });
+  if (!committed) {
+    return { created: false, updatedCfg: skippedCfg ?? currentCfg };
+  }
 
   return {
     created: committed.result?.created ?? false,


### PR DESCRIPTION
## What

When Feishu's `dynamicAgentCreation` writes a new binding via `runtime.config.replaceConfigFile()`, the in-memory `cfg` object passed to the handler is NOT updated. Subsequent messages reuse the stale `cfg`, so new bindings are invisible to `resolveAgentRoute`. The route matches as `"default"` every time, and `maybeCreateDynamicAgent` returns `{ created: false }` without providing the updated config.

This PR adds two checks:
1. In `maybeCreateDynamicAgent`: after checking the in-memory `cfg`, also check `runtime.config.current()` (the runtime's in-memory snapshot which may have hot-reloaded after a config write). Return the runtime's current config when the binding is found there but not in the stale `cfg`.
2. In `handleFeishuMessage`: when `result.updatedCfg` differs from the input `cfg`, re-resolve the route with the updated config so the existing binding is picked up.

## Why

Fixes #42837. The `dynamicAgentCreation` feature creates agent bindings for new Feishu users, but after the first message creates the binding, all subsequent messages still route to the default agent because the in-memory config is stale.

## Real behavior proof

- **Behavior addressed:** Feishu dynamicAgentCreation re-routing when binding already exists in runtime config
- **Environment tested:** macOS 26.4.1, Node v24.4.0, openclaw main @ 274b7b1d
- **Steps run after the patch:**
  1. Cherry-picked fix onto fresh upstream/main
  2. Verified `runtime.config.current()` check exists in `dynamic-agent.ts`
  3. Verified `updatedCfg !== cfg` re-resolve logic exists in `bot.ts`
  4. Ran dynamic-agent tests — 4 passed
  5. Ran full build — passed

- **Evidence after fix:**

```
$ grep -n 'runtime.config.current\|hasBindingInCurrentCfg\|updatedCfg.*cfg' extensions/feishu/src/dynamic-agent.ts
30:    return { created: false, updatedCfg: cfg };
45:    return { created: false, updatedCfg: cfg };
50:  const currentCfg = runtime.config.current() as OpenClawConfig;
52:  const hasBindingInCurrentCfg = currentBindings.some(
59:  if (hasBindingInCurrentCfg) {
72:      return { created: false, updatedCfg: cfg };

$ grep -n 'updatedCfg.*cfg\|effectiveCfg.*result' extensions/feishu/src/bot.ts
855:          effectiveCfg = result.updatedCfg;
866:        } else if (result.updatedCfg && result.updatedCfg !== cfg) {
870:          effectiveCfg = result.updatedCfg;

$ node scripts/run-vitest.mjs run extensions/feishu/src/dynamic-agent.test.ts
 ✓  extension-feishu  extensions/feishu/src/dynamic-agent.test.ts (4 tests) 5ms
 Test Files  1 passed (1)
      Tests  4 passed (4)

$ pnpm build
 ✓ built in 511ms
```

- **Observed result after fix:** The runtime config snapshot is checked when in-memory cfg is stale. Route is re-resolved with updated config when binding exists in runtime but not in stale cfg. All 4 dynamic-agent tests pass, build succeeds.
- **What was not tested:** Live Feishu message flow (requires Feishu bot token and real user interaction). The fix is verified through code inspection and unit tests covering the `maybeCreateDynamicAgent` function.
