### PR TITLE
fix(google): route Gemini CLI OAuth through the env proxy (#46184)

### DIFF
--- a/extensions/google/oauth.http.proxy.test.ts
+++ b/extensions/google/oauth.http.proxy.test.ts
@@ -1,0 +1,121 @@
+// Google tests cover oauth.http proxy-mode selection for the Gemini CLI OAuth
+// token-exchange/identity calls (issue openclaw#46184).
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TOKEN_URL } from "./oauth.shared.js";
+
+const fetchWithSsrFGuardMock = vi.fn();
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
+    "openclaw/plugin-sdk/ssrf-runtime",
+  );
+  return {
+    ...actual,
+    fetchWithSsrFGuard: (params: unknown) => fetchWithSsrFGuardMock(params),
+  };
+});
+
+const { fetchWithTimeout } = await import("./oauth.http.js");
+
+const PROXY_ENV_KEYS = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+  "no_proxy",
+] as const;
+
+const savedEnv = new Map<string, string | undefined>();
+
+type ProxyEnvOverrides = {
+  HTTP_PROXY?: string;
+  HTTPS_PROXY?: string;
+  ALL_PROXY?: string;
+  NO_PROXY?: string;
+};
+
+function setProxyEnv(values: ProxyEnvOverrides): void {
+  for (const key of PROXY_ENV_KEYS) {
+    delete process.env[key];
+  }
+  if (values.HTTP_PROXY !== undefined) {
+    process.env.HTTP_PROXY = values.HTTP_PROXY;
+  }
+  if (values.HTTPS_PROXY !== undefined) {
+    process.env.HTTPS_PROXY = values.HTTPS_PROXY;
+  }
+  if (values.ALL_PROXY !== undefined) {
+    process.env.ALL_PROXY = values.ALL_PROXY;
+  }
+  if (values.NO_PROXY !== undefined) {
+    process.env.NO_PROXY = values.NO_PROXY;
+  }
+}
+
+function lastGuardedOptions(): Record<string, unknown> {
+  const call = fetchWithSsrFGuardMock.mock.calls.at(-1)?.[0];
+  if (!call || typeof call !== "object") {
+    throw new Error("Expected fetchWithSsrFGuard to be called");
+  }
+  return call as Record<string, unknown>;
+}
+
+describe("oauth.http fetchWithTimeout proxy selection", () => {
+  beforeEach(() => {
+    for (const key of PROXY_ENV_KEYS) {
+      savedEnv.set(key, process.env[key]);
+    }
+    fetchWithSsrFGuardMock.mockReset();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response("{}", { status: 200 }),
+      finalUrl: TOKEN_URL,
+      release: async () => {},
+    });
+  });
+
+  afterEach(() => {
+    for (const [key, value] of savedEnv) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    savedEnv.clear();
+  });
+
+  it("routes the Google token exchange through the env proxy when configured", async () => {
+    setProxyEnv({ HTTPS_PROXY: "http://127.0.0.1:7897", HTTP_PROXY: "http://127.0.0.1:7897" });
+
+    await fetchWithTimeout(TOKEN_URL, { method: "POST", body: "grant_type=refresh_token" });
+
+    expect(lastGuardedOptions().mode).toBe("trusted_env_proxy");
+  });
+
+  it("keeps the strict default when no proxy is configured", async () => {
+    setProxyEnv({});
+
+    await fetchWithTimeout(TOKEN_URL, { method: "POST" });
+
+    expect(lastGuardedOptions().mode).toBeUndefined();
+  });
+
+  it("keeps the strict default when NO_PROXY bypasses the target host", async () => {
+    setProxyEnv({ HTTPS_PROXY: "http://127.0.0.1:7897", NO_PROXY: "googleapis.com" });
+
+    await fetchWithTimeout(TOKEN_URL, { method: "POST" });
+
+    expect(lastGuardedOptions().mode).toBeUndefined();
+  });
+
+  it("keeps the strict default for ALL_PROXY-only environments", async () => {
+    setProxyEnv({ ALL_PROXY: "http://127.0.0.1:7897" });
+
+    await fetchWithTimeout(TOKEN_URL, { method: "POST" });
+
+    expect(lastGuardedOptions().mode).toBeUndefined();
+  });
+});

--- a/extensions/google/oauth.http.ts
+++ b/extensions/google/oauth.http.ts
@@ -1,4 +1,8 @@
 // Google plugin module implements oauth.http behavior.
+import {
+  shouldUseEnvHttpProxyForUrl,
+  withTrustedEnvProxyGuardedFetchMode,
+} from "openclaw/plugin-sdk/fetch-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { DEFAULT_FETCH_TIMEOUT_MS } from "./oauth.shared.js";
 
@@ -7,11 +11,12 @@ export async function fetchWithTimeout(
   init: RequestInit,
   timeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
 ): Promise<Response> {
-  const { response, release } = await fetchWithSsrFGuard({
-    url,
-    init,
-    timeoutMs,
-  });
+  const guardedOptions = { url, init, timeoutMs };
+  const { response, release } = await fetchWithSsrFGuard(
+    shouldUseEnvHttpProxyForUrl(url)
+      ? withTrustedEnvProxyGuardedFetchMode(guardedOptions)
+      : guardedOptions,
+  );
   try {
     const body = await response.arrayBuffer();
     return new Response(body, {


### PR DESCRIPTION
## Summary

Logging into the `google-gemini-cli` provider behind an HTTP(S) proxy fails with `TypeError: fetch failed`, even though the proxy can reach every Google endpoint (curl confirms it) and the Gemini API key provider works in the same environment (openclaw#46184).

The fix makes the Gemini CLI OAuth HTTP helper (`extensions/google/oauth.http.ts`) auto-upgrade to trusted env-proxy mode when `HTTP_PROXY`/`HTTPS_PROXY` is configured for the target, mirroring what the data-plane provider transport already does. This routes token exchange, identity discovery, and project onboarding through the configured proxy instead of bypassing it.

## Root cause

Every Gemini CLI OAuth network call (token exchange in `oauth.token.ts`, userinfo + `cloudcode-pa` onboarding in `oauth.project.ts`) funnels through one helper:

```ts
// extensions/google/oauth.http.ts (before)
const { response, release } = await fetchWithSsrFGuard({ url, init, timeoutMs });
```

`fetchWithSsrFGuard` with no `mode` runs in `STRICT` mode, which pins DNS locally: it calls `resolvePinnedHostnameWithPolicy(hostname)` (a Node `dns.lookup`) and dials the resolved IP directly, bypassing the proxy. In a proxy-only environment where only the proxy has egress/DNS (corporate proxies, containers, Clash TUN fake-IP on macOS) that local resolution/direct dial fails, surfacing through `fetch` as `TypeError: fetch failed`. The OAuth flow never reaches the proxy.

The data plane does not have this problem because `provider-transport-fetch.ts` already auto-upgrades to `TRUSTED_ENV_PROXY` via `shouldUseEnvHttpProxyForUrl(url)` (and `media-understanding/shared.ts` documents the identical "Clash TUN fake-IP / EAI_AGAIN in proxy-only env" failure mode it was added for). That is exactly why the Gemini API key provider works while `google-gemini-cli` OAuth login does not. The OAuth/login surface was simply never moved onto the same proxy-aware path.

## Fix

`fetchWithTimeout` now opts into trusted env-proxy mode for the fixed Google OAuth hosts when an env proxy applies:

```ts
const guardedOptions = { url, init, timeoutMs };
const { response, release } = await fetchWithSsrFGuard(
  shouldUseEnvHttpProxyForUrl(url)
    ? withTrustedEnvProxyGuardedFetchMode(guardedOptions)
    : guardedOptions,
);
```

Both helpers are already public via `openclaw/plugin-sdk/fetch-runtime`. This is the single chokepoint for the whole OAuth surface, so token exchange, refresh, userinfo, and onboarding are all covered by one change.

## Why not one-sided

- `fetchWithTimeout` is the only network helper used by the Gemini CLI OAuth flow (`oauth.token.ts` and `oauth.project.ts` both call it; `oauth.credentials.ts` is local file extraction only), so fixing it covers token exchange, refresh, identity, and project onboarding together.
- The gating uses the same `shouldUseEnvHttpProxyForUrl` helper as the data-plane sibling, so it inherits its SSRF-safe carve-outs: it stays in strict pinned-DNS mode when no proxy is set, when `NO_PROXY` bypasses the host, and for `ALL_PROXY`-only environments (which `EnvHttpProxyAgent` ignores). The trusted env-proxy branch still runs `assertHostnameAllowedWithPolicy` before dialing, so hostname policy is preserved.
- Behavior with no proxy configured is unchanged (mode stays `undefined` / strict).

## Verification

- `node scripts/run-vitest.mjs extensions/google/oauth.http.proxy.test.ts` -> 4 passed (proxy upgrade, no-proxy strict, NO_PROXY strict, ALL_PROXY strict).
- `npx oxfmt --check extensions/google/oauth.http.ts extensions/google/oauth.http.proxy.test.ts` -> all files correctly formatted.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json <files>` -> clean.
- `pnpm tsgo:extensions` + `pnpm tsgo:extensions:test` -> clean.

## Real behavior proof

Behavior addressed: `google-gemini-cli` OAuth login/refresh now routes through the configured HTTP(S) proxy instead of doing a local DNS pre-resolution that bypasses the proxy and fails with `TypeError: fetch failed`.

Real environment tested: a throwaway harness (not committed) drove the real production `fetchWithSsrFGuard` and the patched `fetchWithTimeout` against a non-resolvable OAuth host (`oauth2.googleapis.test.invalid`, RFC 6761) with a real local CONNECT-tunneling proxy as the only egress, emulating a Clash fake-IP / proxy-only macOS env.

Exact steps or command run after this patch: set `HTTP_PROXY`/`HTTPS_PROXY` to the local proxy, then (1) call the old strict path `fetchWithSsrFGuard({ url, init })` and (2) call the patched `fetchWithTimeout(url, init)`; the proxy increments a counter on every CONNECT it tunnels to the local origin.

Evidence after fix:

```
# BEFORE (strict default = old oauth.http behavior)
[before] threw: getaddrinfo ENOTFOUND oauth2.googleapis.test.invalid
[before] proxyConnects=0 (proxy never reached)

# AFTER (patched fetchWithTimeout)
[proxy] CONNECT oauth2.googleapis.test.invalid:80 -> 127.0.0.1:37991
[after] status=200 access_token=ya29.viaproxy
[after] proxyConnects=1 (request went through the proxy)
```

Observed result after fix: the same OAuth request that previously failed with a local DNS error and never touched the proxy now tunnels through the proxy and returns the token JSON (HTTP 200).

What was not tested: a live end-to-end Google sign-in behind a real Clash Verge proxy on macOS hardware; this change is in the HTTP helper layer and is covered by the colocated regression test plus the real-proxy before/after harness above.

Fixes #46184
