### PR TITLE
fix(sessions): preserve titles on main upsert

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -164,7 +164,7 @@ two-party event loops that do not go through the shared inbound reply runner.
     });
     ```
 
-    Prefer `getSessionEntry(...)`, `listSessionEntries(...)`, `patchSessionEntry(...)`, or `upsertSessionEntry(...)` for session workflows. These helpers address sessions by agent/session identity so plugins do not depend on the legacy `sessions.json` storage shape. Use `preserveActivity: true` for metadata-only patches that should not refresh session activity, and `replaceEntry: true` only when the callback returns a complete entry and deleted fields must stay deleted. `loadSessionStore(...)` remains as a deprecated compatibility escape hatch for callers that intentionally need a mutable whole-store clone.
+    Prefer `getSessionEntry(...)`, `listSessionEntries(...)`, `patchSessionEntry(...)`, or `upsertSessionEntry(...)` for session workflows. These helpers address sessions by agent/session identity so plugins do not depend on the legacy `sessions.json` storage shape. `upsertSessionEntry(...)` treats omitted human title fields (`label` and `displayName`) as unchanged during replacement writes; pass explicit `null` or empty string values to clear them. Use `preserveActivity: true` for metadata-only patches that should not refresh session activity, and `replaceEntry: true` only when the callback returns a complete entry and deleted fields must stay deleted. `loadSessionStore(...)` remains as a deprecated compatibility escape hatch for callers that intentionally need a mutable whole-store clone.
 
   </Accordion>
   <Accordion title="api.runtime.agent.defaults">

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -164,7 +164,7 @@ two-party event loops that do not go through the shared inbound reply runner.
     });
     ```
 
-    Prefer `getSessionEntry(...)`, `listSessionEntries(...)`, `patchSessionEntry(...)`, or `upsertSessionEntry(...)` for session workflows. These helpers address sessions by agent/session identity so plugins do not depend on the legacy `sessions.json` storage shape. `upsertSessionEntry(...)` treats omitted human title fields (`label` and `displayName`) as unchanged during replacement writes; pass explicit `null` or empty string values to clear them. Use `preserveActivity: true` for metadata-only patches that should not refresh session activity, and `replaceEntry: true` only when the callback returns a complete entry and deleted fields must stay deleted. `loadSessionStore(...)` remains as a deprecated compatibility escape hatch for callers that intentionally need a mutable whole-store clone.
+    Prefer `getSessionEntry(...)`, `listSessionEntries(...)`, `patchSessionEntry(...)`, or `upsertSessionEntry(...)` for session workflows. These helpers address sessions by agent/session identity so plugins do not depend on the legacy `sessions.json` storage shape. `upsertSessionEntry(...)` treats omitted human title fields (`label` and `displayName`) as unchanged during replacement writes; pass explicit empty string values to clear them. Use `preserveActivity: true` for metadata-only patches that should not refresh session activity, and `replaceEntry: true` only when the callback returns a complete entry and deleted fields must stay deleted. `loadSessionStore(...)` remains as a deprecated compatibility escape hatch for callers that intentionally need a mutable whole-store clone.
 
   </Accordion>
   <Accordion title="api.runtime.agent.defaults">

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -795,7 +795,7 @@ describe("sessions", () => {
     expect(store[sessionKey]?.displayName).toBe("Stable Default Lane");
   });
 
-  it("upsertSessionEntry allows explicit empty replacement title metadata", async () => {
+  it("upsertSessionEntry allows explicit empty string replacement title metadata", async () => {
     const sessionKey = "agent:main:direct:opaque-user";
     const { storePath } = await createSessionStoreFixture({
       prefix: "upsertSessionEntry-title-empty-replace",
@@ -815,14 +815,14 @@ describe("sessions", () => {
       entry: {
         sessionId: "sess-2",
         updatedAt: 200,
-        label: null as unknown as string,
+        label: "",
         displayName: "",
       },
     });
 
     const store = loadSessionStore(storePath);
     expect(store[sessionKey]?.sessionId).toBe("sess-2");
-    expect(store[sessionKey]?.label).toBeNull();
+    expect(store[sessionKey]?.label).toBe("");
     expect(store[sessionKey]?.displayName).toBe("");
   });
 

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -689,6 +689,38 @@ describe("sessions", () => {
     expect(store[sessionKey]?.modelProvider).toBeUndefined();
   });
 
+  it("patchSessionEntry replaceEntry remains the intentional human title clear path", async () => {
+    const sessionKey = "agent:main:main";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "patchSessionEntry-title-clear",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 100,
+          label: "Pinned Lane",
+          displayName: "Pinned Lane",
+        },
+      },
+    });
+
+    await patchSessionEntry({
+      storePath,
+      sessionKey,
+      replaceEntry: true,
+      update: (entry) => {
+        const next = { ...entry, updatedAt: 200 };
+        delete next.label;
+        delete next.displayName;
+        return next;
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.updatedAt).toBe(200);
+    expect(store[sessionKey]?.label).toBeUndefined();
+    expect(store[sessionKey]?.displayName).toBeUndefined();
+  });
+
   it("upsertSessionEntry drops legacy embedded ACP metadata", async () => {
     const sessionKey = "agent:main:main";
     const acp = {
@@ -722,6 +754,106 @@ describe("sessions", () => {
     const store = loadSessionStore(storePath);
     expect(store[sessionKey]?.sessionId).toBe("sess-2");
     expect(store[sessionKey]?.acp).toBeUndefined();
+  });
+
+  it("upsertSessionEntry preserves the default lane title when runtime metadata omits it", async () => {
+    const sessionKey = "agent:main:main";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "upsertSessionEntry-main-title-preserve",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 100,
+          label: "Stable Default Lane",
+          displayName: "Stable Default Lane",
+          origin: {
+            provider: "webchat",
+            surface: "webchat",
+            chatType: "direct",
+          },
+        },
+      },
+    });
+
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "sess-2",
+        updatedAt: 200,
+        origin: {
+          provider: "webchat",
+          surface: "webchat",
+          chatType: "direct",
+        },
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.sessionId).toBe("sess-2");
+    expect(store[sessionKey]?.label).toBe("Stable Default Lane");
+    expect(store[sessionKey]?.displayName).toBe("Stable Default Lane");
+  });
+
+  it("upsertSessionEntry allows explicit empty replacement title metadata", async () => {
+    const sessionKey = "agent:main:direct:opaque-user";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "upsertSessionEntry-title-empty-replace",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 100,
+          label: "Channel Lane",
+          displayName: "Channel Lane",
+        },
+      },
+    });
+
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "sess-2",
+        updatedAt: 200,
+        label: null as unknown as string,
+        displayName: "",
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.sessionId).toBe("sess-2");
+    expect(store[sessionKey]?.label).toBeNull();
+    expect(store[sessionKey]?.displayName).toBe("");
+  });
+
+  it("upsertSessionEntry accepts non-empty replacement human titles", async () => {
+    const sessionKey = "agent:main:ops-lane";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "upsertSessionEntry-title-replace",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 100,
+          label: "Old Lane",
+          displayName: "Old Lane",
+        },
+      },
+    });
+
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "sess-2",
+        updatedAt: 200,
+        label: "Ops Lane",
+        displayName: "Ops Lane",
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.label).toBe("Ops Lane");
+    expect(store[sessionKey]?.displayName).toBe("Ops Lane");
   });
 
   it("updateSessionStore preserves concurrent additions", async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -245,6 +245,30 @@ function cloneSessionEntry(entry: SessionEntry): SessionEntry {
   return cloneSessionStoreRecord({ entry }).entry;
 }
 
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasOwnSessionTitleField(entry: SessionEntry, field: "label" | "displayName"): boolean {
+  return Object.hasOwn(entry, field);
+}
+
+function preserveHumanSessionTitleFields(params: {
+  existing?: SessionEntry;
+  next: SessionEntry;
+}): void {
+  const { existing, next } = params;
+  if (!existing) {
+    return;
+  }
+  if (!hasOwnSessionTitleField(next, "label") && hasNonEmptyString(existing.label)) {
+    next.label = existing.label;
+  }
+  if (!hasOwnSessionTitleField(next, "displayName") && hasNonEmptyString(existing.displayName)) {
+    next.displayName = existing.displayName;
+  }
+}
+
 function resolveSessionWorkflowStorePath(
   options: SessionEntryWorkflowOptions & { sessionKey?: string },
 ): string {
@@ -1477,6 +1501,10 @@ export async function upsertSessionEntry(
     const store = loadMutableSessionStoreForWriter(storePath);
     const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
     const next = cloneSessionEntry(params.entry);
+    preserveHumanSessionTitleFields({
+      existing: resolved.existing,
+      next,
+    });
     await persistResolvedSessionEntry({
       storePath,
       store,


### PR DESCRIPTION
## Summary

- Preserves existing non-empty `label` and `displayName` during `upsertSessionEntry` replacement writes when the incoming runtime entry omits those fields.
- Keeps explicit replacement semantics intact: non-empty titles still replace previous titles, and explicit `null` / empty title metadata is still persisted.
- Adds focused regression coverage for omitted runtime title metadata, explicit empty metadata, explicit title replacement, and the existing patch/replace title-clear path.

## Main Target

- Targets `main` after `release/2026.6.8` was already released.
- Replaces #91690 with the same bug fix synchronized onto current `main` and a narrower compatibility-safe contract.

## Motivation

Runtime session refreshes can replace a stored session entry with metadata that does not include user-facing title fields. Before this patch, that replacement could drop stable title metadata even though the caller was only refreshing runtime state. The store boundary is the right place to protect omitted title fields because every replacement upsert passes through it.

## Compatibility

Compatibility risk is intentionally minimized. This patch only preserves title fields when the replacement entry does not own `label` / `displayName` at all. Callers that explicitly send non-empty, `null`, or empty string title values keep their current replacement behavior. Intentional deletion through `patchSessionEntry({ replaceEntry: true })` also remains covered.

## Verification

- `node scripts/run-vitest.mjs run src/config/sessions.test.ts` - 54 passed
- `npx oxfmt --check --threads=1 docs/plugins/sdk-runtime.md src/config/sessions.test.ts src/config/sessions/store.ts`
- `npx oxlint src/config/sessions.test.ts src/config/sessions/store.ts`
- `git diff --check upstream/main...HEAD`
- GitHub checks on `3b6ab1d36f510c7bbbdad50bfd7fe4bb8d4c3719`: dependency/security/proof/label/dispatch/auto-response checks passed; unrelated superseded bot runs were cancelled or skipped by GitHub Actions concurrency/event filters.
## Privacy

The PR text and tests use only generic lane/session fixtures. No personal identifiers, account ids, or real session names are included.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Risk

- Session state: low, targeted store-boundary preservation for omitted fields only.
- Compatibility: low, explicit replacement and explicit clearing behavior remains unchanged.

## Real behavior proof

- Behavior addressed: a replacement `upsertSessionEntry` runtime refresh that omits `label` / `displayName` preserves an existing stable user-facing title.
- Real environment tested: the original store-boundary proof was run on the predecessor PR head; the current main-based head `3b6ab1d36f510c7bbbdad50bfd7fe4bb8d4c3719` carries the same behavior patch synchronized onto `main` and passed focused store tests plus the GitHub Real behavior proof workflow.
- Exact steps or command run after this patch: `node --import tsx --eval <redacted temp OpenClaw session-store proof>`
- Evidence after fix: terminal output from the temporary OpenClaw session-store proof:

```json
{
  "command": "node --import tsx --eval <redacted temp OpenClaw session-store proof>",
  "tempState": "redacted tmp OpenClaw state dir",
  "preservedAfterRuntimeRefresh": {
    "sessionId": "after-redacted",
    "label": "Stable Default Lane",
    "displayName": "Stable Default Lane"
  },
  "explicitEmptyReplacementStillPersists": {
    "label": null,
    "displayName": ""
  }
}
```

- Observed result after fix: the runtime refresh advanced the stored session id while preserving the omitted title fields, and the explicit empty replacement case still persisted `null` / empty string title metadata.
- What was not tested: Full gateway UI rendering was not exercised in this proof; this patch is limited to the session-store replacement boundary and is covered there.


