### PR TITLE
[codex] openai proxy compat for compatible providers

### DIFF
--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -146,6 +146,7 @@ export async function prepareCliRunContext(
     generatedAt: Date.now(),
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
+    sourceRunId: params.runId,
     provider: params.provider,
     model: modelId,
     workspaceDir,

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, ToolResultMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
+  applyCompactionLightTrim,
   estimateMessagesTokens,
   extractCompactionStageTelemetry,
   planCompactionStage,
@@ -99,6 +100,7 @@ describe("planCompactionStage", () => {
   it("builds a conservative stage plan in execution order", () => {
     expect(
       planCompactionStages({
+        lightTrimRequested: true,
         historyPruned: true,
         historySummaryRequested: true,
         splitTurnSummaryRequested: true,
@@ -106,11 +108,37 @@ describe("planCompactionStage", () => {
       }),
     ).toEqual([
       { stage: "prune_history", reason: "new_content_exceeds_history_budget" },
+      { stage: "light_trim", reason: "oversized_tool_results_present" },
       { stage: "summarize_history", reason: "messages_to_summarize_present" },
       { stage: "summarize_split_turn", reason: "split_turn_prefix_present" },
       { stage: "quality_retry", reason: "quality_guard_enabled" },
       { stage: "finalize", reason: "summary_ready" },
     ]);
+  });
+
+  it("keeps prune_history as the entry stage when both pruning and light trim are needed", () => {
+    expect(
+      planCompactionStage({
+        lightTrimRequested: true,
+        historyPruned: true,
+        historySummaryRequested: true,
+      }),
+    ).toEqual({
+      stage: "prune_history",
+      reason: "new_content_exceeds_history_budget",
+    });
+  });
+
+  it("plans light trim before heavier history summarization work when pruning is not needed", () => {
+    expect(
+      planCompactionStage({
+        lightTrimRequested: true,
+        historySummaryRequested: true,
+      }),
+    ).toEqual({
+      stage: "light_trim",
+      reason: "oversized_tool_results_present",
+    });
   });
 
   it("extracts stage telemetry from compaction result details", () => {
@@ -139,6 +167,35 @@ describe("planCompactionStage", () => {
       qualityRetriesUsed: 1,
       droppedChunks: 1,
     });
+  });
+});
+
+describe("applyCompactionLightTrim", () => {
+  it("soft-trims oversized tool results for compaction summaries", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "Inspect the previous command output.", timestamp: 1 },
+      makeToolResult(2, "call_123", "A".repeat(8_000)),
+      { role: "assistant", content: "Done.", timestamp: 3 } as unknown as AgentMessage,
+    ];
+
+    const trimmed = applyCompactionLightTrim({
+      messages,
+      contextWindowTokens: 8_000,
+    });
+
+    expect(trimmed.applied).toBe(true);
+    expect(trimmed.trimmedMessages).toBe(1);
+    expect(trimmed.trimmedToolResults).toBe(1);
+    expect(trimmed.tokenDelta).toBeGreaterThan(0);
+    const toolResult = trimmed.messages[1] as Extract<AgentMessage, { role: "toolResult" }>;
+    expect(toolResult.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("[Tool result trimmed:"),
+        }),
+      ]),
+    );
   });
 });
 

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -3,6 +3,7 @@ import type { AssistantMessage, ToolResultMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
   applyCompactionLightTrim,
+  buildCompactionStageTelemetry,
   estimateMessagesTokens,
   extractCompactionStageTelemetry,
   planCompactionStage,
@@ -141,25 +142,52 @@ describe("planCompactionStage", () => {
     });
   });
 
+  it("builds shared stage telemetry with clamped counters", () => {
+    expect(
+      buildCompactionStageTelemetry({
+        lightTrimRequested: true,
+        lightTrimmedMessages: -1,
+        lightTrimmedToolResults: 2,
+        historyPruned: true,
+        historySummaryRequested: true,
+        qualityGuardEnabled: true,
+        qualityRetriesPlanned: -2,
+        qualityRetriesUsed: 1,
+        recentTurnsPreserve: 99,
+        droppedChunks: -1,
+        droppedMessages: 3,
+        droppedSummaryUsed: true,
+      }),
+    ).toMatchObject({
+      entryStage: "prune_history",
+      outcomeStage: "quality_retry",
+      lightTrimApplied: true,
+      lightTrimmedMessages: 0,
+      lightTrimmedToolResults: 2,
+      recentTurnsPreserve: 12,
+      qualityGuardEnabled: true,
+      qualityRetriesPlanned: 0,
+      qualityRetriesUsed: 1,
+      droppedChunks: 0,
+      droppedMessages: 3,
+      droppedSummaryUsed: true,
+    });
+  });
+
   it("extracts stage telemetry from compaction result details", () => {
     expect(
       extractCompactionStageTelemetry({
-        stageTelemetry: {
-          entryStage: "prune_history",
-          entryReason: "new_content_exceeds_history_budget",
-          outcomeStage: "quality_retry",
-          outcomeReason: "quality_feedback_requested",
-          plan: [{ stage: "finalize", reason: "summary_ready" }],
+        stageTelemetry: buildCompactionStageTelemetry({
           historyPruned: true,
-          splitTurn: false,
-          recentTurnsPreserve: 3,
+          historySummaryRequested: true,
           qualityGuardEnabled: true,
           qualityRetriesPlanned: 1,
           qualityRetriesUsed: 1,
+          recentTurnsPreserve: 3,
           droppedChunks: 1,
           droppedMessages: 2,
           droppedSummaryUsed: true,
-        },
+        }),
       }),
     ).toMatchObject({
       entryStage: "prune_history",

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -3,6 +3,9 @@ import type { AssistantMessage, ToolResultMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
   estimateMessagesTokens,
+  extractCompactionStageTelemetry,
+  planCompactionStage,
+  planCompactionStages,
   pruneHistoryForContextShare,
   splitMessagesByTokenShare,
 } from "./compaction.js";
@@ -75,6 +78,67 @@ describe("splitMessagesByTokenShare", () => {
 
     const parts = splitMessagesByTokenShare(messages, 3);
     expect(parts.flat().map((msg) => msg.timestamp)).toEqual(messages.map((msg) => msg.timestamp));
+  });
+});
+
+describe("planCompactionStage", () => {
+  it("prioritizes quality retries over earlier stages when feedback is requested", () => {
+    expect(
+      planCompactionStage({
+        historyPruned: true,
+        historySummaryRequested: true,
+        splitTurnSummaryRequested: true,
+        qualityRetryRequested: true,
+      }),
+    ).toEqual({
+      stage: "quality_retry",
+      reason: "quality_feedback_requested",
+    });
+  });
+
+  it("builds a conservative stage plan in execution order", () => {
+    expect(
+      planCompactionStages({
+        historyPruned: true,
+        historySummaryRequested: true,
+        splitTurnSummaryRequested: true,
+        qualityGuardEnabled: true,
+      }),
+    ).toEqual([
+      { stage: "prune_history", reason: "new_content_exceeds_history_budget" },
+      { stage: "summarize_history", reason: "messages_to_summarize_present" },
+      { stage: "summarize_split_turn", reason: "split_turn_prefix_present" },
+      { stage: "quality_retry", reason: "quality_guard_enabled" },
+      { stage: "finalize", reason: "summary_ready" },
+    ]);
+  });
+
+  it("extracts stage telemetry from compaction result details", () => {
+    expect(
+      extractCompactionStageTelemetry({
+        stageTelemetry: {
+          entryStage: "prune_history",
+          entryReason: "new_content_exceeds_history_budget",
+          outcomeStage: "quality_retry",
+          outcomeReason: "quality_feedback_requested",
+          plan: [{ stage: "finalize", reason: "summary_ready" }],
+          historyPruned: true,
+          splitTurn: false,
+          recentTurnsPreserve: 3,
+          qualityGuardEnabled: true,
+          qualityRetriesPlanned: 1,
+          qualityRetriesUsed: 1,
+          droppedChunks: 1,
+          droppedMessages: 2,
+          droppedSummaryUsed: true,
+        },
+      }),
+    ).toMatchObject({
+      entryStage: "prune_history",
+      outcomeStage: "quality_retry",
+      qualityRetriesUsed: 1,
+      droppedChunks: 1,
+    });
   });
 });
 

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -8,6 +8,8 @@ import type { AgentCompactionIdentifierPolicy } from "../config/types.agent-defa
 import { retryAsync } from "../infra/retry.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
+import { pruneContextMessages } from "./pi-hooks/context-pruning/pruner.js";
+import { DEFAULT_CONTEXT_PRUNING_SETTINGS } from "./pi-hooks/context-pruning/settings.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
 
 const log = createSubsystemLogger("compaction");
@@ -17,6 +19,16 @@ export const MIN_CHUNK_RATIO = 0.15;
 export const SAFETY_MARGIN = 1.2; // 20% buffer for estimateTokens() inaccuracy
 const DEFAULT_SUMMARY_FALLBACK = "No prior history.";
 const DEFAULT_PARTS = 2;
+const DEFAULT_COMPACTION_LIGHT_TRIM_SETTINGS = {
+  ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+  keepLastAssistants: 0,
+  softTrimRatio: 0,
+  hardClearRatio: 1,
+  hardClear: {
+    ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear,
+    enabled: false,
+  },
+} as const;
 const MERGE_SUMMARIES_INSTRUCTIONS = [
   "Merge these partial summaries into a single cohesive summary.",
   "",
@@ -42,6 +54,7 @@ export type CompactionSummarizationInstructions = {
 
 export type CompactionStage =
   | "boundary"
+  | "light_trim"
   | "prune_history"
   | "summarize_history"
   | "summarize_split_turn"
@@ -50,6 +63,7 @@ export type CompactionStage =
 
 export type CompactionStageReason =
   | "no_real_messages"
+  | "oversized_tool_results_present"
   | "new_content_exceeds_history_budget"
   | "messages_to_summarize_present"
   | "split_turn_prefix_present"
@@ -64,6 +78,7 @@ export type CompactionStageDecision = {
 
 export type CompactionStagePlanningParams = {
   boundaryOnly?: boolean;
+  lightTrimRequested?: boolean;
   historyPruned?: boolean;
   historySummaryRequested?: boolean;
   splitTurnSummaryRequested?: boolean;
@@ -77,6 +92,9 @@ export type CompactionStageTelemetry = {
   outcomeStage: CompactionStage;
   outcomeReason: CompactionStageReason;
   plan: CompactionStageDecision[];
+  lightTrimApplied: boolean;
+  lightTrimmedMessages: number;
+  lightTrimmedToolResults: number;
   historyPruned: boolean;
   splitTurn: boolean;
   recentTurnsPreserve: number;
@@ -507,6 +525,56 @@ export async function summarizeInStages(params: {
   });
 }
 
+export type CompactionLightTrimResult = {
+  messages: AgentMessage[];
+  applied: boolean;
+  trimmedMessages: number;
+  trimmedToolResults: number;
+  tokensBefore: number;
+  tokensAfter: number;
+  tokenDelta: number;
+};
+
+export function applyCompactionLightTrim(params: {
+  messages: AgentMessage[];
+  contextWindowTokens: number;
+}): CompactionLightTrimResult {
+  const tokensBefore = estimateMessagesTokens(params.messages);
+  const trimmedMessages = pruneContextMessages({
+    messages: params.messages,
+    settings: DEFAULT_COMPACTION_LIGHT_TRIM_SETTINGS,
+    ctx: {
+      model: { contextWindow: params.contextWindowTokens },
+    } as Pick<ExtensionContext, "model">,
+    contextWindowTokensOverride: params.contextWindowTokens,
+    isToolPrunable: () => true,
+    dropThinkingBlocksForEstimate: true,
+  });
+
+  let trimmedCount = 0;
+  let trimmedToolResults = 0;
+  for (let i = 0; i < params.messages.length; i += 1) {
+    if (trimmedMessages[i] === params.messages[i]) {
+      continue;
+    }
+    trimmedCount += 1;
+    if (params.messages[i]?.role === "toolResult") {
+      trimmedToolResults += 1;
+    }
+  }
+
+  const tokensAfter = estimateMessagesTokens(trimmedMessages);
+  return {
+    messages: trimmedMessages,
+    applied: trimmedCount > 0,
+    trimmedMessages: trimmedCount,
+    trimmedToolResults,
+    tokensBefore,
+    tokensAfter,
+    tokenDelta: Math.max(0, tokensBefore - tokensAfter),
+  };
+}
+
 export function pruneHistoryForContextShare(params: {
   messages: AgentMessage[];
   maxContextTokens: number;
@@ -583,6 +651,9 @@ export function planCompactionStage(
   if (params.historyPruned) {
     return { stage: "prune_history", reason: "new_content_exceeds_history_budget" };
   }
+  if (params.lightTrimRequested) {
+    return { stage: "light_trim", reason: "oversized_tool_results_present" };
+  }
   if (params.historySummaryRequested) {
     return { stage: "summarize_history", reason: "messages_to_summarize_present" };
   }
@@ -602,6 +673,9 @@ export function planCompactionStages(
   const plan: CompactionStageDecision[] = [];
   if (params.historyPruned) {
     plan.push({ stage: "prune_history", reason: "new_content_exceeds_history_budget" });
+  }
+  if (params.lightTrimRequested) {
+    plan.push({ stage: "light_trim", reason: "oversized_tool_results_present" });
   }
   if (params.historySummaryRequested) {
     plan.push({ stage: "summarize_history", reason: "messages_to_summarize_present" });

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -40,6 +40,54 @@ export type CompactionSummarizationInstructions = {
   identifierInstructions?: string;
 };
 
+export type CompactionStage =
+  | "boundary"
+  | "prune_history"
+  | "summarize_history"
+  | "summarize_split_turn"
+  | "quality_retry"
+  | "finalize";
+
+export type CompactionStageReason =
+  | "no_real_messages"
+  | "new_content_exceeds_history_budget"
+  | "messages_to_summarize_present"
+  | "split_turn_prefix_present"
+  | "quality_guard_enabled"
+  | "quality_feedback_requested"
+  | "summary_ready";
+
+export type CompactionStageDecision = {
+  stage: CompactionStage;
+  reason: CompactionStageReason;
+};
+
+export type CompactionStagePlanningParams = {
+  boundaryOnly?: boolean;
+  historyPruned?: boolean;
+  historySummaryRequested?: boolean;
+  splitTurnSummaryRequested?: boolean;
+  qualityRetryRequested?: boolean;
+  qualityGuardEnabled?: boolean;
+};
+
+export type CompactionStageTelemetry = {
+  entryStage: CompactionStage;
+  entryReason: CompactionStageReason;
+  outcomeStage: CompactionStage;
+  outcomeReason: CompactionStageReason;
+  plan: CompactionStageDecision[];
+  historyPruned: boolean;
+  splitTurn: boolean;
+  recentTurnsPreserve: number;
+  qualityGuardEnabled: boolean;
+  qualityRetriesPlanned: number;
+  qualityRetriesUsed: number;
+  droppedChunks: number;
+  droppedMessages: number;
+  droppedSummaryUsed: boolean;
+};
+
 type GenerateSummaryCompat = {
   (
     currentMessages: AgentMessage[],
@@ -521,6 +569,74 @@ export function pruneHistoryForContextShare(params: {
     keptTokens: estimateMessagesTokens(keptMessages),
     budgetTokens,
   };
+}
+
+export function planCompactionStage(
+  params: CompactionStagePlanningParams,
+): CompactionStageDecision {
+  if (params.boundaryOnly) {
+    return { stage: "boundary", reason: "no_real_messages" };
+  }
+  if (params.qualityRetryRequested) {
+    return { stage: "quality_retry", reason: "quality_feedback_requested" };
+  }
+  if (params.historyPruned) {
+    return { stage: "prune_history", reason: "new_content_exceeds_history_budget" };
+  }
+  if (params.historySummaryRequested) {
+    return { stage: "summarize_history", reason: "messages_to_summarize_present" };
+  }
+  if (params.splitTurnSummaryRequested) {
+    return { stage: "summarize_split_turn", reason: "split_turn_prefix_present" };
+  }
+  return { stage: "finalize", reason: "summary_ready" };
+}
+
+export function planCompactionStages(
+  params: CompactionStagePlanningParams,
+): CompactionStageDecision[] {
+  if (params.boundaryOnly) {
+    return [planCompactionStage(params)];
+  }
+
+  const plan: CompactionStageDecision[] = [];
+  if (params.historyPruned) {
+    plan.push({ stage: "prune_history", reason: "new_content_exceeds_history_budget" });
+  }
+  if (params.historySummaryRequested) {
+    plan.push({ stage: "summarize_history", reason: "messages_to_summarize_present" });
+  }
+  if (params.splitTurnSummaryRequested) {
+    plan.push({ stage: "summarize_split_turn", reason: "split_turn_prefix_present" });
+  }
+  if (params.qualityGuardEnabled) {
+    plan.push({ stage: "quality_retry", reason: "quality_guard_enabled" });
+  }
+  plan.push({ stage: "finalize", reason: "summary_ready" });
+  return plan;
+}
+
+export function extractCompactionStageTelemetry(
+  details: unknown,
+): CompactionStageTelemetry | undefined {
+  if (!details || typeof details !== "object") {
+    return undefined;
+  }
+  const telemetry = (details as { stageTelemetry?: unknown }).stageTelemetry;
+  if (!telemetry || typeof telemetry !== "object") {
+    return undefined;
+  }
+  const candidate = telemetry as Partial<CompactionStageTelemetry>;
+  if (
+    typeof candidate.entryStage !== "string" ||
+    typeof candidate.entryReason !== "string" ||
+    typeof candidate.outcomeStage !== "string" ||
+    typeof candidate.outcomeReason !== "string" ||
+    !Array.isArray(candidate.plan)
+  ) {
+    return undefined;
+  }
+  return candidate as CompactionStageTelemetry;
 }
 
 export function resolveContextWindowTokens(model?: ExtensionContext["model"]): number {

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -106,6 +106,23 @@ export type CompactionStageTelemetry = {
   droppedSummaryUsed: boolean;
 };
 
+export type CompactionStageTelemetryParams = {
+  boundaryOnly?: boolean;
+  lightTrimRequested?: boolean;
+  lightTrimmedMessages?: number;
+  lightTrimmedToolResults?: number;
+  historyPruned?: boolean;
+  historySummaryRequested?: boolean;
+  splitTurnSummaryRequested?: boolean;
+  qualityGuardEnabled?: boolean;
+  qualityRetriesPlanned?: number;
+  qualityRetriesUsed?: number;
+  recentTurnsPreserve: number;
+  droppedChunks?: number;
+  droppedMessages?: number;
+  droppedSummaryUsed?: boolean;
+};
+
 type GenerateSummaryCompat = {
   (
     currentMessages: AgentMessage[],
@@ -688,6 +705,67 @@ export function planCompactionStages(
   }
   plan.push({ stage: "finalize", reason: "summary_ready" });
   return plan;
+}
+
+function clampCompactionStageTelemetryCount(value: unknown, fallback = 0): number {
+  const normalized = typeof value === "number" && Number.isFinite(value) ? value : fallback;
+  return Math.max(0, Math.floor(normalized));
+}
+
+function resolveCompactionStageTelemetryRecentTurnsPreserve(value: unknown): number {
+  const parsed = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : 3;
+  return Math.min(12, Math.max(0, parsed));
+}
+
+export function buildCompactionStageTelemetry(
+  params: CompactionStageTelemetryParams,
+): CompactionStageTelemetry {
+  const qualityRetriesUsed = clampCompactionStageTelemetryCount(params.qualityRetriesUsed);
+  const entryDecision = planCompactionStage({
+    boundaryOnly: params.boundaryOnly,
+    lightTrimRequested: params.lightTrimRequested,
+    historyPruned: params.historyPruned,
+    historySummaryRequested: params.historySummaryRequested,
+    splitTurnSummaryRequested: params.splitTurnSummaryRequested,
+    qualityRetryRequested: false,
+  });
+  const outcomeDecision = planCompactionStage({
+    boundaryOnly: params.boundaryOnly,
+    lightTrimRequested: params.lightTrimRequested,
+    historyPruned: params.historyPruned,
+    historySummaryRequested: params.historySummaryRequested,
+    splitTurnSummaryRequested: params.splitTurnSummaryRequested,
+    qualityRetryRequested: qualityRetriesUsed > 0,
+  });
+
+  return {
+    entryStage: entryDecision.stage,
+    entryReason: entryDecision.reason,
+    outcomeStage: outcomeDecision.stage,
+    outcomeReason: outcomeDecision.reason,
+    plan: planCompactionStages({
+      boundaryOnly: params.boundaryOnly,
+      lightTrimRequested: params.lightTrimRequested,
+      historyPruned: params.historyPruned,
+      historySummaryRequested: params.historySummaryRequested,
+      splitTurnSummaryRequested: params.splitTurnSummaryRequested,
+      qualityGuardEnabled: params.qualityGuardEnabled,
+    }),
+    lightTrimApplied: params.lightTrimRequested === true,
+    lightTrimmedMessages: clampCompactionStageTelemetryCount(params.lightTrimmedMessages),
+    lightTrimmedToolResults: clampCompactionStageTelemetryCount(params.lightTrimmedToolResults),
+    historyPruned: params.historyPruned === true,
+    splitTurn: params.splitTurnSummaryRequested === true,
+    recentTurnsPreserve: resolveCompactionStageTelemetryRecentTurnsPreserve(
+      params.recentTurnsPreserve,
+    ),
+    qualityGuardEnabled: params.qualityGuardEnabled === true,
+    qualityRetriesPlanned: clampCompactionStageTelemetryCount(params.qualityRetriesPlanned),
+    qualityRetriesUsed,
+    droppedChunks: clampCompactionStageTelemetryCount(params.droppedChunks),
+    droppedMessages: clampCompactionStageTelemetryCount(params.droppedMessages),
+    droppedSummaryUsed: params.droppedSummaryUsed === true,
+  };
 }
 
 export function extractCompactionStageTelemetry(

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -426,6 +426,7 @@ describe("session_status tool", () => {
         deliveryStatus: "pending",
         notifyPolicy: "done_only",
         createdAt: Date.now() - 5_000,
+        childSessionKey: "agent:main:subagent:child",
         progressSummary: "Indexing the latest threads",
       },
     ]);
@@ -439,6 +440,7 @@ describe("session_status tool", () => {
     expect(text).toContain("acp");
     expect(text).toContain("Summarize inbox backlog");
     expect(text).toContain("Indexing the latest threads");
+    expect(text).toContain("child session");
   });
 
   it("hides stale completed task rows from session_status output", async () => {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -3355,4 +3355,24 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.prompt_cache_key).toBe("session-default");
     expect(payload.prompt_cache_retention).toBe("24h");
   });
+
+  it("keeps prompt cache fields for allowlisted OpenAI-compatible proxy hosts", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "openai-gpt",
+      applyModelId: "gpt-5.4",
+      model: {
+        api: "openai-responses",
+        provider: "openai-gpt",
+        id: "gpt-5.4",
+        baseUrl: "https://aigateway.chat",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        prompt_cache_key: "session-aigateway",
+        prompt_cache_retention: "24h",
+      },
+    });
+    expect(payload.prompt_cache_key).toBe("session-aigateway");
+    expect(payload.prompt_cache_retention).toBe("24h");
+  });
 });

--- a/src/agents/pi-embedded-runner/compact.dry-run.test.ts
+++ b/src/agents/pi-embedded-runner/compact.dry-run.test.ts
@@ -38,4 +38,31 @@ describe("buildCompactionDryRunDetails", () => {
     expect(details.stageTelemetry.qualityGuardEnabled).toBe(true);
     expect(details.qualityRetriesPlanned).toBe(2);
   });
+
+  it("projects light trim when oversized tool results dominate the transcript", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "Summarize the command output." },
+      {
+        role: "toolResult",
+        toolCallId: "call_123",
+        toolName: "exec",
+        content: [{ type: "text", text: "A".repeat(8_000) }],
+      } as AgentMessage,
+      { role: "assistant", content: "Done." } as AgentMessage,
+    ];
+
+    const details = __testing.buildCompactionDryRunDetails({
+      messages,
+      contextWindowTokens: 8_000,
+    });
+
+    expect(details.lightTrim).toMatchObject({
+      trimmedMessages: 1,
+      trimmedToolResults: 1,
+    });
+    expect(details.stageTelemetry.entryStage).toBe("light_trim");
+    expect(details.stageTelemetry.plan).toEqual(
+      expect.arrayContaining([{ stage: "light_trim", reason: "oversized_tool_results_present" }]),
+    );
+  });
 });

--- a/src/agents/pi-embedded-runner/compact.dry-run.test.ts
+++ b/src/agents/pi-embedded-runner/compact.dry-run.test.ts
@@ -1,0 +1,41 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { __testing } from "./compact.js";
+
+describe("buildCompactionDryRunDetails", () => {
+  it("returns a boundary-only plan when no real conversation messages exist", () => {
+    const details = __testing.buildCompactionDryRunDetails({
+      messages: [] as AgentMessage[],
+      contextWindowTokens: 8_000,
+    });
+
+    expect(details.dryRun).toBe(true);
+    expect(details.stageTelemetry.entryStage).toBe("boundary");
+    expect(details.stageTelemetry.plan).toEqual([
+      { stage: "boundary", reason: "no_real_messages" },
+    ]);
+  });
+
+  it("builds a conservative multi-stage plan for normal conversation history", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "Need a compact summary of our work so far." },
+      { role: "assistant", content: "Sure, here is the current state and next steps." },
+    ];
+
+    const details = __testing.buildCompactionDryRunDetails({
+      messages,
+      contextWindowTokens: 8_000,
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 2,
+      recentTurnsPreserve: 3,
+    });
+
+    expect(details.stageTelemetry.entryStage).toBe("summarize_history");
+    expect(details.stageTelemetry.plan.at(-1)).toEqual({
+      stage: "finalize",
+      reason: "summary_ready",
+    });
+    expect(details.stageTelemetry.qualityGuardEnabled).toBe(true);
+    expect(details.qualityRetriesPlanned).toBe(2);
+  });
+});

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -241,6 +241,7 @@ export async function loadCompactHooksHarness(): Promise<{
       create: vi.fn(() => ({})),
     },
     estimateTokens: estimateTokensMock,
+    generateSummary: vi.fn(async () => "summary"),
   }));
 
   vi.doMock("../session-tool-result-guard-wrapper.js", () => ({
@@ -334,6 +335,7 @@ export async function loadCompactHooksHarness(): Promise<{
     logToolSchemasForGoogle: vi.fn(),
     sanitizeSessionHistory: sanitizeSessionHistoryMock,
     sanitizeToolsForGoogle: vi.fn(({ tools }: { tools: unknown[] }) => tools),
+    validateReplayTurns: vi.fn(async ({ messages }: { messages: unknown[] }) => messages),
   }));
 
   vi.doMock("./tool-split.js", () => ({

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -284,8 +284,16 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     });
 
     expect(sessionHook("compact:after")?.context).toMatchObject({
+      compactionEntryStage: "prune_history",
+      compactionEntryReason: "new_content_exceeds_history_budget",
       compactionStage: "quality_retry",
       compactionReason: "quality_feedback_requested",
+      compactionStageTelemetry: {
+        entryStage: "prune_history",
+        outcomeStage: "quality_retry",
+        qualityRetriesUsed: 1,
+        droppedChunks: 1,
+      },
     });
   });
 

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -95,7 +95,11 @@ const sessionHook = (action: string): SessionHookEvent | undefined =>
     return event?.type === "session" && event.action === action;
   })?.[0] as SessionHookEvent | undefined;
 
-async function runCompactionHooks(params: { sessionKey?: string; messageProvider?: string }) {
+async function runCompactionHooks(params: {
+  sessionKey?: string;
+  messageProvider?: string;
+  details?: unknown;
+}) {
   const originalMessages = sessionMessages.slice(1) as AgentMessage[];
   const currentMessages = sessionMessages.slice(1) as AgentMessage[];
   const beforeMetrics = compactTesting.buildBeforeCompactionHookMetrics({
@@ -129,6 +133,7 @@ async function runCompactionHooks(params: { sessionKey?: string; messageProvider
     summaryLength: "summary".length,
     tokensBefore: 120,
     firstKeptEntryId: "entry-1",
+    details: params.details,
   });
 }
 
@@ -253,6 +258,35 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       },
       expect.objectContaining({ sessionKey: "agent:main:session-1", messageProvider: "telegram" }),
     );
+  });
+
+  it("includes compaction stage telemetry in internal after-hook context when available", async () => {
+    await runCompactionHooks({
+      sessionKey: TEST_SESSION_KEY,
+      details: {
+        stageTelemetry: {
+          entryStage: "prune_history",
+          entryReason: "new_content_exceeds_history_budget",
+          outcomeStage: "quality_retry",
+          outcomeReason: "quality_feedback_requested",
+          plan: [{ stage: "finalize", reason: "summary_ready" }],
+          historyPruned: true,
+          splitTurn: false,
+          recentTurnsPreserve: 3,
+          qualityGuardEnabled: true,
+          qualityRetriesPlanned: 1,
+          qualityRetriesUsed: 1,
+          droppedChunks: 1,
+          droppedMessages: 2,
+          droppedSummaryUsed: true,
+        },
+      },
+    });
+
+    expect(sessionHook("compact:after")?.context).toMatchObject({
+      compactionStage: "quality_retry",
+      compactionReason: "quality_feedback_requested",
+    });
   });
 
   it("uses sessionId as hook session key fallback when sessionKey is missing", async () => {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -41,8 +41,7 @@ import {
 } from "../compaction-real-conversation.js";
 import {
   applyCompactionLightTrim,
-  planCompactionStage,
-  planCompactionStages,
+  buildCompactionStageTelemetry,
   pruneHistoryForContextShare,
   type CompactionLightTrimResult,
   type CompactionStageTelemetry,
@@ -238,68 +237,6 @@ function resolveCompactionRecentTurnsPreserve(value: unknown): number {
 function resolveCompactionQualityGuardMaxRetries(value: unknown): number {
   const parsed = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : 1;
   return Math.min(3, Math.max(0, parsed));
-}
-
-function buildCompactionStageTelemetry(params: {
-  boundaryOnly?: boolean;
-  lightTrimRequested?: boolean;
-  lightTrimmedMessages?: number;
-  lightTrimmedToolResults?: number;
-  historyPruned?: boolean;
-  historySummaryRequested?: boolean;
-  splitTurnSummaryRequested?: boolean;
-  qualityGuardEnabled?: boolean;
-  qualityRetriesPlanned?: number;
-  qualityRetriesUsed?: number;
-  recentTurnsPreserve: number;
-  droppedChunks?: number;
-  droppedMessages?: number;
-  droppedSummaryUsed?: boolean;
-}): CompactionStageTelemetry {
-  const qualityRetriesUsed = Math.max(0, params.qualityRetriesUsed ?? 0);
-  const entryDecision = planCompactionStage({
-    boundaryOnly: params.boundaryOnly,
-    lightTrimRequested: params.lightTrimRequested,
-    historyPruned: params.historyPruned,
-    historySummaryRequested: params.historySummaryRequested,
-    splitTurnSummaryRequested: params.splitTurnSummaryRequested,
-    qualityRetryRequested: false,
-  });
-  const outcomeDecision = planCompactionStage({
-    boundaryOnly: params.boundaryOnly,
-    lightTrimRequested: params.lightTrimRequested,
-    historyPruned: params.historyPruned,
-    historySummaryRequested: params.historySummaryRequested,
-    splitTurnSummaryRequested: params.splitTurnSummaryRequested,
-    qualityRetryRequested: qualityRetriesUsed > 0,
-  });
-
-  return {
-    entryStage: entryDecision.stage,
-    entryReason: entryDecision.reason,
-    outcomeStage: outcomeDecision.stage,
-    outcomeReason: outcomeDecision.reason,
-    plan: planCompactionStages({
-      boundaryOnly: params.boundaryOnly,
-      lightTrimRequested: params.lightTrimRequested,
-      historyPruned: params.historyPruned,
-      historySummaryRequested: params.historySummaryRequested,
-      splitTurnSummaryRequested: params.splitTurnSummaryRequested,
-      qualityGuardEnabled: params.qualityGuardEnabled,
-    }),
-    lightTrimApplied: params.lightTrimRequested === true,
-    lightTrimmedMessages: Math.max(0, params.lightTrimmedMessages ?? 0),
-    lightTrimmedToolResults: Math.max(0, params.lightTrimmedToolResults ?? 0),
-    historyPruned: params.historyPruned === true,
-    splitTurn: params.splitTurnSummaryRequested === true,
-    recentTurnsPreserve: resolveCompactionRecentTurnsPreserve(params.recentTurnsPreserve),
-    qualityGuardEnabled: params.qualityGuardEnabled === true,
-    qualityRetriesPlanned: Math.max(0, params.qualityRetriesPlanned ?? 0),
-    qualityRetriesUsed,
-    droppedChunks: Math.max(0, params.droppedChunks ?? 0),
-    droppedMessages: Math.max(0, params.droppedMessages ?? 0),
-    droppedSummaryUsed: params.droppedSummaryUsed === true,
-  };
 }
 
 function buildCompactionDryRunDetails(params: {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -39,6 +39,13 @@ import {
   hasMeaningfulConversationContent,
   isRealConversationMessage,
 } from "../compaction-real-conversation.js";
+import {
+  estimateMessagesTokens,
+  planCompactionStage,
+  planCompactionStages,
+  pruneHistoryForContextShare,
+  type CompactionStageTelemetry,
+} from "../compaction.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
@@ -57,6 +64,7 @@ import { createBundleMcpToolRuntime } from "../pi-bundle-mcp-tools.js";
 import { ensureSessionHeader } from "../pi-embedded-helpers.js";
 import {
   consumeCompactionSafeguardCancelReason,
+  getCompactionSafeguardRuntime,
   setCompactionSafeguardCancelReason,
 } from "../pi-hooks/compaction-safeguard-runtime.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../pi-project-settings.js";
@@ -177,6 +185,8 @@ export type CompactEmbeddedPiSessionParams = {
   abortSignal?: AbortSignal;
   /** Allow runtime plugins for this compaction to late-bind the gateway subagent. */
   allowGatewaySubagentBinding?: boolean;
+  /** Read-only inspection path: compute likely compaction stages without transcript mutation. */
+  dryRun?: boolean;
 };
 
 type CompactionMessageMetrics = {
@@ -185,6 +195,19 @@ type CompactionMessageMetrics = {
   toolResultChars: number;
   estTokens?: number;
   contributors: Array<{ role: string; chars: number; tool?: string }>;
+};
+
+type CompactionDryRunDetails = {
+  dryRun: true;
+  currentMessages: number;
+  currentEstimatedTokens?: number;
+  contextWindowTokens: number;
+  maxHistoryShare: number;
+  recentTurnsPreserve: number;
+  qualityGuardEnabled: boolean;
+  qualityRetriesPlanned: number;
+  topContributors: Array<{ role: string; chars: number; tool?: string }>;
+  stageTelemetry: CompactionStageTelemetry;
 };
 
 function hasRealConversationContent(
@@ -197,6 +220,126 @@ function hasRealConversationContent(
 
 function createCompactionDiagId(): string {
   return `cmp-${Date.now().toString(36)}-${generateSecureToken(4)}`;
+}
+
+function resolveCompactionRecentTurnsPreserve(value: unknown): number {
+  const parsed = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : 3;
+  return Math.min(12, Math.max(0, parsed));
+}
+
+function resolveCompactionQualityGuardMaxRetries(value: unknown): number {
+  const parsed = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : 1;
+  return Math.min(3, Math.max(0, parsed));
+}
+
+function buildCompactionStageTelemetry(params: {
+  boundaryOnly?: boolean;
+  historyPruned?: boolean;
+  historySummaryRequested?: boolean;
+  splitTurnSummaryRequested?: boolean;
+  qualityGuardEnabled?: boolean;
+  qualityRetriesPlanned?: number;
+  qualityRetriesUsed?: number;
+  recentTurnsPreserve: number;
+  droppedChunks?: number;
+  droppedMessages?: number;
+  droppedSummaryUsed?: boolean;
+}): CompactionStageTelemetry {
+  const qualityRetriesUsed = Math.max(0, params.qualityRetriesUsed ?? 0);
+  const entryDecision = planCompactionStage({
+    boundaryOnly: params.boundaryOnly,
+    historyPruned: params.historyPruned,
+    historySummaryRequested: params.historySummaryRequested,
+    splitTurnSummaryRequested: params.splitTurnSummaryRequested,
+    qualityRetryRequested: false,
+  });
+  const outcomeDecision = planCompactionStage({
+    boundaryOnly: params.boundaryOnly,
+    historyPruned: params.historyPruned,
+    historySummaryRequested: params.historySummaryRequested,
+    splitTurnSummaryRequested: params.splitTurnSummaryRequested,
+    qualityRetryRequested: qualityRetriesUsed > 0,
+  });
+
+  return {
+    entryStage: entryDecision.stage,
+    entryReason: entryDecision.reason,
+    outcomeStage: outcomeDecision.stage,
+    outcomeReason: outcomeDecision.reason,
+    plan: planCompactionStages({
+      boundaryOnly: params.boundaryOnly,
+      historyPruned: params.historyPruned,
+      historySummaryRequested: params.historySummaryRequested,
+      splitTurnSummaryRequested: params.splitTurnSummaryRequested,
+      qualityGuardEnabled: params.qualityGuardEnabled,
+    }),
+    historyPruned: params.historyPruned === true,
+    splitTurn: params.splitTurnSummaryRequested === true,
+    recentTurnsPreserve: resolveCompactionRecentTurnsPreserve(params.recentTurnsPreserve),
+    qualityGuardEnabled: params.qualityGuardEnabled === true,
+    qualityRetriesPlanned: Math.max(0, params.qualityRetriesPlanned ?? 0),
+    qualityRetriesUsed,
+    droppedChunks: Math.max(0, params.droppedChunks ?? 0),
+    droppedMessages: Math.max(0, params.droppedMessages ?? 0),
+    droppedSummaryUsed: params.droppedSummaryUsed === true,
+  };
+}
+
+function buildCompactionDryRunDetails(params: {
+  messages: AgentMessage[];
+  contextWindowTokens: number;
+  maxHistoryShare?: number;
+  recentTurnsPreserve?: number;
+  qualityGuardEnabled?: boolean;
+  qualityGuardMaxRetries?: number;
+}): CompactionDryRunDetails {
+  const metrics = summarizeCompactionMessages(params.messages);
+  const maxHistoryShare =
+    typeof params.maxHistoryShare === "number" && Number.isFinite(params.maxHistoryShare)
+      ? params.maxHistoryShare
+      : 0.5;
+  const recentTurnsPreserve = resolveCompactionRecentTurnsPreserve(params.recentTurnsPreserve);
+  const qualityGuardEnabled = params.qualityGuardEnabled === true;
+  const qualityRetriesPlanned = resolveCompactionQualityGuardMaxRetries(
+    params.qualityGuardMaxRetries,
+  );
+  const boundaryOnly = !containsRealConversationMessages(params.messages);
+  const pruned = boundaryOnly
+    ? null
+    : pruneHistoryForContextShare({
+        messages: params.messages,
+        maxContextTokens: params.contextWindowTokens,
+        maxHistoryShare,
+        parts: 2,
+      });
+  const historyPruned = (pruned?.droppedChunks ?? 0) > 0;
+  const historySummaryRequested = boundaryOnly
+    ? false
+    : (pruned?.messages ?? params.messages).length > 0;
+
+  return {
+    dryRun: true,
+    currentMessages: metrics.messages,
+    currentEstimatedTokens: metrics.estTokens,
+    contextWindowTokens: params.contextWindowTokens,
+    maxHistoryShare,
+    recentTurnsPreserve,
+    qualityGuardEnabled,
+    qualityRetriesPlanned,
+    topContributors: metrics.contributors,
+    stageTelemetry: buildCompactionStageTelemetry({
+      boundaryOnly,
+      historyPruned,
+      historySummaryRequested,
+      splitTurnSummaryRequested: false,
+      qualityGuardEnabled,
+      qualityRetriesPlanned,
+      recentTurnsPreserve,
+      droppedChunks: pruned?.droppedChunks,
+      droppedMessages: pruned?.droppedMessages,
+      droppedSummaryUsed: false,
+    }),
+  };
 }
 
 function normalizeObservedTokenCount(value: unknown): number | undefined {
@@ -847,6 +990,37 @@ export async function compactEmbeddedPiSessionDirect(
           );
         }
 
+        const safeguardRuntime = getCompactionSafeguardRuntime(sessionManager);
+        const dryRunDetails = buildCompactionDryRunDetails({
+          messages: session.messages,
+          contextWindowTokens: ctxInfo.tokens,
+          maxHistoryShare: safeguardRuntime?.maxHistoryShare,
+          recentTurnsPreserve: safeguardRuntime?.recentTurnsPreserve,
+          qualityGuardEnabled: safeguardRuntime?.qualityGuardEnabled,
+          qualityGuardMaxRetries: safeguardRuntime?.qualityGuardMaxRetries,
+        });
+
+        if (params.dryRun) {
+          const stageSummary = dryRunDetails.stageTelemetry.plan
+            .map((entry) => entry.stage)
+            .join(" → ");
+          log.info(
+            `[compaction] dry-run inspect — ${stageSummary || "no stages"} (sessionKey=${params.sessionKey ?? params.sessionId})`,
+          );
+          return {
+            ok: true,
+            compacted: false,
+            reason: "dry run",
+            result: {
+              summary: stageSummary,
+              firstKeptEntryId: "",
+              tokensBefore: dryRunDetails.currentEstimatedTokens ?? 0,
+              tokensAfter: dryRunDetails.currentEstimatedTokens,
+              details: dryRunDetails,
+            },
+          };
+        }
+
         if (!containsRealConversationMessages(session.messages)) {
           log.info(
             `[compaction] skipping — no real conversation messages (sessionKey=${params.sessionKey ?? params.sessionId})`,
@@ -1000,6 +1174,9 @@ export async function compactEmbeddedPiSession(
     params.enqueue ?? ((task, opts) => enqueueCommandInLane(globalLane, task, opts));
   return enqueueCommandInLane(sessionLane, () =>
     enqueueGlobal(async () => {
+      if (params.dryRun) {
+        return await compactEmbeddedPiSessionDirect(params);
+      }
       ensureRuntimePluginsLoaded({
         config: params.config,
         workspaceDir: params.workspaceDir,
@@ -1176,6 +1353,7 @@ export const __testing = {
   containsRealConversationMessages,
   estimateTokensAfterCompaction,
   buildBeforeCompactionHookMetrics,
+  buildCompactionDryRunDetails,
   runBeforeCompactionHooks,
   runAfterCompactionHooks,
   runPostCompactionSideEffects,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -40,10 +40,11 @@ import {
   isRealConversationMessage,
 } from "../compaction-real-conversation.js";
 import {
-  estimateMessagesTokens,
+  applyCompactionLightTrim,
   planCompactionStage,
   planCompactionStages,
   pruneHistoryForContextShare,
+  type CompactionLightTrimResult,
   type CompactionStageTelemetry,
 } from "../compaction.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
@@ -207,6 +208,13 @@ type CompactionDryRunDetails = {
   qualityGuardEnabled: boolean;
   qualityRetriesPlanned: number;
   topContributors: Array<{ role: string; chars: number; tool?: string }>;
+  lightTrim?: {
+    trimmedMessages: number;
+    trimmedToolResults: number;
+    tokensBefore: number;
+    tokensAfter: number;
+    tokenDelta: number;
+  };
   stageTelemetry: CompactionStageTelemetry;
 };
 
@@ -234,6 +242,9 @@ function resolveCompactionQualityGuardMaxRetries(value: unknown): number {
 
 function buildCompactionStageTelemetry(params: {
   boundaryOnly?: boolean;
+  lightTrimRequested?: boolean;
+  lightTrimmedMessages?: number;
+  lightTrimmedToolResults?: number;
   historyPruned?: boolean;
   historySummaryRequested?: boolean;
   splitTurnSummaryRequested?: boolean;
@@ -248,6 +259,7 @@ function buildCompactionStageTelemetry(params: {
   const qualityRetriesUsed = Math.max(0, params.qualityRetriesUsed ?? 0);
   const entryDecision = planCompactionStage({
     boundaryOnly: params.boundaryOnly,
+    lightTrimRequested: params.lightTrimRequested,
     historyPruned: params.historyPruned,
     historySummaryRequested: params.historySummaryRequested,
     splitTurnSummaryRequested: params.splitTurnSummaryRequested,
@@ -255,6 +267,7 @@ function buildCompactionStageTelemetry(params: {
   });
   const outcomeDecision = planCompactionStage({
     boundaryOnly: params.boundaryOnly,
+    lightTrimRequested: params.lightTrimRequested,
     historyPruned: params.historyPruned,
     historySummaryRequested: params.historySummaryRequested,
     splitTurnSummaryRequested: params.splitTurnSummaryRequested,
@@ -268,11 +281,15 @@ function buildCompactionStageTelemetry(params: {
     outcomeReason: outcomeDecision.reason,
     plan: planCompactionStages({
       boundaryOnly: params.boundaryOnly,
+      lightTrimRequested: params.lightTrimRequested,
       historyPruned: params.historyPruned,
       historySummaryRequested: params.historySummaryRequested,
       splitTurnSummaryRequested: params.splitTurnSummaryRequested,
       qualityGuardEnabled: params.qualityGuardEnabled,
     }),
+    lightTrimApplied: params.lightTrimRequested === true,
+    lightTrimmedMessages: Math.max(0, params.lightTrimmedMessages ?? 0),
+    lightTrimmedToolResults: Math.max(0, params.lightTrimmedToolResults ?? 0),
     historyPruned: params.historyPruned === true,
     splitTurn: params.splitTurnSummaryRequested === true,
     recentTurnsPreserve: resolveCompactionRecentTurnsPreserve(params.recentTurnsPreserve),
@@ -312,10 +329,16 @@ function buildCompactionDryRunDetails(params: {
         maxHistoryShare,
         parts: 2,
       });
+  const lightTrim: CompactionLightTrimResult | null = boundaryOnly
+    ? null
+    : applyCompactionLightTrim({
+        messages: pruned?.messages ?? params.messages,
+        contextWindowTokens: params.contextWindowTokens,
+      });
   const historyPruned = (pruned?.droppedChunks ?? 0) > 0;
   const historySummaryRequested = boundaryOnly
     ? false
-    : (pruned?.messages ?? params.messages).length > 0;
+    : (lightTrim?.messages ?? pruned?.messages ?? params.messages).length > 0;
 
   return {
     dryRun: true,
@@ -327,8 +350,20 @@ function buildCompactionDryRunDetails(params: {
     qualityGuardEnabled,
     qualityRetriesPlanned,
     topContributors: metrics.contributors,
+    lightTrim: lightTrim?.applied
+      ? {
+          trimmedMessages: lightTrim.trimmedMessages,
+          trimmedToolResults: lightTrim.trimmedToolResults,
+          tokensBefore: lightTrim.tokensBefore,
+          tokensAfter: lightTrim.tokensAfter,
+          tokenDelta: lightTrim.tokenDelta,
+        }
+      : undefined,
     stageTelemetry: buildCompactionStageTelemetry({
       boundaryOnly,
+      lightTrimRequested: lightTrim?.applied,
+      lightTrimmedMessages: lightTrim?.trimmedMessages,
+      lightTrimmedToolResults: lightTrim?.trimmedToolResults,
       historyPruned,
       historySummaryRequested,
       splitTurnSummaryRequested: false,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -930,6 +930,7 @@ export async function compactEmbeddedPiSessionDirect(
           summaryLength: typeof result.summary === "string" ? result.summary.length : undefined,
           tokensBefore: result.tokensBefore,
           firstKeptEntryId: result.firstKeptEntryId,
+          details: result.details,
         });
         // Truncate session file to remove compacted entries (#39953)
         if (params.config?.agents?.defaults?.compaction?.truncateAfterCompaction) {

--- a/src/agents/pi-embedded-runner/compaction-hooks.ts
+++ b/src/agents/pi-embedded-runner/compaction-hooks.ts
@@ -5,26 +5,9 @@ import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { getActiveMemorySearchManager } from "../../plugins/memory-runtime.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
+import { extractCompactionStageTelemetry } from "../compaction.js";
 import { resolveMemorySearchConfig } from "../memory-search.js";
 import { log } from "./logger.js";
-
-function extractCompactionStageTelemetry(
-  details: unknown,
-): { outcomeStage?: string; outcomeReason?: string } | undefined {
-  if (!details || typeof details !== "object") {
-    return undefined;
-  }
-  const telemetry = (details as { stageTelemetry?: unknown }).stageTelemetry;
-  if (!telemetry || typeof telemetry !== "object") {
-    return undefined;
-  }
-  const candidate = telemetry as { outcomeStage?: unknown; outcomeReason?: unknown };
-  return {
-    outcomeStage: typeof candidate.outcomeStage === "string" ? candidate.outcomeStage : undefined,
-    outcomeReason:
-      typeof candidate.outcomeReason === "string" ? candidate.outcomeReason : undefined,
-  };
-}
 
 function resolvePostCompactionIndexSyncMode(config?: OpenClawConfig): "off" | "async" | "await" {
   const mode = config?.agents?.defaults?.compaction?.postIndexSync;
@@ -292,8 +275,11 @@ export async function runAfterCompactionHooks(params: {
       tokensBefore: params.tokensBefore,
       tokensAfter: params.tokensAfter,
       firstKeptEntryId: params.firstKeptEntryId,
+      compactionEntryStage: stageTelemetry?.entryStage,
+      compactionEntryReason: stageTelemetry?.entryReason,
       compactionStage: stageTelemetry?.outcomeStage,
       compactionReason: stageTelemetry?.outcomeReason,
+      compactionStageTelemetry: stageTelemetry,
     });
     await triggerInternalHook(hookEvent);
   } catch (err) {

--- a/src/agents/pi-embedded-runner/compaction-hooks.ts
+++ b/src/agents/pi-embedded-runner/compaction-hooks.ts
@@ -8,6 +8,24 @@ import { resolveSessionAgentId } from "../agent-scope.js";
 import { resolveMemorySearchConfig } from "../memory-search.js";
 import { log } from "./logger.js";
 
+function extractCompactionStageTelemetry(
+  details: unknown,
+): { outcomeStage?: string; outcomeReason?: string } | undefined {
+  if (!details || typeof details !== "object") {
+    return undefined;
+  }
+  const telemetry = (details as { stageTelemetry?: unknown }).stageTelemetry;
+  if (!telemetry || typeof telemetry !== "object") {
+    return undefined;
+  }
+  const candidate = telemetry as { outcomeStage?: unknown; outcomeReason?: unknown };
+  return {
+    outcomeStage: typeof candidate.outcomeStage === "string" ? candidate.outcomeStage : undefined,
+    outcomeReason:
+      typeof candidate.outcomeReason === "string" ? candidate.outcomeReason : undefined,
+  };
+}
+
 function resolvePostCompactionIndexSyncMode(config?: OpenClawConfig): "off" | "async" | "await" {
   const mode = config?.agents?.defaults?.compaction?.postIndexSync;
   if (mode === "off" || mode === "async" || mode === "await") {
@@ -260,8 +278,10 @@ export async function runAfterCompactionHooks(params: {
   summaryLength?: number;
   tokensBefore?: number;
   firstKeptEntryId?: string;
+  details?: unknown;
 }) {
   try {
+    const stageTelemetry = extractCompactionStageTelemetry(params.details);
     const hookEvent = createInternalHookEvent("session", "compact:after", params.hookSessionKey, {
       sessionId: params.sessionId,
       missingSessionKey: params.missingSessionKey,
@@ -272,6 +292,8 @@ export async function runAfterCompactionHooks(params: {
       tokensBefore: params.tokensBefore,
       tokensAfter: params.tokensAfter,
       firstKeptEntryId: params.firstKeptEntryId,
+      compactionStage: stageTelemetry?.outcomeStage,
+      compactionReason: stageTelemetry?.outcomeReason,
     });
     await triggerInternalHook(hookEvent);
   } catch (err) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -695,34 +695,7 @@ export async function runEmbeddedAttempt(
       contextFiles,
       memoryCitationsMode: params.config?.memory?.citations,
     });
-    const systemPromptReport = buildSystemPromptReport({
-      source: "run",
-      generatedAt: Date.now(),
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      provider: params.provider,
-      model: params.modelId,
-      workspaceDir: effectiveWorkspace,
-      bootstrapMaxChars,
-      bootstrapTotalMaxChars,
-      bootstrapTruncation: buildBootstrapTruncationReportMeta({
-        analysis: bootstrapAnalysis,
-        warningMode: bootstrapPromptWarningMode,
-        warning: bootstrapPromptWarning,
-      }),
-      sandbox: (() => {
-        const runtime = resolveSandboxRuntimeStatus({
-          cfg: params.config,
-          sessionKey: sandboxSessionKey,
-        });
-        return { mode: runtime.mode, sandboxed: runtime.sandboxed };
-      })(),
-      systemPrompt: appendPrompt,
-      bootstrapFiles: hookAdjustedBootstrapFiles,
-      injectedFiles: contextFiles,
-      skillsPrompt,
-      tools: effectiveTools,
-    });
+    let systemPromptReport: ReturnType<typeof buildSystemPromptReport> | undefined;
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
     let systemPromptText = systemPromptOverride();
 
@@ -1545,6 +1518,36 @@ export async function runEmbeddedAttempt(
         }
         const transcriptLeafId =
           (sessionManager.getLeafEntry() as { id?: string } | null | undefined)?.id ?? null;
+        systemPromptReport = buildSystemPromptReport({
+          source: "run",
+          generatedAt: Date.now(),
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          sourceRunId: params.runId,
+          ...(transcriptLeafId ? { sourceMessageId: transcriptLeafId } : {}),
+          provider: params.provider,
+          model: params.modelId,
+          workspaceDir: effectiveWorkspace,
+          bootstrapMaxChars,
+          bootstrapTotalMaxChars,
+          bootstrapTruncation: buildBootstrapTruncationReportMeta({
+            analysis: bootstrapAnalysis,
+            warningMode: bootstrapPromptWarningMode,
+            warning: bootstrapPromptWarning,
+          }),
+          sandbox: (() => {
+            const runtime = resolveSandboxRuntimeStatus({
+              cfg: params.config,
+              sessionKey: sandboxSessionKey,
+            });
+            return { mode: runtime.mode, sandboxed: runtime.sandboxed };
+          })(),
+          systemPrompt: systemPromptText,
+          bootstrapFiles: hookAdjustedBootstrapFiles,
+          injectedFiles: contextFiles,
+          skillsPrompt,
+          tools: effectiveTools,
+        });
 
         try {
           // Idempotent cleanup for legacy sessions with persisted image payloads.

--- a/src/agents/pi-hooks/compaction-safeguard.test.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.test.ts
@@ -173,6 +173,7 @@ async function runCompactionScenario(params: {
       summary: string;
       firstKeptEntryId: string;
       tokensBefore: number;
+      details?: unknown;
     };
   };
   return { result, getApiKeyAndHeadersMock };
@@ -184,6 +185,7 @@ function expectCompactionResult(result: {
     summary: string;
     firstKeptEntryId: string;
     tokensBefore: number;
+    details?: unknown;
   };
 }) {
   expect(result.cancel).not.toBe(true);
@@ -1279,6 +1281,17 @@ describe("compaction-safeguard recent-turn preservation", () => {
     );
     expect(droppedCall?.customInstructions).toContain("## Decisions");
     expect(droppedCall?.customInstructions).toContain("Keep security caveats.");
+    expect(result.compaction?.details).toMatchObject({
+      stageTelemetry: {
+        entryStage: "prune_history",
+        outcomeStage: "prune_history",
+        droppedSummaryUsed: true,
+      },
+    });
+    expect(
+      (result.compaction?.details as { stageTelemetry?: { droppedChunks?: number } })
+        ?.stageTelemetry?.droppedChunks ?? 0,
+    ).toBeGreaterThan(0);
   });
 
   it("does not retry summaries unless quality guard is explicitly enabled", async () => {
@@ -1417,6 +1430,14 @@ describe("compaction-safeguard recent-turn preservation", () => {
     const secondCall = mockSummarizeInStages.mock.calls[1]?.[0];
     expect(secondCall?.customInstructions).toContain("Quality check feedback");
     expect(secondCall?.customInstructions).toContain("missing_section:## Decisions");
+    expect(result.compaction?.details).toMatchObject({
+      stageTelemetry: {
+        entryStage: "summarize_history",
+        outcomeStage: "quality_retry",
+        qualityRetriesPlanned: 1,
+        qualityRetriesUsed: 1,
+      },
+    });
   });
 
   it("does not treat preserved latest asks as satisfying overlap checks", async () => {
@@ -1720,6 +1741,14 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(compaction.summary).toContain("## Open TODOs");
     expect(compaction.firstKeptEntryId).toBe("entry-1");
     expect(compaction.tokensBefore).toBe(1500);
+    expect(compaction.details).toMatchObject({
+      stageTelemetry: {
+        entryStage: "boundary",
+        outcomeStage: "boundary",
+        entryReason: "no_real_messages",
+        outcomeReason: "no_real_messages",
+      },
+    });
     expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
   });
 

--- a/src/agents/pi-hooks/compaction-safeguard.test.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.test.ts
@@ -1342,6 +1342,90 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
   });
 
+  it("records light trim telemetry when older oversized tool results are softened before summarization", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(
+      [
+        "## Decisions",
+        "Keep current flow.",
+        "## Open TODOs",
+        "None.",
+        "## Constraints/Rules",
+        "Follow rules.",
+        "## Pending user asks",
+        "Summarize the command output.",
+        "## Exact identifiers",
+        "call_123",
+      ].join("\n"),
+    );
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      recentTurnsPreserve: 0,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock,
+    });
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "Summarize the command output.", timestamp: 1 },
+          {
+            role: "toolResult",
+            toolCallId: "call_123",
+            toolName: "exec",
+            content: [{ type: "text", text: "A".repeat(8_000) }],
+            timestamp: 2,
+          } as unknown as AgentMessage,
+          { role: "assistant", content: "Done.", timestamp: 3 } as unknown as AgentMessage,
+        ],
+        turnPrefixMessages: [],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: {
+          read: [],
+          edited: [],
+          written: [],
+        },
+        settings: { reserveTokens: 4_000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: {
+        summary?: string;
+        details?: {
+          lightTrim?: { trimmedToolResults?: number; tokenDelta?: number };
+          stageTelemetry?: { entryStage?: string; lightTrimApplied?: boolean; plan?: unknown[] };
+        };
+      };
+    };
+
+    expect(result.cancel).not.toBe(true);
+    expect(result.compaction?.details?.lightTrim).toMatchObject({
+      trimmedToolResults: 1,
+    });
+    expect((result.compaction?.details?.lightTrim?.tokenDelta ?? 0) > 0).toBe(true);
+    expect(result.compaction?.details?.stageTelemetry).toMatchObject({
+      entryStage: "light_trim",
+      lightTrimApplied: true,
+    });
+    expect(result.compaction?.details?.stageTelemetry?.plan).toEqual(
+      expect.arrayContaining([{ stage: "light_trim", reason: "oversized_tool_results_present" }]),
+    );
+  });
+
   it("retries when generated summary misses headings even if preserved turns contain them", async () => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages

--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -15,11 +15,10 @@ import {
   SAFETY_MARGIN,
   SUMMARIZATION_OVERHEAD_TOKENS,
   applyCompactionLightTrim,
+  buildCompactionStageTelemetry,
   computeAdaptiveChunkRatio,
   estimateMessagesTokens,
   isOversizedForSummary,
-  planCompactionStage,
-  planCompactionStages,
   pruneHistoryForContextShare,
   resolveContextWindowTokens,
   summarizeInStages,
@@ -558,68 +557,6 @@ async function readWorkspaceContextForSummary(): Promise<string> {
   } catch {
     return "";
   }
-}
-
-function buildCompactionStageTelemetry(params: {
-  boundaryOnly?: boolean;
-  lightTrimRequested?: boolean;
-  lightTrimmedMessages?: number;
-  lightTrimmedToolResults?: number;
-  historyPruned?: boolean;
-  historySummaryRequested?: boolean;
-  splitTurnSummaryRequested?: boolean;
-  qualityGuardEnabled?: boolean;
-  qualityRetriesPlanned?: number;
-  qualityRetriesUsed?: number;
-  recentTurnsPreserve: number;
-  droppedChunks?: number;
-  droppedMessages?: number;
-  droppedSummaryUsed?: boolean;
-}) {
-  const qualityRetriesUsed = Math.max(0, params.qualityRetriesUsed ?? 0);
-  const entryDecision = planCompactionStage({
-    boundaryOnly: params.boundaryOnly,
-    lightTrimRequested: params.lightTrimRequested,
-    historyPruned: params.historyPruned,
-    historySummaryRequested: params.historySummaryRequested,
-    splitTurnSummaryRequested: params.splitTurnSummaryRequested,
-    qualityRetryRequested: false,
-  });
-  const outcomeDecision = planCompactionStage({
-    boundaryOnly: params.boundaryOnly,
-    lightTrimRequested: params.lightTrimRequested,
-    historyPruned: params.historyPruned,
-    historySummaryRequested: params.historySummaryRequested,
-    splitTurnSummaryRequested: params.splitTurnSummaryRequested,
-    qualityRetryRequested: qualityRetriesUsed > 0,
-  });
-
-  return {
-    entryStage: entryDecision.stage,
-    entryReason: entryDecision.reason,
-    outcomeStage: outcomeDecision.stage,
-    outcomeReason: outcomeDecision.reason,
-    plan: planCompactionStages({
-      boundaryOnly: params.boundaryOnly,
-      lightTrimRequested: params.lightTrimRequested,
-      historyPruned: params.historyPruned,
-      historySummaryRequested: params.historySummaryRequested,
-      splitTurnSummaryRequested: params.splitTurnSummaryRequested,
-      qualityGuardEnabled: params.qualityGuardEnabled,
-    }),
-    lightTrimApplied: params.lightTrimRequested === true,
-    lightTrimmedMessages: Math.max(0, params.lightTrimmedMessages ?? 0),
-    lightTrimmedToolResults: Math.max(0, params.lightTrimmedToolResults ?? 0),
-    historyPruned: params.historyPruned === true,
-    splitTurn: params.splitTurnSummaryRequested === true,
-    recentTurnsPreserve: resolveRecentTurnsPreserve(params.recentTurnsPreserve),
-    qualityGuardEnabled: params.qualityGuardEnabled === true,
-    qualityRetriesPlanned: Math.max(0, params.qualityRetriesPlanned ?? 0),
-    qualityRetriesUsed,
-    droppedChunks: Math.max(0, params.droppedChunks ?? 0),
-    droppedMessages: Math.max(0, params.droppedMessages ?? 0),
-    droppedSummaryUsed: params.droppedSummaryUsed === true,
-  };
 }
 
 export default function compactionSafeguardExtension(api: ExtensionAPI): void {

--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -14,6 +14,7 @@ import {
   MIN_CHUNK_RATIO,
   SAFETY_MARGIN,
   SUMMARIZATION_OVERHEAD_TOKENS,
+  applyCompactionLightTrim,
   computeAdaptiveChunkRatio,
   estimateMessagesTokens,
   isOversizedForSummary,
@@ -561,6 +562,9 @@ async function readWorkspaceContextForSummary(): Promise<string> {
 
 function buildCompactionStageTelemetry(params: {
   boundaryOnly?: boolean;
+  lightTrimRequested?: boolean;
+  lightTrimmedMessages?: number;
+  lightTrimmedToolResults?: number;
   historyPruned?: boolean;
   historySummaryRequested?: boolean;
   splitTurnSummaryRequested?: boolean;
@@ -575,6 +579,7 @@ function buildCompactionStageTelemetry(params: {
   const qualityRetriesUsed = Math.max(0, params.qualityRetriesUsed ?? 0);
   const entryDecision = planCompactionStage({
     boundaryOnly: params.boundaryOnly,
+    lightTrimRequested: params.lightTrimRequested,
     historyPruned: params.historyPruned,
     historySummaryRequested: params.historySummaryRequested,
     splitTurnSummaryRequested: params.splitTurnSummaryRequested,
@@ -582,6 +587,7 @@ function buildCompactionStageTelemetry(params: {
   });
   const outcomeDecision = planCompactionStage({
     boundaryOnly: params.boundaryOnly,
+    lightTrimRequested: params.lightTrimRequested,
     historyPruned: params.historyPruned,
     historySummaryRequested: params.historySummaryRequested,
     splitTurnSummaryRequested: params.splitTurnSummaryRequested,
@@ -595,11 +601,15 @@ function buildCompactionStageTelemetry(params: {
     outcomeReason: outcomeDecision.reason,
     plan: planCompactionStages({
       boundaryOnly: params.boundaryOnly,
+      lightTrimRequested: params.lightTrimRequested,
       historyPruned: params.historyPruned,
       historySummaryRequested: params.historySummaryRequested,
       splitTurnSummaryRequested: params.splitTurnSummaryRequested,
       qualityGuardEnabled: params.qualityGuardEnabled,
     }),
+    lightTrimApplied: params.lightTrimRequested === true,
+    lightTrimmedMessages: Math.max(0, params.lightTrimmedMessages ?? 0),
+    lightTrimmedToolResults: Math.max(0, params.lightTrimmedToolResults ?? 0),
     historyPruned: params.historyPruned === true,
     splitTurn: params.splitTurnSummaryRequested === true,
     recentTurnsPreserve: resolveRecentTurnsPreserve(params.recentTurnsPreserve),
@@ -832,7 +842,11 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         messages: messagesToSummarize,
         recentTurnsPreserve,
       });
-      messagesToSummarize = summaryTargetMessages;
+      const lightTrim = applyCompactionLightTrim({
+        messages: summaryTargetMessages,
+        contextWindowTokens,
+      });
+      messagesToSummarize = lightTrim.messages;
       const historySummaryRequested = messagesToSummarize.length > 0;
       const splitTurnSummaryRequested = preparation.isSplitTurn && turnPrefixMessages.length > 0;
       const preservedTurnsSection = formatPreservedTurnsSection(preservedRecentMessages);
@@ -994,6 +1008,9 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
 
       const qualityRetriesUsed = Math.max(0, summarizationAttemptsUsed - 1);
       const stageTelemetry = buildCompactionStageTelemetry({
+        lightTrimRequested: lightTrim.applied,
+        lightTrimmedMessages: lightTrim.trimmedMessages,
+        lightTrimmedToolResults: lightTrim.trimmedToolResults,
         historyPruned: droppedChunks > 0,
         historySummaryRequested,
         splitTurnSummaryRequested,
@@ -1011,7 +1028,20 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           summary,
           firstKeptEntryId: preparation.firstKeptEntryId,
           tokensBefore: preparation.tokensBefore,
-          details: { readFiles, modifiedFiles, stageTelemetry },
+          details: {
+            readFiles,
+            modifiedFiles,
+            lightTrim: lightTrim.applied
+              ? {
+                  trimmedMessages: lightTrim.trimmedMessages,
+                  trimmedToolResults: lightTrim.trimmedToolResults,
+                  tokensBefore: lightTrim.tokensBefore,
+                  tokensAfter: lightTrim.tokensAfter,
+                  tokenDelta: lightTrim.tokenDelta,
+                }
+              : undefined,
+            stageTelemetry,
+          },
         },
       };
     } catch (error) {

--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -17,6 +17,8 @@ import {
   computeAdaptiveChunkRatio,
   estimateMessagesTokens,
   isOversizedForSummary,
+  planCompactionStage,
+  planCompactionStages,
   pruneHistoryForContextShare,
   resolveContextWindowTokens,
   summarizeInStages,
@@ -557,6 +559,59 @@ async function readWorkspaceContextForSummary(): Promise<string> {
   }
 }
 
+function buildCompactionStageTelemetry(params: {
+  boundaryOnly?: boolean;
+  historyPruned?: boolean;
+  historySummaryRequested?: boolean;
+  splitTurnSummaryRequested?: boolean;
+  qualityGuardEnabled?: boolean;
+  qualityRetriesPlanned?: number;
+  qualityRetriesUsed?: number;
+  recentTurnsPreserve: number;
+  droppedChunks?: number;
+  droppedMessages?: number;
+  droppedSummaryUsed?: boolean;
+}) {
+  const qualityRetriesUsed = Math.max(0, params.qualityRetriesUsed ?? 0);
+  const entryDecision = planCompactionStage({
+    boundaryOnly: params.boundaryOnly,
+    historyPruned: params.historyPruned,
+    historySummaryRequested: params.historySummaryRequested,
+    splitTurnSummaryRequested: params.splitTurnSummaryRequested,
+    qualityRetryRequested: false,
+  });
+  const outcomeDecision = planCompactionStage({
+    boundaryOnly: params.boundaryOnly,
+    historyPruned: params.historyPruned,
+    historySummaryRequested: params.historySummaryRequested,
+    splitTurnSummaryRequested: params.splitTurnSummaryRequested,
+    qualityRetryRequested: qualityRetriesUsed > 0,
+  });
+
+  return {
+    entryStage: entryDecision.stage,
+    entryReason: entryDecision.reason,
+    outcomeStage: outcomeDecision.stage,
+    outcomeReason: outcomeDecision.reason,
+    plan: planCompactionStages({
+      boundaryOnly: params.boundaryOnly,
+      historyPruned: params.historyPruned,
+      historySummaryRequested: params.historySummaryRequested,
+      splitTurnSummaryRequested: params.splitTurnSummaryRequested,
+      qualityGuardEnabled: params.qualityGuardEnabled,
+    }),
+    historyPruned: params.historyPruned === true,
+    splitTurn: params.splitTurnSummaryRequested === true,
+    recentTurnsPreserve: resolveRecentTurnsPreserve(params.recentTurnsPreserve),
+    qualityGuardEnabled: params.qualityGuardEnabled === true,
+    qualityRetriesPlanned: Math.max(0, params.qualityRetriesPlanned ?? 0),
+    qualityRetriesUsed,
+    droppedChunks: Math.max(0, params.droppedChunks ?? 0),
+    droppedMessages: Math.max(0, params.droppedMessages ?? 0),
+    droppedSummaryUsed: params.droppedSummaryUsed === true,
+  };
+}
+
 export default function compactionSafeguardExtension(api: ExtensionAPI): void {
   api.on("session_before_compact", async (event, ctx) => {
     const { preparation, customInstructions: eventInstructions, signal } = event;
@@ -567,6 +622,14 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       isRealConversationMessage(message, messages, index),
     );
     setCompactionSafeguardCancelReason(ctx.sessionManager, undefined);
+    const { readFiles, modifiedFiles } = computeFileLists(preparation.fileOps);
+
+    // Model resolution: ctx.model is undefined in compact.ts workflow (extensionRunner.initialize() is never called).
+    // Fall back to runtime.model which is explicitly passed when building extension paths.
+    const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
+    const recentTurnsPreserve = resolveRecentTurnsPreserve(runtime?.recentTurnsPreserve);
+    const qualityGuardEnabled = runtime?.qualityGuardEnabled ?? false;
+    const qualityGuardMaxRetries = resolveQualityGuardMaxRetries(runtime?.qualityGuardMaxRetries);
     if (!hasRealSummarizable && !hasRealTurnPrefix) {
       // When there are no summarizable messages AND no real turn-prefix content,
       // cancelling compaction leaves context unchanged but the SDK re-triggers
@@ -589,10 +652,19 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           summary: fallbackSummary,
           firstKeptEntryId: preparation.firstKeptEntryId,
           tokensBefore: preparation.tokensBefore,
+          details: {
+            readFiles,
+            modifiedFiles,
+            stageTelemetry: buildCompactionStageTelemetry({
+              boundaryOnly: true,
+              recentTurnsPreserve,
+              qualityGuardEnabled,
+              qualityRetriesPlanned: qualityGuardMaxRetries,
+            }),
+          },
         },
       };
     }
-    const { readFiles, modifiedFiles } = computeFileLists(preparation.fileOps);
     const fileOpsSummary = formatFileOperations(readFiles, modifiedFiles);
     const toolFailures = collectToolFailures([
       ...preparation.messagesToSummarize,
@@ -600,9 +672,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     ]);
     const toolFailureSection = formatToolFailuresSection(toolFailures);
 
-    // Model resolution: ctx.model is undefined in compact.ts workflow (extensionRunner.initialize() is never called).
-    // Fall back to runtime.model which is explicitly passed when building extension paths.
-    const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
     const customInstructions = resolveCompactionInstructions(
       eventInstructions,
       runtime?.customInstructions,
@@ -677,9 +746,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       const contextWindowTokens = runtime?.contextWindowTokens ?? modelContextWindow;
       const turnPrefixMessages = preparation.turnPrefixMessages ?? [];
       let messagesToSummarize = preparation.messagesToSummarize;
-      const recentTurnsPreserve = resolveRecentTurnsPreserve(runtime?.recentTurnsPreserve);
-      const qualityGuardEnabled = runtime?.qualityGuardEnabled ?? false;
-      const qualityGuardMaxRetries = resolveQualityGuardMaxRetries(runtime?.qualityGuardMaxRetries);
       const structuredInstructions = buildCompactionStructureInstructions(
         customInstructions,
         summarizationInstructions,
@@ -693,6 +759,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           : undefined;
 
       let droppedSummary: string | undefined;
+      let droppedChunks = 0;
+      let droppedMessages = 0;
 
       if (tokensBefore !== undefined) {
         const summarizableTokens =
@@ -709,6 +777,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
             parts: 2,
           });
           if (pruned.droppedChunks > 0) {
+            droppedChunks = pruned.droppedChunks;
+            droppedMessages = pruned.droppedMessages;
             const newContentRatio = (newContentTokens / contextWindowTokens) * 100;
             log.warn(
               `Compaction safeguard: new content uses ${newContentRatio.toFixed(
@@ -763,6 +833,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         recentTurnsPreserve,
       });
       messagesToSummarize = summaryTargetMessages;
+      const historySummaryRequested = messagesToSummarize.length > 0;
+      const splitTurnSummaryRequested = preparation.isSplitTurn && turnPrefixMessages.length > 0;
       const preservedTurnsSection = formatPreservedTurnsSection(preservedRecentMessages);
       const latestUserAsk = extractLatestUserAsk([...messagesToSummarize, ...turnPrefixMessages]);
       const identifierSeedText = [...messagesToSummarize, ...turnPrefixMessages]
@@ -793,8 +865,10 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       let currentInstructions = structuredInstructions;
       const totalAttempts = qualityGuardEnabled ? qualityGuardMaxRetries + 1 : 1;
       let lastSuccessfulSummary: string | null = null;
+      let summarizationAttemptsUsed = 0;
 
       for (let attempt = 0; attempt < totalAttempts; attempt += 1) {
+        summarizationAttemptsUsed = attempt + 1;
         let summaryWithoutPreservedTurns = "";
         let summaryWithPreservedTurns = "";
         let splitTurnSection = "";
@@ -918,12 +992,26 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       const bodyToCap = lastHistorySummary || summary;
       summary = capCompactionSummaryPreservingSuffix(bodyToCap, normalizedSuffix ?? "");
 
+      const qualityRetriesUsed = Math.max(0, summarizationAttemptsUsed - 1);
+      const stageTelemetry = buildCompactionStageTelemetry({
+        historyPruned: droppedChunks > 0,
+        historySummaryRequested,
+        splitTurnSummaryRequested,
+        qualityGuardEnabled,
+        qualityRetriesPlanned: qualityGuardMaxRetries,
+        qualityRetriesUsed,
+        recentTurnsPreserve,
+        droppedChunks,
+        droppedMessages,
+        droppedSummaryUsed: Boolean(droppedSummary),
+      });
+
       return {
         compaction: {
           summary,
           firstKeptEntryId: preparation.firstKeptEntryId,
           tokensBefore: preparation.tokensBefore,
-          details: { readFiles, modifiedFiles },
+          details: { readFiles, modifiedFiles, stageTelemetry },
         },
       };
     } catch (error) {

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -492,6 +492,22 @@ describe("provider attribution", () => {
       supportsResponsesStoreField: true,
       shouldStripResponsesPromptCache: true,
     });
+
+    expect(
+      resolveProviderRequestCapabilities({
+        provider: "openai-gpt",
+        api: "openai-responses",
+        baseUrl: "https://aigateway.chat/v1",
+        capability: "llm",
+        transport: "stream",
+      }),
+    ).toMatchObject({
+      endpointClass: "custom",
+      allowsOpenAIServiceTier: false,
+      allowsResponsesStore: false,
+      supportsResponsesStoreField: true,
+      shouldStripResponsesPromptCache: false,
+    });
   });
 
   it("resolves shared compat families and native streaming-usage gates", () => {

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -112,6 +112,7 @@ const MODELSTUDIO_NATIVE_BASE_URLS = new Set([
 ]);
 const OPENAI_RESPONSES_APIS = new Set(["openai-responses", "azure-openai-responses"]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai", "azure-openai-responses"]);
+const OPENAI_RESPONSES_PROMPT_CACHE_COMPAT_HOSTS = new Set(["aigateway.chat"]);
 const MOONSHOT_COMPAT_PROVIDERS = new Set(["moonshot", "kimi"]);
 
 function formatOpenClawUserAgent(version: string): string {
@@ -496,6 +497,9 @@ export function resolveProviderRequestCapabilities(
   const api = input.api?.trim().toLowerCase();
   const normalizedModelId = input.modelId?.trim().toLowerCase();
   const endpointClass = policy.endpointClass;
+  const endpointHost = resolveProviderEndpoint(input.baseUrl).hostname;
+  const allowsCompatPromptCacheHost =
+    endpointHost !== undefined && OPENAI_RESPONSES_PROMPT_CACHE_COMPAT_HOSTS.has(endpointHost);
   const isKnownNativeEndpoint =
     endpointClass === "anthropic-public" ||
     endpointClass === "github-copilot-native" ||
@@ -543,7 +547,10 @@ export function resolveProviderRequestCapabilities(
       OPENAI_RESPONSES_PROVIDERS.has(provider) &&
       policy.usesKnownNativeOpenAIEndpoint,
     shouldStripResponsesPromptCache:
-      api !== undefined && OPENAI_RESPONSES_APIS.has(api) && policy.usesExplicitProxyLikeEndpoint,
+      api !== undefined &&
+      OPENAI_RESPONSES_APIS.has(api) &&
+      policy.usesExplicitProxyLikeEndpoint &&
+      !allowsCompatPromptCacheHost,
     supportsNativeStreamingUsageCompat:
       (provider === "moonshot" && endpointClass === "moonshot-native") ||
       (provider === "modelstudio" && endpointClass === "modelstudio-native"),

--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -19,10 +19,14 @@ describe("buildSystemPromptReport", () => {
     injectedContent: string;
     bootstrapMaxChars?: number;
     bootstrapTotalMaxChars?: number;
+    sourceRunId?: string;
+    sourceMessageId?: string;
   }) =>
     buildSystemPromptReport({
       source: "run",
       generatedAt: 0,
+      sourceRunId: params.sourceRunId,
+      sourceMessageId: params.sourceMessageId,
       bootstrapMaxChars: params.bootstrapMaxChars ?? 20_000,
       bootstrapTotalMaxChars: params.bootstrapTotalMaxChars,
       systemPrompt: "system",
@@ -82,7 +86,7 @@ describe("buildSystemPromptReport", () => {
     expect(report.bootstrapTotalMaxChars).toBe(22_222);
   });
 
-  it("includes prompt hash, tracked totals, and truncation severity", () => {
+  it("includes prompt hash, tracked totals, truncation severity, and run snapshot ids", () => {
     const file = makeBootstrapFile({
       path: "/tmp/workspace/policies/AGENTS.md",
       content: "abcdefghijklmnopqrstuvwxyz",
@@ -91,8 +95,12 @@ describe("buildSystemPromptReport", () => {
       file,
       injectedPath: "/tmp/workspace/policies/AGENTS.md",
       injectedContent: "trimmed",
+      sourceRunId: "run-a2",
+      sourceMessageId: "leaf-123",
     });
 
+    expect(report.sourceRunId).toBe("run-a2");
+    expect(report.sourceMessageId).toBe("leaf-123");
     expect(report.promptHash).toMatch(/^[a-f0-9]{12}$/);
     expect(report.tracked?.chars).toBeGreaterThan(report.systemPrompt.chars - 1);
     expect(report.tracked?.estimatedTokens).toBeGreaterThan(0);

--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -82,6 +82,24 @@ describe("buildSystemPromptReport", () => {
     expect(report.bootstrapTotalMaxChars).toBe(22_222);
   });
 
+  it("includes prompt hash, tracked totals, and truncation severity", () => {
+    const file = makeBootstrapFile({
+      path: "/tmp/workspace/policies/AGENTS.md",
+      content: "abcdefghijklmnopqrstuvwxyz",
+    });
+    const report = makeReport({
+      file,
+      injectedPath: "/tmp/workspace/policies/AGENTS.md",
+      injectedContent: "trimmed",
+    });
+
+    expect(report.promptHash).toMatch(/^[a-f0-9]{12}$/);
+    expect(report.tracked?.chars).toBeGreaterThan(report.systemPrompt.chars - 1);
+    expect(report.tracked?.estimatedTokens).toBeGreaterThan(0);
+    expect(report.tracked?.largestContributors.length).toBeGreaterThan(0);
+    expect(report.truncationSeverity).toBe("low");
+  });
+
   it("reports injectedChars=0 when injected file does not match by path or basename", () => {
     const file = makeBootstrapFile({ path: "/tmp/workspace/policies/AGENTS.md" });
     const report = makeReport({

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -101,6 +101,8 @@ export function buildSystemPromptReport(params: {
   generatedAt: number;
   sessionId?: string;
   sessionKey?: string;
+  sourceRunId?: string;
+  sourceMessageId?: string;
   provider?: string;
   model?: string;
   workspaceDir?: string;
@@ -161,6 +163,8 @@ export function buildSystemPromptReport(params: {
     generatedAt: params.generatedAt,
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
+    sourceRunId: params.sourceRunId,
+    sourceMessageId: params.sourceMessageId,
     provider: params.provider,
     model: params.model,
     workspaceDir: params.workspaceDir,

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -1,5 +1,7 @@
+import { createHash } from "node:crypto";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import type { SessionSystemPromptReport } from "../config/sessions/types.js";
+import { estimateTokensFromChars } from "../utils/cjk-chars.js";
 import { buildBootstrapInjectionStats } from "./bootstrap-budget.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
@@ -77,6 +79,23 @@ function extractToolListText(systemPrompt: string): string {
   return extracted.text.replace(markerA, "").trim();
 }
 
+function resolveTruncationSeverity(params: {
+  truncatedFiles: number;
+  nearLimitFiles?: number;
+  totalNearLimit?: boolean;
+}): NonNullable<SessionSystemPromptReport["truncationSeverity"]> {
+  if (params.truncatedFiles <= 0 && !params.totalNearLimit && (params.nearLimitFiles ?? 0) <= 0) {
+    return "none";
+  }
+  if (params.truncatedFiles >= 5 || (params.nearLimitFiles ?? 0) >= 5) {
+    return "high";
+  }
+  if (params.truncatedFiles >= 2 || params.totalNearLimit || (params.nearLimitFiles ?? 0) >= 2) {
+    return "medium";
+  }
+  return "low";
+}
+
 export function buildSystemPromptReport(params: {
   source: SessionSystemPromptReport["source"];
   generatedAt: number;
@@ -107,6 +126,35 @@ export function buildSystemPromptReport(params: {
   const toolsEntries = buildToolsEntries(params.tools);
   const toolsSchemaChars = toolsEntries.reduce((sum, t) => sum + (t.schemaChars ?? 0), 0);
   const skillsEntries = parseSkillBlocks(params.skillsPrompt);
+  const trackedChars = systemPrompt.length + toolsSchemaChars;
+  const trackedEstimatedTokens = estimateTokensFromChars(trackedChars);
+  const injectedWorkspaceFiles = buildBootstrapInjectionStats({
+    bootstrapFiles: params.bootstrapFiles,
+    injectedFiles: params.injectedFiles,
+  });
+  const largestContributorsSource = [
+    { name: "Project Context", chars: projectContextChars },
+    {
+      name: "Non-project system prompt",
+      chars: Math.max(0, systemPrompt.length - projectContextChars),
+    },
+    { name: "Tool schemas", chars: toolsSchemaChars },
+  ]
+    .filter((entry) => entry.chars > 0)
+    .toSorted((a, b) => b.chars - a.chars)
+    .map((entry) => ({
+      ...entry,
+      estimatedTokens: estimateTokensFromChars(entry.chars),
+      sharePercent: trackedChars > 0 ? Math.round((entry.chars / trackedChars) * 1000) / 10 : 0,
+    }));
+  const promptHash = createHash("sha256").update(systemPrompt).digest("hex").slice(0, 12);
+  const truncationSeverity = resolveTruncationSeverity({
+    truncatedFiles:
+      params.bootstrapTruncation?.truncatedFiles ??
+      injectedWorkspaceFiles.filter((file) => file.truncated).length,
+    nearLimitFiles: params.bootstrapTruncation?.nearLimitFiles,
+    totalNearLimit: params.bootstrapTruncation?.totalNearLimit,
+  });
 
   return {
     source: params.source,
@@ -120,15 +168,19 @@ export function buildSystemPromptReport(params: {
     bootstrapTotalMaxChars: params.bootstrapTotalMaxChars,
     ...(params.bootstrapTruncation ? { bootstrapTruncation: params.bootstrapTruncation } : {}),
     sandbox: params.sandbox,
+    promptHash,
+    tracked: {
+      chars: trackedChars,
+      estimatedTokens: trackedEstimatedTokens,
+      largestContributors: largestContributorsSource,
+    },
+    truncationSeverity,
     systemPrompt: {
       chars: systemPrompt.length,
       projectContextChars,
       nonProjectContextChars: Math.max(0, systemPrompt.length - projectContextChars),
     },
-    injectedWorkspaceFiles: buildBootstrapInjectionStats({
-      bootstrapFiles: params.bootstrapFiles,
-      injectedFiles: params.injectedFiles,
-    }),
+    injectedWorkspaceFiles,
     skills: {
       promptChars: params.skillsPrompt.length,
       entries: skillsEntries,

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -22,6 +22,10 @@ import {
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import {
+  formatLifecycleBackingSummary,
+  formatLifecycleStatusReasonSummary,
+} from "../../tasks/task-lifecycle-status.js";
 import { buildTaskStatusSnapshotForRelatedSessionKeyForOwner } from "../../tasks/task-owner-access.js";
 import { formatTaskStatusDetail, formatTaskStatusTitle } from "../../tasks/task-status.js";
 import { loadModelCatalog } from "../model-catalog.js";
@@ -135,8 +139,10 @@ function formatSessionTaskLine(params: {
         ? `${snapshot.recentFailureCount} recent failure${snapshot.recentFailureCount === 1 ? "" : "s"}`
         : `latest ${task.status.replaceAll("_", " ")}`;
   const title = formatTaskStatusTitle(task);
-  const detail = formatTaskStatusDetail(task);
-  const parts = [headline, task.runtime, title, detail].filter(Boolean);
+  const reason = snapshot.focusReason;
+  const detail = formatTaskStatusDetail(task) ?? formatLifecycleStatusReasonSummary(reason);
+  const backing = formatLifecycleBackingSummary(reason);
+  const parts = [headline, task.runtime, title, detail, backing].filter(Boolean);
   return parts.length ? `📌 Tasks: ${parts.join(" · ")}` : undefined;
 }
 

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -90,6 +90,66 @@ function formatCompactionReason(reason?: string): string | undefined {
   return text;
 }
 
+type CompactionDryRunInspectDetails = {
+  topContributors?: Array<{ role?: string; chars?: number; tool?: string }>;
+  lightTrim?: {
+    trimmedMessages?: number;
+    trimmedToolResults?: number;
+    tokenDelta?: number;
+  };
+};
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function formatCompactionDryRunHints(
+  details: CompactionDryRunInspectDetails | undefined,
+  telemetry: ReturnType<typeof extractCompactionStageTelemetry>,
+): string[] {
+  const hints: string[] = [];
+
+  if (details?.lightTrim) {
+    const trimParts: string[] = [];
+    const trimmedMessages = Math.max(0, details.lightTrim.trimmedMessages ?? 0);
+    const trimmedToolResults = Math.max(0, details.lightTrim.trimmedToolResults ?? 0);
+    if (trimmedMessages > 0) {
+      trimParts.push(pluralize(trimmedMessages, "msg"));
+    }
+    if (trimmedToolResults > 0) {
+      trimParts.push(pluralize(trimmedToolResults, "tool"));
+    }
+    if (trimParts.length > 0) {
+      const tokenDelta = Math.max(0, details.lightTrim.tokenDelta ?? 0);
+      hints.push(
+        tokenDelta > 0
+          ? `light-trim=${trimParts.join("/")} (-${formatTokenCount(tokenDelta)} tok)`
+          : `light-trim=${trimParts.join("/")}`,
+      );
+    }
+  }
+
+  const droppedMessages = Math.max(0, telemetry?.droppedMessages ?? 0);
+  const droppedChunks = Math.max(0, telemetry?.droppedChunks ?? 0);
+  if (droppedMessages > 0 || droppedChunks > 0) {
+    const pruneParts: string[] = [];
+    if (droppedMessages > 0) {
+      pruneParts.push(pluralize(droppedMessages, "msg"));
+    }
+    if (droppedChunks > 0) {
+      pruneParts.push(pluralize(droppedChunks, "chunk"));
+    }
+    hints.push(`history-prune=${pruneParts.join("/")}`);
+  }
+
+  const qualityRetriesPlanned = Math.max(0, telemetry?.qualityRetriesPlanned ?? 0);
+  if (telemetry?.qualityGuardEnabled && qualityRetriesPlanned > 0) {
+    hints.push(`quality-guard≤${pluralize(qualityRetriesPlanned, "retry")}`);
+  }
+
+  return hints;
+}
+
 function formatCompactionDryRunLine(params: {
   result: Awaited<ReturnType<typeof compactEmbeddedPiSession>>;
   contextSummary: string;
@@ -97,9 +157,7 @@ function formatCompactionDryRunLine(params: {
   const telemetry = extractCompactionStageTelemetry(params.result.result?.details);
   const details =
     params.result.result?.details && typeof params.result.result.details === "object"
-      ? (params.result.result.details as {
-          topContributors?: Array<{ role?: string; chars?: number; tool?: string }>;
-        })
+      ? (params.result.result.details as CompactionDryRunInspectDetails)
       : undefined;
   const stagePlan = telemetry?.plan?.map((entry) => entry.stage).join(" → ") || "finalize";
   const entryReason = telemetry?.entryReason?.replaceAll("_", " ") ?? "summary ready";
@@ -107,9 +165,13 @@ function formatCompactionDryRunLine(params: {
   const topLabel = topContributor?.tool
     ? `${topContributor.role}:${topContributor.tool}`
     : topContributor?.role;
-  return topLabel
-    ? `Dry-run: would run ${stagePlan} (${entryReason}) • top=${topLabel} • ${params.contextSummary}`
-    : `Dry-run: would run ${stagePlan} (${entryReason}) • ${params.contextSummary}`;
+  const parts = [`Dry-run: would run ${stagePlan} (${entryReason})`];
+  if (topLabel) {
+    parts.push(`top=${topLabel}`);
+  }
+  parts.push(...formatCompactionDryRunHints(details, telemetry));
+  parts.push(params.contextSummary);
+  return parts.join(" • ");
 }
 
 export const handleCompactCommand: CommandHandler = async (params) => {

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -1,3 +1,4 @@
+import { extractCompactionStageTelemetry } from "../../agents/compaction.js";
 import {
   abortEmbeddedPiRun,
   compactEmbeddedPiSession,
@@ -17,13 +18,13 @@ import type { CommandHandler } from "./commands-types.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import { incrementCompactionCount } from "./session-updates.js";
 
-function extractCompactInstructions(params: {
+function parseCompactCommand(params: {
   rawBody?: string;
   ctx: import("../templating.js").MsgContext;
   cfg: OpenClawConfig;
   agentId?: string;
   isGroup: boolean;
-}): string | undefined {
+}): { instructions?: string; dryRun: boolean } {
   const raw = stripStructuralPrefixes(params.rawBody ?? "");
   const stripped = params.isGroup
     ? stripMentions(raw, params.ctx, params.cfg, params.agentId)
@@ -35,13 +36,26 @@ function extractCompactInstructions(params: {
   const lowered = trimmed.toLowerCase();
   const prefix = lowered.startsWith("/compact") ? "/compact" : null;
   if (!prefix) {
-    return undefined;
+    return { dryRun: false };
   }
   let rest = trimmed.slice(prefix.length).trimStart();
   if (rest.startsWith(":")) {
     rest = rest.slice(1).trimStart();
   }
-  return rest.length ? rest : undefined;
+
+  let dryRun = false;
+  for (const flag of ["--dry-run", "--inspect"]) {
+    if (rest === flag || rest.startsWith(`${flag} `) || rest.startsWith(`${flag}:`)) {
+      dryRun = true;
+      rest = rest.slice(flag.length).trimStart();
+      if (rest.startsWith(":")) {
+        rest = rest.slice(1).trimStart();
+      }
+      break;
+    }
+  }
+
+  return { instructions: rest.length ? rest : undefined, dryRun };
 }
 
 function isCompactionSkipReason(reason?: string): boolean {
@@ -76,6 +90,28 @@ function formatCompactionReason(reason?: string): string | undefined {
   return text;
 }
 
+function formatCompactionDryRunLine(params: {
+  result: Awaited<ReturnType<typeof compactEmbeddedPiSession>>;
+  contextSummary: string;
+}): string {
+  const telemetry = extractCompactionStageTelemetry(params.result.result?.details);
+  const details =
+    params.result.result?.details && typeof params.result.result.details === "object"
+      ? (params.result.result.details as {
+          topContributors?: Array<{ role?: string; chars?: number; tool?: string }>;
+        })
+      : undefined;
+  const stagePlan = telemetry?.plan?.map((entry) => entry.stage).join(" → ") || "finalize";
+  const entryReason = telemetry?.entryReason?.replaceAll("_", " ") ?? "summary ready";
+  const topContributor = details?.topContributors?.[0];
+  const topLabel = topContributor?.tool
+    ? `${topContributor.role}:${topContributor.tool}`
+    : topContributor?.role;
+  return topLabel
+    ? `Dry-run: would run ${stagePlan} (${entryReason}) • top=${topLabel} • ${params.contextSummary}`
+    : `Dry-run: would run ${stagePlan} (${entryReason}) • ${params.contextSummary}`;
+}
+
 export const handleCompactCommand: CommandHandler = async (params) => {
   const compactRequested =
     params.command.commandBodyNormalized === "/compact" ||
@@ -96,17 +132,24 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     };
   }
   const sessionId = params.sessionEntry.sessionId;
-  if (isEmbeddedPiRunActive(sessionId)) {
-    abortEmbeddedPiRun(sessionId);
-    await waitForEmbeddedPiRunEnd(sessionId, 15_000);
-  }
-  const customInstructions = extractCompactInstructions({
+  const compactCommand = parseCompactCommand({
     rawBody: params.ctx.CommandBody ?? params.ctx.RawBody ?? params.ctx.Body,
     ctx: params.ctx,
     cfg: params.cfg,
     agentId: params.agentId,
     isGroup: params.isGroup,
   });
+  if (compactCommand.dryRun && isEmbeddedPiRunActive(sessionId)) {
+    return {
+      shouldContinue: false,
+      reply: { text: "⚙️ Dry-run unavailable while the session is actively running." },
+    };
+  }
+  if (isEmbeddedPiRunActive(sessionId)) {
+    abortEmbeddedPiRun(sessionId);
+    await waitForEmbeddedPiRunEnd(sessionId, 15_000);
+  }
+  const customInstructions = compactCommand.instructions;
   const result = await compactEmbeddedPiSession({
     sessionId,
     sessionKey: params.sessionKey,
@@ -137,13 +180,15 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       defaultLevel: "off",
     },
     customInstructions,
+    dryRun: compactCommand.dryRun,
     trigger: "manual",
     senderIsOwner: params.command.senderIsOwner,
     ownerNumbers: params.command.ownerList.length > 0 ? params.command.ownerList : undefined,
   });
 
-  const compactLabel =
-    result.ok || isCompactionSkipReason(result.reason)
+  const compactLabel = compactCommand.dryRun
+    ? "Compaction dry-run"
+    : result.ok || isCompactionSkipReason(result.reason)
       ? result.compacted
         ? result.result?.tokensBefore != null && result.result?.tokensAfter != null
           ? `Compacted (${formatTokenCount(result.result.tokensBefore)} → ${formatTokenCount(result.result.tokensAfter)})`
@@ -152,7 +197,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
             : "Compacted"
         : "Compaction skipped"
       : "Compaction failed";
-  if (result.ok && result.compacted) {
+  if (!compactCommand.dryRun && result.ok && result.compacted) {
     await incrementCompactionCount({
       sessionEntry: params.sessionEntry,
       sessionStore: params.sessionStore,
@@ -170,9 +215,13 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     params.contextTokens ?? params.sessionEntry.contextTokens ?? null,
   );
   const reason = formatCompactionReason(result.reason);
-  const line = reason
-    ? `${compactLabel}: ${reason} • ${contextSummary}`
-    : `${compactLabel} • ${contextSummary}`;
-  enqueueSystemEvent(line, { sessionKey: params.sessionKey });
+  const line = compactCommand.dryRun
+    ? formatCompactionDryRunLine({ result, contextSummary })
+    : reason
+      ? `${compactLabel}: ${reason} • ${contextSummary}`
+      : `${compactLabel} • ${contextSummary}`;
+  if (!compactCommand.dryRun) {
+    enqueueSystemEvent(line, { sessionKey: params.sessionKey });
+  }
   return { shouldContinue: false, reply: { text: `⚙️ ${line}` } };
 };

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -31,7 +31,7 @@ function parseCompactCommand(params: {
     : raw;
   const trimmed = stripped.trim();
   if (!trimmed) {
-    return undefined;
+    return { dryRun: false };
   }
   const lowered = trimmed.toLowerCase();
   const prefix = lowered.startsWith("/compact") ? "/compact" : null;

--- a/src/auto-reply/reply/commands-context-report.test.ts
+++ b/src/auto-reply/reply/commands-context-report.test.ts
@@ -10,6 +10,7 @@ function makeParams(
     contextTokens?: number | null;
     totalTokens?: number | null;
     totalTokensFresh?: boolean;
+    cfg?: Record<string, unknown>;
   },
 ): HandleCommandsParams {
   return {
@@ -66,7 +67,7 @@ function makeParams(
         },
       },
     },
-    cfg: {},
+    cfg: (options?.cfg ?? {}) as never,
     ctx: {},
     commandBody: "",
     commandArgs: [],
@@ -130,6 +131,77 @@ describe("buildContextReply", () => {
     expect(result.text).toContain("Actual context usage (cached): unavailable");
     expect(result.text).toContain("Session tokens (cached): unknown / ctx=8,192");
     expect(result.text).not.toContain("~645 tok");
+  });
+
+  it("surfaces memory-search config and post-compaction session sync in detail output", async () => {
+    const result = await buildContextReply(
+      makeParams("/context detail", false, {
+        cfg: {
+          agents: {
+            defaults: {
+              memorySearch: {
+                provider: "auto",
+                sources: ["memory", "sessions"],
+                experimental: { sessionMemory: true },
+                sync: {
+                  onSessionStart: true,
+                  onSearch: true,
+                  watch: true,
+                  sessions: { postCompactionForce: true },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    expect(result.text).toContain(
+      "Memory search: enabled | provider=auto | sources=memory, sessions | fallback=none",
+    );
+    expect(result.text).toContain(
+      "Memory session sync: sessionMemory=on | onSessionStart=on | onSearch=on | watch=on",
+    );
+    expect(result.text).toContain(
+      "Memory post-compaction sync: forced when session sources are enabled",
+    );
+    expect(result.text).toContain("Memory multimodal: off");
+  });
+
+  it("includes memory-search snapshot in json output", async () => {
+    const result = await buildContextReply(
+      makeParams("/context json", false, {
+        cfg: {
+          agents: {
+            defaults: {
+              memorySearch: {
+                provider: "auto",
+                sources: ["memory", "sessions"],
+                experimental: { sessionMemory: true },
+                sync: {
+                  onSessionStart: true,
+                  onSearch: true,
+                  watch: true,
+                  sessions: { postCompactionForce: true },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    const payload = JSON.parse(result.text);
+    expect(payload.memorySearch).toMatchObject({
+      enabled: true,
+      provider: "auto",
+      sources: ["memory", "sessions"],
+      experimental: { sessionMemory: true },
+      sync: {
+        onSessionStart: true,
+        onSearch: true,
+        watch: true,
+        postCompactionForce: true,
+      },
+    });
   });
 
   it("shows estimate-vs-run drift in deep output", async () => {

--- a/src/auto-reply/reply/commands-context-report.test.ts
+++ b/src/auto-reply/reply/commands-context-report.test.ts
@@ -76,6 +76,8 @@ describe("buildContextReply", () => {
   it("shows bootstrap truncation warning in list output when context exceeds configured limits", async () => {
     const result = await buildContextReply(makeParams("/context list", true));
     expect(result.text).toContain("Bootstrap max/total: 150,000 chars");
+    expect(result.text).toContain("Truncation severity: low");
+    expect(result.text).toContain("Largest tracked contributors:");
     expect(result.text).toContain("⚠ Bootstrap context is over configured limits");
     expect(result.text).toContain("Causes: 1 file(s) exceeded max/file.");
   });
@@ -103,6 +105,7 @@ describe("buildContextReply", () => {
         totalTokens: 900,
       }),
     );
+    expect(result.text).toContain("Prompt hash: unknown");
     expect(result.text).toContain("Tracked prompt estimate: 1,020 chars (~255 tok)");
     expect(result.text).toContain("Actual context usage (cached): 900 tok");
     expect(result.text).toContain("Untracked provider/runtime overhead: ~645 tok");

--- a/src/auto-reply/reply/commands-context-report.test.ts
+++ b/src/auto-reply/reply/commands-context-report.test.ts
@@ -34,6 +34,8 @@ function makeParams(
       systemPromptReport: {
         source: "run",
         generatedAt: Date.now(),
+        sourceRunId: "run-ctx",
+        sourceMessageId: "leaf-ctx",
         workspaceDir: "/tmp/workspace",
         bootstrapMaxChars: options?.omitBootstrapLimits ? undefined : 20_000,
         bootstrapTotalMaxChars: options?.omitBootstrapLimits ? undefined : 150_000,
@@ -105,10 +107,14 @@ describe("buildContextReply", () => {
         totalTokens: 900,
       }),
     );
+    expect(result.text).toContain("Last run snapshot: run-ctx | leaf=leaf-ctx");
     expect(result.text).toContain("Prompt hash: unknown");
     expect(result.text).toContain("Tracked prompt estimate: 1,020 chars (~255 tok)");
     expect(result.text).toContain("Actual context usage (cached): 900 tok");
     expect(result.text).toContain("Untracked provider/runtime overhead: ~645 tok");
+    expect(result.text).toContain(
+      "Tip: use /context deep or /context delta for current estimate-vs-last-run drift.",
+    );
     expect(result.text).toContain("Session tokens (cached): 900 total / ctx=8,192");
   });
 
@@ -124,6 +130,18 @@ describe("buildContextReply", () => {
     expect(result.text).toContain("Actual context usage (cached): unavailable");
     expect(result.text).toContain("Session tokens (cached): unknown / ctx=8,192");
     expect(result.text).not.toContain("~645 tok");
+  });
+
+  it("shows estimate-vs-run drift in deep output", async () => {
+    const result = await buildContextReply(
+      makeParams("/context deep", false, {
+        contextTokens: 8_192,
+        totalTokens: 900,
+      }),
+    );
+    expect(result.text).toContain("Estimate vs last run:");
+    expect(result.text).toContain("- current estimate:");
+    expect(result.text).toContain("- tracked drift:");
   });
 
   it("compares last run and current estimate drift", () => {

--- a/src/auto-reply/reply/commands-context-report.test.ts
+++ b/src/auto-reply/reply/commands-context-report.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildContextReply } from "./commands-context-report.js";
+import { buildContextReply, compareContextReports } from "./commands-context-report.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
 function makeParams(
@@ -124,5 +124,63 @@ describe("buildContextReply", () => {
     expect(result.text).toContain("Actual context usage (cached): unavailable");
     expect(result.text).toContain("Session tokens (cached): unknown / ctx=8,192");
     expect(result.text).not.toContain("~645 tok");
+  });
+
+  it("compares last run and current estimate drift", () => {
+    const comparison = compareContextReports(
+      {
+        source: "run",
+        generatedAt: 1,
+        promptHash: "aaaa",
+        truncationSeverity: "low",
+        systemPrompt: {
+          chars: 1_000,
+          projectContextChars: 500,
+          nonProjectContextChars: 500,
+        },
+        injectedWorkspaceFiles: [],
+        skills: { promptChars: 0, entries: [] },
+        tools: { listChars: 10, schemaChars: 20, entries: [] },
+        tracked: {
+          chars: 1_020,
+          estimatedTokens: 255,
+          largestContributors: [
+            { name: "Project Context", chars: 500, estimatedTokens: 125, sharePercent: 49 },
+          ],
+        },
+      },
+      {
+        source: "estimate",
+        generatedAt: 2,
+        promptHash: "bbbb",
+        truncationSeverity: "medium",
+        systemPrompt: {
+          chars: 1_240,
+          projectContextChars: 620,
+          nonProjectContextChars: 620,
+        },
+        injectedWorkspaceFiles: [],
+        skills: { promptChars: 0, entries: [] },
+        tools: { listChars: 10, schemaChars: 80, entries: [] },
+        tracked: {
+          chars: 1_320,
+          estimatedTokens: 330,
+          largestContributors: [
+            { name: "Tool schemas", chars: 700, estimatedTokens: 175, sharePercent: 53 },
+          ],
+        },
+      },
+    );
+
+    expect(comparison.trackedCharsDelta).toBe(300);
+    expect(comparison.trackedTokensDelta).toBe(75);
+    expect(comparison.systemPromptCharsDelta).toBe(240);
+    expect(comparison.projectContextCharsDelta).toBe(120);
+    expect(comparison.toolSchemaCharsDelta).toBe(60);
+    expect(comparison.promptHashChanged).toBe(true);
+    expect(comparison.truncationSeverityChanged).toBe(true);
+    expect(comparison.runTopContributor).toBe("Project Context");
+    expect(comparison.estimateTopContributor).toBe("Tool schemas");
+    expect(comparison.topContributorChanged).toBe(true);
   });
 });

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -1,4 +1,5 @@
 import { analyzeBootstrapBudget } from "../../agents/bootstrap-budget.js";
+import { resolveMemorySearchConfig } from "../../agents/memory-search.js";
 import {
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
@@ -8,6 +9,7 @@ import {
   resolveFreshSessionTotalTokens,
   type SessionSystemPromptReport,
 } from "../../config/sessions/types.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { estimateTokensFromChars } from "../../utils/cjk-chars.js";
 import type { ReplyPayload } from "../types.js";
 import { resolveCommandsSystemPromptBundle } from "./commands-system-prompt.js";
@@ -27,6 +29,127 @@ function formatSignedInt(n: number): string {
 
 function formatDeltaCharsAndTokens(chars: number, estimatedTokens: number): string {
   return `${formatSignedInt(chars)} chars (~${formatSignedInt(estimatedTokens)} tok)`;
+}
+
+function normalizeInlineText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+type MemorySearchInspectorSnapshot =
+  | {
+      enabled: false;
+      summaryLine: string;
+      detailLines: string[];
+      json: {
+        enabled: false;
+        error?: string;
+      };
+    }
+  | {
+      enabled: true;
+      summaryLine: string;
+      detailLines: string[];
+      json: {
+        enabled: true;
+        provider: string;
+        sources: Array<"memory" | "sessions">;
+        fallback: string;
+        experimental: {
+          sessionMemory: boolean;
+        };
+        sync: {
+          onSessionStart: boolean;
+          onSearch: boolean;
+          watch: boolean;
+          postCompactionForce: boolean;
+        };
+        multimodal: {
+          enabled: boolean;
+          modalities: string[];
+          maxFileBytes?: number;
+        };
+        store: {
+          driver: string;
+          path: string;
+          tokenizer: string;
+          vectorEnabled: boolean;
+        };
+      };
+    };
+
+function resolveMemorySearchInspectorSnapshot(
+  params: HandleCommandsParams,
+): MemorySearchInspectorSnapshot {
+  const agentId = params.agentId ?? parseAgentSessionKey(params.sessionKey)?.agentId ?? "main";
+  try {
+    const resolved = resolveMemorySearchConfig(params.cfg, agentId);
+    if (!resolved) {
+      return {
+        enabled: false,
+        summaryLine: "Memory search: disabled",
+        detailLines: ["Memory search is disabled for this agent."],
+        json: { enabled: false },
+      };
+    }
+    const multimodalEnabled =
+      Boolean(resolved.multimodal.enabled) && resolved.multimodal.modalities.length > 0;
+    const sourceLabel = resolved.sources.join(", ");
+    const sessionSourceEnabled = resolved.sources.includes("sessions");
+    const summaryLine = `Memory search: enabled | provider=${resolved.provider} | sources=${sourceLabel} | fallback=${resolved.fallback}`;
+    const detailLines = [
+      summaryLine,
+      `Memory session sync: sessionMemory=${resolved.experimental.sessionMemory ? "on" : "off"} | onSessionStart=${resolved.sync.onSessionStart ? "on" : "off"} | onSearch=${resolved.sync.onSearch ? "on" : "off"} | watch=${resolved.sync.watch ? "on" : "off"}`,
+      `Memory post-compaction sync: ${sessionSourceEnabled && resolved.sync.sessions.postCompactionForce ? "forced when session sources are enabled" : "not forced"}`,
+      `Memory store: ${resolved.store.driver} | tokenizer=${resolved.store.fts.tokenizer} | vector=${resolved.store.vector.enabled ? "on" : "off"} | path=${resolved.store.path}`,
+      multimodalEnabled
+        ? `Memory multimodal: ${resolved.multimodal.modalities.join(", ")} | maxFileBytes=${formatInt(resolved.multimodal.maxFileBytes ?? 0)}`
+        : "Memory multimodal: off",
+    ];
+    return {
+      enabled: true,
+      summaryLine,
+      detailLines,
+      json: {
+        enabled: true,
+        provider: resolved.provider,
+        sources: resolved.sources,
+        fallback: resolved.fallback,
+        experimental: {
+          sessionMemory: resolved.experimental.sessionMemory,
+        },
+        sync: {
+          onSessionStart: resolved.sync.onSessionStart,
+          onSearch: resolved.sync.onSearch,
+          watch: resolved.sync.watch,
+          postCompactionForce: resolved.sync.sessions.postCompactionForce,
+        },
+        multimodal: {
+          enabled: multimodalEnabled,
+          modalities: [...resolved.multimodal.modalities],
+          ...(resolved.multimodal.maxFileBytes != null
+            ? { maxFileBytes: resolved.multimodal.maxFileBytes }
+            : {}),
+        },
+        store: {
+          driver: resolved.store.driver,
+          path: resolved.store.path,
+          tokenizer: resolved.store.fts.tokenizer,
+          vectorEnabled: resolved.store.vector.enabled,
+        },
+      },
+    };
+  } catch (error) {
+    const message = normalizeInlineText(error instanceof Error ? error.message : String(error));
+    return {
+      enabled: false,
+      summaryLine: `Memory search: invalid config (${message})`,
+      detailLines: [`Memory search config error: ${message}`],
+      json: {
+        enabled: false,
+        error: message,
+      },
+    };
+  }
 }
 
 function resolveTrackedPrompt(report: SessionSystemPromptReport): {
@@ -213,6 +336,7 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     outputTokens: params.sessionEntry?.outputTokens ?? null,
     contextTokens: params.contextTokens ?? null,
   } as const;
+  const memorySearch = resolveMemorySearchInspectorSnapshot(params);
   const runReport = resolveRunContextReport(params);
 
   if (sub === "json") {
@@ -224,6 +348,7 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
             report: runReport,
             estimateReport,
             comparison: compareContextReports(runReport, estimateReport),
+            memorySearch: memorySearch.json,
             session,
           },
           null,
@@ -232,7 +357,7 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
       };
     }
     const report = await resolveContextReport(params);
-    return { text: JSON.stringify({ report, session }, null, 2) };
+    return { text: JSON.stringify({ report, memorySearch: memorySearch.json, session }, null, 2) };
   }
 
   if (sub === "delta") {
@@ -486,6 +611,8 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
         ...(perSkill.lines.length ? ["Top skills (prompt entry size):", ...perSkill.lines] : []),
         ...(perSkill.omitted ? [`… (+${perSkill.omitted} more skills)`] : []),
         "",
+        ...memorySearch.detailLines,
+        "",
         toolListLine,
         toolSchemaLine,
         toolsNamesLine,
@@ -517,6 +644,7 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     text: [
       "🧠 Context breakdown",
       ...sharedContextLines,
+      memorySearch.summaryLine,
       toolListLine,
       toolSchemaLine,
       toolsNamesLine,

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -21,6 +21,14 @@ function formatCharsAndTokens(chars: number): string {
   return `${formatInt(chars)} chars (~${formatInt(estimateTokensFromChars(chars))} tok)`;
 }
 
+function formatSignedInt(n: number): string {
+  return `${n >= 0 ? "+" : "-"}${formatInt(Math.abs(n))}`;
+}
+
+function formatDeltaCharsAndTokens(chars: number, estimatedTokens: number): string {
+  return `${formatSignedInt(chars)} chars (~${formatSignedInt(estimatedTokens)} tok)`;
+}
+
 function resolveTrackedPrompt(report: SessionSystemPromptReport): {
   chars: number;
   estimatedTokens: number;
@@ -73,6 +81,47 @@ function resolveTruncationSeverity(report: SessionSystemPromptReport): string {
   return "low";
 }
 
+export function compareContextReports(
+  runReport: SessionSystemPromptReport,
+  estimateReport: SessionSystemPromptReport,
+): {
+  trackedCharsDelta: number;
+  trackedTokensDelta: number;
+  systemPromptCharsDelta: number;
+  projectContextCharsDelta: number;
+  toolSchemaCharsDelta: number;
+  promptHashChanged: boolean;
+  runTruncationSeverity: string;
+  estimateTruncationSeverity: string;
+  truncationSeverityChanged: boolean;
+  runTopContributor?: string;
+  estimateTopContributor?: string;
+  topContributorChanged: boolean;
+} {
+  const runTracked = resolveTrackedPrompt(runReport);
+  const estimateTracked = resolveTrackedPrompt(estimateReport);
+  const runTruncationSeverity = resolveTruncationSeverity(runReport);
+  const estimateTruncationSeverity = resolveTruncationSeverity(estimateReport);
+  const runTopContributor = runTracked.largestContributors[0]?.name;
+  const estimateTopContributor = estimateTracked.largestContributors[0]?.name;
+
+  return {
+    trackedCharsDelta: estimateTracked.chars - runTracked.chars,
+    trackedTokensDelta: estimateTracked.estimatedTokens - runTracked.estimatedTokens,
+    systemPromptCharsDelta: estimateReport.systemPrompt.chars - runReport.systemPrompt.chars,
+    projectContextCharsDelta:
+      estimateReport.systemPrompt.projectContextChars - runReport.systemPrompt.projectContextChars,
+    toolSchemaCharsDelta: estimateReport.tools.schemaChars - runReport.tools.schemaChars,
+    promptHashChanged: (estimateReport.promptHash ?? "") !== (runReport.promptHash ?? ""),
+    runTruncationSeverity,
+    estimateTruncationSeverity,
+    truncationSeverityChanged: estimateTruncationSeverity !== runTruncationSeverity,
+    runTopContributor,
+    estimateTopContributor,
+    topContributorChanged: estimateTopContributor !== runTopContributor,
+  };
+}
+
 function parseContextArgs(commandBodyNormalized: string): string {
   if (commandBodyNormalized === "/context") {
     return "";
@@ -94,14 +143,16 @@ function formatListTop(
   return { lines, omitted };
 }
 
-async function resolveContextReport(
+function resolveRunContextReport(
+  params: HandleCommandsParams,
+): SessionSystemPromptReport | undefined {
+  const existing = params.sessionEntry?.systemPromptReport;
+  return existing?.source === "run" ? existing : undefined;
+}
+
+async function buildEstimateContextReport(
   params: HandleCommandsParams,
 ): Promise<SessionSystemPromptReport> {
-  const existing = params.sessionEntry?.systemPromptReport;
-  if (existing && existing.source === "run") {
-    return existing;
-  }
-
   const bootstrapMaxChars = resolveBootstrapMaxChars(params.cfg);
   const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.cfg);
   const { systemPrompt, tools, skillsPrompt, bootstrapFiles, injectedFiles, sandboxRuntime } =
@@ -126,6 +177,12 @@ async function resolveContextReport(
   });
 }
 
+async function resolveContextReport(
+  params: HandleCommandsParams,
+): Promise<SessionSystemPromptReport> {
+  return resolveRunContextReport(params) ?? (await buildEstimateContextReport(params));
+}
+
 export async function buildContextReply(params: HandleCommandsParams): Promise<ReplyPayload> {
   const args = parseContextArgs(params.command.commandBodyNormalized);
   const sub = args.split(/\s+/).filter(Boolean)[0]?.toLowerCase() ?? "";
@@ -140,6 +197,7 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
         "Try:",
         "- /context list   (short breakdown)",
         "- /context detail (per-file + per-tool + per-skill + system prompt size)",
+        "- /context delta  (current estimate vs last run snapshot)",
         "- /context json   (same, machine-readable)",
         "",
         "Inline shortcut = a command token inside a normal message (e.g. “hey /status”). It runs immediately (allowlisted senders only) and is stripped before the model sees the remaining text.",
@@ -147,7 +205,6 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     };
   }
 
-  const report = await resolveContextReport(params);
   const cachedContextUsageTokens = resolveFreshSessionTotalTokens(params.sessionEntry);
   const session = {
     totalTokens: params.sessionEntry?.totalTokens ?? null,
@@ -156,20 +213,79 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     outputTokens: params.sessionEntry?.outputTokens ?? null,
     contextTokens: params.contextTokens ?? null,
   } as const;
+  const runReport = resolveRunContextReport(params);
 
   if (sub === "json") {
+    if (runReport) {
+      const estimateReport = await buildEstimateContextReport(params);
+      return {
+        text: JSON.stringify(
+          {
+            report: runReport,
+            estimateReport,
+            comparison: compareContextReports(runReport, estimateReport),
+            session,
+          },
+          null,
+          2,
+        ),
+      };
+    }
+    const report = await resolveContextReport(params);
     return { text: JSON.stringify({ report, session }, null, 2) };
+  }
+
+  if (sub === "delta") {
+    if (!runReport) {
+      return {
+        text: [
+          "No persisted run snapshot is available for this session yet.",
+          "Run the agent once, then try /context delta again.",
+        ].join("\n"),
+      };
+    }
+    const estimateReport = await buildEstimateContextReport(params);
+    const comparison = compareContextReports(runReport, estimateReport);
+    const runTracked = resolveTrackedPrompt(runReport);
+    const estimateTracked = resolveTrackedPrompt(estimateReport);
+    const cachedLine =
+      cachedContextUsageTokens != null
+        ? `Session tokens (cached): ${formatInt(cachedContextUsageTokens)} total`
+        : "Session tokens (cached): unknown";
+    return {
+      text: [
+        "🧠 Context delta (estimate vs last run)",
+        `Last run snapshot: ${runReport.sourceRunId ?? "unknown"}${runReport.sourceMessageId ? ` | leaf=${runReport.sourceMessageId}` : ""}`,
+        `Run generated: ${new Date(runReport.generatedAt).toISOString()}`,
+        `Estimate generated: ${new Date(estimateReport.generatedAt).toISOString()}`,
+        `Run tracked prompt: ${formatCharsAndTokens(runTracked.chars)}`,
+        `Current estimate: ${formatCharsAndTokens(estimateTracked.chars)}`,
+        `Tracked drift: ${formatDeltaCharsAndTokens(comparison.trackedCharsDelta, comparison.trackedTokensDelta)}`,
+        `System prompt drift: ${formatDeltaCharsAndTokens(comparison.systemPromptCharsDelta, estimateTokensFromChars(comparison.systemPromptCharsDelta))}`,
+        `Project Context drift: ${formatDeltaCharsAndTokens(comparison.projectContextCharsDelta, estimateTokensFromChars(comparison.projectContextCharsDelta))}`,
+        `Tool schema drift: ${formatDeltaCharsAndTokens(comparison.toolSchemaCharsDelta, estimateTokensFromChars(comparison.toolSchemaCharsDelta))}`,
+        `Prompt hash: ${comparison.promptHashChanged ? "changed" : "unchanged"}`,
+        comparison.truncationSeverityChanged
+          ? `Truncation severity: ${comparison.runTruncationSeverity} -> ${comparison.estimateTruncationSeverity}`
+          : `Truncation severity: unchanged (${comparison.estimateTruncationSeverity})`,
+        comparison.topContributorChanged
+          ? `Largest tracked contributor: ${comparison.runTopContributor ?? "none"} -> ${comparison.estimateTopContributor ?? "none"}`
+          : `Largest tracked contributor: unchanged (${comparison.estimateTopContributor ?? comparison.runTopContributor ?? "none"})`,
+        cachedLine,
+      ].join("\n"),
+    };
   }
 
   if (sub !== "list" && sub !== "show" && sub !== "detail" && sub !== "deep") {
     return {
       text: [
         "Unknown /context mode.",
-        "Use: /context, /context list, /context detail, or /context json",
+        "Use: /context, /context list, /context detail, /context delta, or /context json",
       ].join("\n"),
     };
   }
 
+  const report = await resolveContextReport(params);
   const trackedPrompt = resolveTrackedPrompt(report);
   const truncationSeverity = resolveTruncationSeverity(report);
   const fileLines = report.injectedWorkspaceFiles.map((f) => {

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -21,6 +21,58 @@ function formatCharsAndTokens(chars: number): string {
   return `${formatInt(chars)} chars (~${formatInt(estimateTokensFromChars(chars))} tok)`;
 }
 
+function resolveTrackedPrompt(report: SessionSystemPromptReport): {
+  chars: number;
+  estimatedTokens: number;
+  largestContributors: Array<{
+    name: string;
+    chars: number;
+    estimatedTokens: number;
+    sharePercent: number;
+  }>;
+} {
+  if (report.tracked) {
+    return report.tracked;
+  }
+  const chars = report.systemPrompt.chars + report.tools.schemaChars;
+  const largestContributors = [
+    { name: "Project Context", chars: report.systemPrompt.projectContextChars },
+    { name: "Non-project system prompt", chars: report.systemPrompt.nonProjectContextChars },
+    { name: "Tool schemas", chars: report.tools.schemaChars },
+  ]
+    .filter((entry) => entry.chars > 0)
+    .toSorted((a, b) => b.chars - a.chars)
+    .map((entry) => ({
+      ...entry,
+      estimatedTokens: estimateTokensFromChars(entry.chars),
+      sharePercent: chars > 0 ? Math.round((entry.chars / chars) * 1000) / 10 : 0,
+    }));
+  return {
+    chars,
+    estimatedTokens: estimateTokensFromChars(chars),
+    largestContributors,
+  };
+}
+
+function resolveTruncationSeverity(report: SessionSystemPromptReport): string {
+  if (report.truncationSeverity) {
+    return report.truncationSeverity;
+  }
+  const truncatedFiles = report.injectedWorkspaceFiles.filter((file) => file.truncated).length;
+  const nearLimitFiles = report.bootstrapTruncation?.nearLimitFiles ?? 0;
+  const totalNearLimit = report.bootstrapTruncation?.totalNearLimit ?? false;
+  if (truncatedFiles <= 0 && !totalNearLimit && nearLimitFiles <= 0) {
+    return "none";
+  }
+  if (truncatedFiles >= 5 || nearLimitFiles >= 5) {
+    return "high";
+  }
+  if (truncatedFiles >= 2 || totalNearLimit || nearLimitFiles >= 2) {
+    return "medium";
+  }
+  return "low";
+}
+
 function parseContextArgs(commandBodyNormalized: string): string {
   if (commandBodyNormalized === "/context") {
     return "";
@@ -118,6 +170,8 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     };
   }
 
+  const trackedPrompt = resolveTrackedPrompt(report);
+  const truncationSeverity = resolveTruncationSeverity(report);
   const fileLines = report.injectedWorkspaceFiles.map((f) => {
     const status = f.missing ? "MISSING" : f.truncated ? "TRUNCATED" : "OK";
     const raw = f.missing ? "0" : formatCharsAndTokens(f.rawChars);
@@ -143,6 +197,13 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     ? `Tools: ${formatNameList(toolNames, 30)}`
     : "Tools: (none)";
   const systemPromptLine = `System prompt (${report.source}): ${formatCharsAndTokens(report.systemPrompt.chars)} (Project Context ${formatCharsAndTokens(report.systemPrompt.projectContextChars)})`;
+  const promptHashLine = `Prompt hash: ${report.promptHash ?? "unknown"}`;
+  const trackedPromptLine = `Tracked prompt estimate: ${formatCharsAndTokens(trackedPrompt.chars)}`;
+  const truncationSeverityLine = `Truncation severity: ${truncationSeverity}`;
+  const contributorLines = trackedPrompt.largestContributors.map(
+    (entry) =>
+      `- ${entry.name}: ${formatCharsAndTokens(entry.chars)} (${entry.sharePercent.toFixed(1)}%)`,
+  );
   const workspaceLabel = report.workspaceDir ?? params.workspaceDir;
   const bootstrapMaxChars =
     typeof report.bootstrapMaxChars === "number" &&
@@ -203,6 +264,10 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     `Bootstrap max/total: ${bootstrapTotalLabel}`,
     sandboxLine,
     systemPromptLine,
+    promptHashLine,
+    trackedPromptLine,
+    truncationSeverityLine,
+    ...(contributorLines.length ? ["Largest tracked contributors:", ...contributorLines] : []),
     ...(bootstrapWarningLines.length ? ["", ...bootstrapWarningLines] : []),
     "",
     "Injected workspace files:",
@@ -231,17 +296,13 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
       .slice(0, 30)
       .map((t) => `- ${t.name}: ${t.propertiesCount} params`);
 
-    // `systemPrompt.chars` already includes injected files, skills, and tool-list text.
-    // Add only tool schemas here so the tracked estimate stays disjoint.
-    const trackedPromptChars = report.systemPrompt.chars + report.tools.schemaChars;
-    const trackedPromptLine = `Tracked prompt estimate: ${formatCharsAndTokens(trackedPromptChars)}`;
     const actualContextLine =
       cachedContextUsageTokens != null
         ? `Actual context usage (cached): ${formatInt(cachedContextUsageTokens)} tok`
         : "Actual context usage (cached): unavailable";
     const overheadTokens =
       cachedContextUsageTokens != null
-        ? cachedContextUsageTokens - estimateTokensFromChars(trackedPromptChars)
+        ? cachedContextUsageTokens - trackedPrompt.estimatedTokens
         : null;
     const overheadLine =
       overheadTokens == null

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -313,6 +313,12 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     ? `Tools: ${formatNameList(toolNames, 30)}`
     : "Tools: (none)";
   const systemPromptLine = `System prompt (${report.source}): ${formatCharsAndTokens(report.systemPrompt.chars)} (Project Context ${formatCharsAndTokens(report.systemPrompt.projectContextChars)})`;
+  const runSnapshotLine =
+    report.source === "run"
+      ? `Last run snapshot: ${report.sourceRunId ?? "unknown"}${report.sourceMessageId ? ` | leaf=${report.sourceMessageId}` : ""}`
+      : null;
+  const runGeneratedLine =
+    report.source === "run" ? `Run generated: ${new Date(report.generatedAt).toISOString()}` : null;
   const promptHashLine = `Prompt hash: ${report.promptHash ?? "unknown"}`;
   const trackedPromptLine = `Tracked prompt estimate: ${formatCharsAndTokens(trackedPrompt.chars)}`;
   const truncationSeverityLine = `Truncation severity: ${truncationSeverity}`;
@@ -379,6 +385,8 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     `Bootstrap max/file: ${bootstrapMaxLabel}`,
     `Bootstrap max/total: ${bootstrapTotalLabel}`,
     sandboxLine,
+    ...(runSnapshotLine ? [runSnapshotLine] : []),
+    ...(runGeneratedLine ? [runGeneratedLine] : []),
     systemPromptLine,
     promptHashLine,
     trackedPromptLine,
@@ -394,6 +402,50 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
   ];
 
   if (sub === "detail" || sub === "deep") {
+    const estimateComparisonLines =
+      sub === "deep" && report.source === "run"
+        ? await (async () => {
+            const estimateReport = await buildEstimateContextReport(params);
+            const comparison = compareContextReports(report, estimateReport);
+            const estimateTracked = resolveTrackedPrompt(estimateReport);
+            const lines = [
+              "Estimate vs last run:",
+              `- current estimate: ${formatCharsAndTokens(estimateTracked.chars)}`,
+              `- tracked drift: ${formatDeltaCharsAndTokens(comparison.trackedCharsDelta, comparison.trackedTokensDelta)}`,
+            ];
+            if (comparison.systemPromptCharsDelta !== 0) {
+              lines.push(
+                `- system prompt drift: ${formatDeltaCharsAndTokens(comparison.systemPromptCharsDelta, estimateTokensFromChars(comparison.systemPromptCharsDelta))}`,
+              );
+            }
+            if (comparison.projectContextCharsDelta !== 0) {
+              lines.push(
+                `- Project Context drift: ${formatDeltaCharsAndTokens(comparison.projectContextCharsDelta, estimateTokensFromChars(comparison.projectContextCharsDelta))}`,
+              );
+            }
+            if (comparison.toolSchemaCharsDelta !== 0) {
+              lines.push(
+                `- tool schema drift: ${formatDeltaCharsAndTokens(comparison.toolSchemaCharsDelta, estimateTokensFromChars(comparison.toolSchemaCharsDelta))}`,
+              );
+            }
+            lines.push(`- prompt hash: ${comparison.promptHashChanged ? "changed" : "unchanged"}`);
+            lines.push(
+              comparison.truncationSeverityChanged
+                ? `- truncation severity: ${comparison.runTruncationSeverity} -> ${comparison.estimateTruncationSeverity}`
+                : `- truncation severity: unchanged (${comparison.estimateTruncationSeverity})`,
+            );
+            lines.push(
+              comparison.topContributorChanged
+                ? `- largest contributor: ${comparison.runTopContributor ?? "none"} -> ${comparison.estimateTopContributor ?? "none"}`
+                : `- largest contributor: unchanged (${comparison.estimateTopContributor ?? comparison.runTopContributor ?? "none"})`,
+            );
+            return lines;
+          })()
+        : [];
+    const estimateHintLine =
+      sub === "detail" && report.source === "run"
+        ? "Tip: use /context deep or /context delta for current estimate-vs-last-run drift."
+        : null;
     const perSkill = formatListTop(
       report.skills.entries.map((s) => ({ name: s.name, value: s.blockChars })),
       30,
@@ -449,6 +501,8 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
         trackedPromptLine,
         actualContextLine,
         ...(overheadLine ? [overheadLine] : []),
+        ...(estimateComparisonLines.length ? ["", ...estimateComparisonLines] : []),
+        ...(estimateHintLine ? ["", estimateHintLine] : []),
         "",
         totalsLine,
         "",

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -262,6 +262,24 @@ describe("buildStatusReply subagent summary", () => {
     expect(reply?.text).toContain("approval denied");
   });
 
+  it("surfaces compact task backing hints in the session task line", async () => {
+    createRunningTaskRun({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      childSessionKey: "agent:main:subagent:status-task-linked",
+      runId: "run-status-task-linked",
+      task: "linked background task",
+      progressSummary: "still working",
+    });
+
+    const reply = await buildStatusReplyForTest({});
+
+    expect(reply?.text).toContain("linked background task");
+    expect(reply?.text).toContain("still working");
+    expect(reply?.text).toContain("linked flow");
+    expect(reply?.text).toContain("child session");
+  });
+
   it("does not leak internal runtime context through the task status line", async () => {
     createRunningTaskRun({
       runtime: "subagent",

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -23,6 +23,10 @@ import {
 } from "../../infra/provider-usage.js";
 import type { MediaUnderstandingDecision } from "../../media-understanding/types.js";
 import {
+  formatLifecycleBackingSummary,
+  formatLifecycleStatusReasonSummary,
+} from "../../tasks/task-lifecycle-status.js";
+import {
   listTasksForAgentIdForStatus,
   listTasksForSessionKeyForStatus,
 } from "../../tasks/task-status-access.js";
@@ -76,8 +80,10 @@ function formatSessionTaskLine(sessionKey: string): string | undefined {
         ? `${snapshot.recentFailureCount} recent failure${snapshot.recentFailureCount === 1 ? "" : "s"}`
         : "recently finished";
   const title = formatTaskStatusTitle(task);
-  const detail = formatTaskStatusDetail(task);
-  const parts = [headline, task.runtime, title, detail].filter(Boolean);
+  const reason = snapshot.focusReason;
+  const detail = formatTaskStatusDetail(task) ?? formatLifecycleStatusReasonSummary(reason);
+  const backing = formatLifecycleBackingSummary(reason);
+  const parts = [headline, task.runtime, title, detail, backing].filter(Boolean);
   return parts.length ? `📌 Tasks: ${parts.join(" · ")}` : undefined;
 }
 

--- a/src/auto-reply/reply/commands-tasks.test.ts
+++ b/src/auto-reply/reply/commands-tasks.test.ts
@@ -68,6 +68,9 @@ describe("buildTasksReply", () => {
     expect(reply.text).toContain("Current session: 2 active · 3 total");
     expect(reply.text).toContain("🟢 active background task");
     expect(reply.text).toContain("🟡 queued background task");
+    expect(reply.text).toContain("Queued for execution.");
+    expect(reply.text).toContain("linked flow");
+    expect(reply.text).toContain("child session");
     expect(reply.text).toContain("🔴 failed background task");
     expect(reply.text).toContain("approval denied");
   });

--- a/src/auto-reply/reply/commands-tasks.ts
+++ b/src/auto-reply/reply/commands-tasks.ts
@@ -2,6 +2,11 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { logVerbose } from "../../globals.js";
 import { formatDurationCompact } from "../../infra/format-time/format-duration.ts";
 import { formatTimeAgo } from "../../infra/format-time/format-relative.ts";
+import {
+  formatLifecycleBackingSummary,
+  formatLifecycleStatusReasonSummary,
+  resolveTaskLifecycleStatusReason,
+} from "../../tasks/task-lifecycle-status.js";
 import type { TaskRecord } from "../../tasks/task-registry.types.js";
 import {
   listTasksForAgentIdForStatus,
@@ -62,7 +67,10 @@ function formatTaskTiming(task: TaskRecord): string | undefined {
 }
 
 function formatTaskDetail(task: TaskRecord): string | undefined {
-  return formatTaskStatusDetail(task);
+  return (
+    formatTaskStatusDetail(task) ??
+    formatLifecycleStatusReasonSummary(resolveTaskLifecycleStatusReason(task))
+  );
 }
 
 function formatVisibleTask(task: TaskRecord, index: number): string {
@@ -70,10 +78,14 @@ function formatVisibleTask(task: TaskRecord, index: number): string {
   const status = task.status.replaceAll("_", " ");
   const timing = formatTaskTiming(task);
   const detail = formatTaskDetail(task);
+  const backing = formatLifecycleBackingSummary(resolveTaskLifecycleStatusReason(task));
   const meta = [TASK_RUNTIME_LABELS[task.runtime], status, timing].filter(Boolean).join(" · ");
   const lines = [`${index + 1}. ${TASK_STATUS_ICONS[task.status]} ${title}`, `   ${meta}`];
   if (detail) {
     lines.push(`   ${detail}`);
+  }
+  if (backing) {
+    lines.push(`   ${backing}`);
   }
   return lines.join("\n");
 }

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -1439,6 +1439,76 @@ describe("/compact command", () => {
       }),
     );
   });
+
+  it("routes /compact --dry-run as a read-only compaction inspect", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: "/tmp/openclaw-session-store.json" },
+    } as OpenClawConfig;
+    const params = buildParams("/compact --dry-run focus on decisions", cfg);
+    vi.mocked(compactEmbeddedPiSession).mockResolvedValueOnce({
+      ok: true,
+      compacted: false,
+      reason: "dry run",
+      result: {
+        summary: "prune_history → summarize_history → quality_retry → finalize",
+        firstKeptEntryId: "",
+        tokensBefore: 1234,
+        tokensAfter: 1234,
+        details: {
+          dryRun: true,
+          topContributors: [{ role: "assistant", chars: 500 }],
+          stageTelemetry: {
+            entryStage: "prune_history",
+            entryReason: "new_content_exceeds_history_budget",
+            outcomeStage: "prune_history",
+            outcomeReason: "new_content_exceeds_history_budget",
+            plan: [
+              { stage: "prune_history", reason: "new_content_exceeds_history_budget" },
+              { stage: "summarize_history", reason: "messages_to_summarize_present" },
+              { stage: "quality_retry", reason: "quality_guard_enabled" },
+              { stage: "finalize", reason: "summary_ready" },
+            ],
+            historyPruned: true,
+            splitTurn: false,
+            recentTurnsPreserve: 3,
+            qualityGuardEnabled: true,
+            qualityRetriesPlanned: 1,
+            qualityRetriesUsed: 0,
+            droppedChunks: 1,
+            droppedMessages: 2,
+            droppedSummaryUsed: false,
+          },
+        },
+      },
+    });
+
+    const result = await handleCompactCommand(
+      {
+        ...params,
+        sessionEntry: {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+          totalTokens: 12345,
+        },
+      },
+      true,
+    );
+
+    expect(result?.reply?.text).toContain(
+      "Dry-run: would run prune_history → summarize_history → quality_retry → finalize",
+    );
+    expect(result?.reply?.text).toContain("top=assistant");
+    expect(vi.mocked(compactEmbeddedPiSession)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-1",
+        trigger: "manual",
+        dryRun: true,
+        customInstructions: "focus on decisions",
+      }),
+    );
+  });
 });
 
 describe("abort trigger command", () => {

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -1500,6 +1500,8 @@ describe("/compact command", () => {
       "Dry-run: would run prune_history → summarize_history → quality_retry → finalize",
     );
     expect(result?.reply?.text).toContain("top=assistant");
+    expect(result?.reply?.text).toContain("history-prune=2 msgs/1 chunk");
+    expect(result?.reply?.text).toContain("quality-guard≤1 retry");
     expect(vi.mocked(compactEmbeddedPiSession)).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: "session-1",
@@ -1508,6 +1510,75 @@ describe("/compact command", () => {
         customInstructions: "focus on decisions",
       }),
     );
+  });
+
+  it("surfaces projected light-trim impact in /compact --dry-run replies", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: "/tmp/openclaw-session-store.json" },
+    } as OpenClawConfig;
+    const params = buildParams("/compact --inspect", cfg);
+    vi.mocked(compactEmbeddedPiSession).mockResolvedValueOnce({
+      ok: true,
+      compacted: false,
+      reason: "dry run",
+      result: {
+        summary: "light_trim → summarize_history → finalize",
+        firstKeptEntryId: "",
+        tokensBefore: 2400,
+        tokensAfter: 2400,
+        details: {
+          dryRun: true,
+          topContributors: [{ role: "toolResult", tool: "exec", chars: 1800 }],
+          lightTrim: {
+            trimmedMessages: 1,
+            trimmedToolResults: 1,
+            tokensBefore: 2400,
+            tokensAfter: 1500,
+            tokenDelta: 900,
+          },
+          stageTelemetry: {
+            entryStage: "light_trim",
+            entryReason: "oversized_tool_results_present",
+            outcomeStage: "light_trim",
+            outcomeReason: "oversized_tool_results_present",
+            plan: [
+              { stage: "light_trim", reason: "oversized_tool_results_present" },
+              { stage: "summarize_history", reason: "messages_to_summarize_present" },
+              { stage: "finalize", reason: "summary_ready" },
+            ],
+            historyPruned: false,
+            splitTurn: false,
+            recentTurnsPreserve: 3,
+            qualityGuardEnabled: false,
+            qualityRetriesPlanned: 0,
+            qualityRetriesUsed: 0,
+            droppedChunks: 0,
+            droppedMessages: 0,
+            droppedSummaryUsed: false,
+          },
+        },
+      },
+    });
+
+    const result = await handleCompactCommand(
+      {
+        ...params,
+        sessionEntry: {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+          totalTokens: 2400,
+        },
+      },
+      true,
+    );
+
+    expect(result?.reply?.text).toContain(
+      "Dry-run: would run light_trim → summarize_history → finalize",
+    );
+    expect(result?.reply?.text).toContain("top=toolResult:exec");
+    expect(result?.reply?.text).toContain("light-trim=1 msg/1 tool (-900 tok)");
   });
 });
 

--- a/src/auto-reply/thinking.shared.ts
+++ b/src/auto-reply/thinking.shared.ts
@@ -31,6 +31,10 @@ const OPENAI_CODEX_XHIGH_MODEL_IDS = [
 ] as const;
 const GITHUB_COPILOT_XHIGH_MODEL_IDS = ["gpt-5.2", "gpt-5.2-codex"] as const;
 
+function supportsCompatibleOpenAIXHighThinking(modelId: string): boolean {
+  return matchesExactOrPrefix(modelId, OPENAI_XHIGH_MODEL_IDS);
+}
+
 export function normalizeProviderId(provider?: string | null): string {
   if (!provider) {
     return "";
@@ -66,6 +70,10 @@ export function supportsBuiltInXHighThinking(
   }
   if (providerId === "github-copilot") {
     return GITHUB_COPILOT_XHIGH_MODEL_IDS.includes(modelId as never);
+  }
+  // Allow OpenAI-compatible third-party providers that preserve GPT-5.x model ids.
+  if (supportsCompatibleOpenAIXHighThinking(modelId)) {
+    return true;
   }
   return false;
 }

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -11,6 +11,7 @@ let listThinkingLevels: typeof import("./thinking.js").listThinkingLevels;
 let normalizeReasoningLevel: typeof import("./thinking.js").normalizeReasoningLevel;
 let normalizeThinkLevel: typeof import("./thinking.js").normalizeThinkLevel;
 let resolveThinkingDefaultForModel: typeof import("./thinking.js").resolveThinkingDefaultForModel;
+let supportsXHighThinking: typeof import("./thinking.js").supportsXHighThinking;
 
 async function loadFreshThinkingModuleForTest() {
   vi.resetModules();
@@ -36,6 +37,7 @@ beforeEach(async () => {
     normalizeReasoningLevel,
     normalizeThinkLevel,
     resolveThinkingDefaultForModel,
+    supportsXHighThinking,
   } = await loadFreshThinkingModuleForTest());
 });
 
@@ -102,6 +104,11 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("github-copilot", "gpt-5.2-codex")).toContain("xhigh");
   });
 
+  it("includes xhigh for OpenAI-compatible third-party providers that preserve GPT-5.x ids", () => {
+    expect(listThinkingLevels("openai-gpt", "gpt-5.4")).toContain("xhigh");
+    expect(listThinkingLevels("tokenx24", "gpt-5.4")).toContain("xhigh");
+  });
+
   it("excludes xhigh for non-codex models", () => {
     expect(listThinkingLevels(undefined, "gpt-4.1-mini")).not.toContain("xhigh");
   });
@@ -109,6 +116,18 @@ describe("listThinkingLevels", () => {
   it("always includes adaptive", () => {
     expect(listThinkingLevels(undefined, "gpt-4.1-mini")).toContain("adaptive");
     expect(listThinkingLevels("anthropic", "claude-opus-4-6")).toContain("adaptive");
+  });
+});
+
+describe("supportsXHighThinking", () => {
+  it("accepts GPT-5.x ids on OpenAI-compatible third-party providers", () => {
+    expect(supportsXHighThinking("openai-gpt", "gpt-5.4")).toBe(true);
+    expect(supportsXHighThinking("tokenx24", "gpt-5.4")).toBe(true);
+  });
+
+  it("does not over-match unrelated providers or models", () => {
+    expect(supportsXHighThinking("moonshot", "kimi-k2")).toBe(false);
+    expect(supportsXHighThinking("demo", "gpt-4.1-mini")).toBe(false);
   });
 });
 

--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -219,6 +219,45 @@ describe("flows commands", () => {
     });
   });
 
+  it("shows linked task lifecycle reasons in TaskFlow text output", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      const child = createRunningTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: undefined,
+        childSessionKey: "agent:main:subagent:child-missing",
+        runId: "run-child-4",
+        label: "Wait for child",
+        task: "Wait for child",
+        startedAt: 100,
+        lastEventAt: 100,
+      });
+
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/flows-command",
+        goal: "Wait for linked child",
+        status: "waiting",
+        waitJson: { kind: "task", taskId: child.taskId },
+        createdAt: 100,
+        updatedAt: 100,
+      });
+
+      const runtime = createRuntime();
+      await flowsShowCommand({ lookup: flow.flowId, json: false }, runtime);
+
+      const output = vi
+        .mocked(runtime.log)
+        .mock.calls.map(([line]) => String(line))
+        .join("\n");
+      expect(output).toContain(
+        "reason: Waiting on task: Backing session is missing; task may be orphaned.",
+      );
+      expect(output).toContain("Linked tasks: none");
+    });
+  });
+
   it("shows one TaskFlow as JSON with lifecycle reason", async () => {
     await withTaskFlowCommandStateDir(async () => {
       const flow = createManagedTaskFlow({

--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -91,6 +91,7 @@ describe("flows commands", () => {
         status: string | null;
         flows: Array<{
           flowId: string;
+          statusReason?: { code: string; summary: string };
           tasks: Array<{ runId?: string; label?: string }>;
           taskSummary: { total: number; active: number };
         }>;
@@ -102,6 +103,10 @@ describe("flows commands", () => {
         flows: [
           {
             flowId: flow.flowId,
+            statusReason: {
+              code: "blocked",
+              summary: expect.any(String),
+            },
             taskSummary: {
               total: 1,
               active: 1,
@@ -157,6 +162,7 @@ describe("flows commands", () => {
       expect(output).toContain("goal: Investigate a flaky queue");
       expect(output).toContain("currentStep: spawn_child");
       expect(output).toContain("owner: agent:main:main");
+      expect(output).toContain("reason: Waiting on child task output");
       expect(output).toContain("state: Waiting on child task output");
       expect(output).toContain("Linked tasks:");
       expect(output).toContain("run-child-2");
@@ -204,11 +210,41 @@ describe("flows commands", () => {
       expect(lines).toContain("goal: Investigate\\nqueue\\tstate");
       expect(lines).toContain("currentStep: spawn_child");
       expect(lines).toContain("owner: agent:main:owner");
+      expect(lines.some((line) => line.startsWith("reason: "))).toBe(true);
       expect(lines).toContain("state: Waiting on child\\nforged: yes");
       expect(
         lines.some((line) => line.includes("run-child-3") && line.includes("Collect\\nlogs")),
       ).toBe(true);
       expect(lines.join("\n")).not.toContain("\u001b[");
+    });
+  });
+
+  it("shows one TaskFlow as JSON with lifecycle reason", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/flows-command",
+        goal: "Review flow JSON",
+        status: "waiting",
+        createdAt: 100,
+        updatedAt: 100,
+      });
+
+      const runtime = createRuntime();
+      await flowsShowCommand({ lookup: flow.flowId, json: true }, runtime);
+
+      const payload = JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0])) as {
+        flowId: string;
+        statusReason?: { code: string; summary: string };
+      };
+
+      expect(payload).toMatchObject({
+        flowId: flow.flowId,
+        statusReason: {
+          code: "waiting",
+          summary: expect.any(String),
+        },
+      });
     });
   });
 

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -9,6 +9,11 @@ import {
   listTaskFlowRecords,
   resolveTaskFlowForLookupToken,
 } from "../tasks/task-flow-runtime-internal.js";
+import {
+  formatLifecycleBackingSummary,
+  formatLifecycleStatusReasonSummary,
+  resolveTaskFlowLifecycleStatusReason,
+} from "../tasks/task-lifecycle-status.js";
 import { sanitizeTerminalText } from "../terminal/safe-text.js";
 import { isRich, theme } from "../terminal/theme.js";
 
@@ -155,6 +160,7 @@ export async function flowsListCommand(
           status: statusFilter ?? null,
           flows: flows.map((flow) => ({
             ...flow,
+            statusReason: resolveTaskFlowLifecycleStatusReason({ flow }),
             tasks: listTasksForFlowId(flow.flowId),
             taskSummary: getFlowTaskSummary(flow.flowId),
           })),
@@ -194,12 +200,16 @@ export async function flowsShowCommand(
   const tasks = listTasksForFlowId(flow.flowId);
   const taskSummary = getFlowTaskSummary(flow.flowId);
   const stateSummary = summarizeFlowState(flow);
+  const statusReason = resolveTaskFlowLifecycleStatusReason({ flow });
+  const reasonSummary = formatLifecycleStatusReasonSummary(statusReason);
+  const backingSummary = formatLifecycleBackingSummary(statusReason);
 
   if (opts.json) {
     runtime.log(
       JSON.stringify(
         {
           ...flow,
+          statusReason,
           tasks,
           taskSummary,
         },
@@ -218,6 +228,8 @@ export async function flowsShowCommand(
     `currentStep: ${safeFlowDisplayText(flow.currentStep)}`,
     `owner: ${safeFlowDisplayText(flow.ownerKey)}`,
     `notify: ${flow.notifyPolicy}`,
+    ...(reasonSummary ? [`reason: ${safeFlowDisplayText(reasonSummary)}`] : []),
+    ...(backingSummary ? [`links: ${safeFlowDisplayText(backingSummary)}`] : []),
     ...(stateSummary ? [`state: ${safeFlowDisplayText(stateSummary)}`] : []),
     ...(flow.cancelRequestedAt
       ? [`cancelRequestedAt: ${new Date(flow.cancelRequestedAt).toISOString()}`]

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -5,6 +5,7 @@ import type { Tone } from "../plugin-sdk/memory-core-host-status.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import type { HealthSummary } from "./health.js";
 import { getDaemonStatusSummary, getNodeDaemonStatusSummary } from "./status.daemon.js";
+import { readInstallPathStatusSummary } from "./status.install-path-summary.js";
 
 let providerUsagePromise: Promise<typeof import("../infra/provider-usage.js")> | undefined;
 let securityAuditModulePromise: Promise<typeof import("../security/audit.runtime.js")> | undefined;
@@ -210,9 +211,10 @@ export async function statusCommand(
   });
 
   if (opts.json) {
-    const [daemon, nodeDaemon] = await Promise.all([
+    const [daemon, nodeDaemon, installPath] = await Promise.all([
       getDaemonStatusSummary(),
       getNodeDaemonStatusSummary(),
+      readInstallPathStatusSummary({ cfg, update }),
     ]);
     writeRuntimeJson(runtime, {
       ...summary,
@@ -235,6 +237,7 @@ export async function statusCommand(
       },
       gatewayService: daemon,
       nodeService: nodeDaemon,
+      installPathCheck: installPath,
       agents: agentStatus,
       securityAudit,
       secretDiagnostics,
@@ -308,9 +311,10 @@ export async function statusCommand(
         }).httpUrl
       : "disabled";
 
-  const [daemon, nodeDaemon] = await Promise.all([
+  const [daemon, nodeDaemon, installPath] = await Promise.all([
     getDaemonStatusSummary(),
     getNodeDaemonStatusSummary(),
+    readInstallPathStatusSummary({ cfg, update }),
   ]);
   const nodeOnlyGateway = await loadStatusNodeModeModule().then(({ resolveNodeOnlyGatewayInfo }) =>
     resolveNodeOnlyGatewayInfo({
@@ -516,6 +520,7 @@ export async function statusCommand(
       : []),
     { Item: "Gateway service", Value: daemonValue },
     { Item: "Node service", Value: nodeDaemonValue },
+    { Item: "Install path check", Value: installPath.formatted },
     { Item: "Agents", Value: agentsValue },
     { Item: "Memory", Value: memoryValue },
     { Item: "Plugin compatibility", Value: pluginCompatibilityValue },

--- a/src/commands/status.install-path-summary.ts
+++ b/src/commands/status.install-path-summary.ts
@@ -1,0 +1,59 @@
+import { resolveGatewayPort } from "../config/paths.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { readGatewayServiceState, resolveGatewayService } from "../daemon/service.js";
+import { type UpdateCheckResult } from "../infra/update-check.js";
+import {
+  detectCoreInstallPathIssue,
+  formatCoreInstallPathIssue,
+  type CoreInstallPathIssue,
+} from "../infra/core-install-path-check.js";
+import { buildGatewayInstallPlan } from "./daemon-install-helpers.js";
+import { DEFAULT_GATEWAY_DAEMON_RUNTIME, type GatewayDaemonRuntime } from "./daemon-runtime.js";
+
+export type InstallPathStatusSummary = {
+  issue: CoreInstallPathIssue;
+  formatted: string;
+};
+
+function detectGatewayRuntime(programArguments: string[] | undefined): GatewayDaemonRuntime {
+  const first = programArguments?.[0];
+  if (first) {
+    const base = first.split(/[\\/]/).at(-1)?.toLowerCase();
+    if (base === "bun" || base === "bun.exe") {
+      return "bun";
+    }
+    if (base === "node" || base === "node.exe") {
+      return "node";
+    }
+  }
+  return DEFAULT_GATEWAY_DAEMON_RUNTIME;
+}
+
+export async function readInstallPathStatusSummary(params: {
+  cfg: OpenClawConfig;
+  update: UpdateCheckResult;
+}): Promise<InstallPathStatusSummary> {
+  const service = resolveGatewayService();
+  const state = await readGatewayServiceState(service, { env: process.env }).catch(() => null);
+  const runtimeChoice = detectGatewayRuntime(state?.command?.programArguments);
+  const port = resolveGatewayPort(params.cfg, process.env);
+  const expectedPlan = await buildGatewayInstallPlan({
+    env: process.env,
+    port,
+    runtime: runtimeChoice,
+    config: params.cfg,
+  }).catch(() => null);
+
+  const issue = await detectCoreInstallPathIssue({
+    packageRoot: params.update.root,
+    expectedProgramArguments: expectedPlan?.programArguments,
+    serviceProgramArguments: state?.command?.programArguments,
+    configPathCli: process.env.OPENCLAW_CONFIG ?? null,
+    configPathService: state?.env?.OPENCLAW_CONFIG ?? null,
+  });
+
+  return {
+    issue,
+    formatted: formatCoreInstallPathIssue(issue),
+  };
+}

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -9,6 +9,7 @@ import { completeTaskRunByRunId, createRunningTaskRun } from "../tasks/task-exec
 import {
   createManagedTaskFlow,
   resetTaskFlowRegistryForTests,
+  setFlowWaiting,
 } from "../tasks/task-flow-registry.js";
 import {
   resetTaskRegistryDeliveryRuntimeForTests,
@@ -156,6 +157,51 @@ describe("tasks commands", () => {
           ]),
         },
       });
+    });
+  });
+
+  it("shows linked-task lifecycle evidence in tasks audit text output", async () => {
+    await withTaskCommandStateDir(async () => {
+      const now = Date.now();
+      vi.useFakeTimers();
+      vi.setSystemTime(now - 40 * 60_000);
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/tasks-command",
+        goal: "Wait on child evidence",
+        status: "running",
+        createdAt: now - 40 * 60_000,
+        updatedAt: now - 40 * 60_000,
+      });
+      const child = createRunningTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        childSessionKey: "agent:main:subagent:tasks-audit-child-missing",
+        runId: "task-audit-child-missing",
+        task: "Wait for child result",
+        startedAt: now - 40 * 60_000,
+        lastEventAt: now - 40 * 60_000,
+      });
+      setFlowWaiting({
+        flowId: flow.flowId,
+        expectedRevision: flow.revision,
+        waitJson: { kind: "task", taskId: child.taskId },
+        updatedAt: now - 40 * 60_000,
+      });
+      vi.setSystemTime(now);
+
+      const runtime = createRuntime();
+      await tasksAuditCommand({ code: "stale_waiting" }, runtime);
+
+      const output = vi
+        .mocked(runtime.log)
+        .mock.calls.map((call) => String(call[0]))
+        .join("\n");
+      expect(output).toContain("stale_waiting");
+      expect(output).toContain(`waiting on task ${child.taskId}`);
+      expect(output).toContain("Backing session is missing; task may be orphaned.");
     });
   });
 

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -79,8 +79,18 @@ describe("tasks commands", () => {
         scopeKind: "session",
         runId: "task-stale-queued",
         task: "Inspect issue backlog",
+        childSessionKey: "agent:main:subagent:audit-stale-child",
       });
       vi.setSystemTime(now);
+      const storePath = resolveStorePath(undefined, { agentId: "main" });
+      await saveSessionStore(storePath, {
+        "agent:main:subagent:audit-stale-child": {
+          sessionId: "session-audit-stale-child",
+          updatedAt: now - 60_000,
+          status: "running",
+        },
+      });
+      clearSessionStoreCacheForTest();
       createManagedTaskFlow({
         ownerKey: "agent:main:main",
         controllerId: "tests/tasks-command",
@@ -125,7 +135,8 @@ describe("tasks commands", () => {
         token: expect.any(String),
         lifecycleReason: {
           code: "stale_running",
-          evidence: "running task appears stuck",
+          evidence: "Backing session is still running; task has not advanced recently.",
+          summary: "Backing session is running.",
           backing: {
             kind: "task",
             taskId: expect.any(String),

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -89,12 +89,40 @@ describe("tasks commands", () => {
           taskFlows: { total: number; byCode: Record<string, number> };
           combined: { total: number; errors: number; warnings: number };
         };
+        findings: Array<{
+          kind: string;
+          code: string;
+          token?: string;
+          lifecycleReason?: {
+            code: string;
+            evidence: string;
+            backing: {
+              kind: string;
+              taskId: string;
+              runId?: string;
+            };
+          };
+        }>;
       };
 
       expect(payload.summary.byCode.stale_running).toBe(1);
       expect(payload.summary.taskFlows.byCode.stale_waiting).toBe(1);
       expect(payload.summary.taskFlows.byCode.missing_linked_tasks).toBe(1);
       expect(payload.summary.combined.total).toBe(3);
+      expect(payload.findings.find((finding) => finding.kind === "task")).toMatchObject({
+        kind: "task",
+        code: "stale_running",
+        token: expect.any(String),
+        lifecycleReason: {
+          code: "stale_running",
+          evidence: "running task appears stuck",
+          backing: {
+            kind: "task",
+            taskId: expect.any(String),
+            runId: "task-stale-queued",
+          },
+        },
+      });
     });
   });
 

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSessionStoreCacheForTest,
+  resolveStorePath,
+  saveSessionStore,
+} from "../config/sessions.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { completeTaskRunByRunId, createRunningTaskRun } from "../tasks/task-executor.js";
 import {
@@ -30,12 +35,14 @@ function createRuntime(): RuntimeEnv {
 async function withTaskCommandStateDir(run: () => Promise<void>): Promise<void> {
   await withTempDir({ prefix: "openclaw-tasks-command-" }, async (root) => {
     process.env.OPENCLAW_STATE_DIR = root;
+    clearSessionStoreCacheForTest();
     resetTaskRegistryDeliveryRuntimeForTests();
     resetTaskRegistryForTests();
     resetTaskFlowRegistryForTests();
     try {
       await run();
     } finally {
+      clearSessionStoreCacheForTest();
       resetTaskRegistryDeliveryRuntimeForTests();
       resetTaskRegistryForTests();
       resetTaskFlowRegistryForTests();
@@ -55,6 +62,7 @@ describe("tasks commands", () => {
     } else {
       process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
     }
+    clearSessionStoreCacheForTest();
     resetTaskRegistryDeliveryRuntimeForTests();
     resetTaskRegistryForTests();
     resetTaskFlowRegistryForTests();
@@ -158,6 +166,15 @@ describe("tasks commands", () => {
         childSessionKey: "agent:main:child-1",
         parentFlowId: flow.flowId,
       });
+      const storePath = resolveStorePath(undefined, { agentId: "main" });
+      await saveSessionStore(storePath, {
+        "agent:main:child-1": {
+          sessionId: "session-child-1",
+          updatedAt: Date.now(),
+          status: "running",
+        },
+      });
+      clearSessionStoreCacheForTest();
 
       const runtime = createRuntime();
       await tasksListCommand({ json: true }, runtime);
@@ -251,10 +268,61 @@ describe("tasks commands", () => {
       expect(payload).toMatchObject({
         taskId: task.taskId,
         statusReason: {
-          code: "running",
-          summary: "Task is running.",
+          code: "missing_backing_session",
+          summary: "Backing session is missing; task may be orphaned.",
           backing: expect.arrayContaining([
             { kind: "session", relation: "child_session", id: "agent:main:child-3" },
+          ]),
+        },
+      });
+    });
+  });
+
+  it("surfaces blocked backing-session state in task detail JSON before registry reconciliation", async () => {
+    await withTaskCommandStateDir(async () => {
+      const task = createRunningTaskRun({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "task-show-json-backed-failed",
+        task: "Inspect child session failure",
+        childSessionKey: "agent:main:subagent:child-failed-json",
+      });
+      const storePath = resolveStorePath(undefined, { agentId: "main" });
+      await saveSessionStore(storePath, {
+        "agent:main:subagent:child-failed-json": {
+          sessionId: "session-child-failed-json",
+          updatedAt: Date.now(),
+          status: "failed",
+        },
+      });
+      clearSessionStoreCacheForTest();
+
+      const runtime = createRuntime();
+      await tasksShowCommand({ json: true, lookup: task.taskId }, runtime);
+
+      const payload = JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0])) as {
+        taskId: string;
+        statusReason?: {
+          code: string;
+          summary: string;
+          evidence?: Array<{ kind: string; data?: Record<string, string> }>;
+        };
+      };
+
+      expect(payload).toMatchObject({
+        taskId: task.taskId,
+        statusReason: {
+          code: "blocked_on_backing_session_state",
+          summary: "Backing session failed; task has not reconciled yet.",
+          evidence: expect.arrayContaining([
+            expect.objectContaining({
+              kind: "session_state",
+              data: {
+                state: "failed",
+                source: "session_status",
+              },
+            }),
           ]),
         },
       });

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -95,12 +95,9 @@ describe("tasks commands", () => {
           token?: string;
           lifecycleReason?: {
             code: string;
-            evidence: string;
-            backing: {
-              kind: string;
-              taskId: string;
-              runId?: string;
-            };
+            evidence?: string;
+            summary?: string;
+            backing?: unknown;
           };
         }>;
       };
@@ -121,6 +118,18 @@ describe("tasks commands", () => {
             taskId: expect.any(String),
             runId: "task-stale-queued",
           },
+        },
+      });
+      expect(payload.findings.find((finding) => finding.kind === "task_flow")).toMatchObject({
+        kind: "task_flow",
+        code: "stale_waiting",
+        token: expect.any(String),
+        lifecycleReason: {
+          code: "waiting",
+          summary: expect.any(String),
+          backing: expect.arrayContaining([
+            expect.objectContaining({ kind: "session", relation: "owner_session" }),
+          ]),
         },
       });
     });

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -278,7 +278,7 @@ describe("tasks commands", () => {
     });
   });
 
-  it("surfaces blocked backing-session state in task detail JSON before registry reconciliation", async () => {
+  it("projects terminal backing-session evidence in task detail JSON before maintenance apply", async () => {
     await withTaskCommandStateDir(async () => {
       const task = createRunningTaskRun({
         runtime: "cli",
@@ -303,27 +303,21 @@ describe("tasks commands", () => {
 
       const payload = JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0])) as {
         taskId: string;
+        status: string;
+        error?: string;
         statusReason?: {
           code: string;
           summary: string;
-          evidence?: Array<{ kind: string; data?: Record<string, string> }>;
         };
       };
 
       expect(payload).toMatchObject({
         taskId: task.taskId,
+        status: "failed",
+        error: "Backing session failed.",
         statusReason: {
-          code: "blocked_on_backing_session_state",
-          summary: "Backing session failed; task has not reconciled yet.",
-          evidence: expect.arrayContaining([
-            expect.objectContaining({
-              kind: "session_state",
-              data: {
-                state: "failed",
-                source: "session_status",
-              },
-            }),
-          ]),
+          code: "failed",
+          summary: "Backing session failed.",
         },
       });
     });

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
-import { createRunningTaskRun } from "../tasks/task-executor.js";
+import { completeTaskRunByRunId, createRunningTaskRun } from "../tasks/task-executor.js";
 import {
   createManagedTaskFlow,
   resetTaskFlowRegistryForTests,
@@ -10,7 +10,12 @@ import {
   resetTaskRegistryForTests,
 } from "../tasks/task-registry.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
-import { tasksAuditCommand, tasksMaintenanceCommand } from "./tasks.js";
+import {
+  tasksAuditCommand,
+  tasksListCommand,
+  tasksMaintenanceCommand,
+  tasksShowCommand,
+} from "./tasks.js";
 
 const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
 
@@ -129,6 +134,127 @@ describe("tasks commands", () => {
           summary: expect.any(String),
           backing: expect.arrayContaining([
             expect.objectContaining({ kind: "session", relation: "owner_session" }),
+          ]),
+        },
+      });
+    });
+  });
+
+  it("adds lifecycle reasons to tasks list JSON output", async () => {
+    await withTaskCommandStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/tasks-command",
+        goal: "Inspect lifecycle bridge",
+        status: "running",
+      });
+      createRunningTaskRun({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "task-running-1",
+        task: "Inspect lifecycle bridge",
+        progressSummary: "Collecting task status evidence",
+        childSessionKey: "agent:main:child-1",
+        parentFlowId: flow.flowId,
+      });
+
+      const runtime = createRuntime();
+      await tasksListCommand({ json: true }, runtime);
+
+      const payload = JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0])) as {
+        tasks: Array<{
+          runId?: string;
+          statusReason?: {
+            code: string;
+            summary: string;
+            backing?: Array<{ kind: string; relation: string; id: string }>;
+          };
+        }>;
+      };
+
+      expect(payload.tasks).toHaveLength(1);
+      expect(payload.tasks[0]).toMatchObject({
+        runId: "task-running-1",
+        statusReason: {
+          code: "running",
+          summary: "Collecting task status evidence",
+          backing: expect.arrayContaining([
+            { kind: "flow", relation: "parent_flow", id: flow.flowId },
+            { kind: "session", relation: "child_session", id: "agent:main:child-1" },
+          ]),
+        },
+      });
+    });
+  });
+
+  it("shows lifecycle reason and links in task detail output", async () => {
+    await withTaskCommandStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/tasks-command",
+        goal: "Resume gated command",
+        status: "running",
+      });
+      const task = createRunningTaskRun({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "task-blocked-1",
+        task: "Resume gated command",
+        childSessionKey: "agent:main:child-2",
+        parentFlowId: flow.flowId,
+      });
+      completeTaskRunByRunId({
+        runId: "task-blocked-1",
+        endedAt: Date.now(),
+        terminalOutcome: "blocked",
+        terminalSummary: "Writable session approval required.",
+      });
+
+      const runtime = createRuntime();
+      await tasksShowCommand({ lookup: task.taskId }, runtime);
+
+      const output = vi
+        .mocked(runtime.log)
+        .mock.calls.map((call) => String(call[0]))
+        .join("\n");
+
+      expect(output).toContain("reason: Writable session approval required.");
+      expect(output).toContain("links: linked flow · child session");
+    });
+  });
+
+  it("adds lifecycle reason to tasks show JSON output", async () => {
+    await withTaskCommandStateDir(async () => {
+      const task = createRunningTaskRun({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "task-show-json-1",
+        task: "Inspect lost child session",
+        childSessionKey: "agent:main:child-3",
+      });
+
+      const runtime = createRuntime();
+      await tasksShowCommand({ json: true, lookup: task.taskId }, runtime);
+
+      const payload = JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0])) as {
+        taskId: string;
+        statusReason?: {
+          code: string;
+          summary: string;
+          backing?: Array<{ kind: string; relation: string; id: string }>;
+        };
+      };
+
+      expect(payload).toMatchObject({
+        taskId: task.taskId,
+        statusReason: {
+          code: "running",
+          summary: "Task is running.",
+          backing: expect.arrayContaining([
+            { kind: "session", relation: "child_session", id: "agent:main:child-3" },
           ]),
         },
       });

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -204,7 +204,7 @@ function formatAuditRows(findings: TaskSystemAuditFinding[], rich: boolean) {
         shortToken(finding.token).padEnd(ID_PAD),
         status,
         formatAgeMs(finding.ageMs).padEnd(8),
-        truncate(finding.detail, 88),
+        truncate(finding.detail, 160),
       ]
         .join(" ")
         .trimEnd(),

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -21,6 +21,7 @@ import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
 import {
   listTaskAuditFindings,
   summarizeTaskAuditFindings,
+  type LifecycleStatusReason,
   type TaskAuditCode,
   type TaskAuditSeverity,
 } from "../tasks/task-registry.audit.js";
@@ -148,6 +149,7 @@ type TaskSystemAuditFinding = {
   ageMs?: number;
   status?: string;
   token?: string;
+  lifecycleReason?: LifecycleStatusReason;
   task?: TaskRecord;
   flow?: TaskFlowRecord;
 };
@@ -220,6 +222,7 @@ function toSystemAuditFindings(params: {
       ageMs: finding.ageMs,
       status: finding.task.status,
       token: finding.task.taskId,
+      lifecycleReason: finding.lifecycleReason,
       task: finding.task,
     })),
     ...flowFindings.map((finding) => ({
@@ -233,15 +236,17 @@ function toSystemAuditFindings(params: {
       ...(finding.flow ? { flow: finding.flow } : {}),
     })),
   ];
-  const filteredFindings = allFindings.filter((finding) => {
-    if (params.severityFilter && finding.severity !== params.severityFilter) {
-      return false;
-    }
-    if (params.codeFilter && finding.code !== params.codeFilter) {
-      return false;
-    }
-    return true;
-  }).toSorted(compareSystemAuditFindings);
+  const filteredFindings = allFindings
+    .filter((finding) => {
+      if (params.severityFilter && finding.severity !== params.severityFilter) {
+        return false;
+      }
+      if (params.codeFilter && finding.code !== params.codeFilter) {
+        return false;
+      }
+      return true;
+    })
+    .toSorted(compareSystemAuditFindings);
   const sortedAllFindings = [...allFindings].toSorted(compareSystemAuditFindings);
   return {
     allFindings: sortedAllFindings,

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -233,6 +233,7 @@ function toSystemAuditFindings(params: {
       ageMs: finding.ageMs,
       status: finding.flow?.status ?? "n/a",
       token: finding.flow?.flowId,
+      lifecycleReason: finding.lifecycleReason,
       ...(finding.flow ? { flow: finding.flow } : {}),
     })),
   ];

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -19,9 +19,15 @@ import {
 } from "../tasks/task-flow-registry.maintenance.js";
 import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
 import {
+  formatLifecycleBackingSummary,
+  formatLifecycleStatusReasonSummary,
+  resolveTaskLifecycleStatusReason,
+  type LifecycleStatusReason as TaskLifecycleStatusReason,
+} from "../tasks/task-lifecycle-status.js";
+import {
   listTaskAuditFindings,
   summarizeTaskAuditFindings,
-  type LifecycleStatusReason,
+  type LifecycleStatusReason as TaskAuditLifecycleReason,
   type TaskAuditCode,
   type TaskAuditSeverity,
 } from "../tasks/task-registry.audit.js";
@@ -149,7 +155,7 @@ type TaskSystemAuditFinding = {
   ageMs?: number;
   status?: string;
   token?: string;
-  lifecycleReason?: LifecycleStatusReason;
+  lifecycleReason?: TaskAuditLifecycleReason | TaskLifecycleStatusReason;
   task?: TaskRecord;
   flow?: TaskFlowRecord;
 };
@@ -287,7 +293,10 @@ export async function tasksListCommand(
           count: tasks.length,
           runtime: runtimeFilter ?? null,
           status: statusFilter ?? null,
-          tasks,
+          tasks: tasks.map((task) => ({
+            ...task,
+            statusReason: resolveTaskLifecycleStatusReason(task),
+          })),
         },
         null,
         2,
@@ -325,8 +334,21 @@ export async function tasksShowCommand(
     return;
   }
 
+  const statusReason = resolveTaskLifecycleStatusReason(task);
+  const reasonSummary = formatLifecycleStatusReasonSummary(statusReason);
+  const backingSummary = formatLifecycleBackingSummary(statusReason);
+
   if (opts.json) {
-    runtime.log(JSON.stringify(task, null, 2));
+    runtime.log(
+      JSON.stringify(
+        {
+          ...task,
+          statusReason,
+        },
+        null,
+        2,
+      ),
+    );
     return;
   }
 
@@ -346,6 +368,8 @@ export async function tasksShowCommand(
     `runId: ${task.runId ?? "n/a"}`,
     `label: ${task.label ?? "n/a"}`,
     `task: ${task.task}`,
+    ...(reasonSummary ? [`reason: ${reasonSummary}`] : []),
+    ...(backingSummary ? [`links: ${backingSummary}`] : []),
     `createdAt: ${new Date(task.createdAt).toISOString()}`,
     `startedAt: ${task.startedAt ? new Date(task.startedAt).toISOString() : "n/a"}`,
     `endedAt: ${task.endedAt ? new Date(task.endedAt).toISOString() : "n/a"}`,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -368,6 +368,18 @@ export type SessionSystemPromptReport = {
     mode?: string;
     sandboxed?: boolean;
   };
+  promptHash?: string;
+  tracked?: {
+    chars: number;
+    estimatedTokens: number;
+    largestContributors: Array<{
+      name: string;
+      chars: number;
+      estimatedTokens: number;
+      sharePercent: number;
+    }>;
+  };
+  truncationSeverity?: "none" | "low" | "medium" | "high";
   systemPrompt: {
     chars: number;
     projectContextChars: number;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -350,6 +350,8 @@ export type SessionSystemPromptReport = {
   generatedAt: number;
   sessionId?: string;
   sessionKey?: string;
+  sourceRunId?: string;
+  sourceMessageId?: string;
   provider?: string;
   model?: string;
   workspaceDir?: string;

--- a/src/infra/core-install-path-check.test.ts
+++ b/src/infra/core-install-path-check.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectCoreInstallPathIssue,
+  formatCoreInstallPathIssue,
+} from "./core-install-path-check.js";
+
+describe("detectCoreInstallPathIssue", () => {
+  it("reports aligned service entrypoints as none", async () => {
+    const issue = await detectCoreInstallPathIssue({
+      packageRoot: "/opt/openclaw",
+      expectedProgramArguments: ["/usr/bin/node", "/opt/openclaw/dist/index.js", "gateway"],
+      serviceProgramArguments: ["/usr/bin/node", "/opt/openclaw/dist/index.js", "gateway"],
+      configPathCli: "/home/test/.openclaw/openclaw.json",
+      configPathService: "/home/test/.openclaw/openclaw.json",
+    });
+
+    expect(issue.driftKind).toBe("none");
+    expect(issue.severity).toBe("info");
+  });
+
+  it("reports same-root entrypoint differences as a warning", async () => {
+    const issue = await detectCoreInstallPathIssue({
+      packageRoot: "/opt/openclaw",
+      expectedProgramArguments: ["/usr/bin/node", "/opt/openclaw/dist/index.js", "gateway"],
+      serviceProgramArguments: ["/usr/bin/node", "/opt/openclaw/dist/entry.js", "gateway"],
+      configPathCli: "/home/test/.openclaw/openclaw.json",
+      configPathService: "/home/test/.openclaw/openclaw.json",
+    });
+
+    expect(issue.driftKind).toBe("entrypoint-shape-mismatch");
+    expect(issue.severity).toBe("warn");
+  });
+
+  it("reports different install roots as an error", async () => {
+    const issue = await detectCoreInstallPathIssue({
+      packageRoot: "/home/test/.npm-global/lib/node_modules/openclaw",
+      expectedProgramArguments: [
+        "/usr/bin/node",
+        "/home/test/.npm-global/lib/node_modules/openclaw/dist/index.js",
+        "gateway",
+      ],
+      serviceProgramArguments: [
+        "/usr/bin/node",
+        "/usr/lib/node_modules/openclaw/dist/index.js",
+        "gateway",
+      ],
+      configPathCli: "/home/test/.openclaw/openclaw.json",
+      configPathService: "/home/test/.openclaw/openclaw.json",
+    });
+
+    expect(issue.driftKind).toBe("service-points-elsewhere");
+    expect(issue.severity).toBe("error");
+  });
+
+  it("reports config path mismatches before path shape mismatches", async () => {
+    const issue = await detectCoreInstallPathIssue({
+      packageRoot: "/opt/openclaw",
+      expectedProgramArguments: ["/usr/bin/node", "/opt/openclaw/dist/index.js", "gateway"],
+      serviceProgramArguments: ["/usr/bin/node", "/opt/openclaw/dist/index.js", "gateway"],
+      configPathCli: "/home/test/.openclaw/openclaw.json",
+      configPathService: "/srv/openclaw/openclaw.json",
+    });
+
+    expect(issue.driftKind).toBe("config-path-mismatch");
+    expect(issue.severity).toBe("warn");
+  });
+
+  it("formats summaries compactly", async () => {
+    const issue = await detectCoreInstallPathIssue({
+      packageRoot: "/opt/openclaw",
+      expectedProgramArguments: ["/usr/bin/node", "/opt/openclaw/dist/index.js", "gateway"],
+      serviceProgramArguments: ["/usr/bin/node", "/opt/openclaw/dist/index.js", "gateway"],
+    });
+
+    expect(formatCoreInstallPathIssue(issue)).toContain("ok");
+    expect(formatCoreInstallPathIssue(issue)).toContain("Current install root");
+  });
+});

--- a/src/infra/core-install-path-check.ts
+++ b/src/infra/core-install-path-check.ts
@@ -1,0 +1,158 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type CoreInstallPathSeverity = "info" | "warn" | "error";
+
+export type CoreInstallPathDriftKind =
+  | "none"
+  | "service-points-elsewhere"
+  | "entrypoint-shape-mismatch"
+  | "config-path-mismatch"
+  | "insufficient-data";
+
+export type CoreInstallPathIssue = {
+  driftKind: CoreInstallPathDriftKind;
+  severity: CoreInstallPathSeverity;
+  summary: string;
+  packageRoot?: string;
+  expectedEntrypoint?: string | null;
+  serviceEntrypoint?: string | null;
+  configPathCli?: string | null;
+  configPathService?: string | null;
+};
+
+function findGatewayEntrypoint(programArguments?: string[] | null): string | null {
+  if (!programArguments || programArguments.length === 0) {
+    return null;
+  }
+  const gatewayIndex = programArguments.indexOf("gateway");
+  if (gatewayIndex <= 0) {
+    return null;
+  }
+  return programArguments[gatewayIndex - 1] ?? null;
+}
+
+async function normalizePath(value: string | null | undefined): Promise<string | null> {
+  if (!value || !value.trim()) {
+    return null;
+  }
+  const resolved = path.resolve(value.trim());
+  try {
+    return await fs.realpath(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function deriveInstallRootFromEntrypoint(entrypoint: string | null | undefined): string | null {
+  if (!entrypoint) {
+    return null;
+  }
+  const normalized = path.resolve(entrypoint);
+  const match = normalized.match(/^(.*?)[/\\]dist[/\\][^/\\]+\.(?:js|mjs|cjs|ts)$/i);
+  if (!match) {
+    return null;
+  }
+  return path.resolve(match[1] ?? normalized);
+}
+
+export async function detectCoreInstallPathIssue(params: {
+  packageRoot?: string | null;
+  expectedProgramArguments?: string[] | null;
+  serviceProgramArguments?: string[] | null;
+  configPathCli?: string | null;
+  configPathService?: string | null;
+}): Promise<CoreInstallPathIssue> {
+  const packageRoot = params.packageRoot ? path.resolve(params.packageRoot) : undefined;
+  const expectedEntrypoint = findGatewayEntrypoint(params.expectedProgramArguments);
+  const serviceEntrypoint = findGatewayEntrypoint(params.serviceProgramArguments);
+  const normalizedExpectedEntrypoint = await normalizePath(expectedEntrypoint);
+  const normalizedServiceEntrypoint = await normalizePath(serviceEntrypoint);
+  const expectedRoot =
+    packageRoot ?? deriveInstallRootFromEntrypoint(normalizedExpectedEntrypoint ?? expectedEntrypoint);
+  const serviceRoot = deriveInstallRootFromEntrypoint(
+    normalizedServiceEntrypoint ?? serviceEntrypoint,
+  );
+  const normalizedConfigCli = await normalizePath(params.configPathCli);
+  const normalizedConfigService = await normalizePath(params.configPathService);
+
+  if (normalizedConfigCli && normalizedConfigService && normalizedConfigCli !== normalizedConfigService) {
+    return {
+      driftKind: "config-path-mismatch",
+      severity: "warn",
+      summary: "CLI and service resolve different config paths.",
+      packageRoot: expectedRoot ?? undefined,
+      expectedEntrypoint,
+      serviceEntrypoint,
+      configPathCli: params.configPathCli ?? null,
+      configPathService: params.configPathService ?? null,
+    };
+  }
+
+  if (expectedRoot && serviceRoot && expectedRoot !== serviceRoot) {
+    return {
+      driftKind: "service-points-elsewhere",
+      severity: "error",
+      summary: "Gateway service entrypoint resolves outside the current install root.",
+      packageRoot: expectedRoot,
+      expectedEntrypoint,
+      serviceEntrypoint,
+      configPathCli: params.configPathCli ?? null,
+      configPathService: params.configPathService ?? null,
+    };
+  }
+
+  if (
+    normalizedExpectedEntrypoint &&
+    normalizedServiceEntrypoint &&
+    normalizedExpectedEntrypoint !== normalizedServiceEntrypoint &&
+    expectedRoot &&
+    serviceRoot &&
+    expectedRoot === serviceRoot
+  ) {
+    return {
+      driftKind: "entrypoint-shape-mismatch",
+      severity: "warn",
+      summary: "Service and current install share the same root but use different gateway entrypoint files.",
+      packageRoot: expectedRoot,
+      expectedEntrypoint,
+      serviceEntrypoint,
+      configPathCli: params.configPathCli ?? null,
+      configPathService: params.configPathService ?? null,
+    };
+  }
+
+  if (!expectedRoot || !serviceEntrypoint) {
+    return {
+      driftKind: "insufficient-data",
+      severity: "info",
+      summary: "Install-path check could not fully verify the service entrypoint.",
+      packageRoot: expectedRoot ?? undefined,
+      expectedEntrypoint,
+      serviceEntrypoint,
+      configPathCli: params.configPathCli ?? null,
+      configPathService: params.configPathService ?? null,
+    };
+  }
+
+  return {
+    driftKind: "none",
+    severity: "info",
+    summary: "Current install root and gateway service entrypoint appear aligned.",
+    packageRoot: expectedRoot,
+    expectedEntrypoint,
+    serviceEntrypoint,
+    configPathCli: params.configPathCli ?? null,
+    configPathService: params.configPathService ?? null,
+  };
+}
+
+export function formatCoreInstallPathIssue(issue: CoreInstallPathIssue): string {
+  const badge =
+    issue.severity === "error" ? "error" : issue.severity === "warn" ? "warn" : "ok";
+  const detailParts = [
+    issue.driftKind !== "none" ? issue.driftKind : null,
+    issue.packageRoot ? `root ${issue.packageRoot}` : null,
+  ].filter(Boolean);
+  return `${badge} · ${issue.summary}${detailParts.length > 0 ? ` · ${detailParts.join(" · ")}` : ""}`;
+}

--- a/src/plugin-sdk/approval-approvers.test.ts
+++ b/src/plugin-sdk/approval-approvers.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveApprovalApproverResolution,
+  resolveApprovalApprovers,
+} from "./approval-approvers.js";
+
+function normalizeApprover(value: string | number): string | undefined {
+  const normalized = String(value).trim().toLowerCase();
+  return normalized || undefined;
+}
+
+describe("resolveApprovalApproverResolution", () => {
+  it("preserves explicit and inferred approver sets while preferring explicit approvers", () => {
+    expect(
+      resolveApprovalApproverResolution({
+        explicit: [" Owner ", "OWNER", 42],
+        allowFrom: ["fallback-1", "owner"],
+        extraAllowFrom: ["fallback-2", "FALLBACK-2"],
+        defaultTo: "fallback-3",
+        normalizeApprover,
+      }),
+    ).toEqual({
+      explicit: ["owner", "42"],
+      inferred: ["fallback-1", "owner", "fallback-2", "fallback-3"],
+      effective: ["owner", "42"],
+      source: "explicit",
+    });
+  });
+
+  it("falls back to inferred approvers when explicit approvers normalize away", () => {
+    expect(
+      resolveApprovalApproverResolution({
+        explicit: [" ", ""],
+        allowFrom: ["fallback-1", "FALLBACK-1"],
+        extraAllowFrom: ["fallback-2"],
+        defaultTo: "fallback-3",
+        normalizeApprover,
+      }),
+    ).toEqual({
+      explicit: [],
+      inferred: ["fallback-1", "fallback-2", "fallback-3"],
+      effective: ["fallback-1", "fallback-2", "fallback-3"],
+      source: "inferred",
+    });
+  });
+
+  it("supports dedicated default target normalization", () => {
+    expect(
+      resolveApprovalApproverResolution({
+        allowFrom: ["123"],
+        defaultTo: " user:456 ",
+        normalizeApprover,
+        normalizeDefaultTo: (value) => value.trim().replace(/^user:/i, "") || undefined,
+      }),
+    ).toEqual({
+      explicit: [],
+      inferred: ["123", "456"],
+      effective: ["123", "456"],
+      source: "inferred",
+    });
+  });
+
+  it("reports none when neither explicit nor inferred approvers resolve", () => {
+    expect(
+      resolveApprovalApproverResolution({
+        explicit: [" "],
+        allowFrom: [],
+        extraAllowFrom: undefined,
+        defaultTo: " ",
+        normalizeApprover,
+      }),
+    ).toEqual({
+      explicit: [],
+      inferred: [],
+      effective: [],
+      source: "none",
+    });
+  });
+});
+
+describe("resolveApprovalApprovers", () => {
+  it("keeps the legacy effective approver list behavior", () => {
+    const params = {
+      explicit: ["owner"],
+      allowFrom: ["fallback"],
+      defaultTo: "fallback-2",
+      normalizeApprover,
+    } as const;
+
+    expect(resolveApprovalApprovers(params)).toEqual(
+      resolveApprovalApproverResolution(params).effective,
+    );
+  });
+});

--- a/src/plugin-sdk/approval-approvers.ts
+++ b/src/plugin-sdk/approval-approvers.ts
@@ -1,5 +1,23 @@
 type ApproverInput = string | number;
 
+type ApprovalApproverParams = {
+  explicit?: readonly ApproverInput[] | null;
+  allowFrom?: readonly ApproverInput[] | null;
+  extraAllowFrom?: readonly ApproverInput[] | null;
+  defaultTo?: string | null;
+  normalizeApprover: (value: ApproverInput) => string | undefined;
+  normalizeDefaultTo?: (value: string) => string | undefined;
+};
+
+export type ApprovalApproverResolutionSource = "explicit" | "inferred" | "none";
+
+export type ApprovalApproverResolution = {
+  explicit: string[];
+  inferred: string[];
+  effective: string[];
+  source: ApprovalApproverResolutionSource;
+};
+
 function dedupeDefined(values: Array<string | undefined>): string[] {
   const resolved = new Set<string>();
   for (const value of values) {
@@ -11,22 +29,12 @@ function dedupeDefined(values: Array<string | undefined>): string[] {
   return [...resolved];
 }
 
-export function resolveApprovalApprovers(params: {
-  explicit?: readonly ApproverInput[] | null;
-  allowFrom?: readonly ApproverInput[] | null;
-  extraAllowFrom?: readonly ApproverInput[] | null;
-  defaultTo?: string | null;
-  normalizeApprover: (value: ApproverInput) => string | undefined;
-  normalizeDefaultTo?: (value: string) => string | undefined;
-}): string[] {
-  const explicit = dedupeDefined(
-    (params.explicit ?? []).map((entry) => params.normalizeApprover(entry)),
-  );
-  if (explicit.length > 0) {
-    return explicit;
-  }
+function resolveExplicitApprovers(params: ApprovalApproverParams): string[] {
+  return dedupeDefined((params.explicit ?? []).map((entry) => params.normalizeApprover(entry)));
+}
 
-  const inferred = dedupeDefined([
+function resolveInferredApprovers(params: ApprovalApproverParams): string[] {
+  return dedupeDefined([
     ...(params.allowFrom ?? []).map((entry) => params.normalizeApprover(entry)),
     ...(params.extraAllowFrom ?? []).map((entry) => params.normalizeApprover(entry)),
     ...(params.defaultTo?.trim()
@@ -37,5 +45,37 @@ export function resolveApprovalApprovers(params: {
         ]
       : []),
   ]);
-  return inferred;
+}
+
+export function resolveApprovalApproverResolution(
+  params: ApprovalApproverParams,
+): ApprovalApproverResolution {
+  const explicit = resolveExplicitApprovers(params);
+  const inferred = resolveInferredApprovers(params);
+  if (explicit.length > 0) {
+    return {
+      explicit,
+      inferred,
+      effective: explicit,
+      source: "explicit",
+    };
+  }
+  if (inferred.length > 0) {
+    return {
+      explicit,
+      inferred,
+      effective: inferred,
+      source: "inferred",
+    };
+  }
+  return {
+    explicit,
+    inferred,
+    effective: [],
+    source: "none",
+  };
+}
+
+export function resolveApprovalApprovers(params: ApprovalApproverParams): string[] {
+  return resolveApprovalApproverResolution(params).effective;
 }

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -123,6 +123,13 @@ export type {
   TaskRunDetail,
   TaskRunView,
 } from "../plugins/runtime/task-domain-types.js";
+export type {
+  LifecycleBackingLink,
+  LifecycleBackingLinkRelation,
+  LifecycleStatusEvidence,
+  LifecycleStatusEvidenceKind,
+  LifecycleStatusReason,
+} from "../tasks/task-lifecycle-status.js";
 
 export { definePluginEntry } from "./plugin-entry.js";
 export { buildPluginConfigSchema, emptyPluginConfigSchema } from "../plugins/config-schema.js";

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -74,6 +74,13 @@ export type {
   TaskRunDetail,
   TaskRunView,
 } from "../plugins/runtime/task-domain-types.js";
+export type {
+  LifecycleBackingLink,
+  LifecycleBackingLinkRelation,
+  LifecycleStatusEvidence,
+  LifecycleStatusEvidenceKind,
+  LifecycleStatusReason,
+} from "../tasks/task-lifecycle-status.js";
 export type { OpenClawConfig } from "../config/config.js";
 /** @deprecated Use OpenClawConfig instead */
 export type { OpenClawConfig as ClawdbotConfig } from "../config/config.js";

--- a/src/plugins/runtime/runtime-tasks.test.ts
+++ b/src/plugins/runtime/runtime-tasks.test.ts
@@ -94,6 +94,10 @@ describe("runtime tasks", () => {
       ownerKey: "agent:main:main",
       goal: "Review inbox",
       currentStep: "triage",
+      statusReason: {
+        code: "queued",
+        summary: "Queued: triage",
+      },
       state: { lane: "priority" },
       taskSummary: {
         total: 1,
@@ -106,6 +110,18 @@ describe("runtime tasks", () => {
           title: "Review PR 1",
           label: "Inbox triage",
           runId: "runtime-task-run",
+          statusReason: expect.objectContaining({
+            code: "running",
+            summary: "Inspecting",
+            backing: expect.arrayContaining([
+              { kind: "flow", relation: "parent_flow", id: created.flowId },
+              {
+                kind: "session",
+                relation: "child_session",
+                id: "agent:main:subagent:child",
+              },
+            ]),
+          }),
         }),
       ],
     });
@@ -125,6 +141,10 @@ describe("runtime tasks", () => {
       flowId: created.flowId,
       title: "Review PR 1",
       progressSummary: "Inspecting",
+      statusReason: expect.objectContaining({
+        code: "running",
+        summary: "Inspecting",
+      }),
     });
     expect(taskRuns.findLatest()?.id).toBe(child.task.taskId);
     expect(taskRuns.resolve("runtime-task-run")?.id).toBe(child.task.taskId);

--- a/src/plugins/runtime/task-domain-types.ts
+++ b/src/plugins/runtime/task-domain-types.ts
@@ -1,4 +1,5 @@
 import type { JsonValue } from "../../tasks/task-flow-registry.types.js";
+import type { LifecycleStatusReason } from "../../tasks/task-lifecycle-status.js";
 import type {
   TaskDeliveryStatus,
   TaskNotifyPolicy,
@@ -35,6 +36,7 @@ export type TaskRunView = {
   label?: string;
   title: string;
   status: TaskStatus;
+  statusReason?: LifecycleStatusReason;
   deliveryStatus: TaskDeliveryStatus;
   notifyPolicy: TaskNotifyPolicy;
   createdAt: number;
@@ -62,6 +64,7 @@ export type TaskFlowView = {
   ownerKey: string;
   requesterOrigin?: DeliveryContext;
   status: import("../../tasks/task-flow-registry.types.js").TaskFlowStatus;
+  statusReason?: LifecycleStatusReason;
   notifyPolicy: TaskNotifyPolicy;
   goal: string;
   currentStep?: string;

--- a/src/tasks/task-backing-session-terminal.ts
+++ b/src/tasks/task-backing-session-terminal.ts
@@ -1,0 +1,44 @@
+import type { BackingSessionSnapshot } from "./task-lifecycle-status.js";
+import type { TaskStatus } from "./task-registry.types.js";
+
+export function resolveTaskTerminalStatusFromBackingSession(
+  backingSession: BackingSessionSnapshot,
+): Extract<TaskStatus, "succeeded" | "failed" | "timed_out" | "cancelled"> | undefined {
+  switch (backingSession.state) {
+    case "done":
+      return "succeeded";
+    case "failed":
+      return "failed";
+    case "timeout":
+      return "timed_out";
+    case "killed":
+      return "cancelled";
+    default:
+      return undefined;
+  }
+}
+
+export function resolveTaskTerminalEvidenceText(backingSession: BackingSessionSnapshot): {
+  error?: string;
+  terminalSummary?: string;
+} {
+  switch (backingSession.state) {
+    case "done":
+      return { terminalSummary: "Backing session finished." };
+    case "failed":
+      return { error: "Backing session failed." };
+    case "timeout":
+      return { error: "Backing session timed out." };
+    case "killed":
+      return { error: "Backing session was killed." };
+    default:
+      return {};
+  }
+}
+
+export function resolveTaskTerminalAtFromBackingSession(
+  backingSession: BackingSessionSnapshot,
+  fallbackAt: number,
+): number {
+  return backingSession.endedAt ?? backingSession.recordedAt ?? fallbackAt;
+}

--- a/src/tasks/task-domain-views.ts
+++ b/src/tasks/task-domain-views.ts
@@ -6,6 +6,10 @@ import type {
   TaskRunView,
 } from "../plugins/runtime/task-domain-types.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import {
+  resolveTaskFlowLifecycleStatusReason,
+  resolveTaskLifecycleStatusReason,
+} from "./task-lifecycle-status.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
 import type { TaskRecord, TaskRegistrySummary } from "./task-registry.types.js";
 
@@ -36,6 +40,7 @@ export function mapTaskRunView(task: TaskRecord): TaskRunView {
     ...(task.label ? { label: task.label } : {}),
     title: task.task,
     status: task.status,
+    statusReason: resolveTaskLifecycleStatusReason(task),
     deliveryStatus: task.deliveryStatus,
     notifyPolicy: task.notifyPolicy,
     createdAt: task.createdAt,
@@ -60,6 +65,7 @@ export function mapTaskFlowView(flow: TaskFlowRecord): TaskFlowView {
     ownerKey: flow.ownerKey,
     ...(flow.requesterOrigin ? { requesterOrigin: { ...flow.requesterOrigin } } : {}),
     status: flow.status,
+    statusReason: resolveTaskFlowLifecycleStatusReason({ flow }),
     notifyPolicy: flow.notifyPolicy,
     goal: flow.goal,
     ...(flow.currentStep ? { currentStep: flow.currentStep } : {}),

--- a/src/tasks/task-flow-registry.audit.test.ts
+++ b/src/tasks/task-flow-registry.audit.test.ts
@@ -184,6 +184,78 @@ describe("task-flow-registry audit", () => {
     });
   });
 
+  it("reuses linked-task lifecycle evidence in stale waiting and blocked details", async () => {
+    await withTaskFlowAuditStateDir(async () => {
+      const waitingFlow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-audit",
+        goal: "Wait on child evidence",
+        status: "running",
+        createdAt: 1,
+        updatedAt: 1,
+      });
+      const waitingChild = createRunningTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: waitingFlow.flowId,
+        childSessionKey: "agent:main:subagent:waiting-child-missing",
+        runId: "task-flow-audit-waiting-child",
+        task: "Wait on child result",
+        startedAt: 1,
+        lastEventAt: 1,
+      });
+      setFlowWaiting({
+        flowId: waitingFlow.flowId,
+        expectedRevision: waitingFlow.revision,
+        waitJson: { kind: "task", taskId: waitingChild.taskId },
+        updatedAt: 1,
+      });
+
+      const blockedFlow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-audit",
+        goal: "Block on child evidence",
+        status: "running",
+        createdAt: 1,
+        updatedAt: 1,
+      });
+      const blockedChild = createRunningTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: blockedFlow.flowId,
+        childSessionKey: "agent:main:subagent:blocked-child-missing",
+        runId: "task-flow-audit-blocked-child",
+        task: "Blocked child result",
+        startedAt: 1,
+        lastEventAt: 1,
+      });
+      setFlowWaiting({
+        flowId: blockedFlow.flowId,
+        expectedRevision: blockedFlow.revision,
+        blockedTaskId: blockedChild.taskId,
+        updatedAt: 1,
+      });
+
+      const findings = listTaskFlowAuditFindings({ now: 31 * 60_000 });
+      expect(findings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "stale_waiting",
+            flow: expect.objectContaining({ flowId: waitingFlow.flowId }),
+            detail: `waiting TaskFlow has not advanced recently; waiting on task ${waitingChild.taskId}: Backing session is missing; task may be orphaned.`,
+          }),
+          expect.objectContaining({
+            code: "stale_blocked",
+            flow: expect.objectContaining({ flowId: blockedFlow.flowId }),
+            detail: `blocked TaskFlow has not advanced recently; blocked on task ${blockedChild.taskId}: Backing session is missing; task may be orphaned.`,
+          }),
+        ]),
+      );
+    });
+  });
+
   it("does not flag missing linked tasks before the flow is stale", async () => {
     await withTaskFlowAuditStateDir(async () => {
       const now = Date.now();

--- a/src/tasks/task-flow-registry.audit.test.ts
+++ b/src/tasks/task-flow-registry.audit.test.ts
@@ -124,10 +124,26 @@ describe("task-flow-registry audit", () => {
           expect.objectContaining({
             code: "missing_linked_tasks",
             flow: expect.objectContaining({ flowId: running.flowId }),
+            lifecycleReason: expect.objectContaining({
+              code: "running",
+              backing: expect.arrayContaining([
+                expect.objectContaining({ kind: "session", relation: "owner_session" }),
+              ]),
+            }),
           }),
           expect.objectContaining({
             code: "blocked_task_missing",
             flow: expect.objectContaining({ flowId: blocked.flowId }),
+            lifecycleReason: expect.objectContaining({
+              code: "blocked",
+              backing: expect.arrayContaining([
+                expect.objectContaining({
+                  kind: "task",
+                  relation: "blocked_task",
+                  id: "task-missing",
+                }),
+              ]),
+            }),
           }),
         ]),
       );

--- a/src/tasks/task-flow-registry.audit.ts
+++ b/src/tasks/task-flow-registry.audit.ts
@@ -1,6 +1,10 @@
 import { listTasksForFlowId } from "./runtime-internal.js";
 import { getTaskFlowRegistryRestoreFailure, listTaskFlowRecords } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import {
+  resolveTaskFlowLifecycleStatusReason,
+  type LifecycleStatusReason,
+} from "./task-lifecycle-status.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 export type TaskFlowAuditSeverity = "warn" | "error";
@@ -20,6 +24,7 @@ export type TaskFlowAuditFinding = {
   detail: string;
   ageMs?: number;
   flow?: TaskFlowRecord;
+  lifecycleReason?: LifecycleStatusReason;
 };
 
 export type TaskFlowAuditSummary = {
@@ -56,6 +61,9 @@ function createFinding(params: {
     detail: params.detail,
     ...(typeof params.ageMs === "number" ? { ageMs: params.ageMs } : {}),
     ...(params.flow ? { flow: params.flow } : {}),
+    ...(params.flow
+      ? { lifecycleReason: resolveTaskFlowLifecycleStatusReason({ flow: params.flow }) }
+      : {}),
   };
 }
 

--- a/src/tasks/task-flow-registry.audit.ts
+++ b/src/tasks/task-flow-registry.audit.ts
@@ -54,16 +54,18 @@ function createFinding(params: {
   detail: string;
   ageMs?: number;
   flow?: TaskFlowRecord;
+  lifecycleReason?: LifecycleStatusReason;
 }): TaskFlowAuditFinding {
+  const lifecycleReason =
+    params.lifecycleReason ??
+    (params.flow ? resolveTaskFlowLifecycleStatusReason({ flow: params.flow }) : undefined);
   return {
     severity: params.severity,
     code: params.code,
     detail: params.detail,
     ...(typeof params.ageMs === "number" ? { ageMs: params.ageMs } : {}),
     ...(params.flow ? { flow: params.flow } : {}),
-    ...(params.flow
-      ? { lifecycleReason: resolveTaskFlowLifecycleStatusReason({ flow: params.flow }) }
-      : {}),
+    ...(lifecycleReason ? { lifecycleReason } : {}),
   };
 }
 
@@ -96,6 +98,71 @@ function hasBlockingMetadata(flow: TaskFlowRecord): boolean {
   return Boolean(
     flow.blockedTaskId?.trim() || flow.blockedSummary?.trim() || flow.waitJson != null,
   );
+}
+
+function normalizeTaskId(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function getLinkedTaskLifecycleEvidence(
+  reason: LifecycleStatusReason | undefined,
+  relation: "blocked_task" | "wait_task",
+): { summary: string; taskId?: string } | undefined {
+  for (const entry of reason?.evidence ?? []) {
+    if (entry.kind !== "linked_task_reason" || !entry.summary) {
+      continue;
+    }
+    const data = entry.data;
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      continue;
+    }
+    if ((data as { relation?: unknown }).relation !== relation) {
+      continue;
+    }
+    const taskId = normalizeTaskId(
+      typeof (data as { taskId?: unknown }).taskId === "string"
+        ? ((data as { taskId?: unknown }).taskId as string)
+        : undefined,
+    );
+    return {
+      summary: entry.summary,
+      ...(taskId ? { taskId } : {}),
+    };
+  }
+  return undefined;
+}
+
+const GENERIC_FLOW_REASON_SUMMARIES = new Set([
+  "Flow is waiting.",
+  "Flow is blocked.",
+  "Flow is running.",
+]);
+
+function buildStaleFlowDetail(
+  status: Extract<TaskFlowRecord["status"], "running" | "waiting" | "blocked">,
+  lifecycleReason: LifecycleStatusReason | undefined,
+): string {
+  const base = `${status} TaskFlow has not advanced recently`;
+  if (status === "waiting") {
+    const linkedEvidence = getLinkedTaskLifecycleEvidence(lifecycleReason, "wait_task");
+    if (linkedEvidence) {
+      const subject = linkedEvidence.taskId ? `task ${linkedEvidence.taskId}` : "linked task";
+      return `${base}; waiting on ${subject}: ${linkedEvidence.summary}`;
+    }
+  }
+  if (status === "blocked") {
+    const linkedEvidence = getLinkedTaskLifecycleEvidence(lifecycleReason, "blocked_task");
+    if (linkedEvidence) {
+      const subject = linkedEvidence.taskId ? `task ${linkedEvidence.taskId}` : "linked task";
+      return `${base}; blocked on ${subject}: ${linkedEvidence.summary}`;
+    }
+  }
+  const summary = lifecycleReason?.summary?.trim();
+  if (summary && !GENERIC_FLOW_REASON_SUMMARIES.has(summary)) {
+    return `${base}; ${summary}`;
+  }
+  return base;
 }
 
 function findTimestampInconsistency(flow: TaskFlowRecord): TaskFlowAuditFinding | null {
@@ -173,6 +240,7 @@ export function listTaskFlowAuditFindings(
     const activeTasks = linkedTasks.filter(
       (task) => task.status === "queued" || task.status === "running",
     );
+    const lifecycleReason = resolveTaskFlowLifecycleStatusReason({ flow });
 
     if (flow.status === "running" && ageMs >= staleRunningMs) {
       findings.push(
@@ -181,7 +249,8 @@ export function listTaskFlowAuditFindings(
           code: "stale_running",
           flow,
           ageMs,
-          detail: "running TaskFlow has not advanced recently",
+          lifecycleReason,
+          detail: buildStaleFlowDetail(flow.status, lifecycleReason),
         }),
       );
     }
@@ -193,7 +262,8 @@ export function listTaskFlowAuditFindings(
           code: "stale_waiting",
           flow,
           ageMs,
-          detail: "waiting TaskFlow has not advanced recently",
+          lifecycleReason,
+          detail: buildStaleFlowDetail(flow.status, lifecycleReason),
         }),
       );
     }
@@ -205,7 +275,8 @@ export function listTaskFlowAuditFindings(
           code: "stale_blocked",
           flow,
           ageMs,
-          detail: "blocked TaskFlow has not advanced recently",
+          lifecycleReason,
+          detail: buildStaleFlowDetail(flow.status, lifecycleReason),
         }),
       );
     }
@@ -225,6 +296,7 @@ export function listTaskFlowAuditFindings(
           code: "cancel_stuck",
           flow,
           ageMs: Math.max(0, now - flow.cancelRequestedAt),
+          lifecycleReason,
           detail: "cancel-requested TaskFlow has no active child tasks but is still nonterminal",
         }),
       );
@@ -248,6 +320,7 @@ export function listTaskFlowAuditFindings(
           code: "missing_linked_tasks",
           flow,
           ageMs,
+          lifecycleReason,
           detail: "managed TaskFlow has no linked tasks or wait state",
         }),
       );
@@ -262,6 +335,7 @@ export function listTaskFlowAuditFindings(
             code: "blocked_task_missing",
             flow,
             ageMs,
+            lifecycleReason,
             detail: `blocked TaskFlow points at missing task ${blockedTaskId}`,
           }),
         );

--- a/src/tasks/task-flow-registry.maintenance.test.ts
+++ b/src/tasks/task-flow-registry.maintenance.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
-import { createRunningTaskRun } from "./task-executor.js";
+import {
+  completeTaskRunByRunId,
+  createRunningTaskRun,
+  failTaskRunByRunId,
+} from "./task-executor.js";
 import {
   createManagedTaskFlow,
   getTaskFlowById,
@@ -157,6 +161,106 @@ describe("task-flow-registry maintenance", () => {
         cancelRequestedAt: 100,
       });
       expect(child.parentFlowId).toBe(flow.flowId);
+    });
+  });
+
+  it("reconciles managed flows to failed when linked tasks fail terminally", async () => {
+    await withTaskFlowMaintenanceStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Follow failed child",
+        status: "running",
+        createdAt: 1,
+        updatedAt: 100,
+      });
+
+      const child = createRunningTaskRun({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        childSessionKey: "agent:main:child-fail",
+        runId: "run-failed-child",
+        task: "Broken child task",
+        startedAt: 100,
+        lastEventAt: 100,
+      });
+
+      failTaskRunByRunId({
+        runId: child.runId!,
+        runtime: child.runtime,
+        sessionKey: child.childSessionKey,
+        endedAt: 250,
+        error: "Child runner failed.",
+        terminalSummary: "Child runner failed.",
+      });
+
+      expect(previewTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 1,
+        pruned: 0,
+      });
+
+      expect(await runTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 1,
+        pruned: 0,
+      });
+      expect(getTaskFlowById(flow.flowId)).toMatchObject({
+        flowId: flow.flowId,
+        status: "failed",
+        blockedSummary: "Child runner failed.",
+      });
+    });
+  });
+
+  it("reconciles managed flows to blocked when linked tasks end blocked", async () => {
+    await withTaskFlowMaintenanceStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Follow blocked child",
+        status: "waiting",
+        createdAt: 1,
+        updatedAt: 100,
+      });
+
+      const child = createRunningTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        childSessionKey: "agent:main:child-blocked",
+        runId: "run-blocked-child",
+        task: "Needs operator approval",
+        startedAt: 100,
+        lastEventAt: 100,
+      });
+
+      completeTaskRunByRunId({
+        runId: child.runId!,
+        runtime: child.runtime,
+        sessionKey: child.childSessionKey,
+        endedAt: 260,
+        terminalOutcome: "blocked",
+        terminalSummary: "Needs operator approval.",
+        progressSummary: "Needs operator approval.",
+      });
+
+      expect(previewTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 1,
+        pruned: 0,
+      });
+
+      expect(await runTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 1,
+        pruned: 0,
+      });
+      expect(getTaskFlowById(flow.flowId)).toMatchObject({
+        flowId: flow.flowId,
+        status: "blocked",
+        blockedTaskId: child.taskId,
+        blockedSummary: "Needs operator approval.",
+      });
     });
   });
 

--- a/src/tasks/task-flow-registry.maintenance.ts
+++ b/src/tasks/task-flow-registry.maintenance.ts
@@ -6,11 +6,13 @@ import {
 } from "./task-flow-registry.audit.js";
 import {
   deleteTaskFlowRecordById,
+  deriveTaskFlowStatusFromTask,
   getTaskFlowById,
   listTaskFlowRecords,
   updateFlowRecordByIdExpectedRevision,
 } from "./task-flow-registry.js";
-import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import type { TaskFlowRecord, TaskFlowStatus } from "./task-flow-registry.types.js";
+import type { TaskRecord } from "./task-registry.types.js";
 
 const TASK_FLOW_RETENTION_MS = 7 * 24 * 60 * 60_000;
 
@@ -32,6 +34,135 @@ function hasActiveLinkedTasks(flowId: string): boolean {
   return listTasksForFlowId(flowId).some(
     (task) => task.status === "queued" || task.status === "running",
   );
+}
+
+function resolveTaskTerminalReferenceAt(task: TaskRecord): number {
+  return task.endedAt ?? task.lastEventAt ?? task.createdAt;
+}
+
+function pickLatestTask(tasks: TaskRecord[]): TaskRecord | undefined {
+  return [...tasks].sort(
+    (left, right) => resolveTaskTerminalReferenceAt(right) - resolveTaskTerminalReferenceAt(left),
+  )[0];
+}
+
+function resolveManagedFlowTerminalFromLinkedTasks(
+  flow: TaskFlowRecord,
+):
+  | {
+      status: TaskFlowStatus;
+      blockedTaskId: string | null;
+      blockedSummary: string | null;
+      updatedAt: number;
+      endedAt: number;
+    }
+  | undefined {
+  if (flow.syncMode !== "managed" || isTerminalFlow(flow)) {
+    return undefined;
+  }
+  const linkedTasks = listTasksForFlowId(flow.flowId);
+  if (linkedTasks.length === 0) {
+    return undefined;
+  }
+  if (linkedTasks.some((task) => task.status === "queued" || task.status === "running")) {
+    return undefined;
+  }
+
+  const latestEventAt = Math.max(flow.updatedAt, ...linkedTasks.map((task) => resolveTaskTerminalReferenceAt(task)));
+
+  const lostTask = pickLatestTask(linkedTasks.filter((task) => task.status === "lost"));
+  if (lostTask) {
+    return {
+      status: "lost",
+      blockedTaskId: null,
+      blockedSummary: lostTask.error ?? lostTask.terminalSummary ?? lostTask.progressSummary ?? null,
+      updatedAt: latestEventAt,
+      endedAt: latestEventAt,
+    };
+  }
+
+  const failedTask = pickLatestTask(
+    linkedTasks.filter((task) => task.status === "failed" || task.status === "timed_out"),
+  );
+  if (failedTask) {
+    return {
+      status: "failed",
+      blockedTaskId: null,
+      blockedSummary:
+        failedTask.error ?? failedTask.terminalSummary ?? failedTask.progressSummary ?? null,
+      updatedAt: latestEventAt,
+      endedAt: latestEventAt,
+    };
+  }
+
+  const blockedTask = pickLatestTask(
+    linkedTasks.filter(
+      (task) =>
+        task.status === "succeeded" && deriveTaskFlowStatusFromTask(task) === "blocked",
+    ),
+  );
+  if (blockedTask) {
+    return {
+      status: "blocked",
+      blockedTaskId: blockedTask.taskId,
+      blockedSummary: blockedTask.terminalSummary ?? blockedTask.progressSummary ?? null,
+      updatedAt: latestEventAt,
+      endedAt: latestEventAt,
+    };
+  }
+
+  const cancelledTask = pickLatestTask(linkedTasks.filter((task) => task.status === "cancelled"));
+  if (cancelledTask) {
+    return {
+      status: "cancelled",
+      blockedTaskId: null,
+      blockedSummary: null,
+      updatedAt: latestEventAt,
+      endedAt: latestEventAt,
+    };
+  }
+
+  if (linkedTasks.every((task) => task.status === "succeeded")) {
+    return {
+      status: "succeeded",
+      blockedTaskId: null,
+      blockedSummary: null,
+      updatedAt: latestEventAt,
+      endedAt: latestEventAt,
+    };
+  }
+
+  return undefined;
+}
+
+function reconcileManagedFlowTerminalFromLinkedTasks(flow: TaskFlowRecord): boolean {
+  let current = flow;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const projection = resolveManagedFlowTerminalFromLinkedTasks(current);
+    if (!projection) {
+      return false;
+    }
+    const result = updateFlowRecordByIdExpectedRevision({
+      flowId: current.flowId,
+      expectedRevision: current.revision,
+      patch: {
+        status: projection.status,
+        blockedTaskId: projection.blockedTaskId,
+        blockedSummary: projection.blockedSummary,
+        waitJson: null,
+        endedAt: projection.endedAt,
+        updatedAt: projection.updatedAt,
+      },
+    });
+    if (result.applied) {
+      return true;
+    }
+    if (result.reason === "not_found" || !result.current) {
+      return false;
+    }
+    current = result.current;
+  }
+  return false;
 }
 
 function resolveTerminalAt(flow: TaskFlowRecord): number {
@@ -97,6 +228,10 @@ export function previewTaskFlowRegistryMaintenance(): TaskFlowRegistryMaintenanc
   let reconciled = 0;
   let pruned = 0;
   for (const flow of listTaskFlowRecords()) {
+    if (resolveManagedFlowTerminalFromLinkedTasks(flow)) {
+      reconciled += 1;
+      continue;
+    }
     if (shouldFinalizeCancelledFlow(flow)) {
       reconciled += 1;
       continue;
@@ -115,6 +250,10 @@ export async function runTaskFlowRegistryMaintenance(): Promise<TaskFlowRegistry
   for (const flow of listTaskFlowRecords()) {
     const current = getTaskFlowById(flow.flowId);
     if (!current) {
+      continue;
+    }
+    if (reconcileManagedFlowTerminalFromLinkedTasks(current)) {
+      reconciled += 1;
       continue;
     }
     if (shouldFinalizeCancelledFlow(current)) {

--- a/src/tasks/task-lifecycle-status.session-evidence.test.ts
+++ b/src/tasks/task-lifecycle-status.session-evidence.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearSessionStoreCacheForTest,
+  resolveStorePath,
+  saveSessionStore,
+  type SessionEntry,
+} from "../config/sessions.js";
+import { withTempDir } from "../test-helpers/temp-dir.js";
+import { resolveTaskLifecycleStatusReason } from "./task-lifecycle-status.js";
+import type { TaskRecord } from "./task-registry.types.js";
+
+const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+const NOW = 1_000_000_000_000;
+
+function makeTask(overrides: Partial<TaskRecord>): TaskRecord {
+  return {
+    taskId: "task-1",
+    runId: "run-1",
+    task: "default task",
+    runtime: "subagent",
+    status: "running",
+    requesterSessionKey: "agent:main:main",
+    ownerKey: "agent:main:main",
+    scopeKind: "session",
+    createdAt: NOW - 1_000,
+    deliveryStatus: "pending",
+    notifyPolicy: "done_only",
+    ...overrides,
+  };
+}
+
+async function withBackingSessionStore(
+  entries: Record<string, SessionEntry>,
+  run: () => Promise<void> | void,
+): Promise<void> {
+  await withTempDir({ prefix: "openclaw-task-lifecycle-status-" }, async (root) => {
+    process.env.OPENCLAW_STATE_DIR = root;
+    clearSessionStoreCacheForTest();
+    const storePath = resolveStorePath(undefined, { agentId: "main" });
+    await saveSessionStore(storePath, entries);
+    try {
+      await run();
+    } finally {
+      clearSessionStoreCacheForTest();
+    }
+  });
+}
+
+describe("task lifecycle status session evidence", () => {
+  afterEach(() => {
+    clearSessionStoreCacheForTest();
+    if (ORIGINAL_STATE_DIR === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+    }
+  });
+
+  it("distinguishes expected waiting when the backing child session is still running", async () => {
+    await withBackingSessionStore(
+      {
+        "agent:main:subagent:child-live": {
+          sessionId: "session-live",
+          updatedAt: NOW,
+          status: "running",
+        },
+      },
+      () => {
+        const reason = resolveTaskLifecycleStatusReason(
+          makeTask({
+            childSessionKey: "agent:main:subagent:child-live",
+          }),
+        );
+
+        expect(reason).toMatchObject({
+          code: "waiting_on_backing_session",
+          summary: "Backing session is running.",
+          backing: expect.arrayContaining([
+            {
+              kind: "session",
+              relation: "child_session",
+              id: "agent:main:subagent:child-live",
+            },
+          ]),
+          evidence: expect.arrayContaining([
+            expect.objectContaining({
+              kind: "session_state",
+              summary: "Backing session is running.",
+              data: {
+                state: "running",
+                source: "session_status",
+              },
+              recordedAt: NOW,
+            }),
+          ]),
+        });
+      },
+    );
+  });
+
+  it("surfaces blocked-on-session-state when the backing child session already failed", async () => {
+    await withBackingSessionStore(
+      {
+        "agent:main:subagent:child-failed": {
+          sessionId: "session-failed",
+          updatedAt: NOW,
+          status: "failed",
+        },
+      },
+      () => {
+        const reason = resolveTaskLifecycleStatusReason(
+          makeTask({
+            childSessionKey: "agent:main:subagent:child-failed",
+          }),
+        );
+
+        expect(reason).toMatchObject({
+          code: "blocked_on_backing_session_state",
+          summary: "Backing session failed; task has not reconciled yet.",
+          evidence: expect.arrayContaining([
+            expect.objectContaining({
+              kind: "session_state",
+              data: {
+                state: "failed",
+                source: "session_status",
+              },
+            }),
+          ]),
+        });
+      },
+    );
+  });
+
+  it("surfaces missing backing session evidence before the task is fully reconciled lost", async () => {
+    await withBackingSessionStore({}, () => {
+      const reason = resolveTaskLifecycleStatusReason(
+        makeTask({
+          childSessionKey: "agent:main:subagent:child-missing",
+        }),
+      );
+
+      expect(reason).toMatchObject({
+        code: "missing_backing_session",
+        summary: "Backing session is missing; task may be orphaned.",
+        evidence: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "session_state",
+            data: {
+              state: "missing",
+              source: "missing",
+            },
+          }),
+        ]),
+      });
+    });
+  });
+});

--- a/src/tasks/task-lifecycle-status.session-evidence.test.ts
+++ b/src/tasks/task-lifecycle-status.session-evidence.test.ts
@@ -6,7 +6,15 @@ import {
   type SessionEntry,
 } from "../config/sessions.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
-import { resolveTaskLifecycleStatusReason } from "./task-lifecycle-status.js";
+import { createRunningTaskRun } from "./task-executor.js";
+import {
+  resolveTaskFlowLifecycleStatusReason,
+  resolveTaskLifecycleStatusReason,
+} from "./task-lifecycle-status.js";
+import {
+  resetTaskRegistryDeliveryRuntimeForTests,
+  resetTaskRegistryForTests,
+} from "./task-registry.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
@@ -36,12 +44,16 @@ async function withBackingSessionStore(
   await withTempDir({ prefix: "openclaw-task-lifecycle-status-" }, async (root) => {
     process.env.OPENCLAW_STATE_DIR = root;
     clearSessionStoreCacheForTest();
+    resetTaskRegistryDeliveryRuntimeForTests();
+    resetTaskRegistryForTests();
     const storePath = resolveStorePath(undefined, { agentId: "main" });
     await saveSessionStore(storePath, entries);
     try {
       await run();
     } finally {
       clearSessionStoreCacheForTest();
+      resetTaskRegistryDeliveryRuntimeForTests();
+      resetTaskRegistryForTests();
     }
   });
 }
@@ -49,6 +61,8 @@ async function withBackingSessionStore(
 describe("task lifecycle status session evidence", () => {
   afterEach(() => {
     clearSessionStoreCacheForTest();
+    resetTaskRegistryDeliveryRuntimeForTests();
+    resetTaskRegistryForTests();
     if (ORIGINAL_STATE_DIR === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
     } else {
@@ -148,6 +162,48 @@ describe("task lifecycle status session evidence", () => {
             data: {
               state: "missing",
               source: "missing",
+            },
+          }),
+        ]),
+      });
+    });
+  });
+
+  it("bridges linked task session evidence into waiting flow reasons", async () => {
+    await withBackingSessionStore({}, () => {
+      const child = createRunningTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "run-flow-wait-child",
+        task: "Wait for child result",
+        childSessionKey: "agent:main:subagent:child-missing",
+        lastEventAt: NOW,
+      });
+
+      const reason = resolveTaskFlowLifecycleStatusReason({
+        flow: {
+          ownerKey: "agent:main:main",
+          status: "waiting",
+          waitJson: { kind: "task", taskId: child.taskId },
+          updatedAt: NOW,
+        },
+      });
+
+      expect(reason).toMatchObject({
+        code: "waiting_on_task",
+        summary: "Waiting on task: Backing session is missing; task may be orphaned.",
+        backing: expect.arrayContaining([
+          { kind: "task", relation: "wait_task", id: child.taskId },
+        ]),
+        evidence: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "linked_task_reason",
+            summary: "Backing session is missing; task may be orphaned.",
+            data: {
+              relation: "wait_task",
+              taskId: child.taskId,
+              code: "missing_backing_session",
             },
           }),
         ]),

--- a/src/tasks/task-lifecycle-status.ts
+++ b/src/tasks/task-lifecycle-status.ts
@@ -3,6 +3,7 @@ import { sanitizeUserFacingText } from "../agents/pi-embedded-helpers/errors.js"
 import { loadSessionStore, resolveStorePath, type SessionEntry } from "../config/sessions.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { truncateUtf16Safe } from "../utils.js";
+import { getTaskById } from "./runtime-internal.js";
 import type { JsonValue, TaskFlowRecord } from "./task-flow-registry.types.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
@@ -16,7 +17,8 @@ export type LifecycleStatusEvidenceKind =
   | "blocked_summary"
   | "current_step"
   | "wait"
-  | "session_state";
+  | "session_state"
+  | "linked_task_reason";
 
 export type LifecycleStatusEvidence = {
   kind: LifecycleStatusEvidenceKind;
@@ -539,11 +541,38 @@ function resolveFlowReasonCode(flow: Pick<TaskFlowRecord, "status" | "waitJson">
   return flow.status;
 }
 
+function summarizeLinkedTaskReason(
+  prefix: string,
+  reason: LifecycleStatusReason | undefined,
+): string | undefined {
+  const summary = sanitizeLifecycleText(reason?.summary, { errorContext: true });
+  return summary ? `${prefix}: ${summary}` : undefined;
+}
+
+function resolveLinkedTaskLifecycleReason(
+  taskId: string | undefined,
+): LifecycleStatusReason | undefined {
+  const normalizedTaskId = normalizeId(taskId);
+  if (!normalizedTaskId) {
+    return undefined;
+  }
+  try {
+    const task = getTaskById(normalizedTaskId);
+    return task ? resolveTaskLifecycleStatusReason(task) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function resolveFlowReasonSummary(
   flow: Pick<
     TaskFlowRecord,
     "status" | "currentStep" | "blockedSummary" | "blockedTaskId" | "waitJson" | "cancelRequestedAt"
   >,
+  linkedTaskReasons?: {
+    blockedTaskReason?: LifecycleStatusReason;
+    waitTaskReason?: LifecycleStatusReason;
+  },
 ): string {
   const currentStep = sanitizeLifecycleText(flow.currentStep);
   const blockedSummary = sanitizeLifecycleText(flow.blockedSummary, { errorContext: true });
@@ -554,10 +583,15 @@ function resolveFlowReasonSummary(
     case "running":
       return currentStep ? `Running: ${currentStep}` : "Flow is running.";
     case "waiting":
-      return waitSummary || (currentStep ? `Waiting: ${currentStep}` : "Flow is waiting.");
+      return (
+        summarizeLinkedTaskReason("Waiting on task", linkedTaskReasons?.waitTaskReason) ||
+        waitSummary ||
+        (currentStep ? `Waiting: ${currentStep}` : "Flow is waiting.")
+      );
     case "blocked":
       return (
         blockedSummary ||
+        summarizeLinkedTaskReason("Blocked on task", linkedTaskReasons?.blockedTaskReason) ||
         waitSummary ||
         (flow.blockedTaskId?.trim() ? "Flow is blocked on a child task." : "Flow is blocked.")
       );
@@ -589,7 +623,10 @@ export function resolveTaskFlowLifecycleStatusReason(params: {
   const { flow } = params;
   const evidence: LifecycleStatusEvidence[] = [];
   const backing: LifecycleBackingLink[] = [];
+  const blockedTaskId = normalizeId(flow.blockedTaskId);
   const waitTaskId = resolveWaitTaskId(flow.waitJson);
+  const blockedTaskReason = resolveLinkedTaskLifecycleReason(blockedTaskId);
+  const waitTaskReason = resolveLinkedTaskLifecycleReason(waitTaskId);
 
   pushEvidence(
     evidence,
@@ -621,6 +658,44 @@ export function resolveTaskFlowLifecycleStatusReason(params: {
       recordedAt: flow.updatedAt,
     }),
   );
+  pushEvidence(
+    evidence,
+    (() => {
+      if (!blockedTaskReason || !blockedTaskId) {
+        return undefined;
+      }
+      return makeEvidence({
+        kind: "linked_task_reason",
+        value: blockedTaskReason.summary,
+        errorContext: true,
+        data: {
+          relation: "blocked_task",
+          taskId: blockedTaskId,
+          code: blockedTaskReason.code,
+        },
+        recordedAt: flow.updatedAt,
+      });
+    })(),
+  );
+  pushEvidence(
+    evidence,
+    (() => {
+      if (!waitTaskReason || !waitTaskId) {
+        return undefined;
+      }
+      return makeEvidence({
+        kind: "linked_task_reason",
+        value: waitTaskReason.summary,
+        errorContext: true,
+        data: {
+          relation: "wait_task",
+          taskId: waitTaskId,
+          code: waitTaskReason.code,
+        },
+        recordedAt: flow.updatedAt,
+      });
+    })(),
+  );
 
   pushBacking(
     backing,
@@ -631,10 +706,9 @@ export function resolveTaskFlowLifecycleStatusReason(params: {
   );
   pushBacking(
     backing,
-    (() => {
-      const id = normalizeId(flow.blockedTaskId);
-      return id ? { kind: "task" as const, relation: "blocked_task" as const, id } : undefined;
-    })(),
+    blockedTaskId
+      ? { kind: "task" as const, relation: "blocked_task" as const, id: blockedTaskId }
+      : undefined,
   );
   pushBacking(
     backing,
@@ -643,7 +717,10 @@ export function resolveTaskFlowLifecycleStatusReason(params: {
 
   return buildReason({
     code: resolveFlowReasonCode(flow),
-    summary: resolveFlowReasonSummary(flow),
+    summary: resolveFlowReasonSummary(flow, {
+      blockedTaskReason,
+      waitTaskReason,
+    }),
     evidence,
     backing,
   });

--- a/src/tasks/task-lifecycle-status.ts
+++ b/src/tasks/task-lifecycle-status.ts
@@ -1,0 +1,511 @@
+import { sanitizeUserFacingText } from "../agents/pi-embedded-helpers/errors.js";
+import { truncateUtf16Safe } from "../utils.js";
+import type { JsonValue, TaskFlowRecord } from "./task-flow-registry.types.js";
+import type { TaskRecord } from "./task-registry.types.js";
+
+const DEFAULT_REASON_MAX_CHARS = 120;
+
+export type LifecycleStatusEvidenceKind =
+  | "status"
+  | "progress_summary"
+  | "terminal_summary"
+  | "error"
+  | "blocked_summary"
+  | "current_step"
+  | "wait";
+
+export type LifecycleStatusEvidence = {
+  kind: LifecycleStatusEvidenceKind;
+  summary?: string;
+  data?: JsonValue;
+  recordedAt?: number;
+};
+
+export type LifecycleBackingLinkKind = "task" | "flow" | "session";
+
+export type LifecycleBackingLinkRelation =
+  | "owner_session"
+  | "child_session"
+  | "parent_flow"
+  | "parent_task"
+  | "blocked_task"
+  | "wait_task";
+
+export type LifecycleBackingLink = {
+  kind: LifecycleBackingLinkKind;
+  relation: LifecycleBackingLinkRelation;
+  id: string;
+};
+
+export type LifecycleStatusReason = {
+  code: string;
+  summary: string;
+  evidence?: LifecycleStatusEvidence[];
+  backing?: LifecycleBackingLink[];
+};
+
+function truncateText(value: string, maxChars: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxChars) {
+    return trimmed;
+  }
+  return `${truncateUtf16Safe(trimmed, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+function sanitizeLifecycleValue(value: unknown, errorContext: boolean): unknown {
+  if (typeof value === "string") {
+    const sanitized = sanitizeUserFacingText(value, { errorContext }).replace(/\s+/g, " ").trim();
+    return sanitized || undefined;
+  }
+  if (Array.isArray(value)) {
+    const next = value
+      .map((entry) => sanitizeLifecycleValue(entry, errorContext))
+      .filter((entry) => entry !== undefined);
+    return next.length > 0 ? next : undefined;
+  }
+  if (value && typeof value === "object") {
+    const nextEntries = Object.entries(value as Record<string, unknown>)
+      .map(([key, entry]) => [key, sanitizeLifecycleValue(entry, errorContext)] as const)
+      .filter(([, entry]) => entry !== undefined);
+    if (nextEntries.length === 0) {
+      return undefined;
+    }
+    return Object.fromEntries(nextEntries);
+  }
+  return value;
+}
+
+function sanitizeLifecycleText(
+  value: unknown,
+  opts?: { errorContext?: boolean; maxChars?: number },
+): string {
+  const sanitizedValue = sanitizeLifecycleValue(value, opts?.errorContext ?? false);
+  const raw =
+    typeof sanitizedValue === "string"
+      ? sanitizedValue
+      : sanitizedValue == null
+        ? ""
+        : (JSON.stringify(sanitizedValue) ?? "");
+  const sanitized = raw.replace(/\s+/g, " ").trim();
+  if (!sanitized) {
+    return "";
+  }
+  if (typeof opts?.maxChars === "number") {
+    return truncateText(sanitized, opts.maxChars);
+  }
+  return sanitized;
+}
+
+function normalizeId(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function pushEvidence(
+  evidence: LifecycleStatusEvidence[],
+  next: LifecycleStatusEvidence | undefined,
+): void {
+  if (!next) {
+    return;
+  }
+  if (
+    evidence.some(
+      (entry) =>
+        entry.kind === next.kind &&
+        entry.summary === next.summary &&
+        JSON.stringify(entry.data) === JSON.stringify(next.data) &&
+        entry.recordedAt === next.recordedAt,
+    )
+  ) {
+    return;
+  }
+  evidence.push(next);
+}
+
+function pushBacking(
+  backing: LifecycleBackingLink[],
+  next: LifecycleBackingLink | undefined,
+): void {
+  if (!next) {
+    return;
+  }
+  if (
+    backing.some(
+      (entry) =>
+        entry.kind === next.kind && entry.relation === next.relation && entry.id === next.id,
+    )
+  ) {
+    return;
+  }
+  backing.push(next);
+}
+
+function makeEvidence(params: {
+  kind: LifecycleStatusEvidenceKind;
+  value?: unknown;
+  errorContext?: boolean;
+  data?: JsonValue;
+  recordedAt?: number;
+}): LifecycleStatusEvidence | undefined {
+  const summary = sanitizeLifecycleText(params.value, {
+    errorContext: params.errorContext,
+  });
+  if (!summary && params.data === undefined && params.recordedAt == null) {
+    return undefined;
+  }
+  return {
+    kind: params.kind,
+    ...(summary ? { summary } : {}),
+    ...(params.data !== undefined ? { data: params.data } : {}),
+    ...(params.recordedAt != null ? { recordedAt: params.recordedAt } : {}),
+  };
+}
+
+function buildReason(params: {
+  code: string;
+  summary: string;
+  evidence?: LifecycleStatusEvidence[];
+  backing?: LifecycleBackingLink[];
+}): LifecycleStatusReason {
+  return {
+    code: params.code,
+    summary: params.summary,
+    ...(params.evidence && params.evidence.length > 0 ? { evidence: params.evidence } : {}),
+    ...(params.backing && params.backing.length > 0 ? { backing: params.backing } : {}),
+  };
+}
+
+function summarizeWaitJson(waitJson: JsonValue | undefined): string | undefined {
+  if (waitJson === undefined || waitJson === null) {
+    return undefined;
+  }
+  if (typeof waitJson === "string") {
+    return sanitizeLifecycleText(waitJson) || undefined;
+  }
+  if (typeof waitJson !== "object" || Array.isArray(waitJson)) {
+    return sanitizeLifecycleText(waitJson) || undefined;
+  }
+  const kind = typeof waitJson.kind === "string" ? waitJson.kind.trim() : "";
+  if (kind === "task") {
+    return "Waiting on another task.";
+  }
+  if (kind === "external_event") {
+    const topic = typeof waitJson.topic === "string" ? waitJson.topic.trim() : "";
+    return topic ? `Waiting on ${topic}.` : "Waiting on an external event.";
+  }
+  if (kind) {
+    return `Waiting on ${kind.replaceAll("_", " ")}.`;
+  }
+  return "Waiting for the next lifecycle event.";
+}
+
+function resolveWaitTaskId(waitJson: JsonValue | undefined): string | undefined {
+  if (!waitJson || typeof waitJson !== "object" || Array.isArray(waitJson)) {
+    return undefined;
+  }
+  if (typeof waitJson.kind !== "string" || waitJson.kind.trim() !== "task") {
+    return undefined;
+  }
+  return typeof waitJson.taskId === "string" ? normalizeId(waitJson.taskId) : undefined;
+}
+
+function resolveTaskReasonCode(
+  task: Pick<TaskRecord, "status" | "terminalOutcome" | "error">,
+): string {
+  if (task.status === "succeeded" && task.terminalOutcome === "blocked") {
+    return "blocked";
+  }
+  if (task.status === "lost") {
+    const error = task.error?.toLowerCase() ?? "";
+    return error.includes("backing session") ? "lost_backing_session" : "lost";
+  }
+  return task.status;
+}
+
+function resolveTaskReasonSummary(task: {
+  status: TaskRecord["status"];
+  terminalOutcome?: TaskRecord["terminalOutcome"];
+  progressSummary?: string;
+  terminalSummary?: string;
+  error?: string;
+}): string {
+  const progress = sanitizeLifecycleText(task.progressSummary);
+  const terminal = sanitizeLifecycleText(task.terminalSummary, { errorContext: true });
+  const error = sanitizeLifecycleText(task.error, { errorContext: true });
+  switch (task.status) {
+    case "queued":
+      return progress || "Queued for execution.";
+    case "running":
+      return progress || "Task is running.";
+    case "succeeded":
+      if (task.terminalOutcome === "blocked") {
+        return terminal || progress || "Task needs operator follow-up.";
+      }
+      return terminal || "Task completed successfully.";
+    case "failed":
+      return error || terminal || "Task failed.";
+    case "timed_out":
+      return error || terminal || "Task timed out.";
+    case "cancelled":
+      return error || terminal || "Task was cancelled.";
+    case "lost":
+      return error || terminal || "Task lost its backing session.";
+  }
+}
+
+export function resolveTaskLifecycleStatusReason(
+  task: Pick<
+    TaskRecord,
+    | "status"
+    | "terminalOutcome"
+    | "progressSummary"
+    | "terminalSummary"
+    | "error"
+    | "parentFlowId"
+    | "parentTaskId"
+    | "childSessionKey"
+    | "ownerKey"
+    | "lastEventAt"
+    | "endedAt"
+  >,
+): LifecycleStatusReason {
+  const evidence: LifecycleStatusEvidence[] = [];
+  const backing: LifecycleBackingLink[] = [];
+  const recordedAt = task.endedAt ?? task.lastEventAt;
+
+  pushEvidence(
+    evidence,
+    makeEvidence({ kind: "status", value: task.status.replaceAll("_", " "), recordedAt }),
+  );
+  pushEvidence(
+    evidence,
+    makeEvidence({
+      kind: "progress_summary",
+      value: task.progressSummary,
+      recordedAt: task.lastEventAt,
+    }),
+  );
+  pushEvidence(
+    evidence,
+    makeEvidence({
+      kind: "terminal_summary",
+      value: task.terminalSummary,
+      errorContext: true,
+      recordedAt: task.endedAt ?? task.lastEventAt,
+    }),
+  );
+  pushEvidence(
+    evidence,
+    makeEvidence({
+      kind: "error",
+      value: task.error,
+      errorContext: true,
+      recordedAt: task.endedAt ?? task.lastEventAt,
+    }),
+  );
+
+  pushBacking(
+    backing,
+    (() => {
+      const id = normalizeId(task.parentFlowId);
+      return id ? { kind: "flow" as const, relation: "parent_flow" as const, id } : undefined;
+    })(),
+  );
+  pushBacking(
+    backing,
+    (() => {
+      const id = normalizeId(task.parentTaskId);
+      return id ? { kind: "task" as const, relation: "parent_task" as const, id } : undefined;
+    })(),
+  );
+  pushBacking(
+    backing,
+    (() => {
+      const id = normalizeId(task.childSessionKey);
+      return id ? { kind: "session" as const, relation: "child_session" as const, id } : undefined;
+    })(),
+  );
+  pushBacking(
+    backing,
+    (() => {
+      const id = normalizeId(task.ownerKey);
+      return id ? { kind: "session" as const, relation: "owner_session" as const, id } : undefined;
+    })(),
+  );
+
+  return buildReason({
+    code: resolveTaskReasonCode(task),
+    summary: resolveTaskReasonSummary(task),
+    evidence,
+    backing,
+  });
+}
+
+function resolveFlowReasonCode(flow: Pick<TaskFlowRecord, "status" | "waitJson">): string {
+  if (flow.status === "waiting" && resolveWaitTaskId(flow.waitJson)) {
+    return "waiting_on_task";
+  }
+  if (
+    flow.status === "waiting" &&
+    flow.waitJson &&
+    typeof flow.waitJson === "object" &&
+    !Array.isArray(flow.waitJson)
+  ) {
+    const kind = typeof flow.waitJson.kind === "string" ? flow.waitJson.kind.trim() : "";
+    if (kind === "external_event") {
+      return "waiting_on_external_event";
+    }
+  }
+  return flow.status;
+}
+
+function resolveFlowReasonSummary(
+  flow: Pick<
+    TaskFlowRecord,
+    "status" | "currentStep" | "blockedSummary" | "blockedTaskId" | "waitJson" | "cancelRequestedAt"
+  >,
+): string {
+  const currentStep = sanitizeLifecycleText(flow.currentStep);
+  const blockedSummary = sanitizeLifecycleText(flow.blockedSummary, { errorContext: true });
+  const waitSummary = summarizeWaitJson(flow.waitJson);
+  switch (flow.status) {
+    case "queued":
+      return currentStep ? `Queued: ${currentStep}` : "Flow is queued.";
+    case "running":
+      return currentStep ? `Running: ${currentStep}` : "Flow is running.";
+    case "waiting":
+      return waitSummary || (currentStep ? `Waiting: ${currentStep}` : "Flow is waiting.");
+    case "blocked":
+      return (
+        blockedSummary ||
+        waitSummary ||
+        (flow.blockedTaskId?.trim() ? "Flow is blocked on a child task." : "Flow is blocked.")
+      );
+    case "succeeded":
+      return currentStep ? `Completed: ${currentStep}` : "Flow completed successfully.";
+    case "failed":
+      return blockedSummary || (currentStep ? `Failed: ${currentStep}` : "Flow failed.");
+    case "cancelled":
+      return flow.cancelRequestedAt != null ? "Flow was cancelled." : "Flow is cancelled.";
+    case "lost":
+      return blockedSummary || "Flow was lost.";
+  }
+}
+
+export function resolveTaskFlowLifecycleStatusReason(params: {
+  flow: Pick<
+    TaskFlowRecord,
+    | "status"
+    | "currentStep"
+    | "blockedTaskId"
+    | "blockedSummary"
+    | "waitJson"
+    | "ownerKey"
+    | "cancelRequestedAt"
+    | "updatedAt"
+    | "endedAt"
+  >;
+}): LifecycleStatusReason {
+  const { flow } = params;
+  const evidence: LifecycleStatusEvidence[] = [];
+  const backing: LifecycleBackingLink[] = [];
+  const waitTaskId = resolveWaitTaskId(flow.waitJson);
+
+  pushEvidence(
+    evidence,
+    makeEvidence({
+      kind: "status",
+      value: flow.status.replaceAll("_", " "),
+      recordedAt: flow.endedAt ?? flow.updatedAt,
+    }),
+  );
+  pushEvidence(
+    evidence,
+    makeEvidence({ kind: "current_step", value: flow.currentStep, recordedAt: flow.updatedAt }),
+  );
+  pushEvidence(
+    evidence,
+    makeEvidence({
+      kind: "blocked_summary",
+      value: flow.blockedSummary,
+      errorContext: true,
+      recordedAt: flow.endedAt ?? flow.updatedAt,
+    }),
+  );
+  pushEvidence(
+    evidence,
+    makeEvidence({
+      kind: "wait",
+      value: summarizeWaitJson(flow.waitJson),
+      data: flow.waitJson,
+      recordedAt: flow.updatedAt,
+    }),
+  );
+
+  pushBacking(
+    backing,
+    (() => {
+      const id = normalizeId(flow.ownerKey);
+      return id ? { kind: "session" as const, relation: "owner_session" as const, id } : undefined;
+    })(),
+  );
+  pushBacking(
+    backing,
+    (() => {
+      const id = normalizeId(flow.blockedTaskId);
+      return id ? { kind: "task" as const, relation: "blocked_task" as const, id } : undefined;
+    })(),
+  );
+  pushBacking(
+    backing,
+    waitTaskId ? { kind: "task", relation: "wait_task", id: waitTaskId } : undefined,
+  );
+
+  return buildReason({
+    code: resolveFlowReasonCode(flow),
+    summary: resolveFlowReasonSummary(flow),
+    evidence,
+    backing,
+  });
+}
+
+export function formatLifecycleStatusReasonSummary(
+  reason: LifecycleStatusReason | undefined,
+  opts?: { maxChars?: number },
+): string | undefined {
+  const summary = reason?.summary?.trim();
+  if (!summary) {
+    return undefined;
+  }
+  return truncateText(summary, opts?.maxChars ?? DEFAULT_REASON_MAX_CHARS);
+}
+
+export function formatLifecycleBackingSummary(
+  reason: LifecycleStatusReason | undefined,
+  opts?: { maxLinks?: number; maxChars?: number },
+): string | undefined {
+  const links =
+    reason?.backing
+      ?.flatMap((entry) => {
+        switch (entry.relation) {
+          case "parent_flow":
+            return ["linked flow"];
+          case "parent_task":
+            return ["parent task"];
+          case "child_session":
+            return ["child session"];
+          case "blocked_task":
+            return ["blocked task"];
+          case "wait_task":
+            return ["waiting task"];
+          case "owner_session":
+            return [];
+        }
+      })
+      .filter((value, index, values) => values.indexOf(value) === index)
+      .slice(0, opts?.maxLinks ?? 2) ?? [];
+  if (links.length === 0) {
+    return undefined;
+  }
+  return truncateText(links.join(" · "), opts?.maxChars ?? DEFAULT_REASON_MAX_CHARS);
+}

--- a/src/tasks/task-lifecycle-status.ts
+++ b/src/tasks/task-lifecycle-status.ts
@@ -228,6 +228,7 @@ export type BackingSessionSnapshot = {
   source: "session_status" | "acp_state" | "missing";
   summary: string;
   recordedAt?: number;
+  endedAt?: number;
 };
 
 function findSessionEntryByKey(
@@ -269,6 +270,7 @@ function summarizeBackingSessionState(state: Exclude<BackingSessionState, "missi
 function mapPersistedSessionStatus(
   status: SessionEntry["status"],
   recordedAt?: number,
+  endedAt?: number,
 ): BackingSessionSnapshot | undefined {
   if (!status) {
     return undefined;
@@ -278,6 +280,7 @@ function mapPersistedSessionStatus(
     source: "session_status",
     summary: summarizeBackingSessionState(status),
     recordedAt,
+    endedAt,
   };
 }
 
@@ -295,7 +298,7 @@ function loadPersistedBackingSessionSnapshot(
       summary: "Backing session is missing; task may be orphaned.",
     };
   }
-  return mapPersistedSessionStatus(entry.status, entry.updatedAt);
+  return mapPersistedSessionStatus(entry.status, entry.updatedAt, entry.endedAt);
 }
 
 export function resolveTaskBackingSessionSnapshot(
@@ -329,7 +332,11 @@ export function resolveTaskBackingSessionSnapshot(
         recordedAt: acpEntry.acp?.lastActivityAt ?? acpEntry.entry.updatedAt,
       };
     }
-    return mapPersistedSessionStatus(acpEntry.entry.status, acpEntry.entry.updatedAt);
+    return mapPersistedSessionStatus(
+      acpEntry.entry.status,
+      acpEntry.entry.updatedAt,
+      acpEntry.entry.endedAt,
+    );
   }
 
   try {

--- a/src/tasks/task-lifecycle-status.ts
+++ b/src/tasks/task-lifecycle-status.ts
@@ -1,4 +1,7 @@
+import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
 import { sanitizeUserFacingText } from "../agents/pi-embedded-helpers/errors.js";
+import { loadSessionStore, resolveStorePath, type SessionEntry } from "../config/sessions.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
 import { truncateUtf16Safe } from "../utils.js";
 import type { JsonValue, TaskFlowRecord } from "./task-flow-registry.types.js";
 import type { TaskRecord } from "./task-registry.types.js";
@@ -12,7 +15,8 @@ export type LifecycleStatusEvidenceKind =
   | "error"
   | "blocked_summary"
   | "current_step"
-  | "wait";
+  | "wait"
+  | "session_state";
 
 export type LifecycleStatusEvidence = {
   kind: LifecycleStatusEvidenceKind;
@@ -209,11 +213,152 @@ function resolveWaitTaskId(waitJson: JsonValue | undefined): string | undefined 
   return typeof waitJson.taskId === "string" ? normalizeId(waitJson.taskId) : undefined;
 }
 
+type BackingSessionState =
+  | "running"
+  | "done"
+  | "failed"
+  | "killed"
+  | "timeout"
+  | "idle"
+  | "error"
+  | "missing";
+
+type BackingSessionSnapshot = {
+  state: BackingSessionState;
+  source: "session_status" | "acp_state" | "missing";
+  summary: string;
+  recordedAt?: number;
+};
+
+function findSessionEntryByKey(
+  store: Record<string, SessionEntry>,
+  sessionKey: string,
+): SessionEntry | undefined {
+  const direct = store[sessionKey];
+  if (direct) {
+    return direct;
+  }
+  const normalized = sessionKey.toLowerCase();
+  for (const [key, entry] of Object.entries(store)) {
+    if (key.toLowerCase() === normalized) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+function summarizeBackingSessionState(state: Exclude<BackingSessionState, "missing">): string {
+  switch (state) {
+    case "running":
+      return "Backing session is running.";
+    case "done":
+      return "Backing session finished; task has not reconciled yet.";
+    case "failed":
+      return "Backing session failed; task has not reconciled yet.";
+    case "killed":
+      return "Backing session was killed; task has not reconciled yet.";
+    case "timeout":
+      return "Backing session timed out; task has not reconciled yet.";
+    case "idle":
+      return "Backing session is idle; task is waiting for the next session turn.";
+    case "error":
+      return "Backing session hit an error; task has not reconciled yet.";
+  }
+}
+
+function mapPersistedSessionStatus(
+  status: SessionEntry["status"],
+  recordedAt?: number,
+): BackingSessionSnapshot | undefined {
+  if (!status) {
+    return undefined;
+  }
+  return {
+    state: status,
+    source: "session_status",
+    summary: summarizeBackingSessionState(status),
+    recordedAt,
+  };
+}
+
+function loadPersistedBackingSessionSnapshot(
+  sessionKey: string,
+): BackingSessionSnapshot | undefined {
+  const agentId = parseAgentSessionKey(sessionKey)?.agentId;
+  const storePath = resolveStorePath(undefined, { agentId });
+  const store = loadSessionStore(storePath);
+  const entry = findSessionEntryByKey(store, sessionKey);
+  if (!entry) {
+    return {
+      state: "missing",
+      source: "missing",
+      summary: "Backing session is missing; task may be orphaned.",
+    };
+  }
+  return mapPersistedSessionStatus(entry.status, entry.updatedAt);
+}
+
+function resolveTaskBackingSessionSnapshot(
+  task: Pick<TaskRecord, "runtime" | "childSessionKey" | "status"> & {
+    runtime?: TaskRecord["runtime"];
+  },
+): BackingSessionSnapshot | undefined {
+  const childSessionKey = normalizeId(task.childSessionKey);
+  if (!childSessionKey || task.status !== "running") {
+    return undefined;
+  }
+
+  if (task.runtime === "acp") {
+    const acpEntry = readAcpSessionEntry({ sessionKey: childSessionKey });
+    if (!acpEntry || acpEntry.storeReadFailed) {
+      return undefined;
+    }
+    if (!acpEntry.entry) {
+      return {
+        state: "missing",
+        source: "missing",
+        summary: "Backing session is missing; task may be orphaned.",
+      };
+    }
+    const acpState = acpEntry.acp?.state;
+    if (acpState === "running" || acpState === "idle" || acpState === "error") {
+      return {
+        state: acpState,
+        source: "acp_state",
+        summary: summarizeBackingSessionState(acpState),
+        recordedAt: acpEntry.acp?.lastActivityAt ?? acpEntry.entry.updatedAt,
+      };
+    }
+    return mapPersistedSessionStatus(acpEntry.entry.status, acpEntry.entry.updatedAt);
+  }
+
+  try {
+    return loadPersistedBackingSessionSnapshot(childSessionKey);
+  } catch {
+    return undefined;
+  }
+}
+
 function resolveTaskReasonCode(
-  task: Pick<TaskRecord, "status" | "terminalOutcome" | "error">,
+  task: Pick<TaskRecord, "status" | "terminalOutcome" | "error" | "progressSummary">,
+  backingSession?: BackingSessionSnapshot,
 ): string {
   if (task.status === "succeeded" && task.terminalOutcome === "blocked") {
     return "blocked";
+  }
+  if (task.status === "running") {
+    if (sanitizeLifecycleText(task.progressSummary)) {
+      return task.status;
+    }
+    if (backingSession?.state === "missing") {
+      return "missing_backing_session";
+    }
+    if (backingSession && backingSession.state !== "running") {
+      return "blocked_on_backing_session_state";
+    }
+    if (backingSession?.state === "running") {
+      return "waiting_on_backing_session";
+    }
   }
   if (task.status === "lost") {
     const error = task.error?.toLowerCase() ?? "";
@@ -222,13 +367,16 @@ function resolveTaskReasonCode(
   return task.status;
 }
 
-function resolveTaskReasonSummary(task: {
-  status: TaskRecord["status"];
-  terminalOutcome?: TaskRecord["terminalOutcome"];
-  progressSummary?: string;
-  terminalSummary?: string;
-  error?: string;
-}): string {
+function resolveTaskReasonSummary(
+  task: {
+    status: TaskRecord["status"];
+    terminalOutcome?: TaskRecord["terminalOutcome"];
+    progressSummary?: string;
+    terminalSummary?: string;
+    error?: string;
+  },
+  backingSession?: BackingSessionSnapshot,
+): string {
   const progress = sanitizeLifecycleText(task.progressSummary);
   const terminal = sanitizeLifecycleText(task.terminalSummary, { errorContext: true });
   const error = sanitizeLifecycleText(task.error, { errorContext: true });
@@ -236,7 +384,16 @@ function resolveTaskReasonSummary(task: {
     case "queued":
       return progress || "Queued for execution.";
     case "running":
-      return progress || "Task is running.";
+      if (progress) {
+        return progress;
+      }
+      if (backingSession?.state === "missing") {
+        return backingSession.summary;
+      }
+      if (backingSession && backingSession.state !== "running") {
+        return backingSession.summary;
+      }
+      return backingSession?.summary || "Task is running.";
     case "succeeded":
       if (task.terminalOutcome === "blocked") {
         return terminal || progress || "Task needs operator follow-up.";
@@ -256,6 +413,7 @@ function resolveTaskReasonSummary(task: {
 export function resolveTaskLifecycleStatusReason(
   task: Pick<
     TaskRecord,
+    | "runtime"
     | "status"
     | "terminalOutcome"
     | "progressSummary"
@@ -267,11 +425,12 @@ export function resolveTaskLifecycleStatusReason(
     | "ownerKey"
     | "lastEventAt"
     | "endedAt"
-  >,
+  > & { runtime?: TaskRecord["runtime"] },
 ): LifecycleStatusReason {
   const evidence: LifecycleStatusEvidence[] = [];
   const backing: LifecycleBackingLink[] = [];
   const recordedAt = task.endedAt ?? task.lastEventAt;
+  const backingSession = resolveTaskBackingSessionSnapshot(task);
 
   pushEvidence(
     evidence,
@@ -301,6 +460,20 @@ export function resolveTaskLifecycleStatusReason(
       value: task.error,
       errorContext: true,
       recordedAt: task.endedAt ?? task.lastEventAt,
+    }),
+  );
+  pushEvidence(
+    evidence,
+    makeEvidence({
+      kind: "session_state",
+      value: backingSession?.summary,
+      data: backingSession
+        ? {
+            state: backingSession.state,
+            source: backingSession.source,
+          }
+        : undefined,
+      recordedAt: backingSession?.recordedAt,
     }),
   );
 
@@ -334,8 +507,8 @@ export function resolveTaskLifecycleStatusReason(
   );
 
   return buildReason({
-    code: resolveTaskReasonCode(task),
-    summary: resolveTaskReasonSummary(task),
+    code: resolveTaskReasonCode(task, backingSession),
+    summary: resolveTaskReasonSummary(task, backingSession),
     evidence,
     backing,
   });

--- a/src/tasks/task-lifecycle-status.ts
+++ b/src/tasks/task-lifecycle-status.ts
@@ -213,7 +213,7 @@ function resolveWaitTaskId(waitJson: JsonValue | undefined): string | undefined 
   return typeof waitJson.taskId === "string" ? normalizeId(waitJson.taskId) : undefined;
 }
 
-type BackingSessionState =
+export type BackingSessionState =
   | "running"
   | "done"
   | "failed"
@@ -223,7 +223,7 @@ type BackingSessionState =
   | "error"
   | "missing";
 
-type BackingSessionSnapshot = {
+export type BackingSessionSnapshot = {
   state: BackingSessionState;
   source: "session_status" | "acp_state" | "missing";
   summary: string;
@@ -298,7 +298,7 @@ function loadPersistedBackingSessionSnapshot(
   return mapPersistedSessionStatus(entry.status, entry.updatedAt);
 }
 
-function resolveTaskBackingSessionSnapshot(
+export function resolveTaskBackingSessionSnapshot(
   task: Pick<TaskRecord, "runtime" | "childSessionKey" | "status"> & {
     runtime?: TaskRecord["runtime"];
   },

--- a/src/tasks/task-registry.audit.shared.ts
+++ b/src/tasks/task-registry.audit.shared.ts
@@ -20,6 +20,7 @@ export type LifecycleStatusBackingLink = {
 export type LifecycleStatusReason = {
   code: TaskAuditCode;
   evidence: string;
+  summary?: string;
   backing: LifecycleStatusBackingLink;
 };
 

--- a/src/tasks/task-registry.audit.shared.ts
+++ b/src/tasks/task-registry.audit.shared.ts
@@ -9,12 +9,27 @@ export type TaskAuditCode =
   | "missing_cleanup"
   | "inconsistent_timestamps";
 
+export type LifecycleStatusBackingLink = {
+  kind: "task";
+  taskId: string;
+  runId?: string;
+  childSessionKey?: string;
+  parentFlowId?: string;
+};
+
+export type LifecycleStatusReason = {
+  code: TaskAuditCode;
+  evidence: string;
+  backing: LifecycleStatusBackingLink;
+};
+
 export type TaskAuditFinding = {
   severity: TaskAuditSeverity;
   code: TaskAuditCode;
   task: TaskRecord;
   ageMs?: number;
   detail: string;
+  lifecycleReason: LifecycleStatusReason;
 };
 
 export type TaskAuditSummary = {

--- a/src/tasks/task-registry.audit.test.ts
+++ b/src/tasks/task-registry.audit.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearSessionStoreCacheForTest,
+  resolveStorePath,
+  saveSessionStore,
+  type SessionEntry,
+} from "../config/sessions.js";
+import { withTempDir } from "../test-helpers/temp-dir.js";
 import { listTaskAuditFindings, summarizeTaskAuditFindings } from "./task-registry.audit.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 function createTask(partial: Partial<TaskRecord>): TaskRecord {
   return {
     taskId: partial.taskId ?? "task-1",
-    runtime: partial.runtime ?? "acp",
+    runtime: partial.runtime ?? "subagent",
     requesterSessionKey: partial.requesterSessionKey ?? partial.ownerKey ?? "agent:main:main",
     ownerKey: partial.ownerKey ?? partial.requesterSessionKey ?? "agent:main:main",
     scopeKind: partial.scopeKind ?? "session",
@@ -18,54 +25,134 @@ function createTask(partial: Partial<TaskRecord>): TaskRecord {
   };
 }
 
-describe("task-registry audit", () => {
-  it("flags stale running, lost, and missing cleanup tasks", () => {
-    const now = Date.parse("2026-03-30T01:00:00.000Z");
-    const findings = listTaskAuditFindings({
-      now,
-      tasks: [
-        createTask({
-          taskId: "stale-running",
-          status: "running",
-          runId: "run-stale-running",
-          childSessionKey: "agent:codex:acp:child",
-          parentFlowId: "flow-stale-running",
-          startedAt: now - 40 * 60_000,
-          lastEventAt: now - 40 * 60_000,
-        }),
-        createTask({
-          taskId: "lost-task",
-          status: "lost",
-          error: "backing session missing",
-          endedAt: now - 5 * 60_000,
-        }),
-        createTask({
-          taskId: "missing-cleanup",
-          status: "failed",
-          endedAt: now - 60_000,
-          cleanupAfter: undefined,
-        }),
-      ],
-    });
+const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
 
-    expect(findings.map((finding) => [finding.code, finding.task.taskId])).toEqual([
-      ["lost", "lost-task"],
-      ["stale_running", "stale-running"],
-      ["missing_cleanup", "missing-cleanup"],
-    ]);
-    expect(findings.find((finding) => finding.task.taskId === "stale-running")).toMatchObject({
-      lifecycleReason: {
-        code: "stale_running",
-        evidence: "running task appears stuck",
-        backing: {
-          kind: "task",
-          taskId: "stale-running",
-          runId: "run-stale-running",
-          childSessionKey: "agent:codex:acp:child",
-          parentFlowId: "flow-stale-running",
+async function withBackingSessionStore(
+  entries: Record<string, SessionEntry>,
+  run: () => Promise<void> | void,
+): Promise<void> {
+  await withTempDir({ prefix: "openclaw-task-audit-" }, async (root) => {
+    process.env.OPENCLAW_STATE_DIR = root;
+    clearSessionStoreCacheForTest();
+    const storePath = resolveStorePath(undefined, { agentId: "main" });
+    await saveSessionStore(storePath, entries);
+    try {
+      await run();
+    } finally {
+      clearSessionStoreCacheForTest();
+    }
+  });
+}
+
+afterEach(() => {
+  clearSessionStoreCacheForTest();
+  if (ORIGINAL_STATE_DIR === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+  }
+});
+
+describe("task-registry audit", () => {
+  it("flags stale running, lost, and missing cleanup tasks", async () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    await withBackingSessionStore(
+      {
+        "agent:main:subagent:child-failed": {
+          sessionId: "session-child-failed",
+          updatedAt: now - 60_000,
+          status: "failed",
         },
       },
-    });
+      () => {
+        const findings = listTaskAuditFindings({
+          now,
+          tasks: [
+            createTask({
+              taskId: "stale-running",
+              status: "running",
+              runId: "run-stale-running",
+              childSessionKey: "agent:main:subagent:child-failed",
+              parentFlowId: "flow-stale-running",
+              startedAt: now - 40 * 60_000,
+              lastEventAt: now - 40 * 60_000,
+            }),
+            createTask({
+              taskId: "lost-task",
+              status: "lost",
+              error: "backing session missing",
+              endedAt: now - 5 * 60_000,
+            }),
+            createTask({
+              taskId: "missing-cleanup",
+              status: "failed",
+              endedAt: now - 60_000,
+              cleanupAfter: undefined,
+            }),
+          ],
+        });
+
+        expect(findings.map((finding) => [finding.code, finding.task.taskId])).toEqual([
+          ["lost", "lost-task"],
+          ["stale_running", "stale-running"],
+          ["missing_cleanup", "missing-cleanup"],
+        ]);
+        expect(findings.find((finding) => finding.task.taskId === "stale-running")).toMatchObject({
+          detail: "Backing session failed; task has not reconciled yet.",
+          lifecycleReason: {
+            code: "stale_running",
+            evidence: "Backing session failed; task has not reconciled yet.",
+            summary: "Backing session failed; task has not reconciled yet.",
+            backing: {
+              kind: "task",
+              taskId: "stale-running",
+              runId: "run-stale-running",
+              childSessionKey: "agent:main:subagent:child-failed",
+              parentFlowId: "flow-stale-running",
+            },
+          },
+        });
+      },
+    );
+  });
+
+  it("distinguishes backing sessions that are still running from generic stale tasks", async () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    await withBackingSessionStore(
+      {
+        "agent:main:subagent:child-live": {
+          sessionId: "session-child-live",
+          updatedAt: now - 30_000,
+          status: "running",
+        },
+      },
+      () => {
+        const findings = listTaskAuditFindings({
+          now,
+          tasks: [
+            createTask({
+              taskId: "stale-running-live",
+              status: "running",
+              childSessionKey: "agent:main:subagent:child-live",
+              startedAt: now - 40 * 60_000,
+              lastEventAt: now - 40 * 60_000,
+            }),
+          ],
+        });
+
+        expect(findings).toMatchObject([
+          {
+            code: "stale_running",
+            detail: "Backing session is still running; task has not advanced recently.",
+            lifecycleReason: {
+              code: "stale_running",
+              evidence: "Backing session is still running; task has not advanced recently.",
+              summary: "Backing session is running.",
+            },
+          },
+        ]);
+      },
+    );
   });
 
   it("summarizes findings by severity and code", () => {

--- a/src/tasks/task-registry.audit.test.ts
+++ b/src/tasks/task-registry.audit.test.ts
@@ -27,6 +27,9 @@ describe("task-registry audit", () => {
         createTask({
           taskId: "stale-running",
           status: "running",
+          runId: "run-stale-running",
+          childSessionKey: "agent:codex:acp:child",
+          parentFlowId: "flow-stale-running",
           startedAt: now - 40 * 60_000,
           lastEventAt: now - 40 * 60_000,
         }),
@@ -50,6 +53,19 @@ describe("task-registry audit", () => {
       ["stale_running", "stale-running"],
       ["missing_cleanup", "missing-cleanup"],
     ]);
+    expect(findings.find((finding) => finding.task.taskId === "stale-running")).toMatchObject({
+      lifecycleReason: {
+        code: "stale_running",
+        evidence: "running task appears stuck",
+        backing: {
+          kind: "task",
+          taskId: "stale-running",
+          runId: "run-stale-running",
+          childSessionKey: "agent:codex:acp:child",
+          parentFlowId: "flow-stale-running",
+        },
+      },
+    });
   });
 
   it("summarizes findings by severity and code", () => {
@@ -59,12 +75,28 @@ describe("task-registry audit", () => {
         code: "stale_running",
         task: createTask({ taskId: "a", status: "running" }),
         detail: "running task appears stuck",
+        lifecycleReason: {
+          code: "stale_running",
+          evidence: "running task appears stuck",
+          backing: {
+            kind: "task",
+            taskId: "a",
+          },
+        },
       },
       {
         severity: "warn",
         code: "delivery_failed",
         task: createTask({ taskId: "b", status: "failed" }),
         detail: "terminal update delivery failed",
+        lifecycleReason: {
+          code: "delivery_failed",
+          evidence: "terminal update delivery failed",
+          backing: {
+            kind: "task",
+            taskId: "b",
+          },
+        },
       },
     ]);
 

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -1,3 +1,4 @@
+import { resolveTaskLifecycleStatusReason } from "./task-lifecycle-status.js";
 import {
   createEmptyTaskAuditSummary,
   type LifecycleStatusReason,
@@ -31,10 +32,12 @@ function createLifecycleStatusReason(
   task: TaskRecord,
   code: TaskAuditCode,
   evidence: string,
+  summary?: string,
 ): LifecycleStatusReason {
   return {
     code,
     evidence,
+    ...(summary?.trim() ? { summary: summary.trim() } : {}),
     backing: {
       kind: "task",
       taskId: task.taskId,
@@ -50,6 +53,7 @@ function createFinding(params: {
   code: TaskAuditCode;
   task: TaskRecord;
   detail: string;
+  lifecycleSummary?: string;
   ageMs?: number;
 }): TaskAuditFinding {
   return {
@@ -57,7 +61,12 @@ function createFinding(params: {
     code: params.code,
     task: params.task,
     detail: params.detail,
-    lifecycleReason: createLifecycleStatusReason(params.task, params.code, params.detail),
+    lifecycleReason: createLifecycleStatusReason(
+      params.task,
+      params.code,
+      params.detail,
+      params.lifecycleSummary,
+    ),
     ...(typeof params.ageMs === "number" ? { ageMs: params.ageMs } : {}),
   };
 }
@@ -108,6 +117,30 @@ function compareFindings(left: TaskAuditFinding, right: TaskAuditFinding): numbe
   return left.task.createdAt - right.task.createdAt;
 }
 
+function resolveStaleRunningDiagnostic(task: TaskRecord): {
+  detail: string;
+  lifecycleSummary?: string;
+} {
+  const reason = resolveTaskLifecycleStatusReason(task);
+  switch (reason.code) {
+    case "waiting_on_backing_session":
+      return {
+        detail: "Backing session is still running; task has not advanced recently.",
+        lifecycleSummary: reason.summary,
+      };
+    case "blocked_on_backing_session_state":
+    case "missing_backing_session":
+      return {
+        detail: reason.summary,
+        lifecycleSummary: reason.summary,
+      };
+    default:
+      return {
+        detail: "running task appears stuck",
+      };
+  }
+}
+
 export function listTaskAuditFindings(options: TaskAuditOptions = {}): TaskAuditFinding[] {
   const tasks = options.tasks ?? reconcileInspectableTasks();
   const now = options.now ?? Date.now();
@@ -132,13 +165,15 @@ export function listTaskAuditFindings(options: TaskAuditOptions = {}): TaskAudit
     }
 
     if (task.status === "running" && ageMs >= staleRunningMs) {
+      const staleRunningDiagnostic = resolveStaleRunningDiagnostic(task);
       findings.push(
         createFinding({
           severity: "error",
           code: "stale_running",
           task,
           ageMs,
-          detail: "running task appears stuck",
+          detail: staleRunningDiagnostic.detail,
+          lifecycleSummary: staleRunningDiagnostic.lifecycleSummary,
         }),
       );
     }

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -1,5 +1,6 @@
 import {
   createEmptyTaskAuditSummary,
+  type LifecycleStatusReason,
   type TaskAuditCode,
   type TaskAuditFinding,
   type TaskAuditSeverity,
@@ -18,7 +19,31 @@ export type TaskAuditOptions = {
 const DEFAULT_STALE_QUEUED_MS = 10 * 60_000;
 const DEFAULT_STALE_RUNNING_MS = 30 * 60_000;
 export { createEmptyTaskAuditSummary };
-export type { TaskAuditCode, TaskAuditFinding, TaskAuditSeverity, TaskAuditSummary };
+export type {
+  LifecycleStatusReason,
+  TaskAuditCode,
+  TaskAuditFinding,
+  TaskAuditSeverity,
+  TaskAuditSummary,
+};
+
+function createLifecycleStatusReason(
+  task: TaskRecord,
+  code: TaskAuditCode,
+  evidence: string,
+): LifecycleStatusReason {
+  return {
+    code,
+    evidence,
+    backing: {
+      kind: "task",
+      taskId: task.taskId,
+      ...(task.runId?.trim() ? { runId: task.runId.trim() } : {}),
+      ...(task.childSessionKey?.trim() ? { childSessionKey: task.childSessionKey.trim() } : {}),
+      ...(task.parentFlowId?.trim() ? { parentFlowId: task.parentFlowId.trim() } : {}),
+    },
+  };
+}
 
 function createFinding(params: {
   severity: TaskAuditSeverity;
@@ -32,6 +57,7 @@ function createFinding(params: {
     code: params.code,
     task: params.task,
     detail: params.detail,
+    lifecycleReason: createLifecycleStatusReason(params.task, params.code, params.detail),
     ...(typeof params.ageMs === "number" ? { ageMs: params.ageMs } : {}),
   };
 }

--- a/src/tasks/task-registry.maintenance.session-terminal.test.ts
+++ b/src/tasks/task-registry.maintenance.session-terminal.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearSessionStoreCacheForTest,
+  resolveStorePath,
+  saveSessionStore,
+  type SessionEntry,
+} from "../config/sessions.js";
+import { withTempDir } from "../test-helpers/temp-dir.js";
+import { createRunningTaskRun } from "./task-executor.js";
+import { resetTaskFlowRegistryForTests } from "./task-flow-registry.js";
+import { getTaskById, resetTaskRegistryForTests } from "./task-registry.js";
+import {
+  reconcileInspectableTasks,
+  runTaskRegistryMaintenance,
+} from "./task-registry.maintenance.js";
+
+const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+
+type BackingTerminalCase = {
+  backingStatus: NonNullable<SessionEntry["status"]>;
+  expectedTaskStatus: "succeeded" | "failed" | "timed_out" | "cancelled";
+  expectedError?: string;
+  expectedTerminalSummary?: string;
+};
+
+const TERMINAL_CASES: BackingTerminalCase[] = [
+  {
+    backingStatus: "done",
+    expectedTaskStatus: "succeeded",
+    expectedTerminalSummary: "Backing session finished.",
+  },
+  {
+    backingStatus: "failed",
+    expectedTaskStatus: "failed",
+    expectedError: "Backing session failed.",
+  },
+  {
+    backingStatus: "timeout",
+    expectedTaskStatus: "timed_out",
+    expectedError: "Backing session timed out.",
+  },
+  {
+    backingStatus: "killed",
+    expectedTaskStatus: "cancelled",
+    expectedError: "Backing session was killed.",
+  },
+];
+
+async function withTaskRegistryState(run: () => Promise<void>): Promise<void> {
+  await withTempDir({ prefix: "openclaw-task-registry-session-terminal-" }, async (root) => {
+    process.env.OPENCLAW_STATE_DIR = root;
+    clearSessionStoreCacheForTest();
+    resetTaskRegistryForTests();
+    resetTaskFlowRegistryForTests();
+    try {
+      await run();
+    } finally {
+      clearSessionStoreCacheForTest();
+      resetTaskRegistryForTests();
+      resetTaskFlowRegistryForTests();
+    }
+  });
+}
+
+describe("task registry maintenance session terminal bridge", () => {
+  afterEach(() => {
+    clearSessionStoreCacheForTest();
+    if (ORIGINAL_STATE_DIR === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+    }
+    resetTaskRegistryForTests();
+    resetTaskFlowRegistryForTests();
+  });
+
+  for (const testCase of TERMINAL_CASES) {
+    it(`projects ${testCase.backingStatus} backing-session evidence during operator inspection without mutating the registry`, async () => {
+      await withTaskRegistryState(async () => {
+        const task = createRunningTaskRun({
+          runtime: "subagent",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          runId: `run-inspect-${testCase.backingStatus}`,
+          task: `Inspect ${testCase.backingStatus} child session`,
+          childSessionKey: `agent:main:subagent:inspect-${testCase.backingStatus}`,
+        });
+        const storePath = resolveStorePath(undefined, { agentId: "main" });
+        await saveSessionStore(storePath, {
+          [task.childSessionKey!]: {
+            sessionId: `session-inspect-${testCase.backingStatus}`,
+            updatedAt: Date.now(),
+            status: testCase.backingStatus,
+          },
+        });
+        clearSessionStoreCacheForTest();
+
+        const [projected] = reconcileInspectableTasks();
+
+        expect(projected).toMatchObject({
+          taskId: task.taskId,
+          status: testCase.expectedTaskStatus,
+          ...(testCase.expectedError ? { error: testCase.expectedError } : {}),
+          ...(testCase.expectedTerminalSummary
+            ? { terminalSummary: testCase.expectedTerminalSummary }
+            : {}),
+        });
+        expect(projected.cleanupAfter).toBeGreaterThan(projected.endedAt ?? 0);
+        expect(getTaskById(task.taskId)).toMatchObject({
+          status: "running",
+        });
+      });
+    });
+
+    it(`applies ${testCase.backingStatus} backing-session evidence during maintenance`, async () => {
+      await withTaskRegistryState(async () => {
+        const task = createRunningTaskRun({
+          runtime: "subagent",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          runId: `run-maint-${testCase.backingStatus}`,
+          task: `Maintain ${testCase.backingStatus} child session`,
+          childSessionKey: `agent:main:subagent:maint-${testCase.backingStatus}`,
+        });
+        const storePath = resolveStorePath(undefined, { agentId: "main" });
+        await saveSessionStore(storePath, {
+          [task.childSessionKey!]: {
+            sessionId: `session-maint-${testCase.backingStatus}`,
+            updatedAt: Date.now(),
+            status: testCase.backingStatus,
+          },
+        });
+        clearSessionStoreCacheForTest();
+
+        await expect(runTaskRegistryMaintenance()).resolves.toEqual({
+          reconciled: 1,
+          cleanupStamped: 0,
+          pruned: 0,
+        });
+        expect(getTaskById(task.taskId)).toMatchObject({
+          status: testCase.expectedTaskStatus,
+          ...(testCase.expectedError ? { error: testCase.expectedError } : {}),
+          ...(testCase.expectedTerminalSummary
+            ? { terminalSummary: testCase.expectedTerminalSummary }
+            : {}),
+        });
+        expect(getTaskById(task.taskId)?.cleanupAfter).toBeGreaterThan(Date.now());
+      });
+    });
+  }
+});

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -13,9 +13,11 @@ import {
   setTaskCleanupAfterById,
 } from "./runtime-internal.js";
 import {
-  resolveTaskBackingSessionSnapshot,
-  type BackingSessionSnapshot,
-} from "./task-lifecycle-status.js";
+  resolveTaskTerminalAtFromBackingSession,
+  resolveTaskTerminalEvidenceText,
+  resolveTaskTerminalStatusFromBackingSession,
+} from "./task-backing-session-terminal.js";
+import { resolveTaskBackingSessionSnapshot } from "./task-lifecycle-status.js";
 import { listTaskAuditFindings, summarizeTaskAuditFindings } from "./task-registry.audit.js";
 import type { TaskAuditSummary } from "./task-registry.audit.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
@@ -101,41 +103,6 @@ function shouldMarkLost(task: TaskRecord, now: number): boolean {
   return !hasBackingSession(task);
 }
 
-function resolveTaskTerminalStatusFromBackingSession(
-  backingSession: BackingSessionSnapshot,
-): Extract<TaskStatus, "succeeded" | "failed" | "timed_out" | "cancelled"> | undefined {
-  switch (backingSession.state) {
-    case "done":
-      return "succeeded";
-    case "failed":
-      return "failed";
-    case "timeout":
-      return "timed_out";
-    case "killed":
-      return "cancelled";
-    default:
-      return undefined;
-  }
-}
-
-function resolveTaskTerminalEvidenceText(backingSession: BackingSessionSnapshot): {
-  error?: string;
-  terminalSummary?: string;
-} {
-  switch (backingSession.state) {
-    case "done":
-      return { terminalSummary: "Backing session finished." };
-    case "failed":
-      return { error: "Backing session failed." };
-    case "timeout":
-      return { error: "Backing session timed out." };
-    case "killed":
-      return { error: "Backing session was killed." };
-    default:
-      return {};
-  }
-}
-
 function projectTaskTerminalFromBackingSession(task: TaskRecord):
   | {
       status: Extract<TaskStatus, "succeeded" | "failed" | "timed_out" | "cancelled">;
@@ -154,7 +121,7 @@ function projectTaskTerminalFromBackingSession(task: TaskRecord):
     task.createdAt,
     task.startedAt ?? 0,
     task.lastEventAt ?? 0,
-    backingSession.recordedAt ?? 0,
+    resolveTaskTerminalAtFromBackingSession(backingSession, 0),
   );
   const evidenceText = resolveTaskTerminalEvidenceText(backingSession);
   const projected: TaskRecord = {

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -7,14 +7,19 @@ import {
   getTaskById,
   listTaskRecords,
   markTaskLostById,
+  markTaskTerminalById,
   maybeDeliverTaskTerminalUpdate,
   resolveTaskForLookupToken,
   setTaskCleanupAfterById,
 } from "./runtime-internal.js";
+import {
+  resolveTaskBackingSessionSnapshot,
+  type BackingSessionSnapshot,
+} from "./task-lifecycle-status.js";
 import { listTaskAuditFindings, summarizeTaskAuditFindings } from "./task-registry.audit.js";
 import type { TaskAuditSummary } from "./task-registry.audit.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
-import type { TaskRecord, TaskRegistrySummary } from "./task-registry.types.js";
+import type { TaskRecord, TaskRegistrySummary, TaskStatus } from "./task-registry.types.js";
 
 const TASK_RECONCILE_GRACE_MS = 5 * 60_000;
 const TASK_RETENTION_MS = 7 * 24 * 60 * 60_000;
@@ -96,6 +101,86 @@ function shouldMarkLost(task: TaskRecord, now: number): boolean {
   return !hasBackingSession(task);
 }
 
+function resolveTaskTerminalStatusFromBackingSession(
+  backingSession: BackingSessionSnapshot,
+): Extract<TaskStatus, "succeeded" | "failed" | "timed_out" | "cancelled"> | undefined {
+  switch (backingSession.state) {
+    case "done":
+      return "succeeded";
+    case "failed":
+      return "failed";
+    case "timeout":
+      return "timed_out";
+    case "killed":
+      return "cancelled";
+    default:
+      return undefined;
+  }
+}
+
+function resolveTaskTerminalEvidenceText(backingSession: BackingSessionSnapshot): {
+  error?: string;
+  terminalSummary?: string;
+} {
+  switch (backingSession.state) {
+    case "done":
+      return { terminalSummary: "Backing session finished." };
+    case "failed":
+      return { error: "Backing session failed." };
+    case "timeout":
+      return { error: "Backing session timed out." };
+    case "killed":
+      return { error: "Backing session was killed." };
+    default:
+      return {};
+  }
+}
+
+function projectTaskTerminalFromBackingSession(task: TaskRecord):
+  | {
+      status: Extract<TaskStatus, "succeeded" | "failed" | "timed_out" | "cancelled">;
+      task: TaskRecord;
+    }
+  | undefined {
+  const backingSession = resolveTaskBackingSessionSnapshot(task);
+  if (!backingSession) {
+    return undefined;
+  }
+  const status = resolveTaskTerminalStatusFromBackingSession(backingSession);
+  if (!status) {
+    return undefined;
+  }
+  const terminalAt = Math.max(
+    task.createdAt,
+    task.startedAt ?? 0,
+    task.lastEventAt ?? 0,
+    backingSession.recordedAt ?? 0,
+  );
+  const evidenceText = resolveTaskTerminalEvidenceText(backingSession);
+  const projected: TaskRecord = {
+    ...task,
+    status,
+    endedAt: terminalAt,
+    lastEventAt: terminalAt,
+    ...(task.error !== undefined || evidenceText.error === undefined
+      ? {}
+      : { error: evidenceText.error }),
+    ...(task.terminalSummary !== undefined || evidenceText.terminalSummary === undefined
+      ? {}
+      : { terminalSummary: evidenceText.terminalSummary }),
+  };
+  return {
+    status,
+    task:
+      typeof projected.cleanupAfter === "number"
+        ? projected
+        : {
+            ...projected,
+            cleanupAfter: resolveCleanupAfter(projected),
+          },
+  };
+}
+
 function shouldPruneTerminalTask(task: TaskRecord, now: number): boolean {
   if (!isTerminalTask(task)) {
     return false;
@@ -148,6 +233,10 @@ function projectTaskLost(task: TaskRecord, now: number): TaskRecord {
 
 export function reconcileTaskRecordForOperatorInspection(task: TaskRecord): TaskRecord {
   const now = Date.now();
+  const projectedTerminal = projectTaskTerminalFromBackingSession(task);
+  if (projectedTerminal) {
+    return projectedTerminal.task;
+  }
   if (!shouldMarkLost(task, now)) {
     return task;
   }
@@ -181,6 +270,10 @@ export function previewTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary
   let cleanupStamped = 0;
   let pruned = 0;
   for (const task of listTaskRecords()) {
+    if (projectTaskTerminalFromBackingSession(task)) {
+      reconciled += 1;
+      continue;
+    }
     if (shouldMarkLost(task, now)) {
       reconciled += 1;
       continue;
@@ -226,6 +319,27 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
   for (const task of tasks) {
     const current = getTaskById(task.taskId);
     if (!current) {
+      continue;
+    }
+    const terminalProjection = projectTaskTerminalFromBackingSession(current);
+    if (terminalProjection) {
+      const next =
+        markTaskTerminalById({
+          taskId: current.taskId,
+          status: terminalProjection.status,
+          endedAt: terminalProjection.task.endedAt ?? now,
+          lastEventAt: terminalProjection.task.lastEventAt,
+          error: terminalProjection.task.error,
+          terminalSummary: terminalProjection.task.terminalSummary,
+        }) ?? current;
+      void maybeDeliverTaskTerminalUpdate(next.taskId);
+      if (next.status === terminalProjection.status) {
+        reconciled += 1;
+      }
+      processed += 1;
+      if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
+        await yieldToEventLoop();
+      }
       continue;
     }
     if (shouldMarkLost(current, now)) {

--- a/src/tasks/task-registry.session-lifecycle.test.ts
+++ b/src/tasks/task-registry.session-lifecycle.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearSessionStoreCacheForTest,
+  resolveStorePath,
+  saveSessionStore,
+  type SessionEntry,
+} from "../config/sessions.js";
+import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
+import { withTempDir } from "../test-helpers/temp-dir.js";
+import { createRunningTaskRun } from "./task-executor.js";
+import { resetTaskFlowRegistryForTests } from "./task-flow-registry.js";
+import { getTaskById, resetTaskRegistryForTests } from "./task-registry.js";
+
+const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+
+type BackingTerminalCase = {
+  backingStatus: NonNullable<SessionEntry["status"]>;
+  expectedTaskStatus: "succeeded" | "failed" | "timed_out" | "cancelled";
+  expectedError?: string;
+  expectedTerminalSummary?: string;
+};
+
+const TERMINAL_CASES: BackingTerminalCase[] = [
+  {
+    backingStatus: "done",
+    expectedTaskStatus: "succeeded",
+    expectedTerminalSummary: "Backing session finished.",
+  },
+  {
+    backingStatus: "failed",
+    expectedTaskStatus: "failed",
+    expectedError: "Backing session failed.",
+  },
+  {
+    backingStatus: "timeout",
+    expectedTaskStatus: "timed_out",
+    expectedError: "Backing session timed out.",
+  },
+  {
+    backingStatus: "killed",
+    expectedTaskStatus: "cancelled",
+    expectedError: "Backing session was killed.",
+  },
+];
+
+async function withTaskRegistryState(run: () => Promise<void>): Promise<void> {
+  await withTempDir({ prefix: "openclaw-task-registry-session-events-" }, async (root) => {
+    process.env.OPENCLAW_STATE_DIR = root;
+    clearSessionStoreCacheForTest();
+    resetTaskRegistryForTests();
+    resetTaskFlowRegistryForTests();
+    try {
+      await run();
+    } finally {
+      clearSessionStoreCacheForTest();
+      resetTaskRegistryForTests();
+      resetTaskFlowRegistryForTests();
+    }
+  });
+}
+
+describe("task registry session lifecycle bridge", () => {
+  afterEach(() => {
+    clearSessionStoreCacheForTest();
+    if (ORIGINAL_STATE_DIR === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+    }
+    resetTaskRegistryForTests();
+    resetTaskFlowRegistryForTests();
+  });
+
+  for (const testCase of TERMINAL_CASES) {
+    it(`reconciles ${testCase.backingStatus} linked tasks on session lifecycle events`, async () => {
+      await withTaskRegistryState(async () => {
+        const endedAt = 4_000;
+        const updatedAt = 5_000;
+        const task = createRunningTaskRun({
+          runtime: "subagent",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          runId: `run-session-event-${testCase.backingStatus}`,
+          task: `Bridge ${testCase.backingStatus} child session`,
+          childSessionKey: `agent:main:subagent:event-${testCase.backingStatus}`,
+          progressSummary: "Captured child result",
+        });
+        const storePath = resolveStorePath(undefined, { agentId: "main" });
+        await saveSessionStore(storePath, {
+          [task.childSessionKey!]: {
+            sessionId: `session-event-${testCase.backingStatus}`,
+            updatedAt,
+            endedAt,
+            status: testCase.backingStatus,
+          },
+        });
+        clearSessionStoreCacheForTest();
+
+        emitSessionLifecycleEvent({
+          sessionKey: task.childSessionKey!,
+          reason: "subagent-status",
+          parentSessionKey: task.ownerKey,
+        });
+
+        expect(getTaskById(task.taskId)).toMatchObject({
+          taskId: task.taskId,
+          status: testCase.expectedTaskStatus,
+          endedAt,
+          progressSummary: "Captured child result",
+          ...(testCase.expectedError ? { error: testCase.expectedError } : {}),
+          ...(testCase.expectedTerminalSummary
+            ? { terminalSummary: testCase.expectedTerminalSummary }
+            : {}),
+        });
+      });
+    });
+  }
+
+  it("ignores non-terminal session lifecycle events", async () => {
+    await withTaskRegistryState(async () => {
+      const task = createRunningTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "run-session-event-running",
+        task: "Keep waiting on child session",
+        childSessionKey: "agent:main:subagent:event-running",
+      });
+      const storePath = resolveStorePath(undefined, { agentId: "main" });
+      await saveSessionStore(storePath, {
+        [task.childSessionKey!]: {
+          sessionId: "session-event-running",
+          updatedAt: 2_000,
+          status: "running",
+        },
+      });
+      clearSessionStoreCacheForTest();
+
+      emitSessionLifecycleEvent({
+        sessionKey: task.childSessionKey!,
+        reason: "subagent-status",
+        parentSessionKey: task.ownerKey,
+      });
+
+      expect(getTaskById(task.taskId)).toMatchObject({
+        taskId: task.taskId,
+        status: "running",
+      });
+      expect(getTaskById(task.taskId)?.endedAt).toBeUndefined();
+    });
+  });
+});

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -7,8 +7,14 @@ import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
+import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { isDeliverableMessageChannel } from "../utils/message-channel.js";
+import {
+  resolveTaskTerminalAtFromBackingSession,
+  resolveTaskTerminalEvidenceText,
+  resolveTaskTerminalStatusFromBackingSession,
+} from "./task-backing-session-terminal.js";
 import {
   formatTaskBlockedFollowupMessage,
   formatTaskStateChangeMessage,
@@ -24,6 +30,7 @@ import {
   syncFlowFromTask,
   updateFlowRecordByIdExpectedRevision,
 } from "./task-flow-runtime-internal.js";
+import { resolveTaskBackingSessionSnapshot } from "./task-lifecycle-status.js";
 import {
   getTaskRegistryObservers,
   getTaskRegistryStore,
@@ -58,6 +65,7 @@ const taskIdsByRelatedSessionKey = new Map<string, Set<string>>();
 const tasksWithPendingDelivery = new Set<string>();
 let listenerStarted = false;
 let listenerStop: (() => void) | null = null;
+let sessionLifecycleListenerStop: (() => void) | null = null;
 let restoreAttempted = false;
 let deliveryRuntimePromise: Promise<typeof import("./task-registry-delivery-runtime.js")> | null =
   null;
@@ -1270,6 +1278,66 @@ function updateTasksByRunId(params: {
   return updated;
 }
 
+function reconcileTaskTerminalStateFromBackingSession(current: TaskRecord) {
+  if (!isActiveTaskStatus(current.status)) {
+    return null;
+  }
+  const backingSession = resolveTaskBackingSessionSnapshot(current);
+  if (!backingSession) {
+    return null;
+  }
+  const status = resolveTaskTerminalStatusFromBackingSession(backingSession);
+  if (!status) {
+    return null;
+  }
+  const terminalAt = resolveTaskTerminalAtFromBackingSession(backingSession, Date.now());
+  const evidenceText = resolveTaskTerminalEvidenceText(backingSession);
+  const patch: Partial<TaskRecord> = {
+    status,
+    endedAt: terminalAt,
+    lastEventAt: terminalAt,
+    ...(current.error !== undefined || evidenceText.error === undefined
+      ? {}
+      : { error: evidenceText.error }),
+    ...(current.terminalSummary !== undefined || evidenceText.terminalSummary === undefined
+      ? {}
+      : { terminalSummary: evidenceText.terminalSummary }),
+  };
+  const stateChangeEvent =
+    status !== current.status
+      ? appendTaskEvent({
+          at: terminalAt,
+          kind: status,
+          summary:
+            status === "failed" || status === "timed_out" || status === "cancelled"
+              ? (patch.error ?? current.error)
+              : (patch.terminalSummary ?? current.terminalSummary),
+        })
+      : undefined;
+  const updated = updateTask(current.taskId, patch);
+  if (updated) {
+    void maybeDeliverTaskStateChangeUpdate(current.taskId, stateChangeEvent);
+    void maybeDeliverTaskTerminalUpdate(current.taskId);
+  }
+  return updated;
+}
+
+function reconcileTasksForSessionLifecycleEvent(sessionKey: string) {
+  const scopedTasks = listTasksForRelatedSessionKey(sessionKey).filter((task) =>
+    isActiveTaskStatus(task.status),
+  );
+  if (scopedTasks.length === 0) {
+    return;
+  }
+  for (const task of scopedTasks) {
+    const current = tasks.get(task.taskId);
+    if (!current) {
+      continue;
+    }
+    reconcileTaskTerminalStateFromBackingSession(current);
+  }
+}
+
 function ensureListener() {
   if (listenerStarted) {
     return;
@@ -1329,6 +1397,10 @@ function ensureListener() {
         void maybeDeliverTaskTerminalUpdate(current.taskId);
       }
     }
+  });
+  sessionLifecycleListenerStop = onSessionLifecycleEvent((event) => {
+    restoreTaskRegistryOnce();
+    reconcileTasksForSessionLifecycleEvent(event.sessionKey);
   });
 }
 
@@ -1923,6 +1995,10 @@ export function resetTaskRegistryForTests(opts?: { persist?: boolean }) {
   if (listenerStop) {
     listenerStop();
     listenerStop = null;
+  }
+  if (sessionLifecycleListenerStop) {
+    sessionLifecycleListenerStop();
+    sessionLifecycleListenerStop = null;
   }
   listenerStarted = false;
   if (opts?.persist !== false) {

--- a/src/tasks/task-status.test.ts
+++ b/src/tasks/task-status.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from "vitest";
+import {
+  formatLifecycleBackingSummary,
+  resolveTaskFlowLifecycleStatusReason,
+  resolveTaskLifecycleStatusReason,
+} from "./task-lifecycle-status.js";
 import type { TaskRecord } from "./task-registry.types.js";
 import {
   buildTaskStatusSnapshot,
@@ -54,6 +59,26 @@ describe("task status snapshot", () => {
 
     expect(snapshot.totalCount).toBe(0);
     expect(snapshot.focus).toBeUndefined();
+  });
+
+  it("enriches the focused snapshot task with a lifecycle reason", () => {
+    const running = makeTask({
+      status: "running",
+      progressSummary: "Indexing the latest threads",
+      parentFlowId: "flow-123",
+      childSessionKey: "agent:main:child",
+    });
+
+    const snapshot = buildTaskStatusSnapshot([running], { now: NOW });
+
+    expect(snapshot.focusReason).toMatchObject({
+      code: "running",
+      summary: "Indexing the latest threads",
+      backing: expect.arrayContaining([
+        { kind: "flow", relation: "parent_flow", id: "flow-123" },
+        { kind: "session", relation: "child_session", id: "agent:main:child" },
+      ]),
+    });
   });
 });
 
@@ -142,5 +167,50 @@ describe("task status formatting", () => {
         ].join("\n"),
       ),
     ).toBe("");
+  });
+
+  it("derives lifecycle reason evidence and compact backing for blocked tasks", () => {
+    const reason = resolveTaskLifecycleStatusReason(
+      makeTask({
+        status: "succeeded",
+        terminalOutcome: "blocked",
+        terminalSummary: "Writable session required.",
+        parentFlowId: "flow-123",
+        childSessionKey: "agent:main:child",
+      }),
+    );
+
+    expect(reason).toMatchObject({
+      code: "blocked",
+      summary: "Writable session required.",
+      backing: expect.arrayContaining([
+        { kind: "flow", relation: "parent_flow", id: "flow-123" },
+        { kind: "session", relation: "child_session", id: "agent:main:child" },
+      ]),
+    });
+    expect(reason.evidence?.map((entry) => entry.kind)).toContain("terminal_summary");
+    expect(formatLifecycleBackingSummary(reason)).toBe("linked flow · child session");
+  });
+
+  it("derives waiting reasons and task linkage for flows", () => {
+    const reason = resolveTaskFlowLifecycleStatusReason({
+      flow: {
+        ownerKey: "agent:main:main",
+        status: "waiting",
+        currentStep: "wait for approval",
+        waitJson: { kind: "task", taskId: "task-123" },
+        updatedAt: NOW,
+      },
+    });
+
+    expect(reason).toMatchObject({
+      code: "waiting_on_task",
+      summary: "Waiting on another task.",
+      backing: [
+        { kind: "session", relation: "owner_session", id: "agent:main:main" },
+        { kind: "task", relation: "wait_task", id: "task-123" },
+      ],
+    });
+    expect(reason.evidence?.map((entry) => entry.kind)).toContain("wait");
   });
 });

--- a/src/tasks/task-status.ts
+++ b/src/tasks/task-status.ts
@@ -1,5 +1,9 @@
 import { sanitizeUserFacingText } from "../agents/pi-embedded-helpers/errors.js";
 import { truncateUtf16Safe } from "../utils.js";
+import {
+  resolveTaskLifecycleStatusReason,
+  type LifecycleStatusReason,
+} from "./task-lifecycle-status.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 const ACTIVE_TASK_STATUSES = new Set(["queued", "running"]);
@@ -121,7 +125,9 @@ export function formatTaskStatusDetail(task: TaskRecord): string | undefined {
 
 export type TaskStatusSnapshot = {
   latest?: TaskRecord;
+  latestReason?: LifecycleStatusReason;
   focus?: TaskRecord;
+  focusReason?: LifecycleStatusReason;
   visible: TaskRecord[];
   active: TaskRecord[];
   recentTerminal: TaskRecord[];
@@ -141,9 +147,12 @@ export function buildTaskStatusSnapshot(
   const visible = active.length > 0 ? [...active, ...recentTerminal] : recentTerminal;
   const focus =
     active[0] ?? recentTerminal.find((task) => isFailureTask(task)) ?? recentTerminal[0];
+  const latest = active[0] ?? recentTerminal[0];
   return {
-    latest: active[0] ?? recentTerminal[0],
+    latest,
+    ...(latest ? { latestReason: resolveTaskLifecycleStatusReason(latest) } : {}),
     focus,
+    ...(focus ? { focusReason: resolveTaskLifecycleStatusReason(focus) } : {}),
     visible,
     active,
     recentTerminal,

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -100,7 +100,12 @@ type SessionDefaultsSnapshot = {
 type GatewayHostWithShutdownMessage = GatewayHost & {
   pendingShutdownMessage?: string | null;
   resumeChatQueueAfterReconnect?: boolean;
+  sessionsRefreshTimer?: number | null;
 };
+
+function isUiVisible() {
+  return typeof document === "undefined" || !document.hidden;
+}
 
 type ConnectGatewayOptions = {
   reason?: "initial" | "seq-gap";
@@ -249,7 +254,9 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       void loadAssistantIdentity(host as unknown as OpenClawApp);
       void loadAgents(host as unknown as OpenClawApp);
       void loadHealthState(host as unknown as OpenClawApp);
-      void loadNodes(host as unknown as OpenClawApp, { quiet: true });
+      if (isUiVisible() && (host.tab === "overview" || host.tab === "nodes")) {
+        void loadNodes(host as unknown as OpenClawApp, { quiet: true });
+      }
       void loadDevices(host as unknown as OpenClawApp, { quiet: true });
       void refreshActiveTab(host as unknown as Parameters<typeof refreshActiveTab>[0]);
     },
@@ -332,6 +339,7 @@ function handleTerminalChatEvent(
     if (state === "final") {
       void loadSessions(host as unknown as OpenClawApp, {
         activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
+        force: true,
       });
     }
   }
@@ -410,7 +418,16 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
   }
 
   if (evt.event === "sessions.changed") {
-    void loadSessions(host as unknown as OpenClawApp);
+    if (!isUiVisible()) {
+      return;
+    }
+    const refreshHost = host as GatewayHostWithShutdownMessage;
+    if (refreshHost.sessionsRefreshTimer == null) {
+      refreshHost.sessionsRefreshTimer = window.setTimeout(() => {
+        refreshHost.sessionsRefreshTimer = null;
+        void loadSessions(host as unknown as OpenClawApp);
+      }, 1500);
+    }
     return;
   }
 

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -17,6 +17,10 @@ import {
   syncThemeWithSettings,
 } from "./app-settings.ts";
 import { loadControlUiBootstrapConfig } from "./controllers/control-ui-bootstrap.ts";
+import { loadDebug } from "./controllers/debug.ts";
+import { loadLogs } from "./controllers/logs.ts";
+import { loadNodes } from "./controllers/nodes.ts";
+import { loadSessions } from "./controllers/sessions.ts";
 import type { Tab } from "./navigation.ts";
 
 type LifecycleHost = {
@@ -40,7 +44,12 @@ type LifecycleHost = {
   logsEntries: unknown[];
   popStateHandler: () => void;
   topbarObserver: ResizeObserver | null;
+  visibilityHandler?: (() => void) | null;
 };
+
+function isUiVisible() {
+  return typeof document === "undefined" || !document.hidden;
+}
 
 export function handleConnected(host: LifecycleHost) {
   const connectGeneration = ++host.connectGeneration;
@@ -57,12 +66,39 @@ export function handleConnected(host: LifecycleHost) {
     }
     connectGateway(host as unknown as Parameters<typeof connectGateway>[0]);
   });
-  startNodesPolling(host as unknown as Parameters<typeof startNodesPolling>[0]);
-  if (host.tab === "logs") {
-    startLogsPolling(host as unknown as Parameters<typeof startLogsPolling>[0]);
-  }
-  if (host.tab === "debug") {
-    startDebugPolling(host as unknown as Parameters<typeof startDebugPolling>[0]);
+  host.visibilityHandler ??= () => {
+    if (!isUiVisible()) {
+      stopNodesPolling(host as unknown as Parameters<typeof stopNodesPolling>[0]);
+      stopLogsPolling(host as unknown as Parameters<typeof stopLogsPolling>[0]);
+      stopDebugPolling(host as unknown as Parameters<typeof stopDebugPolling>[0]);
+      return;
+    }
+    startNodesPolling(host as unknown as Parameters<typeof startNodesPolling>[0]);
+    if (host.tab === "logs") {
+      startLogsPolling(host as unknown as Parameters<typeof startLogsPolling>[0]);
+      void loadLogs(host as unknown as Parameters<typeof loadLogs>[0], {
+        quiet: true,
+        reset: true,
+      });
+    }
+    if (host.tab === "debug") {
+      startDebugPolling(host as unknown as Parameters<typeof startDebugPolling>[0]);
+      void loadDebug(host as unknown as Parameters<typeof loadDebug>[0]);
+    }
+    if (host.tab === "overview" || host.tab === "nodes") {
+      void loadNodes(host as unknown as Parameters<typeof loadNodes>[0], { quiet: true });
+    }
+    void loadSessions(host as unknown as Parameters<typeof loadSessions>[0], { force: true });
+  };
+  window.addEventListener("visibilitychange", host.visibilityHandler);
+  if (isUiVisible()) {
+    startNodesPolling(host as unknown as Parameters<typeof startNodesPolling>[0]);
+    if (host.tab === "logs") {
+      startLogsPolling(host as unknown as Parameters<typeof startLogsPolling>[0]);
+    }
+    if (host.tab === "debug") {
+      startDebugPolling(host as unknown as Parameters<typeof startDebugPolling>[0]);
+    }
   }
 }
 
@@ -73,6 +109,9 @@ export function handleFirstUpdated(host: LifecycleHost) {
 export function handleDisconnected(host: LifecycleHost) {
   host.connectGeneration += 1;
   window.removeEventListener("popstate", host.popStateHandler);
+  if (host.visibilityHandler) {
+    window.removeEventListener("visibilitychange", host.visibilityHandler);
+  }
   stopNodesPolling(host as unknown as Parameters<typeof stopNodesPolling>[0]);
   stopLogsPolling(host as unknown as Parameters<typeof stopLogsPolling>[0]);
   stopDebugPolling(host as unknown as Parameters<typeof stopDebugPolling>[0]);

--- a/ui/src/ui/app-polling.ts
+++ b/ui/src/ui/app-polling.ts
@@ -10,14 +10,23 @@ type PollingHost = {
   tab: string;
 };
 
+function isUiVisible() {
+  return typeof document === "undefined" || !document.hidden;
+}
+
 export function startNodesPolling(host: PollingHost) {
   if (host.nodesPollInterval != null) {
     return;
   }
-  host.nodesPollInterval = window.setInterval(
-    () => void loadNodes(host as unknown as OpenClawApp, { quiet: true }),
-    5000,
-  );
+  host.nodesPollInterval = window.setInterval(() => {
+    if (!isUiVisible()) {
+      return;
+    }
+    if (host.tab !== "overview" && host.tab !== "nodes") {
+      return;
+    }
+    void loadNodes(host as unknown as OpenClawApp, { quiet: true });
+  }, 30000);
 }
 
 export function stopNodesPolling(host: PollingHost) {
@@ -33,11 +42,11 @@ export function startLogsPolling(host: PollingHost) {
     return;
   }
   host.logsPollInterval = window.setInterval(() => {
-    if (host.tab !== "logs") {
+    if (!isUiVisible() || host.tab !== "logs") {
       return;
     }
     void loadLogs(host as unknown as OpenClawApp, { quiet: true });
-  }, 2000);
+  }, 5000);
 }
 
 export function stopLogsPolling(host: PollingHost) {
@@ -53,11 +62,11 @@ export function startDebugPolling(host: PollingHost) {
     return;
   }
   host.debugPollInterval = window.setInterval(() => {
-    if (host.tab !== "debug") {
+    if (!isUiVisible() || host.tab !== "debug") {
       return;
     }
     void loadDebug(host as unknown as OpenClawApp);
-  }, 3000);
+  }, 15000);
 }
 
 export function stopDebugPolling(host: PollingHost) {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -16,7 +16,12 @@ export type SessionsState = {
   sessionsFilterLimit: string;
   sessionsIncludeGlobal: boolean;
   sessionsIncludeUnknown: boolean;
+  sessionsLastFetchAt?: number | null;
 };
+
+function isUiVisible() {
+  return typeof document === "undefined" || !document.hidden;
+}
 
 export async function subscribeSessions(state: SessionsState) {
   if (!state.client || !state.connected) {
@@ -36,8 +41,18 @@ export async function loadSessions(
     limit?: number;
     includeGlobal?: boolean;
     includeUnknown?: boolean;
+    force?: boolean;
   },
 ) {
+  if (!isUiVisible() && !overrides?.force) {
+    return;
+  }
+  if (!overrides?.force && typeof state.sessionsLastFetchAt === "number") {
+    const minGapMs = 10_000;
+    if (Date.now() - state.sessionsLastFetchAt < minGapMs) {
+      return;
+    }
+  }
   if (!state.client || !state.connected) {
     return;
   }
@@ -65,6 +80,7 @@ export async function loadSessions(
     if (res) {
       state.sessionsResult = res;
     }
+    state.sessionsLastFetchAt = Date.now();
   } catch (err) {
     if (isMissingOperatorReadScopeError(err)) {
       state.sessionsResult = null;
@@ -109,7 +125,7 @@ export async function patchSession(
   }
   try {
     await state.client.request("sessions.patch", params);
-    await loadSessions(state);
+    await loadSessions(state, { force: true });
   } catch (err) {
     state.sessionsError = String(err);
   }

--- a/ui/src/ui/usage-helpers.node.test.ts
+++ b/ui/src/ui/usage-helpers.node.test.ts
@@ -31,6 +31,42 @@ describe("usage-helpers", () => {
     expect(res.warnings.some((w) => w.includes("Invalid number"))).toBe(true);
   });
 
+  it("filters by context inspector source and truncation severity", () => {
+    const run = {
+      key: "run",
+      contextWeight: { source: "run", truncationSeverity: "medium" },
+      usage: { totalTokens: 10, totalCost: 0 },
+    };
+    const estimate = {
+      key: "estimate",
+      contextWeight: { source: "estimate", truncationSeverity: "none" },
+      usage: { totalTokens: 10, totalCost: 0 },
+    };
+
+    expect(filterSessionsByQuery([run, estimate], "source:run").sessions).toEqual([run]);
+    expect(filterSessionsByQuery([run, estimate], "truncation:medium").sessions).toEqual([run]);
+  });
+
+  it("supports has:tracked and has:truncation", () => {
+    const tracked = {
+      key: "tracked",
+      contextWeight: {
+        source: "run",
+        tracked: { estimatedTokens: 255 },
+        truncationSeverity: "low",
+      },
+      usage: { totalTokens: 10, totalCost: 0 },
+    };
+    const plain = {
+      key: "plain",
+      contextWeight: { source: "estimate", truncationSeverity: "none" },
+      usage: { totalTokens: 10, totalCost: 0 },
+    };
+
+    expect(filterSessionsByQuery([tracked, plain], "has:tracked").sessions).toEqual([tracked]);
+    expect(filterSessionsByQuery([tracked, plain], "has:truncation").sessions).toEqual([tracked]);
+  });
+
   it("parses tool summaries from compact session logs", () => {
     const res = parseToolSummary(
       "[Tool: read]\n[Tool Result]\n[Tool: exec]\n[Tool: read]\n[Tool Result]",

--- a/ui/src/ui/usage-helpers.ts
+++ b/ui/src/ui/usage-helpers.ts
@@ -43,6 +43,8 @@ const QUERY_KEYS = new Set([
   "session",
   "id",
   "has",
+  "source",
+  "truncation",
   "mintokens",
   "maxtokens",
   "mincost",
@@ -139,6 +141,36 @@ const getSessionModels = (session: UsageSessionQueryTarget): string[] => {
 const getSessionTools = (session: UsageSessionQueryTarget): string[] =>
   (session.usage?.toolUsage?.tools ?? []).map((tool) => tool.name.toLowerCase());
 
+const getContextWeightShape = (
+  session: UsageSessionQueryTarget,
+): {
+  source?: string;
+  truncationSeverity?: string;
+  tracked?: unknown;
+} | null => {
+  if (!session.contextWeight || typeof session.contextWeight !== "object") {
+    return null;
+  }
+  return session.contextWeight as {
+    source?: string;
+    truncationSeverity?: string;
+    tracked?: unknown;
+  };
+};
+
+const getSessionContextSource = (session: UsageSessionQueryTarget): string | undefined => {
+  const value = getContextWeightShape(session)?.source;
+  return typeof value === "string" ? value.toLowerCase() : undefined;
+};
+
+const getSessionTruncationSeverity = (session: UsageSessionQueryTarget): string | undefined => {
+  const value = getContextWeightShape(session)?.truncationSeverity;
+  return typeof value === "string" ? value.toLowerCase() : undefined;
+};
+
+const hasTrackedContext = (session: UsageSessionQueryTarget): boolean =>
+  Boolean(getContextWeightShape(session)?.tracked);
+
 export const matchesUsageQuery = (
   session: UsageSessionQueryTarget,
   term: UsageQueryTerm,
@@ -165,6 +197,10 @@ export const matchesUsageQuery = (
       return getSessionModels(session).some((model) => model.includes(value));
     case "tool":
       return getSessionTools(session).some((tool) => tool.includes(value));
+    case "source":
+      return getSessionContextSource(session)?.includes(value) ?? false;
+    case "truncation":
+      return getSessionTruncationSeverity(session)?.includes(value) ?? false;
     case "label":
       return session.label?.toLowerCase().includes(value) ?? false;
     case "key":
@@ -188,6 +224,10 @@ export const matchesUsageQuery = (
           return (session.usage?.messageCounts?.errors ?? 0) > 0;
         case "context":
           return Boolean(session.contextWeight);
+        case "tracked":
+          return hasTrackedContext(session);
+        case "truncation":
+          return (getSessionTruncationSeverity(session) ?? "none") !== "none";
         case "usage":
           return Boolean(session.usage);
         case "model":

--- a/ui/src/ui/views/usage-render-details.test.ts
+++ b/ui/src/ui/views/usage-render-details.test.ts
@@ -4,6 +4,7 @@ import {
   CHART_BAR_WIDTH_RATIO,
   CHART_MAX_BAR_WIDTH,
   buildContextMetadataBadges,
+  buildContextTrackedBadges,
 } from "./usage-render-details.ts";
 import type { TimeSeriesPoint, UsageSessionEntry } from "./usageTypes.ts";
 
@@ -145,6 +146,41 @@ describe("buildContextMetadataBadges", () => {
     } as UsageSessionEntry["contextWeight"]);
 
     expect(badges).toEqual(["source:estimate"]);
+  });
+});
+
+describe("buildContextTrackedBadges", () => {
+  it("includes tracked prompt estimate and largest contributor", () => {
+    const badges = buildContextTrackedBadges({
+      tracked: {
+        chars: 1020,
+        estimatedTokens: 255,
+        largestContributors: [
+          { name: "Project Context", chars: 500, estimatedTokens: 125, sharePercent: 49 },
+        ],
+      },
+      systemPrompt: { chars: 100, projectContextChars: 40, nonProjectContextChars: 60 },
+      injectedWorkspaceFiles: [],
+      skills: { promptChars: 0, entries: [] },
+      tools: { listChars: 0, schemaChars: 0, entries: [] },
+      source: "run",
+      generatedAt: 1,
+    } as UsageSessionEntry["contextWeight"]);
+
+    expect(badges).toEqual(["tracked:255 tok", "top:Project Context 49.0%"]);
+  });
+
+  it("returns empty when tracked metrics are absent", () => {
+    expect(
+      buildContextTrackedBadges({
+        source: "estimate",
+        generatedAt: 1,
+        systemPrompt: { chars: 100, projectContextChars: 40, nonProjectContextChars: 60 },
+        injectedWorkspaceFiles: [],
+        skills: { promptChars: 0, entries: [] },
+        tools: { listChars: 0, schemaChars: 0, entries: [] },
+      } as UsageSessionEntry["contextWeight"]),
+    ).toEqual([]);
   });
 });
 

--- a/ui/src/ui/views/usage-render-details.test.ts
+++ b/ui/src/ui/views/usage-render-details.test.ts
@@ -3,6 +3,7 @@ import {
   computeFilteredUsage,
   CHART_BAR_WIDTH_RATIO,
   CHART_MAX_BAR_WIDTH,
+  buildContextMetadataBadges,
 } from "./usage-render-details.ts";
 import type { TimeSeriesPoint, UsageSessionEntry } from "./usageTypes.ts";
 
@@ -105,6 +106,45 @@ describe("computeFilteredUsage", () => {
     expect(result!.output).toBe(35);
     expect(result!.cacheRead).toBe(55);
     expect(result!.cacheWrite).toBe(75);
+  });
+});
+
+describe("buildContextMetadataBadges", () => {
+  it("includes run snapshot badges and non-none truncation severity", () => {
+    const badges = buildContextMetadataBadges({
+      source: "run",
+      sourceRunId: "run-ctx",
+      sourceMessageId: "leaf-ctx",
+      truncationSeverity: "medium",
+      promptHash: "abc123def456",
+      systemPrompt: { chars: 100, projectContextChars: 40, nonProjectContextChars: 60 },
+      injectedWorkspaceFiles: [],
+      skills: { promptChars: 0, entries: [] },
+      tools: { listChars: 0, schemaChars: 0, entries: [] },
+      generatedAt: 1,
+    } as UsageSessionEntry["contextWeight"]);
+
+    expect(badges).toEqual([
+      "source:run",
+      "run:run-ctx",
+      "leaf:leaf-ctx",
+      "truncation:medium",
+      "hash:abc123def456",
+    ]);
+  });
+
+  it("omits optional badges when fields are absent or severity is none", () => {
+    const badges = buildContextMetadataBadges({
+      source: "estimate",
+      truncationSeverity: "none",
+      systemPrompt: { chars: 100, projectContextChars: 40, nonProjectContextChars: 60 },
+      injectedWorkspaceFiles: [],
+      skills: { promptChars: 0, entries: [] },
+      tools: { listChars: 0, schemaChars: 0, entries: [] },
+      generatedAt: 1,
+    } as UsageSessionEntry["contextWeight"]);
+
+    expect(badges).toEqual(["source:estimate"]);
   });
 });
 

--- a/ui/src/ui/views/usage-render-details.ts
+++ b/ui/src/ui/views/usage-render-details.ts
@@ -797,6 +797,28 @@ function renderTimeSeriesCompact(
   `;
 }
 
+export function buildContextMetadataBadges(
+  contextWeight: UsageSessionEntry["contextWeight"],
+): string[] {
+  if (!contextWeight) {
+    return [];
+  }
+  const badges = [`source:${contextWeight.source}`];
+  if (contextWeight.sourceRunId) {
+    badges.push(`run:${contextWeight.sourceRunId}`);
+  }
+  if (contextWeight.sourceMessageId) {
+    badges.push(`leaf:${contextWeight.sourceMessageId}`);
+  }
+  if (contextWeight.truncationSeverity && contextWeight.truncationSeverity !== "none") {
+    badges.push(`truncation:${contextWeight.truncationSeverity}`);
+  }
+  if (contextWeight.promptHash) {
+    badges.push(`hash:${contextWeight.promptHash}`);
+  }
+  return badges;
+}
+
 function renderContextPanel(
   contextWeight: UsageSessionEntry["contextWeight"],
   usage: UsageSessionEntry["usage"],
@@ -828,6 +850,7 @@ function renderContextPanel(
     }
   }
 
+  const contextBadges = buildContextMetadataBadges(contextWeight);
   const skillsList = contextWeight.skills.entries.toSorted((a, b) => b.blockChars - a.blockChars);
   const toolsList = contextWeight.tools.entries.toSorted(
     (a, b) => b.summaryChars + b.schemaChars - (a.summaryChars + a.schemaChars),
@@ -858,6 +881,11 @@ function renderContextPanel(
           : nothing}
       </div>
       <p class="context-weight-desc">${contextPct || t("usage.details.baseContextPerMessage")}</p>
+      ${contextBadges.length > 0
+        ? html`<div class="usage-badges">
+            ${contextBadges.map((badge) => html`<span class="usage-badge">${badge}</span>`)}
+          </div>`
+        : nothing}
       <div class="context-stacked-bar">
         <div
           class="context-segment system"

--- a/ui/src/ui/views/usage-render-details.ts
+++ b/ui/src/ui/views/usage-render-details.ts
@@ -819,6 +819,20 @@ export function buildContextMetadataBadges(
   return badges;
 }
 
+export function buildContextTrackedBadges(
+  contextWeight: UsageSessionEntry["contextWeight"],
+): string[] {
+  if (!contextWeight?.tracked) {
+    return [];
+  }
+  const badges = [`tracked:${formatTokens(contextWeight.tracked.estimatedTokens)} tok`];
+  const top = contextWeight.tracked.largestContributors[0];
+  if (top) {
+    badges.push(`top:${top.name} ${top.sharePercent.toFixed(1)}%`);
+  }
+  return badges;
+}
+
 function renderContextPanel(
   contextWeight: UsageSessionEntry["contextWeight"],
   usage: UsageSessionEntry["usage"],
@@ -851,6 +865,7 @@ function renderContextPanel(
   }
 
   const contextBadges = buildContextMetadataBadges(contextWeight);
+  const trackedBadges = buildContextTrackedBadges(contextWeight);
   const skillsList = contextWeight.skills.entries.toSorted((a, b) => b.blockChars - a.blockChars);
   const toolsList = contextWeight.tools.entries.toSorted(
     (a, b) => b.summaryChars + b.schemaChars - (a.summaryChars + a.schemaChars),
@@ -881,9 +896,10 @@ function renderContextPanel(
           : nothing}
       </div>
       <p class="context-weight-desc">${contextPct || t("usage.details.baseContextPerMessage")}</p>
-      ${contextBadges.length > 0
+      ${contextBadges.length > 0 || trackedBadges.length > 0
         ? html`<div class="usage-badges">
             ${contextBadges.map((badge) => html`<span class="usage-badge">${badge}</span>`)}
+            ${trackedBadges.map((badge) => html`<span class="usage-badge">${badge}</span>`)}
           </div>`
         : nothing}
       <div class="context-stacked-bar">


### PR DESCRIPTION
Allow compatible OpenAI-style providers to keep Responses prompt cache fields and xhigh thinking support. Validated with vitest on provider-attribution, pi-embedded-runner-extraparams, and thinking.