### PR TITLE
fix(provider): expose session identity to stream hooks

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -657,6 +657,11 @@ API key auth, and dynamic model resolution.
       | 41 | `validateReplayTurns` | Strict replay-turn validation before the embedded runner |
       | 42 | `onModelSelected` | Post-selection callback (e.g. telemetry) |
 
+      `createStreamFn` receives request-scoped `sessionId` and `sessionKey`
+      when the caller is an agent turn, compaction, or `/btw` side question.
+      Use them only for local per-conversation transport state, such as native
+      CLI session maps or audit correlation.
+
       Runtime fallback notes:
 
       - `normalizeConfig` checks the matched provider first, then other hook-capable provider plugins until one actually changes the config. If no provider hook rewrites a supported Google-family config entry, the bundled Google config normalizer still applies.

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -1091,11 +1091,17 @@ describe("runBtwSideQuestion", () => {
       .mockReturnValue(makeAsyncEvents([createDoneEvent("Ollama Cloud answer.")]));
     registerProviderStreamForModelMock.mockReturnValue(providerStreamFn);
 
-    const result = await runSideQuestion({ provider: "ollama", model: "glm-5.1" });
+    const result = await runSideQuestion({
+      provider: "ollama",
+      model: "glm-5.1",
+      sessionKey: DEFAULT_SESSION_KEY,
+    });
 
     expect(result).toEqual({ text: "Ollama Cloud answer." });
     const registerParams = expectRecordFields(mockArg(registerProviderStreamForModelMock, 0, 0), {
       workspaceDir: "/tmp/workspace",
+      sessionId: "session-1",
+      sessionKey: DEFAULT_SESSION_KEY,
     });
     expectRecordFields(registerParams.model, {
       provider: "ollama",

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -681,6 +681,8 @@ export async function runBtwSideQuestion(
     agentDir: params.agentDir,
     workspaceDir,
     env: process.env,
+    sessionId,
+    sessionKey: params.sessionKey,
   });
   const streamFn = resolveEmbeddedAgentStreamFn({
     currentStreamFn: streamSimple,

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1509,6 +1509,8 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       config: undefined,
       agentDir: "/tmp",
       effectiveWorkspace: "/tmp",
+      sessionId: "session-compact",
+      sessionKey: "agent:main:telegram:direct:user-1",
     });
 
     expect(result).toBe(streamFn);
@@ -1519,6 +1521,8 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     expectRecordFields(streamRegistration, {
       agentDir: "/tmp",
       workspaceDir: "/tmp",
+      sessionId: "session-compact",
+      sessionKey: "agent:main:telegram:direct:user-1",
     });
     expectRecordFields(streamRegistration.model, {
       provider: "ollama",

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -292,12 +292,16 @@ function resolveCompactionProviderStream(params: {
   config?: OpenClawConfig;
   agentDir: string;
   effectiveWorkspace: string;
+  sessionId?: string;
+  sessionKey?: string;
 }) {
   return registerProviderStreamForModel({
     model: params.effectiveModel,
     cfg: params.config,
     agentDir: params.agentDir,
     workspaceDir: params.effectiveWorkspace,
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
   });
 }
 
@@ -1248,6 +1252,8 @@ async function compactEmbeddedAgentSessionDirectOnce(
         config: params.config,
         agentDir,
         effectiveWorkspace,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
       });
       while (true) {
         // Rebuild the compaction session on retry so provider wrappers, payload

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2712,6 +2712,8 @@ export async function runEmbeddedAttempt(
         cfg: params.config,
         agentDir,
         workspaceDir: effectiveWorkspace,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
       });
       const streamStrategy = describeEmbeddedAgentStreamStrategy({
         currentStreamFn: defaultSessionStreamFn,

--- a/src/agents/provider-stream.test.ts
+++ b/src/agents/provider-stream.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Model } from "../llm/types.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveProviderStreamFn: vi.fn(),
+  ensureCustomApiRegistered: vi.fn(),
+  createTransportAwareStreamFnForModel: vi.fn(),
+}));
+
+vi.mock("../plugins/provider-runtime.js", () => ({
+  resolveProviderStreamFn: mocks.resolveProviderStreamFn,
+}));
+
+vi.mock("./custom-api-registry.js", () => ({
+  ensureCustomApiRegistered: mocks.ensureCustomApiRegistered,
+}));
+
+vi.mock("./provider-transport-stream.js", () => ({
+  createTransportAwareStreamFnForModel: mocks.createTransportAwareStreamFnForModel,
+}));
+
+const { registerProviderStreamForModel } = await import("./provider-stream.js");
+
+function buildModel(): Model {
+  return {
+    id: "claude-sonnet-4.6",
+    name: "Claude Sonnet 4.6",
+    api: "anthropic-messages",
+    provider: "claude-cli",
+    baseUrl: "https://example.invalid",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8_192,
+  };
+}
+
+describe("registerProviderStreamForModel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes request-scoped session identity to provider createStreamFn context", () => {
+    const streamFn = vi.fn();
+    const model = buildModel();
+    mocks.resolveProviderStreamFn.mockReturnValue(streamFn);
+
+    const result = registerProviderStreamForModel({
+      model,
+      agentDir: "/tmp/agent",
+      workspaceDir: "/tmp/workspace",
+      sessionId: "session-123",
+      sessionKey: "agent:main:telegram:direct:user-1",
+    });
+
+    expect(result).toBe(streamFn);
+    expect(mocks.resolveProviderStreamFn).toHaveBeenCalledOnce();
+    expect(mocks.resolveProviderStreamFn.mock.calls[0]?.[0].context).toMatchObject({
+      agentDir: "/tmp/agent",
+      workspaceDir: "/tmp/workspace",
+      provider: "claude-cli",
+      modelId: "claude-sonnet-4.6",
+      model,
+      sessionId: "session-123",
+      sessionKey: "agent:main:telegram:direct:user-1",
+    });
+    expect(mocks.ensureCustomApiRegistered).toHaveBeenCalledWith("anthropic-messages", streamFn);
+  });
+});

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -17,6 +17,8 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
   agentDir?: string;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  sessionId?: string;
+  sessionKey?: string;
   allowRuntimePluginLoad?: boolean;
 }): StreamFn | undefined {
   const streamFn =
@@ -33,6 +35,8 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
         provider: params.model.provider,
         modelId: params.model.id,
         model: params.model,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
       },
     }) ??
     createTransportAwareStreamFnForModel(params.model, {
@@ -40,6 +44,8 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
       env: params.env,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
     });
   if (!streamFn) {
     return undefined;

--- a/src/agents/provider-transport-stream.ts
+++ b/src/agents/provider-transport-stream.ts
@@ -39,6 +39,8 @@ type ProviderTransportStreamContext = {
   agentDir?: string;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  sessionId?: string;
+  sessionKey?: string;
 };
 
 function createProviderOwnedGoogleTransportStreamFn(
@@ -58,6 +60,8 @@ function createProviderOwnedGoogleTransportStreamFn(
         provider: model.provider,
         modelId: model.id,
         model,
+        sessionId: ctx?.sessionId,
+        sessionKey: ctx?.sessionKey,
       },
     }) ??
     resolveProviderStreamFn({
@@ -72,6 +76,8 @@ function createProviderOwnedGoogleTransportStreamFn(
         provider: model.provider,
         modelId: model.id,
         model,
+        sessionId: ctx?.sessionId,
+        sessionKey: ctx?.sessionKey,
       },
     }) ??
     undefined

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -460,10 +460,16 @@ describe("provider-runtime", () => {
         provider: "claude-cli",
         modelId: "claude-sonnet-4-6",
         model: MODEL,
+        sessionId: "session-1",
+        sessionKey: "agent:main:telegram:direct:user-1",
       },
     });
 
     expect(createStreamFn).toHaveBeenCalledOnce();
+    expect(createStreamFn.mock.calls[0]?.[0]).toMatchObject({
+      sessionId: "session-1",
+      sessionKey: "agent:main:telegram:direct:user-1",
+    });
     expectRecordFields(getLastResolvePluginProvidersParams(), {
       providerRefs: ["claude-cli"],
       modelRefs: ["claude-cli/claude-sonnet-4-6", "claude-sonnet-4-6"],

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -898,6 +898,10 @@ export type ProviderCreateStreamFnContext = {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel;
+  /** OpenClaw conversation session id for request-scoped provider state. */
+  sessionId?: string;
+  /** Semantic session key; prefer this over sessionId for local routing decisions. */
+  sessionKey?: string;
 };
 
 /**


### PR DESCRIPTION
Refs #73488

## Summary
- Add optional `sessionId` and `sessionKey` to `ProviderCreateStreamFnContext`.
- Thread that request-scoped identity through provider stream registration for embedded agent turns, compaction, and `/btw` side questions.
- Keep one-off image/simple-completion callers identity-free, and document the `createStreamFn` context contract for provider plugin authors.

## Verification
- `node scripts/run-vitest.mjs src/agents/provider-stream.test.ts src/plugins/provider-runtime.test.ts src/agents/btw.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts`
- `node scripts/run-vitest.mjs src/agents/simple-completion-transport.test.ts src/media-understanding/image.test.ts`
- `git diff --check`
- `pnpm docs:list`
- `pnpm tsgo:core`

## Real behavior proof
Behavior addressed: provider plugins using `createStreamFn` can now key local request/session state by the current OpenClaw conversation instead of collapsing concurrent conversations for the same agent/workspace.

Real environment tested: local OpenClaw source checkout on macOS, branch `codex/provider-stream-session-context`, commit `5dff2e548e5782dcb660e14111ab9e855202cc2e`, Node `v25.9.0`, pnpm `11.2.2`.

Exact steps or command run after this patch: from the repo root, ran a local runtime proof with `pnpm exec tsx`. The proof imported OpenClaw runtime modules, installed a local provider plugin into the active plugin registry, then invoked the normal provider stream registration path twice:

`registerProviderStreamForModel -> resolveProviderStreamFn -> local provider createStreamFn`

This was not a Vitest run and did not use `vi.fn`/mock assertions. The copied terminal output below is from the runtime proof command.

Evidence after fix:
Redacted terminal output copied from local runtime proof:

```json
{
  "proof": "OpenClaw provider createStreamFn receives request-scoped session identity",
  "branch": "codex/provider-stream-session-context",
  "runtimePath": "registerProviderStreamForModel -> resolveProviderStreamFn -> local provider createStreamFn",
  "providerPlugin": {
    "pluginId": "proof-local-provider-plugin",
    "providerId": "proof-local-provider"
  },
  "observedCreateStreamFnContexts": [
    {
      "provider": "proof-local-provider",
      "modelId": "proof-model-a",
      "sessionId": "proof-session-a-redacted",
      "sessionKey": "agent:main:channel:direct:user-a-redacted",
      "stateKey": "agent:main:channel:direct:user-a-redacted",
      "stateCalls": 1
    },
    {
      "provider": "proof-local-provider",
      "modelId": "proof-model-b",
      "sessionId": "proof-session-b-redacted",
      "sessionKey": "agent:main:channel:direct:user-b-redacted",
      "stateKey": "agent:main:channel:direct:user-b-redacted",
      "stateCalls": 1
    }
  ],
  "pluginSessionState": [
    {
      "stateKey": "agent:main:channel:direct:user-a-redacted",
      "provider": "proof-local-provider",
      "modelId": "proof-model-a",
      "sessionId": "proof-session-a-redacted",
      "sessionKey": "agent:main:channel:direct:user-a-redacted",
      "calls": 1
    },
    {
      "stateKey": "agent:main:channel:direct:user-b-redacted",
      "provider": "proof-local-provider",
      "modelId": "proof-model-b",
      "sessionId": "proof-session-b-redacted",
      "sessionKey": "agent:main:channel:direct:user-b-redacted",
      "calls": 1
    }
  ],
  "result": {
    "distinctSessionIds": true,
    "distinctSessionKeys": true,
    "isolatedPluginState": true
  }
}
```

Observed result after fix: the same provider plugin received two distinct request-scoped identities through `ProviderCreateStreamFnContext`, and the plugin's local state map stayed split by `sessionKey` for the two conversations.

What was not tested: a full gateway/native GlueClaw E2E with an external provider account was not run; the proof above exercises the OpenClaw provider runtime hook with a local provider plugin.
