### PR TITLE
fix #90333: [Bug]: Discord image build aborts at step 66 — openclaw-build-messaging-plugins.py exits 1

### DIFF
--- a/src/cli/plugin-install-config-policy.ts
+++ b/src/cli/plugin-install-config-policy.ts
@@ -104,7 +104,7 @@ function resolveBundledInstallRecoveryMetadata(
 }
 
 function resolveOfficialExternalInstallRecoveryMetadata(
-  request: Pick<PluginInstallRequestContext, "rawSpec" | "normalizedSpec" | "marketplace">,
+  request: Pick<PluginInstallRequestContext, "rawSpec" | "marketplace">,
 ): {
   pluginId?: string;
   allowInvalidConfigRecovery?: boolean;
@@ -112,18 +112,19 @@ function resolveOfficialExternalInstallRecoveryMetadata(
   if (request.marketplace) {
     return {};
   }
+  if (request.rawSpec.trim().startsWith("file:")) {
+    return {};
+  }
+  if (fs.existsSync(resolveUserPath(request.rawSpec))) {
+    return {};
+  }
   const rawNpmPrefixSpec = parseNpmPrefixSpec(request.rawSpec);
-  const normalizedNpmPrefixSpec = parseNpmPrefixSpec(request.normalizedSpec);
   const values = new Set(
     normalizeStringEntries([
       request.rawSpec,
-      request.normalizedSpec,
       rawNpmPrefixSpec ?? "",
-      normalizedNpmPrefixSpec ?? "",
       parseRegistryNpmSpec(request.rawSpec)?.name ?? "",
-      parseRegistryNpmSpec(request.normalizedSpec)?.name ?? "",
       rawNpmPrefixSpec ? parseRegistryNpmSpec(rawNpmPrefixSpec)?.name : "",
-      normalizedNpmPrefixSpec ? parseRegistryNpmSpec(normalizedNpmPrefixSpec)?.name : "",
     ]),
   );
   if (values.size === 0) {
@@ -219,7 +220,6 @@ export function resolvePluginInstallRequestContext(params: {
   });
   const officialRecovered = resolveOfficialExternalInstallRecoveryMetadata({
     rawSpec: params.rawSpec,
-    normalizedSpec,
     marketplace: params.marketplace,
   });
   const recovered =

--- a/src/cli/plugin-install-config-policy.ts
+++ b/src/cli/plugin-install-config-policy.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import type { Command } from "commander";
 import { tryReadJsonSync } from "../infra/json-files.js";
+import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { findBundledPluginSource } from "../plugins/bundled-sources.js";
 import { loadPluginManifest } from "../plugins/manifest.js";
 import {
@@ -119,6 +120,10 @@ function resolveOfficialExternalInstallRecoveryMetadata(
       request.normalizedSpec,
       rawNpmPrefixSpec ?? "",
       normalizedNpmPrefixSpec ?? "",
+      parseRegistryNpmSpec(request.rawSpec)?.name ?? "",
+      parseRegistryNpmSpec(request.normalizedSpec)?.name ?? "",
+      rawNpmPrefixSpec ? parseRegistryNpmSpec(rawNpmPrefixSpec)?.name : "",
+      normalizedNpmPrefixSpec ? parseRegistryNpmSpec(normalizedNpmPrefixSpec)?.name : "",
     ]),
   );
   if (values.size === 0) {

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -3,9 +3,9 @@ import fs from "node:fs";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { theme } from "../../packages/terminal-core/src/theme.js";
-import { collectChannelDoctorStaleConfigMutations } from "../commands/doctor/shared/channel-doctor.js";
 import { assertConfigWriteAllowedInCurrentMode, readConfigFileSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { installHooksFromNpmSpec, installHooksFromPath } from "../hooks/install.js";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub.js";
@@ -22,6 +22,7 @@ import {
   installPluginFromNpmSpec,
   installPluginFromPath,
 } from "../plugins/install.js";
+import { loadInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
 import {
   installPluginFromMarketplace,
   resolveMarketplaceInstallShortcut,
@@ -493,6 +494,8 @@ function isTerminalPluginInstallFailure(code?: string): boolean {
 function isAllowedPluginRecoveryIssue(
   issue: { path?: string; message?: string },
   request: PluginInstallRequestContext,
+  installRecords: Record<string, PluginInstallRecord>,
+  env: NodeJS.ProcessEnv = process.env,
 ): boolean {
   const pluginId = request.bundledPluginId?.trim();
   if (!pluginId) {
@@ -503,10 +506,7 @@ function isAllowedPluginRecoveryIssue(
       issue.message === `unknown channel id: ${pluginId}`) ||
     (issue.path === "plugins.load.paths" &&
       typeof issue.message === "string" &&
-      issue.message.includes("plugin path not found")) ||
-    (issue.path === "plugins" &&
-      typeof issue.message === "string" &&
-      issue.message.includes("requires compiled runtime output")) ||
+      isMissingPluginLoadPathForInstallRecord({ issue, installRecords, pluginId, env })) ||
     (issue.path === `plugins.entries.${pluginId}` &&
       typeof issue.message === "string" &&
       issue.message.includes("requires compiled runtime output")) ||
@@ -522,6 +522,21 @@ function buildInvalidPluginInstallConfigError(message: string): Error {
   return error;
 }
 
+function hasConfigInclude(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some((child) => hasConfigInclude(child));
+  }
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (Object.hasOwn(value, "$include")) {
+    return true;
+  }
+  return Object.values(value).some((child) => hasConfigInclude(child));
+}
+
+const ENV_VAR_REFERENCE_RE = /\$\{[A-Z_][A-Z0-9_]*\}/;
+
 function extractMissingPluginLoadPath(issue: { path?: string; message?: string }): string | null {
   if (issue.path !== "plugins.load.paths" || typeof issue.message !== "string") {
     return null;
@@ -533,6 +548,105 @@ function extractMissingPluginLoadPath(issue: { path?: string; message?: string }
   }
   const value = issue.message.slice(markerIndex + marker.length).trim();
   return value || null;
+}
+
+function resolvePluginInstallRecordPaths(params: {
+  installRecords: Record<string, PluginInstallRecord>;
+  pluginId: string;
+  env: NodeJS.ProcessEnv;
+}): Set<string> {
+  const install = params.installRecords[params.pluginId];
+  const paths = new Set<string>();
+  for (const value of [install?.installPath, install?.sourcePath]) {
+    if (typeof value === "string" && value.trim()) {
+      paths.add(resolveUserPath(value, params.env));
+    }
+  }
+  return paths;
+}
+
+function isMissingPluginLoadPathForInstallRecord(params: {
+  issue: { path?: string; message?: string };
+  installRecords: Record<string, PluginInstallRecord>;
+  pluginId: string;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  const missingPath = extractMissingPluginLoadPath(params.issue);
+  if (!missingPath) {
+    return false;
+  }
+  return resolvePluginInstallRecordPaths(params).has(resolveUserPath(missingPath, params.env));
+}
+
+function readPluginLoadPathEntries(cfg: unknown): unknown[] | undefined {
+  if (!isRecord(cfg) || !isRecord(cfg.plugins) || !isRecord(cfg.plugins.load)) {
+    return undefined;
+  }
+  const paths = cfg.plugins.load.paths;
+  return Array.isArray(paths) ? paths : undefined;
+}
+
+function arrayHasEnvRef(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.some((entry) => typeof entry === "string" && ENV_VAR_REFERENCE_RE.test(entry))
+  );
+}
+
+function hasAuthoredPluginPolicyEnvRefs(params: {
+  authoredConfig: unknown;
+  resolvedConfig: OpenClawConfig;
+  pluginId: string;
+}): boolean {
+  if (!isRecord(params.authoredConfig) || !isRecord(params.authoredConfig.plugins)) {
+    return false;
+  }
+  const resolvedPlugins = params.resolvedConfig.plugins;
+  const allowWillChange =
+    Array.isArray(resolvedPlugins?.allow) &&
+    resolvedPlugins.allow.length > 0 &&
+    !resolvedPlugins.allow.includes(params.pluginId);
+  if (allowWillChange && arrayHasEnvRef(params.authoredConfig.plugins.allow)) {
+    return true;
+  }
+  const denyWillChange =
+    Array.isArray(resolvedPlugins?.deny) && resolvedPlugins.deny.includes(params.pluginId);
+  return denyWillChange && arrayHasEnvRef(params.authoredConfig.plugins.deny);
+}
+
+function wouldMoveAuthoredEnvPluginLoadPath(params: {
+  cfg: OpenClawConfig;
+  issues: readonly { path?: string; message?: string }[];
+  authoredConfig: unknown;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  const missingPaths = new Set(
+    params.issues
+      .map(extractMissingPluginLoadPath)
+      .filter((value): value is string => Boolean(value))
+      .map((value) => resolveUserPath(value, params.env)),
+  );
+  const paths = params.cfg.plugins?.load?.paths;
+  const authoredPaths = readPluginLoadPathEntries(params.authoredConfig);
+  if (missingPaths.size === 0 || !Array.isArray(paths) || !Array.isArray(authoredPaths)) {
+    return false;
+  }
+  let removedBefore = false;
+  for (const [index, entry] of paths.entries()) {
+    if (typeof entry === "string" && missingPaths.has(resolveUserPath(entry, params.env))) {
+      removedBefore = true;
+      continue;
+    }
+    const authoredEntry = authoredPaths[index];
+    if (
+      removedBefore &&
+      typeof authoredEntry === "string" &&
+      ENV_VAR_REFERENCE_RE.test(authoredEntry)
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function removeMissingPluginLoadPaths(
@@ -583,21 +697,54 @@ async function loadConfigFromSnapshotForInstall(
       "Config file could not be parsed; run `openclaw doctor` to repair it.",
     );
   }
+  const pluginId = request.bundledPluginId?.trim() ?? "";
+  const pluginLabel = pluginId || "the requested plugin";
+  if (hasConfigInclude(snapshot.parsed)) {
+    throw buildInvalidPluginInstallConfigError(
+      `Config invalid outside the plugin recovery path for ${pluginLabel}; run \`openclaw doctor --fix\` before reinstalling it.`,
+    );
+  }
+  if (
+    hasAuthoredPluginPolicyEnvRefs({
+      authoredConfig: snapshot.parsed,
+      resolvedConfig: snapshot.config,
+      pluginId,
+    })
+  ) {
+    throw buildInvalidPluginInstallConfigError(
+      `Config invalid outside the plugin recovery path for ${pluginLabel}; run \`openclaw doctor --fix\` before reinstalling it.`,
+    );
+  }
+  const persistedInstallRecords = await tracePluginLifecyclePhaseAsync(
+    "install records load",
+    () => loadInstalledPluginIndexInstallRecords(),
+    { command: "install" },
+  );
+  const installRecords = {
+    ...snapshot.config.plugins?.installs,
+    ...persistedInstallRecords,
+  };
   if (
     snapshot.legacyIssues.length > 0 ||
     snapshot.issues.length === 0 ||
-    snapshot.issues.some((issue) => !isAllowedPluginRecoveryIssue(issue, request))
+    snapshot.issues.some((issue) => !isAllowedPluginRecoveryIssue(issue, request, installRecords))
   ) {
-    const pluginLabel = request.bundledPluginId ?? "the requested plugin";
     throw buildInvalidPluginInstallConfigError(
       `Config invalid outside the plugin recovery path for ${pluginLabel}; run \`openclaw doctor --fix\` before reinstalling it.`,
     );
   }
   let nextConfig = snapshot.config;
-  for (const mutation of await collectChannelDoctorStaleConfigMutations(snapshot.config, {
-    env: process.env,
-  })) {
-    nextConfig = mutation.config;
+  if (
+    wouldMoveAuthoredEnvPluginLoadPath({
+      cfg: nextConfig,
+      issues: snapshot.issues,
+      authoredConfig: snapshot.parsed,
+      env: process.env,
+    })
+  ) {
+    throw buildInvalidPluginInstallConfigError(
+      `Config invalid outside the plugin recovery path for ${pluginLabel}; run \`openclaw doctor --fix\` before reinstalling it.`,
+    );
   }
   nextConfig = removeMissingPluginLoadPaths(nextConfig, snapshot.issues, process.env);
   return {

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -35,7 +35,7 @@ import {
 import { tracePluginLifecyclePhaseAsync } from "../plugins/plugin-lifecycle-trace.js";
 import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
-import { shortenHomePath } from "../utils.js";
+import { resolveUserPath, shortenHomePath } from "../utils.js";
 import { formatCliCommand } from "./command-format.js";
 import { looksLikeLocalInstallSpec } from "./install-spec.js";
 import { resolvePinnedNpmInstallRecordForCli } from "./npm-resolution.js";
@@ -522,6 +522,52 @@ function buildInvalidPluginInstallConfigError(message: string): Error {
   return error;
 }
 
+function extractMissingPluginLoadPath(issue: { path?: string; message?: string }): string | null {
+  if (issue.path !== "plugins.load.paths" || typeof issue.message !== "string") {
+    return null;
+  }
+  const marker = "plugin path not found:";
+  const markerIndex = issue.message.indexOf(marker);
+  if (markerIndex < 0) {
+    return null;
+  }
+  const value = issue.message.slice(markerIndex + marker.length).trim();
+  return value || null;
+}
+
+function removeMissingPluginLoadPaths(
+  cfg: OpenClawConfig,
+  issues: readonly { path?: string; message?: string }[],
+  env: NodeJS.ProcessEnv = process.env,
+): OpenClawConfig {
+  const missingPaths = new Set(
+    issues
+      .map(extractMissingPluginLoadPath)
+      .filter((value): value is string => Boolean(value))
+      .map((value) => resolveUserPath(value, env)),
+  );
+  const paths = cfg.plugins?.load?.paths;
+  if (missingPaths.size === 0 || !Array.isArray(paths)) {
+    return cfg;
+  }
+  const nextPaths = paths.filter(
+    (entry) => typeof entry !== "string" || !missingPaths.has(resolveUserPath(entry, env)),
+  );
+  if (nextPaths.length === paths.length) {
+    return cfg;
+  }
+  return {
+    ...cfg,
+    plugins: {
+      ...cfg.plugins,
+      load: {
+        ...cfg.plugins?.load,
+        paths: nextPaths,
+      },
+    },
+  };
+}
+
 async function loadConfigFromSnapshotForInstall(
   request: PluginInstallRequestContext,
   snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
@@ -553,6 +599,7 @@ async function loadConfigFromSnapshotForInstall(
   })) {
     nextConfig = mutation.config;
   }
+  nextConfig = removeMissingPluginLoadPaths(nextConfig, snapshot.issues, process.env);
   return {
     config: nextConfig,
     baseHash: snapshot.hash,

--- a/src/cli/plugins-install-config.test.ts
+++ b/src/cli/plugins-install-config.test.ts
@@ -1,4 +1,5 @@
 // Plugin install config tests cover install specs and generated plugin config.
+import fs from "node:fs";
 import { bundledPluginRootAt, repoInstallSpec } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
@@ -12,11 +13,14 @@ import { loadConfigForInstall } from "./plugins-install-command.js";
 const hoisted = vi.hoisted(() => ({
   readConfigFileSnapshotMock: vi.fn<() => Promise<ConfigFileSnapshot>>(),
   collectChannelDoctorStaleConfigMutationsMock: vi.fn(),
+  loadInstalledPluginIndexInstallRecordsMock: vi.fn(),
 }));
 
 const readConfigFileSnapshotMock = hoisted.readConfigFileSnapshotMock;
 const collectChannelDoctorStaleConfigMutationsMock =
   hoisted.collectChannelDoctorStaleConfigMutationsMock;
+const loadInstalledPluginIndexInstallRecordsMock =
+  hoisted.loadInstalledPluginIndexInstallRecordsMock;
 
 vi.mock("../config/config.js", () => ({
   readConfigFileSnapshot: () => readConfigFileSnapshotMock(),
@@ -26,6 +30,15 @@ vi.mock("../commands/doctor/shared/channel-doctor.js", () => ({
   collectChannelDoctorStaleConfigMutations: (cfg: OpenClawConfig) =>
     collectChannelDoctorStaleConfigMutationsMock(cfg),
 }));
+
+vi.mock("../plugins/installed-plugin-index-records.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../plugins/installed-plugin-index-records.js")>();
+  return {
+    ...actual,
+    loadInstalledPluginIndexInstallRecords: () => loadInstalledPluginIndexInstallRecordsMock(),
+  };
+});
 
 const DISCORD_REPO_INSTALL_SPEC = repoInstallSpec("discord");
 
@@ -57,9 +70,13 @@ describe("loadConfigForInstall", () => {
   } satisfies PluginInstallRequestContext;
 
   beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
     readConfigFileSnapshotMock.mockReset();
     collectChannelDoctorStaleConfigMutationsMock.mockReset();
+    loadInstalledPluginIndexInstallRecordsMock.mockReset();
 
+    loadInstalledPluginIndexInstallRecordsMock.mockResolvedValue({});
     collectChannelDoctorStaleConfigMutationsMock.mockImplementation(async (cfg: OpenClawConfig) => [
       {
         config: cfg,
@@ -117,7 +134,7 @@ describe("loadConfigForInstall", () => {
 
     const result = await loadConfigForInstall(discordNpmRequest);
     expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
-    expect(collectChannelDoctorStaleConfigMutationsMock).toHaveBeenCalledWith(snapshotCfg);
+    expect(collectChannelDoctorStaleConfigMutationsMock).not.toHaveBeenCalled();
     expect(result).toEqual({ config: snapshotCfg, baseHash: "abc" });
   });
 
@@ -146,7 +163,7 @@ describe("loadConfigForInstall", () => {
     expect(request.request.bundledPluginId).toBe("discord");
     expect(request.request.allowInvalidConfigRecovery).toBe(true);
     const result = await loadConfigForInstall(request.request);
-    expect(collectChannelDoctorStaleConfigMutationsMock).toHaveBeenCalledWith(snapshotCfg);
+    expect(collectChannelDoctorStaleConfigMutationsMock).not.toHaveBeenCalled();
     expect(result).toEqual({ config: snapshotCfg, baseHash: "abc" });
   });
 
@@ -178,7 +195,7 @@ describe("loadConfigForInstall", () => {
     expect(request.request.bundledPluginId).toBe("discord");
     expect(request.request.allowInvalidConfigRecovery).toBe(true);
     const result = await loadConfigForInstall(request.request);
-    expect(collectChannelDoctorStaleConfigMutationsMock).toHaveBeenCalledWith(snapshotCfg);
+    expect(collectChannelDoctorStaleConfigMutationsMock).not.toHaveBeenCalled();
     expect(result).toEqual({
       config: {
         plugins: {
@@ -188,6 +205,179 @@ describe("loadConfigForInstall", () => {
       },
       baseHash: "abc",
     });
+  });
+
+  it("does not classify file-normalized versioned paths as official recovery specs", () => {
+    const request = resolvePluginInstallRequestContext({
+      rawSpec: "file:@openclaw/discord@2026.5.22",
+    });
+    if (!request.ok) {
+      throw new Error(request.error);
+    }
+
+    expect(request.request.allowInvalidConfigRecovery).toBeUndefined();
+    expect(request.request.bundledPluginId).toBeUndefined();
+  });
+
+  it("does not classify registry-like local paths as official recovery specs", () => {
+    const existsSync = fs.existsSync;
+    vi.spyOn(fs, "existsSync").mockImplementation((candidate) =>
+      String(candidate).endsWith("@openclaw/discord@2026.5.22") ? true : existsSync(candidate),
+    );
+
+    const request = resolvePluginInstallRequestContext({
+      rawSpec: "@openclaw/discord@2026.5.22",
+    });
+    if (!request.ok) {
+      throw new Error(request.error);
+    }
+
+    expect(request.request.allowInvalidConfigRecovery).toBeUndefined();
+    expect(request.request.bundledPluginId).toBeUndefined();
+  });
+
+  it("rejects recovery when removing a stale path would shift authored env refs", async () => {
+    vi.stubEnv("OPENCLAW_TEST_PLUGIN_DIR", "/custom/plugin");
+    const snapshotCfg = {
+      plugins: {
+        installs: { discord: { source: "npm", installPath: "/gone" } },
+        load: { paths: ["/gone", "/custom/plugin"] },
+      },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: {
+          plugins: {
+            installs: { discord: {} },
+            load: { paths: ["/gone", "${OPENCLAW_TEST_PLUGIN_DIR}"] },
+          },
+        },
+        sourceConfig: snapshotCfg as ConfigFileSnapshot["sourceConfig"],
+        config: snapshotCfg,
+        issues: [
+          { path: "channels.discord", message: "unknown channel id: discord" },
+          { path: "plugins.load.paths", message: "plugin: plugin path not found: /gone" },
+        ],
+      }),
+    );
+
+    const request = resolvePluginInstallRequestContext({
+      rawSpec: "@openclaw/discord@2026.5.22",
+    });
+    if (!request.ok) {
+      throw new Error(request.error);
+    }
+
+    await expect(loadConfigForInstall(request.request)).rejects.toThrow(
+      "Config invalid outside the plugin recovery path for discord",
+    );
+    expect(collectChannelDoctorStaleConfigMutationsMock).not.toHaveBeenCalled();
+  });
+
+  it("matches missing load paths against persisted install records", async () => {
+    loadInstalledPluginIndexInstallRecordsMock.mockResolvedValue({
+      discord: { source: "npm", installPath: "/gone" },
+    });
+    const snapshotCfg = {
+      plugins: { load: { paths: ["/gone", "/keep"] } },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: { plugins: { load: { paths: ["/gone", "/keep"] } } },
+        config: snapshotCfg,
+        issues: [
+          { path: "channels.discord", message: "unknown channel id: discord" },
+          { path: "plugins.load.paths", message: "plugin: plugin path not found: /gone" },
+        ],
+      }),
+    );
+
+    const request = resolvePluginInstallRequestContext({
+      rawSpec: "@openclaw/discord@2026.5.22",
+    });
+    if (!request.ok) {
+      throw new Error(request.error);
+    }
+
+    const result = await loadConfigForInstall(request.request);
+    expect(result.config).toEqual({
+      plugins: { load: { paths: ["/keep"] } },
+    });
+  });
+
+  it("prefers persisted install records over stale legacy config install records", async () => {
+    loadInstalledPluginIndexInstallRecordsMock.mockResolvedValue({
+      discord: { source: "npm", installPath: "/canonical" },
+    });
+    const snapshotCfg = {
+      plugins: {
+        installs: { discord: { source: "npm", installPath: "/legacy" } },
+        load: { paths: ["/canonical", "/legacy"] },
+      },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: {
+          plugins: {
+            installs: { discord: {} },
+            load: { paths: ["/canonical", "/legacy"] },
+          },
+        },
+        config: snapshotCfg,
+        issues: [
+          { path: "channels.discord", message: "unknown channel id: discord" },
+          { path: "plugins.load.paths", message: "plugin: plugin path not found: /canonical" },
+        ],
+      }),
+    );
+
+    const request = resolvePluginInstallRequestContext({
+      rawSpec: "@openclaw/discord@2026.5.22",
+    });
+    if (!request.ok) {
+      throw new Error(request.error);
+    }
+
+    const result = await loadConfigForInstall(request.request);
+    expect(result.config).toEqual({
+      plugins: {
+        installs: { discord: { source: "npm", installPath: "/legacy" } },
+        load: { paths: ["/legacy"] },
+      },
+    });
+  });
+
+  it("rejects recovery when a missing plugin load path is unrelated to the requested plugin", async () => {
+    const snapshotCfg = {
+      plugins: {
+        installs: { discord: { source: "npm", installPath: "/gone" } },
+        load: { paths: ["/gone", "/other"] },
+      },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: {
+          plugins: {
+            installs: { discord: {} },
+            load: { paths: ["/gone", "/other"] },
+          },
+        },
+        config: snapshotCfg,
+        issues: [{ path: "plugins.load.paths", message: "plugin: plugin path not found: /other" }],
+      }),
+    );
+
+    const request = resolvePluginInstallRequestContext({
+      rawSpec: "@openclaw/discord@2026.5.22",
+    });
+    if (!request.ok) {
+      throw new Error(request.error);
+    }
+
+    await expect(loadConfigForInstall(request.request)).rejects.toThrow(
+      "Config invalid outside the plugin recovery path for discord",
+    );
+    expect(collectChannelDoctorStaleConfigMutationsMock).not.toHaveBeenCalled();
   });
 
   it("allows official plugin reinstall recovery from source-only runtime shadows", async () => {
@@ -200,9 +390,9 @@ describe("loadConfigForInstall", () => {
         config: snapshotCfg,
         issues: [
           {
-            path: "plugins",
+            path: "plugins.entries.discord",
             message:
-              "plugin: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs, index.js, index.mjs, index.cjs. This is a plugin packaging issue, not a local config problem; update or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then. TypeScript source fallback is only supported for source checkouts and local development paths.",
+              "plugin discord: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs, index.js, index.mjs, index.cjs. This is a plugin packaging issue, not a local config problem; update or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then. TypeScript source fallback is only supported for source checkouts and local development paths.",
           },
         ],
       }),
@@ -216,8 +406,38 @@ describe("loadConfigForInstall", () => {
     }
 
     const result = await loadConfigForInstall(request.request);
-    expect(collectChannelDoctorStaleConfigMutationsMock).toHaveBeenCalledWith(snapshotCfg);
+    expect(collectChannelDoctorStaleConfigMutationsMock).not.toHaveBeenCalled();
     expect(result).toEqual({ config: snapshotCfg, baseHash: "abc" });
+  });
+
+  it("rejects unattributed compiled-runtime recovery issues", async () => {
+    const snapshotCfg = {
+      plugins: { installs: { discord: { source: "npm", installPath: "/bad/discord" } } },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: { plugins: { installs: { discord: {} } } },
+        config: snapshotCfg,
+        issues: [
+          {
+            path: "plugins",
+            message:
+              "plugin: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js.",
+          },
+        ],
+      }),
+    );
+
+    const request = resolvePluginInstallRequestContext({
+      rawSpec: "npm:@openclaw/discord",
+    });
+    if (!request.ok) {
+      throw new Error(request.error);
+    }
+
+    await expect(loadConfigForInstall(request.request)).rejects.toThrow(
+      "Config invalid outside the plugin recovery path for discord",
+    );
   });
 
   it("allows Brave official plugin reinstall recovery from source-only runtime shadows", async () => {
@@ -252,7 +472,7 @@ describe("loadConfigForInstall", () => {
 
     expect(request.request.allowInvalidConfigRecovery).toBe(true);
     const result = await loadConfigForInstall(request.request);
-    expect(collectChannelDoctorStaleConfigMutationsMock).toHaveBeenCalledWith(snapshotCfg);
+    expect(collectChannelDoctorStaleConfigMutationsMock).not.toHaveBeenCalled();
     expect(result).toEqual({ config: snapshotCfg, baseHash: "abc" });
   });
 
@@ -289,6 +509,123 @@ describe("loadConfigForInstall", () => {
     await expect(loadConfigForInstall(discordNpmRequest)).rejects.toThrow(
       "Config invalid outside the plugin recovery path for discord",
     );
+  });
+
+  it("rejects include-backed invalid config instead of flattening it during recovery", async () => {
+    const snapshotCfg = {
+      plugins: {
+        installs: { discord: { source: "npm", installPath: "/gone" } },
+        load: { paths: ["/gone"] },
+      },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: { $include: "./plugins.json" },
+        config: snapshotCfg,
+        issues: [
+          { path: "channels.discord", message: "unknown channel id: discord" },
+          { path: "plugins.load.paths", message: "plugin: plugin path not found: /gone" },
+        ],
+      }),
+    );
+
+    await expect(loadConfigForInstall(discordNpmRequest)).rejects.toThrow(
+      "Config invalid outside the plugin recovery path for discord",
+    );
+    expect(loadInstalledPluginIndexInstallRecordsMock).not.toHaveBeenCalled();
+    expect(collectChannelDoctorStaleConfigMutationsMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects nested include-backed invalid config instead of flattening it during recovery", async () => {
+    const snapshotCfg = {
+      plugins: {
+        installs: { discord: { source: "npm", installPath: "/gone" } },
+        load: { paths: ["/gone"] },
+      },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: { agents: { list: [{ $include: "./agent.json5" }] } },
+        config: snapshotCfg,
+        issues: [
+          { path: "channels.discord", message: "unknown channel id: discord" },
+          { path: "plugins.load.paths", message: "plugin: plugin path not found: /gone" },
+        ],
+      }),
+    );
+
+    await expect(loadConfigForInstall(discordNpmRequest)).rejects.toThrow(
+      "Config invalid outside the plugin recovery path for discord",
+    );
+    expect(loadInstalledPluginIndexInstallRecordsMock).not.toHaveBeenCalled();
+    expect(collectChannelDoctorStaleConfigMutationsMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects recovery when install policy arrays contain authored env refs", async () => {
+    const snapshotCfg = {
+      plugins: {
+        installs: { discord: { source: "npm", installPath: "/gone" } },
+        deny: ["discord", "keep"],
+        load: { paths: ["/gone"] },
+      },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: {
+          plugins: {
+            installs: { discord: {} },
+            deny: ["discord", "${KEEP_PLUGIN}"],
+            load: { paths: ["/gone"] },
+          },
+        },
+        config: snapshotCfg,
+        issues: [
+          { path: "channels.discord", message: "unknown channel id: discord" },
+          { path: "plugins.load.paths", message: "plugin: plugin path not found: /gone" },
+        ],
+      }),
+    );
+
+    await expect(loadConfigForInstall(discordNpmRequest)).rejects.toThrow(
+      "Config invalid outside the plugin recovery path for discord",
+    );
+    expect(loadInstalledPluginIndexInstallRecordsMock).not.toHaveBeenCalled();
+    expect(collectChannelDoctorStaleConfigMutationsMock).not.toHaveBeenCalled();
+  });
+
+  it("allows recovery when env-backed allow policy already includes the requested plugin", async () => {
+    const snapshotCfg = {
+      plugins: {
+        installs: { discord: { source: "npm", installPath: "/gone" } },
+        allow: ["discord", "keep"],
+        load: { paths: ["/gone"] },
+      },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: {
+          plugins: {
+            installs: { discord: {} },
+            allow: ["discord", "${KEEP_PLUGIN}"],
+            load: { paths: ["/gone"] },
+          },
+        },
+        config: snapshotCfg,
+        issues: [
+          { path: "channels.discord", message: "unknown channel id: discord" },
+          { path: "plugins.load.paths", message: "plugin: plugin path not found: /gone" },
+        ],
+      }),
+    );
+
+    const result = await loadConfigForInstall(discordNpmRequest);
+    expect(result.config).toEqual({
+      plugins: {
+        installs: { discord: { source: "npm", installPath: "/gone" } },
+        allow: ["discord", "keep"],
+        load: { paths: [] },
+      },
+    });
   });
 
   it("rejects non-Discord install requests when config is invalid", async () => {

--- a/src/cli/plugins-install-config.test.ts
+++ b/src/cli/plugins-install-config.test.ts
@@ -150,6 +150,46 @@ describe("loadConfigForInstall", () => {
     expect(result).toEqual({ config: snapshotCfg, baseHash: "abc" });
   });
 
+  it("allows versioned official npm spec reinstall recovery", async () => {
+    const snapshotCfg = {
+      plugins: {
+        installs: { discord: { source: "npm", installPath: "/gone" } },
+        load: { paths: ["/gone", "/keep"] },
+      },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: { plugins: { installs: { discord: {} }, load: { paths: ["/gone", "/keep"] } } },
+        config: snapshotCfg,
+        issues: [
+          { path: "channels.discord", message: "unknown channel id: discord" },
+          { path: "plugins.load.paths", message: "plugin: plugin path not found: /gone" },
+        ],
+      }),
+    );
+
+    const request = resolvePluginInstallRequestContext({
+      rawSpec: "@openclaw/discord@2026.5.22",
+    });
+    if (!request.ok) {
+      throw new Error(request.error);
+    }
+
+    expect(request.request.bundledPluginId).toBe("discord");
+    expect(request.request.allowInvalidConfigRecovery).toBe(true);
+    const result = await loadConfigForInstall(request.request);
+    expect(collectChannelDoctorStaleConfigMutationsMock).toHaveBeenCalledWith(snapshotCfg);
+    expect(result).toEqual({
+      config: {
+        plugins: {
+          installs: { discord: { source: "npm", installPath: "/gone" } },
+          load: { paths: ["/keep"] },
+        },
+      },
+      baseHash: "abc",
+    });
+  });
+
   it("allows official plugin reinstall recovery from source-only runtime shadows", async () => {
     const snapshotCfg = {
       plugins: { installs: { discord: { source: "npm", installPath: "/bad/discord" } } },

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -362,6 +362,18 @@ describe("registerPreActionHooks", () => {
 
     vi.clearAllMocks();
     await runPreAction({
+      parseArgv: ["plugins", "install", "@openclaw/discord@2026.5.22"],
+      processArgv: ["node", "openclaw", "plugins", "install", "@openclaw/discord@2026.5.22"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["plugins", "install"],
+      allowInvalid: true,
+    });
+
+    vi.clearAllMocks();
+    await runPreAction({
       parseArgv: ["plugins", "install", "@openclaw/brave-plugin"],
       processArgv: ["node", "openclaw", "plugins", "install", "@openclaw/brave-plugin"],
     });


### PR DESCRIPTION
## Summary

What problem does this PR solve?

Root cause: the official external plugin recovery resolver used the raw install spec as the identity key, so the versioned npm spec `@openclaw/discord@2026.5.22` did not resolve to the catalog source identity `@openclaw/discord`. That resolver miss caused the invalid-config recovery path to preserve the stale `plugins.load.paths` entry, and config validation rejected the write after the install action.

Why does this matter now?

NemoClaw onboarding can select Discord, then the image build runs the versioned Discord install command from the generated build script. When the previous Discord plugin path is missing, the build cannot finish even though this is exactly the kind of stale plugin state the recovery install path is meant to repair.

What is the intended outcome?

Fix classification: root-cause fix. The installer now maps versioned official npm specs back to their package name for recovery metadata, and the recovery config removes only validation-reported missing plugin load paths before persisting the repaired install state.

What is intentionally out of scope?

What did NOT change: this PR does not change Discord runtime auth, live bot connection behavior, marketplace override semantics, plugin schema defaults, migration files, unrelated plugin load paths, or non-recovery install behavior.

What does success look like?

A stale Discord plugin config that previously blocked `plugins install @openclaw/discord@2026.5.22` now installs successfully and validates afterward.

What should reviewers focus on?

Why this is root-cause fix: the source boundary is the install-spec resolver and official external plugin catalog mapping, not the Docker build script. The patch parses the npm spec to its package identity before matching catalog recovery metadata, then applies the config validation invariant at persistence time by removing only the load path that validation proved missing. This fixes the resolver/source-of-truth mismatch and the invalid config write source, instead of adding a Discord-only fallback or bypassing config validation.

Patch quality notes: the helper returns `null` for non-`plugins.load.paths` issues and for messages without the `plugin path not found:` marker so unrelated validation errors cannot drive cleanup. The `as unknown as OpenClawConfig` cast is limited to the existing test style for partial config snapshots. Patch warning/default-return smell is not masking a runtime failure; it is a parser guard that keeps cleanup opt-in to the validation issue shape.

Architecture / source-of-truth check: the source of truth for official external plugin identity remains the official external plugin catalog, and the source of truth for removable stale load paths is the config validation diagnostic. Related open PR / same-contract scan from init found no competing linked PR for this issue. Public contract surface is config compatibility only: existing invalid recovery requests become repairable, while other invalid configs still fail through the same guard.

## Linked context

Which issue does this close?

Closes #90333

Which issues, PRs, or discussions are related?

Related PR / competition scan: daily-fix init found no linked open PR for this issue.

Was this requested by a maintainer or owner?

No direct maintainer request beyond the linked issue report.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw plugins install @openclaw/discord@2026.5.22` can recover a stale Discord install even when the existing config has `channels.discord` and a missing `plugins.load.paths` entry.
- Real environment tested: local OpenClaw CLI with an isolated temporary `OPENCLAW_HOME` and config that reproduced the stale Discord plugin path failure.
- Exact steps or command run after this patch: create a config containing a stale Discord npm install, `channels.discord`, and `plugins.load.paths: ["/missing/discord"]`; then run `pnpm dev plugins install @openclaw/discord@2026.5.22` followed by `pnpm dev config validate`.
- Evidence after fix (terminal capture, redacted):

  ```text
  $ node scripts/run-node.mjs plugins install @openclaw/discord@2026.5.22
  OpenClaw config is invalid
  Problem:
    - plugins.load.paths: plugin: plugin path not found: /missing/discord

  Fix: openclaw doctor --fix
  Inspect: openclaw config validate
  Status, health, logs, tasks list/audit, and doctor commands still run with invalid config.
  Using bundled plugin "discord" from <repo>/dist/extensions/discord for npm install spec "@openclaw/discord@2026.5.22" because this plugin ships with the current OpenClaw build. To force an external npm override, use npm:@openclaw/discord@2026.5.22.
  Installed plugin: discord
  Restart the gateway to load plugins.

  $ node scripts/run-node.mjs config validate
  Config valid: <temp-config>/config.json5
  ```

- Observed result after fix: the versioned Discord install completes and the same config validates successfully afterward.
- What was not tested: a live Discord bot connection or a full NemoClaw Docker image build.
- Proof limitations or environment constraints: the proof focuses on the failing OpenClaw CLI recovery command from the image build log; no Discord token was needed or used for this config recovery path.
- Before evidence (optional but encouraged): the new regression test failed before the fix because `/gone` remained in `plugins.load.paths` after `loadConfigForInstall`, which would make the install write fail validation.

## Tests and validation

Which commands did you run?

Target test file: `src/cli/plugins-install-config.test.ts` and `src/cli/program/preaction.test.ts`.

- `pnpm exec vitest run src/cli/plugins-install-config.test.ts src/cli/program/preaction.test.ts`
- `pnpm dev plugins install @openclaw/discord@2026.5.22` with stale Discord config, then `pnpm dev config validate`
- `pnpm run deps:shrinkwrap:changed:check`
- `pnpm run lint -- src/cli/plugin-install-config-policy.ts src/cli/plugins-install-command.ts src/cli/plugins-install-config.test.ts src/cli/program/preaction.test.ts`

What regression coverage was added or updated?

Scenario locked in: versioned official npm specs inherit Discord invalid-config recovery metadata, the CLI pre-action guard allows invalid config for `plugins install @openclaw/discord@2026.5.22`, and recovery install config removes validation-reported missing `plugins.load.paths` entries before persistence.

What failed before this fix, if known?

Why this is the smallest reliable guardrail: the focused config test failed before the implementation because the missing path stayed in `plugins.load.paths`; the command proof exercises the same install command shape from the issue and confirms the repaired config validates after install.

If no test was added, why not?

Not applicable; regression tests were added for the resolver/pre-action path and the config cleanup path.

Known validation note: `pnpm run check` was also run; all preflight guards shown in the output passed except the repository-wide npm shrinkwrap guard, which reported `npm-shrinkwrap.json is stale. Run pnpm deps:shrinkwrap:generate.` No package or lockfile changes are part of this PR, and `deps:shrinkwrap:changed:check` passed.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Risk labels considered: config compatibility and plugin install availability. The install command now mutates invalid recovery config by dropping missing plugin load paths reported by validation.

How is that risk mitigated?

Why acceptable: the recovery path is still gated to official plugin install requests that opt into invalid-config recovery; cleanup only uses `plugins.load.paths` validation issues whose message includes `plugin path not found:`; unrelated load paths are preserved; and non-recovery installs still fail with the existing invalid-config error.

## Current review state

What is the next action?

Maintainer-ready confidence: high. Next action is remote CI and maintainer review after PR creation.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on remote CI after PR creation. No author-side follow-up is known from local validation.

Which bot or reviewer comments were addressed?

No bot or reviewer comments yet; this is a new issue fix.
