### PR TITLE
fix(qqbot): improve error messages with actionable guidance and doc links (fixes #65868)

### DIFF
--- a/extensions/qqbot/src/engine/api/api-client.ts
+++ b/extensions/qqbot/src/engine/api/api-client.ts
@@ -129,7 +129,11 @@ export class ApiClient {
         throw new ApiError(`Request timeout [${path}]: exceeded ${timeout}ms`, 0, path);
       }
       this.logger?.error?.(`[qqbot:api] <<< Network error: ${formatErrorMessage(err)}`);
-      throw new ApiError(`Network error [${path}]: ${formatErrorMessage(err)}`, 0, path);
+      throw new ApiError(
+        `QQBot API request failed [${path}]: ${formatErrorMessage(err)}. Check your network connection and that your server IP is whitelisted at https://q.qq.com/ — Docs: https://docs.openclaw.ai/channels/qqbot`,
+        0,
+        path,
+      );
     } finally {
       clearTimeout(timeoutId);
     }

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -296,7 +296,10 @@ export class TokenManager {
       }
 
       if (!data.access_token) {
-        throw new Error(`Failed to get access_token: ${JSON.stringify(data)}`);
+        throw new Error(
+          `Failed to get QQBot access token. Check that QQBOT_APP_ID and QQBOT_CLIENT_SECRET are correct. ` +
+            `Get credentials at: https://q.qq.com/ — Docs: https://docs.openclaw.ai/channels/qqbot`,
+        );
       }
 
       const nowMs = asDateTimestampMs(Date.now());

--- a/extensions/qqbot/src/engine/gateway/gateway.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway.ts
@@ -39,7 +39,10 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
   initCommands(adapters.commands);
 
   if (!account.appId || !account.clientSecret) {
-    throw new Error("QQBot not configured (missing appId or clientSecret)");
+    throw new Error(
+      "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET, or run `openclaw configure`. " +
+        "See: https://docs.openclaw.ai/channels/qqbot",
+    );
   }
 
   const diag = await runDiagnostics();

--- a/extensions/qqbot/src/engine/messaging/outbound.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound.ts
@@ -274,7 +274,12 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
   }
 
   if (!account.appId || !account.clientSecret) {
-    return { channel: "qqbot", error: "QQBot not configured (missing appId or clientSecret)" };
+    return {
+      channel: "qqbot",
+      error:
+        "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET, or run `openclaw configure`. " +
+        "See: https://docs.openclaw.ai/channels/qqbot",
+    };
   }
 
   try {
@@ -311,7 +316,12 @@ export async function sendMedia(ctx: MediaOutboundContext): Promise<OutboundResu
   initApiConfig(account.appId, { markdownSupport: account.markdownSupport });
 
   if (!account.appId || !account.clientSecret) {
-    return { channel: "qqbot", error: "QQBot not configured (missing appId or clientSecret)" };
+    return {
+      channel: "qqbot",
+      error:
+        "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET, or run `openclaw configure`. " +
+        "See: https://docs.openclaw.ai/channels/qqbot",
+    };
   }
   if (!ctx.mediaUrl) {
     return { channel: "qqbot", error: "mediaUrl is required for sendMedia" };


### PR DESCRIPTION
## Real behavior proof

- **Behavior addressed:** QQBot extension error messages dump raw JSON API responses and lack actionable user guidance, env var names, or doc links.
- **Environment tested:** macOS, Node.js, openclaw main branch at d6d7ba80.
- **Steps run after the patch:**
  1. Built the project with `pnpm build` — successful
  2. Ran QQBot token tests: `node scripts/run-vitest.mjs run extensions/qqbot/src/engine/api/token.test.ts` — 5/5 passed
  3. Ran QQBot config tests: `node scripts/run-vitest.mjs run extensions/qqbot/src/config.test.ts` — 19/19 passed
  4. Ran QQBot channel adapter tests: `node scripts/run-vitest.mjs run extensions/qqbot/src/channel.message-adapter.test.ts` — 6/6 passed
  5. Grepped for improved error messages in changed files

- **Evidence after fix:**

```
$ grep -n "QQBOT_APP_ID\|QQBOT_CLIENT_SECRET\|q.qq.com\|docs.openclaw.ai/channels/qqbot" extensions/qqbot/src/engine/api/token.ts extensions/qqbot/src/engine/api/api-client.ts extensions/qqbot/src/engine/messaging/outbound.ts extensions/qqbot/src/engine/gateway/gateway.ts
extensions/qqbot/src/engine/api/token.ts:299:          `Failed to get QQBot access token. Check that QQBOT_APP_ID and QQBOT_CLIENT_SECRET are correct. ` +
extensions/qqbot/src/engine/api/token.ts:300:            `Get credentials at: https://q.qq.com/ — Docs: https://docs.openclaw.ai/channels/qqbot`,
extensions/qqbot/src/engine/api/api-client.ts:132:        `QQBot API request failed [${path}]: ${formatErrorMessage(err)}. Check your network connection and that your server IP is whitelisted at https://q.qq.com/ — Docs: https://docs.openclaw.ai/channels/qqbot`,
extensions/qqbot/src/engine/messaging/outbound.ts:279:        "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET, or run `openclaw configure`. " +
extensions/qqbot/src/engine/messaging/outbound.ts:280:        "See: https://docs.openclaw.ai/channels/qqbot",
extensions/qqbot/src/engine/messaging/outbound.ts:321:        "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET, or run `openclaw configure`. " +
extensions/qqbot/src/engine/messaging/outbound.ts:322:        "See: https://docs.openclaw.ai/channels/qqbot",
extensions/qqbot/src/engine/gateway/gateway.ts:43:      "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET, or run `openclaw configure`. " +
extensions/qqbot/src/engine/gateway/gateway.ts:44:        "See: https://docs.openclaw.ai/channels/qqbot",

$ node scripts/run-vitest.mjs run extensions/qqbot/src/engine/api/token.test.ts
 ✓  extension-messaging  extensions/qqbot/src/engine/api/token.test.ts (5 tests) 69ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

- **Observed result after fix:** All 4 error message sites now include env var names, credential URLs, and docs links. All existing tests pass without modification.
- **What was not tested:** Live QQBot API calls (no QQBot credentials available). The error messages are static strings — the behavioral change is purely in the human-readable output.
