### PR TITLE
Fix media delivery identity accounting

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -3553,6 +3553,46 @@ describe("deliverOutboundPayloads", () => {
     expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
 
+  it("does not count no-identity media results as delivered", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+    const sendText = vi.fn();
+    const sendMedia = vi.fn().mockResolvedValue({
+      channel: "matrix",
+      messageId: "",
+      meta: { error: "media path is not allowed" },
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: { deliveryMode: "direct", sendText, sendMedia },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:1",
+      payloads: [{ text: "caption", mediaUrl: "file:///tmp/generated-tts.opus" }],
+      mirror: {
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        text: "caption",
+      },
+    });
+
+    expect(results).toStrictEqual([]);
+    expect(sendMedia).toHaveBeenCalledTimes(1);
+    expect(sendText).not.toHaveBeenCalled();
+    expect(hookMocks.runner.runMessageSent).not.toHaveBeenCalled();
+    expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
+  });
+
   it("emits message_sent success for sendPayload deliveries", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1891,6 +1891,9 @@ async function deliverOutboundPayloadsCore(
               unit.overrides,
             )
           : await deliveryHandler.sendMedia(unit.caption ?? "", unit.mediaUrl, unit.overrides);
+        if (!hasDeliveryResultIdentity(delivery)) {
+          continue;
+        }
         results.push(delivery);
         firstMessageId ??= delivery.messageId;
         lastMessageId = delivery.messageId;
@@ -1916,6 +1919,12 @@ async function deliverOutboundPayloadsCore(
           results: deliveredResults,
         });
         recordDeliveredMirrorPayload(payloadSummary, deliveredResults);
+        completeDeliveryDiagnostics(deliveredResults.length);
+        emitMessageSent({
+          success: true,
+          content: payloadSummary.hookContent ?? payloadSummary.text,
+          messageId: lastMessageId,
+        });
       } else {
         recordPayloadOutcome(
           suppressedPayloadOutcome({
@@ -1923,13 +1932,8 @@ async function deliverOutboundPayloadsCore(
             reason: "adapter_returned_no_identity",
           }),
         );
+        completeDeliveryDiagnostics(0);
       }
-      completeDeliveryDiagnostics(results.length - beforeCount);
-      emitMessageSent({
-        success: true,
-        content: payloadSummary.hookContent ?? payloadSummary.text,
-        messageId: lastMessageId,
-      });
     } catch (err) {
       recordPayloadOutcome({
         index: payloadIndex,


### PR DESCRIPTION
## Summary

Fixes #92816.

The shared media delivery path counted any adapter media result as delivered, even when the adapter returned no delivery identity. QQBot can return that shape when generated TTS media cannot be sent, which made cron report `delivered` even though no platform message existed.

This applies the same invariant the `sendPayload` path already uses: adapter results without a message/chat/channel identity are suppressed, not mirrored, and do not emit a successful `message_sent` hook.

## Verification

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts`
- `git diff --check`