### PR TITLE
Add OpenRouter Fusion guidance and prompt context

### DIFF
--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -86,6 +86,7 @@ Bundled fallback examples:
 | Model ref                         | Notes                        |
 | --------------------------------- | ---------------------------- |
 | `openrouter/auto`                 | OpenRouter automatic routing |
+| `openrouter/openrouter/fusion`    | OpenRouter Fusion router     |
 | `openrouter/moonshotai/kimi-k2.6` | Kimi K2.6 via MoonshotAI     |
 | `openrouter/moonshotai/kimi-k2.5` | Kimi K2.5 via MoonshotAI     |
 
@@ -212,6 +213,79 @@ media understanding preflight.
 
 OpenClaw sends OpenRouter STT requests as JSON with base64 audio under
 `input_audio` (OpenRouter STT contract), not as multipart OpenAI form uploads.
+
+## Fusion router
+
+Use OpenRouter Fusion when you want one OpenClaw model ref to ask several
+OpenRouter models in parallel, have OpenRouter judge their answers, and return a
+single final response through the normal OpenRouter provider endpoint. Because
+the upstream model slug is `openrouter/fusion`, the OpenClaw model ref includes
+both the OpenClaw provider prefix and the upstream OpenRouter namespace:
+
+```bash
+openclaw models set openrouter/openrouter/fusion
+```
+
+Configure Fusion's panel and judge through the model's `params.extraBody`. Those
+fields are forwarded into the OpenRouter chat-completions request body. Fusion
+works with either OpenRouter OAuth onboarding or API-key onboarding; if you use
+OAuth, omit the `env.OPENROUTER_API_KEY` line from the example below.
+
+```json5
+{
+  env: { OPENROUTER_API_KEY: "sk-or-..." },
+  agents: {
+    defaults: {
+      model: { primary: "openrouter/openrouter/fusion" },
+      models: {
+        "openrouter/openrouter/fusion": {
+          params: {
+            extraBody: {
+              plugins: [
+                {
+                  id: "fusion",
+                  analysis_models: [
+                    "google/gemini-3.5-flash",
+                    "moonshotai/kimi-k2.6",
+                    "deepseek/deepseek-v4-pro",
+                  ],
+                  model: "google/gemini-3.5-flash",
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+The `analysis_models` list is the parallel panel, and `model` inside the Fusion
+plugin config is the judge model. Do not set top-level `tool_choice` to
+`"required"` in normal OpenClaw agent/chat turns to try to force Fusion;
+OpenClaw turns may include OpenClaw tool definitions, and a top-level required
+tool choice can require one of those tools instead of the Fusion router. When
+this Fusion plugin config is present, OpenClaw also adds a sanitized
+system-prompt note with the configured analysis models and judge model so the
+agent can answer questions about its current Fusion panel. Other `extraBody`
+fields are not copied into the prompt.
+
+Fusion is slower by design. OpenRouter may send the same OpenClaw prompt to
+multiple analysis models and then run a final judge/synthesis step, so latency is
+usually higher than a direct single-model request. Use Fusion for deliberate,
+high-quality answers or escalation paths, not as the default for
+latency-sensitive chat. For faster responses, keep the panel small and choose
+faster analysis and judge models.
+
+Test the configured ref with a one-shot local model call:
+
+```bash
+openclaw infer model run --local \
+  --model openrouter/openrouter/fusion \
+  --prompt "Reply with exactly: FUSION_OK" \
+  --json
+```
 
 ## Authentication and headers
 

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -275,6 +275,179 @@ describe("openrouter provider hooks", () => {
     expect(getOpenRouterModelCapabilitiesMock).toHaveBeenCalledWith("openrouter/auto");
   });
 
+  it("describes configured Fusion analysis models in the system prompt", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const contribution = provider.resolveSystemPromptContribution?.({
+      provider: "openrouter",
+      modelId: "openrouter/fusion",
+      promptMode: "full",
+      config: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/openrouter/fusion": {
+                params: {
+                  extraBody: {
+                    plugins: [
+                      {
+                        id: "fusion",
+                        analysis_models: [
+                          "google/gemini-3.5-flash",
+                          "moonshotai/kimi-k2.6",
+                          "deepseek/deepseek-v4-pro",
+                        ],
+                        model: "google/gemini-3.5-flash",
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as never);
+
+    expect(contribution?.dynamicSuffix).toContain("OpenRouter Fusion Configuration");
+    expect(contribution?.dynamicSuffix).toContain(
+      "Analysis models: google/gemini-3.5-flash, moonshotai/kimi-k2.6, deepseek/deepseek-v4-pro.",
+    );
+    expect(contribution?.dynamicSuffix).toContain("Final Fusion model: google/gemini-3.5-flash.");
+  });
+
+  it("describes Fusion config from the canonical OpenRouter model key", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const contribution = provider.resolveSystemPromptContribution?.({
+      provider: "openrouter",
+      modelId: "openrouter/fusion",
+      promptMode: "full",
+      config: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/fusion": {
+                params: {
+                  extraBody: {
+                    plugins: [
+                      {
+                        id: "fusion",
+                        analysis_models: ["deepseek/deepseek-v4-pro"],
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as never);
+
+    expect(contribution?.dynamicSuffix).toContain("Analysis models: deepseek/deepseek-v4-pro.");
+  });
+
+  it("matches transport alias precedence for Fusion extra body", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const contribution = provider.resolveSystemPromptContribution?.({
+      provider: "openrouter",
+      modelId: "openrouter/fusion",
+      promptMode: "full",
+      config: {
+        agents: {
+          defaults: {
+            params: {
+              extra_body: {
+                plugins: [
+                  {
+                    id: "fusion",
+                    analysis_models: ["google/gemini-3.5-flash"],
+                  },
+                ],
+              },
+            },
+            models: {
+              "openrouter/fusion": {
+                params: {
+                  extraBody: {
+                    plugins: [
+                      {
+                        id: "fusion",
+                        analysis_models: ["deepseek/deepseek-v4-pro"],
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as never);
+
+    expect(contribution?.dynamicSuffix).toContain("Analysis models: google/gemini-3.5-flash.");
+    expect(contribution?.dynamicSuffix).not.toContain("deepseek/deepseek-v4-pro");
+  });
+
+  it("keeps arbitrary OpenRouter extraBody fields out of the system prompt", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const contribution = provider.resolveSystemPromptContribution?.({
+      provider: "openrouter",
+      modelId: "openrouter/fusion",
+      promptMode: "full",
+      config: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/openrouter/fusion": {
+                params: {
+                  extraBody: {
+                    metadata: { private: "do-not-render" },
+                    plugins: [{ id: "not-fusion", model: "private-model" }],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as never);
+
+    expect(contribution).toBeUndefined();
+  });
+
+  it("does not describe disabled Fusion plugin config in the system prompt", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const contribution = provider.resolveSystemPromptContribution?.({
+      provider: "openrouter",
+      modelId: "openrouter/fusion",
+      promptMode: "full",
+      config: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/fusion": {
+                params: {
+                  extraBody: {
+                    plugins: [
+                      {
+                        id: "fusion",
+                        enabled: false,
+                        analysis_models: ["deepseek/deepseek-v4-pro"],
+                        model: "google/gemini-3.5-flash",
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as never);
+
+    expect(contribution).toBeUndefined();
+  });
+
   it("does not include retired stealth models in the bundled catalog", () => {
     const modelIds = buildOpenrouterProvider().models?.map((model) => model.id) ?? [];
     expect(modelIds).not.toContain("openrouter/hunter-alpha");

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -41,6 +41,7 @@ import {
 
 const PROVIDER_ID = "openrouter";
 const OPENROUTER_DEFAULT_MAX_TOKENS = 8192;
+const OPENROUTER_FUSION_MODEL_ID = "openrouter/fusion";
 const OPENROUTER_CACHE_TTL_MODEL_PREFIXES = [
   "anthropic/",
   "deepseek/",
@@ -48,6 +49,25 @@ const OPENROUTER_CACHE_TTL_MODEL_PREFIXES = [
   "moonshotai/",
   "zai/",
 ] as const;
+const MAX_PROMPT_MODEL_ID_DISPLAY_CHARS = 256;
+
+type OpenRouterFusionPromptContext = {
+  config?: {
+    agents?: {
+      defaults?: {
+        params?: Record<string, unknown>;
+        models?: Record<string, { params?: Record<string, unknown> }>;
+      };
+      list?: Array<{ id?: string; params?: Record<string, unknown> }>;
+    };
+  };
+  agentId?: string;
+  modelId: string;
+};
+
+type OpenRouterFusionPromptContribution = {
+  dynamicSuffix?: string;
+};
 
 function normalizeOpenRouterResolvedModel<T extends ProviderRuntimeModel>(model: T): T | undefined {
   const normalizedBaseUrl = normalizeOpenRouterBaseUrl(model.baseUrl);
@@ -66,6 +86,144 @@ function normalizeOpenRouterResolvedModel<T extends ProviderRuntimeModel>(model:
     ...(normalizedBaseUrl ? { baseUrl: normalizedBaseUrl } : {}),
     reasoning,
   };
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function sanitizePromptModelId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = Array.from(value)
+    .filter((char) => {
+      const codePoint = char.codePointAt(0) ?? 0;
+      return (
+        codePoint > 0x1f &&
+        (codePoint < 0x7f || codePoint > 0x9f) &&
+        codePoint !== 0x2028 &&
+        codePoint !== 0x2029
+      );
+    })
+    .join("")
+    .trim()
+    .slice(0, MAX_PROMPT_MODEL_ID_DISPLAY_CHARS);
+  return normalized || undefined;
+}
+
+function openRouterModelConfigKey(modelId: string): string {
+  const providerPrefix = `${PROVIDER_ID}/`;
+  return modelId.trim().toLowerCase().startsWith(providerPrefix)
+    ? modelId
+    : `${PROVIDER_ID}/${modelId}`;
+}
+
+function findConfiguredOpenRouterModelParams(
+  ctx: OpenRouterFusionPromptContext,
+): Record<string, unknown> | undefined {
+  const configuredModels = ctx.config?.agents?.defaults?.models;
+  if (!configuredModels) {
+    return undefined;
+  }
+
+  const normalizedModelId = normalizeOpenRouterApiModelId(ctx.modelId) ?? ctx.modelId;
+  const directKeys = [
+    openRouterModelConfigKey(ctx.modelId),
+    openRouterModelConfigKey(normalizedModelId),
+    `${PROVIDER_ID}/${ctx.modelId}`,
+    `${PROVIDER_ID}/${normalizedModelId}`,
+  ];
+  for (const key of directKeys) {
+    const params = readRecord(configuredModels[key]?.params);
+    if (params) {
+      return params;
+    }
+  }
+
+  for (const [rawKey, entry] of Object.entries(configuredModels)) {
+    const slashIndex = rawKey.indexOf("/");
+    if (slashIndex <= 0) {
+      continue;
+    }
+    const provider = rawKey.slice(0, slashIndex).trim().toLowerCase();
+    const modelId = rawKey.slice(slashIndex + 1);
+    const candidateModelId = normalizeOpenRouterApiModelId(modelId) ?? modelId;
+    if (
+      provider === PROVIDER_ID &&
+      candidateModelId.trim().toLowerCase() === normalizedModelId.trim().toLowerCase()
+    ) {
+      return readRecord(entry.params);
+    }
+  }
+
+  return undefined;
+}
+
+function findConfiguredOpenRouterAgentParams(
+  ctx: OpenRouterFusionPromptContext,
+): Record<string, unknown> | undefined {
+  if (!ctx.agentId) {
+    return undefined;
+  }
+  return readRecord(ctx.config?.agents?.list?.find((agent) => agent.id === ctx.agentId)?.params);
+}
+
+function resolveMergedOpenRouterPromptParams(
+  ctx: OpenRouterFusionPromptContext,
+): Record<string, unknown> | undefined {
+  const merged = {
+    ...readRecord(ctx.config?.agents?.defaults?.params),
+    ...findConfiguredOpenRouterModelParams(ctx),
+    ...findConfiguredOpenRouterAgentParams(ctx),
+  };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function resolveFusionExtraBody(
+  ctx: OpenRouterFusionPromptContext,
+): Record<string, unknown> | undefined {
+  const params = resolveMergedOpenRouterPromptParams(ctx);
+  const rawExtraBody =
+    params && Object.hasOwn(params, "extra_body") ? params.extra_body : params?.extraBody;
+  return readRecord(rawExtraBody);
+}
+
+function resolveOpenRouterFusionPromptContribution(
+  ctx: OpenRouterFusionPromptContext,
+): OpenRouterFusionPromptContribution | undefined {
+  const normalizedModelId = normalizeOpenRouterApiModelId(ctx.modelId) ?? ctx.modelId;
+  if (normalizedModelId !== OPENROUTER_FUSION_MODEL_ID) {
+    return undefined;
+  }
+
+  const extraBody = resolveFusionExtraBody(ctx);
+  const fusionPlugin = Array.isArray(extraBody?.plugins)
+    ? extraBody.plugins.map(readRecord).find((plugin) => plugin?.id === "fusion")
+    : undefined;
+  if (!fusionPlugin) {
+    return undefined;
+  }
+  if (fusionPlugin.enabled === false) {
+    return undefined;
+  }
+
+  const analysisModels = Array.isArray(fusionPlugin.analysis_models)
+    ? fusionPlugin.analysis_models
+        .map(sanitizePromptModelId)
+        .filter((model): model is string => Boolean(model))
+    : [];
+  const finalModel = sanitizePromptModelId(fusionPlugin.model);
+  const lines = [
+    "## OpenRouter Fusion Configuration",
+    "The active OpenRouter Fusion request is configured with these non-secret Fusion plugin fields.",
+    analysisModels.length > 0 ? `Analysis models: ${analysisModels.join(", ")}.` : undefined,
+    finalModel ? `Final Fusion model: ${finalModel}.` : undefined,
+  ].filter((line): line is string => Boolean(line));
+
+  return lines.length > 2 ? { dynamicSuffix: lines.join("\n") } : undefined;
 }
 
 export default definePluginEntry({
@@ -196,6 +354,7 @@ export default definePluginEntry({
       supportsXHighThinking: ({ modelId }) => supportsOpenRouterXHighThinking(modelId),
       resolveThinkingProfile: ({ modelId }) => resolveOpenRouterThinkingProfile(modelId),
       isModernModelRef: () => true,
+      resolveSystemPromptContribution: resolveOpenRouterFusionPromptContribution,
       extraParamsForTransport: resolveOpenRouterExtraParamsForTransport,
       wrapStreamFn: wrapOpenRouterProviderStream,
       isCacheTtlEligible: (ctx) => isOpenRouterCacheTtlModel(ctx.modelId),

--- a/src/agents/embedded-agent-runner-extraparams-openrouter.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams-openrouter.test.ts
@@ -165,6 +165,54 @@ describe("applyExtraParamsToAgent OpenRouter reasoning", () => {
     expect(headers?.["X-OpenRouter-Cache-TTL"]).toBe("600");
   });
 
+  it("forwards Fusion plugin config through extraBody", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "openrouter",
+      modelId: "openrouter/fusion",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/openrouter/fusion": {
+                params: {
+                  extraBody: {
+                    plugins: [
+                      {
+                        id: "fusion",
+                        analysis_models: [
+                          "google/gemini-3.5-flash",
+                          "moonshotai/kimi-k2.6",
+                          "deepseek/deepseek-v4-pro",
+                        ],
+                        model: "google/gemini-3.5-flash",
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      payload: { model: "openrouter/fusion" },
+    });
+
+    expect(payload).toEqual({
+      model: "openrouter/fusion",
+      plugins: [
+        {
+          id: "fusion",
+          analysis_models: [
+            "google/gemini-3.5-flash",
+            "moonshotai/kimi-k2.6",
+            "deepseek/deepseek-v4-pro",
+          ],
+          model: "google/gemini-3.5-flash",
+        },
+      ],
+    });
+  });
+
   it("uses configured long retention for OpenRouter Anthropic cache markers", () => {
     const payload = runExtraParamsPayloadCase({
       provider: "openrouter",


### PR DESCRIPTION
## Summary

- Document OpenRouter Fusion setup, including panel/judge `extraBody` configuration, OAuth/API-key compatibility, local test command, and the slower-by-design latency tradeoff.
- Add OpenRouter provider prompt context for configured Fusion panels so agents can answer which non-secret Fusion analysis and judge models are active.
- Cover Fusion extra-body forwarding and prompt-context behavior with focused tests, including canonical model keys and alias precedence.

Fixes #92984

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenClaw users can configure `openrouter/openrouter/fusion`, forward Fusion panel/judge config through OpenRouter `extraBody`, and see the docs describe the slower-by-design latency tradeoff and safe configuration caveats.
- Real environment tested: Local macOS source checkout on branch `openrouter-fusion-docs`, patched OpenClaw CLI, live OpenRouter provider request using the local `OPENROUTER_API_KEY`; local source Gateway/WebChat was also run for manual browser testing.
- Exact steps or command run after this patch: `pnpm openclaw infer model run --local --model openrouter/openrouter/fusion --prompt "Reply with exactly: FUSION_OK" --json`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live output from the OpenRouter Fusion smoke returned assistant text `FUSION_OK`. Screenshot: https://github.com/openclaw/openclaw/pull/93005#issuecomment-4702234997.
- Observed result after fix: The patched local OpenClaw CLI completed a real OpenRouter Fusion request through the single `openrouter/openrouter/fusion` model ref and returned the requested exact response text.
- What was not tested: I did not live-test OpenRouter OAuth-issued credentials separately from `OPENROUTER_API_KEY`; the code path is provider-auth equivalent because both auth methods resolve credentials for provider `openrouter`. I did not test every possible Fusion analysis/judge model combination.
- Proof limitations or environment constraints: The proof command used a live OpenRouter API call and avoids printing secrets. The screenshot proof is intentionally left as a placeholder for maintainer upload.
- Before evidence (optional but encouraged): Before this change, the docs did not explain OpenRouter Fusion setup/latency and the agent had no provider-owned prompt context for reporting configured Fusion analysis or judge models.

## Verification

- `node scripts/run-vitest.mjs extensions/openrouter/index.test.ts src/agents/embedded-agent-runner-extraparams-openrouter.test.ts`
- `pnpm docs:check-mdx`
- `git diff --check`
- `pnpm build`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean: no accepted/actionable findings reported
- Live OpenRouter Fusion smoke earlier in this branch: `pnpm openclaw infer model run --local --model openrouter/openrouter/fusion --prompt "Reply with exactly: FUSION_OK" --json`

## Notes

- PR creation requested `maintainer_can_modify: true` so maintainers can edit the fork branch.