### PR TITLE
[AI-assisted] fix(control-ui): clear chat after hard reset

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1357,7 +1357,7 @@ describe("handleSendChat", () => {
     vi.stubGlobal("confirm", confirm);
     const request = vi.fn(async (method: string) => {
       if (method === "chat.send") {
-        return { status: "started" };
+        return { runId: "run-reset", status: "started" };
       }
       throw new Error(`Unexpected request: ${method}`);
     });
@@ -1377,6 +1377,10 @@ describe("handleSendChat", () => {
     );
     expect(payload.sessionKey).toBe("agent:main");
     expect(payload.message).toBe("/reset");
+    expect(host.refreshSessionsAfterChat.get("run-reset")).toMatchObject({
+      sessionKey: "agent:main",
+      resetChatAfterCompletion: true,
+    });
     expect(host.chatMessage).toBe("");
   });
 
@@ -1402,7 +1406,7 @@ describe("handleSendChat", () => {
     vi.stubGlobal("confirm", confirm);
     const request = vi.fn(async (method: string) => {
       if (method === "chat.send") {
-        return { status: "started" };
+        return { runId: "run-soft-reset", status: "started" };
       }
       throw new Error(`Unexpected request: ${method}`);
     });
@@ -1422,6 +1426,12 @@ describe("handleSendChat", () => {
     );
     expect(payload.sessionKey).toBe("agent:main");
     expect(payload.message).toBe(expected);
+    expect(host.refreshSessionsAfterChat.get("run-soft-reset")).toMatchObject({
+      sessionKey: "agent:main",
+    });
+    expect(host.refreshSessionsAfterChat.get("run-soft-reset")?.resetChatAfterCompletion).toBe(
+      undefined,
+    );
     expect(host.chatMessage).toBe("");
   });
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -252,10 +252,19 @@ function isChatResetCommand(text: string) {
   if (parsed.command.key === "new") {
     return true;
   }
-  if (/^soft(?:\s|$)/.test(normalizeLowercaseStringOrEmpty(parsed.args))) {
+  if (isSoftResetArgs(parsed.args)) {
     return false;
   }
   return true;
+}
+
+function isSoftResetArgs(args: string) {
+  return /^soft(?:\s|$)/.test(normalizeLowercaseStringOrEmpty(args));
+}
+
+function shouldClearChatAfterResetCommand(text: string) {
+  const parsed = parseSlashCommand(text);
+  return Boolean(parsed?.command.key === "reset" && !isSoftResetArgs(parsed.args));
 }
 
 function confirmChatResetCommand(text: string) {
@@ -432,6 +441,7 @@ function enqueuePendingSendMessage(
   sendState: ChatQueueItem["sendState"] = host.connected && host.client
     ? "sending"
     : "waiting-reconnect",
+  resetChatAfterCompletion?: boolean,
   skillWorkshopRevision?: ChatQueueSkillWorkshopRevision,
 ): ChatQueueItem | null {
   const trimmed = text.trim();
@@ -445,6 +455,7 @@ function enqueuePendingSendMessage(
     createdAt: Date.now(),
     attachments: hasAttachments ? attachments : undefined,
     refreshSessions,
+    resetChatAfterCompletion,
     sendAttempts: 0,
     sendRunId: generateUUID(),
     sendState,
@@ -463,6 +474,12 @@ function enqueuePendingSendMessage(
     source: "manual",
   });
   return pending;
+}
+
+function clearChatViewAfterCompletedReset(host: ChatHost) {
+  host.chatMessages = [];
+  host.chatSideResult = null;
+  host.chatSideResultTerminalRuns?.clear();
 }
 
 function updateQueuedMessage(
@@ -1099,6 +1116,9 @@ async function sendQueuedChatMessage(
             armLocalTerminalReconcile: true,
           },
         );
+        if (prepared.resetChatAfterCompletion) {
+          clearChatViewAfterCompletedReset(host);
+        }
         void loadChatHistory(host as unknown as ChatState);
       } else {
         const hasAlreadyAdoptedRunStream =
@@ -1118,6 +1138,7 @@ async function sendQueuedChatMessage(
       const refreshTarget = {
         sessionKey,
         agentId: prepared.agentId,
+        resetChatAfterCompletion: prepared.resetChatAfterCompletion || undefined,
       };
       if (ack.status === "ok") {
         void loadSessions(host as unknown as SessionsState, {
@@ -1173,6 +1194,7 @@ async function sendChatMessageNow(
     previousAttachments?: ChatAttachment[];
     restoreAttachments?: boolean;
     refreshSessions?: boolean;
+    resetChatAfterCompletion?: boolean;
     submittedAtMs?: number;
   },
 ) {
@@ -1188,6 +1210,8 @@ async function sendChatMessageNow(
           opts?.attachments,
           opts?.refreshSessions,
           opts?.submittedAtMs,
+          undefined,
+          opts?.resetChatAfterCompletion,
         );
   if (!queued) {
     return false;
@@ -1783,6 +1807,8 @@ export async function handleSendChat(
   }
 
   const refreshSessions = shouldInterpretChatCommands && isChatResetCommand(message);
+  const resetChatAfterCompletion =
+    shouldInterpretChatCommands && shouldClearChatAfterResetCommand(message);
   const submitKey = chatSubmitKey(
     host,
     "message",
@@ -1811,6 +1837,7 @@ export async function handleSendChat(
       refreshSessions,
       submittedAtMs,
       waitingForModel ? "waiting-model" : undefined,
+      resetChatAfterCompletion,
       skillWorkshopRevision,
     );
     if (!queued) {
@@ -1861,6 +1888,7 @@ export async function handleSendChat(
       previousAttachments: cleared.previousAttachments,
       restoreAttachments: Boolean(messageOverride && opts?.restoreDraft),
       refreshSessions,
+      resetChatAfterCompletion,
       submittedAtMs,
     });
   });
@@ -1890,8 +1918,10 @@ async function dispatchSlashCommand(
       await host.onSlashAction("new-session");
       return;
     case "reset":
-      await sendChatMessageNow(host, args ? `/reset ${args}` : "/reset", {
+      const message = args ? `/reset ${args}` : "/reset";
+      await sendChatMessageNow(host, message, {
         refreshSessions: true,
+        resetChatAfterCompletion: shouldClearChatAfterResetCommand(message),
         previousDraft: sendOpts?.previousDraft,
         restoreDraft: sendOpts?.restoreDraft,
       });

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -264,7 +264,7 @@ function isSoftResetArgs(args: string) {
 
 function shouldClearChatAfterResetCommand(text: string) {
   const parsed = parseSlashCommand(text);
-  return Boolean(parsed?.command.key === "reset" && !isSoftResetArgs(parsed.args));
+  return parsed?.command.key === "reset" && !isSoftResetArgs(parsed.args);
 }
 
 function confirmChatResetCommand(text: string) {
@@ -1917,7 +1917,7 @@ async function dispatchSlashCommand(
       }
       await host.onSlashAction("new-session");
       return;
-    case "reset":
+    case "reset": {
       const message = args ? `/reset ${args}` : "/reset";
       await sendChatMessageNow(host, message, {
         refreshSessions: true,
@@ -1926,6 +1926,7 @@ async function dispatchSlashCommand(
         restoreDraft: sendOpts?.restoreDraft,
       });
       return;
+    }
     case "clear":
       await clearChatHistory(host);
       return;

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -214,6 +214,57 @@ describe("handleGatewayEvent sessions.changed", () => {
     });
   });
 
+  it("clears visible chat and reloads history after a completed hard reset run", async () => {
+    loadSessionsMock.mockReset();
+    loadChatHistoryMock.mockReset().mockResolvedValue(undefined);
+    flushChatQueueForEventMock.mockReset();
+    handleChatEventMock.mockReset().mockReturnValue("final");
+    const host = createHost() as ReturnType<typeof createHost> & {
+      chatMessages: unknown[];
+      chatSideResult?: unknown | null;
+      chatSideResultTerminalRuns?: Set<string>;
+    };
+    host.sessionKey = "agent:ops:main";
+    host.chatMessages = [{ role: "user", content: "old transcript", timestamp: 1 }];
+    host.chatSideResult = { runId: "btw-run" };
+    host.chatSideResultTerminalRuns = new Set(["btw-run"]);
+    host.refreshSessionsAfterChat.set("reset-run", {
+      sessionKey: "agent:ops:main",
+      resetChatAfterCompletion: true,
+    });
+
+    handleGatewayEvent(host, {
+      type: "event",
+      event: "chat",
+      payload: {
+        state: "final",
+        runId: "reset-run",
+        sessionKey: "agent:ops:main",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Reset complete." }],
+          timestamp: 2,
+        },
+      },
+      seq: 1,
+    });
+
+    expect(host.chatMessages).toStrictEqual([]);
+    expect(host.chatSideResult).toBeNull();
+    expect(host.chatSideResultTerminalRuns?.size).toBe(0);
+    expect(loadSessionsMock).toHaveBeenCalledWith(host, {
+      activeMinutes: 10,
+      limit: 25,
+      agentId: "ops",
+    });
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
+
+    await Promise.resolve();
+
+    expect(flushChatQueueForEventMock).toHaveBeenCalledWith(host);
+  });
+
   it("applies reliable session change snapshots without refetching the list", () => {
     loadSessionsMock.mockReset();
     handleChatEventMock.mockReset().mockReturnValue("idle");

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -221,7 +221,7 @@ describe("handleGatewayEvent sessions.changed", () => {
     handleChatEventMock.mockReset().mockReturnValue("final");
     const host = createHost() as ReturnType<typeof createHost> & {
       chatMessages: unknown[];
-      chatSideResult?: unknown | null;
+      chatSideResult?: { runId: string } | null;
       chatSideResultTerminalRuns?: Set<string>;
     };
     host.sessionKey = "agent:ops:main";

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -177,6 +177,10 @@ type GatewayHostWithSideResults = GatewayHost & {
   chatSideResultTerminalRuns?: Set<string>;
 };
 
+type GatewayHostWithResettableChatView = GatewayHostWithSideResults & {
+  chatMessages: unknown[];
+};
+
 const SESSIONS_CHANGED_RELOAD_DEBOUNCE_MS = 5_000;
 const DEFERRED_SESSION_MESSAGE_REPLAY_POLL_MS = 250;
 const DEFERRED_SESSION_MESSAGE_REPLAY_TIMEOUT_MS = 10_000;
@@ -1005,6 +1009,21 @@ function handleTerminalChatEvent(
         ...createChatSessionsLoadOverrides(host),
         ...scopedAgentListParamsForRefreshTarget(host, refreshTarget),
       });
+      if (refreshTarget.resetChatAfterCompletion) {
+        const resetHost = host as GatewayHostWithResettableChatView;
+        resetHost.chatMessages = [];
+        resetHost.chatSideResult = null;
+        resetHost.chatSideResultTerminalRuns?.clear();
+        const completedRunId = runId;
+        void Promise.resolve(loadChatHistory(host as unknown as ChatState)).finally(() => {
+          if (completedRunId && host.chatRunId && host.chatRunId !== completedRunId) {
+            return;
+          }
+          resetToolStream(toolHost);
+          flushQueue();
+        });
+        return true;
+      }
     }
   }
   // Reload history when tools were used only if the terminal event did not carry

--- a/ui/src/ui/chat/composer-persistence.test.ts
+++ b/ui/src/ui/chat/composer-persistence.test.ts
@@ -97,6 +97,26 @@ describe("chat composer persistence", () => {
     ]);
   });
 
+  it("preserves hard reset clear markers on waiting reconnect sends", () => {
+    const queueItem: ChatQueueItem = {
+      id: "hard-reset-queued",
+      text: "/reset",
+      createdAt: 1,
+      refreshSessions: true,
+      resetChatAfterCompletion: true,
+      sendState: "waiting-reconnect",
+      sessionKey: "agent:lily:main",
+      agentId: "lily",
+    };
+
+    persistChatComposerState(createState({ chatQueue: [queueItem] }));
+
+    const restored = createState();
+    expect(restoreChatComposerState(restored)).toBe(true);
+
+    expect(restored.chatQueue).toEqual([queueItem]);
+  });
+
   it("scopes persisted composers by gateway and session key", () => {
     persistChatComposerState(createState({ chatMessage: "main draft" }));
 

--- a/ui/src/ui/chat/composer-persistence.ts
+++ b/ui/src/ui/chat/composer-persistence.ts
@@ -219,6 +219,9 @@ function serializeQueueItem(item: ChatQueueItem): ChatQueueItem | null {
     ...(item.kind === "queued" || item.kind === "steered" ? { kind: item.kind } : {}),
     ...(attachments.length ? { attachments: attachments as ChatAttachment[] } : {}),
     ...(typeof item.refreshSessions === "boolean" ? { refreshSessions: item.refreshSessions } : {}),
+    ...(typeof item.resetChatAfterCompletion === "boolean"
+      ? { resetChatAfterCompletion: item.resetChatAfterCompletion }
+      : {}),
     ...(item.localCommandArgs ? { localCommandArgs: item.localCommandArgs } : {}),
     ...(item.localCommandName ? { localCommandName: item.localCommandName } : {}),
     ...(item.sessionKey ? { sessionKey: item.sessionKey } : {}),
@@ -262,6 +265,10 @@ function normalizeQueueItem(value: unknown): ChatQueueItem | null {
   const refreshSessions = normalizeOptionalBoolean(entry.refreshSessions);
   if (refreshSessions !== undefined) {
     item.refreshSessions = refreshSessions;
+  }
+  const resetChatAfterCompletion = normalizeOptionalBoolean(entry.resetChatAfterCompletion);
+  if (resetChatAfterCompletion !== undefined) {
+    item.resetChatAfterCompletion = resetChatAfterCompletion;
   }
   if (entry.sendState === "failed" || entry.sendState === "waiting-reconnect") {
     item.sendState = entry.sendState;

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -20,6 +20,7 @@ export type ChatQueueItem = {
   kind?: "queued" | "steered";
   attachments?: ChatAttachment[];
   refreshSessions?: boolean;
+  resetChatAfterCompletion?: boolean;
   localCommandArgs?: string;
   localCommandName?: string;
   pendingRunId?: string;
@@ -37,6 +38,7 @@ export type ChatQueueItem = {
 export type ChatSessionRefreshTarget = {
   sessionKey: string;
   agentId?: string;
+  resetChatAfterCompletion?: boolean;
 };
 
 export const CRON_CHANNEL_LAST = "last";


### PR DESCRIPTION
## Summary

- Problem: After sending a hard `/reset` in Control UI, the backend starts a fresh session but the visible chat transcript can keep showing the old conversation until the user switches away from the agent and back.
- Solution: Mark hard reset commands so the Gateway clears the local visible chat state when the reset run finishes, reload history for the fresh session, and preserve that reset-clear marker across persisted queued sends.
- What changed: Added a reset-after-completion marker from the Control UI chat send path through the Gateway refresh target, clear visible chat and side-result state after terminal reset completion, round-trip the marker through composer queue persistence, and added focused regression coverage.
- What did NOT change (scope boundary): Soft reset variants such as `/reset --soft` keep the existing visible transcript behavior, ordinary chat sends are unchanged, and no dependency or lockfile files changed.

## Motivation

- A hard reset should visually match the new backend session immediately. Keeping old messages visible after reset is confusing because the session has already been reset but the UI still looks like it contains the previous conversation.
- Queued hard resets should keep the same clear-after-completion behavior after Control UI queue persistence and restore, including the supported waiting-reconnect path.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- No linked public issue; this PR fixes a Control UI bug/regression observed in the 2026.6.6 line.
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: A hard `/reset` in Control UI should remove the old visible transcript after the reset completes, without requiring an agent switch or page navigation. A hard `/reset` queued while disconnected should also preserve the reset-clear marker after composer queue persistence/restore.
- Real environment tested (affected runtime/layer, not just "unit test"): Disposable Linux OpenClaw checkout on the PR testserver, Control UI browser runtime, Gateway/UI reset-completion path, composer queue persistence path, and focused UI/Gateway source tests.
- Exact steps or command run after this patch:

```bash
pnpm install --frozen-lockfile
pnpm --dir ui exec playwright install --with-deps chromium
git diff --check
node scripts/run-vitest.mjs ui/src/ui/chat/composer-persistence.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/app-gateway.sessions.node.test.ts
node --import tsx reset-stale-transcript-browser-proof.ts before
node --import tsx reset-stale-transcript-browser-proof.ts after
```

- Evidence after fix:

```text
Latest patched head:
81628ec6d2 fix(control-ui): persist reset clear marker

Focused source tests:
ui/src/ui/chat/composer-persistence.test.ts: 13 passed
ui/src/ui/app-chat.test.ts: 94 passed
ui/src/ui/app-gateway.sessions.node.test.ts: 31 passed
2 Vitest shards passed in 5.33s (31 + 107 tests)

git diff --check:
clean

Browser proof after patch:
oldTranscriptVisibleBeforeReset: true
oldTranscriptVisibleAfterFinal: false
oldTranscriptStillInThreadText: false
chatHistoryRequests: 1

Composer persistence proof after branch repair:
waiting-reconnect hard reset queued send preserves resetChatAfterCompletion: true
```

- Observed result after fix: The browser proof starts with an old transcript visible, sends hard `/reset`, waits for the terminal reset event, and then confirms the old transcript is gone while history has been reloaded for the reset session. The composer persistence regression confirms the hard-reset clear marker survives queued waiting-reconnect persistence and restore.
- What was not tested: Full repository-wide validation, packaged desktop app behavior, production personal instances, and every model/provider combination.
- Before evidence:

```text
Browser proof before patch:
oldTranscriptVisibleBeforeReset: true
oldTranscriptVisibleAfterFinal: true
oldTranscriptStillInThreadText: true

Composer persistence risk before branch repair:
A waiting-reconnect hard reset queued send restored refreshSessions but did not round-trip resetChatAfterCompletion.
```

- Visual proof:
  - Before screenshot/video: redacted before screenshots and the trimmed/redacted before video are embedded below.
  - After screenshot/video: redacted after screenshots and the trimmed/redacted after video are embedded below.
  - If not applicable, why: Not applicable. Screenshots and WebM proof recordings are included; the videos were trimmed to remove the first 4 seconds containing setup frames and redacted at the top edge before embedding.

Before, old transcript loaded:

<img width="1280" height="900" alt="Before: old transcript loaded" src="https://github.com/user-attachments/assets/319e26cc-ef2a-4285-959c-aa2b773b26fe" />

Before, after hard reset final still shows old transcript:

<img width="1280" height="900" alt="Before: after hard reset final" src="https://github.com/user-attachments/assets/daff1879-bff0-44cb-b76e-d8433e57849d" />

Before, trimmed/redacted video:

https://github.com/user-attachments/assets/0d119a8f-10b3-4f9c-8acb-6244fadfe50f

After, old transcript loaded before reset:

<img width="1280" height="903" alt="After: old transcript loaded before reset" src="https://github.com/user-attachments/assets/3940a4ae-326b-4e0d-9014-822635e9859a" />

After, after hard reset final clears the old transcript:

<img width="1280" height="900" alt="After: after hard reset final" src="https://github.com/user-attachments/assets/7094a441-38bd-49a1-955d-f702f9f066b6" />

After, trimmed/redacted video:

https://github.com/user-attachments/assets/18c82e31-9fcd-435f-be01-45c98e374ade

- Remaining proof gap: None for the reported Control UI hard-reset stale-transcript behavior and the queued waiting-reconnect marker persistence repair.

## Root Cause

- Root cause: The reset command path reloaded backend session/history state after completion, but the Control UI did not explicitly clear its current visible transcript state for hard reset completion. That left stale in-memory chat content rendered until another navigation path rebuilt the view.
- Missing detection / guardrail: Existing reset tests did not assert that hard reset completion clears visible `chatMessages`/side-result state and reloads history, did not distinguish hard reset from soft reset behavior, and did not assert that the reset-clear marker round-trips through composer queue persistence.
- Contributing context (if known): Agent switching rebuilt the UI state, which made the stale transcript disappear later and masked the missing clear on the reset completion path.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/app-chat.test.ts`, `ui/src/ui/app-gateway.sessions.node.test.ts`, `ui/src/ui/chat/composer-persistence.test.ts`, plus the temporary browser proof harness.
- Scenario the test should lock in: Hard `/reset` carries a reset-after-completion marker, terminal reset completion clears visible chat and side-result state, history reloads once, soft reset variants do not use the hard-reset clear marker, and waiting-reconnect queued hard reset sends preserve the marker through composer queue persistence.
- Why this is the smallest reliable guardrail: The chat test locks command classification at the send boundary, the Gateway sessions test locks the state-clearing completion behavior, the composer persistence test locks the queued reconnect replay marker, and the browser proof verifies the user-visible stale transcript behavior before and after the patch.
- Existing test that already covers this (if any): Existing tests covered reset command flow, but not the visible transcript clear on terminal hard-reset completion or the persisted queue marker.
- If no new test is added, why not: New regression coverage is included.

## User-visible / Behavior Changes

After hard `/reset`, Control UI now clears the old visible chat transcript as soon as the reset run completes and reloads history for the fresh session. Users no longer need to switch agents or navigate away and back to make the old text disappear.

Soft reset variants keep their current behavior and do not trigger the hard-reset transcript clear marker. Hard reset sends queued while disconnected preserve the marker across composer queue persistence and replay.

## Diagram

```text
Before:
/hard reset -> backend session reset completes -> UI refreshes metadata/history request
            -> old in-memory chatMessages stay rendered until another navigation rebuilds state

After:
/hard reset -> reset completion carries resetChatAfterCompletion
            -> clear visible chatMessages and side results
            -> reload chat history for the fresh session

Queued reconnect path:
/hard reset queued while disconnected -> persist queue item with resetChatAfterCompletion
                                     -> restore/replay send
                                     -> terminal reset completion clears visible transcript
```

## Security Impact

- New permissions/capabilities? No.
- Secrets/tokens handling changed? No.
- New/changed network calls? No.
- Command/tool execution surface changed? No.
- Data access scope changed? No.
- If any `Yes`, explain risk + mitigation: Not applicable.

## Repro + Verification

### Environment

- OS: Linux disposable PR testserver checkout
- Runtime/container: Node/pnpm project environment with UI browser proof via Chromium/Playwright
- Model/provider: No external model/provider required for the proof harness
- Integration/channel (if any): Control UI browser runtime, Gateway/UI reset-completion path, and composer queue persistence path
- Relevant config (redacted): No credentials or private accounts used

### Steps

1. Start the disposable Control UI/Gateway proof environment.
2. Seed a visible transcript in the Control UI chat view.
3. Send a hard `/reset` and wait for the terminal reset completion event.
4. Inspect the visible thread text and history reload count.
5. Repeat against the patched branch and compare with the before run.
6. Run the composer queue persistence regression for a waiting-reconnect hard reset queued send.

### Expected

- Hard `/reset` removes the old visible transcript after completion.
- History is reloaded for the reset session.
- Soft reset variants do not trigger this hard-reset clear behavior.
- Persisted waiting-reconnect hard reset sends keep `resetChatAfterCompletion` after restore.

### Actual

- Before: the old transcript was still visible after the hard reset completed.
- After: the old transcript was gone after the hard reset completed, the proof observed one history reload, and the waiting-reconnect queued send preserved the reset-clear marker through composer persistence.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
Before browser proof:
oldTranscriptVisibleAfterFinal=true
oldTranscriptStillInThreadText=true

After browser proof:
oldTranscriptVisibleAfterFinal=false
oldTranscriptStillInThreadText=false
chatHistoryRequests=1

Focused tests after patch:
ui/src/ui/chat/composer-persistence.test.ts: 13 passed
ui/src/ui/app-chat.test.ts: 94 passed
ui/src/ui/app-gateway.sessions.node.test.ts: 31 passed
git diff --check: clean

Branch-repair regression:
waiting-reconnect hard reset queued send preserves resetChatAfterCompletion after composer persistence restore
```

The redacted before/after screenshots and trimmed redacted videos are embedded in the Real behavior proof section above.

## Human Verification

- Verified scenarios: hard `/reset` marker creation, soft reset not marked as hard reset, terminal reset completion clears visible chat state, side-result state clears with the transcript, history reloads after reset, browser before/after behavior, queued waiting-reconnect hard reset marker persistence, and whitespace check.
- Edge cases checked: `/reset --soft` remains out of the hard-reset clear path, ordinary sends do not carry the reset-after-completion marker, the clear runs only on terminal reset completion for the matching refresh target, and the persisted marker is normalized as an optional boolean.
- What you did **not** verify: Full repository suite, packaged app build, production user profile, and external provider/model behavior.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

The top-level ClawSweeper author-action comment for composer queue persistence is addressed by `81628ec6d2`. No re-review comment or thread resolution was posted as part of this PR-body update.

## Compatibility / Migration

- Backward compatible? Yes.
- Config/env changes? No.
- Migration needed? No.
- If yes, exact upgrade steps: Not applicable.

## Risks and Mitigations

- Risk: Clearing visible chat state too broadly could hide content for non-hard-reset paths.
  - Mitigation: The marker is set only for hard `/reset`; soft reset variants and ordinary sends are covered separately.
- Risk: The UI could clear before the reset has actually completed.
  - Mitigation: The clear happens on terminal reset completion through the refresh target, followed by a history reload.
- Risk: Queue persistence could drop the hard-reset clear marker before replay.
  - Mitigation: The marker now round-trips through composer queue serialization/restoration and has focused waiting-reconnect regression coverage.
- Risk: A packaged app environment could expose a different lifecycle detail than the disposable browser proof.
  - Mitigation: The source tests cover the send, queue persistence, and Gateway/UI completion boundaries; the browser proof covers the user-visible stale transcript behavior.