### PR TITLE
feat(slack): update assistant thread status text per tool during execution (refs #33413)

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -126,6 +126,34 @@ const SLACK_REASONING_TAG_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking
 const SLACK_REASONING_LABEL_PREFIX_RE = /^\s*(?:>\s*)?Reasoning:\s*/iu;
 const SLACK_THINKING_LABEL_PREFIX_RE = /^\s*(?:>\s*)?Thinking\.{0,3}(?=\s*(?:\n|_))/iu;
 
+const SLACK_TOOL_STATUS_LABELS: Record<string, string> = {
+  exec: "Running command…",
+  shell: "Running command…",
+  terminal: "Running command…",
+  web_search: "Searching the web…",
+  web_fetch: "Fetching URL…",
+  Read: "Reading files…",
+  read_file: "Reading files…",
+  write_file: "Writing files…",
+  search_files: "Searching files…",
+  memory_search: "Checking memory…",
+  tts: "Converting to speech…",
+  message: "Sending message…",
+  browser_navigate: "Opening browser…",
+  browser_click: "Interacting with page…",
+  browser_type: "Typing…",
+  browser_snapshot: "Reading page…",
+  browser_scroll: "Scrolling…",
+  image_generate: "Generating image…",
+};
+
+function resolveSlackToolStatusLabel(toolName: string | null | undefined): string | undefined {
+  if (!toolName) {
+    return undefined;
+  }
+  return SLACK_TOOL_STATUS_LABELS[toolName] ?? undefined;
+}
+
 function resolveSlackMessageTimestampMs(message: SlackMessageEvent): number | undefined {
   const ts = message.event_ts ?? message.ts;
   return resolveSlackTimestampMs(ts);
@@ -1886,6 +1914,16 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         onToolStart: async (payload) => {
           if (statusReactionsEnabled) {
             await statusReactions.setTool(payload.name);
+          }
+          if (didSetStatus) {
+            const toolStatus = resolveSlackToolStatusLabel(payload.name);
+            if (toolStatus) {
+              await ctx.setSlackThreadStatus({
+                channelId: message.channel,
+                threadTs: statusThreadTs,
+                status: toolStatus,
+              });
+            }
           }
           await pushPreviewToolProgress(
             buildChannelProgressDraftLineForEntry(


### PR DESCRIPTION
## Summary

Update the Slack assistant thread status text dynamically during agent loop execution to reflect which tool is currently running, instead of the static "is typing..." message.

## Changes

- Add `SLACK_TOOL_STATUS_LABELS` map covering 18 common tools (exec, web_search, read_file, memory_search, browser_*, tts, message, image_generate, etc.)
- Add `resolveSlackToolStatusLabel()` helper to look up human-readable status text
- In the `onToolStart` handler, update the thread status when `didSetStatus` is true (i.e., the typing status was already set by the dispatch flow)

The status updates are gated behind `didSetStatus` to prevent stale status on channels without thread status support.

## Real behavior proof

- **Behavior addressed:** Slack thread status shows tool-specific text during agent execution
- **Environment tested:** macOS, OpenClaw local build
- **Steps run after the patch:**
  1. Applied changes to `extensions/slack/src/monitor/message-handler/dispatch.ts`
  2. Ran `node scripts/run-vitest.mjs run extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts` — 26 tests passed
  3. Ran `node scripts/run-vitest.mjs run extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts` — 74 tests passed
  4. Ran `pnpm build` — succeeded

- **Evidence after fix:**

```
$ node scripts/run-vitest.mjs run extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
 ✓  extension-slack  (26 tests) 6ms
 Test Files  1 passed (1)
      Tests  26 passed (26)

$ node scripts/run-vitest.mjs run extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
 ✓  extension-slack  (74 tests) 2223ms
 Test Files  1 passed (1)
      Tests  74 passed (74)

$ grep -n "SLACK_TOOL_STATUS_LABELS\|resolveSlackToolStatusLabel" extensions/slack/src/monitor/message-handler/dispatch.ts
129:const SLACK_TOOL_STATUS_LABELS: Record<string, string> = {
150:function resolveSlackToolStatusLabel(toolName: string | null | undefined): string | undefined {

$ pnpm build
✓ built in 518ms
```

- **Observed result after fix:** All 100 tests pass, build succeeds, tool-specific status labels are defined and wired into the onToolStart handler
- **What was not tested:** Live Slack thread status update (requires running Slack bot with thread status enabled)
