### PR TITLE
fix(agents): tolerate missing attribution baseUrl

### DIFF
--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -2,12 +2,15 @@
 // session write-lock behavior.
 import { Type } from "typebox";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Context, Model, SimpleStreamOptions } from "../../llm/types.js";
 
 const thinkingMocks = vi.hoisted(() => ({
   resolveThinkingDefaultForModel: vi.fn(() => "medium"),
 }));
 const streamMocks = vi.hoisted(() => ({
-  streamSimple: vi.fn(() => "stream"),
+  streamSimple: vi.fn(
+    (_model: Model, _context: Context, _options?: SimpleStreamOptions) => "stream",
+  ),
 }));
 
 vi.mock("../../auto-reply/thinking.js", () => ({
@@ -16,7 +19,6 @@ vi.mock("../../auto-reply/thinking.js", () => ({
 vi.mock("../../llm/stream.js", () => ({
   streamSimple: streamMocks.streamSimple,
 }));
-import type { Model } from "../../llm/types.js";
 import { AuthStorage } from "./auth-storage.js";
 import { createExtensionRuntime } from "./extensions/loader.js";
 import type { LoadExtensionsResult, ToolDefinition } from "./extensions/types.js";
@@ -85,7 +87,7 @@ function createResourceLoaderWithHandlers(
   };
 }
 
-async function createSessionAndStreamModel(model: Model): Promise<Record<string, unknown>> {
+async function createSessionAndStreamModel(model: Model): Promise<SimpleStreamOptions> {
   streamMocks.streamSimple.mockClear();
   const { session } = await createAgentSession({
     model,
@@ -105,7 +107,7 @@ async function createSessionAndStreamModel(model: Model): Promise<Record<string,
     {},
   );
 
-  return streamMocks.streamSimple.mock.calls.at(-1)?.[2] as Record<string, unknown>;
+  return streamMocks.streamSimple.mock.lastCall?.[2] ?? {};
 }
 
 describe("createAgentSession attribution headers", () => {

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -6,9 +6,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const thinkingMocks = vi.hoisted(() => ({
   resolveThinkingDefaultForModel: vi.fn(() => "medium"),
 }));
+const streamMocks = vi.hoisted(() => ({
+  streamSimple: vi.fn(() => "stream"),
+}));
 
 vi.mock("../../auto-reply/thinking.js", () => ({
   resolveThinkingDefaultForModel: thinkingMocks.resolveThinkingDefaultForModel,
+}));
+vi.mock("../../llm/stream.js", () => ({
+  streamSimple: streamMocks.streamSimple,
 }));
 import type { Model } from "../../llm/types.js";
 import { AuthStorage } from "./auth-storage.js";
@@ -33,6 +39,11 @@ const testModel: Model = {
   contextWindow: 1000,
   maxTokens: 1000,
 };
+
+function createModelWithoutBaseUrl(overrides: Partial<Model>): Model {
+  const { baseUrl: _baseUrl, ...model } = { ...testModel, ...overrides };
+  return model as unknown as Model;
+}
 
 function createEmptyResourceLoader(): ResourceLoader {
   return createResourceLoaderWithHandlers(new Map());
@@ -73,6 +84,84 @@ function createResourceLoaderWithHandlers(
     reload: async () => {},
   };
 }
+
+async function createSessionAndStreamModel(model: Model): Promise<Record<string, unknown>> {
+  streamMocks.streamSimple.mockClear();
+  const { session } = await createAgentSession({
+    model,
+    resourceLoader: createEmptyResourceLoader(),
+    sessionManager: SessionManager.inMemory(),
+    settingsManager: SettingsManager.inMemory(),
+    modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+  });
+
+  await session.agent.streamFn?.(
+    model,
+    {
+      messages: [],
+      systemPrompt: "",
+      tools: [],
+    },
+    {},
+  );
+
+  return streamMocks.streamSimple.mock.calls.at(-1)?.[2] as Record<string, unknown>;
+}
+
+describe("createAgentSession attribution headers", () => {
+  it("tolerates Bedrock models that do not expose baseUrl", async () => {
+    const options = await createSessionAndStreamModel(
+      createModelWithoutBaseUrl({
+        id: "global.anthropic.claude-sonnet-4-6",
+        provider: "amazon-bedrock",
+        api: "bedrock-converse-stream",
+      }),
+    );
+
+    expect(streamMocks.streamSimple).toHaveBeenCalledOnce();
+    expect(options.headers).toBeUndefined();
+  });
+
+  it("keeps OpenRouter attribution headers for provider and endpoint matches", async () => {
+    const providerOptions = await createSessionAndStreamModel({
+      ...testModel,
+      provider: "openrouter",
+      baseUrl: "https://example.test",
+    });
+    const endpointOptions = await createSessionAndStreamModel({
+      ...testModel,
+      provider: "custom-openai",
+      baseUrl: "https://openrouter.ai/api/v1",
+    });
+
+    expect(providerOptions.headers).toMatchObject({
+      "HTTP-Referer": "https://openclaw.ai",
+      "X-OpenRouter-Title": "OpenClaw",
+      "X-OpenRouter-Categories": "cli-agent",
+    });
+    expect(endpointOptions.headers).toMatchObject({
+      "HTTP-Referer": "https://openclaw.ai",
+      "X-OpenRouter-Title": "OpenClaw",
+      "X-OpenRouter-Categories": "cli-agent",
+    });
+  });
+
+  it("keeps Cloudflare attribution headers for provider and endpoint matches", async () => {
+    const providerOptions = await createSessionAndStreamModel({
+      ...testModel,
+      provider: "cloudflare-workers-ai",
+      baseUrl: "https://example.test",
+    });
+    const endpointOptions = await createSessionAndStreamModel({
+      ...testModel,
+      provider: "custom-openai",
+      baseUrl: "https://gateway.ai.cloudflare.com/v1/account/gateway/openai",
+    });
+
+    expect(providerOptions.headers).toMatchObject({ "User-Agent": "openclaw" });
+    expect(endpointOptions.headers).toMatchObject({ "User-Agent": "openclaw" });
+  });
+});
 
 describe("createAgentSession tool defaults", () => {
   it("forwards max thinking budgets from settings to the agent", async () => {

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -178,7 +178,9 @@ function getAttributionHeaders(
     return undefined;
   }
 
-  if (model.provider === "openrouter" || model.baseUrl.includes("openrouter.ai")) {
+  const baseUrl = (model as { baseUrl?: string }).baseUrl ?? "";
+
+  if (model.provider === "openrouter" || baseUrl.includes("openrouter.ai")) {
     return {
       "HTTP-Referer": "https://openclaw.ai",
       "X-OpenRouter-Title": "OpenClaw",
@@ -189,8 +191,8 @@ function getAttributionHeaders(
   if (
     model.provider === "cloudflare-workers-ai" ||
     model.provider === "cloudflare-ai-gateway" ||
-    model.baseUrl.includes("api.cloudflare.com") ||
-    model.baseUrl.includes("gateway.ai.cloudflare.com")
+    baseUrl.includes("api.cloudflare.com") ||
+    baseUrl.includes("gateway.ai.cloudflare.com")
   ) {
     return {
       "User-Agent": "openclaw",


### PR DESCRIPTION
Fixes #92974.

## Summary

- Normalize the session attribution helper's runtime `baseUrl` read so Bedrock-shaped models that omit `baseUrl` do not crash before provider routing.
- Keep the existing OpenRouter and Cloudflare attribution header behavior unchanged.
- Add focused session SDK coverage for missing `baseUrl`, OpenRouter attribution, and Cloudflare attribution.

## Root cause

`getAttributionHeaders()` treated `Model.baseUrl` as always present and called `.includes()` on it. Runtime model config can cross this boundary without `baseUrl`, including Bedrock models, so install telemetry attribution could throw before the provider request path ran.

## Real behavior proof

**Behavior addressed:** A Bedrock model object without `baseUrl` should not throw `Cannot read properties of undefined (reading 'includes')` before provider routing.

**Real environment tested:** Local OpenClaw source checkout on macOS at exact head `4143df76efd08c506d238ef9f9ae06eb7210375f`, Node `v26.3.0`, using a Bedrock-shaped `amazon-bedrock` model object with no `baseUrl`; Linux Testbox for the changed gate.

**Exact steps or command run after this patch:** Ran a local Node source harness with `node --import tsx` that imported `createAgentSession`, created a real session with the Bedrock-shaped model, and called `session.agent.streamFn(...)` with an already-aborted signal to avoid any live AWS request.

**Evidence after fix:** Copied live terminal output from the source harness:

```json
{"reachedProviderPath":true,"errorName":"Error","message":"No API provider registered for api: bedrock-converse-stream"}
```

**Observed result after fix:** The stream path reached provider routing and failed with the expected local missing-provider setup error. It did not throw the previous `baseUrl.includes` TypeError.

**What was not tested:** No live AWS Bedrock request was made because no valid AWS credentials were available. The regression occurs before the provider network call; the real session harness and focused tests cover that boundary.

## Validation

- `node scripts/run-vitest.mjs src/agents/sessions/sdk.test.ts src/agents/provider-attribution.test.ts`
  - Passed: 1 Vitest shard, 2 files, 47 tests.
- `CI=true pnpm exec oxfmt --check --threads=1 src/agents/sessions/sdk.ts src/agents/sessions/sdk.test.ts`
  - Passed.
- `git diff --check`
  - Passed.
- Testbox changed gate `tbx_01kv3peewwaj45fgwye7bmbsyz`
  - Passed core and coreTests lanes, including production/test typechecks, lint, and import-cycle checks.
- Fresh autoreview after the test-type fix
  - Clean: no accepted/actionable findings.

## AI-assisted disclosure

AI-assisted PR prepared with Codex. I reviewed the changed code path, kept the change scoped to #92974, and ran the validation listed above.
