### PR TITLE
fix(memory-wiki): tolerate public artifacts without agent ids

### DIFF
--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -150,6 +150,46 @@ describe("syncMemoryWikiBridgeSources", () => {
     expect(logLines).toHaveLength(2);
   });
 
+  it("imports bridge artifacts from legacy providers without agent ids", async () => {
+    const workspaceDir = await createBridgeWorkspace("legacy-agentids-workspace");
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("legacy-agentids-vault"),
+      config: {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+          indexMemoryRoot: true,
+        },
+      },
+    });
+    const memoryPath = path.join(workspaceDir, "MEMORY.md");
+    await fs.writeFile(memoryPath, "# Durable Memory\n", "utf8");
+    registerBridgeArtifacts([
+      {
+        kind: "memory-root",
+        workspaceDir,
+        relativePath: "MEMORY.md",
+        absolutePath: memoryPath,
+        contentType: "markdown",
+      } as Omit<MemoryPluginPublicArtifact, "agentIds"> as MemoryPluginPublicArtifact,
+    ]);
+
+    const appConfig: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", default: true, workspace: workspaceDir }],
+      },
+    };
+
+    const result = await syncMemoryWikiBridgeSources({ config, appConfig });
+
+    expect(result.importedCount).toBe(1);
+    expect(result.artifactCount).toBe(1);
+    const page = await fs.readFile(path.join(vaultDir, result.pagePaths[0] ?? ""), "utf8");
+    expect(page).toContain("# Memory Bridge: MEMORY");
+    expect(page).toContain("- Agents: unknown");
+  });
+
   it("returns a no-op result outside bridge mode", async () => {
     const { config } = await createVault({ rootDir: nextCaseRoot("isolated") });
 

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -18,6 +18,7 @@ import {
   registerMemoryRuntime,
   resolveMemoryFlushPlan,
   restoreMemoryPluginState,
+  type MemoryPluginPublicArtifact,
 } from "./memory-state.js";
 
 function createMemoryRuntime() {
@@ -200,6 +201,35 @@ describe("memory plugin state", () => {
         relativePath: "memory/2026-04-06.md",
         absolutePath: "/tmp/workspace-b/memory/2026-04-06.md",
         agentIds: ["beta"],
+        contentType: "markdown",
+      },
+    ]);
+  });
+
+  it("normalizes public memory artifacts without agent ids", async () => {
+    const legacyArtifact = {
+      kind: "memory-root",
+      workspaceDir: "/tmp/workspace",
+      relativePath: "MEMORY.md",
+      absolutePath: "/tmp/workspace/MEMORY.md",
+      contentType: "markdown" as const,
+    } as Omit<MemoryPluginPublicArtifact, "agentIds"> as MemoryPluginPublicArtifact;
+
+    registerMemoryCapability("memory-core", {
+      publicArtifacts: {
+        async listArtifacts() {
+          return [legacyArtifact];
+        },
+      },
+    });
+
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual([
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/workspace",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/workspace/MEMORY.md",
+        agentIds: [],
         contentType: "markdown",
       },
     ]);

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -303,9 +303,10 @@ export function hasMemoryRuntime(): boolean {
 function cloneMemoryPublicArtifact(
   artifact: MemoryPluginPublicArtifact,
 ): MemoryPluginPublicArtifact {
+  const agentIds = Array.isArray(artifact.agentIds) ? artifact.agentIds : [];
   return {
     ...artifact,
-    agentIds: [...artifact.agentIds],
+    agentIds: [...agentIds],
   };
 }
 


### PR DESCRIPTION
Fixes #92207

## Summary
- Normalize memory public artifacts at the host boundary so legacy providers that omit `agentIds` produce an empty agent list instead of throwing.
- Add regression coverage for `listActiveMemoryPublicArtifacts` and the memory-wiki bridge sync path.

## Real behavior proof
Behavior addressed: memory-wiki bridge imports no longer crash when a public memory artifact omits `agentIds`.
Real environment tested: local OpenClaw source checkout on macOS, running the actual memory-wiki bridge sync against a temporary workspace and temporary bridge vault with a legacy memory provider that omits `agentIds`; no Vitest test harness for this proof.
Exact steps or command run after this patch: ran `./node_modules/.bin/tsx -e '...'` to create a temp workspace containing `MEMORY.md`, register a memory public-artifact provider that returns the artifact without `agentIds`, and call `syncMemoryWikiBridgeSources` with bridge mode enabled.
Evidence after fix: live terminal output from that local OpenClaw setup after this patch:

```json
{
  "importedCount": 1,
  "artifactCount": 1,
  "workspaces": 1,
  "pagePath": "sources/bridge-workspace-0c64b7ec-memory-2d62c497.md",
  "titleLine": "# Memory Bridge: MEMORY",
  "agentsLine": "- Agents: unknown",
  "threwAgentIdsIterableError": false
}
```

Observed result after fix: the bridge imported the public memory artifact, rendered the bridge source page with unknown agents, and did not throw `artifact.agentIds is not iterable`.
What was not tested: a live Windows gateway session calling every `wiki_*` tool; this PR covers the shared bridge sync path that caused the reported crash.

## Verification
- `node scripts/run-vitest.mjs src/plugins/memory-state.test.ts -t "normalizes public memory artifacts without agent ids"`
- `node scripts/run-vitest.mjs extensions/memory-wiki/src/bridge.test.ts -t "imports bridge artifacts from legacy providers without agent ids"`
- `node scripts/run-vitest.mjs src/plugins/memory-state.test.ts extensions/memory-wiki/src/bridge.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/memory-state.ts src/plugins/memory-state.test.ts extensions/memory-wiki/src/bridge.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/memory-state.ts src/plugins/memory-state.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-wiki/src/bridge.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `git diff --check -- src/plugins/memory-state.ts src/plugins/memory-state.test.ts extensions/memory-wiki/src/bridge.test.ts`
