### PR TITLE
fix(outbound): suppress media sends without delivery identity

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -2180,6 +2180,48 @@ describe("deliverOutboundPayloads", () => {
     expect(sendMediaOptions?.accountId).toBeUndefined();
   });
 
+  it("suppresses plugin media sends when the adapter returns no delivery identity", async () => {
+    const sendMedia = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "" });
+    const payloadOutcomes: unknown[] = [];
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: vi.fn().mockResolvedValue({ channel: "matrix", messageId: "text-1" }),
+              sendMedia,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!explicit:example",
+      payloads: [{ text: "voice caption", mediaUrl: "file:///tmp/cron-tts.mp3" }],
+      skipQueue: true,
+      onPayloadDeliveryOutcome: (outcome) => {
+        payloadOutcomes.push(outcome);
+      },
+    });
+
+    expect(sendMedia).toHaveBeenCalledTimes(1);
+    expect(results).toStrictEqual([]);
+    expect(payloadOutcomes).toStrictEqual([
+      {
+        index: 0,
+        status: "suppressed",
+        reason: "adapter_returned_no_identity",
+      },
+    ]);
+  });
+
   it("forwards audioAsVoice through generic plugin media delivery", async () => {
     const sendMedia = vi.fn(async () => ({
       channel: "matrix" as const,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1891,10 +1891,14 @@ async function deliverOutboundPayloadsCore(
               unit.overrides,
             )
           : await deliveryHandler.sendMedia(unit.caption ?? "", unit.mediaUrl, unit.overrides);
+        if (!hasDeliveryResultIdentity(delivery)) {
+          continue;
+        }
         results.push(delivery);
         firstMessageId ??= delivery.messageId;
         lastMessageId = delivery.messageId;
       }
+      const deliveredResults = results.slice(beforeCount);
       await maybePinDeliveredMessage({
         handler: deliveryHandler,
         payload: effectivePayload,
@@ -1906,9 +1910,8 @@ async function deliverOutboundPayloadsCore(
         handler: deliveryHandler,
         payload: effectivePayload,
         target: deliveryTarget,
-        results: results.slice(beforeCount),
+        results: deliveredResults,
       });
-      const deliveredResults = results.slice(beforeCount);
       if (deliveredResults.length > 0) {
         recordPayloadOutcome({
           index: payloadIndex,
@@ -1924,9 +1927,9 @@ async function deliverOutboundPayloadsCore(
           }),
         );
       }
-      completeDeliveryDiagnostics(results.length - beforeCount);
+      completeDeliveryDiagnostics(deliveredResults.length);
       emitMessageSent({
-        success: true,
+        success: deliveredResults.length > 0,
         content: payloadSummary.hookContent ?? payloadSummary.text,
         messageId: lastMessageId,
       });


### PR DESCRIPTION
## Summary

- Fixes #92816, where a QQBot cron/TTS media send could be counted as delivered even when the adapter returned no usable delivery identity.
- The shared outbound media path now suppresses media adapter results that do not include a usable delivery id.
- This does not change QQBot sending itself; it only changes how the shared delivery layer accounts for an empty media result.

## Linked context

Closes #92816

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** QQBot-shaped media results with `messageId: ""` are no longer counted as delivered.
- **Real environment tested:** Local OpenClaw checkout on this PR branch, Node 24.14.0, using the real outbound delivery code path with a QQBot-shaped adapter response.
- **Exact steps or command run after this patch:**

  ```sh
  pnpm tsx --eval 'import { deliverOutboundPayloads } from "./src/infra/outbound/deliver.ts";
  import { setActivePluginRegistry } from "./src/plugins/runtime.ts";
  import { createOutboundTestPlugin, createTestRegistry } from "./src/test-utils/channel-plugins.ts";

  void (async () => {
    setActivePluginRegistry(
      createTestRegistry([
        {
          pluginId: "qqbot",
          source: "manual-proof",
          plugin: createOutboundTestPlugin({
            id: "qqbot",
            outbound: {
              deliveryMode: "direct",
              sendText: async () => ({ channel: "qqbot" as const, messageId: "text-1" }),
              sendMedia: async () => ({ channel: "qqbot" as const, messageId: "" }),
            },
          }),
        },
      ]),
    );
    const outcomes: unknown[] = [];
    const results = await deliverOutboundPayloads({
      cfg: {},
      channel: "qqbot",
      to: "qq-target",
      payloads: [{ text: "voice caption", mediaUrl: "file:///tmp/cron-tts.mp3" }],
      skipQueue: true,
      onPayloadDeliveryOutcome: (outcome) => outcomes.push(outcome),
    });
    console.log(JSON.stringify({ results, outcomes }, null, 2));
  })();'
  ```

- **Evidence after fix:**

  ```json
  {
    "results": [],
    "outcomes": [
      {
        "index": 0,
        "status": "suppressed",
        "reason": "adapter_returned_no_identity"
      }
    ]
  }
  ```

- **Observed result after fix:** The outbound delivery result stays empty when the media adapter returns no delivery identity, so cron/TTS delivery accounting no longer sees that send as delivered.
- **What was not tested:** I did not run a live QQBot cron/TTS delivery. I do not have QQBot credentials available in this checkout.
- **Proof limitations or environment constraints:** The live service was not exercised; the proof covers the shared delivery boundary changed by this PR.
- **Before evidence (optional but encouraged):** The new regression failed before the fix because the media branch counted the empty adapter response as delivered.

## Tests and validation

- `pnpm test src/infra/outbound/deliver.test.ts -- --reporter=verbose`
- `pnpm test extensions/qqbot/src/channel.message-adapter.test.ts -- --reporter=verbose`
- `pnpm test src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts -- --reporter=verbose -t "applies TTS directives before direct cron announce delivery and mirrors spoken text|keeps unresolved message-tool delivery out of delivered status"`
- `pnpm format:check -- src/infra/outbound/deliver.ts src/infra/outbound/deliver.test.ts`
- `git diff --check`
- `pnpm tsgo:core:test`
- Local autoreview completed with no accepted/actionable findings.

Regression coverage added: `src/infra/outbound/deliver.test.ts` now covers a media adapter result with no delivery identity.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: shared outbound media delivery accounting.

How is that risk mitigated? The change is limited to delivery result accounting. Media sends with a real delivery identity are still counted; responses without an identity are treated as not delivered.

## Current review state

Next action: maintainer review and CI.

Waiting on: reviewer feedback and CI.

Bot/reviewer comments addressed: none yet.

AI-assisted (Claude). The proof above was run manually.
