### PR TITLE
docs(browser-control): document OPENCLAW_EAGER_BROWSER_CONTROL_SERVER requirement

### DIFF
--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -13,7 +13,12 @@ CLI, and scripting patterns (snapshots, refs, waits, debug flows).
 
 ## Control API (optional)
 
-For local integrations only, the Gateway exposes a small loopback HTTP API:
+For local integrations only, the Gateway exposes a small loopback HTTP API.
+This standalone server is opt-in — set the environment variable
+`OPENCLAW_EAGER_BROWSER_CONTROL_SERVER=1` in the gateway service environment
+and restart the gateway before the HTTP endpoints become available. Without
+this variable the browser control runtime still works through the CLI and
+agent tools, but nothing listens on the loopback control port.
 
 - Status/start/stop: `GET /`, `POST /start`, `POST /stop`
 - Tabs: `GET /tabs`, `POST /tabs/open`, `POST /tabs/focus`, `DELETE /tabs/:targetId`


### PR DESCRIPTION
## What

Document the `OPENCLAW_EAGER_BROWSER_CONTROL_SERVER` environment variable requirement in the browser control HTTP API docs.

The standalone loopback HTTP API only starts when this variable is set to a truthy value (`1`, `true`, `yes`, `on`). Without it, browser control works through the CLI and agent tools, but nothing listens on the loopback control port.

## Why

The current docs say "the Gateway exposes a small loopback HTTP API" without mentioning the opt-in requirement. Users following the documented curl/API flow find nothing listening on the control port, with no indication of what's missing.

Fixes #92841

## Real behavior proof

- **Behavior addressed:** Browser control HTTP API documentation omits the required `OPENCLAW_EAGER_BROWSER_CONTROL_SERVER` environment variable, causing the documented API endpoints to appear broken.
- **Environment tested:** macOS, OpenClaw workdir at `/Users/liuhao/.hermes/workdir/openclaw`, branch `fix/browser-control-api-docs-eager-env` based on `upstream/main`.
- **Steps run after the patch:**
  1. Verified the env var is not documented anywhere else in `docs/`
  2. Verified the env var is used in source at `extensions/browser/src/plugin-service.ts:11` and `extensions/browser/plugin-registration.ts:20`
  3. Ran `pnpm build` to confirm docs compile cleanly
  4. Confirmed the new paragraph appears in the correct section

- **Evidence after fix:**

```
$ grep -c 'OPENCLAW_EAGER_BROWSER_CONTROL_SERVER' docs/tools/browser-control.md
1

$ sed -n '14,22p' docs/tools/browser-control.md
## Control API (optional)

For local integrations only, the Gateway exposes a small loopback HTTP API.
This standalone server is opt-in — set the environment variable
`OPENCLAW_EAGER_BROWSER_CONTROL_SERVER=1` in the gateway service environment
and restart the gateway before the HTTP endpoints become available. Without
this variable the browser control runtime still works through the CLI and
agent tools, but nothing listens on the loopback control port.

$ pnpm build 2>&1 | tail -3
[build-all] phase timings: total 74.3s; slowest tsdown 68.7s; ui:build 1.46s
✓ built in 545ms
```

- **Observed result after fix:** The docs now clearly state the env var requirement before listing the API endpoints. Build passes cleanly.
- **What was not tested:** Live gateway startup with/without the env var (docs-only change, no runtime code modified).
