### PR TITLE
fix(agents): guard against double-wrapping tools with before_tool_call hook (fixes #92973)

### DIFF
--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -32,6 +32,7 @@ import { resolveAgentConfig } from "./agent-scope.js";
 import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
 import {
   type ToolOutcomeObserver,
+  isToolWrappedWithBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
 import { applyDeferredFollowupToolDescriptions } from "./agent-tools.deferred-followup.js";
@@ -1168,7 +1169,9 @@ export function createOpenClawCodingTools(options?: {
   );
   options?.recordToolPrepStage?.("schema-normalization");
   const withHooks = normalized.map((tool) =>
-    wrapToolWithBeforeToolCallHook(
+    isToolWrappedWithBeforeToolCallHook(tool)
+      ? tool
+      : wrapToolWithBeforeToolCallHook(
       tool,
       {
         agentId,


### PR DESCRIPTION
## Problem

`createOpenClawCodingTools` unconditionally wraps every tool with `wrapToolWithBeforeToolCallHook` without checking if the tool is already wrapped. When tools that were already wrapped by `openclaw-tools.ts` (which does have the guard at line 591) flow through `createOpenClawCodingTools` during isolated-agent/cron spawns, they get wrapped again. The Symbol marker `BEFORE_TOOL_CALL_WRAPPED` survives `normalizeToolParameters`'s object spread (Symbols are enumerable), but no guard existed to skip the second wrap. This causes `before_tool_call` hooks to fire twice for ~4% of tool calls.

## Fix

Add `isToolWrappedWithBeforeToolCallHook` guard in `createOpenClawCodingTools`, matching the pattern already used in `openclaw-tools.ts:591`:

```ts
const withHooks = normalized.map((tool) =>
  isToolWrappedWithBeforeToolCallHook(tool)
    ? tool
    : wrapToolWithBeforeToolCallHook(tool, { ... }),
);
```

This is the same guard pattern used in `openclaw-tools.ts:591-593` and `agent-tool-definition-adapter.ts:365`.

## Real behavior proof

- **Behavior addressed:** `before_tool_call` hook fires twice when tools pass through `createOpenClawCodingTools` after being already wrapped
- **Environment tested:** macOS 26.4.1, Node.js, openclaw main branch (fc6d4481)
- **Steps run after the patch:**
  1. `node scripts/run-vitest.mjs run src/agents/agent-tools.before-tool-call.e2e.test.ts` — 54 tests passed
  2. `node scripts/run-vitest.mjs run src/agents/agent-tools-agent-config.test.ts` — 23 tests passed
  3. `node scripts/run-vitest.mjs run src/agents/agent-tools.safe-bins.test.ts` — 6 tests passed
  4. `node scripts/run-vitest.mjs run src/agents/agent-tools.schema.test.ts` — 41 tests passed
  5. `pnpm build` — built successfully

- **Evidence after fix:**

```
$ grep -n 'isToolWrappedWithBeforeToolCallHook' src/agents/agent-tools.ts
35:  isToolWrappedWithBeforeToolCallHook,
1172:    isToolWrappedWithBeforeToolCallHook(tool)

$ node scripts/run-vitest.mjs run src/agents/agent-tools.before-tool-call.e2e.test.ts
 ✓ src/agents/agent-tools.before-tool-call.e2e.test.ts (54 tests) 167ms
 Test Files  1 passed (1)
      Tests  54 passed (54)

$ node scripts/run-vitest.mjs run src/agents/agent-tools-agent-config.test.ts
 ✓  agents  src/agents/agent-tools-agent-config.test.ts (23 tests) 129ms
 Test Files  1 passed (1)
      Tests  23 passed (23)
```

- **Observed result after fix:** All 124 tests across 4 related test files pass. Build succeeds. The guard prevents double-wrapping by checking `isToolWrappedWithBeforeToolCallHook(tool)` before calling `wrapToolWithBeforeToolCallHook`.
- **What was not tested:** Live runtime verification with actual isolated-agent/cron invocations (requires full gateway startup). The fix is a simple guard addition matching an established pattern in the same codebase.
