### PR TITLE
fix(anthropic): quarantine invalid direct tool schemas

### DIFF
--- a/src/agents/anthropic-tool-projection.ts
+++ b/src/agents/anthropic-tool-projection.ts
@@ -1,0 +1,166 @@
+import { projectRuntimeToolInputSchema } from "./tool-schema-projection.js";
+
+type AnthropicToolDescriptor = {
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: unknown;
+};
+
+export type AnthropicProjectedTool = {
+  readonly originalName: string;
+  readonly wireName: string;
+  readonly description?: string;
+  readonly inputSchema: {
+    readonly type: "object";
+    readonly properties: Record<string, unknown>;
+    readonly required: string[];
+  };
+};
+
+export type AnthropicToolProjection = {
+  readonly inputToolCount: number;
+  readonly unavailableOriginalNames: ReadonlySet<string>;
+  readonly tools: readonly AnthropicProjectedTool[];
+};
+
+type AnthropicParallelToolChoice = {
+  readonly disable_parallel_tool_use?: boolean;
+};
+
+export type AnthropicProjectedToolChoice =
+  | ({ readonly type: "auto" } & AnthropicParallelToolChoice)
+  | ({ readonly type: "any" } & AnthropicParallelToolChoice)
+  | { readonly type: "none" }
+  | ({ readonly type: "tool"; readonly name: string } & AnthropicParallelToolChoice);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isProviderSupportedViolation(violation: string): boolean {
+  return violation.endsWith(".$dynamicRef") || violation.endsWith(".$dynamicAnchor");
+}
+
+/** Snapshots direct/custom tool descriptors before Anthropic payload construction. */
+export function projectAnthropicTools(
+  tools: readonly AnthropicToolDescriptor[],
+  toWireName: (name: string) => string,
+): AnthropicToolProjection {
+  const projectedTools: AnthropicProjectedTool[] = [];
+  const unavailableOriginalNames = new Set<string>();
+  for (const tool of tools) {
+    let projectedTool: AnthropicProjectedTool;
+    let originalName: string | undefined;
+    try {
+      const name = tool.name;
+      originalName = name;
+      if (!name) {
+        continue;
+      }
+      const schemaProjection = projectRuntimeToolInputSchema(tool.parameters, `${name}.parameters`);
+      if (
+        !isRecord(schemaProjection.schema) ||
+        schemaProjection.violations.some((violation) => !isProviderSupportedViolation(violation))
+      ) {
+        unavailableOriginalNames.add(name);
+        continue;
+      }
+      const properties = schemaProjection.schema.properties;
+      const required = schemaProjection.schema.required;
+      if (
+        (properties !== undefined && properties !== null && !isRecord(properties)) ||
+        (required !== undefined &&
+          required !== null &&
+          (!Array.isArray(required) || required.some((entry) => typeof entry !== "string")))
+      ) {
+        unavailableOriginalNames.add(name);
+        continue;
+      }
+      let description: string | undefined;
+      try {
+        description = typeof tool.description === "string" ? tool.description : undefined;
+      } catch {
+        // Description is optional; keep the usable tool schema.
+      }
+      const wireName = toWireName(name);
+      projectedTool = {
+        originalName: name,
+        wireName,
+        ...(description ? { description } : {}),
+        inputSchema: {
+          type: "object",
+          properties: (properties ?? {}) as Record<string, unknown>,
+          required: (required ?? []) as string[],
+        },
+      };
+    } catch {
+      // Direct/custom tool arrays can bypass the runtime quarantine.
+      if (originalName) {
+        unavailableOriginalNames.add(originalName);
+      }
+      continue;
+    }
+    const conflictingTool = projectedTools.find(
+      (entry) => entry.wireName === projectedTool.wireName,
+    );
+    if (conflictingTool && conflictingTool.originalName !== projectedTool.originalName) {
+      throw new Error(
+        `Anthropic tool names "${conflictingTool.originalName}" and "${projectedTool.originalName}" both map to "${projectedTool.wireName}"`,
+      );
+    }
+    projectedTools.push(projectedTool);
+  }
+  return {
+    inputToolCount: tools.length,
+    unavailableOriginalNames,
+    tools: projectedTools,
+  };
+}
+
+/** Keeps forced Anthropic tool choices aligned with the projected wire names. */
+export function reconcileAnthropicToolChoice(
+  choice: AnthropicProjectedToolChoice,
+  projection: AnthropicToolProjection,
+): AnthropicProjectedToolChoice | undefined {
+  if (projection.inputToolCount === 0) {
+    return choice;
+  }
+  if (choice.type === "tool") {
+    const requestedName = choice.name;
+    const originalMatch = projection.tools.find((tool) => tool.originalName === requestedName);
+    if (originalMatch) {
+      return { ...choice, name: originalMatch.wireName };
+    }
+    if (projection.unavailableOriginalNames.has(requestedName)) {
+      throw new Error(
+        `Anthropic tool_choice requested unavailable tool "${requestedName}" after schema conversion`,
+      );
+    }
+    const matchedTool = projection.tools.find((tool) => tool.wireName === requestedName);
+    if (!matchedTool) {
+      throw new Error(
+        `Anthropic tool_choice requested unavailable tool "${requestedName}" after schema conversion`,
+      );
+    }
+    return { ...choice, name: matchedTool.wireName };
+  }
+  if (projection.tools.length === 0) {
+    if (choice.type === "auto") {
+      return undefined;
+    }
+    if (choice.type === "any") {
+      throw new Error(
+        "Anthropic tool_choice requires a tool, but no tools survived schema conversion",
+      );
+    }
+  }
+  return choice;
+}
+
+/** Maps Claude Code wire names without trusting every direct/custom descriptor. */
+export function resolveOriginalAnthropicToolName(
+  name: string,
+  projection: AnthropicToolProjection | undefined,
+): string {
+  return projection?.tools.find((tool) => tool.wireName === name)?.originalName ?? name;
+}

--- a/src/agents/anthropic-tool-projection.ts
+++ b/src/agents/anthropic-tool-projection.ts
@@ -1,4 +1,4 @@
-import { projectRuntimeToolInputSchema } from "./tool-schema-projection.js";
+import { projectRuntimeToolInputSchema } from "./tool-schema-json-projection.js";
 
 type AnthropicToolDescriptor = {
   readonly name: string;

--- a/src/agents/anthropic-transport-stream.live.test.ts
+++ b/src/agents/anthropic-transport-stream.live.test.ts
@@ -6,11 +6,15 @@
 import http from "node:http";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
+import { streamAnthropic } from "../llm/providers/anthropic.js";
 import { createAnthropicMessagesTransportStreamFn } from "./anthropic-transport-stream.js";
 import { isLiveTestEnabled } from "./live-test-helpers.js";
 
 const LIVE = isLiveTestEnabled(["ANTHROPIC_TRANSPORT_LIVE_TEST"]);
 const describeLive = LIVE ? describe : describe.skip;
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const PROVIDER_LIVE = isLiveTestEnabled(["ANTHROPIC_LIVE_TEST"]) && Boolean(ANTHROPIC_KEY);
+const describeProviderLive = PROVIDER_LIVE ? describe : describe.skip;
 
 type AnthropicMessagesModel = Model<"anthropic-messages">;
 type AnthropicStreamFn = ReturnType<typeof createAnthropicMessagesTransportStreamFn>;
@@ -143,4 +147,125 @@ describeLive("anthropic transport stream live", () => {
       await closeServer(server);
     }
   }, 10_000);
+});
+
+describeProviderLive("anthropic transport stream provider live", () => {
+  it("keeps a healthy forced tool when a sibling descriptor is unreadable", async () => {
+    const modelId = process.env.OPENCLAW_LIVE_ANTHROPIC_TOOL_MODEL || "claude-haiku-4-5-20251001";
+    const model: AnthropicMessagesModel = {
+      id: modelId,
+      name: modelId,
+      api: "anthropic-messages",
+      provider: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 512,
+    };
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "Call healthy_probe with value LIVE_OK." }],
+          tools: [
+            {
+              name: "unreadable_probe",
+              description: "Unreadable probe",
+              get parameters() {
+                throw new Error("live unreadable parameters getter");
+              },
+            },
+            {
+              name: "healthy_probe",
+              description: "Return the requested probe value.",
+              parameters: {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+              },
+            },
+          ],
+        } as unknown as AnthropicStreamContext,
+        {
+          apiKey: ANTHROPIC_KEY,
+          maxTokens: 128,
+          toolChoice: { type: "tool", name: "healthy_probe" },
+        } as AnthropicStreamOptions,
+      ),
+    );
+
+    const result = await stream.result();
+    const toolCall = result.content.find(
+      (block) => block.type === "toolCall" && block.name === "healthy_probe",
+    );
+
+    expect(result.stopReason).toBe("toolUse");
+    expect(toolCall).toMatchObject({
+      type: "toolCall",
+      name: "healthy_probe",
+      arguments: { value: "LIVE_OK" },
+    });
+  }, 45_000);
+
+  it("keeps a healthy forced tool through the Anthropic SDK provider", async () => {
+    const modelId = process.env.OPENCLAW_LIVE_ANTHROPIC_TOOL_MODEL || "claude-haiku-4-5-20251001";
+    const model: AnthropicMessagesModel = {
+      id: modelId,
+      name: modelId,
+      api: "anthropic-messages",
+      provider: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 512,
+    };
+    const stream = streamAnthropic(
+      model,
+      {
+        messages: [
+          { role: "user", content: "Call healthy_probe with value SDK_OK.", timestamp: Date.now() },
+        ],
+        tools: [
+          {
+            name: "unreadable_probe",
+            description: "Unreadable probe",
+            get parameters() {
+              throw new Error("live unreadable parameters getter");
+            },
+          },
+          {
+            name: "healthy_probe",
+            description: "Return the requested probe value.",
+            parameters: {
+              type: "object",
+              properties: { value: { type: "string" } },
+              required: ["value"],
+            },
+          },
+        ],
+      } as unknown as Parameters<typeof streamAnthropic>[1],
+      {
+        apiKey: ANTHROPIC_KEY,
+        maxTokens: 128,
+        toolChoice: { type: "tool", name: "healthy_probe" },
+      },
+    );
+
+    const result = await stream.result();
+    const toolCall = result.content.find(
+      (block) => block.type === "toolCall" && block.name === "healthy_probe",
+    );
+
+    expect(result.stopReason).toBe("toolUse");
+    expect(toolCall).toMatchObject({
+      type: "toolCall",
+      name: "healthy_probe",
+      arguments: { value: "SDK_OK" },
+    });
+  }, 45_000);
 });

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -809,6 +809,14 @@ describe("anthropic transport stream", () => {
           messages: [{ role: "user", content: "Read the file" }],
           tools: [
             {
+              name: "Read",
+              description: "Invalid case-colliding tool",
+              parameters: {
+                type: "object",
+                properties: false,
+              },
+            },
+            {
               name: "read",
               description: "Read a file",
               parameters: {
@@ -823,6 +831,7 @@ describe("anthropic transport stream", () => {
         } as unknown as Parameters<typeof streamFn>[1],
         {
           apiKey: "sk-ant-oat-example",
+          toolChoice: { type: "tool", name: "read" },
         } as Parameters<typeof streamFn>[2],
       ),
     );
@@ -847,10 +856,9 @@ describe("anthropic transport stream", () => {
       system.some((item) => requireRecord(item, "system item").text === "Follow policy."),
     ).toBe(true);
     expect(
-      requireArray(firstCallParams.tools, "tools").some(
-        (item) => requireRecord(item, "tool").name === "Read",
-      ),
-    ).toBe(true);
+      requireArray(firstCallParams.tools, "tools").map((item) => requireRecord(item, "tool").name),
+    ).toEqual(["Read"]);
+    expect(firstCallParams.tool_choice).toEqual({ type: "tool", name: "Read" });
     expect(result.stopReason).toBe("toolUse");
     expect(result.content.some((item) => item.type === "toolCall" && item.name === "read")).toBe(
       true,
@@ -1378,9 +1386,21 @@ describe("anthropic transport stream", () => {
         messages: [{ role: "user", content: "hello" }],
         tools: [
           {
+            name: "unreadable_plugin_tool",
+            description: "unreadable schema",
+            get parameters() {
+              throw new Error("fuzz parameters getter exploded");
+            },
+          },
+          {
             name: "bad_plugin_tool",
             description: "missing schema",
             execute: async () => ({ content: [{ type: "text", text: "bad" }] }),
+          },
+          {
+            name: "invalid_properties_tool",
+            description: "invalid properties",
+            parameters: { type: "object", properties: false },
           },
           {
             name: "good_plugin_tool",
@@ -1407,6 +1427,127 @@ describe("anthropic transport stream", () => {
     expect(requireRecord(tool.input_schema, "input schema").properties).toEqual({
       query: { type: "string" },
     });
+  });
+
+  it("omits automatic Anthropic tool choice when every provided schema is unreadable", async () => {
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "hello" }],
+        tools: [
+          {
+            name: "unreadable_plugin_tool",
+            description: "unreadable schema",
+            get parameters() {
+              throw new Error("fuzz parameters getter exploded");
+            },
+          },
+        ],
+      } as unknown as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+        toolChoice: "auto",
+      } as AnthropicStreamOptions,
+    );
+
+    const payload = latestAnthropicRequest().payload;
+    expect(result.stopReason).toBe("stop");
+    expect(payload).not.toHaveProperty("tools");
+    expect(payload).not.toHaveProperty("tool_choice");
+  });
+
+  it("fails locally when a pinned Anthropic tool choice is skipped", async () => {
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "hello" }],
+        tools: [
+          {
+            name: "unreadable_plugin_tool",
+            description: "unreadable schema",
+            get parameters() {
+              throw new Error("fuzz parameters getter exploded");
+            },
+          },
+          {
+            name: "healthy_tool",
+            description: "healthy schema",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      } as unknown as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+        toolChoice: { type: "tool", name: "unreadable_plugin_tool" },
+      } as AnthropicStreamOptions,
+    );
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain(
+      'Anthropic tool_choice requested unavailable tool "unreadable_plugin_tool"',
+    );
+    expect(guardedFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails locally when OAuth tool names collide on the Anthropic wire", async () => {
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "hello" }],
+        tools: [
+          {
+            name: "Read",
+            description: "Uppercase tool",
+            parameters: { type: "object", properties: {} },
+          },
+          {
+            name: "read",
+            description: "Lowercase tool",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      } as unknown as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-oat-example",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain(
+      'Anthropic tool names "Read" and "read" both map to "Read"',
+    );
+    expect(guardedFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not rebind a skipped OAuth tool choice through a sibling wire name", async () => {
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "hello" }],
+        tools: [
+          {
+            name: "Read",
+            description: "Invalid uppercase tool",
+            parameters: { type: "object", properties: false },
+          },
+          {
+            name: "read",
+            description: "Valid lowercase tool",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      } as unknown as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-oat-example",
+        toolChoice: { type: "tool", name: "Read" },
+      } as AnthropicStreamOptions,
+    );
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain(
+      'Anthropic tool_choice requested unavailable tool "Read"',
+    );
+    expect(guardedFetchMock).not.toHaveBeenCalled();
   });
 
   it("coerces replayed malformed tool-call args to an object for Anthropic payloads", async () => {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -35,6 +35,13 @@ import {
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
 } from "./anthropic-payload-policy.js";
+import {
+  projectAnthropicTools,
+  reconcileAnthropicToolChoice,
+  resolveOriginalAnthropicToolName,
+  type AnthropicProjectedToolChoice,
+  type AnthropicToolProjection,
+} from "./anthropic-tool-projection.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
 import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
@@ -143,8 +150,8 @@ const EMPTY_ANTHROPIC_MESSAGES_FALLBACK_TEXT = ".";
 
 function normalizeAnthropicToolChoice(
   model: AnthropicTransportModel,
-  toolChoice: AnthropicTransportOptions["toolChoice"],
-) {
+  toolChoice: NonNullable<AnthropicTransportOptions["toolChoice"]>,
+): AnthropicProjectedToolChoice {
   if (
     requiresClaudeAdaptiveThinking(model) &&
     (toolChoice === "any" || (typeof toolChoice === "object" && toolChoice.type === "tool"))
@@ -310,19 +317,6 @@ function buildAnthropicBetaHeader(
 
 function toClaudeCodeName(name: string): string {
   return CLAUDE_CODE_TOOL_LOOKUP.get(normalizeLowercaseStringOrEmpty(name)) ?? name;
-}
-
-function fromClaudeCodeName(name: string, tools: Context["tools"] | undefined): string {
-  if (tools && tools.length > 0) {
-    const lowerName = normalizeLowercaseStringOrEmpty(name);
-    const matchedTool = tools.find(
-      (tool) => normalizeLowercaseStringOrEmpty(tool.name) === lowerName,
-    );
-    if (matchedTool) {
-      return matchedTool.name;
-    }
-  }
-  return name;
 }
 
 function convertContentBlocks(
@@ -565,9 +559,9 @@ function ensureNonEmptyAnthropicMessages(messages: Array<Record<string, unknown>
 }
 
 function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
-  if (!tools) {
-    return [];
-  }
+  const projection = projectAnthropicTools(tools ?? [], (name) =>
+    isOAuthToken ? toClaudeCodeName(name) : name,
+  );
   const converted: Array<{
     name: string;
     description?: string;
@@ -577,27 +571,14 @@ function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
       required: unknown;
     };
   }> = [];
-  for (const tool of tools) {
-    // Main quarantine happens when plugin tools materialize; this keeps Anthropic
-    // safe for direct/custom tool arrays that bypass the plugin registry.
-    const parameters =
-      tool.parameters && typeof tool.parameters === "object" && !Array.isArray(tool.parameters)
-        ? (tool.parameters as Record<string, unknown>)
-        : undefined;
-    if (!parameters) {
-      continue;
-    }
+  for (const tool of projection.tools) {
     converted.push({
-      name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
+      name: tool.wireName,
       description: tool.description,
-      input_schema: {
-        type: "object",
-        properties: parameters.properties || {},
-        required: parameters.required || [],
-      },
+      input_schema: tool.inputSchema,
     });
   }
-  return converted;
+  return { projection, tools: converted };
 }
 
 function parseAnthropicToolCallArguments(inputJson: string): unknown {
@@ -917,7 +898,10 @@ function buildAnthropicParams(
   context: Context,
   isOAuthToken: boolean,
   options: AnthropicTransportOptions | undefined,
-) {
+): {
+  params: Record<string, unknown>;
+  toolProjection?: AnthropicToolProjection;
+} {
   const fable5 = usesClaudeFable5MessagesContract(model);
   const replayThinkingEnabled = fable5 || options?.thinkingEnabled === true;
   const maxTokens = resolveAnthropicMessagesMaxTokens({
@@ -980,8 +964,13 @@ function buildAnthropicParams(
   if (options?.stop !== undefined && options.stop.length > 0) {
     params.stop_sequences = options.stop;
   }
+  let toolProjection: AnthropicToolProjection | undefined;
   if (context.tools) {
-    params.tools = convertAnthropicTools(context.tools, isOAuthToken);
+    const convertedTools = convertAnthropicTools(context.tools, isOAuthToken);
+    toolProjection = convertedTools.projection;
+    if (convertedTools.tools.length > 0) {
+      params.tools = convertedTools.tools;
+    }
   }
   if (fable5 || model.reasoning || supportsAdaptiveThinking(model)) {
     if (fable5 || options?.thinkingEnabled) {
@@ -1007,10 +996,16 @@ function buildAnthropicParams(
     params.metadata = { user_id: options.metadata.user_id };
   }
   if (options?.toolChoice) {
-    params.tool_choice = normalizeAnthropicToolChoice(model, options.toolChoice);
+    const normalizedToolChoice = normalizeAnthropicToolChoice(model, options.toolChoice);
+    const projectedToolChoice = toolProjection
+      ? reconcileAnthropicToolChoice(normalizedToolChoice, toolProjection)
+      : normalizedToolChoice;
+    if (projectedToolChoice) {
+      params.tool_choice = projectedToolChoice;
+    }
   }
   applyAnthropicPayloadPolicyToParams(params, payloadPolicy);
-  return params;
+  return { params, toolProjection };
 }
 
 function resolveAnthropicTransportOptions(
@@ -1109,7 +1104,9 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
           apiKey,
           options: transportOptions,
         });
-        let params = buildAnthropicParams(model, context, isOAuthToken, transportOptions);
+        const builtParams = buildAnthropicParams(model, context, isOAuthToken, transportOptions);
+        let params = builtParams.params;
+        const toolProjection = builtParams.toolProjection;
         const nextParams = await transportOptions.onPayload?.(params, model);
         if (nextParams !== undefined) {
           params = nextParams as Record<string, unknown>;
@@ -1344,7 +1341,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
                 name:
                   typeof contentBlock.name === "string"
                     ? isOAuthToken
-                      ? fromClaudeCodeName(contentBlock.name, context.tools)
+                      ? resolveOriginalAnthropicToolName(contentBlock.name, toolProjection)
                       : contentBlock.name
                     : "",
                 arguments:

--- a/src/agents/tool-schema-json-projection.ts
+++ b/src/agents/tool-schema-json-projection.ts
@@ -1,0 +1,131 @@
+/** JSON-safe schema value used when projecting runtime tool parameters. */
+export type RuntimeToolInputSchemaJson =
+  | null
+  | boolean
+  | number
+  | string
+  | RuntimeToolInputSchemaJson[]
+  | { [key: string]: RuntimeToolInputSchemaJson };
+
+/** Projected runtime tool schema plus validation violations. */
+export type RuntimeToolInputSchemaProjection = {
+  readonly schema: RuntimeToolInputSchemaJson;
+  readonly violations: readonly string[];
+};
+
+function isJsonValue(value: unknown): value is RuntimeToolInputSchemaJson {
+  if (value === null) {
+    return true;
+  }
+  switch (typeof value) {
+    case "boolean":
+    case "number":
+    case "string":
+      return true;
+    case "object":
+      if (Array.isArray(value)) {
+        return value.every(isJsonValue);
+      }
+      return Object.values(value as Record<string, unknown>).every(isJsonValue);
+    default:
+      return false;
+  }
+}
+
+function isJsonObject(value: RuntimeToolInputSchemaJson): value is {
+  [key: string]: RuntimeToolInputSchemaJson;
+} {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function serializeToolInputSchema(value: unknown, path: string): RuntimeToolInputSchemaProjection {
+  let text: string | undefined;
+  try {
+    text = JSON.stringify(value);
+  } catch {
+    return {
+      schema: {},
+      violations: [`${path} is not JSON-serializable`],
+    };
+  }
+  if (!text) {
+    return {
+      schema: {},
+      violations: [`${path} is not JSON-serializable`],
+    };
+  }
+  const parsed = JSON.parse(text) as unknown;
+  if (!isJsonValue(parsed)) {
+    return {
+      schema: {},
+      violations: [`${path} is not a JSON value`],
+    };
+  }
+  return {
+    schema: parsed,
+    violations: [],
+  };
+}
+
+const schemaMapKeywords = new Set([
+  "$defs",
+  "definitions",
+  "dependencies",
+  "dependentSchemas",
+  "patternProperties",
+  "properties",
+]);
+
+function findDynamicSchemaKeywordViolations(
+  schema: RuntimeToolInputSchemaJson,
+  path: string,
+): string[] {
+  if (Array.isArray(schema)) {
+    return schema.flatMap((entry, index) =>
+      findDynamicSchemaKeywordViolations(entry, `${path}[${index}]`),
+    );
+  }
+  if (!isJsonObject(schema)) {
+    return [];
+  }
+  const violations: string[] = [];
+  for (const key of ["$dynamicRef", "$dynamicAnchor"] as const) {
+    if (key in schema) {
+      violations.push(`${path}.${key}`);
+    }
+  }
+  for (const [key, value] of Object.entries(schema)) {
+    if (!value || typeof value !== "object") {
+      continue;
+    }
+    if (schemaMapKeywords.has(key) && isJsonObject(value)) {
+      for (const [schemaName, childSchema] of Object.entries(value)) {
+        violations.push(
+          ...findDynamicSchemaKeywordViolations(childSchema, `${path}.${key}.${schemaName}`),
+        );
+      }
+    } else {
+      violations.push(...findDynamicSchemaKeywordViolations(value, `${path}.${key}`));
+    }
+  }
+  return violations;
+}
+
+/** Projects one runtime tool input schema to JSON and reports runtime incompatibilities. */
+export function projectRuntimeToolInputSchema(
+  schema: unknown,
+  path = "parameters",
+): RuntimeToolInputSchemaProjection {
+  const projection = serializeToolInputSchema(schema, path);
+  const violations = [...projection.violations];
+  if (!isJsonObject(projection.schema)) {
+    violations.push(`${path} must be a JSON object schema`);
+  } else if (projection.schema.type !== undefined && projection.schema.type !== "object") {
+    violations.push(`${path}.type must be "object"`);
+  }
+  violations.push(...findDynamicSchemaKeywordViolations(projection.schema, path));
+  return {
+    schema: projection.schema,
+    violations,
+  };
+}

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -1,3 +1,4 @@
+import { projectRuntimeToolInputSchema } from "./tool-schema-json-projection.js";
 /**
  * Projects agent tool schemas into JSON-safe runtime shapes and diagnostics.
  * Provider/runtime dispatch uses this module to drop incompatible tools before
@@ -5,20 +6,11 @@
  */
 import type { AnyAgentTool } from "./tools/common.js";
 
-/** JSON-safe schema value used when projecting runtime tool parameters. */
-export type RuntimeToolInputSchemaJson =
-  | null
-  | boolean
-  | number
-  | string
-  | RuntimeToolInputSchemaJson[]
-  | { [key: string]: RuntimeToolInputSchemaJson };
-
-/** Projected runtime tool schema plus validation violations. */
-export type RuntimeToolInputSchemaProjection = {
-  readonly schema: RuntimeToolInputSchemaJson;
-  readonly violations: readonly string[];
-};
+export { projectRuntimeToolInputSchema } from "./tool-schema-json-projection.js";
+export type {
+  RuntimeToolInputSchemaJson,
+  RuntimeToolInputSchemaProjection,
+} from "./tool-schema-json-projection.js";
 
 /** Diagnostic for one incompatible runtime tool schema. */
 export type RuntimeToolSchemaDiagnostic = {
@@ -90,123 +82,6 @@ function readToolProjectionField<TField extends "name" | "parameters">(
   } catch {
     return { readable: false };
   }
-}
-
-function isJsonValue(value: unknown): value is RuntimeToolInputSchemaJson {
-  if (value === null) {
-    return true;
-  }
-  switch (typeof value) {
-    case "boolean":
-    case "number":
-    case "string":
-      return true;
-    case "object":
-      if (Array.isArray(value)) {
-        return value.every(isJsonValue);
-      }
-      return Object.values(value as Record<string, unknown>).every(isJsonValue);
-    default:
-      return false;
-  }
-}
-
-function isJsonObject(value: RuntimeToolInputSchemaJson): value is {
-  [key: string]: RuntimeToolInputSchemaJson;
-} {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function serializeToolInputSchema(value: unknown, path: string): RuntimeToolInputSchemaProjection {
-  let text: string | undefined;
-  try {
-    text = JSON.stringify(value);
-  } catch {
-    return {
-      schema: {},
-      violations: [`${path} is not JSON-serializable`],
-    };
-  }
-  if (!text) {
-    return {
-      schema: {},
-      violations: [`${path} is not JSON-serializable`],
-    };
-  }
-  const parsed = JSON.parse(text) as unknown;
-  if (!isJsonValue(parsed)) {
-    return {
-      schema: {},
-      violations: [`${path} is not a JSON value`],
-    };
-  }
-  return {
-    schema: parsed,
-    violations: [],
-  };
-}
-
-function findDynamicSchemaKeywordViolations(
-  schema: RuntimeToolInputSchemaJson,
-  path: string,
-): string[] {
-  if (Array.isArray(schema)) {
-    return schema.flatMap((entry, index) =>
-      findDynamicSchemaKeywordViolations(entry, `${path}[${index}]`),
-    );
-  }
-  if (!isJsonObject(schema)) {
-    return [];
-  }
-  const violations: string[] = [];
-  for (const key of ["$dynamicRef", "$dynamicAnchor"] as const) {
-    if (key in schema) {
-      violations.push(`${path}.${key}`);
-    }
-  }
-  for (const [key, value] of Object.entries(schema)) {
-    if (!value || typeof value !== "object") {
-      continue;
-    }
-    if (schemaMapKeywords.has(key) && isJsonObject(value)) {
-      for (const [schemaName, childSchema] of Object.entries(value)) {
-        violations.push(
-          ...findDynamicSchemaKeywordViolations(childSchema, `${path}.${key}.${schemaName}`),
-        );
-      }
-    } else {
-      violations.push(...findDynamicSchemaKeywordViolations(value, `${path}.${key}`));
-    }
-  }
-  return violations;
-}
-
-const schemaMapKeywords = new Set([
-  "$defs",
-  "definitions",
-  "dependencies",
-  "dependentSchemas",
-  "patternProperties",
-  "properties",
-]);
-
-/** Projects one runtime tool input schema to JSON and reports runtime incompatibilities. */
-export function projectRuntimeToolInputSchema(
-  schema: unknown,
-  path = "parameters",
-): RuntimeToolInputSchemaProjection {
-  const projection = serializeToolInputSchema(schema, path);
-  const violations = [...projection.violations];
-  if (!isJsonObject(projection.schema)) {
-    violations.push(`${path} must be a JSON object schema`);
-  } else if (projection.schema.type !== undefined && projection.schema.type !== "object") {
-    violations.push(`${path}.type must be "object"`);
-  }
-  violations.push(...findDynamicSchemaKeywordViolations(projection.schema, path));
-  return {
-    schema: projection.schema,
-    violations,
-  };
 }
 
 function inspectToolSchema(

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -1,7 +1,7 @@
 // Anthropic provider tests cover stream events, tools, and message mapping.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../agents/system-prompt-cache-boundary.js";
-import type { Context, Model } from "../types.js";
+import type { Context, Model, Tool } from "../types.js";
 
 const anthropicMockState = vi.hoisted(() => ({
   configs: [] as unknown[],
@@ -1002,6 +1002,101 @@ describe("Anthropic provider", () => {
 
     expect(result.stopReason).toBe("error");
     expect((capturedPayload as { stop_sequences?: unknown }).stop_sequences).toEqual(["STOP"]);
+  });
+
+  it("skips unreadable Anthropic provider tools while preserving healthy siblings", async () => {
+    let capturedPayload: unknown;
+    const unreadableTool = {
+      name: "unreadable_plugin_tool",
+      description: "unreadable schema",
+      get parameters(): Tool["parameters"] {
+        throw new Error("fuzz parameters getter exploded");
+      },
+    } as Tool;
+    const stream = streamAnthropic(
+      makeAnthropicModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [
+          unreadableTool,
+          {
+            name: "invalid_required_tool",
+            description: "invalid required",
+            parameters: {
+              type: "object",
+              properties: { query: { type: "string" } },
+              required: "query",
+            },
+          } as unknown as Tool,
+          {
+            name: "healthy_tool",
+            description: "healthy schema",
+            parameters: {
+              type: "object",
+              properties: { query: { type: "string" } },
+              required: ["query"],
+            },
+          } as Tool,
+        ],
+      },
+      {
+        apiKey: "sk-ant-provider",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+    const payload = capturedPayload as {
+      tools?: Array<{ name?: string; input_schema?: unknown }>;
+    };
+
+    expect(result.stopReason).toBe("error");
+    expect(payload.tools?.map((tool) => tool.name)).toEqual(["healthy_tool"]);
+    expect(payload.tools?.[0]?.input_schema).toMatchObject({
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    });
+  });
+
+  it("fails locally when a pinned Anthropic provider tool is skipped", async () => {
+    const unreadableTool = {
+      name: "unreadable_plugin_tool",
+      description: "unreadable schema",
+      get parameters(): Tool["parameters"] {
+        throw new Error("fuzz parameters getter exploded");
+      },
+    } as Tool;
+    const onPayload = vi.fn();
+    const stream = streamAnthropic(
+      makeAnthropicModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [
+          unreadableTool,
+          {
+            name: "healthy_tool",
+            description: "healthy schema",
+            parameters: { type: "object", properties: {} },
+          } as Tool,
+        ],
+      },
+      {
+        apiKey: "sk-ant-provider",
+        toolChoice: { type: "tool", name: "unreadable_plugin_tool" },
+        onPayload,
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain(
+      'Anthropic tool_choice requested unavailable tool "unreadable_plugin_tool"',
+    );
+    expect(onPayload).not.toHaveBeenCalled();
   });
 
   it("splits the system prompt cache boundary into cached and uncached Anthropic blocks", async () => {

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -9,6 +9,13 @@ import type {
   TextBlockParam,
 } from "@anthropic-ai/sdk/resources/messages.js";
 import {
+  projectAnthropicTools,
+  reconcileAnthropicToolChoice,
+  resolveOriginalAnthropicToolName,
+  type AnthropicProjectedToolChoice,
+  type AnthropicToolProjection,
+} from "../../agents/anthropic-tool-projection.js";
+import {
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
 } from "../../agents/system-prompt-cache-boundary.js";
@@ -121,16 +128,6 @@ const ccToolLookup = new Map(claudeCodeTools.map((t) => [t.toLowerCase(), t]));
 
 // Convert tool name to CC canonical casing if it matches (case-insensitive)
 const toClaudeCodeName = (name: string) => ccToolLookup.get(name.toLowerCase()) ?? name;
-const fromClaudeCodeName = (name: string, tools?: Tool[]) => {
-  if (tools && tools.length > 0) {
-    const lowerName = name.toLowerCase();
-    const matchedTool = tools.find((tool) => tool.name.toLowerCase() === lowerName);
-    if (matchedTool) {
-      return matchedTool.name;
-    }
-  }
-  return name;
-};
 
 /**
  * Convert content blocks to Anthropic API format
@@ -557,7 +554,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         client = created.client;
         isOAuth = created.isOAuthToken;
       }
-      let params = buildParams(model, context, isOAuth, options);
+      const builtParams = buildParams(model, context, isOAuth, options);
+      let params = builtParams.params;
+      const toolProjection = builtParams.toolProjection;
       const nextParams = await options?.onPayload?.(params, model);
       if (nextParams !== undefined) {
         params = nextParams as MessageCreateParamsStreaming;
@@ -648,7 +647,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
               type: "toolCall",
               id: event.content_block.id,
               name: isOAuth
-                ? fromClaudeCodeName(event.content_block.name, context.tools)
+                ? resolveOriginalAnthropicToolName(event.content_block.name, toolProjection)
                 : event.content_block.name,
               arguments: (event.content_block.input as Record<string, unknown>) ?? {},
               partialJson: "",
@@ -804,8 +803,8 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 
 function normalizeAnthropicToolChoice(
   model: Model<"anthropic-messages">,
-  toolChoice: AnthropicOptions["toolChoice"],
-) {
+  toolChoice: NonNullable<AnthropicOptions["toolChoice"]>,
+): AnthropicProjectedToolChoice {
   if (
     requiresClaudeAdaptiveThinking(model) &&
     (toolChoice === "any" || (typeof toolChoice === "object" && toolChoice.type === "tool"))
@@ -1057,13 +1056,16 @@ function buildParams(
   context: Context,
   isOAuthTokenResult: boolean,
   options?: AnthropicOptions,
-): MessageCreateParamsStreaming {
+): {
+  params: MessageCreateParamsStreaming;
+  toolProjection?: AnthropicToolProjection;
+} {
   const fable5 = usesClaudeFable5MessagesContract(model);
   const replayThinkingEnabled = fable5 || options?.thinkingEnabled === true;
   const { cacheControl } = getCacheControl(model, options?.cacheRetention);
   const system = buildAnthropicSystemBlocks(context.systemPrompt, isOAuthTokenResult, cacheControl);
-  const compat = context.tools?.length ? getAnthropicCompat(model) : undefined;
-  const tools =
+  const compat = context.tools ? getAnthropicCompat(model) : undefined;
+  const convertedTools =
     context.tools && compat
       ? convertTools(
           context.tools,
@@ -1072,6 +1074,8 @@ function buildParams(
           compat.supportsCacheControlOnTools ? cacheControl : undefined,
         )
       : undefined;
+  const tools = convertedTools?.tools;
+  const toolProjection = convertedTools?.projection;
   const systemCacheControlCount = countNativeCacheControlMarkers(system);
   const toolCacheControlCount = countNativeCacheControlMarkers(tools);
   const messageCacheControlLimit = Math.max(
@@ -1155,10 +1159,16 @@ function buildParams(
   }
 
   if (options?.toolChoice) {
-    params.tool_choice = normalizeAnthropicToolChoice(model, options.toolChoice);
+    const normalizedToolChoice = normalizeAnthropicToolChoice(model, options.toolChoice);
+    const projectedToolChoice = toolProjection
+      ? reconcileAnthropicToolChoice(normalizedToolChoice, toolProjection)
+      : normalizedToolChoice;
+    if (projectedToolChoice) {
+      params.tool_choice = projectedToolChoice;
+    }
   }
 
-  return params;
+  return { params, toolProjection };
 }
 
 // Normalize tool call IDs to match Anthropic's required pattern and length
@@ -1472,26 +1482,32 @@ function convertTools(
   isOAuthTokenLocal: boolean,
   supportsEagerToolInputStreaming: boolean,
   cacheControl?: CacheControlEphemeral,
-): Anthropic.Messages.Tool[] {
-  if (!tools) {
-    return [];
-  }
-
-  return tools.map((tool, index) => {
-    const schema = tool.parameters as { properties?: unknown; required?: string[] };
-
-    return {
-      name: isOAuthTokenLocal ? toClaudeCodeName(tool.name) : tool.name,
+): {
+  projection: AnthropicToolProjection;
+  tools: Anthropic.Messages.Tool[];
+} {
+  const projection = projectAnthropicTools(tools, (name) =>
+    isOAuthTokenLocal ? toClaudeCodeName(name) : name,
+  );
+  const convertedTools: Anthropic.Messages.Tool[] = [];
+  for (const [index, tool] of projection.tools.entries()) {
+    const convertedTool: Anthropic.Messages.Tool = {
+      name: tool.wireName,
       description: tool.description,
-      ...(supportsEagerToolInputStreaming ? { eager_input_streaming: true } : {}),
-      input_schema: {
-        type: "object",
-        properties: schema.properties ?? {},
-        required: schema.required ?? [],
-      },
-      ...(cacheControl && index === tools.length - 1 ? { cache_control: cacheControl } : {}),
+      input_schema: tool.inputSchema,
     };
-  });
+    if (supportsEagerToolInputStreaming) {
+      convertedTool.eager_input_streaming = true;
+    }
+    if (cacheControl && index === projection.tools.length - 1) {
+      convertedTool.cache_control = cacheControl;
+    }
+    convertedTools.push(convertedTool);
+  }
+  return {
+    projection,
+    tools: convertedTools,
+  };
 }
 
 function mapStopReason(reason: string): StopReason {


### PR DESCRIPTION
## Summary

- add one shared Anthropic tool projection boundary for direct/custom tool arrays that bypass normal runtime quarantine
- skip unreadable or structurally invalid schemas while preserving healthy sibling tools in both native transport and SDK provider paths
- keep forced `tool_choice`, OAuth wire-name mapping, response names, and cache markers aligned with the surviving projected tools
- preserve Anthropic JSON Schema Draft 2020-12 support, including `$dynamicRef` and `$dynamicAnchor`

Supersedes #89418, #89221, #90228, #89622, #89229, and #90278. Contributor credit is preserved for @vincentkoc.

Related but intentionally separate: #90289 covers the deprecated exported OpenAI-shaped Anthropic payload compatibility wrapper rather than either canonical Anthropic request builder.

## Verification

- `node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts src/llm/providers/anthropic.test.ts -- --reporter=dot` (109 tests)
- `node scripts/run-vitest.mjs src/agents/tool-schema-projection.test.ts src/agents/openai-transport-stream.test.ts src/llm/providers/openai-responses-shared.test.ts -- --reporter=dot` (277 OpenAI non-regression tests)
- `pnpm tsgo:core && pnpm tsgo:core:test`
- targeted `oxfmt`, `oxlint`, and `git diff --check`
- fresh autoreview: no actionable findings
- AWS Testbox `pnpm check:changed`, lanes `core, coreTests`: `run_5b331170f6cc`, exit 0
- live Anthropic: `claude-haiku-4-5-20251001`, unreadable sibling plus forced healthy tool, both native transport and SDK provider; 2 passed
- live OpenAI non-regression: `gpt-5.5`, required `noop` tool through the official Responses transport; tool call returned the expected `OPENAI_OK` arguments

Testbox: https://crabbox.openclaw.ai/portal/runs/run_5b331170f6cc

## Real behavior proof

Behavior addressed: direct/custom Anthropic tool descriptors with throwing getters or invalid projected schemas could abort payload construction, and filtering could leave stale forced choices or unsafe response-name remapping.

Real environment tested: official Anthropic Messages API with `claude-haiku-4-5-20251001`; official OpenAI Responses API with `gpt-5.5`; AWS Linux Testbox.

Exact steps or command run after this patch: focused Anthropic and OpenAI Vitest commands above, strict core/test type checks, remote `pnpm check:changed`, and live provider runs using the repository transports.

Evidence after fix: Anthropic native transport and SDK provider each retained the healthy forced tool and completed the live call; OpenAI still emitted and received the required tool call; all local and remote checks passed.

Observed result after fix: malformed Anthropic siblings are quarantined before request serialization, healthy tools remain available, forced choices either map to a surviving tool or fail locally, and official OpenAI construction remains unchanged.

What was not tested: Anthropic OAuth live traffic; OAuth name projection is covered by focused unit tests for collisions, filtered tools, forced choices, and response remapping.

## Risk

Highest risk is provider tool-choice semantics. The implementation does not silently replace required/pinned choices: unavailable pinned tools and `any` with no surviving tools fail locally, while `auto` is omitted only when no tools survive. Official `@anthropic-ai/sdk` 0.100.1 types were checked for the current tool schema and tool-choice contracts.
