### PR TITLE
fix(feishu): handle interactive card sub-messages in merge_forward content (fixes #77909)

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -197,6 +197,25 @@ function formatSubMessageContent(content: string, contentType: string): string {
         return "[Sticker]";
       case "merge_forward":
         return "[Nested Merged Forward]";
+      case "interactive": {
+        if (typeof parsed === "object" && parsed !== null) {
+          const obj = parsed as Record<string, unknown>;
+          const header =
+            typeof obj.header === "object" && obj.header !== null
+              ? (obj.header as Record<string, unknown>)
+              : undefined;
+          const title =
+            header &&
+            typeof header.title === "object" &&
+            header.title !== null
+              ? (header.title as Record<string, unknown>)
+              : undefined;
+          if (title && typeof title.content === "string" && title.content.trim()) {
+            return `[Card: ${title.content.trim()}]`;
+          }
+        }
+        return "[Interactive Card]";
+      }
       default:
         return `[${contentType}]`;
     }

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2897,6 +2897,145 @@ describe("handleFeishuMessage command authorization", () => {
     expect(context.BodyForAgent).toContain("[Merged and Forwarded Message - could not fetch]");
   });
 
+  it("formats interactive card sub-messages with header title in merge_forward", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    const mockGetMerged = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "container",
+            msg_type: "merge_forward",
+            body: { content: JSON.stringify({ text: "Merged and Forwarded Message" }) },
+          },
+          {
+            message_id: "sub-interactive",
+            upper_message_id: "container",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                header: { title: { content: "Approval Request", tag: "plain_text" } },
+                elements: [{ tag: "div", text: { content: "Please approve" } }],
+              }),
+            },
+            create_time: "1000",
+          },
+        ],
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
+        },
+      },
+      im: {
+        message: {
+          get: mockGetMerged,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-interactive",
+        },
+      },
+      message: {
+        message_id: "msg-interactive-forward",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "merge_forward",
+        content: JSON.stringify({ text: "Merged and Forwarded Message" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    const context = mockCallArg<{ BodyForAgent?: string }>(mockFinalizeInboundContext, 0, 0);
+    expect(context.BodyForAgent).toContain(
+      "[Merged and Forwarded Messages]\n- [Card: Approval Request]",
+    );
+  });
+
+  it("formats interactive card sub-messages without header as [Interactive Card]", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    const mockGetMerged = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "container",
+            msg_type: "merge_forward",
+            body: { content: JSON.stringify({ text: "Merged and Forwarded Message" }) },
+          },
+          {
+            message_id: "sub-interactive-no-header",
+            upper_message_id: "container",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                elements: [{ tag: "div", text: { content: "Some content" } }],
+              }),
+            },
+            create_time: "1000",
+          },
+        ],
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
+        },
+      },
+      im: {
+        message: {
+          get: mockGetMerged,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-interactive-no-header",
+        },
+      },
+      message: {
+        message_id: "msg-interactive-no-header",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "merge_forward",
+        content: JSON.stringify({ text: "Merged and Forwarded Message" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    const context = mockCallArg<{ BodyForAgent?: string }>(mockFinalizeInboundContext, 0, 0);
+    expect(context.BodyForAgent).toContain(
+      "[Merged and Forwarded Messages]\n- [Interactive Card]",
+    );
+  });
+
   it("dispatches once and appends permission notice to the main agent body", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockCreateFeishuClient.mockReturnValue({


### PR DESCRIPTION
## Summary

When merge_forward messages contain interactive card sub-messages (e.g. approval cards, tables, dashboards), the content was rendered as `[interactive]` — the raw content type string — because `formatSubMessageContent` in `bot-content.ts` had no case for the `interactive` msg_type.

Now extracts the card header title when available (`[Card: <title>]`) and falls back to `[Interactive Card]` otherwise. This matches the pattern already used in `send.ts` for outbound interactive cards.

Fixes #77909

## Changes

- `extensions/feishu/src/bot-content.ts`: Added `case "interactive"` to `formatSubMessageContent` that extracts the card header title from the JSON content
- `extensions/feishu/src/bot.test.ts`: Added 2 tests covering interactive cards with and without headers in merge_forward sub-messages

## Real behavior proof

- **Behavior addressed:** Interactive card sub-messages in merge_forward content rendered as `[interactive]` instead of showing card title or `[Interactive Card]`
- **Environment tested:** macOS 26.4.1, Node.js v25.8.2, OpenClaw commit c386669b
- **Steps run after the patch:**
  1. Ran `node scripts/run-vitest.mjs run extensions/feishu/src/bot.test.ts` — 84 tests passed (82 existing + 2 new)
  2. Ran `pnpm build` — build succeeded
  3. Verified the `interactive` case in `formatSubMessageContent` extracts header title when present

- **Evidence after fix:**

```
$ node scripts/run-vitest.mjs run extensions/feishu/src/bot.test.ts
 ✓  extension-feishu  extensions/feishu/src/bot.test.ts (84 tests) 52ms
 Test Files  1 passed (1)
      Tests  84 passed (84)

$ grep -n -A 15 'case "interactive"' extensions/feishu/src/bot-content.ts
200:      case "interactive": {
201-        if (typeof parsed === "object" && parsed !== null) {
202-          const obj = parsed as Record<string, unknown>;
203-          const header =
204-            typeof obj.header === "object" && obj.header !== null
205-              ? (obj.header as Record<string, unknown>)
206-              : undefined;
207-          const title =
208-            header &&
209-            typeof header.title === "object" &&
210-            header.title !== null
211-              ? (header.title as Record<string, unknown>)
212-              : undefined;
213-          if (title && typeof title.content === "string" && title.content.trim()) {
214-            return `[Card: ${title.content.trim()}]`;
215-          }

$ pnpm build
[build-all] phase timings: total 68.2s
```

- **Observed result after fix:** Interactive card sub-messages in merge_forward now show `[Card: <title>]` when a header title exists, or `[Interactive Card]` as fallback. All 84 tests pass including 2 new tests covering both cases.
- **What was not tested:** Real Feishu API merge_forward messages — fix is based on the documented card JSON structure and existing codebase patterns in `send.ts`.
