### PR TITLE
fix: continue after empty post-tool replies

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -592,6 +592,108 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(payload?.text).not.toContain("Adding it now.");
   });
 
+  it("does not continue automatically after an unclassified plugin tool result", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Publishing it now."],
+        toolMetas: [
+          {
+            toolName: "custom_side_effect_tool",
+            mutatingAction: false,
+            mutationClassified: false,
+          },
+        ],
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            toolCallId: "call_plugin",
+            content: [{ type: "text", text: '{"ok":true}' }],
+            isError: false,
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          {
+            role: "assistant",
+            stopReason: "stop",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "run-post-tool-empty-unclassified-plugin",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    const [payload] = result.payloads ?? [];
+    expect(payload?.text).toContain("couldn't generate a response");
+    expect(payload?.text).toContain("tool actions may have already been executed");
+    expect(payload?.text).not.toContain("Publishing it now.");
+  });
+
+  it("does not continue when the terminal path already contains tool media", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Checking the image."],
+        toolMetas: [
+          {
+            toolName: "image",
+            mutatingAction: false,
+            mutationClassified: true,
+          },
+        ],
+        toolMediaUrls: ["https://example.com/result.png"],
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            toolCallId: "call_image",
+            content: [{ type: "text", text: '{"ok":true}' }],
+            isError: false,
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          {
+            role: "assistant",
+            stopReason: "stop",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "run-post-tool-empty-media",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads).toEqual([
+      expect.objectContaining({ mediaUrl: "https://example.com/result.png" }),
+    ]);
+  });
+
   it("bounds empty post-tool continuation to one retry", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     const emptyPostToolAttempt = makeAttemptResult({
@@ -2549,6 +2651,23 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(
       buildAttemptReplayMetadata({
         toolMetas: [{ toolName: "cron", meta: "add", mutatingAction: true }],
+        didSendViaMessagingTool: false,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+      }),
+    ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
+  });
+
+  it("fails closed when a completed tool call has no mutation classifier", () => {
+    expect(
+      buildAttemptReplayMetadata({
+        toolMetas: [
+          {
+            toolName: "custom_side_effect_tool",
+            mutatingAction: false,
+            mutationClassified: false,
+          },
+        ],
         didSendViaMessagingTool: false,
         messagingToolSentTexts: [],
         messagingToolSentMediaUrls: [],

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_REASONING_ONLY_RETRY_LIMIT,
   EMPTY_RESPONSE_RETRY_INSTRUCTION,
   extractPlanningOnlyPlanDetails,
+  isPostToolEmptyAssistantTurn,
   isLikelyExecutionAckPrompt,
   PLANNING_ONLY_RETRY_INSTRUCTION,
   REASONING_ONLY_RETRY_INSTRUCTION,
@@ -475,6 +476,163 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         stage: "assistant",
       },
     ]);
+  });
+
+  it("continues once from a read-only tool result when the post-tool assistant is empty", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Looking into it."],
+        toolMetas: [{ toolName: "cron", meta: "status", mutatingAction: false }],
+        messagesSnapshot: [
+          {
+            role: "assistant",
+            stopReason: "toolUse",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [
+              { type: "text", text: "Looking into it." },
+              { type: "toolCall", id: "call_cron", name: "cron", input: { action: "status" } },
+            ],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          {
+            role: "toolResult",
+            toolCallId: "call_cron",
+            content: [{ type: "text", text: '{"jobs":[]}' }],
+            isError: false,
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          {
+            role: "assistant",
+            stopReason: "stop",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["No cron jobs are configured."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [{ type: "text", text: "No cron jobs are configured." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "run-post-tool-empty-continuation",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(runAttemptCall(1).prompt).toContain(
+      "Continue from the current transcript after the latest tool result.",
+    );
+    expect(result.meta.finalAssistantVisibleText).toBe("No cron jobs are configured.");
+    expect(result.meta.finalAssistantVisibleText).not.toBe("Looking into it.");
+    expectWarnMessageWith("empty post-tool assistant turn detected");
+  });
+
+  it("does not continue automatically after a mutating tool result", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Adding it now."],
+        toolMetas: [{ toolName: "cron", meta: "add", mutatingAction: true }],
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            toolCallId: "call_cron_add",
+            content: [{ type: "text", text: '{"ok":true}' }],
+            isError: false,
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          {
+            role: "assistant",
+            stopReason: "stop",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "run-post-tool-empty-mutating",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    const [payload] = result.payloads ?? [];
+    expect(payload?.text).toContain("couldn't generate a response");
+    expect(payload?.text).toContain("tool actions may have already been executed");
+    expect(payload?.text).not.toContain("Adding it now.");
+  });
+
+  it("bounds empty post-tool continuation to one retry", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    const emptyPostToolAttempt = makeAttemptResult({
+      assistantTexts: ["Checking."],
+      toolMetas: [{ toolName: "cron", meta: "status", mutatingAction: false }],
+      messagesSnapshot: [
+        {
+          role: "toolResult",
+          toolCallId: "call_cron",
+          content: [{ type: "text", text: '{"jobs":[]}' }],
+          isError: false,
+        } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+      ],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        provider: "openai",
+        model: "gpt-5.4",
+        content: [],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(emptyPostToolAttempt);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(emptyPostToolAttempt);
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "run-post-tool-empty-bounded",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    const [payload] = result.payloads ?? [];
+    expect(payload?.text).toContain("couldn't generate a response");
   });
 
   it("auto-activates strict-agentic for unconfigured GPT-5 openai runs and surfaces the blocked state", async () => {
@@ -2377,6 +2535,87 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         messagingToolSentMediaUrls: [],
       }),
     ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
+  });
+
+  it("uses per-call mutation metadata before the tool-name fallback", () => {
+    expect(
+      buildAttemptReplayMetadata({
+        toolMetas: [{ toolName: "cron", meta: "status", mutatingAction: false }],
+        didSendViaMessagingTool: false,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+      }),
+    ).toEqual({ hadPotentialSideEffects: false, replaySafe: true });
+    expect(
+      buildAttemptReplayMetadata({
+        toolMetas: [{ toolName: "cron", meta: "add", mutatingAction: true }],
+        didSendViaMessagingTool: false,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+      }),
+    ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
+  });
+
+  it("detects a trailing empty assistant turn after a tool result structurally", () => {
+    expect(
+      isPostToolEmptyAssistantTurn(
+        makeAttemptResult({
+          assistantTexts: ["Looking into it."],
+          toolMetas: [{ toolName: "cron", mutatingAction: false }],
+          messagesSnapshot: [
+            {
+              role: "toolResult",
+              toolCallId: "call_cron",
+              content: [{ type: "text", text: '{"jobs":[]}' }],
+            } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+            {
+              role: "assistant",
+              stopReason: "stop",
+              provider: "openai",
+              model: "gpt-5.4",
+              content: [],
+            } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          ],
+          lastAssistant: {
+            role: "assistant",
+            stopReason: "stop",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [],
+          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
+      ),
+    ).toBe(true);
+
+    expect(
+      isPostToolEmptyAssistantTurn(
+        makeAttemptResult({
+          assistantTexts: ["No cron jobs are configured."],
+          toolMetas: [{ toolName: "cron", mutatingAction: false }],
+          messagesSnapshot: [
+            {
+              role: "toolResult",
+              toolCallId: "call_cron",
+              content: [{ type: "text", text: '{"jobs":[]}' }],
+            } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+            {
+              role: "assistant",
+              stopReason: "stop",
+              provider: "openai",
+              model: "gpt-5.4",
+              content: [{ type: "text", text: "No cron jobs are configured." }],
+            } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          ],
+          lastAssistant: {
+            role: "assistant",
+            stopReason: "stop",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [{ type: "text", text: "No cron jobs are configured." }],
+          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
+      ),
+    ).toBe(false);
   });
 
   it("treats async-started background tools as replay-invalid side effects", () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3395,12 +3395,14 @@ async function runEmbeddedAgentInternal(
           if (
             postToolEmptyAssistantTurn &&
             !emptyAssistantReplyIsSilent &&
+            payloadCount === 0 &&
             !aborted &&
             !timedOut &&
             !attempt.clientToolCalls &&
             !attempt.yieldDetected &&
             !attempt.didSendDeterministicApprovalPrompt &&
             !attempt.lastToolError &&
+            !hasMessagingToolDeliveryEvidence(attempt) &&
             !resolveAttemptReplayMetadata(attempt).hadPotentialSideEffects &&
             postToolEmptyContinuationAttempts < 1
           ) {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -187,6 +187,7 @@ import {
   resolveAckExecutionFastPathInstruction,
   resolveAttemptReplayMetadata,
   extractPlanningOnlyPlanDetails,
+  isPostToolEmptyAssistantTurn,
   resolveEmptyResponseRetryInstruction,
   resolveIncompleteTurnPayloadText,
   resolvePlanningOnlyRetryLimit,
@@ -1332,6 +1333,7 @@ async function runEmbeddedAgentInternal(
       let planningOnlyRetryAttempts = 0;
       let reasoningOnlyRetryAttempts = 0;
       let emptyResponseRetryAttempts = 0;
+      let postToolEmptyContinuationAttempts = 0;
       let compactionContinuationRetryAttempts = 0;
       let beforeAgentFinalizeRevisionAttempts = 0;
       let sameModelIdleTimeoutRetries = 0;
@@ -3169,9 +3171,13 @@ async function runEmbeddedAgentInternal(
           };
           const finalAssistantVisibleText = resolveFinalAssistantVisibleText(sessionLastAssistant);
           const finalAssistantRawText = resolveFinalAssistantRawText(sessionLastAssistant);
+          const postToolEmptyAssistantTurn = isPostToolEmptyAssistantTurn(attempt);
+          const terminalAttempt = postToolEmptyAssistantTurn
+            ? { ...attempt, assistantTexts: [] }
+            : attempt;
 
           const payloads = buildEmbeddedRunPayloads({
-            assistantTexts: attempt.assistantTexts,
+            assistantTexts: terminalAttempt.assistantTexts,
             assistantMessageIndex: attempt.lastAssistantTextMessageIndex,
             toolMetas: attempt.toolMetas,
             lastAssistant: attempt.lastAssistant,
@@ -3349,7 +3355,7 @@ async function runEmbeddedAgentInternal(
             payloadCount,
             aborted,
             timedOut,
-            attempt,
+            attempt: terminalAttempt,
           });
           const nextPlanningOnlyRetryInstruction = emptyAssistantReplyIsSilent
             ? null
@@ -3360,7 +3366,7 @@ async function runEmbeddedAgentInternal(
                 prompt: params.prompt,
                 aborted,
                 timedOut,
-                attempt,
+                attempt: terminalAttempt,
               });
           const nextReasoningOnlyRetryInstruction = emptyAssistantReplyIsSilent
             ? null
@@ -3371,20 +3377,41 @@ async function runEmbeddedAgentInternal(
                 executionContract,
                 aborted,
                 timedOut,
-                attempt,
+                attempt: terminalAttempt,
               });
-          const nextEmptyResponseRetryInstruction = emptyAssistantReplyIsSilent
-            ? null
-            : resolveEmptyResponseRetryInstruction({
-                provider: activeErrorContext.provider,
-                modelId: activeErrorContext.model,
-                modelApi: effectiveModel.api,
-                executionContract,
-                payloadCount,
-                aborted,
-                timedOut,
-                attempt,
-              });
+          const nextEmptyResponseRetryInstruction =
+            emptyAssistantReplyIsSilent || postToolEmptyAssistantTurn
+              ? null
+              : resolveEmptyResponseRetryInstruction({
+                  provider: activeErrorContext.provider,
+                  modelId: activeErrorContext.model,
+                  modelApi: effectiveModel.api,
+                  executionContract,
+                  payloadCount,
+                  aborted,
+                  timedOut,
+                  attempt: terminalAttempt,
+                });
+          if (
+            postToolEmptyAssistantTurn &&
+            !emptyAssistantReplyIsSilent &&
+            !aborted &&
+            !timedOut &&
+            !attempt.clientToolCalls &&
+            !attempt.yieldDetected &&
+            !attempt.didSendDeterministicApprovalPrompt &&
+            !attempt.lastToolError &&
+            !resolveAttemptReplayMetadata(attempt).hadPotentialSideEffects &&
+            postToolEmptyContinuationAttempts < 1
+          ) {
+            postToolEmptyContinuationAttempts += 1;
+            log.warn(
+              `empty post-tool assistant turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
+                "— continuing once from the completed tool result",
+            );
+            continueFromCurrentTranscript();
+            continue;
+          }
           if (
             nextPlanningOnlyRetryInstruction &&
             planningOnlyRetryAttempts < maxPlanningOnlyRetryAttempts
@@ -3453,7 +3480,7 @@ async function runEmbeddedAgentInternal(
               aborted,
               promptError,
               timedOut,
-              attempt,
+              attempt: terminalAttempt,
             }) &&
             missingAssistantRetryAttempts < MAX_MISSING_ASSISTANT_RETRIES
           ) {
@@ -3486,7 +3513,7 @@ async function runEmbeddedAgentInternal(
                 aborted,
                 externalAbort,
                 timedOut,
-                attempt,
+                attempt: terminalAttempt,
               });
           if (
             !emptyAssistantReplyIsSilent &&

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3469,6 +3469,7 @@ export async function runEmbeddedAttempt(
           sessionId: params.sessionId,
           agentId: sessionAgentId,
           builtinToolNames,
+          mutationClassifiedToolNames: coreBuiltinToolNames,
           internalEvents: params.internalEvents,
         }),
       );

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5089,6 +5089,7 @@ export async function runEmbeddedAttempt(
           ): entry is {
             toolName: string;
             meta?: string;
+            mutatingAction?: boolean;
             asyncStarted?: boolean;
             asyncTaskRunId?: string;
             asyncTaskId?: string;
@@ -5098,6 +5099,7 @@ export async function runEmbeddedAttempt(
           const normalized: {
             toolName: string;
             meta?: string;
+            mutatingAction?: boolean;
             asyncStarted?: true;
             asyncTaskRunId?: string;
             asyncTaskId?: string;
@@ -5105,6 +5107,9 @@ export async function runEmbeddedAttempt(
             toolName: entry.toolName,
             meta: entry.meta,
           };
+          if (entry.mutatingAction !== undefined) {
+            normalized.mutatingAction = entry.mutatingAction;
+          }
           if (entry.asyncStarted === true) {
             normalized.asyncStarted = true;
           }

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -249,7 +249,9 @@ export function buildAttemptReplayMetadata(
   params: ReplayMetadataAttempt,
 ): EmbeddedRunAttemptResult["replayMetadata"] {
   const hadMutatingTools = params.toolMetas.some(
-    (toolMeta) => toolMeta.mutatingAction ?? isLikelyMutatingToolName(toolMeta.toolName),
+    (toolMeta) =>
+      toolMeta.mutationClassified === false ||
+      (toolMeta.mutatingAction ?? isLikelyMutatingToolName(toolMeta.toolName)),
   );
   const hadAsyncStartedTool = params.toolMetas.some((t) => t.asyncStarted === true);
   const hadPotentialSideEffects =

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -248,7 +248,9 @@ export type PlanningOnlyPlanDetails = {
 export function buildAttemptReplayMetadata(
   params: ReplayMetadataAttempt,
 ): EmbeddedRunAttemptResult["replayMetadata"] {
-  const hadMutatingTools = params.toolMetas.some((t) => isLikelyMutatingToolName(t.toolName));
+  const hadMutatingTools = params.toolMetas.some(
+    (toolMeta) => toolMeta.mutatingAction ?? isLikelyMutatingToolName(toolMeta.toolName),
+  );
   const hadAsyncStartedTool = params.toolMetas.some((t) => t.asyncStarted === true);
   const hadPotentialSideEffects =
     hadMutatingTools ||
@@ -260,6 +262,51 @@ export function buildAttemptReplayMetadata(
     hadPotentialSideEffects,
     replaySafe: !hadPotentialSideEffects,
   };
+}
+
+/** Detects an empty terminal assistant turn after a completed tool result. */
+export function isPostToolEmptyAssistantTurn(
+  attempt: Pick<
+    EmbeddedRunAttemptResult,
+    | "assistantTexts"
+    | "currentAttemptAssistant"
+    | "lastAssistant"
+    | "messagesSnapshot"
+    | "toolMetas"
+  >,
+): boolean {
+  if (attempt.toolMetas.length === 0) {
+    return false;
+  }
+  if (
+    !isEmptyResponseAssistantTurn({
+      payloadCount: 0,
+      attempt: {
+        assistantTexts: [],
+        currentAttemptAssistant: attempt.currentAttemptAssistant,
+        lastAssistant: attempt.lastAssistant,
+      },
+    })
+  ) {
+    return false;
+  }
+
+  const messages = attempt.messagesSnapshot ?? [];
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message) {
+      continue;
+    }
+    const role = normalizeLowercaseStringOrEmpty(message.role);
+    if (isToolResultRole(role)) {
+      return true;
+    }
+    if (role === "assistant" && !readMessageTextContent(message)) {
+      continue;
+    }
+    return false;
+  }
+  return false;
 }
 
 /** Falls back to replay-unsafe metadata when older attempt records lack replay details. */

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -169,6 +169,7 @@ export type EmbeddedRunAttemptResult = {
     toolName: string;
     meta?: string;
     mutatingAction?: boolean;
+    mutationClassified?: boolean;
     asyncStarted?: boolean;
     asyncTaskRunId?: string;
     asyncTaskId?: string;

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -168,6 +168,7 @@ export type EmbeddedRunAttemptResult = {
   toolMetas: Array<{
     toolName: string;
     meta?: string;
+    mutatingAction?: boolean;
     asyncStarted?: boolean;
     asyncTaskRunId?: string;
     asyncTaskId?: string;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../infra/agent-events.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { recordAdjustedParamsForToolCall } from "./agent-tools.before-tool-call.js";
 import type { MessagingToolSend } from "./embedded-agent-messaging.types.js";
 import {
   handleToolExecutionEnd,
@@ -333,6 +334,7 @@ describe("handleToolExecutionStart read path checks", () => {
 describe("handleToolExecutionEnd cron.add commitment tracking", () => {
   it("increments successfulCronAdds when cron add succeeds", async () => {
     const { ctx } = createTestContext();
+    ctx.mutationClassifiedToolNames = new Set(["cron"]);
     await handleToolExecutionStart(
       ctx as never,
       {
@@ -356,12 +358,18 @@ describe("handleToolExecutionEnd cron.add commitment tracking", () => {
 
     expect(ctx.state.successfulCronAdds).toBe(1);
     expect(ctx.state.toolMetas).toContainEqual(
-      expect.objectContaining({ toolName: "cron", mutatingAction: true }),
+      expect.objectContaining({
+        toolName: "cron",
+        mutatingAction: true,
+        mutationClassified: true,
+      }),
     );
+    expect(ctx.state.successfulCronAdds).toBe(1);
   });
 
   it("retains read-only cron action metadata for replay classification", async () => {
     const { ctx } = createTestContext();
+    ctx.mutationClassifiedToolNames = new Set(["cron"]);
     await handleToolExecutionStart(
       ctx as never,
       {
@@ -384,7 +392,82 @@ describe("handleToolExecutionEnd cron.add commitment tracking", () => {
     );
 
     expect(ctx.state.toolMetas).toContainEqual(
-      expect.objectContaining({ toolName: "cron", mutatingAction: false }),
+      expect.objectContaining({
+        toolName: "cron",
+        mutatingAction: false,
+        mutationClassified: true,
+      }),
+    );
+  });
+
+  it("reclassifies mutation from hook-adjusted execution arguments", async () => {
+    const { ctx } = createTestContext();
+    ctx.mutationClassifiedToolNames = new Set(["cron"]);
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "cron",
+        toolCallId: "tool-cron-adjusted",
+        args: { action: "status" },
+      } as never,
+    );
+    recordAdjustedParamsForToolCall(
+      "tool-cron-adjusted",
+      { action: "add", job: { name: "reminder" } },
+      "run-test",
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "cron",
+        toolCallId: "tool-cron-adjusted",
+        isError: false,
+        result: { details: { status: "ok" } },
+      } as never,
+    );
+
+    expect(ctx.state.toolMetas).toContainEqual(
+      expect.objectContaining({
+        toolName: "cron",
+        mutatingAction: true,
+        mutationClassified: true,
+      }),
+    );
+  });
+
+  it("marks plugin tool mutation behavior as unclassified", async () => {
+    const { ctx } = createTestContext();
+    ctx.mutationClassifiedToolNames = new Set(["cron"]);
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "custom_side_effect_tool",
+        toolCallId: "tool-plugin-side-effect",
+        args: { action: "publish" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "custom_side_effect_tool",
+        toolCallId: "tool-plugin-side-effect",
+        isError: false,
+        result: { ok: true },
+      } as never,
+    );
+
+    expect(ctx.state.toolMetas).toContainEqual(
+      expect.objectContaining({
+        toolName: "custom_side_effect_tool",
+        mutatingAction: false,
+        mutationClassified: false,
+      }),
     );
   });
 

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -355,6 +355,37 @@ describe("handleToolExecutionEnd cron.add commitment tracking", () => {
     );
 
     expect(ctx.state.successfulCronAdds).toBe(1);
+    expect(ctx.state.toolMetas).toContainEqual(
+      expect.objectContaining({ toolName: "cron", mutatingAction: true }),
+    );
+  });
+
+  it("retains read-only cron action metadata for replay classification", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "cron",
+        toolCallId: "tool-cron-status",
+        args: { action: "status" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "cron",
+        toolCallId: "tool-cron-status",
+        isError: false,
+        result: { details: { jobs: [] } },
+      } as never,
+    );
+
+    expect(ctx.state.toolMetas).toContainEqual(
+      expect.objectContaining({ toolName: "cron", mutatingAction: false }),
+    );
   });
 
   it("does not increment successfulCronAdds when cron add fails", async () => {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -228,11 +228,17 @@ function isCronAddAction(args: unknown): boolean {
   return normalizeOptionalLowercaseString(action) === "add";
 }
 
-function buildToolCallSummary(toolName: string, args: unknown, meta?: string): ToolCallSummary {
+function buildToolCallSummary(
+  toolName: string,
+  args: unknown,
+  meta: string | undefined,
+  mutationClassified: boolean,
+): ToolCallSummary {
   const mutation = buildToolMutationState(toolName, args, meta);
   return {
     meta,
     mutatingAction: mutation.mutatingAction,
+    mutationClassified,
     actionFingerprint: mutation.actionFingerprint,
     fileTarget: mutation.fileTarget,
   };
@@ -984,7 +990,15 @@ export function handleToolExecutionStart(
         detailMode: ctx.params.toolProgressDetail ?? "explain",
       }),
     );
-    ctx.state.toolMetaById.set(toolCallId, buildToolCallSummary(toolName, args, meta));
+    ctx.state.toolMetaById.set(
+      toolCallId,
+      buildToolCallSummary(
+        toolName,
+        args,
+        meta,
+        ctx.mutationClassifiedToolNames?.has(rawToolName.trim()) === true,
+      ),
+    );
     ctx.log.debug(
       `embedded run tool start: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
     );
@@ -1237,14 +1251,38 @@ export async function handleToolExecutionEnd(
   toolStartData.delete(toolStartKey);
   ctx.state.execLiveUpdateStateById?.delete(toolCallId);
   const callSummary = ctx.state.toolMetaById.get(toolCallId);
-  const completedMutatingAction = !isToolError && Boolean(callSummary?.mutatingAction);
-  const meta = callSummary?.meta;
+  const { consumeAdjustedParamsForToolCall } = await loadBeforeToolCall();
+  const adjustedArgs = consumeAdjustedParamsForToolCall(toolCallId, runId);
+  const startArgs =
+    adjustedArgs && typeof adjustedArgs === "object"
+      ? (adjustedArgs as Record<string, unknown>)
+      : startData?.args && typeof startData.args === "object"
+        ? (startData.args as Record<string, unknown>)
+        : {};
+  const meta =
+    adjustedArgs && typeof adjustedArgs === "object"
+      ? extendExecMeta(
+          toolName,
+          startArgs,
+          inferToolMetaFromArgs(toolName, startArgs, {
+            detailMode: ctx.params.toolProgressDetail ?? "explain",
+          }),
+        )
+      : callSummary?.meta;
+  const completedCallSummary = buildToolCallSummary(
+    toolName,
+    startArgs,
+    meta,
+    callSummary?.mutationClassified === true,
+  );
+  const completedMutatingAction = !isToolError && completedCallSummary.mutatingAction;
   const asyncStarted = !isToolError && isAsyncStartedToolResult(sanitizedResult);
   const asyncTaskIds = asyncStarted ? readAsyncStartedTaskIds(sanitizedResult) : {};
   ctx.state.toolMetas.push({
     toolName,
     meta,
-    mutatingAction: callSummary?.mutatingAction,
+    mutatingAction: completedCallSummary.mutatingAction,
+    mutationClassified: completedCallSummary.mutationClassified,
     ...(asyncStarted ? { asyncStarted: true, ...asyncTaskIds } : {}),
   });
   const acceptedSessionSpawn =
@@ -1266,9 +1304,9 @@ export async function handleToolExecutionEnd(
       error: errorMessage,
       timedOut: isToolResultTimedOut(sanitizedResult) || undefined,
       middlewareError: isMiddlewareToolResultError(sanitizedResult) || undefined,
-      mutatingAction: callSummary?.mutatingAction,
-      actionFingerprint: callSummary?.actionFingerprint,
-      fileTarget: callSummary?.fileTarget,
+      mutatingAction: completedCallSummary.mutatingAction,
+      actionFingerprint: completedCallSummary.actionFingerprint,
+      fileTarget: completedCallSummary.fileTarget,
     };
   } else if (ctx.state.lastToolError) {
     // Keep unresolved mutating failures until the same action succeeds.
@@ -1277,8 +1315,8 @@ export async function handleToolExecutionEnd(
         isSameToolMutationAction(ctx.state.lastToolError, {
           toolName,
           meta,
-          actionFingerprint: callSummary?.actionFingerprint,
-          fileTarget: callSummary?.fileTarget,
+          actionFingerprint: completedCallSummary.actionFingerprint,
+          fileTarget: completedCallSummary.fileTarget,
         })
       ) {
         ctx.state.lastToolError = undefined;
@@ -1301,10 +1339,6 @@ export async function handleToolExecutionEnd(
   const pendingText = ctx.state.pendingMessagingTexts.get(toolCallId);
   const pendingTarget = ctx.state.pendingMessagingTargets.get(toolCallId);
   const pendingMediaUrls = ctx.state.pendingMessagingMediaUrls.get(toolCallId) ?? [];
-  const startArgs =
-    startData?.args && typeof startData.args === "object"
-      ? (startData.args as Record<string, unknown>)
-      : {};
   const isMessagingSend =
     pendingMediaUrls.length > 0 ||
     (isMessagingTool(toolName) && isMessagingToolSendAction(toolName, startArgs));
@@ -1359,7 +1393,7 @@ export async function handleToolExecutionEnd(
   }
 
   // Track committed reminders only when cron.add completed successfully.
-  if (!isToolError && toolName === "cron" && isCronAddAction(startData?.args)) {
+  if (!isToolError && toolName === "cron" && isCronAddAction(startArgs)) {
     ctx.state.successfulCronAdds += 1;
   }
   if (!isToolError && toolName === HEARTBEAT_RESPONSE_TOOL_NAME) {
@@ -1614,16 +1648,10 @@ export async function handleToolExecutionEnd(
   // Run after_tool_call plugin hook (fire-and-forget)
   const hookRunnerAfter = ctx.hookRunner ?? (await loadHookRunnerGlobal()).getGlobalHookRunner();
   if (hookRunnerAfter?.hasHooks("after_tool_call")) {
-    const { consumeAdjustedParamsForToolCall } = await loadBeforeToolCall();
-    const adjustedArgs = consumeAdjustedParamsForToolCall(toolCallId, runId);
-    const afterToolCallArgs =
-      adjustedArgs && typeof adjustedArgs === "object"
-        ? (adjustedArgs as Record<string, unknown>)
-        : startArgs;
     const durationMs = startData?.startTime != null ? Date.now() - startData.startTime : undefined;
     const hookEvent: PluginHookAfterToolCallEvent = {
       toolName,
-      params: afterToolCallArgs,
+      params: startArgs,
       runId,
       toolCallId,
       result: sanitizedResult,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1244,6 +1244,7 @@ export async function handleToolExecutionEnd(
   ctx.state.toolMetas.push({
     toolName,
     meta,
+    mutatingAction: callSummary?.mutatingAction,
     ...(asyncStarted ? { asyncStarted: true, ...asyncTaskIds } : {}),
   });
   const acceptedSessionSpawn =

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -44,6 +44,7 @@ type EmbeddedSubscribeLogger = {
 export type ToolCallSummary = {
   meta?: string;
   mutatingAction: boolean;
+  mutationClassified: boolean;
   actionFingerprint?: string;
   fileTarget?: import("./tool-mutation.js").FileTarget;
 };
@@ -70,6 +71,7 @@ export type EmbeddedAgentSubscribeState = {
     toolName?: string;
     meta?: string;
     mutatingAction?: boolean;
+    mutationClassified?: boolean;
     asyncStarted?: boolean;
     asyncTaskRunId?: string;
     asyncTaskId?: string;
@@ -190,6 +192,7 @@ export type EmbeddedAgentSubscribeContext = {
   blockChunker: EmbeddedBlockChunker | null;
   hookRunner?: HookRunner;
   builtinToolNames?: ReadonlySet<string>;
+  mutationClassifiedToolNames?: ReadonlySet<string>;
   trustedLocalMediaToolNames?: ReadonlySet<string>;
   noteLastAssistant: (msg: AgentMessage) => void;
 
@@ -330,6 +333,7 @@ export type ToolHandlerContext = {
   log: EmbeddedSubscribeLogger;
   hookRunner?: HookRunner;
   builtinToolNames?: ReadonlySet<string>;
+  mutationClassifiedToolNames?: ReadonlySet<string>;
   trustedLocalMediaToolNames?: ReadonlySet<string>;
   flushBlockReplyBuffer: () => void | Promise<void>;
   shouldEmitToolResult: () => boolean;

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -69,6 +69,7 @@ export type EmbeddedAgentSubscribeState = {
   toolMetas: Array<{
     toolName?: string;
     meta?: string;
+    mutatingAction?: boolean;
     asyncStarted?: boolean;
     asyncTaskRunId?: string;
     asyncTaskId?: string;

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -1254,6 +1254,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     blockChunker,
     hookRunner: params.hookRunner,
     builtinToolNames: params.builtinToolNames,
+    mutationClassifiedToolNames: params.mutationClassifiedToolNames,
     trustedLocalMediaToolNames: params.trustedLocalMediaToolNames,
     noteLastAssistant,
     shouldEmitToolResult,

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -115,6 +115,8 @@ export type SubscribeEmbeddedAgentSessionParams = {
    * Exact raw names of OpenClaw tools registered for this run.
    */
   builtinToolNames?: ReadonlySet<string>;
+  /** Exact raw names whose mutation behavior is classified by OpenClaw. */
+  mutationClassifiedToolNames?: ReadonlySet<string>;
   /**
    * Exact raw names allowed to emit local media paths for this run.
    * Includes core trusted tools plus bundled plugin tools proven from the


### PR DESCRIPTION
## Origin and reported failure

This PR was born from #90872 and the Discord report that motivated it. The concrete failure is:

1. Composer 2.5 emits pre-tool progress text such as `Looking into it.`
2. It calls a read-only action such as `cron status` or `cron list`.
3. The tool succeeds, for example with `{"jobs":[]}`.
4. The provider then emits an empty terminal assistant turn.
5. OpenClaw promotes the earlier pre-tool progress text into the final reply, so the user sees `Looking into it.` instead of the scheduler result.

#90872 addresses this by introducing a broad terminal-tool fallback contract: retained tool observations, public `terminalSummary` / `terminalResultFallback` metadata, deterministic synthesized replies, delivery/side-effect evidence, loop-abort handling, plugin SDK changes, and expanded prose classification. Peter rejected that scope and approach as a 15k-line solution that could not be right.

This PR isolates the reported failure instead: identify the terminal shape structurally, discard pre-tool narration as a final answer, and perform one bounded continuation from the transcript that already contains the completed result. It does not add public fallback APIs or parse prose to decide whether a turn is complete.

## Regression case

The focused runner regression reproduces the exact sequence above:

```text
assistant: "Looking into it." + cron status tool call
tool result: {"jobs":[]}
assistant: empty stop
continuation: "No cron jobs are configured."
```

It asserts that the runner samples exactly once more from the existing transcript, that the continuation prompt explicitly follows the latest completed tool result, and that `Looking into it.` is never returned as the terminal reply. Separate tool-lifecycle tests prove that mutation classification uses actual `before_tool_call`-adjusted execution arguments, while terminal-media and unclassified-plugin regressions prove the continuation fails closed.

#90872 contains related tests for suppressing pre-tool narration and for synthesizing a cron `terminalSummary` when Composer provides no final answer, but it does not combine the exact reported `progress text → read-only cron result → empty assistant → natural final answer` sequence. Its published live scheduler proof also reported that cron was unavailable in that channel session, so it did not exercise this exact cron path end to end.

## Summary

- detect the structural terminal shape where a completed tool result is followed by an empty assistant turn
- prevent assistant text emitted before that tool result (for example, “Looking into it”) from being promoted into the terminal reply
- continue once from the existing transcript only when the terminal path has no payload/delivery and every completed call is proven replay-safe
- recompute mutation metadata from hook-adjusted execution arguments, so a call rewritten by `before_tool_call` is classified from what actually ran
- fail closed for plugin/client tools without OpenClaw mutation classification while preserving read-only `cron status/list` continuation

This is a deliberately narrow alternative to #90872. That PR attempts a general terminal-tool fallback contract across 75 files and roughly 16k added lines. Peter’s stated concern was both the size and that this could not be the right approach. This patch addresses the concrete failure without public tool-summary APIs, plugin SDK changes, deterministic tool-output synthesis, or natural-language regex classification of plans/progress/completion.

The decision here is structural: a tool result exists, the terminal assistant turn is empty, no payload/delivery/error/async terminal state supersedes it, and the recorded tool actions are classified replay-safe. The recovery is bounded to one continuation from the transcript that already contains the completed tool result.

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` — 201 passed
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` — passed
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` — passed
- targeted `oxfmt --check` and `oxlint` over all 10 changed files — passed
- `git diff --check` — clean
- `CI=true pnpm check:changed` reached and passed both core typecheck lanes, then the type-aware `src/agents` lint shard crashed inside `tsgolint` with a Go `SIGSEGV` and hung; targeted non-type-aware lint passed afterward

## Real behavior proof

**Behavior addressed:** A model can emit progress text, successfully call a read-only tool such as `cron status`, then return an empty post-tool assistant turn. OpenClaw previously promoted the pre-tool progress text into the terminal reply and skipped empty-turn recovery.

**Real environment tested:** Repository-native embedded runner and tool lifecycle test harnesses in a dedicated worktree based on freshly fetched `origin/main`.

**Exact steps or command run after this patch:** `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts`, both core `run-tsgo.mjs` commands listed above, targeted `oxfmt`/`oxlint`, and `git diff --check`.

**Evidence after fix:** The regression covers progress text → read-only `cron status` → empty assistant → one transcript continuation → visible final answer. Additional coverage proves pre-tool narration is not surfaced, terminal media prevents continuation, mutating `cron add` does not auto-continue, unclassified plugin tools fail closed, hook-adjusted arguments determine mutation state, a real post-tool answer is left alone, and continuation is bounded.

**Observed result after fix:** 201 focused tests passed; both core typecheck lanes passed; targeted formatting, lint, and diff checks passed.

**What was not tested:** No live Discord delivery or live Composer 2.5 provider call was run. This patch does not synthesize tool output as an answer and does not broaden the plugin/tool public contract. The full changed-file lint lane did not complete because the `tsgolint` process crashed as described above.

