### PR TITLE
fix(cron): mark startup catch-up runs active to avoid false lost detection (#91695)

### DIFF
--- a/src/cron/active-jobs-startup-catchup.test.ts
+++ b/src/cron/active-jobs-startup-catchup.test.ts
@@ -1,0 +1,81 @@
+// Regression: startup catch-up creates cron task-ledger rows before the timer
+// loop is armed. Long catch-up runs still need the active-job marker so task
+// maintenance does not reconcile them as lost while execution is in flight.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isCronJobActive, resetCronActiveJobsForTests } from "./active-jobs.js";
+import { CronService } from "./service.js";
+import {
+  createDeferred,
+  setupCronServiceSuite,
+  writeCronStoreSnapshot,
+} from "./service.test-harness.js";
+import type { CronJob } from "./types.js";
+
+const { logger, makeStorePath } = setupCronServiceSuite({
+  prefix: "openclaw-cron-active-jobs-startup-catchup-",
+  baseTimeIso: "2026-06-14T09:00:00.000Z",
+});
+
+function createOverdueMainWakeNowJob(params: { id: string; nowMs: number }): CronJob {
+  return {
+    id: params.id,
+    name: params.id.replaceAll("-", " "),
+    enabled: true,
+    createdAtMs: params.nowMs - 3_600_000,
+    updatedAtMs: params.nowMs - 60_000,
+    schedule: { kind: "cron", expr: "0 * * * *", tz: "UTC" },
+    sessionTarget: "main",
+    wakeMode: "now",
+    payload: { kind: "systemEvent", text: "startup catch-up" },
+    state: { nextRunAtMs: params.nowMs - 60_000 },
+  };
+}
+
+describe("cron activeJobIds — startup catch-up mark/clear", () => {
+  beforeEach(() => {
+    resetCronActiveJobsForTests();
+  });
+
+  it("marks a startup catch-up job active while its heartbeat run is still in flight", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-06-14T09:00:00.000Z");
+    const jobId = "startup-catchup-active";
+    const heartbeatEntered = createDeferred<void>();
+    const releaseHeartbeat = createDeferred<{ status: "ran"; durationMs: number }>();
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createOverdueMainWakeNowJob({ id: jobId, nowMs })],
+    });
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runHeartbeatOnce: vi.fn(async () => {
+        heartbeatEntered.resolve();
+        return await releaseHeartbeat.promise;
+      }),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    try {
+      const startPromise = cron.start();
+      await heartbeatEntered.promise;
+
+      expect(isCronJobActive(jobId)).toBe(true);
+
+      releaseHeartbeat.resolve({ status: "ran", durationMs: 1 });
+      await startPromise;
+
+      expect(isCronJobActive(jobId)).toBe(false);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+});

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1408,6 +1408,7 @@ async function runStartupCatchupCandidate(
     job: candidate.job,
     startedAt,
   });
+  markCronJobActive(candidate.job.id);
   emit(state, {
     jobId: candidate.job.id,
     action: "started",
@@ -1459,12 +1460,11 @@ async function applyStartupCatchupOutcomes(
     // Startup catch-up runs during service bootstrap, before the timer loop is
     // armed. Reuse the in-memory store instead of forcing a second reload.
     await ensureLoaded(state, { skipRecompute: true });
-    if (!state.store) {
-      return;
-    }
-
     for (const result of outcomes) {
       applyOutcomeToStoredJob(state, result);
+    }
+    if (!state.store) {
+      return;
     }
 
     if (plan.deferredJobs.length > 0) {


### PR DESCRIPTION
## Summary

- Startup cron catch-up runs executed without calling `markCronJobActive`, so task-registry lost-detection marked long-running catch-up jobs as lost after the 5-minute grace window even though they were still running.
- Adds `markCronJobActive(job.id)` to the startup catch-up execution path in `src/cron/service/timer.ts`, matching the existing timer due-run and manual-run paths. Cleanup stays centralized in `applyOutcomeToStoredJob`.
- Also fixes a related ordering issue in `applyStartupCatchupOutcomes` so stored-job outcomes are applied even when the in-memory store reference is unset.

## Linked context

Closes #91695

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: startup catch-up cron runs now mark their cron job id active in-flight, so lost-detection sees a live cron-backed run instead of marking the task lost after the 5-minute grace window.
- Real environment tested: local OpenClaw source worktree (origin/main @462c076) on Linux, exercised through a real `CronService` startup catch-up path via the repo Vitest wrapper (`node scripts/run-vitest.mjs`).
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/cron/active-jobs-startup-catchup.test.ts`
- Evidence after fix (terminal capture):
  ```
  $ node scripts/run-vitest.mjs src/cron/active-jobs-startup-catchup.test.ts
   RUN  v4.1.7
   Test Files  1 passed (1)
        Tests  1 passed (1)
  [test] passed 1 Vitest shard in 11.96s
  ```
- Observed result after fix: the regression test blocks a startup catch-up heartbeat mid-flight and asserts `isCronJobActive(jobId) === true` before the run completes; it fails on the pre-fix code (no active marker) and passes after the fix.
- What was not tested: full gateway runtime + the multi-minute lost-detection window in a live deployment; active-marking behavior is covered through the real CronService startup path in the test harness.
- Proof limitations or environment constraints: a complete live cron lost-detection repro requires a running gateway and the multi-minute grace window; this was reproduced at the CronService level instead.

## Tests and validation

- `node scripts/run-vitest.mjs src/cron/active-jobs-startup-catchup.test.ts` -> 1 passed. New regression test asserts mid-flight `isCronJobActive` for a startup catch-up run.

## Risk checklist

- User-visible behavior change? No (internal lifecycle marking).
- Config/env/migration change? No.
- Security/auth/network/tool-execution change? No.
- Highest-risk area: catch-up outcome ordering change; mitigated by keeping cleanup centralized in `applyOutcomeToStoredJob` and covering it with the new regression test.
