### PR TITLE
[codex] Fix Telegram rich parse fallback text loss

### DIFF
--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -4,6 +4,7 @@ import { createTelegramRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
+import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "../format.js";
 import { isSafeToRetrySendError, isTelegramRateLimitError } from "../network-errors.js";
 import {
   buildTelegramSendParams,
@@ -22,6 +23,7 @@ import type { TelegramThreadSpec } from "./helpers.js";
 export { buildTelegramSendParams } from "../reply-parameters.js";
 
 const QUOTE_PARAM_RE = /\bquote not found\b|\bQUOTE_TEXT_INVALID\b|\bquote text invalid\b/i;
+const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const GrammyErrorCtor: typeof GrammyError | undefined =
   typeof GrammyError === "function" ? GrammyError : undefined;
 
@@ -30,6 +32,14 @@ function isTelegramQuoteParamError(err: unknown): boolean {
     return QUOTE_PARAM_RE.test(err.description);
   }
   return QUOTE_PARAM_RE.test(formatErrorMessage(err));
+}
+
+function isTelegramHtmlParseError(err: unknown): boolean {
+  return PARSE_ERR_RE.test(formatErrorMessage(err));
+}
+
+function optionalParams<T extends Record<string, unknown>>(params: T): T | undefined {
+  return Object.keys(params).length > 0 ? params : undefined;
 }
 
 function createTelegramDeliverySendRetry() {
@@ -118,25 +128,57 @@ export async function sendTelegramText(
   const richMessage = buildTelegramRichMessage(text, textMode, {
     skipEntityDetection: opts?.linkPreview === false,
   });
+  const plainText =
+    textMode === "html"
+      ? telegramHtmlToPlainTextFallback(renderTelegramHtmlText(text, { textMode }))
+      : text;
   const richRawApi = getTelegramRichRawApi(bot.api);
 
   if (!text.trim()) {
     throw new Error("Message must be non-empty for Telegram sends");
   }
-  const res = await sendTelegramWithThreadFallback({
-    operation: "sendRichMessage",
-    runtime,
-    thread: opts?.thread,
-    requestParams: richParams,
-    removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
-    send: (effectiveParams) =>
-      richRawApi.sendRichMessage({
-        chat_id: chatId,
-        rich_message: richMessage,
-        ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
-        ...effectiveParams,
-      }),
-  });
-  runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${res.message_id}`);
+  let res: Awaited<ReturnType<Bot["api"]["sendMessage"]>>;
+  try {
+    res = await sendTelegramWithThreadFallback({
+      operation: "sendRichMessage",
+      runtime,
+      thread: opts?.thread,
+      requestParams: richParams,
+      removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
+      send: (effectiveParams) =>
+        richRawApi.sendRichMessage({
+          chat_id: chatId,
+          rich_message: richMessage,
+          ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
+          ...effectiveParams,
+        }),
+    });
+    runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${res.message_id}`);
+  } catch (err) {
+    if (!isTelegramHtmlParseError(err)) {
+      throw err;
+    }
+    runtime.log?.(
+      `telegram sendRichMessage failed with HTML parse error; retrying plain text: ${formatErrorMessage(
+        err,
+      )}`,
+    );
+    res = await sendTelegramWithThreadFallback({
+      operation: "sendMessage",
+      runtime,
+      thread: opts?.thread,
+      requestParams: baseParams,
+      send: (effectiveParams) =>
+        bot.api.sendMessage(
+          chatId,
+          plainText,
+          optionalParams({
+            ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
+            ...effectiveParams,
+          }),
+        ),
+    });
+    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id}`);
+  }
   return res.message_id;
 }

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -390,6 +390,35 @@ describe("deliverReplies", () => {
     });
   });
 
+  it("retries ordinary direct replies as plain text when rich parsing fails near opening links", async () => {
+    const runtime = createRuntime();
+    const markdown = [
+      "Вот что я бы ему рекомендовал, если задача именно понять, есть ли превышения.",
+      "",
+      "**Рекомендация клиенту**",
+      "",
+      "Если нужен вариант: **[Narda AMS-8061](https://www.narda-sts.com/en/products/emf-monitors/ams-8061/)** или **[Wavecontrol MonitEM-IoT](https://wavecontrol.cn/en/products/monitem-iot/)**.",
+    ].join("\n");
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("400: Bad Request: can't parse entities"))
+      .mockResolvedValueOnce({ message_id: 7, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [{ text: markdown }],
+      runtime,
+      bot,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(mockCallArg(sendMessage, 0, 1)).toBe(markdown);
+    expectRecordFields(mockCallArg(sendMessage, 0, 2), { parse_mode: "HTML" });
+    expect(mockCallArg(sendMessage, 1, 1)).toBe(markdown);
+    expect(mockCallArg(sendMessage, 1, 2)).toBeUndefined();
+    expect(firstSendText(sendMessage)).toMatch(/^Вот что я бы ему рекомендовал/);
+  });
+
   it("reports message_sent success=false when hooks blank out a text-only reply", async () => {
     messageHookRunner.hasHooks.mockImplementation(
       (name: string) => name === "message_sending" || name === "message_sent",

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -947,6 +947,33 @@ describe("sendMessageTelegram", () => {
     });
   });
 
+  it("falls back to original markdown when rich parsing fails near opening links", async () => {
+    const markdown = [
+      "Вот что я бы ему рекомендовал, если задача именно понять, есть ли превышения, и при этом по возможности завести данные в HA.",
+      "",
+      "**Рекомендация клиенту**",
+      "",
+      "Если нужен реально доказательный вариант для контроля рядом с вышкой: **[Narda AMS-8061](https://www.narda-sts.com/en/products/emf-monitors/ams-8061/)** или **[Wavecontrol MonitEM-IoT](https://wavecontrol.cn/en/products/monitem-iot/)**.",
+    ].join("\n");
+    botRawApi.sendRichMessage.mockRejectedValueOnce(
+      new Error("400: Bad Request: can't parse entities"),
+    );
+    botApi.sendMessage.mockResolvedValueOnce({ message_id: 46, chat: { id: "123" } });
+
+    await sendMessageTelegram("123", markdown, {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+    });
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
+      chat_id: "123",
+      rich_message: { markdown },
+    });
+    expect(botApi.sendMessage).toHaveBeenCalledWith("123", markdown, undefined);
+    expect(botApi.sendMessage.mock.calls[0]?.[1]).toMatch(/^Вот что я бы ему рекомендовал/);
+    expect(botApi.sendMessage.mock.calls[0]?.[1]).not.toMatch(/^n\/products\/monitem-iot/);
+  });
+
   it("keeps markdown media syntax on the text-only rich path", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 47, chat: { id: "123" } });
 

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -974,6 +974,31 @@ describe("sendMessageTelegram", () => {
     expect(botApi.sendMessage.mock.calls[0]?.[1]).not.toMatch(/^n\/products\/monitem-iot/);
   });
 
+  it("falls back to readable plain text for HTML when rich parsing fails", async () => {
+    const html =
+      'Intro <a href="https://example.com/path?x=1&amp;y=2">Example &amp; Link</a> <b>done</b>';
+    botRawApi.sendRichMessage.mockRejectedValueOnce(
+      new Error("400: Bad Request: can't parse entities"),
+    );
+    botApi.sendMessage.mockResolvedValueOnce({ message_id: 47, chat: { id: "123" } });
+
+    await sendMessageTelegram("123", html, {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      textMode: "html",
+    });
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
+      chat_id: "123",
+      rich_message: { html },
+    });
+    expect(botApi.sendMessage).toHaveBeenCalledWith(
+      "123",
+      "Intro Example & Link (https://example.com/path?x=1&y=2) done",
+      undefined,
+    );
+  });
+
   it("keeps markdown media syntax on the text-only rich path", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 47, chat: { id: "123" } });
 

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -635,6 +635,8 @@ export async function sendMessageTelegram(
 
   const optionalParams = <T extends Record<string, unknown>>(params: T): T | undefined =>
     Object.keys(params).length > 0 ? params : undefined;
+  const buildPlainFallbackText = (value: string) =>
+    textMode === "html" ? telegramHtmlToPlainTextFallback(renderHtmlText(value)) : value;
 
   const sendTelegramTextChunk = async (
     chunk: TelegramTextChunk,
@@ -659,7 +661,12 @@ export async function sendMessageTelegram(
         ),
       requestPlain: (retryLabel) =>
         requestWithChatNotFound(
-          () => api.sendMessage(chatId, chunk.text, optionalParams(plainParams)),
+          () =>
+            api.sendMessage(
+              chatId,
+              buildPlainFallbackText(chunk.text),
+              optionalParams(plainParams),
+            ),
           retryLabel,
         ),
     });

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -78,6 +78,11 @@ type TelegramEditMessageCaptionParams = Parameters<TelegramApi["editMessageCapti
 type TelegramCreateForumTopicParams = NonNullable<Parameters<TelegramApi["createForumTopic"]>[2]>;
 type TelegramThreadScopedParams = {
   message_thread_id?: number;
+  reply_parameters?: unknown;
+  reply_to_message_id?: number;
+  allow_sending_without_reply?: true;
+  reply_markup?: unknown;
+  disable_notification?: boolean;
 };
 const InputFileCtor = grammy.InputFile;
 const MAX_TELEGRAM_PHOTO_DIMENSION_SUM = 10_000;
@@ -623,31 +628,59 @@ export async function sendMessageTelegram(
     text: string;
   };
 
+  const withSilentParam = <T extends Record<string, unknown> | undefined>(params: T) => ({
+    ...params,
+    ...(opts.silent === true ? { disable_notification: true } : {}),
+  });
+
+  const optionalParams = <T extends Record<string, unknown>>(params: T): T | undefined =>
+    Object.keys(params).length > 0 ? params : undefined;
+
   const sendTelegramTextChunk = async (
     chunk: TelegramTextChunk,
-    params?: TelegramRichMessageContextParams,
+    index: number,
+    isLastChunk: boolean,
   ) => {
     const richRawApi = getTelegramRichRawApi(api);
-    const richParams = {
-      ...params,
-      ...(opts.silent === true ? { disable_notification: true } : {}),
+    const richParams = withSilentParam(buildRichTextParams(isLastChunk));
+    const plainParams = withSilentParam(buildPlainTextParams(isLastChunk));
+    const result = await withTelegramHtmlParseFallback({
+      label: index === 0 ? "richMessage" : `richMessage-${index + 1}`,
+      verbose: opts.verbose,
+      requestHtml: (retryLabel) =>
+        requestWithChatNotFound(
+          () =>
+            richRawApi.sendRichMessage({
+              chat_id: chatId,
+              rich_message: buildRichMessage(chunk.text),
+              ...richParams,
+            }),
+          retryLabel,
+        ),
+      requestPlain: (retryLabel) =>
+        requestWithChatNotFound(
+          () => api.sendMessage(chatId, chunk.text, optionalParams(plainParams)),
+          retryLabel,
+        ),
+    });
+    return {
+      result,
+      acceptedParams: optionalParams(plainParams),
     };
-    const result = await requestWithChatNotFound(
-      () =>
-        richRawApi.sendRichMessage({
-          chat_id: chatId,
-          rich_message: buildRichMessage(chunk.text),
-          ...richParams,
-        }),
-      "richMessage",
-    );
-    return { result, acceptedParams: params };
   };
 
-  const buildTextParams = (isLastChunk: boolean) =>
+  const buildRichTextParams = (isLastChunk: boolean) =>
     hasRichThreadParams || (isLastChunk && replyMarkup)
       ? {
           ...richThreadParams,
+          ...(isLastChunk && replyMarkup ? { reply_markup: replyMarkup } : {}),
+        }
+      : undefined;
+
+  const buildPlainTextParams = (isLastChunk: boolean) =>
+    hasThreadParams || (isLastChunk && replyMarkup)
+      ? {
+          ...threadParams,
           ...(isLastChunk && replyMarkup ? { reply_markup: replyMarkup } : {}),
         }
       : undefined;
@@ -667,7 +700,8 @@ export async function sendMessageTelegram(
       }
       const { result: res, acceptedParams } = await sendTelegramTextChunk(
         chunk,
-        buildTextParams(index === chunks.length - 1),
+        index,
+        index === chunks.length - 1,
       );
       const messageId = resolveTelegramMessageIdOrThrow(res, context);
       recordSentMessage(chatId, messageId, cfg);


### PR DESCRIPTION
Fixes #91383.

## What changed

- Retry normal Telegram rich text sends as plain text when Telegram rejects rich parsing.
- Use the exact original source chunk for the plain retry instead of rendered HTML or separately derived fallback chunks.
- Preserve reply/thread/silent options on the fallback retry.
- Add a regression test for a normal Telegram reply whose opening text contains early Markdown links.

## Why

Telegram can reject rich/HTML parsing for messages with complex markup. The normal text send path did not have the same parse fallback protection used by caption edits, so an early-link reply could lose or corrupt the visible opening when fallback handling went sideways.

The fallback now keeps the source chunk intact, so the visible retry starts from the assistant reply's first characters instead of from the middle of a URL or Markdown link tail.

## Validation

```sh
node scripts/run-vitest.mjs extensions/telegram/src/send.test.ts
node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts src/infra/outbound/message-plan.test.ts
git diff --check
```

I did not run a live Telegram bot repro from this machine; validation is focused source-level regression coverage for the ordinary Telegram send path.
