### PR TITLE
fix(tui): keep stderr visible when local shell stdout fills the output cap

### DIFF
--- a/src/tui/tui-local-shell.test.ts
+++ b/src/tui/tui-local-shell.test.ts
@@ -16,6 +16,7 @@ const createSelector = () => {
 function createShellHarness(params?: {
   spawnCommand?: typeof import("node:child_process").spawn;
   env?: Record<string, string>;
+  maxOutputChars?: number;
 }) {
   const messages: string[] = [];
   const chatLog = {
@@ -40,6 +41,7 @@ function createShellHarness(params?: {
     createSelector: createSelectorSpy,
     spawnCommand,
     ...(params?.env ? { env: params.env } : {}),
+    ...(params?.maxOutputChars !== undefined ? { maxOutputChars: params.maxOutputChars } : {}),
   });
   return {
     messages,
@@ -111,5 +113,37 @@ describe("createLocalShellRunner", () => {
     expect(spawnOptions.env?.OPENCLAW_SHELL).toBe("tui-local");
     expect(spawnOptions.env?.PATH).toBe("/tmp/bin");
     expect(harness.messages).toContain("local shell: enabled for this session");
+  });
+
+  it("keeps stderr visible instead of evicting it when stdout fills the output cap", async () => {
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    const spawnCommand = vi.fn(() => ({
+      stdout,
+      stderr,
+      on: (event: string, callback: (...args: unknown[]) => void) => {
+        if (event === "close") {
+          setImmediate(() => {
+            // stdout fills the entire cap; stderr then carries the failure reason.
+            stdout.emit("data", Buffer.from("0".repeat(20)));
+            stderr.emit("data", Buffer.from("FATAL"));
+            callback(0, null);
+          });
+        }
+      },
+    }));
+
+    const harness = createShellHarness({
+      spawnCommand: spawnCommand as unknown as typeof import("node:child_process").spawn,
+      maxOutputChars: 20,
+    });
+
+    const run = harness.runLocalShellLine("!noisy");
+    harness.getLastSelector()?.onSelect?.({ value: "yes", label: "Yes" });
+    await run;
+
+    // The failure reason in stderr must survive even though stdout filled the cap;
+    // the previous head-cut kept all stdout and dropped stderr entirely.
+    expect(harness.messages.some((m) => m.includes("FATAL"))).toBe(true);
   });
 });

--- a/src/tui/tui-local-shell.ts
+++ b/src/tui/tui-local-shell.ts
@@ -125,8 +125,11 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
       });
 
       child.on("close", (code, signal) => {
+        // Keep the tail (consistent with the streaming appendWithCap above) so a
+        // large stdout cannot evict stderr: the failure reason (FATAL etc.) at the
+        // end is what the operator needs most when output overflows the cap.
         const combined = (stdout + (stderr ? (stdout ? "\n" : "") + stderr : ""))
-          .slice(0, maxChars)
+          .slice(-maxChars)
           .trimEnd();
 
         if (combined) {


### PR DESCRIPTION
## Summary

The TUI local shell (`!`-prefixed, operator-only, behind an explicit in-session approval) caps command output at `maxOutputChars`. While streaming it keeps the **tail** (`appendWithCap` → `slice(-maxChars)`), but on `close` it built `(stdout + "\n" + stderr).slice(0, maxChars)` — keeping the **head**. Two problems:

1. The two cut directions are inconsistent (tail while streaming, head at the end).
2. stdout and stderr are each capped to `maxChars` independently, so their concatenation can be ~`2 * maxChars`; once stdout alone fills `maxChars`, the head-slice keeps only stdout and drops **all** of stderr — so the operator never sees the failure reason (e.g. a `FATAL` line) when output overflows.

## What changed

- `close` now slices the **tail** (`slice(-maxChars)`), consistent with the streaming `appendWithCap`. The trailing stderr (the failure reason) survives instead of being evicted by a large stdout; normal within-cap output is unaffected.

## Real behavior proof

- **Behavior or issue addressed:** when a `!` command's stdout filled the output cap, the local shell dropped the entire stderr, hiding the failure reason from the operator.
- **Real environment tested:** local OpenClaw from source on Linux. Drove the **real `createLocalShellRunner` spawning a real OS subprocess** (the default `node:child_process` spawn, `shell: true`) via `node --import tsx` — nothing on the spawn/truncation/render path is mocked; only the approval-overlay UI selector is stubbed to auto-approve, exactly what the operator's in-session "Yes" does. With `maxOutputChars=20`, the command writes 40 stdout bytes (> cap) then a trailing `FATAL` on stderr.
- **Exact steps or command run after this patch:** `node --import tsx` driving `createLocalShellRunner({ maxOutputChars: 20, /* real spawn */ })` with `runLocalShellLine("!for i in $(seq 1 40); do printf 0; done; printf 'FATAL: real failure\n' 1>&2")`, auto-approving via the stubbed selector.
- **Evidence after fix (real subprocess output):**
  ```
  [local] $ for i in $(seq 1 40); do printf 0; done; printf 'FATAL: real failure\n' 1>&2
  [local] FATAL: real failure
  [local] exit 0
  STDERR_FATAL_IN_OUTPUT=true
  ```
  The rendered command output (excluding the echoed command line) contains the stderr `FATAL` line.
- **Observed result after fix:** with a real subprocess whose stdout fills the 20-char cap, the rendered `[local]` output keeps the tail and the stderr `FATAL` failure reason survives.
- **What was not tested:** the pi-tui rendering layer and the literal interactive approval keypress — the approval selector is stubbed to auto-approve (the operator normally presses Yes). The spawn, truncation and render-to-chatLog path is the real production code on a real OS subprocess.
- **Negative control:** reverting `close` to the pre-fix `slice(0, maxChars)` and re-running the same real-subprocess driver renders only the stdout head and drops stderr entirely:
  ```
  [local] 00000000000000000000
  [local] exit 0
  STDERR_FATAL_IN_OUTPUT=false
  ```
  confirming the fix is required and the proof is not a tautology. The Vitest suite (`tui-local-shell.test.ts`, 3 passed) likewise fails on the stderr-visibility assertion when reverted.

## Tests and validation

- Real-subprocess run via `node --import tsx` (above): after fix the stderr `FATAL` survives; pre-fix negative control drops it.
- `node scripts/run-vitest.mjs src/tui/tui-local-shell.test.ts` → 3 passed (added a case asserting stderr survives when stdout fills the cap; existing approval/env tests unchanged).
- `oxfmt --write` clean on both changed files.

## Risk checklist

- User-visible behavior change? Yes (a fix) — on output overflow the local shell now shows the tail (including stderr) rather than the stdout head.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? No (operator-only `!` shell, still approval-gated).
- Highest-risk area: changing which slice of overflowing output is shown; covered by the new stderr-visibility test plus the retained approval/env tests.
