### PR TITLE
docs(memory): warn about session memory overlap

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -224,6 +224,15 @@ openclaw hooks enable <hook-name>
 
 Extracts the last 15 user/assistant messages and saves to `<workspace>/memory/YYYY-MM-DD-HHMM.md` using the host local date. Memory capture runs in the background so `/new` and `/reset` acknowledgements are not delayed by transcript reads or optional slug generation. Set `hooks.internal.entries.session-memory.llmSlug: true` to generate descriptive filename slugs with the configured model. Requires `workspace.dir` to be configured.
 
+<Warning>
+This hook writes session-derived Markdown into the normal workspace memory tree.
+If memory search also indexes raw session transcripts with
+`memorySearch.sources: ["memory", "sessions"]`, the same conversation can appear
+from both sources. Use this hook with the default `["memory"]` source list, or
+disable the hook when raw transcript search is the desired session recall path.
+See [Session memory search](/reference/memory-config#session-memory-search-experimental).
+</Warning>
+
 <a id="bootstrap-extra-files"></a>
 
 ### bootstrap-extra-files config

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -445,6 +445,15 @@ Index session transcripts and surface them via `memory_search`:
 Session indexing is opt-in and runs asynchronously. Results can be slightly stale. Session logs live on disk, so treat filesystem access as the trust boundary.
 </Warning>
 
+<Warning>
+If you also enable the bundled `session-memory` hook, it writes session summaries
+under `<workspace>/memory/`. Keeping both `memory` and `sessions` in
+`memorySearch.sources` can index the same conversation twice: once from the raw
+session transcript and once from the generated memory summary. Use
+`sources: ["memory"]` when the hook is your session recall path, or disable the
+hook when you want raw transcript search from `sources: ["sessions"]`.
+</Warning>
+
 ---
 
 ## SQLite vector acceleration (sqlite-vec)


### PR DESCRIPTION
## Summary

- Documents that the bundled `session-memory` hook and raw session transcript indexing can cover the same conversation.
- Adds guidance to choose one session recall path: keep `memorySearch.sources` at `["memory"]` when using the hook, or disable the hook when using raw transcript search.
- Leaves runtime indexing, dedupe behavior, hook output paths, and memory search defaults unchanged.

## Linked context

Closes #54524

Related #40618

Was this requested by a maintainer or owner?

No direct maintainer request. ClawSweeper marked #54524 as a narrow docs repair candidate.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: documentation did not warn that `session-memory` writes summaries into `<workspace>/memory/` while `memorySearch.sources: ["memory", "sessions"]` can also index raw session transcripts.
- Real environment tested: local OpenClaw docs checkout on branch `docs/54524-session-memory-overlap`.
- Exact steps or command run after this patch:
  - `nl -ba docs/reference/memory-config.md | sed -n '443,456p'`
  - `nl -ba docs/automation/hooks.md | sed -n '223,236p'`
  - `pnpm docs:list | rg "memory-config|automation/hooks"`
  - `pnpm docs:check-mdx`
  - `pnpm docs:check-links`
  - `pnpm format:docs:check -- docs/reference/memory-config.md docs/automation/hooks.md`
  - `git diff --check -- docs/reference/memory-config.md docs/automation/hooks.md`
- Evidence after fix: terminal output copied from this checkout shows the new warning text on both affected docs pages:

```text
$ nl -ba docs/reference/memory-config.md | sed -n '443,456p'
   443
   444  <Warning>
   445  Session indexing is opt-in and runs asynchronously. Results can be slightly stale. Session logs live on disk, so treat filesystem access as the trust boundary.
   446  </Warning>
   447
   448  <Warning>
   449  If you also enable the bundled `session-memory` hook, it writes session summaries
   450  under `<workspace>/memory/`. Keeping both `memory` and `sessions` in
   451  `memorySearch.sources` can index the same conversation twice: once from the raw
   452  session transcript and once from the generated memory summary. Use
   453  `sources: ["memory"]` when the hook is your session recall path, or disable the
   454  hook when you want raw transcript search from `sources: ["sessions"]`.
   455  </Warning>
   456

$ nl -ba docs/automation/hooks.md | sed -n '223,236p'
   223  ### session-memory details
   224
   225  Extracts the last 15 user/assistant messages and saves to `<workspace>/memory/YYYY-MM-DD-HHMM.md` using the host local date. Memory capture runs in the background so `/new` and `/reset` acknowledgements are not delayed by transcript reads or optional slug generation. Set `hooks.internal.entries.session-memory.llmSlug: true` to generate descriptive filename slugs with the configured model. Requires `workspace.dir` to be configured.
   226
   227  <Warning>
   228  This hook writes session-derived Markdown into the normal workspace memory tree.
   229  If memory search also indexes raw session transcripts with
   230  `memorySearch.sources: ["memory", "sessions"]`, the same conversation can appear
   231  from both sources. Use this hook with the default `["memory"]` source list, or
   232  disable the hook when raw transcript search is the desired session recall path.
   233  See [Session memory search](/reference/memory-config#session-memory-search-experimental).
   234  </Warning>
   235
   236  <a id="bootstrap-extra-files"></a>
```

  Docs validation also passed locally: `pnpm docs:check-mdx` reported `Docs MDX check passed (677 files, 9048ms)`, `pnpm docs:check-links` reported `checked_internal_links=4453` and `broken_links=0`, `pnpm format:docs:check -- docs/reference/memory-config.md docs/automation/hooks.md` reported `Docs formatting clean (662 files)`, and `git diff --check -- docs/reference/memory-config.md docs/automation/hooks.md` produced no output.
- Observed result after fix: both affected docs pages now warn that combining the hook with raw session transcript indexing can duplicate session-derived memory results.
- What was not tested: no live `openclaw memory search` run, because this PR only changes documentation.
- Proof limitations or environment constraints: none for the docs validation path.
- Before evidence: current upstream docs described the hook output and session transcript indexing separately without the overlap warning.

## Tests and validation

- `git diff --check -- docs/reference/memory-config.md docs/automation/hooks.md`
- `pnpm docs:list | rg "memory-config|automation/hooks"`
- `pnpm docs:check-mdx`
- `pnpm docs:check-links`
- `pnpm format:docs:check -- docs/reference/memory-config.md docs/automation/hooks.md`

No regression test was added because this is a docs-only clarification and does not change runtime behavior.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) No. Documentation only.

Did config, environment, or migration behavior change? (`Yes/No`) No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) No.

What is the highest-risk area?

Documentation accuracy for memory search and session-memory setup guidance.

How is that risk mitigated?

The wording is tied to current source behavior: the hook writes under `<workspace>/memory/`, memory search can index both `memory` and `sessions`, and this PR does not claim runtime deduplication or a new config option.

## Current review state

Next action: maintainer review and CI.

Nothing is waiting on the author at PR creation time.

Bot or reviewer comments addressed: Real behavior proof body updated after the first gate run required copied live output in the evidence field.

AI-assisted (Codex). Proof above was run manually in this checkout.
