### PR TITLE
doctor: accept KeepAlive dict form in launchd service audit

### DIFF
--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -226,7 +226,14 @@ async function auditLaunchdPlist(
   }
 
   const hasRunAtLoad = /<key>RunAtLoad<\/key>\s*<true\s*\/>/i.test(content);
-  const hasKeepAlive = /<key>KeepAlive<\/key>\s*<true\s*\/>/i.test(content);
+  // Accept both the bare boolean form and the dict form. The dict form
+  // (e.g. <key>KeepAlive</key><dict><key>SuccessfulExit</key><false/></dict>)
+  // is a valid, commonly-recommended keep-alive policy: restart on crash but
+  // not after a clean exit, so the service can be stopped for maintenance.
+  // See #82250.
+  const hasKeepAlive =
+    /<key>KeepAlive<\/key>\s*<true\s*\/>/i.test(content) ||
+    /<key>KeepAlive<\/key>\s*<dict>[\s\S]*?<key>(SuccessfulExit|Crashed)<\/key>/i.test(content);
   if (!hasRunAtLoad) {
     issues.push({
       code: SERVICE_AUDIT_CODES.launchdRunAtLoad,


### PR DESCRIPTION
The launchd plist audit (`src/daemon/service-audit.ts`) tests only the bare boolean form:

```ts
const hasKeepAlive = /<key>KeepAlive<\/key>\s*<true\s*\/>/i.test(content);
```

So `openclaw doctor` reports **"LaunchAgent is missing KeepAlive=true"** for any plist that uses the `KeepAlive` **dict** form, e.g.:

```xml
<key>KeepAlive</key>
<dict><key>SuccessfulExit</key><false/></dict>
```

That dict form is valid launchd and a commonly-recommended keep-alive policy — restart on crash, but stay down after a *clean* exit so the service can be stopped for maintenance without launchd instantly respawning it. This is exactly the workaround discussed in #82250.

### Change
Broaden `hasKeepAlive` to accept the dict form (matching `SuccessfulExit` or `Crashed`) in addition to the boolean form. No behavior change for plists already using `<true/>`.

### Notes
- I was not able to run the full test suite in my environment; the change is a localized regex broadening with no new dependencies. Happy to add a unit test for the dict-form case if you point me at the right fixture location.

Refs #82250.