### PR TITLE
fix(openai): guard post-hook tool payloads

### DIFF
--- a/src/agents/openai-tool-projection.live.test.ts
+++ b/src/agents/openai-tool-projection.live.test.ts
@@ -2,11 +2,13 @@ import OpenAI from "openai";
 import type { ChatCompletionCreateParamsNonStreaming } from "openai/resources/chat/completions.js";
 import type { ResponseCreateParamsNonStreaming } from "openai/resources/responses/responses.js";
 import { describe, expect, it } from "vitest";
+import { createCodexNativeWebSearchWrapper } from "../llm/providers/stream-wrappers/openai.js";
 import type { Context, Model } from "../llm/types.js";
 import { isLiveTestEnabled } from "./live-test-helpers.js";
 import {
   buildOpenAICompletionsParams,
   buildOpenAIResponsesParams,
+  createOpenAIResponsesTransportStreamFn,
 } from "./openai-transport-stream.js";
 
 const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
@@ -129,6 +131,97 @@ describeLive("OpenAI tool projection live", () => {
     });
     expect(JSON.parse(toolCall.function.arguments)).toEqual({
       value: "OPENAI_PROJECTION_OK",
+    });
+  }, 45_000);
+
+  it("keeps code-mode tools after a payload hook adds an unreadable sibling", async () => {
+    const model = {
+      id: modelId,
+      name: modelId,
+      api: "openai-responses",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 256,
+    } satisfies Model<"openai-responses">;
+    const codeModeContext = {
+      systemPrompt: "Call the requested function exactly once.",
+      messages: [
+        {
+          role: "user",
+          content: "Call exec with value exactly OPENAI_POST_HOOK_OK.",
+          timestamp: 1,
+        },
+      ],
+      tools: [
+        {
+          name: "exec",
+          description: "Return the requested probe value.",
+          parameters: {
+            type: "object",
+            properties: { value: { type: "string" } },
+            required: ["value"],
+            additionalProperties: false,
+          },
+        },
+        {
+          name: "wait",
+          description: "Wait without doing work.",
+          parameters: {
+            type: "object",
+            properties: {},
+            additionalProperties: false,
+          },
+        },
+      ],
+    } satisfies Context;
+    const streamFn = createCodexNativeWebSearchWrapper(createOpenAIResponsesTransportStreamFn(), {
+      codeModeToolSurfaceEnabled: true,
+    });
+    const streamOptions = {
+      apiKey: OPENAI_KEY,
+      maxTokens: 128,
+      reasoning: "low",
+      toolChoice: { type: "function", name: "exec" },
+      openclawCodeModeToolSurface: true,
+      onPayload(payload: unknown) {
+        const record = payload as Record<string, unknown>;
+        const tools = record.tools;
+        if (!Array.isArray(tools) || tools.length !== 2) {
+          throw new Error("Expected projected exec and wait tools");
+        }
+        record.tools = [
+          tools[0],
+          {
+            type: "function",
+            get function(): { name: string } {
+              throw new Error("live unreadable post-hook function getter");
+            },
+          },
+          tools[1],
+        ];
+        return record;
+      },
+    } satisfies Parameters<typeof streamFn>[2] & {
+      reasoning: "low";
+      toolChoice: { type: "function"; name: string };
+      openclawCodeModeToolSurface: true;
+    };
+    const stream = await Promise.resolve(streamFn(model, codeModeContext, streamOptions));
+
+    const result = await stream.result();
+    const toolCall = result.content.find(
+      (block) => block.type === "toolCall" && block.name === "exec",
+    );
+
+    expect(result.stopReason).toBe("toolUse");
+    expect(toolCall).toMatchObject({
+      type: "toolCall",
+      name: "exec",
+      arguments: { value: "OPENAI_POST_HOOK_OK" },
     });
   }, 45_000);
 });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -493,6 +493,38 @@ describe("openai transport stream", () => {
     }
   });
 
+  it("skips unreadable model payload tool names in debug summaries", () => {
+    const previous = process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+    process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = "tools";
+    try {
+      expect(
+        testing.summarizeResponsesTools([
+          {
+            type: "function",
+            get function(): { name: string } {
+              throw new Error("responses debug tool function getter exploded");
+            },
+          },
+          {
+            type: "function",
+            function: {
+              get name(): string {
+                throw new Error("responses debug nested name getter exploded");
+              },
+            },
+          },
+          { type: "function", function: { name: "wait" } },
+        ]),
+      ).toBe("count=3 names=wait");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+      } else {
+        process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = previous;
+      }
+    }
+  });
+
   it("redacts full model payload debug summaries", () => {
     const previous = process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
     process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = "full-redacted";
@@ -528,6 +560,36 @@ describe("openai transport stream", () => {
     testing.enforceCodeModeResponsesToolSurface(payload);
     testing.assertCodeModeResponsesToolSurface(payload);
     expect(payload.tools).toHaveLength(2);
+  });
+
+  it("skips unreadable code mode response payload tool names", () => {
+    const payload = {
+      tools: [
+        { type: "function", name: "exec" },
+        {
+          type: "function",
+          get function(): { name: string } {
+            throw new Error("responses code mode function getter exploded");
+          },
+        },
+        {
+          type: "function",
+          function: {
+            get name(): string {
+              throw new Error("responses code mode nested name getter exploded");
+            },
+          },
+        },
+        { type: "function", function: { name: "wait" } },
+      ],
+    };
+
+    testing.enforceCodeModeResponsesToolSurface(payload);
+    testing.assertCodeModeResponsesToolSurface(payload);
+    expect(payload.tools).toEqual([
+      { type: "function", name: "exec" },
+      { type: "function", function: { name: "wait" } },
+    ]);
   });
 
   it("fails closed when the code mode final payload tool surface is not exec/wait", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -350,19 +350,32 @@ function responseInputRoles(input: unknown): string {
   return [...roles].toSorted().join(",");
 }
 
+function readToolPayloadField(record: Record<string, unknown>, field: string): unknown {
+  try {
+    return record[field];
+  } catch {
+    return undefined;
+  }
+}
+
 function readResponsesToolDisplayName(tool: unknown): string {
   if (!tool || typeof tool !== "object") {
     return "";
   }
   const record = tool as Record<string, unknown>;
-  if (typeof record.name === "string") {
-    return record.name;
+  const name = readToolPayloadField(record, "name");
+  if (typeof name === "string") {
+    return name;
   }
-  const fn = record.function;
-  if (fn && typeof fn === "object" && typeof (fn as Record<string, unknown>).name === "string") {
-    return (fn as Record<string, unknown>).name as string;
+  const fn = readToolPayloadField(record, "function");
+  if (fn && typeof fn === "object") {
+    const fnName = readToolPayloadField(fn as Record<string, unknown>, "name");
+    if (typeof fnName === "string") {
+      return fnName;
+    }
   }
-  return typeof record.type === "string" ? record.type : "";
+  const type = readToolPayloadField(record, "type");
+  return typeof type === "string" && type !== "function" ? type : "";
 }
 
 function summarizeResponsesTools(tools: unknown): string {
@@ -381,11 +394,16 @@ function responsesPayloadToolName(tool: unknown): string | undefined {
   if (!isRecord(tool)) {
     return undefined;
   }
-  if (typeof tool.name === "string") {
-    return tool.name;
+  const name = readToolPayloadField(tool, "name");
+  if (typeof name === "string") {
+    return name;
   }
-  const fn = tool.function;
-  return isRecord(fn) && typeof fn.name === "string" ? fn.name : undefined;
+  const fn = readToolPayloadField(tool, "function");
+  if (!isRecord(fn)) {
+    return undefined;
+  }
+  const fnName = readToolPayloadField(fn, "name");
+  return typeof fnName === "string" ? fnName : undefined;
 }
 
 function enforceCodeModeResponsesToolSurface(payload: unknown): void {

--- a/src/llm/providers/stream-wrappers/openai.test.ts
+++ b/src/llm/providers/stream-wrappers/openai.test.ts
@@ -147,6 +147,12 @@ describe("createCodexNativeWebSearchWrapper", () => {
           const payloadObj = payload as { tools?: unknown } | undefined;
           if (payloadObj && Array.isArray(payloadObj.tools)) {
             payloadObj.tools.push({ type: "function", name: "web_search" });
+            payloadObj.tools.push({
+              type: "function",
+              get function(): { name: string } {
+                throw new Error("code mode payload function getter exploded");
+              },
+            });
           }
         },
       },
@@ -156,6 +162,56 @@ describe("createCodexNativeWebSearchWrapper", () => {
       { type: "function", name: "exec" },
       { type: "function", name: "wait" },
     ]);
+  });
+
+  it("filters async replacement payloads when code mode owns the tool surface", async () => {
+    let observedOptions: Parameters<StreamFn>[2];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      observedOptions = options;
+      return createAssistantMessageEventStream();
+    };
+    const wrapped = createCodexNativeWebSearchWrapper(baseStreamFn, {
+      codeModeToolSurfaceEnabled: true,
+    });
+    const model = {
+      api: "openai-responses",
+      provider: "openai",
+      id: "gpt-5.5",
+    } as Model<"openai-responses">;
+
+    void wrapped(
+      model,
+      {
+        messages: [],
+        tools: [
+          { name: "exec", description: "", parameters: {} },
+          { name: "wait", description: "", parameters: {} },
+        ],
+      },
+      {
+        onPayload: async () => ({
+          tools: [
+            { type: "function", name: "exec" },
+            {
+              type: "function",
+              get function(): { name: string } {
+                throw new Error("async code mode payload function getter exploded");
+              },
+            },
+            { type: "function", name: "wait" },
+            { type: "web_search" },
+          ],
+        }),
+      },
+    );
+
+    const nextPayload = await observedOptions?.onPayload?.({ tools: [] }, model);
+    expect(nextPayload).toEqual({
+      tools: [
+        { type: "function", name: "exec" },
+        { type: "function", name: "wait" },
+      ],
+    });
   });
 
   it("does not enable code-mode transport enforcement when config is on but controls are inactive", () => {

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -123,15 +123,37 @@ function isCodeModeEnabled(config?: OpenClawConfig): boolean {
   );
 }
 
+function readPayloadToolField(record: Record<string, unknown>, field: string): unknown {
+  try {
+    return record[field];
+  } catch {
+    return undefined;
+  }
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
+}
+
 function readPayloadToolName(tool: unknown): string | undefined {
   if (!tool || typeof tool !== "object") {
     return undefined;
   }
-  const record = tool as { name?: unknown; function?: { name?: unknown } };
-  if (typeof record.name === "string") {
-    return record.name;
+  const record = tool as Record<string, unknown>;
+  const name = readPayloadToolField(record, "name");
+  if (typeof name === "string") {
+    return name;
   }
-  return typeof record.function?.name === "string" ? record.function.name : undefined;
+  const fn = readPayloadToolField(record, "function");
+  if (!fn || typeof fn !== "object") {
+    return undefined;
+  }
+  const fnName = readPayloadToolField(fn as Record<string, unknown>, "name");
+  return typeof fnName === "string" ? fnName : undefined;
 }
 
 function isCodeModePayloadToolName(name: string | undefined): boolean {
@@ -154,7 +176,7 @@ function filterCodeModeGroupedToolDeclarations(tool: unknown): Record<string, un
   const record = tool as Record<string, unknown>;
   const filteredGroups: Record<string, unknown> = {};
   for (const key of ["functionDeclarations", "function_declarations"] as const) {
-    const filtered = filterCodeModeToolDeclarations(record[key]);
+    const filtered = filterCodeModeToolDeclarations(readPayloadToolField(record, key));
     if (filtered === undefined) {
       continue;
     }
@@ -181,6 +203,12 @@ function filterCodeModePayloadTools(payload: unknown): void {
     const grouped = filterCodeModeGroupedToolDeclarations(tool);
     return grouped ? [grouped] : [];
   });
+}
+
+function filterCodeModePayloadHookResult(payload: unknown, nextPayload: unknown): unknown {
+  const finalPayload = nextPayload === undefined ? payload : nextPayload;
+  filterCodeModePayloadTools(finalPayload);
+  return nextPayload === undefined ? undefined : finalPayload;
 }
 
 function hasCodeModeVisibleTools(context: { tools?: unknown }): boolean {
@@ -653,12 +681,12 @@ export function createCodexNativeWebSearchWrapper(
         onPayload: (payload) => {
           filterCodeModePayloadTools(payload);
           const nextPayload = originalOnPayload?.(payload, model);
-          if (nextPayload !== undefined) {
-            filterCodeModePayloadTools(nextPayload);
-            return nextPayload;
+          if (isPromiseLike(nextPayload)) {
+            return Promise.resolve(nextPayload).then((resolvedPayload) =>
+              filterCodeModePayloadHookResult(payload, resolvedPayload),
+            );
           }
-          filterCodeModePayloadTools(payload);
-          return undefined;
+          return filterCodeModePayloadHookResult(payload, nextPayload);
         },
       };
       return underlying(model, context, codeModeOptions);


### PR DESCRIPTION
## Summary

- guard post-hook OpenAI tool-name reads in transport debug and code-mode enforcement
- guard the production code-mode wrapper, including asynchronous payload replacements
- preserve valid `exec` and `wait` tools while dropping unreadable or disallowed siblings
- supersedes #89703 with maintainer-owned coverage and live provider proof

## Verification

- `node scripts/run-vitest.mjs src/llm/providers/stream-wrappers/openai.test.ts src/agents/openai-transport-stream.test.ts src/agents/openai-tool-projection.test.ts src/agents/anthropic-transport-stream.test.ts` (376 passed)
- `pnpm tsgo:core:test`
- `pnpm tsgo:core`
- targeted `oxlint` and `git diff --check`
- official OpenAI live suite: Responses projection, Chat Completions projection, and production-composed post-hook code-mode call all passed with `gpt-5.5`
- fresh autoreview: clean, no accepted/actionable findings; overall correct (0.94)
- AWS Crabbox changed gate: run `run_a8329b11391d`, lease `cbx_dde6657af907`, `c7a.8xlarge`, lanes `core, coreTests`, exit 0

## Real behavior proof

Behavior addressed: accessor-backed tool fields and asynchronous payload-hook replacements no longer crash or bypass OpenAI code-mode tool filtering.

Real environment tested: official OpenAI Responses and Chat Completions APIs plus AWS Linux Crabbox.

Exact steps or command run after this patch: `OPENAI_LIVE_TEST=1 node scripts/test-live.mjs --no-quiet -- src/agents/openai-tool-projection.live.test.ts --reporter=verbose`; AWS Crabbox `corepack pnpm check:changed`.

Evidence after fix: all three live OpenAI probes passed; the production-composed code-mode path removed the unreadable sibling and returned the forced `exec` tool call with the expected arguments.

Observed result after fix: valid official OpenAI function tools remain unchanged; unreadable and non-code-mode siblings are filtered before the provider request.

What was not tested: live Azure OpenAI Responses. Azure uses the same guarded transport helper and is covered by focused transport tests.

## Dependency contract

Verified Codex Responses tools serialize as tagged top-level tool objects in `codex-rs/tools/src/tool_spec.rs` and function declarations in `codex-rs/tools/src/responses_api.rs`.

Co-authored-by: Vincent Koc <vincentkoc@ieee.org>
