### PR TITLE
fix(doctor): preserve legacy codex OAuth provider when no models are mergeable

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -4,6 +4,7 @@ import { findLegacyConfigIssues } from "../../../config/legacy.js";
 import type { OpenClawConfig } from "../../../config/types.js";
 import { normalizeCompatibilityConfigValues } from "./legacy-config-core-migrate.js";
 import { LEGACY_CONFIG_MIGRATIONS } from "./legacy-config-migrations.js";
+import { collectBlockedLegacyOpenAICodexProviderWarnings } from "./legacy-config-migrations.runtime.models.js";
 
 function migrateLegacyConfigForTest(raw: unknown): {
   config: OpenClawConfig | null;
@@ -540,6 +541,102 @@ describe("legacy memory search config migrate", () => {
     expect(res.changes).toContain(
       "Removed models.providers.openai-codex because models.providers.openai already exists.",
     );
+  });
+
+  it("keeps legacy codex OAuth provider when all its models overlap canonical openai", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5.5" }],
+          },
+          "openai-codex": {
+            auth: "oauth",
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            headers: { Authorization: "Bearer token" },
+            request: { retry: { maxAttempts: 3 } },
+            models: [{ id: "gpt-5.5", api: "openai-codex-responses" }],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.["openai-codex"]).toEqual({
+      auth: "oauth",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      headers: { Authorization: "Bearer token" },
+      request: { retry: { maxAttempts: 3 } },
+      models: [{ id: "gpt-5.5", api: "openai-chatgpt-responses" }],
+    });
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://api.openai.com/v1",
+      models: [{ id: "gpt-5.5" }],
+    });
+    expect(res.changes).toContain(
+      "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai-codex.auth, models.providers.openai-codex.request, models.providers.openai-codex.headers.",
+    );
+  });
+
+  it("keeps legacy codex OAuth provider that has no models array", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5.5" }],
+          },
+          "openai-codex": {
+            auth: "oauth",
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            headers: { Authorization: "Bearer token" },
+            request: { retry: { maxAttempts: 3 } },
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.["openai-codex"]).toEqual({
+      auth: "oauth",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      headers: { Authorization: "Bearer token" },
+      request: { retry: { maxAttempts: 3 } },
+    });
+    expect(res.changes).toContain(
+      "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai-codex.auth, models.providers.openai-codex.request, models.providers.openai-codex.headers.",
+    );
+  });
+
+  it("previews a doctor warning before removing a codex OAuth provider with no mergeable models", () => {
+    const raw = {
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5.5" }],
+          },
+          "openai-codex": {
+            auth: "oauth",
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            headers: { Authorization: "Bearer token" },
+            models: [{ id: "gpt-5.5" }],
+          },
+        },
+      },
+    };
+
+    expect(collectBlockedLegacyOpenAICodexProviderWarnings(raw)).toEqual([
+      "models.providers.openai-codex cannot be merged automatically into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai-codex.auth, models.providers.openai-codex.headers. Move the affected model/provider defaults manually before removing models.providers.openai-codex.",
+    ]);
   });
 
   it("rewrites top-level legacy auto provider after moving memorySearch into agent defaults", () => {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1080,13 +1080,6 @@ function hasAutoFixableLegacyOpenAICodexProvider(providersValue: unknown): boole
     if (normalized.changed || !canonicalEntry) {
       return true;
     }
-    const modelsToMerge = getMergeableLegacyOpenAIModels({
-      canonical: canonicalEntry.value,
-      legacy: normalized.value,
-    });
-    if (modelsToMerge.length === 0) {
-      return true;
-    }
     const mergeBlockers = collectModelMergeBlockers({
       canonical: canonicalEntry.value,
       legacy: normalized.value,
@@ -1114,13 +1107,6 @@ export function collectBlockedLegacyOpenAICodexProviderWarnings(raw: unknown): s
     }
     const normalized = normalizeLegacyOpenAIResponsesApi(providerId, provider, []);
     if (normalized.changed) {
-      continue;
-    }
-    const modelsToMerge = getMergeableLegacyOpenAIModels({
-      canonical: canonicalEntry.value,
-      legacy: normalized.value,
-    });
-    if (modelsToMerge.length === 0) {
       continue;
     }
     const mergeBlockers = collectModelMergeBlockers({
@@ -1230,10 +1216,7 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
         canonical,
         legacy: normalized.value,
       });
-      const mergeBlockers =
-        modelsToMerge.length > 0
-          ? collectModelMergeBlockers({ canonical, legacy: normalized.value })
-          : [];
+      const mergeBlockers = collectModelMergeBlockers({ canonical, legacy: normalized.value });
       if (mergeBlockers.length > 0) {
         if (normalized.changed) {
           providers[providerId] = normalized.value;


### PR DESCRIPTION
## Summary

`openclaw doctor --fix` can silently delete a legacy `models.providers.openai-codex` provider together with its OAuth credentials (`auth`, `request`, `headers`, `apiKey`, ...) and emit no preview warning.

The merge-blocker safety check added for #90047 (`collectModelMergeBlockers`) exists precisely to stop the migration from dropping provider-level defaults that cannot be re-expressed on per-model entries. But in all three code paths that check was gated behind `modelsToMerge.length > 0`:

- `migrateLegacyOpenAICodexProvider` (the mutation): `const mergeBlockers = modelsToMerge.length > 0 ? collectModelMergeBlockers(...) : []`
- `collectBlockedLegacyOpenAICodexProviderWarnings` (the `openclaw doctor` preview): `if (modelsToMerge.length === 0) continue`
- `hasAutoFixableLegacyOpenAICodexProvider` (the fixable-issue probe): `if (modelsToMerge.length === 0) return true`

So whenever there are zero mergeable legacy models - either because every legacy model id already overlaps canonical `openai`, or because the legacy provider has no `models` array at all - the blocker check was skipped entirely. The provider was deleted with "Removed models.providers.openai-codex because models.providers.openai already exists." and the credential keys went with it, unwarned.

This is the same data-loss class the #90047 check was meant to prevent; it just had a hole for the no-mergeable-models case. It is distinct from the open context-budget metadata work in #90451 (that PR is explicitly scoped to `contextTokens`/`contextWindow`/`maxTokens` and states OAuth/auth is out of scope).

## Fix

Run `collectModelMergeBlockers` unconditionally in all three paths. When the legacy provider carries provider-level defaults that cannot be model-scoped, doctor now keeps it (and the preview warns) instead of deleting it. When it carries no such defaults, behavior is unchanged: the redundant provider is still removed.

## Verification

Local, normal source checkout on this branch, rebased on latest `origin/main`.

```
node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts
  -> Test Files 1 passed, Tests 117 passed (114 existing + 3 new)

oxfmt --check        -> All matched files use the correct format
run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json (both files)  -> EXIT 0
tsgo:core            -> EXIT 0
tsgo:core:test       -> EXIT 0
```

The three added regression tests fail on unpatched `main` (the legacy provider is removed and its auth is gone) and pass with this fix.

## Real behavior proof

- Behavior addressed: `openclaw doctor --fix` deleting a legacy `openai-codex` provider and its OAuth `auth`/`request`/`headers` with no warning when no legacy models are mergeable into canonical `openai` (all ids overlap, or the legacy provider has no `models` array).
- Real environment tested: local OpenClaw source checkout (`/root/openclaw`, Node 22.19), driving the real `LEGACY_CONFIG_MIGRATIONS` doctor pipeline and the real `collectBlockedLegacyOpenAICodexProviderWarnings` preview collector used by `collectDoctorPreviewNotes`.
- Exact steps or command run after this patch: ran a script that feeds two raw configs through every migration in `LEGACY_CONFIG_MIGRATIONS` (same array doctor applies) and inspects the retained `models.providers` plus the doctor preview warnings. Case A: canonical `openai` has `gpt-5.5`; legacy `openai-codex` carries `auth: "oauth"`, `headers`, `request` and a `gpt-5.5` model that overlaps canonical. Case B: same legacy provider but with no `models` array.

- Evidence after fix:

Case A - legacy provider retained with credentials, migration records why it was kept:

```json
"openai-codex": {
  "auth": "oauth",
  "api": "openai-chatgpt-responses",
  "baseUrl": "https://chatgpt.com/backend-api",
  "headers": { "Authorization": "Bearer tok" },
  "request": { "retry": { "maxAttempts": 3 } },
  "models": [{ "id": "gpt-5.5", "api": "openai-chatgpt-responses" }]
}
```
```
change: "Skipped merging models.providers.openai-codex into models.providers.openai
 because provider-level defaults cannot be represented safely on merged models:
 models.providers.openai-codex.auth, models.providers.openai-codex.request,
 models.providers.openai-codex.headers."
```

Case B - legacy provider retained, doctor preview now warns the user:

```json
"openai-codex": {
  "auth": "oauth",
  "api": "openai-chatgpt-responses",
  "baseUrl": "https://chatgpt.com/backend-api",
  "headers": { "Authorization": "Bearer tok" },
  "request": { "retry": { "maxAttempts": 3 } }
}
```
```
preview warning: "models.providers.openai-codex cannot be merged automatically into
 models.providers.openai because provider-level defaults cannot be represented safely
 on merged models: models.providers.openai-codex.auth, models.providers.openai-codex.headers.
 Move the affected model/provider defaults manually before removing models.providers.openai-codex."
```

- Observed result after fix: in both cases the credential-bearing legacy provider survives `--fix` and the user is told to migrate the affected defaults manually.
- Before evidence (same script on unpatched `main`): in both Case A and Case B the provider is deleted - `models.providers["openai-codex"]` is `undefined` after `--fix`, the only change recorded is "Removed models.providers.openai-codex because models.providers.openai already exists.", and `collectBlockedLegacyOpenAICodexProviderWarnings` returns `[]`. The OAuth `auth`/`request`/`headers` are silently lost.
- What was not tested: I did not run this against a live production gateway or mutate a real on-disk `openclaw.json`; verification was done through the real source-level doctor migration and preview-warning pipeline plus the focused and full migration test suites, oxlint, oxfmt, and tsgo.
