### PR TITLE
fix(plugins): surface globally installed plugins in openclaw migrate (#89609)

### DIFF
--- a/src/plugins/manifest-contract-runtime.ts
+++ b/src/plugins/manifest-contract-runtime.ts
@@ -20,12 +20,15 @@ const DEMAND_ONLY_CONTRACT_LOOKUP_OPTIONS = {
 export function resolveManifestContractRuntimePluginResolution(params: {
   cfg?: OpenClawConfig;
   contract: PluginManifestContractListKey;
+  preferPersisted?: boolean;
   value?: string;
 }): ManifestContractRuntimePluginResolution {
   const snapshot = loadPluginMetadataSnapshot({
     config: params.cfg ?? {},
     env: process.env,
-    ...DEMAND_ONLY_CONTRACT_LOOKUP_OPTIONS,
+    ...(params.preferPersisted !== undefined
+      ? { preferPersisted: params.preferPersisted }
+      : DEMAND_ONLY_CONTRACT_LOOKUP_OPTIONS),
   });
   const allContractPlugins = snapshot.plugins.filter((plugin) =>
     hasManifestContractValue({

--- a/src/plugins/migration-provider-runtime.test.ts
+++ b/src/plugins/migration-provider-runtime.test.ts
@@ -226,7 +226,7 @@ describe("migration provider runtime", () => {
     expect(mocks.loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledWith({
       config: cfg,
       env: process.env,
-      preferPersisted: false,
+      preferPersisted: true,
     });
     const manifestParams = requireMockCallArg(
       mocks.loadPluginManifestRegistry,
@@ -247,6 +247,68 @@ describe("migration provider runtime", () => {
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenNthCalledWith(1);
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
       onlyPluginIds: ["external-migration"],
+    });
+  });
+
+  it("resolves persisted global migration-provider plugins from manifest contracts", () => {
+    const cfg = {
+      plugins: { entries: { codex: { enabled: true } } },
+    } as OpenClawConfig;
+    const provider = createMigrationProvider("codex");
+    const active = createEmptyPluginRegistry();
+    const loaded = createEmptyPluginRegistry();
+    loaded.migrationProviders.push({
+      pluginId: "codex",
+      pluginName: "Codex",
+      source: "test",
+      provider,
+    } as never);
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? active : loaded,
+    );
+    mocks.loadPluginRegistrySnapshotWithMetadata.mockImplementation(
+      (params?: { preferPersisted?: boolean; index?: MockPluginIndex }) => ({
+        source: params?.preferPersisted === false ? "derived" : "provided",
+        snapshot:
+          params?.preferPersisted === false
+            ? createMockPluginIndex([])
+            : createMockPluginIndex([
+                {
+                  pluginId: "codex",
+                  origin: "global",
+                  enabled: true,
+                },
+              ]),
+        diagnostics: [],
+      }),
+    );
+    mocks.loadPluginManifestRegistry.mockImplementation((params?: Record<string, unknown>) => {
+      const index = params?.index as MockPluginIndex | undefined;
+      const hasCodex = index?.plugins.some((plugin) => plugin.pluginId === "codex");
+      return {
+        diagnostics: [],
+        plugins: hasCodex
+          ? [
+              {
+                id: "codex",
+                origin: "global",
+                contracts: { migrationProviders: ["codex"] },
+              },
+            ]
+          : [],
+      };
+    });
+
+    const resolved = resolvePluginMigrationProvider({ providerId: "codex", cfg });
+
+    expect(resolved).toBe(provider);
+    expect(mocks.loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledWith({
+      config: cfg,
+      env: process.env,
+      preferPersisted: true,
+    });
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
+      onlyPluginIds: ["codex"],
     });
   });
 
@@ -289,7 +351,7 @@ describe("migration provider runtime", () => {
     expect(mocks.loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledWith({
       config: {},
       env: process.env,
-      preferPersisted: false,
+      preferPersisted: true,
       workspaceDir: undefined,
     });
     const manifestParams = requireMockCallArg(

--- a/src/plugins/migration-provider-runtime.ts
+++ b/src/plugins/migration-provider-runtime.ts
@@ -58,6 +58,7 @@ export function ensureStandaloneMigrationProviderRegistryLoaded(
   const resolution = resolveManifestContractRuntimePluginResolution({
     cfg: params.cfg,
     contract: "migrationProviders",
+    preferPersisted: true,
   });
   if (resolution.pluginIds.length === 0) {
     return;
@@ -93,6 +94,7 @@ export function resolvePluginMigrationProvider(params: {
   const resolution = resolveManifestContractRuntimePluginResolution({
     cfg: params.cfg,
     contract: "migrationProviders",
+    preferPersisted: true,
     value: params.providerId,
   });
   const pluginIds = resolution.pluginIds;
@@ -115,6 +117,7 @@ export function resolvePluginMigrationProviders(
   const resolution = resolveManifestContractRuntimePluginResolution({
     cfg: params.cfg,
     contract: "migrationProviders",
+    preferPersisted: true,
   });
   const pluginIds = resolution.pluginIds;
   if (pluginIds.length === 0) {


### PR DESCRIPTION
## Summary

- `openclaw migrate <provider>` / `migrate list` resolved migration providers through `resolveManifestContractRuntimePluginResolution` with a hard-coded `preferPersisted: false`, so providers known only via persisted/global plugin install records (e.g. a globally installed Codex plugin) were invisible and `migrate codex` could fail with "Unknown migration provider".
- This threads an explicit `preferPersisted` option through the manifest-contract resolver and sets it to `true` on the migration-provider resolution paths, so persisted/global plugins are discoverable by `migrate`.
- Narrow change: one new optional param plus two call sites, with regression coverage.

## Linked context

Closes #89609

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw migrate` could not discover migration providers backed by persisted/global plugin install records, surfacing "Unknown migration provider".
- Real environment tested: local OpenClaw built from source (origin/main @462c076) on Linux, run via `node openclaw.mjs`.
- Exact steps or command run after this patch: `node openclaw.mjs migrate list` and `node scripts/run-vitest.mjs src/plugins/migration-provider-runtime.test.ts`.
- Evidence after fix (terminal capture):
  ```
  $ node openclaw.mjs migrate list
  claude  Claude - Import Claude Code and Claude Desktop instructions, MCP servers, and skills.
  codex   Codex - Inventory and promote Codex CLI skills while keeping Codex native plugins and hooks explicit.
  hermes  Hermes - Import Hermes config, memories, skills, and supported credentials.

  $ node scripts/run-vitest.mjs src/plugins/migration-provider-runtime.test.ts
   Test Files  1 passed (1)
        Tests  5 passed (5)
  ```
- Observed result after fix: `migrate` resolves the Codex provider through the persisted-aware path; the added regression test asserts a persisted/global-only Codex provider is resolved (it was dropped before the fix because `preferPersisted` was forced to `false`).
- What was not tested: end-to-end `migrate apply` against a real external tool install; only provider discovery/resolution is covered.
- Proof limitations or environment constraints: in this environment the Codex plugin is already active, so `migrate list` shows it both before and after the patch; the regression test reproduces the persisted/global-only condition the issue describes (where discovery previously failed) at the resolver level.

## Tests and validation

- `node scripts/run-vitest.mjs src/plugins/migration-provider-runtime.test.ts` -> 5 passed. Added a regression test ("resolves persisted global migration-provider plugins from manifest contracts") and updated existing assertions to the persisted-aware behavior.

## Risk checklist

- User-visible behavior change? Yes - migrate can now discover persisted/global providers.
- Config/env/migration behavior change? Yes (migrate discovery only).
- Security/auth/secrets/network/tool-execution change? No.
- Highest-risk area: broadening provider discovery could surface previously-hidden providers; mitigated by scoping the change to the migration-provider resolution paths only.
