### PR TITLE
fix(providers): quarantine unreadable Anthropic payload tools

### DIFF
--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -245,7 +245,7 @@ function isMoonshotLiveTest(file) {
 export function selectLiveShardFiles(shard, files = collectAllLiveTestFiles()) {
   switch (shard) {
     case "native-live-src-agents":
-      return files.filter((file) => file.startsWith("src/agents/"));
+      return files.filter((file) => file.startsWith("src/agents/") || file.startsWith("src/llm/"));
     case "native-live-src-agents-zai-coding":
       return files.filter((file) => file === "src/agents/zai.live.test.ts");
     case "native-live-src-gateway":

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.live.test.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.live.test.ts
@@ -1,0 +1,82 @@
+import OpenAI from "openai";
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+import { isLiveTestEnabled } from "../../../agents/live-test-helpers.js";
+import { createOpenAIAnthropicToolPayloadCompatibilityWrapper } from "./anthropic-family-tool-payload-compat.js";
+
+const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
+const LIVE = isLiveTestEnabled(["OPENAI_LIVE_TEST"]) && Boolean(OPENAI_KEY);
+const describeLive = LIVE ? describe : describe.skip;
+
+describeLive("OpenAI-compatible Anthropic tool payload wrapper live", () => {
+  it("sends a healthy pinned tool after quarantining an unreadable sibling", async () => {
+    const liveModelId = process.env.OPENCLAW_LIVE_OPENAI_CHAT_TOOL_MODEL || "gpt-5.5";
+    let projectedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn: StreamFn = (model, context, options) => {
+      const payload: Record<string, unknown> = {
+        model: liveModelId,
+        messages: [
+          {
+            role: "user",
+            content: "Call live_probe with value exactly OPENAI_WRAPPER_OK.",
+          },
+        ],
+        tools: [
+          {
+            name: "unreadable_probe",
+            parameters: {
+              type: "object",
+              properties: {
+                get value(): never {
+                  throw new Error("live unreadable nested schema getter");
+                },
+              },
+            },
+          },
+          {
+            name: "live_probe",
+            description: "Return the requested probe value.",
+            input_schema: {
+              type: "object",
+              properties: { value: { type: "string" } },
+              required: ["value"],
+            },
+          },
+        ],
+        tool_choice: { type: "tool", name: "live_probe" },
+        max_completion_tokens: 128,
+      };
+      options?.onPayload?.(payload, model);
+      projectedPayload = structuredClone(payload);
+      return createAssistantMessageEventStream();
+    };
+    const wrapped = createOpenAIAnthropicToolPayloadCompatibilityWrapper(baseStreamFn);
+    const model = {
+      api: "anthropic-messages",
+      provider: "openai-compatible-anthropic",
+      id: liveModelId,
+      compat: { requiresOpenAiAnthropicToolPayload: true },
+    } as unknown as Model<"anthropic-messages">;
+
+    void wrapped(model, { messages: [] }, {});
+    if (!projectedPayload) {
+      throw new Error("wrapper did not produce a payload");
+    }
+
+    const client = new OpenAI({ apiKey: OPENAI_KEY });
+    const response = await client.chat.completions.create(
+      projectedPayload as unknown as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming,
+    );
+    const toolCall = response.choices[0]?.message.tool_calls?.[0];
+
+    if (!toolCall || toolCall.type !== "function") {
+      throw new Error("OpenAI did not return the expected function tool call");
+    }
+    expect(toolCall.function.name).toBe("live_probe");
+    expect(JSON.parse(toolCall.function.arguments)).toEqual({
+      value: "OPENAI_WRAPPER_OK",
+    });
+  }, 45_000);
+});

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
@@ -1,0 +1,493 @@
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+import { createOpenAIAnthropicToolPayloadCompatibilityWrapper } from "./anthropic-family-tool-payload-compat.js";
+
+const model = {
+  api: "anthropic-messages",
+  provider: "openai-compatible-anthropic",
+  id: "claude-compatible",
+  compat: { requiresOpenAiAnthropicToolPayload: true },
+} as unknown as Model<"anthropic-messages">;
+
+function runWrapper(payload: Record<string, unknown>) {
+  const payloads: Array<Record<string, unknown>> = [];
+  const baseStreamFn: StreamFn = (nextModel, context, options) => {
+    options?.onPayload?.(payload, nextModel);
+    payloads.push(structuredClone(payload));
+    return createAssistantMessageEventStream();
+  };
+  const wrapped = createOpenAIAnthropicToolPayloadCompatibilityWrapper(baseStreamFn);
+  void wrapped(model, { messages: [] }, {});
+  return payloads[0];
+}
+
+describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
+  it("skips unreadable schemas while preserving a healthy pinned tool", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          name: "bad_schema",
+          get parameters(): never {
+            throw new Error("parameters getter exploded");
+          },
+        },
+        {
+          name: "lookup",
+          description: "Lookup",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } },
+          },
+        },
+      ],
+      tool_choice: { type: "tool", name: "lookup" },
+    });
+
+    expect(payload?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "lookup",
+          description: "Lookup",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } },
+          },
+        },
+      },
+    ]);
+    expect(payload?.tool_choice).toEqual({
+      type: "function",
+      function: { name: "lookup" },
+    });
+  });
+
+  it("uses input_schema without reading a poisoned parameters fallback", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          name: "lookup",
+          input_schema: {
+            type: "object",
+            properties: { query: { type: "string" } },
+          },
+          get parameters(): never {
+            throw new Error("parameters fallback getter exploded");
+          },
+        },
+      ],
+    });
+
+    expect(payload?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "lookup",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("skips unreadable and structurally invalid schemas while preserving healthy siblings", () => {
+    const circularSchema: Record<string, unknown> = {
+      type: "object",
+      properties: {},
+    };
+    circularSchema.self = circularSchema;
+    const payload = runWrapper({
+      tools: [
+        {
+          name: "circular_schema",
+          parameters: circularSchema,
+        },
+        {
+          type: "function",
+          function: {
+            name: "nested_getter",
+            parameters: {
+              type: "object",
+              properties: {
+                get value(): never {
+                  throw new Error("nested schema getter exploded");
+                },
+              },
+            },
+          },
+        },
+        {
+          name: "invalid_properties",
+          parameters: {
+            type: "object",
+            properties: false,
+          },
+        },
+        {
+          name: "invalid_required",
+          parameters: {
+            type: "object",
+            required: "query",
+          },
+        },
+        {
+          name: "invalid_root",
+          input_schema: [],
+        },
+        {
+          name: "lookup",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } },
+          },
+        },
+      ],
+    });
+
+    expect(payload?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "lookup",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("preserves JSON-serializable dynamic schema references", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          name: "lookup",
+          input_schema: {
+            type: "object",
+            properties: {
+              query: { $dynamicRef: "#query" },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(payload?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "lookup",
+          parameters: {
+            type: "object",
+            properties: {
+              query: { $dynamicRef: "#query" },
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("normalizes null object schema keywords", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          name: "lookup",
+          parameters: {
+            type: "object",
+            properties: null,
+            required: null,
+          },
+        },
+      ],
+    });
+
+    expect(payload?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "lookup",
+          parameters: {
+            type: "object",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("preserves provider metadata on existing OpenAI function tools", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          type: "function",
+          cache_control: { type: "ephemeral" },
+          function: {
+            name: "lookup",
+            parameters: { type: "object", properties: {} },
+            get description(): never {
+              throw new Error("description getter exploded");
+            },
+          },
+        },
+      ],
+      tool_choice: {
+        type: "function",
+        function: { name: "lookup" },
+      },
+    });
+
+    expect(payload).toEqual({
+      tools: [
+        {
+          type: "function",
+          cache_control: { type: "ephemeral" },
+          function: {
+            name: "lookup",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+      tool_choice: {
+        type: "function",
+        function: { name: "lookup" },
+      },
+    });
+  });
+
+  it("preserves custom tools and named custom choices", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          type: "custom",
+          custom: {
+            name: "shell",
+            description: "Run a shell command.",
+          },
+        },
+      ],
+      tool_choice: {
+        type: "custom",
+        custom: { name: "shell" },
+      },
+    });
+
+    expect(payload).toEqual({
+      tools: [
+        {
+          type: "custom",
+          custom: {
+            name: "shell",
+            description: "Run a shell command.",
+          },
+        },
+      ],
+      tool_choice: {
+        type: "custom",
+        custom: { name: "shell" },
+      },
+    });
+  });
+
+  it("filters allowed tool choices against surviving function and custom tools", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          name: "broken",
+          get parameters(): never {
+            throw new Error("parameters getter exploded");
+          },
+        },
+        {
+          type: "custom",
+          custom: {
+            name: "shell",
+          },
+        },
+      ],
+      tool_choice: {
+        type: "allowed_tools",
+        allowed_tools: {
+          mode: "required",
+          tools: [
+            { type: "function", function: { name: "broken" } },
+            { type: "custom", custom: { name: "shell" } },
+          ],
+        },
+      },
+    });
+
+    expect(payload?.tool_choice).toEqual({
+      type: "allowed_tools",
+      allowed_tools: {
+        mode: "required",
+        tools: [{ type: "custom", custom: { name: "shell" } }],
+      },
+    });
+  });
+
+  it("disables tool calls when no auto-allowed tools survive", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          name: "broken",
+          get parameters(): never {
+            throw new Error("parameters getter exploded");
+          },
+        },
+        {
+          type: "custom",
+          custom: { name: "shell" },
+        },
+      ],
+      tool_choice: {
+        type: "allowed_tools",
+        allowed_tools: {
+          mode: "auto",
+          tools: [{ type: "function", function: { name: "broken" } }],
+        },
+      },
+    });
+
+    expect(payload?.tool_choice).toBe("none");
+  });
+
+  it("keeps a usable schema when optional metadata getters throw", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          name: "lookup",
+          parameters: { type: "object", properties: {} },
+          get description(): never {
+            throw new Error("description getter exploded");
+          },
+          get strict(): never {
+            throw new Error("strict getter exploded");
+          },
+        },
+      ],
+    });
+
+    expect(payload?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "lookup",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ]);
+  });
+
+  it("rejects a pinned choice when its tool is unreadable", () => {
+    expect(() =>
+      runWrapper({
+        tools: [
+          {
+            name: "bad_schema",
+            get parameters(): never {
+              throw new Error("parameters getter exploded");
+            },
+          },
+          {
+            name: "lookup",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+        tool_choice: { type: "tool", name: "bad_schema" },
+      }),
+    ).toThrow('requested unavailable tool "bad_schema"');
+  });
+
+  it("rejects required choice when every tool is unreadable", () => {
+    expect(() =>
+      runWrapper({
+        tools: [
+          {
+            name: "bad_schema",
+            get parameters(): never {
+              throw new Error("parameters getter exploded");
+            },
+          },
+        ],
+        tool_choice: { type: "any" },
+      }),
+    ).toThrow("requires a tool, but no tools survived");
+  });
+
+  it("rejects an already-normalized required choice when every tool is unreadable", () => {
+    expect(() =>
+      runWrapper({
+        tools: [
+          {
+            name: "bad_schema",
+            get parameters(): never {
+              throw new Error("parameters getter exploded");
+            },
+          },
+        ],
+        tool_choice: "required",
+      }),
+    ).toThrow("requires a tool, but no tools survived");
+  });
+
+  it("rejects required allowed tools when none survive conversion", () => {
+    expect(() =>
+      runWrapper({
+        tools: [
+          {
+            name: "broken",
+            get parameters(): never {
+              throw new Error("parameters getter exploded");
+            },
+          },
+        ],
+        tool_choice: {
+          type: "allowed_tools",
+          allowed_tools: {
+            mode: "required",
+            tools: [{ type: "function", function: { name: "broken" } }],
+          },
+        },
+      }),
+    ).toThrow("no allowed tools survived");
+  });
+
+  it("omits auto choice and tools when every tool is unreadable", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          name: "bad_schema",
+          get parameters(): never {
+            throw new Error("parameters getter exploded");
+          },
+        },
+      ],
+      tool_choice: { type: "auto" },
+    });
+
+    expect(payload).not.toHaveProperty("tools");
+    expect(payload).not.toHaveProperty("tool_choice");
+  });
+
+  it("omits an already-normalized auto choice when every tool is unreadable", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          name: "bad_schema",
+          get parameters(): never {
+            throw new Error("parameters getter exploded");
+          },
+        },
+      ],
+      tool_choice: "auto",
+    });
+
+    expect(payload).not.toHaveProperty("tools");
+    expect(payload).not.toHaveProperty("tool_choice");
+  });
+});

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
@@ -1,6 +1,7 @@
 // Anthropic-family tool payload compatibility wraps provider tool payload shapes.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { StreamFn } from "../../../agents/runtime/index.js";
+import { projectRuntimeToolInputSchema } from "../../../agents/tool-schema-json-projection.js";
 import { streamSimple } from "../../stream.js";
 type AnthropicToolSchemaMode = "openai-functions";
 type AnthropicToolChoiceMode = "openai-string-modes";
@@ -9,6 +10,108 @@ type AnthropicToolPayloadCompatibilityOptions = {
   toolSchemaMode?: AnthropicToolSchemaMode;
   toolChoiceMode?: AnthropicToolChoiceMode;
 };
+
+type PayloadFieldRead = { ok: true; value: unknown } | { ok: false };
+
+type OpenAiToolProjection = {
+  readonly kind?: "custom" | "function";
+  readonly name?: string;
+  readonly tool: Record<string, unknown>;
+};
+
+type OpenAiFunctionToolsProjection = {
+  readonly customNames: ReadonlySet<string>;
+  readonly functionNames: ReadonlySet<string>;
+  readonly tools: readonly Record<string, unknown>[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readPayloadField(record: Record<string, unknown>, field: string): PayloadFieldRead {
+  try {
+    return { ok: true, value: Reflect.get(record, field) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function isProviderSupportedSchemaViolation(violation: string): boolean {
+  return violation.endsWith(".$dynamicRef") || violation.endsWith(".$dynamicAnchor");
+}
+
+function projectJsonObjectSchema(
+  schema: unknown,
+  path: string,
+): Record<string, unknown> | undefined {
+  const projection = projectRuntimeToolInputSchema(schema, path);
+  if (
+    !isRecord(projection.schema) ||
+    projection.violations.some((violation) => !isProviderSupportedSchemaViolation(violation))
+  ) {
+    return undefined;
+  }
+  const properties = projection.schema.properties;
+  const required = projection.schema.required;
+  if (
+    (properties !== undefined && properties !== null && !isRecord(properties)) ||
+    (required !== undefined &&
+      required !== null &&
+      (!Array.isArray(required) || required.some((entry) => typeof entry !== "string")))
+  ) {
+    return undefined;
+  }
+  const normalizedSchema = { ...projection.schema };
+  if (properties === null) {
+    delete normalizedSchema.properties;
+  }
+  if (required === null) {
+    delete normalizedSchema.required;
+  }
+  return normalizedSchema;
+}
+
+function snapshotJsonRecord(value: unknown): Record<string, unknown> | undefined {
+  try {
+    const serialized = JSON.stringify(value);
+    if (!serialized) {
+      return undefined;
+    }
+    const snapshot = JSON.parse(serialized) as unknown;
+    return isRecord(snapshot) ? snapshot : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function snapshotToolMetadata(tool: Record<string, unknown>): Record<string, unknown> | undefined {
+  let fields: string[];
+  try {
+    fields = Object.keys(tool);
+  } catch {
+    return undefined;
+  }
+  const metadata: Record<string, unknown> = {};
+  for (const field of fields) {
+    if (field === "function" || field === "type") {
+      continue;
+    }
+    const read = readPayloadField(tool, field);
+    if (!read.ok) {
+      continue;
+    }
+    try {
+      const serialized = JSON.stringify(read.value);
+      if (serialized !== undefined) {
+        metadata[field] = JSON.parse(serialized) as unknown;
+      }
+    } catch {
+      // Provider extensions are optional; keep the usable function definition.
+    }
+  }
+  return metadata;
+}
 
 function hasOpenAiAnthropicToolPayloadCompatFlag(model: { compat?: unknown }): boolean {
   if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {
@@ -62,64 +165,285 @@ function usesOpenAiStringModeAnthropicToolChoiceForModel(
 
 function normalizeOpenAiFunctionAnthropicToolDefinition(
   tool: unknown,
-): Record<string, unknown> | undefined {
-  if (!tool || typeof tool !== "object" || Array.isArray(tool)) {
+): OpenAiToolProjection | undefined {
+  if (!isRecord(tool)) {
     return undefined;
   }
 
-  const toolObj = tool as Record<string, unknown>;
-  if (toolObj.function && typeof toolObj.function === "object") {
-    return toolObj;
+  const functionField = readPayloadField(tool, "function");
+  if (!functionField.ok) {
+    return undefined;
+  }
+  if (isRecord(functionField.value)) {
+    const nameField = readPayloadField(functionField.value, "name");
+    if (!nameField.ok) {
+      return undefined;
+    }
+    const name = normalizeOptionalString(nameField.value) ?? undefined;
+    if (!name) {
+      return undefined;
+    }
+    const parametersField = readPayloadField(functionField.value, "parameters");
+    if (!parametersField.ok) {
+      return undefined;
+    }
+    const parameters =
+      parametersField.value === undefined
+        ? undefined
+        : projectJsonObjectSchema(parametersField.value, `${name}.parameters`);
+    if (parametersField.value !== undefined && !parameters) {
+      return undefined;
+    }
+    const functionSpec: Record<string, unknown> = {
+      name,
+      ...(parameters ? { parameters } : {}),
+    };
+    const descriptionField = readPayloadField(functionField.value, "description");
+    if (
+      descriptionField.ok &&
+      typeof descriptionField.value === "string" &&
+      descriptionField.value.trim()
+    ) {
+      functionSpec.description = descriptionField.value;
+    }
+    const strictField = readPayloadField(functionField.value, "strict");
+    if (strictField.ok && (typeof strictField.value === "boolean" || strictField.value === null)) {
+      functionSpec.strict = strictField.value;
+    }
+    const metadata = snapshotToolMetadata(tool);
+    if (!metadata) {
+      return undefined;
+    }
+    return {
+      kind: "function",
+      name,
+      tool: {
+        ...metadata,
+        type: "function",
+        function: functionSpec,
+      },
+    };
   }
 
-  const rawName = normalizeOptionalString(toolObj.name) ?? "";
+  const nameField = readPayloadField(tool, "name");
+  if (!nameField.ok) {
+    return undefined;
+  }
+  const rawName = normalizeOptionalString(nameField.value) ?? "";
   if (!rawName) {
-    return toolObj;
+    const snapshot = snapshotJsonRecord(tool);
+    if (!snapshot) {
+      return undefined;
+    }
+    if (snapshot.type === "custom" && isRecord(snapshot.custom)) {
+      const name = normalizeOptionalString(snapshot.custom.name) ?? undefined;
+      return name ? { kind: "custom", name, tool: snapshot } : undefined;
+    }
+    return { tool: snapshot };
   }
 
+  const inputSchemaField = readPayloadField(tool, "input_schema");
+  if (!inputSchemaField.ok) {
+    return undefined;
+  }
+  let parameters: unknown = { type: "object", properties: {} };
+  if (isRecord(inputSchemaField.value)) {
+    parameters = projectJsonObjectSchema(inputSchemaField.value, `${rawName}.input_schema`);
+    if (!parameters) {
+      return undefined;
+    }
+  } else {
+    const parametersField = readPayloadField(tool, "parameters");
+    if (!parametersField.ok) {
+      return undefined;
+    }
+    if (isRecord(parametersField.value)) {
+      parameters = projectJsonObjectSchema(parametersField.value, `${rawName}.parameters`);
+      if (!parameters) {
+        return undefined;
+      }
+    } else if (inputSchemaField.value !== undefined || parametersField.value !== undefined) {
+      return undefined;
+    }
+  }
   const functionSpec: Record<string, unknown> = {
     name: rawName,
-    parameters:
-      toolObj.input_schema && typeof toolObj.input_schema === "object"
-        ? toolObj.input_schema
-        : toolObj.parameters && typeof toolObj.parameters === "object"
-          ? toolObj.parameters
-          : { type: "object", properties: {} },
+    parameters,
   };
 
-  if (typeof toolObj.description === "string" && toolObj.description.trim()) {
-    functionSpec.description = toolObj.description;
+  const descriptionField = readPayloadField(tool, "description");
+  if (
+    descriptionField.ok &&
+    typeof descriptionField.value === "string" &&
+    descriptionField.value.trim()
+  ) {
+    functionSpec.description = descriptionField.value;
   }
-  if (typeof toolObj.strict === "boolean") {
-    functionSpec.strict = toolObj.strict;
+  const strictField = readPayloadField(tool, "strict");
+  if (strictField.ok && typeof strictField.value === "boolean") {
+    functionSpec.strict = strictField.value;
   }
 
   return {
-    type: "function",
-    function: functionSpec,
+    kind: "function",
+    name: rawName,
+    tool: {
+      type: "function",
+      function: functionSpec,
+    },
   };
 }
 
-function normalizeOpenAiStringModeAnthropicToolChoice(toolChoice: unknown): unknown {
+function projectOpenAiFunctionAnthropicTools(
+  tools: readonly unknown[],
+): OpenAiFunctionToolsProjection {
+  const projectedTools: Record<string, unknown>[] = [];
+  const customNames = new Set<string>();
+  const functionNames = new Set<string>();
+  for (const tool of tools) {
+    const projection = normalizeOpenAiFunctionAnthropicToolDefinition(tool);
+    if (!projection) {
+      continue;
+    }
+    projectedTools.push(projection.tool);
+    if (projection.kind === "custom" && projection.name) {
+      customNames.add(projection.name);
+    } else if (projection.kind === "function" && projection.name) {
+      functionNames.add(projection.name);
+    }
+  }
+  return {
+    customNames,
+    functionNames,
+    tools: projectedTools,
+  };
+}
+
+function isProjectedToolAvailable(
+  projection: OpenAiFunctionToolsProjection | undefined,
+  kind: "custom" | "function",
+  name: string,
+): boolean {
+  return (
+    !projection || (kind === "custom" ? projection.customNames : projection.functionNames).has(name)
+  );
+}
+
+function normalizeAllowedToolChoice(
+  choice: Record<string, unknown>,
+  toolProjection: OpenAiFunctionToolsProjection | undefined,
+): unknown {
+  if (!toolProjection || !isRecord(choice.allowed_tools)) {
+    return choice;
+  }
+  const mode = choice.allowed_tools.mode;
+  if ((mode !== "auto" && mode !== "required") || !Array.isArray(choice.allowed_tools.tools)) {
+    return choice;
+  }
+  const tools = choice.allowed_tools.tools.flatMap((tool) => {
+    const snapshot = snapshotJsonRecord(tool);
+    if (!snapshot) {
+      return [];
+    }
+    const kind =
+      snapshot.type === "custom" ? "custom" : snapshot.type === "function" ? "function" : undefined;
+    const definition = kind && isRecord(snapshot[kind]) ? snapshot[kind] : undefined;
+    const name = definition ? (normalizeOptionalString(definition.name) ?? "") : "";
+    return kind && name && isProjectedToolAvailable(toolProjection, kind, name) ? [snapshot] : [];
+  });
+  if (tools.length === 0) {
+    if (mode === "auto") {
+      return "none";
+    }
+    throw new Error(
+      "OpenAI-compatible Anthropic tool_choice requires a tool, but no allowed tools survived payload conversion",
+    );
+  }
+  return {
+    type: "allowed_tools",
+    allowed_tools: { mode, tools },
+  };
+}
+
+function normalizeOpenAiStringModeAnthropicToolChoice(
+  toolChoice: unknown,
+  toolProjection?: OpenAiFunctionToolsProjection,
+): unknown {
+  if (typeof toolChoice === "string") {
+    if (toolChoice === "auto" && toolProjection?.tools.length === 0) {
+      return undefined;
+    }
+    if (toolChoice === "required" && toolProjection?.tools.length === 0) {
+      throw new Error(
+        "OpenAI-compatible Anthropic tool_choice requires a tool, but no tools survived payload conversion",
+      );
+    }
+    return toolChoice;
+  }
   if (!toolChoice || typeof toolChoice !== "object" || Array.isArray(toolChoice)) {
     return toolChoice;
   }
 
   const choice = toolChoice as Record<string, unknown>;
   if (choice.type === "auto") {
+    if (toolProjection?.tools.length === 0) {
+      return undefined;
+    }
     return "auto";
   }
   if (choice.type === "none") {
     return "none";
   }
   if (choice.type === "required" || choice.type === "any") {
+    if (toolProjection && toolProjection.tools.length === 0) {
+      throw new Error(
+        "OpenAI-compatible Anthropic tool_choice requires a tool, but no tools survived payload conversion",
+      );
+    }
     return "required";
   }
   if (choice.type === "tool" && typeof choice.name === "string" && choice.name.trim()) {
+    const name = choice.name.trim();
+    if (!isProjectedToolAvailable(toolProjection, "function", name)) {
+      throw new Error(
+        `OpenAI-compatible Anthropic tool_choice requested unavailable tool "${name}" after payload conversion`,
+      );
+    }
     return {
       type: "function",
-      function: { name: choice.name.trim() },
+      function: { name },
     };
+  }
+  if (choice.type === "function" && isRecord(choice.function)) {
+    const name = normalizeOptionalString(choice.function.name) ?? "";
+    if (name && !isProjectedToolAvailable(toolProjection, "function", name)) {
+      throw new Error(
+        `OpenAI-compatible Anthropic tool_choice requested unavailable tool "${name}" after payload conversion`,
+      );
+    }
+    if (name) {
+      return {
+        type: "function",
+        function: { name },
+      };
+    }
+  }
+  if (choice.type === "custom" && isRecord(choice.custom)) {
+    const name = normalizeOptionalString(choice.custom.name) ?? "";
+    if (name && !isProjectedToolAvailable(toolProjection, "custom", name)) {
+      throw new Error(
+        `OpenAI-compatible Anthropic tool_choice requested unavailable tool "${name}" after payload conversion`,
+      );
+    }
+    if (name) {
+      return {
+        type: "custom",
+        custom: { name },
+      };
+    }
+  }
+  if (choice.type === "allowed_tools") {
+    return normalizeAllowedToolChoice(choice, toolProjection);
   }
 
   return toolChoice;
@@ -142,18 +466,28 @@ export function createAnthropicToolPayloadCompatibilityWrapper(
           requiresAnthropicToolPayloadCompatibilityForModel(model, options)
         ) {
           const payloadObj = payload as Record<string, unknown>;
+          let toolProjection: OpenAiFunctionToolsProjection | undefined;
           if (
             Array.isArray(payloadObj.tools) &&
             usesOpenAiFunctionAnthropicToolSchemaForModel(model, options)
           ) {
-            payloadObj.tools = payloadObj.tools
-              .map((tool) => normalizeOpenAiFunctionAnthropicToolDefinition(tool))
-              .filter((tool): tool is Record<string, unknown> => Boolean(tool));
+            toolProjection = projectOpenAiFunctionAnthropicTools(payloadObj.tools);
+            if (toolProjection.tools.length > 0) {
+              payloadObj.tools = toolProjection.tools;
+            } else {
+              delete payloadObj.tools;
+            }
           }
           if (usesOpenAiStringModeAnthropicToolChoiceForModel(model, options)) {
-            payloadObj.tool_choice = normalizeOpenAiStringModeAnthropicToolChoice(
+            const toolChoice = normalizeOpenAiStringModeAnthropicToolChoice(
               payloadObj.tool_choice,
+              toolProjection,
             );
+            if (toolChoice === undefined) {
+              delete payloadObj.tool_choice;
+            } else {
+              payloadObj.tool_choice = toolChoice;
+            }
           }
         }
         return originalOnPayload?.(payload, model);

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -83,6 +83,9 @@ describe("scripts/test-live-shard", () => {
   });
 
   it("keeps slow gateway backend and media-capable extension files in their own shards", () => {
+    expect(selectLiveShardFiles("native-live-src-agents", allFiles)).toContain(
+      "src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.live.test.ts",
+    );
     expect(selectLiveShardFiles("native-live-src-agents-zai-coding", allFiles)).toEqual([
       "src/agents/zai.live.test.ts",
     ]);


### PR DESCRIPTION
## Summary

- quarantine unreadable, non-serializable, and structurally invalid Anthropic-family tool schemas before OpenAI-compatible payload serialization
- keep forced, custom, string, and `allowed_tools` choices aligned with surviving function/custom tools without broadening tool access
- preserve JSON-safe provider metadata and add focused plus live OpenAI Chat Completions coverage

Supersedes #90289. The contributor branch could not be updated because maintainer edits are disabled; the commit preserves Vincent Koc's authorship via `Co-authored-by`.

## Verification

- `node scripts/run-vitest.mjs src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts src/llm/providers/anthropic.test.ts src/agents/anthropic-transport-stream.test.ts src/agents/tool-schema-projection.test.ts src/agents/openai-transport-stream.test.ts src/llm/providers/openai-responses-shared.test.ts -- --reporter=dot` (402 tests)
- `pnpm tsgo:core && pnpm tsgo:core:test`
- `pnpm check:architecture`
- targeted `oxfmt`, `oxlint`, and `git diff --check`
- fresh autoreview: no actionable findings, confidence 0.88
- AWS Testbox `pnpm check:changed`, lanes `core, coreTests`: `run_3ef795bee486`, exit 0
- post-rebase wrapper tests: 16 passed; strict core/test type checks passed
- live OpenAI Chat Completions: `gpt-5.5` returned the forced `live_probe` function call with the expected `OPENAI_WRAPPER_OK` arguments after a sibling with a nested throwing schema getter was quarantined

Testbox: https://crabbox.openclaw.ai/portal/runs/run_3ef795bee486

## Real behavior proof

Behavior addressed: OpenAI-compatible Anthropic payload conversion could abort on unreadable or invalid tool schemas, leave stale forced choices after filtering, broaden an empty allowed-tools constraint, or strip provider metadata.

Real environment tested: official OpenAI Chat Completions API with `gpt-5.5`; AWS Linux Testbox; local official Anthropic/OpenAI transport regression suites.

Exact steps or command run after this patch: focused wrapper/provider Vitest suites, strict core/test type checks, architecture/lint/format gates, AWS `pnpm check:changed`, and the live OpenAI test above.

Evidence after fix: the malformed nested schema was removed, the healthy pinned tool reached OpenAI, and OpenAI returned the expected function call; all local and remote checks passed.

Observed result after fix: malformed tools no longer abort healthy siblings, choices remain constrained to surviving tools, `allowed_tools:auto` cannot expand access, and official OpenAI/Anthropic transport tests remain green.

What was not tested: a live third-party Anthropic-compatible proxy using `requiresOpenAiAnthropicToolPayload`; no built-in provider currently enables this compatibility flag. The emitted OpenAI request shape was verified against the installed official OpenAI SDK types and the live OpenAI API.

## Risk

The helper is deprecated but remains a public plugin SDK export. The patch keeps the change inside that compatibility boundary and does not modify the official OpenAI Responses or Anthropic request builders.
