### PR TITLE
fix(auto-reply): preserve message sending hooks

### DIFF
--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -764,7 +764,7 @@ describe("withReplyDispatcher", () => {
     expect(dispatcherOptions.silentReplyContext?.conversationType).toBe("direct");
   });
 
-  it("composes custom beforeDeliver with reply_payload_sending hooks", async () => {
+  it("composes custom beforeDeliver with reply_payload_sending and message_sending hooks", async () => {
     const customBeforeDeliver = vi.fn(async (payload: { text?: string }) => ({
       text: `${payload.text ?? ""} [custom]`,
     }));
@@ -809,7 +809,15 @@ describe("withReplyDispatcher", () => {
 
     expect(customBeforeDeliver).toHaveBeenCalledTimes(2);
     expect(customBeforeDeliver).toHaveBeenCalledWith({ text: "original" }, { kind: "final" });
-    expect(runMessageSending).not.toHaveBeenCalled();
+    expect(runMessageSending).toHaveBeenCalledTimes(2);
+    expect(runMessageSending).toHaveBeenCalledWith(
+      { content: "original [custom] [plugin]", to: "conv-1" },
+      {
+        accountId: "acct-1",
+        channelId: "threads",
+        conversationId: "conv-1",
+      },
+    );
     expect(runReplyPayloadSending).toHaveBeenCalledTimes(2);
     expect(runReplyPayloadSending).toHaveBeenCalledWith(
       {
@@ -826,10 +834,68 @@ describe("withReplyDispatcher", () => {
         runId: undefined,
       },
     );
-    expect(payload).toEqual({ text: "original [custom] [plugin]" });
+    expect(payload).toEqual({ text: "message hook" });
     expect(payloadWithMetadata ? getReplyPayloadMetadata(payloadWithMetadata) : undefined).toEqual({
       assistantMessageIndex: 5,
     });
+  });
+
+  it("composes buffered custom beforeDeliver with reply_payload_sending and message_sending hooks", async () => {
+    const customBeforeDeliver = vi.fn(async (payload: { text?: string }) => ({
+      text: `${payload.text ?? ""} [custom]`,
+    }));
+    const runMessageSending = vi.fn(async () => ({ content: "message hook" }));
+    const runReplyPayloadSending = vi.fn(async ({ payload }: { payload: { text?: string } }) => ({
+      payload: {
+        ...payload,
+        text: `${payload.text ?? ""} [plugin]`,
+      },
+    }));
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn(
+        (hookName?: string) =>
+          hookName === "message_sending" || hookName === "reply_payload_sending",
+      ),
+      runMessageSending,
+      runReplyPayloadSending,
+    });
+    hoisted.createReplyDispatcherWithTypingMock.mockReturnValueOnce({
+      dispatcher: createDispatcher([]),
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+      markRunComplete: vi.fn(),
+    });
+    hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({ text: "ok" });
+
+    await dispatchInboundMessageWithBufferedDispatcher({
+      ctx: buildTestCtx({ Surface: "telegram", SessionKey: "agent:test:session" }),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: {
+        deliver: async () => undefined,
+        beforeDeliver: customBeforeDeliver,
+      },
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    const dispatcherOptions = lastTypingDispatcherOptions();
+    if (!dispatcherOptions.beforeDeliver) {
+      throw new Error("expected beforeDeliver hook");
+    }
+
+    const payload = await dispatcherOptions.beforeDeliver({ text: "original" }, { kind: "final" });
+
+    expect(customBeforeDeliver).toHaveBeenCalledTimes(1);
+    expect(runReplyPayloadSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: "original [custom]" },
+      }),
+      expect.anything(),
+    );
+    expect(runMessageSending).toHaveBeenCalledWith(
+      { content: "original [custom] [plugin]", to: "conv-1" },
+      expect.objectContaining({ channelId: "threads" }),
+    );
+    expect(payload).toEqual({ text: "message hook" });
   });
 
   it("does not copy source conversation type onto cross-session native silent-reply targets", async () => {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -572,13 +572,11 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
     finalized,
     replyPayloadRunState,
   );
-  const globalBeforeDeliver = combineBeforeDeliverHooks(
+  const configuredBeforeDeliver = combineBeforeDeliverHooks(
+    params.dispatcherOptions.beforeDeliver,
     replyPayloadBeforeDeliver,
     buildMessageSendingBeforeDeliver(finalized),
   );
-  const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
-    : globalBeforeDeliver;
   const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
     foregroundReplyFence || configuredBeforeDeliver
       ? async (payload, info) => {
@@ -671,13 +669,11 @@ export async function dispatchInboundMessageWithDispatcher(params: {
     params.ctx,
     replyPayloadRunState,
   );
-  const globalBeforeDeliver = combineBeforeDeliverHooks(
+  const composedBeforeDeliver = combineBeforeDeliverHooks(
+    params.dispatcherOptions.beforeDeliver,
     replyPayloadBeforeDeliver,
     buildMessageSendingBeforeDeliver(params.ctx),
   );
-  const composedBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
-    : globalBeforeDeliver;
   const dispatcher = createReplyDispatcher({
     ...params.dispatcherOptions,
     beforeDeliver: composedBeforeDeliver,


### PR DESCRIPTION
## Summary

- Compose channel/custom `beforeDeliver` hooks with both `reply_payload_sending` and `message_sending` in the shared dispatcher paths.
- Keeps the existing order explicit: channel/custom transform first, reply payload hooks second, message-sending guard/rewrite/cancel hook last.
- Adds regression coverage for both plain and buffered dispatchers when a channel supplies `beforeDeliver`.

Refs #92374. This PR fixes the shared dispatcher `beforeDeliver` bypass path; preview-finalized delivery and diagnostics coverage remain out of scope for this PR.

## Real behavior proof

Behavior addressed: channel/custom `beforeDeliver` previously bypassed documented `message_sending` plugin hooks on agent reply delivery, so safety/rewrite/cancel hooks did not run on that shared dispatcher path.

Real environment tested: local OpenClaw source checkout on the `fix-message-sending-before-deliver` branch using the real global hook runner, a real typed `message_sending` hook registration, and the real `dispatchInboundMessageWithDispatcher` path with a channel/custom `beforeDeliver`. No live Telegram account was used; the setup exercises the shared dispatcher path Telegram calls.

Exact steps or command run after this patch: ran a one-off `npm exec -- pnpm exec tsx --eval` script that initialized `initializeGlobalHookRunner()` with a `message_sending` hook, invoked `dispatchInboundMessageWithDispatcher()` with a custom `beforeDeliver`, and captured the delivered payloads.

Evidence after fix: terminal output from the real dispatcher/hook-runner setup:

```text
branch: fix-message-sending-before-deliver
hook calls: 2
hook input: {"content":"reply from resolver [custom]","to":"telegram:user-1"}
deliveries: reply from resolver [custom] [message_sending] | final reply [custom] [message_sending]
```

Observed result after fix: both block and final reply deliveries first passed through the custom `beforeDeliver` transform and then through the real `message_sending` hook, which rewrote the visible delivery text.

What was not tested: live Telegram delivery, the preview-finalized path, and diagnostics behavior were not tested in this PR.

## Verification

- RED: `CI=true npm exec -- pnpm test src/auto-reply/dispatch.test.ts` failed with two assertions showing `runMessageSending` was called 0 times for custom `beforeDeliver` paths.
- `CI=true npm exec -- pnpm test src/auto-reply/dispatch.test.ts`
- `CI=true npm exec -- pnpm test extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot-native-commands.session-meta.test.ts`
- `CI=true npm exec -- pnpm exec oxfmt --check --threads=1 src/auto-reply/dispatch.ts src/auto-reply/dispatch.test.ts`
- `CI=true npm exec --package corepack -- corepack pnpm check:changed`
- `git diff --check`

## Existing PRs

Searched open PRs for `message_sending beforeDeliver reply_payload_sending`; no duplicate fix PR found.

## Out-of-scope follow-ups

- Preview-finalized delivery hook parity from #92374.
- Diagnostics proof for the remaining non-dispatcher paths from #92374.
