### PR TITLE
fix(doctor): preserve legacy codex OAuth provider when no models are mergeable

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -4,6 +4,7 @@ import { findLegacyConfigIssues } from "../../../config/legacy.js";
 import type { OpenClawConfig } from "../../../config/types.js";
 import { normalizeCompatibilityConfigValues } from "./legacy-config-core-migrate.js";
 import { LEGACY_CONFIG_MIGRATIONS } from "./legacy-config-migrations.js";
+import { collectBlockedLegacyOpenAICodexProviderWarnings } from "./legacy-config-migrations.runtime.models.js";
 
 function migrateLegacyConfigForTest(raw: unknown): {
   config: OpenClawConfig | null;
@@ -540,6 +541,102 @@ describe("legacy memory search config migrate", () => {
     expect(res.changes).toContain(
       "Removed models.providers.openai-codex because models.providers.openai already exists.",
     );
+  });
+
+  it("keeps legacy codex OAuth provider when all its models overlap canonical openai", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5.5" }],
+          },
+          "openai-codex": {
+            auth: "oauth",
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            headers: { Authorization: "Bearer token" },
+            request: { retry: { maxAttempts: 3 } },
+            models: [{ id: "gpt-5.5", api: "openai-codex-responses" }],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.["openai-codex"]).toEqual({
+      auth: "oauth",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      headers: { Authorization: "Bearer token" },
+      request: { retry: { maxAttempts: 3 } },
+      models: [{ id: "gpt-5.5", api: "openai-chatgpt-responses" }],
+    });
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://api.openai.com/v1",
+      models: [{ id: "gpt-5.5" }],
+    });
+    expect(res.changes).toContain(
+      "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai-codex.auth, models.providers.openai-codex.request, models.providers.openai-codex.headers.",
+    );
+  });
+
+  it("keeps legacy codex OAuth provider that has no models array", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5.5" }],
+          },
+          "openai-codex": {
+            auth: "oauth",
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            headers: { Authorization: "Bearer token" },
+            request: { retry: { maxAttempts: 3 } },
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.["openai-codex"]).toEqual({
+      auth: "oauth",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      headers: { Authorization: "Bearer token" },
+      request: { retry: { maxAttempts: 3 } },
+    });
+    expect(res.changes).toContain(
+      "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai-codex.auth, models.providers.openai-codex.request, models.providers.openai-codex.headers.",
+    );
+  });
+
+  it("previews a doctor warning before removing a codex OAuth provider with no mergeable models", () => {
+    const raw = {
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5.5" }],
+          },
+          "openai-codex": {
+            auth: "oauth",
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            headers: { Authorization: "Bearer token" },
+            models: [{ id: "gpt-5.5" }],
+          },
+        },
+      },
+    };
+
+    expect(collectBlockedLegacyOpenAICodexProviderWarnings(raw)).toEqual([
+      "models.providers.openai-codex cannot be merged automatically into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai-codex.auth, models.providers.openai-codex.headers. Move the affected model/provider defaults manually before removing models.providers.openai-codex.",
+    ]);
   });
 
   it("rewrites top-level legacy auto provider after moving memorySearch into agent defaults", () => {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -527,7 +527,6 @@ describe("legacy memory search config migrate", () => {
           },
           "openai-codex": {
             api: "openai-codex-responses",
-            baseUrl: "https://chatgpt.com/backend-api",
             models: [{ id: "gpt-5.5" }, { id: "gpt-5.4" }],
           },
         },
@@ -578,7 +577,7 @@ describe("legacy memory search config migrate", () => {
       models: [{ id: "gpt-5.5" }],
     });
     expect(res.changes).toContain(
-      "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai-codex.auth, models.providers.openai-codex.request, models.providers.openai-codex.headers.",
+      "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai-codex.auth, models.providers.openai-codex.request, models.providers.openai-codex.headers, models.providers.openai-codex.baseUrl.",
     );
   });
 
@@ -627,7 +626,6 @@ describe("legacy memory search config migrate", () => {
           },
           "openai-codex": {
             api: "openai-codex-responses",
-            baseUrl: "https://chatgpt.com/backend-api",
             models: [{ id: "gpt-5.5", api: "openai-codex-responses" }],
           },
         },
@@ -638,6 +636,73 @@ describe("legacy memory search config migrate", () => {
     expect(res.changes).toContain(
       "Removed models.providers.openai-codex because models.providers.openai already exists.",
     );
+  });
+
+  it("keeps legacy codex provider when an overlapping-only model would drop model-scoped routing/runtime defaults", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5.5" }],
+          },
+          "openai-codex": {
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            contextWindow: 200000,
+            contextTokens: 180000,
+            maxTokens: 8192,
+            params: { store: false },
+            agentRuntime: { id: "codex" },
+            models: [{ id: "gpt-5.5", api: "openai-codex-responses" }],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.["openai-codex"]).toEqual({
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      contextWindow: 200000,
+      contextTokens: 180000,
+      maxTokens: 8192,
+      params: { store: false },
+      agentRuntime: { id: "codex" },
+      models: [{ id: "gpt-5.5", api: "openai-chatgpt-responses" }],
+    });
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://api.openai.com/v1",
+      models: [{ id: "gpt-5.5" }],
+    });
+    expect(res.changes).toContain(
+      "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai-codex.baseUrl, models.providers.openai-codex.contextWindow, models.providers.openai-codex.contextTokens, models.providers.openai-codex.maxTokens, models.providers.openai-codex.params, models.providers.openai-codex.agentRuntime.",
+    );
+  });
+
+  it("previews a doctor warning for an overlapping-only codex provider with model-scoped defaults", () => {
+    const raw = {
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5.5" }],
+          },
+          "openai-codex": {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            agentRuntime: { id: "codex" },
+            models: [{ id: "gpt-5.5" }],
+          },
+        },
+      },
+    };
+
+    expect(collectBlockedLegacyOpenAICodexProviderWarnings(raw)).toEqual([
+      "models.providers.openai-codex cannot be merged automatically into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai-codex.baseUrl, models.providers.openai-codex.agentRuntime. Move the affected model/provider defaults manually before removing models.providers.openai-codex.",
+    ]);
   });
 
   it("previews a doctor warning before removing a codex OAuth provider with no mergeable models", () => {
@@ -661,7 +726,7 @@ describe("legacy memory search config migrate", () => {
     };
 
     expect(collectBlockedLegacyOpenAICodexProviderWarnings(raw)).toEqual([
-      "models.providers.openai-codex cannot be merged automatically into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai-codex.auth, models.providers.openai-codex.headers. Move the affected model/provider defaults manually before removing models.providers.openai-codex.",
+      "models.providers.openai-codex cannot be merged automatically into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai-codex.auth, models.providers.openai-codex.headers, models.providers.openai-codex.baseUrl. Move the affected model/provider defaults manually before removing models.providers.openai-codex.",
     ]);
   });
 

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -614,6 +614,32 @@ describe("legacy memory search config migrate", () => {
     );
   });
 
+  it("removes a redundant legacy codex provider with no own defaults even when canonical openai has provider-level defaults", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            apiKey: "OPENAI_API_KEY",
+            params: { store: true },
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5.5" }],
+          },
+          "openai-codex": {
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            models: [{ id: "gpt-5.5", api: "openai-codex-responses" }],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expect(res.changes).toContain(
+      "Removed models.providers.openai-codex because models.providers.openai already exists.",
+    );
+  });
+
   it("previews a doctor warning before removing a codex OAuth provider with no mergeable models", () => {
     const raw = {
       models: {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1007,6 +1007,7 @@ function hasOwnDefinedProperty(record: Record<string, unknown>, key: string): bo
 function collectModelMergeBlockers(params: {
   canonical: Record<string, unknown>;
   legacy: Record<string, unknown>;
+  hasModelsToMerge: boolean;
 }): string[] {
   const blockers: string[] = [];
   for (const key of MODEL_UNSCOPED_PROVIDER_DEFAULT_KEYS) {
@@ -1014,9 +1015,11 @@ function collectModelMergeBlockers(params: {
       blockers.push(`models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID}.${key}`);
     }
   }
-  for (const key of CANONICAL_PROVIDER_MODEL_LEAK_KEYS) {
-    if (hasOwnDefinedProperty(params.canonical, key)) {
-      blockers.push(`models.providers.${OPENAI_PROVIDER_ID}.${key}`);
+  if (params.hasModelsToMerge) {
+    for (const key of CANONICAL_PROVIDER_MODEL_LEAK_KEYS) {
+      if (hasOwnDefinedProperty(params.canonical, key)) {
+        blockers.push(`models.providers.${OPENAI_PROVIDER_ID}.${key}`);
+      }
     }
   }
   return blockers;
@@ -1083,6 +1086,11 @@ function hasAutoFixableLegacyOpenAICodexProvider(providersValue: unknown): boole
     const mergeBlockers = collectModelMergeBlockers({
       canonical: canonicalEntry.value,
       legacy: normalized.value,
+      hasModelsToMerge:
+        getMergeableLegacyOpenAIModels({
+          canonical: canonicalEntry.value,
+          legacy: normalized.value,
+        }).length > 0,
     });
     if (mergeBlockers.length === 0) {
       return true;
@@ -1112,6 +1120,11 @@ export function collectBlockedLegacyOpenAICodexProviderWarnings(raw: unknown): s
     const mergeBlockers = collectModelMergeBlockers({
       canonical: canonicalEntry.value,
       legacy: normalized.value,
+      hasModelsToMerge:
+        getMergeableLegacyOpenAIModels({
+          canonical: canonicalEntry.value,
+          legacy: normalized.value,
+        }).length > 0,
     });
     if (mergeBlockers.length === 0) {
       continue;
@@ -1216,7 +1229,11 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
         canonical,
         legacy: normalized.value,
       });
-      const mergeBlockers = collectModelMergeBlockers({ canonical, legacy: normalized.value });
+      const mergeBlockers = collectModelMergeBlockers({
+        canonical,
+        legacy: normalized.value,
+        hasModelsToMerge: modelsToMerge.length > 0,
+      });
       if (mergeBlockers.length > 0) {
         if (normalized.changed) {
           providers[providerId] = normalized.value;

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -953,6 +953,14 @@ const CANONICAL_PROVIDER_MODEL_LEAK_KEYS = [
   "authHeader",
   "request",
 ] as const;
+const MODEL_SCOPED_LEGACY_PROVIDER_DEFAULT_KEYS = [
+  "baseUrl",
+  "contextWindow",
+  "contextTokens",
+  "maxTokens",
+  "params",
+  "agentRuntime",
+] as const;
 
 function hasCanonicalOpenAIProvider(providers: Record<string, unknown>): boolean {
   return Object.keys(providers).some(
@@ -1008,11 +1016,19 @@ function collectModelMergeBlockers(params: {
   canonical: Record<string, unknown>;
   legacy: Record<string, unknown>;
   hasModelsToMerge: boolean;
+  hasRouteableLegacyModels: boolean;
 }): string[] {
   const blockers: string[] = [];
   for (const key of MODEL_UNSCOPED_PROVIDER_DEFAULT_KEYS) {
     if (hasOwnDefinedProperty(params.legacy, key)) {
       blockers.push(`models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID}.${key}`);
+    }
+  }
+  if (!params.hasModelsToMerge && params.hasRouteableLegacyModels) {
+    for (const key of MODEL_SCOPED_LEGACY_PROVIDER_DEFAULT_KEYS) {
+      if (hasOwnDefinedProperty(params.legacy, key)) {
+        blockers.push(`models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID}.${key}`);
+      }
     }
   }
   if (params.hasModelsToMerge) {
@@ -1068,6 +1084,19 @@ function getMergeableLegacyOpenAIModels(params: {
   });
 }
 
+function hasRouteableLegacyOpenAIModels(legacy: Record<string, unknown>): boolean {
+  const models: unknown[] = Array.isArray(legacy.models) ? (legacy.models as unknown[]) : [];
+  return models.some((m) => {
+    const mr = getRecord(m);
+    if (!mr) {
+      return false;
+    }
+    return (
+      (typeof mr.id === "string" && mr.id !== "") || (typeof mr.name === "string" && mr.name !== "")
+    );
+  });
+}
+
 function hasAutoFixableLegacyOpenAICodexProvider(providersValue: unknown): boolean {
   const providers = getRecord(providersValue);
   if (!providers) {
@@ -1091,6 +1120,7 @@ function hasAutoFixableLegacyOpenAICodexProvider(providersValue: unknown): boole
           canonical: canonicalEntry.value,
           legacy: normalized.value,
         }).length > 0,
+      hasRouteableLegacyModels: hasRouteableLegacyOpenAIModels(normalized.value),
     });
     if (mergeBlockers.length === 0) {
       return true;
@@ -1125,6 +1155,7 @@ export function collectBlockedLegacyOpenAICodexProviderWarnings(raw: unknown): s
           canonical: canonicalEntry.value,
           legacy: normalized.value,
         }).length > 0,
+      hasRouteableLegacyModels: hasRouteableLegacyOpenAIModels(normalized.value),
     });
     if (mergeBlockers.length === 0) {
       continue;
@@ -1233,6 +1264,7 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
         canonical,
         legacy: normalized.value,
         hasModelsToMerge: modelsToMerge.length > 0,
+        hasRouteableLegacyModels: hasRouteableLegacyOpenAIModels(normalized.value),
       });
       if (mergeBlockers.length > 0) {
         if (normalized.changed) {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1080,13 +1080,6 @@ function hasAutoFixableLegacyOpenAICodexProvider(providersValue: unknown): boole
     if (normalized.changed || !canonicalEntry) {
       return true;
     }
-    const modelsToMerge = getMergeableLegacyOpenAIModels({
-      canonical: canonicalEntry.value,
-      legacy: normalized.value,
-    });
-    if (modelsToMerge.length === 0) {
-      return true;
-    }
     const mergeBlockers = collectModelMergeBlockers({
       canonical: canonicalEntry.value,
       legacy: normalized.value,
@@ -1114,13 +1107,6 @@ export function collectBlockedLegacyOpenAICodexProviderWarnings(raw: unknown): s
     }
     const normalized = normalizeLegacyOpenAIResponsesApi(providerId, provider, []);
     if (normalized.changed) {
-      continue;
-    }
-    const modelsToMerge = getMergeableLegacyOpenAIModels({
-      canonical: canonicalEntry.value,
-      legacy: normalized.value,
-    });
-    if (modelsToMerge.length === 0) {
       continue;
     }
     const mergeBlockers = collectModelMergeBlockers({
@@ -1230,10 +1216,7 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
         canonical,
         legacy: normalized.value,
       });
-      const mergeBlockers =
-        modelsToMerge.length > 0
-          ? collectModelMergeBlockers({ canonical, legacy: normalized.value })
-          : [];
+      const mergeBlockers = collectModelMergeBlockers({ canonical, legacy: normalized.value });
       if (mergeBlockers.length > 0) {
         if (normalized.changed) {
           providers[providerId] = normalized.value;


### PR DESCRIPTION
## Summary

`openclaw doctor --fix` can silently delete a legacy `models.providers.openai-codex` provider together with its OAuth credentials (`auth`, `request`, `headers`, `apiKey`, ...) and emit no preview warning.

The merge-blocker safety check added for #90047 (`collectModelMergeBlockers`) exists precisely to stop the migration from dropping provider-level defaults that cannot be re-expressed on per-model entries. But in all three paths that check was gated behind `modelsToMerge.length > 0`:

- `migrateLegacyOpenAICodexProvider` (the mutation)
- `collectBlockedLegacyOpenAICodexProviderWarnings` (the `openclaw doctor` preview)
- `hasAutoFixableLegacyOpenAICodexProvider` (the fixable-issue probe)

So whenever there are zero mergeable legacy models - either because every legacy model id already overlaps canonical `openai`, or because the legacy provider has no `models` array - the blocker check was skipped and the provider was deleted with "Removed models.providers.openai-codex because models.providers.openai already exists.", credentials and all, unwarned.

This reopens the work from #92832, which a triage bot auto-closed as superseded by #90451. That close was incorrect: #90451 is scoped only to context-budget metadata (`contextTokens`/`contextWindow`/`maxTokens`, via the new `OPENAI_CODEX_CONTEXT_METADATA_KEYS`); its own description states "changing OAuth/auth routing" is out of scope and "Did security, auth, secrets ... change? No." A legacy provider carrying only OAuth and no context budget would still be deleted under #90451. The same bot review also acknowledged "the reported OAuth/default-loss hole is real."

## Fix

Run the legacy-side blocker check unconditionally so a credential-bearing provider is preserved (and surfaced) instead of silently dropped.

The bot review made one fair point: an earlier revision ran the entire blocker helper unconditionally, which also counted the canonical-side leak keys when nothing was being merged - that could keep a redundant legacy provider just because canonical `openai` happens to carry, say, an `apiKey`. That is now tightened: the canonical-side leak keys (`CANONICAL_PROVIDER_MODEL_LEAK_KEYS`) are only blockers when legacy models are actually stamped into canonical (that is when merged rows would inherit canonical provider defaults), gated behind a new `hasModelsToMerge` flag. The legacy provider's own un-scopable defaults (`auth`/`request`/`headers`/`apiKey`/...) are checked in every case.

Net effect:
- Legacy provider carries OAuth and no mergeable models -> kept, with a warning (no data loss).
- Legacy provider carries no defaults of its own and all models overlap -> still removed as redundant (canonical `openai` defaults no longer cause a needless keep).
- Existing merge / canonical-leak behavior when models do merge -> unchanged.

## Verification

Local, normal source checkout, rebased on latest `origin/main`.

```
node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts
  -> Test Files 1 passed, Tests 118 passed (114 existing + 4 new)

oxfmt --check        -> All matched files use the correct format
run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json (both files)  -> EXIT 0
tsgo:core            -> EXIT 0
tsgo:core:test       -> EXIT 0
```

The OAuth-preservation regression tests fail on unpatched `main` (provider removed, auth gone) and pass here; the redundant-clean-provider test pins the tightened behavior.

## Real behavior proof

- Behavior addressed: `openclaw doctor --fix` deleting a legacy `openai-codex` provider and its OAuth `auth`/`request`/`headers` with no warning when no legacy models are mergeable into canonical `openai` (all ids overlap, or the legacy provider has no `models` array); and not over-keeping a redundant legacy provider that has no defaults of its own.
- Real environment tested: local OpenClaw source checkout (Node 22.19), driving the real `LEGACY_CONFIG_MIGRATIONS` doctor pipeline and the real `collectBlockedLegacyOpenAICodexProviderWarnings` preview collector used by `collectDoctorPreviewNotes`.
- Exact steps or command run after this patch: fed raw configs through every migration in `LEGACY_CONFIG_MIGRATIONS` (same array doctor applies) and inspected the retained `models.providers` plus preview warnings.

- Evidence after fix:

Case A - all legacy model ids overlap canonical, legacy carries OAuth -> provider retained, migration records why:

```json
"openai-codex": {
  "auth": "oauth",
  "api": "openai-chatgpt-responses",
  "baseUrl": "https://chatgpt.com/backend-api",
  "headers": { "Authorization": "Bearer tok" },
  "request": { "retry": { "maxAttempts": 3 } },
  "models": [{ "id": "gpt-5.5", "api": "openai-chatgpt-responses" }]
}
```
```
change: "Skipped merging models.providers.openai-codex into models.providers.openai
 because provider-level defaults cannot be represented safely on merged models:
 models.providers.openai-codex.auth, models.providers.openai-codex.request,
 models.providers.openai-codex.headers."
```

Case B - legacy has no `models` array, carries OAuth -> provider retained, doctor preview warns:

```
preview warning: "models.providers.openai-codex cannot be merged automatically into
 models.providers.openai because provider-level defaults cannot be represented safely
 on merged models: models.providers.openai-codex.auth, models.providers.openai-codex.headers.
 Move the affected model/provider defaults manually before removing models.providers.openai-codex."
```

Case C (tightened) - legacy has no defaults of its own, all models overlap, canonical openai has `apiKey`/`params` -> provider still removed:

```
change: "Removed models.providers.openai-codex because models.providers.openai already exists."
(models.providers no longer has openai-codex)
```

- Observed result after fix: credential-bearing legacy providers survive `--fix` and the user is told to migrate the defaults manually; redundant ones with nothing to lose are still removed.
- Before evidence (unpatched `main`): in Case A and Case B the provider is deleted - `models.providers["openai-codex"]` is `undefined` after `--fix`, the only change is "Removed models.providers.openai-codex because models.providers.openai already exists.", and `collectBlockedLegacyOpenAICodexProviderWarnings` returns `[]`; the OAuth `auth`/`request`/`headers` are silently lost.
- What was not tested: not run against a live production gateway or a real on-disk `openclaw.json`; verified through the real source-level doctor migration and preview-warning pipeline plus the focused and full migration suites, oxlint, oxfmt, and tsgo.

Supersedes #92832 (force-pushed after an automated close, so it could not be reopened). Not superseded by #90451 (context-budget only).
