### PR TITLE
refactor: consolidate duplicated escapeRegExp helpers

### DIFF
--- a/src/agents/glob-pattern.ts
+++ b/src/agents/glob-pattern.ts
@@ -1,15 +1,12 @@
 /**
  * Compiles and matches lightweight glob patterns used by agent policies.
  */
+import { escapeRegExp } from "../shared/regexp.js";
+
 type CompiledGlobPattern =
   | { kind: "all" }
   | { kind: "exact"; value: string }
   | { kind: "regex"; value: RegExp };
-
-function escapeRegex(value: string) {
-  // Standard "escape string for regex literal" pattern.
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 function compileGlobPattern(params: {
   raw: string;
@@ -27,7 +24,7 @@ function compileGlobPattern(params: {
   }
   return {
     kind: "regex",
-    value: new RegExp(`^${escapeRegex(normalized).replaceAll("\\*", ".*")}$`),
+    value: new RegExp(`^${escapeRegExp(normalized).replaceAll("\\*", ".*")}$`),
   };
 }
 

--- a/src/agents/internal-runtime-context.ts
+++ b/src/agents/internal-runtime-context.ts
@@ -3,6 +3,8 @@
  * Protects runtime-generated prompt blocks from user text and removes old
  * context formats before replaying or comparing messages.
  */
+import { escapeRegExp } from "../shared/regexp.js";
+
 /** Opening delimiter for protected OpenClaw runtime context blocks. */
 export const INTERNAL_RUNTIME_CONTEXT_BEGIN = "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>";
 /** Closing delimiter for protected OpenClaw runtime context blocks. */
@@ -35,10 +37,6 @@ export function escapeInternalRuntimeContextDelimiters(value: string): string {
   return value
     .replaceAll(INTERNAL_RUNTIME_CONTEXT_BEGIN, ESCAPED_INTERNAL_RUNTIME_CONTEXT_BEGIN)
     .replaceAll(INTERNAL_RUNTIME_CONTEXT_END, ESCAPED_INTERNAL_RUNTIME_CONTEXT_END);
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function findDelimitedTokenIndex(text: string, token: string, from: number): number {

--- a/src/auto-reply/reply/commands-export-common.ts
+++ b/src/auto-reply/reply/commands-export-common.ts
@@ -8,6 +8,7 @@ import { loadSessionStore } from "../../config/sessions/store.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { escapeRegExp } from "../../shared/regexp.js";
 import type { ReplyPayload } from "../types.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
@@ -18,10 +19,6 @@ export interface ExportCommandSessionTarget {
 }
 
 const MAX_EXPORT_COMMAND_OUTPUT_PATH_CHARS = 512;
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 /** Parses an optional non-flag output path from export command text. */
 export function parseExportCommandOutputPath(

--- a/src/gateway/session-transcript-index.fs.ts
+++ b/src/gateway/session-transcript-index.fs.ts
@@ -2,6 +2,7 @@
 // Streams JSONL transcript files into byte-offset indexes for history paging.
 import fs from "node:fs";
 import { StringDecoder } from "node:string_decoder";
+import { escapeRegExp } from "../shared/regexp.js";
 
 const TRANSCRIPT_INDEX_READ_CHUNK_BYTES = 64 * 1024;
 const MAX_TRANSCRIPT_INDEX_CACHE_ENTRIES = 256;
@@ -59,10 +60,6 @@ const transcriptIndexBuilds = new Map<
 
 function normalizeOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function extractJsonStringFieldPrefix(prefix: string, field: string): string | undefined {

--- a/src/infra/exec-allowlist-pattern.ts
+++ b/src/infra/exec-allowlist-pattern.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { escapeRegExp } from "../shared/regexp.js";
 import { expandHomePrefix } from "./home-dir.js";
 
 const GLOB_REGEX_CACHE_LIMIT = 512;
@@ -45,10 +46,6 @@ function normalizeDotPathSegments(value: string): string {
   return normalizeMatchTarget(normalized);
 }
 
-function escapeRegExpLiteral(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function compileGlobRegex(pattern: string): RegExp {
   const cacheKey = `${process.platform}:${pattern}`;
   const cached = globRegexCache.get(cacheKey);
@@ -76,7 +73,7 @@ function compileGlobRegex(pattern: string): RegExp {
       i += 1;
       continue;
     }
-    regex += escapeRegExpLiteral(ch);
+    regex += escapeRegExp(ch);
     i += 1;
   }
   regex += "$";

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -5,6 +5,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { escapeRegExp } from "../shared/regexp.js";
 import { isInterpreterLikeAllowlistPattern } from "./command-analysis/inline-eval.js";
 import { detectInlineEvalArgv } from "./command-analysis/risks.js";
 import {
@@ -907,10 +908,6 @@ export type AllowAlwaysPattern = {
   argPattern?: string;
 };
 
-function escapeRegExpLiteral(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function buildScriptArgPatternFromArgv(
   argv: string[],
   scriptPath: string,
@@ -935,7 +932,7 @@ function buildScriptArgPatternFromArgv(
   if (normalized.length === 0) {
     return "^\x00\x00$";
   }
-  return `^${normalized.map(escapeRegExpLiteral).join("\x00")}\x00$`;
+  return `^${normalized.map(escapeRegExp).join("\x00")}\x00$`;
 }
 
 function buildArgPatternFromArgv(argv: string[], platform?: string | null): string | undefined {
@@ -948,7 +945,7 @@ function buildArgPatternFromArgv(argv: string[], platform?: string | null): stri
     return "^\x00\x00$";
   }
   const joined = normalized.join("\x00");
-  return `^${escapeRegExpLiteral(joined)}\x00$`;
+  return `^${escapeRegExp(joined)}\x00$`;
 }
 
 function addAllowAlwaysPattern(

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -1,6 +1,7 @@
 // Plain-text sanitization strips internal runtime scaffolding and converts a
 // conservative subset of model-produced HTML into channel-friendly text.
 import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
+import { escapeRegExp } from "../../shared/regexp.js";
 
 const INTERNAL_RUNTIME_SCAFFOLDING_TAGS = ["system-reminder", "previous_response"] as const;
 const INTERNAL_RUNTIME_SCAFFOLDING_TAG_PATTERN = INTERNAL_RUNTIME_SCAFFOLDING_TAGS.join("|");
@@ -34,10 +35,6 @@ function stripRemainingHtmlTags(text: string): string {
     current = current.replace(HTML_TAG_RE, "");
   } while (current !== previous);
   return current;
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function standaloneLinePattern(token: string): string {

--- a/src/infra/windows-install-roots.ts
+++ b/src/infra/windows-install-roots.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { escapeRegExp } from "../shared/regexp.js";
 
 export const DEFAULT_WINDOWS_SYSTEM_ROOT = "C:\\Windows";
 const DEFAULT_PROGRAM_FILES = "C:\\Program Files";
@@ -106,12 +107,8 @@ function locateWindowsRegExe(): string | null {
   return null;
 }
 
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function parseRegQueryValue(stdout: string, valueName: string): string | null {
-  const pattern = new RegExp(`^\\s*${escapeRegex(valueName)}\\s+REG_[A-Z0-9_]+\\s+(.+)$`, "im");
+  const pattern = new RegExp(`^\\s*${escapeRegExp(valueName)}\\s+REG_[A-Z0-9_]+\\s+(.+)$`, "im");
   const match = stdout.match(pattern);
   return match?.[1]?.trim() || null;
 }

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { escapeRegExp } from "../shared/regexp.js";
 
 export type ParsedAgentSessionKey = {
   agentId: string;
@@ -88,10 +89,6 @@ export function normalizeSessionPeerId(params: {
   return isCasePreservingPeer(params.channel, params.peerKind)
     ? peerId
     : normalizeLowercaseStringOrEmpty(peerId);
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 type PreservedSpan = { start: number; end: number; trim: boolean };

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -11,6 +11,7 @@ import {
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { stripAnsi, visibleWidth } from "../../../packages/terminal-core/src/ansi.js";
+import { escapeRegExp } from "../../shared/regexp.js";
 import { findWordBoundaryIndex, fuzzyFilterLower } from "./fuzzy-filter.js";
 
 const ANSI_ESCAPE = String.fromCharCode(27);
@@ -55,7 +56,7 @@ export class SearchableSelectList implements Component {
   private getCachedRegex(pattern: string): RegExp {
     let regex = this.regexCache.get(pattern);
     if (!regex) {
-      regex = new RegExp(this.escapeRegex(pattern), "gi");
+      regex = new RegExp(escapeRegExp(pattern), "gi");
       this.regexCache.set(pattern, regex);
     }
     return regex;
@@ -129,10 +130,6 @@ export class SearchableSelectList implements Component {
     scoredItems.sort(this.compareByScore);
     const fuzzyMatches = fuzzyFilterLower(fuzzyCandidates, q);
     return [...scoredItems.map((s) => s.item), ...fuzzyMatches.map((entry) => entry.item)];
-  }
-
-  private escapeRegex(str: string): string {
-    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   }
 
   private compareByScore = (


### PR DESCRIPTION
## Summary

Ten core modules each defined a byte-identical private regex-literal escape helper under varying names. They all used the same character class as the existing canonical helper in `src/shared/regexp.ts`:

```ts
value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
```

This PR deletes the local copies and imports the shared `escapeRegExp` instead, renaming call sites where the local name differed (`escapeRegex`, `escapeRegExpLiteral`, and a private class method).

Consolidated copies:

- `src/agents/glob-pattern.ts` (`escapeRegex`)
- `src/agents/internal-runtime-context.ts` (`escapeRegExp`)
- `src/auto-reply/reply/commands-export-common.ts` (`escapeRegExp`)
- `src/gateway/session-transcript-index.fs.ts` (`escapeRegExp`)
- `src/infra/exec-allowlist-pattern.ts` (`escapeRegExpLiteral`)
- `src/infra/exec-approvals-allowlist.ts` (`escapeRegExpLiteral`)
- `src/infra/outbound/sanitize-text.ts` (`escapeRegExp`)
- `src/infra/windows-install-roots.ts` (`escapeRegex`)
- `src/sessions/session-key-utils.ts` (`escapeRegExp`)
- `src/tui/components/searchable-select-list.ts` (private `escapeRegex` method)

Behavior is unchanged: every removed helper's regex matched the canonical one character-for-character. Net `-29` non-test LOC (10 files changed, +18/-47).

### Intentionally left untouched

- `src/agents/agent-bundle-mcp-runtime.ts`, `src/agents/agent-bundle-mcp-materialize.ts`, `src/infra/package-dist-inventory.ts` — these use a **different** character class (`/[\\^$+?.()|[\]{}]/g`) that does **not** escape `*`, so they are not behaviorally equivalent.
- `src/plugin-sdk/memory-host-markdown.ts` — sits on the plugin-sdk facade boundary; left local to avoid a new core dependency from the SDK surface.

## Verification

- `oxfmt --check` on all 10 changed files: clean.
- `tsgo -p tsconfig.core.json`: exit 0, no errors.
- Colocated tests for changed modules pass: `internal-runtime-context`, `exec-allowlist-pattern`, `sanitize-text`, `windows-install-roots`, `searchable-select-list` (75 tests passed, 2 skipped).
- Autoreview (claude engine, `--mode local`): clean, no accepted/actionable findings (`patch is correct`, 0.95).
