### PR TITLE
fix(memory): sweep stale reindex temp sqlite files

### DIFF
--- a/extensions/memory-core/src/memory/manager-db-probe.test.ts
+++ b/extensions/memory-core/src/memory/manager-db-probe.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { openMemoryDatabaseAtPath } from "./manager-db.js";
+import { openMemoryDatabaseAtPath, sweepStaleMemoryIndexTempFiles } from "./manager-db.js";
 
 describe("openMemoryDatabaseAtPath readOnly probe", () => {
   let fixtureRoot = "";
@@ -61,5 +61,48 @@ describe("openMemoryDatabaseAtPath readOnly probe", () => {
     const reopen = openMemoryDatabaseAtPath(dbPath, false, false);
     expect(reopen).toBeDefined();
     reopen.close();
+  });
+
+  it("sweeps stale atomic reindex temp sqlite triplets", async () => {
+    const dbPath = path.join(fixtureRoot, `case-${caseId++}`, "index.sqlite");
+    await fs.mkdir(path.dirname(dbPath), { recursive: true });
+    await fs.writeFile(dbPath, "live");
+
+    const tempPath = `${dbPath}.tmp-old`;
+    for (const suffix of ["", "-wal", "-shm"]) {
+      await fs.writeFile(`${tempPath}${suffix}`, `temp${suffix}`);
+    }
+
+    const now = Date.now();
+    const liveTime = new Date(now - 120_000);
+    const tempTime = new Date(now - 180_000);
+    await fs.utimes(dbPath, liveTime, liveTime);
+    await fs.utimes(tempPath, tempTime, tempTime);
+
+    expect(sweepStaleMemoryIndexTempFiles(dbPath, { nowMs: now, graceMs: 60_000 })).toBe(3);
+    await expect(fs.access(tempPath)).rejects.toThrow("ENOENT");
+    await expect(fs.access(`${tempPath}-wal`)).rejects.toThrow("ENOENT");
+    await expect(fs.access(`${tempPath}-shm`)).rejects.toThrow("ENOENT");
+  });
+
+  it("keeps young or newer atomic reindex temp sqlite files", async () => {
+    const dbPath = path.join(fixtureRoot, `case-${caseId++}`, "index.sqlite");
+    await fs.mkdir(path.dirname(dbPath), { recursive: true });
+    await fs.writeFile(dbPath, "live");
+
+    const youngTempPath = `${dbPath}.tmp-young`;
+    const newerTempPath = `${dbPath}.tmp-newer`;
+    await fs.writeFile(youngTempPath, "young");
+    await fs.writeFile(newerTempPath, "newer");
+
+    const now = Date.now();
+    const liveTime = new Date(now - 120_000);
+    await fs.utimes(dbPath, liveTime, liveTime);
+    await fs.utimes(youngTempPath, new Date(now - 10_000), new Date(now - 10_000));
+    await fs.utimes(newerTempPath, new Date(now - 30_000), new Date(now - 30_000));
+
+    expect(sweepStaleMemoryIndexTempFiles(dbPath, { nowMs: now, graceMs: 60_000 })).toBe(0);
+    await expect(fs.access(youngTempPath)).resolves.toBeUndefined();
+    await expect(fs.access(newerTempPath)).resolves.toBeUndefined();
   });
 });

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -1,4 +1,5 @@
 // Memory Core plugin module implements manager db behavior.
+import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import {
@@ -8,6 +9,73 @@ import {
   requireNodeSqlite,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 
+const staleReindexTempGraceMs = 60_000;
+const sqliteSidecarSuffixes = ["", "-wal", "-shm"] as const;
+
+export function sweepStaleMemoryIndexTempFiles(
+  dbPath: string,
+  options: { nowMs?: number; graceMs?: number } = {},
+): number {
+  const dir = path.dirname(dbPath);
+  const base = path.basename(dbPath);
+  const prefix = `${base}.tmp-`;
+  const nowMs = options.nowMs ?? Date.now();
+  const graceMs = options.graceMs ?? staleReindexTempGraceMs;
+
+  let liveStat: fs.Stats;
+  try {
+    liveStat = fs.statSync(dbPath);
+  } catch {
+    return 0;
+  }
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return 0;
+  }
+
+  let removed = 0;
+  for (const entry of entries) {
+    if (!entry.startsWith(prefix) || entry.endsWith("-wal") || entry.endsWith("-shm")) {
+      continue;
+    }
+
+    const tempPath = path.join(dir, entry);
+    let tempStat: fs.Stats;
+    try {
+      tempStat = fs.statSync(tempPath);
+    } catch {
+      continue;
+    }
+    if (!tempStat.isFile()) {
+      continue;
+    }
+    if (nowMs - tempStat.mtimeMs < graceMs) {
+      continue;
+    }
+    if (liveStat.mtimeMs < tempStat.mtimeMs) {
+      continue;
+    }
+
+    for (const suffix of sqliteSidecarSuffixes) {
+      const targetPath = `${tempPath}${suffix}`;
+      if (!fs.existsSync(targetPath)) {
+        continue;
+      }
+      try {
+        fs.rmSync(targetPath, { force: true });
+        removed += 1;
+      } catch {
+        // Startup cleanup is best-effort. If another process still owns the
+        // temp file or the platform refuses deletion, keep opening the live DB.
+      }
+    }
+  }
+  return removed;
+}
+
 export function openMemoryDatabaseAtPath(
   dbPath: string,
   allowExtension: boolean,
@@ -15,6 +83,7 @@ export function openMemoryDatabaseAtPath(
 ): DatabaseSync {
   const dir = path.dirname(dbPath);
   ensureDir(dir);
+  sweepStaleMemoryIndexTempFiles(dbPath);
   const { DatabaseSync } = requireNodeSqlite();
   // When allowCreate is false, probe with readOnly first.
   // DatabaseSync auto-creates the file in read-write mode, which


### PR DESCRIPTION
## Summary
- Sweep aged `<db>.tmp-*` memory reindex SQLite triplets before opening a live memory DB.
- Keep cleanup conservative: skip when the live DB is missing, temp files are younger than the grace window, or the temp main DB is newer than the live DB.
- Make cleanup best-effort so a locked temp file cannot block startup.

Fixes #92874

## Real behavior proof
Before this change, opening the memory DB never scanned sibling `index.sqlite.tmp-*` files, so a hard-restart orphan stayed on disk indefinitely.

After this change, the focused regression test creates `index.sqlite.tmp-old`, `index.sqlite.tmp-old-wal`, and `index.sqlite.tmp-old-shm`, sets them older than the live DB and grace window, calls the startup sweep, and verifies all three paths are removed. A sibling test creates young/newer temp files and verifies they remain.

Observed command output:

```text
node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-db-probe.test.ts
Test Files  1 passed (1)
Tests  6 passed (6)
```

## Tests
- `pnpm format:check extensions/memory-core/src/memory/manager-db.ts extensions/memory-core/src/memory/manager-db-probe.test.ts`
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-db-probe.test.ts`
- `git diff --check`