### PR TITLE
fix(agents): resolve bound agent for unscoped inbound session keys

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -301,6 +301,7 @@ export function resolveSessionAgentIds(params: {
   sessionKey?: string;
   config?: OpenClawConfig;
   agentId?: string;
+  fallbackAgentId?: string;
 }): {
   defaultAgentId: string;
   sessionAgentId: string;
@@ -311,8 +312,14 @@ export function resolveSessionAgentIds(params: {
   const sessionKey = params.sessionKey?.trim();
   const normalizedSessionKey = sessionKey ? normalizeLowercaseStringOrEmpty(sessionKey) : undefined;
   const parsed = normalizedSessionKey ? parseAgentSessionKey(normalizedSessionKey) : null;
+  const fallbackAgentIdRaw = normalizeLowercaseStringOrEmpty(params.fallbackAgentId);
+  const fallbackAgentId = fallbackAgentIdRaw ? normalizeAgentId(fallbackAgentIdRaw) : null;
+  // Session-key agent wins so command-turn cross-agent targeting still resolves the
+  // target; the bound route agent only fills in when the key carries no agent (e.g.
+  // an unscoped binding session key) before falling back to the default.
   const sessionAgentId =
-    explicitAgentId ?? (parsed?.agentId ? normalizeAgentId(parsed.agentId) : defaultAgentId);
+    explicitAgentId ??
+    (parsed?.agentId ? normalizeAgentId(parsed.agentId) : (fallbackAgentId ?? defaultAgentId));
   return { defaultAgentId, sessionAgentId };
 }
 
@@ -320,6 +327,7 @@ export function resolveSessionAgentId(params: {
   sessionKey?: string;
   config?: OpenClawConfig;
   agentId?: string;
+  fallbackAgentId?: string;
 }): string {
   return resolveSessionAgentIds(params).sessionAgentId;
 }

--- a/src/agents/embedded-agent-runner.resolvesessionagentids.test.ts
+++ b/src/agents/embedded-agent-runner.resolvesessionagentids.test.ts
@@ -68,4 +68,35 @@ describe("resolveSessionAgentIds", () => {
     });
     expect(sessionAgentId).toBe("main");
   });
+
+  it("uses fallbackAgentId when the session key carries no agent", () => {
+    // Channel routes keep the bound agent on the route even when the resolved
+    // session key is unscoped; without this fallback the run defaults away from it.
+    const { sessionAgentId } = resolveSessionAgentIds({
+      sessionKey: "quietchat:slash:123",
+      fallbackAgentId: "main",
+      config: cfg,
+    });
+    expect(sessionAgentId).toBe("main");
+  });
+
+  it("prefers the session-key agent over fallbackAgentId", () => {
+    // Command-turn cross-agent targeting encodes the target in the key; the bound
+    // route agent must not override it.
+    const { sessionAgentId } = resolveSessionAgentIds({
+      sessionKey: "agent:beta:quietchat:channel:c1",
+      fallbackAgentId: "main",
+      config: cfg,
+    });
+    expect(sessionAgentId).toBe("beta");
+  });
+
+  it("prefers explicit agentId over fallbackAgentId", () => {
+    const { sessionAgentId } = resolveSessionAgentIds({
+      agentId: "beta",
+      fallbackAgentId: "main",
+      config: cfg,
+    });
+    expect(sessionAgentId).toBe("beta");
+  });
 });

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -388,7 +388,7 @@ const resolveSessionStoreLookup = (
   if (!sessionKey) {
     return {};
   }
-  const agentId = resolveSessionAgentId({ sessionKey, config: cfg, agentId: ctx.AgentId });
+  const agentId = resolveSessionAgentId({ sessionKey, config: cfg, fallbackAgentId: ctx.AgentId });
   const storePath = resolveStorePath(cfg.session?.store, { agentId });
   try {
     const store = loadSessionStore(storePath);
@@ -1260,7 +1260,7 @@ export async function dispatchReplyFromConfig(
   const sessionAgentId = resolveSessionAgentId({
     sessionKey: acpDispatchSessionKey,
     config: cfg,
-    agentId: ctx.AgentId,
+    fallbackAgentId: ctx.AgentId,
   });
   const sessionAgentCfg = resolveAgentConfig(cfg, sessionAgentId);
   const verboseProgress = createShouldEmitVerboseProgress({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -284,7 +284,7 @@ export async function getReplyFromConfig(
         agentId: resolveSessionAgentId({
           sessionKey: resolvedAgentSessionKey,
           config: cfg,
-          agentId: finalized.AgentId,
+          fallbackAgentId: finalized.AgentId,
         }),
       };
     },

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -272,6 +272,9 @@ export async function initSessionState(params: {
   const agentId = resolveSessionAgentId({
     sessionKey: sessionCtxForState.SessionKey,
     config: cfg,
+    // Keep the store/transcript under the routed bound agent when the session key
+    // is unscoped, so persistence matches the workspace the run actually uses.
+    fallbackAgentId: sessionCtxForState.AgentId,
   });
   const groupResolution = resolveGroupSessionKey(sessionCtxForState) ?? undefined;
   const resetTriggers = sessionCfg?.resetTriggers?.length

--- a/src/channels/inbound-event/context.test.ts
+++ b/src/channels/inbound-event/context.test.ts
@@ -133,6 +133,7 @@ describe("buildChannelInboundEventContext", () => {
       From: "test:user:u1",
       To: "test:room:room-1",
       SessionKey: "agent:main:test:group:room-1",
+      AgentId: "main",
       AccountId: "acct",
       ParentSessionKey: "agent:main:test:group",
       ModelParentSessionKey: "agent:main:test:model",
@@ -182,6 +183,22 @@ describe("buildChannelInboundEventContext", () => {
     for (const [key, value] of Object.entries(expectedFields)) {
       expect(ctx[key as keyof typeof ctx]).toEqual(value);
     }
+  });
+
+  it("carries the routed bound agent so an unscoped session key still resolves its workspace", () => {
+    // Regression for #92903: a bound (non-default) agent whose route session key
+    // is unscoped must still surface AgentId so the run loads the agent's own
+    // bootstrap/workspace instead of the default agent's.
+    const ctx = buildChannelInboundEventContext(
+      createBaseContextParams({
+        route: {
+          agentId: "support",
+          routeSessionKey: "test:group:room-1",
+        },
+      }),
+    );
+    expect(ctx.AgentId).toBe("support");
+    expect(ctx.SessionKey).toBe("test:group:room-1");
   });
 
   it("uses resolved command authorization instead of recomputing authorizers", async () => {

--- a/src/channels/inbound-event/context.ts
+++ b/src/channels/inbound-event/context.ts
@@ -483,6 +483,9 @@ export function buildChannelInboundEventContext(
     From: params.from,
     To: params.reply.to,
     SessionKey: params.route.dispatchSessionKey ?? params.route.routeSessionKey,
+    // Carry the routed (bound) agent so the run resolves its workspace/bootstrap even
+    // when the session key is unscoped; downstream resolvers treat it as a fallback.
+    AgentId: params.route.agentId,
     AccountId: params.route.accountId ?? params.accountId,
     ParentSessionKey: params.route.parentSessionKey,
     ModelParentSessionKey: params.route.modelParentSessionKey,


### PR DESCRIPTION
### Summary

- Multi-agent inbound turns could load the wrong workspace: a channel message routed to a bound, non-default agent injected its system-prompt **Project Context** (`SOUL.md`/`AGENTS.md`/`USER.md`/`IDENTITY.md`) from the **default** workspace instead of the bound agent's own workspace.
- Root cause: `buildChannelInboundEventContext` built the inbound context from the resolved route but dropped `route.agentId`, so `ctx.AgentId` was never populated. Downstream agent resolution (`resolveSessionAgentId` in the dispatch and get-reply paths) then depended solely on the session key. When the resolved session key did not encode an agent id (e.g. an unscoped binding session key), the run fell back to the **default** agent — and its workspace.
- The outbound identity is resolved directly from `route.agentId`, so the bot still presented as the correct agent while the run used the default agent's workspace — the reported "right agent, wrong workspace" symptom.
- Fix: carry the routed bound agent into the inbound context (`AgentId`), and have the inbound agent resolvers use it as a **fallback** below the session-key agent. The context type already declared `AgentId` for exactly this purpose ("resolved agent scope for canonical session keys that do not encode the agent id"); it simply was not wired up at the channel boundary.
- Precedence is `explicit agentId` → `session-key agent` → `bound route agent` → `default`, so command-turn cross-agent targeting (whose target agent is encoded in the session key) still wins and is never overridden by the channel's bound agent.
- The same fallback is applied where the session store/transcript agent is resolved (`initSessionState`), so persistence stays under the bound agent and matches the workspace the run actually uses — otherwise the run would load the bound agent's workspace while filing its session entry/transcript under the default agent.

### Reproduction

1. Configure two or more agents, each with its own `agents.list[].workspace` containing distinct `SOUL.md`/`AGENTS.md`.
2. Bind a channel conversation to a non-default agent such that the resolved route session key does not encode the agent id (unscoped binding session key).
3. Send a direct message to that agent and inspect the injected Project Context (e.g. via the context report).
4. **Before this PR**: the system prompt injects the **default** workspace's bootstrap files; the bound agent's `SOUL.md`/`AGENTS.md` are ignored even though the bot replies under the correct agent identity.
5. **After this PR**: the system prompt injects the **bound agent's own** workspace bootstrap files.

### Real behavior proof

**Behavior addressed** (multi-agent inbound workspace resolution): inbound channel turns for a bound non-default agent resolve the agent's own workspace/bootstrap even when the resolved session key is unscoped, instead of defaulting to the default agent's workspace.

**Real environment tested** (unit-level on the exact code path): the agent-resolution precedence (`resolveSessionAgentIds`/`resolveSessionAgentId`) and the inbound-context builder (`buildChannelInboundEventContext`); not a live multi-agent Feishu gateway deployment.

**Exact steps or command run after this patch**: `pnpm test src/auto-reply/reply/session.test.ts src/agents/embedded-agent-runner.resolvesessionagentids.test.ts src/channels/inbound-event/context.test.ts`

**Evidence after fix** (all green): resolver suite 10/10, channel inbound-context suite 20/20, and session suite 108/108 pass. New cases assert that an unscoped session key plus a bound route agent resolves to the bound agent, an agent-scoped session key still wins over the route agent (command-turn targeting preserved), an explicit agentId still wins over the fallback, and the inbound context carries `AgentId` from `route.agentId` even when the session key is unscoped.

**Observed result after fix**: the bound agent's workspace bootstrap files are the ones resolved for the run; standard agent-scoped session keys are unaffected.

**What was not tested**: no live Feishu/multi-agent gateway deployment with an unscoped binding session key; coverage is via unit tests on the resolver and the inbound-context builder.

### Risks and Mitigations

- Risk: a native command-turn that targets another agent's session could be hijacked by the channel's bound agent. — Mitigation: the bound agent is threaded only as a fallback; the agent encoded in the (target) session key still wins, with a dedicated test.
- Risk: populating `ctx.AgentId` could change unrelated consumers. — Mitigation: the only readers are the four inbound agent-resolution sites, all switched to fallback semantics; `AgentId` is not a prompt-template variable, and behavior is unchanged for agent-scoped session keys. The other `ctx.AgentId` producer (the gateway chat path) already validates that an agent-scoped session key matches the selected agent, so the explicit→fallback switch cannot diverge there.
- Note (one-time, not a defect): sessions previously mis-stored under the default agent for an unscoped bound-agent key are not located after upgrade, because lookups now correctly use the bound agent's store. This is the intended effect of fixing the storage location, not a regression.

### Change Type (select all)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

### Scope (select all touched areas)

- [x] Agents / runtime
- [x] Channels (core)
- [x] Auto-reply / dispatch

Config surface unchanged; plugin/SDK surface unchanged.

### Linked Issue/PR

Fixes #92903
