### PR TITLE
Refresh memory index state after external reindex

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -139,6 +139,8 @@ const SESSION_SYNC_YIELD_EVERY = 10;
 const SOURCE_WIDE_SESSION_INDEX_FLUSH_FILES = 128;
 const VECTOR_LOAD_TIMEOUT_MS = 30_000;
 const MEMORY_WATCH_PRESSURE_STARTUP_CHECK_DELAY_MS = 10_000;
+const MEMORY_INDEX_STALE_TEMP_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const MEMORY_INDEX_TEMP_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
   ".git",
   "node_modules",
@@ -185,6 +187,71 @@ function resolveMemoryNativeWatchFactory(): typeof fsSync.watch {
     }
   }
   return fsSync.watch.bind(fsSync);
+}
+
+function resolveMemoryIndexTempFamilyBaseName(
+  dbBaseName: string,
+  entryName: string,
+): string | null {
+  const prefix = `${dbBaseName}.tmp-`;
+  if (!entryName.startsWith(prefix)) {
+    return null;
+  }
+  const withoutSidecar = entryName.endsWith("-wal")
+    ? entryName.slice(0, -4)
+    : entryName.endsWith("-shm")
+      ? entryName.slice(0, -4)
+      : entryName;
+  const suffix = withoutSidecar.slice(prefix.length);
+  return MEMORY_INDEX_TEMP_UUID_RE.test(suffix) ? withoutSidecar : null;
+}
+
+function removeStaleMemoryIndexTempFamilies(dbPath: string, nowMs = Date.now()): void {
+  const dir = path.dirname(dbPath);
+  const dbBaseName = path.basename(dbPath);
+  let entries: fsSync.Dirent[];
+  try {
+    entries = fsSync.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  const families = new Map<string, string[]>();
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    const familyBaseName = resolveMemoryIndexTempFamilyBaseName(dbBaseName, entry.name);
+    if (!familyBaseName) {
+      continue;
+    }
+    const family = families.get(familyBaseName) ?? [];
+    family.push(path.join(dir, entry.name));
+    families.set(familyBaseName, family);
+  }
+  const staleBeforeMs = nowMs - MEMORY_INDEX_STALE_TEMP_MAX_AGE_MS;
+  for (const family of families.values()) {
+    const stats = family
+      .map((entry) => {
+        try {
+          return fsSync.statSync(entry);
+        } catch {
+          return null;
+        }
+      })
+      .filter((entry): entry is fsSync.Stats => entry !== null);
+    if (stats.length === 0 || stats.some((entry) => entry.mtimeMs > staleBeforeMs)) {
+      continue;
+    }
+    for (const entry of family) {
+      try {
+        fsSync.rmSync(entry, { force: true });
+      } catch (err) {
+        log.debug(
+          `failed to remove stale memory index temp file ${entry}: ${formatErrorMessage(err)}`,
+        );
+      }
+    }
+  }
 }
 
 function shouldIgnoreMemoryWatchPath(
@@ -640,6 +707,7 @@ export abstract class MemoryManagerSyncOps {
 
   protected openDatabase(): DatabaseSync {
     const dbPath = resolveUserPath(this.settings.store.path);
+    removeStaleMemoryIndexTempFamilies(dbPath);
     return openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled);
   }
 

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -139,8 +139,6 @@ const SESSION_SYNC_YIELD_EVERY = 10;
 const SOURCE_WIDE_SESSION_INDEX_FLUSH_FILES = 128;
 const VECTOR_LOAD_TIMEOUT_MS = 30_000;
 const MEMORY_WATCH_PRESSURE_STARTUP_CHECK_DELAY_MS = 10_000;
-const MEMORY_INDEX_STALE_TEMP_MAX_AGE_MS = 24 * 60 * 60 * 1000;
-const MEMORY_INDEX_TEMP_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
   ".git",
   "node_modules",
@@ -187,71 +185,6 @@ function resolveMemoryNativeWatchFactory(): typeof fsSync.watch {
     }
   }
   return fsSync.watch.bind(fsSync);
-}
-
-function resolveMemoryIndexTempFamilyBaseName(
-  dbBaseName: string,
-  entryName: string,
-): string | null {
-  const prefix = `${dbBaseName}.tmp-`;
-  if (!entryName.startsWith(prefix)) {
-    return null;
-  }
-  const withoutSidecar = entryName.endsWith("-wal")
-    ? entryName.slice(0, -4)
-    : entryName.endsWith("-shm")
-      ? entryName.slice(0, -4)
-      : entryName;
-  const suffix = withoutSidecar.slice(prefix.length);
-  return MEMORY_INDEX_TEMP_UUID_RE.test(suffix) ? withoutSidecar : null;
-}
-
-function removeStaleMemoryIndexTempFamilies(dbPath: string, nowMs = Date.now()): void {
-  const dir = path.dirname(dbPath);
-  const dbBaseName = path.basename(dbPath);
-  let entries: fsSync.Dirent[];
-  try {
-    entries = fsSync.readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return;
-  }
-  const families = new Map<string, string[]>();
-  for (const entry of entries) {
-    if (!entry.isFile()) {
-      continue;
-    }
-    const familyBaseName = resolveMemoryIndexTempFamilyBaseName(dbBaseName, entry.name);
-    if (!familyBaseName) {
-      continue;
-    }
-    const family = families.get(familyBaseName) ?? [];
-    family.push(path.join(dir, entry.name));
-    families.set(familyBaseName, family);
-  }
-  const staleBeforeMs = nowMs - MEMORY_INDEX_STALE_TEMP_MAX_AGE_MS;
-  for (const family of families.values()) {
-    const stats = family
-      .map((entry) => {
-        try {
-          return fsSync.statSync(entry);
-        } catch {
-          return null;
-        }
-      })
-      .filter((entry): entry is fsSync.Stats => entry !== null);
-    if (stats.length === 0 || stats.some((entry) => entry.mtimeMs > staleBeforeMs)) {
-      continue;
-    }
-    for (const entry of family) {
-      try {
-        fsSync.rmSync(entry, { force: true });
-      } catch (err) {
-        log.debug(
-          `failed to remove stale memory index temp file ${entry}: ${formatErrorMessage(err)}`,
-        );
-      }
-    }
-  }
 }
 
 function shouldIgnoreMemoryWatchPath(
@@ -707,7 +640,6 @@ export abstract class MemoryManagerSyncOps {
 
   protected openDatabase(): DatabaseSync {
     const dbPath = resolveUserPath(this.settings.store.path);
-    removeStaleMemoryIndexTempFamilies(dbPath);
     return openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled);
   }
 

--- a/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
+++ b/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
@@ -205,4 +205,33 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
     expect(statusAfter.chunks).toBeGreaterThan(0);
     expect(statusAfter.dirty).toBe(false);
   });
+
+  it("clears stale dirty state when search first observes a cli atomic reindex replacement", async () => {
+    await seedChunksWithNoMeta();
+    const memoryManager = await createManager({ provider: "none", vectorEnabled: false });
+
+    expect(indexIdentityStatus(memoryManager)).toBe("missing");
+
+    const cliResult = await getMemorySearchManager({
+      cfg: createCfg({ provider: "none", vectorEnabled: false }),
+      agentId: "main",
+      purpose: "cli",
+    });
+    if (!cliResult.manager) {
+      throw new Error(cliResult.error ?? "cli manager missing");
+    }
+    const cliManager = cliResult.manager as unknown as MemoryIndexManager;
+    try {
+      await cliManager.sync({ reason: "cli", force: true });
+    } finally {
+      await cliManager.close?.();
+    }
+
+    const results = await memoryManager.search("Alpha topic");
+    const statusAfter = memoryManager.status();
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(statusAfter.custom?.indexIdentity).toEqual({ status: "valid" });
+    expect(statusAfter.dirty).toBe(false);
+  });
 });

--- a/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
+++ b/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
@@ -99,15 +99,6 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
     return manager;
   }
 
-  async function expectPathMissing(targetPath: string): Promise<void> {
-    await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
-  }
-
-  async function markOld(paths: string[]): Promise<void> {
-    const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1000);
-    await Promise.all(paths.map((entry) => fs.utimes(entry, oldDate, oldDate)));
-  }
-
   async function seedChunksWithNoMeta(model = "fts-only"): Promise<void> {
     const db = new DatabaseSync(indexPath);
     db.exec(`
@@ -164,19 +155,6 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
     expect(indexIdentityStatus(memoryManager)).toBe("missing");
     expect(statusAfter.chunks).toBe(1);
     expect(statusAfter.dirty).toBe(true);
-  });
-
-  it("removes stale atomic reindex temp sqlite families when opening the manager", async () => {
-    const staleTemp = `${indexPath}.tmp-11111111-1111-4111-8111-111111111111`;
-    const stalePaths = [staleTemp, `${staleTemp}-wal`, `${staleTemp}-shm`];
-    const freshTemp = `${indexPath}.tmp-22222222-2222-4222-8222-222222222222`;
-    await Promise.all([...stalePaths, freshTemp].map((entry) => fs.writeFile(entry, "temp")));
-    await markOld(stalePaths);
-
-    await createManager({ provider: "none", vectorEnabled: false });
-
-    await Promise.all(stalePaths.map((entry) => expectPathMissing(entry)));
-    await expect(fs.access(freshTemp)).resolves.toBeUndefined();
   });
 
   it("refreshes a cached manager after a cli atomic reindex replaces the sqlite file", async () => {

--- a/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
+++ b/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
@@ -212,4 +212,48 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
     expect(statusAfter.custom?.indexIdentity).toEqual({ status: "valid" });
     expect(statusAfter.dirty).toBe(false);
   });
+
+  it("preserves pending memory and session dirty work when replacement refresh clears missing identity", async () => {
+    await seedChunksWithNoMeta();
+    const memoryManager = await createManager({ provider: "none", vectorEnabled: false });
+    const dirtyState = memoryManager as unknown as {
+      dirty: boolean;
+      memoryFullRetryDirty: boolean;
+      sessionsDirty: boolean;
+      sessionsDirtyFiles: Set<string>;
+      sessionsFullRetryDirty: boolean;
+    };
+
+    expect(indexIdentityStatus(memoryManager)).toBe("missing");
+    dirtyState.dirty = true;
+    dirtyState.memoryFullRetryDirty = true;
+    dirtyState.sessionsDirty = true;
+    dirtyState.sessionsDirtyFiles.add("session-a.jsonl");
+    dirtyState.sessionsFullRetryDirty = true;
+
+    const cliResult = await getMemorySearchManager({
+      cfg: createCfg({ provider: "none", vectorEnabled: false }),
+      agentId: "main",
+      purpose: "cli",
+    });
+    if (!cliResult.manager) {
+      throw new Error(cliResult.error ?? "cli manager missing");
+    }
+    const cliManager = cliResult.manager as unknown as MemoryIndexManager;
+    try {
+      await cliManager.sync({ reason: "cli", force: true });
+    } finally {
+      await cliManager.close?.();
+    }
+
+    const statusAfter = memoryManager.status();
+
+    expect(statusAfter.custom?.indexIdentity).toEqual({ status: "valid" });
+    expect(statusAfter.dirty).toBe(true);
+    expect(dirtyState.dirty).toBe(true);
+    expect(dirtyState.memoryFullRetryDirty).toBe(true);
+    expect(dirtyState.sessionsDirty).toBe(true);
+    expect(dirtyState.sessionsDirtyFiles.has("session-a.jsonl")).toBe(true);
+    expect(dirtyState.sessionsFullRetryDirty).toBe(true);
+  });
 });

--- a/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
+++ b/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
@@ -65,14 +65,12 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
     }
   });
 
-  async function createManager(
-    params: { provider?: string; vectorEnabled?: boolean } = {},
-  ): Promise<MemoryIndexManager> {
+  function createCfg(params: { provider?: string; vectorEnabled?: boolean } = {}): OpenClawConfig {
     const store =
       params.vectorEnabled === undefined
         ? { path: indexPath }
         : { path: indexPath, vector: { enabled: params.vectorEnabled } };
-    const cfg = {
+    return {
       memory: { backend: "builtin" },
       agents: {
         defaults: {
@@ -88,12 +86,26 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
         list: [{ id: "main", default: true }],
       },
     } as OpenClawConfig;
-    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+  }
+
+  async function createManager(
+    params: { provider?: string; vectorEnabled?: boolean } = {},
+  ): Promise<MemoryIndexManager> {
+    const result = await getMemorySearchManager({ cfg: createCfg(params), agentId: "main" });
     if (!result.manager) {
       throw new Error(result.error ?? "manager missing");
     }
     manager = result.manager as unknown as MemoryIndexManager;
     return manager;
+  }
+
+  async function expectPathMissing(targetPath: string): Promise<void> {
+    await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+  }
+
+  async function markOld(paths: string[]): Promise<void> {
+    const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    await Promise.all(paths.map((entry) => fs.utimes(entry, oldDate, oldDate)));
   }
 
   async function seedChunksWithNoMeta(model = "fts-only"): Promise<void> {
@@ -152,5 +164,45 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
     expect(indexIdentityStatus(memoryManager)).toBe("missing");
     expect(statusAfter.chunks).toBe(1);
     expect(statusAfter.dirty).toBe(true);
+  });
+
+  it("removes stale atomic reindex temp sqlite families when opening the manager", async () => {
+    const staleTemp = `${indexPath}.tmp-11111111-1111-4111-8111-111111111111`;
+    const stalePaths = [staleTemp, `${staleTemp}-wal`, `${staleTemp}-shm`];
+    const freshTemp = `${indexPath}.tmp-22222222-2222-4222-8222-222222222222`;
+    await Promise.all([...stalePaths, freshTemp].map((entry) => fs.writeFile(entry, "temp")));
+    await markOld(stalePaths);
+
+    await createManager({ provider: "none", vectorEnabled: false });
+
+    await Promise.all(stalePaths.map((entry) => expectPathMissing(entry)));
+    await expect(fs.access(freshTemp)).resolves.toBeUndefined();
+  });
+
+  it("refreshes a cached manager after a cli atomic reindex replaces the sqlite file", async () => {
+    await seedChunksWithNoMeta();
+    const memoryManager = await createManager({ provider: "none", vectorEnabled: false });
+
+    expect(indexIdentityStatus(memoryManager)).toBe("missing");
+
+    const cliResult = await getMemorySearchManager({
+      cfg: createCfg({ provider: "none", vectorEnabled: false }),
+      agentId: "main",
+      purpose: "cli",
+    });
+    if (!cliResult.manager) {
+      throw new Error(cliResult.error ?? "cli manager missing");
+    }
+    const cliManager = cliResult.manager as unknown as MemoryIndexManager;
+    try {
+      await cliManager.sync({ reason: "cli", force: true });
+    } finally {
+      await cliManager.close?.();
+    }
+
+    const statusAfter = memoryManager.status();
+    expect(statusAfter.custom?.indexIdentity).toEqual({ status: "valid" });
+    expect(statusAfter.chunks).toBeGreaterThan(0);
+    expect(statusAfter.dirty).toBe(false);
   });
 });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1,4 +1,5 @@
 // Memory Core plugin module implements manager behavior.
+import fsSync from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import type { FSWatcher } from "chokidar";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -8,6 +9,7 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveMemorySearchConfig,
+  resolveUserPath,
   type OpenClawConfig,
   type ResolvedMemorySearchConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
@@ -88,7 +90,19 @@ type EmbeddingProbeCacheEntry = {
   expireAtMs: number;
 };
 
+type MemoryIndexFileSignature = {
+  dev: number;
+  ino: number;
+};
+
 const EMBEDDING_PROBE_CACHE = new Map<string, EmbeddingProbeCacheEntry>();
+
+function sameMemoryIndexFileSignature(
+  left: MemoryIndexFileSignature | null,
+  right: MemoryIndexFileSignature | null,
+): boolean {
+  return Boolean(left && right && left.dev === right.dev && left.ino === right.ino);
+}
 
 export async function closeAllMemoryIndexManagers(): Promise<void> {
   EMBEDDING_PROBE_CACHE.clear();
@@ -290,6 +304,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private readonlyRecoverySuccesses = 0;
   private readonlyRecoveryFailures = 0;
   private readonlyRecoveryLastError?: string;
+  private indexFileSignature: MemoryIndexFileSignature | null = null;
   private indexIdentityState: MemoryIndexIdentityState = {
     status: "missing",
     reason: "index metadata is missing",
@@ -387,6 +402,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     this.sources = new Set(effectiveSettings.sources);
     this.db = this.openDatabase();
+    this.indexFileSignature = this.readCurrentIndexFileSignature();
     this.providerKey = this.computeProviderKey();
     this.cache = {
       enabled: effectiveSettings.cache.enabled,
@@ -546,6 +562,41 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
   }
 
+  private readCurrentIndexFileSignature(): MemoryIndexFileSignature | null {
+    try {
+      const stat = fsSync.statSync(resolveUserPath(this.settings.store.path));
+      return { dev: stat.dev, ino: stat.ino };
+    } catch {
+      return null;
+    }
+  }
+
+  private refreshDatabaseHandleIfExternallyReplaced(): boolean {
+    if (this.closed || this.syncing) {
+      return false;
+    }
+    const currentSignature = this.readCurrentIndexFileSignature();
+    if (!currentSignature) {
+      return false;
+    }
+    if (!this.indexFileSignature) {
+      this.indexFileSignature = currentSignature;
+      return false;
+    }
+    if (sameMemoryIndexFileSignature(this.indexFileSignature, currentSignature)) {
+      return false;
+    }
+    try {
+      closeMemoryDatabase(this.db);
+    } catch {}
+    this.db = this.openDatabase();
+    this.indexFileSignature = this.readCurrentIndexFileSignature();
+    this.resetVectorState();
+    this.ensureSchema();
+    this.vector.dims = this.readMeta()?.vectorDims;
+    return true;
+  }
+
   async warmSession(sessionKey?: string): Promise<void> {
     if (!this.settings.sync.onSessionStart) {
       return;
@@ -563,6 +614,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   private refreshIndexIdentityDirty(params?: { providerKeyKnown?: boolean }) {
+    const hadIndexIdentityDirty = this.indexIdentityDirty;
+    const refreshedDatabase = this.refreshDatabaseHandleIfExternallyReplaced();
     const provider =
       this.settings.provider === "none"
         ? null
@@ -579,6 +632,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.indexIdentityDirty =
       state.status === "mismatched" ||
       (state.status === "missing" && (this.sources.has("memory") || this.hasIndexedChunks()));
+    if (refreshedDatabase && hadIndexIdentityDirty && state.status === "valid") {
+      this.dirty = false;
+      this.sessionsDirty = false;
+      this.sessionsDirtyFiles.clear();
+      this.memoryFullRetryDirty = false;
+      this.sessionsFullRetryDirty = false;
+    }
     return state;
   }
 
@@ -601,6 +661,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       await this.ensureProviderInitialized();
       this.assertRequiredProviderAvailable("search");
     }
+    this.refreshDatabaseHandleIfExternallyReplaced();
     let hasIndexedContent = this.hasIndexedContent();
     if (!hasIndexedContent) {
       try {
@@ -966,6 +1027,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (this.closed) {
       return;
     }
+    this.refreshDatabaseHandleIfExternallyReplaced();
     if (this.syncing) {
       if (params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
         return this.enqueueTargetedSessionSync(params.sessionFiles);

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -305,6 +305,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private readonlyRecoveryFailures = 0;
   private readonlyRecoveryLastError?: string;
   private indexFileSignature: MemoryIndexFileSignature | null = null;
+  private indexFileRefreshPendingDirtyCleanup = false;
   private indexIdentityState: MemoryIndexIdentityState = {
     status: "missing",
     reason: "index metadata is missing",
@@ -594,6 +595,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.resetVectorState();
     this.ensureSchema();
     this.vector.dims = this.readMeta()?.vectorDims;
+    this.indexFileRefreshPendingDirtyCleanup = true;
     return true;
   }
 
@@ -615,7 +617,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
   private refreshIndexIdentityDirty(params?: { providerKeyKnown?: boolean }) {
     const hadIndexIdentityDirty = this.indexIdentityDirty;
-    const refreshedDatabase = this.refreshDatabaseHandleIfExternallyReplaced();
+    const refreshedDatabase =
+      this.refreshDatabaseHandleIfExternallyReplaced() || this.indexFileRefreshPendingDirtyCleanup;
     const provider =
       this.settings.provider === "none"
         ? null
@@ -638,6 +641,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.sessionsDirtyFiles.clear();
       this.memoryFullRetryDirty = false;
       this.sessionsFullRetryDirty = false;
+    }
+    if (refreshedDatabase) {
+      this.indexFileRefreshPendingDirtyCleanup = false;
     }
     return state;
   }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -636,11 +636,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       state.status === "mismatched" ||
       (state.status === "missing" && (this.sources.has("memory") || this.hasIndexedChunks()));
     if (refreshedDatabase && hadIndexIdentityDirty && state.status === "valid") {
-      this.dirty = false;
-      this.sessionsDirty = false;
-      this.sessionsDirtyFiles.clear();
-      this.memoryFullRetryDirty = false;
-      this.sessionsFullRetryDirty = false;
+      this.dirty = this.memoryFullRetryDirty || this.pendingWatchPaths.size > 0;
+      this.sessionsDirty = this.sessionsFullRetryDirty || this.sessionsDirtyFiles.size > 0;
     }
     if (refreshedDatabase) {
       this.indexFileRefreshPendingDirtyCleanup = false;


### PR DESCRIPTION
## Summary

- Problem: memory gateway/default managers could keep using an old sqlite handle after a CLI/status atomic reindex replaced the index file, so missing identity or dirty state could remain stuck until process restart. Search-first recovery could read the new DB but still keep stale dirty flags.
- Solution: cached managers now detect when the on-disk sqlite file has been atomically replaced, reopen the DB handle, refresh schema/meta/vector state, and carry the replacement-refresh signal into identity dirty cleanup even when `search()` is the first observer.
- ClawSweeper follow-up: replacement refresh now clears identity-only stale dirty state without clearing real pending memory/session work signaled by memory full-retry, pending watch paths, session full-retry, or session dirty files.
- Scope note: stale sqlite temp cleanup is intentionally left to #92891's guarded pid-lock cleanup path; this PR only handles cached-manager refresh after atomic replacement.
- What did NOT change: semantic indexes are still protected when the configured embedding provider is unavailable; this does not force a semantic rebuild, change provider identity rules, or delete temp sqlite files.
- Why it matters / User impact: a gateway should recover from memory index repair/rebuild work performed by CLI/status flows without requiring a restart.
- Fixes #91167
- Refs #90508

## Real behavior proof
- **Behavior or issue addressed:** This patch covers local memory-index lifecycle failures: a cached live/default manager continuing to report missing identity after a CLI-style manager atomically replaces the same sqlite index with a valid FTS-only index; the search-first path where `manager.search()` is the first call after replacement; and the patch-quality edge where replacement refresh must clear identity-only dirty state without dropping unrelated pending memory/session dirty work.
- **Real environment tested:** Local Linux worktree `/media/vdc/code/ai/aispace/openclaw-worktrees/issue-91167-90508`, branch `feat/issue-91167-90508`.
- **Exact steps or command run after this patch:**

```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-91167-90508 && OPENCLAW_REPO=/media/vdc/code/ai/aispace/openclaw-worktrees/issue-91167-90508 node --import tsx /media/vdc/code/ai/aispace/openclaw-issue-91167-90508-evidence/memory-external-reindex-real-proof.mjs > /media/vdc/code/ai/aispace/openclaw-issue-91167-90508-evidence/memory-external-reindex-real-proof.out.json
```

```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-91167-90508 && OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts -t "clears stale dirty state when search first observes a cli atomic reindex replacement"
```

```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-91167-90508 && OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts -t "preserves pending memory and session dirty work"
```

```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-91167-90508 && OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
```

```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-91167-90508 && ./node_modules/.bin/oxfmt --check --threads=1 extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
```

```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-91167-90508 && node scripts/run-tsgo.mjs -p tsconfig.extensions.json --noEmit
```

```bash
git -C /media/vdc/code/ai/aispace/openclaw-worktrees/issue-91167-90508 diff --check
```

- **Evidence after fix:** The independent Node proof below runs outside Vitest, imports the production memory manager, uses real SQLite files, warms a live/default manager, performs an external CLI-purpose force sync, and then verifies the same live manager object recovers without restart.

```json
{
  "proof": "memory-external-cli-reindex-live-manager-refresh",
  "head": "f007c10b7cc47bda43951ee5f5fedac75eed590d",
  "runtime": "node --import tsx; production memory manager; real sqlite files; no Vitest",
  "scenarios": [
    {
      "scenario": "status-first",
      "firstObserver": "status",
      "sameLiveManagerObject": true,
      "before": { "identity": "missing", "dirty": true, "chunks": 1 },
      "after": { "identity": "valid", "dirty": false, "chunks": 1 },
      "recoveredWithoutRestart": true
    },
    {
      "scenario": "search-first",
      "firstObserver": "search",
      "sameLiveManagerObject": true,
      "before": { "identity": "missing", "dirty": true, "chunks": 1 },
      "after": { "identity": "valid", "dirty": false, "chunks": 1, "searchHits": 1 },
      "recoveredWithoutRestart": true
    }
  ],
  "allRecoveredWithoutRestart": true
}
```

```text
Test Files  1 passed (1)
Tests  1 passed | 3 skipped (4)
```

```text
Test Files  1 passed (1)
Tests  1 passed | 4 skipped (5)
```

```text
Test Files  1 passed (1)
Tests  5 passed (5)
[test] passed 1 Vitest shard in 17.71s
```

```text
All matched files use the correct format.
Finished in 22ms on 2 files using 1 threads.
```

```text
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --noEmit exited 0 with no stdout/stderr output.
```

```text
git diff --check exited 0 with no whitespace errors.
```

- **Observed result after fix:** The cached manager no longer stays stuck on the old missing-identity sqlite handle after a CLI atomic reindex publishes a valid replacement. The real runtime proof covers both first observers with no unrelated pending work: `status()` refreshes to `indexIdentity: valid` and `dirty: false`, and `search("Alpha topic")` returns one hit before the subsequent status reports `valid/dirty=false`. The focused pending-dirty regression then seeds memory full-retry state plus session dirty files/full-retry state before the replacement; after refresh, identity becomes valid while `dirty`, `memoryFullRetryDirty`, `sessionsDirty`, `sessionsDirtyFiles`, and `sessionsFullRetryDirty` remain set. In both runtime-proof scenarios the same warmed live manager object is reused, so recovery happens without process restart. Stale temp cleanup is left to #92891's guarded cleanup path rather than duplicated here.
- **What was not tested:** No remote hosted gateway, desktop app, QMD daemon, or separate OS process gateway was run. The added proof uses a long-lived in-process default manager plus a separate CLI-purpose manager against real SQLite files to exercise the same cached manager / external atomic replacement boundary without mocking the memory manager.

## Regression Test Plan
- **Target test file:** `extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts`.
- **Scenario locked in:** A default manager with missing identity refreshes to valid after a CLI manager atomically replaces the sqlite file; the same replacement also clears identity-only stale dirty state when `search()` is the first post-replacement call; pending memory and session dirty work survives the replacement refresh.
- **Why this is the smallest reliable guardrail:** The tests use real sqlite files, real manager cache semantics, real search, and the existing atomic reindex path rather than mocking the state transition.

## Merge risk
- **Risk labels considered:** public-contract related open PRs for #91167/#90508, local-only proof boundary, memory index lifecycle behavior.
- **Risk explanation:** The patch changes manager lifecycle behavior around sqlite handle refresh after an external atomic replacement and narrows dirty cleanup to identity-only stale state.
- **Why acceptable:** The refresh path only reopens when the main sqlite file identity changes on disk, preserves existing semantic-provider safety checks, and clears identity-only stale dirty state only when the manager previously had identity dirty state and the replacement index resolves as valid. Pending memory/session work remains dirty when backed by full-retry, pending watch-path, or session dirty-file state. A pending refresh marker only survives until the next identity refresh consumes it.

## Root Cause
- **Root cause:** Safe reindex publishes by replacing the sqlite file, but an already-cached manager keeps its existing sqlite handle and in-memory identity/dirty flags. `search()` could refresh the handle before `refreshIndexIdentityDirty()` ran, consuming the one-shot replacement signal and leaving stale dirty/retry state in memory. The first cleanup pass also cleared all dirty/session retry state after a valid replacement, which fixed identity-only stale dirty flags but could drop unrelated pending memory/session work.
- **Why this is root-cause fix:** The cached manager now treats the on-disk sqlite file identity as the source-of-truth for whether its handle is stale, reopens when that identity changes, and carries that replacement signal until identity cleanup recomputes state from the replacement DB. Cleanup now recomputes only identity-derived stale dirtiness while preserving independently queued memory/session retry work.
- **Fix classification:** Root-cause reliability fix for memory index lifecycle refresh after external atomic replacement.
- **Maintainer-ready confidence:** High for the local sqlite/index lifecycle paths covered here. The patch is limited to manager open/refresh behavior and deterministic memory-core tests.
- **Patch quality notes:** The diff adds a dev/ino based DB replacement check, a pending dirty-cleanup marker, and regression tests for stale identity cleanup plus pending memory/session dirty preservation. It does not add sleeps, broaden provider compatibility, duplicate #92891's guarded temp cleanup, or relax semantic-index protection.
- **Architecture / source-of-truth check:** The sqlite index file identity and `memory_index_meta_v1` remain the source of truth; the live manager now refreshes its in-memory view from that source instead of trusting stale process-local state.
