### PR TITLE
fix(gateway): fall back to polling when config watcher exhausts inotify retries

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1643,16 +1643,13 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     await reloader.stop();
   });
 
-  it("disables hot-reload and logs at error level after the retry budget is exhausted", async () => {
-    const watchers = [
-      createWatcherMock(),
-      createWatcherMock(),
-      createWatcherMock(),
-      createWatcherMock(),
-    ];
+  it("degrades to polling then disables after both native and polling retries are exhausted", async () => {
+    // Native phase: initial watcher + 3 re-creates = 4 watchers.
+    // Polling phase: 1 polling re-create + 3 re-creates = 4 watchers.
+    const watchers = Array.from({ length: 8 }, () => createWatcherMock());
     const { watchSpy, log, reloader } = startReloaderWithWatchers(watchers);
 
-    // Three errors consume the retry budget; the fourth error escalates.
+    // --- Native retry phase (3 retries) ---
     watchers[0]?.emit("error");
     await vi.advanceTimersByTimeAsync(500);
     watchers[1]?.emit("error");
@@ -1662,16 +1659,36 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     expect(watchSpy).toHaveBeenCalledTimes(4);
     expect(reloader.hotReloadStatus()).toBe("active");
 
+    // Fourth native error triggers degradation to polling mode (not disabled).
     watchers[3]?.emit("error");
+    expect(reloader.hotReloadStatus()).toBe("active");
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("degrading to polling mode"),
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    expect(watchSpy).toHaveBeenCalledTimes(5);
+
+    // --- Polling retry phase (3 retries) ---
+    watchers[4]?.emit("error");
+    await vi.advanceTimersByTimeAsync(500);
+    watchers[5]?.emit("error");
+    await vi.advanceTimersByTimeAsync(2000);
+    watchers[6]?.emit("error");
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(watchSpy).toHaveBeenCalledTimes(8);
+    expect(reloader.hotReloadStatus()).toBe("active");
+
+    // Eighth error in polling mode finally disables hot-reload.
+    watchers[7]?.emit("error");
     expect(reloader.hotReloadStatus()).toBe("disabled");
     expect(log.error).toHaveBeenCalledWith(
       expect.stringContaining(
-        "config hot-reload disabled: watcher failed after 3 re-create attempts",
+        "config hot-reload disabled: watcher failed after 3 re-create attempts in polling mode",
       ),
     );
     // No further watcher is created once disabled.
     await vi.advanceTimersByTimeAsync(10000);
-    expect(watchSpy).toHaveBeenCalledTimes(4);
+    expect(watchSpy).toHaveBeenCalledTimes(8);
 
     await reloader.stop();
   });

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1644,53 +1644,182 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
   });
 
   it("degrades to polling then disables after both native and polling retries are exhausted", async () => {
-    // Native phase: initial watcher + 3 re-creates = 4 watchers.
-    // Polling phase: 1 polling re-create + 3 re-creates = 4 watchers.
-    const watchers = Array.from({ length: 8 }, () => createWatcherMock());
-    const { watchSpy, log, reloader } = startReloaderWithWatchers(watchers);
+    const originalVitest = process.env.VITEST;
+    const originalChokidarPolling = process.env.CHOKIDAR_USEPOLLING;
+    delete process.env.VITEST;
+    delete process.env.CHOKIDAR_USEPOLLING;
+    let reloader: { stop: () => Promise<void>; hotReloadStatus: () => string } | undefined;
+    try {
+      // Native phase: initial watcher + 3 re-creates = 4 watchers.
+      // Polling phase: 1 polling re-create + 3 re-creates = 4 watchers.
+      const watchers = Array.from({ length: 8 }, () => createWatcherMock());
+      const started = startReloaderWithWatchers(watchers);
+      const { watchSpy, log } = started;
+      reloader = started.reloader;
+      const watchOptions = (index: number) =>
+        watchSpy.mock.calls[index]?.[1] as { usePolling?: boolean } | undefined;
 
-    // --- Native retry phase (3 retries) ---
-    watchers[0]?.emit("error");
-    await vi.advanceTimersByTimeAsync(500);
-    watchers[1]?.emit("error");
-    await vi.advanceTimersByTimeAsync(2000);
-    watchers[2]?.emit("error");
-    await vi.advanceTimersByTimeAsync(5000);
-    expect(watchSpy).toHaveBeenCalledTimes(4);
-    expect(reloader.hotReloadStatus()).toBe("active");
+      // --- Native retry phase (3 retries) ---
+      expect(watchOptions(0)?.usePolling).toBe(false);
+      watchers[0]?.emit("error");
+      await vi.advanceTimersByTimeAsync(500);
+      expect(watchOptions(1)?.usePolling).toBe(false);
+      watchers[1]?.emit("error");
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(watchOptions(2)?.usePolling).toBe(false);
+      watchers[2]?.emit("error");
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(watchSpy).toHaveBeenCalledTimes(4);
+      expect(watchOptions(3)?.usePolling).toBe(false);
+      expect(reloader.hotReloadStatus()).toBe("active");
 
-    // Fourth native error triggers degradation to polling mode (not disabled).
-    watchers[3]?.emit("error");
-    expect(reloader.hotReloadStatus()).toBe("active");
-    expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("degrading to polling mode"),
-    );
-    await vi.advanceTimersByTimeAsync(500);
-    expect(watchSpy).toHaveBeenCalledTimes(5);
+      // Fourth native error triggers degradation to polling mode (not disabled).
+      watchers[3]?.emit("error");
+      expect(reloader.hotReloadStatus()).toBe("active");
+      expect(log.warn).toHaveBeenCalledWith(
+        expect.stringContaining("degrading to polling mode"),
+      );
+      await vi.advanceTimersByTimeAsync(500);
+      expect(watchSpy).toHaveBeenCalledTimes(5);
+      expect(watchOptions(4)?.usePolling).toBe(true);
 
-    // --- Polling retry phase (3 retries) ---
-    watchers[4]?.emit("error");
-    await vi.advanceTimersByTimeAsync(500);
-    watchers[5]?.emit("error");
-    await vi.advanceTimersByTimeAsync(2000);
-    watchers[6]?.emit("error");
-    await vi.advanceTimersByTimeAsync(5000);
-    expect(watchSpy).toHaveBeenCalledTimes(8);
-    expect(reloader.hotReloadStatus()).toBe("active");
+      // --- Polling retry phase (3 retries) ---
+      watchers[4]?.emit("error");
+      await vi.advanceTimersByTimeAsync(500);
+      expect(watchOptions(5)?.usePolling).toBe(true);
+      watchers[5]?.emit("error");
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(watchOptions(6)?.usePolling).toBe(true);
+      watchers[6]?.emit("error");
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(watchSpy).toHaveBeenCalledTimes(8);
+      expect(watchOptions(7)?.usePolling).toBe(true);
+      expect(reloader.hotReloadStatus()).toBe("active");
 
-    // Eighth error in polling mode finally disables hot-reload.
-    watchers[7]?.emit("error");
-    expect(reloader.hotReloadStatus()).toBe("disabled");
-    expect(log.error).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "config hot-reload disabled: watcher failed after 3 re-create attempts in polling mode",
-      ),
-    );
-    // No further watcher is created once disabled.
-    await vi.advanceTimersByTimeAsync(10000);
-    expect(watchSpy).toHaveBeenCalledTimes(8);
+      // Eighth error in polling mode finally disables hot-reload.
+      watchers[7]?.emit("error");
+      expect(reloader.hotReloadStatus()).toBe("disabled");
+      expect(log.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "config hot-reload disabled: watcher failed after 3 re-create attempts in polling mode",
+        ),
+      );
+      // No further watcher is created once disabled.
+      await vi.advanceTimersByTimeAsync(10000);
+      expect(watchSpy).toHaveBeenCalledTimes(8);
+    } finally {
+      if (originalVitest === undefined) {
+        delete process.env.VITEST;
+      } else {
+        process.env.VITEST = originalVitest;
+      }
+      if (originalChokidarPolling === undefined) {
+        delete process.env.CHOKIDAR_USEPOLLING;
+      } else {
+        process.env.CHOKIDAR_USEPOLLING = originalChokidarPolling;
+      }
+      await reloader?.stop();
+    }
+  });
 
-    await reloader.stop();
+  it("does not run a redundant native phase when chokidar polling is forced on", async () => {
+    const originalVitest = process.env.VITEST;
+    const originalChokidarPolling = process.env.CHOKIDAR_USEPOLLING;
+    delete process.env.VITEST;
+    process.env.CHOKIDAR_USEPOLLING = "1";
+    let reloader: { stop: () => Promise<void>; hotReloadStatus: () => string } | undefined;
+    try {
+      const watchers = Array.from({ length: 4 }, () => createWatcherMock());
+      const started = startReloaderWithWatchers(watchers);
+      const { watchSpy, log } = started;
+      reloader = started.reloader;
+      const watchOptions = (index: number) =>
+        watchSpy.mock.calls[index]?.[1] as { usePolling?: boolean } | undefined;
+
+      expect(watchOptions(0)?.usePolling).toBe(true);
+      watchers[0]?.emit("error");
+      await vi.advanceTimersByTimeAsync(500);
+      expect(watchOptions(1)?.usePolling).toBe(true);
+      watchers[1]?.emit("error");
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(watchOptions(2)?.usePolling).toBe(true);
+      watchers[2]?.emit("error");
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(watchOptions(3)?.usePolling).toBe(true);
+
+      watchers[3]?.emit("error");
+      expect(reloader.hotReloadStatus()).toBe("disabled");
+      expect(log.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("degrading to polling mode"),
+      );
+      expect(log.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "config hot-reload disabled: watcher failed after 3 re-create attempts in polling mode",
+        ),
+      );
+    } finally {
+      if (originalVitest === undefined) {
+        delete process.env.VITEST;
+      } else {
+        process.env.VITEST = originalVitest;
+      }
+      if (originalChokidarPolling === undefined) {
+        delete process.env.CHOKIDAR_USEPOLLING;
+      } else {
+        process.env.CHOKIDAR_USEPOLLING = originalChokidarPolling;
+      }
+      await reloader?.stop();
+    }
+  });
+
+  it("does not report polling fallback when chokidar polling is forced off", async () => {
+    const originalVitest = process.env.VITEST;
+    const originalChokidarPolling = process.env.CHOKIDAR_USEPOLLING;
+    delete process.env.VITEST;
+    process.env.CHOKIDAR_USEPOLLING = "0";
+    let reloader: { stop: () => Promise<void>; hotReloadStatus: () => string } | undefined;
+    try {
+      const watchers = Array.from({ length: 4 }, () => createWatcherMock());
+      const started = startReloaderWithWatchers(watchers);
+      const { watchSpy, log } = started;
+      reloader = started.reloader;
+      const watchOptions = (index: number) =>
+        watchSpy.mock.calls[index]?.[1] as { usePolling?: boolean } | undefined;
+
+      expect(watchOptions(0)?.usePolling).toBe(false);
+      watchers[0]?.emit("error");
+      await vi.advanceTimersByTimeAsync(500);
+      expect(watchOptions(1)?.usePolling).toBe(false);
+      watchers[1]?.emit("error");
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(watchOptions(2)?.usePolling).toBe(false);
+      watchers[2]?.emit("error");
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(watchOptions(3)?.usePolling).toBe(false);
+
+      watchers[3]?.emit("error");
+      expect(reloader.hotReloadStatus()).toBe("disabled");
+      expect(log.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("degrading to polling mode"),
+      );
+      expect(log.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "config hot-reload disabled: watcher failed after 3 re-create attempts in native mode",
+        ),
+      );
+    } finally {
+      if (originalVitest === undefined) {
+        delete process.env.VITEST;
+      } else {
+        process.env.VITEST = originalVitest;
+      }
+      if (originalChokidarPolling === undefined) {
+        delete process.env.CHOKIDAR_USEPOLLING;
+      } else {
+        process.env.CHOKIDAR_USEPOLLING = originalChokidarPolling;
+      }
+      await reloader?.stop();
+    }
   });
 });
 

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -41,6 +41,21 @@ const MISSING_CONFIG_MAX_RETRIES = 2;
 const WATCHER_RECREATE_MAX_RETRIES = 3;
 const WATCHER_RECREATE_BACKOFF_MS = [500, 2000, 5000] as const;
 
+function resolveChokidarUsePolling(degradedToPolling: boolean): boolean {
+  const envPoll = process.env.CHOKIDAR_USEPOLLING;
+  if (envPoll !== undefined) {
+    const envLower = envPoll.toLowerCase();
+    if (envLower === "false" || envLower === "0") {
+      return false;
+    }
+    if (envLower === "true" || envLower === "1") {
+      return true;
+    }
+    return Boolean(envLower);
+  }
+  return Boolean(process.env.VITEST) || degradedToPolling;
+}
+
 /**
  * Paths under `skills.*` always change the snapshot that sessions cache in
  * sessions.json. Any prefix match here (for example `skills.allowBundled`,
@@ -409,15 +424,17 @@ export function startGatewayConfigReloader(opts: {
   let watcherRecreateTimer: ReturnType<typeof setTimeout> | null = null;
   let hotReloadStatus: GatewayHotReloadStatus = "active";
   let degradedToPolling = false;
+  let watcherUsesPolling = false;
 
   const createWatcher = () => {
     if (stopped) {
       return;
     }
+    const usePolling = resolveChokidarUsePolling(degradedToPolling);
     const next = chokidar.watch(opts.watchPath, {
       ignoreInitial: true,
       awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
-      usePolling: Boolean(process.env.VITEST) || degradedToPolling,
+      usePolling,
     });
     next.on("add", scheduleFromWatcher);
     next.on("change", scheduleFromWatcher);
@@ -426,6 +443,7 @@ export function startGatewayConfigReloader(opts: {
       handleWatcherError(next, err);
     });
     watcher = next;
+    watcherUsesPolling = usePolling;
     hotReloadStatus = "active";
   };
 
@@ -434,13 +452,15 @@ export function startGatewayConfigReloader(opts: {
     if (stopped || source !== watcher) {
       return;
     }
+    const failedWatcherUsedPolling = watcherUsesPolling;
     watcher = null;
+    watcherUsesPolling = false;
     void source?.close().catch(() => {});
     if (watcherRecreateRetries >= WATCHER_RECREATE_MAX_RETRIES) {
       // All native (inotify/kqueue) retries exhausted — fall back to polling
       // mode so config hot-reload survives on hosts where inotify resources
       // are constrained (e.g. low fs.inotify.max_user_watches).
-      if (!degradedToPolling) {
+      if (!failedWatcherUsedPolling && resolveChokidarUsePolling(true)) {
         degradedToPolling = true;
         watcherRecreateRetries = 0;
         opts.log.warn(
@@ -452,9 +472,10 @@ export function startGatewayConfigReloader(opts: {
         }, WATCHER_RECREATE_BACKOFF_MS[0] ?? 500);
         return;
       }
+      const mode = failedWatcherUsedPolling ? "polling mode" : "native mode";
       hotReloadStatus = "disabled";
       opts.log.error(
-        `config hot-reload disabled: watcher failed after ${WATCHER_RECREATE_MAX_RETRIES} re-create attempts in polling mode: ${String(err)}`,
+        `config hot-reload disabled: watcher failed after ${WATCHER_RECREATE_MAX_RETRIES} re-create attempts in ${mode}: ${String(err)}`,
       );
       return;
     }

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -35,8 +35,9 @@ const MISSING_CONFIG_MAX_RETRIES = 2;
 
 // Watcher 'error' events (for example EMFILE/ENOSPC inotify exhaustion) close
 // the chokidar watcher. Re-create it with bounded backoff so a transient fault
-// does not permanently kill config hot-reload, but escalate to error + a
-// persistent disabled status once the retry budget is exhausted.
+// does not permanently kill config hot-reload. If all native retries are
+// exhausted (typical when the host has insufficient inotify watches), fall
+// back to polling mode before giving up entirely.
 const WATCHER_RECREATE_MAX_RETRIES = 3;
 const WATCHER_RECREATE_BACKOFF_MS = [500, 2000, 5000] as const;
 
@@ -407,6 +408,7 @@ export function startGatewayConfigReloader(opts: {
   let watcherRecreateRetries = 0;
   let watcherRecreateTimer: ReturnType<typeof setTimeout> | null = null;
   let hotReloadStatus: GatewayHotReloadStatus = "active";
+  let degradedToPolling = false;
 
   const createWatcher = () => {
     if (stopped) {
@@ -415,7 +417,7 @@ export function startGatewayConfigReloader(opts: {
     const next = chokidar.watch(opts.watchPath, {
       ignoreInitial: true,
       awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
-      usePolling: Boolean(process.env.VITEST),
+      usePolling: Boolean(process.env.VITEST) || degradedToPolling,
     });
     next.on("add", scheduleFromWatcher);
     next.on("change", scheduleFromWatcher);
@@ -435,9 +437,24 @@ export function startGatewayConfigReloader(opts: {
     watcher = null;
     void source?.close().catch(() => {});
     if (watcherRecreateRetries >= WATCHER_RECREATE_MAX_RETRIES) {
+      // All native (inotify/kqueue) retries exhausted — fall back to polling
+      // mode so config hot-reload survives on hosts where inotify resources
+      // are constrained (e.g. low fs.inotify.max_user_watches).
+      if (!degradedToPolling) {
+        degradedToPolling = true;
+        watcherRecreateRetries = 0;
+        opts.log.warn(
+          `config watcher native retries exhausted; degrading to polling mode: ${String(err)}`,
+        );
+        watcherRecreateTimer = setTimeout(() => {
+          watcherRecreateTimer = null;
+          createWatcher();
+        }, WATCHER_RECREATE_BACKOFF_MS[0] ?? 500);
+        return;
+      }
       hotReloadStatus = "disabled";
       opts.log.error(
-        `config hot-reload disabled: watcher failed after ${WATCHER_RECREATE_MAX_RETRIES} re-create attempts: ${String(err)}`,
+        `config hot-reload disabled: watcher failed after ${WATCHER_RECREATE_MAX_RETRIES} re-create attempts in polling mode: ${String(err)}`,
       );
       return;
     }


### PR DESCRIPTION
## Summary

When `fs.inotify.max_user_watches` is exhausted (ENOSPC), the config hot-reload watcher permanently disables itself after 3 failed re-create attempts. This PR adds a polling-mode degradation step so config hot-reload survives on hosts where inotify resources are constrained.

Fixes #92851.

## Problem

`startGatewayConfigReloader` creates a chokidar watcher with native inotify watching. When the kernel limit is hit, all 3 retry attempts fail identically (same native mode), and hot-reload is permanently disabled for the session. This is common on hosts running multiple Node processes (tsx watch, vite dev servers, codex agents, etc.) where the default `fs.inotify.max_user_watches` is insufficient.

## Fix

After all native retries are exhausted, reset the retry counter and recreate the watcher with `usePolling: true`. Only if polling **also** fails does hot-reload become permanently disabled.

## Real behavior proof

Behavior or issue addressed: Config hot-reload watcher permanently disables itself when `fs.inotify.max_user_watches` is exhausted (ENOSPC) after 3 failed native re-create attempts, with no fallback to polling mode.

Real environment tested: Debian 13 (Linux 6.12.63+deb13-amd64), Node v24.13.0, OpenClaw 2026.6.6 production gateway, `fs.inotify.max_user_watches=61023`, 53 inotify FDs consumed across systemd, warp remote-server, OpenAI codex, tsx/vite dev servers.

Exact steps or command run after this patch:
1. Built a standalone Node.js script replicating the exact `handleWatcherError` logic from `config-reload.ts` (with the fix applied), using the real `chokidar@5.0.0` library on the host where ENOSPC was occurring.
2. Created a config file at `/tmp/proof-config.json`.
3. Created a chokidar watcher in native (inotify) mode.
4. Emitted 4 simulated ENOSPC errors via `watcher.emit('error', new Error('ENOSPC: ...'))` to exhaust the 3-retry budget and trigger the polling fallback.
5. Wrote a new version of the config file: `writeFileSync('/tmp/proof-config.json', JSON.stringify({ v: 2 }))`.
6. Waited for the polling watcher to detect the change.

Before evidence (optional): Production gateway logs showing permanent disable without the fix:
```
2026-06-14T10:14:14+08:00 warn  gateway/reload  config watcher error; re-creating watcher (attempt 1/3 in 500ms): Error: ENOSPC: System limit for number of file watchers reached
2026-06-14T10:14:16+08:00 warn  gateway/reload  config watcher error; re-creating watcher (attempt 2/3 in 2000ms): Error: ENOSPC: System limit for number of file watchers reached
2026-06-14T10:14:21+08:00 warn  gateway/reload  config watcher error; re-creating watcher (attempt 3/3 in 5000ms): Error: ENOSPC: System limit for number of file watchers reached
2026-06-14T10:14:23+08:00 error gateway/reload  config hot-reload disabled: watcher failed after 3 re-create attempts: Error: ENOSPC: System limit for number of file watchers reached
```

Evidence after fix: Console output from the verification script on the same host:
```
[03:25:18.223] Watcher created (usePolling=false)
[03:25:18.242] config watcher error; re-creating watcher (attempt 1/3 in 100ms): Error: ENOSPC: System limit for number of file watchers reached
[03:25:18.343] Watcher created (usePolling=false)
[03:25:18.344] config watcher error; re-creating watcher (attempt 2/3 in 300ms): Error: ENOSPC: System limit for number of file watchers reached
[03:25:18.648] Watcher created (usePolling=false)
[03:25:18.649] config watcher error; re-creating watcher (attempt 3/3 in 800ms): Error: ENOSPC: System limit for number of file watchers reached
[03:25:19.450] Watcher created (usePolling=false)
[03:25:19.450] config watcher native retries exhausted; degrading to polling mode: Error: ENOSPC: System limit for number of file watchers reached
[03:25:19.551] Watcher created (usePolling=true)
[03:25:20.183] After 4 native errors: degradedToPolling=true, watcher alive=true
[03:25:20.783] Writing config change...
[03:25:20.990] CHANGE detected on config file (usePolling=true)
VERDICT: PASS
```

Observed result after fix: After 3 native retries exhausted, the watcher degraded to polling mode (`usePolling=true`) instead of permanently disabling. The polling watcher detected the real config file write within ~200ms. Hot-reload status remained `"active"` throughout. Zero inotify resources consumed in polling mode.

What was not tested: Full integration test inside a live OpenClaw gateway process (would require rebuilding the dist bundle and restarting the production gateway mid-session). The updated unit test in `config-reload.test.ts` covers the two-phase lifecycle with mocked chokidar.

## Tradeoffs

- **Polling latency**: ~200ms (controlled by `awaitWriteFinish.pollInterval`) vs instant inotify events. Negligible for config files that change infrequently.
- **CPU**: One stat() call per polling interval on a single file. Effectively zero.
- **No inotify usage**: Polling uses zero inotify watches, completely sidestepping the resource exhaustion.

## Testing

- Updated `config-reload.test.ts` to cover the two-phase degradation: native retries → polling fallback → polling retries → disabled.
- 2242 other gateway-core tests pass unchanged.
