### PR TITLE
feat(ui): wire seamColor from bootstrap config to CSS custom properties (fixes #56068)

### DIFF
--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -20,4 +20,5 @@ export type ControlUiBootstrapConfig = {
   embedSandbox?: ControlUiEmbedSandboxMode;
   allowExternalEmbedUrls?: boolean;
   chatMessageMaxWidth?: string;
+  seamColor?: string;
 };

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -979,6 +979,7 @@ export async function handleControlUiHttpRequest(
             : "scripts",
       allowExternalEmbedUrls: config?.gateway?.controlUi?.allowExternalEmbedUrls === true,
       chatMessageMaxWidth: config?.gateway?.controlUi?.chatMessageMaxWidth,
+      seamColor: config?.ui?.seamColor,
     } satisfies ControlUiBootstrapConfig);
     return true;
   }

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -136,7 +136,33 @@ export async function loadControlUiBootstrapConfig(
       typeof parsed.chatMessageMaxWidth === "string" && parsed.chatMessageMaxWidth.trim()
         ? parsed.chatMessageMaxWidth
         : null;
+    if (typeof parsed.seamColor === "string" && parsed.seamColor) {
+      applySeamColor(parsed.seamColor);
+    }
   } catch {
     // Ignore bootstrap failures; UI will update identity after connecting.
+  }
+}
+
+function applySeamColor(hex: string): void {
+  const root = document.documentElement;
+  root.style.setProperty("--accent", hex);
+  root.style.setProperty("--accent-muted", hex);
+  root.style.setProperty("--primary", hex);
+  root.style.setProperty(
+    "--accent-subtle",
+    `color-mix(in srgb, ${hex} 12%, transparent)`,
+  );
+  root.style.setProperty(
+    "--accent-glow",
+    `color-mix(in srgb, ${hex} 20%, transparent)`,
+  );
+  try {
+    root.style.setProperty(
+      "--accent-hover",
+      `oklch(from ${hex} calc(l + 0.1) c h)`,
+    );
+  } catch {
+    /* relative color syntax not supported */
   }
 }


### PR DESCRIPTION
## Summary

Wire the `ui.seamColor` config setting from `openclaw.json` through the gateway bootstrap endpoint to the frontend CSS custom properties. Previously, the setting was validated and stored but never included in the `/control-ui-config.json` response, so the frontend had no way to read it.

## Changes

- **`src/gateway/control-ui-contract.ts`**: Add `seamColor?: string` to `ControlUiBootstrapConfig` type
- **`src/gateway/control-ui.ts`**: Include `seamColor: config?.ui?.seamColor` in the bootstrap config JSON response
- **`ui/src/ui/controllers/control-ui-bootstrap.ts`**: Read `seamColor` from bootstrap config and apply it as CSS custom properties (`--accent`, `--accent-muted`, `--accent-subtle`, `--accent-glow`, `--accent-hover`, `--primary`) via `applySeamColor()` helper

## Real behavior proof

- **Behavior addressed:** `ui.seamColor` config setting is ignored by the web UI frontend
- **Environment tested:** macOS 26.4.1, Node.js v24, pnpm build
- **Steps run after the patch:**
  1. `pnpm build` — full project build including UI bundle
  2. `node scripts/run-vitest.mjs run src/gateway/control-ui.http.test.ts` — gateway bootstrap endpoint tests
  3. `node scripts/run-vitest.mjs run ui/src/ui/controllers/control-ui-bootstrap.test.ts` — frontend bootstrap loader tests
  4. `grep -n seamColor` across all 3 changed files to verify wiring

- **Evidence after fix:**

```
$ grep -n 'seamColor' src/gateway/control-ui-contract.ts src/gateway/control-ui.ts ui/src/ui/controllers/control-ui-bootstrap.ts
src/gateway/control-ui-contract.ts:23:  seamColor?: string;
src/gateway/control-ui.ts:982:      seamColor: config?.ui?.seamColor,
ui/src/ui/controllers/control-ui-bootstrap.ts:139:    if (typeof parsed.seamColor === "string" && parsed.seamColor) {
ui/src/ui/controllers/control-ui-bootstrap.ts:140:      applySeamColor(parsed.seamColor);

$ pnpm build
✓ built in 504ms
[build-all] ui:build done in 1.27s

$ node scripts/run-vitest.mjs run src/gateway/control-ui.http.test.ts
✓  gateway-core  (56 tests) 305ms
✓  gateway-server  (56 tests) 277ms
✓  gateway-client  (56 tests) 288ms
✓  gateway-methods  (56 tests) 272ms
Test Files  4 passed (4)
     Tests  224 passed (224)

$ node scripts/run-vitest.mjs run ui/src/ui/controllers/control-ui-bootstrap.test.ts
✓  ui  (10 tests) 4ms
Test Files  1 passed (1)
     Tests  10 passed (10)
```

- **Observed result after fix:** `seamColor` now flows from `openclaw.json` → gateway bootstrap JSON → frontend CSS custom properties. The `applySeamColor()` function sets `--accent`, `--accent-muted`, `--primary`, `--accent-subtle`, `--accent-glow`, and `--accent-hover` on `document.documentElement`. All existing tests pass.
- **What was not tested:** Live browser rendering with a custom `seamColor` value (requires running gateway + browser). The CSS `color-mix()` and `oklch()` functions are used for derived colors — browser compatibility for `oklch(from ...)` is wrapped in try/catch as a graceful fallback.
