### PR TITLE
gateway hangs at `[gateway] starting...` when a declared provider lacks credentials (regression v2026.4.8 → v2026.4.26)

### DIFF
--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -161,6 +161,39 @@ describe("resolveImplicitProviders startup discovery scope", () => {
     expect(catalogOptions?.timeoutMs).toBe(1234);
   });
 
+  it("bounds runtime provider catalog discovery by default", async () => {
+    await resolveImplicitProviders({
+      agentDir: "/tmp/openclaw-agent",
+      config: {},
+      env: {} as NodeJS.ProcessEnv,
+      explicitProviders: {},
+    });
+
+    const catalogOptions = firstMockArg(mocks.runProviderCatalog, "provider catalog") as {
+      timeoutMs?: number;
+    };
+    expect(catalogOptions?.timeoutMs).toBe(15_000);
+  });
+
+  it("skips runtime provider catalog discovery after the default timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.runProviderCatalog.mockReturnValue(new Promise(() => {}));
+
+      const providers = resolveImplicitProviders({
+        agentDir: "/tmp/openclaw-agent",
+        config: {},
+        env: {} as NodeJS.ProcessEnv,
+        explicitProviders: {},
+      });
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      await expect(providers).resolves.toEqual({});
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("can keep startup discovery on provider discovery entries only", async () => {
     await resolveImplicitProviders({
       agentDir: "/tmp/openclaw-agent",

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -73,18 +73,19 @@ type ImplicitProviderContext = ImplicitProviderParams & {
   resolveProviderAuth: ProviderAuthResolver;
 };
 
-function resolveLiveProviderCatalogTimeoutMs(env: NodeJS.ProcessEnv): number | null {
+const DEFAULT_PROVIDER_CATALOG_TIMEOUT_MS = 15_000;
+
+function resolveProviderCatalogTimeoutMs(env: NodeJS.ProcessEnv): number {
   const live =
     env.OPENCLAW_LIVE_TEST === "1" || env.OPENCLAW_LIVE_GATEWAY === "1" || env.LIVE === "1";
-  if (!live) {
-    return null;
-  }
-  const raw = env.OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS?.trim();
+  const raw = live ? env.OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS?.trim() : undefined;
   if (!raw) {
-    return 15_000;
+    return DEFAULT_PROVIDER_CATALOG_TIMEOUT_MS;
   }
   const parsed = Number(raw);
-  return /^[+]?\d+$/.test(raw) && Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 15_000;
+  return /^[+]?\d+$/.test(raw) && Number.isSafeInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_PROVIDER_CATALOG_TIMEOUT_MS;
 }
 
 function resolveProviderDiscoveryFilter(params: {
@@ -425,7 +426,7 @@ async function resolvePluginImplicitProviders(
           resolveProviderApiKey: resolveCatalogProviderApiKey,
           resolveProviderAuth: (providerId, options) =>
             ctx.resolveProviderAuth(providerId?.trim() || provider.id, options),
-          timeoutMs: ctx.providerDiscoveryTimeoutMs ?? resolveLiveProviderCatalogTimeoutMs(ctx.env),
+          timeoutMs: ctx.providerDiscoveryTimeoutMs ?? resolveProviderCatalogTimeoutMs(ctx.env),
         });
     if (!result && !useStaticCatalog && provider.staticCatalog) {
       result = await runProviderStaticCatalog({


### PR DESCRIPTION
## Summary

- Fix classification: Root-cause fix for a gateway startup lifecycle hang caused by unbounded implicit runtime provider catalog discovery.
- Maintainer-ready confidence: High. The failing regression reproduced the missing timeout at the provider discovery boundary, and the behavior test verifies a never-resolving catalog is skipped after the bounded timeout.
- Root cause: implicit runtime provider catalog discovery violated the resolver contract because it only applied the 15s timeout in live-test mode; normal gateway startup callers without an explicit `providerDiscoveryTimeoutMs` passed `timeoutMs: null`, so a provider catalog that never resolved could keep `resolveImplicitProviders` pending and block gateway sidecar startup.
- Why this is root-cause fix: the patch moves the bounded default into the shared provider catalog timeout resolver, so every implicit runtime catalog run gets either the caller's explicit timeout or the 15s default. That addresses the source wait instead of special-casing OpenAI, Copilot, Kubernetes, probes, or credential names.
- What did NOT change: provider credential policy, fallback-model selection, config schema, migrations, Kubernetes probe behavior, static catalog handling, and caller-supplied timeout behavior remain unchanged.
- Intentionally out of scope: adding a new config knob or changing how uncredentialed providers are selected for runtime use after startup.
- Review focus: the default timeout contract in implicit discovery and the regression coverage for a never-resolving runtime catalog.

## Linked context

Addresses #90886

Related context: the issue reports `openclaw gateway run --bind custom --allow-unconfigured` hanging at `[gateway] starting...` when `models.providers` declares fallback providers whose credentials are absent. ClawSweeper pointed to the implicit provider catalog path as the source-backed unbounded wait and recommended a default bounded timeout without adding config surface.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: gateway startup should no longer be able to wait indefinitely on implicit runtime provider catalog discovery for a declared provider that cannot complete discovery.
- Real environment tested: OpenClaw source runtime test harness for provider discovery and gateway startup, plus a Docker-level gateway startup proof against the current PR checkout. Linked issue live proof in the external Kubernetes environment is unavailable here; completed local validation and Docker-level verification are included below.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs src/agents/models-config.providers.implicit.discovery-scope.test.ts`
  - `node scripts/run-vitest.mjs src/gateway/server-startup.test.ts`
  - `git diff --check`
  - `pr-auto bounded-live-proof -- bash docker-gateway-startup-proof.sh` (`proof=provider=google with openai/copilot credentials absent; expected route is bounded implicit provider catalog discovery instead of an unbounded startup wait`)
- Evidence after fix:

```text
$ pr-auto bounded-live-proof -- bash docker-gateway-startup-proof.sh
Exit code: 0
OpenClaw 2026.6.2 (0131230)

Docker gateway startup proof
image: multi-agent-dev:latest
runtime: current PR checkout mounted read-only in the container; Node v22.22.0 mounted read-only in the container
config: google configured with fake proof-only key; github-copilot/openai declared without credentials
secret handling: OPENAI_API_KEY and COPILOT_GITHUB_TOKEN unset inside gateway command
healthz: HTTP 200 after 9s
container_running: true

Relevant gateway log lines:
[gateway] loading configuration…
[gateway] resolving authentication…
[gateway] auth mode=none explicitly configured; all gateway connections are unauthenticated.
[gateway] starting...
[gateway] starting HTTP server...
[gateway] agent model: google/gemini-3-flash-preview (thinking=off, fast=off)
[gateway] http server listening (8 plugins; 2.9s)
[gateway] ready
[gateway] starting channels and sidecars...
[gateway/channels] skipping channel start (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)
```

```text
$ node scripts/run-vitest.mjs src/agents/models-config.providers.implicit.discovery-scope.test.ts
Exit code: 0

 RUN  v4.1.7 [redacted-local-path]

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Duration  7.49s (transform 3.14s, setup 514ms, import 5.07s, tests 1.62s, environment 0ms)
```

```text
$ node scripts/run-vitest.mjs src/gateway/server-startup.test.ts
Exit code: 0

 RUN  v4.1.7 [redacted-local-path]

 Test Files  2 passed (2)
      Tests  10 passed (10)
   Duration  21.10s (transform 12.11s, setup 2.13s, import 46ms, tests 18.14s, environment 0ms)
```

```text
$ git diff --check
Exit code: 0
<no output captured>
```

- Observed result after fix: `proof=provider=google` with OpenAI/Copilot credentials absent exercises the expected route through bounded implicit provider catalog discovery; runtime provider catalog discovery now receives a 15s default timeout even outside live-test mode, a never-resolving runtime catalog is skipped after that timeout, and the Docker gateway proof reached HTTP `/healthz` 200 instead of staying at `[gateway] starting...`.
- What was not tested: a live Kubernetes/AKS sidecar using real Google credentials and missing OpenAI/Copilot credentials.
- Proof limitations or environment constraints: external Kubernetes access is unavailable here. The Docker proof used a fake proof-only Google key and skipped channel sidecars to keep the run scoped to gateway/model startup; no real model request was made, and no OpenAI/Copilot credentials were passed to the container.
- Before evidence: the new regression test failed before the fix with `expected null to be 15000`, matching the unbounded discovery path called out in the issue.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/models-config.providers.implicit.discovery-scope.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server-startup.test.ts`
- `git diff --check`

Regression coverage added:

- `resolveImplicitProviders` now asserts runtime provider catalog discovery gets the 15s default timeout when no explicit timeout is supplied.
- A fake-timer regression test covers a never-resolving runtime catalog and verifies implicit provider resolution completes with that provider skipped.

What failed before this fix: the default-timeout regression failed with `expected null to be 15000`, matching the unbounded discovery path called out in the issue.

## Risk checklist

Did user-visible behavior change? (`Yes`)

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`Yes`)

What is the highest-risk area?

Provider catalog discovery may skip a provider whose runtime catalog takes longer than 15s when the caller has not provided a narrower or wider timeout.

How is that risk mitigated?

- The change only bounds implicit runtime catalog discovery; static catalogs and explicit provider config remain available.
- Existing explicit `providerDiscoveryTimeoutMs` callers still control their own timeout.
- The live discovery env override still applies in live mode.
- Timeout handling uses the existing warning-and-skip behavior rather than introducing a new failure mode or config surface.

## Current review state

Next action: maintainer review after CI.

Still waiting on: optional maintainer or reporter confirmation from a live Docker/Kubernetes reproduction, if required.

Bot or reviewer comments addressed: ClawSweeper's source-backed recommendation to add a default bounded timeout for implicit provider catalog discovery without new config surface.
