### PR TITLE
fix(gateway): scope sessions.describe to the requested agent

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1728,21 +1728,25 @@ public struct SessionsPreviewParams: Codable, Sendable {
 
 public struct SessionsDescribeParams: Codable, Sendable {
     public let key: String
+    public let agentid: String?
     public let includederivedtitles: Bool?
     public let includelastmessage: Bool?
 
     public init(
         key: String,
+        agentid: String? = nil,
         includederivedtitles: Bool?,
         includelastmessage: Bool?)
     {
         self.key = key
+        self.agentid = agentid
         self.includederivedtitles = includederivedtitles
         self.includelastmessage = includelastmessage
     }
 
     private enum CodingKeys: String, CodingKey {
         case key
+        case agentid = "agentId"
         case includederivedtitles = "includeDerivedTitles"
         case includelastmessage = "includeLastMessage"
     }

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -216,6 +216,7 @@ export const SessionsPreviewParamsSchema = Type.Object(
 export const SessionsDescribeParamsSchema = Type.Object(
   {
     key: NonEmptyString,
+    agentId: Type.Optional(NonEmptyString),
     includeDerivedTitles: Type.Optional(Type.Boolean()),
     includeLastMessage: Type.Optional(Type.Boolean()),
   },

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1230,7 +1230,16 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     const cfg = context.getRuntimeConfig();
-    const { target, storePath, store, entry } = loadSessionEntriesForTarget({ key, cfg });
+    const requestedAgent = resolveRequestedGlobalAgentId(cfg, key, p.agentId);
+    if (!requestedAgent.ok) {
+      respond(false, undefined, requestedAgent.error);
+      return;
+    }
+    const { target, storePath, store, entry } = loadSessionEntriesForTarget({
+      key,
+      cfg,
+      ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
+    });
     if (!entry) {
       respond(true, { session: null }, undefined);
       return;
@@ -1244,6 +1253,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       includeDerivedTitles: p.includeDerivedTitles,
       includeLastMessage: p.includeLastMessage,
       transcriptUsageMaxBytes: 64 * 1024,
+      ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
     });
     respond(true, { session: row }, undefined);
   },

--- a/src/gateway/server.sessions.describe.test.ts
+++ b/src/gateway/server.sessions.describe.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Gateway sessions.describe agent-scope tests.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, test } from "vitest";
+import { testState } from "./test-helpers.js";
+import {
+  setupGatewaySessionsTestHarness,
+  sessionStoreEntry,
+  directSessionReq,
+} from "./test/server-sessions.test-helpers.js";
+
+const { createSelectedGlobalSessionStore } = setupGatewaySessionsTestHarness();
+
+async function writeSelectedGlobalStores(params: {
+  mainStorePath: string;
+  workStorePath: string;
+}): Promise<void> {
+  await fs.mkdir(path.dirname(params.mainStorePath), { recursive: true });
+  await fs.mkdir(path.dirname(params.workStorePath), { recursive: true });
+  await fs.writeFile(
+    params.mainStorePath,
+    JSON.stringify({ global: sessionStoreEntry("sess-main-global") }, null, 2),
+  );
+  await fs.writeFile(
+    params.workStorePath,
+    JSON.stringify({ global: sessionStoreEntry("sess-work-global") }, null, 2),
+  );
+}
+
+function clearSessionTestState(): void {
+  testState.sessionStorePath = undefined;
+  testState.sessionConfig = undefined;
+  testState.agentsConfig = undefined;
+}
+
+type DescribeResult = { session: { sessionId?: string } | null };
+
+test("sessions.describe scopes a selected global session to the requested agent", async () => {
+  const { mainStorePath, workStorePath } = await createSelectedGlobalSessionStore();
+  await writeSelectedGlobalStores({ mainStorePath, workStorePath });
+
+  const described = await directSessionReq<DescribeResult>("sessions.describe", {
+    key: "global",
+    agentId: "work",
+  });
+  expect(described.ok).toBe(true);
+  expect(described.payload?.session?.sessionId).toBe("sess-work-global");
+
+  // Without an explicit agentId the global session resolves through the default store agent.
+  const describedDefault = await directSessionReq<DescribeResult>("sessions.describe", {
+    key: "global",
+  });
+  expect(describedDefault.ok).toBe(true);
+  expect(describedDefault.payload?.session?.sessionId).toBe("sess-main-global");
+
+  clearSessionTestState();
+});
+
+test("sessions.describe rejects an unknown agentId", async () => {
+  const { mainStorePath, workStorePath } = await createSelectedGlobalSessionStore();
+  await writeSelectedGlobalStores({ mainStorePath, workStorePath });
+
+  const described = await directSessionReq("sessions.describe", {
+    key: "global",
+    agentId: "ghost",
+  });
+  expect(described.ok).toBe(false);
+  expect(described.error?.message).toMatch(/Unknown agent id/);
+
+  clearSessionTestState();
+});


### PR DESCRIPTION
## Summary

- Problem: the Gateway `sessions.describe` handler ignored the `agentId` parameter and resolved `global` sessions through the **default store agent**. A caller scoped to a non-default agent could be served a different agent's global session.
- Why it matters: every other agent-aware session method (`sessions.compaction.list/get/branch/restore`, etc.) routes through `resolveRequestedGlobalAgentId`; `sessions.describe` was the lone exception, so the contract was silently inconsistent. The current consumer (`src/mcp/channel-bridge.ts`) does not pass `agentId` today, so the bug is latent — it surfaces the moment any caller relies on agent scoping (e.g. a TUI scoped to a selected agent).
- What changed: `sessions.describe` now resolves the requested agent via `resolveRequestedGlobalAgentId` and threads the resulting `agentId` into both `loadSessionEntriesForTarget` and `buildGatewaySessionRow`; the optional `agentId` field is added to `SessionsDescribeParamsSchema` (and the regenerated Swift protocol models).
- Scope boundary: no behavior change for callers that omit `agentId` (still resolves the default agent), no new RPC, no auth/permission change.

## Change Type

- [x] Bug fix

## Linked Issue

- Closes #92960

## Root Cause

`sessions.describe` called `loadSessionEntriesForTarget({ key, cfg })` without an `agentId` and never read `params.agentId`. For `global` keys the store target then falls back to the default store agent regardless of the requested agent. Sibling handlers avoid this by calling `resolveRequestedGlobalAgentId(cfg, key, p.agentId)` first; describe simply did not.

## Real behavior proof

- Behavior addressed: Gateway `sessions.describe` now returns the requested agent's `global` session instead of always resolving the default store agent's session.
- Real environment tested: a real local OpenClaw config (`OPENCLAW_CONFIG_PATH`) with two agents (`main` default, `work`), `session.scope = global`, and two on-disk session stores under `{agentId}` holding `sess-main-global` and `sess-work-global`. The production `sessions.describe` handler from `src/gateway/server-methods/sessions.ts` was driven directly through the real runtime config loader (`getRuntimeConfig`).
- Exact steps or command run after this patch: invoked the real handler against the on-disk stores with `node --import tsx`, calling `describe({ key: "global", agentId: "work" })` and `describe({ key: "global" })`, both before and after the handler change.
- Evidence after fix: copied live output from the real handler run via `node`:

```text
===== BEFORE FIX (handler at upstream/main) =====
describe({ key:'global', agentId:'work' }) -> sessionId = sess-main-global | ok = true
describe({ key:'global' })                 -> sessionId = sess-main-global | ok = true

===== AFTER FIX =====
describe({ key:'global', agentId:'work' }) -> sessionId = sess-work-global | ok = true
describe({ key:'global' })                 -> sessionId = sess-main-global | ok = true
```

- Observed result after fix: with `agentId: "work"` the handler returns `sess-work-global` (the requested agent's session). Before the change the same call returned `sess-main-global` — the default agent's session — which is the bug. Omitting `agentId` still resolves the default agent (`sess-main-global`), so existing callers are unaffected.
- What was not tested: did not exercise the full websocket Gateway transport or a CLI front-end; the handler was driven in-process against real on-disk stores through the real config loader.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No — this **tightens** scoping so describe returns the requested agent's session instead of the default agent's.

## Supplemental checks

- New regression test `src/gateway/server.sessions.describe.test.ts` covers selected-agent scope, default-agent fallback, and unknown-agent rejection.
- Formatter, linter, and the type checker (`tsgo -p tsconfig.json --noEmit`) all clean on the changed files.

## Compatibility / Migration

- Backward compatible? Yes (omitting `agentId` keeps existing behavior)
- Config/env changes? No
- Migration needed? No