### PR TITLE
fix(daemon): prefer stderr over stale stdout in gateway restart diagnostics

### DIFF
--- a/src/daemon/diagnostics.test.ts
+++ b/src/daemon/diagnostics.test.ts
@@ -36,4 +36,21 @@ describe("readLastGatewayErrorLine", () => {
       "gateway stdout current",
     );
   });
+
+  it("prefers the current stderr error over a stale stdout match on linux", async () => {
+    const stateDir = makeTempStateDir();
+    const homeDir = makeTempStateDir();
+    const env = { HOME: homeDir, OPENCLAW_STATE_DIR: stateDir };
+    const stateLogs = resolveGatewayLogPaths(env);
+    fs.mkdirSync(stateLogs.logDir, { recursive: true });
+    // stderr carries the real, current failure; stdout carries an older matching
+    // line. On non-darwin platforms stderr is the strongest failure signal, so
+    // it must win instead of the stale stdout match.
+    fs.writeFileSync(stateLogs.stderrPath, "failed to bind gateway socket EADDRINUSE\n", "utf8");
+    fs.writeFileSync(stateLogs.stdoutPath, "gateway start blocked: stale prior reason\n", "utf8");
+
+    await expect(readLastGatewayErrorLine(env, { platform: "linux" })).resolves.toBe(
+      "failed to bind gateway socket EADDRINUSE",
+    );
+  });
 });

--- a/src/daemon/diagnostics.ts
+++ b/src/daemon/diagnostics.ts
@@ -40,7 +40,10 @@ export async function readLastGatewayErrorLine(
       : resolveGatewayLogPaths(env);
   const stderrRaw = readStderr ? await fs.readFile(stderrPath, "utf8").catch(() => "") : "";
   const stdoutRaw = await fs.readFile(stdoutPath, "utf8").catch(() => "");
-  const lines = [...stderrRaw.split(/\r?\n/), ...stdoutRaw.split(/\r?\n/)].map((line) =>
+  // stderr is the strongest failure signal on non-darwin platforms, so place it
+  // last and scan from the end: the most recent stderr error line then wins over
+  // any (possibly stale) stdout match, matching the stderr-first fallback below.
+  const lines = [...stdoutRaw.split(/\r?\n/), ...stderrRaw.split(/\r?\n/)].map((line) =>
     line.trim(),
   );
   for (let i = lines.length - 1; i >= 0; i -= 1) {


### PR DESCRIPTION
## Summary

`readLastGatewayErrorLine` (`src/daemon/diagnostics.ts`) surfaces the most relevant gateway error line for daemon restart diagnostics (shown in `status` / `doctor`). On non-darwin platforms it reads both stderr and stdout, builds `[...stderrRaw.split, ...stdoutRaw.split]`, then scans **from the end**. Because stdout is appended last, scanning backwards walks the entire stdout block before reaching any stderr line — so **any** (even stale) stdout match wins over a newer stderr match. This contradicts the function's own comment ("stderr [is] the strongest failure signal" on non-darwin) and its stderr-first fallback. The existing test only covered the darwin branch (stderr suppressed), so the linux/win32 two-log merge path was uncovered.

## What changed

- Place stderr **last** in the combined list (`[...stdoutRaw.split, ...stderrRaw.split]`) so the backward scan reaches the most recent stderr error first, with stdout as the fallback — matching the comment and the stderr-first fallback below. The darwin (stderr-suppressed) behavior is unchanged.

## Real behavior proof

- **Behavior or issue addressed:** on linux/win32, a stale matching line in gateway stdout was returned as the restart "error reason" instead of the newer real failure in stderr, pointing `status`/`doctor` users at an outdated cause.
- **Real environment tested:** local OpenClaw from source on Linux. Seeded real gateway service logs at the paths `resolveGatewayLogPaths(env)` resolves to (`$STATE/logs/gateway.log` = stdout with a stale matching line; `$STATE/logs/gateway.err.log` = stderr with the newer real failure), then drove the **real exported `readLastGatewayErrorLine`** via `node --import tsx` — no mocks; the production function reads the on-disk logs. This returns the exact value `status` prints as `Last gateway error:` (`status.gather.ts:709` → `status.print.ts:440`) and `doctor` prints via `note("Last gateway error: …")` (`doctor-gateway-daemon-flow.ts:290`).
- **Exact steps or command run after this patch:**
  ```
  # seed real gateway logs at the resolved paths
  printf '...[error] refusing to bind gateway: stale stdout from a previous failed start\n' > "$STATE/logs/gateway.log"
  printf '...[error] failed to bind gateway socket: address already in use (the real current failure)\n' > "$STATE/logs/gateway.err.log"
  # drive the real production diagnostics function against the on-disk logs
  OPENCLAW_STATE_DIR=$STATE node --import tsx -e \
    'import {readLastGatewayErrorLine} from "./src/daemon/diagnostics.ts"; console.log("Last gateway error: " + await readLastGatewayErrorLine(process.env,{platform:"linux"}))'
  ```
- **Evidence after fix (terminal capture):**
  ```
  Last gateway error: 2026-06-14T12:00:00Z [error] failed to bind gateway socket: address already in use (the real current failure)
  ```
  i.e. the **stderr** line (the real current failure) — exactly what `status` / `doctor` would print.
- **Observed result after fix:** with both logs containing a matching error pattern, the surfaced reason is the newer **stderr** line, not the stale stdout line. The Vitest unit suite (`src/daemon/diagnostics.test.ts`) also asserts this for linux while keeping the darwin stderr-suppressed case.
- **What was not tested:** spawning the full `openclaw daemon status` CLI process end-to-end — in this isolated sandbox a from-scratch CLI build is blocked by native postinstall binaries (e.g. `@matrix-org/matrix-sdk-crypto-nodejs`, `node-llama-cpp`) downloaded from GitHub Releases timing out. The proof instead drives the exact production function those commands call, against real on-disk logs (real runtime, not a test double).
- **Negative control:** reverting `diagnostics.ts` to the pre-fix `[...stderr, ...stdout]` order (`git checkout 357000c8^ -- src/daemon/diagnostics.ts`) and re-running the same command prints the **stale stdout** line instead:
  ```
  Last gateway error: 2026-06-10T00:00:01Z [error] refusing to bind gateway: stale stdout from a previous failed start
  ```
  confirming the fix is required and the proof is not a tautology. The Vitest suite likewise fails on the linux assertion when reverted.

## Tests and validation

- `node --import tsx` driving the real `readLastGatewayErrorLine` on seeded on-disk gateway logs → returns the stderr line (after fix) / the stale stdout line (pre-fix negative control).
- `node scripts/run-vitest.mjs src/daemon/diagnostics.test.ts` → 2 passed (added a linux case asserting stderr wins over a stale stdout match; the existing darwin case still passes). The non-darwin two-log path previously had no coverage.
- `oxfmt --write` clean on both changed files.

## Risk checklist

- User-visible behavior change? Yes (diagnostics only) — `status`/`doctor` now report the stderr failure reason on non-darwin instead of a possibly stale stdout line.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? No.
- Highest-risk area: regressing the darwin (stderr-suppressed) path; covered by the retained darwin test.
