### PR TITLE
fix(qqbot): surface failed media sends

### DIFF
--- a/extensions/qqbot/src/channel.message-adapter.test.ts
+++ b/extensions/qqbot/src/channel.message-adapter.test.ts
@@ -114,4 +114,30 @@ describe("qqbot message adapter", () => {
     expect(proofResults.find((result) => result.capability === "media")?.status).toBe("verified");
     expect(proofResults.find((result) => result.capability === "replyTo")?.status).toBe("verified");
   });
+
+  it("rejects media sends when QQBot reports an outbound error", async () => {
+    sendMediaMock.mockResolvedValue({ error: "QQ API returned 400 Bad Request" });
+
+    await expect(
+      qqbotPlugin.message?.send?.media?.({
+        cfg,
+        to: "qqbot:c2c:user-1",
+        text: "image",
+        mediaUrl: "https://example.com/image.png",
+      }),
+    ).rejects.toThrow("QQ API returned 400 Bad Request");
+  });
+
+  it("rejects media sends without a QQ platform message id", async () => {
+    sendMediaMock.mockResolvedValue({});
+
+    await expect(
+      qqbotPlugin.message?.send?.media?.({
+        cfg,
+        to: "qqbot:c2c:user-1",
+        text: "image",
+        mediaUrl: "https://example.com/image.png",
+      }),
+    ).rejects.toThrow("QQBot message adapter send did not return a platform message id");
+  });
 });

--- a/extensions/qqbot/src/channel.message-adapter.test.ts
+++ b/extensions/qqbot/src/channel.message-adapter.test.ts
@@ -128,6 +128,18 @@ describe("qqbot message adapter", () => {
     ).rejects.toThrow("QQ API returned 400 Bad Request");
   });
 
+  it("rejects text sends when QQBot reports an outbound error", async () => {
+    sendTextMock.mockResolvedValue({ error: "QQ API returned 400 Bad Request" });
+
+    await expect(
+      qqbotPlugin.message?.send?.text?.({
+        cfg,
+        to: "qqbot:c2c:user-1",
+        text: "hello",
+      }),
+    ).rejects.toThrow("QQ API returned 400 Bad Request");
+  });
+
   it("rejects media sends without a QQ platform message id", async () => {
     sendMediaMock.mockResolvedValue({});
 
@@ -137,6 +149,18 @@ describe("qqbot message adapter", () => {
         to: "qqbot:c2c:user-1",
         text: "image",
         mediaUrl: "https://example.com/image.png",
+      }),
+    ).rejects.toThrow("QQBot message adapter send did not return a platform message id");
+  });
+
+  it("rejects text sends without a QQ platform message id", async () => {
+    sendTextMock.mockResolvedValue({});
+
+    await expect(
+      qqbotPlugin.message?.send?.text?.({
+        cfg,
+        to: "qqbot:c2c:user-1",
+        text: "hello",
       }),
     ).rejects.toThrow("QQBot message adapter send did not return a platform message id");
   });

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -134,8 +134,14 @@ async function sendQQBotMedia(params: {
 }
 
 function toQQBotMessageSendResult(result: Awaited<ReturnType<typeof sendQQBotText>>) {
+  if (result.meta?.error) {
+    throw new Error(result.meta.error);
+  }
+  if (result.receipt.platformMessageIds.length === 0) {
+    throw new Error("QQBot message adapter send did not return a platform message id");
+  }
   return {
-    messageId: result.messageId,
+    messageId: result.messageId || result.receipt.primaryPlatformMessageId,
     receipt: result.receipt,
   } satisfies ChannelMessageSendResult;
 }


### PR DESCRIPTION
## Summary

- Fixes the QQBot message adapter so failed media sends no longer look like successful sends with an empty `platformMessageIds` receipt.
- Keeps the QQ C2C media upload routing unchanged after the #92747 maintainer feedback; this PR does not switch one-shot uploads to chunked uploads.
- Treats both known outbound errors and missing QQ platform message ids as send failures, so callers can see the failure instead of receiving a misleading successful receipt.
- This is intentionally a smaller follow-up to #92747: it only fixes the error-propagation boundary that maintainers called useful, while leaving QQ upload contract selection for a separately proven change.

## Linked context

Related #92246

Related #92747

This follows the maintainer feedback on #92747 that the adapter error-propagation improvement is useful but should be separated from the broader C2C upload-route change.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: QQBot media sends that hit an outbound failure are now surfaced as failures instead of successful empty receipts.
- Real environment tested: local OpenClaw PR branch using the real QQBot channel message adapter, a real QQBot app credential, a local PNG stored under the QQBot-owned media directory, and a redacted invalid C2C target so the request safely reaches QQ's media upload endpoint but cannot deliver to a real user.
- Exact steps or command run after this patch:
  - Credentialed runtime probe: `env -u QQBOT_CLIENT_SECRET QQBOT_APP_ID='[redacted]' QQBOT_APP_SECRET='[redacted]' OPENCLAW_PROXY_ACTIVE=1 http_proxy='[redacted proxy]' https_proxy='[redacted proxy]' node_modules/.bin/tsx '<temporary local probe script>'`
  - Regression suite: `node scripts/run-vitest.mjs extensions/qqbot/src/channel.message-adapter.test.ts extensions/qqbot/src/engine/api/media.test.ts extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts`
- Evidence after fix: Redacted runtime log copied from the credentialed real QQBot plugin/media path:

  ```json
  {
    "scenario": "credentialed real QQBot plugin media adapter call through proxy with allowed local png and invalid redacted C2C target",
    "credentialed": true,
    "openclawManagedEnvProxy": true,
    "globalUndiciProxyDispatcher": true,
    "mockedOutbound": false,
    "localMediaFile": true,
    "qqApiAttempted": true,
    "targetRedacted": true,
    "outcome": "rejected",
    "error": "API Error [/v2/users/redacted-invalid-openid-for-proof/files]: invalid request"
  }
  ```

- Additional live token probe after fix (same credential and proxy, token redacted):

  ```json
  {
    "scenario": "credentialed QQ token endpoint probe through proxy",
    "credentialed": true,
    "proxyConfigured": true,
    "status": 200,
    "body": "{"access_token":"[redacted-token]","expires_in":"2323"}"
  }
  ```

- Regression validation: Validation `qqbot-channel-and-media` (pass, exit_code=0, 39982ms):

  ```text
  [test] starting test/vitest/vitest.extension-messaging.config.ts
  
   RUN  v4.1.7 [local path redacted]
  
  
   Test Files  3 passed (3)
        Tests  42 passed (42)
     Start at  09:21:58
     Duration  29.53s (transform 26.32s, setup 808ms, import 35.23s, tests 270ms, environment 1ms)
  
  [test] passed 1 Vitest shard in 39.76s
  ```

- Observed result after fix: the real QQBot plugin media adapter call reached QQ's `/v2/users/{openid}/files` media upload endpoint with a credentialed request and rejected with the QQ API error. It did not resolve with `{ messageId: "", receipt: { platformMessageIds: [] } }`.
- What was not tested: no media message was delivered to a real QQ user. The target was intentionally redacted/invalid so the proof could exercise the real QQ API failure path without sending a message to someone.
- Proof limitations or environment constraints: this proves this PR's bounded failure-propagation behavior through the real plugin/media path and QQ API failure response. It still does not claim to fix or replace the QQ upload route/payload contract from #92246.
- Before evidence (optional but encouraged): the new regression tests failed before the adapter change because the promise resolved with `{ messageId: '', receipt: { platformMessageIds: [] } }` instead of rejecting.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/qqbot/src/channel.message-adapter.test.ts`
- `node scripts/run-vitest.mjs extensions/qqbot/src/channel.message-adapter.test.ts extensions/qqbot/src/engine/api/media.test.ts extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts`

Regression coverage added:

- QQBot media adapter rejects when the lower-level outbound send returns an error.
- QQBot media adapter rejects when the lower-level outbound send returns neither an error nor a QQ platform message id.

The first new regression failed before this fix with a resolved empty receipt instead of a rejected send.

## Risk checklist

Did user-visible behavior change? (`Yes`)

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?

- QQBot callers now see media send failures instead of receiving a successful empty receipt.

How is that risk mitigated?

- The change is limited to `extensions/qqbot/src/channel.ts` and its adapter tests.
- The PR does not change C2C upload routing, QQ API payload shape, config, schema, migrations, or channel public APIs.
- Existing QQBot media/API/outbound-dispatch focused tests still pass.

## Current review state

What is the next action?

- Maintainer review or ClawSweeper re-review of the credentialed runtime proof.

What is still waiting on author, maintainer, CI, or external proof?

- Nothing author-side for this smaller error-propagation fix. A future upload-route fix would still need separate before/after delivery proof and any QQ response details needed to justify changing the upload route or payload contract.

Which bot or reviewer comments were addressed?

- Addresses the #92747 maintainer feedback by splitting out only the adapter error-propagation improvement and dropping the speculative broad C2C chunked upload routing change.
- Addresses ClawSweeper's `mock-only-proof` feedback by adding credentialed runtime proof through the real QQBot plugin adapter, media path, token endpoint, and QQ media upload endpoint.


