### PR TITLE
fix(status): warm model context-window cache before /status reads it

### DIFF
--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -639,4 +639,135 @@ describe("lookupContextTokens", () => {
     });
     expect(result).toBeUndefined();
   });
+
+  it("fires context window cache warming when skipRuntimeConfigLoad=true and allowAsyncLoad is unspecified", async () => {
+    mockDiscoveryDeps([
+      {
+        provider: "openrouter",
+        id: "openrouter/claude-sonnet",
+        contextWindow: 200_000,
+      },
+      {
+        provider: "anthropic",
+        id: "anthropic/claude-opus-4.7-20260219",
+        contextWindow: 200_000,
+      },
+    ]);
+
+    contextTestState.loadModelCatalog.mockClear();
+    const cfg = createContextOverrideConfig("openrouter", "openrouter/claude-sonnet", 200_000);
+    const { resolveContextTokensForModel } = await importContextModule();
+
+    // Act: call with cfg but no allowAsyncLoad
+    resolveContextTokensForModel({
+      cfg: cfg as never,
+      provider: "openrouter",
+      model: "openrouter/claude-sonnet",
+    });
+
+    // Warming is fire-and-forget. Flush microtasks to let it run.
+    await flushAsyncWarmup();
+
+    // Assert: warming triggered catalog loading
+    expect(contextTestState.loadModelCatalog).toHaveBeenCalled();
+    // Assert: discovered tokens now populate cache
+    const { lookupContextTokens } = await importContextModule();
+    const discoveredTokens = lookupContextTokens("anthropic/claude-opus-4.7-20260219");
+    // ANTHROPIC_CONTEXT_1M_TOKENS = 1_048_576
+    expect(discoveredTokens).toBe(1_048_576);
+  });
+
+  it("does not fire cache warming when allowAsyncLoad=false even with skipRuntimeConfigLoad=true", async () => {
+    contextTestState.loadModelCatalog.mockClear();
+    const cfg = createContextOverrideConfig("openrouter", "openrouter/claude-sonnet", 200_000);
+    const { resolveContextTokensForModel } = await importContextModule();
+
+    // Act: call with cfg AND explicit allowAsyncLoad: false
+    const result = resolveContextTokensForModel({
+      cfg: cfg as never,
+      provider: "openrouter",
+      model: "openrouter/claude-sonnet",
+      allowAsyncLoad: false,
+    });
+
+    // Assert: synchronous result from config scan (not warming)
+    expect(result).toBe(200_000);
+
+    // Assert: catalog was NEVER loaded — warming did not fire
+    await flushAsyncWarmup();
+    expect(contextTestState.loadModelCatalog).not.toHaveBeenCalled();
+  });
+
+  it("returns discovered context tokens on second call after first triggers warming", async () => {
+    mockDiscoveryDeps([
+      {
+        provider: "anthropic",
+        id: "anthropic/claude-opus-4.7-20260219",
+        contextWindow: 200_000,
+      },
+    ]);
+
+    const cfg = createContextOverrideConfig("anthropic", "claude-opus-4.7-20260219", 200_000);
+    const { resolveContextTokensForModel, lookupContextTokens } = await importContextModule();
+
+    // Act 1: First call with cfg triggers warming (allowAsyncLoad not set)
+    const firstResult = resolveContextTokensForModel({
+      cfg: cfg as never,
+      provider: "anthropic",
+      model: "claude-opus-4.7-20260219",
+      fallbackContextTokens: 200_000,
+    });
+
+    // First call result is from the configured window (config is 200k)
+    expect(firstResult).toBe(200_000);
+
+    // Let warming complete
+    await flushAsyncWarmup();
+
+    // Act 2: Second call without cfg — reads from warmed cache
+    const secondResult = resolveContextTokensForModel({
+      provider: "anthropic",
+      model: "claude-opus-4.7-20260219",
+    });
+
+    // discovered 200k is upgraded to 1M by the fixed anthropic 1M logic
+    expect(secondResult).toBe(1_048_576);
+  });
+
+  it("startup warming followed by status call returns discovered tokens not default 200K", async () => {
+    mockDiscoveryDeps([
+      {
+        provider: "anthropic",
+        id: "anthropic/claude-opus-4.7-20260219",
+        contextWindow: 200_000,
+      },
+    ]);
+
+    // Simulate startup: ensureContextWindowCacheLoaded is called
+    const { ensureContextWindowCacheLoaded, resolveContextTokensForModel } =
+      await importFreshContextModule();
+    void ensureContextWindowCacheLoaded();
+
+    // Simulate status command: calls resolveContextTokensForModel with cfg
+    // and no allowAsyncLoad: false (our fix removed that).
+    const cfg = createContextOverrideConfig("anthropic", "claude-opus-4.7-20260219", 200_000);
+    const firstStatusResult = resolveContextTokensForModel({
+      cfg: cfg as never,
+      provider: "anthropic",
+      model: "claude-opus-4.7-20260219",
+    });
+    // First call returns config override (200k) before warming completes
+    expect(firstStatusResult).toBe(200_000);
+
+    await flushAsyncWarmup();
+
+    // After warming: call without cfg (reads from warmed cache)
+    const afterWarmResult = resolveContextTokensForModel({
+      provider: "anthropic",
+      model: "claude-opus-4.7-20260219",
+    });
+
+    // The discovered 200k should be upgraded to 1M
+    expect(afterWarmResult).toBe(1_048_576);
+  });
 });

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -184,7 +184,7 @@ function primeConfiguredContextWindows(): OpenClawConfig | undefined {
   }
 }
 
-export function ensureContextWindowCacheLoaded(): Promise<void> {
+export function ensureContextWindowCacheLoaded(cfgOverride?: OpenClawConfig): Promise<void> {
   const generation = CONTEXT_WINDOW_RUNTIME_STATE.generation;
   if (
     CONTEXT_WINDOW_RUNTIME_STATE.loadPromise &&
@@ -193,7 +193,7 @@ export function ensureContextWindowCacheLoaded(): Promise<void> {
     return CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
   }
 
-  const cfg = primeConfiguredContextWindows();
+  const cfg = cfgOverride ?? primeConfiguredContextWindows();
   if (!cfg) {
     return Promise.resolve();
   }
@@ -254,8 +254,16 @@ export async function refreshContextWindowCache(cfg: OpenClawConfig): Promise<vo
 function prepareContextWindowCache(options?: {
   allowAsyncLoad?: boolean;
   skipRuntimeConfigLoad?: boolean;
+  cfg?: OpenClawConfig;
 }) {
   if (options?.skipRuntimeConfigLoad) {
+    // Callers that pass cfg already have the config struct, but discovery cache
+    // warming is still needed. Fire async loading if allowed (won't block caller).
+    // This is safe to call repeatedly — ensureContextWindowCacheLoaded()
+    // has an internal singleton guard that deduplicates concurrent loads.
+    if (options?.allowAsyncLoad !== false) {
+      void ensureContextWindowCacheLoaded(options.cfg);
+    }
     return;
   }
   if (options?.allowAsyncLoad === false) {
@@ -307,6 +315,7 @@ export function resolveContextTokensForModel(
   const lookupOptions = {
     allowAsyncLoad: params.allowAsyncLoad,
     skipRuntimeConfigLoad: Boolean(params.cfg),
+    cfg: params.cfg,
   };
   prepareContextWindowCache(lookupOptions);
   const sourceCfg =

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -9,7 +9,7 @@ import {
 import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { resolveConfiguredProviderFallback } from "../agents/configured-provider-fallback.js";
-import { resolveContextTokensForModelFromCache as resolveContextTokensForModel } from "../agents/context-resolution.js";
+import { resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { parseModelRef, resolvePersistedSelectedModelRef } from "../agents/model-selection.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -315,12 +315,11 @@ describe("getStatusSummary", () => {
     expect(resolveLinkChannelContext).not.toHaveBeenCalled();
   });
 
-  it("does not trigger async context warmup while building status summaries", async () => {
+  it("fires background context warmup while building status summaries", async () => {
     await getStatusSummary();
 
     const contextCall = vi.mocked(statusSummaryRuntime.resolveContextTokensForModel).mock
       .calls[0]?.[0];
-    expect(contextCall?.allowAsyncLoad).toBe(false);
     expect(contextCall).toMatchObject({
       modelContextWindow: 1_000_000,
       modelContextTokens: 272_000,
@@ -341,7 +340,6 @@ describe("getStatusSummary", () => {
       provider: "google",
       model: "gemini-3.1-pro-preview",
       modelContextWindow: 1_048_576,
-      allowAsyncLoad: false,
     });
   });
 
@@ -366,7 +364,6 @@ describe("getStatusSummary", () => {
       provider: "google-gemini-cli",
       model: "google/gemini-3.1-pro-preview",
       modelContextWindow: 1_048_576,
-      allowAsyncLoad: false,
     });
   });
 

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -304,9 +304,10 @@ export async function getStatusSummary(
       ...configModelContext,
       contextTokensOverride: cfg.agents?.defaults?.contextTokens,
       fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
-      // Keep `status`/`status --json` startup read-only. These summary lookups
-      // use offline static catalogs but never start live provider discovery.
-      allowAsyncLoad: false,
+      // Context lookup is synchronous for status rendering; async cache warming
+      // fires in the background if the discovery cache hasn't been loaded yet.
+      // This makes provider-qualified context tokens available for all models
+      // discovered from the catalog, not just those in config.
     }) ?? DEFAULT_CONTEXT_TOKENS;
 
   const storeCache = new Map<string, Record<string, SessionEntry | undefined>>();
@@ -369,7 +370,6 @@ export async function getStatusSummary(
             ...modelContext,
             contextTokensOverride: entry?.contextTokens,
             fallbackContextTokens: configContextTokens ?? undefined,
-            allowAsyncLoad: false,
           }) ?? null;
         const total = resolveSessionTotalTokens(entry);
         const totalTokensFresh =

--- a/src/gateway/server-startup-early.ts
+++ b/src/gateway/server-startup-early.ts
@@ -4,6 +4,7 @@ import type { GatewayTailscaleMode } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveCronJobsStorePath } from "../cron/store.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
+import { ensureContextWindowCacheLoaded } from "../agents/context.js";
 
 type Awaitable<T> = T | Promise<T>;
 
@@ -125,6 +126,7 @@ export async function startGatewayEarlyRuntime(params: {
       );
     setSkillsRemoteRegistry(params.nodeRegistry);
     void primeRemoteSkillsCache();
+    void ensureContextWindowCacheLoaded();
     // Task registry maintenance is authoritative in the Gateway process so
     // restart-blocker counts reflect the same cron store as runtime execution.
     taskRegistryMaintenance.configureTaskRegistryMaintenance({

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -94,8 +94,10 @@ function loadStatusQueueRuntime(): Promise<typeof import("./status-queue.runtime
   return runtimePromise;
 }
 
-// Context lookup stays synchronous/non-refreshing so status output does not
-// trigger provider/catalog IO while rendering a command response.
+// Context lookup stays synchronous for status rendering — the cache is read
+// directly, not awaited. Async cache warming fires in the background if the
+// discovery cache has not been loaded yet, so catalog IO does not block the
+// command response.
 function resolveStatusRuntimeContextTokens(params: {
   cfg: OpenClawConfig;
   provider: string;
@@ -105,7 +107,6 @@ function resolveStatusRuntimeContextTokens(params: {
     cfg: params.cfg,
     provider: params.provider,
     model: params.model,
-    allowAsyncLoad: false,
   });
 }
 


### PR DESCRIPTION
## Problem

\/status\ shows \200K\ (DEFAULT_CONTEXT_TOKENS) for any model discovered from the provider catalog, regardless of the model's actual context window.

## Root Cause

**Four** independent gaps kept MODEL_CONTEXT_TOKEN_CACHE empty when \/status\ read it:

1. **No startup warming**: \server-startup-early.ts\ had no cache warming call
2. **prepareContextWindowCache short-circuit**: \skipRuntimeConfigLoad=true\ blocked even async warming
3. **Status explicitly disabled warming**: \status-text.ts\ passed \llowAsyncLoad: false\
4. **CLI status also disabled warming**: \status.summary.ts\ passed \llowAsyncLoad: false\ in BOTH config-model and session-row calls
5. **Import bypass**: \status.summary.runtime.ts\ imported raw cache from \context-resolution.js\ instead of warming wrapper from \context.ts\

## Fix (6 files)

| File | Change | Gap Closed |
|------|--------|-----------|
| \src/gateway/server-startup-early.ts\ | Add \oid ensureContextWindowCacheLoaded()\ at startup | #1 |
| \src/agents/context.ts\ | Fire async warming when \skipRuntimeConfigLoad=true\ and \llowAsyncLoad !== false\ | #2 |
| \src/status/status-text.ts\ | Remove \llowAsyncLoad: false\ | #3 |
| \src/commands/status.summary.ts\ | Remove \llowAsyncLoad: false\ (both config-model and session-row call sites) | #4 |
| \src/commands/status.summary.runtime.ts\ | Import from \context.js\ (warming wrapper) | #5 |
| \src/agents/context.lookup.test.ts\ | 4 regression tests | Coverage |

## Design Notes

- **Fire-and-forget**: Uses \oid\ matching existing \primeRemoteSkillsCache()\
- **Backward-compatible**: \llowAsyncLoad !== false\ correctly distinguishes \undefined\ (fire warming) from \alse\ (skip)
- **No slash-model behavior change**: Does not touch \status-message.ts\ (unlike superseded PR #92772)
- **Startup warming + on-demand warming**: Covers both Gateway \/status\ and CLI \openclaw status\ paths

## Related

- Closes #92760
- Supersedes #92772 (narrower scope)