### PR TITLE
fix(memory-core): cleanup orphaned *.sqlite.tmp-* reindex files on startup

### DIFF
--- a/extensions/memory-core/src/memory/manager-atomic-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-atomic-reindex.ts
@@ -1,6 +1,7 @@
 // Memory Core plugin module implements manager atomic reindex behavior.
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
 type MemoryIndexFileOps = {
@@ -84,10 +85,10 @@ export async function moveMemoryIndexFiles(
   }
 }
 
-async function rmWithRetry(path: string, options: ResolvedMemoryIndexFileOptions): Promise<void> {
+async function rmWithRetry(filePath: string, options: ResolvedMemoryIndexFileOptions): Promise<void> {
   for (let attempt = 1; attempt <= options.maxRemoveAttempts; attempt++) {
     try {
-      await options.fileOps.rm(path, { force: true });
+      await options.fileOps.rm(filePath, { force: true });
       return;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
@@ -241,5 +242,91 @@ export async function runMemoryAtomicReindex<T>(params: {
       throw aggregateErr;
     }
     throw err;
+  }
+}
+
+export const MEMORY_TEMP_STALE_AGE_MS = 30_000;
+const TEMP_FILE_PATTERN = /\.sqlite\.tmp-[0-9a-f-]+$/;
+
+type CleanupLogger = {
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};
+
+export async function cleanupOrphanedTempFiles(
+  storeDir: string,
+  logger?: CleanupLogger,
+): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(storeDir);
+  } catch (err) {
+    logger?.warn(`memory: failed to read store directory for temp cleanup: ${String(err)}`);
+    return;
+  }
+
+  // Group files by base name (stripping -wal/-shm suffixes) so we can
+  // collect all sidecars that belong to the same temp file.
+  const tempCandidates = new Map<string, string[]>();
+  for (const entry of entries) {
+    const baseName = entry.replace(/-(wal|shm)$/, "");
+    if (TEMP_FILE_PATTERN.test(baseName)) {
+      const group = tempCandidates.get(baseName) ?? [];
+      group.push(entry);
+      tempCandidates.set(baseName, group);
+    }
+  }
+
+  if (tempCandidates.size === 0) {
+    return;
+  }
+
+  const nowMs = Date.now();
+  const staleGroups: string[][] = [];
+  const freshBaseNames: string[] = [];
+  let cleanedCount = 0;
+
+  for (const [baseName, files] of tempCandidates) {
+    const fullPath = path.join(storeDir, baseName);
+    let stat;
+    try {
+      stat = await fs.stat(fullPath);
+    } catch {
+      // Base temp file may have been deleted already; skip the group.
+      freshBaseNames.push(baseName);
+      continue;
+    }
+
+    if (stat.mtimeMs < nowMs - MEMORY_TEMP_STALE_AGE_MS) {
+      staleGroups.push(files);
+    } else {
+      freshBaseNames.push(baseName);
+    }
+  }
+
+  if (freshBaseNames.length > 0) {
+    logger?.info(
+      `memory: skipped ${freshBaseNames.length} active temp file(s) during startup cleanup`,
+      { freshCandidates: freshBaseNames },
+    );
+  }
+
+  for (const files of staleGroups) {
+    for (const file of files) {
+      try {
+        if (file === files[0]) {
+          // The base file: use removeMemoryIndexFiles which handles all sidecars
+          await removeMemoryIndexFiles(path.join(storeDir, file.replace(/-(wal|shm)$/, "")));
+        }
+      } catch (err) {
+        logger?.warn(`memory: failed to remove stale temp file "${file}": ${String(err)}`);
+      }
+    }
+    cleanedCount += files.length;
+  }
+
+  if (cleanedCount > 0) {
+    logger?.info(`memory: cleaned up ${cleanedCount} orphaned temp file(s) on startup`);
   }
 }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -11,6 +11,7 @@ import {
   type OpenClawConfig,
   type ResolvedMemorySearchConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import path from "node:path";
 import { extractKeywords } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import {
   readMemoryFile,
@@ -65,6 +66,7 @@ import {
   type MemoryReadonlyRecoveryState,
 } from "./manager-sync-control.js";
 import { applyTemporalDecayToHybridResults } from "./temporal-decay.js";
+import { cleanupOrphanedTempFiles } from "./manager-atomic-reindex.js";
 const SNIPPET_MAX_CHARS = 700;
 const VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = "chunks_fts";
@@ -387,6 +389,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     this.sources = new Set(effectiveSettings.sources);
     this.db = this.openDatabase();
+    // Fire-and-forget cleanup of orphaned temp files from prior hard restarts.
+    void cleanupOrphanedTempFiles(path.dirname(this.settings.store.path), log).catch(
+      (err: unknown) => {
+        log.warn(`memory: orphaned temp file cleanup failed: ${String(err)}`);
+      },
+    );
     this.providerKey = this.computeProviderKey();
     this.cache = {
       enabled: effectiveSettings.cache.enabled,


### PR DESCRIPTION
## Summary

Fixes #92874.

The builtin memory backend atomic reindex creates temporary SQLite databases in the store directory. On a hard restart during a reindex, the temp files are orphaned permanently.

## What changed

- Added `cleanupOrphanedTempFiles()` to scan the store directory at startup for stale `*.sqlite.tmp-*` files (including `-wal`/`-shm` sidecars).
- Uses a 30-second staleness guard (`MEMORY_TEMP_STALE_AGE_MS`) — files with mtime newer than the threshold are skipped.
- Called fire-and-forget from the MemoryIndexManager constructor.
- Reuses the existing `removeMemoryIndexFiles()` helper.

## Real behavior proof

- **Behavior addressed**: Orphaned temp reindex files accumulate on disk after hard gateway restarts and are never reclaimed.
- **Real environment tested**: Node v22.19.0, Linux x64, commit 9439acc.
- **Exact steps or command run after this patch**:
  - `node --import tsx scripts/repro/repro-92874-orphaned-tmp-cleanup.mts`
  - `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.atomic-reindex.test.ts`
- **Evidence after fix**:
```
=== Reproduction for issue #92874 ===
Store directory: /tmp/repro-92874/memory

Creating stale orphan (mtime 60s ago): test.sqlite.tmp-abc123
Creating stale sidecars: test.sqlite.tmp-abc123-wal, test.sqlite.tmp-abc123-shm
Creating active temp file (current mtime): test.sqlite.tmp-def456

Before cleanup:
  test.sqlite.tmp-abc123 (stale, mtime 60s ago)
  test.sqlite.tmp-abc123-wal
  test.sqlite.tmp-abc123-shm
  test.sqlite.tmp-def456 (active, mtime now)

After cleanupOrphanedTempFiles():
  test.sqlite.tmp-def456 (active, SKIPPED)
  stale test.sqlite.tmp-abc123 (REMOVED)
  stale test.sqlite.tmp-abc123-wal (REMOVED)
  stale test.sqlite.tmp-abc123-shm (REMOVED)

Active files preserved: 1
Stale files cleaned: 3

PASS: Startup sweep correctly removes stale orphans and preserves active temp files.

Test suite: 18 passed, 0 failed
exit code: 0
```
- **Observed result after fix**: The new `cleanupOrphanedTempFiles()` function correctly scans the store directory, removes stale temp file groups (mtime > 30s old), preserves active groups (recent mtime), logs cleaned/skipped counts, and handles missing files gracefully. The constructor fires cleanup without blocking startup.
- **What was not tested**: Actual SIGKILL during a live reindex on a production store. Cross-platform file locking behavior (Windows, macOS).