### PR TITLE
fix(channels): expose runtime controls in CLI

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -26,6 +26,7 @@ openclaw channels capabilities --channel discord --target channel:123
 openclaw channels capabilities --channel discord --target channel:<voice-channel-id>
 openclaw channels resolve --channel slack "#general" "@jane"
 openclaw channels logs --channel all
+openclaw channels restart --channel whatsapp --account default
 ```
 
 `channels list` shows chat channels only: configured accounts by default, with `installed`, `configured`, and `enabled` status tags per account. Pass `--all` to also surface bundled channels that have no configured account yet and installable catalog channels that are not yet on disk. Auth providers (OAuth + API keys) and model-provider usage/quota snapshots are no longer printed here; use `openclaw models auth list` for provider auth profiles and `openclaw status` or `openclaw models list` for usage.
@@ -36,6 +37,9 @@ openclaw channels logs --channel all
 - `channels capabilities`: `--channel <name>`, `--account <id>` (only with `--channel`), `--target <dest>`, `--timeout <ms>`, `--json`
 - `channels resolve`: `<entries...>`, `--channel <name>`, `--account <id>`, `--kind <auto|user|group>`, `--json`
 - `channels logs`: `--channel <name|all>`, `--lines <n>`, `--json`
+- `channels start`: `--channel <name>`, `--account <id>`
+- `channels stop`: `--channel <name>`, `--account <id>`
+- `channels restart`: `--channel <name>`, `--account <id>`
 
 `channels status --probe` is the live path: on a reachable gateway it runs per-account
 `probeAccount` and optional `auditAccount` checks, so output can include transport
@@ -48,6 +52,23 @@ Do not use `openclaw sessions`, Gateway `sessions.list`, or the agent
 stored conversation rows, not provider runtime state. After a Discord provider
 restart, a connected but quiet account may be healthy while no Discord session
 row appears until the next inbound or outbound conversation event.
+
+## Runtime lifecycle
+
+Use `channels start`, `channels stop`, and `channels restart` to control an
+already configured runtime-backed channel account through the running Gateway
+without rerunning interactive login:
+
+```bash
+openclaw channels start --channel whatsapp --account default
+openclaw channels stop --channel whatsapp --account default
+openclaw channels restart --channel whatsapp --account default
+```
+
+`restart` calls the Gateway stop path for the selected account before starting
+it again. These commands do not remove local auth state, clear channel config,
+or start a QR/login flow; use `channels login` or `channels logout` when you
+need to create or clear provider credentials.
 
 ## Add / remove accounts
 

--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -1,6 +1,6 @@
 // Channel auth CLI tests cover channel auth command routing and credential prompts.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { runChannelLogin, runChannelLogout } from "./channel-auth.js";
+import { runChannelLogin, runChannelLogout, runChannelRuntimeCommand } from "./channel-auth.js";
 
 const mocks = vi.hoisted(() => ({
   resolveAgentWorkspaceDir: vi.fn(),
@@ -558,6 +558,119 @@ describe("channel-auth", () => {
     expect(mocks.resolveAccount).not.toHaveBeenCalled();
     expect(mocks.logoutAccount).not.toHaveBeenCalled();
     expect(mocks.setVerbose).not.toHaveBeenCalled();
+  });
+
+  it("starts a linked channel runtime through the live gateway without running auth login", async () => {
+    mocks.callGateway.mockResolvedValueOnce({ started: true });
+
+    await runChannelRuntimeCommand({ channel: "whatsapp", account: " acct-2 " }, "start", runtime);
+
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      config: { channels: { whatsapp: {} } },
+      method: "channels.start",
+      params: {
+        channel: "whatsapp",
+        accountId: "acct-2",
+      },
+      mode: "backend",
+      clientName: "gateway-client",
+      deviceIdentity: null,
+    });
+    expect(mocks.login).not.toHaveBeenCalled();
+    expect(mocks.logoutAccount).not.toHaveBeenCalled();
+    expect(readFirstLogMessage(runtime)).toContain("Channel start completed for whatsapp/acct-2.");
+  });
+
+  it("stops a linked channel runtime through the live gateway without clearing auth", async () => {
+    mocks.callGateway.mockResolvedValueOnce({ stopped: true });
+
+    await runChannelRuntimeCommand({ channel: "whatsapp", account: "acct-2" }, "stop", runtime);
+
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      config: { channels: { whatsapp: {} } },
+      method: "channels.stop",
+      params: {
+        channel: "whatsapp",
+        accountId: "acct-2",
+      },
+      mode: "backend",
+      clientName: "gateway-client",
+      deviceIdentity: null,
+    });
+    expect(mocks.logoutAccount).not.toHaveBeenCalled();
+    expect(readFirstLogMessage(runtime)).toContain("Channel stop completed for whatsapp/acct-2.");
+  });
+
+  it("restarts a linked channel runtime by stopping before starting the resolved account", async () => {
+    mocks.callGateway
+      .mockResolvedValueOnce({ stopped: true })
+      .mockResolvedValueOnce({ started: true });
+
+    await runChannelRuntimeCommand({ channel: "whatsapp" }, "restart", runtime);
+
+    expect(mocks.resolveChannelDefaultAccountId).toHaveBeenCalledWith({
+      plugin,
+      cfg: { channels: { whatsapp: {} } },
+    });
+    expect(mocks.callGateway).toHaveBeenNthCalledWith(1, {
+      config: { channels: { whatsapp: {} } },
+      method: "channels.stop",
+      params: {
+        channel: "whatsapp",
+        accountId: "default-account",
+      },
+      mode: "backend",
+      clientName: "gateway-client",
+      deviceIdentity: null,
+    });
+    expect(mocks.callGateway).toHaveBeenNthCalledWith(2, {
+      config: { channels: { whatsapp: {} } },
+      method: "channels.start",
+      params: {
+        channel: "whatsapp",
+        accountId: "default-account",
+      },
+      mode: "backend",
+      clientName: "gateway-client",
+      deviceIdentity: null,
+    });
+    expect(readFirstLogMessage(runtime)).toContain(
+      "Channel restart completed for whatsapp/default-account.",
+    );
+  });
+
+  it("throws when channel does not support runtime start", async () => {
+    mocks.getChannelPlugin.mockReturnValueOnce({
+      id: "whatsapp",
+      auth: { login: mocks.login },
+      gateway: { logoutAccount: mocks.logoutAccount },
+      config: {
+        listAccountIds: vi.fn().mockReturnValue(["default"]),
+        resolveAccount: mocks.resolveAccount,
+      },
+    });
+    mocks.loadChannelSetupPluginRegistrySnapshotForChannel.mockReturnValueOnce({
+      channels: [
+        {
+          plugin: {
+            id: "whatsapp",
+            auth: { login: mocks.login },
+            gateway: { logoutAccount: mocks.logoutAccount },
+            config: {
+              listAccountIds: vi.fn().mockReturnValue(["default"]),
+              resolveAccount: mocks.resolveAccount,
+            },
+          },
+        },
+      ],
+      channelSetups: [],
+    });
+
+    await expect(
+      runChannelRuntimeCommand({ channel: "whatsapp" }, "start", runtime),
+    ).rejects.toThrow(
+      'Channel "whatsapp" does not support start. Run `openclaw channels status --channel whatsapp` to inspect supported actions.',
+    );
   });
 
   it("falls back to local auth cleanup when a local gateway logout is unreachable", async () => {

--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -601,6 +601,39 @@ describe("channel-auth", () => {
     expect(readFirstLogMessage(runtime)).toContain("Channel stop completed for whatsapp/acct-2.");
   });
 
+  it("allows stop-only gateway adapters to use the runtime stop command", async () => {
+    const stopOnlyPlugin = {
+      id: "whatsapp",
+      auth: { login: mocks.login },
+      gateway: { stopAccount: vi.fn() },
+      config: {
+        listAccountIds: vi.fn().mockReturnValue(["default"]),
+        resolveAccount: mocks.resolveAccount,
+      },
+    };
+    mocks.getChannelPlugin.mockReturnValueOnce(stopOnlyPlugin as typeof plugin);
+    mocks.loadChannelSetupPluginRegistrySnapshotForChannel.mockReturnValueOnce({
+      channels: [{ plugin: stopOnlyPlugin }],
+      channelSetups: [],
+    });
+    mocks.callGateway.mockResolvedValueOnce({ stopped: true });
+
+    await runChannelRuntimeCommand({ channel: "whatsapp", account: "acct-2" }, "stop", runtime);
+
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      config: { channels: { whatsapp: {} } },
+      method: "channels.stop",
+      params: {
+        channel: "whatsapp",
+        accountId: "acct-2",
+      },
+      mode: "backend",
+      clientName: "gateway-client",
+      deviceIdentity: null,
+    });
+    expect(mocks.logoutAccount).not.toHaveBeenCalled();
+    expect(readFirstLogMessage(runtime)).toContain("Channel stop completed for whatsapp/acct-2.");
+  });
   it("restarts a linked channel runtime by stopping before starting the resolved account", async () => {
     mocks.callGateway
       .mockResolvedValueOnce({ stopped: true })

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -20,7 +20,7 @@ import { formatCliCommand } from "./command-format.js";
 import { formatUnsupportedChannelActionMessage } from "./error-format.js";
 import { commitConfigWithPendingPluginInstalls } from "./plugins-install-record-commit.js";
 
-type ChannelAuthOptions = {
+type ChannelRuntimeOptions = {
   channel?: string;
   account?: string;
   verbose?: boolean;
@@ -28,9 +28,20 @@ type ChannelAuthOptions = {
 
 type ChannelPlugin = NonNullable<ReturnType<typeof getChannelPlugin>>;
 type ChannelAuthMode = "login" | "logout";
+type ChannelRuntimeMode = "start" | "stop" | "restart";
+type ChannelActionMode = ChannelAuthMode | ChannelRuntimeMode;
 
-function supportsChannelAuthMode(plugin: ChannelPlugin, mode: ChannelAuthMode): boolean {
-  return mode === "login" ? Boolean(plugin.auth?.login) : Boolean(plugin.gateway?.logoutAccount);
+function supportsChannelActionMode(plugin: ChannelPlugin, mode: ChannelActionMode): boolean {
+  if (mode === "login") {
+    return Boolean(plugin.auth?.login);
+  }
+  if (mode === "logout") {
+    return Boolean(plugin.gateway?.logoutAccount);
+  }
+  if (mode === "stop") {
+    return Boolean(plugin.gateway?.startAccount || plugin.gateway?.logoutAccount);
+  }
+  return Boolean(plugin.gateway?.startAccount);
 }
 
 function isConfiguredAuthPlugin(plugin: ChannelPlugin, cfg: OpenClawConfig): boolean {
@@ -67,9 +78,9 @@ function isConfiguredAuthPlugin(plugin: ChannelPlugin, cfg: OpenClawConfig): boo
   return false;
 }
 
-function resolveConfiguredAuthChannelInput(cfg: OpenClawConfig, mode: ChannelAuthMode): string {
+function resolveConfiguredAuthChannelInput(cfg: OpenClawConfig, mode: ChannelActionMode): string {
   const configured = listChannelPlugins()
-    .filter((plugin): plugin is ChannelPlugin => supportsChannelAuthMode(plugin, mode))
+    .filter((plugin): plugin is ChannelPlugin => supportsChannelActionMode(plugin, mode))
     .filter((plugin) => isConfiguredAuthPlugin(plugin, cfg))
     .map((plugin) => plugin.id);
 
@@ -88,8 +99,8 @@ function resolveConfiguredAuthChannelInput(cfg: OpenClawConfig, mode: ChannelAut
 }
 
 async function resolveChannelPluginForMode(
-  opts: ChannelAuthOptions,
-  mode: ChannelAuthMode,
+  opts: ChannelRuntimeOptions,
+  mode: ChannelActionMode,
   cfg: OpenClawConfig,
   runtime: RuntimeEnv,
 ): Promise<{
@@ -108,8 +119,8 @@ async function resolveChannelPluginForMode(
     runtime,
     rawChannel: channelInput,
     ...(normalizedChannelId ? { channelId: normalizedChannelId } : {}),
-    allowInstall: true,
-    supports: (candidate) => supportsChannelAuthMode(candidate, mode),
+    allowInstall: mode === "login" || mode === "logout",
+    supports: (candidate) => supportsChannelActionMode(candidate, mode),
   });
   const channelId = resolved.channelId ?? normalizedChannelId;
   if (!channelId) {
@@ -118,7 +129,7 @@ async function resolveChannelPluginForMode(
     );
   }
   const plugin = resolved.plugin;
-  if (!plugin || !supportsChannelAuthMode(plugin, mode)) {
+  if (!plugin || !supportsChannelActionMode(plugin, mode)) {
     throw new Error(
       formatUnsupportedChannelActionMessage({
         channel: channelId,
@@ -138,7 +149,7 @@ async function resolveChannelPluginForMode(
 
 function resolveAccountContext(
   plugin: ChannelPlugin,
-  opts: ChannelAuthOptions,
+  opts: ChannelRuntimeOptions,
   cfg: OpenClawConfig,
 ) {
   const accountId =
@@ -212,8 +223,77 @@ async function logoutViaGatewayRuntime(params: {
   }
 }
 
+async function callChannelRuntimeGateway(params: {
+  cfg: OpenClawConfig;
+  method: "channels.start" | "channels.stop";
+  channelId: string;
+  accountId: string;
+}) {
+  return await callGateway({
+    config: params.cfg,
+    method: params.method,
+    params: {
+      channel: params.channelId,
+      accountId: params.accountId,
+    },
+    mode: GATEWAY_CLIENT_MODES.BACKEND,
+    clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+    deviceIdentity: null,
+  });
+}
+
+function formatChannelRuntimeResult(params: {
+  action: ChannelRuntimeMode;
+  channelId: string;
+  accountId: string;
+  payload: unknown;
+}): string {
+  const payload = params.payload && typeof params.payload === "object" ? params.payload : {};
+  const actionFlag =
+    params.action === "start" ? "started" : params.action === "stop" ? "stopped" : "started";
+  const succeeded = (payload as Record<string, unknown>)[actionFlag] === true;
+  const state = succeeded ? "completed" : "requested";
+  return `Channel ${params.action} ${state} for ${params.channelId}/${params.accountId}.`;
+}
+
+export async function runChannelRuntimeCommand(
+  opts: ChannelRuntimeOptions,
+  action: ChannelRuntimeMode,
+  runtime: RuntimeEnv = defaultRuntime,
+) {
+  const autoEnabled = applyPluginAutoEnable({
+    config: getRuntimeConfig(),
+    env: process.env,
+  });
+  const loadedCfg = autoEnabled.config;
+  const resolvedChannel = await resolveChannelPluginForMode(opts, action, loadedCfg, runtime);
+  const { accountId } = resolveAccountContext(resolvedChannel.plugin, opts, resolvedChannel.cfg);
+  if (action === "restart") {
+    await callChannelRuntimeGateway({
+      cfg: resolvedChannel.cfg,
+      method: "channels.stop",
+      channelId: resolvedChannel.plugin.id,
+      accountId,
+    });
+  }
+  const result = await callChannelRuntimeGateway({
+    cfg: resolvedChannel.cfg,
+    method: action === "stop" ? "channels.stop" : "channels.start",
+    channelId: resolvedChannel.plugin.id,
+    accountId,
+  });
+  runtime.log(
+    formatChannelRuntimeResult({
+      action,
+      channelId: resolvedChannel.plugin.id,
+      accountId,
+      payload: result,
+    }),
+  );
+}
+
 export async function runChannelLogin(
-  opts: ChannelAuthOptions,
+  opts: ChannelRuntimeOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
   const sourceSnapshotPromise = readConfigFileSnapshot().catch(() => null);
@@ -262,7 +342,7 @@ export async function runChannelLogin(
 }
 
 export async function runChannelLogout(
-  opts: ChannelAuthOptions,
+  opts: ChannelRuntimeOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
   const sourceSnapshotPromise = readConfigFileSnapshot().catch(() => null);

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -39,7 +39,9 @@ function supportsChannelActionMode(plugin: ChannelPlugin, mode: ChannelActionMod
     return Boolean(plugin.gateway?.logoutAccount);
   }
   if (mode === "stop") {
-    return Boolean(plugin.gateway?.startAccount || plugin.gateway?.logoutAccount);
+    return Boolean(
+      plugin.gateway?.startAccount || plugin.gateway?.stopAccount || plugin.gateway?.logoutAccount,
+    );
   }
   return Boolean(plugin.gateway?.startAccount);
 }

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -6,7 +6,7 @@ import { danger } from "../globals.js";
 import { defaultRuntime } from "../runtime.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
-import { runChannelLogin, runChannelLogout } from "./channel-auth.js";
+import { runChannelLogin, runChannelLogout, runChannelRuntimeCommand } from "./channel-auth.js";
 import { formatCliChannelOptions } from "./channel-options.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
 import { hasExplicitOptions } from "./command-options.js";
@@ -111,6 +111,7 @@ export async function registerChannelsCli(
             "Add or update a channel account non-interactively.",
           ],
           ["openclaw channels login --channel whatsapp", "Link a WhatsApp Web account."],
+          ["openclaw channels restart --channel whatsapp", "Restart a linked channel listener."],
         ])}\n\n${theme.muted("Docs:")} ${formatDocsLink(
           "/cli/channels",
           "docs.openclaw.ai/cli/channels",
@@ -251,6 +252,60 @@ export async function registerChannelsCli(
         const hasFlags = hasExplicitOptions(command, optionNamesRemove);
         await channelsRemoveCommand(opts, defaultRuntime, { hasFlags });
       });
+    });
+
+  channels
+    .command("start")
+    .description("Start a linked channel listener without relinking")
+    .option("--channel <channel>", "Channel alias (auto when only one is configured)")
+    .option("--account <id>", "Account id (accountId)")
+    .action(async (opts) => {
+      await runChannelsCommandWithDanger(async () => {
+        await runChannelRuntimeCommand(
+          {
+            channel: opts.channel as string | undefined,
+            account: opts.account as string | undefined,
+          },
+          "start",
+          defaultRuntime,
+        );
+      }, "Channel start failed");
+    });
+
+  channels
+    .command("stop")
+    .description("Stop a linked channel listener without clearing auth")
+    .option("--channel <channel>", "Channel alias (auto when only one is configured)")
+    .option("--account <id>", "Account id (accountId)")
+    .action(async (opts) => {
+      await runChannelsCommandWithDanger(async () => {
+        await runChannelRuntimeCommand(
+          {
+            channel: opts.channel as string | undefined,
+            account: opts.account as string | undefined,
+          },
+          "stop",
+          defaultRuntime,
+        );
+      }, "Channel stop failed");
+    });
+
+  channels
+    .command("restart")
+    .description("Restart a linked channel listener without relinking")
+    .option("--channel <channel>", "Channel alias (auto when only one is configured)")
+    .option("--account <id>", "Account id (accountId)")
+    .action(async (opts) => {
+      await runChannelsCommandWithDanger(async () => {
+        await runChannelRuntimeCommand(
+          {
+            channel: opts.channel as string | undefined,
+            account: opts.account as string | undefined,
+          },
+          "restart",
+          defaultRuntime,
+        );
+      }, "Channel restart failed");
     });
 
   channels


### PR DESCRIPTION
Fixes #75153

Adds `openclaw channels start`, `openclaw channels stop`, and `openclaw channels restart` so linked channel listeners can be controlled through the existing gateway `channels.start` / `channels.stop` RPCs without rerunning login or clearing auth. `restart` stops the resolved account before starting it again, and runtime control does not trigger channel auth login/logout flows.

Validation:
- `node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.cli.config.ts --reporter=dot src/cli/channel-auth.test.ts`
- `node node_modules/oxfmt/bin/oxfmt --check --threads=1 src/cli/channel-auth.ts src/cli/channel-auth.test.ts src/cli/channels-cli.ts`
- `node node_modules/oxfmt/bin/oxfmt --check --threads=1 docs/cli/channels.md`
- `node node_modules/oxlint/bin/oxlint src/cli/channel-auth.ts src/cli/channel-auth.test.ts src/cli/channels-cli.ts`
- `git diff --check`