### PR TITLE
fix(read): decode Windows legacy text files

### DIFF
--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -4,13 +4,26 @@ import { Buffer } from "node:buffer";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../../../test-utils/env.js";
+import { withMockedWindowsPlatform } from "../../../test-utils/vitest-spies.js";
 import { createReadToolDefinition } from "./read.js";
 import { DEFAULT_MAX_BYTES } from "./truncate.js";
 
 const ONE_PIXEL_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+const { spawnSyncMock } = vi.hoisted(() => ({
+  spawnSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawnSync: spawnSyncMock,
+  };
+});
 
 function textContent(
   result: Awaited<ReturnType<ReturnType<typeof createReadToolDefinition>["execute"]>>,
@@ -20,6 +33,11 @@ function textContent(
 }
 
 describe("read tool", () => {
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValue({ stdout: "Active code page: 936", stderr: "" });
+  });
+
   it("reads managed inbound media refs as image files", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-media-"));
     const mediaId = `read-tool-${Date.now()}-${Math.random().toString(36).slice(2)}.png`;
@@ -99,5 +117,27 @@ describe("read tool", () => {
     );
 
     expect(textContent(result)).toBe("alpha\n\n[2 more lines in file. Use offset=2 to continue.]");
+  });
+
+  it("decodes GBK text files on Chinese Windows", async () => {
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        detectImageMimeType: async () => null,
+        readFile: async () => Buffer.from([0xb2, 0xe2, 0xca, 0xd4, 0xa1, 0xab, 0xa3, 0xbb]),
+      },
+    });
+
+    await withMockedWindowsPlatform(async () => {
+      const result = await tool.execute(
+        "call-1",
+        { path: "gbk-notes.txt" },
+        undefined,
+        undefined,
+        {} as never,
+      );
+
+      expect(textContent(result)).toBe("测试～；");
+    });
   });
 });

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -8,6 +8,7 @@ import { access as fsAccess, readFile as fsReadFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, relative, resolve as resolvePath, sep } from "node:path";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import { decodeWindowsOutputBuffer } from "../../../infra/windows-encoding.js";
 import type { ImageContent, Model, TextContent } from "../../../llm/types.js";
 import {
   classifyMediaReferenceSource,
@@ -339,7 +340,7 @@ export function createReadToolDefinition(
             } else {
               // Read text content.
               const buffer = await ops.readFile(absolutePath);
-              const textContent = buffer.toString("utf-8");
+              const textContent = decodeWindowsOutputBuffer({ buffer });
               const allLines = textContent.split("\n");
               const totalFileLines = allLines.length;
               // Apply offset if specified. Convert from 1-indexed input to 0-indexed array access.


### PR DESCRIPTION
Summary
- Route read-tool text buffers through the existing Windows decoder so valid UTF-8 stays unchanged while invalid UTF-8 can fall back to the active Windows code page.
- Add a read-tool regression that simulates Chinese Windows code page 936 and verifies GBK bytes render as Chinese text instead of mojibake.

Fixes #92664

Real behavior proof
Behavior addressed: On Chinese Windows, the read tool decoded GBK text files as UTF-8 and returned mojibake.
Real environment tested: Local macOS test runner with Vitest simulating Windows `process.platform === "win32"` and `chcp` code page 936 for the read-tool path.
Exact steps or command run after this patch:
- `CI=true npm exec -- pnpm test src/agents/sessions/tools/read.test.ts src/infra/windows-encoding.test.ts src/process/exec.windows.test.ts`
- `CI=true npm exec -- pnpm exec oxfmt --check --threads=1 src/agents/sessions/tools/read.ts src/agents/sessions/tools/read.test.ts`
- `git diff --check`
- `CI=true npm exec --package corepack -- corepack pnpm check:changed`
Evidence after fix: The targeted test command passed 3 shards with 27 tests; formatter reported all matched files correctly formatted; `git diff --check` exited 0; `check:changed` exited 0.
Observed result after fix: The read tool returns `测试～；` for a GBK buffer under simulated Windows CP936 instead of `���ԡ���`.
What was not tested: I did not have access to a real Windows/Testbox/Crabbox run with an actual GBK file on disk.

Verification
- `CI=true npm exec -- pnpm test src/agents/sessions/tools/read.test.ts src/infra/windows-encoding.test.ts src/process/exec.windows.test.ts`
- `CI=true npm exec -- pnpm exec oxfmt --check --threads=1 src/agents/sessions/tools/read.ts src/agents/sessions/tools/read.test.ts`
- `git diff --check`
- `CI=true npm exec --package corepack -- corepack pnpm check:changed`