### PR TITLE
fix(subagents): require assistant ack for completion wake

### DIFF
--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -32,6 +32,7 @@ export type EmbeddedAgentQueueMessageOptions = {
   debounceMs?: number;
   deliveryTimeoutMs?: number;
   waitForTranscriptCommit?: boolean;
+  waitForAssistantResponseAfterTranscriptCommit?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 };
 

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
@@ -47,6 +47,44 @@ describe("embedded OpenClaw queued steering cancellation", () => {
     expect(settled).toBe(true);
   });
 
+  it("rejects when a queued completion is committed but the requester ends before consuming it", async () => {
+    vi.useFakeTimers();
+    let emit!: (event: unknown) => void;
+    const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
+      getSteeringMessages: () => [],
+      steer: async () => {},
+      subscribe: (listener) => {
+        emit = listener;
+        return () => {};
+      },
+    };
+
+    const wait = steerAndWaitForTranscriptCommit(activeSession, "queued completion", 10_000, {
+      waitForAssistantResponseAfterTranscriptCommit: true,
+    });
+
+    emit({
+      type: "message_end",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "queued completion" }],
+      },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    const rejection = expect(wait).rejects.toThrow(
+      "active session ended before queued steering message was consumed",
+    );
+    emit({ type: "agent_end", messages: [] });
+    await vi.advanceTimersByTimeAsync(0);
+
+    try {
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("removes only the timed-out steering message and preserves unrelated payloads", async () => {
     // Timeout cleanup must surgically remove the queued text entry without
     // damaging rich unrelated queued content.

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
@@ -60,6 +60,21 @@ function isTerminalActiveSessionEvent(event: unknown): boolean {
   );
 }
 
+function isAssistantMessageEvent(event: unknown): boolean {
+  if (!event || typeof event !== "object") {
+    return false;
+  }
+  const record = event as { message?: unknown; type?: unknown };
+  if (record.type !== "message_start" && record.type !== "message_end") {
+    return false;
+  }
+  return Boolean(
+    record.message &&
+    typeof record.message === "object" &&
+    (record.message as { role?: unknown }).role === "assistant",
+  );
+}
+
 function isAutoRetryStartEvent(event: unknown): boolean {
   return Boolean(
     event && typeof event === "object" && (event as { type?: unknown }).type === "auto_retry_start",
@@ -117,17 +132,18 @@ export async function cancelQueuedSteeringMessage(
 }
 
 /**
- * Sends a steering message and resolves only after the matching user
- * `message_end` event appears. If the run ends or times out first, the pending
- * queue entry is removed so an abandoned steer does not leak into a later turn.
+ * Sends a steering message and waits until the matching user `message_end` is
+ * durable. Completion handoffs can also require a following assistant response.
  */
 export async function steerAndWaitForTranscriptCommit(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,
   timeoutMs: number,
+  options: { waitForAssistantResponseAfterTranscriptCommit?: boolean } = {},
 ): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     let settled = false;
+    let committed = false;
     let terminalTimer: ReturnType<typeof setTimeout> | undefined;
     const finish = (err?: unknown) => {
       if (settled) {
@@ -147,6 +163,9 @@ export async function steerAndWaitForTranscriptCommit(
       }
       resolve();
     };
+    const rejectWithoutCancellation = (message: string) => {
+      finish(new Error(message));
+    };
     const rejectAfterCancellation = (message: string) => {
       // Cancellation is best-effort but must finish before rejecting so callers
       // do not return while a stale queued message can leak into the next turn.
@@ -163,22 +182,31 @@ export async function steerAndWaitForTranscriptCommit(
           finish(new Error(message));
         });
     };
+    const rejectForCurrentState = (beforeCommit: string, afterCommit: string) => {
+      if (committed) {
+        rejectWithoutCancellation(afterCommit);
+        return;
+      }
+      rejectAfterCancellation(beforeCommit);
+    };
     const scheduleTerminalCancellation = () => {
       if (terminalTimer) {
         return;
       }
       terminalTimer = setTimeout(() => {
         terminalTimer = undefined;
-        rejectAfterCancellation(
+        rejectForCurrentState(
           "active session ended before queued steering message was committed to the transcript",
+          "active session ended before queued steering message was consumed",
         );
       }, 0);
       terminalTimer.unref?.();
     };
     const timer: ReturnType<typeof setTimeout> | undefined = setTimeout(
       () => {
-        rejectAfterCancellation(
+        rejectForCurrentState(
           "queued steering message was not committed to the transcript before timeout",
+          "queued steering message was committed to the transcript but not consumed before timeout",
         );
       },
       Math.max(1, timeoutMs),
@@ -194,8 +222,15 @@ export async function steerAndWaitForTranscriptCommit(
         }
         return;
       }
-      if (isQueuedUserMessageEnd(event, text)) {
+      if (committed && isAssistantMessageEvent(event)) {
         finish();
+        return;
+      }
+      if (isQueuedUserMessageEnd(event, text)) {
+        committed = true;
+        if (options.waitForAssistantResponseAfterTranscriptCommit !== true) {
+          finish();
+        }
         return;
       }
       if (isTerminalActiveSessionEvent(event)) {
@@ -218,7 +253,13 @@ export async function steerAndWaitForTranscriptCommit(
 export async function steerActiveSessionWithOptionalDeliveryWait(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,
-  options: { deliveryTimeoutMs?: number; waitForTranscriptCommit?: boolean } | undefined,
+  options:
+    | {
+        deliveryTimeoutMs?: number;
+        waitForTranscriptCommit?: boolean;
+        waitForAssistantResponseAfterTranscriptCommit?: boolean;
+      }
+    | undefined,
 ): Promise<void> {
   if (options?.waitForTranscriptCommit !== true) {
     await activeSession.steer(text);
@@ -228,6 +269,10 @@ export async function steerActiveSessionWithOptionalDeliveryWait(
     activeSession,
     text,
     options.deliveryTimeoutMs ?? DEFAULT_QUEUE_TRANSCRIPT_COMMIT_TIMEOUT_MS,
+    {
+      waitForAssistantResponseAfterTranscriptCommit:
+        options.waitForAssistantResponseAfterTranscriptCommit,
+    },
   );
 }
 

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1084,6 +1084,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         steeringMode: "all",
         debounceMs: 500,
         waitForTranscriptCommit: true,
+        waitForAssistantResponseAfterTranscriptCommit: true,
         deliveryTimeoutMs: 120_000,
       },
     );
@@ -2092,6 +2093,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         deliveryTimeoutMs: 120_000,
         steeringMode: "all",
         waitForTranscriptCommit: true,
+        waitForAssistantResponseAfterTranscriptCommit: true,
       },
     );
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenNthCalledWith(
@@ -2330,6 +2332,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         steeringMode: "all",
         debounceMs: 500,
         waitForTranscriptCommit: true,
+        waitForAssistantResponseAfterTranscriptCommit: true,
         deliveryTimeoutMs: 10,
       },
     );
@@ -3938,6 +3941,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         steeringMode: "all",
         debounceMs: 500,
         waitForTranscriptCommit: true,
+        waitForAssistantResponseAfterTranscriptCommit: true,
         deliveryTimeoutMs: 120_000,
       },
     );

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1987,6 +1987,66 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("requires requester assistant acknowledgement when completion direct failure fallback-steers", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [{ text: "Tests passed and the PR is ready for review." }],
+        deliveryStatus: {
+          status: "failed",
+          errorMessage: "Slack send failed: channel not found",
+        },
+      },
+    });
+    const sendMessage = createSendMessageMock();
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock([
+      "no_active_run",
+      true,
+    ]);
+    const result = await deliverSlackThreadAnnouncement({
+      callGateway,
+      sendMessage,
+      queueEmbeddedAgentMessageWithOutcome,
+      sessionId: "requester-session-4",
+      isActive: true,
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-thread-delivery-fallback-steer-ack",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:worker:subagent:child",
+          childSessionId: "child-session-id",
+          announceType: "subagent task",
+          taskLabel: "thread completion smoke",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "child completion output",
+          replyInstruction: "Summarize the result.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "steered",
+    });
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(2);
+    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenNthCalledWith(
+      2,
+      "requester-session-4",
+      "child done",
+      {
+        debounceMs: 500,
+        deliveryTimeoutMs: 120_000,
+        steeringMode: "all",
+        waitForTranscriptCommit: true,
+        waitForAssistantResponseAfterTranscriptCommit: true,
+      },
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("does not raw-send grouped child results when requester-agent output is empty", async () => {
     const callGateway = createGatewayMock({
       result: {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -281,6 +281,7 @@ async function resolveActiveWakeWithRetries(
     ) {
       const bestEffortOptions = { ...currentOptions };
       delete bestEffortOptions.waitForTranscriptCommit;
+      delete bestEffortOptions.waitForAssistantResponseAfterTranscriptCommit;
       currentOptions = bestEffortOptions;
       outcome = await resolveQueueEmbeddedAgentMessageOutcome(sessionId, message, currentOptions);
       continue;
@@ -1358,6 +1359,7 @@ async function sendSubagentAnnounceDirectly(params: {
           ? { debounceMs: requesterQueueSettings.debounceMs }
           : {}),
         waitForTranscriptCommit: true,
+        waitForAssistantResponseAfterTranscriptCommit: true,
       };
       // Reuse the shared active-wake retry helper so the generated-completion
       // wake also waits through compaction (and best-effort transcript retry)

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -600,6 +600,7 @@ async function maybeSteerSubagentAnnounce(params: {
   deliveryTimeoutMs?: number;
   requesterSessionKey: string;
   steerMessage: string;
+  expectsCompletionMessage: boolean;
   signal?: AbortSignal;
 }): Promise<
   { status: "steered"; deliveredAt?: number; enqueuedAt?: number } | { status: "none" | "dropped" }
@@ -630,6 +631,9 @@ async function maybeSteerSubagentAnnounce(params: {
     steeringMode: "all",
     ...(queueSettings.debounceMs !== undefined ? { debounceMs: queueSettings.debounceMs } : {}),
     waitForTranscriptCommit: true,
+    ...(params.expectsCompletionMessage
+      ? { waitForAssistantResponseAfterTranscriptCommit: true }
+      : {}),
   };
   const queueOutcome = await resolveActiveWakeWithRetries(
     sessionId,
@@ -1688,6 +1692,7 @@ export async function deliverSubagentAnnouncement(params: {
         ),
         requesterSessionKey: params.requesterSessionKey,
         steerMessage: params.steerMessage,
+        expectsCompletionMessage: params.expectsCompletionMessage,
         signal: params.signal,
       }),
     direct: async () =>


### PR DESCRIPTION
## Summary

- Problem: active requester completion handoffs treated a queued internal completion user `message_end` as delivered even when the requester ended before consuming it; the direct-failure fallback steering path also used transcript commit alone.
- Solution: completion handoff wakes now opt into waiting for a following assistant response after transcript commit, including fallback steering after a completion direct-send failure.
- What changed: added `waitForAssistantResponseAfterTranscriptCommit` to the embedded queue wait path and enabled it only for completion handoff steering.
- What did NOT change: non-completion progress steering still resolves at the transcript commit boundary; channel transports, gateway send behavior, message-tool-only delivery, and timeout defaults were not changed.
- Why it matters / User impact: completed subagent results should either be consumed by the active requester or remain eligible for existing fallback delivery, not silently disappear at requester shutdown.
- Fixes #92433

## Real behavior proof
- **Behavior or issue addressed:** Subagent completion is no longer marked delivered just because the internal completion user message reached the requester transcript. The fixed boundaries are both `queued completion user message_end -> requester agent_end -> no assistant response` and `completion direct send fails -> fallback steering`; both now require requester assistant acknowledgement before reporting a steered completion as delivered.
- **Real environment tested:** Local Linux worktree `/media/vdc/code/ai/aispace/openclaw-worktrees/issue-92433`, branch `feat/issue-92433`, head `ef5a2f8fd7daedac01fd5e93eecab43111d57b81`.
- **Exact steps or command run after this patch:**

```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-92433 && OPENCLAW_REPO=/media/vdc/code/ai/aispace/openclaw-worktrees/issue-92433 OPENCLAW_EVIDENCE_DIR=/media/vdc/code/ai/aispace/openclaw-issue-92433-evidence node --import tsx /media/vdc/code/ai/aispace/openclaw-issue-92433-evidence/subagent-completion-active-run-queue-proof.mjs > /media/vdc/code/ai/aispace/openclaw-issue-92433-evidence/subagent-completion-active-run-queue-proof.out.json
```

```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-92433 && OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts -t "requires requester assistant acknowledgement when completion direct failure fallback-steers"
```

```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-92433 && OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts src/agents/subagent-announce-dispatch.test.ts src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
```

```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-92433 && node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit
```

```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-92433 && ./node_modules/.bin/oxfmt --check --threads=1 src/agents/subagent-announce-delivery.ts src/agents/subagent-announce-delivery.test.ts
```

```bash
git -C /media/vdc/code/ai/aispace/openclaw-worktrees/issue-92433 diff --check
```

- **Evidence after fix:** The active-run proof runs outside Vitest and does not call `testing.setDepsForTest()`. It registers a requester in the production `ACTIVE_EMBEDDED_RUNS` registry, lets the default production `deliverAgentHarnessTaskCompletion()` path resolve requester activity, and lets `queueEmbeddedAgentMessageWithOutcomeAsync()` call the real active-run handle. The handle uses the production `steerAndWaitForTranscriptCommit()` wait logic, so queue/gateway outcomes are not injected.

```json
{
  "proof": "subagent-completion-active-run-queue-ack",
  "head": "ef5a2f8fd7daedac01fd5e93eecab43111d57b81",
  "runtime": "node --import tsx; production deliverAgentHarnessTaskCompletion; production ACTIVE_EMBEDDED_RUNS registry; production queueEmbeddedAgentMessageWithOutcomeAsync; production steerAndWaitForTranscriptCommit; no testing.setDepsForTest and no injected queue/gateway outcome",
  "ackScenario": {
    "delivery": {
      "delivered": true,
      "path": "steered",
      "phases": [
        {
          "phase": "direct-primary",
          "delivered": true,
          "path": "steered"
        }
      ]
    }
  },
  "teardownScenario": {
    "queueOutcome": {
      "queued": false,
      "sessionId": "active-run-proof-teardown-session",
      "reason": "runtime_rejected",
      "gatewayHealth": "live",
      "errorMessage": "active session ended before queued steering message was consumed"
    }
  },
  "assertions": {
    "completionDeliveredAfterAssistantAck": true,
    "activeQueueUsedAssistantAckOption": true,
    "teardownBeforeAssistantDoesNotReportDelivered": true,
    "teardownFailureMentionsUnconsumed": true,
    "noInjectedQueueOrGatewayOutcome": true
  },
  "events": [
    {
      "event": "active-run-registered",
      "mode": "assistant-ack",
      "resolvedSessionId": "active-run-proof-ack-session",
      "isActive": true
    },
    {
      "event": "queue-handle-called",
      "mode": "assistant-ack",
      "waitForTranscriptCommit": true,
      "waitForAssistantResponseAfterTranscriptCommit": true
    },
    {
      "event": "queued-user-message-end",
      "mode": "assistant-ack"
    },
    {
      "event": "assistant-message-start",
      "mode": "assistant-ack"
    },
    {
      "event": "active-run-registered",
      "mode": "teardown-before-assistant",
      "resolvedSessionId": "active-run-proof-teardown-session",
      "isActive": true
    },
    {
      "event": "queue-handle-called",
      "mode": "teardown-before-assistant",
      "waitForTranscriptCommit": true,
      "waitForAssistantResponseAfterTranscriptCommit": true
    },
    {
      "event": "queued-user-message-end",
      "mode": "teardown-before-assistant"
    },
    {
      "event": "agent-end-before-assistant",
      "mode": "teardown-before-assistant"
    }
  ]
}
```

```text
Test Files  2 passed (2)
Tests  2 passed | 200 skipped (202)
```

```text
Test Files  3 passed (3)
Tests  118 passed (118)
[test] passed 1 Vitest shard in 18.79s
```

```text
node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit exited 0 with no stdout/stderr output.
```

```text
All matched files use the correct format.
Finished in 48ms on 2 files using 1 threads.
```

```text
git diff --check exited 0 with no whitespace errors.
```

- **Observed result after fix:** A completion handoff delivered through the production active-run queue returns delivered only after the queued completion is followed by requester assistant activity. The same production queue wait returns `runtime_rejected` with `active session ended before queued steering message was consumed` when the requester reaches `agent_end` after the queued completion but before any assistant response, so transcript durability alone is no longer treated as completion delivery. Ordinary non-completion steering still uses transcript-commit delivery.
- **What was not tested:** No live Discord, Telegram, Slack, Desktop, Mantis, or other external channel transport proof was run in this environment. The active-run proof uses deterministic in-process requester transcript events against the production active-run registry and queue owner; it is not a full external Gateway/model-provider/channel run. It specifically removes the previous proof gap where queue/gateway delivery outcomes were injected.

## Regression Test Plan
- **Target test file:** `src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts`, `src/agents/subagent-announce-delivery.test.ts`, `src/agents/subagent-announce-dispatch.test.ts`
- **Scenario locked in:** `queued completion user message_end -> requester agent_end -> no assistant response` rejects the active completion wake as unconsumed, and completion direct-send failure fallback steering also waits for requester assistant acknowledgement.
- **Why this is the smallest reliable guardrail:** The new acknowledgement option is opt-in and enabled only for completion handoff steering. It reuses existing queue outcome and fallback paths rather than adding channel-specific delivery logic.

## Merge risk
- **Risk labels considered:** `clawsweeper:no-new-fix-pr`, `clawsweeper:needs-maintainer-review`, `clawsweeper:needs-product-decision`, nonlocal channel/live proof boundary.
- **Risk explanation:** The patch changes runtime completion acknowledgement semantics, so maintainer review should focus on whether assistant `message_start`/`message_end` is the intended completion-consumption boundary. The risk is contained because non-completion steering keeps its previous transcript-commit behavior and unsupported transcript-wait targets still fall back to best-effort wake options.
- **Why acceptable:** The local proof exercises the production active-run queue owner and converts the false delivered signal into the already-supported fallback flow without changing public channel contracts.

## Root Cause
- **Root cause:** The active requester wake and fallback steering paths used `waitForTranscriptCommit` as delivery proof for subagent completion handoffs. That proves the internal completion message was committed as a queued user entry, but it does not prove the requester consumed the completion or produced a visible assistant response.
- **Why this is root-cause fix:** The requester transcript event stream now distinguishes durability from consumption. A matching queued user `message_end` proves durability; a later assistant `message_start`/`message_end` proves requester consumption. If terminal requester state arrives first, the wake is unconfirmed and can fall through to existing fallback delivery.
- **Fix classification:** Root-cause reliability fix for subagent completion delivery acknowledgement.
- **Maintainer-ready confidence:** High for the active-run queue owner and source-level race covered here. The fix narrows the delivered boundary only for completion handoff paths, and related local runtime tests pass. External channel/live transport proof remains outside this local environment.
- **Patch quality notes:** The diff is limited to subagent completion steering options and regression expectations. It does not add sleeps, widen channel transport behavior, or change the completion direct-first dispatch ordering.
- **Architecture / source-of-truth check:** The active requester transcript stream is the source of truth. The patch changes the source-of-truth delivery boundary before downstream fallback decisions, rather than adding downstream string checks or transport-specific special cases.
