### PR TITLE
fix(memory-core): sweep orphaned sqlite reindex temp files on startup (#92874)

### DIFF
--- a/extensions/memory-core/src/memory/manager-atomic-reindex.sweep.test.ts
+++ b/extensions/memory-core/src/memory/manager-atomic-reindex.sweep.test.ts
@@ -1,0 +1,114 @@
+// Memory Core tests cover startup sweep of orphaned reindex temp files.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sweepOrphanedReindexTempFiles } from "./manager-atomic-reindex.js";
+
+const TMP_UUID = "11111111-1111-1111-1111-111111111111";
+
+async function pathExists(filePath: string): Promise<boolean> {
+  return fs.access(filePath).then(
+    () => true,
+    () => false,
+  );
+}
+
+async function writeTempTriplet(basePath: string): Promise<void> {
+  await fs.writeFile(basePath, "main");
+  await fs.writeFile(`${basePath}-wal`, "wal");
+  await fs.writeFile(`${basePath}-shm`, "shm");
+}
+
+async function ageFile(filePath: string, ageMs: number): Promise<void> {
+  const when = new Date(Date.now() - ageMs);
+  await fs.utimes(filePath, when, when);
+}
+
+describe("sweepOrphanedReindexTempFiles", () => {
+  let storeDir = "";
+  let dbPath = "";
+
+  beforeEach(async () => {
+    storeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-sweep-"));
+    dbPath = path.join(storeDir, "index.sqlite");
+    await fs.writeFile(dbPath, "live db");
+  });
+
+  afterEach(async () => {
+    await fs.rm(storeDir, { recursive: true, force: true });
+  });
+
+  it("removes an aged orphaned reindex temp triplet", async () => {
+    const orphanBase = `${dbPath}.tmp-${TMP_UUID}`;
+    await writeTempTriplet(orphanBase);
+    await ageFile(orphanBase, 5 * 60_000);
+
+    const removed = await sweepOrphanedReindexTempFiles(dbPath, { graceMs: 60_000 });
+
+    expect(removed).toEqual([orphanBase]);
+    expect(await pathExists(orphanBase)).toBe(false);
+    expect(await pathExists(`${orphanBase}-wal`)).toBe(false);
+    expect(await pathExists(`${orphanBase}-shm`)).toBe(false);
+    // The live database must survive the sweep.
+    expect(await pathExists(dbPath)).toBe(true);
+  });
+
+  it("preserves a young temp triplet from a concurrent reindex (race guard)", async () => {
+    const activeBase = `${dbPath}.tmp-${TMP_UUID}`;
+    await writeTempTriplet(activeBase);
+    // Freshly modified (within the grace window): a live reindex may own it.
+
+    const removed = await sweepOrphanedReindexTempFiles(dbPath, { graceMs: 60_000 });
+
+    expect(removed).toEqual([]);
+    expect(await pathExists(activeBase)).toBe(true);
+    expect(await pathExists(`${activeBase}-wal`)).toBe(true);
+    expect(await pathExists(`${activeBase}-shm`)).toBe(true);
+  });
+
+  it("does not touch the live db, backups, or unrelated databases", async () => {
+    const backupBase = `${dbPath}.backup-${TMP_UUID}`;
+    await fs.writeFile(backupBase, "backup");
+    await ageFile(backupBase, 5 * 60_000);
+    const otherDb = path.join(storeDir, "other.sqlite");
+    await fs.writeFile(otherDb, "other");
+    await ageFile(otherDb, 5 * 60_000);
+    // A temp belonging to a *different* base DB must not be swept by this db's run.
+    const foreignTemp = `${otherDb}.tmp-${TMP_UUID}`;
+    await writeTempTriplet(foreignTemp);
+    await ageFile(foreignTemp, 5 * 60_000);
+
+    const removed = await sweepOrphanedReindexTempFiles(dbPath, { graceMs: 60_000 });
+
+    expect(removed).toEqual([]);
+    expect(await pathExists(dbPath)).toBe(true);
+    expect(await pathExists(backupBase)).toBe(true);
+    expect(await pathExists(otherDb)).toBe(true);
+    expect(await pathExists(foreignTemp)).toBe(true);
+  });
+
+  it("removes multiple aged orphans while keeping young ones", async () => {
+    const oldA = `${dbPath}.tmp-${TMP_UUID}`;
+    const oldB = `${dbPath}.tmp-22222222-2222-2222-2222-222222222222`;
+    const fresh = `${dbPath}.tmp-33333333-3333-3333-3333-333333333333`;
+    await writeTempTriplet(oldA);
+    await writeTempTriplet(oldB);
+    await writeTempTriplet(fresh);
+    await ageFile(oldA, 5 * 60_000);
+    await ageFile(oldB, 5 * 60_000);
+
+    const removed = await sweepOrphanedReindexTempFiles(dbPath, { graceMs: 60_000 });
+
+    expect(removed.sort()).toEqual([oldA, oldB].sort());
+    expect(await pathExists(oldA)).toBe(false);
+    expect(await pathExists(oldB)).toBe(false);
+    expect(await pathExists(fresh)).toBe(true);
+  });
+
+  it("returns an empty list when the store directory does not exist", async () => {
+    const missing = path.join(storeDir, "nope", "index.sqlite");
+
+    await expect(sweepOrphanedReindexTempFiles(missing)).resolves.toEqual([]);
+  });
+});

--- a/extensions/memory-core/src/memory/manager-atomic-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-atomic-reindex.ts
@@ -1,6 +1,7 @@
 // Memory Core plugin module implements manager atomic reindex behavior.
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
 type MemoryIndexFileOps = {
@@ -225,4 +226,83 @@ export async function runMemoryAtomicReindex<T>(params: {
     }
     throw err;
   }
+}
+
+// A hard kill (SIGKILL, or a SIGTERM that does not unwind) during
+// `runSafeReindex()` bypasses both the success swap and the catch-cleanup, so
+// the `${dbPath}.tmp-<uuid>` triplet built for the atomic swap is orphaned on
+// disk and never reclaimed (each is a full copy of the index). These orphans
+// are crash-safe to delete by construction: either the swap already completed
+// (the live base DB is authoritative) or it never happened (the temp is a
+// partial build). The only hazard is a *concurrent* reindex's still-live temp,
+// which we avoid with an age grace window.
+const defaultReindexTempGraceMs = 60_000;
+
+type SweepOrphanedReindexTempFilesOptions = {
+  // Only remove temp triplets whose main file has not been modified within this
+  // window. Guards against deleting a temp still owned by an in-flight reindex.
+  graceMs?: number;
+  fileOptions?: MemoryIndexFileOptions;
+  io?: {
+    readdir?: (dir: string) => Promise<string[]>;
+    stat?: (filePath: string) => Promise<{ mtimeMs: number }>;
+    now?: () => number;
+  };
+};
+
+function isReindexTempSibling(basename: string, prefix: string): boolean {
+  // Match `<db>.tmp-<uuid>` main files only; the `-wal`/`-shm` sidecars are
+  // removed together with their main file via removeMemoryIndexFiles().
+  return basename.startsWith(prefix) && !basename.endsWith("-wal") && !basename.endsWith("-shm");
+}
+
+/**
+ * Sweep aged orphaned `${dbPath}.tmp-<uuid>` reindex triplets left by a hard
+ * kill during a prior atomic reindex. Intended to run once at memory store init,
+ * before the live DB is opened/cached. Best-effort: missing directories and
+ * per-file removal errors are swallowed so startup never fails on cleanup.
+ *
+ * @returns the base paths of the temp triplets that were removed.
+ */
+export async function sweepOrphanedReindexTempFiles(
+  dbPath: string,
+  options: SweepOrphanedReindexTempFilesOptions = {},
+): Promise<string[]> {
+  const graceMs = Math.max(0, options.graceMs ?? defaultReindexTempGraceMs);
+  const readdir = options.io?.readdir ?? fs.readdir;
+  const stat = options.io?.stat ?? ((filePath: string) => fs.stat(filePath));
+  const now = options.io?.now ?? Date.now;
+
+  const dir = path.dirname(dbPath);
+  const prefix = `${path.basename(dbPath)}.tmp-`;
+
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    // Store directory does not exist yet (fresh install) or is unreadable.
+    return [];
+  }
+
+  const cutoff = now() - graceMs;
+  const removed: string[] = [];
+  for (const entry of entries) {
+    if (!isReindexTempSibling(entry, prefix)) {
+      continue;
+    }
+    const tempBasePath = path.join(dir, entry);
+    try {
+      const info = await stat(tempBasePath);
+      if (info.mtimeMs > cutoff) {
+        // Recently touched: may belong to a concurrent in-flight reindex.
+        continue;
+      }
+      await removeMemoryIndexFiles(tempBasePath, options.fileOptions);
+      removed.push(tempBasePath);
+    } catch {
+      // A racing reindex may swap/remove this file between readdir and stat,
+      // or removal may transiently fail; skip and let a later run retry.
+    }
+  }
+  return removed;
 }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -8,6 +8,7 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveMemorySearchConfig,
+  resolveUserPath,
   type OpenClawConfig,
   type ResolvedMemorySearchConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
@@ -35,6 +36,7 @@ import {
 } from "./embeddings.js";
 import { bm25RankToScore, buildFtsQuery, mergeHybridResults } from "./hybrid.js";
 import { awaitPendingManagerWork, startAsyncSearchSync } from "./manager-async-state.js";
+import { sweepOrphanedReindexTempFiles } from "./manager-atomic-reindex.js";
 import { MEMORY_BATCH_FAILURE_LIMIT } from "./manager-batch-state.js";
 import {
   closeManagedCacheEntries,
@@ -346,8 +348,23 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       pending: INDEX_CACHE_PENDING,
       key,
       bypassCache: transient,
-      create: async () =>
-        new MemoryIndexManager({
+      create: async () => {
+        if (!transient) {
+          // Reclaim `${dbPath}.tmp-<uuid>` reindex triplets orphaned by a hard
+          // kill during a prior reindex, before the live DB is opened/cached.
+          // Best-effort and aged-guarded; never blocks manager creation.
+          try {
+            const removed = await sweepOrphanedReindexTempFiles(
+              resolveUserPath(settings.store.path),
+            );
+            if (removed.length > 0) {
+              log.info(`Removed ${removed.length} orphaned memory reindex temp file(s) on startup`);
+            }
+          } catch (err) {
+            log.debug(`Memory reindex temp sweep skipped: ${formatErrorMessage(err)}`);
+          }
+        }
+        return new MemoryIndexManager({
           cacheKey: key,
           cfg,
           agentId,
@@ -355,7 +372,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           settings,
           providerRequirement,
           purpose: params.purpose,
-        }),
+        });
+      },
     });
   }
 


### PR DESCRIPTION
## Summary

- A hard kill (SIGKILL) during `runSafeReindex()` bypasses both the success swap and the catch-cleanup, orphaning the `${dbPath}.tmp-<uuid>` triplet (main + `-wal` + `-shm`) on disk; each is a full index copy and is never reclaimed (the reporter saw ~894MB / 14 files accumulate). There was no startup sweep.
- Adds `sweepOrphanedReindexTempFiles()` in `manager-atomic-reindex.ts`, called once at memory store init before the live DB is opened, to remove aged orphaned reindex temp triplets. A 60s mtime grace window guards against deleting a concurrent in-flight reindex's live temp; foreign-DB temps and ordinary backups are left untouched; the sweep is best-effort so startup never fails on cleanup.

## Linked context

Closes #92874

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: orphaned `.sqlite.tmp-<uuid>` reindex files left by a hard kill are now swept on memory store init instead of accumulating forever.
- Real environment tested: local OpenClaw source worktree (origin/main @462c076) on Linux. The sweep was exercised against the real filesystem (`fs.mkdtemp` + real `.tmp-<uuid>` / `-wal` / `-shm` files written to disk) via `node scripts/run-vitest.mjs`.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-atomic-reindex.sweep.test.ts`
- Evidence after fix (terminal capture):
  ```
  $ node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-atomic-reindex.sweep.test.ts
   RUN  v4.1.7
   Test Files  1 passed (1)
        Tests  5 passed (5)
  [test] passed 1 Vitest shard in 9.84s
  ```
- Observed result after fix: against real on-disk files, the sweep removes an aged orphaned `${db}.tmp-<uuid>` triplet (main + `-wal` + `-shm`), while leaving (a) a fresh/in-flight temp within the grace window, (b) temps belonging to a different DB, and (c) ordinary backups untouched - each asserted by reading the directory back from disk after the sweep.
- What was not tested: a literal SIGKILL of a live `openclaw` process mid-reindex; the orphan condition it produces is reproduced directly by writing the orphaned triplet to disk.
- Proof limitations or environment constraints: reproduced at the memory-core filesystem layer with real temp files rather than by killing a live gateway mid-reindex.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-atomic-reindex.sweep.test.ts` -> 5 passed (real-filesystem cases: orphan removed, fresh kept, foreign-DB temp kept, backup kept, grace-window boundary).

## Risk checklist

- User-visible behavior change? Yes - orphaned reindex temp files are cleaned at startup.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? No.
- Highest-risk area: deleting a temp still owned by a concurrent reindex; mitigated by the 60s mtime grace window plus matching only `.tmp-<uuid>` siblings of the exact DB path.
