### PR TITLE
fix(agents): clamp unsupported thinking for subagent spawns instead of hard-failing

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -328,7 +328,6 @@ vi.mock("../routing/session-key.js", async () => {
   );
   return {
     ...actual,
-    isSubagentSessionKey: () => false,
     normalizeAgentId: (id: string) => id,
     normalizeMainKey: (key?: string | null) => key?.trim() || "main",
   };
@@ -1338,6 +1337,41 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       timeoutMs: 600_000,
       runTimeoutOverrideMs: 600_000,
     });
+  });
+
+  it("clamps unsupported explicit thinking for subagent spawns instead of throwing", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("anthropic", "claude-fable-5"));
+    state.resolvedSessionKeyMock = "agent:planner:subagent:00000000-0000-4000-8000-000000000000";
+    state.isThinkingLevelSupportedMock.mockReturnValue(false);
+    state.resolveSupportedThinkingLevelMock.mockReturnValue("high");
+
+    await agentCommand({
+      message: "hello",
+      sessionKey: state.resolvedSessionKeyMock,
+      thinking: "xhigh",
+    });
+
+    expect(state.resolveSupportedThinkingLevelMock).toHaveBeenCalled();
+    expectRecordFields(mockCallArg(state.runAgentAttemptMock), {
+      resolvedThinkLevel: "high",
+    });
+  });
+
+  it("rejects unsupported explicit thinking for direct interactive runs", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("anthropic", "claude-fable-5"));
+    state.resolvedSessionKeyMock = "agent:main:main";
+    state.isThinkingLevelSupportedMock.mockReturnValue(false);
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        to: "+1234567890",
+        thinking: "xhigh",
+      }),
+    ).rejects.toThrow(/is not supported/u);
+    expect(state.runAgentAttemptMock).not.toHaveBeenCalled();
   });
 
   it("skips the initial session touch after gateway ingress already persisted activity", async () => {

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1350,12 +1350,46 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       message: "hello",
       sessionKey: state.resolvedSessionKeyMock,
       thinking: "xhigh",
+      lane: "subagent",
     });
 
     expect(state.resolveSupportedThinkingLevelMock).toHaveBeenCalled();
     expectRecordFields(mockCallArg(state.runAgentAttemptMock), {
       resolvedThinkLevel: "high",
     });
+  });
+
+  it("rejects unsupported explicit thinking for interactive subagent-key runs", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("anthropic", "claude-fable-5"));
+    state.resolvedSessionKeyMock = "agent:planner:subagent:00000000-0000-4000-8000-000000000000";
+    state.isThinkingLevelSupportedMock.mockReturnValue(false);
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        sessionKey: state.resolvedSessionKeyMock,
+        thinking: "xhigh",
+      }),
+    ).rejects.toThrow(/is not supported/u);
+    expect(state.runAgentAttemptMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported explicit thinking for non-subagent sessions on the subagent lane", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("anthropic", "claude-fable-5"));
+    state.resolvedSessionKeyMock = "agent:main:main";
+    state.isThinkingLevelSupportedMock.mockReturnValue(false);
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        sessionKey: state.resolvedSessionKeyMock,
+        thinking: "xhigh",
+        lane: "subagent",
+      }),
+    ).rejects.toThrow(/is not supported/u);
+    expect(state.runAgentAttemptMock).not.toHaveBeenCalled();
   });
 
   it("rejects unsupported explicit thinking for direct interactive runs", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -819,6 +819,7 @@ async function prepareAgentCommandExecution(opts: AgentCommandOpts, runtime: Run
     manifestMetadataSnapshot,
     modelManifestContext,
     runId,
+    isSubagentLane,
     acpManager,
     acpResolution,
   };
@@ -859,6 +860,7 @@ async function agentCommandInternal(
     cwd,
     agentDir,
     runId,
+    isSubagentLane,
     acpManager,
     acpResolution,
     pluginsEnabled,
@@ -1597,10 +1599,11 @@ async function agentCommandInternal(
       })
     ) {
       const explicitThink = Boolean(thinkOnce || thinkOverride);
-      // Subagent spawns are fire-and-forget; the orchestrator already got an
-      // "accepted" ack, so throwing here strands the run and half-fails fan-outs.
+      const isSubagentSpawnRun = isSubagentLane && isSubagentSessionKey(sessionKey);
+      // Spawn-lane subagents are fire-and-forget; the orchestrator already got
+      // an "accepted" ack, so throwing here strands the run and half-fails fan-outs.
       // Clamp like the embedded runner; interactive --thinking keeps the throw.
-      if (explicitThink && !isSubagentSessionKey(sessionKey)) {
+      if (explicitThink && !isSubagentSpawnRun) {
         throw new Error(
           `Thinking level "${resolvedThinkLevel}" is not supported for ${provider}/${model}. Use one of: ${formatThinkingLevels(provider, model, ", ", thinkingCatalog)}.`,
         );

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1597,7 +1597,10 @@ async function agentCommandInternal(
       })
     ) {
       const explicitThink = Boolean(thinkOnce || thinkOverride);
-      if (explicitThink) {
+      // Subagent spawns are fire-and-forget; the orchestrator already got an
+      // "accepted" ack, so throwing here strands the run and half-fails fan-outs.
+      // Clamp like the embedded runner; interactive --thinking keeps the throw.
+      if (explicitThink && !isSubagentSessionKey(sessionKey)) {
         throw new Error(
           `Thinking level "${resolvedThinkLevel}" is not supported for ${provider}/${model}. Use one of: ${formatThinkingLevels(provider, model, ", ", thinkingCatalog)}.`,
         );


### PR DESCRIPTION
### Summary

- **Problem**: Issue #92412 reports that `sessions_spawn` silently half-fails when the requested thinking level is unsupported for the resolved model (e.g. `thinking: "xhigh"` for `anthropic/claude-fable-5`). The spawn ack still returns `status: "accepted"` with `modelApplied: true`, but the child run never completes, and parallel fan-outs produce non-deterministic survivors with no failure signal to the orchestrator.
- **Root Cause**: A subagent spawn dispatches the child run through the gateway `agent` method and is acked immediately (fire-and-forget). The async run reaches `agentCommandInternal`, which validates the thinking level before dispatching to any runner. For an explicit thinking override it throws hard when the level is unsupported, instead of clamping. The embedded runner already clamps unsupported levels and continues, and cron and directive handling clamp as well — but the pre-dispatch throw fires first, so the spawned run dies after the orchestrator has already been told the spawn was accepted. Whether a given run trips the throw depends on per-run thinking-profile resolution, which is why a parallel fan-out yields some silent casualties and some survivors.
- **Fix**: Make the hard throw apply only to interactive/direct runs, not to fire-and-forget subagent spawns. When the run targets a subagent session, fall through to the existing supported-level clamp so the run continues on a valid level — symmetrizing the CLI/ingress validation path with the embedded runner. Interactive `openclaw agent --thinking <level>` keeps the hard error for immediate feedback.
- **What changed**:
  - `src/agents/agent-command.ts` — gate the unsupported-explicit-thinking throw with `!isSubagentSessionKey(sessionKey)`. Subagent-keyed runs now reach the adjacent `resolveSupportedThinkingLevel` clamp (which already uses the run's own thinking catalog), so the run proceeds on a supported level.
  - `src/agents/agent-command.live-model-switch.test.ts` — regression coverage: a subagent spawn with an unsupported explicit level clamps and runs (no throw); a direct interactive run with the same unsupported level still rejects. The test's session-key helper now exercises the real keying instead of a hardcoded stub so the clamp-vs-throw branch is covered.
- **What did NOT change (scope boundary)**:
  - The interactive/direct throw path is unchanged; `openclaw agent --thinking <level>` still hard-errors on an unsupported level.
  - The thinking catalog, profile resolution, and clamp helper (`resolveSupportedThinkingLevel`) are unchanged; the fix only routes subagent runs into the existing clamp.
  - The spawn ack shape, model resolution, and session persistence are unchanged.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. Configure an agent on a model whose reasoning vocabulary excludes `xhigh` (e.g. `anthropic/claude-fable-5`).
2. Call `sessions_spawn` with `thinking: "xhigh"` several times in parallel (`mode: "run"`).
3. Inspect the spawn ack and `openclaw tasks list` for the child runs.
4. **Before this PR**: each spawn returns `status: "accepted"`, `modelApplied: true`, but the child run throws `Thinking level "xhigh" is not supported for anthropic/claude-fable-5` at validation and never produces a transcript. Across a fan-out some runs survive via internal retry and others die silently, with no signal to the orchestrator.
5. **After this PR**: each spawned run clamps to the closest supported level and completes; the accepted ack is truthful, the fan-out is deterministic, and an interactive `openclaw agent --thinking xhigh` on the same model still hard-errors.

### Real behavior proof

**Behavior addressed (#92412)**: an unsupported explicit thinking level on a fire-and-forget subagent spawn no longer throws before dispatch; the run clamps to a supported level and completes, matching the embedded runner, while the interactive direct path keeps its hard error.

**Real environment tested (Linux, Node 22 — Vitest driving the production `agentCommandInternal` thinking-validation branch: the real `isSubagentSessionKey` gating and the real throw-vs-clamp decision; the thinking-catalog support/clamp helpers are stubbed to force the unsupported case)**: the run is dispatched through `agentCommand` with the production attempt-execution path, asserting the clamp reaches `runAgentAttempt` for subagent keys and the throw still fires for direct keys.

**Exact steps or command run after this patch**: `pnpm test src/agents/agent-command.live-model-switch.test.ts`; `node scripts/run-oxlint.mjs` and `oxfmt --check` on the two changed files; `pnpm tsgo:core`.

**Evidence after fix (Vitest output for the touched test file)**:

```text
 agent-command.live-model-switch.test.ts   Tests  60 passed (60)
```

The two added cases are `clamps unsupported explicit thinking for subagent spawns instead of throwing` and `rejects unsupported explicit thinking for direct interactive runs`.

**Observed result after fix**: for a subagent session key, an unsupported explicit `xhigh` no longer throws; the supported-level clamp runs and `runAgentAttempt` receives the clamped level (`high`). For a direct interactive run with the same unsupported level, the command still rejects with `... is not supported ...` and never reaches `runAgentAttempt`.

**What was not tested**: a live end-to-end spawn through a running gateway against a real model that rejects the level. The clamp-vs-throw decision, the subagent-key gating, and the dispatch into the attempt path are covered deterministically against the production functions; a full gateway round-trip with a live model was not driven.

**Repro confirmation**: the subagent case fails on the pre-fix tree (the run throws `... is not supported ...` instead of clamping) and passes with the fix; the direct case passes on both trees, confirming the interactive throw is preserved.

### Risk / Mitigation

- **Risk**: A run that should hard-fail could be silently clamped. **Mitigation**: the gate is keyed to subagent sessions only; interactive/direct runs keep the throw, and clamping for programmatic spawns matches the embedded runner, cron downgrade, and directive remap that already clamp unsupported levels.
- **Risk**: The clamp could change the durable session thinking level. **Mitigation**: the clamp is turn-local (unchanged from the existing fallback branch); durable session/directive thinking state is not rewritten here.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents / runtime
- [x] Subagents / spawn

### Linked Issue/PR

Fixes #92412
