### PR TITLE
feat(onboard): show upfront ETA timeline during setup wizard (fixes #74399)

### DIFF
--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1185,6 +1185,37 @@ describe("runSetupWizard", () => {
     expect(matchingQuickStartNotes.length).toBeGreaterThan(0);
   });
 
+  it("shows an upfront ETA timeline before setup choices", async () => {
+    const note: WizardPrompter["note"] = vi.fn(async () => {});
+    const prompter = buildWizardPrompter({ note });
+    const runtime = createRuntime();
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        authChoice: "skip",
+        installDaemon: false,
+        skipProviders: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      runtime,
+      prompter,
+    );
+
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("plan for up to ~40 minutes"),
+      "Setup timeline",
+    );
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("Typical timeline:"),
+      "Setup timeline",
+    );
+  });
+
   it("localizes the quickstart summary", async () => {
     const previousPort = process.env.OPENCLAW_GATEWAY_PORT;
     const previousLocale = process.env.OPENCLAW_LOCALE;

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -43,6 +43,15 @@ type ConfigLoggingModule = typeof import("../config/logging.js");
 type ModelPickerModule = typeof import("../commands/model-picker.js");
 type OnboardConfigModule = typeof import("../commands/onboard-config.js");
 
+const ONBOARDING_TIMELINE_NOTE = [
+  "Setup can take a while on a fresh machine — plan for up to ~40 minutes if OpenClaw needs to install dependencies, build UI assets, or configure channel runtimes.",
+  "Typical timeline:",
+  "1. Choose setup mode and accept the security note (1-2 min)",
+  "2. Configure gateway, auth, model, skills, and channels (5-15 min)",
+  "3. Install or verify local runtime dependencies (10-25 min)",
+  "4. Run health checks and launch the dashboard/TUI (2-5 min)",
+].join("\n");
+
 let authChoiceModulePromise: Promise<AuthChoiceModule> | undefined;
 let configLoggingModulePromise: Promise<ConfigLoggingModule> | undefined;
 let modelPickerModulePromise: Promise<ModelPickerModule> | undefined;
@@ -231,6 +240,7 @@ export async function runSetupWizard(
   const onboardHelpers = await import("../commands/onboard-helpers.js");
   onboardHelpers.printWizardHeader(runtime);
   await prompter.intro(t("wizard.setup.intro"));
+  await prompter.note(ONBOARDING_TIMELINE_NOTE, "Setup timeline");
   await requireRiskAcknowledgement({ opts, prompter });
 
   const snapshot = await readSetupConfigFileSnapshot();


### PR DESCRIPTION
## What

Adds a `Setup timeline` note to `runSetupWizard` that displays immediately after the intro prompt, telling users to plan for up to ~40 minutes and breaking down the typical phases.

## Why

Issue #74399: `openclaw onboard` takes ~40 minutes on a fresh machine but gives no upfront indication. Beginners expect a quick setup and are frustrated when it drags on with no ETA. A prior PR (#75622) attempted this but was self-closed.

## How

- Add `ONBOARDING_TIMELINE_NOTE` constant in `src/wizard/setup.ts` with a 4-phase breakdown
- Call `prompter.note(ONBOARDING_TIMELINE_NOTE, "Setup timeline")` after `prompter.intro()` and before `requireRiskAcknowledgement()`
- Add test in `src/wizard/setup.test.ts` verifying the note appears with expected content

## Real behavior proof

- **Behavior addressed:** Show upfront ETA timeline during `openclaw onboard` setup wizard
- **Environment tested:** macOS arm64, Node v22, OpenClaw main branch
- **Steps run after the patch:**
  1. `node scripts/run-vitest.mjs run src/wizard/setup.test.ts` — 20 tests passed
  2. `pnpm build` — succeeded
  3. `grep -n` confirmed constant at line 46, note call at line 243, test at line 1188
- **Evidence after fix:**

```
$ grep -n 'ONBOARDING_TIMELINE_NOTE\|Setup timeline' src/wizard/setup.ts
46:const ONBOARDING_TIMELINE_NOTE = [
243:  await prompter.note(ONBOARDING_TIMELINE_NOTE, "Setup timeline");

$ node scripts/run-vitest.mjs run src/wizard/setup.test.ts
 ✓  wizard  src/wizard/setup.test.ts (20 tests) 187ms
 Test Files  1 passed (1)
      Tests  20 passed (20)

$ pnpm build
✓ built in 517ms
```

- **Observed result after fix:** Setup wizard now shows a timeline note with 4-phase breakdown after the intro prompt. All 20 tests pass including the new ETA timeline test.
- **What was not tested:** Actual end-to-end `openclaw onboard` run (requires fresh environment with no existing config). The test verifies the note is called with correct content via mocked prompter.
