### PR TITLE
fix(memory-qmd): preserve Windows absolute paths in QMD command resolution

### DIFF
--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -439,8 +439,12 @@ export function resolveMemoryBackendConfig(params: {
   ];
 
   const rawCommand = qmdCfg?.command?.trim() || "qmd";
-  const parsedCommand = splitShellArgs(rawCommand);
-  const command = parsedCommand?.[0] || rawCommand.split(/\s+/)[0] || "qmd";
+  // Windows absolute paths (e.g. C:\Users\bin\qmd.exe or C:/Users/bin/qmd.exe)
+  // must not pass through splitShellArgs, which treats backslashes as POSIX
+  // escape characters and mangles the drive-letter path.
+  const isWindowsAbsPath = /^[A-Za-z]:[\\/]/.test(rawCommand);
+  const parsedCommand = isWindowsAbsPath ? null : splitShellArgs(rawCommand);
+  const command = parsedCommand?.[0] || (isWindowsAbsPath ? rawCommand : rawCommand.split(/\s+/)[0]) || "qmd";
   const resolved: ResolvedQmdConfig = {
     command,
     mcporter: resolveMcporterConfig(qmdCfg?.mcporter),


### PR DESCRIPTION
Fixes #92302

When `memory.qmd.command` contains a Windows absolute path (e.g. `C:\Users\bin\qmd.exe`), the raw value was passed through `splitShellArgs()` which treats backslashes as POSIX escape characters, mangling the drive-letter path into a garbage token that cannot be found on disk.

This adds a Windows absolute-path guard (`/^[A-Za-z]:[\\/]/`) before the `splitShellArgs` call in `resolveMemoryBackendQmdConfig()` so that drive-letter paths are passed through verbatim as the command, bypassing POSIX-style shell argument splitting.

## Real behavior proof

**Behavior or issue addressed:** `memory.qmd.command` set to a Windows absolute path like `C:\Users\test\qmd.exe` was mangled by `splitShellArgs()` into `C:Users estqmd.exe` (backslashes consumed as POSIX escapes, tabs treated as whitespace), causing `ENOENT` when spawning the QMD process.

**Real environment tested:** Linux (WSL2), Node v24.16.0, upstream commit 808f677a.

**Exact steps or command run after this patch:** Ran a Node.js script that tests the fix logic against all path variants:
```
node -e "
function splitShellArgs(raw) { ... } // full POSIX parser
const tests = [
  'C:\\\\Users\\\\test\\\\qmd.js',
  'C:/Users/test/qmd.js',
  'D:\\\\Program Files\\\\qmd\\\\bin\\\\qmd.exe',
  '/usr/local/bin/qmd',
  'qmd',
  'qmd --extra-flag',
];
for (const raw of tests) {
  const isWindowsAbsPath = /^[A-Za-z]:[\\\\/]/.test(raw);
  const parsedCommand = isWindowsAbsPath ? null : splitShellArgs(raw);
  const command = parsedCommand?.[0] || (isWindowsAbsPath ? raw : raw.split(/\s+/)[0]) || 'qmd';
  console.log(raw, '->', command);
}
"
```

**Evidence after fix:**
```
C:\Users\test\qmd.js -> C:\Users\test\qmd.js
C:/Users/test/qmd.js -> C:/Users/test/qmd.js
D:\Program Files\qmd\bin\qmd.exe -> D:\Program Files\qmd\bin\qmd.exe
/usr/local/bin/qmd -> /usr/local/bin/qmd
qmd -> qmd
qmd --extra-flag -> qmd
```

**Observed result after fix:** Windows drive-letter paths (both `\` and `/` separators) are correctly detected and passed through verbatim as the command value. POSIX paths and bare command names continue through `splitShellArgs` as before. The change is a targeted 3-line guard in `backend-config.ts` before the `splitShellArgs` call.

**What was not tested:** Actual Windows runtime with real QMD binary; the fix was verified on Linux by confirming the path detection logic and POSIX parsing behavior are correct. The regex guard covers all single-letter drive letters.

**Proof limitations:** Tested path detection logic only (not full QMD spawn on Windows). The regex `^[A-Za-z]:[\\/]` matches all single-letter drive-letter paths on Windows; UNC paths (`\\server\share`) are not covered as QMD command paths would not typically use them.