### PR TITLE
fix(agents): make wrapToolWithBeforeToolCallHook idempotent to prevent double hook execution (fixes #92973)

### DIFF
--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -1357,11 +1357,20 @@ export function rewrapToolWithBeforeToolCallHook(
     wrappedContext && typeof wrappedContext === "object"
       ? (wrappedContext as HookContext)
       : undefined;
-  return wrapToolWithBeforeToolCallHook(
-    source && typeof source === "object" ? (source as AnyAgentTool) : tool,
-    ctx ?? preservedContext,
-    options,
-  );
+  const sourceTool = source && typeof source === "object" ? (source as AnyAgentTool) : tool;
+  if (sourceTool === tool) {
+    return wrapToolWithBeforeToolCallHook(tool, ctx ?? preservedContext, options);
+  }
+  // Keep schema and metadata replacements applied after the original wrap while
+  // restoring the unwrapped execute function for the new hook context.
+  const rewrapSource: AnyAgentTool = {
+    ...tool,
+    execute: sourceTool.execute,
+  };
+  delete (rewrapSource as unknown as Record<symbol, unknown>)[BEFORE_TOOL_CALL_WRAPPED];
+  copyPluginToolMeta(tool, rewrapSource);
+  copyChannelAgentToolMeta(tool as never, rewrapSource as never);
+  return wrapToolWithBeforeToolCallHook(rewrapSource, ctx ?? preservedContext, options);
 }
 
 /** Copy before_tool_call marker metadata when another wrapper replaces a tool. */

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -20,6 +20,7 @@ import { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
 import "./test-helpers/fast-bash-tools.js";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
+import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import * as openClawPluginTools from "./openclaw-plugin-tools.js";
@@ -211,6 +212,36 @@ describe("createOpenClawCodingTools", () => {
     expect(beforeToolCall.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({ channelId: "-100123" }),
     );
+  });
+
+  it("re-wraps existing before_tool_call hooks once with the current context", async () => {
+    const beforeToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    const wrapped = wrapToolWithBeforeToolCallHook(
+      {
+        name: "already_wrapped",
+        label: "Already wrapped",
+        description: "Already wrapped tool",
+        parameters: {},
+        execute,
+      },
+      { agentId: "main", sessionId: "session-original" },
+    );
+    vi.mocked(createOpenClawTools).mockReturnValueOnce([wrapped as never]);
+
+    const tools = createOpenClawCodingTools({ agentId: "main", sessionId: "session-new" });
+    const tool = requireTool(tools, "already_wrapped");
+    await requireToolExecute(tool)("call-wrapped", {});
+
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    expect(beforeToolCall.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ agentId: "main", sessionId: "session-new" }),
+    );
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(tool.parameters).toEqual({ type: "object", properties: {} });
   });
 
   it("adds Tool Search control tools when explicitly requested", () => {

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -7,7 +7,11 @@ import { runAgentLoop, type AgentEvent, type StreamFn } from "openclaw/plugin-sd
 import { createAssistantMessageEventStream, validateToolArguments } from "openclaw/plugin-sdk/llm";
 import { Type, type TSchema } from "typebox";
 import { describe, expect, it, vi } from "vitest";
-import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
+import {
+  isToolWrappedWithBeforeToolCallHook,
+  testing as beforeToolCallTesting,
+  wrapToolWithBeforeToolCallHook,
+} from "./agent-tools.before-tool-call.js";
 import {
   cleanToolSchemaForGemini,
   normalizeToolParameterSchema,
@@ -655,6 +659,19 @@ function makeTool(parameters: TSchema): AnyAgentTool {
 }
 
 describe("normalizeToolParameters", () => {
+  it("preserves before_tool_call wrapper metadata", () => {
+    const source = makeTool(Type.Object({ value: Type.String() }));
+    const hookContext = { agentId: "main", sessionId: "session-before-normalize" };
+    const wrapped = wrapToolWithBeforeToolCallHook(source, hookContext);
+
+    const normalized = normalizeToolParameters(wrapped);
+    const tagged = normalized as unknown as Record<symbol, unknown>;
+
+    expect(isToolWrappedWithBeforeToolCallHook(normalized)).toBe(true);
+    expect(tagged[beforeToolCallTesting.BEFORE_TOOL_CALL_SOURCE_TOOL]).toBe(source);
+    expect(tagged[beforeToolCallTesting.BEFORE_TOOL_CALL_HOOK_CONTEXT]).toBe(hookContext);
+  });
+
   it("normalizes truly empty schemas to type:object with properties:{} (MCP parameter-free tools)", () => {
     const tool: AnyAgentTool = {
       name: "get_flux_instance",

--- a/src/agents/agent-tools.schema.ts
+++ b/src/agents/agent-tools.schema.ts
@@ -8,6 +8,7 @@ import {
   normalizeToolParameterSchema,
   type ToolParameterSchemaOptions,
 } from "./agent-tools-parameter-schema.js";
+import { copyBeforeToolCallHookMarker } from "./agent-tools.before-tool-call.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { copyChannelAgentToolMeta } from "./channel-tools.js";
 
@@ -72,6 +73,7 @@ export function normalizeToolParameters(
   function preserveToolMeta(target: AnyAgentTool): AnyAgentTool {
     copyPluginToolMeta(tool, target);
     copyChannelAgentToolMeta(tool as never, target as never);
+    copyBeforeToolCallHookMarker(tool, target);
     return target;
   }
   const schema =

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -31,6 +31,8 @@ import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
 import {
+  isToolWrappedWithBeforeToolCallHook,
+  rewrapToolWithBeforeToolCallHook,
   type ToolOutcomeObserver,
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
@@ -1173,28 +1175,28 @@ export function createOpenClawCodingTools(options?: {
     }),
   );
   options?.recordToolPrepStage?.("schema-normalization");
+  const hookContext = {
+    agentId,
+    ...(options?.config ? { config: options.config } : {}),
+    cwd: codingRoot,
+    workspaceDir: workspaceRoot,
+    ...(options?.skillsSnapshot ? { skillsSnapshot: options.skillsSnapshot } : {}),
+    ...(sandboxRoot && allowWorkspaceWrites
+      ? { sandbox: { root: sandboxRoot, bridge: sandboxFsBridge! } }
+      : {}),
+    sessionKey: options?.sessionKey,
+    sessionId: options?.sessionId,
+    runId: options?.runId,
+    channelId: options?.hookChannelId ?? options?.currentChannelId,
+    ...(options?.trace ? { trace: options.trace } : {}),
+    loopDetection: resolveToolLoopDetectionConfig({ cfg: options?.config, agentId }),
+    onToolOutcome: options?.onToolOutcome,
+  };
+  const hookOptions = { emitDiagnostics: options?.emitBeforeToolCallDiagnostics };
   const withHooks = normalized.map((tool) =>
-    wrapToolWithBeforeToolCallHook(
-      tool,
-      {
-        agentId,
-        ...(options?.config ? { config: options.config } : {}),
-        cwd: codingRoot,
-        workspaceDir: workspaceRoot,
-        ...(options?.skillsSnapshot ? { skillsSnapshot: options.skillsSnapshot } : {}),
-        ...(sandboxRoot && allowWorkspaceWrites
-          ? { sandbox: { root: sandboxRoot, bridge: sandboxFsBridge! } }
-          : {}),
-        sessionKey: options?.sessionKey,
-        sessionId: options?.sessionId,
-        runId: options?.runId,
-        channelId: options?.hookChannelId ?? options?.currentChannelId,
-        ...(options?.trace ? { trace: options.trace } : {}),
-        loopDetection: resolveToolLoopDetectionConfig({ cfg: options?.config, agentId }),
-        onToolOutcome: options?.onToolOutcome,
-      },
-      { emitDiagnostics: options?.emitBeforeToolCallDiagnostics },
-    ),
+    isToolWrappedWithBeforeToolCallHook(tool)
+      ? rewrapToolWithBeforeToolCallHook(tool, hookContext, hookOptions)
+      : wrapToolWithBeforeToolCallHook(tool, hookContext, hookOptions),
   );
   options?.recordToolPrepStage?.("tool-hooks");
   const withAbort = options?.abortSignal

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -131,6 +131,9 @@ vi.mock("../apply-patch.js", () => ({
 }));
 
 vi.mock("../agent-tools.before-tool-call.js", () => ({
+  copyBeforeToolCallHookMarker: vi.fn(),
+  isToolWrappedWithBeforeToolCallHook: vi.fn(() => false),
+  rewrapToolWithBeforeToolCallHook: vi.fn((tool) => tool),
   wrapToolWithBeforeToolCallHook: vi.fn((tool) => tool),
 }));
 


### PR DESCRIPTION
## Summary

- Preserve `before_tool_call` wrapper provenance through tool schema normalization.
- Replace an existing hook wrapper with exactly one wrapper using the current agent/session/run/sandbox context.
- Retain the normalized tool schema and argument-preparation behavior during rewrap, protecting OpenAI/Anthropic tool definitions from reverting to the original unnormalized schema.
- Fixes #92973.

## Verification

- `node scripts/run-vitest.mjs src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/agents/agent-tools.schema.test.ts src/agents/agent-tools.before-tool-call.integration.e2e.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts src/agents/agent-tool-definition-adapter.test.ts src/agents/tool-search.test.ts src/mcp/plugin-tools-handlers.cancel.test.ts`
  - 242 tests passed across unit, agents, and E2E shards.
- Production-path Node/tsx probe using `createOpenClawCodingTools`, a real active channel registry, and one deliberately prewrapped tool:
  - `openai`: one hook call, one execution, current session/run context, normalized empty-object schema retained.
  - `anthropic`: one hook call, one execution, current session/run context, normalized empty-object schema retained.
- Testbox `pnpm check:changed`: `tbx_01kv3n790s40ertvxzv2xsbbzf` passed.
- Full agents-tools Testbox shard: `tbx_01kv3nqsg2yc40gszdpscnjs7m` passed, 53 files and 951 tests.
- Fresh autoreview: clean, no accepted/actionable findings.
- Exact-head GitHub CI: 95 successful checks, 1 neutral, 3 skipped, no failures.

## Real behavior proof

Behavior addressed: An already wrapped tool passing through `normalizeToolParameters` and `createOpenClawCodingTools` could acquire a nested `before_tool_call` wrapper, causing duplicate policy/plugin hook execution.

Real environment tested: macOS host, Node with tsx, production OpenClaw tool assembly and plugin registry paths; Linux Testbox for changed-surface checks.

Exact steps or command run after this patch: Ran a Node/tsx production-path probe that registered a channel tool already wrapped with stale context, assembled it once with `modelProvider: "openai"` and once with `modelProvider: "anthropic"`, then executed each resulting tool.

Evidence after fix: Copied live console output from the production-path probe:

```text
{"providers":["openai","anthropic"],"executeCalls":2,"hookCalls":2,"contexts":[{"agentId":"main","sessionId":"live-openai","runId":"run-openai"},{"agentId":"main","sessionId":"live-anthropic","runId":"run-anthropic"}]}
```

Observed result after fix: Each provider-policy path executed the underlying tool once, fired the hook once, adopted the current run context, and retained `{ "type": "object", "properties": {} }` after normalization.

What was not tested: No external model API request was needed because this change does not touch provider serialization or transport. Official OpenAI and Anthropic tool schema paths were exercised through production assembly; direct provider tool calls remain covered by unchanged provider code and CI.
