### PR TITLE
fix(bonjour): classify ciao 'no valid addresses' assertion as non-fatal (fixes #76499)

### DIFF
--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -416,6 +416,12 @@ export async function startGatewayBonjourAdvertiser(
         logger.warn(
           `bonjour: disabling mDNS — networkInterfaces() unavailable in this environment: ${classification.formatted}`,
         );
+      } else if (classification.kind === "no-valid-addresses") {
+        // IPv6-only or misconfigured interfaces have no address ciao considers
+        // valid.  Recovery would re-enter the same assertion immediately.
+        logger.warn(
+          `bonjour: disabling mDNS — no valid addresses for interface: ${classification.formatted}`,
+        );
       } else {
         const label =
           classification.kind === "netmask-assertion"
@@ -562,7 +568,14 @@ export async function startGatewayBonjourAdvertiser(
             svc,
           )}): ${classification.formatted}`,
         );
-        requestCiaoRecovery?.(classification);
+        // Skip recovery for non-recoverable classifications — the interface
+        // state won't change, so re-creating the advertiser would just fail again.
+        if (
+          classification.kind !== "interface-enumeration-failure" &&
+          classification.kind !== "no-valid-addresses"
+        ) {
+          requestCiaoRecovery?.(classification);
+        }
         return;
       }
       logger.warn(

--- a/extensions/bonjour/src/ciao.test.ts
+++ b/extensions/bonjour/src/ciao.test.ts
@@ -147,6 +147,29 @@ describe("bonjour-ciao", () => {
     expect(ignoreCiaoUnhandledRejection(wrapper)).toBe(true);
   });
 
+  it("classifies ciao no-valid-addresses assertion for IPv6-only interfaces", () => {
+    expect(
+      classifyCiaoUnhandledRejection(
+        Object.assign(
+          new Error("Could not find valid addresses for interface 'fly-redis'"),
+          { name: "AssertionError" },
+        ),
+      ),
+    ).toEqual({
+      kind: "no-valid-addresses",
+      formatted:
+        "AssertionError: Could not find valid addresses for interface 'fly-redis'",
+    });
+  });
+
+  it("suppresses ciao no-valid-addresses rejections as non-fatal", () => {
+    const error = Object.assign(
+      new Error("Could not find valid addresses for interface 'eth0'"),
+      { name: "AssertionError" },
+    );
+    expect(ignoreCiaoUnhandledRejection(error)).toBe(true);
+  });
+
   it("keeps unrelated rejections visible", () => {
     expect(ignoreCiaoUnhandledRejection(new Error("boom"))).toBe(false);
   });

--- a/extensions/bonjour/src/ciao.ts
+++ b/extensions/bonjour/src/ciao.ts
@@ -16,6 +16,9 @@ const CIAO_SELF_PROBE_MESSAGE_RE =
 // can refuse os.networkInterfaces(), which ciao calls during NetworkManager init.
 // Node surfaces this as a SystemError mentioning the libuv syscall by name.
 const CIAO_INTERFACE_ENUMERATION_FAILURE_RE = /\bUV_INTERFACE_ADDRESSES\b/u;
+// IPv6-only or otherwise misconfigured interfaces lack an address that ciao
+// considers valid.  Ciao throws an AssertionError and the gateway crash-loops.
+const CIAO_NO_VALID_ADDRESSES_RE = /COULD NOT FIND VALID ADDRESSES FOR INTERFACE\b/u;
 
 /** Known ciao process-level errors that OpenClaw handles specially. */
 export type CiaoProcessErrorClassification =
@@ -23,7 +26,8 @@ export type CiaoProcessErrorClassification =
   | { kind: "interface-assertion"; formatted: string }
   | { kind: "netmask-assertion"; formatted: string }
   | { kind: "self-probe"; formatted: string }
-  | { kind: "interface-enumeration-failure"; formatted: string };
+  | { kind: "interface-enumeration-failure"; formatted: string }
+  | { kind: "no-valid-addresses"; formatted: string };
 
 /** Classify a ciao error/rejection chain into a known category. */
 export function classifyCiaoProcessError(reason: unknown): CiaoProcessErrorClassification | null {
@@ -51,6 +55,9 @@ export function classifyCiaoProcessError(reason: unknown): CiaoProcessErrorClass
     }
     if (CIAO_INTERFACE_ENUMERATION_FAILURE_RE.test(message)) {
       return { kind: "interface-enumeration-failure", formatted };
+    }
+    if (CIAO_NO_VALID_ADDRESSES_RE.test(message)) {
+      return { kind: "no-valid-addresses", formatted };
     }
   }
   return null;


### PR DESCRIPTION
## Summary

Add a regex pattern for the ciao `AssertionError: Could not find valid addresses for interface '<name>'` thrown when a network interface (e.g. IPv6-only WireGuard on Fly.io) lacks an address that `@homebridge/ciao` considers valid.

Without this classification, the error propagates as an unhandled promise rejection and the gateway crash-loops (systemd restart → same assertion → exit 1 → restart).

The fix is modeled after the existing `interface-enumeration-failure` classification: log a single warning and skip recovery, since re-creating the advertiser would immediately hit the same assertion.

## Changes

- **`extensions/bonjour/src/ciao.ts`**: Add `CIAO_NO_VALID_ADDRESSES_RE` regex + `no-valid-addresses` classification kind + classification check in `classifyCiaoProcessError`.
- **`extensions/bonjour/src/advertiser.ts`**: In `handleCiaoProcessError`, add `no-valid-addresses` branch that logs a warning and skips recovery (same pattern as `interface-enumeration-failure`). In `handleAdvertiseFailure`, skip `requestCiaoRecovery` for both non-recoverable kinds.
- **`extensions/bonjour/src/ciao.test.ts`**: Add 2 test cases — classification and non-fatal suppression.

## Real behavior proof

- **Behavior addressed:** Ciao `AssertionError: Could not find valid addresses for interface` thrown on IPv6-only interfaces is now classified as `no-valid-addresses` and suppressed instead of crashing the gateway.
- **Environment tested:** macOS 26.4.1, Node v24.3.0, openclaw main branch (`7e12a332`).
- **Steps run after the patch:**
  1. Ran `node scripts/run-vitest.mjs run extensions/bonjour/src/ciao.test.ts` — 17 tests passed (15 existing + 2 new).
  2. Ran `pnpm build` — completed successfully.
  3. Verified the new regex matches the error pattern with `node -e`.
- **Evidence after fix:**

```
$ node scripts/run-vitest.mjs run extensions/bonjour/src/ciao.test.ts
 ✓  extensions/bonjour/src/ciao.test.ts (17 tests) 63ms
 Test Files  1 passed (1)
      Tests  17 passed (17)

$ grep -n "no-valid-addresses\|NO_VALID_ADDRESSES" extensions/bonjour/src/ciao.ts extensions/bonjour/src/advertiser.ts
extensions/bonjour/src/ciao.ts:21:const CIAO_NO_VALID_ADDRESSES_RE = /COULD NOT FIND VALID ADDRESSES FOR INTERFACE\b/u;
extensions/bonjour/src/ciao.ts:30:  | { kind: "no-valid-addresses"; formatted: string };
extensions/bonjour/src/ciao.ts:59:    if (CIAO_NO_VALID_ADDRESSES_RE.test(message)) {
extensions/bonjour/src/ciao.ts:60:      return { kind: "no-valid-addresses", formatted };
extensions/bonjour/src/advertiser.ts:419:      } else if (classification.kind === "no-valid-addresses") {
extensions/bonjour/src/advertiser.ts:575:          classification.kind !== "no-valid-addresses"

$ node -e "const re = /COULD NOT FIND VALID ADDRESSES FOR INTERFACE\b/u; const msg = \"AssertionError: Could not find valid addresses for interface 'fly-redis'\".toUpperCase(); console.log('regex match:', re.test(msg))"
regex match: true
```

- **Observed result after fix:** The `no-valid-addresses` classification correctly matches the ciao assertion, tests pass, and the advertiser skips recovery for this non-recoverable error kind.
- **What was not tested:** Live reproduction with an IPv6-only network interface (requires specific network configuration). The classification logic is verified via unit tests with the exact error message from the ciao source.
