### PR TITLE
fix(ui): refresh overview model auth status on demand

### DIFF
--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -391,6 +391,7 @@ describe("refreshActiveTab", () => {
     expect(mocks.loadChannelsMock).toHaveBeenCalled();
     expect(mocks.loadSessionsMock).toHaveBeenCalled();
     expect(mocks.loadUsageMock).toHaveBeenCalled();
+    expect(mocks.loadModelAuthStatusStateMock).toHaveBeenCalledWith(host, { refresh: true });
   });
 
   it("skips overview usage refresh if the user leaves while primary loaders run", async () => {

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -436,7 +436,7 @@ export async function refreshActiveTab(host: SettingsHost, opts?: { chatStartup?
         }
         break;
       case "overview":
-        await loadOverview(host);
+        await loadOverview(host, { refresh: true });
         break;
       case "activity":
         break;


### PR DESCRIPTION
Fixes #92888

## Summary
- pass `{ refresh: true }` from `refreshActiveTab` when the Overview tab is manually refreshed
- keep the existing deferred Overview secondary loader behavior, but force the model auth status call to bypass the gateway's 60s cache
- add regression coverage so Overview refreshes request a fresh auth-status snapshot

## Tests
- `node scripts/run-vitest.mjs ui/src/ui/app-settings.refresh-active-tab.node.test.ts`
- `git diff --check`
