### PR TITLE
fix(ui): dedupe relay chat copies by message id

### DIFF
--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -456,6 +456,33 @@ describe("buildChatItems", () => {
     ]);
   });
 
+  it("deduplicates adjacent relay copies by transcript metadata id", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "assistant",
+          senderLabel: "Parzival",
+          content: [{ type: "text", text: "Parzival There it is..." }],
+          timestamp: 1,
+          __openclaw: { id: "msg-agent-meta-1", seq: 7 },
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "There it is..." }],
+          timestamp: 2,
+          __openclaw: { id: "msg-agent-meta-1", seq: 7 },
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].senderLabel).toBeNull();
+    expect(groups[0].messages).toHaveLength(1);
+    expect(messageRecord(groups[0]).content).toStrictEqual([
+      { type: "text", text: "There it is..." },
+    ]);
+  });
+
   it("keeps relay-labeled assistant messages with different ids separate", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -403,6 +403,82 @@ describe("buildChatItems", () => {
     expect(groups[2].messages[0].duplicateCount).toBeUndefined();
   });
 
+  it("deduplicates adjacent relay copies by transcript message id", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          id: "msg-agent-1",
+          role: "assistant",
+          content: [{ type: "text", text: "There it is..." }],
+          timestamp: 1,
+        },
+        {
+          messageId: "msg-agent-1",
+          role: "assistant",
+          senderLabel: "Parzival",
+          content: [{ type: "text", text: "There it is..." }],
+          timestamp: 2,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].senderLabel).toBeNull();
+    expect(groups[0].messages).toHaveLength(1);
+    expect(messageRecord(groups[0]).content).toStrictEqual([
+      { type: "text", text: "There it is..." },
+    ]);
+  });
+
+  it("prefers the native chat copy when a relay copy arrives first", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          messageId: "msg-agent-2",
+          role: "assistant",
+          senderLabel: "Parzival",
+          content: [{ type: "text", text: "Parzival There it is..." }],
+          timestamp: 1,
+        },
+        {
+          id: "msg-agent-2",
+          role: "assistant",
+          content: [{ type: "text", text: "There it is..." }],
+          timestamp: 2,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].senderLabel).toBeNull();
+    expect(messageRecord(groups[0]).content).toStrictEqual([
+      { type: "text", text: "There it is..." },
+    ]);
+  });
+
+  it("keeps relay-labeled assistant messages with different ids separate", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          id: "msg-agent-3",
+          role: "assistant",
+          content: [{ type: "text", text: "There it is..." }],
+          timestamp: 1,
+        },
+        {
+          messageId: "msg-agent-4",
+          role: "assistant",
+          senderLabel: "Parzival",
+          content: [{ type: "text", text: "There it is..." }],
+          timestamp: 2,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map((group) => group.senderLabel)).toEqual([null, "Parzival"]);
+  });
+
   it("does not collapse messages that carry canvas previews", () => {
     const canvasBlock = createAssistantCanvasBlock({ suffix: "duplicate_guard" });
     const groups = messageGroups({

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -28,6 +28,8 @@ export type BuildChatItemsProps = {
   historyRenderLimit?: number;
 };
 
+type ChatMessageItem = Extract<ChatItem, { kind: "message" }>;
+
 function appendCanvasBlockToAssistantMessage(
   message: unknown,
   preview: Extract<NonNullable<ToolCard["preview"]>, { kind: "canvas" }>,
@@ -264,24 +266,84 @@ function collapseDuplicateDisplaySignature(message: unknown): string | null {
   return `${role}:${senderLabel}:${text}`;
 }
 
+function collapseDuplicateTranscriptKey(message: unknown): string | null {
+  const marker = asRecord(message)?.["__openclaw"];
+  if (asRecord(marker)?.kind === "pending-send") {
+    return null;
+  }
+  const raw = asRecord(message);
+  if (!raw) {
+    return null;
+  }
+  const normalized = safeNormalizeMessage(message);
+  if (!normalized) {
+    return null;
+  }
+  const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
+  if (role !== "assistant" && role !== "user") {
+    return null;
+  }
+  const id =
+    typeof raw.id === "string" && raw.id.trim()
+      ? raw.id.trim()
+      : typeof raw.messageId === "string" && raw.messageId.trim()
+        ? raw.messageId.trim()
+        : "";
+  return id ? `${role}:${id}` : null;
+}
+
+function prefersNativeChatSurface(message: unknown): boolean {
+  const normalized = safeNormalizeMessage(message);
+  if (!normalized) {
+    return false;
+  }
+  const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
+  return (role === "assistant" || role === "user") && !normalized.senderLabel?.trim();
+}
+
+function preferTranscriptDuplicate(
+  existing: ChatMessageItem,
+  candidate: ChatMessageItem,
+): ChatMessageItem {
+  if (!prefersNativeChatSurface(existing.message) && prefersNativeChatSurface(candidate.message)) {
+    return candidate;
+  }
+  return existing;
+}
+
 function collapseSequentialDuplicateMessages(items: ChatItem[]): ChatItem[] {
   const collapsed: ChatItem[] = [];
   let previousSignature: string | null = null;
+  let previousTranscriptKey: string | null = null;
 
   for (const item of items) {
     if (item.kind !== "message") {
       collapsed.push(item);
       previousSignature = null;
+      previousTranscriptKey = null;
       continue;
     }
     const signature = collapseDuplicateDisplaySignature(item.message);
+    const transcriptKey = collapseDuplicateTranscriptKey(item.message);
     const previous = collapsed[collapsed.length - 1];
+    // dmScope=main can project the same transcript row through native chat and relay paths;
+    // collapse by transcript id before display-signature counting so relay labels do not double-paint.
+    if (transcriptKey && previousTranscriptKey === transcriptKey && previous?.kind === "message") {
+      const preferred = preferTranscriptDuplicate(previous, item);
+      if (preferred !== previous) {
+        collapsed[collapsed.length - 1] = preferred;
+        previousSignature = collapseDuplicateDisplaySignature(preferred.message);
+      }
+      previousTranscriptKey = transcriptKey;
+      continue;
+    }
     if (signature && previousSignature === signature && previous?.kind === "message") {
       previous.duplicateCount = (previous.duplicateCount ?? 1) + 1;
       continue;
     }
     collapsed.push(item);
     previousSignature = signature;
+    previousTranscriptKey = transcriptKey;
   }
 
   return collapsed;

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -268,7 +268,8 @@ function collapseDuplicateDisplaySignature(message: unknown): string | null {
 
 function collapseDuplicateTranscriptKey(message: unknown): string | null {
   const marker = asRecord(message)?.["__openclaw"];
-  if (asRecord(marker)?.kind === "pending-send") {
+  const markerRecord = asRecord(marker);
+  if (markerRecord?.kind === "pending-send") {
     return null;
   }
   const raw = asRecord(message);
@@ -288,7 +289,9 @@ function collapseDuplicateTranscriptKey(message: unknown): string | null {
       ? raw.id.trim()
       : typeof raw.messageId === "string" && raw.messageId.trim()
         ? raw.messageId.trim()
-        : "";
+        : typeof markerRecord?.id === "string" && markerRecord.id.trim()
+          ? markerRecord.id.trim()
+          : "";
   return id ? `${role}:${id}` : null;
 }
 


### PR DESCRIPTION
## Summary

- Deduplicate adjacent Control UI chat render copies that share the same transcript `id`/`messageId`.
- Prefer the native unlabeled chat copy when the duplicate pair includes a relay-labeled projection.
- Keep existing display-signature duplicate counting for repeated identical messages without transcript ids.

## Linked context

Closes #93044.

## Real behavior proof

- Behavior addressed: with `dmScope=main`, Control UI webchat can receive the same assistant transcript row through the native chat path and the session relay path; current rendering painted both when one copy carried a relay sender label or prefixed text.
- Real environment tested: macOS local checkout on `upstream/main` at `f1b8827d20c8f1d648cdb1d4034120a67d1ff3e7`, Node/Vitest via the repo `scripts/run-vitest.mjs` wrapper.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs ui/src/ui/chat/build-chat-items.test.ts`
- Evidence after fix:

```text
[test] starting test/vitest/vitest.unit-ui.config.ts

 RUN  v4.1.7 /Users/andy/Codex/openclaw-prs/93044-webchat-dedupe

 Test Files  1 passed (1)
      Tests  36 passed (36)
```

- Observed result after fix: the regression covers the #93044 render shape directly: same transcript id plus raw/relay-labeled assistant copies now renders one native unlabeled message, reversed arrival order still prefers the native copy, and different transcript ids still render separately.
- What was not tested: no live Telegram plus Control UI `dmScope=main` run was performed from this machine; the proof is source-level renderer coverage for the duplicated transcript-id shape.
- Before evidence: adding the same regression test on unmodified current main failed with `expected ... to have a length of 1 but got 2`, confirming the duplicate render before this patch.
- Proof limitations or environment constraints: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --shell -- 'env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed'` could not run locally because Blacksmith/Testbox is not authenticated on this machine. Fallback providers were also unavailable locally: Azure requires `az`/login, AWS requires Crabbox broker login, and local-container requires Docker.

## Tests and validation

- `node scripts/run-vitest.mjs ui/src/ui/chat/build-chat-items.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/chat/build-chat-items.ts ui/src/ui/chat/build-chat-items.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json ui/src/ui/chat/build-chat-items.ts ui/src/ui/chat/build-chat-items.test.ts`
- `git diff --check`

## Risk checklist

- User-visible behavior changed: yes, duplicate Control UI chat bubbles for the same transcript row are suppressed.
- Config, environment, or migration behavior changed: no.
- Security, auth, secrets, network, or tool execution behavior changed: no.
- Highest-risk area: Control UI message rendering could hide a legitimate adjacent message if the same transcript id is reused incorrectly.
- Mitigation: dedupe is limited to adjacent rendered user/assistant messages with the same normalized role and transcript id, preserves different ids, and keeps the existing display-signature duplicate counter path intact.

## Current review state

Ready for CI and ClawSweeper review. The local Testbox changed gate is blocked by local provider authentication/tooling, so GitHub CI should be treated as the remote gate for this branch.
