### PR TITLE
fix(android): show live chat context usage

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -443,6 +443,7 @@ class NodeRuntime(
         updateStatus()
         micCapture.onGatewayConnectionChanged(true)
         scope.launch {
+          subscribeOperatorSessionEvents()
           refreshHomeCanvasOverviewIfConnected()
           if (voiceReplySpeakerLazy.isInitialized()) {
             voiceReplySpeaker.refreshConfig()
@@ -484,6 +485,14 @@ class NodeRuntime(
         handleGatewayEvent(event, payloadJson)
       },
     )
+
+  private suspend fun subscribeOperatorSessionEvents() {
+    try {
+      operatorSession.request("sessions.subscribe", null)
+    } catch (err: Throwable) {
+      Log.d("OpenClawRuntime", "sessions.subscribe failed: ${err.message ?: err::class.java.simpleName}")
+    }
+  }
 
   private val nodeSession =
     GatewaySession(

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -311,7 +311,6 @@ class ChatController(
     }
   }
 
-  /** Applies gateway chat/agent stream events to local transcript and pending-run state. */
   fun handleGatewayEvent(
     event: String,
     payloadJson: String?,
@@ -321,7 +320,6 @@ class ChatController(
         scope.launch { pollHealthIfNeeded(force = false) }
       }
       "health" -> {
-        // If we receive a health snapshot, the gateway is reachable.
         _healthOk.value = true
       }
       "seqGap" -> {
@@ -334,7 +332,7 @@ class ChatController(
       }
       "sessions.changed" -> {
         if (payloadJson.isNullOrBlank()) {
-          scope.launch { fetchSessions(limit = _sessions.value.size.takeIf { it > 0 } ?: 100) }
+          refreshSessionsForCurrentWindow()
         } else {
           handleSessionsChangedEvent(payloadJson)
         }
@@ -398,6 +396,10 @@ class ChatController(
     } catch (_: Throwable) {
       // best-effort
     }
+  }
+
+  private fun refreshSessionsForCurrentWindow() {
+    scope.launch { fetchSessions(limit = _sessions.value.size.takeIf { it > 0 } ?: 100) }
   }
 
   private suspend fun pollHealthIfNeeded(force: Boolean) {
@@ -491,21 +493,24 @@ class ChatController(
       removeSessionEntry(payload["sessionKey"].asStringOrNull() ?: payload["key"].asStringOrNull())
       return
     }
-    val entry = payload["session"].asObjectOrNull()?.let(::parseSessionEntry) ?: parseSessionEntry(payload)
+    val entry = parseEventSessionEntry(payload)
     if (entry != null) {
       upsertSessionEntry(entry)
     } else {
-      scope.launch { fetchSessions(limit = _sessions.value.size.takeIf { it > 0 } ?: 100) }
+      refreshSessionsForCurrentWindow()
     }
   }
 
   private fun handleSessionMessageEvent(payloadJson: String) {
     val payload = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: return
-    val entry = payload["session"].asObjectOrNull()?.let(::parseSessionEntry) ?: parseSessionEntry(payload)
+    val entry = parseEventSessionEntry(payload)
     if (entry != null) {
       upsertSessionEntry(entry)
     }
   }
+
+  private fun parseEventSessionEntry(payload: JsonObject): ChatSessionEntry? =
+    payload["session"].asObjectOrNull()?.let(::parseSessionEntry) ?: parseSessionEntry(payload)
 
   private fun handleAgentEvent(payloadJson: String) {
     val payload = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: return

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -332,6 +332,17 @@ class ChatController(
         if (payloadJson.isNullOrBlank()) return
         handleChatEvent(payloadJson)
       }
+      "sessions.changed" -> {
+        if (payloadJson.isNullOrBlank()) {
+          scope.launch { fetchSessions(limit = _sessions.value.size.takeIf { it > 0 } ?: 100) }
+        } else {
+          handleSessionsChangedEvent(payloadJson)
+        }
+      }
+      "session.message" -> {
+        if (payloadJson.isNullOrBlank()) return
+        handleSessionMessageEvent(payloadJson)
+      }
       "agent" -> {
         if (payloadJson.isNullOrBlank()) return
         handleAgentEvent(payloadJson)
@@ -353,6 +364,7 @@ class ChatController(
         )
       if (!isCurrentHistoryLoad(sessionKey, _sessionKey.value, generation, historyLoadGeneration.get())) return
       val history = parseHistory(historyJson, sessionKey = sessionKey, previousMessages = _messages.value)
+      updateSessionFromHistory(history)
       prunePersistedOptimisticMessages(history.messages)
       _messages.value = mergeOptimisticMessages(incoming = history.messages, optimistic = optimisticMessagesByRunId.values)
       _sessionId.value = history.sessionId
@@ -457,6 +469,7 @@ class ChatController(
                 sessionKey = currentSessionKey,
                 previousMessages = _messages.value,
               )
+            updateSessionFromHistory(history)
             prunePersistedOptimisticMessages(history.messages)
             _messages.value = mergeOptimisticMessages(incoming = history.messages, optimistic = optimisticMessagesByRunId.values)
             _sessionId.value = history.sessionId
@@ -469,6 +482,28 @@ class ChatController(
           }
         }
       }
+    }
+  }
+
+  private fun handleSessionsChangedEvent(payloadJson: String) {
+    val payload = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: return
+    if (payload["reason"].asStringOrNull() == "delete") {
+      removeSessionEntry(payload["sessionKey"].asStringOrNull() ?: payload["key"].asStringOrNull())
+      return
+    }
+    val entry = payload["session"].asObjectOrNull()?.let(::parseSessionEntry) ?: parseSessionEntry(payload)
+    if (entry != null) {
+      upsertSessionEntry(entry)
+    } else {
+      scope.launch { fetchSessions(limit = _sessions.value.size.takeIf { it > 0 } ?: 100) }
+    }
+  }
+
+  private fun handleSessionMessageEvent(payloadJson: String) {
+    val payload = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: return
+    val entry = payload["session"].asObjectOrNull()?.let(::parseSessionEntry) ?: parseSessionEntry(payload)
+    if (entry != null) {
+      upsertSessionEntry(entry)
     }
   }
 
@@ -600,6 +635,7 @@ class ChatController(
     val root = json.parseToJsonElement(historyJson).asObjectOrNull() ?: return ChatHistory(sessionKey, null, null, emptyList())
     val sid = root["sessionId"].asStringOrNull()
     val thinkingLevel = root["thinkingLevel"].asStringOrNull()
+    val sessionInfo = root["sessionInfo"].asObjectOrNull()?.let { parseSessionEntry(it, fallbackKey = sessionKey) }
     val array = root["messages"].asArrayOrNull() ?: JsonArray(emptyList())
 
     val messages =
@@ -622,21 +658,68 @@ class ChatController(
       sessionId = sid,
       thinkingLevel = thinkingLevel,
       messages = reconcileMessageIds(previous = previousMessages, incoming = messages),
+      sessionInfo = sessionInfo,
     )
   }
 
   private fun parseSessions(jsonString: String): List<ChatSessionEntry> {
     val root = json.parseToJsonElement(jsonString).asObjectOrNull() ?: return emptyList()
     val sessions = root["sessions"].asArrayOrNull() ?: return emptyList()
-    return sessions.mapNotNull { item ->
-      val obj = item.asObjectOrNull() ?: return@mapNotNull null
-      val key = obj["key"].asStringOrNull()?.trim().orEmpty()
-      if (key.isEmpty()) return@mapNotNull null
-      val updatedAt = obj["updatedAt"].asLongOrNull()
-      val displayName = obj["displayName"].asStringOrNull()?.trim()
-      ChatSessionEntry(key = key, updatedAtMs = updatedAt, displayName = displayName)
-    }
+    return sessions.mapNotNull { item -> parseSessionEntry(item.asObjectOrNull()) }
   }
+
+  private fun parseSessionEntry(
+    obj: JsonObject?,
+    fallbackKey: String? = null,
+  ): ChatSessionEntry? {
+    if (obj == null) return null
+    val key =
+      obj["key"].asStringOrNull()?.trim().orEmpty()
+        .ifEmpty { obj["sessionKey"].asStringOrNull()?.trim().orEmpty() }
+        .ifEmpty { fallbackKey?.trim().orEmpty() }
+    if (key.isEmpty()) return null
+    return ChatSessionEntry(
+      key = key,
+      updatedAtMs = obj["updatedAt"].asLongOrNull(),
+      displayName = obj["displayName"].asStringOrNull()?.trim(),
+      totalTokens = obj["totalTokens"].asLongOrNull(),
+      totalTokensFresh = obj["totalTokensFresh"].asBooleanOrNull(),
+      contextTokens = obj["contextTokens"].asLongOrNull(),
+    )
+  }
+
+  private fun updateSessionFromHistory(history: ChatHistory) {
+    val info = history.sessionInfo ?: return
+    upsertSessionEntry(info)
+  }
+
+  private fun upsertSessionEntry(entry: ChatSessionEntry) {
+    val current = _sessions.value
+    val index = current.indexOfFirst { it.key == entry.key }
+    _sessions.value =
+      if (index >= 0) {
+        current.toMutableList().also { it[index] = mergeSessionEntry(it[index], entry) }
+      } else {
+        listOf(entry) + current
+      }
+  }
+
+  private fun removeSessionEntry(sessionKey: String?) {
+    val key = sessionKey?.trim()?.takeIf { it.isNotEmpty() } ?: return
+    _sessions.value = _sessions.value.filterNot { it.key == key }
+  }
+
+  private fun mergeSessionEntry(
+    existing: ChatSessionEntry,
+    next: ChatSessionEntry,
+  ): ChatSessionEntry =
+    existing.copy(
+      updatedAtMs = next.updatedAtMs ?: existing.updatedAtMs,
+      displayName = next.displayName ?: existing.displayName,
+      totalTokens = next.totalTokens ?: existing.totalTokens,
+      totalTokensFresh = next.totalTokensFresh ?: existing.totalTokensFresh,
+      contextTokens = next.contextTokens ?: existing.contextTokens,
+    )
 
   private fun parseRunId(resJson: String): String? =
     try {
@@ -855,5 +938,11 @@ private fun JsonElement?.asStringOrNull(): String? =
 private fun JsonElement?.asLongOrNull(): Long? =
   when (this) {
     is JsonPrimitive -> content.toLongOrNull()
+    else -> null
+  }
+
+private fun JsonElement?.asBooleanOrNull(): Boolean? =
+  when (this) {
+    is JsonPrimitive -> content.toBooleanStrictOrNull()
     else -> null
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -685,6 +685,10 @@ class ChatController(
       totalTokens = obj["totalTokens"].asLongOrNull(),
       totalTokensFresh = obj["totalTokensFresh"].asBooleanOrNull(),
       contextTokens = obj["contextTokens"].asLongOrNull(),
+      hasContextUsageMetadata =
+        "totalTokens" in obj ||
+          "totalTokensFresh" in obj ||
+          "contextTokens" in obj,
     )
   }
 
@@ -698,7 +702,7 @@ class ChatController(
     val index = current.indexOfFirst { it.key == entry.key }
     _sessions.value =
       if (index >= 0) {
-        current.toMutableList().also { it[index] = mergeSessionEntry(it[index], entry) }
+        current.toMutableList().also { it[index] = mergeChatSessionEntry(it[index], entry) }
       } else {
         listOf(entry) + current
       }
@@ -708,18 +712,6 @@ class ChatController(
     val key = sessionKey?.trim()?.takeIf { it.isNotEmpty() } ?: return
     _sessions.value = _sessions.value.filterNot { it.key == key }
   }
-
-  private fun mergeSessionEntry(
-    existing: ChatSessionEntry,
-    next: ChatSessionEntry,
-  ): ChatSessionEntry =
-    existing.copy(
-      updatedAtMs = next.updatedAtMs ?: existing.updatedAtMs,
-      displayName = next.displayName ?: existing.displayName,
-      totalTokens = next.totalTokens ?: existing.totalTokens,
-      totalTokensFresh = next.totalTokensFresh ?: existing.totalTokensFresh,
-      contextTokens = next.contextTokens ?: existing.contextTokens,
-    )
 
   private fun parseRunId(resJson: String): String? =
     try {
@@ -946,3 +938,16 @@ private fun JsonElement?.asBooleanOrNull(): Boolean? =
     is JsonPrimitive -> content.toBooleanStrictOrNull()
     else -> null
   }
+
+internal fun mergeChatSessionEntry(
+  existing: ChatSessionEntry,
+  next: ChatSessionEntry,
+): ChatSessionEntry =
+  existing.copy(
+    updatedAtMs = next.updatedAtMs ?: existing.updatedAtMs,
+    displayName = next.displayName ?: existing.displayName,
+    totalTokens = if (next.hasContextUsageMetadata) next.totalTokens else null,
+    totalTokensFresh = if (next.hasContextUsageMetadata) next.totalTokensFresh else null,
+    contextTokens = if (next.hasContextUsageMetadata) next.contextTokens else null,
+    hasContextUsageMetadata = next.hasContextUsageMetadata,
+  )

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -699,15 +699,25 @@ class ChatController(
 
   private fun updateSessionFromHistory(history: ChatHistory) {
     val info = history.sessionInfo ?: return
-    upsertSessionEntry(info)
+    upsertSessionEntry(info, preserveExistingContextUsageWithoutTotal = true)
   }
 
-  private fun upsertSessionEntry(entry: ChatSessionEntry) {
+  private fun upsertSessionEntry(
+    entry: ChatSessionEntry,
+    preserveExistingContextUsageWithoutTotal: Boolean = false,
+  ) {
     val current = _sessions.value
     val index = current.indexOfFirst { it.key == entry.key }
     _sessions.value =
       if (index >= 0) {
-        current.toMutableList().also { it[index] = mergeChatSessionEntry(it[index], entry) }
+        current.toMutableList().also {
+          it[index] =
+            mergeChatSessionEntry(
+              existing = it[index],
+              next = entry,
+              preserveExistingContextUsageWithoutTotal = preserveExistingContextUsageWithoutTotal,
+            )
+        }
       } else {
         listOf(entry) + current
       }
@@ -947,12 +957,34 @@ private fun JsonElement?.asBooleanOrNull(): Boolean? =
 internal fun mergeChatSessionEntry(
   existing: ChatSessionEntry,
   next: ChatSessionEntry,
-): ChatSessionEntry =
-  existing.copy(
+  preserveExistingContextUsageWithoutTotal: Boolean = false,
+): ChatSessionEntry {
+  val preserveExistingContextUsage = preserveExistingContextUsageWithoutTotal && next.totalTokens == null
+  return existing.copy(
     updatedAtMs = next.updatedAtMs ?: existing.updatedAtMs,
     displayName = next.displayName ?: existing.displayName,
-    totalTokens = if (next.hasContextUsageMetadata) next.totalTokens else null,
-    totalTokensFresh = if (next.hasContextUsageMetadata) next.totalTokensFresh else null,
-    contextTokens = if (next.hasContextUsageMetadata) next.contextTokens else null,
-    hasContextUsageMetadata = next.hasContextUsageMetadata,
+    totalTokens =
+      when {
+        preserveExistingContextUsage -> existing.totalTokens
+        next.hasContextUsageMetadata -> next.totalTokens
+        else -> null
+      },
+    totalTokensFresh =
+      when {
+        preserveExistingContextUsage -> existing.totalTokensFresh
+        next.hasContextUsageMetadata -> next.totalTokensFresh
+        else -> null
+      },
+    contextTokens =
+      when {
+        preserveExistingContextUsage -> next.contextTokens ?: existing.contextTokens
+        next.hasContextUsageMetadata -> next.contextTokens
+        else -> null
+      },
+    hasContextUsageMetadata =
+      when {
+        preserveExistingContextUsage -> existing.hasContextUsageMetadata || next.contextTokens != null
+        else -> next.hasContextUsageMetadata
+      },
   )
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -40,6 +40,9 @@ data class ChatSessionEntry(
   val key: String,
   val updatedAtMs: Long?,
   val displayName: String? = null,
+  val totalTokens: Long? = null,
+  val totalTokensFresh: Boolean? = null,
+  val contextTokens: Long? = null,
 )
 
 /**
@@ -50,6 +53,7 @@ data class ChatHistory(
   val sessionId: String?,
   val thinkingLevel: String?,
   val messages: List<ChatMessage>,
+  val sessionInfo: ChatSessionEntry? = null,
 )
 
 /**

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -43,6 +43,7 @@ data class ChatSessionEntry(
   val totalTokens: Long? = null,
   val totalTokensFresh: Boolean? = null,
   val contextTokens: Long? = null,
+  val hasContextUsageMetadata: Boolean = totalTokens != null || totalTokensFresh != null || contextTokens != null,
 )
 
 /**

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -74,6 +74,7 @@ import kotlinx.coroutines.withContext
 import java.text.DateFormat
 import java.util.Date
 import java.util.Locale
+import kotlin.math.roundToInt
 
 /** Full chat surface that wires MainViewModel state to messages, attachments, voice, and composer actions. */
 @Composable
@@ -95,6 +96,7 @@ fun ChatScreen(
   val sessions by viewModel.chatSessions.collectAsState()
   val chatDraft by viewModel.chatDraft.collectAsState()
   val pendingAssistantAutoSend by viewModel.pendingAssistantAutoSend.collectAsState()
+  val contextUsage = resolveChatContextUsage(sessionKey = sessionKey, mainSessionKey = mainSessionKey, sessions = sessions)
   val context = LocalContext.current
   val resolver = context.contentResolver
   val scope = rememberCoroutineScope()
@@ -196,6 +198,7 @@ fun ChatScreen(
       onValueChange = { input = it },
       attachments = attachments,
       thinkingLevel = thinkingLevel,
+      contextUsage = contextUsage,
       healthOk = healthOk,
       pendingRunCount = pendingRunCount,
       onThinkingLevelChange = viewModel::setChatThinkingLevel,
@@ -685,6 +688,7 @@ private fun ChatComposer(
   onValueChange: (String) -> Unit,
   attachments: List<PendingImageAttachment>,
   thinkingLevel: String,
+  contextUsage: ChatContextUsage,
   healthOk: Boolean,
   pendingRunCount: Int,
   onThinkingLevelChange: (String) -> Unit,
@@ -699,7 +703,11 @@ private fun ChatComposer(
       AttachmentStrip(attachments = attachments, onRemoveAttachment = onRemoveAttachment)
     }
 
-    ChatContextMeter(thinkingLevel = thinkingLevel, onClick = { onThinkingLevelChange(nextThinkingValue(thinkingLevel)) })
+    ChatContextMeter(
+      thinkingLevel = thinkingLevel,
+      contextUsage = contextUsage,
+      onClick = { onThinkingLevelChange(nextThinkingValue(thinkingLevel)) },
+    )
 
     Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
       ChatInputPill(value = value, onValueChange = onValueChange, onPickImages = onPickImages, onVoice = onVoice, modifier = Modifier.weight(1f))
@@ -735,8 +743,10 @@ private fun ChatComposer(
 @Composable
 private fun ChatContextMeter(
   thinkingLevel: String,
+  contextUsage: ChatContextUsage,
   onClick: () -> Unit,
 ) {
+  val contextFraction = contextMeterWidth(contextUsage) ?: 0f
   Row(
     modifier = Modifier.width(178.dp),
     verticalAlignment = Alignment.CenterVertically,
@@ -755,7 +765,13 @@ private fun ChatContextMeter(
         horizontalArrangement = Arrangement.spacedBy(6.dp),
       ) {
         Icon(imageVector = Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(12.dp), tint = ClawTheme.colors.textSubtle)
-        Text(text = "Context ${contextPercent(thinkingLevel)}%", style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textMuted)
+        Text(
+          text = contextMeterLabel(contextUsage, thinkingLevel),
+          style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp),
+          color = ClawTheme.colors.textMuted,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
       }
     }
     Box(
@@ -768,7 +784,7 @@ private fun ChatContextMeter(
       Box(
         modifier =
           Modifier
-            .fillMaxWidth(thinkingMeterWidth(thinkingLevel))
+            .fillMaxWidth(contextFraction)
             .height(3.dp)
             .background(ClawTheme.colors.primary, RoundedCornerShape(999.dp)),
       )
@@ -902,6 +918,32 @@ private fun isActiveSessionChoice(
   return choiceKey == current
 }
 
+internal data class ChatContextUsage(
+  val totalTokens: Long?,
+  val totalTokensFresh: Boolean?,
+  val contextTokens: Long?,
+)
+
+internal fun resolveChatContextUsage(
+  sessionKey: String,
+  mainSessionKey: String,
+  sessions: List<ChatSessionEntry>,
+): ChatContextUsage {
+  val entry =
+    sessions.firstOrNull {
+      isActiveSessionChoice(
+        choiceKey = it.key,
+        sessionKey = sessionKey,
+        mainSessionKey = mainSessionKey,
+      )
+  }
+  return ChatContextUsage(
+    totalTokens = entry?.totalTokens,
+    totalTokensFresh = entry?.totalTokensFresh,
+    contextTokens = entry?.contextTokens,
+  )
+}
+
 @Composable
 private fun SendButton(
   enabled: Boolean,
@@ -958,16 +1000,28 @@ private fun nextThinkingValue(value: String): String =
     else -> "off"
   }
 
-/** Maps thinking presets to the visual context meter fill fraction. */
-private fun thinkingMeterWidth(value: String): Float =
-  when (value.lowercase(Locale.US)) {
-    "low" -> 0.34f
-    "medium" -> 0.58f
-    "high" -> 0.82f
-    else -> 0.18f
-  }
+internal fun contextMeterWidth(usage: ChatContextUsage): Float? {
+  if (usage.totalTokensFresh == false) return null
+  val total = usage.totalTokens?.takeIf { it >= 0L } ?: return null
+  val context = usage.contextTokens?.takeIf { it > 0L } ?: return null
+  return (total.toDouble() / context.toDouble()).coerceIn(0.0, 1.0).toFloat()
+}
 
-private fun contextPercent(value: String): Int = (thinkingMeterWidth(value) * 100).toInt()
+internal fun contextMeterLabel(
+  usage: ChatContextUsage,
+  thinkingLevel: String,
+): String {
+  val contextLabel = contextMeterWidth(usage)?.let { "Context ${(it * 100).roundToInt()}%" } ?: "Context --"
+  return "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}"
+}
+
+internal fun contextMeterThinkingLabel(value: String): String =
+  when (value.lowercase(Locale.US)) {
+    "low" -> "low"
+    "medium" -> "medium"
+    "high" -> "high"
+    else -> "off"
+  }
 
 private fun formatChatTimestamp(timestampMs: Long): String = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault()).format(Date(timestampMs))
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionPolicyTest.kt
@@ -59,4 +59,61 @@ class ChatControllerSessionPolicyTest {
       ),
     )
   }
+
+  @Test
+  fun sessionMergeClearsUsageWhenNewSnapshotOmitsUsageMetadata() {
+    val existing =
+      ChatSessionEntry(
+        key = "agent:main:phone",
+        updatedAtMs = 1L,
+        displayName = "Phone",
+        totalTokens = 41_000L,
+        totalTokensFresh = true,
+        contextTokens = 100_000L,
+      )
+    val next =
+      ChatSessionEntry(
+        key = "agent:main:phone",
+        updatedAtMs = 2L,
+        displayName = "Phone renamed",
+        hasContextUsageMetadata = false,
+      )
+
+    val merged = mergeChatSessionEntry(existing, next)
+
+    assertEquals("agent:main:phone", merged.key)
+    assertEquals(2L, merged.updatedAtMs)
+    assertEquals("Phone renamed", merged.displayName)
+    assertEquals(null, merged.totalTokens)
+    assertEquals(null, merged.totalTokensFresh)
+    assertEquals(null, merged.contextTokens)
+    assertFalse(merged.hasContextUsageMetadata)
+  }
+
+  @Test
+  fun sessionMergeAppliesExplicitStaleUsageMetadata() {
+    val existing =
+      ChatSessionEntry(
+        key = "agent:main:phone",
+        updatedAtMs = 1L,
+        totalTokens = 41_000L,
+        totalTokensFresh = true,
+        contextTokens = 100_000L,
+      )
+    val next =
+      ChatSessionEntry(
+        key = "agent:main:phone",
+        updatedAtMs = 2L,
+        totalTokens = 82_000L,
+        totalTokensFresh = false,
+        contextTokens = 100_000L,
+      )
+
+    val merged = mergeChatSessionEntry(existing, next)
+
+    assertEquals(82_000L, merged.totalTokens)
+    assertEquals(false, merged.totalTokensFresh)
+    assertEquals(100_000L, merged.contextTokens)
+    assertTrue(merged.hasContextUsageMetadata)
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionPolicyTest.kt
@@ -91,6 +91,41 @@ class ChatControllerSessionPolicyTest {
   }
 
   @Test
+  fun sessionMergePreservesUsageWhenHistorySnapshotOmitsTotalTokens() {
+    val existing =
+      ChatSessionEntry(
+        key = "agent:main:phone",
+        updatedAtMs = 1L,
+        displayName = "Phone",
+        totalTokens = 41_000L,
+        totalTokensFresh = true,
+        contextTokens = 100_000L,
+      )
+    val next =
+      ChatSessionEntry(
+        key = "agent:main:phone",
+        updatedAtMs = 2L,
+        displayName = "Phone renamed",
+        totalTokensFresh = false,
+        contextTokens = 120_000L,
+      )
+
+    val merged =
+      mergeChatSessionEntry(
+        existing = existing,
+        next = next,
+        preserveExistingContextUsageWithoutTotal = true,
+      )
+
+    assertEquals(2L, merged.updatedAtMs)
+    assertEquals("Phone renamed", merged.displayName)
+    assertEquals(41_000L, merged.totalTokens)
+    assertEquals(true, merged.totalTokensFresh)
+    assertEquals(120_000L, merged.contextTokens)
+    assertTrue(merged.hasContextUsageMetadata)
+  }
+
+  @Test
   fun sessionMergeAppliesExplicitStaleUsageMetadata() {
     val existing =
       ChatSessionEntry(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatContextMeterTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatContextMeterTest.kt
@@ -1,0 +1,84 @@
+package ai.openclaw.app.ui.chat
+
+import ai.openclaw.app.chat.ChatSessionEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChatContextMeterTest {
+  @Test
+  fun contextMeterUsesActiveSessionTokenBudget() {
+    val sessions =
+      listOf(
+        ChatSessionEntry(key = "main", updatedAtMs = 1L, displayName = "Main", totalTokens = 8_000L, totalTokensFresh = true, contextTokens = 10_000L),
+        ChatSessionEntry(
+          key = "agent:main:mobile:test-device",
+          updatedAtMs = 2L,
+          displayName = "Phone",
+          totalTokens = 1_250L,
+          totalTokensFresh = true,
+          contextTokens = 5_000L,
+        ),
+      )
+
+    val usage =
+      resolveChatContextUsage(
+        sessionKey = "agent:main:mobile:test-device",
+        mainSessionKey = "main",
+        sessions = sessions,
+      )
+
+    assertEquals(ChatContextUsage(totalTokens = 1_250L, totalTokensFresh = true, contextTokens = 5_000L), usage)
+    assertEquals(0.25f, contextMeterWidth(usage))
+    assertEquals("Context 25% · high", contextMeterLabel(usage, "high"))
+  }
+
+  @Test
+  fun contextMeterResolvesCanonicalMainAlias() {
+    val sessions =
+      listOf(
+        ChatSessionEntry(
+          key = "agent:main:node-phone",
+          updatedAtMs = 1L,
+          displayName = "Main",
+          totalTokens = 41_000L,
+          totalTokensFresh = true,
+          contextTokens = 100_000L,
+        ),
+      )
+
+    val usage =
+      resolveChatContextUsage(
+        sessionKey = "main",
+        mainSessionKey = "agent:main:node-phone",
+        sessions = sessions,
+      )
+
+    assertEquals(ChatContextUsage(totalTokens = 41_000L, totalTokensFresh = true, contextTokens = 100_000L), usage)
+    assertEquals("Context 41% · off", contextMeterLabel(usage, "off"))
+  }
+
+  @Test
+  fun contextMeterDoesNotInventPercentWhenBudgetIsMissing() {
+    val usage = ChatContextUsage(totalTokens = 8_200L, totalTokensFresh = true, contextTokens = null)
+
+    assertNull(contextMeterWidth(usage))
+    assertEquals("Context -- · medium", contextMeterLabel(usage, "medium"))
+  }
+
+  @Test
+  fun contextMeterClampsOverfullSessions() {
+    val usage = ChatContextUsage(totalTokens = 150_000L, totalTokensFresh = true, contextTokens = 100_000L)
+
+    assertEquals(1.0f, contextMeterWidth(usage))
+    assertEquals("Context 100% · low", contextMeterLabel(usage, "low"))
+  }
+
+  @Test
+  fun contextMeterDoesNotDisplayStaleTokenUsage() {
+    val usage = ChatContextUsage(totalTokens = 82_000L, totalTokensFresh = false, contextTokens = 100_000L)
+
+    assertNull(contextMeterWidth(usage))
+    assertEquals("Context -- · high", contextMeterLabel(usage, "high"))
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes the Android chat context meter so it renders live session context usage from gateway `totalTokens` / `contextTokens` metadata instead of mapping the thinking preset to a fixed percentage.
- Keeps the compact thinking control visible by showing the current thinking level next to the context usage label.
- Wires Android operator sessions into gateway session events (`sessions.subscribe`) and consumes `sessions.changed`, `session.message`, and `chat.history.sessionInfo` session metadata so the meter can update after normal chat activity.
- Treats missing, stale, or explicitly absent token usage as `Context --` instead of displaying a stale or misleading percentage.
- Follow-up for ClawSweeper's session-state risk: newer session snapshots that omit context-usage fields now clear cached usage instead of silently preserving an older chat's token state.
- Out of scope: changing gateway token accounting semantics or redesigning the chat composer control.

## Linked context

Closes #

Related #

Was this requested by a maintainer or owner?

No public maintainer issue. This was found while testing the Android chat UI: the composer showed the same `Context 82%` value across different selected chats.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Android chat composer context usage no longer stays at a fixed thinking-derived percentage across chats.
- Real environment tested: Android emulator running the third-party debug APK from this branch, paired to a throwaway local OpenClaw proof gateway with a synthetic `Proof Main` session.
- Exact steps or command run after this patch:
  - Rebased branch onto current `upstream/main`.
  - `git diff --check`
  - `ANDROID_HOME=/home/nabu/Android/Sdk ANDROID_SDK_ROOT=/home/nabu/Android/Sdk ./gradlew :app:clean :app:testThirdPartyDebugUnitTest :app:assembleThirdPartyDebug --no-daemon --stacktrace`
  - `ANDROID_HOME=/home/nabu/Android/Sdk ANDROID_SDK_ROOT=/home/nabu/Android/Sdk ./gradlew :app:testPlayDebugUnitTest :app:assemblePlayDebug --no-daemon --stacktrace`
  - Earlier connected proof on this branch: `./gradlew :app:installThirdPartyDebug --no-daemon --stacktrace`, Android emulator pairing to a throwaway local proof gateway, opening the synthetic `Proof Main` chat, and capturing `adb` screenshots plus `uiautomator` dumps.
  - Earlier lint probe: `./gradlew :app:lintThirdPartyDebug --no-daemon --stacktrace`.
- Gateway metadata used for live proof, redacted to only the fields relevant to this UI contract:

```text
session=Proof Main
totalTokens=20500
totalTokensFresh=true
contextTokens=50000
thinkingLevel=high
```

- Evidence after fix:
  - Current rebased head: `BUILD SUCCESSFUL` for `:app:clean :app:testThirdPartyDebugUnitTest :app:assembleThirdPartyDebug`.
  - Current rebased head: `BUILD SUCCESSFUL` for `:app:testPlayDebugUnitTest :app:assemblePlayDebug`.
  - Focused regression coverage now verifies session metadata merge behavior clears old token usage when a newer session snapshot omits usage fields.
  - Focused regression coverage also verifies explicit stale metadata (`totalTokensFresh=false`) replaces previous fresh metadata and renders as unknown usage.
  - Emulator screenshot with fresh gateway metadata: Android composer shows `Context 41% · high`, matching `20500 / 50000 = 41%`.
  - Emulator screenshot with stale gateway metadata: Android composer shows `Context -- · high` when `totalTokensFresh=false`.

Fresh metadata screenshot:

![Android emulator showing Context 41% high from live gateway metadata](https://github.com/Tosko4/openclaw/blob/proof/pr-92837-android-context-meter/proof/pr-92837/android-context-meter-live-41.png?raw=1)

Stale metadata screenshot:

![Android emulator showing Context dash high when totalTokensFresh is false](https://github.com/Tosko4/openclaw/blob/proof/pr-92837-android-context-meter/proof/pr-92837/android-context-meter-stale-dash.png?raw=1)

- Observed result after fix: context label is computed from fresh token usage and displays `Context --` for stale or absent usage. Thinking level remains visible in the same control.
- What was not tested: full manual exploration against a private real user gateway/session was not tested; proof uses a throwaway local gateway and synthetic session to avoid exposing private data.
- Proof limitations or environment constraints: screenshots use a synthetic local proof session and a throwaway local gateway, not a private real user session. No personal chats, account data, tokens, local endpoints, or non-public session identifiers are included. The follow-up for missing usage metadata is covered by focused merge-policy tests because the visible UI outcome is the same safe `Context --` state shown in the stale-metadata screenshot.
- Before evidence: source-reproducible on current main: the Android `ChatContextMeter` derives the percentage from `thinkingLevel`, with `high` mapped to `82%`, so the displayed context value is independent of gateway `totalTokens` / `contextTokens` usage.

## Tests and validation

Commands run on the current rebased head:

- `git diff --check`
- `ANDROID_HOME=/home/nabu/Android/Sdk ANDROID_SDK_ROOT=/home/nabu/Android/Sdk ./gradlew :app:clean :app:testThirdPartyDebugUnitTest :app:assembleThirdPartyDebug --no-daemon --stacktrace`
- `ANDROID_HOME=/home/nabu/Android/Sdk ANDROID_SDK_ROOT=/home/nabu/Android/Sdk ./gradlew :app:testPlayDebugUnitTest :app:assemblePlayDebug --no-daemon --stacktrace`

Connected Android proof also run earlier on this branch:

- `./gradlew :app:installThirdPartyDebug --no-daemon --stacktrace`
- Android emulator + `adb` connected-runtime screenshot proof against a throwaway local proof gateway.

Regression coverage added:

- Active session token usage resolution.
- Canonical `main` alias resolution.
- Missing context budget fallback.
- Stale token usage fallback.
- Overfull usage clamping.
- Session merge clears old usage when a newer snapshot omits context-usage metadata.
- Session merge applies explicit stale usage metadata instead of retaining older fresh usage.

Known validation note:

- `:app:lintThirdPartyDebug` still fails on existing unrelated lint errors outside this PR's touched code:
  - `OnboardingFlow.kt`: `POST_NOTIFICATIONS` API-level lint.
  - `DeviceHandler.kt`: package visibility lint.
  - `GatewayDiscovery.kt`: two `@RequiresApi` lint findings.
  - `app/src/debug/AndroidManifest.xml`: exported receiver permission lint.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No security/auth change. The Android operator connection now best-effort subscribes to existing gateway session events after connect.

What is the highest-risk area?

Session metadata freshness in the Android chat UI.

How is that risk mitigated?

The controller now distinguishes snapshots that explicitly include context-usage metadata from snapshots that omit usage fields. Explicit fresh usage renders the percentage, explicit stale usage renders `Context --`, and newer snapshots with no usage fields clear previously cached token usage so the active chat cannot inherit stale context usage from an earlier event. Focused tests cover the meter decision logic and the session merge policy. The debug build installs on an emulator and the redacted emulator proof shows both fresh and stale gateway metadata states.

## Current review state

What is the next action?

Android maintainer review and merge judgment on the clean rebased head.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on maintainer review/merge judgment. CI is green on the pushed head, and ClawSweeper re-review is complete with `status: ready for maintainer look`, `proof: sufficient`, and no contributor-facing automated repair. ClawSweeper still flags the session-state risk for maintainer awareness because this path depends on session event freshness.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's proof request with redacted Android emulator proof showing the composer context meter updating from connected gateway `totalTokens` / `contextTokens` metadata and showing `Context --` for stale usage. Also addressed ClawSweeper's session-state risk by clearing cached usage when newer session snapshots omit usage metadata, so Android prefers unknown usage over stale or wrong usage.

AI-assisted: implemented with Codex, then manually inspected and tested in a local Android/OpenClaw setup.

