### PR TITLE
fix(opencode-go): load context windows from bundled catalog

### DIFF
--- a/docs/providers/opencode-go.md
+++ b/docs/providers/opencode-go.md
@@ -18,26 +18,27 @@ provider id `opencode-go` so upstream per-model routing stays correct.
 
 ## Built-in catalog
 
-OpenClaw sources most Go catalog rows from the bundled OpenClaw model registry and
-supplements current upstream rows while the registry catches up. Run
-`openclaw models list --provider opencode-go` for the current model list.
+OpenClaw ships the bundled OpenCode Go catalog directly for sync lookups and
+model listing. Run `openclaw models list --provider opencode-go` for the current
+installed list.
 
 The provider includes:
 
-| Model ref                       | Name                  |
-| ------------------------------- | --------------------- |
-| `opencode-go/glm-5`             | GLM-5                 |
-| `opencode-go/glm-5.1`           | GLM-5.1               |
-| `opencode-go/kimi-k2.5`         | Kimi K2.5             |
-| `opencode-go/kimi-k2.6`         | Kimi K2.6 (3x limits) |
-| `opencode-go/deepseek-v4-pro`   | DeepSeek V4 Pro       |
-| `opencode-go/deepseek-v4-flash` | DeepSeek V4 Flash     |
-| `opencode-go/mimo-v2-omni`      | MiMo V2 Omni          |
-| `opencode-go/mimo-v2-pro`       | MiMo V2 Pro           |
-| `opencode-go/minimax-m2.5`      | MiniMax M2.5          |
-| `opencode-go/minimax-m2.7`      | MiniMax M2.7          |
-| `opencode-go/qwen3.5-plus`      | Qwen3.5 Plus          |
-| `opencode-go/qwen3.6-plus`      | Qwen3.6 Plus          |
+| Model ref                       | Name              |
+| ------------------------------- | ----------------- |
+| `opencode-go/deepseek-v4-flash` | DeepSeek V4 Flash |
+| `opencode-go/deepseek-v4-pro`   | DeepSeek V4 Pro   |
+| `opencode-go/glm-5`             | GLM-5             |
+| `opencode-go/glm-5.1`           | GLM-5.1           |
+| `opencode-go/kimi-k2.6`         | Kimi K2.6         |
+| `opencode-go/kimi-k2.7-code`    | Kimi K2.7 Code    |
+| `opencode-go/mimo-v2.5`         | MiMo V2.5         |
+| `opencode-go/mimo-v2.5-pro`     | MiMo V2.5 Pro     |
+| `opencode-go/minimax-m2.7`      | MiniMax M2.7      |
+| `opencode-go/minimax-m3`        | MiniMax M3        |
+| `opencode-go/qwen3.6-plus`      | Qwen3.6 Plus      |
+| `opencode-go/qwen3.7-max`       | Qwen3.7 Max       |
+| `opencode-go/qwen3.7-plus`      | Qwen3.7 Plus      |
 
 ## Getting started
 
@@ -51,7 +52,7 @@ The provider includes:
       </Step>
       <Step title="Set a Go model as default">
         ```bash
-        openclaw config set agents.defaults.model.primary "opencode-go/kimi-k2.6"
+        openclaw config set agents.defaults.model.primary "opencode-go/kimi-k2.7-code"
         ```
       </Step>
       <Step title="Verify models are available">
@@ -83,7 +84,7 @@ The provider includes:
 ```json5
 {
   env: { OPENCODE_API_KEY: "YOUR_API_KEY_HERE" }, // pragma: allowlist secret
-  agents: { defaults: { model: { primary: "opencode-go/kimi-k2.6" } } },
+  agents: { defaults: { model: { primary: "opencode-go/kimi-k2.7-code" } } },
 }
 ```
 

--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -10,7 +10,11 @@ import { expectPassthroughReplayPolicy } from "openclaw/plugin-sdk/provider-test
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
-import { buildOpencodeGoLiveProviderConfig } from "./provider-catalog.js";
+import {
+  buildOpencodeGoLiveProviderConfig,
+  buildStaticOpencodeGoProviderConfig,
+  listOpencodeGoModelCatalogEntries,
+} from "./provider-catalog.js";
 import opencodeGoProviderDiscovery from "./provider-discovery.js";
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
@@ -212,6 +216,65 @@ describe("opencode-go provider plugin", () => {
     expect(compat.supportsUsageInStreaming).toBe(true);
     expect(compat.supportsReasoningEffort).toBe(true);
     expect(compat.maxTokensField).toBe("max_tokens");
+  });
+
+  it("keeps the static OpenCode Go catalog on the current 13-row set", () => {
+    expect(listOpencodeGoModelCatalogEntries().map((entry) => entry.id)).toEqual([
+      "deepseek-v4-pro",
+      "deepseek-v4-flash",
+      "glm-5",
+      "glm-5.1",
+      "kimi-k2.7-code",
+      "kimi-k2.6",
+      "mimo-v2.5",
+      "mimo-v2.5-pro",
+      "minimax-m2.7",
+      "minimax-m3",
+      "qwen3.6-plus",
+      "qwen3.7-max",
+      "qwen3.7-plus",
+    ]);
+    expect(buildStaticOpencodeGoProviderConfig().models).toHaveLength(13);
+  });
+
+  it("keeps shipped OpenCode Go model ids resolving as compatibility rows", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(
+      [
+        "hy3-preview",
+        "kimi-k2.5",
+        "mimo-v2-omni",
+        "mimo-v2-pro",
+        "minimax-m2.5",
+        "qwen3.5-plus",
+      ].map((modelId) => provider.resolveDynamicModel?.({ modelId } as never)?.id),
+    ).toEqual([
+      "hy3-preview",
+      "kimi-k2.5",
+      "mimo-v2-omni",
+      "mimo-v2-pro",
+      "minimax-m2.5",
+      "qwen3.5-plus",
+    ]);
+  });
+
+  it("keeps shipped OpenCode Go compatibility ids in provider-discovery static rows", async () => {
+    const catalog = await opencodeGoProviderDiscovery.staticCatalog?.run({} as never);
+
+    if (!catalog || !("provider" in catalog)) {
+      throw new Error("expected opencode-go static catalog");
+    }
+    expect(catalog.provider.models.map((model) => model.id)).toEqual(
+      expect.arrayContaining([
+        "hy3-preview",
+        "kimi-k2.5",
+        "mimo-v2-omni",
+        "mimo-v2-pro",
+        "minimax-m2.5",
+        "qwen3.5-plus",
+      ]),
+    );
   });
 
   it("loads OpenCode Go model discovery through the provider runtime", () => {

--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -89,6 +89,7 @@ describe("opencode-go provider plugin", () => {
       "glm-5.1",
       "hy3-preview",
       "kimi-k2.5",
+      "kimi-k2.7-code",
       "kimi-k2.6",
       "mimo-v2-omni",
       "mimo-v2.5",
@@ -125,13 +126,21 @@ describe("opencode-go provider plugin", () => {
     expect(deepSeekFlash.provider).toBe("opencode-go");
     expect(deepSeekFlash.name).toBe("DeepSeek V4 Flash");
 
-    const kimi = requireMapEntry(models, "kimi-k2.6");
+    const kimi = requireMapEntry(models, "kimi-k2.7-code");
     expect(kimi.api).toBe("openai-completions");
     expect(kimi.baseUrl).toBe("https://opencode.ai/zen/go/v1");
     expect(kimi.input).toEqual(["text", "image"]);
     expect(kimi.reasoning).toBe(true);
     expect(kimi.contextWindow).toBe(262_144);
-    expect(kimi.maxTokens).toBe(65_536);
+    expect(kimi.maxTokens).toBe(262_144);
+
+    const kimiK26 = requireMapEntry(models, "kimi-k2.6");
+    expect(kimiK26.api).toBe("openai-completions");
+    expect(kimiK26.baseUrl).toBe("https://opencode.ai/zen/go/v1");
+    expect(kimiK26.input).toEqual(["text", "image"]);
+    expect(kimiK26.reasoning).toBe(true);
+    expect(kimiK26.contextWindow).toBe(262_144);
+    expect(kimiK26.maxTokens).toBe(262_144);
 
     const minimax = requireMapEntry(models, "minimax-m2.7");
     expect(minimax.api).toBe("anthropic-messages");
@@ -144,8 +153,8 @@ describe("opencode-go provider plugin", () => {
     expect(minimaxM3.api).toBe("anthropic-messages");
     expect(minimaxM3.baseUrl).toBe("https://opencode.ai/zen/go");
     expect(minimaxM3.reasoning).toBe(true);
-    expect(minimaxM3.contextWindow).toBe(204_800);
-    expect(minimaxM3.maxTokens).toBe(131_072);
+    expect(minimaxM3.contextWindow).toBe(512_000);
+    expect(minimaxM3.maxTokens).toBe(128_000);
 
     const mimoPro = requireMapEntry(models, "mimo-v2.5-pro");
     expect(mimoPro.api).toBe("openai-completions");
@@ -153,13 +162,13 @@ describe("opencode-go provider plugin", () => {
     expect(mimoPro.input).toEqual(["text"]);
     expect(mimoPro.reasoning).toBe(true);
     expect(mimoPro.contextWindow).toBe(1_048_576);
-    expect(mimoPro.maxTokens).toBe(128_000);
+    expect(mimoPro.maxTokens).toBe(131_072);
 
     const mimo = requireMapEntry(models, "mimo-v2.5");
     expect(mimo.input).toEqual(["text", "image"]);
     expect(mimo.reasoning).toBe(true);
-    expect(mimo.contextWindow).toBe(1_000_000);
-    expect(mimo.maxTokens).toBe(128_000);
+    expect(mimo.contextWindow).toBe(1_048_576);
+    expect(mimo.maxTokens).toBe(131_072);
 
     const qwenMax = requireMapEntry(models, "qwen3.7-max");
     expect(qwenMax.api).toBe("anthropic-messages");
@@ -175,6 +184,8 @@ describe("opencode-go provider plugin", () => {
     const qwenPlus = requireMapEntry(models, "qwen3.6-plus");
     expect(qwenPlus.api).toBe("anthropic-messages");
     expect(qwenPlus.baseUrl).toBe("https://opencode.ai/zen/go");
+    expect(qwenPlus.contextWindow).toBe(1_000_000);
+    expect(qwenPlus.maxTokens).toBe(65_536);
 
     const qwen37Plus = requireMapEntry(models, "qwen3.7-plus");
     expect(qwen37Plus.api).toBe("anthropic-messages");
@@ -182,12 +193,12 @@ describe("opencode-go provider plugin", () => {
     expect(qwen37Plus.input).toEqual(["text", "image"]);
     expect(qwen37Plus.reasoning).toBe(true);
     expect(qwen37Plus.contextWindow).toBe(1_000_000);
-    expect(qwen37Plus.maxTokens).toBe(65_536);
+    expect(qwen37Plus.maxTokens).toBe(64_000);
     expect(qwen37Plus.cost).toMatchObject({
-      input: 0.4,
-      output: 1.6,
-      cacheRead: 0.04,
-      cacheWrite: 0.5,
+      input: 0.5,
+      output: 3,
+      cacheRead: 0.05,
+      cacheWrite: 0.625,
     });
 
     const dynamicModel = requireRecord(
@@ -211,7 +222,7 @@ describe("opencode-go provider plugin", () => {
 
   it("loads OpenCode Go model discovery through the provider runtime", () => {
     expect(manifest.providerCatalogEntry).toBe("./provider-discovery.ts");
-    expect(manifest.modelCatalog.discovery["opencode-go"]).toBe("runtime");
+    expect(manifest.modelCatalog.discovery["opencode-go"]).toBe("refreshable");
   });
 
   it("exposes the complete offline catalog through provider discovery", async () => {
@@ -397,6 +408,42 @@ describe("opencode-go provider plugin", () => {
     ]);
   });
 
+  it("strips unsupported Kimi K2.7 Code reasoning payloads on OpenCode Go", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const capturedPayloads: Record<string, unknown>[] = [];
+    const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {
+      const payload = {
+        model: "kimi-k2.7-code",
+        reasoning_effort: "high",
+        reasoning: { effort: "high" },
+        reasoningEffort: "high",
+      };
+      (options as { onPayload?: (payload: Record<string, unknown>) => void })?.onPayload?.(payload);
+      capturedPayloads.push(payload);
+      return {} as never;
+    };
+
+    const streamFn = provider.wrapStreamFn?.({
+      streamFn: baseStreamFn as never,
+      providerId: "opencode-go",
+      modelId: "kimi-k2.7-code",
+      thinkingLevel: "high",
+    } as never);
+
+    expect(streamFn).toBeTypeOf("function");
+    await streamFn?.(
+      { provider: "opencode-go", id: "kimi-k2.7-code", api: "openai-completions" } as never,
+      {} as never,
+      {},
+    );
+
+    expect(capturedPayloads).toEqual([
+      {
+        model: "kimi-k2.7-code",
+      },
+    ]);
+  });
+
   it("canonicalizes stale OpenCode Go base URLs", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
 
@@ -418,8 +465,8 @@ describe("opencode-go provider plugin", () => {
         provider: "opencode-go",
         model: {
           provider: "opencode-go",
-          id: "kimi-k2.5",
-          name: "Kimi K2.5",
+          id: "kimi-k2.6",
+          name: "Kimi K2.6",
           api: "openai-completions",
           baseUrl: "https://opencode.ai/go/v1",
           reasoning: true,

--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -289,7 +289,7 @@ describe("opencode-go provider plugin", () => {
     }
     const deepSeekPro = result.provider.models.find((model) => model.id === "deepseek-v4-pro");
 
-    expect(result.provider.models).toHaveLength(18);
+    expect(result.provider.models).toHaveLength(19);
     expect(deepSeekPro).toMatchObject({
       provider: "opencode-go",
       contextWindow: 1_000_000,

--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -87,18 +87,12 @@ describe("opencode-go provider plugin", () => {
       "deepseek-v4-pro",
       "glm-5",
       "glm-5.1",
-      "hy3-preview",
-      "kimi-k2.5",
       "kimi-k2.7-code",
       "kimi-k2.6",
-      "mimo-v2-omni",
       "mimo-v2.5",
-      "mimo-v2-pro",
       "mimo-v2.5-pro",
-      "minimax-m2.5",
       "minimax-m2.7",
       "minimax-m3",
-      "qwen3.5-plus",
       "qwen3.6-plus",
       "qwen3.7-max",
       "qwen3.7-plus",
@@ -372,7 +366,43 @@ describe("opencode-go provider plugin", () => {
     ]);
   });
 
-  it("strips unsupported Kimi reasoning payloads on OpenCode Go", async () => {
+  it("strips unsupported Kimi K2.5 reasoning payloads on OpenCode Go", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const capturedPayloads: Record<string, unknown>[] = [];
+    const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {
+      const payload = {
+        model: "kimi-k2.5",
+        reasoning_effort: "high",
+        reasoning: { effort: "high" },
+        reasoningEffort: "high",
+      };
+      (options as { onPayload?: (payload: Record<string, unknown>) => void })?.onPayload?.(payload);
+      capturedPayloads.push(payload);
+      return {} as never;
+    };
+
+    const streamFn = provider.wrapStreamFn?.({
+      streamFn: baseStreamFn as never,
+      providerId: "opencode-go",
+      modelId: "kimi-k2.5",
+      thinkingLevel: "high",
+    } as never);
+
+    expect(streamFn).toBeTypeOf("function");
+    await streamFn?.(
+      { provider: "opencode-go", id: "kimi-k2.5", api: "openai-completions" } as never,
+      {} as never,
+      {},
+    );
+
+    expect(capturedPayloads).toEqual([
+      {
+        model: "kimi-k2.5",
+      },
+    ]);
+  });
+
+  it("strips unsupported Kimi K2.6 reasoning payloads on OpenCode Go", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
     const capturedPayloads: Record<string, unknown>[] = [];
     const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {

--- a/extensions/opencode-go/openclaw.plugin.json
+++ b/extensions/opencode-go/openclaw.plugin.json
@@ -33,9 +33,9 @@
             "contextWindow": 1000000,
             "maxTokens": 384000,
             "cost": {
-              "input": 1.74,
-              "output": 3.48,
-              "cacheRead": 0.145,
+              "input": 0.435,
+              "output": 0.87,
+              "cacheRead": 0.003625,
               "cacheWrite": 0
             },
             "compat": {
@@ -54,7 +54,7 @@
             "cost": {
               "input": 0.14,
               "output": 0.28,
-              "cacheRead": 0.028,
+              "cacheRead": 0.0028,
               "cacheWrite": 0
             },
             "compat": {
@@ -62,12 +62,185 @@
               "supportsReasoningEffort": true,
               "maxTokensField": "max_tokens"
             }
+          },
+          {
+            "id": "glm-5",
+            "name": "GLM-5",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 204800,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 1,
+              "output": 3.2,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "glm-5.1",
+            "name": "GLM-5.1",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 200000,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 6,
+              "output": 24,
+              "cacheRead": 1.3,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "kimi-k2.7-code",
+            "name": "Kimi K2.7 Code",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 262144,
+            "cost": {
+              "input": 0.75,
+              "output": 3.5,
+              "cacheRead": 0.16,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "kimi-k2.6",
+            "name": "Kimi K2.6",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 262144,
+            "cost": {
+              "input": 0.95,
+              "output": 4,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "mimo-v2.5",
+            "name": "MiMo V2.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1048576,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 0.14,
+              "output": 0.28,
+              "cacheRead": 0.0028,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "mimo-v2.5-pro",
+            "name": "MiMo V2.5 Pro",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 0.435,
+              "output": 0.87,
+              "cacheRead": 0.0036,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "minimax-m2.7",
+            "name": "MiniMax M2.7",
+            "api": "anthropic-messages",
+            "baseUrl": "https://opencode.ai/zen/go",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 204800,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 0.3,
+              "output": 1.2,
+              "cacheRead": 0.06,
+              "cacheWrite": 0.375
+            }
+          },
+          {
+            "id": "minimax-m3",
+            "name": "MiniMax M3",
+            "api": "anthropic-messages",
+            "baseUrl": "https://opencode.ai/zen/go",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 512000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0.6,
+              "output": 2.4,
+              "cacheRead": 0.12,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "qwen3.6-plus",
+            "name": "Qwen3.6 Plus",
+            "api": "anthropic-messages",
+            "baseUrl": "https://opencode.ai/zen/go",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.5,
+              "output": 3,
+              "cacheRead": 0.05,
+              "cacheWrite": 0.625
+            },
+            "compat": {
+              "thinkingFormat": "qwen"
+            }
+          },
+          {
+            "id": "qwen3.7-max",
+            "name": "Qwen3.7 Max",
+            "api": "anthropic-messages",
+            "baseUrl": "https://opencode.ai/zen/go",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 2.5,
+              "output": 7.5,
+              "cacheRead": 0.5,
+              "cacheWrite": 3.125
+            },
+            "compat": {
+              "thinkingFormat": "qwen"
+            }
+          },
+          {
+            "id": "qwen3.7-plus",
+            "name": "Qwen3.7 Plus",
+            "api": "anthropic-messages",
+            "baseUrl": "https://opencode.ai/zen/go",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 64000,
+            "cost": {
+              "input": 0.5,
+              "output": 3,
+              "cacheRead": 0.05,
+              "cacheWrite": 0.625
+            },
+            "compat": {
+              "thinkingFormat": "qwen"
+            }
           }
         ]
       }
     },
     "discovery": {
-      "opencode-go": "runtime"
+      "opencode-go": "refreshable"
     }
   },
   "setup": {

--- a/extensions/opencode-go/openclaw.plugin.json
+++ b/extensions/opencode-go/openclaw.plugin.json
@@ -19,6 +19,7 @@
       }
     }
   },
+  "providerCatalogEntry": "./provider-discovery.ts",
   "modelCatalog": {
     "providers": {
       "opencode-go": {

--- a/extensions/opencode-go/openclaw.plugin.json
+++ b/extensions/opencode-go/openclaw.plugin.json
@@ -19,7 +19,6 @@
       }
     }
   },
-  "providerCatalogEntry": "./provider-discovery.ts",
   "modelCatalog": {
     "providers": {
       "opencode-go": {

--- a/extensions/opencode-go/provider-catalog.ts
+++ b/extensions/opencode-go/provider-catalog.ts
@@ -29,7 +29,7 @@ type OpencodeGoModelDefinition = ModelDefinitionConfig & {
   input: Array<"text" | "image">;
 };
 
-const OPENCODE_GO_RUNTIME_MODELS = (
+const OPENCODE_GO_ACTIVE_MODELS = (
   [
     {
       id: "deepseek-v4-pro",
@@ -268,6 +268,116 @@ const OPENCODE_GO_RUNTIME_MODELS = (
   ] satisfies OpencodeGoModelDefinition[]
 ).map((model) => normalizeModelCompat(model) as OpencodeGoModelDefinition);
 
+const OPENCODE_GO_COMPAT_MODELS = (
+  [
+    {
+      id: "hy3-preview",
+      name: "HY3 Preview",
+      api: "openai-completions",
+      provider: PROVIDER_ID,
+      baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
+      reasoning: true,
+      input: ["text"],
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+      contextWindow: 262_144,
+      maxTokens: 32_768,
+    },
+    {
+      id: "kimi-k2.5",
+      name: "Kimi K2.5",
+      api: "openai-completions",
+      provider: PROVIDER_ID,
+      baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
+      reasoning: true,
+      input: ["text", "image"],
+      cost: {
+        input: 0.6,
+        output: 3,
+        cacheRead: 0.1,
+        cacheWrite: 0,
+      },
+      contextWindow: 262_144,
+      maxTokens: 65_536,
+    },
+    {
+      id: "mimo-v2-omni",
+      name: "MiMo V2 Omni",
+      api: "openai-completions",
+      provider: PROVIDER_ID,
+      baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
+      reasoning: true,
+      input: ["text", "image"],
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+      contextWindow: 262_144,
+      maxTokens: 32_000,
+    },
+    {
+      id: "mimo-v2-pro",
+      name: "MiMo V2 Pro",
+      api: "openai-completions",
+      provider: PROVIDER_ID,
+      baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
+      reasoning: true,
+      input: ["text"],
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+      contextWindow: 1_048_576,
+      maxTokens: 32_000,
+    },
+    {
+      id: "minimax-m2.5",
+      name: "MiniMax M2.5",
+      api: "anthropic-messages",
+      provider: PROVIDER_ID,
+      baseUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
+      reasoning: true,
+      input: ["text"],
+      cost: {
+        input: 0.3,
+        output: 1.2,
+        cacheRead: 0.03,
+        cacheWrite: 0.375,
+      },
+      contextWindow: 204_800,
+      maxTokens: 65_536,
+    },
+    {
+      id: "qwen3.5-plus",
+      name: "Qwen3.5 Plus",
+      api: "openai-completions",
+      provider: PROVIDER_ID,
+      baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
+      compat: { thinkingFormat: "qwen" },
+      reasoning: true,
+      input: ["text", "image"],
+      cost: {
+        input: 0.2,
+        output: 1.2,
+        cacheRead: 0.02,
+        cacheWrite: 0.25,
+      },
+      contextWindow: 262_144,
+      maxTokens: 65_536,
+    },
+  ] satisfies OpencodeGoModelDefinition[]
+).map((model) => normalizeModelCompat(model) as OpencodeGoModelDefinition);
+
+const OPENCODE_GO_RUNTIME_MODELS = [...OPENCODE_GO_ACTIVE_MODELS, ...OPENCODE_GO_COMPAT_MODELS];
+
 export type FetchOpencodeGoLiveModelIdsParams = {
   apiKey?: string;
   discoveryApiKey?: string;
@@ -288,6 +398,10 @@ function buildOpencodeGoProviderConfig(
 }
 
 export function buildStaticOpencodeGoProviderConfig(apiKey?: string): ModelProviderConfig {
+  return buildOpencodeGoProviderConfig(OPENCODE_GO_ACTIVE_MODELS, apiKey);
+}
+
+export function buildStaticOpencodeGoCompatProviderConfig(apiKey?: string): ModelProviderConfig {
   return buildOpencodeGoProviderConfig(OPENCODE_GO_RUNTIME_MODELS, apiKey);
 }
 
@@ -313,7 +427,7 @@ export async function buildOpencodeGoLiveProviderConfig(
 }
 
 export function listOpencodeGoModelCatalogEntries(): ModelCatalogEntry[] {
-  return OPENCODE_GO_RUNTIME_MODELS.map((model) => ({
+  return OPENCODE_GO_ACTIVE_MODELS.map((model) => ({
     provider: model.provider,
     id: model.id,
     name: model.name,

--- a/extensions/opencode-go/provider-catalog.ts
+++ b/extensions/opencode-go/provider-catalog.ts
@@ -1,24 +1,27 @@
-// Opencode Go provider module implements model/runtime integration.
 import type { ModelCatalogEntry } from "openclaw/plugin-sdk/agent-runtime";
-import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import {
   buildLiveModelProviderConfig,
   type LiveModelCatalogFetchGuard,
 } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import { normalizeModelCompat } from "openclaw/plugin-sdk/provider-model-shared";
 import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const PROVIDER_ID = "opencode-go";
-
 const OPENCODE_GO_OPENAI_BASE_URL = "https://opencode.ai/zen/go/v1";
 const OPENCODE_GO_ANTHROPIC_BASE_URL = "https://opencode.ai/zen/go";
-const OPENCODE_GO_KIMI_NO_REASONING_MODEL_IDS = new Set(["kimi-k2.5", "kimi-k2.6"]);
 const OPENCODE_GO_MODELS_ENDPOINT = "https://opencode.ai/zen/go/v1/models";
 const OPENCODE_GO_MODELS_TIMEOUT_MS = 5_000;
 const OPENCODE_GO_MODELS_CACHE_TTL_MS = 60_000;
+const OPENCODE_GO_KIMI_NO_REASONING_MODEL_IDS = new Set([
+  "kimi-k2.6",
+  "kimi-k2.7-code",
+]);
 
 type OpencodeGoModelDefinition = ModelDefinitionConfig & {
   provider: typeof PROVIDER_ID;
@@ -27,7 +30,7 @@ type OpencodeGoModelDefinition = ModelDefinitionConfig & {
   input: Array<"text" | "image">;
 };
 
-const OPENCODE_GO_MODELS = (
+const OPENCODE_GO_RUNTIME_MODELS = (
   [
     {
       id: "deepseek-v4-pro",
@@ -38,9 +41,9 @@ const OPENCODE_GO_MODELS = (
       reasoning: true,
       input: ["text"],
       cost: {
-        input: 1.74,
-        output: 3.48,
-        cacheRead: 0.145,
+        input: 0.435,
+        output: 0.87,
+        cacheRead: 0.003625,
         cacheWrite: 0,
       },
       contextWindow: 1_000_000,
@@ -62,7 +65,7 @@ const OPENCODE_GO_MODELS = (
       cost: {
         input: 0.14,
         output: 0.28,
-        cacheRead: 0.028,
+        cacheRead: 0.0028,
         cacheWrite: 0,
       },
       contextWindow: 1_000_000,
@@ -87,8 +90,8 @@ const OPENCODE_GO_MODELS = (
         cacheRead: 0.2,
         cacheWrite: 0,
       },
-      contextWindow: 202_752,
-      maxTokens: 32_768,
+      contextWindow: 204_800,
+      maxTokens: 131_072,
     },
     {
       id: "glm-5.1",
@@ -99,13 +102,13 @@ const OPENCODE_GO_MODELS = (
       reasoning: true,
       input: ["text"],
       cost: {
-        input: 1.4,
-        output: 4.4,
-        cacheRead: 0.26,
+        input: 6,
+        output: 24,
+        cacheRead: 1.3,
         cacheWrite: 0,
       },
-      contextWindow: 202_752,
-      maxTokens: 32_768,
+      contextWindow: 200_000,
+      maxTokens: 131_072,
     },
     {
       id: "hy3-preview",
@@ -142,6 +145,23 @@ const OPENCODE_GO_MODELS = (
       maxTokens: 65_536,
     },
     {
+      id: "kimi-k2.7-code",
+      name: "Kimi K2.7 Code",
+      api: "openai-completions",
+      provider: PROVIDER_ID,
+      baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
+      reasoning: true,
+      input: ["text", "image"],
+      cost: {
+        input: 0.75,
+        output: 3.5,
+        cacheRead: 0.16,
+        cacheWrite: 0,
+      },
+      contextWindow: 262_144,
+      maxTokens: 262_144,
+    },
+    {
       id: "kimi-k2.6",
       name: "Kimi K2.6",
       api: "openai-completions",
@@ -152,11 +172,11 @@ const OPENCODE_GO_MODELS = (
       cost: {
         input: 0.95,
         output: 4,
-        cacheRead: 0.16,
+        cacheRead: 0.2,
         cacheWrite: 0,
       },
       contextWindow: 262_144,
-      maxTokens: 65_536,
+      maxTokens: 262_144,
     },
     {
       id: "mimo-v2-omni",
@@ -184,13 +204,13 @@ const OPENCODE_GO_MODELS = (
       reasoning: true,
       input: ["text", "image"],
       cost: {
-        input: 0.4,
-        output: 2,
-        cacheRead: 0.08,
+        input: 0.14,
+        output: 0.28,
+        cacheRead: 0.0028,
         cacheWrite: 0,
       },
-      contextWindow: 1_000_000,
-      maxTokens: 128_000,
+      contextWindow: 1_048_576,
+      maxTokens: 131_072,
     },
     {
       id: "mimo-v2-pro",
@@ -218,13 +238,13 @@ const OPENCODE_GO_MODELS = (
       reasoning: true,
       input: ["text"],
       cost: {
-        input: 1,
-        output: 3,
-        cacheRead: 0.2,
+        input: 0.435,
+        output: 0.87,
+        cacheRead: 0.0036,
         cacheWrite: 0,
       },
       contextWindow: 1_048_576,
-      maxTokens: 128_000,
+      maxTokens: 131_072,
     },
     {
       id: "minimax-m2.5",
@@ -272,10 +292,10 @@ const OPENCODE_GO_MODELS = (
         input: 0.6,
         output: 2.4,
         cacheRead: 0.12,
-        cacheWrite: 0.75,
+        cacheWrite: 0,
       },
-      contextWindow: 204_800,
-      maxTokens: 131_072,
+      contextWindow: 512_000,
+      maxTokens: 128_000,
     },
     {
       id: "qwen3.5-plus",
@@ -293,6 +313,24 @@ const OPENCODE_GO_MODELS = (
         cacheWrite: 0.25,
       },
       contextWindow: 262_144,
+      maxTokens: 65_536,
+    },
+    {
+      id: "qwen3.6-plus",
+      name: "Qwen3.6 Plus",
+      api: "anthropic-messages",
+      provider: PROVIDER_ID,
+      baseUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
+      compat: { thinkingFormat: "qwen" },
+      reasoning: true,
+      input: ["text", "image"],
+      cost: {
+        input: 0.5,
+        output: 3,
+        cacheRead: 0.05,
+        cacheWrite: 0.625,
+      },
+      contextWindow: 1_000_000,
       maxTokens: 65_536,
     },
     {
@@ -323,34 +361,34 @@ const OPENCODE_GO_MODELS = (
       reasoning: true,
       input: ["text", "image"],
       cost: {
-        input: 0.4,
-        output: 1.6,
-        cacheRead: 0.04,
-        cacheWrite: 0.5,
-      },
-      contextWindow: 1_000_000,
-      maxTokens: 65_536,
-    },
-    {
-      id: "qwen3.6-plus",
-      name: "Qwen3.6 Plus",
-      api: "anthropic-messages",
-      provider: PROVIDER_ID,
-      baseUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
-      compat: { thinkingFormat: "qwen" },
-      reasoning: true,
-      input: ["text", "image"],
-      cost: {
         input: 0.5,
         output: 3,
         cacheRead: 0.05,
         cacheWrite: 0.625,
       },
-      contextWindow: 262_144,
-      maxTokens: 65_536,
+      contextWindow: 1_000_000,
+      maxTokens: 64_000,
     },
   ] satisfies OpencodeGoModelDefinition[]
 ).map((model) => normalizeModelCompat(model) as OpencodeGoModelDefinition);
+
+const OPENCODE_GO_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
+  providerId: PROVIDER_ID,
+  catalog: manifest.modelCatalog.providers[PROVIDER_ID],
+});
+
+const OPENCODE_GO_STATIC_MODELS = OPENCODE_GO_MANIFEST_PROVIDER.models.map((model) =>
+  normalizeModelCompat({
+    ...model,
+    provider: PROVIDER_ID,
+    api: model.api ?? OPENCODE_GO_MANIFEST_PROVIDER.api ?? "openai-completions",
+    baseUrl:
+      model.baseUrl ??
+      (model.api === "anthropic-messages"
+        ? OPENCODE_GO_ANTHROPIC_BASE_URL
+        : OPENCODE_GO_MANIFEST_PROVIDER.baseUrl),
+  } satisfies ProviderRuntimeModel),
+);
 
 export type FetchOpencodeGoLiveModelIdsParams = {
   apiKey?: string;
@@ -360,19 +398,19 @@ export type FetchOpencodeGoLiveModelIdsParams = {
 };
 
 function buildOpencodeGoProviderConfig(
-  models: OpencodeGoModelDefinition[],
+  models: readonly ProviderRuntimeModel[],
   apiKey?: string,
 ): ModelProviderConfig {
   return {
     api: "openai-completions",
     baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
     ...(apiKey ? { apiKey } : {}),
-    models,
+    models: [...models],
   };
 }
 
 export function buildStaticOpencodeGoProviderConfig(apiKey?: string): ModelProviderConfig {
-  return buildOpencodeGoProviderConfig(OPENCODE_GO_MODELS, apiKey);
+  return buildOpencodeGoProviderConfig(OPENCODE_GO_RUNTIME_MODELS, apiKey);
 }
 
 export async function buildOpencodeGoLiveProviderConfig(
@@ -385,7 +423,7 @@ export async function buildOpencodeGoLiveProviderConfig(
       api: "openai-completions",
       baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
     },
-    models: OPENCODE_GO_MODELS,
+    models: OPENCODE_GO_RUNTIME_MODELS,
     apiKey: params.apiKey,
     discoveryApiKey: params.discoveryApiKey,
     fetchGuard: params.fetchGuard,
@@ -397,7 +435,7 @@ export async function buildOpencodeGoLiveProviderConfig(
 }
 
 export function listOpencodeGoModelCatalogEntries(): ModelCatalogEntry[] {
-  return OPENCODE_GO_MODELS.map((model) => ({
+  return OPENCODE_GO_RUNTIME_MODELS.map((model) => ({
     provider: model.provider,
     id: model.id,
     name: model.name,
@@ -409,7 +447,7 @@ export function listOpencodeGoModelCatalogEntries(): ModelCatalogEntry[] {
 
 export function resolveOpencodeGoModel(modelId: string): ProviderRuntimeModel | undefined {
   const normalizedModelId = modelId.trim().toLowerCase();
-  return OPENCODE_GO_MODELS.find((model) => model.id === normalizedModelId);
+  return OPENCODE_GO_RUNTIME_MODELS.find((model) => model.id === normalizedModelId);
 }
 
 export function isOpencodeGoKimiNoReasoningModelId(modelId: unknown): boolean {
@@ -469,4 +507,11 @@ export function normalizeOpencodeGoBaseUrl(params: {
       : OPENCODE_GO_OPENAI_BASE_URL;
   }
   return undefined;
+}
+
+export function resolveBundledOpencodeGoStaticModel(
+  modelId: string,
+): ProviderRuntimeModel | undefined {
+  const normalizedModelId = modelId.trim().toLowerCase();
+  return OPENCODE_GO_STATIC_MODELS.find((model) => model.id === normalizedModelId);
 }

--- a/extensions/opencode-go/provider-catalog.ts
+++ b/extensions/opencode-go/provider-catalog.ts
@@ -1,16 +1,14 @@
 import type { ModelCatalogEntry } from "openclaw/plugin-sdk/agent-runtime";
+import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import {
   buildLiveModelProviderConfig,
   type LiveModelCatalogFetchGuard,
 } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
-import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
-import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import { normalizeModelCompat } from "openclaw/plugin-sdk/provider-model-shared";
 import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
-import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const PROVIDER_ID = "opencode-go";
 const OPENCODE_GO_OPENAI_BASE_URL = "https://opencode.ai/zen/go/v1";
@@ -19,6 +17,7 @@ const OPENCODE_GO_MODELS_ENDPOINT = "https://opencode.ai/zen/go/v1/models";
 const OPENCODE_GO_MODELS_TIMEOUT_MS = 5_000;
 const OPENCODE_GO_MODELS_CACHE_TTL_MS = 60_000;
 const OPENCODE_GO_KIMI_NO_REASONING_MODEL_IDS = new Set([
+  "kimi-k2.5",
   "kimi-k2.6",
   "kimi-k2.7-code",
 ]);
@@ -111,40 +110,6 @@ const OPENCODE_GO_RUNTIME_MODELS = (
       maxTokens: 131_072,
     },
     {
-      id: "hy3-preview",
-      name: "HY3 Preview",
-      api: "openai-completions",
-      provider: PROVIDER_ID,
-      baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
-      reasoning: true,
-      input: ["text"],
-      cost: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-      },
-      contextWindow: 262_144,
-      maxTokens: 32_768,
-    },
-    {
-      id: "kimi-k2.5",
-      name: "Kimi K2.5",
-      api: "openai-completions",
-      provider: PROVIDER_ID,
-      baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
-      reasoning: true,
-      input: ["text", "image"],
-      cost: {
-        input: 0.6,
-        output: 3,
-        cacheRead: 0.1,
-        cacheWrite: 0,
-      },
-      contextWindow: 262_144,
-      maxTokens: 65_536,
-    },
-    {
       id: "kimi-k2.7-code",
       name: "Kimi K2.7 Code",
       api: "openai-completions",
@@ -179,23 +144,6 @@ const OPENCODE_GO_RUNTIME_MODELS = (
       maxTokens: 262_144,
     },
     {
-      id: "mimo-v2-omni",
-      name: "MiMo V2 Omni",
-      api: "openai-completions",
-      provider: PROVIDER_ID,
-      baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
-      reasoning: true,
-      input: ["text", "image"],
-      cost: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-      },
-      contextWindow: 262_144,
-      maxTokens: 32_000,
-    },
-    {
       id: "mimo-v2.5",
       name: "MiMo V2.5",
       api: "openai-completions",
@@ -213,23 +161,6 @@ const OPENCODE_GO_RUNTIME_MODELS = (
       maxTokens: 131_072,
     },
     {
-      id: "mimo-v2-pro",
-      name: "MiMo V2 Pro",
-      api: "openai-completions",
-      provider: PROVIDER_ID,
-      baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
-      reasoning: true,
-      input: ["text"],
-      cost: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-      },
-      contextWindow: 1_048_576,
-      maxTokens: 32_000,
-    },
-    {
       id: "mimo-v2.5-pro",
       name: "MiMo V2.5 Pro",
       api: "openai-completions",
@@ -245,23 +176,6 @@ const OPENCODE_GO_RUNTIME_MODELS = (
       },
       contextWindow: 1_048_576,
       maxTokens: 131_072,
-    },
-    {
-      id: "minimax-m2.5",
-      name: "MiniMax M2.5",
-      api: "anthropic-messages",
-      provider: PROVIDER_ID,
-      baseUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
-      reasoning: true,
-      input: ["text"],
-      cost: {
-        input: 0.3,
-        output: 1.2,
-        cacheRead: 0.03,
-        cacheWrite: 0.375,
-      },
-      contextWindow: 204_800,
-      maxTokens: 65_536,
     },
     {
       id: "minimax-m2.7",
@@ -296,24 +210,6 @@ const OPENCODE_GO_RUNTIME_MODELS = (
       },
       contextWindow: 512_000,
       maxTokens: 128_000,
-    },
-    {
-      id: "qwen3.5-plus",
-      name: "Qwen3.5 Plus",
-      api: "openai-completions",
-      provider: PROVIDER_ID,
-      baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
-      compat: { thinkingFormat: "qwen" },
-      reasoning: true,
-      input: ["text", "image"],
-      cost: {
-        input: 0.2,
-        output: 1.2,
-        cacheRead: 0.02,
-        cacheWrite: 0.25,
-      },
-      contextWindow: 262_144,
-      maxTokens: 65_536,
     },
     {
       id: "qwen3.6-plus",
@@ -372,24 +268,6 @@ const OPENCODE_GO_RUNTIME_MODELS = (
   ] satisfies OpencodeGoModelDefinition[]
 ).map((model) => normalizeModelCompat(model) as OpencodeGoModelDefinition);
 
-const OPENCODE_GO_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
-  providerId: PROVIDER_ID,
-  catalog: manifest.modelCatalog.providers[PROVIDER_ID],
-});
-
-const OPENCODE_GO_STATIC_MODELS = OPENCODE_GO_MANIFEST_PROVIDER.models.map((model) =>
-  normalizeModelCompat({
-    ...model,
-    provider: PROVIDER_ID,
-    api: model.api ?? OPENCODE_GO_MANIFEST_PROVIDER.api ?? "openai-completions",
-    baseUrl:
-      model.baseUrl ??
-      (model.api === "anthropic-messages"
-        ? OPENCODE_GO_ANTHROPIC_BASE_URL
-        : OPENCODE_GO_MANIFEST_PROVIDER.baseUrl),
-  } satisfies ProviderRuntimeModel),
-);
-
 export type FetchOpencodeGoLiveModelIdsParams = {
   apiKey?: string;
   discoveryApiKey?: string;
@@ -398,7 +276,7 @@ export type FetchOpencodeGoLiveModelIdsParams = {
 };
 
 function buildOpencodeGoProviderConfig(
-  models: readonly ProviderRuntimeModel[],
+  models: readonly ModelDefinitionConfig[],
   apiKey?: string,
 ): ModelProviderConfig {
   return {
@@ -512,6 +390,5 @@ export function normalizeOpencodeGoBaseUrl(params: {
 export function resolveBundledOpencodeGoStaticModel(
   modelId: string,
 ): ProviderRuntimeModel | undefined {
-  const normalizedModelId = modelId.trim().toLowerCase();
-  return OPENCODE_GO_STATIC_MODELS.find((model) => model.id === normalizedModelId);
+  return resolveOpencodeGoModel(modelId);
 }

--- a/extensions/opencode-go/provider-discovery.ts
+++ b/extensions/opencode-go/provider-discovery.ts
@@ -1,6 +1,11 @@
 // Opencode Go provider module exposes offline catalog metadata to core discovery.
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
-import { buildStaticOpencodeGoProviderConfig } from "./provider-catalog.js";
+import { buildStaticOpencodeGoCompatProviderConfig } from "./provider-catalog.js";
+
+export function buildBundledStaticProviderConfig(): ModelProviderConfig {
+  return buildStaticOpencodeGoCompatProviderConfig();
+}
 
 const opencodeGoProviderDiscovery: ProviderPlugin = {
   id: "opencode-go",
@@ -10,7 +15,7 @@ const opencodeGoProviderDiscovery: ProviderPlugin = {
   staticCatalog: {
     order: "simple",
     run: async () => ({
-      provider: buildStaticOpencodeGoProviderConfig(),
+      provider: buildBundledStaticProviderConfig(),
     }),
   },
 };

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -41,6 +41,46 @@ vi.mock("./model-catalog.runtime.js", () => ({
 
 vi.mock("./embedded-agent-runner/model.static-catalog.js", () => ({
   loadBundledProviderStaticCatalogContextModels: contextTestState.loadStaticCatalog,
+  resolveBundledStaticCatalogModel: vi.fn(
+    ({
+      provider,
+      modelId,
+      includeRuntimeDiscovery,
+    }: {
+      provider?: string;
+      modelId?: string;
+      includeRuntimeDiscovery?: boolean;
+    }) => {
+      if (includeRuntimeDiscovery !== true || !provider || !modelId) {
+        return undefined;
+      }
+      const normalizedProvider = provider.trim().toLowerCase();
+      const normalizedModelId = modelId.trim().toLowerCase();
+      const model = contextTestState.staticCatalogModels.find((candidate) => {
+        const candidateProvider =
+          typeof candidate.provider === "string" ? candidate.provider.trim().toLowerCase() : "";
+        return (
+          candidateProvider === normalizedProvider &&
+          candidate.id.trim().toLowerCase() === normalizedModelId
+        );
+      });
+      return model
+        ? {
+            provider: normalizedProvider,
+            id: normalizedModelId,
+            name: normalizedModelId,
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: model.contextWindow ?? model.contextTokens ?? 0,
+            ...(typeof model.contextTokens === "number"
+              ? { contextTokens: model.contextTokens }
+              : {}),
+            maxTokens: 4096,
+          }
+        : undefined;
+    },
+  ),
 }));
 
 function mockContextDeps(params: {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -1,6 +1,9 @@
 // Covers context-window cache application and session-manager runtime registry.
-import { describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { setBundledPluginsDirOverrideForTest } from "../plugins/bundled-dir.js";
+import { resetBundledPluginPublicArtifactLoaderForTest } from "../plugins/public-surface-loader.js";
 import { createSessionManagerRuntimeRegistry } from "./agent-hooks/session-manager-runtime-registry.js";
 import {
   MODEL_CONFIGURED_CONTEXT_TOKEN_CACHE,
@@ -22,6 +25,19 @@ vi.mock("../config/config.js", () => ({
   getRuntimeConfig: () => ({}),
   projectConfigOntoRuntimeSourceSnapshot: (config: unknown) => config,
 }));
+
+beforeEach(() => {
+  const bundledPluginsDir = path.resolve(import.meta.dirname, "../../extensions");
+  setBundledPluginsDirOverrideForTest(bundledPluginsDir);
+  resetBundledPluginPublicArtifactLoaderForTest();
+  vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", bundledPluginsDir);
+});
+
+afterEach(() => {
+  setBundledPluginsDirOverrideForTest(undefined);
+  resetBundledPluginPublicArtifactLoaderForTest();
+  vi.unstubAllEnvs();
+});
 
 function testModelContextWindow(id: string, contextWindow: number) {
   return {
@@ -314,6 +330,17 @@ describe("resolveContextTokensForModel", () => {
     });
 
     expect(result).toBe(1_048_576);
+  });
+
+  it("keeps shipped OpenCode Go compatibility ids on bundled sync context lookup", () => {
+    const result = resolveContextTokensForModel({
+      provider: "opencode-go",
+      model: "kimi-k2.5",
+      fallbackContextTokens: 200_000,
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(262_144);
   });
 
   it("uses provider-level context defaults when no model-level cap is set", () => {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -305,6 +305,17 @@ describe("createSessionManagerRuntimeRegistry", () => {
 });
 
 describe("resolveContextTokensForModel", () => {
+  it("uses bundled refreshable manifest context windows for sync provider lookups", () => {
+    const result = resolveContextTokensForModel({
+      provider: "opencode-go",
+      model: "mimo-v2.5-pro",
+      fallbackContextTokens: 200_000,
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(1_048_576);
+  });
+
   it("uses provider-level context defaults when no model-level cap is set", () => {
     const result = resolveContextTokensForModel({
       cfg: {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -25,6 +25,7 @@ import {
   beginContextWindowCacheRefresh,
   CONTEXT_WINDOW_RUNTIME_STATE,
 } from "./context-runtime-state.js";
+import { resolveBundledStaticCatalogModel } from "./embedded-agent-runner/model.static-catalog.js";
 import { normalizeProviderId } from "./model-selection.js";
 
 export {
@@ -301,6 +302,48 @@ function resolveDiscoveredAnthropicFixedContextWindow(model: ModelEntry): number
     : undefined;
 }
 
+function resolveBundledStaticCatalogProviderModelRef(params: {
+  provider?: string;
+  model?: string;
+}): { provider: string; model: string } | undefined {
+  const modelRaw = params.model?.trim();
+  if (!modelRaw) {
+    return undefined;
+  }
+  const providerRaw = params.provider?.trim();
+  if (providerRaw) {
+    const provider = normalizeProviderId(providerRaw);
+    return provider ? { provider, model: modelRaw } : undefined;
+  }
+  const slash = modelRaw.indexOf("/");
+  if (slash <= 0) {
+    return undefined;
+  }
+  const provider = normalizeProviderId(modelRaw.slice(0, slash));
+  const model = modelRaw.slice(slash + 1).trim();
+  return provider && model ? { provider, model } : undefined;
+}
+
+function resolveBundledStaticCatalogContextTokens(params: {
+  cfg?: OpenClawConfig;
+  provider: string;
+  modelId: string;
+}): number | undefined {
+  const model = resolveBundledStaticCatalogModel({
+    provider: params.provider,
+    modelId: params.modelId,
+    cfg: params.cfg,
+    includeRefreshableDiscovery: true,
+  });
+  if (typeof model?.contextTokens === "number" && model.contextTokens > 0) {
+    return model.contextTokens;
+  }
+  if (typeof model?.contextWindow === "number" && model.contextWindow > 0) {
+    return model.contextWindow;
+  }
+  return undefined;
+}
+
 export function resolveContextTokensForModel(
   params: ContextTokenResolutionParams,
 ): number | undefined {
@@ -315,9 +358,32 @@ export function resolveContextTokensForModel(
       : params.cfg
         ? projectConfigOntoRuntimeSourceSnapshot(params.cfg)
         : undefined;
-  return resolveContextTokensForModelFromCache(
-    { ...params, sourceCfg },
+  const resolved = resolveContextTokensForModelFromCache(
+    { ...params, sourceCfg, fallbackContextTokens: undefined },
     (modelId) => lookupCachedContextTokens(modelId),
     (modelId) => lookupCachedContextWindow(modelId),
   );
+  if (resolved !== undefined) {
+    return resolved;
+  }
+
+  const explicitProvider = params.provider?.trim();
+  const ref = explicitProvider
+    ? resolveBundledStaticCatalogProviderModelRef({
+        provider: explicitProvider,
+        model: params.model,
+      })
+    : undefined;
+  if (explicitProvider && ref) {
+    const bundledStaticCatalogResult = resolveBundledStaticCatalogContextTokens({
+      cfg: params.cfg,
+      provider: ref.provider,
+      modelId: ref.model,
+    });
+    if (bundledStaticCatalogResult !== undefined) {
+      return bundledStaticCatalogResult;
+    }
+  }
+
+  return params.fallbackContextTokens;
 }

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -204,6 +204,19 @@ describe("resolveBundledStaticCatalogModel", () => {
     expect(model?.maxTokens).toBe(8192);
   });
 
+  it("can include bundled refreshable manifest catalog rows for read-only metadata fallbacks", () => {
+    setManifestPlugins([createMistralManifestPlugin({ discovery: "refreshable" })]);
+
+    const model = resolveBundledStaticCatalogModel({
+      provider: "mistral",
+      modelId: "mistral-medium-3-5",
+      cfg: {},
+      includeRefreshableDiscovery: true,
+    });
+
+    expect(model?.maxTokens).toBe(8192);
+  });
+
   it("requires an exact provider and model match", () => {
     setManifestPlugins([createMistralManifestPlugin()]);
 

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -315,6 +315,62 @@ describe("resolveBundledStaticCatalogModel", () => {
     );
   });
 
+  it.each([
+    "Unable to resolve bundled plugin public surface opencode-go/./provider-discovery.js",
+    "Unable to open bundled plugin public surface opencode-go/./provider-discovery.js",
+  ])("falls through when the provider catalog entry artifact is unavailable: %s", (message) => {
+    setManifestPlugins([
+      {
+        id: "opencode-go",
+        origin: "bundled",
+        providers: ["opencode-go"],
+        providerCatalogEntry: "./provider-discovery.ts",
+        modelCatalog: {
+          providers: {
+            "opencode-go": {
+              baseUrl: "https://opencode.ai/zen/go/v1",
+              api: "openai-completions",
+              models: [
+                {
+                  id: "kimi-k2.7-code",
+                  name: "Kimi K2.7 Code",
+                  input: ["text", "image"],
+                  contextWindow: 262144,
+                  maxTokens: 262144,
+                  cost: { input: 0.75, output: 3.5, cacheRead: 0.16, cacheWrite: 0 },
+                },
+              ],
+            },
+          },
+          discovery: {
+            "opencode-go": "refreshable",
+          },
+        },
+      },
+    ]);
+    publicSurfaceLoaderMocks.loadBundledPluginPublicArtifactModuleSync.mockImplementation(() => {
+      throw new Error(message);
+    });
+
+    expect(
+      resolveBundledStaticCatalogModel({
+        provider: "opencode-go",
+        modelId: "kimi-k2.5",
+        includeRefreshableDiscovery: true,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveBundledStaticCatalogModel({
+        provider: "opencode-go",
+        modelId: "kimi-k2.5",
+        includeRefreshableDiscovery: true,
+      }),
+    ).toBeUndefined();
+    expect(
+      publicSurfaceLoaderMocks.loadBundledPluginPublicArtifactModuleSync,
+    ).toHaveBeenCalledTimes(1);
+  });
+
   it("requires an exact provider and model match", () => {
     setManifestPlugins([createMistralManifestPlugin()]);
 

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -13,6 +13,9 @@ const providerMocks = vi.hoisted(() => ({
   resolveRuntimePluginDiscoveryProviders: vi.fn(),
   runProviderStaticCatalog: vi.fn(),
 }));
+const publicSurfaceLoaderMocks = vi.hoisted(() => ({
+  loadBundledPluginPublicArtifactModuleSync: vi.fn(),
+}));
 
 vi.mock("../../plugins/manifest-metadata-scan.js", () => ({
   listOpenClawPluginManifestMetadata: manifestMocks.listOpenClawPluginManifestMetadata,
@@ -41,12 +44,19 @@ vi.mock("../../plugins/provider-discovery.js", async (importOriginal) => ({
   runProviderStaticCatalog: providerMocks.runProviderStaticCatalog,
 }));
 
+vi.mock("../../plugins/public-surface-loader.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/public-surface-loader.js")>()),
+  loadBundledPluginPublicArtifactModuleSync:
+    publicSurfaceLoaderMocks.loadBundledPluginPublicArtifactModuleSync,
+}));
+
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
 import {
   createBundledProviderStaticCatalogContextResolver,
   createBundledProviderStaticCatalogModelResolver,
   createBundledStaticCatalogModelResolver,
   loadBundledProviderStaticCatalogContextModels,
+  resetBundledStaticCatalogResolverCacheForTest,
   resolveBundledProviderStaticCatalogModel,
   resolveBundledStaticCatalogModel,
 } from "./model.static-catalog.js";
@@ -128,6 +138,8 @@ beforeEach(() => {
   providerMocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([]);
   providerMocks.runProviderStaticCatalog.mockResolvedValue(undefined);
   providerMocks.normalizePluginDiscoveryResult.mockReturnValue({});
+  publicSurfaceLoaderMocks.loadBundledPluginPublicArtifactModuleSync.mockReset();
+  resetBundledStaticCatalogResolverCacheForTest();
 });
 
 describe("resolveBundledStaticCatalogModel", () => {
@@ -215,6 +227,92 @@ describe("resolveBundledStaticCatalogModel", () => {
     });
 
     expect(model?.maxTokens).toBe(8192);
+  });
+
+  it("caches repeated refreshable manifest misses across direct lookups", () => {
+    setManifestPlugins([createMistralManifestPlugin({ discovery: "refreshable" })]);
+
+    expect(
+      resolveBundledStaticCatalogModel({
+        provider: "mistral",
+        modelId: "missing-model",
+        cfg: {},
+        includeRefreshableDiscovery: true,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveBundledStaticCatalogModel({
+        provider: "mistral",
+        modelId: "still-missing",
+        cfg: {},
+        includeRefreshableDiscovery: true,
+      }),
+    ).toBeUndefined();
+
+    expect(manifestMocks.listOpenClawPluginManifestMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to provider catalog entry rows for bundled compatibility-only ids", () => {
+    setManifestPlugins([
+      {
+        id: "opencode-go",
+        origin: "bundled",
+        providers: ["opencode-go"],
+        providerCatalogEntry: "./provider-discovery.ts",
+        modelCatalog: {
+          providers: {
+            "opencode-go": {
+              baseUrl: "https://opencode.ai/zen/go/v1",
+              api: "openai-completions",
+              models: [
+                {
+                  id: "kimi-k2.7-code",
+                  name: "Kimi K2.7 Code",
+                  input: ["text", "image"],
+                  contextWindow: 262144,
+                  maxTokens: 262144,
+                  cost: { input: 0.75, output: 3.5, cacheRead: 0.16, cacheWrite: 0 },
+                },
+              ],
+            },
+          },
+          discovery: {
+            "opencode-go": "refreshable",
+          },
+        },
+      },
+    ]);
+    publicSurfaceLoaderMocks.loadBundledPluginPublicArtifactModuleSync.mockReturnValue({
+      buildBundledStaticProviderConfig: () => ({
+        baseUrl: "https://opencode.ai/zen/go/v1",
+        api: "openai-completions",
+        models: [
+          {
+            id: "kimi-k2.5",
+            name: "Kimi K2.5",
+            input: ["text", "image"],
+            contextWindow: 262144,
+            maxTokens: 65536,
+            cost: { input: 0.6, output: 3, cacheRead: 0.1, cacheWrite: 0 },
+          },
+        ],
+      }),
+    });
+
+    const model = resolveBundledStaticCatalogModel({
+      provider: "opencode-go",
+      modelId: "kimi-k2.5",
+      includeRefreshableDiscovery: true,
+    });
+
+    expect(model?.id).toBe("kimi-k2.5");
+    expect(model?.contextWindow).toBe(262144);
+    expect(publicSurfaceLoaderMocks.loadBundledPluginPublicArtifactModuleSync).toHaveBeenCalledWith(
+      {
+        dirName: "opencode-go",
+        artifactBasename: "./provider-discovery.js",
+      },
+    );
   });
 
   it("requires an exact provider and model match", () => {

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -20,6 +20,7 @@ import {
   resolveBundledProviderCompatPluginIds,
   resolveOwningPluginIdsForProviderRef,
 } from "../../plugins/providers.js";
+import { loadBundledPluginPublicArtifactModuleSync } from "../../plugins/public-surface-loader.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { normalizeStaticProviderModelId } from "../model-ref-shared.js";
 import { buildInlineProviderModels } from "./model.inline-provider.js";
@@ -134,7 +135,10 @@ function modelFromProviderStaticCatalog(params: {
 
 type StaticCatalogPlugin = Parameters<
   typeof planManifestModelCatalogRows
->[0]["registry"]["plugins"][number];
+>[0]["registry"]["plugins"][number] & {
+  providerAuthAliases?: Record<string, string>;
+  providerCatalogEntry?: string;
+};
 
 function listBundledStaticCatalogPlugins(env: NodeJS.ProcessEnv): StaticCatalogPlugin[] {
   return listOpenClawPluginManifestMetadata(env).flatMap((record): StaticCatalogPlugin[] => {
@@ -142,7 +146,7 @@ function listBundledStaticCatalogPlugins(env: NodeJS.ProcessEnv): StaticCatalogP
       return [];
     }
     const loaded = loadPluginManifest(record.pluginDir);
-    if (!loaded.ok || !loaded.manifest.modelCatalog) {
+    if (!loaded.ok) {
       return [];
     }
     return [
@@ -150,9 +154,93 @@ function listBundledStaticCatalogPlugins(env: NodeJS.ProcessEnv): StaticCatalogP
         id: loaded.manifest.id,
         providers: loaded.manifest.providers,
         modelCatalog: loaded.manifest.modelCatalog,
+        providerAuthAliases: loaded.manifest.providerAuthAliases,
+        providerCatalogEntry: loaded.manifest.providerCatalogEntry,
       },
     ];
   });
+}
+
+function pluginOwnsBundledProviderRef(plugin: StaticCatalogPlugin, provider: string): boolean {
+  const normalizedProvider = normalizeProviderId(provider);
+  const ownedProviders = plugin.providers ?? [];
+  if (!normalizedProvider) {
+    return false;
+  }
+  if (ownedProviders.some((candidate) => normalizeProviderId(candidate) === normalizedProvider)) {
+    return true;
+  }
+  for (const [rawAlias, rawTarget] of Object.entries(plugin.providerAuthAliases ?? {})) {
+    const normalizedAlias = normalizeProviderId(rawAlias);
+    const normalizedTarget = normalizeProviderId(rawTarget);
+    if (
+      normalizedAlias === normalizedProvider &&
+      normalizedTarget &&
+      ownedProviders.some((candidate) => normalizeProviderId(candidate) === normalizedTarget)
+    ) {
+      return true;
+    }
+  }
+  for (const [rawAlias, alias] of Object.entries(plugin.modelCatalog?.aliases ?? {})) {
+    const normalizedAlias = normalizeProviderId(rawAlias);
+    const normalizedTarget = normalizeProviderId(alias.provider);
+    if (
+      normalizedAlias === normalizedProvider &&
+      normalizedTarget &&
+      ownedProviders.some((candidate) => normalizeProviderId(candidate) === normalizedTarget)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function normalizeProviderCatalogArtifactPath(providerCatalogEntry: string): string {
+  const normalized = providerCatalogEntry.replace(/\\/gu, "/");
+  return normalized.replace(/\.(?:[cm]?ts|[cm]?js)$/u, ".js");
+}
+
+type BundledProviderCatalogEntrySurface = {
+  buildBundledStaticProviderConfig?: () => ModelProviderConfig | undefined;
+};
+
+function loadBundledProviderCatalogEntryModel(params: {
+  provider: string;
+  modelId: string;
+  plugins: readonly StaticCatalogPlugin[];
+}): ProviderRuntimeModel | undefined {
+  const provider = normalizeProviderId(params.provider);
+  if (!provider) {
+    return undefined;
+  }
+  for (const plugin of params.plugins) {
+    if (!plugin.providerCatalogEntry || !pluginOwnsBundledProviderRef(plugin, provider)) {
+      continue;
+    }
+    const mod = loadBundledPluginPublicArtifactModuleSync<BundledProviderCatalogEntrySurface>({
+      dirName: plugin.id,
+      artifactBasename: normalizeProviderCatalogArtifactPath(plugin.providerCatalogEntry),
+    });
+    const providerConfig = mod.buildBundledStaticProviderConfig?.();
+    if (!providerConfig?.models) {
+      continue;
+    }
+    const matchedModel = providerConfig.models.find((candidate) =>
+      staticModelIdMatches({
+        candidateId: candidate.id,
+        provider,
+        modelId: params.modelId,
+      }),
+    );
+    if (matchedModel) {
+      return modelFromProviderStaticCatalog({
+        provider,
+        providerConfig,
+        model: matchedModel,
+      });
+    }
+  }
+  return undefined;
 }
 
 function resolveManifestModelCatalogProviderAlias(params: {
@@ -249,6 +337,17 @@ type BundledProviderStaticCatalogResolverParams = {
   env?: NodeJS.ProcessEnv;
 };
 
+type BundledStaticCatalogResolverCacheKey = `${0 | 1}:${0 | 1}`;
+
+const bundledStaticCatalogResolverCache = new Map<
+  BundledStaticCatalogResolverCacheKey,
+  ReturnType<typeof createBundledStaticCatalogModelResolver>
+>();
+
+export function resetBundledStaticCatalogResolverCacheForTest(): void {
+  bundledStaticCatalogResolverCache.clear();
+}
+
 /**
  * Prepares a process-stable bundled manifest catalog lookup.
  * Manifest discovery runs once; provider-specific plans are cached on demand.
@@ -260,9 +359,11 @@ export function createBundledStaticCatalogModelResolver(params?: {
 }): (lookup: BundledStaticCatalogLookup) => ProviderRuntimeModel | undefined {
   const bundledStaticPlugins = listBundledStaticCatalogPlugins(params?.env ?? process.env);
   const plans = new Map<string, ReturnType<typeof planManifestModelCatalogRows>>();
+  const providerCatalogEntryLookups = new Map<string, ProviderRuntimeModel | null>();
   return (lookup) => {
     const provider = normalizeProviderId(lookup.provider);
-    if (!provider || !lookup.modelId.trim() || bundledStaticPlugins.length === 0) {
+    const modelId = lookup.modelId.trim();
+    if (!provider || !modelId) {
       return undefined;
     }
     let plan = plans.get(provider);
@@ -293,7 +394,18 @@ export function createBundledStaticCatalogModelResolver(params?: {
         return modelFromStaticCatalogRow(row);
       }
     }
-    return undefined;
+    const fallbackKey = `${provider}\0${modelId.toLowerCase()}`;
+    const cachedFallback = providerCatalogEntryLookups.get(fallbackKey);
+    if (cachedFallback !== undefined) {
+      return cachedFallback ?? undefined;
+    }
+    const fallbackModel = loadBundledProviderCatalogEntryModel({
+      provider,
+      modelId,
+      plugins: bundledStaticPlugins,
+    });
+    providerCatalogEntryLookups.set(fallbackKey, fallbackModel ?? null);
+    return fallbackModel;
   };
 }
 
@@ -307,15 +419,33 @@ export function resolveBundledStaticCatalogModel(
     includeRuntimeDiscovery?: boolean;
   },
 ): ProviderRuntimeModel | undefined {
-  return createBundledStaticCatalogModelResolver({
-    ...(params.env ? { env: params.env } : {}),
-    ...(params.includeRefreshableDiscovery !== undefined
-      ? { includeRefreshableDiscovery: params.includeRefreshableDiscovery }
-      : {}),
-    ...(params.includeRuntimeDiscovery !== undefined
-      ? { includeRuntimeDiscovery: params.includeRuntimeDiscovery }
-      : {}),
-  })(params);
+  if (params.env) {
+    return createBundledStaticCatalogModelResolver({
+      env: params.env,
+      ...(params.includeRefreshableDiscovery !== undefined
+        ? { includeRefreshableDiscovery: params.includeRefreshableDiscovery }
+        : {}),
+      ...(params.includeRuntimeDiscovery !== undefined
+        ? { includeRuntimeDiscovery: params.includeRuntimeDiscovery }
+        : {}),
+    })(params);
+  }
+  const cacheKey = `${params.includeRefreshableDiscovery === true ? 1 : 0}:${
+    params.includeRuntimeDiscovery === true ? 1 : 0
+  }` as BundledStaticCatalogResolverCacheKey;
+  let resolver = bundledStaticCatalogResolverCache.get(cacheKey);
+  if (!resolver) {
+    resolver = createBundledStaticCatalogModelResolver({
+      ...(params.includeRefreshableDiscovery !== undefined
+        ? { includeRefreshableDiscovery: params.includeRefreshableDiscovery }
+        : {}),
+      ...(params.includeRuntimeDiscovery !== undefined
+        ? { includeRuntimeDiscovery: params.includeRuntimeDiscovery }
+        : {}),
+    });
+    bundledStaticCatalogResolverCache.set(cacheKey, resolver);
+  }
+  return resolver(params);
 }
 
 function resolveBundledProviderStaticCatalogPluginIds(params: {

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -255,6 +255,7 @@ type BundledProviderStaticCatalogResolverParams = {
  */
 export function createBundledStaticCatalogModelResolver(params?: {
   env?: NodeJS.ProcessEnv;
+  includeRefreshableDiscovery?: boolean;
   includeRuntimeDiscovery?: boolean;
 }): (lookup: BundledStaticCatalogLookup) => ProviderRuntimeModel | undefined {
   const bundledStaticPlugins = listBundledStaticCatalogPlugins(params?.env ?? process.env);
@@ -273,9 +274,11 @@ export function createBundledStaticCatalogModelResolver(params?: {
       plans.set(provider, plan);
     }
     for (const entry of plan.entries) {
+      const discovery = entry.discovery ?? "static";
       if (
-        entry.discovery !== "static" &&
-        !(params?.includeRuntimeDiscovery && entry.discovery === "runtime")
+        discovery !== "static" &&
+        !(discovery === "refreshable" && params?.includeRefreshableDiscovery === true) &&
+        !(discovery === "runtime" && params?.includeRuntimeDiscovery === true)
       ) {
         continue;
       }
@@ -300,11 +303,15 @@ export function resolveBundledStaticCatalogModel(
     cfg?: OpenClawConfig;
     workspaceDir?: string;
     env?: NodeJS.ProcessEnv;
+    includeRefreshableDiscovery?: boolean;
     includeRuntimeDiscovery?: boolean;
   },
 ): ProviderRuntimeModel | undefined {
   return createBundledStaticCatalogModelResolver({
     ...(params.env ? { env: params.env } : {}),
+    ...(params.includeRefreshableDiscovery !== undefined
+      ? { includeRefreshableDiscovery: params.includeRefreshableDiscovery }
+      : {}),
     ...(params.includeRuntimeDiscovery !== undefined
       ? { includeRuntimeDiscovery: params.includeRuntimeDiscovery }
       : {}),

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -204,6 +204,17 @@ type BundledProviderCatalogEntrySurface = {
   buildBundledStaticProviderConfig?: () => ModelProviderConfig | undefined;
 };
 
+const MISSING_BUNDLED_PUBLIC_SURFACE_PREFIX = "Unable to resolve bundled plugin public surface ";
+const UNOPENABLE_BUNDLED_PUBLIC_SURFACE_PREFIX = "Unable to open bundled plugin public surface ";
+
+function isOptionalBundledPublicSurfaceLoadError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message.startsWith(MISSING_BUNDLED_PUBLIC_SURFACE_PREFIX) ||
+      error.message.startsWith(UNOPENABLE_BUNDLED_PUBLIC_SURFACE_PREFIX))
+  );
+}
+
 function loadBundledProviderCatalogEntryModel(params: {
   provider: string;
   modelId: string;
@@ -217,10 +228,20 @@ function loadBundledProviderCatalogEntryModel(params: {
     if (!plugin.providerCatalogEntry || !pluginOwnsBundledProviderRef(plugin, provider)) {
       continue;
     }
-    const mod = loadBundledPluginPublicArtifactModuleSync<BundledProviderCatalogEntrySurface>({
-      dirName: plugin.id,
-      artifactBasename: normalizeProviderCatalogArtifactPath(plugin.providerCatalogEntry),
-    });
+    let mod: BundledProviderCatalogEntrySurface;
+    try {
+      mod = loadBundledPluginPublicArtifactModuleSync<BundledProviderCatalogEntrySurface>({
+        dirName: plugin.id,
+        artifactBasename: normalizeProviderCatalogArtifactPath(plugin.providerCatalogEntry),
+      });
+    } catch (error) {
+      // providerCatalogEntry is an optional metadata fast path. Missing or
+      // unreadable bundled artifacts should fall through to other lookup paths.
+      if (isOptionalBundledPublicSurfaceLoadError(error)) {
+        continue;
+      }
+      throw error;
+    }
     const providerConfig = mod.buildBundledStaticProviderConfig?.();
     if (!providerConfig?.models) {
       continue;
@@ -430,9 +451,9 @@ export function resolveBundledStaticCatalogModel(
         : {}),
     })(params);
   }
-  const cacheKey = `${params.includeRefreshableDiscovery === true ? 1 : 0}:${
-    params.includeRuntimeDiscovery === true ? 1 : 0
-  }` as BundledStaticCatalogResolverCacheKey;
+  const refreshableFlag: 0 | 1 = params.includeRefreshableDiscovery === true ? 1 : 0;
+  const runtimeFlag: 0 | 1 = params.includeRuntimeDiscovery === true ? 1 : 0;
+  const cacheKey: BundledStaticCatalogResolverCacheKey = `${refreshableFlag}:${runtimeFlag}`;
   let resolver = bundledStaticCatalogResolverCache.get(cacheKey);
   if (!resolver) {
     resolver = createBundledStaticCatalogModelResolver({

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -442,6 +442,15 @@ describe("resolveMemoryFlushContextWindowTokens", () => {
     expect(resolveMemoryFlushContextWindowTokens({ agentCfgContextTokens: 42_000 })).toBe(42_000);
   });
 
+  it("uses bundled opencode-go manifest limits for sync memory flush callers", () => {
+    expect(
+      resolveMemoryFlushContextWindowTokens({
+        provider: "opencode-go",
+        modelId: "mimo-v2.5-pro",
+      }),
+    ).toBe(1_048_576);
+  });
+
   it("uses provider-specific configured limits when the same model id exists on multiple providers", () => {
     const cfg = {
       models: {


### PR DESCRIPTION
## Summary

- Fixes the `opencode-go` sync context-window fallback so explicit provider lookups can read bundled refreshable catalog rows after config and cache misses.
- Aligns the bundled OpenCode Go catalog with the requested 13 current models and keeps those rows available through the provider-owned static catalog entry.
- Restores `kimi-k2.5` no-reasoning sanitization coverage for legacy or already-configured sessions even though it is no longer in the bundled model list.

This matters because issue #92912 is a real session-state regression: memory flush and preflight compaction were falling back to `DEFAULT_CONTEXT_TOKENS` for `opencode-go` models, so large-window models compacted around ~156K instead of their provider-owned limits.

Closes #92912

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
  `opencode-go` sync context-window lookups now resolve bundled provider metadata instead of falling back to `200000` for the supported Go catalog.
- Real environment tested:
  Local source checkout on macOS against the actual `openclaw` repo working tree after rebuilding bundled plugin artifacts.
- Exact steps or command run after this patch:
  `pnpm build`
  `pnpm openclaw models list --provider opencode-go --json`
  `pnpm exec tsx -e 'import { resolveContextTokensForModel } from "./src/agents/context.ts"; console.log("opencode-go/mimo-v2.5-pro", resolveContextTokensForModel({cfg:{},sourceCfg:{},provider:"opencode-go",model:"mimo-v2.5-pro",allowAsyncLoad:false,fallbackContextTokens:200000})); console.log("opencode-go/kimi-k2.6", resolveContextTokensForModel({cfg:{},sourceCfg:{},provider:"opencode-go",model:"kimi-k2.6",allowAsyncLoad:false,fallbackContextTokens:200000}));'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  Terminal capture from a real local checkout after rebuilding bundled plugin metadata:
  ```text
  $ pnpm openclaw models list --provider opencode-go --json
  {
    "count": 13,
    "models": [
      {
        "key": "opencode-go/kimi-k2.6",
        "name": "Kimi K2.6",
        "contextWindow": 262144
      },
      {
        "key": "opencode-go/mimo-v2.5-pro",
        "name": "MiMo V2.5 Pro",
        "contextWindow": 1048576
      }
    ]
  }
  $ pnpm exec tsx -e 'import { resolveContextTokensForModel } from "./src/agents/context.ts"; console.log("opencode-go/mimo-v2.5-pro", resolveContextTokensForModel({cfg:{},sourceCfg:{},provider:"opencode-go",model:"mimo-v2.5-pro",allowAsyncLoad:false,fallbackContextTokens:200000})); console.log("opencode-go/kimi-k2.6", resolveContextTokensForModel({cfg:{},sourceCfg:{},provider:"opencode-go",model:"kimi-k2.6",allowAsyncLoad:false,fallbackContextTokens:200000}));'
  opencode-go/mimo-v2.5-pro 1048576
  opencode-go/kimi-k2.6 262144
  ```
- Observed result after fix:
  `openclaw models list --provider opencode-go --json` now shows the bundled 13-model OpenCode Go catalog, and the sync resolver returns the same large-window limits for `mimo-v2.5-pro` and `kimi-k2.6` instead of the `200000` fallback.
- What was not tested:
  No live OpenCode Go network request or gateway conversation was rerun in this pass.
- Proof limitations or environment constraints:
  The local `openclaw models list` run printed unrelated config-version warnings for this machine's globally installed CLI, but the command still returned the post-fix bundled OpenCode Go catalog rows shown above.

## Tests and validation

- `git diff --check`
- `pnpm build`
- `node scripts/run-vitest.mjs extensions/opencode-go/index.test.ts`
- `node scripts/run-vitest.mjs src/agents/context.lookup.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/reply-state.test.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.static-catalog.test.ts`
- `pnpm tsgo:core && pnpm tsgo:extensions`
- `pnpm tsgo:test`

## Notes

- `opencode-go` now keeps one bundled 13-model catalog for sync fallback and model listing.
- `kimi-k2.5` sanitizer compatibility stays in place for older configured sessions and replay paths.
