### PR TITLE
Fix Telegram progress draft cleanup before tool output

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2410,6 +2410,32 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
+  it("clears progress drafts before durable verbose tool output", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        replyOptions?.onVerboseProgressVisibility?.(() => true);
+        await dispatcherOptions.deliver({ text: "Tool output visible to Telegram" }, { kind: "tool" });
+        await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+    });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Shelling\n\n`🛠️ Exec`");
+    expectDeliveredReply(0, { text: "Tool output visible to Telegram" });
+    expectDeliveredReply(0, { text: "Final answer" }, 1);
+    expect(answerDraftStream.clear.mock.invocationCallOrder[0]).toBeLessThan(
+      deliverReplies.mock.invocationCallOrder[0],
+    );
+  });
+
   it("does not stream text-only tool results into progress drafts", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2436,6 +2436,34 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
+  it("clears progress drafts before visible tool artifacts", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver(
+          { mediaUrl: "https://example.com/validation.txt" },
+          { kind: "tool" },
+        );
+        await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+    });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Shelling\n\n`🛠️ Exec`");
+    expectDeliveredReply(0, { mediaUrl: "https://example.com/validation.txt" });
+    expectDeliveredReply(0, { text: "Final answer" }, 1);
+    expect(answerDraftStream.clear.mock.invocationCallOrder[0]).toBeLessThan(
+      deliverReplies.mock.invocationCallOrder[0],
+    );
+  });
+
   it("does not stream text-only tool results into progress drafts", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2136,6 +2136,9 @@ export const dispatchTelegramMessage = async ({
                       }
                       return;
                     }
+                    if (streamMode === "progress" && info.kind === "tool") {
+                      await rotateAnswerLaneAfterToolProgress();
+                    }
                     const delivered = await sendPayload(effectivePayload, {
                       durable: info.kind === "final",
                     });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1982,8 +1982,9 @@ export const dispatchTelegramMessage = async ({
                       }
                       if (segment.lane === "answer" && info.kind === "tool") {
                         if (verboseProgressActive()) {
-                          // Durable lane owns tool payloads: send standalone instead
-                          // of diverting into the draft, which is discarded at final.
+                          if (streamMode === "progress") {
+                            await rotateAnswerLaneAfterToolProgress();
+                          }
                           if (
                             await sendPayload(
                               applyTextToPayload(effectivePayload, segment.update.text),


### PR DESCRIPTION
## Summary

- Problem: Telegram progress-mode drafts could remain visible when verbose tool output or visible tool artifacts were delivered as standalone messages.
- Solution: Rotate and clear tool-progress-only answer drafts before sending visible tool output payloads.
- What changed: Updated Telegram dispatch ordering and added regression coverage for verbose tool text and visible tool artifact paths.
- What did NOT change: Telegram transport, rich message rendering, provider behavior, tool execution, auth, secrets, network, or progress draft implementation internals.

Fixes #90753

## Regression Test Plan

- Coverage level: Unit test
- Target test file: `extensions/telegram/src/bot-message-dispatch.test.ts`
- Scenario locked in: progress drafts are cleared before durable verbose tool output and visible tool artifacts are delivered.
- Why this is the smallest reliable guardrail: the regression is dispatch ordering, so the test asserts draft clearing happens before standalone Telegram deliveries.

Verification run:

```text
pnpm test extensions/telegram/src/bot-message-dispatch.test.ts -- -t "clears progress drafts before"

Test Files  1 passed (1)
Tests       2 passed | 118 skipped (120)
```

## Root Cause

- Root cause: progress-mode tool status drafts were not rotated before all visible tool-output delivery paths.
- Missing detection / guardrail: existing tests covered final-answer cleanup but not durable verbose tool output or visible tool artifact delivery.
