### PR TITLE
fix(feishu): prefer context open_message_id over temporary card-action callback ID (fixes #56818)

### DIFF
--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -136,6 +136,12 @@ function buildSyntheticMessageEvent(
   chatType: "p2p" | "group",
 ): FeishuMessageEvent {
   const replyTargetMessageId = event.context.open_message_id ?? event.open_message_id;
+  // card-action-c-* IDs are temporary callback tokens, not valid Feishu message IDs.
+  // Using them as reply targets causes "Invalid ids" errors from the streaming reply API.
+  const isTemporaryCardActionId = replyTargetMessageId?.startsWith("card-action-c-");
+  const validReplyTargetId = replyTargetMessageId && !isTemporaryCardActionId
+    ? replyTargetMessageId
+    : undefined;
   return {
     sender: {
       sender_id: {
@@ -146,9 +152,9 @@ function buildSyntheticMessageEvent(
     },
     message: {
       message_id: `card-action-${event.token}`,
-      ...(replyTargetMessageId ? { reply_target_message_id: replyTargetMessageId } : {}),
-      ...(replyTargetMessageId ? { typing_target_message_id: replyTargetMessageId } : {}),
-      ...(!replyTargetMessageId ? { suppress_reply_target: true } : {}),
+      ...(validReplyTargetId ? { reply_target_message_id: validReplyTargetId } : {}),
+      ...(validReplyTargetId ? { typing_target_message_id: validReplyTargetId } : {}),
+      ...(!validReplyTargetId ? { suppress_reply_target: true } : {}),
       chat_id: event.context.chat_id || event.operator.open_id,
       chat_type: chatType,
       message_type: "text",

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -237,7 +237,9 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
   );
   const tag = readString(action.tag);
   const actionValue = action.value;
-  const openMessageId = firstString(value.open_message_id, context.open_message_id);
+  // Prefer context.open_message_id (original card message) over value.open_message_id
+  // which may be a temporary card-action-c-* ID that is not a valid Feishu message ID.
+  const openMessageId = firstString(context.open_message_id, value.open_message_id);
   const contextOpenId = firstString(context.open_id, openId);
   const contextUserId = firstString(context.user_id, userId);
   const chatId = firstString(context.chat_id, context.open_chat_id);


### PR DESCRIPTION
## Summary

Fixes Feishu card action callback streaming reply failure by preferring `context.open_message_id` (the original card message ID) over `value.open_message_id` (a temporary `card-action-c-*` callback token).

## Root Cause

When a Feishu interactive card button is clicked, the callback event contains:
- `value.open_message_id`: a temporary ID like `card-action-c-xxx` (the callback token)
- `context.open_message_id`: the original message ID where the card was posted

`parseCardAction` in `monitor.account.ts:239` used `firstString(value.open_message_id, context.open_message_id)` — preferring the temporary ID. This temporary ID was then passed as `reply_target_message_id` to the streaming reply API, which rejected it with:

```
code: 99992354
msg: Invalid ids: [card-action-c-xxx]
```

## Fix

Two changes:

1. **`extensions/feishu/src/monitor.account.ts:242`** — Swap `firstString` argument order to prefer `context.open_message_id` over `value.open_message_id`.

2. **`extensions/feishu/src/card-action.ts:141-143`** — Add guard in `buildSyntheticMessageEvent` to detect `card-action-c-*` temporary IDs and suppress `reply_target_message_id` when only a temporary ID is available (fallback safety).

## Real behavior proof

- **Behavior addressed:** Feishu card action callback streaming reply fails with "Invalid ids" when `value.open_message_id` contains a temporary `card-action-c-*` ID.
- **Environment tested:** macOS, OpenClaw local build from `upstream/main` (fff19340).
- **Steps run after the patch:**
  1. `node scripts/run-vitest.mjs run extensions/feishu/src/bot.card-action.test.ts` — 21 tests passed
  2. `node scripts/run-vitest.mjs run extensions/feishu/src/monitor.lifecycle.test.ts` — 14 tests passed
  3. `pnpm build` — succeeded (102.7s)
- **Evidence after fix:**

```
$ node -e "const fs=require('fs'); const src=fs.readFileSync('extensions/feishu/src/monitor.account.ts','utf8'); const line=src.split('\\n').findIndex(l=>l.includes('firstString(context.open_message_id, value.open_message_id)')); console.log('monitor.account.ts:'+(line+1)+': priority fix applied:',line>=0);"
monitor.account.ts:242: priority fix applied: true

$ grep -n "firstString(context.open_message_id" extensions/feishu/src/monitor.account.ts
242:  const openMessageId = firstString(context.open_message_id, value.open_message_id);

$ grep -n "isTemporaryCardActionId\|validReplyTargetId" extensions/feishu/src/card-action.ts
141:  const isTemporaryCardActionId = replyTargetMessageId?.startsWith("card-action-c-");
142:  const validReplyTargetId = replyTargetMessageId && !isTemporaryCardActionId
155:      ...(validReplyTargetId ? { reply_target_message_id: validReplyTargetId } : {}),
156:      ...(validReplyTargetId ? { typing_target_message_id: validReplyTargetId } : {}),
157:      ...(!validReplyTargetId ? { suppress_reply_target: true } : {}),
```

- **Observed result after fix:** Tests pass, build succeeds. `context.open_message_id` (real message ID) is now preferred over `value.open_message_id` (temporary card-action token). Temporary IDs are additionally filtered as a safety guard.
- **What was not tested:** Live Feishu tenant with interactive card buttons (requires Feishu app setup).
