### PR TITLE
[AI-assisted] fix(feishu): let active followups reach queue

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -4300,6 +4300,63 @@ describe("createFeishuMessageReceiveHandler", () => {
     await firstPromise;
   });
 
+  it("keeps same-tick ordinary same-chat events ordered until the first task starts", async () => {
+    const firstStarted = createDeferred();
+    const firstCanFinish = createDeferred();
+    const calls: string[] = [];
+    const handleMessage = vi.fn(
+      async ({ event }: { event?: FeishuMessageEvent; processingClaimHeld?: boolean }) => {
+        const messageId = event?.message.message_id;
+        if (messageId) {
+          calls.push(messageId);
+        }
+        if (messageId === "msg-same-tick-first") {
+          firstStarted.resolve();
+          await firstCanFinish.promise;
+        }
+      },
+    );
+    const core = {
+      channel: createReceiveHandlerChannelRuntime(),
+    } as unknown as PluginRuntime;
+    const handler = createFeishuMessageReceiveHandler({
+      cfg: { channels: { feishu: { dmPolicy: "open" } } } as ClawdbotConfig,
+      channelRuntime: core.channel,
+      accountId: "receive-same-tick-followup",
+      chatHistories: new Map(),
+      handleMessage,
+      resolveDebounceText: ({ event }) => JSON.parse(event.message.content).text,
+      hasProcessedMessage: vi.fn(async () => false),
+      recordProcessedMessage: vi.fn(async () => true),
+    });
+
+    const firstPromise = handler(
+      createReceiveTextEvent({
+        messageId: "msg-same-tick-first",
+        text: "start a queued run",
+      }),
+    );
+    const secondPromise = handler(
+      createReceiveTextEvent({
+        messageId: "msg-same-tick-second",
+        text: "arrives before the first task starts",
+      }),
+    );
+
+    expect(handleMessage).not.toHaveBeenCalled();
+    await firstStarted.promise;
+    expect(calls).toEqual(["msg-same-tick-first"]);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(calls).toEqual(["msg-same-tick-first"]);
+
+    firstCanFinish.resolve();
+    await Promise.all([firstPromise, secondPromise]);
+
+    expect(calls).toEqual(["msg-same-tick-first", "msg-same-tick-second"]);
+  });
+
   it.each([
     { label: "control", suffix: "control", text: "/stop" },
     { label: "btw", suffix: "btw", text: "/btw keep this in order" },

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -4299,4 +4299,71 @@ describe("createFeishuMessageReceiveHandler", () => {
     firstCanFinish.resolve();
     await firstPromise;
   });
+
+  it.each([
+    { label: "control", suffix: "control", text: "/stop" },
+    { label: "btw", suffix: "btw", text: "/btw keep this in order" },
+  ])("keeps same-chat $label lane serialized while the lane is active", async ({ suffix, text }) => {
+    const firstStarted = createDeferred();
+    const firstCanFinish = createDeferred();
+    let secondStarted = false;
+    const handleMessage = vi.fn(
+      async ({ event }: { event?: FeishuMessageEvent; processingClaimHeld?: boolean }) => {
+        if (event?.message.message_id === `msg-${suffix}-first`) {
+          firstStarted.resolve();
+          await firstCanFinish.promise;
+        }
+        if (event?.message.message_id === `msg-${suffix}-second`) {
+          secondStarted = true;
+        }
+      },
+    );
+    const core = {
+      channel: createReceiveHandlerChannelRuntime(),
+    } as unknown as PluginRuntime;
+    const handler = createFeishuMessageReceiveHandler({
+      cfg: { channels: { feishu: { dmPolicy: "open" } } } as ClawdbotConfig,
+      channelRuntime: core.channel,
+      accountId: `receive-${suffix}-lane`,
+      chatHistories: new Map(),
+      handleMessage,
+      resolveDebounceText: ({ event }) => JSON.parse(event.message.content).text,
+      resolveSequentialKey: () => `feishu:receive-lane:oc-dm:${suffix}`,
+      hasProcessedMessage: vi.fn(async () => false),
+      recordProcessedMessage: vi.fn(async () => true),
+    });
+
+    const firstPromise = handler(
+      createReceiveTextEvent({
+        messageId: `msg-${suffix}-first`,
+        text,
+      }),
+    );
+    await firstStarted.promise;
+
+    const secondPromise = handler(
+      createReceiveTextEvent({
+        messageId: `msg-${suffix}-second`,
+        text,
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(secondStarted).toBe(false);
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+
+    firstCanFinish.resolve();
+    await firstPromise;
+    await secondPromise;
+
+    expect(secondStarted).toBe(true);
+    expect(handleMessage).toHaveBeenCalledTimes(2);
+    expect(
+      mockCallArg<{ event?: FeishuMessageEvent; processingClaimHeld?: boolean }>(
+        handleMessage,
+        1,
+        0,
+      ).event?.message.message_id,
+    ).toBe(`msg-${suffix}-second`);
+  });
 });

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -4137,25 +4137,61 @@ describe("handleFeishuMessage command authorization", () => {
   });
 });
 
-describe("createFeishuMessageReceiveHandler media dedupe", () => {
+describe("createFeishuMessageReceiveHandler", () => {
+  function createReceiveHandlerChannelRuntime() {
+    return {
+      debounce: {
+        resolveInboundDebounceMs: vi.fn(() => 0),
+        createInboundDebouncer: vi.fn(
+          (options: { onFlush: (entries: FeishuMessageEvent[]) => Promise<void> | void }) => ({
+            enqueue: async (event: FeishuMessageEvent) => {
+              await options.onFlush([event]);
+            },
+          }),
+        ),
+      },
+      commands: {
+        isControlCommandMessage: vi.fn(() => false),
+      },
+    };
+  }
+
+  function createDeferred() {
+    let resolve: (() => void) | undefined;
+    const promise = new Promise<void>((res) => {
+      resolve = res;
+    });
+    if (!resolve) {
+      throw new Error("Expected deferred resolver to be initialized");
+    }
+    return { promise, resolve };
+  }
+
+  function createReceiveTextEvent(params: {
+    messageId: string;
+    text: string;
+    chatId?: string;
+  }): FeishuMessageEvent {
+    return {
+      sender: {
+        sender_id: {
+          open_id: "ou-receive-text",
+        },
+      },
+      message: {
+        message_id: params.messageId,
+        chat_id: params.chatId ?? "oc-dm",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: params.text }),
+      },
+    };
+  }
+
   it("keeps same-id media variants distinct at receive time", async () => {
     const handleMessage = vi.fn(async () => undefined);
     const core = {
-      channel: {
-        debounce: {
-          resolveInboundDebounceMs: vi.fn(() => 0),
-          createInboundDebouncer: vi.fn(
-            (options: { onFlush: (entries: FeishuMessageEvent[]) => Promise<void> | void }) => ({
-              enqueue: async (event: FeishuMessageEvent) => {
-                await options.onFlush([event]);
-              },
-            }),
-          ),
-        },
-        text: {
-          hasControlCommand: vi.fn(() => false),
-        },
-      },
+      channel: createReceiveHandlerChannelRuntime(),
     } as unknown as PluginRuntime;
     const createAudioEvent = (fileKey: string): FeishuMessageEvent => ({
       sender: {
@@ -4204,5 +4240,63 @@ describe("createFeishuMessageReceiveHandler media dedupe", () => {
     }>(handleMessage, 1, 0);
     expect(secondCall.event).toEqual(secondEvent);
     expect(secondCall.processingClaimHeld).toBe(true);
+  });
+
+  it("lets same-chat followups reach the gateway while an ordinary queue task is active", async () => {
+    const firstStarted = createDeferred();
+    const firstCanFinish = createDeferred();
+    const secondStarted = createDeferred();
+    const handleMessage = vi.fn(
+      async ({ event }: { event?: FeishuMessageEvent; processingClaimHeld?: boolean }) => {
+        if (event?.message.message_id === "msg-active-run") {
+          firstStarted.resolve();
+          await firstCanFinish.promise;
+        }
+        if (event?.message.message_id === "msg-followup") {
+          secondStarted.resolve();
+        }
+      },
+    );
+    const core = {
+      channel: createReceiveHandlerChannelRuntime(),
+    } as unknown as PluginRuntime;
+    const handler = createFeishuMessageReceiveHandler({
+      cfg: { channels: { feishu: { dmPolicy: "open" } } } as ClawdbotConfig,
+      channelRuntime: core.channel,
+      accountId: "receive-active-followup",
+      chatHistories: new Map(),
+      handleMessage,
+      resolveDebounceText: ({ event }) => JSON.parse(event.message.content).text,
+      hasProcessedMessage: vi.fn(async () => false),
+      recordProcessedMessage: vi.fn(async () => true),
+    });
+
+    const firstPromise = handler(
+      createReceiveTextEvent({
+        messageId: "msg-active-run",
+        text: "start a long run",
+      }),
+    );
+    await firstStarted.promise;
+
+    await handler(
+      createReceiveTextEvent({
+        messageId: "msg-followup",
+        text: "please include this",
+      }),
+    );
+    await secondStarted.promise;
+
+    expect(handleMessage).toHaveBeenCalledTimes(2);
+    expect(
+      mockCallArg<{ event?: FeishuMessageEvent; processingClaimHeld?: boolean }>(
+        handleMessage,
+        1,
+        0,
+      ).event?.message.message_id,
+    ).toBe("msg-followup");
+
+    firstCanFinish.resolve();
+    await firstPromise;
   });
 });

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -207,7 +207,7 @@ export function createFeishuMessageReceiveHandler({
         accountId,
         processingClaimHeld: true,
       });
-    if (canBypassActiveSequentialQueue(sequentialKey) && enqueue.has(sequentialKey)) {
+    if (canBypassActiveSequentialQueue(sequentialKey) && enqueue.isRunning(sequentialKey)) {
       void task().catch((err: unknown) => {
         releaseFeishuMessageProcessing(resolveFeishuMessageDedupeKey(event), accountId);
         error(`feishu[${accountId}]: concurrent follow-up dispatch failed: ${String(err)}`);

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -154,6 +154,10 @@ function resolveFeishuDebounceMentions(params: {
   return botMentions.length > 0 ? botMentions : undefined;
 }
 
+function canBypassActiveSequentialQueue(sequentialKey: string): boolean {
+  return !sequentialKey.endsWith(":control") && !sequentialKey.endsWith(":btw");
+}
+
 export function createFeishuMessageReceiveHandler({
   cfg,
   channelRuntime,
@@ -203,6 +207,13 @@ export function createFeishuMessageReceiveHandler({
         accountId,
         processingClaimHeld: true,
       });
+    if (canBypassActiveSequentialQueue(sequentialKey) && enqueue.has(sequentialKey)) {
+      void task().catch((err: unknown) => {
+        releaseFeishuMessageProcessing(resolveFeishuMessageDedupeKey(event), accountId);
+        error(`feishu[${accountId}]: concurrent follow-up dispatch failed: ${String(err)}`);
+      });
+      return;
+    }
     await enqueue(sequentialKey, task);
   };
 

--- a/extensions/feishu/src/sequential-queue.test.ts
+++ b/extensions/feishu/src/sequential-queue.test.ts
@@ -43,6 +43,23 @@ describe("createSequentialQueue", () => {
     expect(order).toEqual(["first:start", "first:end", "second:start", "second:end"]);
   });
 
+  it("reports active keys while queued work is pending", async () => {
+    const enqueue = createSequentialQueue();
+    const gate = createDeferred();
+
+    const first = enqueue("feishu:default:chat-1", async () => {
+      await gate.promise;
+    });
+
+    await Promise.resolve();
+    expect(enqueue.has("feishu:default:chat-1")).toBe(true);
+    expect(enqueue.has("feishu:default:chat-2")).toBe(false);
+
+    gate.resolve();
+    await first;
+    expect(enqueue.has("feishu:default:chat-1")).toBe(false);
+  });
+
   it("allows different keys to run concurrently", async () => {
     const enqueue = createSequentialQueue();
     const gateA = createDeferred();

--- a/extensions/feishu/src/sequential-queue.test.ts
+++ b/extensions/feishu/src/sequential-queue.test.ts
@@ -43,7 +43,7 @@ describe("createSequentialQueue", () => {
     expect(order).toEqual(["first:start", "first:end", "second:start", "second:end"]);
   });
 
-  it("reports active keys while queued work is pending", async () => {
+  it("reports queued keys separately from running keys", async () => {
     const enqueue = createSequentialQueue();
     const gate = createDeferred();
 
@@ -51,13 +51,19 @@ describe("createSequentialQueue", () => {
       await gate.promise;
     });
 
+    expect(enqueue.has("feishu:default:chat-1")).toBe(true);
+    expect(enqueue.isRunning("feishu:default:chat-1")).toBe(false);
+
     await Promise.resolve();
     expect(enqueue.has("feishu:default:chat-1")).toBe(true);
+    expect(enqueue.isRunning("feishu:default:chat-1")).toBe(true);
     expect(enqueue.has("feishu:default:chat-2")).toBe(false);
+    expect(enqueue.isRunning("feishu:default:chat-2")).toBe(false);
 
     gate.resolve();
     await first;
     expect(enqueue.has("feishu:default:chat-1")).toBe(false);
+    expect(enqueue.isRunning("feishu:default:chat-1")).toBe(false);
   });
 
   it("allows different keys to run concurrently", async () => {

--- a/extensions/feishu/src/sequential-queue.ts
+++ b/extensions/feishu/src/sequential-queue.ts
@@ -42,16 +42,25 @@ export interface SequentialQueueOptions {
 export type SequentialQueue = {
   (key: string, task: () => Promise<void>): Promise<void>;
   has: (key: string) => boolean;
+  isRunning: (key: string) => boolean;
 };
 
 export function createSequentialQueue(options: SequentialQueueOptions = {}): SequentialQueue {
   const queues = new Map<string, Promise<void>>();
+  const runningKeys = new Set<string>();
   const taskTimeoutMs = options.taskTimeoutMs ?? DEFAULT_TASK_TIMEOUT_MS;
   const onTaskTimeout = options.onTaskTimeout;
 
   const enqueue = ((key: string, task: () => Promise<void>): Promise<void> => {
     const previous = queues.get(key) ?? Promise.resolve();
-    const wrapped = () => boundedRun(key, task, taskTimeoutMs, onTaskTimeout);
+    const wrapped = async () => {
+      runningKeys.add(key);
+      try {
+        await boundedRun(key, task, taskTimeoutMs, onTaskTimeout);
+      } finally {
+        runningKeys.delete(key);
+      }
+    };
     const next = previous.then(wrapped, wrapped);
     queues.set(key, next);
     const cleanup = () => {
@@ -63,6 +72,7 @@ export function createSequentialQueue(options: SequentialQueueOptions = {}): Seq
     return next;
   }) as SequentialQueue;
   enqueue.has = (key: string): boolean => queues.has(key);
+  enqueue.isRunning = (key: string): boolean => runningKeys.has(key);
   return enqueue;
 }
 

--- a/extensions/feishu/src/sequential-queue.ts
+++ b/extensions/feishu/src/sequential-queue.ts
@@ -39,12 +39,17 @@ export interface SequentialQueueOptions {
   onTaskTimeout?: (key: string, timeoutMs: number) => void;
 }
 
-export function createSequentialQueue(options: SequentialQueueOptions = {}) {
+export type SequentialQueue = {
+  (key: string, task: () => Promise<void>): Promise<void>;
+  has: (key: string) => boolean;
+};
+
+export function createSequentialQueue(options: SequentialQueueOptions = {}): SequentialQueue {
   const queues = new Map<string, Promise<void>>();
   const taskTimeoutMs = options.taskTimeoutMs ?? DEFAULT_TASK_TIMEOUT_MS;
   const onTaskTimeout = options.onTaskTimeout;
 
-  return (key: string, task: () => Promise<void>): Promise<void> => {
+  const enqueue = ((key: string, task: () => Promise<void>): Promise<void> => {
     const previous = queues.get(key) ?? Promise.resolve();
     const wrapped = () => boundedRun(key, task, taskTimeoutMs, onTaskTimeout);
     const next = previous.then(wrapped, wrapped);
@@ -56,7 +61,9 @@ export function createSequentialQueue(options: SequentialQueueOptions = {}) {
     };
     next.then(cleanup, cleanup);
     return next;
-  };
+  }) as SequentialQueue;
+  enqueue.has = (key: string): boolean => queues.has(key);
+  return enqueue;
 }
 
 async function boundedRun(


### PR DESCRIPTION
## Summary

- Problem: Feishu same-chat message dispatch waits behind the plugin sequential queue until the prior full agent turn finishes, so `messages.queue.mode = "collect"` follow-ups can reach the shared queue after the session is no longer active and become separate `run-now` turns. The first PR version also used queued-key presence as active state, which could bypass too early in same-tick delivery.
- Solution: Keep the first ordinary same-chat task on the Feishu sequential queue, let later ordinary same-key tasks bypass only after that key is actually running, and keep `:control` and `/btw` lanes serialized.
- What changed: Added running-key introspection to the Feishu sequential queue, changed the bypass predicate from queued/present to running-only, and added regression coverage for active follow-ups, same-tick ordinary ordering, queue API state, and active control/`/btw` lane serialization.
- What did NOT change (scope boundary): No shared queue policy change, no dependency or lockfile change, no control-lane or `/btw` bypass, no Feishu config change, and no live tenant integration change.

## Motivation

- Feishu users who enable active-run queue modes should get the same collect/steer opportunity as channels that do not serialize a full message handler before it reaches the shared queue layer.
- The issue is user-visible because follow-up messages fragment into separate turns, increasing token use and splitting conversation context.
- The repair must preserve Feishu ordering around the first ordinary task and dedicated control lanes, so the bypass has to distinguish queued work from actually running work.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54409
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: Ordinary Feishu same-chat follow-up messages can reach the active-run queue path while an earlier ordinary Feishu task for that chat is running; same-tick ordinary events do not bypass before the first task starts; `:control` and `/btw` lanes remain serialized.
- Real environment tested (affected runtime/layer, not just "unit test"): Disposable Linux OpenClaw checkout on the PR testserver, Feishu plugin handler integration path, Feishu same-key sequential queue, and shared active-run queue behavior through the existing source test harness.
- Exact steps or command run after this patch:

```bash
git diff --check
node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts -t "same-tick ordinary same-chat"
node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts -t "same-chat"
node scripts/run-vitest.mjs extensions/feishu/src/sequential-queue.test.ts extensions/feishu/src/sequential-key.test.ts extensions/feishu/src/monitor.reaction.test.ts extensions/feishu/src/bot.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/queue-policy.test.ts src/auto-reply/reply/get-reply-run-queue.test.ts src/utils/queue-helpers.test.ts
pnpm check:changed
```

- Evidence after fix:

```text
Latest patched head:
f349ef6ca5 fix(feishu): gate active followup bypass on running tasks

same-tick ordinary same-chat regression:
1 file passed, 1 test passed

same-chat focused diagnostic:
1 file passed, 4 tests passed
- ordinary same-chat follow-up reaches the gateway while the first ordinary task is active
- same-tick ordinary same-chat events stay ordered until the first task starts
- same-chat :control lane stays serialized while active
- same-chat :btw lane stays serialized while active

Feishu focused proof:
4 files passed, 123 tests passed

Shared queue focused proof:
3 files passed, 20 tests passed

git diff --check:
clean

pnpm check:changed:
blocked before changed checks ran because the selected crabbox binary failed its basic --version/--help sanity checks. No green check:changed claim is made.
```

- Observed result after fix: The same-chat active follow-up regression reaches the handler/gateway path while the first ordinary task is running, the same-tick regression keeps a second ordinary event from bypassing before the first task starts, and the focused control/`/btw` diagnostics confirm those lanes still wait behind the active lane task instead of bypassing Feishu serialization.
- What was not tested: No live Feishu tenant, real Feishu transport, external provider, full repository suite, or successful `pnpm check:changed` run.
- Before evidence:

```text
Before the running-key fix, with the same-tick regression applied to the previous PR head:

extensions/feishu/src/bot.test.ts:
expect(handleMessage).not.toHaveBeenCalled() failed because the old queued-key bypass called handleMessage before the first queued ordinary task had started.
The received event was msg-same-tick-second.

Before the original production change, with the active follow-up regression applied to the old code:

extensions/feishu/src/bot.test.ts:
Test "lets same-chat followups reach the gateway while an ordinary queue task is active" timed out after 120000ms.
```

- Visual proof:
  - Before screenshot/video: Not applicable.
  - After screenshot/video: Not applicable.
  - If not applicable, why: This is a runtime queue/handler behavior bug without UI output; command output and test timeline assertions are the appropriate artifacts.
- Remaining proof gap: No redacted live Feishu tenant transport proof was run, and `pnpm check:changed` was blocked by the crabbox binary sanity failure on the test host.

## Root Cause

- Root cause: Feishu serialized the full `handleFeishuMessage` path per same-chat key. Later ordinary same-chat messages were held until the prior agent turn completed, so the shared active-run queue saw `isActive=false` and treated them as new `run-now` turns. The first PR version repaired that too broadly by treating queued-key presence as active state.
- Missing detection / guardrail: Existing Feishu coverage did not assert that ordinary same-chat follow-ups can reach the gateway while a prior ordinary task is active, that queued-not-yet-running same-tick events stay ordered, or that control and `/btw` lanes stay serialized under the active-key bypass.
- Contributing context (if known): Feishu still needs same-key ordering for the first ordinary task and dedicated control lanes; this fix avoids changing the shared queue policy and keeps `:control`/`/btw` serialization intact.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/sequential-queue.test.ts`, `extensions/feishu/src/sequential-key.test.ts`, and `extensions/feishu/src/bot.test.ts`.
- Scenario the test should lock in: A later ordinary Feishu same-chat follow-up should enter the handler/gateway path only while the first ordinary task is actually running; same-tick queued-not-yet-running ordinary events must not overtake the first task; control and `/btw` lanes must remain serialized.
- Why this is the smallest reliable guardrail: The sequential queue test locks the `has` versus `isRunning` state boundary, the sequential-key test keeps lane suffixes explicit, and the bot tests exercise the Feishu dispatch boundary where the reported behavior and the same-tick ordering risk occur.
- Existing test that already covers this (if any): Existing Feishu tests covered sequential ordering and related reaction/control behavior, but not active-run follow-up delivery through the shared queue path, queued-vs-running bypass timing, or the active-lane control/`/btw` preservation case.
- If no new test is added, why not: New regression tests are included.

## User-visible / Behavior Changes

Feishu same-chat follow-up messages sent during an active ordinary run can now be observed by the shared active-run queue while the session is active. That lets configured collect/steer behavior operate instead of waiting for the prior full turn to finish and starting a separate turn.

The first ordinary same-chat task remains queued, same-tick ordinary events stay ordered until that task starts, and control and `/btw` lanes remain queued through their existing sequential keys.

## Diagram

```text
Before:
msg A -> Feishu same-chat queue -> full handler/agent turn -> completes
msg B waits behind A ---------------------------------------> handler sees inactive session -> run-now

First PR version risk:
msg A queued but not started
msg B arrives in the same tick -> queued-key presence bypass -> may overtake msg A

After:
msg A -> Feishu same-chat queue -> starts running -> full handler/agent turn still active
msg B -> ordinary running-key bypass -> handler reaches shared active-run queue -> collect/steer path can apply

Still serialized:
queued-not-running ordinary events, :control lane, and /btw lane -> Feishu sequential queue
```

## Security Impact

- New permissions/capabilities? No.
- Secrets/tokens handling changed? No.
- New/changed network calls? No.
- Command/tool execution surface changed? No.
- Data access scope changed? No.
- If any `Yes`, explain risk + mitigation: Not applicable.

## Repro + Verification

### Environment

- OS: Linux disposable PR testserver checkout
- Runtime/container: Node/pnpm project environment installed with the frozen lockfile
- Model/provider: No external model/provider; tests use existing source harnesses and test doubles
- Integration/channel (if any): Feishu plugin handler dispatch path, same-key lane routing, and shared active-run queue path
- Relevant config (redacted): Queue-mode behavior exercised by the regression harness; no real credentials or private accounts used

### Steps

1. Add the active-key and same-chat active follow-up regression tests to the old code and confirm the old behavior fails.
2. Add the same-tick ordinary same-chat regression to the previous PR head and confirm the queued-key bypass can fire before the first task starts.
3. Apply the production change that tracks running keys separately from queued keys and bypasses only ordinary running same-key dispatches.
4. Run the focused Feishu tests, adjacent shared queue tests, same-chat lane diagnostic, same-tick diagnostic, and whitespace check after the patch.

### Expected

- Ordinary Feishu follow-up messages can reach the shared active-run queue while the first same-chat ordinary task is actually running.
- Same-tick ordinary Feishu events do not bypass before the first queued task starts.
- `:control` and `/btw` lanes remain serialized.
- No dependency, lockfile, or global queue policy changes are needed.

### Actual

- Before: the original active follow-up regression timed out on the old code; the same-tick regression failed on the previous PR head because `handleMessage` was called for `msg-same-tick-second` before the first task started.
- After: the same-tick regression passed, the same-chat diagnostic passed 4 tests, the focused Feishu suite passed 123 tests, the adjacent shared queue suite passed 20 tests, and `git diff --check` was clean.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
Before original fix:
same-chat active follow-up regression timed out after 120000ms

Before running-key fix on the previous PR head:
expect(handleMessage).not.toHaveBeenCalled() failed; received msg-same-tick-second before the first queued ordinary task had started

After f349ef6ca5:
same-tick ordinary same-chat regression: 1 file passed, 1 test passed
same-chat focused diagnostic: 1 file passed, 4 tests passed
Feishu focused proof: 4 files passed, 123 tests passed
Shared queue focused proof: 3 files passed, 20 tests passed
git diff --check: clean

Blocked validation:
pnpm check:changed could not complete because the crabbox binary failed its basic --version/--help sanity checks.
```

## Human Verification

- Verified scenarios: Active-key tracking, queued-vs-running state separation, ordinary same-chat active follow-up bypass, same-tick ordinary ordering before first task start, preservation of `:control`/`/btw` serialization, Feishu bot dispatch regression, adjacent shared queue policy tests, and whitespace check.
- Edge cases checked: First ordinary task still enters the sequential queue; `has` remains true for queued or running work while `isRunning` is true only inside the wrapped task; only an already-running ordinary same-key dispatch bypasses; control and `/btw` sequential keys are not bypassed; bypassed task errors still release processing and are logged; same-chat control and `/btw` events wait for the active lane task before dispatching.
- What you did **not** verify: Live Feishu tenant behavior, external provider behavior, full repo-wide validation, successful `pnpm check:changed`, screenshots/video, or production plugin package behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No inline review threads were changed by this body update. The remaining live Feishu tenant proof ask still needs an environment with real Feishu access.

## Compatibility / Migration

- Backward compatible? Yes.
- Config/env changes? No.
- Migration needed? No.
- If yes, exact upgrade steps: Not applicable.

## Risks and Mitigations

- Risk: Bypassing the same-chat sequential queue could accidentally weaken Feishu ordering guarantees.
  - Mitigation: The bypass is limited to ordinary same-key messages while that key is actually running; the first ordinary task, queued-not-yet-running same-tick events, `:control`, and `/btw` lanes still use the sequential queue, with regression coverage for the active-key API and active control/`/btw` serialization.
- Risk: A live Feishu tenant may expose timing or delivery behavior not represented by the source harness.
  - Mitigation: The PR body calls out the missing live transport proof, and the regression targets the exact dispatch boundary and queue behavior described in the issue.
- Risk: `pnpm check:changed` might still reveal a broader issue once crabbox works on the test host.
  - Mitigation: Focused Feishu and shared queue tests plus `git diff --check` passed, and the blocked changed-check is explicitly reported instead of claimed green.