### PR TITLE
fix(memory): search memory and wiki concurrently for corpus=all (#92633)

### DIFF
--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -495,6 +495,104 @@ describe("memory tools", () => {
     expect(getMemorySearchManagerMockCalls()).toBe(1);
   });
 
+  it("runs the memory and wiki branches concurrently for corpus=all (#92633)", async () => {
+    // Regression: corpus=all awaited the memory/sessions branch fully before
+    // starting the wiki/supplement branch, so two searches that each finished
+    // well under the 15s tool deadline summed past it and the tool returned
+    // nothing. Running them concurrently keeps the combined wall time near
+    // max(branch), so the same two 9s searches now resolve at ~9s.
+    vi.useFakeTimers();
+    try {
+      const delay = (ms: number) =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, ms);
+        });
+      setMemorySearchImpl(async () => {
+        await delay(9_000);
+        return [
+          {
+            path: "MEMORY.md",
+            startLine: 5,
+            endLine: 7,
+            score: 0.9,
+            snippet: "@@ -5,3 @@\nAssistant: noted",
+            source: "memory" as const,
+          },
+        ];
+      });
+      registerMemoryCorpusSupplement("memory-wiki", {
+        search: async () => {
+          await delay(9_000);
+          return [
+            {
+              corpus: "wiki",
+              path: "entities/alpha.md",
+              title: "Alpha",
+              kind: "entity",
+              score: 1.1,
+              snippet: "Alpha wiki entry",
+            },
+          ];
+        },
+        get: async () => null,
+      });
+
+      const tool = createMemorySearchToolOrThrow();
+      const resultPromise = tool.execute("call_all_concurrent", {
+        query: "alpha",
+        corpus: "all",
+      });
+      // Sequentially the two branches take 18s and trip the 15s deadline;
+      // concurrently the tool resolves once the shared 9s elapses.
+      await vi.advanceTimersByTimeAsync(9_000);
+      const result = await resultPromise;
+      const details = result.details as {
+        disabled?: boolean;
+        results: Array<{ corpus: string; path: string }>;
+      };
+      expect(details.disabled).toBeUndefined();
+      expect(details.results.map((entry) => [entry.corpus, entry.path])).toEqual([
+        ["wiki", "entities/alpha.md"],
+        ["memory", "MEMORY.md"],
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("records the memory cooldown when corpus=all memory and wiki both fail (#92633)", async () => {
+    // Concurrency must not let a wiki failure mask a real memory backend failure:
+    // when both branches throw, the memory cooldown still has to be recorded so a
+    // broken embedding provider is suppressed rather than re-hit on the next turn.
+    let searchCalls = 0;
+    setMemorySearchImpl(async () => {
+      searchCalls += 1;
+      throw new Error("openai embeddings failed: 500 server_error");
+    });
+    registerMemoryCorpusSupplement("memory-wiki", {
+      search: async () => {
+        throw new Error("wiki supplement unavailable");
+      },
+      get: async () => null,
+    });
+
+    const tool = createMemorySearchToolOrThrow();
+    const bothFail = await tool.execute("call_all_both_fail", {
+      query: "alpha",
+      corpus: "all",
+    });
+    expectUnavailableMemorySearchDetails(bothFail.details, {
+      error: "openai embeddings failed: 500 server_error",
+      warning: "Memory search is unavailable due to an embedding/provider error.",
+      action: "Check embedding provider configuration and retry memory_search.",
+    });
+
+    // The next memory search is suppressed by the cooldown (no second backend hit).
+    const followup = await tool.execute("call_memory_after_both_fail", { query: "alpha" });
+    expect((followup.details as { disabled?: boolean }).disabled).toBe(true);
+    expect(searchCalls).toBe(1);
+  });
+
   it("does not cooldown primary memory when a corpus=all wiki supplement stalls", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -393,10 +393,13 @@ export function createMemorySearchTool(options: {
         });
         const cooldown =
           requestedCorpus === "wiki" ? undefined : readMemorySearchToolCooldown(cooldownKey);
-        let activeUnavailablePhase: "memory" | "supplement" | undefined;
-        let failedUnavailablePhase: "memory" | "supplement" | undefined;
+        // Only the memory/sessions branch feeds this tracker; the wiki branch
+        // runs concurrently (see below) and a second writer would make the
+        // corpus=all cooldown attribution race on last-writer-wins.
+        let activeUnavailablePhase: "memory" | undefined;
+        let failedUnavailablePhase: "memory" | undefined;
         const runUnavailablePhase = async <T>(
-          phase: "memory" | "supplement",
+          phase: "memory",
           task: () => Promise<T>,
         ): Promise<T> => {
           activeUnavailablePhase = phase;
@@ -430,6 +433,23 @@ export function createMemorySearchTool(options: {
               return context;
             };
             try {
+              // Run the wiki/supplement branch concurrently with memory/sessions:
+              // corpus=all previously awaited them sequentially under one 15s
+              // deadline, so two individually-fast searches summed past it and
+              // returned nothing (#92633). It stays outside runUnavailablePhase so
+              // the cooldown's memory-failure attribution is unaffected by the
+              // wiki branch; .catch absorbs the rejection on the rare paused-index
+              // early return that skips the await below.
+              const supplementResultsPromise: Promise<MemoryCorpusSearchResult[]> =
+                shouldQuerySupplements
+                  ? searchMemoryCorpusSupplements({
+                      query,
+                      maxResults,
+                      agentSessionKey: options.agentSessionKey,
+                      corpus: requestedCorpus,
+                    })
+                  : Promise.resolve([]);
+              supplementResultsPromise.catch(() => undefined);
               const memory = shouldQueryMemory
                 ? await runUnavailablePhase("memory", async () =>
                     trackMemoryManager(
@@ -599,18 +619,7 @@ export function createMemorySearchTool(options: {
                   );
                 }
               }
-              const supplementResults = shouldQuerySupplements
-                ? await runUnavailablePhase(
-                    "supplement",
-                    async () =>
-                      await searchMemoryCorpusSupplements({
-                        query,
-                        maxResults,
-                        agentSessionKey: options.agentSessionKey,
-                        corpus: requestedCorpus,
-                      }),
-                  )
-                : [];
+              const supplementResults = await supplementResultsPromise;
               // Wiki and memory scores use incomparable scales, so corpus=all first
               // balances candidate selection and then backfills any unused slots.
               const effectiveMax = Math.max(1, maxResults ?? 10);


### PR DESCRIPTION
### Summary

- `memory_search` with `corpus=all` ran the builtin memory/sessions branch and the wiki/supplement branch **sequentially** under one 15s tool deadline. Two searches that each finished well under 15s individually summed past the deadline, so `corpus=all` consistently returned `results: []` with `disabled: true` while `corpus=memory`, `corpus=sessions`, `corpus=wiki`, and the CLI all succeeded.
- This change starts the wiki/supplement search concurrently with the memory/sessions search inside the same deadline. The combined wall time drops from `memory + wiki` to roughly `max(memory, wiki)`, so `corpus=all` fits the deadline and returns merged results.
- The two branches share no mutable state, so overlapping them is safe; result merging, corpus balancing, the cooldown decision, and paused-index handling are unchanged.

### Root cause

In the memory_search tool runner, the supplement branch was awaited only after the memory branch fully resolved (manager fetch → vector search → optional forced resync → visibility filtering → decoration). The wiki/supplement branch then performed its own independent embedding and search. Under a single shared 15s deadline the two latencies added together, so an aggregation that was healthy per-corpus timed out as a whole and was misreported as an embedding/provider failure.

### Fix

- Kick off the supplement-search promise before the memory branch begins and await it at the existing merge point, so both branches run within the same deadline window concurrently.
- Keep the supplement branch out of the memory cooldown phase tracker so the `corpus=all` cooldown attribution stays single-writer and deterministic: a wiki failure can no longer race a real memory-backend failure into skipping the cooldown.
- Guard the hoisted promise so an early paused-index return cannot leave it rejected-but-unobserved.
- No change to result merging, corpus balancing, cooldown recording semantics, or the unavailable/paused result shapes.

### Real behavior proof

**Behavior addressed: `memory_search({ corpus: "all" })` no longer times out and returns empty when the memory and wiki branches each complete within the deadline but sum past it; it now returns merged memory + wiki results, and a real memory-backend failure still records the cooldown even when the wiki branch fails too.**

**Real environment tested (memory-core extension Vitest suite, Linux, Node 24): a deterministic concurrency regression test drives the real tool runner with a memory search and a registered wiki supplement that each take 9s under fake timers, plus a both-branches-throw test for the cooldown attribution.**

**Exact steps or command run after this patch (`pnpm test extensions/memory-core/src/tools.citations.test.ts extensions/memory-core/src/tools.test.ts`): the new cases `runs the memory and wiki branches concurrently for corpus=all (#92633)` and `records the memory cooldown when corpus=all memory and wiki both fail (#92633)`, plus the full files.**

**Evidence after fix (advancing fake time by 9s resolves the tool with both corpora): `corpus=all` returns `[["wiki","entities/alpha.md"],["memory","MEMORY.md"]]` with `disabled` undefined; the both-fail case still records the memory cooldown so the next memory search is suppressed. All 39 cases across the two suites pass.**

**Observed result after fix (the same two 9s branches that summed to 18s sequentially now complete at ~9s): with the production change reverted, the identical concurrency test hangs until the 120s test timeout because the wiki branch only starts after the memory branch finishes; with the change it resolves at 9s.**

**What was not tested (a live gateway against a real OpenAI-compatible embedding endpoint, `text-embedding-v4`, and a real compiled-wiki supplement on Windows Server): the reporter's exact environment was not reproduced; proof is the deterministic two-slow-branch simulation of the shared-deadline path.**

### Reproduction

1. Configure `memory_search` with a healthy embedding provider and at least one registered wiki/compiled-wiki supplement, where the builtin memory/sessions search and the wiki search each take several seconds.
2. Call `memory_search({ query, corpus: "memory" })`, `corpus: "sessions"`, and `corpus: "wiki"` — each succeeds within the 15s deadline.
3. Call `memory_search({ query, corpus: "all" })`.
4. **Before this PR**: the memory and wiki branches run one after the other, their latencies add up past 15s, and the tool returns `results: []`, `disabled: true`, `error: "memory_search timed out after 15s"`.
5. **After this PR**: both branches run concurrently within the deadline, the tool returns the merged memory + wiki results.

### Risk / Mitigation

- Risk: concurrent execution could race shared per-call state. Mitigation: the branches write disjoint locals (memory result/provider/debug vs. supplement results), and the supplement branch is deliberately kept out of the cooldown phase tracker so that tracker has a single writer.
- Risk: a hoisted supplement promise could become an unobserved rejection if the memory branch returns early (paused index). Mitigation: the promise is guarded with a no-op `catch`, and the real rejection still surfaces at the awaited merge point on the normal path.
- Risk: a genuinely hung wiki supplement could still trip the deadline. Mitigation: unchanged from today — a non-resolving branch still times out, and the existing stall tests continue to pass.

### Change Type (select all)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / internal change

### Scope (select all touched areas)

- [x] Memory / dreaming (`extensions/memory-core`)
- [ ] Core runtime / gateway
- [ ] Channels / plugins
- [ ] Config / migrations
- [ ] Docs

### Linked Issue/PR

Fixes #92633
