### PR TITLE
Fix Telegram progress draft cleanup before tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Highlights
 
-- **Richer Telegram delivery:** Telegram now sends rich HTML, preserves rich markdown and sticker paths, renders progress drafts and command output more faithfully, normalizes HTML tables safely, and keeps mentions and spooled handlers on the right delivery path. (#93286, #93164, #93124, #93364, #93130, #93088, #93281, #94891, #94856) Thanks @obviyus, @vincentkoc, @goutamadwant, @kesslerio, @NianJiuZst, @SweetSophia, @Marvinthebored, @aaajiao, @zhangqueping, and @jairrab.
+- **Richer Telegram delivery:** Telegram now sends rich HTML, preserves rich markdown and sticker paths, renders progress drafts and command output more faithfully, normalizes HTML tables safely, and keeps mentions and spooled handlers on the right delivery path. (#93286, #93164, #93124, #93364, #93130, #93002, #93088, #93281, #94891, #94856) Thanks @obviyus, @vincentkoc, @goutamadwant, @kesslerio, @NianJiuZst, @SweetSophia, @Marvinthebored, @aaajiao, @zhangguiping-xydt, @zhangqueping, and @jairrab.
 - **More dependable agent recovery:** retries, terminal outcomes, usage after compaction, session history repair, and reply reconciliation now keep more interrupted or partial turns moving toward a visible final result. (#92191, #93073, #93228, #93084, #93469, #93291, #90943) Thanks @ai-hpc, @lml2468, @fuller-stack-dev, @Hollychou924, @leno23, @de1tydev, @425072024, @wuwahe3, @drvoss, @yetval, @sandieman2, and @vincentkoc.
 - **A stronger Codex integration:** Codex gains automatic plugin approvals, GPT-5.3 Spark OAuth routing, remote-node `exec` as a dynamic tool, and more reliable app-server teardown and terminal outcomes. (#92625, #89133, #93654, #91767, #93287) Thanks @kevinslin, @VACInc, @vincentkoc, @JPKay-AI, and @aliahnaf2013-max.
 - **Standalone official provider plugins:** external provider packages are now first-class npm releases, externally installed channel plugins load at Gateway startup, and StepFun is available from npm and ClawHub. (#93470) Thanks @sunlit-deng, @cxdnicole, and @vincentkoc.
@@ -25,7 +25,7 @@ Docs: https://docs.openclaw.ai
 
 - Security and privacy: redact secrets from debug/config output, block internal HTTP session overrides, audit open-DM tool exposure, and retain plugin write ownership checks. (#93333, #88496, #93443, #92883, #93353) Thanks @Alix-007, @jason-allen-oneal, @coygeek, @RichardCao, @yu-xin-c, @cjg20ss, @eleqtrizit, and @vincentkoc.
 - Agent and session runtime: retry thinking-only and empty post-tool turns, prevent duplicate hook execution, preserve pending subagent delivery, preserve fresh usage through compaction, and repair partial JSON/history artifacts. (#92191, #93073, #93009, #93084, #93469, #94349, #92383, #94257) Thanks @ai-hpc, @lml2468, @fuller-stack-dev, @zenglingbiao, @dertbv, @Hollychou924, @leno23, @de1tydev, @425072024, @wuwahe3, @drvoss, @vincentkoc, @sallyom, @oiGaDio, @Hidetsugu55, and @Nas01010101.
-- Channels and replies: fix Telegram rich delivery, table rendering, action-error handling, and ingress recovery; preserve command progress detail across channel adapters; retain WhatsApp opening text after a media failure; keep Mattermost thread replies intact; and harden Discord action handling. (#93286, #93364, #93281, #93076, #93334, #93424, #93488, #94868, #94891, #94856, #94810, #93823) Thanks @obviyus, @NianJiuZst, @mcaxtr, @rushindrasinha, @amknight, @lzyyzznl, @darealgege, @vincentkoc, @zhangqueping, @jairrab, @ZOOWH, @parveshsaini, and @yetval.
+- Channels and replies: fix Telegram rich delivery, table rendering, action-error handling, progress draft cleanup before visible tool output, and ingress recovery; preserve command progress detail across channel adapters; retain WhatsApp opening text after a media failure; keep Mattermost thread replies intact; and harden Discord action handling. (#93286, #93364, #93281, #93002, #93076, #93334, #93424, #93488, #94868, #94891, #94856, #94810, #93823) Thanks @obviyus, @NianJiuZst, @mcaxtr, @zhangguiping-xydt, @rushindrasinha, @amknight, @lzyyzznl, @darealgege, @vincentkoc, @zhangqueping, @jairrab, @ZOOWH, @parveshsaini, and @yetval.
 - Storage and migrations: avoid SQLite WAL on network filesystems, clean reindex artifacts, keep setup state out of workspace dot-directories, and import default-agent auth profiles into SQLite. (#93454, #92891, #93182, #93295, #93520, #93156) Thanks @vincentkoc, @ZengWen-DT, @Zeng-wen, @potterdigital, @Alix-007, @Pick-cat, @sallyom, @1qh, and @Tazio7.
 - Provider and model behavior: fix Gemini CLI proxy OAuth, restore Codex Spark OAuth routing, correct Bedrock embedding model IDs, and preserve configured defaults in embedded runs. (#92815, #89133, #93452, #93428) Thanks @yetval, @EvetteYoung, @VACInc, @LiuwqGit, @aleck31, @zenglingbiao, @danielgerlag, and @vincentkoc.
 - CLI, TUI, and apps: accept global flags after subcommands, keep terminal output and activity indicators visible, preserve CJK IME composition, and refresh stale UI state. (#93455, #93460, #93006, #93427, #93498, #93606) Thanks @ooiuuii, @Alix-007, @ZengWen-DT, @Zeng-wen, @AlethiaQuizForge, @Zhaoqj2016, @liuhao1024, @BrianClaw1955, @vincentkoc, and @NicoBoom13.
@@ -33,7 +33,7 @@ Docs: https://docs.openclaw.ai
 
 ### Complete contribution record
 
-This audited record covers the complete v2026.6.8..HEAD history: 422 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
+This audited record covers the complete v2026.6.8..HEAD history: 423 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
 
 #### Pull requests
 
@@ -57,6 +57,7 @@ This audited record covers the complete v2026.6.8..HEAD history: 422 merged PRs.
 - **PR #88792** fix(state): harden sqlite path caching. Thanks @vincentkoc.
 - **PR #93022** fix(gateway): repair usage cost aggregation across agents. Thanks @luke-skywalker-open-claw and @stablegenius49.
 - **PR #93020** fix(telegram): cool down transient sendChatAction failures. Related #56096. Thanks @Boulea7 and @sumaiazaman and @Pick-cat and @cal-rufus.
+- **PR #93002** fix(telegram): clear progress drafts before visible tool output. Thanks @zhangguiping-xydt.
 - **PR #89160** fix(agents): detect truncated API responses to prevent silent session hang. Related #89051. Thanks @joelnishanth and @ArthurusDent.
 - **PR #93009** fix(agents): make wrapToolWithBeforeToolCallHook idempotent to prevent double hook execution (fixes #92973). Thanks @zenglingbiao and @dertbv.
 - **PR #92991** fix(agents): tolerate missing attribution baseUrl. Related #92974. Thanks @samrusani and @Haderach-Ram.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2689,6 +2689,34 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
+  it("clears progress drafts before visible tool artifacts", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver(
+          { mediaUrl: "https://example.com/validation.txt" },
+          { kind: "tool" },
+        );
+        await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+    });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Shelling\n\n`🛠️ Exec`");
+    expectDeliveredReply(0, { mediaUrl: "https://example.com/validation.txt" });
+    expectDeliveredReply(0, { text: "Final answer" }, 1);
+    expect(answerDraftStream.clear.mock.invocationCallOrder[0]).toBeLessThan(
+      deliverReplies.mock.invocationCallOrder[0],
+    );
+  });
+
   it("does not stream text-only tool results into progress drafts", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2663,6 +2663,32 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
+  it("clears progress drafts before durable verbose tool output", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        replyOptions?.onVerboseProgressVisibility?.(() => true);
+        await dispatcherOptions.deliver({ text: "Tool output visible to Telegram" }, { kind: "tool" });
+        await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+    });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Shelling\n\n`🛠️ Exec`");
+    expectDeliveredReply(0, { text: "Tool output visible to Telegram" });
+    expectDeliveredReply(0, { text: "Final answer" }, 1);
+    expect(answerDraftStream.clear.mock.invocationCallOrder[0]).toBeLessThan(
+      deliverReplies.mock.invocationCallOrder[0],
+    );
+  });
+
   it("does not stream text-only tool results into progress drafts", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2681,7 +2681,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
     });
 
-    expect(answerDraftStream.update).toHaveBeenCalledWith("Shelling\n\n`🛠️ Exec`");
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
+    );
     expectDeliveredReply(0, { text: "Tool output visible to Telegram" });
     expectDeliveredReply(0, { text: "Final answer" }, 1);
     expect(answerDraftStream.clear.mock.invocationCallOrder[0]).toBeLessThan(
@@ -2709,7 +2711,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
     });
 
-    expect(answerDraftStream.update).toHaveBeenCalledWith("Shelling\n\n`🛠️ Exec`");
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
+    );
     expectDeliveredReply(0, { mediaUrl: "https://example.com/validation.txt" });
     expectDeliveredReply(0, { text: "Final answer" }, 1);
     expect(answerDraftStream.clear.mock.invocationCallOrder[0]).toBeLessThan(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2118,8 +2118,9 @@ export const dispatchTelegramMessage = async ({
                       }
                       if (segment.lane === "answer" && info.kind === "tool") {
                         if (verboseProgressActive()) {
-                          // Durable lane owns tool payloads: send standalone instead
-                          // of diverting into the draft, which is discarded at final.
+                          if (streamMode === "progress") {
+                            await rotateAnswerLaneAfterToolProgress();
+                          }
                           if (
                             await sendPayload(
                               applyTextToPayload(effectivePayload, segment.update.text),

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2276,6 +2276,9 @@ export const dispatchTelegramMessage = async ({
                       }
                       return;
                     }
+                    if (streamMode === "progress" && info.kind === "tool") {
+                      await rotateAnswerLaneAfterToolProgress();
+                    }
                     const delivered = await sendPayload(effectivePayload, {
                       durable: info.kind === "final",
                     });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2131,10 +2131,6 @@ export const dispatchTelegramMessage = async ({
                           continue;
                         }
                         if (streamMode === "progress" && answerLane.stream) {
-                          // Progress-mode streams render tool status in the
-                          // live draft. Do not also emit text-only tool output
-                          // as answer text, or simple commands duplicate and
-                          // restart the progress draft.
                           continue;
                         }
                         await prepareAnswerLaneForToolProgress();


### PR DESCRIPTION
## Summary

- Problem: Telegram progress-mode drafts could remain visible when verbose tool output or visible tool artifacts were delivered as standalone messages.
- Solution: Rotate and clear tool-progress-only answer drafts before sending visible tool output payloads.
- What changed: Updated Telegram dispatch ordering and added regression coverage for verbose tool text and visible tool artifact paths.
- What did NOT change: Telegram transport, rich message rendering, provider behavior, tool execution, auth, secrets, network, or progress draft implementation internals.

Fixes #90753

## Real behavior proof

- Behavior addressed: Telegram progress-mode handling for visible tool output and visible tool artifacts after an active progress draft.
- Real environment tested: Mantis native Telegram Desktop proof on pull_request_target at candidate head `48bea40e8c3619919c23fc0881e0892c798cc1bd`, plus contributor-run macOS 26.5 / Node v24.15.0 / pnpm 11.2.2 / local OpenClaw gateway / real Telegram private chat with bot `@moongpbot`.
- Exact steps or command run after this patch:

```bash
# Mantis native Telegram Desktop proof
telegram-desktop-proof

# Contributor-run supplemental live gateway proof
pnpm openclaw gateway --port 19879
# Telegram private chat stimulus:
/verbose on
clean exec proof 1840
```

- Evidence after fix: Mantis captured native Telegram Desktop before/after GIF evidence for the tool-output progress draft behavior.

  - Mantis proof comment: https://github.com/openclaw/openclaw/pull/93002#issuecomment-4702371122
  - Mantis run: https://github.com/openclaw/openclaw/actions/runs/27503350048
  - Mantis artifact: https://github.com/openclaw/openclaw/actions/runs/27503350048/artifacts/7622943022
  - Baseline: `pass` at `3826cda4d854b72f81b4d8cbd4a671d5aa9cc0f8`, expected baseline visual proof captured
  - Candidate: `pass` at `48bea40e8c3619919c23fc0881e0892c798cc1bd`, expected candidate visual proof captured
  - Overall: `true`

  Mantis visual artifacts:

  - Baseline screenshot: https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-93002/run-27503350048-1/baseline/telegram-desktop-proof.png
  - Candidate screenshot: https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-93002/run-27503350048-1/candidate/telegram-desktop-proof.png
  - Baseline GIF: https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-93002/run-27503350048-1/baseline/telegram-desktop-proof.gif
  - Candidate GIF: https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-93002/run-27503350048-1/candidate/telegram-desktop-proof.gif
  - Baseline MP4: https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-93002/run-27503350048-1/baseline/telegram-desktop-proof.mp4
  - Candidate MP4: https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-93002/run-27503350048-1/candidate/telegram-desktop-proof.mp4
  - Raw QA files: https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-93002/run-27503350048-1/index.json

  Supplemental redacted contributor-run runtime log excerpt:

```text
2026-06-14T20:06:11.285+08:00 [gateway] ready
2026-06-14T20:06:12.551+08:00 [telegram] [default] starting provider (@moongpbot)
2026-06-14T20:06:13.873+08:00 [telegram] [diag] isolated polling ingress started
2026-06-14T20:09:06.704+08:00 [telegram] Inbound message telegram:<redacted-chat-id> -> @moongpbot (direct, 21 chars)
2026-06-14T20:09:11.801+08:00 [telegram] sendRichMessage ok chat=<redacted-chat-id> message=36
2026-06-14T20:09:13.576+08:00 [telegram] outbound send ok accountId=default chatId=<redacted-chat-id> messageId=37 operation=sendRichMessage deliveryKind=text chunkCount=1
```

- Observed result after fix: Mantis native Telegram Desktop proof passed for the candidate head with `Overall: true` for the tool-output progress draft behavior, and the supplemental live gateway run processed a real Telegram inbound message through OpenClaw and produced outbound Telegram responses without runtime delivery errors.
- What was not tested: no known gaps for the dispatch ordering regression covered by this patch.

## Regression Test Plan

- Coverage level: Unit test
- Target test file: `extensions/telegram/src/bot-message-dispatch.test.ts`
- Scenario locked in: progress drafts are cleared before durable verbose tool output and visible tool artifacts are delivered.
- Why this is the smallest reliable guardrail: the regression is dispatch ordering, so the test asserts draft clearing happens before standalone Telegram deliveries.

Verification run:

```text
pnpm test extensions/telegram/src/bot-message-dispatch.test.ts -- -t "clears progress drafts before"

Test Files  1 passed (1)
Tests       2 passed | 118 skipped (120)
```

## Root Cause

- Root cause: progress-mode tool status drafts were not rotated before all visible tool-output delivery paths.
- Missing detection / guardrail: existing tests covered final-answer cleanup but not durable verbose tool output or visible tool artifact delivery.
