### PR TITLE
fix(openai): quarantine unreadable tool schemas

### DIFF
--- a/src/agents/openai-tool-projection.live.test.ts
+++ b/src/agents/openai-tool-projection.live.test.ts
@@ -1,0 +1,134 @@
+import OpenAI from "openai";
+import type { ChatCompletionCreateParamsNonStreaming } from "openai/resources/chat/completions.js";
+import type { ResponseCreateParamsNonStreaming } from "openai/resources/responses/responses.js";
+import { describe, expect, it } from "vitest";
+import type { Context, Model } from "../llm/types.js";
+import { isLiveTestEnabled } from "./live-test-helpers.js";
+import {
+  buildOpenAICompletionsParams,
+  buildOpenAIResponsesParams,
+} from "./openai-transport-stream.js";
+
+const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
+const LIVE = isLiveTestEnabled(["OPENAI_LIVE_TEST"]) && Boolean(OPENAI_KEY);
+const describeLive = LIVE ? describe : describe.skip;
+
+const probeTools = [
+  {
+    name: "unreadable_probe",
+    description: "Unreadable probe.",
+    parameters: {
+      type: "object",
+      get properties(): never {
+        throw new Error("live unreadable nested schema getter");
+      },
+    },
+  },
+  {
+    name: "live_probe",
+    description: "Return the requested probe value.",
+    parameters: {
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+      additionalProperties: false,
+    },
+  },
+];
+
+const context = {
+  systemPrompt: "Call the requested function exactly once.",
+  messages: [
+    {
+      role: "user",
+      content: "Call live_probe with value exactly OPENAI_PROJECTION_OK.",
+      timestamp: 1,
+    },
+  ],
+  tools: probeTools,
+} satisfies Context;
+
+describeLive("OpenAI tool projection live", () => {
+  const modelId = process.env.OPENCLAW_LIVE_OPENAI_TOOL_MODEL || "gpt-5.5";
+  const client = new OpenAI({ apiKey: OPENAI_KEY });
+
+  it("calls a healthy Responses function after quarantining an unreadable sibling", async () => {
+    const model = {
+      id: modelId,
+      name: modelId,
+      api: "openai-responses",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 256,
+    } satisfies Model<"openai-responses">;
+    const params = buildOpenAIResponsesParams(model, context, {
+      maxTokens: 128,
+      reasoning: "low",
+      toolChoice: { type: "function", name: "live_probe" },
+    });
+
+    const response = await client.responses.create({
+      ...params,
+      stream: false,
+    } as unknown as ResponseCreateParamsNonStreaming);
+    const toolCall = response.output.find((item) => item.type === "function_call");
+
+    expect(toolCall).toMatchObject({
+      type: "function_call",
+      name: "live_probe",
+    });
+    expect(JSON.parse(toolCall?.arguments ?? "{}")).toEqual({
+      value: "OPENAI_PROJECTION_OK",
+    });
+  }, 45_000);
+
+  it("calls a healthy Chat Completions function after quarantining an unreadable sibling", async () => {
+    const model = {
+      id: modelId,
+      name: modelId,
+      api: "openai-completions",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 256,
+    } satisfies Model<"openai-completions">;
+    const params = buildOpenAICompletionsParams(model, context, {
+      maxTokens: 128,
+      toolChoice: {
+        type: "allowed_tools",
+        allowed_tools: {
+          mode: "required",
+          tools: [
+            { type: "function", function: { name: "unreadable_probe" } },
+            { type: "function", function: { name: "live_probe" } },
+          ],
+        },
+      },
+    });
+    const { stream_options: _streamOptions, ...nonStreamingParams } = params;
+
+    const response = await client.chat.completions.create({
+      ...nonStreamingParams,
+      stream: false,
+    } as unknown as ChatCompletionCreateParamsNonStreaming);
+    const toolCall = response.choices[0]?.message.tool_calls?.[0];
+
+    if (!toolCall || toolCall.type !== "function") {
+      throw new Error("OpenAI did not return the expected function tool call");
+    }
+    expect(toolCall).toMatchObject({
+      type: "function",
+      function: { name: "live_probe" },
+    });
+    expect(JSON.parse(toolCall.function.arguments)).toEqual({
+      value: "OPENAI_PROJECTION_OK",
+    });
+  }, 45_000);
+});

--- a/src/agents/openai-tool-projection.test.ts
+++ b/src/agents/openai-tool-projection.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from "vitest";
+import {
+  projectOpenAITools,
+  reconcileOpenAICompletionsToolChoice,
+  reconcileOpenAIResponsesToolChoice,
+} from "./openai-tool-projection.js";
+
+describe("OpenAI tool projection", () => {
+  it("keeps healthy tools when sibling descriptors or schemas are unreadable", () => {
+    const projection = projectOpenAITools([
+      {
+        get name(): never {
+          throw new Error("name exploded");
+        },
+        parameters: {},
+      },
+      {
+        name: "bad_schema",
+        parameters: {
+          type: "object",
+          get properties(): never {
+            throw new Error("properties exploded");
+          },
+        },
+      },
+      {
+        name: "lookup",
+        get description(): never {
+          throw new Error("description exploded");
+        },
+        parameters: { type: "object", properties: {} },
+      },
+    ]);
+
+    expect(projection.tools).toEqual([
+      {
+        toolIndex: 2,
+        name: "lookup",
+        parameters: { type: "object", properties: {} },
+      },
+    ]);
+    expect(projection.diagnostics).toHaveLength(2);
+  });
+
+  it("reads optional descriptions once before projecting them", () => {
+    let descriptionReads = 0;
+    const projection = projectOpenAITools([
+      {
+        name: "lookup",
+        get description() {
+          descriptionReads += 1;
+          return descriptionReads === 1 ? "Lookup" : Symbol("invalid");
+        },
+        parameters: {},
+      },
+    ]);
+
+    expect(projection.tools[0]?.description).toBe("Lookup");
+    expect(descriptionReads).toBe(1);
+  });
+
+  it("keeps a healthy pinned Responses function choice", () => {
+    const projection = projectOpenAITools([{ name: "lookup", parameters: {} }]);
+
+    expect(
+      reconcileOpenAIResponsesToolChoice({ type: "function", name: "lookup" }, projection),
+    ).toEqual({ type: "function", name: "lookup" });
+  });
+
+  it("materializes pinned function choices after one name read", () => {
+    const projection = projectOpenAITools([{ name: "lookup", parameters: {} }]);
+    let responsesNameReads = 0;
+    let completionsNameReads = 0;
+    const responsesChoice = {
+      type: "function",
+      get name() {
+        responsesNameReads += 1;
+        return responsesNameReads === 1 ? "lookup" : "broken";
+      },
+    };
+    const completionsChoice = {
+      type: "function",
+      function: {
+        get name() {
+          completionsNameReads += 1;
+          return completionsNameReads === 1 ? "lookup" : "broken";
+        },
+      },
+    };
+
+    expect(reconcileOpenAIResponsesToolChoice(responsesChoice as never, projection)).toEqual({
+      type: "function",
+      name: "lookup",
+    });
+    expect(reconcileOpenAICompletionsToolChoice(completionsChoice as never, projection)).toEqual({
+      type: "function",
+      function: { name: "lookup" },
+    });
+    expect(responsesNameReads).toBe(1);
+    expect(completionsNameReads).toBe(1);
+  });
+
+  it("normalizes omitted parameters to an empty schema", () => {
+    expect(projectOpenAITools([{ name: "lookup", parameters: undefined }]).tools).toEqual([
+      {
+        toolIndex: 0,
+        name: "lookup",
+        parameters: {},
+      },
+    ]);
+  });
+
+  it("quarantines OpenAI tools with unsupported dynamic schema references", () => {
+    const projection = projectOpenAITools([
+      {
+        name: "dynamic",
+        parameters: {
+          type: "object",
+          properties: {
+            value: { $dynamicRef: "#value" },
+          },
+        },
+      },
+    ]);
+
+    expect(projection.tools).toEqual([]);
+    expect(projection.diagnostics).toEqual([
+      {
+        toolIndex: 0,
+        toolName: "dynamic",
+        violations: ["dynamic.parameters.properties.value.$dynamicRef"],
+      },
+    ]);
+  });
+
+  it("quarantines an inventory with an unreadable length", () => {
+    const tools = new Proxy([], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          throw new Error("length exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(projectOpenAITools(tools)).toEqual({
+      inputToolCount: 0,
+      tools: [],
+      diagnostics: [{ toolIndex: 0, violations: ["tool[0] is unreadable"] }],
+    });
+  });
+
+  it("rejects pinned and required choices when their function tools are unavailable", () => {
+    const projection = projectOpenAITools([
+      {
+        name: "broken",
+        get parameters(): never {
+          throw new Error("parameters exploded");
+        },
+      },
+    ]);
+
+    expect(() =>
+      reconcileOpenAIResponsesToolChoice({ type: "function", name: "broken" }, projection),
+    ).toThrow('requested unavailable tool "broken"');
+    expect(() => reconcileOpenAIResponsesToolChoice("required", projection)).toThrow(
+      "no tools survived schema conversion",
+    );
+    expect(() =>
+      reconcileOpenAICompletionsToolChoice(
+        { type: "function", function: { name: "broken" } },
+        projection,
+      ),
+    ).toThrow('requested unavailable tool "broken"');
+    expect(() => reconcileOpenAICompletionsToolChoice("required", projection)).toThrow(
+      "no tools survived schema conversion",
+    );
+  });
+
+  it("filters official Responses allowed_tools without broadening access", () => {
+    const projection = projectOpenAITools([{ name: "lookup", parameters: {} }]);
+
+    expect(
+      reconcileOpenAIResponsesToolChoice(
+        {
+          type: "allowed_tools",
+          mode: "required",
+          tools: [
+            { type: "function", name: "broken" },
+            { type: "function", name: "lookup" },
+            { type: "web_search_preview" },
+          ],
+        },
+        projection,
+      ),
+    ).toEqual({
+      type: "allowed_tools",
+      mode: "required",
+      tools: [{ type: "function", name: "lookup" }, { type: "web_search_preview" }],
+    });
+  });
+
+  it("disables an auto allowed_tools choice when no allowed tools survive", () => {
+    const projection = projectOpenAITools([{ name: "lookup", parameters: {} }]);
+
+    expect(
+      reconcileOpenAIResponsesToolChoice(
+        {
+          type: "allowed_tools",
+          mode: "auto",
+          tools: [{ type: "function", name: "broken" }],
+        },
+        projection,
+      ),
+    ).toBe("none");
+  });
+
+  it("filters official Chat Completions allowed_tools without broadening access", () => {
+    const projection = projectOpenAITools([{ name: "lookup", parameters: {} }]);
+
+    expect(
+      reconcileOpenAICompletionsToolChoice(
+        {
+          type: "allowed_tools",
+          allowed_tools: {
+            mode: "required",
+            tools: [
+              { type: "function", function: { name: "broken" } },
+              { type: "function", function: { name: "lookup" } },
+              { type: "custom", custom: { name: "shell" } },
+            ],
+          },
+        },
+        projection,
+      ),
+    ).toEqual({
+      type: "allowed_tools",
+      allowed_tools: {
+        mode: "required",
+        tools: [{ type: "function", function: { name: "lookup" } }],
+      },
+    });
+  });
+
+  it("rejects unsupported top-level Chat Completions custom choices", () => {
+    const projection = projectOpenAITools([{ name: "lookup", parameters: {} }]);
+
+    expect(() =>
+      reconcileOpenAICompletionsToolChoice(
+        { type: "custom", custom: { name: "shell" } },
+        projection,
+      ),
+    ).toThrow("custom tool_choice is unsupported");
+  });
+
+  it("disables an auto Chat Completions allowed_tools choice when none survive", () => {
+    const projection = projectOpenAITools([{ name: "lookup", parameters: {} }]);
+
+    expect(
+      reconcileOpenAICompletionsToolChoice(
+        {
+          type: "allowed_tools",
+          allowed_tools: {
+            mode: "auto",
+            tools: [
+              { type: "function", function: { name: "broken" } },
+              { type: "custom", custom: { name: "shell" } },
+            ],
+          },
+        },
+        projection,
+      ),
+    ).toBe("none");
+  });
+
+  it("preserves non-function Responses choices", () => {
+    const projection = projectOpenAITools([]);
+
+    expect(reconcileOpenAIResponsesToolChoice({ type: "web_search_preview" }, projection)).toEqual({
+      type: "web_search_preview",
+    });
+  });
+});

--- a/src/agents/openai-tool-projection.ts
+++ b/src/agents/openai-tool-projection.ts
@@ -1,0 +1,303 @@
+import type OpenAI from "openai";
+import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
+import { projectRuntimeToolInputSchema } from "./tool-schema-json-projection.js";
+
+type OpenAIToolDescriptor = {
+  readonly name?: unknown;
+  readonly description?: unknown;
+  readonly parameters: unknown;
+};
+
+export type OpenAIProjectedTool = {
+  readonly toolIndex: number;
+  readonly name: string;
+  readonly description?: string;
+  readonly parameters: Record<string, unknown>;
+};
+
+export type OpenAIToolProjectionDiagnostic = {
+  readonly toolIndex: number;
+  readonly toolName?: string;
+  readonly violations: readonly string[];
+};
+
+export type OpenAIToolProjection = {
+  readonly inputToolCount: number;
+  readonly tools: readonly OpenAIProjectedTool[];
+  readonly diagnostics: readonly OpenAIToolProjectionDiagnostic[];
+};
+
+type OpenAIResponsesToolChoice = ResponseCreateParamsStreaming["tool_choice"];
+type OpenAIResponsesAllowedToolChoice = Extract<
+  OpenAIResponsesToolChoice,
+  { type: "allowed_tools" }
+>;
+type OpenAICompletionsSdkToolChoice =
+  OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming["tool_choice"];
+type OpenAICompletionsAllowedToolChoice = Extract<
+  OpenAICompletionsSdkToolChoice,
+  { type: "allowed_tools" }
+>;
+export type OpenAICompletionsToolChoice = Exclude<
+  OpenAICompletionsSdkToolChoice,
+  { type: "custom" }
+>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function unreadableToolDiagnostic(toolIndex: number): OpenAIToolProjectionDiagnostic {
+  return {
+    toolIndex,
+    violations: [`tool[${toolIndex}] is unreadable`],
+  };
+}
+
+/** Snapshots direct/custom tool descriptors before OpenAI payload construction. */
+export function projectOpenAITools(tools: readonly OpenAIToolDescriptor[]): OpenAIToolProjection {
+  let inputToolCount: number;
+  try {
+    inputToolCount = tools.length;
+  } catch {
+    return {
+      inputToolCount: 0,
+      tools: [],
+      diagnostics: [unreadableToolDiagnostic(0)],
+    };
+  }
+
+  const projectedTools: OpenAIProjectedTool[] = [];
+  const diagnostics: OpenAIToolProjectionDiagnostic[] = [];
+  for (let toolIndex = 0; toolIndex < inputToolCount; toolIndex += 1) {
+    let tool: OpenAIToolDescriptor;
+    try {
+      tool = tools[toolIndex];
+    } catch {
+      diagnostics.push(unreadableToolDiagnostic(toolIndex));
+      continue;
+    }
+
+    let name: unknown;
+    try {
+      name = tool.name;
+    } catch {
+      diagnostics.push({
+        toolIndex,
+        violations: [`tool[${toolIndex}].name is unreadable`],
+      });
+      continue;
+    }
+    if (typeof name !== "string" || !name) {
+      diagnostics.push({
+        toolIndex,
+        violations: [`tool[${toolIndex}].name is empty`],
+      });
+      continue;
+    }
+
+    let parameters: unknown;
+    try {
+      parameters = tool.parameters;
+    } catch {
+      diagnostics.push({
+        toolIndex,
+        toolName: name,
+        violations: [`${name}.parameters is unreadable`],
+      });
+      continue;
+    }
+    const schemaProjection = projectRuntimeToolInputSchema(parameters ?? {}, `${name}.parameters`);
+    if (!isRecord(schemaProjection.schema) || schemaProjection.violations.length > 0) {
+      diagnostics.push({
+        toolIndex,
+        toolName: name,
+        violations:
+          schemaProjection.violations.length > 0
+            ? schemaProjection.violations
+            : [`${name}.parameters must be a JSON object schema`],
+      });
+      continue;
+    }
+
+    let descriptionValue: unknown;
+    try {
+      descriptionValue = tool.description;
+    } catch {
+      // Description is optional; preserve the usable function schema.
+    }
+    const description = typeof descriptionValue === "string" ? descriptionValue : undefined;
+    projectedTools.push({
+      toolIndex,
+      name,
+      ...(description !== undefined ? { description } : {}),
+      parameters: schemaProjection.schema,
+    });
+  }
+
+  return {
+    inputToolCount,
+    tools: projectedTools,
+    diagnostics,
+  };
+}
+
+function requireProjectedFunction(
+  name: string,
+  projection: OpenAIToolProjection,
+  choiceLabel: string,
+): void {
+  if (!projection.tools.some((tool) => tool.name === name)) {
+    throw new Error(`${choiceLabel} requested unavailable tool "${name}" after schema conversion`);
+  }
+}
+
+/** Keeps Responses tool choices aligned with surviving function schemas. */
+export function reconcileOpenAIResponsesToolChoice(
+  choice: OpenAIResponsesToolChoice,
+  projection: OpenAIToolProjection,
+): OpenAIResponsesToolChoice | undefined {
+  if (choice === "auto") {
+    return projection.tools.length > 0 ? choice : undefined;
+  }
+  if (choice === "required") {
+    if (projection.tools.length === 0) {
+      throw new Error(
+        "OpenAI Responses tool_choice requires a tool, but no tools survived schema conversion",
+      );
+    }
+    return choice;
+  }
+  if (choice === "none" || !isRecord(choice)) {
+    return choice;
+  }
+  const choiceType = choice.type;
+  if (choiceType === "function") {
+    const functionName = choice.name;
+    if (typeof functionName !== "string") {
+      return choice;
+    }
+    requireProjectedFunction(functionName, projection, "OpenAI Responses tool_choice");
+    return { type: "function", name: functionName };
+  }
+  if (choiceType !== "allowed_tools") {
+    return choice;
+  }
+
+  const mode = choice.mode;
+  const tools = choice.tools;
+  if ((mode !== "auto" && mode !== "required") || !Array.isArray(tools)) {
+    return choice;
+  }
+  const normalizedAllowedTools: OpenAIResponsesAllowedToolChoice["tools"] = [];
+  for (const tool of tools) {
+    if (!isRecord(tool) || tool.type !== "function") {
+      normalizedAllowedTools.push(tool);
+      continue;
+    }
+    const functionName = tool.name;
+    if (
+      typeof functionName === "string" &&
+      projection.tools.some((projectedTool) => projectedTool.name === functionName)
+    ) {
+      normalizedAllowedTools.push({ type: "function", name: functionName });
+    }
+  }
+  if (normalizedAllowedTools.length === 0) {
+    if (mode === "auto") {
+      return "none";
+    }
+    throw new Error(
+      "OpenAI Responses tool_choice requires a tool, but no allowed tools survived schema conversion",
+    );
+  }
+  return {
+    type: "allowed_tools",
+    mode,
+    tools: normalizedAllowedTools,
+  };
+}
+
+/** Keeps Chat Completions tool choices aligned with surviving function schemas. */
+export function reconcileOpenAICompletionsToolChoice(
+  choice: OpenAICompletionsSdkToolChoice,
+  projection: OpenAIToolProjection,
+): OpenAICompletionsSdkToolChoice | undefined {
+  if (choice === "auto") {
+    return projection.tools.length > 0 ? choice : undefined;
+  }
+  if (choice === "required") {
+    if (projection.tools.length === 0) {
+      throw new Error(
+        "OpenAI Chat Completions tool_choice requires a tool, but no tools survived schema conversion",
+      );
+    }
+    return choice;
+  }
+  if (choice === "none" || !isRecord(choice)) {
+    return choice;
+  }
+  const choiceType = choice.type;
+  if (choiceType === "custom") {
+    throw new Error(
+      "OpenAI Chat Completions custom tool_choice is unsupported because this adapter emits function tools only",
+    );
+  }
+  if (choiceType === "function") {
+    const functionChoice = choice.function;
+    if (!isRecord(functionChoice)) {
+      return choice;
+    }
+    const functionName = functionChoice.name;
+    if (typeof functionName !== "string") {
+      return choice;
+    }
+    requireProjectedFunction(functionName, projection, "OpenAI Chat Completions tool_choice");
+    return { type: "function", function: { name: functionName } };
+  }
+  if (choiceType !== "allowed_tools") {
+    return choice;
+  }
+
+  const allowedConfig = choice.allowed_tools;
+  if (!isRecord(allowedConfig)) {
+    return choice;
+  }
+  const mode = allowedConfig.mode;
+  const tools = allowedConfig.tools;
+  if ((mode !== "auto" && mode !== "required") || !Array.isArray(tools)) {
+    return choice;
+  }
+  const normalizedAllowedTools: OpenAICompletionsAllowedToolChoice["allowed_tools"]["tools"] = [];
+  for (const tool of tools) {
+    if (!isRecord(tool) || tool.type !== "function") {
+      continue;
+    }
+    const functionChoice = tool.function;
+    const functionName = isRecord(functionChoice) ? functionChoice.name : undefined;
+    if (
+      typeof functionName === "string" &&
+      projection.tools.some((projectedTool) => projectedTool.name === functionName)
+    ) {
+      normalizedAllowedTools.push({
+        type: "function",
+        function: { name: functionName },
+      });
+    }
+  }
+  if (normalizedAllowedTools.length === 0) {
+    if (mode === "auto") {
+      return "none";
+    }
+    throw new Error(
+      "OpenAI Chat Completions tool_choice requires a tool, but no allowed tools survived schema conversion",
+    );
+  }
+  return {
+    type: "allowed_tools",
+    allowed_tools: {
+      mode,
+      tools: normalizedAllowedTools,
+    },
+  };
+}

--- a/src/agents/openai-tool-schema.test.ts
+++ b/src/agents/openai-tool-schema.test.ts
@@ -1,10 +1,14 @@
 // Verifies OpenAI strict tool schema normalization and cache behavior.
 import { beforeEach, describe, expect, it } from "vitest";
+import { projectOpenAITools } from "./openai-tool-projection.js";
 import {
   clearOpenAIToolSchemaCacheForTest,
+  findOpenAIStrictToolSchemaDiagnostics,
   isStrictOpenAIJsonSchemaCompatible,
+  normalizeOpenAIStrictToolParameters,
   normalizeStrictOpenAIJsonSchema,
   resolveOpenAIStrictToolFlagForInventory,
+  resolveOpenAIStrictToolFlagForProjection,
 } from "./openai-tool-schema.js";
 
 describe("OpenAI strict tool schema normalization", () => {
@@ -93,5 +97,53 @@ describe("OpenAI strict tool schema normalization", () => {
         unsupportedToolSchemaKeywords: ["minimum"],
       }),
     ).toBe(third);
+  });
+
+  it("reports unreadable nested tool schemas instead of throwing", () => {
+    const unreadable = {
+      name: "broken",
+      parameters: {
+        type: "object",
+        get properties(): never {
+          throw new Error("properties exploded");
+        },
+      },
+    };
+
+    expect(findOpenAIStrictToolSchemaDiagnostics([unreadable])).toEqual([
+      {
+        toolIndex: 0,
+        toolName: "broken",
+        violations: ["broken.parameters is not JSON-serializable"],
+      },
+    ]);
+    expect(resolveOpenAIStrictToolFlagForInventory([unreadable], true)).toBe(false);
+  });
+
+  it("reuses projected schemas for strict checks and normalization", () => {
+    let serializationCount = 0;
+    const projection = projectOpenAITools([
+      {
+        name: "lookup",
+        parameters: {
+          toJSON() {
+            serializationCount += 1;
+            return {
+              type: "object",
+              properties: {},
+              required: [],
+              additionalProperties: false,
+            };
+          },
+        },
+      },
+    ]);
+    const tool = projection.tools[0];
+    expect(tool).toBeDefined();
+
+    expect(resolveOpenAIStrictToolFlagForProjection(projection, true)).toBe(true);
+    const normalized = normalizeOpenAIStrictToolParameters(tool?.parameters, true);
+    expect(normalizeOpenAIStrictToolParameters(tool?.parameters, true)).toBe(normalized);
+    expect(serializationCount).toBe(1);
   });
 });

--- a/src/agents/openai-tool-schema.ts
+++ b/src/agents/openai-tool-schema.ts
@@ -6,6 +6,7 @@
 import type { ModelCompatConfig } from "../config/types.models.js";
 import { shouldOmitEmptyArrayItems } from "../plugins/provider-model-compat.js";
 import { normalizeToolParameterSchema } from "./agent-tools-parameter-schema.js";
+import { projectOpenAITools, type OpenAIToolProjection } from "./openai-tool-projection.js";
 
 /**
  * OpenAI strict-tool-schema normalization and diagnostics.
@@ -20,6 +21,7 @@ type ToolSchemaCompatInput = {
 
 type ToolWithParameters = {
   name?: unknown;
+  description?: unknown;
   parameters: unknown;
 };
 
@@ -183,22 +185,29 @@ type OpenAIStrictToolSchemaDiagnostic = {
 export function findOpenAIStrictToolSchemaDiagnostics(
   tools: readonly ToolWithParameters[],
 ): OpenAIStrictToolSchemaDiagnostic[] {
-  return tools.flatMap((tool, toolIndex) => {
-    const violations = findStrictOpenAIJsonSchemaViolations(
-      normalizeStrictOpenAIJsonSchema(tool.parameters),
-      `${typeof tool.name === "string" && tool.name ? tool.name : `tool[${toolIndex}]`}.parameters`,
-    );
-    if (violations.length === 0) {
-      return [];
-    }
-    return [
-      {
-        toolIndex,
-        ...(typeof tool.name === "string" && tool.name ? { toolName: tool.name } : {}),
-        violations,
-      },
-    ];
-  });
+  return findOpenAIStrictToolProjectionDiagnostics(projectOpenAITools(tools));
+}
+
+/** Returns strict-schema diagnostics for an already materialized OpenAI tool projection. */
+export function findOpenAIStrictToolProjectionDiagnostics(
+  projection: OpenAIToolProjection,
+): OpenAIStrictToolSchemaDiagnostic[] {
+  return [
+    ...projection.diagnostics.map((diagnostic) => ({
+      toolIndex: diagnostic.toolIndex,
+      ...(diagnostic.toolName ? { toolName: diagnostic.toolName } : {}),
+      violations: [...diagnostic.violations],
+    })),
+    ...projection.tools.flatMap((tool) => {
+      const violations = findStrictOpenAIJsonSchemaViolations(
+        normalizeStrictOpenAIJsonSchema(tool.parameters),
+        `${tool.name}.parameters`,
+      );
+      return violations.length > 0
+        ? [{ toolIndex: tool.toolIndex, toolName: tool.name, violations }]
+        : [];
+    }),
+  ];
 }
 
 function isStrictOpenAIJsonSchemaCompatibleRecursive(schema: unknown): boolean {
@@ -319,8 +328,20 @@ export function resolveOpenAIStrictToolFlagForInventory(
   tools: readonly ToolWithParameters[],
   strict: boolean | null | undefined,
 ): boolean | undefined {
+  const projection = projectOpenAITools(tools);
+  if (strict === true && projection.diagnostics.length > 0) {
+    return false;
+  }
+  return resolveOpenAIStrictToolFlagForProjection(projection, strict);
+}
+
+/** Resolves the strict flag without reserializing an existing OpenAI tool projection. */
+export function resolveOpenAIStrictToolFlagForProjection(
+  projection: OpenAIToolProjection,
+  strict: boolean | null | undefined,
+): boolean | undefined {
   if (strict !== true) {
     return strict === false ? false : undefined;
   }
-  return tools.every((tool) => isStrictOpenAIJsonSchemaCompatible(tool.parameters));
+  return projection.tools.every((tool) => isStrictOpenAIJsonSchemaCompatible(tool.parameters));
 }

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5065,6 +5065,247 @@ describe("openai transport stream", () => {
     expect(params.tool_choice).toBe("required");
   });
 
+  it("keeps healthy Responses tools when a sibling schema is unreadable", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          {
+            name: "broken",
+            description: "Broken",
+            get parameters(): never {
+              throw new Error("parameters exploded");
+            },
+          },
+          {
+            name: "lookup",
+            description: "Lookup",
+            parameters: {},
+          },
+        ],
+      } as never,
+      { toolChoice: { type: "function", name: "lookup" } },
+    ) as {
+      tools?: Array<{ name?: string; strict?: boolean }>;
+      tool_choice?: unknown;
+    };
+
+    expect(params.tools).toEqual([expect.objectContaining({ name: "lookup", strict: true })]);
+    expect(params.tool_choice).toEqual({ type: "function", name: "lookup" });
+  });
+
+  it("fails locally when a pinned Responses tool is unreadable", () => {
+    expect(() =>
+      buildOpenAIResponsesParams(
+        {
+          id: "gpt-5.5",
+          name: "GPT-5.5",
+          api: "openai-responses",
+          provider: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } satisfies Model<"openai-responses">,
+        {
+          systemPrompt: "system",
+          messages: [],
+          tools: [
+            {
+              name: "broken",
+              get parameters(): never {
+                throw new Error("parameters exploded");
+              },
+            },
+          ],
+        } as never,
+        { toolChoice: { type: "function", name: "broken" } },
+      ),
+    ).toThrow('requested unavailable tool "broken"');
+  });
+
+  it("filters official Responses allowed_tools against projected functions", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          {
+            name: "lookup",
+            description: "Lookup",
+            parameters: {},
+          },
+        ],
+      } as never,
+      {
+        toolChoice: {
+          type: "allowed_tools",
+          mode: "required",
+          tools: [
+            { type: "function", name: "broken" },
+            { type: "function", name: "lookup" },
+          ],
+        },
+      },
+    ) as { tool_choice?: unknown };
+
+    expect(params.tool_choice).toEqual({
+      type: "allowed_tools",
+      mode: "required",
+      tools: [{ type: "function", name: "lookup" }],
+    });
+  });
+
+  it("fails locally when required Chat Completions has no usable tools", () => {
+    expect(() =>
+      buildOpenAICompletionsParams(
+        {
+          id: "gpt-5.5",
+          name: "GPT-5.5",
+          api: "openai-completions",
+          provider: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } satisfies Model<"openai-completions">,
+        {
+          systemPrompt: "system",
+          messages: [],
+          tools: [
+            {
+              name: "broken",
+              get parameters(): never {
+                throw new Error("parameters exploded");
+              },
+            },
+          ],
+        } as never,
+        { toolChoice: "required" },
+      ),
+    ).toThrow("no tools survived schema conversion");
+  });
+
+  it("preserves the native empty tools marker for tool history after quarantining every schema", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_abc",
+                name: "lookup",
+                arguments: {},
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "done" }],
+            toolCallId: "call_abc",
+          },
+          { role: "user", content: "continue", timestamp: 1 },
+        ],
+        tools: [
+          {
+            name: "broken",
+            description: "Broken tool.",
+            get parameters(): never {
+              throw new Error("parameters exploded");
+            },
+          },
+        ],
+      } as never,
+      undefined,
+    ) as { tools?: unknown[] };
+
+    expect(params.tools).toEqual([]);
+  });
+
+  it("does not reread an unreadable tool inventory length", () => {
+    const tools = new Proxy([], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          throw new Error("length exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const responsesModel = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      api: "openai-responses",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-responses">;
+    const completionsModel = {
+      ...responsesModel,
+      api: "openai-completions",
+      reasoning: false,
+    } satisfies Model<"openai-completions">;
+    const context = {
+      systemPrompt: "system",
+      messages: [{ role: "user", content: "hello", timestamp: 1 }],
+      tools,
+    } as never;
+
+    expect(buildOpenAIResponsesParams(responsesModel, context, undefined)).not.toHaveProperty(
+      "tools",
+    );
+    expect(buildOpenAICompletionsParams(completionsModel, context, undefined)).not.toHaveProperty(
+      "tools",
+    );
+  });
+
   it("sorts Responses tools by name for stable prompt-cache payloads", () => {
     const model = {
       id: "gpt-5.4",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -72,9 +72,16 @@ import {
 import { resolveReplayableResponsesMessageId } from "./openai-responses-replay.js";
 import { resolveOpenAIStrictToolSetting } from "./openai-strict-tool-setting.js";
 import {
-  findOpenAIStrictToolSchemaDiagnostics,
+  projectOpenAITools,
+  reconcileOpenAICompletionsToolChoice,
+  reconcileOpenAIResponsesToolChoice,
+  type OpenAICompletionsToolChoice,
+  type OpenAIToolProjection,
+} from "./openai-tool-projection.js";
+import {
+  findOpenAIStrictToolProjectionDiagnostics,
   normalizeOpenAIStrictToolParameters,
-  resolveOpenAIStrictToolFlagForInventory,
+  resolveOpenAIStrictToolFlagForProjection,
 } from "./openai-tool-schema.js";
 import { resolveProviderRequestPolicyConfig } from "./provider-request-config.js";
 import {
@@ -199,16 +206,7 @@ type OpenAIResponsesReplayContext = {
 };
 
 type OpenAICompletionsOptions = BaseStreamOptions & {
-  toolChoice?:
-    | "auto"
-    | "none"
-    | "required"
-    | {
-        type: "function";
-        function: {
-          name: string;
-        };
-      };
+  toolChoice?: OpenAICompletionsToolChoice;
   reasoning?: OpenAIReasoningEffort;
   reasoningEffort?: OpenAIReasoningEffort;
 };
@@ -1282,37 +1280,41 @@ function convertResponsesTools(
   tools: NonNullable<Context["tools"]>,
   model: OpenAIModeModel,
   options?: { strict?: boolean | null },
-): FunctionTool[] {
-  const strict = resolveOpenAIStrictToolFlagWithDiagnostics(tools, options?.strict, {
+): { projection: OpenAIToolProjection; tools: FunctionTool[] } {
+  const projection = projectOpenAITools(tools);
+  const strict = resolveOpenAIStrictToolFlagWithDiagnostics(projection, options?.strict, {
     transport: "responses",
     model,
   });
-  return sortTransportToolsByName(tools).map((tool): FunctionTool => {
-    const result = {
-      type: "function" as const,
-      name: tool.name,
-      description: tool.description,
-      parameters: normalizeOpenAIStrictToolParameters(
-        tool.parameters,
-        strict === true,
-        model.compat,
-      ) as Record<string, unknown>,
-    } as FunctionTool;
-    if (strict !== undefined) {
-      result.strict = strict;
-    }
-    return result;
-  });
+  return {
+    projection,
+    tools: sortTransportToolsByName(projection.tools).map((tool): FunctionTool => {
+      const result = {
+        type: "function" as const,
+        name: tool.name,
+        description: tool.description,
+        parameters: normalizeOpenAIStrictToolParameters(
+          tool.parameters,
+          strict === true,
+          model.compat,
+        ),
+      } as FunctionTool;
+      if (strict !== undefined) {
+        result.strict = strict;
+      }
+      return result;
+    }),
+  };
 }
 
 function resolveOpenAIStrictToolFlagWithDiagnostics(
-  tools: NonNullable<Context["tools"]>,
+  projection: OpenAIToolProjection,
   strictSetting: boolean | null | undefined,
   context: { transport: "responses" | "completions"; model: OpenAIModeModel },
 ): boolean | undefined {
-  const strict = resolveOpenAIStrictToolFlagForInventory(tools, strictSetting);
+  const strict = resolveOpenAIStrictToolFlagForProjection(projection, strictSetting);
   if (strictSetting === true && strict === false && log.isEnabled("debug", "any")) {
-    const diagnostics = findOpenAIStrictToolSchemaDiagnostics(tools);
+    const diagnostics = findOpenAIStrictToolProjectionDiagnostics(projection);
     if (!shouldLogOpenAIStrictToolDowngradeDiagnostic(diagnostics, context)) {
       return strict;
     }
@@ -1337,7 +1339,7 @@ function resolveOpenAIStrictToolFlagWithDiagnostics(
 }
 
 function buildOpenAIStrictToolDowngradeDiagnosticKey(
-  diagnostics: ReturnType<typeof findOpenAIStrictToolSchemaDiagnostics>,
+  diagnostics: ReturnType<typeof findOpenAIStrictToolProjectionDiagnostics>,
   context: { transport: "responses" | "completions"; model: OpenAIModeModel },
 ): string {
   return createHash("sha256")
@@ -1357,7 +1359,7 @@ function buildOpenAIStrictToolDowngradeDiagnosticKey(
 }
 
 function shouldLogOpenAIStrictToolDowngradeDiagnostic(
-  diagnostics: ReturnType<typeof findOpenAIStrictToolSchemaDiagnostics>,
+  diagnostics: ReturnType<typeof findOpenAIStrictToolProjectionDiagnostics>,
   context: { transport: "responses" | "completions"; model: OpenAIModeModel },
 ): boolean {
   const key = buildOpenAIStrictToolDowngradeDiagnosticKey(diagnostics, context);
@@ -2261,13 +2263,25 @@ export function buildOpenAIResponsesParams(
     params.service_tier = options.serviceTier;
   }
   if (context.tools) {
-    params.tools = convertResponsesTools(context.tools, model as OpenAIModeModel, {
+    const converted = convertResponsesTools(context.tools, model as OpenAIModeModel, {
       strict: resolveOpenAIStrictToolSetting(model as OpenAIModeModel, {
         transport: "stream",
       }),
     });
+    if (
+      converted.tools.length > 0 ||
+      (converted.projection.inputToolCount === 0 && converted.projection.diagnostics.length === 0)
+    ) {
+      params.tools = converted.tools;
+    }
     if (options?.toolChoice) {
-      params.tool_choice = options.toolChoice;
+      const toolChoice = reconcileOpenAIResponsesToolChoice(
+        options.toolChoice,
+        converted.projection,
+      );
+      if (toolChoice !== undefined) {
+        params.tool_choice = toolChoice;
+      }
     }
   }
   if (model.reasoning) {
@@ -3707,8 +3721,9 @@ function convertTools(
   compat: ReturnType<typeof getCompat>,
   model: OpenAIModeModel,
 ) {
+  const projection = projectOpenAITools(tools);
   const strict = resolveOpenAIStrictToolFlagWithDiagnostics(
-    tools,
+    projection,
     resolveOpenAIStrictToolSetting(model, {
       transport: "stream",
       supportsStrictMode: compat?.supportsStrictMode,
@@ -3718,29 +3733,32 @@ function convertTools(
       model,
     },
   );
-  return sortTransportToolsByName(tools).map((tool) => {
-    const functionTool: {
-      name: string;
-      description: string | undefined;
-      parameters: ReturnType<typeof normalizeOpenAIStrictToolParameters>;
-      strict?: boolean;
-    } = {
-      name: tool.name,
-      description: tool.description,
-      parameters: normalizeOpenAIStrictToolParameters(
-        tool.parameters,
-        strict === true,
-        model.compat,
-      ),
-    };
-    if (strict !== undefined) {
-      functionTool.strict = strict;
-    }
-    return {
-      type: "function",
-      function: functionTool,
-    };
-  });
+  return {
+    projection,
+    tools: sortTransportToolsByName(projection.tools).map((tool) => {
+      const functionTool: {
+        name: string;
+        description: string | undefined;
+        parameters: ReturnType<typeof normalizeOpenAIStrictToolParameters>;
+        strict?: boolean;
+      } = {
+        name: tool.name,
+        description: tool.description,
+        parameters: normalizeOpenAIStrictToolParameters(
+          tool.parameters,
+          strict === true,
+          model.compat,
+        ),
+      };
+      if (strict !== undefined) {
+        functionTool.strict = strict;
+      }
+      return {
+        type: "function",
+        function: functionTool,
+      };
+    }),
+  };
 }
 
 function compareTransportToolText(left: string | undefined, right: string | undefined): number {
@@ -4142,9 +4160,23 @@ export function buildOpenAICompletionsParams(
   }
   if (supportsModelTools(model)) {
     if (context.tools) {
-      params.tools = convertTools(context.tools, compat, model);
+      const converted = convertTools(context.tools, compat, model);
+      if (
+        converted.tools.length > 0 ||
+        (converted.projection.inputToolCount === 0 && converted.projection.diagnostics.length === 0)
+      ) {
+        params.tools = converted.tools;
+      } else if (hasToolHistory(context.messages)) {
+        params.tools = [];
+      }
       if (options?.toolChoice) {
-        params.tool_choice = options.toolChoice;
+        const toolChoice = reconcileOpenAICompletionsToolChoice(
+          options.toolChoice,
+          converted.projection,
+        );
+        if (toolChoice !== undefined) {
+          params.tool_choice = toolChoice;
+        }
       } else if (
         compatDetection.capabilities.usesExplicitProxyLikeEndpoint &&
         Array.isArray(params.tools) &&

--- a/src/llm/providers/openai-chatgpt-responses.test.ts
+++ b/src/llm/providers/openai-chatgpt-responses.test.ts
@@ -246,6 +246,75 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(functionCall).not.toHaveProperty("id");
   });
 
+  it("omits ChatGPT tool controls when every tool schema is unreadable", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const stream = streamOpenAICodexResponses(
+      model,
+      {
+        ...context,
+        tools: [
+          {
+            name: "broken",
+            description: "Broken tool.",
+            get parameters(): never {
+              throw new Error("parameters exploded");
+            },
+          },
+        ],
+      },
+      {
+        apiKey: createJwt({
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: "acct-1",
+          },
+        }),
+        transport: "sse",
+        onPayload: (payload) => {
+          capturedPayload = payload as Record<string, unknown>;
+          throw new Error("stop after payload");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedPayload).not.toHaveProperty("tools");
+    expect(capturedPayload).not.toHaveProperty("tool_choice");
+    expect(capturedPayload).not.toHaveProperty("parallel_tool_calls");
+  });
+
+  it("does not reread an unreadable ChatGPT tool inventory length", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const tools = new Proxy([], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          throw new Error("length exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const stream = streamOpenAICodexResponses(model, { ...context, tools } as never, {
+      apiKey: createJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "acct-1",
+        },
+      }),
+      transport: "sse",
+      onPayload: (payload) => {
+        capturedPayload = payload as Record<string, unknown>;
+        throw new Error("stop after payload");
+      },
+    });
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedPayload).not.toHaveProperty("tools");
+    expect(capturedPayload).not.toHaveProperty("tool_choice");
+    expect(capturedPayload).not.toHaveProperty("parallel_tool_calls");
+  });
+
   it("caps oversized timeoutMs before creating request abort signals", async () => {
     stubHangingFetch(MAX_TIMER_TIMEOUT_MS);
 

--- a/src/llm/providers/openai-chatgpt-responses.ts
+++ b/src/llm/providers/openai-chatgpt-responses.ts
@@ -49,7 +49,7 @@ import { resolveOpenAICodexAccountId } from "../utils/oauth/openai-chatgpt-jwt.j
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
 import {
   convertResponsesMessages,
-  convertResponsesTools,
+  convertResponsesToolPayload,
   processResponsesStream,
 } from "./openai-responses-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
@@ -508,8 +508,16 @@ function buildRequestBody(
     body.service_tier = options.serviceTier;
   }
 
-  if (context.tools && context.tools.length > 0) {
-    body.tools = convertResponsesTools(context.tools, { strict: null });
+  if (context.tools) {
+    const converted = convertResponsesToolPayload(context.tools, { strict: null });
+    if (converted.projection.inputToolCount > 0 || converted.projection.diagnostics.length > 0) {
+      body.tools = converted.tools;
+      if (body.tools.length === 0) {
+        delete body.tools;
+        delete body.tool_choice;
+        delete body.parallel_tool_calls;
+      }
+    }
   }
 
   if (options?.reasoningEffort !== undefined) {

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -118,6 +118,160 @@ function makeFinishChunk(
 }
 
 describe("OpenAI-compatible completions params", () => {
+  it("skips unreadable schemas while preserving healthy official OpenAI tools", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const stream = streamOpenAICompletions(
+      model,
+      {
+        ...context,
+        tools: [
+          {
+            name: "broken",
+            description: "Broken",
+            parameters: {
+              type: "object",
+              get properties(): never {
+                throw new Error("properties exploded");
+              },
+            },
+          },
+          {
+            name: "lookup",
+            description: "Lookup",
+            parameters: {},
+          },
+        ],
+      },
+      {
+        apiKey: "sk-test",
+        toolChoice: { type: "function", function: { name: "lookup" } },
+        onPayload(payload) {
+          capturedPayload = payload as Record<string, unknown>;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedPayload?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "lookup",
+          description: "Lookup",
+          parameters: {},
+          strict: false,
+        },
+      },
+    ]);
+    expect(capturedPayload?.tool_choice).toEqual({
+      type: "function",
+      function: { name: "lookup" },
+    });
+  });
+
+  it("fails locally when a pinned official OpenAI tool is unreadable", async () => {
+    const stream = streamOpenAICompletions(
+      model,
+      {
+        ...context,
+        tools: [
+          {
+            name: "broken",
+            description: "Broken tool.",
+            get parameters(): never {
+              throw new Error("parameters exploded");
+            },
+          },
+        ],
+      },
+      {
+        apiKey: "sk-test",
+        toolChoice: { type: "function", function: { name: "broken" } },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain('requested unavailable tool "broken"');
+  });
+
+  it("preserves the empty tools marker for tool history after quarantining every schema", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const stream = streamOpenAICompletions(
+      model,
+      {
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_abc",
+                name: "lookup",
+                arguments: {},
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "done" }],
+            toolCallId: "call_abc",
+          },
+          ...context.messages,
+        ],
+        tools: [
+          {
+            name: "broken",
+            description: "Broken tool.",
+            get parameters(): never {
+              throw new Error("parameters exploded");
+            },
+          },
+        ],
+      } as never,
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedPayload = payload as Record<string, unknown>;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedPayload?.tools).toEqual([]);
+  });
+
+  it("does not reread an unreadable tool inventory length", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const tools = new Proxy([], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          throw new Error("length exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const stream = streamOpenAICompletions(model, { ...context, tools } as never, {
+      apiKey: "sk-test",
+      onPayload(payload) {
+        capturedPayload = payload as Record<string, unknown>;
+        throw new Error("stop before network");
+      },
+    });
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedPayload).not.toHaveProperty("tools");
+  });
+
   it("clamps requested max tokens to the model output cap", async () => {
     let capturedMaxTokens: unknown;
     const stream = streamOpenAICompletions(createModel(32_000), context, {

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -12,6 +12,12 @@ import type {
   ChatCompletionToolMessageParam,
 } from "openai/resources/chat/completions.js";
 import {
+  projectOpenAITools,
+  reconcileOpenAICompletionsToolChoice,
+  type OpenAICompletionsToolChoice,
+  type OpenAIToolProjection,
+} from "../../agents/openai-tool-projection.js";
+import {
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
 } from "../../agents/system-prompt-cache-boundary.js";
@@ -82,7 +88,7 @@ function isImageContentBlock(block: { type: string }): block is ImageContent {
 }
 
 export interface OpenAICompletionsOptions extends StreamOptions {
-  toolChoice?: "auto" | "none" | "required" | { type: "function"; function: { name: string } };
+  toolChoice?: OpenAICompletionsToolChoice;
   reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
 }
 
@@ -653,9 +659,16 @@ function buildParams(
     params.stop = options.stop;
   }
 
-  if (context.tools && context.tools.length > 0) {
-    params.tools = convertTools(context.tools, compat);
-    if (compat.zaiToolStream) {
+  let toolProjection: OpenAIToolProjection | undefined;
+  if (context.tools) {
+    const converted = convertTools(context.tools, compat);
+    toolProjection = converted.projection;
+    if (converted.tools.length > 0) {
+      params.tools = converted.tools;
+    } else if (hasToolHistory(context.messages)) {
+      params.tools = [];
+    }
+    if (compat.zaiToolStream && converted.tools.length > 0) {
       params.tool_stream = true;
     }
   } else if (hasToolHistory(context.messages)) {
@@ -668,7 +681,13 @@ function buildParams(
   }
 
   if (options?.toolChoice) {
-    params.tool_choice = options.toolChoice;
+    const toolChoice = reconcileOpenAICompletionsToolChoice(
+      options.toolChoice,
+      toolProjection ?? projectOpenAITools([]),
+    );
+    if (toolChoice !== undefined) {
+      params.tool_choice = toolChoice;
+    }
   }
 
   if (compat.thinkingFormat === "zai" && model.reasoning) {
@@ -1155,17 +1174,24 @@ export function convertMessages(
 function convertTools(
   tools: Tool[],
   compat: ResolvedOpenAICompletionsCompat,
-): OpenAI.Chat.Completions.ChatCompletionTool[] {
-  return tools.map((tool) => ({
-    type: "function",
-    function: {
-      name: tool.name,
-      description: tool.description,
-      parameters: tool.parameters as Record<string, unknown>, // TypeBox already generates JSON Schema
-      // Only include strict if provider supports it. Some reject unknown fields.
-      ...(compat.supportsStrictMode && { strict: false }),
-    },
-  }));
+): {
+  projection: OpenAIToolProjection;
+  tools: OpenAI.Chat.Completions.ChatCompletionTool[];
+} {
+  const projection = projectOpenAITools(tools);
+  return {
+    projection,
+    tools: projection.tools.map((tool) => ({
+      type: "function",
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+        // Only include strict if provider supports it. Some reject unknown fields.
+        ...(compat.supportsStrictMode && { strict: false }),
+      },
+    })),
+  };
 }
 
 function parseChunkUsage(

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { AssistantMessage, AssistantMessageEvent, Context, Model, Tool } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import {
+  applyCommonResponsesParams,
   createResponsesAssistantOutput,
   convertResponsesMessages,
   type OpenAIResponsesStreamEvent,
@@ -176,6 +177,63 @@ describe("convertResponsesTools", () => {
     expect(
       convertResponsesTools([zeta, alpha]).map((tool) => expectResponsesFunctionTool(tool).name),
     ).toEqual(["alpha", "zeta"]);
+  });
+
+  it("skips unreadable schemas and preserves healthy native strict tools", () => {
+    const converted = convertResponsesTools(
+      [
+        {
+          name: "broken",
+          description: "Broken",
+          parameters: {
+            type: "object",
+            get properties(): never {
+              throw new Error("properties exploded");
+            },
+          },
+        },
+        {
+          name: "lookup",
+          description: "Lookup",
+          parameters: {},
+        },
+      ],
+      { model: nativeOpenAIModel },
+    );
+
+    expect(converted).toEqual([
+      {
+        type: "function",
+        name: "lookup",
+        description: "Lookup",
+        strict: true,
+        parameters: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      },
+    ]);
+  });
+
+  it("does not reread an unreadable tool inventory length", () => {
+    const tools = new Proxy([], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          throw new Error("length exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const params = {} as never;
+
+    applyCommonResponsesParams(params, nativeOpenAIModel, {
+      messages: [{ role: "user", content: "hello", timestamp: 1 }],
+      tools,
+    } as never);
+
+    expect(params).not.toHaveProperty("tools");
   });
 });
 

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -42,7 +42,7 @@ import { shortHash } from "../utils/hash.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
-import { convertResponsesTools } from "./openai-responses-tools.js";
+import { convertResponsesToolPayload, convertResponsesTools } from "./openai-responses-tools.js";
 import { transformMessages } from "./transform-messages.js";
 
 // =============================================================================
@@ -158,7 +158,7 @@ export interface ConvertResponsesMessagesOptions {
   includeSystemPrompt?: boolean;
   replayResponsesItemIds?: boolean;
 }
-export { convertResponsesTools };
+export { convertResponsesToolPayload, convertResponsesTools };
 export type { ConvertResponsesToolsOptions } from "./openai-responses-tools.js";
 
 type ResponsesRequestOptions = {
@@ -464,8 +464,11 @@ export function applyCommonResponsesParams<TApi extends Api>(
     params.temperature = options.temperature;
   }
 
-  if (context.tools && context.tools.length > 0) {
-    params.tools = convertResponsesTools(context.tools, { model });
+  if (context.tools) {
+    const converted = convertResponsesToolPayload(context.tools, { model });
+    if (converted.tools.length > 0) {
+      params.tools = converted.tools;
+    }
   }
 
   if (!model.reasoning) {

--- a/src/llm/providers/openai-responses-tools.ts
+++ b/src/llm/providers/openai-responses-tools.ts
@@ -3,9 +3,13 @@ import { createHash } from "node:crypto";
 import type { Tool as OpenAITool } from "openai/resources/responses/responses.js";
 import { resolveOpenAIStrictToolSetting } from "../../agents/openai-strict-tool-setting.js";
 import {
-  findOpenAIStrictToolSchemaDiagnostics,
+  projectOpenAITools,
+  type OpenAIToolProjection,
+} from "../../agents/openai-tool-projection.js";
+import {
+  findOpenAIStrictToolProjectionDiagnostics,
   normalizeOpenAIStrictToolParameters,
-  resolveOpenAIStrictToolFlagForInventory,
+  resolveOpenAIStrictToolFlagForProjection,
 } from "../../agents/openai-tool-schema.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { Model, Tool } from "../types.js";
@@ -26,6 +30,11 @@ type ResponsesFunctionTool = {
   strict?: boolean | null;
 };
 
+export type ConvertedResponsesTools = {
+  projection: OpenAIToolProjection;
+  tools: OpenAITool[];
+};
+
 // Converts OpenClaw tool schemas to OpenAI Responses tools, including strict-mode compatibility.
 const log = createSubsystemLogger("llm/openai-responses");
 const MAX_STRICT_TOOL_DOWNGRADE_DIAGNOSTIC_KEYS = 64;
@@ -36,10 +45,19 @@ export function convertResponsesTools(
   tools: Tool[],
   options?: ConvertResponsesToolsOptions,
 ): OpenAITool[] {
+  return convertResponsesToolPayload(tools, options).tools;
+}
+
+/** Converts and returns the projection used to reconcile tool choices. */
+export function convertResponsesToolPayload(
+  tools: Tool[],
+  options?: ConvertResponsesToolsOptions,
+): ConvertedResponsesTools {
+  const projection = projectOpenAITools(tools);
   const strictSetting = resolveResponsesStrictToolSetting(options);
-  const strict = resolveResponsesStrictToolFlag(tools, strictSetting, options?.model);
+  const strict = resolveResponsesStrictToolFlag(projection, strictSetting, options?.model);
   // Sort tools before request construction so prompt-cache bytes stay deterministic.
-  return sortResponsesToolsByName(tools).map((tool) => {
+  const convertedTools = sortResponsesToolsByName(projection.tools).map((tool) => {
     const result: ResponsesFunctionTool = {
       type: "function",
       name: tool.name,
@@ -48,13 +66,14 @@ export function convertResponsesTools(
         tool.parameters,
         strict === true,
         options?.model?.compat as OpenAIToolSchemaCompat,
-      ) as Record<string, unknown>,
+      ),
     };
     if (strict !== undefined) {
       result.strict = strict;
     }
     return result as OpenAITool;
   });
+  return { projection, tools: convertedTools };
 }
 
 function resolveResponsesStrictToolSetting(
@@ -73,13 +92,13 @@ function resolveResponsesStrictToolSetting(
 }
 
 function resolveResponsesStrictToolFlag(
-  tools: Tool[],
+  projection: OpenAIToolProjection,
   strictSetting: boolean | null | undefined,
   model: Model | undefined,
 ): boolean | undefined {
-  const strict = resolveOpenAIStrictToolFlagForInventory(tools, strictSetting);
+  const strict = resolveOpenAIStrictToolFlagForProjection(projection, strictSetting);
   if (strictSetting === true && strict === false && model && log.isEnabled("debug", "any")) {
-    const diagnostics = findOpenAIStrictToolSchemaDiagnostics(tools);
+    const diagnostics = findOpenAIStrictToolProjectionDiagnostics(projection);
     if (shouldLogStrictToolDowngradeDiagnostic(diagnostics, model)) {
       const sample = diagnostics.slice(0, 5).map((entry) => ({
         tool: entry.toolName ?? `tool[${entry.toolIndex}]`,
@@ -102,7 +121,7 @@ function resolveResponsesStrictToolFlag(
 }
 
 function shouldLogStrictToolDowngradeDiagnostic(
-  diagnostics: ReturnType<typeof findOpenAIStrictToolSchemaDiagnostics>,
+  diagnostics: ReturnType<typeof findOpenAIStrictToolProjectionDiagnostics>,
   model: Model,
 ): boolean {
   // Strict downgrade diagnostics can repeat per turn; hash details and cap memory.


### PR DESCRIPTION
## Summary

- Snapshot and quarantine unreadable OpenAI function tool descriptors and JSON schemas before Responses or Chat Completions payload construction, preserving healthy siblings.
- Reconcile pinned, required, and `allowed_tools` choices with the surviving function inventory; unsupported custom choices and unavailable tools fail locally instead of producing invalid official OpenAI payloads.
- Share the canonical projection across strict-schema checks and payload shaping so native strict mode stays correct without repeated schema serialization.

Related and supersedes the overlapping unreadable-schema work in #89413, #89013, #89016, #89378, #89543, #90200, #90283, #90286, and #90397. #89703 remains separate because it hardens tool objects introduced later by payload hooks.

## Verification

- `pnpm tsgo:core:test`
- `pnpm tsgo:core`
- `pnpm test src/agents/openai-tool-schema.test.ts src/agents/openai-tool-projection.test.ts src/agents/openai-transport-stream.test.ts src/llm/providers/openai-responses-shared.test.ts src/llm/providers/openai-chatgpt-responses.test.ts src/llm/providers/openai-completions.test.ts src/agents/anthropic-transport-stream.test.ts src/llm/providers/anthropic.test.ts src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts src/llm/providers/stream-wrappers/anthropic-cache-control-payload.test.ts` (462 passed)
- Targeted oxlint over all touched production and test files
- `OPENAI_LIVE_TEST=1 pnpm test:live --no-quiet src/agents/openai-tool-projection.live.test.ts` (2 passed: official Responses and Chat Completions `allowed_tools` using `gpt-5.5`)
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean; overall correct 0.91)
- AWS Crabbox Linux `check:changed`: run `run_e9f784db79fd`, lease `cbx_bc56df93ed0e`, lanes `core, coreTests`, exit 0
- `git diff --check`

## Real behavior proof

Behavior addressed: An accessor-backed or otherwise unreadable OpenAI tool descriptor/schema could abort request construction, while filtered tools could leave stale pinned, required, or allowed tool choices in the outgoing payload.

Real environment tested: Local Node 24 test/typecheck environment, official OpenAI Responses and Chat Completions APIs, and a fresh AWS Linux Crabbox checkout.

Exact steps or command run after this patch: `OPENAI_LIVE_TEST=1 pnpm test:live --no-quiet src/agents/openai-tool-projection.live.test.ts`; `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`.

Evidence after fix: Both official OpenAI APIs called the forced healthy `live_probe` function after an unreadable sibling was quarantined. Chat Completions used the SDK's nested `allowed_tools` shape. The remote changed gate passed core and coreTests.

Observed result after fix: Healthy function tools remain callable and native strict-compatible; unreadable or unsupported schemas are omitted; unavailable hard choices fail before network I/O; official OpenAI and Anthropic regression suites stay green.

What was not tested: Live Anthropic API execution was not needed because no Anthropic production path changed; Anthropic provider and compatibility suites were included in the 462-test regression matrix.

## Risk

Highest risk is official OpenAI tool-choice semantics. Mitigation: installed OpenAI SDK 6.39.1 types were inspected directly, both official API surfaces were exercised live, and OpenAI plus Anthropic regressions passed. No config, auth, migration, or dependency behavior changes.
