### PR TITLE
fix(openai): allow Codex Spark OAuth catalog refs

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -99,7 +99,7 @@ Official provider plugins publish their own model catalog rows. These providers 
 - Use `params.serviceTier` when you want an explicit tier instead of the shared `/fast` toggle
 - Hidden OpenClaw attribution headers (`originator`, `version`, `User-Agent`) apply only on native OpenAI traffic to `api.openai.com`, not generic OpenAI-compatible proxies
 - Native OpenAI routes also keep Responses `store`, prompt-cache hints, and OpenAI reasoning-compat payload shaping; proxy routes do not
-- `openai/gpt-5.3-codex-spark` is intentionally suppressed in OpenClaw because live OpenAI API requests reject it and the current Codex catalog does not expose it
+- Direct OpenAI API `gpt-5.3-codex-spark` rows are intentionally suppressed because live OpenAI API requests reject them; Codex subscription catalog rows may still expose `openai/gpt-5.3-codex-spark` for eligible signed-in accounts
 
 ```json5
 {

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -380,13 +380,14 @@ If discovery fails or times out, OpenClaw uses a bundled fallback catalog for:
 The current bundled harness is `@openai/codex` `0.139.0`. A `model/list` probe
 against that bundled app-server returned:
 
-| Model id        | Default | Hidden | Input modalities | Reasoning efforts        |
-| --------------- | ------- | ------ | ---------------- | ------------------------ |
-| `gpt-5.5`       | Yes     | No     | text, image      | low, medium, high, xhigh |
-| `gpt-5.4`       | No      | No     | text, image      | low, medium, high, xhigh |
-| `gpt-5.4-mini`  | No      | No     | text, image      | low, medium, high, xhigh |
-| `gpt-5.3-codex` | No      | No     | text, image      | low, medium, high, xhigh |
-| `gpt-5.2`       | No      | No     | text, image      | low, medium, high, xhigh |
+| Model id              | Default | Hidden | Input modalities | Reasoning efforts        |
+| --------------------- | ------- | ------ | ---------------- | ------------------------ |
+| `gpt-5.5`             | Yes     | No     | text, image      | low, medium, high, xhigh |
+| `gpt-5.4`             | No      | No     | text, image      | low, medium, high, xhigh |
+| `gpt-5.4-mini`        | No      | No     | text, image      | low, medium, high, xhigh |
+| `gpt-5.3-codex-spark` | No      | No     | text             | low, medium, high, xhigh |
+| `gpt-5.3-codex`       | No      | No     | text, image      | low, medium, high, xhigh |
+| `gpt-5.2`             | No      | No     | text, image      | low, medium, high, xhigh |
 
 Hidden models can be returned by the app-server catalog for internal or
 specialized flows, but they are not normal model-picker choices.

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -215,7 +215,10 @@
       {
         "provider": "openai",
         "model": "gpt-5.3-codex-spark",
-        "reason": "gpt-5.3-codex-spark is not exposed by the OpenAI API catalog. Use openai/gpt-5.5."
+        "reason": "gpt-5.3-codex-spark is not exposed by the OpenAI API catalog. Use openai/gpt-5.5.",
+        "when": {
+          "baseUrlHosts": ["api.openai.com"]
+        }
       },
       {
         "provider": "azure-openai-responses",

--- a/src/config/config.model-ref-validation.test.ts
+++ b/src/config/config.model-ref-validation.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from "vitest";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { validateConfigObjectWithPlugins } from "./validation.js";
 
-function createModelSuppressionRegistry(): PluginManifestRegistry {
+function createModelSuppressionRegistry(params?: {
+  sparkSuppressionWhen?: {
+    baseUrlHosts?: string[];
+    providerConfigApiIn?: string[];
+  };
+}): PluginManifestRegistry {
   return {
     diagnostics: [],
     plugins: [
@@ -26,6 +31,7 @@ function createModelSuppressionRegistry(): PluginManifestRegistry {
               model: "gpt-5.3-codex-spark",
               reason:
                 "gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+              ...(params?.sparkSuppressionWhen ? { when: params.sparkSuppressionWhen } : {}),
             },
           ],
         },
@@ -80,6 +86,29 @@ describe("config model reference validation", () => {
       {
         pluginMetadataSnapshot: {
           manifestRegistry: createModelSuppressionRegistry(),
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts conditionally suppressed provider/model pairs during config validation", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-5.3-codex-spark",
+            },
+          },
+        },
+      },
+      {
+        pluginMetadataSnapshot: {
+          manifestRegistry: createModelSuppressionRegistry({
+            sparkSuppressionWhen: { baseUrlHosts: ["api.openai.com"] },
+          }),
         },
       },
     );


### PR DESCRIPTION
## Summary

- Narrow the OpenAI `gpt-5.3-codex-spark` manifest suppression to direct `api.openai.com` rows so ChatGPT/Codex OAuth catalog rows are not rejected during config validation.
- Keep Azure/direct API Spark suppression behavior intact while allowing `openai/gpt-5.3-codex-spark` when the signed-in Codex account catalog exposes it.
- Update OpenAI/Codex docs to describe the direct API vs Codex subscription distinction and include Spark in the Codex harness model snapshot.

## Verification

- `node scripts/run-vitest.mjs src/config/config.model-ref-validation.test.ts src/plugins/manifest-model-suppression.test.ts src/commands/models/list.list-command.forward-compat.test.ts extensions/openai/openai-provider.test.ts src/agents/model-catalog.test.ts src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts src/agents/embedded-agent-runner/model.test.ts`
- `npx pnpm@11.2.2 exec oxfmt --check extensions/openai/openclaw.plugin.json src/config/config.model-ref-validation.test.ts docs/concepts/model-providers.md docs/plugins/codex-harness-reference.md`
- `git diff --check`

## Real behavior proof

Behavior addressed: OpenClaw rejected `openai/gpt-5.3-codex-spark` at config/model selection even when the user is signed in through ChatGPT/Codex OAuth and the Codex catalog exposes Spark.

Real environment tested: Ubuntu homeserver over Tailscale with OpenClaw 2026.6.6, `@openai/codex` 0.139.0, and a ChatGPT/Codex OAuth login.

Exact steps or command run after this patch: Ran the targeted Vitest suites above after changing the manifest suppression to conditional and adding the config validation regression test.

Evidence after fix: The tests now cover that conditionally suppressed provider/model pairs are accepted by config validation, while direct OpenAI/Azure Spark suppression tests still pass.

Observed result after fix: Targeted suites passed: runtime-config 4 tests, commands-light 27 tests, agents 185 tests, plugins 8 tests, OpenAI provider 38 tests.

What was not tested: I did not run the full OpenClaw test suite or a rebuilt packaged OpenClaw binary against the homeserver. Live dependency proof from the homeserver confirmed `codex debug models` exposes `gpt-5.3-codex-spark` and `codex exec -m gpt-5.3-codex-spark "Reply with exactly: pong"` returns `pong`.
