### PR TITLE
fix(cron): trust agent output when channel is unresolved without explicit delivery

### DIFF
--- a/src/cron/isolated-agent/channel-output-policy.test.ts
+++ b/src/cron/isolated-agent/channel-output-policy.test.ts
@@ -56,6 +56,16 @@ describe("cron channel output policy", () => {
     ).resolves.toEqual({
       preferFinalAssistantVisibleText: false,
     });
+    // deliveryRequested is optional — undefined and missing opts are
+    // equivalent to "not requested" (no channel to deliver to). #90664
+    await expect(
+      resolveCronChannelOutputPolicy(undefined, { deliveryRequested: undefined }),
+    ).resolves.toEqual({
+      preferFinalAssistantVisibleText: true,
+    });
+    await expect(resolveCronChannelOutputPolicy(undefined)).resolves.toEqual({
+      preferFinalAssistantVisibleText: true,
+    });
   });
 
   it("lets channel plugins format current tool context targets", async () => {

--- a/src/cron/isolated-agent/channel-output-policy.ts
+++ b/src/cron/isolated-agent/channel-output-policy.ts
@@ -21,7 +21,7 @@ export async function resolveCronChannelOutputPolicy(
 }> {
   const channelId = normalizeOptionalLowercaseString(channel);
   if (!channelId) {
-    return { preferFinalAssistantVisibleText: opts?.deliveryRequested === false };
+    return { preferFinalAssistantVisibleText: opts?.deliveryRequested !== true };
   }
   const { getChannelPlugin } = await loadChannelPluginRuntime();
   return {


### PR DESCRIPTION
## Summary

`--no-deliver` cron jobs that encounter recoverable tool warnings were marked `status: error` even when the agent successfully produced a final answer.

The basic fix (`deliveryRequested === false`) was already implemented on main, but it missed the edge case where `deliveryRequested` is `undefined` — which happens in the `run-executor.ts` code path where the field is typed `?: boolean`.

## Fix

One character in `src/cron/isolated-agent/channel-output-policy.ts`:

```diff
- return { preferFinalAssistantVisibleText: opts?.deliveryRequested === false };
+ return { preferFinalAssistantVisibleText: opts?.deliveryRequested !== true };
```

When no channel exists, trust the agent's final visible text unless delivery was **explicitly** requested (`=== true`). `false`, `undefined`, and missing opts all mean "not requested" → allow the rescue path.

This closes the gap left by the earlier fix: `=== false` works for `run.ts` (where `deliveryRequested` is always `boolean`), but fails for `run-executor.ts` (where it's `?: boolean` and can be `undefined`).

## Files changed

- `src/cron/isolated-agent/channel-output-policy.ts`: +1/-1
- `src/cron/isolated-agent/channel-output-policy.test.ts`: +10 (undefined + missing opts cases)

## Related

Fixes #90664

Context: @TurboTheTurtle confirmed the basic `=== false` fix was already on main but missed the `undefined` edge case in `run-executor.ts` (June 13 comment).

### Real behavior proof

- **Behavior addressed**: `resolveCronChannelOutputPolicy` returns `false` when `deliveryRequested` is `undefined` or not passed — `=== false` only matches explicit `false`, but `?: boolean` means `undefined` is a real runtime value in `run-executor.ts`
- **Real environment tested**: Linux Node 24, production code imported via `node --import tsx`
- **Exact steps or command run after this patch**:
  ```bash
  $ node --import tsx -e "
  import { resolveCronChannelOutputPolicy } from './src/cron/isolated-agent/channel-output-policy.js';
  console.log('undefined:', (await resolveCronChannelOutputPolicy(undefined, { deliveryRequested: undefined })).preferFinalAssistantVisibleText);
  console.log('no opts:', (await resolveCronChannelOutputPolicy(undefined)).preferFinalAssistantVisibleText);
  "
  ```
- **Evidence after fix**:
  ```console
  $ node --import tsx -e "
  import { resolveCronChannelOutputPolicy } from './src/cron/isolated-agent/channel-output-policy.js';
  const r = (v) => resolveCronChannelOutputPolicy(undefined, v);
  console.log('false:    ', (await r({ deliveryRequested: false })).preferFinalAssistantVisibleText);
  console.log('true:     ', (await r({ deliveryRequested: true })).preferFinalAssistantVisibleText);
  console.log('undefined:', (await r({ deliveryRequested: undefined })).preferFinalAssistantVisibleText);
  console.log('no opts:  ', (await resolveCronChannelOutputPolicy(undefined)).preferFinalAssistantVisibleText);
  "
  false:     true
  true:      false
  undefined: true    ← was false before the fix
  no opts:   true    ← was false before the fix
  ```
- **Observed result after fix**: `false`, `undefined`, and missing opts all correctly return `true` — the rescue path in `resolveCronPayloadOutcome` is no longer blocked for `--no-deliver` cron when `deliveryRequested` comes through `run-executor.ts` as `undefined`. Explicit `true` (delivery requested) still correctlys returns `false`.
- **What was not tested**: Full `--no-deliver` cron run with a real agent producing recoverable tool warnings via the `run-executor.ts` path; the function-level edge case is verified through direct import

🤖 Generated with [Claude Code](https://claude.com/claude-code)
