### PR TITLE
fix(telegram): preserve delivery without rich API

### DIFF
--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -5,7 +5,7 @@ import { createTelegramRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
-import { markdownToTelegramHtml } from "../format.js";
+import { markdownToTelegramHtml, telegramHtmlToPlainTextFallback } from "../format.js";
 import {
   isSafeToRetrySendError,
   isTelegramRateLimitError,
@@ -20,6 +20,8 @@ import {
   buildTelegramRichMessage,
   getTelegramRichRawApi,
   removeTelegramRichNativeQuoteParam,
+  splitTelegramRichTextChunks,
+  TELEGRAM_LEGACY_TEXT_LIMIT,
   toTelegramRichMessageContextParams,
 } from "../rich-message.js";
 import { buildInlineKeyboard } from "../send.js";
@@ -147,7 +149,7 @@ export async function sendTelegramText(
     runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id} (plain)`);
     return res.message_id;
   };
-  const sendFormattedFallback = async () => {
+  const sendFormattedFallback = async (chunkLegacyFallback = false) => {
     // Markdown can render to empty HTML for syntax-only chunks; recover with plain text.
     if (!htmlText.trim()) {
       if (!hasFallbackText) {
@@ -156,6 +158,68 @@ export async function sendTelegramText(
         );
       }
       return await sendPlainFallback();
+    }
+    if (chunkLegacyFallback) {
+      let lastMessageId: number | undefined;
+      const chunks = splitTelegramRichTextChunks({
+        text,
+        textLimit: TELEGRAM_LEGACY_TEXT_LIMIT,
+        textMode,
+        chunkMode: "length",
+      });
+      for (let index = 0; index < chunks.length; index += 1) {
+        const chunk = chunks[index] ?? "";
+        const chunkHtml = textMode === "html" ? chunk : markdownToTelegramHtml(chunk);
+        const chunkPlain = textMode === "html" ? telegramHtmlToPlainTextFallback(chunkHtml) : chunk;
+        try {
+          const res = await sendTelegramWithThreadFallback({
+            operation: "sendMessage",
+            runtime,
+            thread: opts?.thread,
+            requestParams: baseParams,
+            shouldLog: (err) => {
+              const errText = formatErrorMessage(err);
+              return !PARSE_ERR_RE.test(errText) && !EMPTY_TEXT_ERR_RE.test(errText);
+            },
+            send: (effectiveParams) =>
+              bot.api.sendMessage(chatId, chunkHtml, {
+                parse_mode: "HTML",
+                ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
+                ...(index === chunks.length - 1 && opts?.replyMarkup
+                  ? { reply_markup: opts.replyMarkup }
+                  : {}),
+                ...effectiveParams,
+              }),
+          });
+          lastMessageId = res.message_id;
+        } catch (err) {
+          const errText = formatErrorMessage(err);
+          if (!PARSE_ERR_RE.test(errText) && !EMPTY_TEXT_ERR_RE.test(errText)) {
+            throw err;
+          }
+          const res = await sendTelegramWithThreadFallback({
+            operation: "sendMessage-plain",
+            runtime,
+            thread: opts?.thread,
+            requestParams: baseParams,
+            send: (effectiveParams) =>
+              bot.api.sendMessage(chatId, chunkPlain, {
+                ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
+                ...(index === chunks.length - 1 && opts?.replyMarkup
+                  ? { reply_markup: opts.replyMarkup }
+                  : {}),
+                ...effectiveParams,
+              }),
+          });
+          lastMessageId = res.message_id;
+        }
+      }
+      if (lastMessageId == null) {
+        throw new Error(
+          "telegram sendMessage failed: empty formatted text and empty plain fallback",
+        );
+      }
+      return lastMessageId;
     }
     try {
       const res = await sendTelegramWithThreadFallback({
@@ -220,7 +284,7 @@ export async function sendTelegramText(
           err,
         )}`,
       );
-      return await sendFormattedFallback();
+      return await sendFormattedFallback(true);
     }
   }
   return await sendFormattedFallback();

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -5,7 +5,7 @@ import { createTelegramRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
-import { markdownToTelegramHtml, telegramHtmlToPlainTextFallback } from "../format.js";
+import { markdownToTelegramHtml } from "../format.js";
 import {
   isSafeToRetrySendError,
   isTelegramRateLimitError,
@@ -20,7 +20,7 @@ import {
   buildTelegramRichMessage,
   getTelegramRichRawApi,
   removeTelegramRichNativeQuoteParam,
-  splitTelegramRichTextChunks,
+  splitTelegramRichMessageTextChunks,
   TELEGRAM_LEGACY_TEXT_LIMIT,
   toTelegramRichMessageContextParams,
 } from "../rich-message.js";
@@ -161,16 +161,21 @@ export async function sendTelegramText(
     }
     if (chunkLegacyFallback) {
       let lastMessageId: number | undefined;
-      const chunks = splitTelegramRichTextChunks({
+      const chunks = splitTelegramRichMessageTextChunks({
         text,
         textLimit: TELEGRAM_LEGACY_TEXT_LIMIT,
         textMode,
         chunkMode: "length",
+        tableMode: opts?.tableMode,
+        skipEntityDetection: linkPreviewEnabled === false,
       });
       for (let index = 0; index < chunks.length; index += 1) {
-        const chunk = chunks[index] ?? "";
-        const chunkHtml = textMode === "html" ? chunk : markdownToTelegramHtml(chunk);
-        const chunkPlain = textMode === "html" ? telegramHtmlToPlainTextFallback(chunkHtml) : chunk;
+        const chunk = chunks[index];
+        if (!chunk) {
+          continue;
+        }
+        const chunkHtml = chunk.text;
+        const chunkPlain = chunk.plainText;
         try {
           const res = await sendTelegramWithThreadFallback({
             operation: "sendMessage",

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -6,7 +6,11 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
 import { markdownToTelegramHtml } from "../format.js";
-import { isSafeToRetrySendError, isTelegramRateLimitError } from "../network-errors.js";
+import {
+  isSafeToRetrySendError,
+  isTelegramRateLimitError,
+  isTelegramRichMethodUnavailableError,
+} from "../network-errors.js";
 import {
   buildTelegramSendParams,
   getTelegramNativeQuoteReplyMessageId,
@@ -121,28 +125,6 @@ export async function sendTelegramText(
     silent: opts?.silent,
   });
   const textMode = opts?.textMode ?? "markdown";
-  if (opts?.richMessages === true) {
-    const richMessage = buildTelegramRichMessage(text, textMode, {
-      skipEntityDetection: opts.linkPreview === false,
-      tableMode: opts.tableMode,
-    });
-    const res = await sendTelegramWithThreadFallback({
-      operation: "sendRichMessage",
-      runtime,
-      thread: opts.thread,
-      requestParams: toTelegramRichMessageContextParams(baseParams),
-      removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
-      send: (effectiveParams) =>
-        getTelegramRichRawApi(bot.api).sendRichMessage({
-          chat_id: chatId,
-          rich_message: richMessage,
-          ...(opts.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
-          ...effectiveParams,
-        }),
-    });
-    runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${res.message_id}`);
-    return res.message_id;
-  }
   // Add link_preview_options when link preview is disabled.
   const linkPreviewEnabled = opts?.linkPreview ?? true;
   const linkPreviewOptions = linkPreviewEnabled ? undefined : { is_disabled: true };
@@ -165,43 +147,81 @@ export async function sendTelegramText(
     runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id} (plain)`);
     return res.message_id;
   };
-
-  // Markdown can render to empty HTML for syntax-only chunks; recover with plain text.
-  if (!htmlText.trim()) {
-    if (!hasFallbackText) {
-      throw new Error("telegram sendMessage failed: empty formatted text and empty plain fallback");
-    }
-    return await sendPlainFallback();
-  }
-  try {
-    const res = await sendTelegramWithThreadFallback({
-      operation: "sendMessage",
-      runtime,
-      thread: opts?.thread,
-      requestParams: baseParams,
-      shouldLog: (err) => {
-        const errText = formatErrorMessage(err);
-        return !PARSE_ERR_RE.test(errText) && !EMPTY_TEXT_ERR_RE.test(errText);
-      },
-      send: (effectiveParams) =>
-        bot.api.sendMessage(chatId, htmlText, {
-          parse_mode: "HTML",
-          ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
-          ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
-          ...effectiveParams,
-        }),
-    });
-    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id}`);
-    return res.message_id;
-  } catch (err) {
-    const errText = formatErrorMessage(err);
-    if (PARSE_ERR_RE.test(errText) || EMPTY_TEXT_ERR_RE.test(errText)) {
+  const sendFormattedFallback = async () => {
+    // Markdown can render to empty HTML for syntax-only chunks; recover with plain text.
+    if (!htmlText.trim()) {
       if (!hasFallbackText) {
-        throw err;
+        throw new Error(
+          "telegram sendMessage failed: empty formatted text and empty plain fallback",
+        );
       }
-      runtime.log?.(`telegram formatted send failed; retrying without formatting: ${errText}`);
       return await sendPlainFallback();
     }
-    throw err;
+    try {
+      const res = await sendTelegramWithThreadFallback({
+        operation: "sendMessage",
+        runtime,
+        thread: opts?.thread,
+        requestParams: baseParams,
+        shouldLog: (err) => {
+          const errText = formatErrorMessage(err);
+          return !PARSE_ERR_RE.test(errText) && !EMPTY_TEXT_ERR_RE.test(errText);
+        },
+        send: (effectiveParams) =>
+          bot.api.sendMessage(chatId, htmlText, {
+            parse_mode: "HTML",
+            ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
+            ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
+            ...effectiveParams,
+          }),
+      });
+      runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id}`);
+      return res.message_id;
+    } catch (err) {
+      const errText = formatErrorMessage(err);
+      if (PARSE_ERR_RE.test(errText) || EMPTY_TEXT_ERR_RE.test(errText)) {
+        if (!hasFallbackText) {
+          throw err;
+        }
+        runtime.log?.(`telegram formatted send failed; retrying without formatting: ${errText}`);
+        return await sendPlainFallback();
+      }
+      throw err;
+    }
+  };
+  if (opts?.richMessages === true) {
+    const richMessage = buildTelegramRichMessage(text, textMode, {
+      skipEntityDetection: opts.linkPreview === false,
+      tableMode: opts.tableMode,
+    });
+    try {
+      const res = await sendTelegramWithThreadFallback({
+        operation: "sendRichMessage",
+        runtime,
+        thread: opts.thread,
+        requestParams: toTelegramRichMessageContextParams(baseParams),
+        removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
+        send: (effectiveParams) =>
+          getTelegramRichRawApi(bot.api).sendRichMessage({
+            chat_id: chatId,
+            rich_message: richMessage,
+            ...(opts.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
+            ...effectiveParams,
+          }),
+      });
+      runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${res.message_id}`);
+      return res.message_id;
+    } catch (err) {
+      if (!isTelegramRichMethodUnavailableError(err)) {
+        throw err;
+      }
+      runtime.log?.(
+        `telegram sendRichMessage unavailable; retrying via sendMessage: ${formatErrorMessage(
+          err,
+        )}`,
+      );
+      return await sendFormattedFallback();
+    }
   }
+  return await sendFormattedFallback();
 }

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -933,6 +933,29 @@ describe("deliverReplies", () => {
     expect(mockCallArg(sendMessage, 0, 2)).not.toHaveProperty("skip_entity_detection");
   });
 
+  it("falls back to sendMessage when rich final delivery is unsupported", async () => {
+    const { runtime, sendMessage, bot } = createSendMessageHarness();
+    const raw = (bot.api as unknown as { raw: { sendRichMessage: ReturnType<typeof vi.fn> } }).raw;
+    raw.sendRichMessage.mockRejectedValueOnce(
+      Object.assign(new Error("Call to 'sendRichMessage' failed! (404: Not Found)"), {
+        error_code: 404,
+      }),
+    );
+
+    await deliverWith({
+      replies: [{ text: "hi **boss**" }],
+      runtime,
+      bot,
+      linkPreview: false,
+    });
+
+    expect(raw.sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith("123", "hi <b>boss</b>", {
+      link_preview_options: { is_disabled: true },
+      parse_mode: "HTML",
+    });
+  });
+
   it("includes message_thread_id for DM topics", async () => {
     const { runtime, sendMessage, bot } = createSendMessageHarness();
 

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -58,6 +58,7 @@ vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
 
 vi.resetModules();
 const { deliverReplies } = await import("./delivery.js");
+const { TELEGRAM_LEGACY_TEXT_LIMIT } = await import("../rich-message.js");
 
 vi.mock("grammy", () => ({
   API_CONSTANTS: {
@@ -947,6 +948,7 @@ describe("deliverReplies", () => {
       runtime,
       bot,
       linkPreview: false,
+      richMessages: true,
     });
 
     expect(raw.sendRichMessage).toHaveBeenCalledTimes(1);
@@ -954,6 +956,59 @@ describe("deliverReplies", () => {
       link_preview_options: { is_disabled: true },
       parse_mode: "HTML",
     });
+  });
+
+  it("re-chunks rich final delivery fallback to Telegram's legacy text limit", async () => {
+    const { runtime, sendMessage, bot } = createSendMessageHarness();
+    const raw = (bot.api as unknown as { raw: { sendRichMessage: ReturnType<typeof vi.fn> } }).raw;
+    raw.sendRichMessage.mockRejectedValueOnce(
+      Object.assign(new Error("Call to 'sendRichMessage' failed! (404: Not Found)"), {
+        error_code: 404,
+      }),
+    );
+    const text = "A".repeat(TELEGRAM_LEGACY_TEXT_LIMIT + 9);
+
+    await deliverWith({
+      replies: [{ text }],
+      runtime,
+      bot,
+      richMessages: true,
+      textLimit: 100_000,
+    });
+
+    expect(raw.sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage.mock.calls.every((call) => String(call[1]).length <= 4_096)).toBe(true);
+  });
+
+  it("does not replay delivered chunks when one legacy fallback chunk needs plain text", async () => {
+    const { runtime, sendMessage, bot } = createSendMessageHarness();
+    const raw = (bot.api as unknown as { raw: { sendRichMessage: ReturnType<typeof vi.fn> } }).raw;
+    raw.sendRichMessage.mockRejectedValueOnce(
+      Object.assign(new Error("Call to 'sendRichMessage' failed! (404: Not Found)"), {
+        error_code: 404,
+      }),
+    );
+    sendMessage
+      .mockResolvedValueOnce({ message_id: 1, chat: { id: "123" } })
+      .mockRejectedValueOnce(new Error("can't parse entities"))
+      .mockResolvedValueOnce({ message_id: 2, chat: { id: "123" } });
+    const text = "A".repeat(TELEGRAM_LEGACY_TEXT_LIMIT + 9);
+
+    await deliverWith({
+      replies: [{ text }],
+      runtime,
+      bot,
+      richMessages: true,
+      textLimit: 100_000,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(3);
+    expect(String(sendMessage.mock.calls[0]?.[1]).length).toBeLessThanOrEqual(
+      TELEGRAM_LEGACY_TEXT_LIMIT,
+    );
+    expect(String(sendMessage.mock.calls[2]?.[1]).length).toBe(9);
+    expect(mockCallArg(sendMessage, 2, 2)).not.toHaveProperty("parse_mode");
   });
 
   it("includes message_thread_id for DM topics", async () => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -704,6 +704,38 @@ describe("createTelegramDraftStream", () => {
     expect(api.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("falls back to message previews when rich previews are unsupported", async () => {
+    const api = createMockDraftApi();
+    api.raw.sendRichMessage.mockRejectedValueOnce(
+      Object.assign(new Error("Call to 'sendRichMessage' failed! (404: Not Found)"), {
+        error_code: 404,
+      }),
+    );
+    const warn = vi.fn();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      richMessages: true,
+      warn,
+      renderText: (text) => ({ text: `<i>${text}</i>`, richMessage: { html: `<i>${text}</i>` } }),
+    });
+
+    stream.update("hello");
+    await stream.flush();
+    stream.update("hello again");
+    await stream.flush();
+
+    expect(api.raw.sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "<i>hello</i>", { parse_mode: "HTML" });
+    expect(api.raw.editMessageText).not.toHaveBeenCalled();
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "<i>hello again</i>", {
+      parse_mode: "HTML",
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "telegram rich stream preview unavailable; retrying with message preview: Call to 'sendRichMessage' failed! (404: Not Found)",
+    );
+  });
+
   it("clamps rich previews to the block limit", async () => {
     const api = createMockDraftApi();
     const text = Array.from({ length: 501 }, (_, index) => `paragraph ${index}`).join("\n\n");

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -2,7 +2,7 @@
 import type { Bot } from "grammy";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTelegramDraftStream } from "./draft-stream.js";
-import type { TelegramInputRichMessage } from "./rich-message.js";
+import { TELEGRAM_LEGACY_TEXT_LIMIT, type TelegramInputRichMessage } from "./rich-message.js";
 
 type TelegramDraftStreamParams = Parameters<typeof createTelegramDraftStream>[0];
 
@@ -733,6 +733,37 @@ describe("createTelegramDraftStream", () => {
     });
     expect(warn).toHaveBeenCalledWith(
       "telegram rich stream preview unavailable; retrying with message preview: Call to 'sendRichMessage' failed! (404: Not Found)",
+    );
+  });
+
+  it("caps legacy message previews to Telegram's legacy text limit", async () => {
+    const api = createMockDraftApi();
+    api.raw.sendRichMessage.mockRejectedValueOnce(
+      Object.assign(new Error("Call to 'sendRichMessage' failed! (404: Not Found)"), {
+        error_code: 404,
+      }),
+    );
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      richMessages: true,
+      renderText: (text) => ({ text: `<i>${text}</i>`, richMessage: { html: `<i>${text}</i>` } }),
+    });
+    const text = "A".repeat(TELEGRAM_LEGACY_TEXT_LIMIT + 100);
+
+    stream.update(text);
+    await stream.flush();
+    stream.update(`${text}B`);
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    const sendMessageCalls = api.sendMessage.mock.calls as unknown as Array<
+      [unknown, unknown, unknown?]
+    >;
+    expect(String(sendMessageCalls[0]?.[1]).length).toBeLessThanOrEqual(TELEGRAM_LEGACY_TEXT_LIMIT);
+    expect(api.editMessageText).toHaveBeenCalledTimes(1);
+    expect(String(api.editMessageText.mock.calls[0]?.[2]).length).toBeLessThanOrEqual(
+      TELEGRAM_LEGACY_TEXT_LIMIT,
     );
   });
 

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -13,6 +13,7 @@ import {
   isTelegramClientRejection,
   isTelegramMessageNotModifiedError,
   isTelegramRateLimitError,
+  isTelegramRichMethodUnavailableError,
   readTelegramRetryAfterMs,
 } from "./network-errors.js";
 import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
@@ -231,18 +232,12 @@ export function createTelegramDraftStream(params: {
   let previewRevision = 0;
   let generation = 0;
   let deliveredTextOffset = 0;
+  let richPreviewUnavailable = false;
   type PreviewSendParams = {
     preview: TelegramDraftPreview;
     sendGeneration: number;
   };
-  const sendRenderedMessage = async (preview: TelegramDraftPreview) => {
-    if (richMessages) {
-      return await getTelegramRichRawApi(params.api).sendRichMessage({
-        chat_id: chatId,
-        rich_message: preview.richMessage ?? buildTelegramRichMarkdown(preview.text),
-        ...richMessageParams,
-      });
-    }
+  const sendLegacyRenderedMessage = async (preview: TelegramDraftPreview) => {
     const transportPreview = normalizeTelegramDraftTransportPreview(preview);
     const sendPlain = async () =>
       await params.api.sendMessage(chatId, transportPreview.plainText, sendMessageParams);
@@ -261,6 +256,32 @@ export function createTelegramDraftStream(params: {
       return await sendPlain();
     }
   };
+  const sendRenderedMessage = async (preview: TelegramDraftPreview) => {
+    if (richMessages) {
+      if (richPreviewUnavailable) {
+        return await sendLegacyRenderedMessage(preview);
+      }
+      try {
+        return await getTelegramRichRawApi(params.api).sendRichMessage({
+          chat_id: chatId,
+          rich_message: preview.richMessage ?? buildTelegramRichMarkdown(preview.text),
+          ...richMessageParams,
+        });
+      } catch (err) {
+        if (!isTelegramRichMethodUnavailableError(err)) {
+          throw err;
+        }
+        richPreviewUnavailable = true;
+        params.warn?.(
+          `telegram rich stream preview unavailable; retrying with message preview: ${formatErrorMessage(
+            err,
+          )}`,
+        );
+        return await sendLegacyRenderedMessage(preview);
+      }
+    }
+    return await sendLegacyRenderedMessage(preview);
+  };
   const sendMessageTransportPreview = async ({
     preview,
     sendGeneration,
@@ -268,11 +289,54 @@ export function createTelegramDraftStream(params: {
     if (typeof streamMessageId === "number") {
       streamVisibleSinceMs ??= Date.now();
       if (richMessages) {
-        await getTelegramRichRawApi(params.api).editMessageText({
-          chat_id: chatId,
-          message_id: streamMessageId,
-          rich_message: preview.richMessage ?? buildTelegramRichMarkdown(preview.text),
-        });
+        if (richPreviewUnavailable) {
+          if (transportPreview.parseMode === "HTML") {
+            try {
+              await params.api.editMessageText(chatId, streamMessageId, transportPreview.text, {
+                parse_mode: "HTML" as const,
+              });
+            } catch (err) {
+              if (!isTelegramHtmlParseError(err)) {
+                throw err;
+              }
+              await params.api.editMessageText(chatId, streamMessageId, transportPreview.plainText);
+            }
+          } else {
+            await params.api.editMessageText(chatId, streamMessageId, transportPreview.text);
+          }
+          return true;
+        }
+        try {
+          await getTelegramRichRawApi(params.api).editMessageText({
+            chat_id: chatId,
+            message_id: streamMessageId,
+            rich_message: preview.richMessage ?? buildTelegramRichMarkdown(preview.text),
+          });
+        } catch (err) {
+          if (!isTelegramRichMethodUnavailableError(err)) {
+            throw err;
+          }
+          richPreviewUnavailable = true;
+          params.warn?.(
+            `telegram rich stream preview edit unavailable; retrying with message preview: ${formatErrorMessage(
+              err,
+            )}`,
+          );
+          if (transportPreview.parseMode === "HTML") {
+            try {
+              await params.api.editMessageText(chatId, streamMessageId, transportPreview.text, {
+                parse_mode: "HTML" as const,
+              });
+            } catch (htmlErr) {
+              if (!isTelegramHtmlParseError(htmlErr)) {
+                throw htmlErr;
+              }
+              await params.api.editMessageText(chatId, streamMessageId, transportPreview.plainText);
+            }
+          } else {
+            await params.api.editMessageText(chatId, streamMessageId, transportPreview.text);
+          }
+        }
         return true;
       }
       const transportPreview = normalizeTelegramDraftTransportPreview(preview);

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -6,7 +6,11 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
-import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "./format.js";
+import {
+  renderTelegramHtmlText,
+  splitTelegramHtmlChunks,
+  telegramHtmlToPlainTextFallback,
+} from "./format.js";
 import {
   isRecoverableTelegramNetworkError,
   isSafeToRetrySendError,
@@ -22,6 +26,7 @@ import {
   buildTelegramRichMarkdown,
   getTelegramRichRawApi,
   isTelegramRichMessageWithinStructuralLimits,
+  TELEGRAM_LEGACY_TEXT_LIMIT,
   TELEGRAM_RICH_TEXT_LIMIT,
   type TelegramInputRichMessage,
   type TelegramSendRichMessageParams,
@@ -120,6 +125,32 @@ function normalizeTelegramDraftTransportPreview(
   return {
     text: preview.text,
     plainText: preview.text,
+  };
+}
+
+function capTelegramLegacyTransportPreview(
+  preview: TelegramDraftPreview,
+): TelegramDraftTransportPreview {
+  const transportPreview = normalizeTelegramDraftTransportPreview(preview);
+  if (
+    transportPreview.text.length <= TELEGRAM_LEGACY_TEXT_LIMIT &&
+    transportPreview.plainText.length <= TELEGRAM_LEGACY_TEXT_LIMIT
+  ) {
+    return transportPreview;
+  }
+  if (transportPreview.parseMode === "HTML") {
+    const text =
+      splitTelegramHtmlChunks(transportPreview.text, TELEGRAM_LEGACY_TEXT_LIMIT)[0] ?? "";
+    return {
+      text,
+      parseMode: "HTML",
+      plainText: telegramHtmlToPlainTextFallback(text).slice(0, TELEGRAM_LEGACY_TEXT_LIMIT),
+    };
+  }
+  const text = transportPreview.text.slice(0, TELEGRAM_LEGACY_TEXT_LIMIT);
+  return {
+    text,
+    plainText: text,
   };
 }
 
@@ -238,7 +269,7 @@ export function createTelegramDraftStream(params: {
     sendGeneration: number;
   };
   const sendLegacyRenderedMessage = async (preview: TelegramDraftPreview) => {
-    const transportPreview = normalizeTelegramDraftTransportPreview(preview);
+    const transportPreview = capTelegramLegacyTransportPreview(preview);
     const sendPlain = async () =>
       await params.api.sendMessage(chatId, transportPreview.plainText, sendMessageParams);
     if (transportPreview.parseMode !== "HTML") {
@@ -286,24 +317,28 @@ export function createTelegramDraftStream(params: {
     preview,
     sendGeneration,
   }: PreviewSendParams): Promise<boolean> => {
+    const editLegacyRenderedMessage = async () => {
+      const legacyPreview = capTelegramLegacyTransportPreview(preview);
+      if (legacyPreview.parseMode === "HTML") {
+        try {
+          await params.api.editMessageText(chatId, streamMessageId!, legacyPreview.text, {
+            parse_mode: "HTML" as const,
+          });
+        } catch (err) {
+          if (!isTelegramHtmlParseError(err)) {
+            throw err;
+          }
+          await params.api.editMessageText(chatId, streamMessageId!, legacyPreview.plainText);
+        }
+      } else {
+        await params.api.editMessageText(chatId, streamMessageId!, legacyPreview.text);
+      }
+    };
     if (typeof streamMessageId === "number") {
       streamVisibleSinceMs ??= Date.now();
       if (richMessages) {
         if (richPreviewUnavailable) {
-          if (transportPreview.parseMode === "HTML") {
-            try {
-              await params.api.editMessageText(chatId, streamMessageId, transportPreview.text, {
-                parse_mode: "HTML" as const,
-              });
-            } catch (err) {
-              if (!isTelegramHtmlParseError(err)) {
-                throw err;
-              }
-              await params.api.editMessageText(chatId, streamMessageId, transportPreview.plainText);
-            }
-          } else {
-            await params.api.editMessageText(chatId, streamMessageId, transportPreview.text);
-          }
+          await editLegacyRenderedMessage();
           return true;
         }
         try {
@@ -322,20 +357,7 @@ export function createTelegramDraftStream(params: {
               err,
             )}`,
           );
-          if (transportPreview.parseMode === "HTML") {
-            try {
-              await params.api.editMessageText(chatId, streamMessageId, transportPreview.text, {
-                parse_mode: "HTML" as const,
-              });
-            } catch (htmlErr) {
-              if (!isTelegramHtmlParseError(htmlErr)) {
-                throw htmlErr;
-              }
-              await params.api.editMessageText(chatId, streamMessageId, transportPreview.plainText);
-            }
-          } else {
-            await params.api.editMessageText(chatId, streamMessageId, transportPreview.text);
-          }
+          await editLegacyRenderedMessage();
         }
         return true;
       }

--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -7,6 +7,7 @@ import {
   isSafeToRetrySendError,
   isTelegramClientRejection,
   isTelegramPollingNetworkError,
+  isTelegramRichMethodUnavailableError,
   isTelegramServerError,
   tagTelegramNetworkError,
 } from "./network-errors.js";
@@ -283,6 +284,34 @@ describe("isSafeToRetrySendError", () => {
     expect(
       isSafeToRetrySendError(
         Object.assign(new Error("Misdirected Request"), { statusCode: "421abc" }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isTelegramRichMethodUnavailableError", () => {
+  it.each([
+    "Telegram rich messages require grammY api.raw",
+    "Call to 'sendRichMessage' failed! (404: Not Found)",
+    "sendRichMessage method not found",
+    "sendRichMessage is unsupported by this Bot API root",
+  ])("detects rich Bot API method gaps: %s", (message) => {
+    expect(isTelegramRichMethodUnavailableError(new Error(message))).toBe(true);
+  });
+
+  it("detects nested rich method gaps", () => {
+    const inner = new Error(
+      "Call to 'sendRichMessage' failed! (400: Bad Request: method not found)",
+    );
+    const outer = Object.assign(new Error("wrapped"), { cause: inner });
+
+    expect(isTelegramRichMethodUnavailableError(outer)).toBe(true);
+  });
+
+  it("does not treat ambiguous send network failures as method gaps", () => {
+    expect(
+      isTelegramRichMethodUnavailableError(
+        new Error("Network request for 'sendRichMessage' failed!"),
       ),
     ).toBe(false);
   });

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -291,6 +291,19 @@ export function isTelegramEditTargetMissingError(err: unknown): boolean {
   return EDIT_TARGET_MISSING_RE.test(formatErrorMessage(err));
 }
 
+const RICH_METHOD_UNAVAILABLE_RE =
+  /Telegram rich messages require grammY api\.raw|does not expose sendRichMessage|Call to ['"]?sendRichMessage['"]? failed!\s*\((?:404|400):|sendRichMessage.*(?:method not found|not found|unsupported|unknown method)|(?:404|400):\s*(?:Not Found|Bad Request: method not found)/i;
+
+/** True when the configured Telegram Bot API surface lacks rich-message methods. */
+export function isTelegramRichMethodUnavailableError(err: unknown): boolean {
+  for (const candidate of collectTelegramErrorCandidates(err)) {
+    if (RICH_METHOD_UNAVAILABLE_RE.test(formatErrorMessage(candidate))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Returns true for HTTP 4xx client errors (Telegram explicitly rejected, not applied). */
 export function isTelegramClientRejection(err: unknown): boolean {
   return hasTelegramErrorCode(err, (code) => code >= 400 && code < 500);

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -27,6 +27,7 @@ type TelegramRichMessageReplyMarkup =
   | ForceReply;
 
 export const TELEGRAM_RICH_TEXT_LIMIT = 32_768;
+export const TELEGRAM_LEGACY_TEXT_LIMIT = 4_096;
 export const TELEGRAM_RICH_BLOCK_LIMIT = 500;
 export const TELEGRAM_RICH_MEDIA_LIMIT = 50;
 export const TELEGRAM_RICH_NESTING_LIMIT = 16;

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -48,6 +48,7 @@ const {
 } = getTelegramSendTestMocks();
 const telegramSendModule = await importTelegramSendModule();
 const { resetLogger, setLoggerOverride } = await import("openclaw/plugin-sdk/runtime-env");
+const { TELEGRAM_LEGACY_TEXT_LIMIT } = await import("./rich-message.js");
 const {
   buildInlineKeyboard,
   createForumTopicTelegram,
@@ -974,6 +975,27 @@ describe("sendMessageTelegram", () => {
       link_preview_options: { is_disabled: true },
       parse_mode: "HTML",
     });
+  });
+
+  it("re-chunks rich text send fallback to Telegram's legacy text limit", async () => {
+    botRawApi.sendRichMessage.mockRejectedValueOnce(
+      Object.assign(new Error("Call to 'sendRichMessage' failed! (404: Not Found)"), {
+        error_code: 404,
+      }),
+    );
+    botApi.sendMessage.mockResolvedValue({ message_id: 47, chat: { id: "123" } });
+    const text = "A".repeat(TELEGRAM_LEGACY_TEXT_LIMIT + 12);
+
+    await sendMessageTelegram("123", text, {
+      cfg: { channels: { telegram: { richMessages: true } } },
+      token: "tok",
+    });
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(botApi.sendMessage).toHaveBeenCalledTimes(2);
+    expect(botApi.sendMessage.mock.calls.every((call) => String(call[1]).length <= 4_096)).toBe(
+      true,
+    );
   });
 
   it("does not fall back from ambiguous rich text send network errors", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -956,6 +956,46 @@ describe("sendMessageTelegram", () => {
     expect(richMessage?.html).toContain("<table>");
   });
 
+  it("falls back to sendMessage when rich text send is unsupported", async () => {
+    botRawApi.sendRichMessage.mockRejectedValueOnce(
+      Object.assign(new Error("Call to 'sendRichMessage' failed! (404: Not Found)"), {
+        error_code: 404,
+      }),
+    );
+    botApi.sendMessage.mockResolvedValue({ message_id: 46, chat: { id: "123" } });
+
+    await sendMessageTelegram("123", "hi **boss**", {
+      cfg: { channels: { telegram: { richMessages: true, linkPreview: false } } },
+      token: "tok",
+    });
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(botApi.sendMessage).toHaveBeenCalledWith("123", "hi <b>boss</b>", {
+      link_preview_options: { is_disabled: true },
+      parse_mode: "HTML",
+    });
+  });
+
+  it("does not fall back from ambiguous rich text send network errors", async () => {
+    botRawApi.sendRichMessage.mockRejectedValueOnce(
+      Object.assign(new Error("Network request for 'sendRichMessage' failed!"), {
+        name: "HttpError",
+        error: Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }),
+      }),
+    );
+    botApi.sendMessage.mockResolvedValue({ message_id: 46, chat: { id: "123" } });
+
+    await expect(
+      sendMessageTelegram("123", "hi **boss**", {
+        cfg: { channels: { telegram: { richMessages: true } } },
+        token: "tok",
+      }),
+    ).rejects.toThrow("Network request");
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: "list",
@@ -3514,6 +3554,30 @@ describe("editMessageTelegram", () => {
       parse_mode: "HTML",
     });
     expect(botRawApi.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to text edit when rich edit is unsupported", async () => {
+    botRawApi.editMessageText.mockRejectedValueOnce(
+      Object.assign(
+        new Error("Call to 'editMessageText' failed! (400: Bad Request: method not found)"),
+        {
+          error_code: 400,
+        },
+      ),
+    );
+    botApi.editMessageText.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, "**edited**", {
+      token: "tok",
+      cfg: { channels: { telegram: { richMessages: true } } },
+      linkPreview: false,
+    });
+
+    expect(botRawApi.editMessageText).toHaveBeenCalledTimes(1);
+    expect(botApi.editMessageText).toHaveBeenCalledWith("123", 1, "<b>edited</b>", {
+      link_preview_options: { is_disabled: true },
+      parse_mode: "HTML",
+    });
   });
 
   it("edits complex text as formatted HTML", async () => {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -32,6 +32,7 @@ import {
   isRecoverableTelegramNetworkError,
   isSafeToRetrySendError,
   isTelegramRateLimitError,
+  isTelegramRichMethodUnavailableError,
   isTelegramServerError,
 } from "./network-errors.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
@@ -841,10 +842,24 @@ export async function sendMessageTelegram(
     }));
   };
 
-  const sendChunkedText = async (rawText: string, context: string) =>
-    useRichMessages
-      ? await sendTelegramRichTextChunks(buildRichTextPlan(rawText), context)
-      : await sendTelegramTextChunks(buildChunkedTextPlan(rawText, context), context);
+  const sendChunkedText = async (rawText: string, context: string) => {
+    if (!useRichMessages) {
+      return await sendTelegramTextChunks(buildChunkedTextPlan(rawText, context), context);
+    }
+    try {
+      return await sendTelegramRichTextChunks(buildRichTextPlan(rawText), context);
+    } catch (err) {
+      if (!isTelegramRichMethodUnavailableError(err)) {
+        throw err;
+      }
+      if (opts.verbose) {
+        sendLogger.warn(
+          `telegram richMessage unavailable, retrying via sendMessage: ${formatErrorMessage(err)}`,
+        );
+      }
+      return await sendTelegramTextChunks(buildChunkedTextPlan(rawText, context), context);
+    }
+  };
 
   const buildRichTextPlan = (rawText: string): TelegramRichTextChunk[] => {
     const textLimit = Math.min(
@@ -1616,23 +1631,8 @@ export async function editMessageTelegram(
     plainCaptionParams.reply_markup = replyMarkup;
   }
 
-  const performTextEdit = () => {
-    if (richRawApi && richMessage) {
-      const richEditParams: Pick<TelegramEditRichMessageTextParams, "reply_markup"> =
-        replyMarkup === undefined ? {} : { reply_markup: replyMarkup };
-      return requestWithEditShouldLog(
-        () =>
-          richRawApi.editMessageText({
-            chat_id: chatId,
-            message_id: messageId,
-            rich_message: richMessage,
-            ...richEditParams,
-          }),
-        "editMessage",
-        (err) => !isTelegramMessageNotModifiedError(err),
-      );
-    }
-    return withTelegramHtmlParseFallback({
+  const performLegacyTextEdit = () =>
+    withTelegramHtmlParseFallback({
       label: "editMessage",
       verbose: opts.verbose,
       requestHtml: (retryLabel) =>
@@ -1651,6 +1651,38 @@ export async function editMessageTelegram(
           (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
         ),
     });
+
+  const performTextEdit = async () => {
+    if (richRawApi && richMessage) {
+      const richEditParams: Pick<TelegramEditRichMessageTextParams, "reply_markup"> =
+        replyMarkup === undefined ? {} : { reply_markup: replyMarkup };
+      try {
+        return await requestWithEditShouldLog(
+          () =>
+            richRawApi.editMessageText({
+              chat_id: chatId,
+              message_id: messageId,
+              rich_message: richMessage,
+              ...richEditParams,
+            }),
+          "editMessage",
+          (err) => !isTelegramMessageNotModifiedError(err),
+        );
+      } catch (err) {
+        if (!isTelegramRichMethodUnavailableError(err)) {
+          throw err;
+        }
+        if (opts.verbose) {
+          sendLogger.warn(
+            `telegram rich edit unavailable, retrying via editMessageText: ${formatErrorMessage(
+              err,
+            )}`,
+          );
+        }
+        return await performLegacyTextEdit();
+      }
+    }
+    return await performLegacyTextEdit();
   };
 
   const performCaptionEdit = () =>


### PR DESCRIPTION
## Summary

- Preserves Telegram text delivery when rich Bot API methods are unavailable on a custom or lagging Bot API root.
- Falls back from `sendRichMessage` / rich text edit to legacy `sendMessage` / `editMessageText`.
- Re-chunks legacy fallback sends to Telegram's 4096-character text limit and avoids replaying already-delivered chunks when a later HTML chunk needs plain-text fallback.

## Why this matters

OpenClaw's Telegram plugin now uses Telegram's newer rich Bot API methods for better formatting, but not every supported deployment reaches the official latest Bot API directly. Some users run through custom `apiRoot` deployments, self-hosted Bot API services, proxies, or lagging infrastructure where classic `sendMessage` still works but `sendRichMessage` does not exist yet.

Without this fallback, a formatting upgrade can turn into a message-delivery outage: ordinary text replies, edits, and stream previews can fail even though Telegram still supports the legacy send path. This PR keeps the new rich path as the preferred behavior while preserving basic Telegram delivery on older or custom Bot API surfaces, which is the safer compatibility posture for a channel plugin.

The fix stays local to the Telegram plugin, adds no new config surface, and follows Telegram's legacy 4096-character text contract so long replies do not fail after falling back.

## Verification

- `node scripts/run-vitest.mjs extensions/telegram/src/network-errors.test.ts extensions/telegram/src/send.test.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/draft-stream.test.ts`
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/rich-message.ts extensions/telegram/src/network-errors.ts extensions/telegram/src/network-errors.test.ts extensions/telegram/src/send.ts extensions/telegram/src/send.test.ts extensions/telegram/src/bot/delivery.send.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/draft-stream.ts extensions/telegram/src/draft-stream.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/rich-message.ts extensions/telegram/src/send.ts extensions/telegram/src/send.test.ts extensions/telegram/src/bot/delivery.send.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/draft-stream.ts extensions/telegram/src/draft-stream.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: Telegram final text delivery still reaches a real Telegram user when the rich Bot API method is unavailable and OpenClaw has to fall back to legacy `sendMessage`.

Real environment tested: Local OpenClaw PR head `5558aed2d66a49d232e2c75e3c233b2f30e99a7e` against a real Telegram bot and real Telegram user chat, using a local Bot API proxy that intentionally returns `404` for `sendRichMessage` while forwarding legacy `sendMessage` to Telegram's official Bot API.

Exact steps or command run after this patch:

```bash
node --import tsx .artifacts/manual-telegram-proof/rich-fallback-proof.ts proof
```

Evidence after fix:

```text
# Telegram Rich Fallback Manual Proof

- PR: https://github.com/openclaw/openclaw/pull/92946
- Branch head: 5558aed2d66a49d232e2c75e3c233b2f30e99a7e
- Marker sent to Telegram: OPENCLAW-RICH-FALLBACK-2026-06-14T12:23:22.322Z
- Result: PASS

## Evidence

- Local Bot API proxy returned 404 for `sendRichMessage`.
- OpenClaw retried with legacy `sendMessage`.
- Telegram accepted the legacy message and returned a real `message_id`.
```

```json
{
  "pass": true,
  "result": {
    "messageId": "5",
    "chatId": "[redacted]"
  },
  "proxyEvents": [
    {
      "method": "sendRichMessage",
      "richUnavailable": true,
      "status": 404
    },
    {
      "method": "sendMessage",
      "ok": true,
      "messageId": 5,
      "textLength": 54
    }
  ]
}
```

Observed result after fix: The local proxy rejected the rich Telegram method with `404`, OpenClaw retried through legacy `sendMessage`, Telegram accepted the real API call, and the marker message appeared in the Telegram client.

What was not tested: This manual proof did not use the official Mantis/Crabbox burner-account workflow because the current contributor credentials cannot apply `mantis: telegram-visible-proof` or dispatch the maintainer-only workflow.
