### PR TITLE
#92944: Telegram commands can remain empty after interrupted sync due to stale local command hash

### DIFF
--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -423,10 +423,12 @@ describe("bot-native-command-menu", () => {
     expect(hashCommandList(a)).not.toBe(hashCommandList(b));
   });
 
-  it("skips sync when command hash is unchanged and remote is populated (#32017)", async () => {
+  it("cached-hash skips sync when default and group remote command states are populated (#32017)", async () => {
     const deleteMyCommands = vi.fn(async () => undefined);
     const setMyCommands = vi.fn(async () => undefined);
-    const getMyCommands = vi.fn(async () => [{ command: "skip_test", description: "Skip test command" }]);
+    const getMyCommands = vi.fn(async () => [
+      { command: "skip_test", description: "Skip test command" },
+    ]);
     const runtimeLog = vi.fn();
 
     const accountId = `test-skip-${Date.now()}`;
@@ -446,7 +448,7 @@ describe("bot-native-command-menu", () => {
       expect(setMyCommands).toHaveBeenCalledTimes(2);
     });
 
-    // Second sync: hash matches AND getMyCommands returns non-empty → skip
+    // Second sync: hash matches and every remote scope is non-empty.
     syncMenuCommandsWithMocks({
       deleteMyCommands,
       setMyCommands,
@@ -462,6 +464,8 @@ describe("bot-native-command-menu", () => {
       expect(getMyCommands).toHaveBeenCalled();
     });
     expect(setMyCommands).toHaveBeenCalledTimes(2);
+    expect(getMyCommands).toHaveBeenCalledWith(undefined);
+    expect(getMyCommands).toHaveBeenCalledWith({ scope: { type: "all_group_chats" } });
   });
 
   it("does not reuse cached hash across different bot identities", async () => {
@@ -621,7 +625,7 @@ describe("bot-native-command-menu", () => {
     );
   });
 
-  it("re-syncs when remote command state is empty despite matching hash (#92944)", async () => {
+  it("cached-hash re-syncs when default remote command state is empty despite matching hash (#92944)", async () => {
     const deleteMyCommands = vi.fn(async () => undefined);
     const setMyCommands = vi.fn(async () => undefined);
     const getMyCommands = vi.fn(async () => []);
@@ -629,23 +633,66 @@ describe("bot-native-command-menu", () => {
     const accountId = `test-empty-remote-${Date.now()}`;
     const commands = [{ command: "test", description: "Test" }];
 
-    // First sync — populates hash
     syncMenuCommandsWithMocks({
-      deleteMyCommands, setMyCommands, getMyCommands, runtimeLog,
-      commandsToRegister: commands, accountId, botIdentity: "bot-a",
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      runtimeLog,
+      commandsToRegister: commands,
+      accountId,
+      botIdentity: "bot-a",
     });
     await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(2));
 
-    // Second sync — hash matches but getMyCommands returns empty → should re-sync
     syncMenuCommandsWithMocks({
-      deleteMyCommands, setMyCommands, getMyCommands, runtimeLog,
-      commandsToRegister: commands, accountId, botIdentity: "bot-a",
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      runtimeLog,
+      commandsToRegister: commands,
+      accountId,
+      botIdentity: "bot-a",
     });
     await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(4));
     expect(getMyCommands).toHaveBeenCalled();
   });
 
-  it("skips sync when remote command state is non-empty and hash matches", async () => {
+  it("cached-hash re-syncs when group remote command state is empty despite matching hash (#92944)", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const getMyCommands = vi.fn(async (opts?: { scope?: { type?: string } }) =>
+      opts?.scope?.type === "all_group_chats" ? [] : [{ command: "test", description: "Test" }],
+    );
+    const runtimeLog = vi.fn();
+    const accountId = `test-empty-group-remote-${Date.now()}`;
+    const commands = [{ command: "test", description: "Test" }];
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      runtimeLog,
+      commandsToRegister: commands,
+      accountId,
+      botIdentity: "bot-group",
+    });
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(2));
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      runtimeLog,
+      commandsToRegister: commands,
+      accountId,
+      botIdentity: "bot-group",
+    });
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(4));
+    expect(getMyCommands).toHaveBeenCalledWith(undefined);
+    expect(getMyCommands).toHaveBeenCalledWith({ scope: { type: "all_group_chats" } });
+  });
+
+  it("cached-hash skips sync when remote command state is non-empty and hash matches", async () => {
     const deleteMyCommands = vi.fn(async () => undefined);
     const setMyCommands = vi.fn(async () => undefined);
     const getMyCommands = vi.fn(async () => [{ command: "test", description: "Test" }]);
@@ -653,60 +700,121 @@ describe("bot-native-command-menu", () => {
     const accountId = `test-populated-remote-${Date.now()}`;
     const commands = [{ command: "test", description: "Test" }];
 
-    // First sync — populates hash
     syncMenuCommandsWithMocks({
-      deleteMyCommands, setMyCommands, getMyCommands, runtimeLog,
-      commandsToRegister: commands, accountId, botIdentity: "bot-b",
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      runtimeLog,
+      commandsToRegister: commands,
+      accountId,
+      botIdentity: "bot-b",
     });
     await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(2));
 
-    // Second sync — hash matches AND getMyCommands returns non-empty → skip
     syncMenuCommandsWithMocks({
-      deleteMyCommands, setMyCommands, getMyCommands, runtimeLog,
-      commandsToRegister: commands, accountId, botIdentity: "bot-b",
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      runtimeLog,
+      commandsToRegister: commands,
+      accountId,
+      botIdentity: "bot-b",
     });
-    // No additional setMyCommands calls — sync was skipped
     await vi.waitFor(() => {
       expect(getMyCommands).toHaveBeenCalled();
     });
     expect(setMyCommands).toHaveBeenCalledTimes(2);
   });
 
-  it("re-syncs when localized command variant is empty despite base scopes being populated (#92945)", async () => {
+  it("cached-hash re-syncs when localized command variant is empty despite base scopes being populated (#92945)", async () => {
     const deleteMyCommands = vi.fn(async () => undefined);
     const setMyCommands = vi.fn(async () => undefined);
-    // getMyCommands returns populated for base scopes but empty for localized variant
     const getMyCommands = vi.fn(async (opts?: { language_code?: string }) => {
       if (opts?.language_code === "ko") {
-        return []; // Localized variant is empty — stale!
+        return [];
       }
       return [{ command: "test", description: "Test" }];
     });
     const runtimeLog = vi.fn();
     const accountId = `test-localized-empty-${Date.now()}`;
-    const commands = [{
-      command: "test",
-      description: "Test",
-      descriptionLocalizations: { ko: "테스트" },
-    }];
+    const commands = [
+      {
+        command: "test",
+        description: "Test",
+        descriptionLocalizations: { ko: "테스트" },
+      },
+    ];
 
-    // First sync — populates hash
     syncMenuCommandsWithMocks({
-      deleteMyCommands, setMyCommands, getMyCommands, runtimeLog,
-      commandsToRegister: commands, accountId, botIdentity: "bot-c",
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      runtimeLog,
+      commandsToRegister: commands,
+      accountId,
+      botIdentity: "bot-c",
     });
     await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(4));
 
-    // Second sync — hash matches, base scopes populated, but ko variant empty → re-sync
     syncMenuCommandsWithMocks({
-      deleteMyCommands, setMyCommands, getMyCommands, runtimeLog,
-      commandsToRegister: commands, accountId, botIdentity: "bot-c",
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      runtimeLog,
+      commandsToRegister: commands,
+      accountId,
+      botIdentity: "bot-c",
     });
     await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(8));
-    // Verify the localized language_code query was made
     const langCodeCalls = getMyCommands.mock.calls.filter(
       (c: unknown[]) => (c[0] as Record<string, unknown>)?.language_code === "ko",
     );
     expect(langCodeCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("cached-hash re-syncs when localized group command variant is empty (#92945)", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const getMyCommands = vi.fn(
+      async (opts?: { scope?: { type?: string }; language_code?: string }) =>
+        opts?.scope?.type === "all_group_chats" && opts.language_code === "ko"
+          ? []
+          : [{ command: "test", description: "Test" }],
+    );
+    const runtimeLog = vi.fn();
+    const accountId = `test-localized-group-empty-${Date.now()}`;
+    const commands = [
+      {
+        command: "test",
+        description: "Test",
+        descriptionLocalizations: { ko: "테스트" },
+      },
+    ];
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      runtimeLog,
+      commandsToRegister: commands,
+      accountId,
+      botIdentity: "bot-d",
+    });
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(4));
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      runtimeLog,
+      commandsToRegister: commands,
+      accountId,
+      botIdentity: "bot-d",
+    });
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(8));
+    expect(getMyCommands).toHaveBeenCalledWith({
+      scope: { type: "all_group_chats" },
+      language_code: "ko",
+    });
   });
 });

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -550,7 +550,9 @@ describe("bot-native-command-menu", () => {
       accountId,
       botIdentity: "bot-a",
     });
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
     expect(deleteMyCommands).toHaveBeenCalledTimes(2);
     expect(setMyCommands).not.toHaveBeenCalled();
     expect(getMyCommands).not.toHaveBeenCalled();

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -629,6 +629,55 @@ describe("bot-native-command-menu", () => {
     expect(setMyCommandsCall(setMyCommands, 3).at(1)).toEqual({ language_code: "ko" });
   });
 
+  it("cached-hash verifier ignores retry-omitted localized variants", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("400: Bad Request: BOT_COMMANDS_TOO_MUCH"))
+      .mockResolvedValue(undefined);
+    const getMyCommands = vi.fn(
+      async (opts?: { scope?: { type?: string }; language_code?: string }) =>
+        opts?.language_code === "ko" ? [] : [{ command: "cmd_0", description: "Command 0" }],
+    );
+    const accountId = `test-retry-omitted-localized-${Date.now()}`;
+    const commands = Array.from({ length: 100 }, (_, i) => ({
+      command: `cmd_${i}`,
+      description: `Command ${i}`,
+      ...(i >= 80 ? { descriptionLocalizations: { ko: `명령 ${i}` } } : undefined),
+    }));
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      commandsToRegister: commands,
+      accountId,
+      botIdentity: "bot-a",
+    });
+    await vi.waitFor(() => {
+      expect(setMyCommands).toHaveBeenCalledTimes(3);
+    });
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      commandsToRegister: commands,
+      accountId,
+      botIdentity: "bot-a",
+    });
+    await vi.waitFor(() => {
+      expect(getMyCommands).toHaveBeenCalledTimes(2);
+    });
+    expect(getMyCommands).not.toHaveBeenCalledWith({ language_code: "ko" });
+    expect(getMyCommands).not.toHaveBeenCalledWith({
+      scope: { type: "all_group_chats" },
+      language_code: "ko",
+    });
+    expect(deleteMyCommands).toHaveBeenCalledTimes(2);
+    expect(setMyCommands).toHaveBeenCalledTimes(3);
+  });
+
   it.each([
     { label: "description envelope", error: { description: "BOT_COMMANDS_TOO_MUCH" } },
     { label: "message envelope", error: { message: "BOT_COMMANDS_TOO_MUCH" } },

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -658,7 +658,9 @@ describe("bot-native-command-menu", () => {
       commandsToRegister: commands, accountId, botIdentity: "bot-b",
     });
     // No additional setMyCommands calls — sync was skipped
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), 100);
+    });
     expect(setMyCommands).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -11,6 +11,7 @@ import {
 type SyncMenuOptions = {
   deleteMyCommands: ReturnType<typeof vi.fn>;
   setMyCommands: ReturnType<typeof vi.fn>;
+  getMyCommands?: ReturnType<typeof vi.fn>;
   commandsToRegister: Parameters<typeof syncTelegramMenuCommands>[0]["commandsToRegister"];
   accountId: string;
   botIdentity: string;
@@ -21,7 +22,11 @@ type SyncMenuOptions = {
 function syncMenuCommandsWithMocks(options: SyncMenuOptions): void {
   syncTelegramMenuCommands({
     bot: {
-      api: { deleteMyCommands: options.deleteMyCommands, setMyCommands: options.setMyCommands },
+      api: {
+        deleteMyCommands: options.deleteMyCommands,
+        setMyCommands: options.setMyCommands,
+        ...(options.getMyCommands ? { getMyCommands: options.getMyCommands } : {}),
+      },
     } as unknown as Parameters<typeof syncTelegramMenuCommands>[0]["bot"],
     runtime: {
       log: options.runtimeLog ?? vi.fn(),
@@ -606,5 +611,54 @@ describe("bot-native-command-menu", () => {
     expect(runtimeLog).toHaveBeenCalledWith(
       "Telegram rejected 10 commands (BOT_COMMANDS_TOO_MUCH); retrying with 8.",
     );
+  });
+
+  it("re-syncs when remote command state is empty despite matching hash (#92944)", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const getMyCommands = vi.fn(async () => []);
+    const runtimeLog = vi.fn();
+    const accountId = `test-empty-remote-${Date.now()}`;
+    const commands = [{ command: "test", description: "Test" }];
+
+    // First sync — populates hash
+    syncMenuCommandsWithMocks({
+      deleteMyCommands, setMyCommands, getMyCommands, runtimeLog,
+      commandsToRegister: commands, accountId, botIdentity: "bot-a",
+    });
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(2));
+
+    // Second sync — hash matches but getMyCommands returns empty → should re-sync
+    syncMenuCommandsWithMocks({
+      deleteMyCommands, setMyCommands, getMyCommands, runtimeLog,
+      commandsToRegister: commands, accountId, botIdentity: "bot-a",
+    });
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(4));
+    expect(getMyCommands).toHaveBeenCalled();
+  });
+
+  it("skips sync when remote command state is non-empty and hash matches", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const getMyCommands = vi.fn(async () => [{ command: "test", description: "Test" }]);
+    const runtimeLog = vi.fn();
+    const accountId = `test-populated-remote-${Date.now()}`;
+    const commands = [{ command: "test", description: "Test" }];
+
+    // First sync — populates hash
+    syncMenuCommandsWithMocks({
+      deleteMyCommands, setMyCommands, getMyCommands, runtimeLog,
+      commandsToRegister: commands, accountId, botIdentity: "bot-b",
+    });
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(2));
+
+    // Second sync — hash matches AND getMyCommands returns non-empty → skip
+    syncMenuCommandsWithMocks({
+      deleteMyCommands, setMyCommands, getMyCommands, runtimeLog,
+      commandsToRegister: commands, accountId, botIdentity: "bot-b",
+    });
+    // No additional setMyCommands calls — sync was skipped
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(setMyCommands).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -423,9 +423,10 @@ describe("bot-native-command-menu", () => {
     expect(hashCommandList(a)).not.toBe(hashCommandList(b));
   });
 
-  it("skips sync when command hash is unchanged (#32017)", async () => {
+  it("skips sync when command hash is unchanged and remote is populated (#32017)", async () => {
     const deleteMyCommands = vi.fn(async () => undefined);
     const setMyCommands = vi.fn(async () => undefined);
+    const getMyCommands = vi.fn(async () => [{ command: "skip_test", description: "Skip test command" }]);
     const runtimeLog = vi.fn();
 
     const accountId = `test-skip-${Date.now()}`;
@@ -434,6 +435,7 @@ describe("bot-native-command-menu", () => {
     syncMenuCommandsWithMocks({
       deleteMyCommands,
       setMyCommands,
+      getMyCommands,
       runtimeLog,
       commandsToRegister: commands,
       accountId,
@@ -444,15 +446,21 @@ describe("bot-native-command-menu", () => {
       expect(setMyCommands).toHaveBeenCalledTimes(2);
     });
 
+    // Second sync: hash matches AND getMyCommands returns non-empty → skip
     syncMenuCommandsWithMocks({
       deleteMyCommands,
       setMyCommands,
+      getMyCommands,
       runtimeLog,
       commandsToRegister: commands,
       accountId,
       botIdentity: "bot-a",
     });
 
+    // No additional calls — sync was skipped
+    await vi.waitFor(() => {
+      expect(getMyCommands).toHaveBeenCalled();
+    });
     expect(setMyCommands).toHaveBeenCalledTimes(2);
   });
 
@@ -658,9 +666,47 @@ describe("bot-native-command-menu", () => {
       commandsToRegister: commands, accountId, botIdentity: "bot-b",
     });
     // No additional setMyCommands calls — sync was skipped
-    await new Promise<void>((resolve) => {
-      setTimeout(() => resolve(), 100);
+    await vi.waitFor(() => {
+      expect(getMyCommands).toHaveBeenCalled();
     });
     expect(setMyCommands).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-syncs when localized command variant is empty despite base scopes being populated (#92945)", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    // getMyCommands returns populated for base scopes but empty for localized variant
+    const getMyCommands = vi.fn(async (opts?: { language_code?: string }) => {
+      if (opts?.language_code === "ko") {
+        return []; // Localized variant is empty — stale!
+      }
+      return [{ command: "test", description: "Test" }];
+    });
+    const runtimeLog = vi.fn();
+    const accountId = `test-localized-empty-${Date.now()}`;
+    const commands = [{
+      command: "test",
+      description: "Test",
+      descriptionLocalizations: { ko: "테스트" },
+    }];
+
+    // First sync — populates hash
+    syncMenuCommandsWithMocks({
+      deleteMyCommands, setMyCommands, getMyCommands, runtimeLog,
+      commandsToRegister: commands, accountId, botIdentity: "bot-c",
+    });
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(4));
+
+    // Second sync — hash matches, base scopes populated, but ko variant empty → re-sync
+    syncMenuCommandsWithMocks({
+      deleteMyCommands, setMyCommands, getMyCommands, runtimeLog,
+      commandsToRegister: commands, accountId, botIdentity: "bot-c",
+    });
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(8));
+    // Verify the localized language_code query was made
+    const langCodeCalls = getMyCommands.mock.calls.filter(
+      (c: unknown[]) => (c[0] as Record<string, unknown>)?.language_code === "ko",
+    );
+    expect(langCodeCalls.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -526,6 +526,36 @@ describe("bot-native-command-menu", () => {
     await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(4));
   });
 
+  it("cached-hash skips sync after empty menu deletes successfully (#32017)", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const getMyCommands = vi.fn(async () => []);
+    const accountId = `test-empty-delete-cache-${Date.now()}`;
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      commandsToRegister: [],
+      accountId,
+      botIdentity: "bot-a",
+    });
+    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(2));
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      getMyCommands,
+      commandsToRegister: [],
+      accountId,
+      botIdentity: "bot-a",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(deleteMyCommands).toHaveBeenCalledTimes(2);
+    expect(setMyCommands).not.toHaveBeenCalled();
+    expect(getMyCommands).not.toHaveBeenCalled();
+  });
+
   it("retries with fewer commands on BOT_COMMANDS_TOO_MUCH", async () => {
     const deleteMyCommands = vi.fn(async () => undefined);
     const setMyCommands = vi

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -462,6 +462,42 @@ async function deleteTelegramMenuCommandsForScopes(params: {
   return allDeleted;
 }
 
+function collectTelegramCommandLanguageCodes(commands: TelegramMenuCommand[]): string[] {
+  const languageCodes = new Set<string>();
+  for (const command of commands) {
+    for (const languageCode of Object.keys(command.descriptionLocalizations ?? {})) {
+      const normalized = normalizeTelegramLanguageCode(languageCode);
+      if (normalized) {
+        languageCodes.add(normalized);
+      }
+    }
+  }
+  return [...languageCodes].toSorted();
+}
+
+async function hasRemoteTelegramMenuCommands(params: {
+  bot: Bot;
+  commands: TelegramMenuCommand[];
+}): Promise<boolean> {
+  const languageCodes = collectTelegramCommandLanguageCodes(params.commands);
+  for (const scope of TELEGRAM_COMMAND_MENU_SCOPES) {
+    const baseCommands = await params.bot.api.getMyCommands(scope.options);
+    if (baseCommands.length === 0) {
+      return false;
+    }
+    for (const languageCode of languageCodes) {
+      const localizedCommands = await params.bot.api.getMyCommands({
+        ...scope.options,
+        language_code: languageCode as LanguageCode,
+      });
+      if (localizedCommands.length === 0) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 async function setTelegramMenuCommandsForScopes(params: {
   bot: Bot;
   runtime: RuntimeEnv;
@@ -511,49 +547,13 @@ export function syncTelegramMenuCommands(params: {
       // Localized command menus (setMyCommands with language_code) must also
       // be checked — a stale hash can leave those variants empty.  See #92945.
       try {
-        // Collect supported language codes from command localizations.
-        const languageCodes = new Set<string>();
-        for (const cmd of commandsToRegister) {
-          if (cmd.descriptionLocalizations) {
-            for (const lang of Object.keys(cmd.descriptionLocalizations)) {
-              const normalized = normalizeTelegramLanguageCode(lang);
-              if (normalized) {
-                languageCodes.add(normalized);
-              }
-            }
-          }
-        }
-
-        let allScopesPopulated = true;
-        for (const scope of TELEGRAM_COMMAND_MENU_SCOPES) {
-          // Check base scope (no language_code).
-          const baseCommands = await bot.api.getMyCommands(
-            scope.options,
-          );
-          if (!baseCommands || baseCommands.length === 0) {
-            allScopesPopulated = false;
-            break;
-          }
-          // Check each localized variant for this scope.
-          for (const langCode of languageCodes) {
-            const langCommands = await bot.api.getMyCommands({
-              ...scope.options,
-              language_code: langCode as LanguageCode,
-            });
-            if (!langCommands || langCommands.length === 0) {
-              allScopesPopulated = false;
-              break;
-            }
-          }
-          if (!allScopesPopulated) {
-            break;
-          }
-        }
-        if (allScopesPopulated) {
+        if (await hasRemoteTelegramMenuCommands({ bot, commands: commandsToRegister })) {
           logVerbose("telegram: command menu unchanged; skipping sync");
           return;
         }
-        logVerbose("telegram: command menu hash matches but remote is empty in at least one scope or language variant; re-syncing");
+        logVerbose(
+          "telegram: command menu hash matches but remote is empty in at least one scope or language variant; re-syncing",
+        );
       } catch {
         // If getMyCommands fails (network, rate limit, etc.), fall through to
         // re-sync rather than trusting the stale hash.

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -507,15 +507,24 @@ export function syncTelegramMenuCommands(params: {
     if (cachedHash === currentHash) {
       // The local hash matches, but the remote Telegram state may have been
       // cleared (e.g. after an interrupted sync or gateway restart).  Verify
-      // with getMyCommands before skipping — if remote is empty we must
-      // re-register.  See #92944.
+      // every scope we write (default, all_group_chats) with getMyCommands
+      // before skipping.  See #92944.
       try {
-        const remoteCommands = await bot.api.getMyCommands();
-        if (remoteCommands && remoteCommands.length > 0) {
+        let allScopesPopulated = true;
+        for (const scope of TELEGRAM_COMMAND_MENU_SCOPES) {
+          const remoteCommands = await bot.api.getMyCommands(
+            scope.options ?? {},
+          );
+          if (!remoteCommands || remoteCommands.length === 0) {
+            allScopesPopulated = false;
+            break;
+          }
+        }
+        if (allScopesPopulated) {
           logVerbose("telegram: command menu unchanged; skipping sync");
           return;
         }
-        logVerbose("telegram: command menu hash matches but remote is empty; re-syncing");
+        logVerbose("telegram: command menu hash matches but remote is empty in at least one scope; re-syncing");
       } catch {
         // If getMyCommands fails (network, rate limit, etc.), fall through to
         // re-sync rather than trusting the stale hash.

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -507,16 +507,45 @@ export function syncTelegramMenuCommands(params: {
     if (cachedHash === currentHash) {
       // The local hash matches, but the remote Telegram state may have been
       // cleared (e.g. after an interrupted sync or gateway restart).  Verify
-      // every scope we write (default, all_group_chats) with getMyCommands
-      // before skipping.  See #92944.
+      // every scope and language variant we write before skipping.  See #92944.
+      // Localized command menus (setMyCommands with language_code) must also
+      // be checked — a stale hash can leave those variants empty.  See #92945.
       try {
+        // Collect supported language codes from command localizations.
+        const languageCodes = new Set<string>();
+        for (const cmd of commandsToRegister) {
+          if (cmd.descriptionLocalizations) {
+            for (const lang of Object.keys(cmd.descriptionLocalizations)) {
+              const normalized = normalizeTelegramLanguageCode(lang);
+              if (normalized) {
+                languageCodes.add(normalized);
+              }
+            }
+          }
+        }
+
         let allScopesPopulated = true;
         for (const scope of TELEGRAM_COMMAND_MENU_SCOPES) {
-          const remoteCommands = await bot.api.getMyCommands(
+          // Check base scope (no language_code).
+          const baseCommands = await bot.api.getMyCommands(
             scope.options ?? {},
           );
-          if (!remoteCommands || remoteCommands.length === 0) {
+          if (!baseCommands || baseCommands.length === 0) {
             allScopesPopulated = false;
+            break;
+          }
+          // Check each localized variant for this scope.
+          for (const langCode of languageCodes) {
+            const langCommands = await bot.api.getMyCommands({
+              ...(scope.options ?? {}),
+              language_code: langCode as LanguageCode,
+            });
+            if (!langCommands || langCommands.length === 0) {
+              allScopesPopulated = false;
+              break;
+            }
+          }
+          if (!allScopesPopulated) {
             break;
           }
         }
@@ -524,7 +553,7 @@ export function syncTelegramMenuCommands(params: {
           logVerbose("telegram: command menu unchanged; skipping sync");
           return;
         }
-        logVerbose("telegram: command menu hash matches but remote is empty in at least one scope; re-syncing");
+        logVerbose("telegram: command menu hash matches but remote is empty in at least one scope or language variant; re-syncing");
       } catch {
         // If getMyCommands fails (network, rate limit, etc.), fall through to
         // re-sync rather than trusting the stale hash.

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -505,8 +505,22 @@ export function syncTelegramMenuCommands(params: {
     const currentHash = hashCommandList(commandsToRegister);
     const cachedHash = readCachedCommandHash(accountId, botIdentity);
     if (cachedHash === currentHash) {
-      logVerbose("telegram: command menu unchanged; skipping sync");
-      return;
+      // The local hash matches, but the remote Telegram state may have been
+      // cleared (e.g. after an interrupted sync or gateway restart).  Verify
+      // with getMyCommands before skipping — if remote is empty we must
+      // re-register.  See #92944.
+      try {
+        const remoteCommands = await bot.api.getMyCommands();
+        if (remoteCommands && remoteCommands.length > 0) {
+          logVerbose("telegram: command menu unchanged; skipping sync");
+          return;
+        }
+        logVerbose("telegram: command menu hash matches but remote is empty; re-syncing");
+      } catch {
+        // If getMyCommands fails (network, rate limit, etc.), fall through to
+        // re-sync rather than trusting the stale hash.
+        logVerbose("telegram: getMyCommands failed; re-syncing command menu");
+      }
     }
 
     // Keep delete -> set ordering to avoid stale deletions racing after fresh registrations.

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -338,25 +338,34 @@ export function hashCommandList(commands: TelegramMenuCommand[]): string {
   return createHash("sha256").update(JSON.stringify(sorted)).digest("hex").slice(0, 16);
 }
 
+type SyncedCommandState = {
+  hash: string;
+  registeredCommands: TelegramMenuCommand[];
+};
+
 // Keep the sync cache process-local so restarts always re-register commands.
-const syncedCommandHashes = new Map<string, string>();
+const syncedCommandStates = new Map<string, SyncedCommandState>();
 
 function getCommandHashKey(accountId?: string, botIdentity?: string): string {
   return `${accountId ?? "default"}:${botIdentity ?? ""}`;
 }
 
-function readCachedCommandHash(accountId?: string, botIdentity?: string): string | null {
+function readCachedCommandState(
+  accountId?: string,
+  botIdentity?: string,
+): SyncedCommandState | null {
   const key = getCommandHashKey(accountId, botIdentity);
-  return syncedCommandHashes.get(key) ?? null;
+  return syncedCommandStates.get(key) ?? null;
 }
 
-function writeCachedCommandHash(
+function writeCachedCommandState(
   accountId: string | undefined,
   botIdentity: string | undefined,
   hash: string,
+  registeredCommands: TelegramMenuCommand[],
 ): void {
   const key = getCommandHashKey(accountId, botIdentity);
-  syncedCommandHashes.set(key, hash);
+  syncedCommandStates.set(key, { hash, registeredCommands });
 }
 
 function normalizeTelegramLanguageCode(languageCode: string): string | null {
@@ -539,8 +548,8 @@ export function syncTelegramMenuCommands(params: {
     // is restarted several times in quick succession.
     // See: openclaw/openclaw#32017
     const currentHash = hashCommandList(commandsToRegister);
-    const cachedHash = readCachedCommandHash(accountId, botIdentity);
-    if (cachedHash === currentHash) {
+    const cachedState = readCachedCommandState(accountId, botIdentity);
+    if (cachedState?.hash === currentHash) {
       if (commandsToRegister.length === 0) {
         logVerbose("telegram: empty command menu unchanged; skipping sync");
         return;
@@ -551,7 +560,12 @@ export function syncTelegramMenuCommands(params: {
       // Localized command menus (setMyCommands with language_code) must also
       // be checked — a stale hash can leave those variants empty.  See #92945.
       try {
-        if (await hasRemoteTelegramMenuCommands({ bot, commands: commandsToRegister })) {
+        if (
+          await hasRemoteTelegramMenuCommands({
+            bot,
+            commands: cachedState.registeredCommands,
+          })
+        ) {
           logVerbose("telegram: command menu unchanged; skipping sync");
           return;
         }
@@ -576,7 +590,7 @@ export function syncTelegramMenuCommands(params: {
       if (typeof bot.api.deleteMyCommands !== "function") {
         await setTelegramMenuCommandsForScopes({ bot, runtime, commands: [] });
       }
-      writeCachedCommandHash(accountId, botIdentity, currentHash);
+      writeCachedCommandState(accountId, botIdentity, currentHash, []);
       return;
     }
 
@@ -640,7 +654,7 @@ export function syncTelegramMenuCommands(params: {
         languageCode: variant.languageCode,
       });
     }
-    writeCachedCommandHash(accountId, botIdentity, currentHash);
+    writeCachedCommandState(accountId, botIdentity, currentHash, acceptedCommands);
   };
 
   void sync().catch((err: unknown) => {

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -541,6 +541,10 @@ export function syncTelegramMenuCommands(params: {
     const currentHash = hashCommandList(commandsToRegister);
     const cachedHash = readCachedCommandHash(accountId, botIdentity);
     if (cachedHash === currentHash) {
+      if (commandsToRegister.length === 0) {
+        logVerbose("telegram: empty command menu unchanged; skipping sync");
+        return;
+      }
       // The local hash matches, but the remote Telegram state may have been
       // cleared (e.g. after an interrupted sync or gateway restart).  Verify
       // every scope and language variant we write before skipping.  See #92944.

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -528,7 +528,7 @@ export function syncTelegramMenuCommands(params: {
         for (const scope of TELEGRAM_COMMAND_MENU_SCOPES) {
           // Check base scope (no language_code).
           const baseCommands = await bot.api.getMyCommands(
-            scope.options ?? {},
+            scope.options,
           );
           if (!baseCommands || baseCommands.length === 0) {
             allScopesPopulated = false;
@@ -537,7 +537,7 @@ export function syncTelegramMenuCommands(params: {
           // Check each localized variant for this scope.
           for (const langCode of languageCodes) {
             const langCommands = await bot.api.getMyCommands({
-              ...(scope.options ?? {}),
+              ...scope.options,
               language_code: langCode as LanguageCode,
             });
             if (!langCommands || langCommands.length === 0) {


### PR DESCRIPTION
## What Problem This Solves

Verify remote Telegram command state via `getMyCommands()` before skipping command sync based on the local hash cache. This prevents the bot menu from staying empty when the remote state was cleared but the local hash still matches.

In `extensions/telegram/src/bot-native-command-menu.ts`, `syncTelegramMenuCommands()` skipped sync when the cached hash matched — without checking whether the remote Telegram commands had been cleared by an interrupted sync or gateway restart.

Fixes #92944

## Change

| File | Change |
|------|--------|
| `extensions/telegram/src/bot-native-command-menu.ts` | Before skipping sync based on cached hash, call `getMyCommands()` for every scope+language_code combination to verify remote state — if any scope or localized variant is empty, proceed with re-sync; on API errors, also fall through to re-sync |

## Evidence

- **Environment tested**: Linux 4.19.112-2.el8.x86_64 (x64), Node.js v22.22.0
- **Baseline vs candidate**: Source-level verification + Mantis Telegram Desktop native proof (GIF/MP4) captured at commit f538929c
- See https://github.com/openclaw/openclaw/pull/92945#issuecomment-4701685123 for proof artifacts
- Covers default, all_group_chats, and all localized language_code variants from descriptionLocalizations

## Risk

- **Low risk**: adds a pre-sync remote verification step that only triggers re-sync when needed
- Extra `getMyCommands()` calls only occur when the local hash suggests "no sync needed"
- On API errors the behavior falls through to re-sync (fails safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
