### PR TITLE
fix(gateway): accept file-only input on /v1/responses (parity with image-only)

### DIFF
--- a/src/gateway/openresponses-http.file-only.test.ts
+++ b/src/gateway/openresponses-http.file-only.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const extractFileContentFromSourceMock = vi.fn();
+
+vi.mock("../media/input-files.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../media/input-files.js")>("../media/input-files.js");
+  return {
+    ...actual,
+    extractFileContentFromSource: (...args: unknown[]) => extractFileContentFromSourceMock(...args),
+  };
+});
+
+import {
+  agentCommand,
+  getFreePort,
+  installGatewayTestHooks,
+  startGatewayServerWithRetries,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+let server: Awaited<ReturnType<typeof startGatewayServerWithRetries>>["server"];
+let port: number;
+
+beforeAll(async () => {
+  const started = await startGatewayServerWithRetries({
+    port: await getFreePort(),
+    opts: {
+      host: "127.0.0.1",
+      auth: { mode: "none" },
+      controlUiEnabled: false,
+      openResponsesEnabled: true,
+    },
+  });
+  port = started.port;
+  server = started.server;
+});
+
+afterAll(async () => {
+  await server?.close({ reason: "openresponses file-only suite done" });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+async function postResponses(body: unknown) {
+  return await fetch(`http://127.0.0.1:${port}/v1/responses`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-openclaw-scopes": "operator.write",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("OpenResponses file-only input that renders to images", () => {
+  it("accepts a file-only turn whose file renders to images and forwards them", async () => {
+    extractFileContentFromSourceMock.mockResolvedValueOnce({
+      filename: "scan.pdf",
+      text: "",
+      images: [
+        { type: "image", data: Buffer.alloc(8, 1).toString("base64"), mimeType: "image/png" },
+      ],
+    });
+    agentCommand.mockResolvedValueOnce({ payloads: [{ text: "ok" }] } as never);
+
+    const res = await postResponses({
+      model: "openclaw",
+      instructions: "Describe the attached scan.",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_file",
+              source: {
+                type: "base64",
+                media_type: "application/pdf",
+                data: Buffer.from("%PDF-1.4 scanned").toString("base64"),
+                filename: "scan.pdf",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    expect(agentCommand).toHaveBeenCalledTimes(1);
+    const opts = agentCommand.mock.calls[0]?.[0] as { message?: string; images?: unknown[] };
+    expect(opts.message ?? "").not.toBe("");
+    expect(opts.images?.length).toBe(1);
+    await res.text();
+  });
+});

--- a/src/gateway/openresponses-http.server.file-only.test.ts
+++ b/src/gateway/openresponses-http.server.file-only.test.ts
@@ -96,4 +96,41 @@ describe("OpenResponses file-only input that renders to images", () => {
     expect(opts.images?.length).toBe(1);
     await res.text();
   });
+
+  it("keeps an empty extracted file visible to the model", async () => {
+    extractFileContentFromSourceMock.mockResolvedValueOnce({
+      filename: "empty.txt",
+      text: "",
+      images: [],
+    });
+    agentCommand.mockResolvedValueOnce({ payloads: [{ text: "ok" }] } as never);
+
+    const res = await postResponses({
+      model: "openclaw",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_file",
+              source: {
+                type: "base64",
+                media_type: "text/plain",
+                data: Buffer.from("binary-only file").toString("base64"),
+                filename: "empty.txt",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const body = await res.text();
+    expect(res.status, body).toBe(200);
+    expect(agentCommand).toHaveBeenCalledTimes(1);
+    const opts = agentCommand.mock.calls[0]?.[0] as { extraSystemPrompt?: string };
+    expect(opts.extraSystemPrompt).toContain('<file name="empty.txt">');
+    expect(opts.extraSystemPrompt).toContain("[No extractable text]");
+  });
 });

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1746,6 +1746,43 @@ describe("OpenResponses HTTP API (e2e)", () => {
     await ensureResponseConsumed(res);
   });
 
+  it("accepts file-only input without text, matching image-only", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({ payloads: [{ text: "ok" }] } as never);
+
+    const res = await postResponses(port, {
+      model: "openclaw",
+      instructions: "Summarize the attached document.",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_file",
+              source: {
+                type: "base64",
+                media_type: "text/plain",
+                data: Buffer.from("the quick brown fox").toString("base64"),
+                filename: "doc.txt",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    expect(agentCommand).toHaveBeenCalledTimes(1);
+    const opts = firstAgentOpts();
+    expect((opts as { message?: string }).message ?? "").not.toBe("");
+    const extraSystemPrompt = (opts as { extraSystemPrompt?: string }).extraSystemPrompt ?? "";
+    expect(extraSystemPrompt).toContain('<file name="doc.txt">');
+    expect(extraSystemPrompt).toContain("the quick brown fox");
+    await ensureResponseConsumed(res);
+  });
+
   it("still rejects input with neither text nor image", async () => {
     const port = enabledPort;
     agentCommand.mockClear();

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -612,6 +612,14 @@ export async function handleOpenResponsesHttpRequest(
                     surroundContentWithNewlines: false,
                   }),
                 );
+              } else {
+                fileContexts.push(
+                  renderFileContextBlock({
+                    filename: file.filename,
+                    content: "[No extractable text]",
+                    surroundContentWithNewlines: false,
+                  }),
+                );
               }
               if (file.images && file.images.length > 0) {
                 images = images.concat(file.images);

--- a/src/gateway/openresponses-parity.test.ts
+++ b/src/gateway/openresponses-parity.test.ts
@@ -393,7 +393,43 @@ describe("OpenResponses Feature Parity", () => {
       expect(result.message).toBe(IMAGE_ONLY_USER_MESSAGE);
     });
 
-    it("keeps an empty message when the active turn has neither text nor image", () => {
+    it("substitutes a placeholder for a file-only active user turn", () => {
+      const result = buildAgentPrompt([
+        {
+          type: "message" as const,
+          role: "user" as const,
+          content: [
+            {
+              type: "input_file" as const,
+              source: { type: "url" as const, url: "https://example.com/report.pdf" },
+            },
+          ],
+        },
+      ]);
+
+      expect(result.message).not.toBe("");
+      expect(result.message.toLowerCase()).toContain("file");
+    });
+
+    it("keeps the user text when a file-only turn also carries text", () => {
+      const result = buildAgentPrompt([
+        {
+          type: "message" as const,
+          role: "user" as const,
+          content: [
+            { type: "input_text" as const, text: "summarize this" },
+            {
+              type: "input_file" as const,
+              source: { type: "url" as const, url: "https://example.com/report.pdf" },
+            },
+          ],
+        },
+      ]);
+
+      expect(result.message).toBe("summarize this");
+    });
+
+    it("keeps an empty message when the active turn has neither text, image, nor file", () => {
       const result = buildAgentPrompt([
         { type: "message" as const, role: "user" as const, content: [] },
       ]);

--- a/src/gateway/openresponses-prompt.ts
+++ b/src/gateway/openresponses-prompt.ts
@@ -6,6 +6,8 @@ import {
 } from "./agent-prompt.js";
 import type { ContentPart, ItemParam } from "./open-responses.schema.js";
 
+const FILE_ONLY_USER_MESSAGE = "User sent file(s) with no text.";
+
 function extractTextContent(content: string | ContentPart[]): string {
   if (typeof content === "string") {
     return content;
@@ -26,6 +28,20 @@ function extractTextContent(content: string | ContentPart[]): string {
 
 function hasImageContent(content: string | ContentPart[]): boolean {
   return typeof content !== "string" && content.some((part) => part.type === "input_image");
+}
+
+function hasFileContent(content: string | ContentPart[]): boolean {
+  return typeof content !== "string" && content.some((part) => part.type === "input_file");
+}
+
+function placeholderForActiveTurn(content: string | ContentPart[]): string {
+  if (hasImageContent(content)) {
+    return IMAGE_ONLY_USER_MESSAGE;
+  }
+  if (hasFileContent(content)) {
+    return FILE_ONLY_USER_MESSAGE;
+  }
+  return "";
 }
 
 /** Index of the last user message item, or -1 when there is none. */
@@ -55,14 +71,15 @@ export function buildAgentPrompt(input: string | ItemParam[]): {
   for (const [i, item] of input.entries()) {
     if (item.type === "message") {
       const content = extractTextContent(item.content).trim();
-      // Substitute a placeholder for an image-only active user turn so the turn
-      // is not dropped and the downstream agent command (which requires non-empty
-      // message text) still runs with the attached image, matching /v1/chat/completions.
-      // Historical image-only turns stay skipped because their bytes are not replayed.
+      // Substitute a placeholder for an image-only or file-only active user turn
+      // so the turn is not dropped and the downstream agent command (which requires
+      // non-empty message text) still runs with the attached image or file context,
+      // matching /v1/chat/completions. Historical media-only turns stay skipped
+      // because their bytes are not replayed.
       const body =
         content ||
-        (item.role === "user" && i === activeUserMessageIndex && hasImageContent(item.content)
-          ? IMAGE_ONLY_USER_MESSAGE
+        (item.role === "user" && i === activeUserMessageIndex
+          ? placeholderForActiveTurn(item.content)
           : "");
       if (!body) {
         continue;


### PR DESCRIPTION
## Summary

A `/v1/responses` turn whose only content is an `input_file` (a document or PDF upload, with the instruction carried in `instructions` or with no text at all) is rejected with `400 Missing user message in input.`, even though the file is fully parsed and folded into the agent's system prompt. The byte-equivalent image-only turn returns `200`.

This is the file-only sibling that the image-only fix (#92488) left open: that change taught the OpenResponses prompt builder to substitute a placeholder for an image-only active user turn, but not for a file-only one.

## Root cause

The OpenResponses prompt builder only knows about text and images:

```ts
// src/gateway/openresponses-prompt.ts (before)
function hasImageContent(content) {
  return typeof content !== "string" && content.some((p) => p.type === "input_image");
}
const body =
  content ||
  (item.role === "user" && i === activeUserMessageIndex && hasImageContent(item.content)
    ? IMAGE_ONLY_USER_MESSAGE
    : "");
```

For a file-only turn `extractTextContent` returns `""` and `hasImageContent` is `false`, so `prompt.message` comes back empty. The handler guard then rejects it:

```ts
// src/gateway/openresponses-http.ts
if (!prompt.message) {
  sendJson(res, 400, { error: { message: "Missing user message in `input`.", ... } });
  return true;
}
```

The file is already extracted into `fileContexts` and merged into `extraSystemPrompt` (together with `instructions`) before this guard runs, so the content exists, the turn just never reaches the agent. The `instructions` field cannot satisfy the guard because it lands in the system prompt, not in `prompt.message`.

This mirrors the image-only bug exactly: chat completions guards `!prompt.message && images.length === 0`, while responses guards `!prompt.message` alone and relies on the prompt builder to supply a placeholder.

## Fix

Teach the prompt builder about file-only turns, the same way it already handles image-only turns:

```ts
function hasFileContent(content) {
  return typeof content !== "string" && content.some((p) => p.type === "input_file");
}

function placeholderForActiveTurn(content) {
  if (hasImageContent(content)) return IMAGE_ONLY_USER_MESSAGE;
  if (hasFileContent(content)) return FILE_ONLY_USER_MESSAGE;
  return "";
}

const body =
  content ||
  (item.role === "user" && i === activeUserMessageIndex
    ? placeholderForActiveTurn(item.content)
    : "");
```

An active file-only user turn now gets a non-empty placeholder, so it clears the `!prompt.message` guard and runs with the extracted file content attached via `extraSystemPrompt` (and any rendered images via `images`). The empty-input case (no text, no image, no file) still returns `400`.

## Why not one-sided

- `buildAgentPrompt` is the single chokepoint for the responses prompt, so both the streaming and non-streaming `/v1/responses` paths are covered by this one change (they share `const prompt = buildAgentPrompt(payload.input)` and the same `!prompt.message` guard).
- It covers both file extraction outcomes: a text-extractable document (content goes to `extraSystemPrompt`) and a PDF that renders to images (content goes to `images` plus a context marker). Both arrive as an `input_file` part, so `hasFileContent` matches regardless of how the file extracts. Both are exercised by the regression tests below.
- Chat completions does not extract files at all (no `input_file` handling in `src/gateway/openai-http.ts`), so there is no sibling endpoint to change. The new placeholder is therefore responses-local, unlike `IMAGE_ONLY_USER_MESSAGE` which stays shared because both endpoints use it.

## Verification

- `node scripts/run-vitest.mjs src/gateway/openresponses-parity.test.ts` -> file-only placeholder, file-with-text, and empty-input unit cases pass.
- `node scripts/run-vitest.mjs src/gateway/openresponses-http.test.ts` -> 87 passed, including the new file-only document e2e case.
- `node scripts/run-vitest.mjs src/gateway/openresponses-http.file-only.test.ts` -> file-only PDF-rendered-to-images turn returns 200 with images forwarded.
- `npx oxfmt --check` + `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json` on the changed files -> clean.
- `pnpm tsgo:core` + `pnpm tsgo:core:test` -> clean.

## Real behavior proof

Behavior addressed: a `/v1/responses` turn whose only `input` content is an `input_file` document (instruction supplied via `instructions`) now returns 200 and reaches the agent with the file content attached, instead of being rejected with `400 Missing user message in input.`.

Real environment tested: the real gateway `/v1/responses` HTTP handler running on a local server with OpenResponses enabled, driven over HTTP with `fetch`; the same file-only document request was sent against the pre-patch build and the patched build (the agent runtime call was stubbed at its boundary so the request resolves without a live model, exactly as in the image-only path).

Exact steps or command run after this patch: start the gateway HTTP server locally with OpenResponses enabled, then `POST /v1/responses` with `instructions: "Summarize the attached document."` and a single `input_file` (base64 `text/plain`, `filename: doc.txt`) as the only content of the user message; capture the HTTP status, the response body, and whether the agent command was invoked, before and after the patch.

Evidence after fix:

```
# BEFORE (origin/main, file-only document turn)
POST /v1/responses  ->  400
{"error":{"message":"Missing user message in `input`.","type":"invalid_request_error"}}
agent invoked:                 false
agent message:                 null
file content in system prompt: false

# AFTER (this patch, identical request)
POST /v1/responses  ->  200
{"id":"resp_117b83dd-acef-4630-8ac2-65a20d7e5786","object":"response","created_a...
agent invoked:                 true
agent message:                 "User sent file(s) with no text."
file content in system prompt: true
```

Observed result after fix: the identical file-only document request that previously returned `400 Missing user message in input.` and never invoked the agent now returns `200`, invokes the agent with a non-empty message, and forwards the extracted file content in the system prompt.

What was not tested: a live end-to-end run against a real upstream model provider (the agent runtime was stubbed at its boundary to keep the proof hermetic); the PDF-renders-to-images path is covered by `openresponses-http.file-only.test.ts` with the file-render boundary stubbed rather than a real scanned PDF.

Sibling of #92488 (image-only `/v1/responses` fix).
