### PR TITLE
fix(tools): add encoding parameter to read tool for non-UTF-8 files

### DIFF
--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -100,4 +100,49 @@ describe("read tool", () => {
 
     expect(textContent(result)).toBe("alpha\n\n[2 more lines in file. Use offset=2 to continue.]");
   });
+
+  it("reads GBK-encoded files with explicit encoding (regression #92664)", async () => {
+    // GBK encoded "中文测试内容"
+    const gbkBuffer = Buffer.from([
+      0xd6, 0xd0, 0xce, 0xc4, 0xb2, 0xe2, 0xca, 0xd4, 0xc4, 0xda, 0xc8, 0xdd,
+    ]);
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        detectImageMimeType: async () => null,
+        readFile: async () => gbkBuffer,
+      },
+    });
+
+    const result = await tool.execute(
+      "call-1",
+      { path: "test.txt", encoding: "gbk" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toBe("中文测试内容");
+  });
+
+  it("reads UTF-8 files by default", async () => {
+    const utf8Buffer = Buffer.from("Hello World", "utf-8");
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        detectImageMimeType: async () => null,
+        readFile: async () => utf8Buffer,
+      },
+    });
+
+    const result = await tool.execute(
+      "call-1",
+      { path: "test.txt" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toBe("Hello World");
+  });
 });

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -42,7 +42,7 @@ const readSchema = Type.Object({
   encoding: Type.Optional(
     Type.String({
       description:
-        "File encoding (e.g. 'utf-8', 'gbk', 'gb2312', 'shift_jis'). Default: 'utf-8'. Use 'auto' to auto-detect.",
+        "File encoding (e.g. 'utf-8', 'gbk', 'gb2312', 'shift_jis'). Default: 'utf-8'.",
     }),
   ),
 });
@@ -50,32 +50,15 @@ export type { ReadToolDetails, ReadToolInput } from "./tool-contracts.js";
 
 /**
  * Decode a buffer using the specified encoding.
- * Supports 'auto' to detect BOM or default to utf-8.
  * Uses TextDecoder for non-UTF-8 encodings (e.g. gbk, gb2312, shift_jis).
  */
 function decodeBuffer(buffer: Buffer, encoding?: string): string {
   if (!encoding || encoding === "utf-8" || encoding === "utf8") {
     return buffer.toString("utf-8");
   }
-  if (encoding === "auto") {
-    // Check for BOM
-    if (buffer[0] === 0xef && buffer[1] === 0xbb && buffer[2] === 0xbf) {
-      return buffer.toString("utf-8");
-    }
-    if (buffer[0] === 0xff && buffer[1] === 0xfe) {
-      return new TextDecoder("utf-16le").decode(buffer);
-    }
-    if (buffer[0] === 0xfe && buffer[1] === 0xff) {
-      return new TextDecoder("utf-16be").decode(buffer);
-    }
-    // Default to utf-8
-    return buffer.toString("utf-8");
-  }
-  // Use TextDecoder for non-UTF-8 encodings
   try {
     return new TextDecoder(encoding).decode(buffer);
   } catch {
-    // Fallback to Buffer.toString for standard Node.js encodings
     return buffer.toString(encoding as BufferEncoding);
   }
 }

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -39,8 +39,40 @@ const readSchema = Type.Object({
     Type.Number({ description: "Line number to start reading from (1-indexed)" }),
   ),
   limit: Type.Optional(Type.Number({ description: "Maximum number of lines to read" })),
+  encoding: Type.Optional(
+    Type.String({
+      description:
+        "File encoding (e.g. 'utf-8', 'gbk', 'gb2312', 'shift_jis'). Default: 'utf-8'. Use 'auto' to auto-detect.",
+    }),
+  ),
 });
 export type { ReadToolDetails, ReadToolInput } from "./tool-contracts.js";
+
+/**
+ * Decode a buffer using the specified encoding.
+ * Supports 'auto' to detect BOM or default to utf-8.
+ */
+function decodeBuffer(buffer: Buffer, encoding?: string): string {
+  if (!encoding || encoding === "utf-8" || encoding === "utf8") {
+    return buffer.toString("utf-8");
+  }
+  if (encoding === "auto") {
+    // Check for BOM
+    if (buffer[0] === 0xef && buffer[1] === 0xbb && buffer[2] === 0xbf) {
+      return buffer.toString("utf-8");
+    }
+    if (buffer[0] === 0xff && buffer[1] === 0xfe) {
+      return buffer.toString("utf-16le");
+    }
+    if (buffer[0] === 0xfe && buffer[1] === 0xff) {
+      return buffer.toString("utf-16be");
+    }
+    // Default to utf-8
+    return buffer.toString("utf-8");
+  }
+  // Use the specified encoding
+  return buffer.toString(encoding as BufferEncoding);
+}
 
 interface CompactReadClassification {
   kind: "docs" | "resource" | "skill";
@@ -339,7 +371,7 @@ export function createReadToolDefinition(
             } else {
               // Read text content.
               const buffer = await ops.readFile(absolutePath);
-              const textContent = buffer.toString("utf-8");
+              const textContent = decodeBuffer(buffer, encoding);
               const allLines = textContent.split("\n");
               const totalFileLines = allLines.length;
               // Apply offset if specified. Convert from 1-indexed input to 0-indexed array access.

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -51,6 +51,7 @@ export type { ReadToolDetails, ReadToolInput } from "./tool-contracts.js";
 /**
  * Decode a buffer using the specified encoding.
  * Supports 'auto' to detect BOM or default to utf-8.
+ * Uses TextDecoder for non-UTF-8 encodings (e.g. gbk, gb2312, shift_jis).
  */
 function decodeBuffer(buffer: Buffer, encoding?: string): string {
   if (!encoding || encoding === "utf-8" || encoding === "utf8") {
@@ -62,16 +63,21 @@ function decodeBuffer(buffer: Buffer, encoding?: string): string {
       return buffer.toString("utf-8");
     }
     if (buffer[0] === 0xff && buffer[1] === 0xfe) {
-      return buffer.toString("utf-16le");
+      return new TextDecoder("utf-16le").decode(buffer);
     }
     if (buffer[0] === 0xfe && buffer[1] === 0xff) {
-      return buffer.toString("utf-16be");
+      return new TextDecoder("utf-16be").decode(buffer);
     }
     // Default to utf-8
     return buffer.toString("utf-8");
   }
-  // Use the specified encoding
-  return buffer.toString(encoding as BufferEncoding);
+  // Use TextDecoder for non-UTF-8 encodings
+  try {
+    return new TextDecoder(encoding).decode(buffer);
+  } catch {
+    // Fallback to Buffer.toString for standard Node.js encodings
+    return buffer.toString(encoding as BufferEncoding);
+  }
 }
 
 interface CompactReadClassification {
@@ -295,7 +301,12 @@ export function createReadToolDefinition(
     parameters: readSchema,
     async execute(
       toolCallId,
-      { path, offset, limit }: { path: string; offset?: number; limit?: number },
+      {
+        path,
+        offset,
+        limit,
+        encoding,
+      }: { path: string; offset?: number; limit?: number; encoding?: string },
       signal?: AbortSignal,
       onUpdate?,
       ctx?,

--- a/src/agents/sessions/tools/tool-contracts.ts
+++ b/src/agents/sessions/tools/tool-contracts.ts
@@ -71,6 +71,7 @@ export interface ReadToolInput {
   path: string;
   offset?: number;
   limit?: number;
+  encoding?: string;
 }
 
 export interface ReadToolDetails {


### PR DESCRIPTION
> AI-assisted (Claude). All behavior proof below was produced and verified by a human-run command in a real local checkout using OpenClaw CLI.

## Summary

- **Problem:** The read tool always decodes files as UTF-8, causing garbled text (mojibake) when reading GBK-encoded files on Chinese Windows.
- **Why now:** Chinese Windows users commonly have GBK-encoded text files. The read tool produces garbled output instead of readable text.
- **Outcome:** Add an optional `encoding` parameter to the read tool schema. Users can specify file encoding (e.g. "gbk", "gb2312", "shift_jis"). Default is "utf-8". Uses `TextDecoder` for non-UTF-8 encodings.

## Linked context

Closes #92664

## Real behavior proof

- **Behavior or issue addressed:** Read tool displays garbled text when reading GBK-encoded files on Chinese Windows.
- **Real environment tested:** Windows 10, Node.js v22.22.3, OpenClaw latest main, local checkout with the patch applied.
- **Exact steps or command run after this patch:**
  1. Created a GBK-encoded test file with content "中文测试内容"
  2. Ran read tool with `encoding: "gbk"` parameter
  3. Ran read tool without encoding parameter (default UTF-8)
  Invoked via `node --import tsx -e "import { createReadToolDefinition } from './src/agents/sessions/tools/read.js'; ..."`
- **Evidence after fix:** Terminal capture from the OpenClaw CLI:
  ```
  === Read tool GBK encoding proof ===
  File: C:\Users\dwc\AppData\Local\Temp\test-gbk.txt
  Encoding: gbk
  Output: 中文测试内容
  Pass: YES

  === Read tool UTF-8 encoding proof ===
  File: C:\Users\dwc\AppData\Local\Temp\test-gbk.txt
  Encoding: utf-8 (default)
  Output: ���Ĳ�������
  Pass: YES (garbled, as expected)

  === result ===
  GBK encoding works? YES
  UTF-8 default works? YES
  ALL CHECKS PASSED: YES
  ```
- **Observed result after fix:** GBK-encoded files are correctly decoded when `encoding: "gbk"` is specified. UTF-8 files work as before.
- **Before evidence:** Same test with the fix reverted shows garbled output for GBK-encoded files.
- **What was not tested:** Live read tool call with real GBK file on Chinese Windows via gateway.

## Tests and validation

- `node scripts/run-vitest.mjs run src/agents/sessions/tools/read.test.ts` — 6/6 passed

## Current review state

- The `checks-node-auto-reply-reply-agent-runner` CI check shows a timeout in `src/auto-reply/reply/agent-runner-payloads.test.ts:304` ("does not dedupe text for cross-target messaging sends"). This test is **not touched by this PR** — the file is identical on main. The timeout is a pre-existing flaky test, unrelated to the encoding parameter change.
- All other CI checks pass, including: lint, type-check, security, critical quality, prod types, dependencies, shrinkwrap, and the read tool unit tests.

## Risk checklist

- **userVisible:** Yes (read tool now supports encoding parameter)
- **configEnvMigration:** No
- **securityAuthNetwork:** No
- **Mitigation:** Default encoding is "utf-8", backward compatible. Uses TextDecoder for non-UTF-8 encodings.