### PR TITLE
#92207 fix(memory-wiki): guard against missing agentIds in public artifacts

### DIFF
--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -236,7 +236,7 @@ export async function syncMemoryWikiBridgeSources(params: {
   });
   const agentIdsByWorkspace = new Map<string, string[]>();
   for (const artifact of publicArtifacts) {
-    agentIdsByWorkspace.set(artifact.workspaceDir, artifact.agentIds);
+    agentIdsByWorkspace.set(artifact.workspaceDir, artifact.agentIds ?? []);
   }
   const artifactCount = artifacts.length;
   for (const artifact of artifacts) {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -305,7 +305,7 @@ function cloneMemoryPublicArtifact(
 ): MemoryPluginPublicArtifact {
   return {
     ...artifact,
-    agentIds: [...artifact.agentIds],
+    agentIds: [...(artifact.agentIds ?? [])],
   };
 }
 
@@ -315,27 +315,29 @@ export async function listActiveMemoryPublicArtifacts(params: {
   const artifacts =
     (await memoryPluginState.capability?.capability.publicArtifacts?.listArtifacts(params)) ?? [];
   return artifacts.map(cloneMemoryPublicArtifact).toSorted((left, right) => {
-    const workspaceOrder = left.workspaceDir.localeCompare(right.workspaceDir);
+    const workspaceOrder = (left.workspaceDir ?? "").localeCompare(right.workspaceDir ?? "");
     if (workspaceOrder !== 0) {
       return workspaceOrder;
     }
-    const relativePathOrder = left.relativePath.localeCompare(right.relativePath);
+    const relativePathOrder = (left.relativePath ?? "").localeCompare(right.relativePath ?? "");
     if (relativePathOrder !== 0) {
       return relativePathOrder;
     }
-    const kindOrder = left.kind.localeCompare(right.kind);
+    const kindOrder = (left.kind ?? "").localeCompare(right.kind ?? "");
     if (kindOrder !== 0) {
       return kindOrder;
     }
-    const contentTypeOrder = left.contentType.localeCompare(right.contentType);
+    const contentTypeOrder = (left.contentType ?? "").localeCompare(right.contentType ?? "");
     if (contentTypeOrder !== 0) {
       return contentTypeOrder;
     }
-    const agentOrder = left.agentIds.join("\0").localeCompare(right.agentIds.join("\0"));
+    const leftAgentIds = left.agentIds ?? [];
+    const rightAgentIds = right.agentIds ?? [];
+    const agentOrder = leftAgentIds.join("\0").localeCompare(rightAgentIds.join("\0"));
     if (agentOrder !== 0) {
       return agentOrder;
     }
-    return left.absolutePath.localeCompare(right.absolutePath);
+    return (left.absolutePath ?? "").localeCompare(right.absolutePath ?? "");
   });
 }
 


### PR DESCRIPTION
## Summary

Fix two null-safety issues in `memory-wiki` bridge and `memory-state` sorted artifact listing where `MemoryPluginPublicArtifact.agentIds` could be `undefined` at runtime despite being typed as `string[]`.

**Root cause:** `agentIds` is typed as `string[]` (required) in `MemoryPluginPublicArtifact` but certain plugin implementations may not populate this field, resulting in `undefined`. Two call sites assumed the field was always present, causing runtime errors.

**Fix 1 — `extensions/memory-wiki/src/bridge.ts`:** Line 239 passes `artifact.agentIds ?? []` instead of raw `artifact.agentIds` to `agentIdsByWorkspace.set()`.

**Fix 2 — `src/plugins/memory-state.ts`:** The sort comparator in `listActiveMemoryPublicArtifacts()` guards all 6 property chains with `?? ""` / `?? []` fallbacks, and `cloneMemoryPublicArtifact()` uses `[...(artifact.agentIds ?? [])]` to handle undefined during the spread.

## Real behavior proof

**Behavior or issue addressed:** `listMemoryHostPublicArtifacts` may omit `agentIds` for some workspaces. Newer code spreads that value via `[...artifact.agentIds]` and uses `.join()` in sort comparators, crashing on `undefined`. After the fix, `undefined agentIds` is safely handled at both call sites.

**Real environment tested:** Linux 4.19.112, Node.js v24.13.1 via tsx, openclaw workspace importing the production `memory-state` module.

**Exact steps or command run after this patch:**
```
1. Register a memory capability with public artifacts where agentIds is undefined
2. Call listActiveMemoryPublicArtifacts()
3. Verify sort does not throw and agentIds defaults to empty array
4. Verify bridge-style agentIds ?? [] guard produces empty array
5. Verify spread/join operations on guarded agentIds do not crash
```

**Evidence after fix:**
```
$ npx tsx test-agentids-fix.ts
=== Test: undefined agentIds does not crash ===
Artifact count: 2
Artifact 0 agentIds: []
Artifact 1 agentIds: ["alpha"]
Sort stable: PASS

=== Test: bridge agentIdsByWorkspace pattern ===
agentIds via ?? [] guard: []
Join works: 
Spread works: 0

All tests PASS
```

**Observed result after fix:** Undefined `agentIds` is safely handled — `cloneMemoryPublicArtifact()` defaults to `[]` via `?? []`, sort comparators never see `undefined`, and the bridge's `agentIdsByWorkspace` map stores `[]` instead of crashing. Both unit test suites continue to pass (14 memory-state tests, 1 memory-wiki test).

**What was not tested:** No plugin implementations were modified to emit `agentIds`. The fix is defensive — it handles `undefined` at the consumer side. End-to-end integration with LanceDB or other memory backends was not tested; each backend's `agentIds` population behavior remains unchanged.

## Test plan

- [x] `pnpm vitest run src/plugins/memory-state.test.ts` — 14 passed
- [x] `pnpm vitest run extensions/memory-wiki/src/source-page-shared.test.ts` — 1 passed
- [x] Manual verification: undefined agentIds is now safely handled at both call sites
- [x] Real behavior proof: reproduced the undefined agentIds scenario via production module and confirmed fix