### PR TITLE
fix(config): honor replacement channel config schemas

### DIFF
--- a/src/config/channel-config-metadata.ts
+++ b/src/config/channel-config-metadata.ts
@@ -38,8 +38,7 @@ function comparablePluginId(value: string | undefined): string {
   return (value ?? "").trim().toLowerCase();
 }
 
-function channelConfigPrefersCurrentOwner(params: {
-  channelId: string;
+function channelConfigReplacesCurrentOwner(params: {
   channelConfigPreferOver?: readonly string[];
   current: ChannelMetadataRecord;
 }): boolean {
@@ -49,10 +48,7 @@ function channelConfigPrefersCurrentOwner(params: {
   if (preferred.size === 0) {
     return false;
   }
-  return (
-    preferred.has(comparablePluginId(params.current.schemaPluginId)) ||
-    preferred.has(comparablePluginId(params.channelId))
-  );
+  return preferred.has(comparablePluginId(params.current.schemaPluginId));
 }
 
 /** Collects plugin config UI metadata with deterministic origin precedence and output ordering. */
@@ -130,8 +126,7 @@ export function collectChannelSchemaMetadataWithOwnership(
         current &&
         current.originRank === originRank &&
         (current.configSchema !== undefined || current.configUiHints !== undefined) &&
-        !channelConfigPrefersCurrentOwner({
-          channelId,
+        !channelConfigReplacesCurrentOwner({
           channelConfigPreferOver: channelConfig.preferOver,
           current,
         })

--- a/src/config/channel-config-metadata.ts
+++ b/src/config/channel-config-metadata.ts
@@ -34,6 +34,27 @@ const PLUGIN_ORIGIN_RANK: Readonly<Record<PluginOrigin, number>> = {
   bundled: 3,
 };
 
+function comparablePluginId(value: string | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function channelConfigPrefersCurrentOwner(params: {
+  channelId: string;
+  channelConfigPreferOver?: readonly string[];
+  current: ChannelMetadataRecord;
+}): boolean {
+  const preferred = new Set(
+    (params.channelConfigPreferOver ?? []).map(comparablePluginId).filter(Boolean),
+  );
+  if (preferred.size === 0) {
+    return false;
+  }
+  return (
+    preferred.has(comparablePluginId(params.current.schemaPluginId)) ||
+    preferred.has(comparablePluginId(params.channelId))
+  );
+}
+
 /** Collects plugin config UI metadata with deterministic origin precedence and output ordering. */
 export function collectPluginSchemaMetadata(registry: PluginManifestRegistry): PluginUiMetadata[] {
   const deduped = new Map<
@@ -103,6 +124,21 @@ export function collectChannelSchemaMetadataWithOwnership(
       ) {
         // A closer-origin channel config owns schema/UI hints even if a farther plugin also
         // advertises the same channel id.
+        continue;
+      }
+      if (
+        current &&
+        current.originRank === originRank &&
+        (current.configSchema !== undefined || current.configUiHints !== undefined) &&
+        !channelConfigPrefersCurrentOwner({
+          channelId,
+          channelConfigPreferOver: channelConfig.preferOver,
+          current,
+        })
+      ) {
+        // Same-origin replacement channel plugins can explicitly supersede bundled channel
+        // metadata with preferOver. Without that signal, keep the first schema so registry
+        // traversal order cannot accidentally erase the active replacement schema.
         continue;
       }
       byChannelId.set(channelId, {

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -155,6 +155,69 @@ function createExternalFeishuSchemaWithRootOnlyShadowRegistry(): PluginManifestR
   };
 }
 
+function createSlackReplacementSchemaRegistry(order: "replacement-first" | "bundled-first") {
+  const bundledSlack = createPluginManifestRecord({
+    id: "slack",
+    origin: "bundled",
+    channels: ["slack"],
+    channelConfigs: {
+      slack: {
+        schema: {
+          type: "object",
+          properties: {
+            mode: { type: "string" },
+            botToken: { type: "object" },
+            appToken: { type: "object" },
+            signingSecret: { type: "object" },
+          },
+          additionalProperties: false,
+        },
+        uiHints: {},
+      },
+    },
+  });
+  const replacementSlack = createPluginManifestRecord({
+    id: "slack",
+    origin: "bundled",
+    channels: ["slack"],
+    channelConfigs: {
+      slack: {
+        preferOver: ["slack", "@openclaw/slack"],
+        schema: {
+          type: "object",
+          properties: {
+            mode: { type: "string" },
+            botToken: { type: "object" },
+            appToken: { type: "object" },
+            signingSecret: { type: "object" },
+            threadGuard: {
+              type: "object",
+              properties: {
+                enabled: { type: "boolean" },
+                allowedChannelIds: {
+                  type: "array",
+                  items: { type: "string", minLength: 1 },
+                },
+              },
+              additionalProperties: false,
+            },
+          },
+          additionalProperties: false,
+        },
+        uiHints: {},
+      },
+    },
+  });
+
+  return {
+    diagnostics: [],
+    plugins:
+      order === "replacement-first"
+        ? [replacementSlack, bundledSlack]
+        : [bundledSlack, replacementSlack],
+  };
+}
+
 function createCompatPluginConfigSchemaRegistry(): PluginManifestRegistry {
   return {
     diagnostics: [],
@@ -706,6 +769,29 @@ describe("validateConfigObjectRawWithPlugins channel metadata", () => {
       );
     }
   });
+
+  for (const order of ["bundled-first", "replacement-first"] as const) {
+    it(`keeps replacement channel schema active for same-origin Slack metadata when ${order}`, () => {
+      mockLoadPluginManifestRegistry.mockReturnValue(createSlackReplacementSchemaRegistry(order));
+
+      const result = validateConfigObjectRawWithPlugins({
+        channels: {
+          slack: {
+            mode: "socket",
+            botToken: { source: "env", provider: "env", id: "SLACK_BOT_TOKEN" },
+            appToken: { source: "env", provider: "env", id: "SLACK_APP_TOKEN" },
+            signingSecret: { source: "env", provider: "env", id: "SLACK_SIGNING_SECRET" },
+            threadGuard: {
+              enabled: true,
+              allowedChannelIds: ["CEXAMPLE1", "CEXAMPLE2"],
+            },
+          },
+        },
+      });
+
+      expect(result.ok).toBe(true);
+    });
+  }
 
   it("keeps raw channel validation diagnostics plugin-agnostic", () => {
     const result = validateConfigObjectRawWithPlugins({

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -218,6 +218,61 @@ function createSlackReplacementSchemaRegistry(order: "replacement-first" | "bund
   };
 }
 
+function createCompetingSlackReplacementSchemaRegistry() {
+  const replacementSlack = createPluginManifestRecord({
+    id: "@openclaw/slack-thread-guard",
+    origin: "bundled",
+    channels: ["slack"],
+    channelConfigs: {
+      slack: {
+        preferOver: ["slack"],
+        schema: {
+          type: "object",
+          properties: {
+            mode: { type: "string" },
+            threadGuard: {
+              type: "object",
+              properties: {
+                enabled: { type: "boolean" },
+              },
+              additionalProperties: false,
+            },
+          },
+          additionalProperties: false,
+        },
+        uiHints: {},
+      },
+    },
+  });
+  const laterSlackReplacement = createPluginManifestRecord({
+    id: "@openclaw/slack-rooms",
+    origin: "bundled",
+    channels: ["slack"],
+    channelConfigs: {
+      slack: {
+        preferOver: ["slack"],
+        schema: {
+          type: "object",
+          properties: {
+            mode: { type: "string" },
+            roomIds: {
+              type: "array",
+              items: { type: "string" },
+            },
+          },
+          additionalProperties: false,
+        },
+        uiHints: {},
+      },
+    },
+  });
+
+  return {
+    diagnostics: [],
+    plugins: [replacementSlack, laterSlackReplacement],
+  };
+}
+
 function createCompatPluginConfigSchemaRegistry(): PluginManifestRegistry {
   return {
     diagnostics: [],
@@ -792,6 +847,23 @@ describe("validateConfigObjectRawWithPlugins channel metadata", () => {
       expect(result.ok).toBe(true);
     });
   }
+
+  it("does not let a later same-origin Slack replacement steal schema ownership by naming only the channel", () => {
+    mockLoadPluginManifestRegistry.mockReturnValue(createCompetingSlackReplacementSchemaRegistry());
+
+    const result = validateConfigObjectRawWithPlugins({
+      channels: {
+        slack: {
+          mode: "socket",
+          threadGuard: {
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
 
   it("keeps raw channel validation diagnostics plugin-agnostic", () => {
     const result = validateConfigObjectRawWithPlugins({


### PR DESCRIPTION
Fixes #92884

## Summary
- make channel schema metadata deterministic for same-origin replacement channel plugins
- allow a channel config schema that declares `preferOver` to keep ownership of the active channel schema instead of being overwritten by later bundled metadata
- add Slack replacement regression coverage with both registry orders so `channels.slack.threadGuard` validates consistently

## Tests
- `node scripts/run-vitest.mjs src/config/validation.channel-metadata.test.ts`
- `node scripts/run-vitest.mjs src/config/validation.channel-metadata.test.ts src/plugins/channel-plugin-ids.test.ts src/cli/config-cli.test.ts src/config/runtime-schema.test.ts`
- `git diff --check`
