### PR TITLE
fix(whatsapp): preserve auth on terminal disconnects

### DIFF
--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -26,12 +26,12 @@ import {
   setRuntimeConfigSourceSnapshotMock,
   startWebAutoReplyMonitor,
 } from "./auto-reply.test-harness.js";
-import { waitForWaConnection } from "./session.js";
 import {
   createTestLegacyFlatWebInboundMessage,
   createTestWebInboundMessage,
 } from "./inbound/test-message.test-helper.js";
 import type { WebInboundMessageInput } from "./inbound/types.js";
+import { waitForWaConnection } from "./session.js";
 
 type DrainSelectionEntry = {
   channel: string;
@@ -125,16 +125,6 @@ function mockCallArg(mocked: unknown, callIndex: number, argIndex: number): unkn
     throw new Error(`Expected mock call at index ${callIndex}`);
   }
   return call[argIndex];
-}
-
-async function expectPathMissing(targetPath: string): Promise<void> {
-  try {
-    await fs.stat(targetPath);
-  } catch (error) {
-    expect((error as { code?: unknown }).code).toBe("ENOENT");
-    return;
-  }
-  throw new Error(`Expected path to be missing: ${targetPath}`);
 }
 
 describe("web auto-reply connection", () => {
@@ -417,6 +407,7 @@ describe("web auto-reply connection", () => {
     expect(sleep).not.toHaveBeenCalled();
     expectErrorContaining(runtime.error, "status 440");
     expectErrorContaining(runtime.error, "session conflict");
+    expectErrorContaining(runtime.error, "openclaw channels logout --channel whatsapp");
     expectErrorContaining(runtime.error, "Stopping web monitoring");
   });
 
@@ -434,15 +425,14 @@ describe("web auto-reply connection", () => {
       error: "Stream Errored (logged out)",
     },
   ] as const)(
-    "clears stale auth and active listener after terminal status $status",
+    "stops active listener and preserves auth after terminal status $status",
     async ({ status, isLoggedOut, healthState, error }) => {
       const accountId = `terminal-${status}`;
       const authDir = path.join(resolveOAuthDir(), "whatsapp", accountId);
+      const credsPath = resolveWebCredsPath(authDir);
+      const credsJson = JSON.stringify({ me: { id: "123@s.whatsapp.net" } });
       await fs.mkdir(authDir, { recursive: true });
-      await fs.writeFile(
-        resolveWebCredsPath(authDir),
-        JSON.stringify({ me: { id: "123@s.whatsapp.net" } }),
-      );
+      await fs.writeFile(credsPath, credsJson);
       setLoadConfigMock({
         channels: {
           whatsapp: {
@@ -489,7 +479,7 @@ describe("web auto-reply connection", () => {
       expect(scripted.getListenerCount()).toBe(1);
       expect(sleep).not.toHaveBeenCalled();
       expect(getActiveWebListener(accountId)).toBeNull();
-      await expectPathMissing(authDir);
+      await expect(fs.readFile(credsPath, "utf8")).resolves.toBe(credsJson);
       expect(
         statuses.filter((entry) => entry.connected === false && entry.healthState === healthState),
       ).not.toEqual([]);

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -35,7 +35,7 @@ import {
   resolveReconnectPolicy,
   sleepWithAbort,
 } from "../reconnect.js";
-import { formatError, getWebAuthAgeMs, logoutWeb, readWebSelfId } from "../session.js";
+import { formatError, getWebAuthAgeMs, readWebSelfId } from "../session.js";
 import { resolveWhatsAppSocketTiming } from "../socket-timing.js";
 import { getRuntimeConfig, getRuntimeConfigSourceSnapshot } from "./config.runtime.js";
 import { whatsappHeartbeatLog, whatsappLog } from "./loggers.js";
@@ -142,43 +142,6 @@ function isRetryableAuthUnstableError(error: unknown): error is WhatsAppAuthUnst
   );
 }
 
-async function clearTerminalWebAuthState(params: {
-  account: ReturnType<typeof resolveWhatsAppAccount>;
-  runtime: RuntimeEnv;
-  statusLabel: number | "unknown";
-  healthState: "logged-out" | "conflict";
-  log: ReturnType<typeof getChildLogger>;
-}) {
-  try {
-    const cleared = await logoutWeb({
-      authDir: params.account.authDir,
-      isLegacyAuthDir: params.account.isLegacyAuthDir,
-      runtime: params.runtime,
-    });
-    params.log.warn(
-      {
-        accountId: params.account.accountId,
-        cleared,
-        healthState: params.healthState,
-        status: params.statusLabel,
-      },
-      "web reconnect: cleared cached auth after terminal close",
-    );
-  } catch (error) {
-    params.log.warn(
-      {
-        accountId: params.account.accountId,
-        error: formatError(error),
-        healthState: params.healthState,
-        status: params.statusLabel,
-      },
-      "web reconnect: failed clearing cached auth after terminal close",
-    );
-    params.runtime.error(
-      `WhatsApp Web cleanup failed after terminal close (status ${params.statusLabel}). Run \`${formatCliCommand("openclaw channels logout --channel whatsapp")}\`, then relink with \`${formatCliCommand("openclaw channels login --channel whatsapp")}\`.`,
-    );
-  }
-}
 const DEFAULT_TRANSPORT_TIMEOUT_MS = 5 * 60 * 1000;
 
 export async function monitorWebChannel(
@@ -431,26 +394,12 @@ export async function monitorWebChannel(
               "web reconnect: setup status error; max attempts reached",
             );
             if (setupDecision.healthState === "logged-out") {
-              await clearTerminalWebAuthState({
-                account,
-                runtime,
-                statusLabel: setupDecision.normalized.statusLabel,
-                healthState: setupDecision.healthState,
-                log: reconnectLogger,
-              });
               runtime.error(
                 `WhatsApp session logged out during setup. Run \`${formatCliCommand("openclaw channels login --channel whatsapp")}\` to relink.`,
               );
             } else if (setupDecision.healthState === "conflict") {
-              await clearTerminalWebAuthState({
-                account,
-                runtime,
-                statusLabel: setupDecision.normalized.statusLabel,
-                healthState: setupDecision.healthState,
-                log: reconnectLogger,
-              });
               runtime.error(
-                `WhatsApp Web connection closed during setup (status ${setupDecision.normalized.statusLabel}: session conflict). Resolve conflicting WhatsApp Web sessions, then relink with \`${formatCliCommand("openclaw channels login --channel whatsapp")}\`. Stopping web monitoring.`,
+                `WhatsApp Web connection closed during setup (status ${setupDecision.normalized.statusLabel}: session conflict). Resolve conflicting WhatsApp Web sessions, then restart the channel. To force a fresh QR, run \`${formatCliCommand("openclaw channels logout --channel whatsapp")}\` before \`${formatCliCommand("openclaw channels login --channel whatsapp")}\`. Stopping web monitoring.`,
               );
             } else {
               runtime.error(
@@ -668,24 +617,10 @@ export async function monitorWebChannel(
         });
 
         if (decision.healthState === "logged-out") {
-          await clearTerminalWebAuthState({
-            account,
-            runtime,
-            statusLabel: decision.normalized.statusLabel,
-            healthState: decision.healthState,
-            log: reconnectLogger,
-          });
           runtime.error(
             `WhatsApp session logged out. Run \`${formatCliCommand("openclaw channels login --channel whatsapp")}\` to relink.`,
           );
         } else if (decision.healthState === "conflict") {
-          await clearTerminalWebAuthState({
-            account,
-            runtime,
-            statusLabel: decision.normalized.statusLabel,
-            healthState: decision.healthState,
-            log: reconnectLogger,
-          });
           reconnectLogger.warn(
             {
               connectionId: connection.connectionId,
@@ -695,7 +630,7 @@ export async function monitorWebChannel(
             "web reconnect: non-retryable close status; stopping monitor",
           );
           runtime.error(
-            `WhatsApp Web connection closed (status ${decision.normalized.statusLabel}: session conflict). Resolve conflicting WhatsApp Web sessions, then relink with \`${formatCliCommand("openclaw channels login --channel whatsapp")}\`. Stopping web monitoring.`,
+            `WhatsApp Web connection closed (status ${decision.normalized.statusLabel}: session conflict). Resolve conflicting WhatsApp Web sessions, then restart the channel. To force a fresh QR, run \`${formatCliCommand("openclaw channels logout --channel whatsapp")}\` before \`${formatCliCommand("openclaw channels login --channel whatsapp")}\`. Stopping web monitoring.`,
           );
         } else {
           reconnectLogger.warn(

--- a/extensions/whatsapp/src/connection-controller.test.ts
+++ b/extensions/whatsapp/src/connection-controller.test.ts
@@ -13,7 +13,12 @@ import {
 } from "./connection-controller.js";
 import { enqueueCredsSave, writeCredsJsonAtomically } from "./creds-persistence.js";
 import { createAcceptedWhatsAppSendResult } from "./inbound/send-result.test-helper.js";
-import { createWaSocket, readWebAuthExistsForDecision, waitForWaConnection } from "./session.js";
+import {
+  createWaSocket,
+  logoutWeb,
+  readWebAuthExistsForDecision,
+  waitForWaConnection,
+} from "./session.js";
 import { DEFAULT_WHATSAPP_SOCKET_TIMING } from "./socket-timing.js";
 
 vi.mock("./session.js", async () => {
@@ -22,12 +27,14 @@ vi.mock("./session.js", async () => {
     ...actual,
     createWaSocket: vi.fn(),
     waitForWaConnection: vi.fn(),
+    logoutWeb: vi.fn(async () => true),
     readWebAuthExistsForDecision: vi.fn(async () => ({ outcome: "stable" as const, exists: true })),
   };
 });
 
 const createWaSocketMock = vi.mocked(createWaSocket);
 const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
+const logoutWebMock = vi.mocked(logoutWeb);
 const readWebAuthExistsForDecisionMock = vi.mocked(readWebAuthExistsForDecision);
 
 function createListenerStub(messageId = "ok") {
@@ -48,11 +55,78 @@ function createSocketWithTransportEmitter() {
   };
 }
 
+const loginAuthDir = "/tmp/wa-auth";
+
+function loggedOutError() {
+  return { output: { statusCode: DisconnectReason.loggedOut } };
+}
+
+function createLoginResultHarness() {
+  const initialSock = createSocketWithTransportEmitter();
+  const replacementSock = createSocketWithTransportEmitter();
+  const runtime = { log: vi.fn() } as never;
+
+  return {
+    initialSock,
+    replacementSock,
+    runtime,
+    run: (opts: {
+      waitForConnection: ReturnType<typeof vi.fn>;
+      createSocket: ReturnType<typeof vi.fn>;
+      verbose?: boolean;
+      socketTiming?: {
+        connectTimeoutMs: number;
+        defaultQueryTimeoutMs: number;
+        keepAliveIntervalMs: number;
+      };
+      onQr?: (qr: string) => void;
+      onSocketReplaced?: (sock: unknown) => void;
+    }) =>
+      waitForWhatsAppLoginResult({
+        sock: initialSock as never,
+        authDir: loginAuthDir,
+        isLegacyAuthDir: false,
+        verbose: opts.verbose ?? false,
+        runtime,
+        waitForConnection: opts.waitForConnection as never,
+        createSocket: opts.createSocket as never,
+        ...(opts.socketTiming ? { socketTiming: opts.socketTiming } : {}),
+        ...(opts.onQr ? { onQr: opts.onQr } : {}),
+        ...(opts.onSocketReplaced ? { onSocketReplaced: opts.onSocketReplaced } : {}),
+      }),
+  };
+}
+
+async function runLoggedOutRecovery(opts: {
+  cleanupCleared?: boolean;
+  authDecisions?: Array<{ outcome: "stable"; exists: boolean }>;
+  secondWait?: "resolve" | "logged-out";
+}) {
+  if (opts.cleanupCleared === false) {
+    logoutWebMock.mockResolvedValueOnce(false);
+  }
+  for (const decision of opts.authDecisions ?? []) {
+    readWebAuthExistsForDecisionMock.mockResolvedValueOnce(decision);
+  }
+  const harness = createLoginResultHarness();
+  const error = loggedOutError();
+  const waitForConnection = vi.fn().mockRejectedValueOnce(error);
+  if (opts.secondWait === "resolve") {
+    waitForConnection.mockResolvedValueOnce(undefined);
+  } else if (opts.secondWait === "logged-out") {
+    waitForConnection.mockRejectedValueOnce(error);
+  }
+  const createSocket = vi.fn(async () => harness.replacementSock);
+  const result = await harness.run({ waitForConnection, createSocket });
+  return { createSocket, error, harness, result, waitForConnection };
+}
+
 describe("WhatsAppConnectionController", () => {
   let controller: WhatsAppConnectionController;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    logoutWebMock.mockResolvedValue(true);
     readWebAuthExistsForDecisionMock
       .mockReset()
       .mockResolvedValue({ outcome: "stable", exists: true });
@@ -138,8 +212,7 @@ describe("WhatsAppConnectionController", () => {
   });
 
   it("restarts login once on status 408 and preserves replacement socket options", async () => {
-    const initialSock = createSocketWithTransportEmitter();
-    const replacementSock = createSocketWithTransportEmitter();
+    const harness = createLoginResultHarness();
     const waitForConnection = vi
       .fn()
       .mockRejectedValueOnce({ output: { statusCode: DisconnectReason.timedOut } })
@@ -149,18 +222,14 @@ describe("WhatsAppConnectionController", () => {
     const createSocket = vi.fn(
       async (_printQr: boolean, _verbose: boolean, opts?: { onQr?: (qr: string) => void }) => {
         opts?.onQr?.("qr-after-timeout");
-        return replacementSock;
+        return harness.replacementSock;
       },
     );
 
-    const result = await waitForWhatsAppLoginResult({
-      sock: initialSock as never,
-      authDir: "/tmp/wa-auth",
-      isLegacyAuthDir: false,
+    const result = await harness.run({
       verbose: true,
-      runtime: { log: vi.fn() } as never,
-      waitForConnection: waitForConnection as never,
-      createSocket: createSocket as never,
+      waitForConnection,
+      createSocket,
       socketTiming: {
         connectTimeoutMs: 10_000,
         defaultQueryTimeoutMs: 20_000,
@@ -173,24 +242,28 @@ describe("WhatsAppConnectionController", () => {
     expect(result).toEqual({
       outcome: "connected",
       restarted: true,
-      sock: replacementSock,
+      sock: harness.replacementSock,
     });
-    expect(initialSock.end).toHaveBeenCalledOnce();
+    expect(harness.initialSock.end).toHaveBeenCalledOnce();
     expect(createSocket).toHaveBeenCalledWith(false, true, {
-      authDir: "/tmp/wa-auth",
+      authDir: loginAuthDir,
       connectTimeoutMs: 10_000,
       defaultQueryTimeoutMs: 20_000,
       keepAliveIntervalMs: 30_000,
       onQr,
     });
     expect(onQr).toHaveBeenCalledWith("qr-after-timeout");
-    expect(onSocketReplaced).toHaveBeenCalledWith(replacementSock);
-    expect(waitForConnection).toHaveBeenNthCalledWith(1, initialSock, { timeout: "none" });
-    expect(waitForConnection).toHaveBeenNthCalledWith(2, replacementSock, { timeout: "none" });
+    expect(onSocketReplaced).toHaveBeenCalledWith(harness.replacementSock);
+    expect(waitForConnection).toHaveBeenNthCalledWith(1, harness.initialSock, {
+      timeout: "none",
+    });
+    expect(waitForConnection).toHaveBeenNthCalledWith(2, harness.replacementSock, {
+      timeout: "none",
+    });
   });
 
   it("still honors the post-pairing 515 restart after a status 408 recovery", async () => {
-    const initialSock = createSocketWithTransportEmitter();
+    const harness = createLoginResultHarness();
     const afterTimeoutSock = createSocketWithTransportEmitter();
     const afterPairingRestartSock = createSocketWithTransportEmitter();
     const waitForConnection = vi
@@ -203,15 +276,7 @@ describe("WhatsAppConnectionController", () => {
       .mockResolvedValueOnce(afterTimeoutSock)
       .mockResolvedValueOnce(afterPairingRestartSock);
 
-    const result = await waitForWhatsAppLoginResult({
-      sock: initialSock as never,
-      authDir: "/tmp/wa-auth",
-      isLegacyAuthDir: false,
-      verbose: false,
-      runtime: { log: vi.fn() } as never,
-      waitForConnection: waitForConnection as never,
-      createSocket: createSocket as never,
-    });
+    const result = await harness.run({ waitForConnection, createSocket });
 
     expect(result).toEqual({
       outcome: "connected",
@@ -220,34 +285,131 @@ describe("WhatsAppConnectionController", () => {
     });
     expect(createSocket).toHaveBeenCalledTimes(2);
     expect(waitForConnection).toHaveBeenCalledTimes(3);
-    expect(waitForConnection).toHaveBeenNthCalledWith(1, initialSock, { timeout: "none" });
+    expect(waitForConnection).toHaveBeenNthCalledWith(1, harness.initialSock, {
+      timeout: "none",
+    });
     expect(waitForConnection).toHaveBeenNthCalledWith(2, afterTimeoutSock, { timeout: "none" });
     expect(waitForConnection).toHaveBeenNthCalledWith(3, afterPairingRestartSock, {
       timeout: "none",
     });
-    expect(initialSock.end).toHaveBeenCalledOnce();
+    expect(harness.initialSock.end).toHaveBeenCalledOnce();
     expect(afterTimeoutSock.end).toHaveBeenCalledOnce();
   });
 
+  it("clears stale logged-out auth once and continues login with a fresh socket", async () => {
+    const harness = createLoginResultHarness();
+    const error = loggedOutError();
+    const waitForConnection = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce(undefined);
+    const onQr = vi.fn();
+    const onSocketReplaced = vi.fn();
+    const createSocket = vi.fn(
+      async (_printQr: boolean, _verbose: boolean, opts?: { onQr?: (qr: string) => void }) => {
+        opts?.onQr?.("qr-after-logout");
+        return harness.replacementSock;
+      },
+    );
+
+    const result = await harness.run({
+      verbose: true,
+      waitForConnection,
+      createSocket,
+      onQr,
+      onSocketReplaced,
+    });
+
+    expect(result).toEqual({
+      outcome: "connected",
+      restarted: true,
+      sock: harness.replacementSock,
+    });
+    expect(logoutWebMock).toHaveBeenCalledWith({
+      authDir: loginAuthDir,
+      isLegacyAuthDir: false,
+      runtime: harness.runtime,
+    });
+    expect(harness.initialSock.end).toHaveBeenCalledOnce();
+    expect(createSocket).toHaveBeenCalledWith(false, true, {
+      authDir: loginAuthDir,
+      onQr,
+    });
+    expect(onQr).toHaveBeenCalledWith("qr-after-logout");
+    expect(onSocketReplaced).toHaveBeenCalledWith(harness.replacementSock);
+    expect(waitForConnection).toHaveBeenNthCalledWith(1, harness.initialSock, {
+      timeout: "none",
+    });
+    expect(waitForConnection).toHaveBeenNthCalledWith(2, harness.replacementSock, {
+      timeout: "none",
+    });
+  });
+
+  it("does not retry logged-out login when stale auth cleanup is skipped", async () => {
+    const { createSocket, error, harness, result, waitForConnection } = await runLoggedOutRecovery({
+      cleanupCleared: false,
+      authDecisions: [{ outcome: "stable", exists: true }],
+    });
+
+    expect(result).toEqual({
+      outcome: "failed",
+      message:
+        "existing auth could not be cleared. Remove or fix the configured WhatsApp auth directory, then retry login.",
+      error,
+    });
+    expect(logoutWebMock).toHaveBeenCalledWith({
+      authDir: loginAuthDir,
+      isLegacyAuthDir: false,
+      runtime: harness.runtime,
+    });
+    expect(harness.initialSock.end).toHaveBeenCalledOnce();
+    expect(createSocket).not.toHaveBeenCalled();
+    expect(waitForConnection).toHaveBeenCalledOnce();
+  });
+
+  it("retries logged-out login when cleanup is a no-op because no auth exists", async () => {
+    const { createSocket, harness, result, waitForConnection } = await runLoggedOutRecovery({
+      cleanupCleared: false,
+      authDecisions: [
+        { outcome: "stable", exists: false },
+        { outcome: "stable", exists: true },
+      ],
+      secondWait: "resolve",
+    });
+
+    expect(result).toEqual({
+      outcome: "connected",
+      restarted: true,
+      sock: harness.replacementSock,
+    });
+    expect(createSocket).toHaveBeenCalledOnce();
+    expect(waitForConnection).toHaveBeenNthCalledWith(2, harness.replacementSock, {
+      timeout: "none",
+    });
+  });
+
+  it("does not clear stale logged-out auth more than once", async () => {
+    const { createSocket, error, result, waitForConnection } = await runLoggedOutRecovery({
+      secondWait: "logged-out",
+    });
+
+    expect(result).toMatchObject({
+      outcome: "logged-out",
+      statusCode: DisconnectReason.loggedOut,
+      error,
+    });
+    expect(logoutWebMock).toHaveBeenCalledOnce();
+    expect(createSocket).toHaveBeenCalledOnce();
+    expect(waitForConnection).toHaveBeenCalledTimes(2);
+  });
+
   it("does not keep recreating sockets when login status 408 persists", async () => {
-    const initialSock = createSocketWithTransportEmitter();
-    const replacementSock = createSocketWithTransportEmitter();
+    const harness = createLoginResultHarness();
     const timeoutError = { output: { statusCode: DisconnectReason.timedOut } };
     const waitForConnection = vi
       .fn()
       .mockRejectedValueOnce(timeoutError)
       .mockRejectedValueOnce(timeoutError);
-    const createSocket = vi.fn(async () => replacementSock);
+    const createSocket = vi.fn(async () => harness.replacementSock);
 
-    const result = await waitForWhatsAppLoginResult({
-      sock: initialSock as never,
-      authDir: "/tmp/wa-auth",
-      isLegacyAuthDir: false,
-      verbose: false,
-      runtime: { log: vi.fn() } as never,
-      waitForConnection: waitForConnection as never,
-      createSocket: createSocket as never,
-    });
+    const result = await harness.run({ waitForConnection, createSocket });
 
     expect(result).toMatchObject({
       outcome: "failed",

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -36,6 +36,8 @@ const WHATSAPP_LOGIN_AUTH_UNSTABLE_MESSAGE =
   "WhatsApp connected, but saving the linked credentials has not settled on disk yet. Retry login in a moment.";
 const WHATSAPP_LOGIN_AUTH_NOT_PERSISTED_MESSAGE =
   "WhatsApp connected, but the linked credentials were not found on disk. Retry login in a moment.";
+const WHATSAPP_LOGIN_AUTH_NOT_CLEARED_MESSAGE =
+  "existing auth could not be cleared. Remove or fix the configured WhatsApp auth directory, then retry login.";
 export const WHATSAPP_LOGGED_OUT_QR_MESSAGE =
   "WhatsApp reported the session is logged out. Cleared cached web session; please scan a new QR.";
 export const WHATSAPP_WATCHDOG_TIMEOUT_ERROR = "watchdog-timeout";
@@ -236,6 +238,31 @@ export async function waitForWhatsAppLoginResult(params: {
   let currentSock = params.sock;
   let postPairingRestarted = false;
   let timeoutRestarted = false;
+  let loggedOutRestarted = false;
+
+  const replaceLoginSocket = async (
+    opts: { closeCurrent?: boolean } = {},
+  ): Promise<WhatsAppLoginWaitResult | null> => {
+    if (opts.closeCurrent ?? true) {
+      closeWaSocket(currentSock);
+    }
+    try {
+      currentSock = await createSocket(false, params.verbose, {
+        authDir: params.authDir,
+        ...params.socketTiming,
+        onQr: params.onQr,
+      });
+      params.onSocketReplaced?.(currentSock);
+      return null;
+    } catch (createErr) {
+      return {
+        outcome: "failed",
+        message: formatError(createErr),
+        statusCode: getStatusCode(createErr),
+        error: createErr,
+      };
+    }
+  };
 
   while (true) {
     try {
@@ -258,7 +285,7 @@ export async function waitForWhatsAppLoginResult(params: {
       }
       return {
         outcome: "connected",
-        restarted: postPairingRestarted || timeoutRestarted,
+        restarted: postPairingRestarted || timeoutRestarted || loggedOutRestarted,
         sock: currentSock,
       };
     } catch (err) {
@@ -274,37 +301,51 @@ export async function waitForWhatsAppLoginResult(params: {
           timeoutRestarted = true;
         }
         params.runtime.log(info(getLoginSocketRestartMessage(restartKind)));
-        closeWaSocket(currentSock);
-        try {
-          currentSock = await createSocket(false, params.verbose, {
-            authDir: params.authDir,
-            ...params.socketTiming,
-            onQr: params.onQr,
-          });
-          params.onSocketReplaced?.(currentSock);
-          continue;
-        } catch (createErr) {
-          return {
-            outcome: "failed",
-            message: formatError(createErr),
-            statusCode: getStatusCode(createErr),
-            error: createErr,
-          };
+        const replacementFailure = await replaceLoginSocket();
+        if (replacementFailure) {
+          return replacementFailure;
         }
+        continue;
       }
 
       if (statusCode === LOGGED_OUT_STATUS) {
-        await logoutWeb({
+        if (loggedOutRestarted) {
+          return {
+            outcome: "logged-out",
+            message: WHATSAPP_LOGGED_OUT_RELINK_MESSAGE,
+            statusCode: LOGGED_OUT_STATUS,
+            error: err,
+          };
+        }
+        closeWaSocket(currentSock);
+        const cleared = await logoutWeb({
           authDir: params.authDir,
           isLegacyAuthDir: params.isLegacyAuthDir,
           runtime: params.runtime,
         });
-        return {
-          outcome: "logged-out",
-          message: WHATSAPP_LOGGED_OUT_RELINK_MESSAGE,
-          statusCode: LOGGED_OUT_STATUS,
-          error: err,
-        };
+        if (!cleared) {
+          const existingAuth = await readWebAuthExistsForDecision(params.authDir);
+          if (existingAuth.outcome === "unstable") {
+            return {
+              outcome: "failed",
+              message: WHATSAPP_LOGIN_AUTH_UNSTABLE_MESSAGE,
+              error: new WhatsAppAuthUnstableError(WHATSAPP_LOGIN_AUTH_UNSTABLE_MESSAGE),
+            };
+          }
+          if (existingAuth.exists) {
+            return {
+              outcome: "failed",
+              message: WHATSAPP_LOGIN_AUTH_NOT_CLEARED_MESSAGE,
+              error: err,
+            };
+          }
+        }
+        loggedOutRestarted = true;
+        const replacementFailure = await replaceLoginSocket({ closeCurrent: false });
+        if (replacementFailure) {
+          return replacementFailure;
+        }
+        continue;
       }
 
       return {

--- a/extensions/whatsapp/src/login-qr.test.ts
+++ b/extensions/whatsapp/src/login-qr.test.ts
@@ -1,6 +1,7 @@
 // Whatsapp tests cover login qr plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getActiveWebListener } from "./active-listener.js";
 import { startWebLoginWithQr, waitForWebLogin } from "./login-qr.js";
 import { renderQrPngDataUrl } from "./qr-image.js";
 import {
@@ -41,17 +42,82 @@ vi.mock("./session.js", async () => {
   };
 });
 
+vi.mock("./active-listener.js", () => ({
+  getActiveWebListener: vi.fn(() => null),
+}));
+
 vi.mock("./qr-image.js", () => ({
   renderQrPngBase64: vi.fn(async () => "base64"),
   renderQrPngDataUrl: vi.fn(async (input: string) => `data:image/png;base64,encoded:${input}`),
 }));
 
 const createWaSocketMock = vi.mocked(createWaSocket);
+const getActiveWebListenerMock = vi.mocked(getActiveWebListener);
 const readWebAuthExistsForDecisionMock = vi.mocked(readWebAuthExistsForDecision);
 const readWebSelfIdMock = vi.mocked(readWebSelfId);
 const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
 const logoutWebMock = vi.mocked(logoutWeb);
 const renderQrPngDataUrlMock = vi.mocked(renderQrPngDataUrl);
+const scanQrMessage = "Scan this QR in WhatsApp → Linked Devices.";
+const refreshedQrMessage = "QR refreshed. Scan the latest code in WhatsApp → Linked Devices.";
+const cleanupFailureMessage =
+  "WhatsApp login failed: existing auth could not be cleared. Remove or fix the configured WhatsApp auth directory, then retry login.";
+
+function encodedQr(qr: string) {
+  return `data:image/png;base64,encoded:${qr}`;
+}
+
+function queueQrSocket(qr: string) {
+  createWaSocketMock.mockImplementationOnce(
+    async (
+      _printQr: boolean,
+      _verbose: boolean,
+      opts?: { authDir?: string; onQr?: (qr: string) => void },
+    ) => {
+      const sock = { ws: { close: vi.fn() } };
+      setImmediate(() => opts?.onQr?.(qr));
+      return sock as never;
+    },
+  );
+}
+
+function queueRotatingQrSocket(firstQr: string, secondQr: string, delayMs: number) {
+  createWaSocketMock.mockImplementationOnce(
+    async (
+      _printQr: boolean,
+      _verbose: boolean,
+      opts?: { authDir?: string; onQr?: (qr: string) => void },
+    ) => {
+      const sock = { ws: { close: vi.fn() } };
+      setImmediate(() => opts?.onQr?.(firstQr));
+      setTimeout(() => opts?.onQr?.(secondQr), delayMs);
+      return sock as never;
+    },
+  );
+}
+
+function queueSilentSocket() {
+  createWaSocketMock.mockImplementationOnce(async () => ({ ws: { close: vi.fn() } }) as never);
+}
+
+function expectScanQrResult(result: unknown, qr = "qr-data") {
+  expect(result).toEqual({
+    qrDataUrl: encodedQr(qr),
+    message: scanQrMessage,
+  });
+}
+
+function expectQrRefreshResult(result: unknown, qr: string) {
+  expect(result).toEqual({
+    connected: false,
+    message: refreshedQrMessage,
+    qrDataUrl: encodedQr(qr),
+  });
+}
+
+function waitForever() {
+  return new Promise<never>(() => {});
+}
 
 async function flushTasks() {
   await Promise.resolve();
@@ -98,6 +164,7 @@ describe("login-qr", () => {
       outcome: "stable",
       exists: false,
     });
+    getActiveWebListenerMock.mockReset().mockReturnValue(null);
     readWebSelfIdMock.mockReset().mockReturnValue({ e164: null, jid: null, lid: null });
     logoutWebMock.mockReset().mockResolvedValue(true);
     renderQrPngDataUrlMock
@@ -122,7 +189,7 @@ describe("login-qr", () => {
       timeoutMs: 5000,
       accountId: rotatingAccountId,
     });
-    expect(start.qrDataUrl).toBe("data:image/png;base64,encoded:qr-data");
+    expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
 
     const resultPromise = waitForWebLogin({
       timeoutMs: 5000,
@@ -142,62 +209,195 @@ describe("login-qr", () => {
 
   it("returns a replacement QR when status 408 happens before the first QR", async () => {
     const accountId = "timeout-before-first-qr";
-    createWaSocketMock
-      .mockImplementationOnce(async () => ({ ws: { close: vi.fn() } }) as never)
-      .mockImplementationOnce(
-        async (
-          _printQr: boolean,
-          _verbose: boolean,
-          opts?: { authDir?: string; onQr?: (qr: string) => void },
-        ) => {
-          const sock = { ws: { close: vi.fn() } };
-          setImmediate(() => opts?.onQr?.("qr-after-timeout"));
-          return sock as never;
-        },
-      );
+    queueSilentSocket();
+    queueQrSocket("qr-after-timeout");
     waitForWaConnectionMock
       .mockRejectedValueOnce({ output: { statusCode: 408 } })
-      .mockImplementation(() => new Promise(() => {}));
+      .mockImplementation(waitForever);
 
     const start = await startWebLoginWithQr({
       timeoutMs: 5000,
       accountId,
     });
 
-    expect(start).toEqual({
-      qrDataUrl: "data:image/png;base64,encoded:qr-after-timeout",
-      message: "Scan this QR in WhatsApp → Linked Devices.",
-    });
+    expectScanQrResult(start, "qr-after-timeout");
     expect(createWaSocketMock).toHaveBeenCalledTimes(2);
   });
 
-  it("clears auth and reports a relink message when WhatsApp is logged out", async () => {
-    waitForWaConnectionMock.mockRejectedValueOnce({
-      output: { statusCode: 401 },
-    });
+  it("clears auth and returns a replacement QR when WhatsApp is logged out", async () => {
+    const accountId = "logged-out-replacement-qr";
+    queueQrSocket("qr-data");
+    queueQrSocket("qr-after-logout");
+    waitForWaConnectionMock
+      .mockRejectedValueOnce({
+        output: { statusCode: 401 },
+      })
+      .mockImplementation(waitForever);
 
-    const start = await startWebLoginWithQr({ timeoutMs: 5000 });
-    expect(start.qrDataUrl).toBe("data:image/png;base64,encoded:qr-data");
+    const start = await startWebLoginWithQr({ timeoutMs: 5000, accountId });
+    expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
 
     const result = await waitForWebLogin({
       timeoutMs: 5000,
       currentQrDataUrl: start.qrDataUrl,
+      accountId,
     });
 
     expect(result).toEqual({
       connected: false,
-      message:
-        "WhatsApp reported the session is logged out. Cleared cached web session; please scan a new QR.",
+      message: refreshedQrMessage,
+      qrDataUrl: encodedQr("qr-after-logout"),
     });
     expect(logoutWebMock).toHaveBeenCalledOnce();
   });
 
-  it("caps oversized wait timeouts to a timer-safe delay", async () => {
-    const accountId = "oversized-wait-timeout";
-    waitForWaConnectionMock.mockImplementation(() => new Promise(() => {}));
+  it("keeps the linked shortcut when existing auth has an active listener", async () => {
+    getActiveWebListenerMock.mockReturnValue({} as never);
+    readWebSelfIdMock.mockReturnValueOnce({ e164: "+15551234567", jid: null, lid: null });
+    readWebAuthExistsForDecisionMock.mockResolvedValueOnce({
+      outcome: "stable",
+      exists: true,
+    });
+
+    await expect(startWebLoginWithQr({ timeoutMs: 5000 })).resolves.toEqual({
+      message: "WhatsApp is already linked (+15551234567). Say “relink” if you want a fresh QR.",
+    });
+    expect(createWaSocketMock).not.toHaveBeenCalled();
+    expect(logoutWebMock).not.toHaveBeenCalled();
+  });
+
+  it("clears saved auth for an explicit fresh QR relink", async () => {
+    const accountId = "force-fresh-qr";
+    getActiveWebListenerMock.mockReturnValue({} as never);
+    waitForWaConnectionMock.mockImplementation(waitForever);
+    readWebAuthExistsForDecisionMock.mockResolvedValueOnce({
+      outcome: "stable",
+      exists: true,
+    });
+
+    const result = await startWebLoginWithQr({
+      timeoutMs: 5000,
+      accountId,
+      force: true,
+    });
+
+    expectScanQrResult(result);
+    expect(logoutWebMock).toHaveBeenCalledWith({
+      authDir: expect.stringContaining(accountId),
+      isLegacyAuthDir: false,
+      runtime: expect.anything(),
+    });
+  });
+
+  it("rederives logged-out auth after restart when preserved creds have no active listener", async () => {
+    const accountId = "restart-preserved-logged-out";
+    queueSilentSocket();
+    queueQrSocket("qr-after-restart-logout");
+    waitForWaConnectionMock
+      .mockRejectedValueOnce({ output: { statusCode: 401 } })
+      .mockImplementation(waitForever);
+    readWebAuthExistsForDecisionMock.mockResolvedValueOnce({
+      outcome: "stable",
+      exists: true,
+    });
+
+    const result = await startWebLoginWithQr({ timeoutMs: 5000, accountId });
+
+    expectScanQrResult(result, "qr-after-restart-logout");
+    expect(logoutWebMock).toHaveBeenCalledWith({
+      authDir: expect.stringContaining(accountId),
+      isLegacyAuthDir: false,
+      runtime: expect.anything(),
+    });
+    expect(createWaSocketMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not start a fresh QR when existing auth cleanup is skipped", async () => {
+    const accountId = "skipped-cleanup-qr";
+    queueSilentSocket();
+    waitForWaConnectionMock.mockRejectedValueOnce({
+      output: { statusCode: 401 },
+    });
+    logoutWebMock.mockResolvedValueOnce(false);
+    readWebAuthExistsForDecisionMock
+      .mockResolvedValueOnce({ outcome: "stable", exists: true })
+      .mockResolvedValueOnce({ outcome: "stable", exists: true });
+
+    const result = await startWebLoginWithQr({ timeoutMs: 5000, accountId });
+
+    expect(result).toEqual({ message: cleanupFailureMessage });
+    expect(createWaSocketMock).toHaveBeenCalledOnce();
+  });
+
+  it("reports skipped cleanup during QR login as an auth cleanup failure", async () => {
+    const accountId = "skipped-cleanup-after-qr";
+    waitForWaConnectionMock.mockRejectedValueOnce({
+      output: { statusCode: 401 },
+    });
+    readWebAuthExistsForDecisionMock
+      .mockResolvedValueOnce({ outcome: "stable", exists: false })
+      .mockResolvedValueOnce({ outcome: "stable", exists: true });
+    logoutWebMock.mockResolvedValueOnce(false);
 
     const start = await startWebLoginWithQr({ timeoutMs: 5000, accountId });
-    expect(start.qrDataUrl).toBe("data:image/png;base64,encoded:qr-data");
+    expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
+
+    await expect(
+      waitForWebLogin({
+        timeoutMs: 5000,
+        currentQrDataUrl: start.qrDataUrl,
+        accountId,
+      }),
+    ).resolves.toEqual({
+      connected: false,
+      message: cleanupFailureMessage,
+    });
+  });
+
+  it("uses the linked shortcut after successful QR relink starts a listener", async () => {
+    const accountId = "qr-success-clears-terminal-state";
+    let finishLogin!: () => void;
+    waitForWaConnectionMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishLogin = resolve;
+        }),
+    );
+    readWebAuthExistsForDecisionMock
+      .mockResolvedValueOnce({ outcome: "stable", exists: false })
+      .mockResolvedValueOnce({ outcome: "stable", exists: true })
+      .mockResolvedValueOnce({ outcome: "stable", exists: true });
+    readWebSelfIdMock.mockReturnValue({ e164: "+15551234567", jid: null, lid: null });
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000, accountId });
+    expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
+
+    finishLogin();
+    await expect(
+      waitForWebLogin({
+        timeoutMs: 5000,
+        currentQrDataUrl: start.qrDataUrl,
+        accountId,
+      }),
+    ).resolves.toEqual({
+      connected: true,
+      message: "✅ Linked! WhatsApp is ready.",
+    });
+
+    logoutWebMock.mockClear();
+    getActiveWebListenerMock.mockReturnValue({} as never);
+    await expect(startWebLoginWithQr({ timeoutMs: 5000, accountId })).resolves.toEqual({
+      message: "WhatsApp is already linked (+15551234567). Say “relink” if you want a fresh QR.",
+    });
+    expect(logoutWebMock).not.toHaveBeenCalled();
+  });
+
+  it("caps oversized wait timeouts to a timer-safe delay", async () => {
+    const accountId = "oversized-wait-timeout";
+    waitForWaConnectionMock.mockImplementation(waitForever);
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000, accountId });
+    expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
 
     vi.useFakeTimers();
     const resultPromise = waitForWebLogin({
@@ -220,7 +420,7 @@ describe("login-qr", () => {
     logoutWebMock.mockRejectedValueOnce(new Error("cleanup failed"));
 
     const start = await startWebLoginWithQr({ timeoutMs: 5000 });
-    expect(start.qrDataUrl).toBe("data:image/png;base64,encoded:qr-data");
+    expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
 
     const result = await waitForWebLogin({
       timeoutMs: 5000,
@@ -273,7 +473,7 @@ describe("login-qr", () => {
     expect(result.message).toMatch(/retry/i);
   });
 
-  it("reports a recovered linked session when socket bootstrap restores auth without a QR", async () => {
+  it("reports a recovered linked session when saved auth has no active listener", async () => {
     createWaSocketMock.mockImplementationOnce(
       async (
         _printQr: boolean,
@@ -286,9 +486,7 @@ describe("login-qr", () => {
     );
     waitForWaConnectionMock.mockResolvedValueOnce(undefined);
     readWebSelfIdMock.mockReturnValueOnce({ e164: "+5511977000000", jid: null, lid: null });
-    readWebAuthExistsForDecisionMock
-      .mockResolvedValueOnce({ outcome: "stable", exists: false })
-      .mockResolvedValue({ outcome: "stable", exists: true });
+    readWebAuthExistsForDecisionMock.mockResolvedValue({ outcome: "stable", exists: true });
 
     const result = await startWebLoginWithQr({ timeoutMs: 5000 });
 
@@ -304,22 +502,11 @@ describe("login-qr", () => {
   });
 
   it("surfaces the latest QR after the socket rotates it", async () => {
-    createWaSocketMock.mockImplementationOnce(
-      async (
-        _printQr: boolean,
-        _verbose: boolean,
-        opts?: { authDir?: string; onQr?: (qr: string) => void },
-      ) => {
-        const sock = { ws: { close: vi.fn() } };
-        setImmediate(() => opts?.onQr?.("qr-data"));
-        setTimeout(() => opts?.onQr?.("qr-data-2"), 100);
-        return sock as never;
-      },
-    );
-    waitForWaConnectionMock.mockImplementation(() => new Promise(() => {}));
+    queueRotatingQrSocket("qr-data", "qr-data-2", 100);
+    waitForWaConnectionMock.mockImplementation(waitForever);
 
     const start = await startWebLoginWithQr({ timeoutMs: 5000 });
-    expect(start.qrDataUrl).toBe("data:image/png;base64,encoded:qr-data");
+    expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
 
     const resultPromise = waitForWebLogin({
       timeoutMs: 5000,
@@ -329,11 +516,7 @@ describe("login-qr", () => {
     await waitMs(140);
     await flushTasks();
 
-    await expect(resultPromise).resolves.toEqual({
-      connected: false,
-      message: "QR refreshed. Scan the latest code in WhatsApp → Linked Devices.",
-      qrDataUrl: "data:image/png;base64,encoded:qr-data-2",
-    });
+    expectQrRefreshResult(await resultPromise, "qr-data-2");
   });
 
   it("does not short-circuit on an existing QR when the waiter has no current QR image", async () => {
@@ -352,7 +535,7 @@ describe("login-qr", () => {
       timeoutMs: 5000,
       accountId,
     });
-    expect(start.qrDataUrl).toBe("data:image/png;base64,encoded:qr-data");
+    expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
 
     await expect(
       waitForWebLogin({
@@ -370,18 +553,7 @@ describe("login-qr", () => {
     let resolveLogin: () => void = () => {
       throw new Error("Expected login wait to be pending");
     };
-    createWaSocketMock.mockImplementationOnce(
-      async (
-        _printQr: boolean,
-        _verbose: boolean,
-        opts?: { authDir?: string; onQr?: (qr: string) => void },
-      ) => {
-        const sock = { ws: { close: vi.fn() } };
-        setImmediate(() => opts?.onQr?.("qr-data"));
-        setTimeout(() => opts?.onQr?.("qr-data-2"), 20);
-        return sock as never;
-      },
-    );
+    queueRotatingQrSocket("qr-data", "qr-data-2", 20);
     waitForWaConnectionMock.mockImplementationOnce(
       () =>
         new Promise<void>((resolve) => {
@@ -396,7 +568,7 @@ describe("login-qr", () => {
       timeoutMs: 5000,
       accountId,
     });
-    expect(start.qrDataUrl).toBe("data:image/png;base64,encoded:qr-data");
+    expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
 
     await waitMs(50);
     await flushTasks();
@@ -427,13 +599,13 @@ describe("login-qr", () => {
             resolveFirstConnection = resolve;
           }),
       )
-      .mockImplementation(() => new Promise(() => {}));
+      .mockImplementation(waitForever);
 
     const start = await startWebLoginWithQr({
       timeoutMs: 5000,
       accountId,
     });
-    expect(start.qrDataUrl).toBe("data:image/png;base64,encoded:qr-data");
+    expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
 
     const waiter = waitForWebLogin({
       timeoutMs: 1000,
@@ -449,7 +621,7 @@ describe("login-qr", () => {
         timeoutMs: 5000,
         accountId,
       });
-      expect(replacement.qrDataUrl).toBe("data:image/png;base64,encoded:qr-data");
+      expect(replacement.qrDataUrl).toBe(encodedQr("qr-data"));
 
       resolveFirstConnection();
 
@@ -479,7 +651,7 @@ describe("login-qr", () => {
         return sock as never;
       },
     );
-    waitForWaConnectionMock.mockImplementation(() => new Promise(() => {}));
+    waitForWaConnectionMock.mockImplementation(waitForever);
     renderQrPngDataUrlMock.mockImplementation((qr) =>
       qr === "qr-data-2"
         ? new Promise<string>(() => {})
@@ -490,7 +662,7 @@ describe("login-qr", () => {
       timeoutMs: 5000,
       accountId,
     });
-    expect(start.qrDataUrl).toBe("data:image/png;base64,encoded:qr-data");
+    expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
 
     onQr("qr-data-2");
     await flushTasks();
@@ -502,7 +674,7 @@ describe("login-qr", () => {
 
     expect(createWaSocketMock).toHaveBeenCalledTimes(1);
     expect(reused).toEqual({
-      qrDataUrl: "data:image/png;base64,encoded:qr-data",
+      qrDataUrl: encodedQr("qr-data"),
       message: "QR already active. Scan it in WhatsApp → Linked Devices.",
     });
   });
@@ -518,7 +690,7 @@ describe("login-qr", () => {
           resolveRender = resolve;
         }),
     );
-    waitForWaConnectionMock.mockImplementation(() => new Promise(() => {}));
+    waitForWaConnectionMock.mockImplementation(waitForever);
 
     const resultPromise = startWebLoginWithQr({
       timeoutMs: 5000,
@@ -528,34 +700,20 @@ describe("login-qr", () => {
 
     expect(renderQrPngDataUrlMock).toHaveBeenCalledTimes(1);
 
-    resolveRender("data:image/png;base64,encoded:qr-data");
-    await expect(resultPromise).resolves.toEqual({
-      qrDataUrl: "data:image/png;base64,encoded:qr-data",
-      message: "Scan this QR in WhatsApp → Linked Devices.",
-    });
+    resolveRender(encodedQr("qr-data"));
+    expectScanQrResult(await resultPromise);
     expect(renderQrPngDataUrlMock).toHaveBeenCalledTimes(1);
   });
 
   it("returns the same rotated QR to concurrent waiters that share the same current image", async () => {
-    createWaSocketMock.mockImplementationOnce(
-      async (
-        _printQr: boolean,
-        _verbose: boolean,
-        opts?: { authDir?: string; onQr?: (qr: string) => void },
-      ) => {
-        const sock = { ws: { close: vi.fn() } };
-        setImmediate(() => opts?.onQr?.("qr-data"));
-        setTimeout(() => opts?.onQr?.("qr-data-2"), 100);
-        return sock as never;
-      },
-    );
-    waitForWaConnectionMock.mockImplementation(() => new Promise(() => {}));
+    queueRotatingQrSocket("qr-data", "qr-data-2", 100);
+    waitForWaConnectionMock.mockImplementation(waitForever);
 
     const start = await startWebLoginWithQr({
       timeoutMs: 5000,
       accountId: concurrentAccountId,
     });
-    expect(start.qrDataUrl).toBe("data:image/png;base64,encoded:qr-data");
+    expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
 
     const waiterA = waitForWebLogin({
       timeoutMs: 5000,
@@ -572,15 +730,7 @@ describe("login-qr", () => {
     await waitMs(140);
     await flushTasks();
 
-    await expect(waiterA).resolves.toEqual({
-      connected: false,
-      message: "QR refreshed. Scan the latest code in WhatsApp → Linked Devices.",
-      qrDataUrl: "data:image/png;base64,encoded:qr-data-2",
-    });
-    await expect(waiterB).resolves.toEqual({
-      connected: false,
-      message: "QR refreshed. Scan the latest code in WhatsApp → Linked Devices.",
-      qrDataUrl: "data:image/png;base64,encoded:qr-data-2",
-    });
+    expectQrRefreshResult(await waiterA, "qr-data-2");
+    expectQrRefreshResult(await waiterB, "qr-data-2");
   });
 });

--- a/extensions/whatsapp/src/login-qr.ts
+++ b/extensions/whatsapp/src/login-qr.ts
@@ -6,6 +6,7 @@ import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, info, success } from "openclaw/plugin-sdk/runtime-env";
 import { defaultRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { resolveWhatsAppAccount } from "./accounts.js";
+import { getActiveWebListener } from "./active-listener.js";
 import {
   closeWaSocket,
   waitForWhatsAppLoginResult,
@@ -14,6 +15,8 @@ import {
 import { renderQrPngDataUrl } from "./qr-image.js";
 import {
   createWaSocket,
+  formatError,
+  logoutWeb,
   readWebAuthExistsForDecision,
   readWebSelfId,
   WHATSAPP_AUTH_UNSTABLE_CODE,
@@ -327,12 +330,31 @@ export async function startWebLoginWithQr(
       message: "WhatsApp auth state is still stabilizing. Retry login in a moment.",
     };
   }
-  if (authState.exists && !opts.force) {
+  if (authState.exists && !opts.force && getActiveWebListener(account.accountId)) {
     const selfId = readWebSelfId(account.authDir);
     const who = selfId.e164 ?? selfId.jid ?? "unknown";
     return {
       message: `WhatsApp is already linked (${who}). Say “relink” if you want a fresh QR.`,
     };
+  }
+  if (authState.exists && opts.force) {
+    try {
+      const cleared = await logoutWeb({
+        authDir: account.authDir,
+        isLegacyAuthDir: account.isLegacyAuthDir,
+        runtime,
+      });
+      if (!cleared) {
+        return {
+          message:
+            "WhatsApp login failed: existing auth could not be cleared. Remove or fix the configured WhatsApp auth directory, then retry login.",
+        };
+      }
+    } catch (err) {
+      return {
+        message: `WhatsApp login failed: ${formatError(err)}`,
+      };
+    }
   }
 
   const existing = activeLogins.get(account.accountId);

--- a/extensions/whatsapp/src/login.coverage.test.ts
+++ b/extensions/whatsapp/src/login.coverage.test.ts
@@ -168,18 +168,21 @@ describe("loginWeb coverage", () => {
     expect(renderQrTerminalMock).toHaveBeenCalledWith("restart-qr", { small: true });
   });
 
-  it("clears creds and throws when logged out", async () => {
-    waitForWaConnectionMock.mockRejectedValueOnce({
-      output: { statusCode: 401 },
-    });
+  it("clears stale creds and continues login when logged out", async () => {
+    waitForWaConnectionMock
+      .mockRejectedValueOnce({
+        output: { statusCode: 401 },
+      })
+      .mockResolvedValueOnce(undefined);
 
     const runtime: RuntimeEnv = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
-    await expect(loginWeb(false, waitForWaConnectionMock as never, runtime)).rejects.toThrow(
-      /cache cleared/i,
+    await loginWeb(false, waitForWaConnectionMock as never, runtime);
+
+    expect(createWaSocketMock).toHaveBeenCalledTimes(2);
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtimeMessageCalls(runtime.log)).toContain(
+      "✅ Linked after restart; web session ready.",
     );
-    expect(runtimeMessageCalls(runtime.error)).toEqual([
-      "WhatsApp reported the session is logged out. Cleared cached web session; please rerun openclaw channels login and scan the QR again.",
-    ]);
     expect(rmMock).toHaveBeenCalledWith(path.resolve(testState.authDir), {
       recursive: true,
       force: true,

--- a/src/gateway/server-methods/web.start.test.ts
+++ b/src/gateway/server-methods/web.start.test.ts
@@ -72,11 +72,30 @@ describe("webHandlers web.login.start", () => {
     vi.clearAllMocks();
   });
 
-  it("restarts a previously running channel when login start exits early without a QR", async () => {
-    const loginWithQrStart = vi.fn().mockResolvedValue({
-      code: "whatsapp-auth-unstable",
-      message: "retry later",
-    });
+  it.each([
+    {
+      name: "leaves a running channel alone when non-forced login start exits early without a QR",
+      params: {},
+      result: { code: "whatsapp-auth-unstable", message: "retry later" },
+      stopsChannel: false,
+      restartsChannel: false,
+    },
+    {
+      name: "stops a running channel after non-forced login start takes over with a QR flow",
+      params: {},
+      result: { qrDataUrl: "data:image/png;base64,qr", message: "scan qr" },
+      stopsChannel: true,
+      restartsChannel: false,
+    },
+    {
+      name: "stops and restores a running channel around forced login failures without a QR",
+      params: { force: true },
+      result: { code: "whatsapp-auth-unstable", message: "retry later" },
+      stopsChannel: true,
+      restartsChannel: true,
+    },
+  ] as const)("$name", async ({ params, result, stopsChannel, restartsChannel }) => {
+    const loginWithQrStart = vi.fn().mockResolvedValue(result);
     mocks.listChannelPlugins.mockReturnValue([
       {
         id: "whatsapp",
@@ -89,7 +108,7 @@ describe("webHandlers web.login.start", () => {
 
     await webHandlers["web.login.start"](
       createOptions(
-        { accountId: "default" },
+        { accountId: "default", ...params },
         {
           respond,
           context,
@@ -97,43 +116,17 @@ describe("webHandlers web.login.start", () => {
       ),
     );
 
-    expect(stopChannel).toHaveBeenCalledWith("whatsapp", "default");
-    expect(startChannel).toHaveBeenCalledWith("whatsapp", "default");
-    expect(respond).toHaveBeenCalledWith(
-      true,
-      {
-        code: "whatsapp-auth-unstable",
-        message: "retry later",
-      },
-      undefined,
-    );
-  });
-
-  it("keeps the channel stopped when login start has taken over with a QR flow", async () => {
-    const loginWithQrStart = vi.fn().mockResolvedValue({
-      qrDataUrl: "data:image/png;base64,qr",
-      message: "scan qr",
-    });
-    mocks.listChannelPlugins.mockReturnValue([
-      {
-        id: "whatsapp",
-        gatewayMethods: ["web.login.start"],
-        gateway: { loginWithQrStart },
-      },
-    ]);
-    const { context, startChannel, stopChannel } = createRunningWhatsappContext();
-
-    await webHandlers["web.login.start"](
-      createOptions(
-        { accountId: "default" },
-        {
-          context,
-        },
-      ),
-    );
-
-    expect(stopChannel).toHaveBeenCalledWith("whatsapp", "default");
-    expect(startChannel).not.toHaveBeenCalled();
+    if (stopsChannel) {
+      expect(stopChannel).toHaveBeenCalledWith("whatsapp", "default");
+    } else {
+      expect(stopChannel).not.toHaveBeenCalled();
+    }
+    if (restartsChannel) {
+      expect(startChannel).toHaveBeenCalledWith("whatsapp", "default");
+    } else {
+      expect(startChannel).not.toHaveBeenCalled();
+    }
+    expect(respond).toHaveBeenCalledWith(true, result, undefined);
   });
 
   it("preserves gateway method receiver state for login start", async () => {

--- a/src/gateway/server-methods/web.ts
+++ b/src/gateway/server-methods/web.ts
@@ -119,16 +119,25 @@ export const webHandlers: GatewayRequestHandlers = {
         channelId: provider.id,
         accountId,
       });
-      await context.stopChannel(provider.id, accountId);
+      const forceLogin = Boolean(params.force);
+      const stoppedBeforeLogin = forceLogin || !wasRunning;
+      if (stoppedBeforeLogin) {
+        await context.stopChannel(provider.id, accountId);
+      }
       const result = await run({
-        force: Boolean(params.force),
+        force: forceLogin,
         timeoutMs: typeof params.timeoutMs === "number" ? params.timeoutMs : undefined,
         verbose: Boolean(params.verbose),
         accountId,
       });
-      if (result.connected) {
+      const stoppedAfterQrTakeover = !stoppedBeforeLogin && Boolean(result.qrDataUrl);
+      if (stoppedAfterQrTakeover) {
+        await context.stopChannel(provider.id, accountId);
+      }
+      const stoppedForLogin = stoppedBeforeLogin || stoppedAfterQrTakeover;
+      if (result.connected && stoppedForLogin) {
         await context.startChannel(provider.id, accountId);
-      } else if (wasRunning && !result.qrDataUrl) {
+      } else if (wasRunning && stoppedForLogin && !result.qrDataUrl) {
         // When start fails before producing a QR code, restore the previously
         // running channel/account so a transient login failure does not stop it.
         await context.startChannel(provider.id, accountId);


### PR DESCRIPTION
## Summary

- Preserve WhatsApp Web credentials on passive logged-out/conflict terminal monitor disconnects; the monitor now stops the listener without calling `logoutWeb`.
- Remove the process-local terminal auth marker entirely and derive QR/CLI relink behavior from actual saved-auth/socket outcomes.
- When saved auth exists with no active listener, bootstrap it first: a valid session recovers without QR, while a 401 clears auth once through `logoutWeb` and then surfaces one replacement QR.
- Keep forced relink and explicit logout as the explicit owners of auth cleanup, and keep gateway `web.login.start` from stopping a running channel until a non-forced QR flow actually takes over.

## Verification

- `node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts extensions/whatsapp/src/connection-controller.test.ts extensions/whatsapp/src/auth-store.test.ts extensions/whatsapp/src/logout.test.ts extensions/whatsapp/src/login.coverage.test.ts extensions/whatsapp/src/login-qr.test.ts src/gateway/server-methods/web.start.test.ts`
- `pnpm check:test-types`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `run-whatsapp-qa-branch.sh --pr 93076`

## Real behavior proof

Behavior addressed: WhatsApp passive monitor terminal disconnects no longer remove saved credentials, while explicit login/relink/logout flows still own stale-auth cleanup.

Real environment tested: Local OpenClaw WhatsApp unit/e2e harness and gateway server-method harness in the branch worktree. Live WhatsApp QA also ran on the local maintainer host against PR 93076 using the `default` driver account, `work` SUT account, configured/redacted QA group, and `mock-openai`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts extensions/whatsapp/src/connection-controller.test.ts extensions/whatsapp/src/auth-store.test.ts extensions/whatsapp/src/logout.test.ts extensions/whatsapp/src/login.coverage.test.ts extensions/whatsapp/src/login-qr.test.ts src/gateway/server-methods/web.start.test.ts`; `pnpm check:test-types`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`; `run-whatsapp-qa-branch.sh --pr 93076`

Evidence after fix: Focused Vitest passed 3 shards: 2 gateway test files with 10 tests, 1 e2e file with 26 tests, and 5 WhatsApp extension files with 66 tests. Test typecheck and diff whitespace checks passed. Autoreview reported no accepted/actionable findings. Live WhatsApp QA ran 35 discovered scenarios and passed 35/35 with 0 failures and 0 skipped.

Observed result after fix: Passive logged-out/conflict monitor paths preserve auth files. QR login returns already-linked only with an active listener, recovers valid saved auth without QR when no listener exists, clears 401 stale auth once before a replacement QR, and fails clearly when cleanup reports auth still present. Forced relink still clears auth before QR generation, and non-forced gateway login failures do not stop a running channel before QR takeover. Live WhatsApp proof covered DM canary, pairing gate, group mention/audio gating, command replies, reply context, inbound image/audio/structured messages, outbound media/document/poll, message actions, access control, reply chunking, stream final accounting, native `/new`, status reactions, allowlist quiet behavior, and native approval flows.

Live WhatsApp QA artifacts:

- Branch/head tested: `fix/whatsapp-preserve-terminal-auth` @ `86cdb86014156c6877d4e3223680ac59f9e6ec4d`
- Base tested: `origin/main` @ `ac1042b09b5cfa4dcee7bfe1f8e5ae7771d4a35a`
- Report: `.artifacts/qa-e2e/whatsapp-full-pr-93076-20260615-040153/whatsapp-qa-report.md`
- Evidence summary: `.artifacts/qa-e2e/whatsapp-full-pr-93076-20260615-040153/qa-evidence.json`
- Observed messages: `.artifacts/qa-e2e/whatsapp-full-pr-93076-20260615-040153/whatsapp-qa-observed-messages.json`

What was not tested: No live-provider model call was run; the live WhatsApp lane used `mock-openai`. No manual real-device QR scan or real conflict-session reproduction was run outside the automated QA lane.
