### PR TITLE
fix(imessage): honor actions.reply=false when resolving replyToId

### DIFF
--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -1165,4 +1165,116 @@ describe("sendMessageIMessage receipts", () => {
 
     expect(runCliJson).not.toHaveBeenCalled();
   });
+
+  describe("actions.reply gating", () => {
+    const BASE_CFG = {
+      channels: {
+        imessage: {
+          accounts: { default: {} },
+        },
+      },
+    };
+    const REPLY_CFG = {
+      channels: {
+        imessage: {
+          accounts: {
+            default: { actions: { reply: true } },
+          },
+        },
+      },
+    };
+    const NO_REPLY_CFG = {
+      channels: {
+        imessage: {
+          accounts: {
+            default: { actions: { reply: false } },
+          },
+        },
+      },
+    };
+
+    it("includes reply_to when actions.reply is true", async () => {
+      const client = createClient({ guid: "p:0/GUID", status: "sent" });
+
+      await sendMessageIMessage("+15551234567", "hello", {
+        config: REPLY_CFG,
+        client,
+        replyToId: "reply-guid",
+      });
+
+      const params = (client.request as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(params.reply_to).toBe("reply-guid");
+    });
+
+    it("includes reply_to when actions.reply is not set (default-enabled)", async () => {
+      const client = createClient({ guid: "p:0/GUID", status: "sent" });
+
+      await sendMessageIMessage("+15551234567", "hello", {
+        config: BASE_CFG,
+        client,
+        replyToId: "reply-guid",
+      });
+
+      const params = (client.request as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(params.reply_to).toBe("reply-guid");
+    });
+
+    it("strips reply_to when actions.reply is false", async () => {
+      const client = createClient({ guid: "p:0/GUID", status: "sent" });
+
+      await sendMessageIMessage("+15551234567", "hello", {
+        config: NO_REPLY_CFG,
+        client,
+        replyToId: "reply-guid",
+      });
+
+      const params = (client.request as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(params.reply_to).toBeUndefined();
+    });
+
+    it("strips reply_to from media sends when actions.reply is false", async () => {
+      const client = createClient({ guid: "p:0/GUID", status: "sent" });
+      // send-attachment hits the imsg CLI which is unavailable in tests;
+      // provide a mock runCliJson to bypass the external binary.
+      const runCliJson = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("unknown command send-attachment"));
+
+      await sendMessageIMessage("+15551234567", "", {
+        config: NO_REPLY_CFG,
+        client,
+        replyToId: "reply-guid",
+        mediaUrl: "https://example.com/test.png",
+        resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+        runCliJson,
+      });
+
+      // send-attachment failed → falls back to rpc send; reply_to must be absent.
+      const sendCalls = (client.request as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([method]: [string]) => method === "send",
+      );
+      for (const [, params] of sendCalls) {
+        expect(params.reply_to).toBeUndefined();
+      }
+    });
+
+    it("strips reply_to from attachment send-attachment when actions.reply is false and audioAsVoice", async () => {
+      // AudioAsVoice goes through send-attachment in spawn (needs mock runCliJson).
+      const runCliJson = vi.fn().mockResolvedValueOnce({ guid: "p:0/GUID", status: "sent" });
+
+      const result = await sendMessageIMessage("+15551234567", "", {
+        config: NO_REPLY_CFG,
+        replyToId: "reply-guid",
+        mediaUrl: "https://example.com/test.caf",
+        audioAsVoice: true,
+        resolveAttachmentImpl: async () => ({ path: "/tmp/voice.caf", contentType: "audio/x-caf" }),
+        runCliJson,
+      });
+
+      expect(result.messageId).toBe("p:0/GUID");
+      // runCliJson should have been called without --reply-to
+      const attachArgs = runCliJson.mock.calls[0][0];
+      expect(attachArgs).not.toContain("--reply-to");
+    });
+  });
 });

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -948,7 +948,12 @@ export async function sendMessageIMessage(
     throw new Error("iMessage send requires text or media");
   }
   const echoText = resolveOutboundEchoText(message, filePath ? mediaContentType : undefined);
-  const resolvedReplyToId = sanitizeReplyToId(opts.replyToId);
+  // Honor actions.reply === false: when the user explicitly disables
+  // threaded/native reply actions (e.g. because SIP prevents private-API
+  // injection), strip replyToId so the bridge sends a normal top-level
+  // message instead of triggering a SIP-gated reply pathway.
+  const replyActionsEnabled = account.config.actions?.reply !== false;
+  const resolvedReplyToId = replyActionsEnabled ? sanitizeReplyToId(opts.replyToId) : undefined;
   const runCliJson =
     opts.runCliJson ??
     ((args: readonly string[]) => runIMessageCliJson(cliPath, dbPath, args, timeoutMs));


### PR DESCRIPTION
## Summary

When `channels.imessage.accounts.<id>.actions.reply` is explicitly `false`, the iMessage send path still forwarded `replyToId` to the imsg bridge, causing outbound delivery to fail with:

```
System Integrity Protection (SIP) is enabled. Refusing to inject
into Messages.app. Disable SIP before using imsg launch.
```

The bridge attempts a threaded/native reply via Messages.app private API, which requires SIP to be disabled. When `actions.reply` is `false`, the user has explicitly opted out of reply actions (making this a no-SIP-safe configuration), but the send layer ignored this setting.

## Fix

Gate `resolvedReplyToId` on `account.config.actions?.reply !== false`. When `actions.reply` is `false`, `replyToId` is stripped before any delivery path, so the bridge sends a normal top-level message instead of a threaded reply.

Default behavior (`actions.reply` undefined or `true`) is preserved unchanged.

## Files changed
- `extensions/imessage/src/send.ts` — gate `resolvedReplyToId` on `actions.reply`
- `extensions/imessage/src/send.test.ts` — 5 new regression tests

## Real behavior proof

**Behavior addressed:** iMessage final reply delivery fails under SIP because `replyToId` is forwarded to the imsg bridge even when `actions.reply` is `false`.

**Real environment tested:** Local OpenClaw checkout at PR head, macOS/Darwin arm64, Node v22.22.0.

**Before-fix (source-level):**
```typescript
const resolvedReplyToId = sanitizeReplyToId(opts.replyToId);
// → replyToId is always set, imsg sees --reply-to, triggers SIP gated reply injection
```

**After-fix (source-level):**
```typescript
const replyActionsEnabled = account.config.actions?.reply !== false;
const resolvedReplyToId = replyActionsEnabled ? sanitizeReplyToId(opts.replyToId) : undefined;
// → when actions.reply=false, replyToId is stripped, imsg sends a normal top-level message
```

**Test results:**
```
node scripts/run-vitest.mjs extensions/imessage/src/send.test.ts extensions/imessage/src/monitor/deliver.test.ts

Test Files  2 passed (2)
Tests      52 passed (52)
```

New regression tests in `actions.reply gating` block:
1. `includes reply_to when actions.reply is true` — explicit enable still works
2. `includes reply_to when actions.reply is not set` — default (not configured) preserves existing behavior
3. `strips reply_to when actions.reply is false` — core fix
4. `strips reply_to from media sends when actions.reply is false` — media path also gated
5. `strips reply_to from attachment send-attachment when actions.reply is false and audioAsVoice` — voice attachment path gated

Closes #92142