### PR TITLE
fix(cli): reject present-but-invalid --timeout on status/health fast path

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -561,6 +561,16 @@ describe("argv helpers", () => {
       argv: ["node", "openclaw", "--", "--timeout=99"],
       expected: undefined,
     },
+    {
+      name: "repeated flag uses final value",
+      argv: ["node", "openclaw", "status", "--timeout", "100", "--timeout=200"],
+      expected: "200",
+    },
+    {
+      name: "missing repeated value remains invalid",
+      argv: ["node", "openclaw", "status", "--timeout", "--timeout", "200"],
+      expected: null,
+    },
   ])("extracts flag values: $name", ({ argv, expected }) => {
     expect(getFlagValue(argv, "--timeout")).toBe(expected);
   });
@@ -597,17 +607,37 @@ describe("argv helpers", () => {
     {
       name: "invalid integer",
       argv: ["node", "openclaw", "status", "--timeout", "nope"],
-      expected: undefined,
+      expected: null,
     },
     {
       name: "non-decimal integer",
       argv: ["node", "openclaw", "status", "--timeout", "0x10"],
-      expected: undefined,
+      expected: null,
     },
     {
       name: "partial integer",
       argv: ["node", "openclaw", "status", "--timeout", "5s"],
-      expected: undefined,
+      expected: null,
+    },
+    {
+      name: "zero",
+      argv: ["node", "openclaw", "status", "--timeout", "0"],
+      expected: null,
+    },
+    {
+      name: "negative integer",
+      argv: ["node", "openclaw", "status", "--timeout", "-5"],
+      expected: null,
+    },
+    {
+      name: "repeated value uses final valid integer",
+      argv: ["node", "openclaw", "status", "--timeout", "nope", "--timeout", "5000"],
+      expected: 5000,
+    },
+    {
+      name: "repeated value rejects final invalid integer",
+      argv: ["node", "openclaw", "status", "--timeout", "5000", "--timeout", "nope"],
+      expected: null,
     },
   ])("parses positive integer flag values: $name", ({ argv, expected }) => {
     expect(getPositiveIntFlagValue(argv, "--timeout")).toBe(expected);

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -403,6 +403,7 @@ export function normalizeRootLogLevelArgv(
 
 export function getFlagValue(argv: string[], name: string): string | null | undefined {
   const args = argv.slice(2);
+  let value: string | undefined;
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === FLAG_TERMINATOR) {
@@ -410,14 +411,22 @@ export function getFlagValue(argv: string[], name: string): string | null | unde
     }
     if (arg === name) {
       const next = args[i + 1];
-      return isValueToken(next) ? next : null;
+      if (!isValueToken(next)) {
+        return null;
+      }
+      value = next;
+      i += 1;
+      continue;
     }
     if (arg.startsWith(`${name}=`)) {
-      const value = arg.slice(name.length + 1);
-      return value ? value : null;
+      const assigned = arg.slice(name.length + 1);
+      if (!assigned) {
+        return null;
+      }
+      value = assigned;
     }
   }
-  return undefined;
+  return value;
 }
 
 export function getVerboseFlag(argv: string[], options?: { includeDebug?: boolean }): boolean {
@@ -435,7 +444,9 @@ export function getPositiveIntFlagValue(argv: string[], name: string): number | 
   if (raw === null || raw === undefined) {
     return raw;
   }
-  return parsePositiveInt(raw);
+  // Keep absent distinct from present-but-invalid so route-first callers can
+  // defer invalid input to Commander instead of silently applying defaults.
+  return parsePositiveInt(raw) ?? null;
 }
 
 export function getCommandPathWithRootOptions(argv: string[], depth = 2): string[] {

--- a/src/cli/program/route-args.test.ts
+++ b/src/cli/program/route-args.test.ts
@@ -54,6 +54,28 @@ describe("route-args", () => {
       expect(parseStatusRouteArgs(["node", "openclaw", "status", "--timeout", bad])).toBeNull();
       expect(parseHealthRouteArgs(["node", "openclaw", "health", "--timeout", bad])).toBeNull();
     }
+    expect(
+      parseStatusRouteArgs([
+        "node",
+        "openclaw",
+        "status",
+        "--timeout",
+        "5000",
+        "--timeout",
+        "nope",
+      ]),
+    ).toBeNull();
+    expect(
+      parseHealthRouteArgs([
+        "node",
+        "openclaw",
+        "health",
+        "--timeout",
+        "nope",
+        "--timeout",
+        "5000",
+      ]),
+    ).toMatchObject({ timeoutMs: 5000 });
     // A valid positive integer still parses on the fast path.
     expect(parseStatusRouteArgs(["node", "openclaw", "status", "--timeout", "5000"])).toMatchObject(
       { timeoutMs: 5000 },

--- a/src/cli/program/route-args.test.ts
+++ b/src/cli/program/route-args.test.ts
@@ -44,6 +44,26 @@ describe("route-args", () => {
     expect(parseStatusRouteArgs(["node", "openclaw", "status", "--timeout"])).toBeNull();
   });
 
+  it("defers status/health --timeout with a present-but-invalid value to Commander", () => {
+    // Regression: the route-first fast path used to silently accept invalid
+    // --timeout values (0, negative, non-numeric, unit-suffixed) and run with
+    // the default timeout, diverging from the full Commander path which rejects
+    // them with a non-zero exit. Returning null defers to Commander so both
+    // paths share the same validation.
+    for (const bad of ["0", "-5", "nope", "5s"]) {
+      expect(parseStatusRouteArgs(["node", "openclaw", "status", "--timeout", bad])).toBeNull();
+      expect(parseHealthRouteArgs(["node", "openclaw", "health", "--timeout", bad])).toBeNull();
+    }
+    // A valid positive integer still parses on the fast path.
+    expect(parseStatusRouteArgs(["node", "openclaw", "status", "--timeout", "5000"])).toMatchObject(
+      { timeoutMs: 5000 },
+    );
+    // No --timeout flag at all still uses the fast path (undefined timeout).
+    expect(parseStatusRouteArgs(["node", "openclaw", "status"])).toMatchObject({
+      timeoutMs: undefined,
+    });
+  });
+
   it("parses gateway status route args and rejects probe-only ssh flags", () => {
     expect(
       parseGatewayStatusRouteArgs([

--- a/src/cli/program/route-args.ts
+++ b/src/cli/program/route-args.ts
@@ -3,7 +3,6 @@ import { isValueToken } from "../../infra/cli-root-options.js";
 import {
   getCommandPositionalsWithRootOptions,
   getFlagValue,
-  getPositiveIntFlagValue,
   getVerboseFlag,
   hasFlag,
 } from "../argv.js";
@@ -74,7 +73,8 @@ export function parseHealthRouteArgs(argv: string[]) {
   if (rawTimeout === null) {
     return null;
   }
-  const timeoutMs = getPositiveIntFlagValue(argv, "--timeout");
+  const timeoutMs =
+    rawTimeout === undefined ? undefined : parseStrictPositiveIntOrUndefined(rawTimeout);
   if (rawTimeout !== undefined && timeoutMs === undefined) {
     return null;
   }
@@ -94,7 +94,8 @@ export function parseStatusRouteArgs(argv: string[]) {
   if (rawTimeout === null) {
     return null;
   }
-  const timeoutMs = getPositiveIntFlagValue(argv, "--timeout");
+  const timeoutMs =
+    rawTimeout === undefined ? undefined : parseStrictPositiveIntOrUndefined(rawTimeout);
   if (rawTimeout !== undefined && timeoutMs === undefined) {
     return null;
   }

--- a/src/cli/program/route-args.ts
+++ b/src/cli/program/route-args.ts
@@ -3,6 +3,7 @@ import { isValueToken } from "../../infra/cli-root-options.js";
 import {
   getCommandPositionalsWithRootOptions,
   getFlagValue,
+  getPositiveIntFlagValue,
   getVerboseFlag,
   hasFlag,
 } from "../argv.js";
@@ -66,16 +67,8 @@ function parseSinglePositional(
 
 /** Parse `openclaw health` flags for the route-first status family. */
 export function parseHealthRouteArgs(argv: string[]) {
-  // A present-but-invalid --timeout (0, negative, non-numeric) must defer to
-  // Commander so it surfaces the same validation error as the full command
-  // path, instead of the fast path silently falling back to the default.
-  const rawTimeout = getFlagValue(argv, "--timeout");
-  if (rawTimeout === null) {
-    return null;
-  }
-  const timeoutMs =
-    rawTimeout === undefined ? undefined : parseStrictPositiveIntOrUndefined(rawTimeout);
-  if (rawTimeout !== undefined && timeoutMs === undefined) {
+  const timeoutMs = getPositiveIntFlagValue(argv, "--timeout");
+  if (timeoutMs === null) {
     return null;
   }
   return {
@@ -87,16 +80,8 @@ export function parseHealthRouteArgs(argv: string[]) {
 
 /** Parse `openclaw status` flags without registering the full command tree. */
 export function parseStatusRouteArgs(argv: string[]) {
-  // A present-but-invalid --timeout (0, negative, non-numeric) must defer to
-  // Commander so it surfaces the same validation error as the full command
-  // path, instead of the fast path silently falling back to the default.
-  const rawTimeout = getFlagValue(argv, "--timeout");
-  if (rawTimeout === null) {
-    return null;
-  }
-  const timeoutMs =
-    rawTimeout === undefined ? undefined : parseStrictPositiveIntOrUndefined(rawTimeout);
-  if (rawTimeout !== undefined && timeoutMs === undefined) {
+  const timeoutMs = getPositiveIntFlagValue(argv, "--timeout");
+  if (timeoutMs === null) {
     return null;
   }
   return {

--- a/src/cli/program/route-args.ts
+++ b/src/cli/program/route-args.ts
@@ -67,8 +67,15 @@ function parseSinglePositional(
 
 /** Parse `openclaw health` flags for the route-first status family. */
 export function parseHealthRouteArgs(argv: string[]) {
+  // A present-but-invalid --timeout (0, negative, non-numeric) must defer to
+  // Commander so it surfaces the same validation error as the full command
+  // path, instead of the fast path silently falling back to the default.
+  const rawTimeout = getFlagValue(argv, "--timeout");
+  if (rawTimeout === null) {
+    return null;
+  }
   const timeoutMs = getPositiveIntFlagValue(argv, "--timeout");
-  if (timeoutMs === null) {
+  if (rawTimeout !== undefined && timeoutMs === undefined) {
     return null;
   }
   return {
@@ -80,8 +87,15 @@ export function parseHealthRouteArgs(argv: string[]) {
 
 /** Parse `openclaw status` flags without registering the full command tree. */
 export function parseStatusRouteArgs(argv: string[]) {
+  // A present-but-invalid --timeout (0, negative, non-numeric) must defer to
+  // Commander so it surfaces the same validation error as the full command
+  // path, instead of the fast path silently falling back to the default.
+  const rawTimeout = getFlagValue(argv, "--timeout");
+  if (rawTimeout === null) {
+    return null;
+  }
   const timeoutMs = getPositiveIntFlagValue(argv, "--timeout");
-  if (timeoutMs === null) {
+  if (rawTimeout !== undefined && timeoutMs === undefined) {
     return null;
   }
   return {


### PR DESCRIPTION
## Summary

`openclaw status` and `openclaw health` have a route-first fast path (`parseStatusRouteArgs` / `parseHealthRouteArgs` in `src/cli/program/route-args.ts`) that skips full Commander startup. Its `--timeout` guard was `if (getPositiveIntFlagValue(...) === null) return null`, which only catches a **missing** value. A **present-but-invalid** value (`0`, negative, non-numeric, unit-suffixed like `5s`) makes `getPositiveIntFlagValue` return `undefined` — indistinguishable from "flag absent" — so the fast path silently accepts it and runs with the default 10s timeout, exiting 0. The full Commander path rejects the same input with `--timeout must be a positive integer (milliseconds)` and a non-zero exit. Same command, same argument, two different behaviors / exit codes (a script that checks the exit code would read failure as success).

This mirrors the bug PR #84901 fixed for `openclaw tasks audit --limit` **in this same file** — `parseTasksAuditRouteArgs` already uses the correct guard (`raw !== undefined && parsed === undefined → return null`); `status`/`health` were the sibling parsers it didn't touch. It is the same "CLI numeric option silently accepts invalid value" class as the merged #92490.

## What changed

- `getPositiveIntFlagValue` now has an explicit tri-state contract: `undefined` means absent, `null` means present but missing/invalid, and a number means valid. The two route-first callers can therefore keep one canonical parse branch instead of duplicating raw-token validation.
- `getFlagValue` now follows Commander's last-value semantics for repeated scalar options while still rejecting any occurrence with a missing required value. This closes the remaining `--timeout 5000 --timeout nope` fast-path bypass found during maintainer autoreview.

## Real behavior proof

- **Behavior or issue addressed:** `openclaw status --timeout 0` (and negative / non-numeric / `5s`) was silently accepted on the route-first fast path and run with the default timeout (exit 0), instead of being rejected like the full Commander path.
- **Real environment tested:** OpenClaw from the exact prepared PR head on AWS Crabbox `cbx_c1082c8bfe60` (run `run_f287e57d8653`), driven through the real CLI plus the repo Vitest wrapper.
- **Exact steps or command run after this patch:** `node scripts/run-node.mjs status --timeout 0`; `node scripts/run-node.mjs health --timeout nope`; `node scripts/run-vitest.mjs src/cli/program/route-args.test.ts`.
- **Evidence after fix (terminal capture):**
  ```
  $ node scripts/run-node.mjs status --timeout 0
  --timeout must be a positive integer (milliseconds)
  (exit 1)

  $ node scripts/run-node.mjs health --timeout nope
  --timeout must be a positive integer (milliseconds)
  (exit 1)

  $ node scripts/run-vitest.mjs src/cli/program/route-args.test.ts
   Test Files  1 passed (1)
        Tests  6 passed (6)

  AWS Crabbox run_f287e57d8653
  /tmp/status-timeout.out:--timeout must be a positive integer (milliseconds)
  /tmp/health-timeout.out:--timeout must be a positive integer (milliseconds)
  cli-timeout-e2e=ok status=1 health=1
  Test Files  3 passed (3)
  Tests      163 passed (163)
  ```
- **Observed result after fix:** `status`/`health` with a present-but-invalid `--timeout` now exit 1 with the Commander validation error (matching the full command path); a valid `--timeout 5000` still parses on the fast path; omitting `--timeout` still uses the fast path with the default.
- **What was not tested:** route-first numeric flags other than `--timeout` (out of scope); the change is localized to the two status-family parsers.
- **Negative control:** reverting `route-args.ts` to the `=== null`-only guard (origin/main HEAD) and re-running the suite fails exactly on the new `parseStatusRouteArgs([...,"status","--timeout","0"]).toBeNull()` assertion (`1 failed | 5 passed`), confirming the test is not a tautology and the fix is required.

## Tests and validation

- `node scripts/run-vitest.mjs src/cli/argv.test.ts src/cli/program/route-args.test.ts src/cli/program/register.status-health-sessions.test.ts` → 163 passed locally and on AWS Crabbox.
- Real `openclaw status --timeout 0` and `openclaw health --timeout 5s` invocations → both exit 1 with the expected validation message.
- Fresh autoreview accepted one repeated-option precedence finding; the final local autoreview is clean after the fix.
- `oxfmt --write` clean on all changed files.

## Risk checklist

- User-visible behavior change? Yes — `status`/`health --timeout <invalid>` now errors with exit 1 instead of silently using the default, aligning the fast path with the full-command behavior.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? No.
- Highest-risk area: accidentally rejecting a valid `--timeout` or breaking the no-flag fast path; covered by the valid-value (`5000`) and no-flag assertions in the regression test.
