### PR TITLE
fix(usage): make built-in footer easier to wrap on Telegram

### DIFF
--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -24,7 +24,7 @@ title: "Usage tracking"
 ## Where it shows up
 
 - `/status` in chats: emoji-rich status card with session tokens + estimated cost (API key only). Provider usage shows for the **current model provider** when available as a normalized `X% left` window or provider summary text.
-- `/usage off|tokens|full` in chats: per-response usage footer (OAuth shows tokens only).
+- `/usage off|tokens|full` in chats: per-response usage footer.
 - `/usage cost` in chats: local cost summary aggregated from OpenClaw session logs.
 - CLI: `openclaw status --usage` prints a full per-provider breakdown.
 - CLI: `openclaw channels list` prints the same usage snapshot alongside provider config (use `--no-usage` to skip).
@@ -95,8 +95,8 @@ With no config the prior behavior holds (footer off until `/usage`). Use
 ## Custom `/usage full` footer
 
 `/usage full` shows a built-in compact footer with model, reasoning, fast/slow,
-context window, turn tokens, cache, and cost when those fields are available. No
-template file is required.
+context window, and cost when those fields are available. Token and cache fields
+remain available to custom templates. No template file is required.
 
 `messages.usageTemplate` is only for advanced custom layouts. The value is a
 JSON file path (supports `~`) or an inline object, and it replaces the built-in
@@ -150,42 +150,30 @@ change:
   "output": {
     "sep": "",
     "default": [
-      { "text": "{model.provider}{identity.emoji|🤖} {model.display_name|alias:models}" },
-      { "map": "model.is_fallback", "cases": { "true": " 🔄" } },
-      { "map": "model.is_override", "cases": { "true": " 📌" } },
-      { "when": "model.reasoning", "text": " {model.reasoning|alias:reasoning}" },
-      { "map": "state.fast_mode", "cases": { "true": " ⚡", "false": " 🐌" } },
+      { "text": "{model.provider}{identity.emoji|🤖}{model.display_name|alias:models}" },
+      { "map": "model.is_fallback", "cases": { "true": "🔄" } },
+      { "map": "model.is_override", "cases": { "true": "📌" } },
+      { "when": "model.reasoning", "text": "{model.reasoning|alias:reasoning}" },
+      { "map": "state.fast_mode", "cases": { "true": "⚡️", "false": "🐌" } },
       {
         "when": "context.max_tokens",
-        "text": " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
+        "text": "\u00A0| 📚[{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
       },
-      {
-        "when": "usage.has_split_tokens",
-        "text": " ↕️ {usage.input_tokens|num|?}/{usage.output_tokens|num|?}",
-      },
-      { "when": "usage.has_total_only_tokens", "text": " ↕️ {usage.total_tokens|num}" },
-      { "when": "usage.cache_hit_pct", "text": " 🗄 {usage.cache_hit_pct|pct}" },
-      { "when": "cost.turn_usd", "text": " 💰{cost.turn_usd|fixed:4}" },
+      { "when": "cost.turn_usd", "text": "\u00A0💰{cost.turn_usd|fixed:4}" },
     ],
     "surfaces": {
       "discord": [
         { "text": "-# -\n" },
-        { "text": "-# {model.provider}{identity.emoji|🤖} {model.display_name|alias:models}" },
+        { "text": "-# {model.provider}{identity.emoji|🤖}{model.display_name|alias:models}" },
         { "map": "model.is_fallback", "cases": { "true": "🔄" } },
         { "map": "model.is_override", "cases": { "true": "📌" } },
-        { "when": "model.reasoning", "text": " {model.reasoning|alias:reasoning}" },
-        { "map": "state.fast_mode", "cases": { "true": " ⚡️", "false": " 🐌" } },
+        { "when": "model.reasoning", "text": "{model.reasoning|alias:reasoning}" },
+        { "map": "state.fast_mode", "cases": { "true": "⚡️", "false": "🐌" } },
         {
           "when": "context.max_tokens",
-          "text": " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
+          "text": "\u00A0| 📚[{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
         },
-        {
-          "when": "usage.has_split_tokens",
-          "text": " ↕️ {usage.input_tokens|num|?}/{usage.output_tokens|num|?}",
-        },
-        { "when": "usage.has_total_only_tokens", "text": " ↕️ {usage.total_tokens|num}" },
-        { "when": "usage.cache_hit_pct", "text": " 🗄 {usage.cache_hit_pct|pct}" },
-        { "when": "cost.turn_usd", "text": " 💰{cost.turn_usd|fixed:4}" },
+        { "when": "cost.turn_usd", "text": "\u00A0💰{cost.turn_usd|fixed:4}" },
       ],
     },
   },

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -333,7 +333,7 @@ Defaults:
 ### What to inspect
 
 - Cache trace events are JSONL and include staged snapshots like `session:loaded`, `prompt:before`, `stream:context`, and `session:after`.
-- Per-turn cache token impact is visible in normal usage surfaces via `cacheRead` and `cacheWrite` (for example `/usage full` and session usage summaries).
+- Per-turn cache token impact is visible in normal usage surfaces via `cacheRead` and `cacheWrite` (for example `/usage tokens`, `/status`, session usage summaries, and custom `messages.usageTemplate` layouts).
 - For Anthropic, expect both `cacheRead` and `cacheWrite` when caching is active.
 - For OpenAI, expect `cacheRead` on cache hits. GPT-5.6 Responses can also report `cacheWrite` while prompt segments are written; other Responses payloads that omit the write counter keep it at `0`.
 - If you need request tracing, log request IDs and rate-limit headers separately from cache metrics. OpenClaw's current cache-trace output is focused on prompt/session shape and normalized token usage rather than raw provider response headers.

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -78,8 +78,10 @@ Use these in chat:
   - Persists per session (stored as `responseUsage`).
   - `/usage reset` (aliases: `inherit`, `clear`, `default`) — clears the session
     override so the session re-inherits the configured default.
-  - `/usage full` shows estimated cost only when OpenClaw has usage metadata and
-    local pricing for the active model. Otherwise it shows tokens only.
+  - `/usage tokens` shows turn token/cache details.
+  - `/usage full` shows compact model/context/cost details; estimated cost appears
+    only when OpenClaw has usage metadata and local pricing for the active model.
+    Custom `messages.usageTemplate` layouts can include token/cache fields.
 - `/usage cost` → shows a local cost summary from OpenClaw session logs.
 
 Other surfaces:
@@ -131,10 +133,11 @@ models.providers.<provider>.models[].cost
 ```
 
 These are **USD per 1M tokens** for `input`, `output`, `cacheRead`, and
-`cacheWrite`. If pricing is missing, OpenClaw shows tokens only. Cost display is
-not limited to API-key auth: non-API-key providers such as `aws-sdk` can show
-estimated cost when their configured model entry includes local pricing and the
-provider returns usage metadata.
+`cacheWrite`. If pricing is missing, `/usage full` omits cost; use `/usage tokens`
+or a custom `messages.usageTemplate` when you need token/cache details in every
+reply. Cost display is not limited to API-key auth: non-API-key providers such
+as `aws-sdk` can show estimated cost when their configured model entry includes
+local pricing and the provider returns usage metadata.
 
 After sidecars and channels reach the Gateway ready path, OpenClaw starts an
 optional background pricing bootstrap for configured model refs that do not

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2776,9 +2776,9 @@ describe("runReplyAgent response usage footer", () => {
     const res = await createRun({ responseUsage: "full", sessionKey });
     const payload = Array.isArray(res) ? res[0] : res;
     const text = payload?.text ?? "";
-    expect(text).toContain("anthropic🤖 claude 🌘 🐌");
-    expect(text).toContain("↕️ 12/3");
-    expect(text).toContain("🗄 22%");
+    expect(text).toContain("anthropic🤖claude🌘🐌");
+    expect(text).not.toContain("↕️");
+    expect(text).not.toContain("🗄");
     expect(text).not.toContain("Usage:");
     expect(text).not.toContain("· session ");
   });
@@ -2825,7 +2825,7 @@ describe("runReplyAgent response usage footer", () => {
     expect(text).not.toContain("· session ");
   });
 
-  it("keeps partial token counts in the built-in full footer", async () => {
+  it("omits partial token counts from the built-in full footer", async () => {
     runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "ok" }],
       meta: {
@@ -2843,11 +2843,12 @@ describe("runReplyAgent response usage footer", () => {
     });
     const payload = Array.isArray(res) ? res[0] : res;
     const text = payload?.text ?? "";
-    expect(text).toContain("↕️ ?/125");
+    expect(text).toContain("anthropic🤖claude");
+    expect(text).not.toContain("↕️");
     expect(text).not.toContain("Usage:");
   });
 
-  it("shows aggregate-only token totals in the built-in full footer", async () => {
+  it("omits aggregate-only token totals in the built-in full footer", async () => {
     runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "ok" }],
       meta: {
@@ -2874,8 +2875,8 @@ describe("runReplyAgent response usage footer", () => {
     });
     const payload = Array.isArray(res) ? res[0] : res;
     const text = payload?.text ?? "";
-    expect(text).toContain("↕️ 1.3k");
-    expect(text).not.toContain("↕️ ?/?");
+    expect(text).toContain("anthropic🤖claude");
+    expect(text).not.toContain("↕️");
     expect(text).not.toContain("💰");
     expect(text).not.toContain("Usage:");
   });
@@ -2922,9 +2923,9 @@ describe("runReplyAgent response usage footer", () => {
     const payload = Array.isArray(res) ? res[0] : res;
     const text = payload?.text ?? "";
 
-    expect(text).toContain("amazon-bedrock🤖 us.anthropic.claude-sonnet-4-6 🌘 🐌");
-    expect(text).toContain("↕️ 1.0k/2.0k");
-    expect(text).toContain("🗄 14%");
+    expect(text).toContain("amazon-bedrock🤖us.anthropic.claude-sonnet-4-6🌘🐌");
+    expect(text).not.toContain("↕️");
+    expect(text).not.toContain("🗄");
     expect(text).toContain("💰0.0406");
     expect(text).not.toContain("Usage:");
     expect(text).not.toContain("· session ");

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2776,6 +2776,8 @@ describe("runReplyAgent response usage footer", () => {
     const res = await createRun({ responseUsage: "full", sessionKey });
     const payload = Array.isArray(res) ? res[0] : res;
     const text = payload?.text ?? "";
+    expect(text).toContain("ok\nanthropic🤖claude🌘🐌");
+    expect(text).not.toContain("ok\n\nanthropic");
     expect(text).toContain("anthropic🤖claude🌘🐌");
     expect(text).not.toContain("↕️");
     expect(text).not.toContain("🗄");

--- a/src/auto-reply/usage-bar/default-template.ts
+++ b/src/auto-reply/usage-bar/default-template.ts
@@ -24,15 +24,8 @@ export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
   },
   output: {
     sep: "",
-    // Telegram (and any surface without its own list) falls through to `default`,
-    // so the default is built to read well on a narrow phone screen:
-    // - Tight badges: no separators between model/flags/reasoning/fast.
-    // - NBSP (\u00A0) before "|" and before 💰 keeps those joins non-breaking.
-    // - 📚 is glued hard to the meter so it can't wrap between books and bars.
-    // - The single regular space after "|" is the only sanctioned wrap point.
-    // - Leading \n drops the footer onto its own line, below the message body.
     default: [
-      { text: "\n{model.provider}{identity.emoji|🤖}{model.display_name|alias:models}" },
+      { text: "{model.provider}{identity.emoji|🤖}{model.display_name|alias:models}" },
       { map: "model.is_fallback", cases: { true: "🔄" } },
       { map: "model.is_override", cases: { true: "📌" } },
       { when: "model.reasoning", text: "{model.reasoning|alias:reasoning}" },

--- a/src/auto-reply/usage-bar/default-template.ts
+++ b/src/auto-reply/usage-bar/default-template.ts
@@ -24,43 +24,38 @@ export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
   },
   output: {
     sep: "",
+    // Telegram (and any surface without its own list) falls through to `default`,
+    // so the default is built to read well on a narrow phone screen:
+    // - Tight badges: no separators between model/flags/reasoning/fast.
+    // - NBSP (\u00A0) before "|" and before 💰 keeps those joins non-breaking.
+    // - 📚 is glued hard to the meter so it can't wrap between books and bars.
+    // - The single regular space after "|" is the only sanctioned wrap point.
+    // - Leading \n drops the footer onto its own line, below the message body.
     default: [
-      { text: "{model.provider}{identity.emoji|🤖} {model.display_name|alias:models}" },
-      { map: "model.is_fallback", cases: { true: " 🔄" } },
-      { map: "model.is_override", cases: { true: " 📌" } },
-      { when: "model.reasoning", text: " {model.reasoning|alias:reasoning}" },
-      { map: "state.fast_mode", cases: { true: " ⚡", false: " 🐌" } },
+      { text: "\n{model.provider}{identity.emoji|🤖}{model.display_name|alias:models}" },
+      { map: "model.is_fallback", cases: { true: "🔄" } },
+      { map: "model.is_override", cases: { true: "📌" } },
+      { when: "model.reasoning", text: "{model.reasoning|alias:reasoning}" },
+      { map: "state.fast_mode", cases: { true: "⚡️", false: "🐌" } },
       {
         when: "context.max_tokens",
-        text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
+        text: "\u00A0| 📚[{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
       },
-      {
-        when: "usage.has_split_tokens",
-        text: " ↕️ {usage.input_tokens|num|?}/{usage.output_tokens|num|?}",
-      },
-      { when: "usage.has_total_only_tokens", text: " ↕️ {usage.total_tokens|num}" },
-      { when: "usage.cache_hit_pct", text: " 🗄 {usage.cache_hit_pct|pct}" },
-      { when: "cost.turn_usd", text: " 💰{cost.turn_usd|fixed:4}" },
+      { when: "cost.turn_usd", text: "\u00A0💰{cost.turn_usd|fixed:4}" },
     ],
     surfaces: {
       discord: [
         { text: "-# -\n" },
-        { text: "-# {model.provider}{identity.emoji|🤖} {model.display_name|alias:models}" },
+        { text: "-# {model.provider}{identity.emoji|🤖}{model.display_name|alias:models}" },
         { map: "model.is_fallback", cases: { true: "🔄" } },
         { map: "model.is_override", cases: { true: "📌" } },
-        { when: "model.reasoning", text: " {model.reasoning|alias:reasoning}" },
-        { map: "state.fast_mode", cases: { true: " ⚡️", false: " 🐌" } },
+        { when: "model.reasoning", text: "{model.reasoning|alias:reasoning}" },
+        { map: "state.fast_mode", cases: { true: "⚡️", false: "🐌" } },
         {
           when: "context.max_tokens",
-          text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
+          text: "\u00A0| 📚[{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
         },
-        {
-          when: "usage.has_split_tokens",
-          text: " ↕️ {usage.input_tokens|num|?}/{usage.output_tokens|num|?}",
-        },
-        { when: "usage.has_total_only_tokens", text: " ↕️ {usage.total_tokens|num}" },
-        { when: "usage.cache_hit_pct", text: " 🗄 {usage.cache_hit_pct|pct}" },
-        { when: "cost.turn_usd", text: " 💰{cost.turn_usd|fixed:4}" },
+        { when: "cost.turn_usd", text: "\u00A0💰{cost.turn_usd|fixed:4}" },
       ],
     },
   },


### PR DESCRIPTION
## Summary
- Simplify the built-in `/usage full` default footer so Telegram has a cleaner wrap point.
- Keep the model/provider/status badges compact and glue the context meter label to the meter.
- Remove the default token-count and cache-percentage atoms from the stock footer; custom templates can still add them back.

## Real behavior proof

Behavior addressed: the built-in `/usage full` default footer should be easier to read on Telegram/mobile surfaces, with the footer on its own line and a cleaner wrap point before the context meter instead of arbitrary breaks around the meter.

Real environment tested: MarvinMBP live OpenClaw gateway, real Telegram direct chat, running the patched dist built from the matching source change before this source-only PR was extracted.

Exact steps or command run after this patch: Patched the live default template, hard-restarted the gateway with `launchctl kickstart -k`, sent real Telegram messages through the gateway, and asked Peter to inspect the resulting mobile Telegram footer wrap. Then extracted the same `src/auto-reply/usage-bar/default-template.ts` change onto this clean PR branch.

Evidence after fix: Copied live Telegram-observed footer shape from the verified turn:

```text
pioneer🤖opus48📌🌗⚡️ |
📚[⣿⣿⡀⠐⠐]1000k 💰0.0035
```

Peter's live verdict after checking the patched Telegram output: "That's acceptable. Please make a PR with that minor adjustment. Then I can forget about it and put my own custom footer back :)"

Observed result after fix: The footer rendered as an acceptable mobile Telegram default. The books/meter section still can wrap on very narrow displays, but the v2 default is materially cleaner and acceptable for the stock template.

What was not tested: No isolated Telegram bot-to-bot proof run for this PR head. The behavior was proven in the live local gateway before extraction. Discord was not re-proven in this PR turn beyond preserving the same `-#` surface shape with the simplified atoms. Custom `messages.usageTemplate` overrides are unaffected by this source-only default-template change.

## Verification
- Focused usage-bar tests passed locally: `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts -- src/auto-reply/usage-bar`
- Reply-agent footer tests passed locally: `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- `pnpm oxfmt src/auto-reply/usage-bar/default-template.ts` reported the file clean.
- `pnpm tsgo` was attempted locally; it hit pre-existing unrelated main-branch TypeScript errors outside this file. The changed default-template file and focused usage-bar tests are clean.

## Notes
This is intentionally a conservative default-footer adjustment, not a template-engine change. It trades some dense telemetry (`↕️` token counts and `🗄` cache percentage) for better mobile readability in Telegram. Users who want the denser version can keep using a custom `messages.usageTemplate`.

