### PR TITLE
fix(memory): align session file counter denominator with indexer filter (fixes #77338)

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -9,6 +9,7 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
+import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import {
   colorize,
@@ -526,7 +527,7 @@ async function scanSessionFiles(agentId: string): Promise<SourceScan> {
   try {
     const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
     const totalFiles = entries.filter(
-      (entry) => entry.isFile() && entry.name.endsWith(".jsonl"),
+      (entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name),
     ).length;
     return { source: "sessions", totalFiles, issues };
   } catch (err) {


### PR DESCRIPTION
## What

`openclaw memory status` reports `sessions · N/M` where N > M (numerator exceeds denominator) when `.jsonl.reset.*` or `.jsonl.deleted.*` archive files exist in the sessions directory.

**Root cause:** `scanSessionFiles` (denominator) uses `.endsWith(".jsonl")` which only counts primary transcript files. The indexer `listSessionFilesForAgent` (numerator) uses `isUsageCountedSessionTranscriptFileName` which also includes reset/deleted archive files. This filter divergence causes the overflow.

**Fix:** Replace `.endsWith(".jsonl")` with `isUsageCountedSessionTranscriptFileName` in `scanSessionFiles` to align the denominator with the indexer.

Fixes #77338

## Real behavior proof

- **Behavior addressed:** Session file counter in `openclaw memory status` showing N > M when archive artifacts exist
- **Environment tested:** macOS 26.4.1, Node.js, openclaw/openclaw main branch
- **Steps run after the patch:**
  1. Verified `scanSessionFiles` uses `isUsageCountedSessionTranscriptFileName` via grep
  2. Built the project with `pnpm build` — compiled successfully
  3. Verified the built output contains the updated filter
  4. Ran `src/config/sessions/artifacts.test.ts` — 9 verification passes
- **Evidence after fix:**

```
$ grep -n 'isUsageCountedSessionTranscriptFileName' extensions/memory-core/src/cli.runtime.ts
12:import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
530:      (entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name),

$ grep -n 'isUsageCountedSessionTranscriptFileName\|scanSessionFiles' dist/cli.runtime-*.js
12:import { b as isUsageCountedSessionTranscriptFileName, l as resolveSessionTranscriptsDirForAgent } from "./paths-NEwU8m3X.js";
284:async function scanSessionFiles(agentId) {
290:			totalFiles: (await fs$1.readdir(sessionsDir, { withFileTypes: true })).filter((entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name)).length,
390:		if (source === "sessions") scans.push(await scanSessionFiles(params.agentId));

$ pnpm build
✓ built in 485ms
```

- **Observed result after fix:** Denominator filter now matches indexer filter — both use `isUsageCountedSessionTranscriptFileName` which includes primary `.jsonl` files plus `.jsonl.reset.*` and `.jsonl.deleted.*` archives
- **What was not tested:** Live `openclaw memory status` command on a container with archive files (requires agent setup with session history)