### PR TITLE
fix(qqbot): deliver cron auto-TTS voice by trusting OpenClaw temp root

### DIFF
--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
@@ -25,7 +25,6 @@ import {
   getQQBotMediaDir,
   isLocalPath as isLocalFilePath,
   normalizePath,
-  resolveQQBotPayloadLocalFilePath,
 } from "../utils/platform.js";
 import { normalizeLowercaseStringOrEmpty, sanitizeFileName } from "../utils/string-normalize.js";
 import { audioFileToSilkBase64, shouldTranscodeVoice, waitForFile } from "./outbound-audio-port.js";
@@ -42,6 +41,7 @@ import {
   type DeliveryTarget,
 } from "./sender.js";
 import { parseTarget as coreParseTarget } from "./target-parser.js";
+import { resolveTrustedOutboundMediaPath } from "./trusted-media-path.js";
 
 /** Parse a qqbot target into a structured delivery target. */
 export function parseTarget(to: string): { type: "c2c" | "group" | "channel"; id: string } {
@@ -139,7 +139,9 @@ export function resolveOutboundMediaPath(
     return { ok: true, mediaPath: normalizedPath };
   }
 
-  const allowedPath = resolveQQBotPayloadLocalFilePath(normalizedPath);
+  const allowedPath = resolveTrustedOutboundMediaPath(normalizedPath, {
+    allowMissing: options.allowMissingLocalPath,
+  });
   if (allowedPath) {
     return { ok: true, mediaPath: allowedPath };
   }
@@ -368,7 +370,7 @@ async function sendVoiceFromLocal(
   }
 
   // Re-check containment after the file appears to prevent symlink-race escapes.
-  const safeMediaPath = resolveQQBotPayloadLocalFilePath(mediaPath);
+  const safeMediaPath = resolveTrustedOutboundMediaPath(mediaPath);
   if (!safeMediaPath) {
     debugWarn(`sendVoice: blocked local voice path outside QQ Bot media storage`);
     return { channel: "qqbot", error: "Voice path must be inside QQ Bot media storage" };

--- a/extensions/qqbot/src/engine/messaging/reply-dispatcher.ts
+++ b/extensions/qqbot/src/engine/messaging/reply-dispatcher.ts
@@ -17,7 +17,7 @@ import {
   isMediaPayload,
   type MediaPayload,
 } from "../utils/payload.js";
-import { normalizePath, resolveQQBotPayloadLocalFilePath } from "../utils/platform.js";
+import { normalizePath } from "../utils/platform.js";
 import { normalizeLowercaseStringOrEmpty } from "../utils/string-normalize.js";
 import { sanitizeFileName } from "../utils/string-normalize.js";
 import { openLocalFile } from "./media-source.js";
@@ -28,6 +28,7 @@ import {
   buildDeliveryTarget,
   accountToCreds,
 } from "./sender.js";
+import { resolveTrustedOutboundMediaPath } from "./trusted-media-path.js";
 
 // ---- Injected dependencies ----
 
@@ -207,7 +208,7 @@ function validateStructuredPayloadLocalPath(
   payloadPath: string,
   mediaType: StructuredPayloadMediaType,
 ): string | null {
-  const allowedPath = resolveQQBotPayloadLocalFilePath(payloadPath);
+  const allowedPath = resolveTrustedOutboundMediaPath(payloadPath);
   if (allowedPath) {
     return allowedPath;
   }

--- a/extensions/qqbot/src/engine/messaging/trusted-media-path.test.ts
+++ b/extensions/qqbot/src/engine/messaging/trusted-media-path.test.ts
@@ -1,0 +1,70 @@
+// Qqbot tests cover trusted outbound media-path root resolution.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/sandbox";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveOutboundMediaPath } from "./outbound-media-send.js";
+import { resolveTrustedOutboundMediaPath } from "./trusted-media-path.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+  while (cleanupPaths.length > 0) {
+    const target = cleanupPaths.pop();
+    if (target) {
+      fs.rmSync(target, { recursive: true, force: true });
+    }
+  }
+});
+
+function makeTtsStyleVoiceFile(): string {
+  // Mirrors cron auto-TTS: speech-core writes the voice file under the preferred
+  // OpenClaw temp root, which is outside the QQ Bot media storage tree.
+  const tmpRoot = resolvePreferredOpenClawTmpDir();
+  const ttsDir = fs.mkdtempSync(path.join(tmpRoot, "tts-"));
+  cleanupPaths.push(ttsDir);
+  const voicePath = path.join(ttsDir, "voice-123.mp3");
+  fs.writeFileSync(voicePath, "audio");
+  return voicePath;
+}
+
+describe("resolveTrustedOutboundMediaPath", () => {
+  it("trusts framework media under OpenClaw's hardened temp root", () => {
+    const voicePath = makeTtsStyleVoiceFile();
+    expect(resolveTrustedOutboundMediaPath(voicePath)).toBe(fs.realpathSync(voicePath));
+  });
+
+  it("rejects local media outside every trusted root", () => {
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "qq-out-of-root-"));
+    cleanupPaths.push(outsideDir);
+    const strayPath = path.join(outsideDir, "stray.mp3");
+    fs.writeFileSync(strayPath, "audio");
+
+    expect(resolveTrustedOutboundMediaPath(strayPath)).toBeNull();
+  });
+
+  it("accepts a not-yet-flushed temp file only when allowMissing is set", () => {
+    const tmpRoot = resolvePreferredOpenClawTmpDir();
+    const ttsDir = fs.mkdtempSync(path.join(tmpRoot, "tts-pending-"));
+    cleanupPaths.push(ttsDir);
+    const pendingPath = path.join(ttsDir, "voice-pending.mp3");
+
+    expect(resolveTrustedOutboundMediaPath(pendingPath)).toBeNull();
+    expect(resolveTrustedOutboundMediaPath(pendingPath, { allowMissing: true })).not.toBeNull();
+  });
+});
+
+describe("resolveOutboundMediaPath", () => {
+  it("resolves a cron/TTS voice file under the temp root end to end", () => {
+    // Both the initial resolve and the voice send re-check funnel through
+    // resolveTrustedOutboundMediaPath, so this gate now passes for temp media.
+    const voicePath = makeTtsStyleVoiceFile();
+    const resolved = resolveOutboundMediaPath(voicePath, "voice", {
+      allowMissingLocalPath: true,
+    });
+
+    expect(resolved.ok).toBe(true);
+    expect(resolved.ok && resolved.mediaPath).toBe(fs.realpathSync(voicePath));
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/trusted-media-path.ts
+++ b/extensions/qqbot/src/engine/messaging/trusted-media-path.ts
@@ -1,0 +1,59 @@
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/sandbox";
+import { resolveLocalPathFromRootsSync } from "openclaw/plugin-sdk/security-runtime";
+import { resolveQQBotPayloadLocalFilePath } from "../utils/platform.js";
+
+// The temp root is process-stable, so resolve it once. Only the success value is
+// cached: a transient provisioning failure returns null without poisoning later
+// calls.
+let cachedTrustedTmpRoot: string | undefined;
+function trustedOpenClawTmpRoot(): string | null {
+  if (cachedTrustedTmpRoot === undefined) {
+    try {
+      cachedTrustedTmpRoot = resolvePreferredOpenClawTmpDir();
+    } catch {
+      return null;
+    }
+  }
+  return cachedTrustedTmpRoot;
+}
+
+/**
+ * Resolve a local outbound media path against every trusted root, returning the
+ * canonical path or null when it sits outside all of them.
+ *
+ * QQBot is the only channel that root-sandboxes outbound local files, and the
+ * same check runs at three sites (`resolveOutboundMediaPath`, the voice send
+ * re-check, and structured-payload validation), so they must all agree or a file
+ * accepted at one gate is rejected at the next. Beyond the QQ Bot media storage
+ * roots, this also trusts OpenClaw's permission-hardened temp root, where
+ * framework scratch media is written (e.g. cron auto-TTS voice files). Core
+ * already treats that temp root as a sanctioned media root (`buildMediaLocalRoots`);
+ * without it here, auto-routed sends are dropped and cron delivery silently loses
+ * the message.
+ *
+ * `allowMissing` lets callers accept a not-yet-flushed temp file (e.g. TTS still
+ * writing) under the temp root; existence is then enforced later by the voice
+ * send re-check before upload.
+ */
+export function resolveTrustedOutboundMediaPath(
+  p: string,
+  options: { allowMissing?: boolean } = {},
+): string | null {
+  const storageRootPath = resolveQQBotPayloadLocalFilePath(p);
+  if (storageRootPath) {
+    return storageRootPath;
+  }
+
+  const tmpRoot = trustedOpenClawTmpRoot();
+  if (!tmpRoot) {
+    return null;
+  }
+  return (
+    resolveLocalPathFromRootsSync({
+      filePath: p,
+      roots: [tmpRoot],
+      label: "OpenClaw temp media root",
+      allowMissing: options.allowMissing === true,
+    })?.path ?? null
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #92816. When `messages.tts.auto = "always"`, cron deliveries to QQBot are silently lost while the run is still recorded as delivered.

Root cause: cron auto-TTS (speech-core) writes the generated voice file under OpenClaw's preferred temp root (`resolvePreferredOpenClawTmpDir`, e.g. `/tmp/openclaw/tts-*/voice-*.mp3`). QQBot is the **only** channel that root-sandboxes outbound local files, and its gate only trusted the QQ Bot media storage roots (`~/.openclaw/media`, `~/.openclaw/media/qqbot`). So the temp file was rejected, `sendMedia` returned a no-identity error, the QQ message was lost — but the shared delivery layer still counted it.

The trust check runs at **three** sites that must agree (a file accepted at one is otherwise rejected at the next):
- `resolveOutboundMediaPath` (initial resolve)
- the `sendVoiceFromLocal` re-check (the gate that actually blocks the voice send)
- `validateStructuredPayloadLocalPath` (structured image/video/file payloads)

This adds one shared resolver, `resolveTrustedOutboundMediaPath`, that also trusts OpenClaw's permission-hardened temp root — which core already treats as a sanctioned media root in `buildMediaLocalRoots` (`src/media/local-roots.ts`) — and routes all three gates through it. The temp root is provisioned `0o700`, owner-checked, non-symlink, and never world/group-writable (`src/infra/tmp-openclaw-dir.ts`), so it is the same trust class as `~/.openclaw/media`; `resolveLocalPathFromRootsSync` realpaths both root and candidate to prevent symlink escape. Out-of-root paths are still rejected.

### Relation to #79811 (not a duplicate)
This is the **delivery** fix: it makes the QQ message actually arrive. #79811 (and the earlier, now-closed #92826) only correct **accounting** — turning a false "delivered" into an honest "failed". The two are complementary: this PR fixes the message loss the user reported; the accounting fix makes a genuine failure visible. Neither has landed on `main`, and the media accounting asymmetry there is out of scope here.

## Real behavior proof

- **Behavior addressed:** A cron auto-TTS voice file written under OpenClaw's preferred temp root now resolves through every QQBot outbound media gate and is delivered to QQ, instead of being rejected as out-of-root and silently dropped.
- **Real environment tested:** A live, real QQ Bot on the official API (`wss://api.sgroup.qq.com`), with the OpenClaw gateway built from this branch (`pnpm dev gateway`), a real C2C recipient, `messages.tts.auto = "always"`, and the keyless Microsoft Edge TTS provider. Also the local resolver unit suite on Node 24.
- **Exact steps or command run after this patch:** Ran a deterministic live gate check against the real QQ API (isolates the gate fix from TTS flakiness), then an end-to-end cron auto-TTS run, then the unit suite:

```sh
# 1a) Positive: media staged UNDER the OpenClaw temp root
openclaw message send --channel qqbot --target <c2c-openid> \
  --media /tmp/openclaw/proof/temp-root-voice.mp3 --json
# 1b) Negative control: same bytes from a path OUTSIDE every trusted root
openclaw message send --channel qqbot --target <c2c-openid> \
  --media ~/qq-untrusted-proof/untrusted-voice.mp3 --json
# 2) End-to-end cron auto-TTS (tts.auto=always) to the C2C target
openclaw cron add --channel qqbot --to <c2c-openid> --announce --message "<one English sentence>"
openclaw cron run <job-id>
# 3) Local resolver unit suite
pnpm test extensions/qqbot/src/engine/messaging/trusted-media-path.test.ts
```

- **Evidence after fix:** Positive live send (temp-root media) was **delivered** with a real platform identity `messageId: ROBOT1.0_m-9gIoJjF…` (`kind: media`, `conversationId: qqbot:c2c:…`). Negative control (untrusted path) was **rejected**: `messageId: ""`, `platformMessageIds: []`. The end-to-end cron auto-TTS run wrote a voice file under the temp root (`/tmp/openclaw/tts-*/voice-*.mp3`) and it arrived on the phone as a QQ voice message (screenshot attached below); no `~/.openclaw/media/outbound` copy existed, confirming it was sent straight from the temp root. Unit suite: `Test Files 1 passed (1) / Tests 4 passed (4)`.
- **Observed result after fix:** The QQ recipient received the cron auto-TTS voice message. Temp-root media delivers with a real platform message id; media outside the trusted roots is still rejected with no delivery identity, so the gate is not over-broadened (security preserved).
- **Before evidence:** With the temp-root trust removed, the resolver suite fails 3/4 (including the end-to-end `resolveOutboundMediaPath` voice case) while the out-of-root rejection test still passes; on unpatched code the same temp-root file is rejected, `sendMedia` returns a no-identity error, and the QQ voice is dropped while cron still records the run as delivered.
- **What was not tested:** Microsoft Edge TTS synthesis is intermittent from this host (public service, no SLA): it synthesized on the first cron run and fell back to text on later runs. The deterministic `message send --media` runs above isolate the gate fix from that flakiness and exercise the exact code this PR changes against the live QQ API.

<img width="1220" height="2615" alt="Screenshot_2026-06-14-22-33-16-350_com tencent mo" src="https://github.com/user-attachments/assets/cd78f641-a736-4bae-a40a-288a3cfdd85f" />


## Tests and validation

- `pnpm test extensions/qqbot` — 526 passed (64 files), no regressions from rewiring the three gates.
- `pnpm tsgo:extensions` and `pnpm tsgo:test:extensions` — clean.
- `pnpm exec oxfmt --check` + `oxlint` on all changed files — clean.
- Live QQ Bot run on the official API: deterministic temp-root vs. untrusted-path `message send` (delivered vs. rejected) plus an end-to-end cron auto-TTS voice delivered to the device.
- Multi-agent review (correctness + security + altitude): confirmed the fix is at the right owner boundary (plugin-local; QQBot is the only sandboxing channel), no symlink/TOCTOU escape, memo caches success only. The first iteration was caught missing two sibling gates; this revision consolidates all three.

## Risk

User-visible behavior change: `Yes` (QQBot now delivers framework temp-root media that was previously dropped). Config/migration: `No`. Security/auth/secrets: `No` — trust is limited to OpenClaw's already-hardened temp root, consistent with core's existing media allowlist; realpath containment is preserved, and the live negative control confirms out-of-root media is still rejected.

AI-assisted (Claude). Proof above includes a live QQ Bot run on the official API.
