### PR TITLE
fix(qqbot): honor durable media roots for cron TTS

### DIFF
--- a/extensions/qqbot/src/channel.message-adapter.test.ts
+++ b/extensions/qqbot/src/channel.message-adapter.test.ts
@@ -36,6 +36,7 @@ type SentMediaParams = {
   to?: string;
   text?: string;
   mediaUrl?: string;
+  extraLocalRoots?: readonly string[];
 };
 
 function latestMockArg(mock: ReturnType<typeof vi.fn>, label: string): unknown {
@@ -113,5 +114,24 @@ describe("qqbot message adapter", () => {
     expect(proofResults.find((result) => result.capability === "text")?.status).toBe("verified");
     expect(proofResults.find((result) => result.capability === "media")?.status).toBe("verified");
     expect(proofResults.find((result) => result.capability === "replyTo")?.status).toBe("verified");
+  });
+
+  it("forwards mediaLocalRoots and surfaces underlying media send errors", async () => {
+    sendMediaMock.mockResolvedValueOnce({
+      error: "Voice path must be inside QQ Bot media storage",
+    });
+
+    await expect(
+      qqbotPlugin.message?.send?.media?.({
+        cfg,
+        to: "qqbot:c2c:user-1",
+        text: "voice",
+        mediaUrl: "/tmp/openclaw-tts/voice.wav",
+        mediaLocalRoots: ["/tmp/openclaw-tts"],
+      }),
+    ).rejects.toThrow("Voice path must be inside QQ Bot media storage");
+
+    const sent = latestMockArg(sendMediaMock, "sendMedia") as SentMediaParams;
+    expect(sent.extraLocalRoots).toEqual(["/tmp/openclaw-tts"]);
   });
 });

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -108,6 +108,7 @@ async function sendQQBotMedia(params: {
   mediaUrl?: string | null;
   accountId?: string | null;
   replyToId?: string | null;
+  extraLocalRoots?: readonly string[];
 }) {
   // Same guard as sendText — ensure adapters are registered.
   await loadGatewayModule();
@@ -120,6 +121,7 @@ async function sendQQBotMedia(params: {
     accountId: params.accountId,
     replyToId: params.replyToId,
     account: toGatewayAccount(account),
+    extraLocalRoots: params.extraLocalRoots,
   });
   return {
     channel: "qqbot" as const,
@@ -134,6 +136,9 @@ async function sendQQBotMedia(params: {
 }
 
 function toQQBotMessageSendResult(result: Awaited<ReturnType<typeof sendQQBotText>>) {
+  if (result.meta?.error) {
+    throw new Error(result.meta.error);
+  }
   return {
     messageId: result.messageId,
     receipt: result.receipt,
@@ -169,6 +174,7 @@ const qqbotMessageAdapter = defineChannelMessageAdapter({
           mediaUrl: ctx.mediaUrl,
           accountId: ctx.accountId,
           replyToId: ctx.replyToId,
+          extraLocalRoots: ctx.mediaLocalRoots,
         }),
       ),
   },

--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const senderSendMediaMock = vi.hoisted(() => vi.fn());
+const accountToCredsMock = vi.hoisted(() =>
+  vi.fn(() => ({ appId: "app", clientSecret: "secret" })),
+);
+const waitForFileMock = vi.hoisted(() => vi.fn(async () => 16));
+const audioFileToSilkBase64Mock = vi.hoisted(() => vi.fn(async () => "silk-base64"));
+const shouldTranscodeVoiceMock = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock("./sender.js", () => ({
+  senderSendMedia: senderSendMediaMock,
+  sendMedia: senderSendMediaMock,
+  accountToCreds: accountToCredsMock,
+  UploadDailyLimitExceededError: class UploadDailyLimitExceededError extends Error {},
+}));
+
+vi.mock("./outbound-audio-port.js", () => ({
+  waitForFile: waitForFileMock,
+  audioFileToSilkBase64: audioFileToSilkBase64Mock,
+  shouldTranscodeVoice: shouldTranscodeVoiceMock,
+}));
+
+import { sendVoice } from "./outbound-media-send.js";
+
+describe("qqbot sendVoice extraLocalRoots", () => {
+  const tempPaths: string[] = [];
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    for (const target of tempPaths.splice(0)) {
+      fs.rmSync(target, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts trusted local voice files from mediaLocalRoots for durable sends", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-voice-root-"));
+    tempPaths.push(root);
+    const voicePath = path.join(root, "voice.wav");
+    fs.writeFileSync(voicePath, "voice");
+
+    senderSendMediaMock.mockResolvedValueOnce({ id: "msg-1", timestamp: 123 });
+
+    const result = await sendVoice(
+      {
+        targetType: "c2c",
+        targetId: "OPENID",
+        account: { appId: "app", clientSecret: "secret", accountId: "default" },
+        extraLocalRoots: [root],
+      },
+      voicePath,
+      undefined,
+      true,
+    );
+
+    expect(result).toMatchObject({ channel: "qqbot", messageId: "msg-1" });
+    expect(senderSendMediaMock).toHaveBeenCalledTimes(1);
+    expect(senderSendMediaMock.mock.calls[0]?.[0]).toMatchObject({
+      kind: "voice",
+      source: { base64: "silk-base64" },
+      localPathForMeta: fs.realpathSync(voicePath),
+    });
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
@@ -59,6 +59,7 @@ export function buildMediaTarget(ctx: {
   to: string;
   account: GatewayAccount;
   replyToId?: string | null;
+  extraLocalRoots?: readonly string[];
 }): MediaTargetContext {
   const target = parseTarget(ctx.to);
   return {
@@ -66,6 +67,7 @@ export function buildMediaTarget(ctx: {
     targetId: target.id,
     account: ctx.account,
     replyToId: ctx.replyToId ?? undefined,
+    extraLocalRoots: ctx.extraLocalRoots,
   };
 }
 
@@ -307,6 +309,7 @@ export async function sendVoice(
 ): Promise<OutboundResult> {
   const resolvedMediaPath = resolveOutboundMediaPath(voicePath, "voice", {
     allowMissingLocalPath: true,
+    extraLocalRoots: ctx.extraLocalRoots ? [...ctx.extraLocalRoots] : undefined,
   });
   if (!resolvedMediaPath.ok) {
     return { channel: "qqbot", error: resolvedMediaPath.error };
@@ -368,16 +371,19 @@ async function sendVoiceFromLocal(
   }
 
   // Re-check containment after the file appears to prevent symlink-race escapes.
-  const safeMediaPath = resolveQQBotPayloadLocalFilePath(mediaPath);
-  if (!safeMediaPath) {
+  const safeMediaPath = resolveOutboundMediaPath(mediaPath, "voice", {
+    extraLocalRoots: ctx.extraLocalRoots ? [...ctx.extraLocalRoots] : undefined,
+  });
+  if (!safeMediaPath.ok) {
     debugWarn(`sendVoice: blocked local voice path outside QQ Bot media storage`);
-    return { channel: "qqbot", error: "Voice path must be inside QQ Bot media storage" };
+    return { channel: "qqbot", error: safeMediaPath.error };
   }
+  const safeLocalPath = safeMediaPath.mediaPath;
 
-  const needsTranscode = shouldTranscodeVoice(safeMediaPath);
+  const needsTranscode = shouldTranscodeVoice(safeLocalPath);
 
   if (needsTranscode && !transcodeEnabled) {
-    const ext = normalizeLowercaseStringOrEmpty(path.extname(safeMediaPath));
+    const ext = normalizeLowercaseStringOrEmpty(path.extname(safeLocalPath));
     debugLog(
       `sendVoice: transcode disabled, format ${ext} needs transcode, returning error for fallback`,
     );
@@ -388,11 +394,11 @@ async function sendVoiceFromLocal(
   }
 
   try {
-    const silkBase64 = await audioFileToSilkBase64(safeMediaPath, directUploadFormats);
+    const silkBase64 = await audioFileToSilkBase64(safeLocalPath, directUploadFormats);
     let uploadBase64 = silkBase64;
 
     if (!uploadBase64) {
-      const buf = await readFileAsync(safeMediaPath);
+      const buf = await readFileAsync(safeLocalPath);
       uploadBase64 = buf.toString("base64");
       debugLog(`sendVoice: SILK conversion failed, uploading raw (${formatFileSize(buf.length)})`);
     } else {
@@ -409,7 +415,7 @@ async function sendVoiceFromLocal(
         kind: "voice",
         source: { base64: uploadBase64 },
         msgId: ctx.replyToId,
-        localPathForMeta: safeMediaPath,
+        localPathForMeta: safeLocalPath,
       });
       return { channel: "qqbot", messageId: r.id, timestamp: r.timestamp };
     }

--- a/extensions/qqbot/src/engine/messaging/outbound-types.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-types.ts
@@ -13,6 +13,7 @@ export interface OutboundContext {
 export interface MediaOutboundContext extends OutboundContext {
   mediaUrl: string;
   mimeType?: string;
+  extraLocalRoots?: readonly string[];
 }
 
 /**
@@ -45,4 +46,5 @@ export interface MediaTargetContext {
   account: GatewayAccount;
   replyToId?: string;
   logPrefix?: string;
+  extraLocalRoots?: readonly string[];
 }

--- a/extensions/qqbot/src/engine/messaging/outbound.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound.ts
@@ -319,13 +319,19 @@ export async function sendMedia(ctx: MediaOutboundContext): Promise<OutboundResu
 
   const resolvedMediaPath = resolveOutboundMediaPath(ctx.mediaUrl, "media", {
     allowMissingLocalPath: true,
+    extraLocalRoots: ctx.extraLocalRoots ? [...ctx.extraLocalRoots] : undefined,
   });
   if (!resolvedMediaPath.ok) {
     return { channel: "qqbot", error: resolvedMediaPath.error };
   }
   const mediaUrl = resolvedMediaPath.mediaPath;
 
-  const target = buildMediaTarget({ to, account, replyToId });
+  const target = buildMediaTarget({
+    to,
+    account,
+    replyToId,
+    extraLocalRoots: ctx.extraLocalRoots,
+  });
 
   if (isAudioFile(mediaUrl, mimeType)) {
     const formats =


### PR DESCRIPTION
## Summary
- pass durable mediaLocalRoots through QQBot outbound media sends
- allow QQBot voice sends to re-validate trusted temp/local TTS files against those roots
- throw channel-adapter send errors so durable cron delivery is not marked sent on failure
- add regression coverage for adapter error surfacing and trusted local voice sends

## Testing
- pnpm exec vitest run extensions/qqbot/src/engine/utils/platform.test.ts extensions/qqbot/src/channel.message-adapter.test.ts extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts

Closes #92816