### PR TITLE
fix(feishu): pass card_msg_content_type to get full card content (fixes #78289)

### DIFF
--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -414,6 +414,7 @@ export async function getMessageFeishu(params: {
 
   try {
     const response = (await client.im.message.get({
+      params: { card_msg_content_type: "user_card_content" },
       path: { message_id: messageId },
     })) as FeishuGetMessageResponse;
 


### PR DESCRIPTION
## Summary

When reading Feishu interactive card messages via `message(action=read)`, the Feishu API returns a degraded structure (title + "请升级客户端" prompt) unless the query parameter `card_msg_content_type=user_card_content` is passed. This PR adds that parameter to the `getMessageFeishu` call.

Fixes #78289

## Changes

- `extensions/feishu/src/send.ts:417` — add `params: { card_msg_content_type: "user_card_content" }` to `client.im.message.get()` call in `getMessageFeishu`

## Real behavior proof

- **Behavior addressed:** Feishu `getMessageFeishu` omits `card_msg_content_type` query parameter, causing interactive card messages to return `[Interactive Card]` instead of full card content
- **Environment tested:** macOS 26.4.1, Node.js, openclaw@main
- **Steps run after the patch:**
  1. Verified the parameter was added: `grep -n "card_msg_content_type" extensions/feishu/src/send.ts`
  2. Built the project: `pnpm build`
  3. Ran feishu send tests: `node scripts/run-vitest.mjs run extensions/feishu/src/send.test.ts`
  4. Ran feishu bot tests: `node scripts/run-vitest.mjs run extensions/feishu/src/bot.test.ts`
  5. Ran feishu channel tests: `node scripts/run-vitest.mjs run extensions/feishu/src/channel.test.ts`
- **Evidence after fix:**

```
$ grep -n "card_msg_content_type" extensions/feishu/src/send.ts
417:      params: { card_msg_content_type: "user_card_content" },

$ pnpm build
[build-all] phase timings: total 96.6s; slowest tsdown 84.5s

$ node scripts/run-vitest.mjs run extensions/feishu/src/send.test.ts
✓ extension-feishu extensions/feishu/src/send.test.ts (16 tests) 6ms
Test Files 1 passed (1)

$ node scripts/run-vitest.mjs run extensions/feishu/src/bot.test.ts
✓ extension-feishu extensions/feishu/src/bot.test.ts (82 tests) 52ms
Test Files 1 passed (1)

$ node scripts/run-vitest.mjs run extensions/feishu/src/channel.test.ts
✓ extension-feishu extensions/feishu/src/channel.test.ts (61 tests) 12ms
Test Files 1 passed (1)
```

- **Observed result after fix:** All 159 feishu tests pass. Build succeeds. The `card_msg_content_type` parameter is now passed to the Feishu API, which will return the full original card JSON instead of the degraded structure.
- **What was not tested:** Live Feishu API interaction (requires Feishu bot credentials and a real card message). The SDK type definition at `node_modules/@larksuiteoapi/node-sdk/types/index.d.ts:257268` confirms `card_msg_content_type` is a valid optional string parameter.
