### PR TITLE
Fix stale auto-fallback origin model selection

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -261,7 +261,7 @@ vi.mock("../config/sessions.js", () => ({
 vi.mock("../config/sessions/transcript-resolve.runtime.js", () => ({
   resolveSessionTranscriptFile: async () => ({
     sessionFile: "/tmp/session.jsonl",
-    sessionEntry: { sessionId: "session-1", updatedAt: Date.now() },
+    sessionEntry: state.sessionEntryMock ?? { sessionId: "session-1", updatedAt: Date.now() },
   }),
 }));
 
@@ -344,7 +344,64 @@ vi.mock("../sessions/level-overrides.js", () => ({
 }));
 
 vi.mock("../sessions/model-overrides.js", () => ({
-  applyModelOverrideToSessionEntry: () => ({ updated: false }),
+  applyModelOverrideToSessionEntry: ({
+    entry,
+    selection,
+    profileOverride,
+    preserveAuthProfileOverride,
+  }: {
+    entry: SessionEntry;
+    selection: { provider: string; model: string; isDefault?: boolean };
+    profileOverride?: string;
+    preserveAuthProfileOverride?: boolean;
+  }) => {
+    let updated = false;
+    if (selection.isDefault) {
+      for (const key of [
+        "providerOverride",
+        "modelOverride",
+        "modelOverrideSource",
+        "modelOverrideFallbackOriginProvider",
+        "modelOverrideFallbackOriginModel",
+      ] as const) {
+        if (entry[key] !== undefined) {
+          delete entry[key];
+          updated = true;
+        }
+      }
+    } else {
+      if (entry.providerOverride !== selection.provider) {
+        entry.providerOverride = selection.provider;
+        updated = true;
+      }
+      if (entry.modelOverride !== selection.model) {
+        entry.modelOverride = selection.model;
+        updated = true;
+      }
+    }
+    if (profileOverride) {
+      if (entry.authProfileOverride !== profileOverride) {
+        entry.authProfileOverride = profileOverride;
+        updated = true;
+      }
+      if (entry.authProfileOverrideSource !== "user") {
+        entry.authProfileOverrideSource = "user";
+        updated = true;
+      }
+    } else if (!preserveAuthProfileOverride) {
+      for (const key of [
+        "authProfileOverride",
+        "authProfileOverrideSource",
+        "authProfileOverrideCompactionCount",
+      ] as const) {
+        if (entry[key] !== undefined) {
+          delete entry[key];
+          updated = true;
+        }
+      }
+    }
+    return { updated };
+  },
   repairProviderWrappedModelOverride: () => ({ updated: false }),
 }));
 
@@ -377,7 +434,25 @@ vi.mock("../utils/message-channel.js", () => ({
 }));
 
 vi.mock("./agent-scope.js", () => ({
-  clearAutoFallbackPrimaryProbeSelection: vi.fn(),
+  clearAutoFallbackPrimaryProbeSelection: vi.fn((entry: SessionEntry) => {
+    delete entry.providerOverride;
+    delete entry.modelOverride;
+    delete entry.modelOverrideSource;
+    delete entry.modelOverrideFallbackOriginProvider;
+    delete entry.modelOverrideFallbackOriginModel;
+    if (
+      entry.authProfileOverrideSource === "auto" ||
+      (entry.authProfileOverrideSource === undefined &&
+        entry.authProfileOverrideCompactionCount !== undefined)
+    ) {
+      delete entry.authProfileOverride;
+      delete entry.authProfileOverrideSource;
+      delete entry.authProfileOverrideCompactionCount;
+    }
+    delete entry.fallbackNoticeSelectedModel;
+    delete entry.fallbackNoticeActiveModel;
+    delete entry.fallbackNoticeReason;
+  }),
   entryMatchesAutoFallbackPrimaryProbe: () => true,
   hasLegacyAutoFallbackWithoutOrigin: (entry: unknown) =>
     state.hasLegacyAutoFallbackWithoutOriginMock(entry),
@@ -641,6 +716,28 @@ vi.mock("./model-selection.js", () => {
             ? { provider: raw.slice(0, slash), model: raw.slice(slash + 1) }
             : { provider: defaultProvider, model: raw },
       };
+    },
+    resolvePersistedOverrideModelRef: ({
+      defaultProvider,
+      overrideProvider,
+      overrideModel,
+    }: {
+      defaultProvider: string;
+      overrideProvider?: string;
+      overrideModel?: string;
+    }) => {
+      const model = overrideModel?.trim();
+      if (!model) {
+        return null;
+      }
+      const provider = overrideProvider?.trim();
+      if (provider) {
+        return { provider, model };
+      }
+      const slash = model.indexOf("/");
+      return slash > 0
+        ? { provider: model.slice(0, slash), model: model.slice(slash + 1) }
+        : { provider: defaultProvider, model };
     },
     resolveConfiguredModelRef: ({ cfg }: { cfg?: unknown }) => {
       const raw = (cfg as { agents?: { defaults?: { model?: string | { primary?: string } } } })
@@ -1675,6 +1772,336 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     const fallbackParams = mockCallArg(state.runWithModelFallbackMock) as FallbackRunnerParams;
     expect(fallbackParams.provider).toBe("openai");
     expect(fallbackParams.model).toBe("channel-model");
+  });
+
+  it("prepares stale auto-fallback origin pins as primary attempts without fallback auth", async () => {
+    setupSingleAttemptFallback();
+    state.runtimeConfigMock = {
+      agents: {
+        defaults: {
+          model: "anthropic/default-model",
+          models: {
+            "anthropic/default-model": {},
+            "anthropic/fallback-model": {},
+            "openai/channel-model": {},
+          },
+        },
+      },
+      channels: {
+        modelByChannel: {
+          discord: {
+            "channel-123": "openai/channel-model",
+          },
+        },
+      },
+    };
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      channel: "discord",
+      groupId: "channel-123",
+      providerOverride: "anthropic",
+      modelOverride: "fallback-model",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "old-channel-model",
+      authProfileOverride: "anthropic:fallback",
+      authProfileOverrideSource: "auto",
+      skillsSnapshot: { prompt: "", skills: [], version: 0 },
+    };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = { "agent:main:main": sessionEntry };
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "channel-model"));
+
+    await runBasicAgentCommand();
+
+    const fallbackParams = mockCallArg(state.runWithModelFallbackMock) as FallbackRunnerParams;
+    expect(fallbackParams.provider).toBe("openai");
+    expect(fallbackParams.model).toBe("channel-model");
+    expectRecordFields(mockCallArg(state.resolveEffectiveModelFallbacksMock), {
+      hasSessionModelOverride: false,
+      hasAutoFallbackProvenance: false,
+    });
+    const attemptParams = requireRecord(mockCallArg(state.runAgentAttemptMock), "attempt params");
+    const attemptEntry = requireRecord(attemptParams.sessionEntry, "attempt session entry");
+    expect(attemptEntry.providerOverride).toBeUndefined();
+    expect(attemptEntry.modelOverride).toBeUndefined();
+    expect(attemptEntry.modelOverrideSource).toBeUndefined();
+    expect(attemptEntry.authProfileOverride).toBeUndefined();
+    expect(attemptEntry.authProfileOverrideSource).toBeUndefined();
+    const cleanupWrite = state.persistSessionEntryMock.mock.calls
+      .map((call) => call[0] as { entry?: SessionEntry; shouldPersist?: unknown })
+      .find(
+        (params) =>
+          params.shouldPersist &&
+          params.entry?.providerOverride === undefined &&
+          params.entry?.modelOverride === undefined &&
+          params.entry?.authProfileOverride === undefined,
+      );
+    expect(cleanupWrite).toBeDefined();
+  });
+
+  it("does not persist stale auto-fallback origin cleanup after exhausted fallback runs", async () => {
+    state.runtimeConfigMock = {
+      agents: {
+        defaults: {
+          model: "openai/primary-model",
+          models: {
+            "openai/primary-model": {},
+            "anthropic/fallback-model": {},
+          },
+        },
+      },
+    };
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      providerOverride: "anthropic",
+      modelOverride: "fallback-model",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "old-primary-model",
+      authProfileOverride: "anthropic:fallback",
+      authProfileOverrideSource: "auto",
+      skillsSnapshot: { prompt: "", skills: [], version: 0 },
+    };
+    const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = sessionStore;
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "primary-model"));
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      outcome: "exhausted",
+      result: await params.run(params.provider, params.model),
+      provider: params.provider,
+      model: params.model,
+      attempts: [
+        {
+          provider: params.provider,
+          model: params.model,
+          error: "all fallback candidates failed",
+          reason: "network",
+        },
+      ],
+    }));
+
+    await runBasicAgentCommand();
+
+    const attemptParams = requireRecord(mockCallArg(state.runAgentAttemptMock), "attempt params");
+    expectRecordFields(attemptParams, {
+      providerOverride: "openai",
+      modelOverride: "primary-model",
+    });
+    const cleanupWrite = state.persistSessionEntryMock.mock.calls
+      .map((call) => call[0] as { entry?: SessionEntry; shouldPersist?: unknown })
+      .find(
+        (params) =>
+          params.shouldPersist &&
+          params.entry?.providerOverride === undefined &&
+          params.entry?.modelOverride === undefined &&
+          params.entry?.authProfileOverride === undefined,
+      );
+    expect(cleanupWrite).toBeUndefined();
+    expectRecordFields(sessionStore["agent:main:main"], {
+      providerOverride: "anthropic",
+      modelOverride: "fallback-model",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "old-primary-model",
+      authProfileOverride: "anthropic:fallback",
+      authProfileOverrideSource: "auto",
+    });
+  });
+
+  it("preserves a direct stale auto-fallback pin that changes before cleanup persists", async () => {
+    setupSingleAttemptFallback();
+    state.runtimeConfigMock = {
+      agents: {
+        defaults: {
+          model: "anthropic/default-model",
+          models: {
+            "anthropic/default-model": {},
+            "anthropic/fallback-model": {},
+            "openai/channel-model": {},
+          },
+        },
+      },
+      channels: {
+        modelByChannel: {
+          discord: {
+            "channel-123": "openai/channel-model",
+          },
+        },
+      },
+    };
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      channel: "discord",
+      groupId: "channel-123",
+      providerOverride: "anthropic",
+      modelOverride: "fallback-model",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "old-channel-model",
+      authProfileOverride: "anthropic:fallback",
+      authProfileOverrideSource: "auto",
+      skillsSnapshot: { prompt: "", skills: [], version: 0 },
+    };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = { "agent:main:main": sessionEntry };
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.runAgentAttemptMock.mockImplementation(async () => {
+      const store = state.sessionStoreMock as Record<string, SessionEntry>;
+      store["agent:main:main"] = {
+        ...store["agent:main:main"],
+        providerOverride: "anthropic",
+        modelOverride: "newer-fallback-model",
+        modelOverrideSource: "auto",
+        modelOverrideFallbackOriginProvider: "openai",
+        modelOverrideFallbackOriginModel: "older-channel-model",
+        authProfileOverride: "anthropic:newer-fallback",
+        authProfileOverrideSource: "auto",
+        updatedAt: 2,
+      };
+      return makeSuccessResult("openai", "channel-model");
+    });
+
+    await runBasicAgentCommand();
+
+    const cleanupWrite = state.persistSessionEntryMock.mock.calls
+      .map((call) => call[0] as { entry?: SessionEntry; shouldPersist?: unknown })
+      .find(
+        (params) =>
+          params.shouldPersist &&
+          params.entry?.providerOverride === undefined &&
+          params.entry?.modelOverride === undefined &&
+          params.entry?.authProfileOverride === undefined,
+      );
+    expect(cleanupWrite).toBeDefined();
+    const stored = (state.sessionStoreMock as Record<string, SessionEntry>)["agent:main:main"];
+    expect(stored?.providerOverride).toBe("anthropic");
+    expect(stored?.modelOverride).toBe("newer-fallback-model");
+    expect(stored?.modelOverrideSource).toBe("auto");
+    expect(stored?.modelOverrideFallbackOriginProvider).toBe("openai");
+    expect(stored?.modelOverrideFallbackOriginModel).toBe("older-channel-model");
+    expect(stored?.authProfileOverride).toBe("anthropic:newer-fallback");
+    expect(stored?.authProfileOverrideSource).toBe("auto");
+  });
+
+  it("does not persist stale auto-fallback origin cleanup when preserving session model state", async () => {
+    setupSingleAttemptFallback();
+    state.runtimeConfigMock = {
+      agents: {
+        defaults: {
+          model: "openai/primary-model",
+          models: {
+            "openai/primary-model": {},
+            "anthropic/fallback-model": {},
+          },
+        },
+      },
+    };
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      providerOverride: "anthropic",
+      modelOverride: "fallback-model",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "old-primary-model",
+      authProfileOverride: "anthropic:fallback",
+      authProfileOverrideSource: "auto",
+      skillsSnapshot: { prompt: "", skills: [], version: 0 },
+    };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = { "agent:main:main": sessionEntry };
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "primary-model"));
+
+    await agentCommand({
+      message: "hello",
+      to: "+1234567890",
+      preserveUserFacingSessionModelState: true,
+      skipInitialSessionTouch: true,
+    });
+
+    const fallbackParams = mockCallArg(state.runWithModelFallbackMock) as FallbackRunnerParams;
+    expect(fallbackParams.provider).toBe("openai");
+    expect(fallbackParams.model).toBe("primary-model");
+    const attemptParams = requireRecord(mockCallArg(state.runAgentAttemptMock), "attempt params");
+    const attemptEntry = requireRecord(attemptParams.sessionEntry, "attempt session entry");
+    expect(attemptEntry.authProfileOverride).toBeUndefined();
+    const stored = (state.sessionStoreMock as Record<string, SessionEntry>)["agent:main:main"];
+    expect(stored?.providerOverride).toBe("anthropic");
+    expect(stored?.modelOverride).toBe("fallback-model");
+    expect(stored?.modelOverrideSource).toBe("auto");
+    expect(stored?.authProfileOverride).toBe("anthropic:fallback");
+  });
+
+  it("strips user-sourced incompatible stale-origin auth only from preserved direct attempts", async () => {
+    setupSingleAttemptFallback();
+    state.runtimeConfigMock = {
+      agents: {
+        defaults: {
+          model: "openai/primary-model",
+          models: {
+            "openai/primary-model": {},
+            "anthropic/fallback-model": {},
+          },
+        },
+      },
+    };
+    state.authProfileStoreMock = {
+      profiles: {
+        "anthropic:fallback": {
+          type: "api_key",
+          provider: "anthropic",
+          key: "sk-test",
+        },
+      },
+    };
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      providerOverride: "anthropic",
+      modelOverride: "fallback-model",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "old-primary-model",
+      authProfileOverride: "anthropic:fallback",
+      authProfileOverrideSource: "user",
+      skillsSnapshot: { prompt: "", skills: [], version: 0 },
+    };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = { "agent:main:main": sessionEntry };
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "primary-model"));
+
+    await agentCommand({
+      message: "hello",
+      to: "+1234567890",
+      preserveUserFacingSessionModelState: true,
+      skipInitialSessionTouch: true,
+    });
+
+    const fallbackParams = mockCallArg(state.runWithModelFallbackMock) as FallbackRunnerParams;
+    expect(fallbackParams.provider).toBe("openai");
+    expect(fallbackParams.model).toBe("primary-model");
+    const attemptParams = requireRecord(mockCallArg(state.runAgentAttemptMock), "attempt params");
+    const attemptEntry = requireRecord(attemptParams.sessionEntry, "attempt session entry");
+    expect(attemptEntry.providerOverride).toBeUndefined();
+    expect(attemptEntry.modelOverride).toBeUndefined();
+    expect(attemptEntry.authProfileOverride).toBeUndefined();
+    expect(attemptEntry.authProfileOverrideSource).toBeUndefined();
+    expect(state.clearSessionAuthProfileOverrideMock).not.toHaveBeenCalled();
+    const stored = (state.sessionStoreMock as Record<string, SessionEntry>)["agent:main:main"];
+    expect(stored?.providerOverride).toBe("anthropic");
+    expect(stored?.modelOverride).toBe("fallback-model");
+    expect(stored?.modelOverrideSource).toBe("auto");
+    expect(stored?.authProfileOverride).toBe("anthropic:fallback");
+    expect(stored?.authProfileOverrideSource).toBe("user");
   });
 
   it("uses current threaded session key for parent channel model overrides", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -88,6 +88,7 @@ import {
 import { isStoredCredentialCompatibleWithAuthProvider } from "./auth-profiles/order.js";
 import { clearSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
+import { isStaleAutoFallbackOriginOverride } from "./auto-fallback-stale-origin.js";
 import { isHeartbeatLifecycleRunKind } from "./bootstrap-mode.js";
 import {
   createAgentAttemptLifecycleCallbacks,
@@ -408,6 +409,61 @@ const OVERRIDE_FIELDS_CLEARED_BY_DELETE: OverrideFieldClearedByDelete[] = [
 ];
 
 const OVERRIDE_VALUE_MAX_LENGTH = 256;
+
+type StaleAutoFallbackOriginCleanupGuard = Pick<
+  SessionEntry,
+  | "providerOverride"
+  | "modelOverride"
+  | "modelOverrideSource"
+  | "modelOverrideFallbackOriginProvider"
+  | "modelOverrideFallbackOriginModel"
+  | "authProfileOverride"
+  | "authProfileOverrideSource"
+  | "authProfileOverrideCompactionCount"
+  | "fallbackNoticeSelectedModel"
+  | "fallbackNoticeActiveModel"
+  | "fallbackNoticeReason"
+>;
+
+function captureStaleAutoFallbackOriginCleanupGuard(
+  entry: SessionEntry,
+): StaleAutoFallbackOriginCleanupGuard {
+  return {
+    providerOverride: entry.providerOverride,
+    modelOverride: entry.modelOverride,
+    modelOverrideSource: entry.modelOverrideSource,
+    modelOverrideFallbackOriginProvider: entry.modelOverrideFallbackOriginProvider,
+    modelOverrideFallbackOriginModel: entry.modelOverrideFallbackOriginModel,
+    authProfileOverride: entry.authProfileOverride,
+    authProfileOverrideSource: entry.authProfileOverrideSource,
+    authProfileOverrideCompactionCount: entry.authProfileOverrideCompactionCount,
+    fallbackNoticeSelectedModel: entry.fallbackNoticeSelectedModel,
+    fallbackNoticeActiveModel: entry.fallbackNoticeActiveModel,
+    fallbackNoticeReason: entry.fallbackNoticeReason,
+  };
+}
+
+function entryMatchesStaleAutoFallbackOriginCleanupGuard(
+  entry: SessionEntry | undefined,
+  guard: StaleAutoFallbackOriginCleanupGuard | undefined,
+): boolean {
+  if (!entry || !guard) {
+    return false;
+  }
+  return (
+    entry.providerOverride === guard.providerOverride &&
+    entry.modelOverride === guard.modelOverride &&
+    entry.modelOverrideSource === guard.modelOverrideSource &&
+    entry.modelOverrideFallbackOriginProvider === guard.modelOverrideFallbackOriginProvider &&
+    entry.modelOverrideFallbackOriginModel === guard.modelOverrideFallbackOriginModel &&
+    entry.authProfileOverride === guard.authProfileOverride &&
+    entry.authProfileOverrideSource === guard.authProfileOverrideSource &&
+    entry.authProfileOverrideCompactionCount === guard.authProfileOverrideCompactionCount &&
+    entry.fallbackNoticeSelectedModel === guard.fallbackNoticeSelectedModel &&
+    entry.fallbackNoticeActiveModel === guard.fallbackNoticeActiveModel &&
+    entry.fallbackNoticeReason === guard.fallbackNoticeReason
+  );
+}
 
 async function persistSessionEntry(
   params: PersistSessionEntryParams & {
@@ -1402,7 +1458,7 @@ async function agentCommandInternal(
       }
     }
 
-    const storedProviderOverride = hasLegacyAutoFallbackOverrideWithoutOrigin
+    let storedProviderOverride = hasLegacyAutoFallbackOverrideWithoutOrigin
       ? undefined
       : sessionEntry?.providerOverride?.trim();
     let storedModelOverride = hasLegacyAutoFallbackOverrideWithoutOrigin
@@ -1449,6 +1505,21 @@ async function agentCommandInternal(
       : null;
     const primaryProvider = normalizedChannelOverride?.provider ?? defaultProvider;
     const primaryModel = normalizedChannelOverride?.model ?? defaultModel;
+    const hasStaleAutoFallbackOriginOverride =
+      hasStoredOverride &&
+      !hasExplicitRunOverride &&
+      isStaleAutoFallbackOriginOverride({
+        entry: sessionEntry,
+        defaultProvider,
+        defaultModel,
+        primaryProvider,
+        primaryModel,
+      });
+    if (hasStaleAutoFallbackOriginOverride) {
+      storedProviderOverride = undefined;
+      storedModelOverride = undefined;
+      storedModelOverrideSource = undefined;
+    }
     const hasEffectiveStoredOverride = Boolean(storedProviderOverride || storedModelOverride);
     if (normalizedChannelOverride && !hasEffectiveStoredOverride) {
       provider = normalizedChannelOverride.provider;
@@ -1482,6 +1553,14 @@ async function agentCommandInternal(
       model = autoFallbackPrimaryProbe.model;
       autoFallbackPrimaryProbeSessionEntry = { ...sessionEntry };
       clearAutoFallbackPrimaryProbeSelection(autoFallbackPrimaryProbeSessionEntry);
+    }
+    let staleAutoFallbackOriginAttemptSessionEntry: SessionEntry | undefined;
+    let staleAutoFallbackOriginCleanupGuard: StaleAutoFallbackOriginCleanupGuard | undefined;
+    if (hasStaleAutoFallbackOriginOverride && sessionEntry) {
+      staleAutoFallbackOriginCleanupGuard =
+        captureStaleAutoFallbackOriginCleanupGuard(sessionEntry);
+      staleAutoFallbackOriginAttemptSessionEntry = { ...sessionEntry };
+      clearAutoFallbackPrimaryProbeSelection(staleAutoFallbackOriginAttemptSessionEntry);
     }
     let providerForAuthProfileValidation = provider;
     if (hasExplicitRunOverride) {
@@ -1536,7 +1615,10 @@ async function agentCommandInternal(
       workspaceDir,
     });
 
-    let sessionEntryForAttempt = autoFallbackPrimaryProbeSessionEntry ?? sessionEntry;
+    let sessionEntryForAttempt =
+      autoFallbackPrimaryProbeSessionEntry ??
+      staleAutoFallbackOriginAttemptSessionEntry ??
+      sessionEntry;
     if (sessionEntryForAttempt) {
       const authProfileId = sessionEntryForAttempt.authProfileOverride;
       if (authProfileId) {
@@ -1585,7 +1667,11 @@ async function agentCommandInternal(
             }),
           );
         if (!profileMatchesRuntime) {
-          if (hasExplicitRunOverride || autoFallbackPrimaryProbe) {
+          if (
+            hasExplicitRunOverride ||
+            autoFallbackPrimaryProbe ||
+            staleAutoFallbackOriginAttemptSessionEntry
+          ) {
             sessionEntryForAttempt = {
               ...entry,
               authProfileOverride: undefined,
@@ -2020,6 +2106,36 @@ async function agentCommandInternal(
               ),
           });
           sessionEntry = persistedEntry ?? sessionEntry;
+        }
+        if (
+          !fallbackExhausted &&
+          hasStaleAutoFallbackOriginOverride &&
+          sessionEntry &&
+          sessionStore &&
+          sessionKey &&
+          !suppressVisibleSessionEffects &&
+          !preserveUserFacingSessionModelState
+        ) {
+          const staleCleanupSourceEntry = sessionStore[sessionKey] ?? sessionEntry;
+          const nextSessionEntry = { ...staleCleanupSourceEntry };
+          const { updated } = applyModelOverrideToSessionEntry({
+            entry: nextSessionEntry,
+            selection: { provider: primaryProvider, model: primaryModel, isDefault: true },
+          });
+          if (updated) {
+            const persistedEntry = await persistSessionEntry({
+              sessionStore,
+              sessionKey,
+              storePath,
+              entry: nextSessionEntry,
+              shouldPersist: (current) =>
+                entryMatchesStaleAutoFallbackOriginCleanupGuard(
+                  current,
+                  staleAutoFallbackOriginCleanupGuard,
+                ),
+            });
+            sessionEntry = persistedEntry ?? sessionEntry;
+          }
         }
         if (fallbackResult.attempts.length > 0 && result.meta.agentMeta) {
           result = {

--- a/src/agents/auto-fallback-stale-origin.ts
+++ b/src/agents/auto-fallback-stale-origin.ts
@@ -1,0 +1,69 @@
+// Shared stale-origin detection for auto-fallback model pins.
+import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import {
+  modelKey,
+  normalizeModelRef,
+  resolvePersistedOverrideModelRef,
+} from "./model-selection.js";
+
+type AutoFallbackOriginEntry = Pick<
+  SessionEntry,
+  | "providerOverride"
+  | "modelOverride"
+  | "modelOverrideSource"
+  | "modelOverrideFallbackOriginProvider"
+  | "modelOverrideFallbackOriginModel"
+>;
+
+function resolveOverrideKey(params: {
+  defaultProvider: string;
+  overrideProvider?: string;
+  overrideModel?: string;
+}): string | null {
+  const ref = resolvePersistedOverrideModelRef(params);
+  if (!ref) {
+    return null;
+  }
+  const normalized = normalizeModelRef(ref.provider, ref.model);
+  return modelKey(normalized.provider, normalized.model);
+}
+
+/** Detects auto-fallback pins whose recorded origin no longer matches the current primary. */
+export function isStaleAutoFallbackOriginOverride(params: {
+  entry: AutoFallbackOriginEntry | null | undefined;
+  defaultProvider: string;
+  defaultModel: string;
+  primaryProvider?: string;
+  primaryModel?: string;
+}): boolean {
+  const entry = params.entry;
+  if (!entry) {
+    return false;
+  }
+  const recoveredAutoFallbackOverride =
+    entry.modelOverrideSource === undefined && hasSessionAutoModelFallbackProvenance(entry);
+  if (entry.modelOverrideSource !== "auto" && !recoveredAutoFallbackOverride) {
+    return false;
+  }
+
+  const storedOverrideKey = resolveOverrideKey({
+    defaultProvider: params.defaultProvider,
+    overrideProvider: entry.providerOverride,
+    overrideModel: entry.modelOverride,
+  });
+  const originKey = resolveOverrideKey({
+    defaultProvider: params.defaultProvider,
+    overrideProvider: entry.modelOverrideFallbackOriginProvider,
+    overrideModel: entry.modelOverrideFallbackOriginModel,
+  });
+  const primaryKey = resolveOverrideKey({
+    defaultProvider: params.defaultProvider,
+    overrideProvider: params.primaryProvider ?? params.defaultProvider,
+    overrideModel: params.primaryModel ?? params.defaultModel,
+  });
+  if (!storedOverrideKey || !originKey || !primaryKey) {
+    return false;
+  }
+  return originKey !== primaryKey && storedOverrideKey !== primaryKey;
+}

--- a/src/auto-reply/reply/get-reply-directives-apply.test.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.test.ts
@@ -27,7 +27,7 @@ describe("formatModelOverrideResetEvent", () => {
       formatModelOverrideResetEvent({
         rejectedRef: "openai/gpt-5.5",
         initialModelLabel: "openai/gpt-5.4",
-        reason: "stale",
+        reason: "stale-legacy-auto-fallback-without-origin",
       }),
     ).toBe(
       "Stored model override openai/gpt-5.5 is stale for this session; reverted to openai/gpt-5.4. Pick a model again with /model if you still want to override the default.",

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -12,7 +12,7 @@ import { resolveModelSelectionFromDirective } from "./directive-handling.model-s
 import type { ApplyInlineDirectivesFastLaneParams } from "./directive-handling.params.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import { clearInlineDirectives } from "./get-reply-directives-utils.js";
-import type { createModelSelectionState } from "./model-selection.js";
+import type { createModelSelectionState, ModelOverrideResetReason } from "./model-selection.js";
 import type { TypingController } from "./typing.js";
 
 type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
@@ -68,9 +68,9 @@ function hasOnlyModelDirective(directives: InlineDirectives): boolean {
 export function formatModelOverrideResetEvent(params: {
   rejectedRef?: string;
   initialModelLabel: string;
-  reason?: "disallowed" | "stale";
+  reason?: ModelOverrideResetReason;
 }): string {
-  if (params.reason === "stale") {
+  if (params.reason && params.reason !== "disallowed") {
     if (params.rejectedRef) {
       return `Stored model override ${params.rejectedRef} is stale for this session; reverted to ${params.initialModelLabel}. Pick a model again with /model if you still want to override the default.`;
     }
@@ -196,7 +196,10 @@ export async function applyInlineDirectiveOverrides(params: {
 
   let directiveAck: ReplyPayload | undefined;
 
-  if (modelState.resetModelOverride) {
+  if (
+    modelState.resetModelOverride &&
+    modelState.resetModelOverrideReason !== "stale-auto-fallback-origin"
+  ) {
     enqueueSystemEvent(
       formatModelOverrideResetEvent({
         rejectedRef: modelState.resetModelOverrideRef,

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -540,6 +540,7 @@ export async function resolveReplyDirectives(params: {
         skipStoredModelOverride,
         hasResolvedHeartbeatModelOverride,
         isHeartbeat: opts?.isHeartbeat === true,
+        deferModelOverrideReset: true,
       });
   provider = modelState.provider;
   model = modelState.model;

--- a/src/auto-reply/reply/get-reply.test-fixtures.ts
+++ b/src/auto-reply/reply/get-reply.test-fixtures.ts
@@ -128,6 +128,7 @@ export function createGetReplyContinueDirectivesResult(params: {
       provider: params.provider ?? "openai",
       model: params.model ?? "gpt-4o-mini",
       modelState: {
+        persistModelOverrideReset: async () => false,
         resolveDefaultThinkingLevel: async () => undefined,
         resolveThinkingCatalog: async () => [],
       },

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -891,6 +891,7 @@ export async function getReplyFromConfig(
   directives = inlineActionResult.directives;
   cleanedBody = inlineActionResult.cleanedBody;
   abortedLastRun = inlineActionResult.abortedLastRun ?? abortedLastRun;
+  await modelState.persistModelOverrideReset();
   const runAutoFallbackPrimaryProbe = directives.hasModelDirective
     ? undefined
     : autoFallbackPrimaryProbe;

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../agents/model-catalog.runtime.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { createModelSelectionState, resolveContextTokens } from "./model-selection.js";
 
 vi.mock("../../agents/model-catalog.runtime.js", () => ({
@@ -1243,6 +1244,7 @@ describe("createModelSelectionState auto-failover overrides", () => {
     primaryModel?: string;
     isHeartbeat?: boolean;
     skipStoredModelOverride?: boolean;
+    deferModelOverrideReset?: boolean;
   }) {
     const cfg = {} as OpenClawConfig;
     const sessionEntry = makeEntry({
@@ -1271,6 +1273,7 @@ describe("createModelSelectionState auto-failover overrides", () => {
       hasModelDirective: false,
       isHeartbeat: params.isHeartbeat,
       skipStoredModelOverride: params.skipStoredModelOverride,
+      deferModelOverrideReset: params.deferModelOverrideReset,
     });
     return { state, sessionEntry, sessionStore };
   }
@@ -1308,6 +1311,103 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
     expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
     expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("auto");
+  });
+
+  it("clears stale auto-failover overrides when origin no longer matches primary", async () => {
+    const { state, sessionStore } = await resolveStateWithOverride({
+      providerOverride: "openrouter",
+      modelOverride: "minimax/minimax-m2.7",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "gpt-5.3",
+      authProfileOverride: "openrouter:fallback",
+      authProfileOverrideSource: "auto",
+      provider: "openrouter",
+      model: "minimax/minimax-m2.7",
+    });
+
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideRef).toBe("openrouter/minimax/minimax-m2.7");
+    expect(state.resetModelOverrideReason).toBe("stale-auto-fallback-origin");
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginProvider).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginModel).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBeUndefined();
+  });
+
+  it("defers stale auto-failover cleanup until the prepared selection is persisted", async () => {
+    const { state, sessionStore } = await resolveStateWithOverride({
+      providerOverride: "openrouter",
+      modelOverride: "minimax/minimax-m2.7",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "gpt-5.3",
+      authProfileOverride: "openrouter:fallback",
+      authProfileOverrideSource: "auto",
+      provider: "openrouter",
+      model: "minimax/minimax-m2.7",
+      deferModelOverrideReset: true,
+    });
+
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideReason).toBe("stale-auto-fallback-origin");
+    expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
+    expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBe("openrouter:fallback");
+
+    await expect(state.persistModelOverrideReset()).resolves.toBe(true);
+
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBeUndefined();
+  });
+
+  it("preserves a mixed /model directive that changes the stale row before deferred cleanup", async () => {
+    const { state, sessionStore } = await resolveStateWithOverride({
+      providerOverride: "openrouter",
+      modelOverride: "minimax/minimax-m2.7",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "gpt-5.3",
+      authProfileOverride: "openrouter:fallback",
+      authProfileOverrideSource: "auto",
+      provider: "openrouter",
+      model: "minimax/minimax-m2.7",
+      deferModelOverrideReset: true,
+    });
+
+    expect(state.resetModelOverrideReason).toBe("stale-auto-fallback-origin");
+
+    const entry = sessionStore[sessionKey];
+    expect(entry).toBeDefined();
+    // Mirrors persistInlineDirectives for a mixed `/model openai/gpt-4o hello` message.
+    applyModelOverrideToSessionEntry({
+      entry,
+      selection: {
+        provider: "openai",
+        model: "gpt-4o",
+      },
+      selectionSource: "user",
+    });
+
+    await expect(state.persistModelOverrideReset()).resolves.toBe(false);
+
+    expect(sessionStore[sessionKey]?.providerOverride).toBe("openai");
+    expect(sessionStore[sessionKey]?.modelOverride).toBe("gpt-4o");
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("user");
+    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginProvider).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginModel).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBeUndefined();
   });
 
   it("keeps a legacy auto pin when the current selection already matches it", async () => {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -5,6 +5,7 @@ import {
 } from "../../agents/agent-scope.js";
 import { isStoredCredentialCompatibleWithAuthProvider } from "../../agents/auth-profiles/order.js";
 import { clearSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
+import { isStaleAutoFallbackOriginOverride } from "../../agents/auto-fallback-stale-origin.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
@@ -47,14 +48,37 @@ import {
 
 type ModelCatalog = ModelCatalogEntry[];
 
-type ModelSelectionState = {
+type DeferredModelOverrideResetGuard = Pick<
+  SessionEntry,
+  | "providerOverride"
+  | "modelOverride"
+  | "modelOverrideSource"
+  | "modelOverrideFallbackOriginProvider"
+  | "modelOverrideFallbackOriginModel"
+  | "authProfileOverride"
+  | "authProfileOverrideSource"
+  | "authProfileOverrideCompactionCount"
+  | "fallbackNoticeSelectedModel"
+  | "fallbackNoticeActiveModel"
+  | "fallbackNoticeReason"
+>;
+
+export type ModelOverrideResetReason =
+  | "disallowed"
+  | "stale-auto-fallback-origin"
+  | "stale-heartbeat-auto-fallback"
+  | "stale-legacy-openai-codex-auto"
+  | "stale-legacy-auto-fallback-without-origin";
+
+export type ModelSelectionState = {
   provider: string;
   model: string;
   allowedModelKeys: Set<string>;
   allowedModelCatalog: ModelCatalog;
   resetModelOverride: boolean;
   resetModelOverrideRef?: string;
-  resetModelOverrideReason?: "disallowed" | "stale";
+  resetModelOverrideReason?: ModelOverrideResetReason;
+  persistModelOverrideReset: () => Promise<boolean>;
   resolveThinkingCatalog: () => Promise<ModelCatalog | undefined>;
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel>;
   /** Default reasoning level from model capability: "on" if model has reasoning, else "off". */
@@ -78,6 +102,7 @@ export function createFastTestModelSelectionState(params: {
     resetModelOverride: false,
     resetModelOverrideRef: undefined,
     resetModelOverrideReason: undefined,
+    persistModelOverrideReset: async () => false,
     resolveThinkingCatalog: async () => [],
     resolveDefaultThinkingLevel: async () => params.agentCfg?.thinkingDefault as ThinkLevel,
     resolveDefaultReasoningLevel: async () => "off",
@@ -107,6 +132,65 @@ function loadModelCatalogRuntime() {
 
 function loadSessionAccessorRuntime() {
   return sessionAccessorRuntimeLoader.load();
+}
+
+function captureDeferredModelOverrideResetGuard(
+  entry: SessionEntry,
+): DeferredModelOverrideResetGuard {
+  return {
+    providerOverride: entry.providerOverride,
+    modelOverride: entry.modelOverride,
+    modelOverrideSource: entry.modelOverrideSource,
+    modelOverrideFallbackOriginProvider: entry.modelOverrideFallbackOriginProvider,
+    modelOverrideFallbackOriginModel: entry.modelOverrideFallbackOriginModel,
+    authProfileOverride: entry.authProfileOverride,
+    authProfileOverrideSource: entry.authProfileOverrideSource,
+    authProfileOverrideCompactionCount: entry.authProfileOverrideCompactionCount,
+    fallbackNoticeSelectedModel: entry.fallbackNoticeSelectedModel,
+    fallbackNoticeActiveModel: entry.fallbackNoticeActiveModel,
+    fallbackNoticeReason: entry.fallbackNoticeReason,
+  };
+}
+
+function matchesDeferredModelOverrideResetGuard(
+  entry: SessionEntry,
+  guard: DeferredModelOverrideResetGuard | undefined,
+): boolean {
+  if (!guard) {
+    return true;
+  }
+  return (
+    entry.providerOverride === guard.providerOverride &&
+    entry.modelOverride === guard.modelOverride &&
+    entry.modelOverrideSource === guard.modelOverrideSource &&
+    entry.modelOverrideFallbackOriginProvider === guard.modelOverrideFallbackOriginProvider &&
+    entry.modelOverrideFallbackOriginModel === guard.modelOverrideFallbackOriginModel &&
+    entry.authProfileOverride === guard.authProfileOverride &&
+    entry.authProfileOverrideSource === guard.authProfileOverrideSource &&
+    entry.authProfileOverrideCompactionCount === guard.authProfileOverrideCompactionCount &&
+    entry.fallbackNoticeSelectedModel === guard.fallbackNoticeSelectedModel &&
+    entry.fallbackNoticeActiveModel === guard.fallbackNoticeActiveModel &&
+    entry.fallbackNoticeReason === guard.fallbackNoticeReason
+  );
+}
+
+function applyModelOverrideResetToEntry(params: {
+  entry: SessionEntry;
+  primaryProvider: string;
+  primaryModel: string;
+  staleDirectStoredOverride: boolean;
+  staleAutoFallbackOriginOverride: boolean;
+}): boolean {
+  return applyModelOverrideToSessionEntry({
+    entry: params.entry,
+    selection: {
+      provider: params.primaryProvider,
+      model: params.primaryModel,
+      isDefault: true,
+    },
+    preserveAuthProfileOverride:
+      params.staleDirectStoredOverride && !params.staleAutoFallbackOriginOverride,
+  }).updated;
 }
 
 function findSelectedCatalogEntry(params: {
@@ -142,6 +226,7 @@ export async function createModelSelectionState(params: {
    *  In that case, skip session-stored overrides so the heartbeat selection wins. */
   hasResolvedHeartbeatModelOverride?: boolean;
   isHeartbeat?: boolean;
+  deferModelOverrideReset?: boolean;
 }): Promise<ModelSelectionState> {
   const timingEnabled = shouldLogModelSelectionTiming();
   const startMs = timingEnabled ? Date.now() : 0;
@@ -197,7 +282,8 @@ export async function createModelSelectionState(params: {
   let modelCatalog: ModelCatalog | null = null;
   let resetModelOverride = false;
   let resetModelOverrideRef: string | undefined;
-  let resetModelOverrideReason: "disallowed" | "stale" | undefined;
+  let resetModelOverrideReason: ModelOverrideResetReason | undefined;
+  let persistModelOverrideReset = async () => false;
   const agentEntry = params.agentId ? resolveAgentConfig(cfg, params.agentId) : undefined;
   const normalizedDirectStoredOverride = normalizeStoredOverrideModel({
     providerOverride: sessionEntry?.providerOverride,
@@ -249,10 +335,22 @@ export async function createModelSelectionState(params: {
     normalizedDirectOverride !== null &&
     modelKey(normalizedCurrentSelection.provider, normalizedCurrentSelection.model) !==
       modelKey(normalizedDirectOverride.provider, normalizedDirectOverride.model);
+  const staleAutoFallbackOriginOverride =
+    directStoredModelOverride?.source === "session" &&
+    !staleHeartbeatAutoFallbackOverride &&
+    isStaleAutoFallbackOriginOverride({
+      entry: sessionEntry,
+      defaultProvider,
+      defaultModel,
+      primaryProvider,
+      primaryModel,
+    });
   const staleDirectStoredOverride =
+    staleAutoFallbackOriginOverride ||
     staleHeartbeatAutoFallbackOverride ||
     staleLegacyOpenAICodexAutoOverride ||
     staleLegacyAutoFallbackWithoutOrigin;
+  const deferSessionCleanup = params.deferModelOverrideReset === true && staleDirectStoredOverride;
 
   if (needsModelCatalog) {
     modelCatalog = await (await loadModelCatalogRuntime()).loadModelCatalog({ config: cfg });
@@ -302,23 +400,76 @@ export async function createModelSelectionState(params: {
       directStoredOverride.model,
     );
     const key = modelKey(normalizedOverride.provider, normalizedOverride.model);
-    if (staleDirectStoredOverride || !visibilityPolicy.allowsKey(key)) {
-      const { updated } = applyModelOverrideToSessionEntry({
-        entry: sessionEntry,
-        selection: { provider: primaryProvider, model: primaryModel, isDefault: true },
-        preserveAuthProfileOverride: staleDirectStoredOverride,
-      });
-      if (updated) {
-        sessionStore[sessionKey] = sessionEntry;
-        if (storePath) {
-          const { replaceSessionEntry } = await loadSessionAccessorRuntime();
-          await replaceSessionEntry({ storePath, sessionKey }, sessionEntry);
+    const disallowedStoredOverride = !visibilityPolicy.allowsKey(key);
+    if (staleDirectStoredOverride || disallowedStoredOverride) {
+      resetModelOverrideReason = staleAutoFallbackOriginOverride
+        ? "stale-auto-fallback-origin"
+        : staleHeartbeatAutoFallbackOverride
+          ? "stale-heartbeat-auto-fallback"
+          : staleLegacyOpenAICodexAutoOverride
+            ? "stale-legacy-openai-codex-auto"
+            : staleLegacyAutoFallbackWithoutOrigin
+              ? "stale-legacy-auto-fallback-without-origin"
+              : "disallowed";
+      resetModelOverrideRef = key;
+      const resetGuard = staleDirectStoredOverride
+        ? captureDeferredModelOverrideResetGuard(sessionEntry)
+        : undefined;
+      persistModelOverrideReset = async () => {
+        const currentEntry = sessionStore[sessionKey];
+        if (!currentEntry || !matchesDeferredModelOverrideResetGuard(currentEntry, resetGuard)) {
+          return false;
         }
-      }
-      resetModelOverride = updated;
-      if (updated) {
-        resetModelOverrideRef = key;
-        resetModelOverrideReason = staleDirectStoredOverride ? "stale" : "disallowed";
+        let persistedUpdated = false;
+        if (storePath) {
+          let persistedMatched = false;
+          const { updateSessionEntry } = await loadSessionAccessorRuntime();
+          await updateSessionEntry({ storePath, sessionKey }, (persistedEntry) => {
+            if (!matchesDeferredModelOverrideResetGuard(persistedEntry, resetGuard)) {
+              return null;
+            }
+            persistedMatched = true;
+            const nextEntry = { ...persistedEntry };
+            if (
+              applyModelOverrideResetToEntry({
+                entry: nextEntry,
+                primaryProvider,
+                primaryModel,
+                staleDirectStoredOverride,
+                staleAutoFallbackOriginOverride,
+              })
+            ) {
+              persistedUpdated = true;
+              return nextEntry;
+            }
+            return null;
+          });
+          if (!persistedMatched) {
+            return false;
+          }
+        }
+        const latestEntry = sessionStore[sessionKey];
+        if (!latestEntry || !matchesDeferredModelOverrideResetGuard(latestEntry, resetGuard)) {
+          return persistedUpdated;
+        }
+        const updated = applyModelOverrideResetToEntry({
+          entry: latestEntry,
+          primaryProvider,
+          primaryModel,
+          staleDirectStoredOverride,
+          staleAutoFallbackOriginOverride,
+        });
+        if (updated) {
+          sessionStore[sessionKey] = latestEntry;
+        }
+        return updated || persistedUpdated;
+      };
+      resetModelOverride = params.deferModelOverrideReset
+        ? true
+        : await persistModelOverrideReset();
+      if (!resetModelOverride) {
+        resetModelOverrideRef = undefined;
+        resetModelOverrideReason = undefined;
       }
     }
   }
@@ -381,6 +532,7 @@ export async function createModelSelectionState(params: {
 
   if (
     !params.skipStoredModelOverride &&
+    !deferSessionCleanup &&
     sessionEntry &&
     sessionStore &&
     sessionKey &&
@@ -612,6 +764,7 @@ export async function createModelSelectionState(params: {
     resetModelOverride,
     resetModelOverrideRef,
     resetModelOverrideReason,
+    persistModelOverrideReset,
     resolveThinkingCatalog,
     resolveDefaultThinkingLevel,
     resolveDefaultReasoningLevel,

--- a/src/commands/agent-command.test-mocks.ts
+++ b/src/commands/agent-command.test-mocks.ts
@@ -87,6 +87,27 @@ vi.mock("../agents/model-selection.js", () => {
     provider: normalizeProviderId(provider),
     model: model.trim(),
   });
+  const resolvePersistedOverrideModelRef = ({
+    defaultProvider,
+    overrideProvider,
+    overrideModel,
+  }: {
+    defaultProvider?: unknown;
+    overrideProvider?: unknown;
+    overrideModel?: unknown;
+  }): ModelRef | null => {
+    const model = typeof overrideModel === "string" ? overrideModel.trim() : "";
+    if (!model) {
+      return null;
+    }
+    const provider =
+      typeof overrideProvider === "string" && overrideProvider.trim()
+        ? overrideProvider.trim()
+        : typeof defaultProvider === "string" && defaultProvider.trim()
+          ? defaultProvider.trim()
+          : "openai";
+    return normalizeModelRef(provider, model);
+  };
   const modelKey = (provider: string, model: string) =>
     `${normalizeProviderId(provider)}/${model.trim().toLowerCase()}`;
   const isModelKeyAllowedBySet = (allowedKeys: ReadonlySet<string>, key: string) => {
@@ -203,6 +224,7 @@ vi.mock("../agents/model-selection.js", () => {
         return ref ? { ref, source: "parsed" } : null;
       },
     ),
+    resolvePersistedOverrideModelRef: vi.fn(resolvePersistedOverrideModelRef),
     resolveThinkingDefault: vi.fn(
       ({
         cfg,


### PR DESCRIPTION
## Summary
- Adds a shared stale auto-fallback-origin classifier so reply and agent-command selection agree when recorded fallback origin no longer matches the current primary.
- Defers reply-side model/auth cleanup until after read-only slash/inline actions have dispatched and a real run is about to start.
- Guards deferred reply cleanup against post-selection session changes so mixed `/model ...` directives and concurrent row updates are not overwritten.
- Prepares agent-command attempts with stale fallback model/auth cleared in memory, then persists durable cleanup only after a non-exhausted visible run and only if the store row still exactly matches the stale fallback pin captured at selection time.

## Maintainer feedback addressed
- One prepared selection result now carries reset reason and persistence behavior through the reply turn.
- Stale-origin repair no longer emits the disallowed-allowlist reset event.
- Preserve-state/non-mutating agent-command runs strip fallback auth for the primary attempt without writing durable cleanup.
- Deferred reply cleanup is guarded against concurrent user model switches and mixed inline model directives.
- Direct agent-command cleanup captures the stale row fields at selection time and refuses to persist if the current store row has changed to a different stale auto-fallback pin.
- Direct agent-command cleanup is now also gated on non-exhausted fallback runs, so failed exhausted runs do not persist cleared model/auth state.
- Auto-reply and agent-command test doubles now satisfy the deferred cleanup/model-selection helper contract used by CI.

## What Problem This Solves

Stale auto-fallback model pins whose recorded fallback origin no longer matches the current primary were being treated as active stored overrides. That could make the next real agent run continue using an old `fallback-model` and stale auto auth instead of the current `primary-model`.

This patch prepares the primary selection for the next real run and defers durable cleanup until the run boundary without overwriting user-owned, newer auto-owned, or exhausted-run model/auth state.

## Evidence

- Real environment tested: isolated OpenClaw worktree rebased onto current `origin/main` `d68ba5edc59`, PR head `844c625a8a0e99bc7de934c286fbdd105d5cec39`.
- Exact steps run after this patch:

```text
node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts src/auto-reply/reply/model-selection.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-directives-apply.test.ts
pnpm exec oxfmt --check --threads=1 src/agents/agent-command.ts src/agents/agent-command.live-model-switch.test.ts src/agents/auto-fallback-stale-origin.ts src/auto-reply/reply/model-selection.ts src/auto-reply/reply/model-selection.test.ts src/auto-reply/reply/get-reply-directives-apply.ts src/auto-reply/reply/get-reply-directives-apply.test.ts src/auto-reply/reply/get-reply-directives.ts src/auto-reply/reply/get-reply.test-fixtures.ts src/auto-reply/reply/get-reply.ts src/commands/agent-command.test-mocks.ts
pnpm tsgo:prod
pnpm check:test-types
pnpm run test:extensions:package-boundary:compile
pnpm build
git diff --check origin/main...HEAD
```

- Evidence after rebase: focused Vitest passed 2 shards / 133 tests for agent-command live model switch plus reply model selection, and the directives regression passed 3 tests. `oxfmt --check`, `pnpm tsgo:prod`, `pnpm check:test-types`, extension package boundary compile for 116 plugins, `pnpm build`, and `git diff --check origin/main...HEAD` passed.
- Observed result after fix: unchanged captured stale pins can still be cleaned up after a real non-exhausted run; changed rows and exhausted fallback runs are left untouched.

### Redacted runtime/session proof

I also ran a real `openclaw agent --local` turn on this rebased PR head using a throwaway `OPENCLAW_STATE_DIR`, a synthetic session row, and a local OpenAI-compatible test endpoint. No production config, production session store, production auth profile, or external provider was used.

The seeded session row contained a stale auto fallback pin:

```json
{
  "providerOverride": "proof-local",
  "modelOverride": "fallback-model",
  "modelOverrideSource": "auto",
  "modelOverrideFallbackOriginProvider": "proof-local",
  "modelOverrideFallbackOriginModel": "old-primary-model",
  "authProfileOverride": "proof-local:auto-fallback",
  "authProfileOverrideSource": "auto"
}
```

The real CLI run completed successfully and sent exactly one streamed model request to the local endpoint:

```json
{
  "head": "844c625a8a0e99bc7de934c286fbdd105d5cec39",
  "isolatedStateDir": "<temp OPENCLAW_STATE_DIR>",
  "localEndpoint": "<127.0.0.1 OpenAI-compatible test server>",
  "cliExit": 0,
  "stdoutContainsProofToken": true,
  "requests": [
    {
      "method": "POST",
      "url": "/v1/chat/completions",
      "model": "primary-model",
      "stream": true,
      "messageCount": 2,
      "toolCount": 39
    }
  ],
  "after": {
    "modelProvider": "proof-local",
    "model": "primary-model"
  },
  "assertions": {
    "requestedPrimaryModel": true,
    "neverRequestedFallbackModel": true,
    "staleModelOverrideCleared": true,
    "staleAutoAuthCleared": true,
    "replyObserved": true
  }
}
```

That proves the stale fallback row was not reused for the next real run: the request went to `primary-model`, no request went to `fallback-model`, and the persisted session row no longer contains the stale model/auth override fields.

## Verification
- `node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts src/auto-reply/reply/model-selection.test.ts` (passed: 2 shards, 133 tests)
- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-directives-apply.test.ts` (passed: 3 tests)
- `pnpm exec oxfmt --check --threads=1 src/agents/agent-command.ts src/agents/agent-command.live-model-switch.test.ts src/agents/auto-fallback-stale-origin.ts src/auto-reply/reply/model-selection.ts src/auto-reply/reply/model-selection.test.ts src/auto-reply/reply/get-reply-directives-apply.ts src/auto-reply/reply/get-reply-directives-apply.test.ts src/auto-reply/reply/get-reply-directives.ts src/auto-reply/reply/get-reply.test-fixtures.ts src/auto-reply/reply/get-reply.ts src/commands/agent-command.test-mocks.ts`
- `pnpm tsgo:prod`
- `pnpm check:test-types`
- `pnpm run test:extensions:package-boundary:compile`
- `pnpm build`
- `git diff --check origin/main...HEAD`

Fixes #92776
Supersedes #92790
