### PR TITLE
fix(agents): truncate frozen subagent result on a UTF-8 character boundary

### DIFF
--- a/src/agents/subagent-registry-helpers.test.ts
+++ b/src/agents/subagent-registry-helpers.test.ts
@@ -2,7 +2,11 @@
 // for announce delivery give-up paths.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { defaultRuntime } from "../runtime.js";
-import { logAnnounceGiveUp, reconcileOrphanedRun } from "./subagent-registry-helpers.js";
+import {
+  capFrozenResultText,
+  logAnnounceGiveUp,
+  reconcileOrphanedRun,
+} from "./subagent-registry-helpers.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 function createRunEntry(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
@@ -19,6 +23,29 @@ function createRunEntry(overrides: Partial<SubagentRunRecord> = {}): SubagentRun
     ...overrides,
   };
 }
+
+describe("capFrozenResultText", () => {
+  const MAX_BYTES = 100 * 1024;
+
+  it("truncates oversized multibyte text on a character boundary without U+FFFD or exceeding the cap", () => {
+    for (const char of ["😀", "中"]) {
+      const charBytes = Buffer.byteLength(char, "utf8");
+      const oversized = char.repeat(Math.ceil((MAX_BYTES + 4096) / charBytes));
+      const capped = capFrozenResultText(oversized);
+      // A mid-character cut would append a 3-byte U+FFFD and spill 1+ byte over
+      // the documented cap; a boundary-safe cut keeps the payload within it.
+      expect(Buffer.byteLength(capped, "utf8")).toBeLessThanOrEqual(MAX_BYTES);
+      // No replacement character from a split multibyte sequence.
+      expect(capped.includes("�")).toBe(false);
+      expect(capped).toContain("[truncated:");
+    }
+  });
+
+  it("returns trimmed text unchanged when within the cap", () => {
+    expect(capFrozenResultText("  hello world  ")).toBe("hello world");
+    expect(capFrozenResultText("   ")).toBe("");
+  });
+});
 
 describe("reconcileOrphanedRun", () => {
   afterEach(() => {

--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -61,7 +61,16 @@ export function capFrozenResultText(resultText: string): string {
     0,
     FROZEN_RESULT_TEXT_MAX_BYTES - Buffer.byteLength(notice, "utf8"),
   );
-  const payload = Buffer.from(trimmed, "utf8").subarray(0, maxPayloadBytes).toString("utf8");
+  const encoded = Buffer.from(trimmed, "utf8");
+  // Back off to a UTF-8 character boundary so we never split a multi-byte
+  // sequence: a mid-character cut decodes the orphaned bytes to U+FFFD, which
+  // both corrupts the boundary character and (being 3 bytes) pushes the stored
+  // payload back over FROZEN_RESULT_TEXT_MAX_BYTES.
+  let payloadEnd = maxPayloadBytes;
+  while (payloadEnd > 0 && (encoded[payloadEnd] & 0xc0) === 0x80) {
+    payloadEnd -= 1;
+  }
+  const payload = encoded.subarray(0, payloadEnd).toString("utf8");
   return `${payload}${notice}`;
 }
 


### PR DESCRIPTION
## Summary

`capFrozenResultText` (`src/agents/subagent-registry-helpers.ts`) caps an oversized subagent completion result before it is frozen for later announce/recovery delivery to the parent session. It truncated with `Buffer.from(text, "utf8").subarray(0, maxPayloadBytes).toString("utf8")`, cutting at an arbitrary **byte** offset. When that offset lands inside a 2/3/4-byte UTF-8 sequence (CJK, emoji), `.toString("utf8")` decodes the orphaned bytes to a U+FFFD replacement character (`�`): the boundary character is corrupted **and**, because U+FFFD is 3 bytes, the stored payload can spill past the documented `FROZEN_RESULT_TEXT_MAX_BYTES` (100KB) cap.

The frozen text is delivered/announced to the parent session (`subagent-registry-lifecycle.ts`), so a large CJK/emoji-heavy child reply reaches the user with a `�` at the truncation point.

## What changed

- `capFrozenResultText` now backs off to a UTF-8 character boundary before slicing: it walks back over any trailing continuation bytes (`0b10xxxxxx`) so the cut never splits a multi-byte sequence. The payload stays within the cap and contains no replacement junk; short text and the truncation notice are unchanged.

## Real behavior proof

- **Behavior or issue addressed:** an oversized (>100KB) subagent completion result containing multibyte characters was truncated mid-character, inserting a U+FFFD `�` at the boundary and pushing the stored payload over the 100KB cap.
- **Real environment tested:** local OpenClaw built from source (origin/main @ef47dd610c8) on Linux, via the repo Vitest wrapper `node scripts/run-vitest.mjs` driving the real exported `capFrozenResultText` (no mock).
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs src/agents/subagent-registry-helpers.test.ts`
- **Evidence after fix (terminal capture):**
  ```
  $ node scripts/run-vitest.mjs src/agents/subagent-registry-helpers.test.ts
   Test Files  1 passed (1)
        Tests  5 passed (5)
  ```
- **Observed result after fix:** for both a 4-byte emoji (`😀`) and a 3-byte CJK char (`中`) repeated past the cap, the capped output is `<= 100KB` and contains no `�`, while still ending with the `[truncated: ...]` notice; short text is returned trimmed and unchanged.
- **What was not tested:** the end-to-end parent-session announce delivery path (covered by existing lifecycle tests); this change is confined to the byte-capping helper.
- **Negative control:** reverting `capFrozenResultText` to the `subarray(...).toString()` byte cut (origin/main HEAD) and re-running the suite fails exactly on the boundary test (`expected 102401 to be less than or equal to 102400` and output contains `�`, `1 failed | 4 passed`), confirming the test is not a tautology and the fix is required.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/subagent-registry-helpers.test.ts` → 5 passed (added a `capFrozenResultText` suite: multibyte boundary truncation stays within the cap with no U+FFFD, plus a within-cap passthrough case). The helper previously had no direct truncation coverage.
- `oxfmt --write` clean on both changed files.

## Risk checklist

- User-visible behavior change? Yes (a fix) — truncated frozen completion text no longer contains a `�` at the boundary and stays within the 100KB cap.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? No.
- Highest-risk area: off-by-one at the boundary; covered by the cap-size and no-U+FFFD assertions for both 3-byte and 4-byte sequences.
