### PR TITLE
fix(qmd): strip XDG env vars from mcporter spawn env to fix mcporter ≥ 0.10 integration (fixes #79847)

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3986,7 +3986,7 @@ describe("QmdMemoryManager", () => {
     });
   });
 
-  it("passes manager-scoped XDG env to mcporter commands", async () => {
+  it("strips XDG env vars from mcporter commands so mcporter resolves its own config", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -4019,11 +4019,14 @@ describe("QmdMemoryManager", () => {
     const searchCall = requireValue(mcporterCall, "mcporter search call missing");
     const spawnOpts = searchCall[2] as { env?: NodeJS.ProcessEnv } | undefined;
     const normalizePath = (value?: string) => value?.replace(/\\/g, "/");
-    expect(normalizePath(spawnOpts?.env?.XDG_CONFIG_HOME)).toContain("/agents/main/qmd/xdg-config");
+    // mcporter must NOT receive per-agent XDG overrides — it resolves its own
+    // config via default XDG paths (see #79847).
+    expect(spawnOpts?.env?.XDG_CONFIG_HOME).toBeUndefined();
+    expect(spawnOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
+    // QMD_CONFIG_DIR is qmd-specific but harmless for mcporter — it stays.
     expect(normalizePath(spawnOpts?.env?.QMD_CONFIG_DIR)).toContain(
       "/agents/main/qmd/xdg-config/qmd",
     );
-    expect(normalizePath(spawnOpts?.env?.XDG_CACHE_HOME)).toContain("/agents/main/qmd/xdg-cache");
     expect(spawnOpts?.env?.PATH?.split(path.delimiter)).toContain(path.dirname(process.execPath));
 
     await manager.close();

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -370,6 +370,13 @@ export class QmdMemoryManager implements MemorySearchManager {
   private readonly xdgCacheHome: string;
   private readonly indexPath: string;
   private readonly env: NodeJS.ProcessEnv;
+  /**
+   * Environment for mcporter spawns.  Strips XDG_CONFIG_HOME and
+   * XDG_CACHE_HOME so mcporter ≥ 0.10 resolves its own config dir
+   * instead of falling into the per-agent qmd XDG tree.
+   * See https://github.com/openclaw/openclaw/issues/79847.
+   */
+  private readonly mcporterEnv: NodeJS.ProcessEnv;
   private readonly syncSettings: ReturnType<typeof resolveMemorySearchSyncConfig>;
   private readonly managedCollectionNames: string[];
   private readonly collectionRoots = new Map<string, CollectionRoot>();
@@ -446,6 +453,10 @@ export class QmdMemoryManager implements MemorySearchManager {
       XDG_CACHE_HOME: this.xdgCacheHome,
       NO_COLOR: "1",
     };
+    // mcporter must NOT inherit the per-agent XDG overrides — it needs its
+    // own default config/cache dirs to find ~/.mcporter/mcporter.json.
+    const { XDG_CONFIG_HOME: _xdgCfg, XDG_CACHE_HOME: _xdgCache, ...mcporterBase } = this.env;
+    this.mcporterEnv = mcporterBase;
     this.closeSignal = new Promise<void>((resolve) => {
       this.resolveCloseSignal = resolve;
     });
@@ -2238,14 +2249,14 @@ export class QmdMemoryManager implements MemorySearchManager {
     const spawnInvocation = resolveCliSpawnInvocation({
       command: "mcporter",
       args,
-      env: this.env,
+      env: this.mcporterEnv,
       packageName: "mcporter",
     });
     return await runCliCommand({
       commandSummary: `${spawnInvocation.command} ${spawnInvocation.argv.join(" ")}`,
       spawnInvocation,
-      // Keep mcporter and direct qmd commands on the same agent-scoped XDG state.
-      env: this.env,
+      // mcporter uses its own env without per-agent XDG overrides (see mcporterEnv).
+      env: this.mcporterEnv,
       cwd: this.workspaceDir,
       timeoutMs: opts?.timeoutMs,
       maxOutputChars: this.maxQmdOutputChars,


### PR DESCRIPTION
## Real behavior proof

- **Behavior addressed:** qmd-manager passes per-agent XDG_CONFIG_HOME / XDG_CACHE_HOME to mcporter child spawns, causing mcporter ≥ 0.10 to resolve its config under the qmd data dir instead of `~/.mcporter/`, breaking `memory.backend: qmd` integration.
- **Environment tested:** macOS 26.4.1, Node.js v22, openclaw main branch at `02acb0bd`.
- **Steps run after the patch:**
  1. Verified `mcporterEnv` property strips `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` via destructuring rest-spread.
  2. Confirmed `runMcporter` uses `this.mcporterEnv` (not `this.env`) at both `resolveCliSpawnInvocation` and `runCliCommand` call sites.
  3. Ran `node scripts/run-vitest.mjs run extensions/memory-core/src/memory/qmd-manager.test.ts` — all 127 tests pass including updated test that asserts XDG vars are `undefined` in mcporter spawn env.
  4. Ran `pnpm build` — builds cleanly.
- **Evidence after fix:**

```
$ node -e "..."
mcporterEnv declared at line 379
mcporterEnv assigned at line 459
runMcporter uses mcporterEnv at lines: [ 2252, 2258, 2259 ]
XDG refs near mcporterEnv assignment: 0

$ grep -n 'mcporterEnv\|XDG_CONFIG_HOME.*mcporter\|XDG_CACHE_HOME.*mcporter' extensions/memory-core/src/memory/qmd-manager.ts
375:   * XDG_CACHE_HOME so mcporter ≥ 0.10 resolves its own config dir
379:  private readonly mcporterEnv: NodeJS.ProcessEnv;
458:    const { XDG_CONFIG_HOME: _xdgCfg, XDG_CACHE_HOME: _xdgCache, ...mcporterBase } = this.env;
459:    this.mcporterEnv = mcporterBase;
2252:      env: this.mcporterEnv,
2258:      // mcporter uses its own env without per-agent XDG overrides (see mcporterEnv).
2259:      env: this.mcporterEnv,

$ node scripts/run-vitest.mjs run extensions/memory-core/src/memory/qmd-manager.test.ts
 ✓  extension-memory  extensions/memory-core/src/memory/qmd-manager.test.ts (127 tests) 194ms
 Test Files  1 passed (1)
      Tests  127 passed (127)
```

- **Observed result after fix:** mcporter spawns no longer receive `XDG_CONFIG_HOME` or `XDG_CACHE_HOME`, so mcporter ≥ 0.10 resolves its config via default XDG paths (`~/.config/mcporter/`) instead of the per-agent qmd data dir. `QMD_CONFIG_DIR` and `PATH` are preserved.
- **What was not tested:** Live mcporter ≥ 0.10 integration (requires mcporter installed and a running qmd MCP server). The fix is validated via unit tests that inspect the spawn env object.
