### PR TITLE
Add agent role eval harness

### DIFF
--- a/.github/workflows/agent-role-evals.yml
+++ b/.github/workflows/agent-role-evals.yml
@@ -1,0 +1,32 @@
+name: Agent Role Evals
+
+on:
+  schedule:
+    - cron: "37 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agent-role-evals-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.x"
+
+jobs:
+  contract-catalog:
+    name: Agent role contract catalog
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install-bun: "false"
+      - name: Validate role contracts
+        run: pnpm agents:eval:contracts

--- a/package.json
+++ b/package.json
@@ -1873,7 +1873,9 @@
     "ui:i18n:report": "node --import tsx scripts/control-ui-i18n-report.ts",
     "ui:i18n:sync": "node --import tsx scripts/control-ui-i18n.ts sync --write",
     "ui:install": "node scripts/ui.js install",
-    "verify": "node scripts/verify.mjs"
+    "verify": "node scripts/verify.mjs",
+    "agents:eval": "node scripts/agent-role-eval.mjs",
+    "agents:eval:contracts": "node scripts/agent-role-eval.mjs --contracts-only"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "0.22.1",

--- a/scripts/agent-role-eval.mjs
+++ b/scripts/agent-role-eval.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+import process from "node:process";
+import {
+  AGENT_ROLE_CONTRACTS,
+  AGENT_ROLE_CONTRACT_BY_ID,
+  DEFAULT_SELF_CONTAINED_LIVE_MODEL,
+  createSelfContainedLiveEvalEnvironment,
+  defaultConfigPath,
+  evaluateAgentRoleContractCatalog,
+  evaluateAgentStaticContracts,
+  loadConfigFile,
+  runLiveAgentEval,
+} from "./lib/agent-role-evals.mjs";
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/agent-role-eval.mjs [--config <path>] [--json]",
+    "  node scripts/agent-role-eval.mjs --contracts-only [--json]",
+    "  node scripts/agent-role-eval.mjs --live [--agent <id>] [--model <id>] [--timeout <seconds>] [--self-contained] [--json]",
+    "",
+    "Default mode runs deterministic static contract checks.",
+    "--contracts-only validates the checked-in role contract catalog without private local agent state.",
+    "--live runs real local agent turns against the same role contracts.",
+    "--self-contained creates temporary agent workspaces/config/state for live evals.",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const args = {
+    configPath: defaultConfigPath(),
+    json: false,
+    live: false,
+    contractsOnly: false,
+    selfContained: false,
+    keepSelfContainedState: false,
+    timeoutSeconds: 180,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") {
+      continue;
+    } else if (arg === "--config") {
+      args.configPath = argv[++index];
+    } else if (arg === "--agent") {
+      args.agentId = argv[++index];
+    } else if (arg === "--model") {
+      args.model = argv[++index];
+    } else if (arg === "--timeout") {
+      args.timeoutSeconds = Number(argv[++index]);
+    } else if (arg === "--live") {
+      args.live = true;
+    } else if (arg === "--self-contained") {
+      args.selfContained = true;
+    } else if (arg === "--keep-self-contained-state") {
+      args.keepSelfContainedState = true;
+    } else if (arg === "--contracts-only") {
+      args.contractsOnly = true;
+    } else if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!Number.isFinite(args.timeoutSeconds) || args.timeoutSeconds <= 0) {
+    throw new Error("--timeout must be a positive number of seconds");
+  }
+  if (args.selfContained && !args.live) {
+    throw new Error("--self-contained is only supported with --live");
+  }
+  return args;
+}
+
+function printCatalogText(result) {
+  console.log(`Agent role contract catalog: ${result.ok ? "passed" : "failed"}`);
+  console.log(`Contracts checked: ${result.contractCount}`);
+  console.log(`Critical contracts required: ${result.criticalContractCount}`);
+  if (result.issues.length > 0) {
+    console.log("");
+    for (const issue of result.issues) {
+      console.log(`- [${issue.severity}] ${issue.agentId} ${issue.code}: ${issue.message}`);
+    }
+  }
+}
+
+function printStaticText(result) {
+  console.log(`Agent role static eval: ${result.ok ? "passed" : "failed"}`);
+  console.log(`Agents checked: ${result.agentCount}`);
+  console.log(`Contracts available: ${result.contractCount}`);
+  if (result.issues.length > 0) {
+    console.log("");
+    for (const issue of result.issues) {
+      console.log(`- [${issue.severity}] ${issue.agentId} ${issue.code}: ${issue.message}`);
+    }
+  }
+}
+
+function printLiveText(results) {
+  const failed = results.filter((entry) => !entry.ok);
+  console.log(`Agent role live eval: ${failed.length === 0 ? "passed" : "failed"}`);
+  console.log(`Agents checked: ${results.length}`);
+  for (const result of results) {
+    const model = result.provider && result.model ? ` ${result.provider}/${result.model}` : "";
+    const duration = result.durationMs ? ` ${result.durationMs}ms` : "";
+    console.log(`- ${result.ok ? "PASS" : "FAIL"} ${result.agentId}${model}${duration}`);
+    if (!result.ok) {
+      const detail = result.error ?? result.evaluation?.issues?.join("; ") ?? "unknown failure";
+      console.log(`  ${detail}`);
+    }
+  }
+}
+
+function runCatalog(args) {
+  const result = evaluateAgentRoleContractCatalog();
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    printCatalogText(result);
+  }
+  process.exitCode = result.ok ? 0 : 1;
+}
+
+function runStatic(args) {
+  const config = loadConfigFile(args.configPath);
+  const result = evaluateAgentStaticContracts(config);
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    printStaticText(result);
+  }
+  process.exitCode = result.ok ? 0 : 1;
+}
+
+function runLive(args) {
+  const contracts = args.agentId
+    ? [AGENT_ROLE_CONTRACT_BY_ID.get(args.agentId)].filter(Boolean)
+    : AGENT_ROLE_CONTRACTS;
+  if (args.agentId && contracts.length === 0) {
+    throw new Error(`No role eval contract exists for ${args.agentId}`);
+  }
+  let fixture;
+  let model = args.model;
+  let staticResult;
+  if (args.selfContained) {
+    model =
+      model ??
+      process.env.OPENCLAW_AGENT_ROLE_EVAL_MODEL ??
+      process.env.OPENCLAW_AGENT_EVAL_LIVE_MODEL ??
+      DEFAULT_SELF_CONTAINED_LIVE_MODEL;
+    fixture = createSelfContainedLiveEvalEnvironment(contracts, {
+      modelRef: model,
+      keep: args.keepSelfContainedState,
+    });
+    staticResult = evaluateAgentStaticContracts(fixture.config, {
+      stateDir: fixture.stateDir,
+    });
+    if (!staticResult.ok) {
+      const result = { ok: false, selfContained: true, staticResult, results: [] };
+      if (args.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        printStaticText(staticResult);
+      }
+      process.exitCode = 1;
+      fixture.cleanup();
+      return;
+    }
+  }
+
+  try {
+    const results = contracts.map((contract) =>
+      runLiveAgentEval(contract, {
+        model,
+        timeoutSeconds: args.timeoutSeconds,
+        env: fixture?.env,
+      }),
+    );
+    const ok = results.every((entry) => entry.ok);
+    if (args.json) {
+      console.log(
+        JSON.stringify(
+          {
+            ok,
+            selfContained: Boolean(fixture),
+            ...(staticResult ? { staticResult } : {}),
+            results,
+          },
+          null,
+          2,
+        ),
+      );
+    } else {
+      if (fixture) {
+        console.log(`Self-contained live eval state: prepared (${model})`);
+      }
+      printLiveText(results);
+    }
+    process.exitCode = ok ? 0 : 1;
+  } finally {
+    fixture?.cleanup();
+  }
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+  } else if (args.contractsOnly) {
+    runCatalog(args);
+  } else if (args.live) {
+    runLive(args);
+  } else {
+    runStatic(args);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/lib/agent-role-evals.mjs
+++ b/scripts/lib/agent-role-evals.mjs
@@ -1,0 +1,1121 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+const CORE_TOOL_PROFILES = Object.freeze({
+  minimal: ["session_status"],
+  coding: [
+    "read",
+    "write",
+    "edit",
+    "apply_patch",
+    "exec",
+    "process",
+    "code_execution",
+    "web_search",
+    "web_fetch",
+    "x_search",
+    "memory_search",
+    "memory_get",
+    "sessions_list",
+    "sessions_history",
+    "sessions_send",
+    "sessions_spawn",
+    "sessions_yield",
+    "subagents",
+    "session_status",
+    "cron",
+    "update_plan",
+    "image",
+    "image_generate",
+    "music_generate",
+    "video_generate",
+    "bundle-mcp",
+  ],
+  messaging: [
+    "sessions_list",
+    "sessions_history",
+    "sessions_send",
+    "session_status",
+    "message",
+    "bundle-mcp",
+  ],
+  full: ["*"],
+});
+
+const GENERIC_FAILURE_TERMS = Object.freeze([
+  "as an ai language model",
+  "i do not know my role",
+  "i don't know my role",
+  "cannot determine my role",
+  "unknown agent",
+  "no reply",
+  "ignore previous instructions",
+]);
+
+function contract(id, name, domain, task, expectedSignals, docTerms = expectedSignals) {
+  const [firstSignal, secondSignal, thirdSignal, fourthSignal = firstSignal] = expectedSignals;
+  return {
+    id,
+    name,
+    domain,
+    task,
+    expectedSignals,
+    docTerms,
+    forbiddenSignals: GENERIC_FAILURE_TERMS,
+    prompt: [
+      `Direct role-eval request for ${name}. Reply visibly; do not return NO_REPLY.`,
+      `Scenario: ${task}`,
+      `Role signal terms: ${expectedSignals.join(", ")}.`,
+      "Use at least two exact role signal terms from that list in the visible answer.",
+      "Put one exact role signal in ROLE and a different exact role signal in NEXT_ACTION.",
+      "Every label must include content after the colon; do not use slash commands as content.",
+      "For BLOCK_OR_ESCALATE, write CLEAR, BLOCKED: <reason>, or ESCALATE: <reason>.",
+      "Reply in exactly five short lines using this concrete answer shape:",
+      `ROLE: ${firstSignal} ${name}`,
+      `EVIDENCE: ${secondSignal} evidence`,
+      "RISK: risk",
+      `NEXT_ACTION: ${thirdSignal} ${fourthSignal}`,
+      "BLOCK_OR_ESCALATE: CLEAR",
+      "Stop immediately after the BLOCK_OR_ESCALATE line; do not repeat the template or add extra lines.",
+    ].join("\n"),
+  };
+}
+
+export const AGENT_ROLE_CONTRACTS = Object.freeze([
+  contract(
+    "main",
+    "Control Director",
+    "control",
+    "Route a high-risk user request to the right agent while staying truthful about what is verified.",
+    ["route", "verify", "evidence", "handoff", "block"],
+    ["control director", "todd", "route"],
+  ),
+  contract(
+    "strategic-director",
+    "Strategic Director",
+    "strategy",
+    "Assess a major direction decision and identify the highest-leverage next move.",
+    ["strategy", "tradeoff", "decision", "risk", "priority"],
+  ),
+  contract(
+    "judge",
+    "Judge",
+    "evaluation",
+    "Review a completion claim and decide whether evidence is sufficient.",
+    ["verdict", "evidence", "risk", "approve", "reject"],
+  ),
+  contract(
+    "program-manager",
+    "Program Manager",
+    "operations",
+    "Turn a multi-agent objective into milestones, owners, acceptance criteria, and status tracking.",
+    ["milestone", "owner", "acceptance", "status", "dependency"],
+  ),
+  contract(
+    "automation-playbook-architect",
+    "Automation & Playbook Architect",
+    "automation",
+    "Design a repeatable playbook with triggers, guardrails, rollback, and verification.",
+    ["playbook", "trigger", "guardrail", "rollback", "verification"],
+  ),
+  contract(
+    "telemetry-evaluation-analyst",
+    "Telemetry & Evaluation Analyst",
+    "evaluation",
+    "Convert runtime telemetry into an evaluation plan with metrics and failure thresholds.",
+    ["metric", "telemetry", "baseline", "threshold", "regression"],
+  ),
+  contract(
+    "browser-session-credential-steward",
+    "Browser / Session / Credential Steward",
+    "security",
+    "Handle a browser/session credential request without leaking secrets or overbroad access.",
+    ["credential", "session", "least privilege", "redact", "approval"],
+  ),
+  contract(
+    "market-research-analyst",
+    "Market Research Analyst",
+    "research",
+    "Research a market with source-backed facts, uncertainty, and competitor signals.",
+    ["source", "market", "competitor", "uncertainty", "trend"],
+  ),
+  contract(
+    "polymarket-market-watch-agent",
+    "Polymarket Market Watch Agent",
+    "prediction markets",
+    "Watch markets and flag notable movement without claiming unsupported causality.",
+    ["market", "movement", "liquidity", "watch", "evidence"],
+  ),
+  contract(
+    "polymarket-research-agent",
+    "Polymarket Research Agent",
+    "prediction markets",
+    "Research a prediction market using source-backed resolution criteria.",
+    ["source", "resolution", "market", "probability", "evidence"],
+  ),
+  contract(
+    "polymarket-risk-controller",
+    "Polymarket Risk Controller",
+    "risk",
+    "Decide whether a proposed market action violates risk controls.",
+    ["risk", "limit", "exposure", "block", "approval"],
+  ),
+  contract(
+    "polymarket-strategy-improvement-analyst",
+    "Polymarket Strategy Improvement Analyst",
+    "strategy",
+    "Evaluate strategy performance and propose a measurable improvement.",
+    ["strategy", "performance", "metric", "experiment", "drawdown"],
+  ),
+  contract(
+    "polymarket-mispricing-arbitrage-analyst",
+    "Polymarket Mispricing / Arbitrage Analyst",
+    "prediction markets",
+    "Assess whether a price discrepancy is real after fees, liquidity, and resolution risk.",
+    ["mispricing", "arbitrage", "fee", "liquidity", "resolution"],
+  ),
+  contract(
+    "prediction-market-position-exposure-monitor",
+    "Prediction Market Position Exposure Monitor",
+    "risk",
+    "Review position exposure and flag concentration or correlated-market risks.",
+    ["exposure", "position", "correlation", "limit", "risk"],
+  ),
+  contract(
+    "prediction-market-resolution-settlement-auditor",
+    "Prediction Market Resolution & Settlement Auditor",
+    "audit",
+    "Audit whether a market outcome can be graded from authoritative sources.",
+    ["resolution", "settlement", "source", "audit", "pending"],
+  ),
+  contract(
+    "prediction-market-execution-agent",
+    "Prediction Market Execution Agent",
+    "execution",
+    "Prepare an execution checklist that requires approvals and bounded paper/live limits.",
+    ["execution", "order", "limit", "approval", "slippage"],
+  ),
+  contract(
+    "topic-trend-researcher",
+    "Topic Trend Researcher",
+    "content",
+    "Find a topic trend and separate evidence-backed demand from vibes.",
+    ["trend", "source", "audience", "signal", "angle"],
+  ),
+  contract(
+    "script-writer",
+    "Script Writer",
+    "content",
+    "Draft a script structure for a specific audience and retention goal.",
+    ["hook", "outline", "audience", "script", "retention"],
+  ),
+  contract(
+    "publisher-scheduler",
+    "Publisher Scheduler",
+    "content operations",
+    "Schedule a publish plan with timing, dependencies, and fallback slots.",
+    ["schedule", "publish", "calendar", "dependency", "fallback"],
+  ),
+  contract(
+    "youtube-performance-analyst",
+    "YouTube Performance Analyst",
+    "analytics",
+    "Analyze video performance and recommend a testable improvement.",
+    ["retention", "click", "watch", "metric", "experiment"],
+  ),
+  contract(
+    "shorts-repurposer",
+    "Shorts Repurposer",
+    "content",
+    "Turn long-form content into short-form concepts with hooks and constraints.",
+    ["short", "hook", "clip", "repurpose", "format"],
+  ),
+  contract(
+    "comment-response-drafter",
+    "Comment Response Drafter",
+    "community",
+    "Draft safe, brand-appropriate replies to audience comments.",
+    ["comment", "tone", "reply", "brand", "escalate"],
+  ),
+  contract(
+    "offer-extraction-agent",
+    "Offer Extraction Agent",
+    "sales",
+    "Extract a clear offer, promise, audience, proof, and CTA from source material.",
+    ["offer", "audience", "proof", "cta", "promise"],
+  ),
+  contract(
+    "video-production-orchestrator",
+    "Video Production Orchestrator",
+    "production",
+    "Coordinate a video production workflow from brief to publish-ready asset.",
+    ["production", "asset", "owner", "deadline", "handoff"],
+  ),
+  contract(
+    "transcript-knowledge-distiller",
+    "Transcript Knowledge Distiller",
+    "knowledge",
+    "Distill a transcript into claims, source-backed lessons, and reusable notes.",
+    ["transcript", "claim", "source", "summary", "memory"],
+  ),
+  contract(
+    "newsletter-editor",
+    "Newsletter Editor",
+    "content",
+    "Edit a newsletter for clarity, structure, claims, and reader action.",
+    ["newsletter", "edit", "claim", "structure", "cta"],
+  ),
+  contract(
+    "curriculum-architect",
+    "Curriculum Architect",
+    "education",
+    "Design a curriculum path with outcomes, modules, and assessment gates.",
+    ["curriculum", "outcome", "module", "assessment", "sequence"],
+  ),
+  contract(
+    "lesson-builder",
+    "Lesson Builder",
+    "education",
+    "Build one lesson with objective, explanation, practice, and check for understanding.",
+    ["lesson", "objective", "practice", "assessment", "example"],
+  ),
+  contract(
+    "funnel-builder",
+    "Funnel Builder",
+    "growth",
+    "Build a funnel with audience, entry point, conversion step, and measurement.",
+    ["funnel", "audience", "conversion", "metric", "offer"],
+  ),
+  contract(
+    "book-drafting-agent",
+    "Book Drafting Agent",
+    "writing",
+    "Plan or draft a book section with thesis, structure, and continuity constraints.",
+    ["book", "chapter", "thesis", "outline", "continuity"],
+  ),
+  contract(
+    "asset-repurposer",
+    "Asset Repurposer",
+    "content",
+    "Repurpose one asset into multiple channel-ready variants.",
+    ["asset", "repurpose", "channel", "variant", "constraint"],
+  ),
+  contract(
+    "problem-miner",
+    "Problem Miner",
+    "product",
+    "Mine repeated problems from source material and rank by urgency/value.",
+    ["problem", "pain", "evidence", "rank", "customer"],
+  ),
+  contract(
+    "product-strategist",
+    "Product Strategist",
+    "product",
+    "Turn a customer problem into a product strategy and validation path.",
+    ["product", "customer", "positioning", "validation", "roadmap"],
+  ),
+  contract(
+    "engineering-spec-writer",
+    "Engineering Spec Writer",
+    "engineering",
+    "Write an engineering spec with scope, interfaces, risks, and acceptance tests.",
+    ["scope", "interface", "test", "risk", "acceptance"],
+  ),
+  contract(
+    "builder-agent",
+    "Builder Agent",
+    "engineering",
+    "Implement a scoped build task with verification and rollback notes.",
+    ["implement", "test", "diff", "verify", "rollback"],
+  ),
+  contract(
+    "qa-test-agent",
+    "QA Test Agent",
+    "quality",
+    "Design a focused test plan for a risky change.",
+    ["test", "coverage", "regression", "fixture", "edge"],
+  ),
+  contract(
+    "release-ops-agent",
+    "Release Ops Agent",
+    "release",
+    "Prepare a release readiness checklist with gates and rollback.",
+    ["release", "gate", "changelog", "rollback", "artifact"],
+  ),
+  contract(
+    "support-incident-response-agent",
+    "Support / Incident Response Agent",
+    "support",
+    "Triage an incident with severity, impact, mitigation, and customer communication.",
+    ["incident", "severity", "impact", "mitigation", "status"],
+  ),
+  contract(
+    "executive-assistant-agent",
+    "Executive Assistant Agent",
+    "assistant",
+    "Prioritize a busy day with constraints, deadlines, and delegated follow-ups.",
+    ["priority", "calendar", "follow-up", "deadline", "delegate"],
+  ),
+  contract(
+    "scheduling-booking-coordinator",
+    "Scheduling / Booking Coordinator",
+    "assistant",
+    "Coordinate scheduling with availability, constraints, and confirmation state.",
+    ["schedule", "availability", "confirm", "timezone", "constraint"],
+  ),
+  contract(
+    "email-triage-drafting-agent",
+    "Email Triage / Drafting Agent",
+    "assistant",
+    "Triage emails and draft a response while preserving approval boundaries.",
+    ["email", "triage", "draft", "approval", "priority"],
+  ),
+  contract(
+    "call-prep-follow-up-agent",
+    "Call Prep / Follow-up Agent",
+    "assistant",
+    "Prepare a call brief and follow-up checklist with open questions.",
+    ["call", "brief", "agenda", "follow-up", "question"],
+  ),
+  contract(
+    "research-brief-agent",
+    "Research Brief Agent",
+    "research",
+    "Prepare a concise research brief with sources, confidence, and open questions.",
+    ["brief", "source", "confidence", "question", "summary"],
+  ),
+  contract(
+    "hiring-screen-agent",
+    "Hiring Screen Agent",
+    "hiring",
+    "Screen a candidate against criteria while avoiding unsupported or biased claims.",
+    ["candidate", "criteria", "evidence", "bias", "recommendation"],
+  ),
+  contract(
+    "journal-check-in-coach",
+    "Journal Check-in Coach",
+    "coaching",
+    "Guide a reflective check-in without overclaiming or replacing professional care.",
+    ["journal", "reflect", "pattern", "next step", "boundary"],
+  ),
+  contract(
+    "pattern-detection-agent",
+    "Pattern Detection Agent",
+    "analysis",
+    "Detect repeated patterns from notes and separate evidence from speculation.",
+    ["pattern", "evidence", "frequency", "hypothesis", "confidence"],
+  ),
+  contract(
+    "direction-niche-advisor",
+    "Direction / Niche Advisor",
+    "strategy",
+    "Advise on niche direction using strengths, market evidence, and testable bets.",
+    ["niche", "direction", "evidence", "bet", "positioning"],
+  ),
+  contract(
+    "music-ideation-agent",
+    "Music Ideation Agent",
+    "music",
+    "Generate music ideas with mood, references, arrangement, and constraints.",
+    ["music", "mood", "reference", "arrangement", "constraint"],
+  ),
+  contract(
+    "arrangement-release-planner",
+    "Arrangement / Release Planner",
+    "music",
+    "Plan arrangement and release steps with dependencies and quality gates.",
+    ["arrangement", "release", "mix", "deadline", "asset"],
+  ),
+  contract(
+    "memory-knowledge-curator",
+    "Memory & Knowledge Curator",
+    "knowledge",
+    "Promote memory only with provenance, confidence, and privacy boundaries.",
+    ["memory", "provenance", "confidence", "source", "privacy"],
+  ),
+  contract(
+    "openbrain-local-smoke",
+    "OpenBrain Local Smoke",
+    "smoke",
+    "Verify the local memory/model integration without requiring unsafe tools.",
+    ["local", "smoke", "session", "model", "verify"],
+  ),
+]);
+
+export const AGENT_ROLE_CONTRACT_BY_ID = new Map(
+  AGENT_ROLE_CONTRACTS.map((entry) => [entry.id, entry]),
+);
+
+const CRITICAL_AGENT_CONTRACT_IDS = Object.freeze([
+  "main",
+  "judge",
+  "program-manager",
+  "automation-playbook-architect",
+  "memory-knowledge-curator",
+  "telemetry-evaluation-analyst",
+  "browser-session-credential-steward",
+  "market-research-analyst",
+]);
+
+export const DEFAULT_LIVE_AGENT_ROLE_EVAL_AGENTS = Object.freeze([
+  "main",
+  "judge",
+  "program-manager",
+  "memory-knowledge-curator",
+  "market-research-analyst",
+]);
+
+export const DEFAULT_SELF_CONTAINED_LIVE_MODEL = "ollama/qwen3.5:4b";
+export const DEFAULT_SELF_CONTAINED_OLLAMA_MIN_MEM_MB = 8192;
+export const DEFAULT_SELF_CONTAINED_LIVE_PARAMS = Object.freeze({
+  temperature: 0,
+  maxTokens: 64,
+});
+
+function normalizeText(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function unique(values) {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function expandHome(value, homeDir = os.homedir()) {
+  if (typeof value !== "string" || !value.startsWith("~")) {
+    return value;
+  }
+  if (value === "~") {
+    return homeDir;
+  }
+  if (value.startsWith("~/")) {
+    return path.join(homeDir, value.slice(2));
+  }
+  return value;
+}
+
+function splitModelRef(modelRef) {
+  const normalized = String(modelRef ?? "").trim();
+  const slashIndex = normalized.indexOf("/");
+  if (slashIndex <= 0 || slashIndex === normalized.length - 1) {
+    throw new Error(`Model ref must be provider/model, got: ${JSON.stringify(modelRef)}`);
+  }
+  return {
+    providerId: normalized.slice(0, slashIndex),
+    modelId: normalized.slice(slashIndex + 1),
+    modelRef: normalized,
+  };
+}
+
+function writeTextFile(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, value, "utf8");
+}
+
+function providerConfigForModelRef(modelRef) {
+  const { providerId, modelId } = splitModelRef(modelRef);
+  const baseConfig = {
+    models: [
+      {
+        id: modelId,
+        name: modelId,
+        input: ["text"],
+      },
+    ],
+  };
+  if (providerId === "ollama") {
+    return {
+      api: "ollama",
+      apiKey: "ollama-local",
+      baseUrl: process.env.OPENCLAW_AGENT_ROLE_EVAL_OLLAMA_BASE_URL ?? "http://127.0.0.1:11434",
+      timeoutSeconds: 300,
+      ...baseConfig,
+    };
+  }
+  return baseConfig;
+}
+
+function roleDocForContract(contractEntry) {
+  return [
+    `# ${contractEntry.name}`,
+    "",
+    `Agent id: ${contractEntry.id}`,
+    `Domain: ${contractEntry.domain}`,
+    "",
+    "Responsibilities:",
+    `- ${contractEntry.task}`,
+    `- Use these role signals when relevant: ${contractEntry.expectedSignals.join(", ")}.`,
+    "- Keep answers evidence-aware, risk-aware, and explicit about blockers.",
+    "",
+  ].join("\n");
+}
+
+export function createSelfContainedLiveEvalEnvironment(contracts, options = {}) {
+  const modelRef = options.modelRef ?? DEFAULT_SELF_CONTAINED_LIVE_MODEL;
+  const { providerId } = splitModelRef(modelRef);
+  const root = options.root ?? fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-role-eval-"));
+  const stateDir = path.join(root, "state");
+  const configPath = path.join(stateDir, "openclaw.json");
+  const workspacesRoot = path.join(root, "workspaces");
+  const selectedContracts = contracts.length > 0 ? contracts : AGENT_ROLE_CONTRACTS;
+
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.mkdirSync(workspacesRoot, { recursive: true });
+
+  const agents = selectedContracts.map((contractEntry) => {
+    const workspace = path.join(workspacesRoot, contractEntry.id);
+    const agentDir = path.join(stateDir, "agents", contractEntry.id, "agent");
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.mkdirSync(agentDir, { recursive: true });
+    const doc = roleDocForContract(contractEntry);
+    writeTextFile(path.join(workspace, "AGENTS.md"), doc);
+    writeTextFile(path.join(workspace, "IDENTITY.md"), doc);
+    return {
+      id: contractEntry.id,
+      name: contractEntry.name,
+      workspace,
+      agentDir,
+      model: { primary: modelRef, fallbacks: [] },
+      params: { ...DEFAULT_SELF_CONTAINED_LIVE_PARAMS },
+      tools: { profile: "minimal" },
+    };
+  });
+
+  const config = {
+    models: {
+      providers: {
+        [providerId]: providerConfigForModelRef(modelRef),
+      },
+    },
+    agents: {
+      defaults: {
+        model: { primary: modelRef, fallbacks: [] },
+        workspace: path.join(workspacesRoot, "default"),
+      },
+      list: agents,
+    },
+  };
+  writeTextFile(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+  const env = {
+    OPENCLAW_CONFIG_PATH: configPath,
+    OPENCLAW_STATE_DIR: stateDir,
+  };
+  if (providerId === "ollama" && !process.env.OLLAMA_API_KEY) {
+    env.OLLAMA_API_KEY = "ollama-local";
+  }
+
+  return {
+    root,
+    stateDir,
+    configPath,
+    workspacesRoot,
+    config,
+    env,
+    cleanup() {
+      if (!options.keep) {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+  };
+}
+
+export function resolveConfiguredAgents(config) {
+  return Array.isArray(config?.agents?.list) ? config.agents.list : [];
+}
+
+export function resolveAgentPrimaryModel(agent, defaults = {}) {
+  if (typeof agent?.model === "string") {
+    return agent.model;
+  }
+  return agent?.model?.primary ?? defaults?.model?.primary ?? null;
+}
+
+export function resolveAgentFallbackModels(agent, defaults = {}) {
+  if (typeof agent?.model === "string") {
+    return [];
+  }
+  return Array.isArray(agent?.model?.fallbacks)
+    ? agent.model.fallbacks
+    : Array.isArray(defaults?.model?.fallbacks)
+      ? defaults.model.fallbacks
+      : [];
+}
+
+export function collectConfiguredModelRefs(config) {
+  const refs = new Set();
+  for (const [providerId, provider] of Object.entries(config?.models?.providers ?? {})) {
+    for (const model of provider?.models ?? []) {
+      if (typeof model?.id === "string" && model.id.trim()) {
+        refs.add(`${providerId}/${model.id}`);
+      }
+    }
+  }
+  for (const modelRef of Object.keys(config?.agents?.defaults?.models ?? {})) {
+    if (modelRef.trim()) {
+      refs.add(modelRef);
+    }
+  }
+  return refs;
+}
+
+function resolveWorkspace(agent, defaults, homeDir) {
+  return expandHome(agent.workspace ?? defaults.workspace, homeDir);
+}
+
+function resolveAgentDir(agent, stateDir, homeDir) {
+  if (agent.agentDir) {
+    return expandHome(agent.agentDir, homeDir);
+  }
+  return stateDir && agent.id ? path.join(stateDir, "agents", agent.id, "agent") : undefined;
+}
+
+function readTextFile(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function isDirectory(dirPath) {
+  try {
+    return fs.statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isFile(filePath) {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function hasDocIdentity(contractEntry, agent, workspace) {
+  const text = normalizeText(
+    ["AGENTS.md", "IDENTITY.md", "SOUL.md"]
+      .map((file) => readTextFile(path.join(workspace, file)))
+      .join("\n"),
+  );
+  const idWords = normalizeText(agent.id?.replaceAll("-", " "));
+  const nameWords = normalizeText(agent.name ?? contractEntry.name);
+  const contractTerms = contractEntry.docTerms.map(normalizeText);
+  const directMatch =
+    (idWords && text.includes(idWords)) || (nameWords && text.includes(nameWords));
+  const termMatches = contractTerms.filter((term) => term && text.includes(term));
+  return directMatch || termMatches.length >= Math.min(2, contractTerms.length);
+}
+
+function resolveToolPolicy(agent) {
+  const tools = agent.tools ?? {};
+  if (tools.enabled === false || tools.disable === true) {
+    return { enabled: false, callable: [] };
+  }
+  const profile = tools.profile ?? "coding";
+  let callable;
+  if (Array.isArray(tools.allow) && tools.allow.length > 0) {
+    callable = tools.allow;
+  } else {
+    callable = [...(CORE_TOOL_PROFILES[profile] ?? CORE_TOOL_PROFILES.coding)];
+    if (Array.isArray(tools.alsoAllow)) {
+      callable.push(...tools.alsoAllow);
+    }
+  }
+  const denied = new Set((tools.deny ?? []).map((entry) => normalizeText(entry)));
+  const normalized = unique(callable.map((entry) => String(entry).trim()).filter(Boolean));
+  if (normalized.includes("*")) {
+    return { enabled: true, callable: ["*"] };
+  }
+  return {
+    enabled: true,
+    callable: normalized.filter((entry) => !denied.has(normalizeText(entry))),
+  };
+}
+
+function pushIssue(issues, severity, agentId, code, message, details = {}) {
+  issues.push({ severity, agentId, code, message, ...details });
+}
+
+export function evaluateAgentRoleContractCatalog(contracts = AGENT_ROLE_CONTRACTS) {
+  const issues = [];
+  const seenIds = new Set();
+  const requiredLabels = ["ROLE:", "EVIDENCE:", "RISK:", "NEXT_ACTION:", "BLOCK_OR_ESCALATE:"];
+
+  for (const entry of contracts) {
+    const id = String(entry?.id ?? "").trim();
+    if (!id) {
+      pushIssue(
+        issues,
+        "error",
+        "(catalog)",
+        "contract_id_missing",
+        "Role contract is missing id.",
+      );
+      continue;
+    }
+    if (seenIds.has(id)) {
+      pushIssue(issues, "error", id, "contract_id_duplicate", `Duplicate role contract id: ${id}.`);
+    }
+    seenIds.add(id);
+
+    for (const field of ["name", "domain", "task", "prompt"]) {
+      if (!String(entry?.[field] ?? "").trim()) {
+        pushIssue(issues, "error", id, "contract_field_missing", `${id} is missing ${field}.`, {
+          field,
+        });
+      }
+    }
+
+    if (!Array.isArray(entry?.expectedSignals) || entry.expectedSignals.length < 3) {
+      pushIssue(
+        issues,
+        "error",
+        id,
+        "contract_expected_signals_weak",
+        `${id} needs at least three expected role signals.`,
+      );
+    }
+    if (!Array.isArray(entry?.docTerms) || entry.docTerms.length < 2) {
+      pushIssue(
+        issues,
+        "error",
+        id,
+        "contract_doc_terms_weak",
+        `${id} needs at least two documentation identity terms.`,
+      );
+    }
+
+    const normalizedSignals = (entry?.expectedSignals ?? []).map(normalizeText);
+    if (new Set(normalizedSignals).size !== normalizedSignals.length) {
+      pushIssue(
+        issues,
+        "error",
+        id,
+        "contract_expected_signal_duplicate",
+        `${id} has duplicate expected role signals.`,
+      );
+    }
+
+    const prompt = entry?.prompt ?? "";
+    for (const label of requiredLabels) {
+      if (!prompt.includes(label)) {
+        pushIssue(
+          issues,
+          "error",
+          id,
+          "contract_prompt_label_missing",
+          `${id} prompt is missing ${label}.`,
+          { label },
+        );
+      }
+    }
+  }
+
+  for (const id of CRITICAL_AGENT_CONTRACT_IDS) {
+    if (!seenIds.has(id)) {
+      pushIssue(
+        issues,
+        "error",
+        id,
+        "critical_contract_missing",
+        `Critical agent contract is missing: ${id}.`,
+      );
+    }
+  }
+
+  return {
+    ok: issues.every((issue) => issue.severity !== "error"),
+    contractCount: contracts.length,
+    criticalContractCount: CRITICAL_AGENT_CONTRACT_IDS.length,
+    issues,
+  };
+}
+
+export function evaluateAgentStaticContracts(config, options = {}) {
+  const homeDir = options.homeDir ?? os.homedir();
+  const stateDir = expandHome(
+    options.stateDir ?? process.env.OPENCLAW_STATE_DIR ?? path.join(homeDir, ".openclaw"),
+    homeDir,
+  );
+  const defaults = config?.agents?.defaults ?? {};
+  const agents = resolveConfiguredAgents(config);
+  const modelRefs = collectConfiguredModelRefs(config);
+  const catalog = evaluateAgentRoleContractCatalog();
+  const issues = [...catalog.issues];
+  const seenIds = new Set();
+
+  for (const agent of agents) {
+    const id = String(agent?.id ?? "").trim();
+    if (!id) {
+      pushIssue(
+        issues,
+        "error",
+        "(missing)",
+        "agent_id_missing",
+        "Configured agent is missing id.",
+      );
+      continue;
+    }
+    if (seenIds.has(id)) {
+      pushIssue(issues, "error", id, "agent_id_duplicate", `Duplicate configured agent id: ${id}.`);
+    }
+    seenIds.add(id);
+
+    const contractEntry = AGENT_ROLE_CONTRACT_BY_ID.get(id);
+    if (!contractEntry) {
+      pushIssue(issues, "error", id, "contract_missing", `No role eval contract exists for ${id}.`);
+      continue;
+    }
+
+    const workspace = resolveWorkspace(agent, defaults, homeDir);
+    const agentDir = resolveAgentDir(agent, stateDir, homeDir);
+    if (!workspace || !isDirectory(workspace)) {
+      pushIssue(
+        issues,
+        "error",
+        id,
+        "workspace_missing",
+        `${id} workspace is missing or not a directory.`,
+      );
+    } else {
+      for (const file of ["AGENTS.md", "IDENTITY.md"]) {
+        if (!isFile(path.join(workspace, file))) {
+          pushIssue(issues, "error", id, "identity_file_missing", `${id} is missing ${file}.`, {
+            file,
+          });
+        }
+      }
+      if (!hasDocIdentity(contractEntry, agent, workspace)) {
+        pushIssue(
+          issues,
+          "error",
+          id,
+          "role_docs_weak",
+          `${id} workspace docs do not identify the role or core responsibilities.`,
+        );
+      }
+    }
+    if (!agentDir || !isDirectory(agentDir)) {
+      pushIssue(
+        issues,
+        "error",
+        id,
+        "agent_dir_missing",
+        `${id} agent runtime directory is missing.`,
+      );
+    }
+
+    const primary = resolveAgentPrimaryModel(agent, defaults);
+    const fallbacks = resolveAgentFallbackModels(agent, defaults);
+    if (!primary) {
+      pushIssue(issues, "error", id, "primary_model_missing", `${id} has no primary model.`);
+    } else if (!modelRefs.has(primary)) {
+      pushIssue(
+        issues,
+        "error",
+        id,
+        "primary_model_unconfigured",
+        `${id} primary model is not configured.`,
+        {
+          model: primary,
+        },
+      );
+    }
+    for (const fallback of fallbacks) {
+      if (!modelRefs.has(fallback)) {
+        pushIssue(
+          issues,
+          "warn",
+          id,
+          "fallback_model_unconfigured",
+          `${id} fallback model is not configured.`,
+          {
+            model: fallback,
+          },
+        );
+      }
+    }
+
+    const toolPolicy = resolveToolPolicy(agent);
+    if (toolPolicy.enabled && toolPolicy.callable.length === 0) {
+      pushIssue(
+        issues,
+        "error",
+        id,
+        "tool_policy_empty",
+        `${id} tool policy resolves to zero callable tools.`,
+      );
+    }
+  }
+
+  return {
+    ok: issues.every((issue) => issue.severity !== "error"),
+    agentCount: agents.length,
+    contractCount: AGENT_ROLE_CONTRACTS.length,
+    issues,
+  };
+}
+
+export function evaluateAgentLiveText(contractEntry, visibleText) {
+  const rawText = String(visibleText ?? "");
+  const text = normalizeText(visibleText);
+  const expectedMatches = contractEntry.expectedSignals.filter((signal) =>
+    text.includes(normalizeText(signal)),
+  );
+  const forbiddenMatches = contractEntry.forbiddenSignals.filter((signal) =>
+    text.includes(normalizeText(signal)),
+  );
+  const evidenceLike = [
+    "evidence",
+    "verify",
+    "source",
+    "metric",
+    "risk",
+    "approval",
+    "block",
+  ].filter((term) => text.includes(term));
+  const issues = [];
+  const lines = rawText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const requiredLabels = ["ROLE:", "EVIDENCE:", "RISK:", "NEXT_ACTION:", "BLOCK_OR_ESCALATE:"];
+  if (lines.length !== requiredLabels.length) {
+    issues.push(`live response must be exactly ${requiredLabels.length} non-empty lines`);
+  }
+  for (const label of requiredLabels) {
+    const matchingLines = lines.filter((entry) => entry.toUpperCase().startsWith(label));
+    const line = matchingLines[0];
+    if (!line) {
+      issues.push(`missing live response label: ${label}`);
+      continue;
+    }
+    if (matchingLines.length > 1) {
+      issues.push(`duplicate live response label: ${label}`);
+    }
+    const content = line.slice(label.length).trim();
+    if (!content) {
+      issues.push(`empty live response label: ${label}`);
+    } else if (content.startsWith("/") || /(?:^|\s)\/[a-z0-9_-]+(?:\s|$)/i.test(content)) {
+      issues.push(`slash command content is not allowed in ${label}`);
+    }
+  }
+  if (forbiddenMatches.length > 0) {
+    issues.push(`forbidden signal(s): ${forbiddenMatches.join(", ")}`);
+  }
+  if (expectedMatches.length < Math.min(2, contractEntry.expectedSignals.length)) {
+    issues.push(
+      `missing role signal coverage: expected at least 2 of ${contractEntry.expectedSignals.join(", ")}`,
+    );
+  }
+  if (evidenceLike.length === 0) {
+    issues.push("missing evidence/risk/verification language");
+  }
+  return {
+    ok: issues.length === 0,
+    expectedMatches,
+    forbiddenMatches,
+    evidenceLike,
+    issues,
+  };
+}
+
+function extractAgentJson(stdout) {
+  const trimmed = stdout.trim();
+  if (trimmed.startsWith("{")) {
+    return JSON.parse(trimmed);
+  }
+  const marker = '{\n  "payloads"';
+  const index = stdout.indexOf(marker);
+  if (index >= 0) {
+    return JSON.parse(stdout.slice(index));
+  }
+  throw new Error("agent command did not emit JSON payload");
+}
+
+export function runLiveAgentEval(contractEntry, options = {}) {
+  const timeoutSeconds = Number(options.timeoutSeconds ?? 180);
+  const sessionId = options.sessionId ?? `agent-eval-${Date.now()}-${contractEntry.id}`;
+  const args = [
+    "scripts/run-node.mjs",
+    "agent",
+    "--local",
+    "--agent",
+    contractEntry.id,
+    "--thinking",
+    "off",
+    "--session-id",
+    sessionId,
+    "--message",
+    options.prompt ?? contractEntry.prompt,
+    "--timeout",
+    String(timeoutSeconds),
+    "--json",
+  ];
+  if (options.model) {
+    args.splice(5, 0, "--model", options.model);
+  }
+  const run = spawnSync(process.execPath, args, {
+    cwd: options.cwd ?? process.cwd(),
+    encoding: "utf8",
+    maxBuffer: Number(options.maxBuffer ?? 24 * 1024 * 1024),
+    timeout: (timeoutSeconds + 30) * 1000,
+    env: { ...process.env, ...options.env },
+  });
+  if (run.error) {
+    return { ok: false, agentId: contractEntry.id, error: run.error.message };
+  }
+  if (run.status !== 0) {
+    return {
+      ok: false,
+      agentId: contractEntry.id,
+      error: `${run.stderr || ""}\n${run.stdout || ""}`.trim().slice(-4000),
+    };
+  }
+  try {
+    const parsed = extractAgentJson(run.stdout);
+    const visibleText = String(
+      parsed.payloads?.[0]?.text ?? parsed.meta?.finalAssistantVisibleText ?? "",
+    );
+    const evaluation = evaluateAgentLiveText(contractEntry, visibleText);
+    return {
+      ok: evaluation.ok,
+      agentId: contractEntry.id,
+      visibleText,
+      evaluation,
+      provider: parsed.meta?.executionTrace?.winnerProvider ?? parsed.meta?.agentMeta?.provider,
+      model: parsed.meta?.executionTrace?.winnerModel ?? parsed.meta?.agentMeta?.model,
+      durationMs: parsed.meta?.durationMs,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      agentId: contractEntry.id,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function loadConfigFile(configPath) {
+  return JSON.parse(fs.readFileSync(configPath, "utf8"));
+}
+
+export function defaultConfigPath(homeDir = os.homedir(), env = process.env) {
+  const configPath = env.OPENCLAW_CONFIG_PATH?.trim();
+  if (configPath) {
+    return configPath;
+  }
+  const stateDir = env.OPENCLAW_STATE_DIR?.trim();
+  if (stateDir) {
+    return path.join(stateDir, "openclaw.json");
+  }
+  return path.join(homeDir, ".openclaw", "openclaw.json");
+}

--- a/test/scripts/agent-role-eval.test.ts
+++ b/test/scripts/agent-role-eval.test.ts
@@ -1,0 +1,346 @@
+import fs, { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import {
+  AGENT_ROLE_CONTRACTS,
+  AGENT_ROLE_CONTRACT_BY_ID,
+  DEFAULT_SELF_CONTAINED_LIVE_PARAMS,
+  DEFAULT_SELF_CONTAINED_LIVE_MODEL,
+  createSelfContainedLiveEvalEnvironment,
+  defaultConfigPath,
+  evaluateAgentLiveText,
+  evaluateAgentRoleContractCatalog,
+  evaluateAgentStaticContracts,
+} from "../../scripts/lib/agent-role-evals.mjs";
+import { createScriptTestHarness } from "./test-helpers.ts";
+
+type WorkflowStep = {
+  env?: Record<string, string>;
+  name?: string;
+  run?: string;
+  with?: Record<string, string>;
+};
+
+type WorkflowJob = {
+  if?: string;
+  steps?: WorkflowStep[];
+};
+
+type AgentRoleEvalWorkflow = {
+  on?: {
+    workflow_dispatch?: {
+      inputs?: Record<string, { default?: string | boolean }>;
+    };
+  };
+  jobs?: Record<string, WorkflowJob>;
+};
+
+function readAgentRoleEvalWorkflow(): AgentRoleEvalWorkflow {
+  return parse(
+    readFileSync(".github/workflows/agent-role-evals.yml", "utf8"),
+  ) as AgentRoleEvalWorkflow;
+}
+
+function requireWorkflowStep(job: WorkflowJob | undefined, name: string): WorkflowStep {
+  const step = job?.steps?.find((candidate) => candidate.name === name);
+  if (!step) {
+    throw new Error(`Expected Agent Role Evals workflow step: ${name}`);
+  }
+  return step;
+}
+
+function writeAgentWorkspace(root: string, id: string, body: string) {
+  const workspace = path.join(root, `workspace-${id}`);
+  fs.mkdirSync(workspace, { recursive: true });
+  fs.writeFileSync(path.join(workspace, "AGENTS.md"), body);
+  fs.writeFileSync(path.join(workspace, "IDENTITY.md"), body);
+  return workspace;
+}
+
+function writeAgentDir(root: string, id: string) {
+  const agentDir = path.join(root, "state", "agents", id, "agent");
+  fs.mkdirSync(agentDir, { recursive: true });
+  return agentDir;
+}
+
+function baseConfig(root: string, agent: Record<string, unknown>) {
+  return {
+    models: {
+      providers: {
+        ollama: {
+          models: [{ id: "qwen3.5:4b" }, { id: "qwen3.5:9b-q4_K_M" }],
+        },
+      },
+    },
+    agents: {
+      defaults: {
+        model: { primary: "ollama/qwen3.5:4b", fallbacks: [] },
+        workspace: path.join(root, "workspace"),
+      },
+      list: [agent],
+    },
+  };
+}
+
+describe("agent role eval harness", () => {
+  const harness = createScriptTestHarness();
+
+  it("keeps role contracts unique and covers critical agents", () => {
+    const ids = AGENT_ROLE_CONTRACTS.map((entry) => entry.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(AGENT_ROLE_CONTRACT_BY_ID.has("main")).toBe(true);
+    expect(AGENT_ROLE_CONTRACT_BY_ID.has("judge")).toBe(true);
+    expect(AGENT_ROLE_CONTRACT_BY_ID.has("memory-knowledge-curator")).toBe(true);
+    expect(AGENT_ROLE_CONTRACT_BY_ID.has("openbrain-local-smoke")).toBe(true);
+  });
+
+  it("passes the deterministic checked-in contract catalog gate", () => {
+    const result = evaluateAgentRoleContractCatalog();
+
+    expect(result).toMatchObject({
+      ok: true,
+      contractCount: AGENT_ROLE_CONTRACTS.length,
+      criticalContractCount: 8,
+      issues: [],
+    });
+  });
+
+  it("prompts live evals to emit exact role signals", () => {
+    const contract = AGENT_ROLE_CONTRACT_BY_ID.get("program-manager")!;
+
+    expect(contract.prompt).toContain("Use at least two exact role signal terms");
+    expect(contract.prompt).toContain("Put one exact role signal in ROLE");
+    expect(contract.prompt).toContain("do not use slash commands as content");
+    expect(contract.prompt).toContain("BLOCKED: <reason>");
+    expect(contract.prompt).toContain("Stop immediately after the BLOCK_OR_ESCALATE line");
+    expect(contract.prompt).toContain("milestone, owner, acceptance, status, dependency");
+  });
+
+  it("creates a self-contained live eval state that passes static checks", () => {
+    const contract = AGENT_ROLE_CONTRACT_BY_ID.get("judge")!;
+    const fixture = createSelfContainedLiveEvalEnvironment([contract], {
+      modelRef: DEFAULT_SELF_CONTAINED_LIVE_MODEL,
+      keep: true,
+    });
+    harness.trackTempDir(fixture.root);
+
+    expect(fs.existsSync(fixture.configPath)).toBe(true);
+    expect(fixture.env.OPENCLAW_CONFIG_PATH).toBe(fixture.configPath);
+    expect(fixture.env.OPENCLAW_STATE_DIR).toBe(fixture.stateDir);
+    expect(fixture.config.agents.list[0]?.params).toEqual(DEFAULT_SELF_CONTAINED_LIVE_PARAMS);
+
+    const result = evaluateAgentStaticContracts(fixture.config, {
+      stateDir: fixture.stateDir,
+    });
+    expect(result).toMatchObject({ ok: true, agentCount: 1, issues: [] });
+  });
+
+  it("keeps the CI workflow deterministic and secret-free", () => {
+    const source = readFileSync(".github/workflows/agent-role-evals.yml", "utf8");
+    const workflow = readAgentRoleEvalWorkflow();
+    const contractJob = workflow.jobs?.["contract-catalog"];
+
+    expect(workflow.on?.workflow_dispatch).toEqual(null);
+    expect(workflow.jobs?.["live-role-turns"]).toBeUndefined();
+    expect(source).not.toContain("secrets.");
+    expect(source).not.toContain("OPENCLAW_AGENT_ROLE_EVAL_LIVE");
+    expect(source).not.toContain("ci-hydrate-live-auth");
+    expect(source).not.toContain("actions/upload-artifact");
+    expect(requireWorkflowStep(contractJob, "Validate role contracts").run).toBe(
+      "pnpm agents:eval:contracts",
+    );
+  });
+
+  it("defaults agent eval config lookup to the canonical OpenClaw config path", () => {
+    expect(defaultConfigPath("/tmp/home", {})).toBe("/tmp/home/.openclaw/openclaw.json");
+    expect(defaultConfigPath("/tmp/home", { OPENCLAW_STATE_DIR: "/tmp/state" })).toBe(
+      "/tmp/state/openclaw.json",
+    );
+    expect(
+      defaultConfigPath("/tmp/home", {
+        OPENCLAW_CONFIG_PATH: "/tmp/custom/openclaw.json",
+        OPENCLAW_STATE_DIR: "/tmp/state",
+      }),
+    ).toBe("/tmp/custom/openclaw.json");
+  });
+
+  it("passes a configured agent with docs, runtime dir, model, and callable tools", () => {
+    const root = harness.createTempDir("openclaw-agent-eval-");
+    const id = "program-manager";
+    const workspace = writeAgentWorkspace(
+      root,
+      id,
+      "Program Manager owns milestone planning, owners, acceptance criteria, dependencies, and status.",
+    );
+    const agentDir = writeAgentDir(root, id);
+    const result = evaluateAgentStaticContracts(
+      baseConfig(root, {
+        id,
+        name: "Program Manager",
+        workspace,
+        agentDir,
+        model: { primary: "ollama/qwen3.5:4b", fallbacks: [] },
+      }),
+      { stateDir: path.join(root, "state") },
+    );
+
+    expect(result).toMatchObject({ ok: true, agentCount: 1, issues: [] });
+  });
+
+  it("uses canonical OpenClaw state dir for omitted agentDir", () => {
+    const root = harness.createTempDir("openclaw-agent-eval-");
+    const homeDir = path.join(root, "home");
+    const id = "program-manager";
+    const workspace = writeAgentWorkspace(
+      root,
+      id,
+      "Program Manager owns milestone planning, owners, acceptance criteria, dependencies, and status.",
+    );
+    fs.mkdirSync(path.join(homeDir, ".openclaw", "agents", id, "agent"), { recursive: true });
+
+    const result = evaluateAgentStaticContracts(
+      baseConfig(root, {
+        id,
+        name: "Program Manager",
+        workspace,
+        model: { primary: "ollama/qwen3.5:4b", fallbacks: [] },
+      }),
+      { homeDir },
+    );
+
+    expect(result.issues).not.toContainEqual(
+      expect.objectContaining({ agentId: id, code: "agent_dir_missing" }),
+    );
+    expect(result).toMatchObject({ ok: true, agentCount: 1, issues: [] });
+  });
+
+  it("fails unknown agents so every configured role needs an eval contract", () => {
+    const root = harness.createTempDir("openclaw-agent-eval-");
+    const id = "new-agent-without-contract";
+    const workspace = writeAgentWorkspace(root, id, "New Agent Without Contract");
+    const agentDir = writeAgentDir(root, id);
+    const result = evaluateAgentStaticContracts(
+      baseConfig(root, {
+        id,
+        name: "New Agent Without Contract",
+        workspace,
+        agentDir,
+      }),
+      { stateDir: path.join(root, "state") },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ agentId: id, code: "contract_missing" }),
+    );
+  });
+
+  it("fails unconfigured primary model references", () => {
+    const root = harness.createTempDir("openclaw-agent-eval-");
+    const id = "program-manager";
+    const workspace = writeAgentWorkspace(
+      root,
+      id,
+      "Program Manager owns milestone planning, owners, acceptance criteria, dependencies, and status.",
+    );
+    const agentDir = writeAgentDir(root, id);
+    const result = evaluateAgentStaticContracts(
+      baseConfig(root, {
+        id,
+        name: "Program Manager",
+        workspace,
+        agentDir,
+        model: { primary: "ollama/not-configured", fallbacks: [] },
+      }),
+      { stateDir: path.join(root, "state") },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ agentId: id, code: "primary_model_unconfigured" }),
+    );
+  });
+
+  it("detects tool policies that remove every callable tool", () => {
+    const root = harness.createTempDir("openclaw-agent-eval-");
+    const id = "openbrain-local-smoke";
+    const workspace = writeAgentWorkspace(
+      root,
+      id,
+      "OpenBrain Local Smoke verifies local model session smoke.",
+    );
+    const agentDir = writeAgentDir(root, id);
+    const result = evaluateAgentStaticContracts(
+      baseConfig(root, {
+        id,
+        name: "OpenBrain Local Smoke",
+        workspace,
+        agentDir,
+        model: { primary: "ollama/qwen3.5:4b", fallbacks: [] },
+        tools: { profile: "minimal", deny: ["session_status"] },
+      }),
+      { stateDir: path.join(root, "state") },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ agentId: id, code: "tool_policy_empty" }),
+    );
+  });
+
+  it("scores live response text against role and truthfulness signals", () => {
+    const contract = AGENT_ROLE_CONTRACT_BY_ID.get("judge")!;
+
+    expect(
+      evaluateAgentLiveText(
+        contract,
+        [
+          "ROLE: verdict evidence",
+          "EVIDENCE: evidence was reviewed",
+          "RISK: risk remains until the claim is verified",
+          "NEXT_ACTION: approve or reject after review",
+          "BLOCK_OR_ESCALATE: CLEAR",
+        ].join("\n"),
+      ).ok,
+    ).toBe(true);
+    expect(evaluateAgentLiveText(contract, "I do not know my role.").ok).toBe(false);
+  });
+
+  it("rejects live responses with slash-command label content", () => {
+    const contract = AGENT_ROLE_CONTRACT_BY_ID.get("program-manager")!;
+    const result = evaluateAgentLiveText(
+      contract,
+      [
+        "ROLE: milestone owner",
+        "EVIDENCE: evidence is pending",
+        "RISK: risk remains",
+        "NEXT_ACTION: acceptance status",
+        "BLOCK_OR_ESCALATE: /no_think",
+      ].join("\n"),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.issues).toContain("slash command content is not allowed in BLOCK_OR_ESCALATE:");
+  });
+
+  it("rejects duplicated live response labels", () => {
+    const contract = AGENT_ROLE_CONTRACT_BY_ID.get("program-manager")!;
+    const result = evaluateAgentLiveText(
+      contract,
+      [
+        "ROLE: milestone owner",
+        "EVIDENCE: evidence is pending",
+        "RISK: risk remains",
+        "NEXT_ACTION: acceptance status",
+        "BLOCK_OR_ESCALATE: CLEAR",
+        "ROLE: dependency owner",
+      ].join("\n"),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.issues).toContain("live response must be exactly 5 non-empty lines");
+    expect(result.issues).toContain("duplicate live response label: ROLE:");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a minimal deterministic agent role evaluation harness: CLI, reusable contract catalog, tests, package scripts, and a read-only contract-catalog workflow.
- Creates a clean prerequisite for follow-up Browser Steward runtime-enforcement work without carrying the older 49-commit / 300-file stacked branch.
- Intentionally excludes the secret-bearing/live workflow path; live eval automation is split out for separate maintainer review.
- Intentionally out of scope: Browser Steward runtime enforcement, unrelated dashboard/music/backup/SNES work, generated bundle hashes, and any credential/session mutation.
- Review focus: deterministic harness boundaries, workflow validity, test coverage, and the fact that the diff is limited to the minimal prerequisite surface.

## Linked context

Related: https://github.com/SnowBelt/openclaw/pull/1
Related: https://github.com/openclaw/openclaw/pull/93018

Requested by: local OpenClaw agent-build audit workflow to unblock Browser Steward upstream integration safely.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: The Browser Steward runtime-enforcement PR was blocked by an unsafe prerequisite branch containing 49 commits and 300 files. This PR provides the minimal reusable deterministic agent-role-eval harness needed as a clean upstream prerequisite.
- Real environment tested: Local OpenClaw checkout on macOS, branch `codex/agent-role-eval-harness-clean`, based on current `origin/main`.
- Exact steps or command run after this patch: `pnpm agents:eval:contracts`; `node scripts/agent-role-eval.mjs --contracts-only --json`; `node scripts/run-vitest.mjs test/scripts/agent-role-eval.test.ts -- --reporter=verbose`; `pnpm exec oxfmt --check --threads=1 .github/workflows/agent-role-evals.yml scripts/agent-role-eval.mjs scripts/lib/agent-role-evals.mjs test/scripts/agent-role-eval.test.ts package.json`; `git diff --check -- .github/workflows/agent-role-evals.yml package.json scripts test/scripts/agent-role-eval.test.ts`; `PATH=/tmp/openclaw-precommit-venv/bin:$PATH pnpm check:workflows`; `env NODE_OPTIONS=--max-old-space-size=8192 pnpm build`.
- Evidence after fix: Local terminal output showed the contract catalog passing with 51 contracts and 8 critical contracts, the focused test file passing, `zizmor` workflow audit passing, and `pnpm build` completing successfully.
- Observed result after fix: The harness validates deterministically, the workflow passes local workflow sanity, and the build succeeds while the branch remains one commit with five files changed.
- What was not tested: Secret-bearing live eval workflow behavior is not part of this PR and should be reviewed separately if reintroduced.
- Proof limitations or environment constraints: `pnpm check:workflows` required a temporary `/tmp` Python virtualenv for `pre-commit`; no repo-tracked dependency files were changed for that local tool setup.
- Before evidence: The previous upstream Browser Steward PR targeted `main` directly and showed an oversized stacked diff, proving the old prerequisite path was too large for focused review.

## Tests and validation

- `pnpm docs:list`
- `pnpm agents:eval:contracts`
- `node scripts/agent-role-eval.mjs --contracts-only --json`
- `node scripts/run-vitest.mjs test/scripts/agent-role-eval.test.ts -- --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 .github/workflows/agent-role-evals.yml scripts/agent-role-eval.mjs scripts/lib/agent-role-evals.mjs test/scripts/agent-role-eval.test.ts package.json`
- `git diff --check -- .github/workflows/agent-role-evals.yml package.json scripts test/scripts/agent-role-eval.test.ts`
- `PATH=/tmp/openclaw-precommit-venv/bin:$PATH pnpm check:workflows`
- `env NODE_OPTIONS=--max-old-space-size=8192 pnpm build`

Regression coverage added:
- `test/scripts/agent-role-eval.test.ts` covers contract catalog validity, prompt scoring, config path resolution, configured-agent static checks, canonical omitted-agentDir state resolution, and deterministic workflow safety checks.

Known validation notes:
- First `pnpm check:workflows` failed because local `pre-commit` was missing; reran successfully using a temporary `/tmp` venv.
- First `pnpm build` failed because sandboxing blocked the repo-local heavy-check lock under Git metadata; reran successfully with escalated local filesystem access.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) No.

Did config, environment, or migration behavior change? (`Yes/No`) Yes, adds package scripts and a scheduled/manual read-only workflow.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) No secret-bearing or live workflow behavior remains in this PR. The workflow has read-only contents permission and runs deterministic catalog validation only.

Highest-risk area: recurring repository automation from the scheduled contract-catalog workflow.

Mitigation: The workflow is read-only, disables checkout credential persistence, does not reference `secrets.*`, and only runs `pnpm agents:eval:contracts`; local workflow sanity, `zizmor`, focused tests, GitHub CI, and build passed.

## Current review state

Current status: ClawSweeper is non-blocking and ready for maintainer review; current-head GitHub CI is green/skipped/neutral.

Next action: maintainer acceptance of the read-only scheduled workflow, then merge this prerequisite before opening the Browser Steward upstream PR.
