### PR TITLE
fix(agents): retry empty post-tool final turns

### DIFF
--- a/extensions/codex/src/app-server/attempt-results.ts
+++ b/extensions/codex/src/app-server/attempt-results.ts
@@ -100,6 +100,7 @@ export function buildCodexTurnStartFailureResult(params: {
     assistantTexts: [],
     toolMetas: [],
     lastAssistant: undefined,
+    currentAttemptAssistant: undefined,
     didSendViaMessagingTool: false,
     messagingToolSentTexts: [],
     messagingToolSentMediaUrls: [],

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -1391,6 +1391,45 @@ describe("createCodexDynamicToolBridge", () => {
     expect(result.sideEffectEvidence).toBe(true);
   });
 
+  it("keeps audited core read-only dynamic tools replay-safe", async () => {
+    const bridge = createBridgeWithToolResult("search", textToolResult("no matches"));
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: null,
+      tool: "search",
+      arguments: { query: "scheduler" },
+    });
+
+    expect(result).toEqual(expectInputText("no matches"));
+    expect(result.sideEffectEvidence).toBeUndefined();
+  });
+
+  it("keeps async-started read-only tools replay-unsafe", async () => {
+    const bridge = createBridgeWithToolResult(
+      "search",
+      textToolResult("Background task started.", {
+        async: true,
+        status: "started",
+        taskId: "task-1",
+      }),
+    );
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: null,
+      tool: "search",
+      arguments: { query: "scheduler" },
+    });
+
+    expect(result.asyncStarted).toBe(true);
+    expect(result.sideEffectEvidence).toBe(true);
+  });
+
   it("does not mark pre-execution argument failures as side-effect evidence", async () => {
     const execute = vi.fn(async () => textToolResult("should not run"));
     const bridge = createCodexDynamicToolBridge({

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -12,7 +12,10 @@ import {
   filterToolResultMediaUrls,
   HEARTBEAT_RESPONSE_TOOL_NAME,
   embeddedAgentLog,
+  getChannelAgentToolMeta,
+  getPluginToolMeta,
   type EmbeddedRunAttemptParams,
+  isAgentToolReplaySafe,
   isToolWrappedWithBeforeToolCallHook,
   isToolResultError,
   isMessagingTool,
@@ -178,6 +181,16 @@ export function createCodexDynamicToolBridge(params: {
     runtime: "codex",
     ...toolResultHookContext,
   });
+  const isReplaySafeTool = (tool: AnyAgentTool) =>
+    isAgentToolReplaySafe(tool, {
+      declaredReplaySafe: (candidate) => {
+        const pluginMeta = getPluginToolMeta(candidate as AnyAgentTool);
+        if (pluginMeta) {
+          return pluginMeta.replaySafe === true;
+        }
+        return getChannelAgentToolMeta(candidate as never) ? false : undefined;
+      },
+    });
   const legacyExtensionRunner =
     createCodexAppServerToolResultExtensionRunner(toolResultHookContext);
   const directToolNames = new Set([
@@ -316,11 +329,13 @@ export function createCodexDynamicToolBridge(params: {
             isToolResultYield(rawResult) ||
             isToolResultYield(result),
         );
-        withDynamicToolAsyncStarted(
+        const asyncStarted =
+          isAsyncStartedToolResult(rawResult) || isAsyncStartedToolResult(result);
+        withDynamicToolAsyncStarted(response, asyncStarted);
+        return withSideEffectEvidence(
           response,
-          isAsyncStartedToolResult(rawResult) || isAsyncStartedToolResult(result),
+          asyncStarted || (terminalType !== "blocked" && !isReplaySafeTool(toolEntry.tool)),
         );
-        return withSideEffectEvidence(response, terminalType !== "blocked");
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         notifyAgentToolResult(
@@ -361,7 +376,7 @@ export function createCodexDynamicToolBridge(params: {
             },
             "error",
           ),
-          didStartExecution,
+          didStartExecution && !isReplaySafeTool(toolEntry.tool),
         );
       }
     },

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -309,6 +309,7 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.assistantTexts).toEqual(["hello"]);
     expect(result.messagesSnapshot.map((message) => message.role)).toEqual(["user", "assistant"]);
     expect(result.lastAssistant?.content).toEqual([{ type: "text", text: "hello" }]);
+    expect(result.currentAttemptAssistant?.content).toEqual([{ type: "text", text: "hello" }]);
     expectUsageFields(result.attemptUsage, { input: 3, output: 7, cacheRead: 2, total: 12 });
     expectUsageFields(result.lastAssistant?.usage, {
       input: 3,
@@ -751,6 +752,7 @@ describe("CodexAppServerEventProjector", () => {
 
     expect(result.assistantTexts).toEqual([]);
     expect(result.lastAssistant).toBeUndefined();
+    expect(result.currentAttemptAssistant).toBeUndefined();
   });
 
   it("does not treat app-server interrupted status as a user cancellation by itself", async () => {
@@ -1050,6 +1052,34 @@ describe("CodexAppServerEventProjector", () => {
       },
     ]);
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("checking thread context");
+  });
+
+  it("preserves an empty final assistant item after tool activity", async () => {
+    const projector = await createProjector();
+    projector.recordDynamicToolCall({
+      callId: "call-search",
+      tool: "memory_search",
+      arguments: { query: "scheduler" },
+    });
+    projector.recordDynamicToolResult({
+      callId: "call-search",
+      tool: "memory_search",
+      success: true,
+      sideEffectEvidence: false,
+      contentItems: [{ type: "inputText", text: "no matches" }],
+    });
+    await projector.handleNotification(
+      turnCompleted([
+        { type: "agentMessage", id: "msg-before-tool", text: "Checking the scheduler now." },
+        { type: "agentMessage", id: "msg-final", text: "" },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.assistantTexts).toEqual(["Checking the scheduler now."]);
+    expect(result.currentAttemptAssistant?.content).toEqual([{ type: "text", text: "" }]);
+    expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: false, replaySafe: true });
   });
 
   it("streams commentary agent messages as keyed progress events", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -313,6 +313,7 @@ export class CodexAppServerEventProjector {
       assistantTexts.length > 0
         ? this.createAssistantMessage(assistantTexts.join("\n\n"))
         : undefined;
+    const currentAttemptAssistant = this.createCurrentAttemptAssistantMessage();
     // Each snapshot entry is tagged with a stable mirror identity of the
     // shape `${turnId}:${kind}`. The mirror's idempotency key is derived
     // from this identity rather than from snapshot position or content
@@ -385,6 +386,7 @@ export class CodexAppServerEventProjector {
       assistantTexts,
       toolMetas,
       lastAssistant,
+      currentAttemptAssistant,
       ...(this.lastNativeToolError ? { lastToolError: this.lastNativeToolError } : {}),
       didSendViaMessagingTool: toolTelemetry.didSendViaMessagingTool,
       messagingToolSentTexts: toolTelemetry.messagingToolSentTexts,
@@ -614,10 +616,10 @@ export class CodexAppServerEventProjector {
       this.completedItemIds.add(itemId);
     }
     this.rememberAssistantPhase(item);
-    if (item?.type === "agentMessage" && typeof item.text === "string" && item.text) {
+    if (item?.type === "agentMessage" && typeof item.text === "string") {
       this.rememberAssistantItem(item.id);
       this.assistantTextByItem.set(item.id, item.text);
-      if (this.isCommentaryAssistantItem(item.id)) {
+      if (item.text && this.isCommentaryAssistantItem(item.id)) {
         this.emitCommentaryProgress({ itemId: item.id, text: item.text });
       }
     }
@@ -752,7 +754,7 @@ export class CodexAppServerEventProjector {
     }
     for (const item of turn.items ?? []) {
       this.rememberAssistantPhase(item);
-      if (item.type === "agentMessage" && typeof item.text === "string" && item.text) {
+      if (item.type === "agentMessage" && typeof item.text === "string") {
         this.rememberAssistantItem(item.id);
         this.assistantTextByItem.set(item.id, item.text);
       }
@@ -1688,6 +1690,26 @@ export class CodexAppServerEventProjector {
       return;
     }
     this.assistantItemOrder.push(itemId);
+  }
+
+  private createCurrentAttemptAssistantMessage(): AssistantMessage | undefined {
+    for (let i = this.assistantItemOrder.length - 1; i >= 0; i -= 1) {
+      const itemId = this.assistantItemOrder[i];
+      if (
+        !itemId ||
+        this.isCommentaryAssistantItem(itemId) ||
+        !this.assistantTextByItem.has(itemId)
+      ) {
+        continue;
+      }
+      const text = this.assistantTextByItem.get(itemId) ?? "";
+      const normalizedText = text.trim();
+      if (normalizedText && this.toolProgressTexts.has(normalizedText)) {
+        continue;
+      }
+      return this.createAssistantMessage(text);
+    }
+    return undefined;
   }
 
   private async readMirroredSessionMessages(): Promise<AgentMessage[]> {

--- a/extensions/copilot/src/replay-shim.test.ts
+++ b/extensions/copilot/src/replay-shim.test.ts
@@ -284,7 +284,6 @@ describe("copilotToolMetasHavePotentialSideEffects", () => {
     expect(copilotToolMetasHavePotentialSideEffects([{ toolName: "status" }])).toBe(false);
     expect(copilotToolMetasHavePotentialSideEffects([{ toolName: "file_read" }])).toBe(false);
     expect(copilotToolMetasHavePotentialSideEffects([{ toolName: "memory_get" }])).toBe(false);
-    expect(copilotToolMetasHavePotentialSideEffects([{ toolName: "memory_search" }])).toBe(false);
     expect(copilotToolMetasHavePotentialSideEffects([{ toolName: "sessions_history" }])).toBe(
       false,
     );
@@ -292,6 +291,10 @@ describe("copilotToolMetasHavePotentialSideEffects", () => {
     expect(copilotToolMetasHavePotentialSideEffects([{ toolName: "tool_search" }])).toBe(false);
     expect(copilotToolMetasHavePotentialSideEffects([{ toolName: "web_fetch" }])).toBe(false);
     expect(copilotToolMetasHavePotentialSideEffects([{ toolName: "web_search" }])).toBe(false);
+  });
+
+  it("treats memory_search recall tracking as a potential side effect", () => {
+    expect(copilotToolMetasHavePotentialSideEffects([{ toolName: "memory_search" }])).toBe(true);
   });
 
   it("detects async-started tools even without a mutating name", () => {

--- a/extensions/copilot/src/replay-shim.ts
+++ b/extensions/copilot/src/replay-shim.ts
@@ -223,7 +223,6 @@ const COPILOT_REPLAY_SAFE_READ_ONLY_TOOL_NAMES = new Set([
   "list",
   "ls",
   "memory_get",
-  "memory_search",
   "probe",
   "query",
   "read",

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -7,6 +7,11 @@
   "contracts": {
     "tools": ["memory_get", "memory_search"]
   },
+  "toolMetadata": {
+    "memory_get": {
+      "replaySafe": true
+    }
+  },
   "commandAliases": [
     {
       "name": "dreaming",

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -181,6 +181,7 @@
       ]
     },
     "x_search": {
+      "replaySafe": true,
       "authSignals": [
         {
           "provider": "xai"

--- a/src/agents/channel-tool-metadata.test.ts
+++ b/src/agents/channel-tool-metadata.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import {
+  copyChannelAgentToolMeta,
+  getChannelAgentToolMeta,
+  setChannelAgentToolMeta,
+} from "./channel-tool-metadata.js";
+
+describe("channel tool metadata", () => {
+  it("preserves ownership when a concrete tool is wrapped", () => {
+    const source = {};
+    const wrapped = {};
+
+    setChannelAgentToolMeta(source as never, { channelId: "telegram" });
+    copyChannelAgentToolMeta(source as never, wrapped as never);
+
+    expect(getChannelAgentToolMeta(wrapped as never)).toEqual({ channelId: "telegram" });
+  });
+});

--- a/src/agents/channel-tool-metadata.ts
+++ b/src/agents/channel-tool-metadata.ts
@@ -1,0 +1,26 @@
+/** Dependency-light ownership metadata for channel-contributed agent tools. */
+import type { ChannelAgentTool } from "../channels/plugins/types.public.js";
+
+export type ChannelAgentToolMeta = {
+  channelId: string;
+};
+
+const channelAgentToolMeta = new WeakMap<ChannelAgentTool, ChannelAgentToolMeta>();
+
+/** Read channel metadata attached to a channel-owned agent tool. */
+export function getChannelAgentToolMeta(tool: ChannelAgentTool): ChannelAgentToolMeta | undefined {
+  return channelAgentToolMeta.get(tool);
+}
+
+/** Attach channel ownership metadata to a concrete agent tool. */
+export function setChannelAgentToolMeta(tool: ChannelAgentTool, meta: ChannelAgentToolMeta): void {
+  channelAgentToolMeta.set(tool, meta);
+}
+
+/** Copy channel metadata when wrapping or replacing a channel-owned tool. */
+export function copyChannelAgentToolMeta(source: ChannelAgentTool, target: ChannelAgentTool): void {
+  const meta = channelAgentToolMeta.get(source);
+  if (meta) {
+    channelAgentToolMeta.set(target, meta);
+  }
+}

--- a/src/agents/channel-tools.ts
+++ b/src/agents/channel-tools.ts
@@ -22,10 +22,9 @@ import type {
 } from "../channels/plugins/types.public.js";
 import { normalizeAnyChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { setChannelAgentToolMeta } from "./channel-tool-metadata.js";
 
-type ChannelAgentToolMeta = {
-  channelId: string;
-};
+export { copyChannelAgentToolMeta, getChannelAgentToolMeta } from "./channel-tool-metadata.js";
 
 type ChannelMessageActionDiscoveryParams = {
   cfg?: OpenClawConfig;
@@ -38,21 +37,6 @@ type ChannelMessageActionDiscoveryParams = {
   agentId?: string | null;
   requesterSenderId?: string | null;
 };
-
-const channelAgentToolMeta = new WeakMap<ChannelAgentTool, ChannelAgentToolMeta>();
-
-/** Read channel metadata attached to a channel-owned agent tool. */
-export function getChannelAgentToolMeta(tool: ChannelAgentTool): ChannelAgentToolMeta | undefined {
-  return channelAgentToolMeta.get(tool);
-}
-
-/** Copy channel metadata when wrapping or replacing a channel-owned tool. */
-export function copyChannelAgentToolMeta(source: ChannelAgentTool, target: ChannelAgentTool): void {
-  const meta = channelAgentToolMeta.get(source);
-  if (meta) {
-    channelAgentToolMeta.set(target, meta);
-  }
-}
 
 /**
  * Get the list of supported message actions for a specific channel.
@@ -115,7 +99,7 @@ export function listChannelAgentTools(params: { cfg?: OpenClawConfig }): Channel
     const resolved = typeof entry === "function" ? entry(params) : entry;
     if (Array.isArray(resolved)) {
       for (const tool of resolved) {
-        channelAgentToolMeta.set(tool, { channelId: plugin.id });
+        setChannelAgentToolMeta(tool, { channelId: plugin.id });
       }
       tools.push(...resolved);
     }

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2078,6 +2078,91 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
+  it("retries replay-safe post-tool empty final turns after pre-tool narration", () => {
+    const finalAssistant = {
+      role: "assistant",
+      stopReason: "stop",
+      provider: "ollama",
+      model: "gemma4:31b",
+      content: [],
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    const retryInstruction = resolveEmptyResponseRetryInstruction({
+      provider: "ollama",
+      modelId: "gemma4:31b",
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Checking the scheduler now."],
+        toolMetas: [{ toolName: "search" }],
+        currentAttemptAssistant: finalAssistant,
+        lastAssistant: finalAssistant,
+      }),
+    });
+
+    expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+  });
+
+  it("does not retry post-tool turns with a visible final assistant answer", () => {
+    const finalAssistant = {
+      role: "assistant",
+      stopReason: "stop",
+      provider: "custom",
+      model: "composer-2.5",
+      content: [{ type: "text", text: "There are zero matches." }],
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    const retryInstruction = resolveEmptyResponseRetryInstruction({
+      provider: "custom",
+      modelId: "composer-2.5",
+      modelApi: "custom-api",
+      payloadCount: 2,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Checking the scheduler now.", "There are zero matches."],
+        toolMetas: [{ toolName: "search" }],
+        currentAttemptAssistant: finalAssistant,
+        lastAssistant: finalAssistant,
+      }),
+    });
+
+    expect(retryInstruction).toBeNull();
+  });
+
+  it("surfaces exhausted post-tool empty final turns without replacing terminal output", () => {
+    const finalAssistant = {
+      role: "assistant",
+      stopReason: "stop",
+      provider: "custom",
+      model: "composer-2.5",
+      content: [],
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    const attempt = makeAttemptResult({
+      assistantTexts: ["Checking the scheduler now."],
+      toolMetas: [{ toolName: "search" }],
+      currentAttemptAssistant: finalAssistant,
+      lastAssistant: finalAssistant,
+    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt,
+    });
+
+    expect(incompleteTurnText).toContain("couldn't generate a response");
+    expect(
+      resolveEmptyResponseRetryInstruction({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        payloadCount: 1,
+        aborted: false,
+        timedOut: false,
+        attempt: { ...attempt, toolMediaUrls: ["file:///tmp/render.png"] },
+      }),
+    ).toBeNull();
+  });
+
   it("does not retry clean zero-token Ollama stop turns", () => {
     const retryInstruction = resolveEmptyResponseRetryInstruction({
       provider: "ollama",
@@ -3239,7 +3324,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.meta.livenessState).toBe("working");
   });
 
-  it("retries post-tool openai-compatible empty stop turns even when empty silence is allowed", async () => {
+  it("retries post-tool empty final turns after pre-tool narration even when silence is allowed", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedResolveModelAsync.mockResolvedValue({
       model: {
@@ -3254,18 +3339,20 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       },
       modelRegistry: {},
     });
+    const finalAssistant = {
+      role: "assistant",
+      api: "openai-completions",
+      stopReason: "stop",
+      provider: "stepfun",
+      model: "step-router-v1",
+      content: [],
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
-        assistantTexts: [],
+        assistantTexts: ["Checking the scheduler now."],
         toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
-        lastAssistant: {
-          role: "assistant",
-          api: "openai-completions",
-          stopReason: "stop",
-          provider: "stepfun",
-          model: "step-router-v1",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        currentAttemptAssistant: finalAssistant,
+        lastAssistant: finalAssistant,
       }),
     );
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2078,29 +2078,60 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
-  it("retries replay-safe post-tool empty final turns after pre-tool narration", () => {
+  it.each(["search", "web_search", "memory_search", "x_search", "tool_describe"])(
+    "retries post-tool empty final turns after known read-only %s calls",
+    (toolName) => {
+      const finalAssistant = {
+        role: "assistant",
+        stopReason: "stop",
+        provider: "ollama",
+        model: "gemma4:31b",
+        content: [],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+      const retryInstruction = resolveEmptyResponseRetryInstruction({
+        provider: "ollama",
+        modelId: "gemma4:31b",
+        payloadCount: 1,
+        aborted: false,
+        timedOut: false,
+        attempt: makeAttemptResult({
+          assistantTexts: ["Checking the scheduler now."],
+          toolMetas: [{ toolName }],
+          currentAttemptAssistant: finalAssistant,
+          lastAssistant: finalAssistant,
+        }),
+      });
+
+      expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+    },
+  );
+
+  it("does not retry post-tool empty final turns after unclassified tools", () => {
     const finalAssistant = {
       role: "assistant",
       stopReason: "stop",
-      provider: "ollama",
-      model: "gemma4:31b",
+      provider: "custom",
+      model: "composer-2.5",
       content: [],
     } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    const attempt = makeAttemptResult({
+      assistantTexts: ["Checking the scheduler now."],
+      toolMetas: [{ toolName: "search" }, { toolName: "vendor_widget" }],
+      currentAttemptAssistant: finalAssistant,
+      lastAssistant: finalAssistant,
+    });
     const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "ollama",
-      modelId: "gemma4:31b",
+      provider: "custom",
+      modelId: "composer-2.5",
+      modelApi: "custom-api",
       payloadCount: 1,
       aborted: false,
       timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Checking the scheduler now."],
-        toolMetas: [{ toolName: "search" }],
-        currentAttemptAssistant: finalAssistant,
-        lastAssistant: finalAssistant,
-      }),
+      attempt,
     });
 
-    expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+    expect(attempt.replayMetadata).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
+    expect(retryInstruction).toBeNull();
   });
 
   it("does not retry post-tool turns with a visible final assistant answer", () => {
@@ -2468,6 +2499,17 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(
       buildAttemptReplayMetadata({
         toolMetas: [{ toolName: "image_generate", asyncStarted: true }],
+        didSendViaMessagingTool: false,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+      }),
+    ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
+  });
+
+  it("treats unclassified tools as replay-invalid potential side effects", () => {
+    expect(
+      buildAttemptReplayMetadata({
+        toolMetas: [{ toolName: "vendor_widget" }],
         didSendViaMessagingTool: false,
         messagingToolSentTexts: [],
         messagingToolSentMediaUrls: [],
@@ -3350,7 +3392,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Checking the scheduler now."],
-        toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
+        toolMetas: [{ toolName: "search", meta: "query=scheduler" }],
         currentAttemptAssistant: finalAssistant,
         lastAssistant: finalAssistant,
       }),
@@ -3383,6 +3425,57 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.meta.terminalReplyKind).toBeUndefined();
     expect(result.meta.finalAssistantVisibleText).toBe("Visible StepFun answer.");
     expectWarnMessageWith("empty response detected");
+  });
+
+  it("does not retry post-tool empty final turns after unclassified tools", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedResolveModelAsync.mockResolvedValue({
+      model: {
+        id: "step-router-v1",
+        provider: "stepfun",
+        contextWindow: 200000,
+        api: "openai-completions",
+      },
+      error: null,
+      authStorage: {
+        setRuntimeApiKey: vi.fn(),
+      },
+      modelRegistry: {},
+    });
+    const finalAssistant = {
+      role: "assistant",
+      api: "openai-completions",
+      stopReason: "stop",
+      provider: "stepfun",
+      model: "step-router-v1",
+      content: [],
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({
+        assistantTexts: ["Checking the scheduler now."],
+        toolMetas: [{ toolName: "vendor_widget" }],
+        currentAttemptAssistant: finalAssistant,
+        lastAssistant: finalAssistant,
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      allowEmptyAssistantReplyAsSilent: true,
+      provider: "stepfun",
+      model: "step-router-v1",
+      runId: "run-post-tool-unclassified-empty-stop",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expectNoWarnMessageWith("empty response detected");
+    expect(result.payloads).toEqual([
+      {
+        text: "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying.",
+        isError: true,
+      },
+    ]);
+    expect(result.meta.livenessState).toBe("abandoned");
   });
 
   it("returns NO_REPLY without retrying post-tool exact silent assistant replies", async () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1,6 +1,7 @@
 // Coverage for incomplete-turn safety, retry instructions, and liveness states.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { isCoreToolNameReplaySafe } from "../tool-replay-safety.js";
 import {
   hasCommittedMessagingToolDeliveryEvidence,
   hasOutboundDeliveryEvidence,
@@ -2078,7 +2079,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
-  it.each(["search", "web_search", "memory_search", "x_search", "tool_describe"])(
+  it.each(["search", "web_search", "x_search", "memory_get", "tool_describe"])(
     "retries post-tool empty final turns after known read-only %s calls",
     (toolName) => {
       const finalAssistant = {
@@ -2105,6 +2106,31 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
     },
   );
+
+  it("does not retry post-tool empty final turns after memory_search recall tracking", () => {
+    const finalAssistant = {
+      role: "assistant",
+      stopReason: "stop",
+      provider: "ollama",
+      model: "gemma4:31b",
+      content: [],
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    const retryInstruction = resolveEmptyResponseRetryInstruction({
+      provider: "ollama",
+      modelId: "gemma4:31b",
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Checking memory now."],
+        toolMetas: [{ toolName: "memory_search" }],
+        currentAttemptAssistant: finalAssistant,
+        lastAssistant: finalAssistant,
+      }),
+    });
+
+    expect(retryInstruction).toBeNull();
+  });
 
   it("retries post-tool reasoning-only final turns after earlier narration", () => {
     const finalAssistant = {
@@ -2135,6 +2161,53 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+  });
+
+  it("uses lastAssistant for legacy harness results that omit currentAttemptAssistant", () => {
+    const retryInstruction = resolveEmptyResponseRetryInstruction({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Checking the scheduler now."],
+        toolMetas: [{ toolName: "search" }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+  });
+
+  it("does not reuse historical lastAssistant when the current assistant is explicitly absent", () => {
+    const retryInstruction = resolveEmptyResponseRetryInstruction({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Checking the scheduler now."],
+        toolMetas: [{ toolName: "search" }],
+        currentAttemptAssistant: undefined,
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(retryInstruction).toBeNull();
   });
 
   it("does not retry post-tool empty final turns after unclassified tools", () => {
@@ -3737,7 +3810,10 @@ describe("resolvePlanningOnlyRetryInstruction single-action loophole", () => {
     toolNames: string[],
     assistantText: string,
   ): Parameters<typeof resolvePlanningOnlyRetryInstruction>[0]["attempt"] {
-    const toolMetas = toolNames.map((toolName) => ({ toolName }));
+    const toolMetas = toolNames.map((toolName) => ({
+      toolName,
+      replaySafe: isCoreToolNameReplaySafe(toolName),
+    }));
     return {
       toolMetas,
       assistantTexts: [assistantText],

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2106,6 +2106,37 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     },
   );
 
+  it("retries post-tool reasoning-only final turns after earlier narration", () => {
+    const finalAssistant = {
+      role: "assistant",
+      stopReason: "stop",
+      provider: "openai",
+      model: "gpt-5.4",
+      content: [
+        {
+          type: "thinking",
+          thinking: "internal reasoning",
+          thinkingSignature: JSON.stringify({ id: "rs_post_tool", type: "reasoning" }),
+        },
+      ],
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    const retryInstruction = resolveEmptyResponseRetryInstruction({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Checking the scheduler now."],
+        toolMetas: [{ toolName: "search" }],
+        currentAttemptAssistant: finalAssistant,
+        lastAssistant: finalAssistant,
+      }),
+    });
+
+    expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+  });
+
   it("does not retry post-tool empty final turns after unclassified tools", () => {
     const finalAssistant = {
       role: "assistant",
@@ -3195,7 +3226,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   it("treats post-tool exact NO_REPLY assistant turns as intentional silence", () => {
     const attempt = makeAttemptResult({
       assistantTexts: ["NO_REPLY"],
-      toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
+      toolMetas: [{ toolName: "search", meta: "query=scheduler" }],
       lastAssistant: {
         role: "assistant",
         stopReason: "stop",
@@ -3251,7 +3282,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
     const postToolEmptyAttempt = makeAttemptResult({
       assistantTexts: [],
-      toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
+      toolMetas: [{ toolName: "search", meta: "query=scheduler" }],
       lastAssistant: {
         role: "assistant",
         api: "openai-completions",
@@ -3503,7 +3534,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["NO_REPLY"],
-        toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
+        toolMetas: [{ toolName: "search", meta: "query=scheduler" }],
         lastAssistant: {
           role: "assistant",
           api: "openai-completions",

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2129,9 +2129,16 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt,
     });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt,
+    });
 
     expect(attempt.replayMetadata).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
     expect(retryInstruction).toBeNull();
+    expect(incompleteTurnText).toContain("tool actions may have already been executed");
   });
 
   it("does not retry post-tool turns with a visible final assistant answer", () => {

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.fixture.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.fixture.ts
@@ -1,3 +1,4 @@
+import { isCoreToolNameReplaySafe } from "../tool-replay-safety.js";
 /**
  * Test fixtures for embedded-run overflow compaction scenarios.
  */
@@ -36,7 +37,10 @@ export function makeCompactionSuccess(params: {
 export function makeAttemptResult(
   overrides: Partial<EmbeddedRunAttemptResult> = {},
 ): EmbeddedRunAttemptResult {
-  const toolMetas = overrides.toolMetas ?? [];
+  const toolMetas = (overrides.toolMetas ?? []).map((entry) => ({
+    ...entry,
+    replaySafe: entry.replaySafe ?? isCoreToolNameReplaySafe(entry.toolName),
+  }));
   const didSendViaMessagingTool = overrides.didSendViaMessagingTool ?? false;
   const messagingToolSentTexts = overrides.messagingToolSentTexts ?? [];
   const messagingToolSentMediaUrls = overrides.messagingToolSentMediaUrls ?? [];
@@ -54,7 +58,6 @@ export function makeAttemptResult(
     promptErrorSource: null,
     sessionIdUsed: "test-session",
     assistantTexts: ["Hello!"],
-    toolMetas,
     acceptedSessionSpawns,
     lastAssistant: undefined,
     messagesSnapshot: [],
@@ -80,6 +83,7 @@ export function makeAttemptResult(
     messagingToolSentTargets,
     cloudCodeAssistFormatError: false,
     ...overrides,
+    toolMetas,
   };
 }
 

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.fixture.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.fixture.ts
@@ -37,10 +37,11 @@ export function makeCompactionSuccess(params: {
 export function makeAttemptResult(
   overrides: Partial<EmbeddedRunAttemptResult> = {},
 ): EmbeddedRunAttemptResult {
-  const toolMetas = (overrides.toolMetas ?? []).map((entry) => ({
-    ...entry,
-    replaySafe: entry.replaySafe ?? isCoreToolNameReplaySafe(entry.toolName),
-  }));
+  const toolMetas = (overrides.toolMetas ?? []).map((entry) =>
+    Object.assign({}, entry, {
+      replaySafe: entry.replaySafe ?? isCoreToolNameReplaySafe(entry.toolName),
+    }),
+  );
   const didSendViaMessagingTool = overrides.didSendViaMessagingTool ?? false;
   const messagingToolSentTexts = overrides.messagingToolSentTexts ?? [];
   const messagingToolSentMediaUrls = overrides.messagingToolSentMediaUrls ?? [];

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3345,13 +3345,15 @@ async function runEmbeddedAgentInternal(
                 ? [silentToolResultReplyPayload]
                 : payloadsWithToolMedia;
           const payloadCount = payloadsForTerminalPath?.length ?? 0;
-          const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
-            allowEmptyAssistantReplyAsSilent: params.allowEmptyAssistantReplyAsSilent,
-            payloadCount,
-            aborted,
-            timedOut,
-            attempt,
-          });
+          const emptyAssistantReplyIsSilent =
+            Boolean(silentToolResultReplyPayload) ||
+            shouldTreatEmptyAssistantReplyAsSilent({
+              allowEmptyAssistantReplyAsSilent: params.allowEmptyAssistantReplyAsSilent,
+              payloadCount,
+              aborted,
+              timedOut,
+              attempt,
+            });
           const nextPlanningOnlyRetryInstruction = emptyAssistantReplyIsSilent
             ? null
             : resolvePlanningOnlyRetryInstruction({

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -130,6 +130,7 @@ import {
 } from "../../bootstrap-files.js";
 import { createCacheTrace } from "../../cache-trace.js";
 import {
+  getChannelAgentToolMeta,
   listChannelSupportedActions,
   resolveChannelMessageToolHints,
   resolveChannelReactionGuidance,
@@ -213,6 +214,7 @@ import {
   buildEmptyExplicitToolAllowlistError,
   collectExplicitToolAllowlistSources,
 } from "../../tool-allowlist-guard.js";
+import { collectReplaySafeToolNames, isAgentToolReplaySafe } from "../../tool-replay-safety.js";
 import { filterRuntimeCompatibleTools } from "../../tool-schema-projection.js";
 import { logRuntimeToolSchemaQuarantine } from "../../tool-schema-quarantine.js";
 import {
@@ -2266,6 +2268,24 @@ export async function runEmbeddedAttempt(
         isPluginTool: (tool) =>
           Boolean(getPluginToolMeta(tool as Parameters<typeof getPluginToolMeta>[0])),
       });
+      const replaySafetyOptions = {
+        declaredReplaySafe: (candidate: { name?: string }) => {
+          const pluginMeta = getPluginToolMeta(
+            candidate as Parameters<typeof getPluginToolMeta>[0],
+          );
+          if (pluginMeta) {
+            return pluginMeta.replaySafe === true;
+          }
+          return getChannelAgentToolMeta(candidate as never) ? false : undefined;
+        },
+      };
+      const isReplaySafeTool = (tool: { name?: string }) =>
+        isAgentToolReplaySafe(tool, replaySafetyOptions);
+      const replaySafeTools = new Set(uncompactedEffectiveTools.filter(isReplaySafeTool));
+      const replaySafeToolNames = collectReplaySafeToolNames(
+        uncompactedEffectiveTools,
+        replaySafetyOptions,
+      );
       // Directory exact-name hydration cannot distinguish a hidden catalog tool
       // from a visible client tool that shadows it. Other modes preserve the
       // existing client/plugin coexistence behavior and use core conflicts only.
@@ -3469,6 +3489,7 @@ export async function runEmbeddedAttempt(
           sessionId: params.sessionId,
           agentId: sessionAgentId,
           builtinToolNames,
+          replaySafeToolNames,
           internalEvents: params.internalEvents,
         }),
       );
@@ -3511,6 +3532,7 @@ export async function runEmbeddedAttempt(
             toolName: toolParams.toolName,
             toolCallId: toolParams.toolCallId,
             args: toolParams.input,
+            replaySafe: replaySafeTools.has(toolParams.tool as never),
             execute: async () =>
               await toolParams.tool.execute(
                 toolParams.toolCallId,
@@ -5089,6 +5111,7 @@ export async function runEmbeddedAttempt(
           ): entry is {
             toolName: string;
             meta?: string;
+            replaySafe?: boolean;
             asyncStarted?: boolean;
             asyncTaskRunId?: string;
             asyncTaskId?: string;
@@ -5098,12 +5121,14 @@ export async function runEmbeddedAttempt(
           const normalized: {
             toolName: string;
             meta?: string;
+            replaySafe: boolean;
             asyncStarted?: true;
             asyncTaskRunId?: string;
             asyncTaskId?: string;
           } = {
             toolName: entry.toolName,
             meta: entry.meta,
+            replaySafe: entry.replaySafe === true,
           };
           if (entry.asyncStarted === true) {
             normalized.asyncStarted = true;

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -19,7 +19,6 @@ import {
 } from "../../execution-contract.js";
 import { hasOnlyAssistantReasoningContent } from "../../replay-turn-classification.js";
 import type { AgentMessage } from "../../runtime/index.js";
-import { isLikelyMutatingToolName } from "../../tool-mutation.js";
 import {
   hasCommittedMessagingToolDeliveryEvidence,
   hasMessagingToolDeliveryEvidence,
@@ -150,6 +149,25 @@ const SINGLE_ACTION_RETRY_SAFE_TOOL_NAMES = new Set([
   "glob",
   "ls",
 ]);
+// Blind attempt retries may repeat completed tools. Admit only names with an
+// unconditional read-only or idempotent contract; action-dependent and unknown tools fail closed.
+const REPLAY_SAFE_TOOL_NAMES = new Set([
+  ...SINGLE_ACTION_RETRY_SAFE_TOOL_NAMES,
+  "web_search",
+  "web_fetch",
+  "x_search",
+  "memory_search",
+  "memory_get",
+  "sessions_list",
+  "sessions_history",
+  "agents_list",
+  "get_goal",
+  "update_plan",
+  "tool_search",
+  "tool_describe",
+  "image",
+  "process.poll",
+]);
 const GEMINI_INCOMPLETE_TURN_PROVIDER_IDS = new Set([
   "google",
   "google-vertex",
@@ -249,10 +267,12 @@ export type PlanningOnlyPlanDetails = {
 export function buildAttemptReplayMetadata(
   params: ReplayMetadataAttempt,
 ): EmbeddedRunAttemptResult["replayMetadata"] {
-  const hadMutatingTools = params.toolMetas.some((t) => isLikelyMutatingToolName(t.toolName));
+  const hadUnsafeTools = params.toolMetas.some(
+    (entry) => !REPLAY_SAFE_TOOL_NAMES.has(normalizeLowercaseStringOrEmpty(entry.toolName)),
+  );
   const hadAsyncStartedTool = params.toolMetas.some((t) => t.asyncStarted === true);
   const hadPotentialSideEffects =
-    hadMutatingTools ||
+    hadUnsafeTools ||
     hadAsyncStartedTool ||
     hasMessagingToolDeliveryEvidence(params) ||
     hasAcceptedSessionSpawn(params.acceptedSessionSpawns) ||

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -12,6 +12,7 @@ import {
 import type { EmbeddedAgentExecutionContract } from "../../../config/types.agent-defaults.js";
 import { hasAcceptedSessionSpawn } from "../../accepted-session-spawn.js";
 import { collectTextContentBlocks } from "../../content-blocks.js";
+import { extractAssistantVisibleText } from "../../embedded-agent-utils.js";
 import {
   isStrictAgenticSupportedProviderModel,
   stripProviderPrefix,
@@ -355,9 +356,17 @@ export function resolveIncompleteTurnPayloadText(params: {
     !joinAssistantTexts(params.attempt.assistantTexts).length &&
     !hasTerminalOutput &&
     Boolean(assistant && hasOnlyAssistantReasoningContent(assistant));
+  const emptyResponseAssistant = isEmptyResponseAssistantTurn({
+    payloadCount: params.payloadCount,
+    attempt: params.attempt,
+  });
 
   if (
-    (params.payloadCount !== 0 && !toolUseTerminal && !lengthTerminal && !thinkingOnlyTerminal) ||
+    (params.payloadCount !== 0 &&
+      !toolUseTerminal &&
+      !lengthTerminal &&
+      !thinkingOnlyTerminal &&
+      !emptyResponseAssistant) ||
     (params.aborted && params.externalAbort) ||
     params.timedOut ||
     params.attempt.clientToolCalls ||
@@ -391,10 +400,6 @@ export function resolveIncompleteTurnPayloadText(params: {
     lastAssistant: params.attempt.lastAssistant,
   });
   const reasoningOnlyAssistant = isReasoningOnlyAssistantTurn(assistant);
-  const emptyResponseAssistant = isEmptyResponseAssistantTurn({
-    payloadCount: params.payloadCount,
-    attempt: params.attempt,
-  });
   if (
     !incompleteTerminalAssistant &&
     !lengthTerminal &&
@@ -610,6 +615,17 @@ function isReasoningOnlyAssistantTurn(message: unknown): boolean {
   return assessLastAssistantMessage(message as AgentMessage) === "incomplete-text";
 }
 
+function hasEmptyPostToolFinalAssistantTurn(attempt: IncompleteTurnAttempt): boolean {
+  // assistantTexts aggregates earlier narration. After tools, the latest typed
+  // assistant message is the final-delivery contract and must carry the answer.
+  return Boolean(
+    attempt.toolMetas.length > 0 &&
+    !hasAttemptTerminalState(attempt) &&
+    attempt.currentAttemptAssistant &&
+    extractAssistantVisibleText(attempt.currentAttemptAssistant).trim().length === 0,
+  );
+}
+
 // Unsigned thinking blocks have no cryptographic signature; assessLastAssistantMessage
 // returns "incomplete-thinking" for them. Empty content also returns "incomplete-thinking",
 // so the content.length > 0 guard is required to distinguish the two cases.
@@ -670,15 +686,16 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
 
 function isEmptyResponseAssistantTurn(params: {
   payloadCount: number;
-  attempt: Pick<
-    IncompleteTurnAttempt,
-    "assistantTexts" | "currentAttemptAssistant" | "lastAssistant"
-  >;
+  attempt: IncompleteTurnAttempt;
 }): boolean {
-  if (params.payloadCount !== 0) {
+  const emptyPostToolFinalAssistant = hasEmptyPostToolFinalAssistantTurn(params.attempt);
+  if (params.payloadCount !== 0 && !emptyPostToolFinalAssistant) {
     return false;
   }
-  if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
+  if (
+    joinAssistantTexts(params.attempt.assistantTexts).length > 0 &&
+    !emptyPostToolFinalAssistant
+  ) {
     return false;
   }
   const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
@@ -702,10 +719,7 @@ function isEmptyResponseAssistantTurn(params: {
 
 function isNonVisibleAssistantTurnEligibleForSilentReply(params: {
   payloadCount: number;
-  attempt: Pick<
-    IncompleteTurnAttempt,
-    "assistantTexts" | "currentAttemptAssistant" | "lastAssistant"
-  >;
+  attempt: IncompleteTurnAttempt;
 }): boolean {
   if (isEmptyResponseAssistantTurn(params)) {
     return true;
@@ -857,12 +871,14 @@ export function resolveEmptyResponseRetryInstruction(params: {
   }
 
   const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant ?? null;
+  const emptyPostToolFinalAssistant = hasEmptyPostToolFinalAssistantTurn(params.attempt);
   if (
     assistant?.stopReason === "stop" &&
     OLLAMA_INCOMPLETE_TURN_PROVIDER_ID_PATTERN.test(
       normalizeLowercaseStringOrEmpty(params.provider ?? ""),
     ) &&
-    !hasPositiveOutputTokenUsage(assistant)
+    !hasPositiveOutputTokenUsage(assistant) &&
+    !emptyPostToolFinalAssistant
   ) {
     return null;
   }
@@ -874,6 +890,7 @@ export function resolveEmptyResponseRetryInstruction(params: {
       modelApi: params.modelApi,
       executionContract: params.executionContract,
     }) ||
+    emptyPostToolFinalAssistant ||
     // Keep the generic zero-usage stop retry for providers that expose a
     // provider-neutral "nothing was generated" signal, even outside the
     // provider allowlist above.

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -166,7 +166,6 @@ const REPLAY_SAFE_TOOL_NAMES = new Set([
   "tool_search",
   "tool_describe",
   "image",
-  "process.poll",
 ]);
 const GEMINI_INCOMPLETE_TURN_PROVIDER_IDS = new Set([
   "google",
@@ -730,7 +729,7 @@ function isEmptyResponseAssistantTurn(params: {
       hasAssistantVisibleText: false,
       lastAssistant: assistant,
     }) ||
-    isReasoningOnlyAssistantTurn(assistant)
+    (isReasoningOnlyAssistantTurn(assistant) && !emptyPostToolFinalAssistant)
   ) {
     return false;
   }

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -149,24 +149,6 @@ const SINGLE_ACTION_RETRY_SAFE_TOOL_NAMES = new Set([
   "glob",
   "ls",
 ]);
-// Blind attempt retries may repeat completed tools. Admit only names with an
-// unconditional read-only or idempotent contract; action-dependent and unknown tools fail closed.
-const REPLAY_SAFE_TOOL_NAMES = new Set([
-  ...SINGLE_ACTION_RETRY_SAFE_TOOL_NAMES,
-  "web_search",
-  "web_fetch",
-  "x_search",
-  "memory_search",
-  "memory_get",
-  "sessions_list",
-  "sessions_history",
-  "agents_list",
-  "get_goal",
-  "update_plan",
-  "tool_search",
-  "tool_describe",
-  "image",
-]);
 const GEMINI_INCOMPLETE_TURN_PROVIDER_IDS = new Set([
   "google",
   "google-vertex",
@@ -259,16 +241,14 @@ export type PlanningOnlyPlanDetails = {
 };
 
 /**
- * Marks whether retrying the attempt can safely replay the prompt. Mutating
- * tools, async work, committed delivery, spawned sessions, and cron writes all
- * count as side effects that make blind replay unsafe.
+ * Marks whether retrying the attempt can safely replay the prompt. Concrete
+ * tool-instance policy, async work, committed delivery, spawned sessions, and
+ * cron writes all contribute side-effect evidence.
  */
 export function buildAttemptReplayMetadata(
   params: ReplayMetadataAttempt,
 ): EmbeddedRunAttemptResult["replayMetadata"] {
-  const hadUnsafeTools = params.toolMetas.some(
-    (entry) => !REPLAY_SAFE_TOOL_NAMES.has(normalizeLowercaseStringOrEmpty(entry.toolName)),
-  );
+  const hadUnsafeTools = params.toolMetas.some((entry) => entry.replaySafe !== true);
   const hadAsyncStartedTool = params.toolMetas.some((t) => t.asyncStarted === true);
   const hadPotentialSideEffects =
     hadUnsafeTools ||
@@ -637,11 +617,14 @@ function isReasoningOnlyAssistantTurn(message: unknown): boolean {
 function hasEmptyPostToolFinalAssistantTurn(attempt: IncompleteTurnAttempt): boolean {
   // assistantTexts aggregates earlier narration. After tools, the latest typed
   // assistant message is the final-delivery contract and must carry the answer.
+  const currentAssistant = Object.hasOwn(attempt, "currentAttemptAssistant")
+    ? attempt.currentAttemptAssistant
+    : attempt.lastAssistant;
   return Boolean(
     attempt.toolMetas.length > 0 &&
     !hasAttemptTerminalState(attempt) &&
-    attempt.currentAttemptAssistant &&
-    extractAssistantVisibleText(attempt.currentAttemptAssistant).trim().length === 0,
+    currentAssistant &&
+    extractAssistantVisibleText(currentAssistant).trim().length === 0,
   );
 }
 

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -168,6 +168,7 @@ export type EmbeddedRunAttemptResult = {
   toolMetas: Array<{
     toolName: string;
     meta?: string;
+    replaySafe?: boolean;
     asyncStarted?: boolean;
     asyncTaskRunId?: string;
     asyncTaskId?: string;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -25,6 +25,7 @@ function createMockContext(overrides?: {
       toolResultFormat: overrides?.toolResultFormat,
     },
     state: {
+      replayState: { replayInvalid: false, hadPotentialSideEffects: false },
       toolMetaById: new Map(),
       toolMetas: [],
       toolSummaryById: new Set(),

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -655,7 +655,7 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
     });
   });
 
-  it("keeps read-only subagents list actions replay-safe", async () => {
+  it("keeps action-dependent subagents calls replay-unsafe", async () => {
     const { ctx } = createTestContext();
 
     await handleToolExecutionStart(
@@ -681,6 +681,39 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
       } as never,
     );
 
+    expect(ctx.state.replayState).toEqual({
+      replayInvalid: true,
+      hadPotentialSideEffects: true,
+    });
+  });
+
+  it("keeps audited core read-only tools replay-safe", async () => {
+    const { ctx } = createTestContext();
+    ctx.params.replaySafeToolNames = new Set(["search"]);
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "search",
+        toolCallId: "tool-search",
+        args: { query: "scheduler" },
+      } as never,
+    );
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "search",
+        toolCallId: "tool-search",
+        isError: false,
+        result: { matches: [] },
+      } as never,
+    );
+
+    expect(ctx.state.toolMetas).toEqual([
+      expect.objectContaining({ toolName: "search", replaySafe: true }),
+    ]);
     expect(ctx.state.replayState).toEqual({
       replayInvalid: false,
       hadPotentialSideEffects: false,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -228,10 +228,16 @@ function isCronAddAction(args: unknown): boolean {
   return normalizeOptionalLowercaseString(action) === "add";
 }
 
-function buildToolCallSummary(toolName: string, args: unknown, meta?: string): ToolCallSummary {
+function buildToolCallSummary(
+  toolName: string,
+  args: unknown,
+  meta: string | undefined,
+  replaySafe: boolean,
+): ToolCallSummary {
   const mutation = buildToolMutationState(toolName, args, meta);
   return {
     meta,
+    replaySafe: replaySafe && !mutation.mutatingAction,
     mutatingAction: mutation.mutatingAction,
     actionFingerprint: mutation.actionFingerprint,
     fileTarget: mutation.fileTarget,
@@ -888,7 +894,12 @@ async function emitToolResultOutput(params: {
 /** Handles a tool-execution start event and emits UI/telemetry start state. */
 export function handleToolExecutionStart(
   ctx: ToolHandlerContext,
-  evt: AgentEvent & { toolName: string; toolCallId: string; args: unknown },
+  evt: AgentEvent & {
+    toolName: string;
+    toolCallId: string;
+    args: unknown;
+    replaySafe?: boolean;
+  },
 ): void | Promise<void> {
   const continueAfterBlockReplyFlush = (): void | Promise<void> => {
     const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.();
@@ -984,7 +995,11 @@ export function handleToolExecutionStart(
         detailMode: ctx.params.toolProgressDetail ?? "explain",
       }),
     );
-    ctx.state.toolMetaById.set(toolCallId, buildToolCallSummary(toolName, args, meta));
+    const replaySafe =
+      evt.replaySafe === true ||
+      ctx.params.replaySafeToolNames?.has(rawToolName) === true ||
+      ctx.params.replaySafeToolNames?.has(toolName) === true;
+    ctx.state.toolMetaById.set(toolCallId, buildToolCallSummary(toolName, args, meta, replaySafe));
     ctx.log.debug(
       `embedded run tool start: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
     );
@@ -1237,13 +1252,14 @@ export async function handleToolExecutionEnd(
   toolStartData.delete(toolStartKey);
   ctx.state.execLiveUpdateStateById?.delete(toolCallId);
   const callSummary = ctx.state.toolMetaById.get(toolCallId);
-  const completedMutatingAction = !isToolError && Boolean(callSummary?.mutatingAction);
+  const completedReplayUnsafeAction = !isToolError && callSummary?.replaySafe !== true;
   const meta = callSummary?.meta;
   const asyncStarted = !isToolError && isAsyncStartedToolResult(sanitizedResult);
   const asyncTaskIds = asyncStarted ? readAsyncStartedTaskIds(sanitizedResult) : {};
   ctx.state.toolMetas.push({
     toolName,
     meta,
+    replaySafe: callSummary?.replaySafe === true,
     ...(asyncStarted ? { asyncStarted: true, ...asyncTaskIds } : {}),
   });
   const acceptedSessionSpawn =
@@ -1289,7 +1305,7 @@ export async function handleToolExecutionEnd(
   if (asyncStarted) {
     ctx.state.hadDeterministicSideEffect = true;
   }
-  if (completedMutatingAction || acceptedSessionSpawn || asyncStarted) {
+  if (completedReplayUnsafeAction || acceptedSessionSpawn || asyncStarted) {
     ctx.state.replayState = mergeEmbeddedRunReplayState(ctx.state.replayState, {
       replayInvalid: true,
       hadPotentialSideEffects: true,

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -43,6 +43,7 @@ type EmbeddedSubscribeLogger = {
 /** Per-tool metadata tracked between tool start/update/end events. */
 export type ToolCallSummary = {
   meta?: string;
+  replaySafe: boolean;
   mutatingAction: boolean;
   actionFingerprint?: string;
   fileTarget?: import("./tool-mutation.js").FileTarget;
@@ -69,6 +70,7 @@ export type EmbeddedAgentSubscribeState = {
   toolMetas: Array<{
     toolName?: string;
     meta?: string;
+    replaySafe?: boolean;
     asyncStarted?: boolean;
     asyncTaskRunId?: string;
     asyncTaskId?: string;
@@ -286,6 +288,7 @@ type ToolHandlerParams = Pick<
   | "hasRepliedRef"
   | "sessionId"
   | "agentId"
+  | "replaySafeToolNames"
   | "toolResultFormat"
   | "toolProgressDetail"
   | "sourceReplyDeliveryMode"

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -1336,6 +1336,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       toolName: string;
       toolCallId: string;
       args: unknown;
+      replaySafe?: boolean;
       execute: () => Promise<T>;
     }): Promise<T> => {
       await handleToolExecutionStart(ctx, {
@@ -1343,6 +1344,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
         toolName: toolParams.toolName,
         toolCallId: toolParams.toolCallId,
         args: toolParams.args,
+        replaySafe: toolParams.replaySafe,
       } as never);
       try {
         const result = await toolParams.execute();

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -115,6 +115,8 @@ export type SubscribeEmbeddedAgentSessionParams = {
    * Exact raw names of OpenClaw tools registered for this run.
    */
   builtinToolNames?: ReadonlySet<string>;
+  /** Exact registered tool names whose concrete instances are safe to replay. */
+  replaySafeToolNames?: ReadonlySet<string>;
   /**
    * Exact raw names allowed to emit local media paths for this run.
    * Includes core trusted tools plus bundled plugin tools proven from the

--- a/src/agents/tool-replay-safety.test.ts
+++ b/src/agents/tool-replay-safety.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectReplaySafeToolNames,
+  isAgentToolReplaySafe,
+  isCoreToolNameReplaySafe,
+} from "./tool-replay-safety.js";
+
+describe("agent tool replay safety", () => {
+  it("allows only audited unconditional core tools", () => {
+    expect(isAgentToolReplaySafe({ name: "search" })).toBe(true);
+    expect(isAgentToolReplaySafe({ name: "update_plan" })).toBe(true);
+    expect(isAgentToolReplaySafe({ name: "process" })).toBe(false);
+    expect(isAgentToolReplaySafe({ name: "vendor_widget" })).toBe(false);
+  });
+
+  it("requires extension-owned tools to opt in even when they reuse an audited name", () => {
+    const pluginTool = { name: "search" };
+
+    expect(
+      isAgentToolReplaySafe(pluginTool, {
+        declaredReplaySafe: (tool) => (tool === pluginTool ? false : undefined),
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts opted-in extension tools only for audited names", () => {
+    const xSearch = { name: "x_search" };
+    const vendorWidget = { name: "vendor_widget" };
+    const declaredReplaySafe = () => true;
+
+    expect(isAgentToolReplaySafe(xSearch, { declaredReplaySafe })).toBe(true);
+    expect(isAgentToolReplaySafe(vendorWidget, { declaredReplaySafe })).toBe(false);
+  });
+
+  it("rejects memory_search because it records durable recall signals", () => {
+    expect(
+      isAgentToolReplaySafe(
+        { name: "memory_search" },
+        {
+          declaredReplaySafe: () => true,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects duplicate names from name-only replay metadata", () => {
+    const coreTool = { name: "search" };
+    const pluginTool = { name: "search" };
+
+    expect(
+      collectReplaySafeToolNames([coreTool, pluginTool], {
+        declaredReplaySafe: (tool) => (tool === pluginTool ? true : undefined),
+      }),
+    ).toEqual(new Set());
+  });
+
+  it("classifies fixture names with the same audited contract", () => {
+    expect(isCoreToolNameReplaySafe("web_search")).toBe(true);
+    expect(isCoreToolNameReplaySafe("browser")).toBe(false);
+  });
+});

--- a/src/agents/tool-replay-safety.ts
+++ b/src/agents/tool-replay-safety.ts
@@ -1,0 +1,73 @@
+/**
+ * Defines the narrow set of tool instances that blind attempt retries may repeat.
+ */
+import { normalizeToolName } from "./tool-policy-shared.js";
+
+const UNCONDITIONALLY_REPLAY_SAFE_TOOL_NAMES = new Set([
+  "read",
+  "search",
+  "find",
+  "grep",
+  "glob",
+  "ls",
+  "web_search",
+  "web_fetch",
+  "x_search",
+  "memory_get",
+  "sessions_list",
+  "sessions_history",
+  "agents_list",
+  "get_goal",
+  "update_plan",
+  "tool_search",
+  "tool_describe",
+  "image",
+]);
+
+/**
+ * Tool names are not ownership boundaries. Callers must reject plugin/channel
+ * instances before using this audited core-tool allowlist.
+ */
+export function isAgentToolReplaySafe(
+  tool: { name?: string },
+  options?: { declaredReplaySafe?: (tool: { name?: string }) => boolean | undefined },
+): boolean {
+  if (options?.declaredReplaySafe?.(tool) === false) {
+    return false;
+  }
+  return UNCONDITIONALLY_REPLAY_SAFE_TOOL_NAMES.has(normalizeToolName(tool.name ?? ""));
+}
+
+/**
+ * Name-only tool events are safe only when one concrete registered instance
+ * owns the name. Duplicate/shadowed names fail closed.
+ */
+export function collectReplaySafeToolNames(
+  tools: Array<{ name?: string }>,
+  options?: { declaredReplaySafe?: (tool: { name?: string }) => boolean | undefined },
+): Set<string> {
+  const toolsByName = new Map<string, Array<{ name?: string }>>();
+  for (const tool of tools) {
+    const name = normalizeToolName(tool.name ?? "");
+    if (!name) {
+      continue;
+    }
+    const entries = toolsByName.get(name) ?? [];
+    entries.push(tool);
+    toolsByName.set(name, entries);
+  }
+
+  const replaySafeNames = new Set<string>();
+  for (const [name, entries] of toolsByName) {
+    const tool = entries.length === 1 ? entries[0] : undefined;
+    if (tool && isAgentToolReplaySafe(tool, options)) {
+      replaySafeNames.add(name);
+    }
+  }
+  return replaySafeNames;
+}
+
+/** Test/fixture helper for constructing metadata for audited core tool names. */
+export function isCoreToolNameReplaySafe(toolName: string): boolean {
+  return UNCONDITIONALLY_REPLAY_SAFE_TOOL_NAMES.has(normalizeToolName(toolName));
+}

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -145,6 +145,8 @@ export {
 } from "../agents/agent-scope.js";
 export { resolveModelAuthMode } from "../agents/model-auth.js";
 export { supportsModelTools } from "../agents/model-tool-support.js";
+export { isAgentToolReplaySafe } from "../agents/tool-replay-safety.js";
+export { getChannelAgentToolMeta } from "../agents/channel-tool-metadata.js";
 export {
   buildSkillWorkshopPromptSection,
   SKILL_WORKSHOP_TOOL_NAME,

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -1845,7 +1845,7 @@ describe("loadPluginManifestRegistry", () => {
       contracts: {
         mediaUnderstandingProviders: ["openai"],
         imageGenerationProviders: ["openai"],
-        tools: ["image_generate"],
+        tools: ["image_generate", "memory_get"],
       },
       imageGenerationProviderMetadata: {
         openai: {
@@ -1918,6 +1918,9 @@ describe("loadPluginManifestRegistry", () => {
               required: ["apiKey"],
             },
           ],
+        },
+        memory_get: {
+          replaySafe: true,
         },
       },
       configSchema: { type: "object" },
@@ -1994,6 +1997,9 @@ describe("loadPluginManifestRegistry", () => {
             required: ["apiKey"],
           },
         ],
+      },
+      memory_get: {
+        replaySafe: true,
       },
     });
   });

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -505,6 +505,8 @@ export type PluginManifestCapabilityProviderMetadata = {
 
 export type PluginManifestToolMetadata = PluginManifestCapabilityProviderMetadata & {
   optional?: boolean;
+  /** Tool execution is safe to repeat after an incomplete model turn. */
+  replaySafe?: boolean;
 };
 
 export type PluginManifestProviderAuthChoice = {
@@ -848,6 +850,7 @@ function normalizePluginToolMetadata(
     const metadata = {
       ...providerMetadata,
       ...(rawMetadata.optional === true ? { optional: true } : {}),
+      ...(rawMetadata.replaySafe === true ? { replaySafe: true } : {}),
     } satisfies PluginManifestToolMetadata;
     if (Object.keys(metadata).length > 0) {
       normalized[toolName] = metadata;

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -372,6 +372,7 @@ function createXaiToolManifest() {
     },
     toolMetadata: {
       x_search: {
+        replaySafe: true,
         authSignals: [{ provider: "xai" }],
         configSignals: [
           {
@@ -1269,6 +1270,7 @@ describe("resolvePluginTools optional tools", () => {
     });
 
     expectResolvedToolNames(tools, ["x_search"]);
+    expect(getPluginToolMeta(tools[0])?.replaySafe).toBe(true);
     expect(factory).toHaveBeenCalledTimes(1);
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -54,6 +54,7 @@ export type PluginToolMcpMeta = {
 export type PluginToolMeta = {
   pluginId: string;
   optional: boolean;
+  replaySafe?: boolean;
   trustedLocalMedia?: boolean;
   mcp?: PluginToolMcpMeta;
 };
@@ -262,6 +263,13 @@ function isPluginToolOptional(params: {
     params.entry.optional ||
     (params.manifestPlugin ? isManifestToolOptional(params.manifestPlugin, params.toolName) : false)
   );
+}
+
+function isManifestToolReplaySafe(params: {
+  manifestPlugin: PluginManifestRecord | undefined;
+  toolName: string;
+}): boolean {
+  return params.manifestPlugin?.toolMetadata?.[params.toolName]?.replaySafe === true;
 }
 
 function isTrustedManifestLocalMediaTool(params: {
@@ -733,6 +741,10 @@ function createCachedDescriptorPluginTool(params: {
   setPluginToolMeta(tool, {
     pluginId,
     optional: params.descriptor.optional,
+    replaySafe: isManifestToolReplaySafe({
+      manifestPlugin: params.plugin,
+      toolName,
+    }),
     trustedLocalMedia: isTrustedManifestLocalMediaTool({
       manifestPlugin: params.plugin,
       toolName,
@@ -1332,6 +1344,10 @@ export function resolvePluginTools(params: {
       pluginToolMeta.set(tool, {
         pluginId: entry.pluginId,
         optional,
+        replaySafe: isManifestToolReplaySafe({
+          manifestPlugin,
+          toolName: tool.name,
+        }),
         trustedLocalMedia: isTrustedManifestLocalMediaTool({
           manifestPlugin,
           toolName: tool.name,


### PR DESCRIPTION
## Summary

- Fix a silent terminal-turn failure where earlier pre-tool narration made an attempt look non-empty even though the latest typed post-tool assistant message contained no visible final answer.
- Reuse the existing single visible-answer continuation and incomplete-turn error paths. The change does not add a second tool loop, a raw tool-result fallback, or a public SDK/tool contract.
- Base the decision on typed attempt facts: current-attempt tool activity, the latest assistant message, visible assistant content, terminal output/delivery state, and replay safety.
- Make the embedded/Pi replay metadata fail closed for unclassified tool names. Only tools with an unconditional read-only or idempotent contract remain replay-safe; unknown/action-dependent tools surface a verify-before-retrying warning.
- Intentionally avoid parsing assistant prose. No new regular expressions, provider phrases, tool-result interpretation, config, or public API are added.

Success means a replay-safe `checking... -> tool/search -> empty final assistant` trajectory receives one bounded continuation, while visible final answers, explicit silence, terminal media/delivery, async work, and side-effectful attempts retain their existing behavior.

## Linked context

Supersedes #90872.

That PR established a real channel-facing problem, but its current head is 75 files and +15,999/-1,907 with public Plugin SDK/core tool-contract changes. The maintainer decision was explicit: [the 15k LOC approach is not landing](https://github.com/openclaw/openclaw/pull/90872#issuecomment-4702733677).

## Root cause and best-fix rationale

`assistantTexts` and `payloadCount` aggregate visible text from the whole attempt. If the model says it is checking something before a tool call, that narration remains non-empty even when the latest post-tool assistant message is a typed empty `stop` turn. The existing empty-response recovery therefore never runs and the channel sees narration followed by silence.

The tool result itself is valid model input, including sparse values such as `0`. Parsing, rewriting, or surfacing raw tool results would move responsibility to the wrong boundary and could expose unsafe output. The narrow invariant is:

> After tool activity, the latest current-attempt assistant message is the final-delivery contract. If it exists but has no visible content, and no terminal output/delivery already completed the attempt, classify it as an empty final turn.

Each harness replay metadata still decides whether the one continuation is safe. The embedded/Pi replay-metadata builder now positively classifies known replay-safe tools and treats unknown/action-dependent tool names as potential side effects. If replay is unsafe, it does not continue automatically and the existing verify-before-retrying warning is used; if a safe retry is exhausted, the existing incomplete-turn warning is used.

### Other harnesses inspected

Source audit used exact heads:

| Harness | Head | Relevant completion contract |
| --- | --- | --- |
| [Pi](https://github.com/earendil-works/pi) | `d683a581b747` | Agent loop branches on typed `stopReason` and `toolCall` blocks. |
| [OpenCode](https://github.com/anomalyco/opencode) | `85e278b728f5` | Provider adapters and session state use typed finish reasons and tool-call/tool-result parts. |
| [Codex](https://github.com/openai/codex) | `cdc1d592df7f` | Tool calls set typed `needs_follow_up`; empty finalized agent messages become `None`; the turn loop continues or ends from typed state (`codex-rs/core/src/session/turn.rs`, `codex-rs/core/src/stream_events_utils.rs`). |
| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `9e5599c323f1` | Strict local/subagent execution requires the explicit `complete_task` tool and treats stopping without it as a protocol violation. |
| [Goose](https://github.com/aaif-goose/goose) | `9d166ecee976` | Structured recipe output uses an explicit `final_output` tool. |
| [Hermes](https://github.com/NousResearch/hermes-agent) | `2a14e8957d75` | Branches on typed `tool_calls`. After a no-tool empty response with a recent `tool` role, it inserts one synthetic continuation nudge, then uses bounded generic empty-response retries/fallback; finalization strips recovery scaffolding and surfaces an explanation. Its regex in this branch recognizes provider `<think>` markup, not natural-language completion. |
| [community Grok CLI](https://github.com/superagent-ai/grok-cli) | `fb97af83f06d` | Uses typed content/tool-call/tool-result/done chunks. Official Grok Build source was not available for inspection. |

The common pattern is typed continuation/completion state, with explicit completion tools for strict workflows. None of these findings support language-regex classification or generic raw-result fallback for a normal chat turn.

## Real behavior proof

- Behavior addressed: A channel-facing agent could announce it was checking something, complete a replay-safe tool/search call, then stop with no final visible reply because the earlier narration masked the empty final assistant turn.
- Real environment tested: The motivating failure and the discarded broad repair were observed on a live Discord-backed OpenClaw stack in #90872. The narrow patch was also exercised locally through the real embedded xAI OAuth/provider path with `xai/grok-composer-2.5-fast`; the original Discord delivery path was not used.
- Exact steps or command run after this patch: focused Vitest comparison on exact base `f1b8827d20c8f1d648cdb1d4034120a67d1ff3e7` with only the original regression tests applied; the expanded post-tool safety matrix and full owner test on pre-maintainer head `92502cd8b4c3ce16c8ec493bf221512c7b36a656`, plus exact-head focused Testbox proof on current head `3c55d30f9ca7223b3068fe640a5f0a3463269f3f`; plus three bounded `openclaw agent --local --model xai/grok-composer-2.5-fast` turns covering healthy read-only search, terminal tool failure, and narration without a tool call.
- Evidence after fix: The exact base comparison failed all three original logical regressions (`6` failures across the two Vitest projects): retry resolver returned `null`, exhausted handling returned `null`, and the full runner stopped after one attempt. Pre-maintainer-head focused safety coverage passes `20/20` across the two projects, including known read-only recovery, mixed known-plus-unknown fail-closed behavior, and the side-effect-aware terminal warning. The full owner test file passes `150/150`.
- Observed result after fix: The regression trajectory receives the existing visible-answer continuation once; a visible final answer does not retry; terminal output is preserved; exhausted recovery surfaces the existing incomplete-turn error. Known read-only tools including `web_search`, `memory_search`, `x_search`, and `tool_describe` remain eligible. An unclassified tool receives no automatic retry, records `replaySafe: false`, and surfaces the verify-before-retrying warning. Live Composer completed one successful read-only `x_search` round with `COMPOSER_FINAL_OK` and no unnecessary retry. A denied terminal tool attempt was marked replay-invalid and was not replayed.
- What was not tested: A post-patch live Discord reproduction. Composer did not emit an empty final assistant message after the successful live `x_search` round, so the exact model-generated failure was not reproduced on demand outside the deterministic captured trajectory; broad cross-channel E2E was not run.
- Proof limitations or environment constraints: The original Discord stack and identifiers are private/redacted. One live Composer prompt produced narration without calling the requested `web_search`; that is a separate planning-only failure and does not prove this patch. The old PR's live after-fix output validated its discarded broad fallback approach, not this narrow patch, so it is retained only as provenance.
- Before evidence: Redacted motivating Discord sequence recovered from the #90872 investigation: Composer 2.5 said it was looking into the scheduler, performed a tool/search call whose result was `0`, then emitted no final user-visible assistant reply.

## Tests and validation

- Exact base reproduction: base `f1b8827d20c8f1d648cdb1d4034120a67d1ff3e7` + original regression tests -> `6 failed` across two projects (`3` logical regressions)
- Pre-maintainer-head focused safety matrix: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts --reporter=dot -t "known read-only|unclassified tools|unclassified tools as replay-invalid|pre-tool narration even when silence is allowed|post-tool exact NO_REPLY"` -> `20 passed` across two projects
- Full owner test: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts --reporter=dot` -> `150 passed`
- Mutation classification test: `node scripts/run-vitest.mjs src/agents/tool-mutation.test.ts --reporter=dot` -> `48 passed`
- Exact-head focused Testbox proof: current head `3c55d30f9ca7223b3068fe640a5f0a3463269f3f`; Blacksmith Testbox-through-Crabbox `tbx_01kv4v9gbv92mnv435bsqdvn9p` ([run](https://github.com/openclaw/openclaw/actions/runs/27525578808)) -> owner test `150/150`, mutation classification `48/48`
- Live Composer healthy path: real embedded `xai/grok-composer-2.5-fast` + one successful read-only `x_search` -> final `COMPOSER_FINAL_OK`, no extra retry
- Live Composer unsafe-terminal guard: denied tool attempt -> `replayInvalid: true`, no replay
- CI timeout recheck: `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-payloads.test.ts --reporter=dot -t "does not dedupe text for cross-target messaging sends"` -> passed (`1/1`); the earlier PR CI failure was the same unrelated test timing out after 127 seconds and could not be rerun from contributor permissions/workflow state
- `pnpm format:check src/agents/embedded-agent-runner/run/incomplete-turn.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` -> passed
- `pnpm changed:lanes --json` -> `core`, `coreTests`
- `pnpm check:changed` -> passed on pre-maintainer head Blacksmith Testbox `tbx_01kv41nef5fjxznf9p64z6yhct` ([run](https://github.com/openclaw/openclaw/actions/runs/27513060293))
- Trusted exact-head autoreview on `3c55d30f9ca7223b3068fe640a5f0a3463269f3f` -> clean, no accepted/actionable findings
- `git diff --check` -> clean
- Current PR surface: source `+56/-19`, tests `+198/-11`, two files

The original regression fails on the exact base before the production change. The final head fixes it while failing closed for unclassified tools and preserving recovery for the known read-only tool surface.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `Yes`: one existing bounded continuation can now run for this previously missed typed terminal state.

Highest-risk area: retrying after tool activity could duplicate work or replace already-delivered terminal output.

Mitigation: the continuation remains limited to one attempt and is blocked by harness replay metadata, terminal output, committed delivery, accepted spawn, error, abort, timeout, and explicit-silence guards. The embedded/Pi replay builder now fails closed for unclassified or action-dependent tool names; those attempts surface a verify-before-retrying warning. The patch does not surface raw tool results.

## Current review state

Ready for maintainer review at current head `3c55d30f9ca7223b3068fe640a5f0a3463269f3f`. Exact-head focused Testbox proof and trusted autoreview are green; the prior exact-base reproduction, remote changed gate, and bounded live Composer safety/healthy-path checks remain recorded above. Current-head GitHub CI is running without failures observed at this refresh. The remaining proof gap is forcing the original successful-tool-then-empty-final Composer failure on the private Discord/model stack.
