### PR TITLE
fix(cli): tolerate deleted startup cwd

### DIFF
--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -545,6 +545,7 @@ function resolveInfraShardName(file) {
     name.startsWith("home-dir") ||
     name.startsWith("host-env") ||
     name.startsWith("openclaw-exec-env") ||
+    name.startsWith("safe-cwd") ||
     name.startsWith("secret") ||
     name.startsWith("secure-random")
   ) {

--- a/src/cli/dotenv.ts
+++ b/src/cli/dotenv.ts
@@ -2,12 +2,15 @@
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { loadGlobalRuntimeDotEnvFiles, loadWorkspaceDotEnvFile } from "../infra/dotenv.js";
+import { tryProcessCwd } from "../infra/safe-cwd.js";
 
 /** Load `.env` files for normal CLI commands without overriding existing process env. */
 export function loadCliDotEnv(opts?: { quiet?: boolean }) {
   const quiet = opts?.quiet ?? true;
-  const cwdEnvPath = path.join(process.cwd(), ".env");
-  loadWorkspaceDotEnvFile(cwdEnvPath, { quiet });
+  const cwd = tryProcessCwd();
+  if (cwd) {
+    loadWorkspaceDotEnvFile(path.join(cwd, ".env"), { quiet });
+  }
 
   // Then load the global fallback set without overriding any env vars that
   // were already set or loaded from CWD. This includes the Ubuntu fresh-install

--- a/src/cli/gateway-dispatch-dotenv.ts
+++ b/src/cli/gateway-dispatch-dotenv.ts
@@ -3,12 +3,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { loadGlobalRuntimeDotEnvFiles } from "../infra/dotenv-global.js";
+import { tryProcessCwd } from "../infra/safe-cwd.js";
 
 /** Load only the env files needed before dispatching a command through the gateway. */
 export async function loadGatewayDispatchCliDotEnv(opts?: { quiet?: boolean }) {
   const quiet = opts?.quiet ?? true;
-  const cwdEnvPath = path.join(process.cwd(), ".env");
-  if (fs.existsSync(cwdEnvPath)) {
+  const cwd = tryProcessCwd();
+  if (cwd && fs.existsSync(path.join(cwd, ".env"))) {
     const { loadCliDotEnv } = await import("./dotenv.js");
     loadCliDotEnv({ quiet });
     return;

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -11,6 +11,7 @@ import { isMainModule } from "../infra/is-main.js";
 import type { ProxyHandle } from "../infra/net/proxy/proxy-lifecycle.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
+import { tryProcessCwd } from "../infra/safe-cwd.js";
 import type { PluginManifestCommandAliasRegistry } from "../plugins/manifest-command-aliases.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
 import { normalizeGeneratedHelpCommandArgv, normalizeRootHelpTargetArgv } from "./argv.js";
@@ -296,7 +297,8 @@ export function resolveMissingPluginCommandMessage(
 }
 
 function shouldLoadCliDotEnv(env: NodeJS.ProcessEnv = process.env): boolean {
-  if (existsSync(path.join(process.cwd(), ".env"))) {
+  const cwd = tryProcessCwd();
+  if (cwd && existsSync(path.join(cwd, ".env"))) {
     return true;
   }
   return existsSync(path.join(resolveStateDir(env), ".env"));

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -73,6 +73,13 @@ const WINDOWS_SHELL_TRUST_ROOT_ENV_KEYS = [
   "WINDIR",
 ] as const;
 
+const PATH_OVERRIDE_ENV_KEYS = [
+  "OPENCLAW_AGENT_DIR",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_OAUTH_DIR",
+  "PI_CODING_AGENT_DIR",
+] as const;
+
 async function writeEnvFile(filePath: string, contents: string) {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, contents, "utf8");
@@ -91,23 +98,13 @@ function expectEnvUndefined(keys: readonly string[]) {
 }
 
 async function withIsolatedEnvAndCwd(run: () => Promise<void>) {
-  const prevEnv = { ...process.env };
+  const prevEnv = process.env;
+  process.env = { ...prevEnv };
   try {
     await run();
   } finally {
     vi.restoreAllMocks();
-    for (const key of Object.keys(process.env)) {
-      if (!(key in prevEnv)) {
-        delete process.env[key];
-      }
-    }
-    for (const [key, value] of Object.entries(prevEnv)) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
+    process.env = prevEnv;
   }
 }
 
@@ -471,17 +468,11 @@ describe("loadDotEnv", () => {
           ].join("\n"),
         );
 
-        delete process.env.OPENCLAW_AGENT_DIR;
-        delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
-        delete process.env.OPENCLAW_OAUTH_DIR;
-        delete process.env.PI_CODING_AGENT_DIR;
+        clearEnv(PATH_OVERRIDE_ENV_KEYS);
 
         loadWorkspaceDotEnvFile(path.join(cwdDir, ".env"), { quiet: true });
 
-        expect(process.env.OPENCLAW_AGENT_DIR).toBeUndefined();
-        expect(process.env.OPENCLAW_BUNDLED_PLUGINS_DIR).toBeUndefined();
-        expect(process.env.OPENCLAW_OAUTH_DIR).toBeUndefined();
-        expect(process.env.PI_CODING_AGENT_DIR).toBeUndefined();
+        expectEnvUndefined(PATH_OVERRIDE_ENV_KEYS);
       });
     });
   });

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -225,6 +225,24 @@ describe("loadDotEnv", () => {
     });
   });
 
+  it("skips workspace .env and still loads global env when cwd was deleted", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ stateDir }) => {
+        await writeEnvFile(path.join(stateDir, ".env"), "FOO=from-global\n");
+        vi.spyOn(process, "cwd").mockImplementation(() => {
+          throw Object.assign(new Error("ENOENT: no such file or directory, uv_cwd"), {
+            code: "ENOENT",
+          });
+        });
+        delete process.env.FOO;
+
+        loadDotEnv({ quiet: true });
+
+        expect(process.env.FOO).toBe("from-global");
+      });
+    });
+  });
+
   it("loads the Ubuntu gateway.env compatibility fallback after ~/.openclaw/.env", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ base, cwdDir }) => {
@@ -686,6 +704,24 @@ describe("loadCliDotEnv", () => {
 
         expect(process.env.FOO).toBe("from-global");
         expect(process.env.BAR).toBe("from-gateway");
+      });
+    });
+  });
+
+  it("still loads global CLI env when cwd was deleted", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ stateDir }) => {
+        await writeEnvFile(path.join(stateDir, ".env"), "FOO=from-global\n");
+        vi.spyOn(process, "cwd").mockImplementation(() => {
+          throw Object.assign(new Error("ENOENT: no such file or directory, uv_cwd"), {
+            code: "ENOENT",
+          });
+        });
+        delete process.env.FOO;
+
+        loadCliDotEnv({ quiet: true });
+
+        expect(process.env.FOO).toBe("from-global");
       });
     });
   });

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -10,6 +10,7 @@ import {
   isDangerousHostEnvVarName,
   normalizeEnvVarKey,
 } from "./host-env-security.js";
+import { tryProcessCwd } from "./safe-cwd.js";
 
 const logger = createSubsystemLogger("infra:dotenv");
 
@@ -297,8 +298,10 @@ export { loadGlobalRuntimeDotEnvFiles };
 
 export function loadDotEnv(opts?: { quiet?: boolean }) {
   const quiet = opts?.quiet ?? true;
-  const cwdEnvPath = path.join(process.cwd(), ".env");
-  loadWorkspaceDotEnvFile(cwdEnvPath, { quiet });
+  const cwd = tryProcessCwd();
+  if (cwd) {
+    loadWorkspaceDotEnvFile(path.join(cwd, ".env"), { quiet });
+  }
 
   // Then load global fallback: ~/.openclaw/.env (or OPENCLAW_STATE_DIR/.env),
   // without overriding any env vars already present.

--- a/src/infra/home-dir.test.ts
+++ b/src/infra/home-dir.test.ts
@@ -1,6 +1,7 @@
 // Tests OpenClaw home directory resolution.
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   expandHomePrefix,
   resolveEffectiveHomeDir,
@@ -165,6 +166,24 @@ describe("resolveRequiredHomeDir", () => {
     },
   ])("$name", ({ env, homedir, expected }) => {
     expect(resolveRequiredHomeDir(env, homedir)).toBe(expected);
+  });
+
+  it("falls back to the OS temp dir when no home source exists and cwd was deleted", () => {
+    const cwdSpy = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw Object.assign(new Error("ENOENT: no such file or directory, uv_cwd"), {
+        code: "ENOENT",
+      });
+    });
+
+    try {
+      expect(
+        resolveRequiredHomeDir({} as NodeJS.ProcessEnv, () => {
+          throw new Error("no home");
+        }),
+      ).toBe(path.resolve(os.tmpdir()));
+    } finally {
+      cwdSpy.mockRestore();
+    }
   });
 });
 

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -1,6 +1,7 @@
 // Resolves OpenClaw home and platform-specific config directories.
 import os from "node:os";
 import path from "node:path";
+import { resolveProcessCwdOrFallback } from "./safe-cwd.js";
 
 function normalize(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -75,7 +76,9 @@ export function resolveRequiredHomeDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = os.homedir,
 ): string {
-  return resolveEffectiveHomeDir(env, homedir) ?? path.resolve(process.cwd());
+  return (
+    resolveEffectiveHomeDir(env, homedir) ?? path.resolve(resolveProcessCwdOrFallback(os.tmpdir()))
+  );
 }
 
 /** Resolves the OS home or falls back to cwd when no OS home source exists. */
@@ -83,7 +86,7 @@ export function resolveRequiredOsHomeDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = os.homedir,
 ): string {
-  return resolveOsHomeDir(env, homedir) ?? path.resolve(process.cwd());
+  return resolveOsHomeDir(env, homedir) ?? path.resolve(resolveProcessCwdOrFallback(os.tmpdir()));
 }
 
 /** Expands leading `~`, `~/`, or `~\` with the effective home when one is known. */

--- a/src/infra/is-main.ts
+++ b/src/infra/is-main.ts
@@ -1,6 +1,7 @@
 // Identifies whether an ESM module is running as the process entry point.
 import fs from "node:fs";
 import path from "node:path";
+import { resolveProcessCwdOrFallback } from "./safe-cwd.js";
 
 type IsMainModuleOptions = {
   currentFile: string;
@@ -28,13 +29,8 @@ function normalizePathCandidate(candidate: string | undefined, cwd: string): str
 }
 
 function resolveDefaultCwd(currentFile: string): string {
-  try {
-    return process.cwd();
-  } catch {
-    // `process.cwd()` can throw when the launch directory was removed; entrypoint checks should
-    // still work relative to the current module path.
-    return path.dirname(currentFile);
-  }
+  // Entry point checks still work relative to the current module path when the launch cwd is gone.
+  return resolveProcessCwdOrFallback(path.dirname(currentFile));
 }
 
 /** Detects whether a module is executing as the process entrypoint, including wrapper launches. */

--- a/src/infra/path-env.test.ts
+++ b/src/infra/path-env.test.ts
@@ -232,6 +232,35 @@ describe("ensureOpenClawCliOnPath", () => {
     },
   );
 
+  it("skips project-local bin fallback when cwd was deleted", () => {
+    const { tmp, appCli } = setupAppCliRoot("case-deleted-cwd");
+    const localBinDir = path.join(tmp, "node_modules", ".bin");
+    const localCli = path.join(localBinDir, "openclaw");
+    setDir(path.join(tmp, "node_modules"));
+    setDir(localBinDir);
+    setExe(localCli);
+
+    resetBootstrapEnv();
+    process.env.OPENCLAW_ALLOW_PROJECT_LOCAL_BIN = "1";
+    const cwdSpy = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw Object.assign(new Error("ENOENT: no such file or directory, uv_cwd"), {
+        code: "ENOENT",
+      });
+    });
+
+    try {
+      ensureOpenClawCliOnPath({
+        execPath: appCli,
+        homeDir: tmp,
+        platform: "darwin",
+      });
+    } finally {
+      cwdSpy.mockRestore();
+    }
+
+    expect((process.env.PATH ?? "").split(path.delimiter).includes(localBinDir)).toBe(false);
+  });
+
   it("prepends XDG_BIN_HOME ahead of other user bin fallbacks", () => {
     const { tmp, appCli } = setupAppCliRoot("case-xdg-bin-home");
     const xdgBinHome = path.join(tmp, "xdg-bin");

--- a/src/infra/path-env.ts
+++ b/src/infra/path-env.ts
@@ -8,6 +8,7 @@ import {
 } from "@openclaw/normalization-core/string-normalization";
 import { resolveBrewPathDirs } from "./brew.js";
 import { isTruthyEnvValue } from "./env.js";
+import { tryProcessCwd } from "./safe-cwd.js";
 
 type EnsureOpenClawPathOpts = {
   /** Executable whose directory should stay first for shebang-compatible child processes. */
@@ -80,7 +81,7 @@ function candidateBinDirs(
   existingPathParts: ReadonlySet<string>,
 ): { prepend: string[]; append: string[] } {
   const execPath = opts.execPath ?? process.execPath;
-  const cwd = opts.cwd ?? process.cwd();
+  const cwd = opts.cwd ?? tryProcessCwd();
   const homeDir = opts.homeDir ?? os.homedir();
   const platform = opts.platform ?? process.platform;
 
@@ -114,7 +115,7 @@ function candidateBinDirs(
   const allowProjectLocalBin =
     opts.allowProjectLocalBin === true ||
     isTruthyEnvValue(process.env.OPENCLAW_ALLOW_PROJECT_LOCAL_BIN);
-  if (allowProjectLocalBin) {
+  if (allowProjectLocalBin && cwd) {
     const localBinDir = path.join(cwd, "node_modules", ".bin");
     if (isExecutable(path.join(localBinDir, "openclaw"))) {
       append.push(localBinDir);

--- a/src/infra/safe-cwd.test.ts
+++ b/src/infra/safe-cwd.test.ts
@@ -1,0 +1,20 @@
+// Tests safe cwd helpers for deleted launch directories.
+import { describe, expect, it, vi } from "vitest";
+import { resolveProcessCwdOrFallback, tryProcessCwd } from "./safe-cwd.js";
+
+describe("safe cwd helpers", () => {
+  it("returns null when process.cwd throws", () => {
+    const cwdSpy = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw Object.assign(new Error("ENOENT: no such file or directory, uv_cwd"), {
+        code: "ENOENT",
+      });
+    });
+
+    try {
+      expect(tryProcessCwd()).toBeNull();
+      expect(resolveProcessCwdOrFallback("/fallback")).toBe("/fallback");
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
+});

--- a/src/infra/safe-cwd.ts
+++ b/src/infra/safe-cwd.ts
@@ -1,0 +1,12 @@
+// Safe process.cwd() helpers for launch paths that may run after the cwd was deleted.
+export function tryProcessCwd(): string | null {
+  try {
+    return process.cwd();
+  } catch {
+    return null;
+  }
+}
+
+export function resolveProcessCwdOrFallback(fallback: string): string {
+  return tryProcessCwd() ?? fallback;
+}

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -334,6 +334,26 @@ describe("resolveInitialTuiAgentId", () => {
       }),
     ).toBe("main");
   });
+
+  it("falls back when cwd was deleted before TUI startup", () => {
+    const cwdSpy = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw Object.assign(new Error("ENOENT: no such file or directory, uv_cwd"), {
+        code: "ENOENT",
+      });
+    });
+
+    try {
+      expect(
+        resolveInitialTuiAgentId({
+          cfg,
+          fallbackAgentId: "main",
+          initialSessionInput: "",
+        }),
+      ).toBe("main");
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
 });
 
 describe("resolveGatewayDisconnectState", () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -18,6 +18,7 @@ import type { CommandEntry } from "../../packages/gateway-protocol/src/index.js"
 import { resolveAgentIdByWorkspacePath, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
 import { isChatStopCommandText } from "../gateway/chat-abort.js";
+import { tryProcessCwd } from "../infra/safe-cwd.js";
 import { registerUncaughtExceptionHandler } from "../infra/unhandled-rejections.js";
 import { setConsoleSubsystemFilter } from "../logging/console.js";
 import { loggingState } from "../logging/state.js";
@@ -135,7 +136,8 @@ export function resolveLocalAuthSpawnOptions(params: {
 }
 
 export function resolveLocalAuthSpawnCwd(params: { args: string[]; defaultCwd?: string }): string {
-  const defaultCwd = params.defaultCwd ?? process.cwd();
+  const defaultCwd =
+    params.defaultCwd ?? tryProcessCwd() ?? path.dirname(OPENCLAW_CLI_WRAPPER_PATH);
   const entryArg = params.args[0]?.trim();
   if (!entryArg) {
     return defaultCwd;
@@ -196,10 +198,8 @@ export function resolveInitialTuiAgentId(params: {
     return normalizeAgentId(parsed.agentId);
   }
 
-  const inferredFromWorkspace = resolveAgentIdByWorkspacePath(
-    params.cfg,
-    params.cwd ?? process.cwd(),
-  );
+  const cwd = params.cwd ?? tryProcessCwd();
+  const inferredFromWorkspace = cwd ? resolveAgentIdByWorkspacePath(params.cfg, cwd) : null;
   if (inferredFromWorkspace) {
     return inferredFromWorkspace;
   }
@@ -510,6 +510,8 @@ function resolveEmptySessionInfoDefaults(config: OpenClawConfig): SessionInfo {
 export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   const isLocalMode = opts.local === true || opts.backend !== undefined;
   const config = opts.config ?? getRuntimeConfig({ skipPluginValidation: !isLocalMode });
+  const launchCwd = tryProcessCwd();
+  const fallbackLaunchCwd = launchCwd ?? path.dirname(OPENCLAW_CLI_WRAPPER_PATH);
   const emptySessionInfoDefaults = resolveEmptySessionInfoDefaults(config);
   const initialSessionInput = (opts.session ?? "").trim();
   let sessionScope: SessionScope = (config.session?.scope ?? "per-sender") as SessionScope;
@@ -519,7 +521,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     cfg: config,
     fallbackAgentId: agentDefaultId,
     initialSessionInput,
-    cwd: process.cwd(),
+    ...(launchCwd ? { cwd: launchCwd } : {}),
   });
   let agents: AgentSummary[] = [];
   const agentNames = new Map<string, string>();
@@ -799,7 +801,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
           thinkingLevels: sessionInfo.thinkingLevels,
           dynamicCommands: dynamicSlashCommandsKey === dynamicKey ? dynamicSlashCommands : [],
         }),
-        process.cwd(),
+        fallbackLaunchCwd,
       ),
     );
   };
@@ -1192,7 +1194,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
                 }
 
                 const child = spawn(command, args, {
-                  cwd: resolveLocalAuthSpawnCwd({ args, defaultCwd: process.cwd() }),
+                  cwd: resolveLocalAuthSpawnCwd({ args, defaultCwd: fallbackLaunchCwd }),
                   env: process.env,
                   stdio: "inherit",
                   ...resolveLocalAuthSpawnOptions({ command }),


### PR DESCRIPTION
Fixes #73676

Adds a small safe cwd helper for startup paths that may run after the invoking directory has been deleted. CLI/runtime dotenv loading now skips project-local `.env` when `process.cwd()` fails while still loading global env, PATH bootstrap no longer appends project-local bins without a valid cwd, home-dir required fallbacks avoid `uv_cwd`, and TUI agent inference falls back instead of crashing.

## Real behavior proof

Behavior addressed: CLI startup paths no longer assume `process.cwd()` is always available, so deleted working directories are handled by falling back or skipping project-local lookup instead of throwing `uv_cwd`.

Real environment tested: Windows 11 local OpenClaw source checkout on commit `41b9d012fad91ad012f4b665d53174f89d640d96`, Node.js from the local development environment.

Exact steps or command run after this patch:
```console
F:\ZPtarget\openclaw-issue-73676> node openclaw.mjs --version
```

Evidence after fix:
```console
OpenClaw 2026.6.2 (41b9d01)
```

Observed result after fix: The real CLI launcher starts and reports the patched commit version successfully after the startup-path changes. The deleted-cwd branches are covered by focused tests that force `process.cwd()` to throw the same `ENOENT: uv_cwd` shape and verify CLI dotenv loading, PATH bootstrap, home-dir fallback, and TUI agent inference do not crash.

What was not tested: Windows does not allow deleting the active current directory of the running shell, so I could not produce a literal `cd deleted-dir && openclaw tui` terminal transcript on this machine. The exact deleted-cwd failure mode is exercised by the new focused tests.

Validation:
- `node scripts/test-projects.mjs src/infra/safe-cwd.test.ts src/infra/dotenv.test.ts`
- `node scripts/test-projects.mjs src/cli/run-main.test.ts`
- `node scripts/test-projects.mjs src/infra/home-dir.test.ts`
- `node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.boundary.config.ts --reporter=dot src/infra/path-env.test.ts -t "skips project-local bin fallback when cwd was deleted"`
- `node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.tui.config.ts --reporter=dot src/tui/tui.test.ts`
- planner module check confirmed `src/infra/safe-cwd.test.ts` maps to `core-runtime-infra-env-auth` and does not emit `core-runtime-infra-misc`
- `node node_modules/oxfmt/bin/oxfmt --check --threads=1 src/infra/safe-cwd.ts src/infra/safe-cwd.test.ts src/cli/dotenv.ts src/cli/gateway-dispatch-dotenv.ts src/cli/run-main.ts src/infra/dotenv.ts src/infra/dotenv.test.ts src/infra/home-dir.ts src/infra/home-dir.test.ts src/infra/is-main.ts src/infra/path-env.ts src/infra/path-env.test.ts src/tui/tui.ts src/tui/tui.test.ts scripts/lib/ci-node-test-plan.mjs`
- `node node_modules/oxlint/bin/oxlint src/infra/safe-cwd.ts src/infra/safe-cwd.test.ts src/cli/dotenv.ts src/cli/gateway-dispatch-dotenv.ts src/cli/run-main.ts src/infra/dotenv.ts src/infra/dotenv.test.ts src/infra/home-dir.ts src/infra/home-dir.test.ts src/infra/is-main.ts src/infra/path-env.ts src/infra/path-env.test.ts src/tui/tui.ts src/tui/tui.test.ts scripts/lib/ci-node-test-plan.mjs`
- `git diff --check`