### PR TITLE
fix(openai): recover invalid reasoning signatures

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1,5 +1,6 @@
 // Verifies OpenAI-compatible streaming payloads, failures, and transport wrapping.
 import { createServer } from "node:http";
+import OpenAI from "openai";
 import type { Api, Model } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -4500,6 +4501,86 @@ describe("openai transport stream", () => {
     expect(stripped.input[0]).not.toHaveProperty("encrypted_content");
     expect(stripped.input[0].nested).not.toHaveProperty("encrypted_content");
     expect(stripped.input[1]).toEqual(params.input[1]);
+  });
+
+  it("retries thinking_signature_invalid once without encrypted reasoning content", async () => {
+    const request = {
+      model: "gpt-5.5",
+      stream: true,
+      input: [
+        {
+          type: "reasoning",
+          id: "rs_prior",
+          encrypted_content: "ciphertext",
+          summary: [],
+        },
+        {
+          type: "message",
+          id: "msg_prior",
+          role: "assistant",
+          content: [{ type: "output_text", text: "visible answer" }],
+        },
+        {
+          type: "function_call",
+          id: "fc_prior",
+          call_id: "call_abc",
+          name: "price_lookup",
+          arguments: "{}",
+        },
+      ],
+    };
+    const recoveredStream = streamChunks([]);
+    const create = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new OpenAI.BadRequestError(
+          400,
+          {
+            code: "thinking_signature_invalid",
+            message:
+              "The encrypted content for item rs_prior could not be verified. Reason: Encrypted content could not be decrypted or parsed.",
+            type: "invalid_request_error",
+          },
+          undefined,
+          new Headers(),
+        ),
+      )
+      .mockResolvedValueOnce(recoveredStream);
+
+    await expect(
+      testing.createResponsesStreamWithEncryptedContentRetry({
+        client: { responses: { create } } as never,
+        request: request as never,
+        requestOptions: undefined,
+        model: {
+          id: "gpt-5.5",
+          name: "GPT-5.5",
+          api: "openai-responses",
+          provider: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200_000,
+          maxTokens: 8192,
+        },
+      }),
+    ).resolves.toBe(recoveredStream);
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create.mock.calls[0]?.[0]).toBe(request);
+    expect(create.mock.calls[1]?.[0]).toEqual({
+      ...request,
+      input: [
+        {
+          type: "reasoning",
+          id: "rs_prior",
+          summary: [],
+        },
+        request.input[1],
+        request.input[2],
+      ],
+    });
   });
 
   it("normalizes overlong Copilot Responses replay tool ids before dispatch", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -801,10 +801,14 @@ function isInvalidEncryptedContentError(error: unknown): boolean {
     return false;
   }
   const record = error as { code?: unknown; message?: unknown };
-  if (record.code === "invalid_encrypted_content") {
+  if (record.code === "invalid_encrypted_content" || record.code === "thinking_signature_invalid") {
     return true;
   }
-  return typeof record.message === "string" && record.message.includes("invalid_encrypted_content");
+  return (
+    typeof record.message === "string" &&
+    (record.message.includes("invalid_encrypted_content") ||
+      record.message.includes("thinking_signature_invalid"))
+  );
 }
 
 function stripEncryptedContentFields(value: unknown): { value: unknown; changed: boolean } {
@@ -4400,6 +4404,7 @@ export const testing = {
   buildOpenAIResponsesReasoningReplayMetadata,
   normalizeResponsesFailedEvent,
   prepareOpenAIResponsesReasoningItemForReplay,
+  createResponsesStreamWithEncryptedContentRetry,
   stripResponsesRequestEncryptedContent,
   tagOpenAIResponsesReasoningReplayItem,
   summarizeResponsesFailedNoDetailsObservation,


### PR DESCRIPTION
## Summary

- recognize OpenAI Responses `thinking_signature_invalid` as the same stale encrypted-reasoning rejection class as `invalid_encrypted_content`
- reuse the existing one-shot transport retry, removing only `encrypted_content` while preserving reasoning/message/function-call identifiers and ordering
- keep valid official OpenAI reasoning replay unchanged and leave Anthropic transport/tool calling untouched

Addresses the OpenAI Responses half of #84002. This is a smaller transport-owned replacement for #84267 and makes the session-reset fallback proposed in #85362 unnecessary for this pre-stream provider rejection. Thanks @tianxiaochannel-oss88 for the report and provider-shaped proof.

Release-note context: OpenAI Responses sessions now recover from stale encrypted reasoning reported as `thinking_signature_invalid` instead of failing the turn.

## Verification

- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts` (269 passed after rebase)
- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts src/agents/openai-responses.reasoning-replay.test.ts src/agents/openai-tool-projection.test.ts src/agents/anthropic-transport-stream.test.ts` (367 passed)
- `ANTHROPIC_LIVE_TEST=1 OPENAI_LIVE_TEST=1 node scripts/test-live.mjs --no-quiet -- src/agents/openai-tool-projection.live.test.ts src/agents/anthropic-transport-stream.live.test.ts` (6 live tests passed: 3 OpenAI, 3 Anthropic)
- official OpenAI GPT-5.5 Responses replay: forced tool call emitted encrypted reasoning; the next request preserved reasoning -> function call -> function output ordering and matching call IDs; final marker `OPENAI_GPT55_ENCRYPTED_REPLAY_OK`
- AWS Crabbox `cbx_f380dd7dadd7`, run `run_ab4092a2dd74`: `pnpm check:changed` passed core production/test typechecks, changed lint, import-cycle and guard checks
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`: clean, no accepted/actionable findings
- `pnpm exec oxfmt --check src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`
- `git diff --check origin/main...HEAD`

## Real behavior proof

Behavior or issue addressed: OpenAI Responses continuation can reject replayed encrypted reasoning with `thinking_signature_invalid` before streaming begins.

Real environment tested: Official OpenAI Responses API with `openai/gpt-5.5`, plus official Anthropic API tool-call smokes; Linux CI-parity checks on AWS Crabbox.

Exact steps or command run after this patch: Ran the repository live provider suites above, then an exact two-turn `createOpenAIResponsesTransportStreamFn()` flow with a forced tool call and replayed encrypted reasoning.

Evidence after fix: The official GPT-5.5 follow-up accepted the encrypted reasoning/tool transcript, preserved replay ordering and call IDs, and returned `OPENAI_GPT55_ENCRYPTED_REPLAY_OK`. The regression test constructs the official OpenAI SDK `BadRequestError` with `code=thinking_signature_invalid` and verifies exactly one retry without `encrypted_content`.

Observed result after fix: Valid encrypted reasoning replay still succeeds; stale encrypted reasoning carrying the alternate provider code enters the existing bounded retry rather than ending the turn.

What was not tested: A live provider-generated `thinking_signature_invalid` cannot be induced deterministically without corrupting provider-owned ciphertext. Its exact HTTP/SDK error shape is covered with the official SDK error class, while the normal official replay and OpenAI/Anthropic tool paths were tested live.
