### PR TITLE
fix(dreaming): increase narrative timeout from 60s to 120s for ARM devices (fixes #92494)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -979,7 +979,7 @@ describe("generateAndAppendDreamNarrative", () => {
     });
 
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(60_000);
+    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(120_000);
     expectLogIncludes(logger.warn, "narrative session cleanup failed for rem phase");
   });
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -95,10 +95,13 @@ const NARRATIVE_SYSTEM_PROMPT = [
 // many minutes after the reports have already been written. The previous 15 s
 // limit was empirically too tight for warm-gateway runs across light, REM, and
 // deep phases — even unblocked LLM calls hit it on the first sweep after a
-// restart. 60 s gives realistic latency headroom while still capping the
-// worst case at one minute, well below the multi-minute stall the original
-// comment warned against.
-const NARRATIVE_TIMEOUT_MS = 60_000;
+// restart. 60 s was still too tight for ARM devices with 600+ skills where
+// cold-loading tool definitions takes ~57 s on the first narrative phase,
+// leaving almost no headroom for the LLM call itself. 120 s gives realistic
+// latency headroom for resource-constrained environments while still capping
+// the worst case at two minutes, well below the multi-minute stall the
+// original comment warned against.
+const NARRATIVE_TIMEOUT_MS = 120_000;
 const NARRATIVE_MESSAGE_FETCH_LIMIT = 5;
 // A completed run can reach the session reader before the final assistant text
 // is visible, so retry briefly before falling back to synthetic diary text.


### PR DESCRIPTION
## Summary

Increase `NARRATIVE_TIMEOUT_MS` from 60s to 120s in the dreaming narrative phase. On ARM devices with 600+ skills, cold-loading tool definitions takes ~57s on the first narrative phase, leaving almost no headroom for the LLM call itself within the 60s timeout.

Fixes #92494

## Changes

- `extensions/memory-core/src/dreaming-narrative.ts`: bump `NARRATIVE_TIMEOUT_MS` from `60_000` to `120_000`, update comment to document ARM cold-load scenario
- `extensions/memory-core/src/dreaming-narrative.test.ts`: update timeout expectation from 60s to 120s

## Real behavior proof

- **Behavior addressed:** Dreaming narrative phases timeout on ARM devices with large skill counts because tool definition cold-loading consumes most of the 60s budget
- **Environment tested:** macOS 26.4.1 (arm64), Node v24, OpenClaw workdir at upstream/main
- **Steps run after the patch:**
  1. Verified `NARRATIVE_TIMEOUT_MS` constant changed to 120_000 via grep
  2. Ran dreaming-narrative test suite (53 tests)
  3. Ran full build
- **Evidence after fix:**

```
$ grep -n 'NARRATIVE_TIMEOUT_MS' extensions/memory-core/src/dreaming-narrative.ts
101:const NARRATIVE_TIMEOUT_MS = 120_000;
954:            timeoutMs: NARRATIVE_TIMEOUT_MS,

$ node scripts/run-vitest.mjs run extensions/memory-core/src/dreaming-narrative.test.ts
 ✓  extension-memory  extensions/memory-core/src/dreaming-narrative.test.ts (53 tests) 506ms
 Test Files  1 passed (1)
      Tests  53 passed (53)

$ pnpm build
✓ built in 497ms
```

- **Observed result after fix:** All 53 dreaming-narrative tests pass. Build succeeds. The timeout constant is now 120s, providing sufficient headroom for ARM cold-load + LLM call.
- **What was not tested:** Actual ARM device runtime (no ARM hardware available). The timeout increase is conservative and well-documented in the code comment.
