### PR TITLE
feat(sbx): add Docker Sandboxes sbx sandbox backend plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -578,6 +578,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/openshell/**"
+"extensions: sbx":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/sbx/**"
 "extensions: parallel":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -488,6 +488,30 @@
     "target": "沙箱注意事项"
   },
   {
+    "source": "Docker Sandboxes (sbx)",
+    "target": "Docker Sandboxes (sbx)"
+  },
+  {
+    "source": "Sbx plugin",
+    "target": "Sbx plugin"
+  },
+  {
+    "source": "OpenShell",
+    "target": "OpenShell"
+  },
+  {
+    "source": "Sandbox CLI",
+    "target": "Sandbox CLI"
+  },
+  {
+    "source": "Sandbox vs Tool Policy vs Elevated",
+    "target": "Sandbox vs Tool Policy vs Elevated"
+  },
+  {
+    "source": "Multi-Agent Sandbox and Tools",
+    "target": "Multi-Agent Sandbox and Tools"
+  },
+  {
     "source": "Companion apps",
     "target": "配套应用"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1583,6 +1583,7 @@
                       "gateway/operator-scopes",
                       "gateway/sandboxing",
                       "gateway/openshell",
+                      "gateway/sbx",
                       "gateway/sandbox-vs-tool-policy-vs-elevated"
                     ]
                   },

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -70,8 +70,9 @@ Not sandboxed:
 - `"docker"` (default when sandboxing is enabled): local Docker-backed sandbox runtime.
 - `"ssh"`: generic SSH-backed remote sandbox runtime.
 - `"openshell"`: OpenShell-backed sandbox runtime.
+- `"sbx"`: Docker Sandboxes (`sbx` CLI) backed sandbox runtime.
 
-SSH-specific config lives under `agents.defaults.sandbox.ssh`. OpenShell-specific config lives under `plugins.entries.openshell.config`.
+SSH-specific config lives under `agents.defaults.sandbox.ssh`. OpenShell-specific config lives under `plugins.entries.openshell.config`. sbx-specific config lives under `plugins.entries.sbx.config`.
 
 ### Choosing a backend
 
@@ -292,6 +293,35 @@ For `remote` mode, recreate is especially important:
 - the next use seeds a fresh remote workspace from the local workspace
 
 For `mirror` mode, recreate mainly resets the remote execution environment because the local workspace remains canonical anyway.
+
+### sbx backend
+
+Use `backend: "sbx"` when you want OpenClaw to sandbox tools with the Docker Sandboxes `sbx` CLI (equivalently `docker sandbox`) instead of driving Docker directly. For the full setup guide and configuration reference, see the dedicated [Docker Sandboxes page](/gateway/sbx).
+
+Like the built-in Docker backend, sbx bind-mounts the host workspace at the same path inside the sandbox, so writes are visible on the host immediately. OpenClaw creates the sandbox with `sbx create <agent> <workspace>` on first use and runs commands through `sbx exec`. sbx-specific config (CLI path, agent template, image, CPU/memory limits) lives under `plugins.entries.sbx.config`.
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        mode: "all",
+        backend: "sbx",
+      },
+    },
+  },
+  plugins: {
+    entries: {
+      sbx: {
+        enabled: true,
+        config: { agent: "shell" },
+      },
+    },
+  },
+}
+```
+
+The sbx backend does not support sandbox browsers or `sandbox.docker.binds`; the host workspace (and, when enabled, the agent and skills workspaces) are mounted automatically.
 
 ## Workspace access
 
@@ -541,6 +571,7 @@ Each agent can override sandbox + tools: `agents.list[].sandbox` and `agents.lis
 
 - [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) — per-agent overrides and precedence
 - [OpenShell](/gateway/openshell) — managed sandbox backend setup, workspace modes, and config reference
+- [Docker Sandboxes (sbx)](/gateway/sbx) — sbx CLI sandbox backend setup and config reference
 - [Sandbox configuration](/gateway/config-agents#agentsdefaultssandbox)
 - [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) — debugging "why is this blocked?"
 - [Security](/gateway/security)

--- a/docs/gateway/sbx.md
+++ b/docs/gateway/sbx.md
@@ -1,0 +1,233 @@
+---
+summary: "Use Docker Sandboxes (sbx) as a sandbox backend for OpenClaw agents"
+title: Docker Sandboxes (sbx)
+read_when:
+  - You want OpenClaw to sandbox tools with the Docker Sandboxes sbx CLI
+  - You are setting up the sbx plugin
+  - You want a Docker-backed sandbox managed outside OpenClaw's built-in docker backend
+---
+
+Docker Sandboxes is a sandbox backend for OpenClaw built on the `sbx` CLI
+(equivalently `docker sandbox`). Instead of OpenClaw driving the Docker engine
+directly through its built-in `docker` backend, OpenClaw delegates sandbox
+lifecycle to `sbx`, which provisions an isolated container, bind-mounts the host
+workspace into it, and runs commands through `sbx exec`.
+
+Like the built-in [Docker backend](/gateway/sandboxing#docker-backend), the host
+workspace is mounted at the same path inside the sandbox, so file edits are
+visible on the host immediately. No mirror/upload step is needed.
+
+## Prerequisites
+
+- sbx plugin installed (`openclaw plugins install @openclaw/sbx-sandbox`)
+- The `sbx` CLI installed and on `PATH` (or set a custom path via
+  `plugins.entries.sbx.config.command`). See the
+  [Docker Sandboxes project](https://github.com/docker/sandboxes) for install
+  options (Docker Desktop, standalone binary, or build from source).
+- Docker Desktop or Docker Engine running on the host
+- OpenClaw Gateway running on the host
+
+## Quick start
+
+1. Install and enable the plugin, then set the sandbox backend:
+
+```bash
+openclaw plugins install @openclaw/sbx-sandbox
+```
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        mode: "all",
+        backend: "sbx",
+        scope: "session",
+        workspaceAccess: "rw",
+      },
+    },
+  },
+  plugins: {
+    entries: {
+      sbx: {
+        enabled: true,
+        config: {
+          agent: "shell",
+        },
+      },
+    },
+  },
+}
+```
+
+2. Restart the Gateway. On the next agent turn, OpenClaw creates an sbx sandbox
+   and routes tool execution through it.
+
+3. Verify:
+
+```bash
+openclaw sandbox list
+openclaw sandbox explain
+```
+
+## Configuration reference
+
+All sbx config lives under `plugins.entries.sbx.config`:
+
+| Key              | Type      | Default   | Description                                                           |
+| ---------------- | --------- | --------- | --------------------------------------------------------------------- |
+| `command`        | `string`  | `"sbx"`   | Path or name of the `sbx` CLI                                         |
+| `agent`          | `string`  | `"shell"` | Docker Sandboxes agent used at create time (`sbx create <agent> ...`) |
+| `template`       | `string`  | —         | Container image override (`--template`)                               |
+| `cpus`           | `number`  | —         | CPUs to allocate (`--cpus`; 0 = all host CPUs)                        |
+| `memory`         | `string`  | —         | Memory limit in binary units, for example `8g` (`--memory`)           |
+| `user`           | `string`  | —         | Username or UID for command execution (`sbx exec -u`)                 |
+| `clone`          | `boolean` | `false`   | Use an in-container Git clone instead of a bind mount (`--clone`)     |
+| `timeoutSeconds` | `number`  | `120`     | Timeout for `sbx` CLI operations                                      |
+
+Sandbox-level settings (`mode`, `scope`, `workspaceAccess`) are configured under
+`agents.defaults.sandbox` as with any backend. See
+[Sandboxing](/gateway/sandboxing) for the full matrix.
+
+<Warning>
+With `clone: true` the workspace is mounted read-only and the agent works on an in-container clone. Host files are not updated until the agent's commits are pulled through the `sandbox-<name>` git remote. Leave `clone` disabled if you want the default bind-mount behavior where writes appear on the host.
+</Warning>
+
+## Examples
+
+### Minimal setup
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        mode: "all",
+        backend: "sbx",
+      },
+    },
+  },
+  plugins: {
+    entries: {
+      sbx: {
+        enabled: true,
+      },
+    },
+  },
+}
+```
+
+### Custom image with resource limits
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        mode: "all",
+        backend: "sbx",
+        scope: "agent",
+        workspaceAccess: "rw",
+      },
+    },
+  },
+  plugins: {
+    entries: {
+      sbx: {
+        enabled: true,
+        config: {
+          agent: "shell",
+          template: "ghcr.io/example/sandbox:latest",
+          cpus: 4,
+          memory: "8g",
+          timeoutSeconds: 180,
+        },
+      },
+    },
+  },
+}
+```
+
+### Per-agent sbx sandbox
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: { mode: "off" },
+    },
+    list: [
+      {
+        id: "researcher",
+        sandbox: {
+          mode: "all",
+          backend: "sbx",
+          scope: "agent",
+          workspaceAccess: "rw",
+        },
+      },
+    ],
+  },
+  plugins: {
+    entries: {
+      sbx: {
+        enabled: true,
+        config: { agent: "shell" },
+      },
+    },
+  },
+}
+```
+
+## Lifecycle management
+
+sbx sandboxes are managed through the normal sandbox CLI:
+
+```bash
+# List all sandbox runtimes (built-in Docker + sbx)
+openclaw sandbox list
+
+# Inspect effective policy
+openclaw sandbox explain
+
+# Recreate (removes the sbx sandbox; a fresh one is created on next use)
+openclaw sandbox recreate --all
+```
+
+Recreate after changing any of these:
+
+- `agents.defaults.sandbox.backend`
+- `plugins.entries.sbx.config.agent`
+- `plugins.entries.sbx.config.template`
+
+```bash
+openclaw sandbox recreate --all
+```
+
+## Current limitations
+
+- Sandbox browser is not supported on the sbx backend.
+- `sandbox.docker.binds` does not apply to sbx; the host workspace (and, when
+  enabled, the agent and skills workspaces) are mounted automatically.
+- Docker-specific runtime knobs under `sandbox.docker.*` apply only to the
+  built-in Docker backend. Use `plugins.entries.sbx.config` for sbx options.
+
+## How it works
+
+1. OpenClaw calls `sbx create <agent> <workspace> --name <name>` (with
+   `--template`, `--cpus`, `--memory`, and `--clone` flags as configured) the
+   first time a sandbox scope is used.
+2. The host workspace is bind-mounted at the same path inside the sandbox, so
+   file tools and exec operate on the shared workspace directly.
+3. Command execution runs through `sbx exec`, using a login shell so custom
+   PATH entries survive `/etc/profile`.
+4. File tools read and write through the sandbox using `sbx exec`-backed shell
+   commands.
+
+## Related
+
+- [Sandboxing](/gateway/sandboxing) -- modes, scopes, and backend comparison
+- [OpenShell](/gateway/openshell) -- managed remote sandbox backend
+- [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) -- debugging blocked tools
+- [Multi-Agent Sandbox and Tools](/tools/multi-agent-sandbox-tools) -- per-agent overrides
+- [Sandbox CLI](/cli/sandbox) -- `openclaw sandbox` commands

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -235,7 +235,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-35 plugins
+36 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -288,6 +288,8 @@ Each entry lists the package, distribution route, and description.
 - **[pixverse](/plugins/reference/pixverse)** (`@openclaw/pixverse-provider`) - npm; ClawHub: `clawhub:@openclaw/pixverse-provider`. OpenClaw PixVerse video generation provider plugin.
 
 - **[qqbot](/plugins/reference/qqbot)** (`@openclaw/qqbot`) - npm; ClawHub. OpenClaw QQ Bot channel plugin for group and direct-message workflows.
+
+- **[sbx](/plugins/reference/sbx)** (`@openclaw/sbx-sandbox`) - npm; ClawHub. OpenClaw sandbox backend for the Docker Sandboxes (sbx) CLI with bind-mounted workspaces and container command execution.
 
 - **[slack](/plugins/reference/slack)** (`@openclaw/slack`) - npm; ClawHub. OpenClaw Slack channel plugin for channels, DMs, commands, and app events.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 127
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 128
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/sbx.md
+++ b/docs/plugins/reference/sbx.md
@@ -1,0 +1,19 @@
+---
+summary: "OpenClaw sandbox backend for the Docker Sandboxes (sbx) CLI with bind-mounted workspaces and container command execution."
+read_when:
+  - You are installing, configuring, or auditing the sbx plugin
+title: "Sbx plugin"
+---
+
+# Sbx plugin
+
+OpenClaw sandbox backend for the Docker Sandboxes (sbx) CLI with bind-mounted workspaces and container command execution.
+
+## Distribution
+
+- Package: `@openclaw/sbx-sandbox`
+- Install route: npm; ClawHub
+
+## Surface
+
+plugin

--- a/extensions/sbx/README.md
+++ b/extensions/sbx/README.md
@@ -1,0 +1,28 @@
+# @openclaw/sbx-sandbox
+
+Official Docker Sandboxes (`sbx`) sandbox backend for OpenClaw.
+
+This plugin lets OpenClaw run agent tools inside Docker Sandboxes managed by the
+`sbx` CLI, with the host workspace bind-mounted into the sandbox and command
+execution through `sbx exec`.
+
+## Install
+
+```bash
+openclaw plugins install @openclaw/sbx-sandbox
+```
+
+Restart the Gateway after installing or updating the plugin.
+
+## Configure
+
+Use the Docker Sandboxes docs for installation, workspace mounting, runtime
+selection, and troubleshooting:
+
+- https://docs.openclaw.ai/gateway/sbx
+
+## Package
+
+- Plugin id: `sbx`
+- Package: `@openclaw/sbx-sandbox`
+- Minimum OpenClaw host: `2026.5.12-beta.1`

--- a/extensions/sbx/index.ts
+++ b/extensions/sbx/index.ts
@@ -1,0 +1,28 @@
+// sbx plugin entrypoint registers its OpenClaw integration.
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { registerSandboxBackend } from "openclaw/plugin-sdk/sandbox";
+import {
+  createSbxSandboxBackendFactory,
+  createSbxSandboxBackendManager,
+} from "./src/backend.js";
+import { createSbxPluginConfigSchema, resolveSbxPluginConfig } from "./src/config.js";
+
+export default definePluginEntry({
+  id: "sbx",
+  name: "Docker Sandboxes",
+  description: "Docker Sandboxes (sbx) backed sandbox runtime for agent exec and file tools.",
+  configSchema: createSbxPluginConfigSchema(),
+  register(api) {
+    if (api.registrationMode !== "full") {
+      return;
+    }
+    const pluginConfig = resolveSbxPluginConfig(api.pluginConfig);
+    registerSandboxBackend("sbx", {
+      factory: createSbxSandboxBackendFactory({ pluginConfig }),
+      manager: createSbxSandboxBackendManager({ pluginConfig }),
+      // sbx bind-mounts the host workspace at the same path, so the runtime
+      // workdir is just the workspace dir and needs no running container.
+      resolveWorkdir: ({ workspaceDir }) => workspaceDir,
+    });
+  },
+});

--- a/extensions/sbx/npm-shrinkwrap.json
+++ b/extensions/sbx/npm-shrinkwrap.json
@@ -1,0 +1,24 @@
+{
+  "name": "@openclaw/sbx-sandbox",
+  "version": "2026.6.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openclaw/sbx-sandbox",
+      "version": "2026.6.2",
+      "dependencies": {
+        "zod": "4.4.3"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/extensions/sbx/openclaw.plugin.json
+++ b/extensions/sbx/openclaw.plugin.json
@@ -1,0 +1,86 @@
+{
+  "id": "sbx",
+  "activation": {
+    "onStartup": true
+  },
+  "name": "Docker Sandboxes",
+  "description": "OpenClaw sandbox backend for the Docker Sandboxes (sbx) CLI with bind-mounted workspaces and container command execution.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "command": {
+        "type": "string",
+        "minLength": 1
+      },
+      "agent": {
+        "type": "string",
+        "minLength": 1
+      },
+      "template": {
+        "type": "string",
+        "minLength": 1
+      },
+      "cpus": {
+        "type": "number",
+        "minimum": 0
+      },
+      "memory": {
+        "type": "string",
+        "minLength": 1
+      },
+      "user": {
+        "type": "string",
+        "minLength": 1
+      },
+      "clone": {
+        "type": "boolean"
+      },
+      "timeoutSeconds": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 2147000
+      }
+    }
+  },
+  "uiHints": {
+    "command": {
+      "label": "sbx Command",
+      "help": "Path or command name for the Docker Sandboxes CLI (the standalone `sbx` binary, equivalently `docker sandbox`)."
+    },
+    "agent": {
+      "label": "Agent Template",
+      "help": "Docker Sandboxes agent used when creating a sandbox. Defaults to shell for a generic sandbox."
+    },
+    "template": {
+      "label": "Container Image",
+      "help": "Optional container image override passed as --template.",
+      "advanced": true
+    },
+    "cpus": {
+      "label": "CPUs",
+      "help": "Number of CPUs to allocate to the sandbox (0 = auto: all host CPUs).",
+      "advanced": true
+    },
+    "memory": {
+      "label": "Memory",
+      "help": "Memory limit in binary units (for example 1024m or 8g).",
+      "advanced": true
+    },
+    "user": {
+      "label": "Exec User",
+      "help": "Username or UID used for command execution inside the sandbox (sbx exec -u).",
+      "advanced": true
+    },
+    "clone": {
+      "label": "Clone Mode",
+      "help": "Run the agent on an in-container clone of the host Git repo instead of a bind mount. Host writes are not reflected until committed via the sandbox remote.",
+      "advanced": true
+    },
+    "timeoutSeconds": {
+      "label": "Command Timeout Seconds",
+      "help": "Timeout for sbx CLI operations such as create, exec, and rm.",
+      "advanced": true
+    }
+  }
+}

--- a/extensions/sbx/package.json
+++ b/extensions/sbx/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@openclaw/sbx-sandbox",
+  "version": "2026.6.2",
+  "description": "OpenClaw sandbox backend for the Docker Sandboxes (sbx) CLI with bind-mounted workspaces and container command execution.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
+  "type": "module",
+  "dependencies": {
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "npmSpec": "@openclaw/sbx-sandbox",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.5.12-beta.1"
+    },
+    "compat": {
+      "pluginApi": ">=2026.6.2"
+    },
+    "build": {
+      "openclawVersion": "2026.6.2",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/sbx/src/backend.test.ts
+++ b/extensions/sbx/src/backend.test.ts
@@ -1,0 +1,72 @@
+// sbx tests cover backend plugin behavior.
+import { describe, expect, it } from "vitest";
+import { buildSbxExecArgv } from "./cli.js";
+import { resolveSbxPluginConfig } from "./config.js";
+import { buildSbxSandboxName } from "./backend.js";
+
+describe("buildSbxSandboxName", () => {
+  it("produces a deterministic, sbx-safe name", () => {
+    const name = buildSbxSandboxName("Agent/Session 1");
+    expect(name).toBe(buildSbxSandboxName("Agent/Session 1"));
+    expect(name).toMatch(/^openclaw-[a-z0-9-]+-[0-9a-f]{1,8}$/);
+  });
+
+  it("falls back to session for empty scope keys", () => {
+    expect(buildSbxSandboxName("   ")).toMatch(/^openclaw-session-/);
+  });
+});
+
+describe("buildSbxExecArgv", () => {
+  const baseConfig = resolveSbxPluginConfig(undefined);
+
+  it("builds a non-pty exec invocation through a login shell", () => {
+    const argv = buildSbxExecArgv({
+      config: baseConfig,
+      sandboxName: "openclaw-test-1",
+      command: "echo hi",
+      workdir: "/work",
+      env: { FOO: "bar" },
+      usePty: false,
+    });
+    expect(argv).toEqual([
+      "sbx",
+      "exec",
+      "-i",
+      "-w",
+      "/work",
+      "-e",
+      "FOO=bar",
+      "openclaw-test-1",
+      "/bin/sh",
+      "-lc",
+      "echo hi",
+    ]);
+  });
+
+  it("adds a tty flag and exec user when requested", () => {
+    const argv = buildSbxExecArgv({
+      config: resolveSbxPluginConfig({ user: "root" }),
+      sandboxName: "openclaw-test-1",
+      command: "bash",
+      env: {},
+      usePty: true,
+    });
+    expect(argv).toContain("-t");
+    expect(argv.join(" ")).toContain("-u root");
+  });
+
+  it("reattaches a custom PATH after the login shell instead of via -e PATH", () => {
+    const argv = buildSbxExecArgv({
+      config: baseConfig,
+      sandboxName: "openclaw-test-1",
+      command: "node --version",
+      env: { PATH: "/custom/bin" },
+      usePty: false,
+    });
+    expect(argv).not.toContain("PATH=/custom/bin");
+    expect(argv).toContain("OPENCLAW_PREPEND_PATH=/custom/bin");
+    const script = argv.at(-1) ?? "";
+    expect(script).toContain('export PATH="${OPENCLAW_PREPEND_PATH}:$PATH"');
+    expect(script).toContain("node --version");
+  });
+});

--- a/extensions/sbx/src/backend.ts
+++ b/extensions/sbx/src/backend.ts
@@ -1,0 +1,249 @@
+// sbx plugin module implements backend behavior.
+import path from "node:path";
+import type {
+  CreateSandboxBackendParams,
+  SandboxBackendCommandParams,
+  SandboxBackendCommandResult,
+  SandboxBackendFactory,
+  SandboxBackendHandle,
+  SandboxBackendManager,
+} from "openclaw/plugin-sdk/sandbox";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  buildSbxExecArgv,
+  runSbxCli,
+  runSbxExecShell,
+  type SbxExecContext,
+} from "./cli.js";
+import type { ResolvedSbxPluginConfig } from "./config.js";
+
+type CreateSbxSandboxBackendFactoryParams = {
+  pluginConfig: ResolvedSbxPluginConfig;
+};
+
+export function createSbxSandboxBackendFactory(
+  params: CreateSbxSandboxBackendFactoryParams,
+): SandboxBackendFactory {
+  return async (createParams) =>
+    await createSbxSandboxBackend({
+      pluginConfig: params.pluginConfig,
+      createParams,
+    });
+}
+
+export function createSbxSandboxBackendManager(params: {
+  pluginConfig: ResolvedSbxPluginConfig;
+}): SandboxBackendManager {
+  return {
+    async describeRuntime({ entry }) {
+      const context: SbxExecContext = {
+        config: params.pluginConfig,
+        sandboxName: entry.containerName,
+      };
+      const running = await sbxSandboxRunning(context, entry.containerName);
+      const configuredLabel = params.pluginConfig.template ?? params.pluginConfig.agent;
+      return {
+        running,
+        actualConfigLabel: entry.image,
+        configLabelMatch: entry.image === configuredLabel,
+      };
+    },
+    async removeRuntime({ entry }) {
+      const context: SbxExecContext = {
+        config: params.pluginConfig,
+        sandboxName: entry.containerName,
+      };
+      const result = await runSbxCli({
+        context,
+        args: ["rm", "--force", entry.containerName],
+      });
+      if (result.code !== 0 && !/no such|not found/i.test(result.stderr)) {
+        throw new Error(
+          result.stderr.trim() || `Failed to remove sbx sandbox runtime ${entry.containerName}`,
+        );
+      }
+    },
+  };
+}
+
+async function createSbxSandboxBackend(params: {
+  pluginConfig: ResolvedSbxPluginConfig;
+  createParams: CreateSandboxBackendParams;
+}): Promise<SandboxBackendHandle> {
+  if ((params.createParams.cfg.docker.binds?.length ?? 0) > 0) {
+    throw new Error("sbx sandbox backend does not support sandbox.docker.binds.");
+  }
+
+  const sandboxName = buildSbxSandboxName(params.createParams.scopeKey);
+  const impl = new SbxSandboxBackendImpl({
+    pluginConfig: params.pluginConfig,
+    createParams: params.createParams,
+    sandboxName,
+  });
+  const configLabel = params.pluginConfig.template ?? params.pluginConfig.agent;
+
+  return {
+    id: "sbx",
+    runtimeId: sandboxName,
+    runtimeLabel: sandboxName,
+    // sbx bind-mounts the host workspace at the same path, so the container
+    // workdir is the host workspace dir.
+    workdir: params.createParams.workspaceDir,
+    env: params.createParams.cfg.docker.env,
+    configLabel,
+    configLabelKind: params.pluginConfig.template ? "Image" : "Agent",
+    async buildExecSpec({ command, workdir, env, usePty }) {
+      await impl.ensureSandboxExists();
+      return {
+        argv: buildSbxExecArgv({
+          config: params.pluginConfig,
+          sandboxName,
+          command,
+          workdir: workdir ?? params.createParams.workspaceDir,
+          env,
+          usePty,
+        }),
+        env: process.env,
+        stdinMode: usePty ? "pipe-open" : "pipe-closed",
+      };
+    },
+    async runShellCommand(command) {
+      return await impl.runShellCommand(command);
+    },
+  };
+}
+
+class SbxSandboxBackendImpl {
+  private ensurePromise: Promise<void> | null = null;
+
+  constructor(
+    private readonly params: {
+      pluginConfig: ResolvedSbxPluginConfig;
+      createParams: CreateSandboxBackendParams;
+      sandboxName: string;
+    },
+  ) {}
+
+  private get context(): SbxExecContext {
+    return { config: this.params.pluginConfig, sandboxName: this.params.sandboxName };
+  }
+
+  async runShellCommand(
+    command: SandboxBackendCommandParams,
+  ): Promise<SandboxBackendCommandResult> {
+    await this.ensureSandboxExists();
+    return await runSbxExecShell({
+      config: this.params.pluginConfig,
+      sandboxName: this.params.sandboxName,
+      script: command.script,
+      args: command.args,
+      stdin: command.stdin,
+      allowFailure: command.allowFailure,
+      signal: command.signal,
+    });
+  }
+
+  async ensureSandboxExists(): Promise<void> {
+    if (this.ensurePromise) {
+      return await this.ensurePromise;
+    }
+    this.ensurePromise = this.ensureSandboxExistsInner();
+    try {
+      await this.ensurePromise;
+    } catch (error) {
+      this.ensurePromise = null;
+      throw error;
+    }
+  }
+
+  private async ensureSandboxExistsInner(): Promise<void> {
+    if (await sbxSandboxExists(this.context, this.params.sandboxName)) {
+      return;
+    }
+    const createArgs = [
+      "create",
+      this.params.pluginConfig.agent,
+      ...this.buildWorkspaceArgs(),
+      "--name",
+      this.params.sandboxName,
+      "--quiet",
+      ...(this.params.pluginConfig.template
+        ? ["--template", this.params.pluginConfig.template]
+        : []),
+      ...(typeof this.params.pluginConfig.cpus === "number"
+        ? ["--cpus", String(this.params.pluginConfig.cpus)]
+        : []),
+      ...(this.params.pluginConfig.memory
+        ? ["--memory", this.params.pluginConfig.memory]
+        : []),
+      ...(this.params.pluginConfig.clone ? ["--clone"] : []),
+    ];
+    const result = await runSbxCli({
+      context: this.context,
+      args: createArgs,
+      cwd: this.params.createParams.workspaceDir,
+      timeoutMs: Math.max(this.params.pluginConfig.timeoutMs, 300_000),
+    });
+    if (result.code !== 0) {
+      throw new Error(result.stderr.trim() || "sbx create failed");
+    }
+  }
+
+  private buildWorkspaceArgs(): string[] {
+    const workspaceDir = this.params.createParams.workspaceDir;
+    const args = [workspaceDir];
+    const workspaceAccess = this.params.createParams.cfg.workspaceAccess;
+    const agentWorkspaceDir = this.params.createParams.agentWorkspaceDir;
+    if (
+      workspaceAccess !== "none" &&
+      path.resolve(agentWorkspaceDir) !== path.resolve(workspaceDir)
+    ) {
+      args.push(workspaceAccess === "ro" ? `${agentWorkspaceDir}:ro` : agentWorkspaceDir);
+    }
+    if (workspaceAccess === "rw" && this.params.createParams.skillsWorkspaceDir) {
+      args.push(this.params.createParams.skillsWorkspaceDir);
+    }
+    return args;
+  }
+}
+
+type SbxListEntry = { name?: string; status?: string };
+
+async function listSbxSandboxes(context: SbxExecContext): Promise<SbxListEntry[]> {
+  const result = await runSbxCli({ context, args: ["ls", "--json"] });
+  if (result.code !== 0) {
+    return [];
+  }
+  const trimmed = result.stdout.trim();
+  if (!trimmed) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? (parsed as SbxListEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function sbxSandboxExists(context: SbxExecContext, name: string): Promise<boolean> {
+  return (await listSbxSandboxes(context)).some((entry) => entry.name === name);
+}
+
+async function sbxSandboxRunning(context: SbxExecContext, name: string): Promise<boolean> {
+  const entry = (await listSbxSandboxes(context)).find((item) => item.name === name);
+  return entry?.status?.toLowerCase() === "running";
+}
+
+export function buildSbxSandboxName(scopeKey: string): string {
+  const trimmed = scopeKey.trim() || "session";
+  const safe = normalizeLowercaseStringOrEmpty(trimmed)
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32);
+  const hash = Array.from(trimmed).reduce(
+    (acc, char) => ((acc * 33) ^ char.charCodeAt(0)) >>> 0,
+    5381,
+  );
+  return `openclaw-${safe || "session"}-${hash.toString(16).slice(0, 8)}`;
+}

--- a/extensions/sbx/src/cli.ts
+++ b/extensions/sbx/src/cli.ts
@@ -1,0 +1,158 @@
+// sbx plugin module implements cli behavior.
+import { spawn } from "node:child_process";
+import {
+  runPluginCommandWithTimeout,
+  type SandboxBackendCommandResult,
+} from "openclaw/plugin-sdk/sandbox";
+import type { ResolvedSbxPluginConfig } from "./config.js";
+
+const SBX_FS_SCRIPT_LABEL = "openclaw-sbx-fs";
+
+export type SbxExecContext = {
+  config: ResolvedSbxPluginConfig;
+  sandboxName: string;
+  timeoutMs?: number;
+};
+
+export function buildSbxBaseArgv(config: ResolvedSbxPluginConfig): string[] {
+  return [config.command];
+}
+
+/** Run a one-shot sbx CLI command (create, ls, rm) and capture text output. */
+export async function runSbxCli(params: {
+  context: SbxExecContext;
+  args: string[];
+  cwd?: string;
+  timeoutMs?: number;
+}): Promise<{ code: number; stdout: string; stderr: string }> {
+  return await runPluginCommandWithTimeout({
+    argv: [...buildSbxBaseArgv(params.context.config), ...params.args],
+    cwd: params.cwd,
+    timeoutMs: params.timeoutMs ?? params.context.timeoutMs ?? params.context.config.timeoutMs,
+    env: process.env,
+  });
+}
+
+/**
+ * Build the argv core spawns for an interactive exec. Mirrors the Docker
+ * backend's login-shell + PATH handling so custom PATH survives /etc/profile.
+ */
+export function buildSbxExecArgv(params: {
+  config: ResolvedSbxPluginConfig;
+  sandboxName: string;
+  command: string;
+  workdir?: string;
+  env: Record<string, string>;
+  usePty: boolean;
+}): string[] {
+  const args = [...buildSbxBaseArgv(params.config), "exec", "-i"];
+  if (params.usePty) {
+    args.push("-t");
+  }
+  if (params.workdir) {
+    args.push("-w", params.workdir);
+  }
+  if (params.config.user) {
+    args.push("-u", params.config.user);
+  }
+  for (const [key, value] of Object.entries(params.env)) {
+    // Skip PATH: a host PATH (for example Windows paths) passed via -e poisons
+    // executable lookup inside the sandbox. It is reattached below instead.
+    if (key === "PATH") {
+      continue;
+    }
+    args.push("-e", `${key}=${value}`);
+  }
+  const hasCustomPath = typeof params.env.PATH === "string" && params.env.PATH.length > 0;
+  if (hasCustomPath) {
+    args.push("-e", `OPENCLAW_PREPEND_PATH=${params.env.PATH}`);
+  }
+  // A login shell (-l) sources /etc/profile, which resets PATH; re-prepend the
+  // custom PATH afterwards so custom tools stay reachable.
+  const pathExport = hasCustomPath
+    ? 'export PATH="${OPENCLAW_PREPEND_PATH}:$PATH"; unset OPENCLAW_PREPEND_PATH; '
+    : "";
+  args.push(params.sandboxName, "/bin/sh", "-lc", `${pathExport}${params.command}`);
+  return args;
+}
+
+/** Run a backend shell command via `sbx exec` and capture raw buffers. */
+export function runSbxExecShell(params: {
+  config: ResolvedSbxPluginConfig;
+  sandboxName: string;
+  script: string;
+  args?: string[];
+  stdin?: Buffer | string;
+  allowFailure?: boolean;
+  signal?: AbortSignal;
+}): Promise<SandboxBackendCommandResult> {
+  const argv = [
+    ...buildSbxBaseArgv(params.config),
+    "exec",
+    "-i",
+    params.sandboxName,
+    "sh",
+    "-c",
+    params.script,
+    SBX_FS_SCRIPT_LABEL,
+    ...(params.args ?? []),
+  ];
+  return new Promise<SandboxBackendCommandResult>((resolve, reject) => {
+    const [command, ...rest] = argv;
+    const child = spawn(command, rest, {
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let aborted = false;
+
+    const handleAbort = () => {
+      if (aborted) {
+        return;
+      }
+      aborted = true;
+      child.kill("SIGTERM");
+    };
+    if (params.signal) {
+      if (params.signal.aborted) {
+        handleAbort();
+      } else {
+        params.signal.addEventListener("abort", handleAbort, { once: true });
+      }
+    }
+
+    child.stdout?.on("data", (chunk) => {
+      stdoutChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    child.on("error", (error) => {
+      params.signal?.removeEventListener("abort", handleAbort);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      params.signal?.removeEventListener("abort", handleAbort);
+      const stdout = Buffer.concat(stdoutChunks);
+      const stderr = Buffer.concat(stderrChunks);
+      if (aborted || params.signal?.aborted) {
+        reject(new Error("sbx exec command aborted"));
+        return;
+      }
+      const exitCode = code ?? 0;
+      if (exitCode !== 0 && !params.allowFailure) {
+        const message = stderr.length > 0 ? stderr.toString("utf8").trim() : "";
+        reject(new Error(message || `sbx exec ${params.sandboxName} failed`));
+        return;
+      }
+      resolve({ stdout, stderr, code: exitCode });
+    });
+
+    if (params.stdin !== undefined) {
+      child.stdin?.end(params.stdin);
+    } else {
+      child.stdin?.end();
+    }
+  });
+}

--- a/extensions/sbx/src/config.test.ts
+++ b/extensions/sbx/src/config.test.ts
@@ -1,0 +1,67 @@
+// sbx tests cover config plugin behavior.
+import fsSync from "node:fs";
+import { describe, expect, it } from "vitest";
+import { createSbxPluginConfigSchema, resolveSbxPluginConfig } from "./config.js";
+
+describe("sbx plugin config", () => {
+  it("applies defaults", () => {
+    expect(resolveSbxPluginConfig(undefined)).toEqual({
+      command: "sbx",
+      agent: "shell",
+      template: undefined,
+      cpus: undefined,
+      memory: undefined,
+      user: undefined,
+      clone: false,
+      timeoutMs: 120_000,
+    });
+  });
+
+  it("resolves provided values", () => {
+    expect(
+      resolveSbxPluginConfig({
+        command: "/usr/local/bin/sbx",
+        agent: "claude",
+        template: "ghcr.io/example/image:tag",
+        cpus: 4,
+        memory: "8g",
+        user: "root",
+        clone: true,
+        timeoutSeconds: 180,
+      }),
+    ).toEqual({
+      command: "/usr/local/bin/sbx",
+      agent: "claude",
+      template: "ghcr.io/example/image:tag",
+      cpus: 4,
+      memory: "8g",
+      user: "root",
+      clone: true,
+      timeoutMs: 180_000,
+    });
+  });
+
+  it("rejects empty command", () => {
+    expect(() => resolveSbxPluginConfig({ command: "  " })).toThrow(
+      "command must be a non-empty string",
+    );
+  });
+
+  it("rejects negative cpus", () => {
+    expect(() => resolveSbxPluginConfig({ cpus: -1 })).toThrow("cpus must be a number >= 0");
+  });
+
+  it("rejects timeouts beyond Node's safe timer range", () => {
+    expect(() => resolveSbxPluginConfig({ timeoutSeconds: 2_147_001 })).toThrow(
+      "timeoutSeconds must be a number <= 2147000",
+    );
+  });
+
+  it("keeps the runtime json schema in sync with the manifest config schema", () => {
+    const manifest = JSON.parse(
+      fsSync.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+    ) as { configSchema?: unknown };
+
+    expect(createSbxPluginConfigSchema().jsonSchema).toEqual(manifest.configSchema);
+  });
+});

--- a/extensions/sbx/src/config.ts
+++ b/extensions/sbx/src/config.ts
@@ -1,0 +1,99 @@
+// sbx helper module supports config behavior.
+import { buildPluginConfigSchema, type OpenClawPluginConfigSchema } from "openclaw/plugin-sdk/core";
+import {
+  formatPluginConfigIssue,
+  mapPluginConfigIssues,
+} from "openclaw/plugin-sdk/extension-shared";
+import { MAX_TIMER_TIMEOUT_SECONDS } from "openclaw/plugin-sdk/number-runtime";
+import { z } from "zod";
+
+export type ResolvedSbxPluginConfig = {
+  command: string;
+  agent: string;
+  template?: string;
+  cpus?: number;
+  memory?: string;
+  user?: string;
+  clone: boolean;
+  timeoutMs: number;
+};
+
+const DEFAULT_COMMAND = "sbx";
+const DEFAULT_AGENT = "shell";
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+const nonEmptyTrimmedString = (message: string) =>
+  z.string({ error: message }).trim().min(1, { error: message });
+
+const SbxPluginConfigSchema = z.strictObject({
+  command: nonEmptyTrimmedString("command must be a non-empty string").optional(),
+  agent: nonEmptyTrimmedString("agent must be a non-empty string").optional(),
+  template: nonEmptyTrimmedString("template must be a non-empty string").optional(),
+  cpus: z
+    .number({ error: "cpus must be a number >= 0" })
+    .min(0, { error: "cpus must be a number >= 0" })
+    .optional(),
+  memory: nonEmptyTrimmedString("memory must be a non-empty string").optional(),
+  user: nonEmptyTrimmedString("user must be a non-empty string").optional(),
+  clone: z.boolean({ error: "clone must be a boolean" }).optional(),
+  timeoutSeconds: z
+    .number({
+      error: `timeoutSeconds must be a number between 1 and ${MAX_TIMER_TIMEOUT_SECONDS}`,
+    })
+    .min(1, { error: "timeoutSeconds must be a number >= 1" })
+    .max(MAX_TIMER_TIMEOUT_SECONDS, {
+      error: `timeoutSeconds must be a number <= ${MAX_TIMER_TIMEOUT_SECONDS}`,
+    })
+    .optional(),
+});
+
+export function createSbxPluginConfigSchema(): OpenClawPluginConfigSchema {
+  return buildPluginConfigSchema(SbxPluginConfigSchema, {
+    safeParse(value) {
+      if (value === undefined) {
+        return { success: true, data: undefined };
+      }
+      const parsed = SbxPluginConfigSchema.safeParse(value);
+      if (parsed.success) {
+        return { success: true, data: parsed.data };
+      }
+      return {
+        success: false,
+        error: {
+          issues: mapPluginConfigIssues(parsed.error.issues),
+        },
+      };
+    },
+  });
+}
+
+export function resolveSbxPluginConfig(value: unknown): ResolvedSbxPluginConfig {
+  if (value === undefined) {
+    return {
+      command: DEFAULT_COMMAND,
+      agent: DEFAULT_AGENT,
+      clone: false,
+      timeoutMs: DEFAULT_TIMEOUT_MS,
+    };
+  }
+
+  const parsed = SbxPluginConfigSchema.safeParse(value);
+  if (!parsed.success) {
+    const message = formatPluginConfigIssue(parsed.error.issues[0]);
+    throw new Error(`Invalid sbx plugin config: ${message}`);
+  }
+  const cfg = parsed.data;
+  return {
+    command: cfg.command ?? DEFAULT_COMMAND,
+    agent: cfg.agent ?? DEFAULT_AGENT,
+    template: cfg.template,
+    cpus: cfg.cpus,
+    memory: cfg.memory,
+    user: cfg.user,
+    clone: cfg.clone ?? false,
+    timeoutMs:
+      typeof cfg.timeoutSeconds === "number"
+        ? Math.floor(cfg.timeoutSeconds * 1000)
+        : DEFAULT_TIMEOUT_MS,
+  };
+}

--- a/extensions/sbx/tsconfig.json
+++ b/extensions/sbx/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "!dist/extensions/qa-lab/**",
     "!dist/extensions/qa-matrix/**",
     "!dist/extensions/openshell/**",
+    "!dist/extensions/sbx/**",
     "!dist/extensions/slack/**",
     "!dist/extensions/synology-chat/**",
     "!dist/extensions/tokenjuice/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1419,6 +1419,16 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/sbx:
+    dependencies:
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/searxng:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -246,6 +246,23 @@
       }
     },
     {
+      "name": "@openclaw/sbx-sandbox",
+      "description": "OpenClaw Docker Sandboxes (sbx) sandbox backend",
+      "source": "official",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "sbx",
+          "label": "Docker Sandboxes"
+        },
+        "install": {
+          "npmSpec": "@openclaw/sbx-sandbox",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.5.12-beta.1"
+        }
+      }
+    },
+    {
       "name": "@openclaw/tokenjuice",
       "description": "OpenClaw tokenjuice exec output compaction plugin",
       "source": "official",

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -49,6 +49,7 @@ const EXPECTED_BUNDLED_STARTUP_PLUGIN_IDS = [
   "openshell",
   "phone-control",
   "policy",
+  "sbx",
   "talk-voice",
   "thread-ownership",
   "voice-call",

--- a/src/plugins/contracts/package-manifest.contract.test.ts
+++ b/src/plugins/contracts/package-manifest.contract.test.ts
@@ -63,6 +63,7 @@ const packageManifestContractTests: PackageManifestContractParams[] = [
     pluginId: "qqbot",
     pluginLocalRuntimeDeps: ["@tencent-connect/qqbot-connector", "mpg123-decoder", "silk-wasm"],
   },
+  { pluginId: "sbx" },
   { pluginId: "slack" },
   { pluginId: "synology-chat", minHostVersionBaseline: "2026.3.22" },
   { pluginId: "telegram" },

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -185,7 +185,7 @@ describe("bundled plugin build entries", () => {
     const entries = listBundledPluginBuildEntries();
     const artifacts = listBundledPluginPackArtifacts();
 
-    for (const pluginId of ["copilot", "openshell", "slack", "tokenjuice"]) {
+    for (const pluginId of ["copilot", "openshell", "sbx", "slack", "tokenjuice"]) {
       expectNoPrefixMatches(Object.keys(entries), `extensions/${pluginId}/`);
       expectNoPrefixMatches(artifacts, `dist/extensions/${pluginId}/`);
     }

--- a/test/vitest/vitest.extension-misc-paths.mjs
+++ b/test/vitest/vitest.extension-misc-paths.mjs
@@ -18,6 +18,7 @@ export const miscExtensionTestRoots = [
   "extensions/parallel",
   "extensions/perplexity",
   "extensions/phone-control",
+  "extensions/sbx",
   "extensions/searxng",
   "extensions/synthetic",
   "extensions/tavily",


### PR DESCRIPTION
## Summary

Adds an official external sandbox-backend plugin, `@openclaw/sbx-sandbox` (plugin id `sbx`), that delegates sandbox lifecycle to the Docker Sandboxes `sbx` CLI (equivalently `docker sandbox`). It is wired up to be on par with the existing OpenShell sandbox backend plugin, including documentation, discovery/catalog entries, and contract tests.

Unlike OpenShell's SSH mirror/remote model, `sbx` bind-mounts the host workspace at the same path and runs commands through `sbx exec`, so it behaves like the built-in `docker` backend but is driven by the `sbx` CLI. The plugin reuses the core default filesystem bridge through `runShellCommand`, so it stays small.

## What changed

New plugin `extensions/sbx/`:

- `index.ts` — `definePluginEntry` + `registerSandboxBackend("sbx", { factory, manager, resolveWorkdir })`.
- `src/config.ts` — Zod config schema + defaults (`command`, `agent`, `template`, `cpus`, `memory`, `user`, `clone`, `timeoutSeconds`).
- `src/cli.ts` — `sbx` CLI helpers: one-shot runner, `sbx exec` argv builder (login shell + PATH handling mirroring the Docker backend), and a buffer/stdin-aware `sbx exec` runner for the fs bridge.
- `src/backend.ts` — `SandboxBackendFactory`/`SandboxBackendManager`: ensure-create via `sbx create <agent> <workspace> --name ...`, exec via `sbx exec`, lifecycle via `sbx ls --json` / `sbx rm -f`.
- `package.json`, `openclaw.plugin.json`, `npm-shrinkwrap.json`, `tsconfig.json`, `README.md`, and unit tests.

Integration points (parity with OpenShell):

- `pnpm-lock.yaml` — new `extensions/sbx` workspace importer (required for `--frozen-lockfile` installs)
- `scripts/lib/official-external-plugin-catalog.json` — catalog entry
- root `package.json` — `!dist/extensions/sbx/**` files exclusion
- `.github/labeler.yml` — `extensions: sbx` label
- `test/vitest/vitest.extension-misc-paths.mjs` — test routing
- enumeration/contract tests: `bundled-plugin-metadata.test.ts`, `package-manifest.contract.test.ts`, `bundled-plugin-build-entries.test.ts`

Documentation:

- New `docs/gateway/sbx.md` (prerequisites, quick start, full config reference, examples, lifecycle, limitations, how it works)
- Generated `docs/plugins/reference/sbx.md` + inventory/reference index (via `pnpm plugins:inventory:gen`)
- `docs/docs.json` nav entry; `docs/gateway/sandboxing.md` backend list, a new "sbx backend" subsection, and a related link
- `docs/.i18n/glossary.zh-CN.json` — keep-English glossary terms for the new page titles/labels (i18n guard)

## Verification

Ran locally against a full `pnpm install` (Node, pnpm 11.2.2):

- `pnpm install --frozen-lockfile` — passes (was the original CI blocker; fixed by the lockfile importer).
- `extensions/sbx` unit tests — 11 passed (config + backend/exec-argv + name generation; includes the manifest `configSchema` vs zod `jsonSchema` sync assertion).
- `tsgo` prod extension types and extension test types — pass.
- oxlint on `extensions/sbx` — clean.
- `package-manifest.contract.test.ts`, `bundled-plugin-build-entries.test.ts`, `official-external-plugin-catalog.test.ts`, `bundled-plugin-metadata.test.ts` — pass.
- `pnpm check:docs` (format, lint, MDX, i18n glossary, links) — pass.

Not included: an `sbx` e2e CI lane (OpenShell's e2e needs the real CLI + Docker). Happy to add a gated e2e test + workflow entry if wanted.

## Release note

Add a Docker Sandboxes (`sbx`) sandbox backend plugin (`@openclaw/sbx-sandbox`) for running agent tools in `sbx`-managed containers.


## Real behavior proof

- **Behavior addressed:** Adds a `sbx` sandbox backend so OpenClaw routes agent exec/file tools through Docker Sandboxes; also fixes the CI install break by adding the `extensions/sbx` workspace importer to `pnpm-lock.yaml`.
- **Real environment tested:** Local macOS checkout with a full `pnpm install` (Node, pnpm 11.2.2). Real OpenClaw Gateway + `sbx` CLI + Docker runtime were not available in this environment.
- **Exact steps or command run after this patch:**
  - `pnpm install --frozen-lockfile`
  - `pnpm test extensions/sbx`
  - `pnpm tsgo:extensions && pnpm tsgo:extensions:test`
  - `pnpm test src/plugins/bundled-plugin-metadata.test.ts src/plugins/contracts/package-manifest.contract.test.ts test/scripts/bundled-plugin-build-entries.test.ts`
  - `pnpm check:docs`
- **Evidence after fix:** `--frozen-lockfile` install now succeeds (previously `ERR_PNPM_OUTDATED_LOCKFILE` blocked every job); `extensions/sbx` tests 11/11 pass; tsgo prod+test extension types pass; contract/metadata tests pass; `check:docs` passes.
- **Observed result after fix:** The plugin registers the `sbx` backend, builds `sbx exec`/`sbx create` argv as expected (covered by unit tests), and all touched-surface checks are green locally.
- **What was not tested:** End-to-end execution against a live `sbx` CLI + Docker daemon inside a running OpenClaw Gateway (no sbx binary/Docker in this environment). A maintainer can apply a `proof:` override, or I can add a gated e2e lane if desired.
