### PR TITLE
fix(openai): drop encrypted reasoning from history for Responses-family APIs (fixes #90093)

### DIFF
--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -1116,6 +1116,7 @@ describe("buildOpenAIProvider", () => {
       validateGeminiTurns: false,
       validateAnthropicTurns: false,
       allowSyntheticToolResults: true,
+      dropReasoningFromHistory: true,
     });
   });
 

--- a/extensions/openai/replay-policy.ts
+++ b/extensions/openai/replay-policy.ts
@@ -21,6 +21,7 @@ export function buildOpenAIReplayPolicy(ctx: ProviderReplayPolicyContext): Provi
     validateGeminiTurns: false,
     validateAnthropicTurns: false,
     ...(isResponsesFamily ? { allowSyntheticToolResults: true } : {}),
+    ...(isResponsesFamily ? { dropReasoningFromHistory: true } : {}),
     ...(ctx.modelApi === "openai-completions"
       ? {
           sanitizeToolCallIds: true,


### PR DESCRIPTION
## Summary

Responses-family APIs (`openai-chatgpt-responses`, `openai-responses`, `azure-openai-responses`) request encrypted reasoning content via `include: ["reasoning.encrypted_content"]`. When replaying prior assistant turns, the encrypted `thinkingSignature` is sent back to the ChatGPT/Codex backend, which rejects it with `400 invalid_encrypted_content` because it cannot verify stale encrypted content from a previous session.

Set `dropReasoningFromHistory: true` for all Responses-family APIs so reasoning blocks are stripped before replay, matching the existing behavior for `openai-completions`.

## Root cause

`buildOpenAIReplayPolicy` in `extensions/openai/replay-policy.ts` did not set `dropReasoningFromHistory` for Responses-family APIs. The core fallback in `src/agents/transcript-policy.ts:130` only sets it for `openai-completions`. This left `openai-chatgpt-responses` sessions replaying stale encrypted reasoning that the backend can no longer decrypt.

## Fix

One line in `extensions/openai/replay-policy.ts`: add `dropReasoningFromHistory: true` for Responses-family APIs alongside the existing `allowSyntheticToolResults: true`.

## Test

Updated the existing `buildReplayPolicy` test expectation in `openai-provider.test.ts` to include the new field.

## Real behavior proof

- **Behavior addressed:** openai-chatgpt-responses replaying encrypted reasoning causes 400 invalid_encrypted_content on subsequent turns
- **Environment tested:** macOS 26.4.1 arm64, Node 25.9.0, OpenClaw main (4c0899c0)
- **Steps run after the patch:**
  1. Ran `node scripts/run-vitest.mjs run extensions/openai/openai-provider.test.ts`
  2. Ran `pnpm build`
  3. Verified the replay policy returns `dropReasoningFromHistory: true` for `openai-chatgpt-responses`
- **Evidence after fix:**

```
$ node scripts/run-vitest.mjs run extensions/openai/openai-provider.test.ts
✓ extension-provider-openai (38 tests) 371ms
Test Files  1 passed (1)
     Tests  38 passed (38)

$ grep -n "dropReasoningFromHistory" extensions/openai/replay-policy.ts
24:    ...(isResponsesFamily ? { dropReasoningFromHistory: true } : {}),

$ node -e "const {buildOpenAIReplayPolicy}=require('./dist/extensions/openai/replay-policy.js'); const p=buildOpenAIReplayPolicy({modelApi:'openai-chatgpt-responses',modelId:'gpt-5.5'}); console.log('dropReasoningFromHistory:', p.dropReasoningFromHistory);"
dropReasoningFromHistory: true
```

- **Observed result after fix:** The replay policy now returns `dropReasoningFromHistory: true` for all Responses-family APIs. `openai-chatgpt-responses` sessions will strip reasoning blocks before replay, preventing the `400 invalid_encrypted_content` error.
- **What was not tested:** Live ChatGPT/Codex backend roundtrip (requires ChatGPT subscription and native runtime). The fix follows the exact mitigation the issue reporter confirmed works locally.
