### PR TITLE
perf(tasks): memoize reconcileInspectableTasks for same-tick calls

### DIFF
--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -879,11 +879,17 @@ export function reconcileTaskRecordForOperatorInspection(
   );
 }
 
+let reconcileCache: { result: TaskRecord[]; time: number } | null = null;
+
 export function reconcileInspectableTasks(): TaskRecord[] {
+  const now = Date.now();
+  if (reconcileCache && now - reconcileCache.time < 5) {
+    return reconcileCache.result;
+  }
   taskRegistryMaintenanceRuntime.ensureTaskRegistryReady();
   const cronRecoveryContext = createCronRecoveryContext();
   const backingSessionContext = createBackingSessionLookupContext();
-  return taskRegistryMaintenanceRuntime
+  const result = taskRegistryMaintenanceRuntime
     .listTaskRecords()
     .map((task) =>
       reconcileTaskRecordForOperatorInspectionWithContexts(
@@ -892,6 +898,8 @@ export function reconcileInspectableTasks(): TaskRecord[] {
         backingSessionContext,
       ),
     );
+  reconcileCache = { result, time: now };
+  return result;
 }
 
 configureTaskAuditTaskProvider(reconcileInspectableTasks);
@@ -1239,6 +1247,7 @@ export function resetTaskRegistryMaintenanceRuntimeForTests(): void {
   taskRegistryMaintenanceRuntime = defaultTaskRegistryMaintenanceRuntime;
   configuredCronStorePath = undefined;
   configuredRuntimeAuthoritative = false;
+  reconcileCache = null;
 }
 
 export function configureTaskRegistryMaintenance(options: {


### PR DESCRIPTION
## Summary

`openclaw status` calls `reconcileInspectableTasks()` twice per invocation — once via `getInspectableTaskRegistrySummary()` and again via `getInspectableTaskAuditSummary()`. Each call independently deep-clones and sorts the full task list. With 10K+ task records this doubles reconciliation cost for no benefit.

Add a 5ms in-memory cache that deduplicates same-tick calls. The TTL is intentionally short (5ms) to avoid stale data while covering the synchronous double-call pattern within a single `getStatusSummary()` execution.

Fixes #73531

## Changes

- `src/tasks/task-registry.maintenance.ts`: Add module-level `reconcileCache` with 5ms TTL, clear in `resetTaskRegistryMaintenanceRuntimeForTests()`

## Real behavior proof

- **Behavior addressed:** `reconcileInspectableTasks()` is called twice per `openclaw status` invocation. Each call does an O(n) clone+sort. The second call within the same tick should return the cached result.
- **Environment tested:** macOS 26.4.1, Node v25.8.2, OpenClaw local build (pnpm build)
- **Steps run after the patch:**
  1. Applied the memoization change to `src/tasks/task-registry.maintenance.ts`
  2. Ran `node scripts/run-vitest.mjs run src/tasks/task-registry.maintenance.issue-60299.test.ts src/tasks/task-registry.audit.test.ts` — all 25 tests passed
  3. Ran `pnpm build` — build succeeded
  4. Verified cache variable and reset function with `grep -n`

- **Evidence after fix:**

```
$ node scripts/run-vitest.mjs run src/tasks/task-registry.maintenance.issue-60299.test.ts src/tasks/task-registry.audit.test.ts
 ✓  unit-fast  src/tasks/task-registry.audit.test.ts (6 tests) 2ms
 ✓  tasks  src/tasks/task-registry.maintenance.issue-60299.test.ts (19 tests) 11ms
 Test Files  2 passed (2)
      Tests  25 passed (25)

$ grep -n "reconcileCache" src/tasks/task-registry.maintenance.ts
882:let reconcileCache: { result: TaskRecord[]; time: number } | null = null;
886:  if (reconcileCache && now - reconcileCache.time < 5) {
887:    return reconcileCache.result;
901:  reconcileCache = { result, time: now };
1250:  reconcileCache = null;
```

- **Observed result after fix:** Cache variable is correctly defined at module level, checked at function entry, populated on miss, and cleared in the test reset function. All 25 existing tests pass.
- **What was not tested:** Performance measurement with 10K+ task records (requires production-scale data). The 5ms TTL was chosen to cover same-tick synchronous calls without risking stale data across event loop turns.
