### PR TITLE
fix(telegram): respect group-level groupPolicy: open for /models callbacks in forum topics

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1575,6 +1575,39 @@ export const registerTelegramHandlers = ({
       }).isAuthorizedSender;
     }
 
+    // If the group is explicitly configured with groupPolicy: "open", treat the
+    // callback the same way native commands do and authorize it without requiring
+    // account-level groupAllowFrom entries. Fixes issue #92655.
+    if (isGroup) {
+      const policyAccess = evaluateTelegramGroupPolicyAccess({
+        isGroup,
+        chatId,
+        cfg: cfgLocal,
+        telegramCfg,
+        topicConfig: context.topicConfig,
+        groupConfig: context.groupConfig,
+        effectiveGroupAllow: context.effectiveGroupAllow,
+        senderId,
+        senderUsername,
+        resolveGroupPolicy,
+        enforcePolicy: true,
+        useTopicAndGroupOverrides: true,
+        enforceAllowlistAuthorization: false,
+        allowEmptyAllowlistEntries: true,
+        requireSenderForAllowlistAuthorization: true,
+        checkChatAllowlist: true,
+      });
+      if (!policyAccess.allowed) {
+        logVerbose(
+          `Blocked telegram model callback from ${senderId || "unknown"} (${policyAccess.reason})`,
+        );
+        return false;
+      }
+      if (policyAccess.groupPolicy === "open") {
+        return true;
+      }
+    }
+
     const expandedDmAllowFrom = await expandTelegramAllowFromWithAccessGroups({
       cfg: cfgLocal,
       allowFrom: dmAllowFrom,

--- a/extensions/telegram/src/bot.create-telegram-bot.forum-models.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.forum-models.test.ts
@@ -1,0 +1,204 @@
+// Focused regression test for /models callback handling in Telegram forum topics.
+// This file can be merged into bot.create-telegram-bot.test.ts once the bug is fixed.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { getOnHandler, telegramBotDepsForTest } from "./bot.create-telegram-bot.test-harness.js";
+
+const harness = await import("./bot.create-telegram-bot.test-harness.js");
+const pluginStateTestRuntime = await import("openclaw/plugin-sdk/plugin-state-test-runtime");
+const configMutation = await import("openclaw/plugin-sdk/config-mutation");
+const {
+  editMessageTextSpy,
+  getChatSpy,
+  middlewareUseSpy,
+  onSpy,
+  sequentializeSpy,
+  telegramBotRuntimeForTest,
+  answerCallbackQuerySpy,
+} = harness;
+const { createTelegramBotCore: createTelegramBotBase, setTelegramBotRuntimeForTest } =
+  await import("./bot-core.js");
+const { resetTelegramForumFlagCacheForTest } = await import("./bot/helpers.js");
+
+let createTelegramBot: (
+  opts: Omit<Parameters<typeof createTelegramBotBase>[0], "telegramDeps">,
+) => ReturnType<typeof createTelegramBotBase>;
+
+const FORUM_CHAT_ID = -1001234567890;
+const TOPIC_ID = 28;
+const SENDER_ID = 1115595084;
+
+function makeForumCallbackCtx(params: {
+  data: string;
+  messageThreadId?: number;
+  isTopicMessage?: boolean;
+}) {
+  return {
+    update: { update_id: 1001 },
+    callbackQuery: {
+      id: "cbq-forum-models-1",
+      data: params.data,
+      from: { id: SENDER_ID, first_name: "Renaud", username: "renaud13x6t" },
+      message: {
+        chat: {
+          id: FORUM_CHAT_ID,
+          type: "supergroup",
+          title: "Forum Group",
+          is_forum: true,
+        },
+        from: { id: 1, is_bot: true, username: "openclaw_bot" },
+        date: 1736380800,
+        message_id: 1261,
+        ...(params.messageThreadId === undefined
+          ? {}
+          : { message_thread_id: params.messageThreadId }),
+        is_topic_message: params.isTopicMessage ?? true,
+        text: "Select a provider:",
+      },
+    },
+    me: { username: "openclaw_bot", has_topics_enabled: true },
+    getFile: async () => ({ download: async () => new Uint8Array() }),
+  };
+}
+
+async function runMiddlewareChainForCallback(ctx: Record<string, unknown>) {
+  const callbackHandler = getOnHandler("callback_query");
+  const middlewares = middlewareUseSpy.mock.calls
+    .map((call) => call[0])
+    .filter(
+      (fn): fn is (ctx: Record<string, unknown>, next: () => Promise<void>) => Promise<void> =>
+        typeof fn === "function",
+    );
+  let idx = -1;
+  const dispatch = async (i: number): Promise<void> => {
+    if (i <= idx) {
+      throw new Error("middleware dispatch called multiple times");
+    }
+    idx = i;
+    const fn = middlewares[i];
+    if (!fn) {
+      await callbackHandler(ctx);
+      return;
+    }
+    await fn(ctx, async () => dispatch(i + 1));
+  };
+  await dispatch(0);
+}
+
+function mockTelegramConfigWrites() {
+  return vi.spyOn(configMutation, "mutateConfigFile").mockResolvedValue({} as never);
+}
+
+const FORUM_OPEN_CONFIG: OpenClawConfig = {
+  agents: {
+    defaults: {
+      model: "openai/gpt-5.4",
+    },
+  },
+  channels: {
+    telegram: {
+      dmPolicy: "open",
+      allowFrom: [],
+      groupPolicy: "allowlist",
+      groupAllowFrom: [],
+      groups: {
+        [String(FORUM_CHAT_ID)]: {
+          groupPolicy: "open",
+          requireMention: false,
+        },
+      },
+    },
+  },
+};
+
+describe("createTelegramBot /models in forum topic", () => {
+  beforeAll(() => {
+    process.env.TZ = "UTC";
+  });
+  afterAll(() => {
+    delete process.env.TZ;
+  });
+  beforeEach(() => {
+    resetTelegramForumFlagCacheForTest();
+    sequentializeSpy.mockImplementation(() => async (_ctx: unknown, next?: () => Promise<void>) => {
+      if (typeof next === "function") {
+        await next();
+      }
+    });
+    setTelegramBotRuntimeForTest(
+      telegramBotRuntimeForTest as unknown as Parameters<typeof setTelegramBotRuntimeForTest>[0],
+    );
+    createTelegramBot = (opts) =>
+      createTelegramBotBase({
+        ...opts,
+        telegramDeps: telegramBotDepsForTest,
+      });
+    pluginStateTestRuntime.resetPluginStateStoreForTests({ closeDatabase: false });
+    onSpy.mockReset();
+    middlewareUseSpy.mockReset();
+    editMessageTextSpy.mockReset();
+    editMessageTextSpy.mockResolvedValue({ message_id: 88 });
+    answerCallbackQuerySpy.mockReset();
+    answerCallbackQuerySpy.mockResolvedValue(undefined);
+    getChatSpy.mockReset();
+    getChatSpy.mockResolvedValue({ id: FORUM_CHAT_ID, is_forum: true, type: "supergroup" });
+    (telegramBotDepsForTest.getRuntimeConfig as ReturnType<typeof vi.fn>).mockReturnValue(
+      FORUM_OPEN_CONFIG,
+    );
+  });
+
+  it("renders model list when a provider button is clicked in a forum topic", async () => {
+    const cleanup = mockTelegramConfigWrites();
+    try {
+      createTelegramBot({ token: "tok" });
+      const ctx = makeForumCallbackCtx({
+        data: "mdl_list_openai_1",
+        messageThreadId: TOPIC_ID,
+        isTopicMessage: true,
+      });
+
+      await runMiddlewareChainForCallback(ctx);
+
+      expect(answerCallbackQuerySpy).toHaveBeenCalledTimes(1);
+      expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
+      const call = editMessageTextSpy.mock.calls[0];
+      const text = call?.[2];
+      const params = call?.[3];
+      expect(typeof text === "string" ? text : "").toContain("openai");
+      expect(params).toMatchObject({
+        reply_markup: {
+          inline_keyboard: expect.arrayContaining([
+            expect.arrayContaining([
+              expect.objectContaining({
+                callback_data: expect.stringMatching(/^mdl_sel_openai\/gpt-5\.4$/),
+              }),
+            ]),
+          ]),
+        },
+      });
+    } finally {
+      cleanup.mockRestore();
+    }
+  });
+
+  it("preserves topic session key for /models callbacks in a forum topic", async () => {
+    const cleanup = mockTelegramConfigWrites();
+    try {
+      createTelegramBot({ token: "tok" });
+      const ctx = makeForumCallbackCtx({
+        data: "mdl_sel_openai/gpt-5.4",
+        messageThreadId: TOPIC_ID,
+        isTopicMessage: true,
+      });
+
+      await runMiddlewareChainForCallback(ctx);
+
+      expect(answerCallbackQuerySpy).toHaveBeenCalledTimes(1);
+      expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
+      const finalText = editMessageTextSpy.mock.calls[0]?.[2];
+      expect(typeof finalText === "string" ? finalText : "").toContain("reset to default");
+    } finally {
+      cleanup.mockRestore();
+    }
+  });
+});

--- a/extensions/telegram/src/bot.create-telegram-bot.forum-models.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.forum-models.test.ts
@@ -24,9 +24,9 @@ let createTelegramBot: (
   opts: Omit<Parameters<typeof createTelegramBotBase>[0], "telegramDeps">,
 ) => ReturnType<typeof createTelegramBotBase>;
 
-const FORUM_CHAT_ID = -1001234567890;
+const FORUM_CHAT_ID = -1009999999999;
 const TOPIC_ID = 28;
-const SENDER_ID = 1115595084;
+const SENDER_ID = 123456789;
 
 function makeForumCallbackCtx(params: {
   data: string;
@@ -38,7 +38,7 @@ function makeForumCallbackCtx(params: {
     callbackQuery: {
       id: "cbq-forum-models-1",
       data: params.data,
-      from: { id: SENDER_ID, first_name: "Renaud", username: "renaud13x6t" },
+      from: { id: SENDER_ID, first_name: "Test", username: "testuser" },
       message: {
         chat: {
           id: FORUM_CHAT_ID,


### PR DESCRIPTION
## Problem

In Telegram forum topics, clicking provider/model buttons from the `/models` inline menu silently does nothing when:
- the account-level `channels.telegram.groupPolicy` is `"allowlist"`,
- `channels.telegram.groupAllowFrom` is empty, and
- the specific group is configured with `groupPolicy: "open"` under `channels.telegram.groups.<chatId>`.

Native commands work in that same chat, but the model callback path drops the update without any visible error.

## Root cause

`isTelegramModelCallbackAuthorized` in `extensions/telegram/src/bot-handlers.runtime.ts` only evaluated the account-level allowlist via `resolveTelegramCommandIngressAuthorization`. It never consulted the per-group `groupPolicy` override, so a group explicitly marked `"open"` was still rejected because the global `groupAllowFrom` was empty.

## Fix

Add a group policy evaluation step before the existing fallback, mirroring what native commands already do:
- Pass `useTopicAndGroupOverrides: true` so `groupConfig.groupPolicy` is honored.
- Pass `allowEmptyAllowlistEntries: true` and `checkChatAllowlist: true` so a group listed in `groups` is treated as explicitly allowed even when the global allowlist is empty.
- Short-circuit with `true` when the effective policy is `"open"`.
- If the policy evaluation rejects, log the reason and return `false`.

## Regression test

Added `extensions/telegram/src/bot.create-telegram-bot.forum-models.test.ts` (collected `*.test.ts` filename) with two forum-topic cases:
- `mdl_list_openai_1` verifies the original message is edited into the provider's model list.
- `mdl_sel_openai/gpt-5.4` verifies the model selection callback updates the message with the success text.

## Verification

Full telegram extension suite:

```
npx vitest run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/

Test Files  120 passed (120)
     Tests  2072 passed (2072)
Duration  87.94s
```

Focused regression test:

```
npx vitest run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot.create-telegram-bot.forum-models.test.ts

Test Files  1 passed (1)
     Tests  2 passed (2)
```

## Real Telegram proof

See PR comment below for terminal-based proof that `/models` provider/model buttons update the message after the patch.

Fixes #92655