### PR TITLE
fix(ui): restore provider usage pill in desktop chat composer [AI]

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1418,6 +1418,12 @@
     min-width: 0;
   }
 
+  /* Desktop restores the quota pill in the composer flex row (#93041); the mobile composer is a
+     fixed 2-col grid (model | settings), so the pill would push the settings chip to a new row. */
+  .agent-chat__composer-controls .chat-controls__quota {
+    display: none;
+  }
+
   .chat-settings-popover-wrapper {
     width: 44px;
     margin-left: 0;

--- a/ui/src/ui/app-render.helpers.browser.test.ts
+++ b/ui/src/ui/app-render.helpers.browser.test.ts
@@ -136,6 +136,48 @@ describe("chat header controls (browser)", () => {
     }
   });
 
+  // Proves the pill is wired into renderChatControls — the surface that actually ships — not the
+  // orphaned session-select wrapper that chat.test.ts exercises. (Live re-render when authStatus
+  // arrives is enforced by the renderGuardedChatControls dep list and verified via screenshot.)
+  it("renders the provider quota pill in the desktop composer controls when usage data is present", async () => {
+    const state = createState();
+    state.modelAuthStatusResult = {
+      ts: 0,
+      providers: [
+        {
+          provider: "openai",
+          displayName: "Codex",
+          status: "ok",
+          profiles: [{ profileId: "codex", type: "oauth", status: "ok" }],
+          usage: {
+            windows: [
+              { label: "3h", usedPercent: 18 },
+              { label: "Week", usedPercent: 72 },
+            ],
+          },
+        },
+      ],
+    };
+    const container = document.createElement("div");
+    render(renderChatControls(state), container);
+    await Promise.resolve();
+
+    const quota = requireElement(
+      container.querySelector<HTMLAnchorElement>('[data-chat-provider-usage="true"]'),
+      "quota pill",
+    );
+    expect(quota.getAttribute("href")).toBe("/usage");
+    expect(quota.getAttribute("title")).toContain("Codex");
+  });
+
+  it("omits the quota pill from the desktop composer controls when no usage data is present", async () => {
+    const container = document.createElement("div");
+    render(renderChatControls(createState()), container);
+    await Promise.resolve();
+
+    expect(container.querySelector('[data-chat-provider-usage="true"]')).toBeNull();
+  });
+
   it("renders explicit hover tooltip metadata for the color mode buttons", async () => {
     const container = document.createElement("div");
     render(renderTopbarThemeModeToggle(createState({ themeMode: "system" })), container);

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -16,6 +16,7 @@ import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
 import {
   renderChatSessionSelect as renderChatSessionSelectBase,
   renderChatModelSelect,
+  renderChatQuotaPill,
   resetChatSessionPickerState,
   resolveSessionOptionGroups,
 } from "./chat/session-controls.ts";
@@ -392,6 +393,7 @@ export function renderChatControls(state: AppViewState) {
     >
       ${renderChatModelSelect(state)}
     </div>
+    ${renderChatQuotaPill(state)}
     <div class="chat-settings-popover-wrapper">
       <button
         class="chat-settings-chip ${settingsOpen ? "chat-settings-chip--open" : ""}"

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1023,6 +1023,9 @@ function renderGuardedChatControls(state: AppViewState) {
       state.chatModelSwitchPromises,
       state.chatModelsLoading,
       state.chatModelCatalog,
+      // Provider usage windows arrive async after auth status loads; without this the guarded
+      // composer controls never re-render and the quota pill stays absent/stale (#93041).
+      state.modelAuthStatusResult,
       state.settings.chatShowThinking,
       state.settings.chatShowToolCalls,
       state.settings.chatAutoScroll,

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -739,7 +739,7 @@ function renderChatSessionPickerPopover(
   `;
 }
 
-function renderChatQuotaPill(state: AppViewState) {
+export function renderChatQuotaPill(state: AppViewState) {
   const windows = collectQuotaWindowsFromAuthStatus(
     state.modelAuthStatusResult,
     isMonitoredAuthProvider,

--- a/ui/src/ui/e2e/chat-quota-pill-93041.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-quota-pill-93041.e2e.test.ts
@@ -1,5 +1,5 @@
 // Real-browser proof + regression for #93041: the desktop chat composer renders the provider
-// usage pill from models.authStatus. Captures screenshots to .e2e-proof-93041/ for the PR proof.
+// usage pill from models.authStatus. Screenshots go to the ignored .artifacts/ tree.
 import path from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -16,7 +16,7 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const describeE2e = chromiumAvailable ? describe : describe.skip;
 
 const baseTime = 1_700_000_000_000;
-const artifactDir = path.resolve(process.cwd(), ".e2e-proof-93041");
+const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-quota-pill-93041");
 
 const authStatusWithUsage = {
   ts: baseTime,

--- a/ui/src/ui/e2e/chat-quota-pill-93041.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-quota-pill-93041.e2e.test.ts
@@ -1,0 +1,96 @@
+// Real-browser proof + regression for #93041: the desktop chat composer renders the provider
+// usage pill from models.authStatus. Captures screenshots to .e2e-proof-93041/ for the PR proof.
+import path from "node:path";
+import { chromium, type Browser, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const describeE2e = chromiumAvailable ? describe : describe.skip;
+
+const baseTime = 1_700_000_000_000;
+const artifactDir = path.resolve(process.cwd(), ".e2e-proof-93041");
+
+const authStatusWithUsage = {
+  ts: baseTime,
+  providers: [
+    {
+      provider: "openai",
+      displayName: "Codex",
+      status: "ok",
+      profiles: [{ profileId: "codex", type: "oauth", status: "ok" }],
+      usage: {
+        windows: [
+          { label: "5h", usedPercent: 42, resetAt: baseTime + 3 * 3_600_000 },
+          { label: "Week", usedPercent: 71, resetAt: baseTime + 4 * 86_400_000 },
+        ],
+      },
+    },
+  ],
+};
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+async function openChat(authStatus: unknown): Promise<{ page: Page; close: () => Promise<void> }> {
+  const context = await browser.newContext({
+    locale: "en-US",
+    serviceWorkers: "block",
+    viewport: { height: 900, width: 1280 },
+  });
+  const page = await context.newPage();
+  page.setDefaultTimeout(15_000);
+  await installMockGateway(page, { methodResponses: { "models.authStatus": authStatus } });
+  await page.goto(`${server.baseUrl}chat`);
+  return { page, close: () => context.close() };
+}
+
+describeE2e("Control UI #93041 desktop chat quota pill (mocked Gateway E2E)", () => {
+  beforeAll(async () => {
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("renders the provider usage pill in the desktop chat composer", async () => {
+    const { page, close } = await openChat(authStatusWithUsage);
+    try {
+      const pill = page.locator('[data-chat-provider-usage="true"]');
+      await pill.waitFor({ state: "visible" });
+      await page.screenshot({ path: path.join(artifactDir, "01-chat-with-pill.png") });
+      await page
+        .locator(".agent-chat__composer-controls")
+        .first()
+        .screenshot({ path: path.join(artifactDir, "02-composer-controls.png") });
+
+      const text = (await pill.textContent())?.replace(/\s+/g, " ").trim();
+      expect(text).toContain("Usage");
+      expect(await pill.getAttribute("href")).toBe("/usage");
+      expect(await pill.getAttribute("title")).toContain("Codex");
+    } finally {
+      await close();
+    }
+  });
+
+  it("shows no pill when no provider usage windows are present", async () => {
+    const { page, close } = await openChat({ ts: baseTime, providers: [] });
+    try {
+      await page.locator(".agent-chat__composer-controls").first().waitFor({ state: "visible" });
+      await page.waitForTimeout(500);
+      expect(await page.locator('[data-chat-provider-usage="true"]').count()).toBe(0);
+    } finally {
+      await close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
After 2026.6.6 the provider usage/quota pill (5h + weekly limits) disappeared from the desktop Control UI chat. The composer refactors (`feat: calm composer controls #88772`, `feat(webui): add session workspace rail #92856`) moved the desktop chat controls into `renderChatControls` but dropped the quota pill; the only desktop caller that still rendered it (the `renderChatSessionSelect` wrapper) became orphaned, so the pill rendered nowhere on desktop. Mobile was unaffected.

This restores the **existing** pill (`renderChatQuotaPill`) into `renderChatControls` using the existing `models.authStatus` usage-window contract — provider-agnostic, no new config, no Codex/protocol change. It is intentionally scoped to re-attaching the existing pill, not the separately-tracked always-visible topbar. The pill now sits in the composer controls row (next to the model selector) rather than the pre-2026.6.6 upper-right header, since that desktop header no longer exists.

Surface: `ui/` (Control UI desktop chat composer controls).

Root cause / fix details:
- `renderChatControls` (the shipped desktop composer controls) rendered the model select + settings popover but no longer the quota pill.
- `renderGuardedChatControls` wraps `renderChatControls` in `guard([...])`; the dep list omitted `state.modelAuthStatusResult`, so even once the pill is re-attached the guarded controls would not re-render when usage windows arrive async. Added that dependency.
- Desktop `.agent-chat__composer-controls` is flex (pill fits); the `@media (max-width: 768px)` layout is a fixed 2-column grid (model | settings), so the pill is hidden on mobile to avoid pushing the settings chip onto a second row.

## Linked context
Refs #93041

## Real behavior proof
- **Behavior addressed:** Desktop Control UI chat no longer shows the OpenAI/Codex (or any monitored provider) usage pill after 2026.6.6; this restores it and makes it update when `models.authStatus` usage windows arrive.
- **Real environment tested:** The production Control UI, served by the mocked-gateway harness and rendered in **real headless Chromium 148** (Playwright) at a 1280×900 desktop viewport — the full app on the real `/chat` route, not jsdom. `models.authStatus` returned an OAuth Codex provider with 5h + Week usage windows.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-quota-pill-93041.e2e.test.ts`
- **Evidence after fix:** Headless Chromium screenshot of the production Control UI desktop chat — the composer controls row shows the restored provider pill reading **"Usage 29%"**, linking to `/usage`, between the model selector and the Chat settings button.

  <!-- screenshots: desktop chat with the restored Usage pill (full page) + cropped composer controls -->
  
<img width="559" height="36" alt="openclaw-93041-composer-controls" src="https://github.com/user-attachments/assets/fa588d80-801a-4973-b796-b3b356b4ddda" />
<img width="1280" height="900" alt="openclaw-93041-chat-with-pill" src="https://github.com/user-attachments/assets/748d3aa9-8880-4ec9-9c19-c1667ca54493" />


- **Observed result after fix:** The pill renders **"Usage 29%"** in the desktop composer controls and links to `/usage`; it is absent when no provider usage windows are present. On `origin/main`, the identical harness rendered no pill even with usage windows present.
- **What was not tested:** No live in-browser session against a real ChatGPT/Codex OAuth subscription (the gateway `models.authStatus` was mocked with representative OAuth usage windows). Mobile intentionally keeps no composer pill (hidden via CSS to preserve the 2-column mobile grid).

## Tests and validation
- `ui/src/ui/e2e/chat-quota-pill-93041.e2e.test.ts` — **real-browser (Playwright/Chromium)** test: mocks `models.authStatus` usage windows, asserts the pill renders in `.agent-chat__composer-controls` on `/chat`, and that it is absent without usage windows. Skips gracefully when Chromium is unavailable. 2/2 pass.
- `ui/src/ui/app-render.helpers.browser.test.ts` — added 2 jsdom tests asserting the pill renders in `renderChatControls` with usage data and is absent without it (guards the live surface the existing `chat.test.ts` test missed — it rendered the orphaned wrapper). 9/9 pass.
- `ui/src/ui/views/chat.test.ts` — 104/104, unchanged.
- `oxfmt --check`, `oxlint`, `tsgo:core`, `tsgo:test:ui` — all clean.

## Risk
Low, UI-only. Reuses an existing render helper and the existing `models.authStatus` projection; no config/default/migration/auth-logic change.

## AI assistance
AI-assisted (Claude). Investigation, fix, and proof were reviewed and are owned by me.
