### PR TITLE
fix(compaction): emit after_compaction on no-op and use JSON-safe validator delimiters (#81925)

### DIFF
--- a/packages/gateway-protocol/src/index.test.ts
+++ b/packages/gateway-protocol/src/index.test.ts
@@ -447,7 +447,7 @@ describe("formatValidationErrors", () => {
       params: { additionalProperty: "token" },
     });
 
-    expect(formatValidationErrors([err])).toBe("at root: unexpected property 'token'");
+    expect(formatValidationErrors([err])).toBe('at root: unexpected property "token"');
   });
 
   it("formats additionalProperties with instancePath", () => {
@@ -457,7 +457,7 @@ describe("formatValidationErrors", () => {
       params: { additionalProperty: "token" },
     });
 
-    expect(formatValidationErrors([err])).toBe("at /auth: unexpected property 'token'");
+    expect(formatValidationErrors([err])).toBe('at /auth: unexpected property "token"');
   });
 
   it("formats message with path for other errors", () => {
@@ -594,7 +594,7 @@ describe("validateTalkClientCreateParams", () => {
       }),
     ).toBe(false);
     expect(formatValidationErrors(validateTalkClientCreateParams.errors)).toContain(
-      "unexpected property 'instructions'",
+      'unexpected property "instructions"',
     );
   });
 
@@ -633,7 +633,7 @@ describe("validateTalkSession", () => {
       }),
     ).toBe(false);
     expect(formatValidationErrors(validateTalkSessionCreateParams.errors)).toContain(
-      "unexpected property 'instructionsOverride'",
+      'unexpected property "instructionsOverride"',
     );
     expect(validateTalkSessionCreateParams({ mode: "realtime", language: "de-DE" })).toBe(false);
   });

--- a/packages/gateway-protocol/src/validation-errors.test.ts
+++ b/packages/gateway-protocol/src/validation-errors.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatValidationErrors,
+  messageReportsUnexpectedProperty,
+  type ValidationError,
+} from "./validation-errors.js";
+
+const makeError = (overrides: Partial<ValidationError>): ValidationError => ({
+  keyword: "type",
+  instancePath: "",
+  schemaPath: "#/",
+  params: {},
+  message: "validation error",
+  ...overrides,
+});
+
+describe("formatValidationErrors property-name delimiters", () => {
+  it("formats required-property misses with JSON-compatible double quotes", () => {
+    const err = makeError({
+      keyword: "required",
+      instancePath: "/auth",
+      params: { missingProperty: "token" },
+    });
+
+    expect(formatValidationErrors([err])).toBe('at /auth: must have required property "token"');
+  });
+
+  it("escapes embedded quotes/backslashes in unexpected-property names as valid JSON tokens", () => {
+    const weird = 'weird"key\\path';
+    const err = makeError({
+      keyword: "additionalProperties",
+      params: { additionalProperty: weird },
+    });
+
+    const message = formatValidationErrors([err]);
+    expect(message).toBe(`at root: unexpected property ${JSON.stringify(weird)}`);
+    expect(JSON.parse(message.slice(message.indexOf('"')))).toBe(weird);
+  });
+
+  it("escapes embedded quotes/backslashes in required-property names as valid JSON tokens", () => {
+    const weird = 'weird"key\\path';
+    const err = makeError({
+      keyword: "required",
+      instancePath: "/auth",
+      params: { missingProperty: weird },
+    });
+
+    const message = formatValidationErrors([err]);
+    expect(message).toBe(`at /auth: must have required property ${JSON.stringify(weird)}`);
+    expect(JSON.parse(message.slice(message.indexOf('"')))).toBe(weird);
+  });
+});
+
+describe("messageReportsUnexpectedProperty", () => {
+  it.each([
+    ["legacy single-quoted", "at /auth: unexpected property 'agentRuntimeIdentityToken'"],
+    ["JSON-quoted", 'at /auth: unexpected property "agentRuntimeIdentityToken"'],
+  ])("matches an unexpected-property rejection in %s form", (_label, message) => {
+    expect(messageReportsUnexpectedProperty(message, "agentRuntimeIdentityToken")).toBe(true);
+  });
+
+  it("matches the current formatValidationErrors output for the same property", () => {
+    const message = formatValidationErrors([
+      {
+        keyword: "additionalProperties",
+        instancePath: "/auth",
+        params: { additionalProperty: "timeZone" },
+      },
+    ]);
+    expect(messageReportsUnexpectedProperty(message, "timeZone")).toBe(true);
+  });
+
+  it("requires the request context when one is supplied", () => {
+    const message = 'invalid cron.list params: at root: unexpected property "compact"';
+    expect(messageReportsUnexpectedProperty(message, "compact", "invalid cron.list params")).toBe(
+      true,
+    );
+    expect(messageReportsUnexpectedProperty(message, "compact", "invalid connect params")).toBe(
+      false,
+    );
+  });
+
+  it("does not match a different property or an unrelated failure", () => {
+    expect(
+      messageReportsUnexpectedProperty('at root: unexpected property "timeZone"', "compact"),
+    ).toBe(false);
+    expect(messageReportsUnexpectedProperty("must have required property 'token'", "token")).toBe(
+      false,
+    );
+  });
+});

--- a/packages/gateway-protocol/src/validation-errors.ts
+++ b/packages/gateway-protocol/src/validation-errors.ts
@@ -42,7 +42,7 @@ export function formatValidationErrors(errors: ValidationError[] | null | undefi
         firstStringParam(err?.params?.additionalProperties);
       if (additionalProperty) {
         const where = instancePath ? `at ${instancePath}` : "at root";
-        parts.push(`${where}: unexpected property '${additionalProperty}'`);
+        parts.push(`${where}: unexpected property ${JSON.stringify(additionalProperty)}`);
         continue;
       }
     }
@@ -52,7 +52,7 @@ export function formatValidationErrors(errors: ValidationError[] | null | undefi
         firstStringParam(err?.params?.requiredProperties);
       if (missingProperty) {
         const where = instancePath ? `at ${instancePath}: ` : "";
-        parts.push(`${where}must have required property '${missingProperty}'`);
+        parts.push(`${where}must have required property ${JSON.stringify(missingProperty)}`);
         continue;
       }
     }
@@ -73,4 +73,18 @@ export function formatValidationErrors(errors: ValidationError[] | null | undefi
 
   const unique = [...new Set(parts.filter((part) => part.trim()))];
   return unique.length > 0 ? unique.join("; ") : "unknown validation error";
+}
+
+export function messageReportsUnexpectedProperty(
+  message: string,
+  propertyName: string,
+  requestContext?: string,
+): boolean {
+  if (requestContext !== undefined && !message.includes(requestContext)) {
+    return false;
+  }
+  return (
+    message.includes(`unexpected property '${propertyName}'`) ||
+    message.includes(`unexpected property ${JSON.stringify(propertyName)}`)
+  );
 }

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1789,6 +1789,40 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     });
   });
 
+  it("fires after_compaction on the no-op skip so paired observers are not left waiting", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    sessionMessages.splice(0, sessionMessages.length, {
+      role: "user",
+      content: "<b>HEARTBEAT_OK</b>",
+      timestamp: 1,
+    });
+
+    const result = await compactEmbeddedAgentSessionDirect({
+      sessionId: "session-1",
+      sessionKey: TEST_SESSION_KEY,
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+      provider: "openai",
+      model: "gpt-primary",
+      messageProvider: "telegram",
+    });
+
+    expectRecordFields(result, {
+      ok: true,
+      compacted: false,
+    });
+    expect(hookRunner.runBeforeCompaction).toHaveBeenCalledTimes(1);
+    expect(hookRunner.runAfterCompaction).toHaveBeenCalledTimes(1);
+    expectRecordFields(mockCallArg(hookRunner.runAfterCompaction), {
+      compactedCount: 0,
+      reason: "no_real_conversation_messages",
+    });
+    expectRecordFields(mockCallArg(hookRunner.runAfterCompaction, 0, 1), {
+      sessionKey: TEST_SESSION_KEY,
+      messageProvider: "telegram",
+    });
+  });
+
   it("emits internal + plugin compaction hooks with counts", async () => {
     hookRunner.hasHooks.mockReturnValue(true);
     await runCompactionHooks({
@@ -2586,6 +2620,61 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     expectRecordFields(mockCallArg(hookRunner.runAfterCompaction, 0, 1), {
       sessionKey: TEST_SESSION_KEY,
       messageProvider: "telegram",
+    });
+  });
+
+  it("fires after_compaction with compactedCount 0 when the engine skips compaction", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    contextEngineCompactMock.mockResolvedValue({
+      ok: true,
+      compacted: false,
+      reason: "no_real_conversation_messages",
+      result: undefined,
+    });
+
+    const result = await compactEmbeddedAgentSession(
+      wrappedCompactionArgs({
+        messageChannel: "telegram",
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(false);
+
+    expect(hookRunner.runBeforeCompaction).toHaveBeenCalledTimes(1);
+    expect(hookRunner.runAfterCompaction).toHaveBeenCalledTimes(1);
+    expect(mockCallArg(hookRunner.runAfterCompaction)).toEqual({
+      messageCount: -1,
+      compactedCount: 0,
+      tokenCount: undefined,
+      sessionFile: TEST_SESSION_FILE,
+      reason: "no_real_conversation_messages",
+    });
+    expectRecordFields(mockCallArg(hookRunner.runAfterCompaction, 0, 1), {
+      sessionKey: TEST_SESSION_KEY,
+      messageProvider: "telegram",
+    });
+  });
+
+  it("defaults the skip reason to policy_skipped when the engine omits one", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    contextEngineCompactMock.mockResolvedValue({
+      ok: true,
+      compacted: false,
+      reason: undefined,
+      result: undefined,
+    });
+
+    const result = await compactEmbeddedAgentSession(wrappedCompactionArgs({}));
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(false);
+    expect(mockCallArg(hookRunner.runAfterCompaction)).toEqual({
+      messageCount: -1,
+      compactedCount: 0,
+      tokenCount: undefined,
+      sessionFile: TEST_SESSION_FILE,
+      reason: "policy_skipped",
     });
   });
 

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -48,6 +48,7 @@ import {
   compactContextEngineWithSafetyTimeout,
   resolveCompactionTimeoutMs,
 } from "./compaction-safety-timeout.js";
+import { afterCompactionSkipFields } from "./compaction-skip.js";
 import {
   rotateTranscriptFileAfterCompaction,
   shouldRotateCompactionTranscript,
@@ -730,7 +731,6 @@ async function compactResolvedContextEngine(
         }
         if (
           result.ok &&
-          result.compacted &&
           hookRunner?.hasHooks?.("after_compaction") &&
           hookRunner.runAfterCompaction
         ) {
@@ -742,12 +742,12 @@ async function compactResolvedContextEngine(
             await hookRunner.runAfterCompaction(
               {
                 messageCount: -1,
-                compactedCount: -1,
                 tokenCount: result.result?.tokensAfter,
                 sessionFile: postCompactionSessionFile,
                 ...(postCompactionSessionId !== params.sessionId
                   ? { previousSessionId: params.sessionId }
                   : {}),
+                ...afterCompactionSkipFields(result),
               },
               afterHookCtx,
             );

--- a/src/agents/embedded-agent-runner/compaction-hooks.ts
+++ b/src/agents/embedded-agent-runner/compaction-hooks.ts
@@ -148,6 +148,7 @@ type CompactionHookRunner = {
       tokenCount?: number;
       compactedCount: number;
       sessionFile: string;
+      reason?: string;
     },
     context: {
       sessionId: string;
@@ -297,8 +298,7 @@ export function estimateTokensAfterCompaction(params: {
   return tokensAfter;
 }
 
-/** Runs internal and plugin after-compaction hooks with the final compacted metrics. */
-export async function runAfterCompactionHooks(params: {
+type AfterCompactionHookParams = {
   hookRunner?: CompactionHookRunner | null;
   sessionId: string;
   sessionAgentId: string;
@@ -314,13 +314,43 @@ export async function runAfterCompactionHooks(params: {
   summaryLength?: number;
   tokensBefore?: number;
   firstKeptEntryId?: string;
+  reason?: string;
   onHookMessages?: (payload: {
     phase: "after";
     messages: string[];
     sessionId: string;
     sessionKey: string;
   }) => void | Promise<void>;
-}) {
+};
+
+type SkippedCompactionHookBase = Omit<
+  AfterCompactionHookParams,
+  | "messageCountAfter"
+  | "tokensAfter"
+  | "compactedCount"
+  | "sessionFile"
+  | "reason"
+  | "previousSessionId"
+  | "summaryLength"
+  | "tokensBefore"
+  | "firstKeptEntryId"
+>;
+
+/** Runs after-compaction hooks for a compaction that completed without compacting anything. */
+export async function runSkippedCompactionHooks(
+  base: SkippedCompactionHookBase,
+  skip: {
+    messageCountAfter: number;
+    tokensAfter?: number;
+    sessionFile: string;
+    reason: string;
+  },
+) {
+  await runAfterCompactionHooks({ ...base, ...skip, compactedCount: 0 });
+}
+
+/** Runs internal and plugin after-compaction hooks with the final compacted metrics. */
+export async function runAfterCompactionHooks(params: AfterCompactionHookParams) {
   try {
     const hookEvent = createInternalHookEvent("session", "compact:after", params.hookSessionKey, {
       sessionId: params.sessionId,
@@ -332,6 +362,7 @@ export async function runAfterCompactionHooks(params: {
       tokensBefore: params.tokensBefore,
       tokensAfter: params.tokensAfter,
       firstKeptEntryId: params.firstKeptEntryId,
+      ...(params.reason !== undefined ? { reason: params.reason } : {}),
     });
     await triggerInternalHook(hookEvent);
     if (hookEvent.messages.length > 0) {
@@ -357,6 +388,7 @@ export async function runAfterCompactionHooks(params: {
           compactedCount: params.compactedCount,
           sessionFile: params.sessionFile,
           ...(params.previousSessionId ? { previousSessionId: params.previousSessionId } : {}),
+          ...(params.reason !== undefined ? { reason: params.reason } : {}),
         },
         {
           sessionId: params.sessionId,

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -45,6 +45,7 @@ import {
   runAfterCompactionHooks,
   runBeforeCompactionHooks,
   runPostCompactionSideEffects,
+  runSkippedCompactionHooks,
 } from "./compaction-hooks.js";
 import {
   compactWithSafetyTimeout,
@@ -365,17 +366,20 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             observedTokenCount,
             estimateTokensFn: estimateTokens,
           });
-          const { hookSessionKey, missingSessionKey } = await runBeforeCompactionHooks({
+          const hookBase = {
             hookRunner,
             sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
             sessionAgentId,
             workspaceDir: effectiveWorkspace,
             messageProvider: resolvedMessageProvider,
-            metrics: beforeHookMetrics,
             onHookMessages: params.onCompactionHookMessages,
+          };
+          const { hookSessionKey, missingSessionKey } = await runBeforeCompactionHooks({
+            ...hookBase,
+            sessionKey: params.sessionKey,
+            metrics: beforeHookMetrics,
           });
-          const { messageCountOriginal } = beforeHookMetrics;
+          const afterHookBase = { ...hookBase, hookSessionKey, missingSessionKey };
           const diagEnabled = log.isEnabled("debug");
           const preMetrics = diagEnabled
             ? summarizeCompactionMessages(session.messages)
@@ -397,17 +401,19 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             log.info(
               `[compaction] skipping — no real conversation messages (sessionKey=${params.sessionKey ?? params.sessionId})`,
             );
-            return {
-              ok: true,
-              compacted: false,
-              reason: "no real conversation messages",
-            };
+            await runSkippedCompactionHooks(afterHookBase, {
+              messageCountAfter: beforeHookMetrics.messageCountOriginal,
+              tokensAfter: observedTokenCount,
+              sessionFile: params.sessionFile,
+              reason: "no_real_conversation_messages",
+            });
+            return { ok: true, compacted: false, reason: "no real conversation messages" };
           }
 
           const compactStartedAt = Date.now();
           // Measure compactedCount from the original pre-limiting transcript so compaction
           // lifecycle metrics represent total reduction through the compaction pipeline.
-          const messageCountCompactionInput = messageCountOriginal;
+          const messageCountCompactionInput = beforeHookMetrics.messageCountOriginal;
           // Estimate all limited transcript messages before compaction. This is the
           // same token domain as messagesAfter; result.tokensBefore can cover only the
           // summarizable subset.
@@ -536,13 +542,8 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             );
           }
           await runAfterCompactionHooks({
-            hookRunner,
+            ...afterHookBase,
             sessionId: activeSessionId,
-            sessionAgentId,
-            hookSessionKey,
-            missingSessionKey,
-            workspaceDir: effectiveWorkspace,
-            messageProvider: resolvedMessageProvider,
             messageCountAfter,
             tokensAfter,
             compactedCount,
@@ -553,7 +554,6 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             summaryLength: typeof result.summary === "string" ? result.summary.length : undefined,
             tokensBefore: result.tokensBefore,
             firstKeptEntryId: effectiveFirstKeptEntryId,
-            onHookMessages: params.onCompactionHookMessages,
           });
           return {
             ok: true,

--- a/src/agents/embedded-agent-runner/compaction-skip.ts
+++ b/src/agents/embedded-agent-runner/compaction-skip.ts
@@ -1,0 +1,12 @@
+const DEFAULT_ENGINE_SKIP_REASON = "policy_skipped";
+
+export function afterCompactionSkipFields(result: { compacted?: boolean; reason?: unknown }): {
+  compactedCount: number;
+  reason?: string;
+} {
+  if (result.compacted === true) {
+    return { compactedCount: -1 };
+  }
+  const reason = typeof result.reason === "string" && result.reason.trim() ? result.reason : "";
+  return { compactedCount: 0, reason: reason || DEFAULT_ENGINE_SKIP_REASON };
+}

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -3735,6 +3735,33 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
     });
   });
 
+  it("fires after_compaction on a no-op overflow recovery so paired observers stay balanced", async () => {
+    mockedContextEngine.info.ownsCompaction = true;
+    mockedGlobalHookRunner.hasHooks.mockImplementation(
+      (hookName) => hookName === "before_compaction" || hookName === "after_compaction",
+    );
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: makeOverflowError() }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: true,
+      compacted: false,
+      reason: "no_real_conversation_messages",
+    });
+
+    await runEmbeddedAgent(overflowBaseRunParams);
+
+    expect(mockedGlobalHookRunner.runBeforeCompaction).toHaveBeenCalledTimes(1);
+    expect(mockedGlobalHookRunner.runAfterCompaction).toHaveBeenCalledTimes(1);
+    expect(mockCallArg(mockedGlobalHookRunner.runAfterCompaction)).toEqual({
+      messageCount: -1,
+      compactedCount: 0,
+      tokenCount: undefined,
+      sessionFile: "/tmp/session.json",
+      reason: "no_real_conversation_messages",
+    });
+  });
+
   it("runs maintenance after successful overflow-recovery compaction", async () => {
     mockedContextEngine.info.ownsCompaction = true;
     mockedRunEmbeddedAttempt

--- a/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test.ts
@@ -622,6 +622,43 @@ describe("timeout-triggered compaction", () => {
     expect(mockedRunPostCompactionSideEffects).toHaveBeenCalledTimes(1);
   });
 
+  it("fires after_compaction on a no-op timeout recovery so paired observers stay balanced", async () => {
+    mockedContextEngine.info.ownsCompaction = true;
+    mockedGlobalHookRunner.hasHooks.mockImplementation(
+      (hookName) => hookName === "before_compaction" || hookName === "after_compaction",
+    );
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          timedOut: true,
+          lastAssistant: {
+            usage: { input: 160000 },
+          } as never,
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: true,
+      compacted: false,
+      reason: "no_real_conversation_messages",
+    });
+
+    await runEmbeddedAgent(overflowBaseRunParams);
+
+    const [beforeEvent] = hookCallAt(0, "before");
+    expect(beforeEvent).toEqual({ messageCount: -1, sessionFile: "/tmp/session.json" });
+    const [afterEvent, afterContext] = hookCallAt(0, "after");
+    expect(afterEvent).toEqual({
+      messageCount: -1,
+      compactedCount: 0,
+      tokenCount: undefined,
+      sessionFile: "/tmp/session.json",
+      reason: "no_real_conversation_messages",
+    });
+    expect(afterContext.sessionKey).toBe("test-key");
+    expect(mockedRunPostCompactionSideEffects).not.toHaveBeenCalled();
+  });
+
   it("counts compacted:false timeout compactions against the retry cap across profile rotation", async () => {
     useTwoAuthProfiles();
     // Attempt 1 (profile-a): timeout → compaction #1 fails → rotate to profile-b

--- a/src/agents/embedded-agent-runner/run/compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-runtime.ts
@@ -1,5 +1,6 @@
 import type { resolveContextEngine } from "../../../context-engine/registry.js";
 import { resolveCompactionSuccessorTranscript } from "../../../context-engine/types.js";
+import { afterCompactionSkipFields } from "../compaction-skip.js";
 import { log } from "../logger.js";
 import type { PreparedEmbeddedRunInput } from "./execution-context.js";
 import type { createEmbeddedRunSessionPromptState } from "./session-prompt-state.js";
@@ -84,7 +85,6 @@ export function createEmbeddedRunCompactionRuntime(input: {
     if (
       contextEngine.info.ownsCompaction !== true ||
       !compactResult.ok ||
-      !compactResult.compacted ||
       !hookRunner?.hasHooks("after_compaction")
     ) {
       return;
@@ -93,12 +93,12 @@ export function createEmbeddedRunCompactionRuntime(input: {
       await hookRunner.runAfterCompaction(
         {
           messageCount: -1,
-          compactedCount: -1,
           tokenCount: compactResult.result?.tokensAfter,
           sessionFile:
             resolveCompactionSuccessorTranscript(compactResult).sessionFile ??
             sessionPromptState.sessionFile,
           ...(previousSessionId ? { previousSessionId } : {}),
+          ...afterCompactionSkipFields(compactResult),
         },
         resolveActiveHookContext(),
       );

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -631,37 +631,43 @@ describe("cron tool", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
-  it("retries cron.list without compact for older gateways", async () => {
-    callGatewayMock
-      .mockRejectedValueOnce(
-        new GatewayClientRequestError({
-          code: "INVALID_REQUEST",
-          message: "invalid cron.list params: at root: unexpected property 'compact'",
-        }),
-      )
-      .mockResolvedValueOnce({ jobs: [] });
-    const tool = createTestCronTool({
-      agentSessionKey: "agent:agent-123:telegram:direct:channing",
-    });
+  it.each([
+    ["legacy single-quoted", "invalid cron.list params: at root: unexpected property 'compact'"],
+    ["JSON-quoted", 'invalid cron.list params: at root: unexpected property "compact"'],
+  ])(
+    "retries cron.list without compact for older gateways (%s rejection)",
+    async (_label, message) => {
+      callGatewayMock
+        .mockRejectedValueOnce(
+          new GatewayClientRequestError({
+            code: "INVALID_REQUEST",
+            message,
+          }),
+        )
+        .mockResolvedValueOnce({ jobs: [] });
+      const tool = createTestCronTool({
+        agentSessionKey: "agent:agent-123:telegram:direct:channing",
+      });
 
-    await tool.execute("call-list-older-gateway", { action: "list" });
+      await tool.execute("call-list-older-gateway", { action: "list" });
 
-    expect(readGatewayCall(0)).toEqual({
-      method: "cron.list",
-      params: {
-        includeDisabled: false,
-        compact: true,
-        agentId: "agent-123",
-      },
-    });
-    expect(readGatewayCall(1)).toEqual({
-      method: "cron.list",
-      params: {
-        includeDisabled: false,
-        agentId: "agent-123",
-      },
-    });
-  });
+      expect(readGatewayCall(0)).toEqual({
+        method: "cron.list",
+        params: {
+          includeDisabled: false,
+          compact: true,
+          agentId: "agent-123",
+        },
+      });
+      expect(readGatewayCall(1)).toEqual({
+        method: "cron.list",
+        params: {
+          includeDisabled: false,
+          agentId: "agent-123",
+        },
+      });
+    },
+  );
 
   describe("wake routing", () => {
     // Pin the agentId / sessionKey resolution contract for `action: "wake"`.

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -4,6 +4,7 @@
  * Manages scheduled jobs, wake/run actions, delivery context, and reminder-style payload normalization.
  */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { messageReportsUnexpectedProperty } from "../../../packages/gateway-protocol/src/validation-errors.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../../config/config.js";
 import { resolveCronCreationDelivery } from "../../cron/delivery-context.js";
@@ -276,8 +277,7 @@ function isOlderGatewayWithoutCompactCronList(error: unknown): boolean {
   return (
     error instanceof GatewayClientRequestError &&
     error.gatewayCode === "INVALID_REQUEST" &&
-    error.message.includes("invalid cron.list params") &&
-    error.message.includes("unexpected property 'compact'")
+    messageReportsUnexpectedProperty(error.message, "compact", "invalid cron.list params")
   );
 }
 

--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -456,27 +456,35 @@ describe("gateway tool defaults", () => {
     );
   });
 
-  it("explains stale gateway cron connection metadata rejections", async () => {
-    mocks.callGateway.mockRejectedValueOnce(
-      new Error(
-        "invalid connect params: at /auth: unexpected property 'agentRuntimeIdentityToken'",
-      ),
-    );
+  it.each([
+    [
+      "legacy single-quoted",
+      "invalid connect params: at /auth: unexpected property 'agentRuntimeIdentityToken'",
+    ],
+    [
+      "JSON-quoted",
+      'invalid connect params: at /auth: unexpected property "agentRuntimeIdentityToken"',
+    ],
+  ])(
+    "explains stale gateway cron connection metadata rejections (%s rejection)",
+    async (_label, message) => {
+      mocks.callGateway.mockRejectedValueOnce(new Error(message));
 
-    await expect(
-      withGatewayToolCallerIdentity(
-        { agentId: "ops", sessionKey: "agent:ops:telegram:direct:alice" },
-        async () => {
-          await callGatewayTool("cron.remove", {}, { id: "job-1" });
-        },
-      ),
-    ).rejects.toThrow(
-      "The running Gateway is from an older OpenClaw build and rejected current agent runtime connection metadata. Restart the Gateway with `openclaw gateway restart`, then retry.",
-    );
+      await expect(
+        withGatewayToolCallerIdentity(
+          { agentId: "ops", sessionKey: "agent:ops:telegram:direct:alice" },
+          async () => {
+            await callGatewayTool("cron.remove", {}, { id: "job-1" });
+          },
+        ),
+      ).rejects.toThrow(
+        "The running Gateway is from an older OpenClaw build and rejected current agent runtime connection metadata. Restart the Gateway with `openclaw gateway restart`, then retry.",
+      );
 
-    const call = capturedGatewayCall();
-    expect(call.agentRuntimeIdentityToken).toEqual(expect.any(String));
-  });
+      const call = capturedGatewayCall();
+      expect(call.agentRuntimeIdentityToken).toEqual(expect.any(String));
+    },
+  );
 
   it("explains fail-closed stale gateway cron identity rejections", async () => {
     mocks.callGateway.mockRejectedValueOnce(
@@ -674,47 +682,53 @@ describe("gateway tool defaults", () => {
     });
   });
 
-  it("strips turn-source fields for gateways with the preceding node schema", async () => {
-    const schemaError = Object.assign(
-      new Error("invalid node.invoke params: at root: unexpected property 'turnSourceChannel'"),
-      {
+  it.each([
+    [
+      "legacy single-quoted",
+      "invalid node.invoke params: at root: unexpected property 'turnSourceChannel'",
+    ],
+    ["JSON-quoted", 'invalid node.invoke params: at root: unexpected property "turnSourceChannel"'],
+  ])(
+    "strips turn-source fields for gateways with the preceding node schema (%s rejection)",
+    async (_label, message) => {
+      const schemaError = Object.assign(new Error(message), {
         name: "GatewayClientRequestError",
         gatewayCode: "INVALID_REQUEST",
-      },
-    );
-    mocks.callGateway.mockRejectedValueOnce(schemaError).mockResolvedValueOnce({ ok: true });
+      });
+      mocks.callGateway.mockRejectedValueOnce(schemaError).mockResolvedValueOnce({ ok: true });
 
-    await withGatewayToolCallerIdentity(
-      {
-        agentId: "ops",
-        sessionKey: "agent:ops:main",
-        turnSourceChannel: "telegram",
-        turnSourceTo: "chat:123",
-      },
-      async () => {
-        await callGatewayTool(
-          "node.invoke",
-          {},
-          {
-            nodeId: "node-1",
-            command: "device.info",
-            idempotencyKey: "invoke-preceding-schema",
-          },
-        );
-      },
-    );
+      await withGatewayToolCallerIdentity(
+        {
+          agentId: "ops",
+          sessionKey: "agent:ops:main",
+          turnSourceChannel: "telegram",
+          turnSourceTo: "chat:123",
+        },
+        async () => {
+          await callGatewayTool(
+            "node.invoke",
+            {},
+            {
+              nodeId: "node-1",
+              command: "device.info",
+              idempotencyKey: "invoke-preceding-schema",
+            },
+          );
+        },
+      );
 
-    expect(mocks.callGateway).toHaveBeenCalledTimes(2);
-    expect(mocks.callGateway.mock.calls[1]?.[0].params).toEqual({
-      nodeId: "node-1",
-      command: "device.info",
-      idempotencyKey: "invoke-preceding-schema",
-    });
-    expect(mocks.callGateway.mock.calls[1]?.[0]).toHaveProperty(
-      "agentRuntimeIdentityToken",
-      expect.any(String),
-    );
-  });
+      expect(mocks.callGateway).toHaveBeenCalledTimes(2);
+      expect(mocks.callGateway.mock.calls[1]?.[0].params).toEqual({
+        nodeId: "node-1",
+        command: "device.info",
+        idempotencyKey: "invoke-preceding-schema",
+      });
+      expect(mocks.callGateway.mock.calls[1]?.[0]).toHaveProperty(
+        "agentRuntimeIdentityToken",
+        expect.any(String),
+      );
+    },
+  );
 
   it("does not retry a dispatched node invoke whose error resembles schema rejection", async () => {
     const dispatchedError = Object.assign(

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -13,6 +13,7 @@ import {
   GATEWAY_CLIENT_NAMES,
 } from "../../../packages/gateway-protocol/src/client-info.js";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/schema/error-codes.js";
+import { messageReportsUnexpectedProperty } from "../../../packages/gateway-protocol/src/validation-errors.js";
 import { getRuntimeConfig, resolveGatewayPort } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { mintAgentRuntimeIdentityToken } from "../../gateway/agent-runtime-identity-token.js";
@@ -458,9 +459,8 @@ function isStaleGatewayAgentRuntimeIdentityRejection(error: unknown): boolean {
     return true;
   }
   return (
-    message.includes("invalid connect params") &&
     message.includes("/auth") &&
-    message.includes("unexpected property 'agentRuntimeIdentityToken'")
+    messageReportsUnexpectedProperty(message, "agentRuntimeIdentityToken", "invalid connect params")
   );
 }
 
@@ -479,11 +479,8 @@ function isStaleGatewayNodeInvokeTurnSourceRejection(error: unknown): boolean {
     return false;
   }
   const message = formatErrorMessage(error);
-  if (!message.includes("invalid node.invoke params:")) {
-    return false;
-  }
   return ["turnSourceChannel", "turnSourceTo", "turnSourceAccountId", "turnSourceThreadId"].some(
-    (field) => message.includes(`unexpected property '${field}'`),
+    (field) => messageReportsUnexpectedProperty(message, field, "invalid node.invoke params:"),
   );
 }
 

--- a/src/agents/tools/sessions-resolution.test.ts
+++ b/src/agents/tools/sessions-resolution.test.ts
@@ -334,70 +334,79 @@ describe("resolveSessionReference", () => {
     });
   });
 
-  it("retries literal current probes without allowMissing for older gateways", async () => {
-    const unsupportedAllowMissing = () =>
-      new GatewayClientRequestError({
-        code: "INVALID_REQUEST",
-        message: "invalid sessions.resolve params: at root: unexpected property 'allowMissing'",
-      });
-    callGatewayMock
-      .mockRejectedValueOnce(unsupportedAllowMissing())
-      .mockRejectedValueOnce(
+  it.each([
+    [
+      "legacy single-quoted",
+      "invalid sessions.resolve params: at root: unexpected property 'allowMissing'",
+    ],
+    ["JSON-quoted", 'invalid sessions.resolve params: at root: unexpected property "allowMissing"'],
+  ])(
+    "retries literal current probes without allowMissing for older gateways (%s rejection)",
+    async (_label, message) => {
+      const unsupportedAllowMissing = () =>
         new GatewayClientRequestError({
           code: "INVALID_REQUEST",
-          message: "No session found: current",
-        }),
-      )
-      .mockRejectedValueOnce(unsupportedAllowMissing())
-      .mockResolvedValueOnce({ key: "agent:ops:main" });
+          message,
+        });
+      callGatewayMock
+        .mockRejectedValueOnce(unsupportedAllowMissing())
+        .mockRejectedValueOnce(
+          new GatewayClientRequestError({
+            code: "INVALID_REQUEST",
+            message: "No session found: current",
+          }),
+        )
+        .mockRejectedValueOnce(unsupportedAllowMissing())
+        .mockResolvedValueOnce({ key: "agent:ops:main" });
 
-    const result = await resolveSessionReference({
-      sessionKey: "current",
-      alias: "main",
-      mainKey: "main",
-      requesterInternalKey: "agent:main:subagent:child",
-      restrictToSpawned: false,
-    });
-    expectResolvedSessionReference(result, {
-      key: "agent:ops:main",
-      displayKey: "agent:ops:main",
-      resolvedViaSessionId: true,
-    });
-    expect(callGatewayMock).toHaveBeenNthCalledWith(1, {
-      method: "sessions.resolve",
-      params: {
-        key: "current",
-        spawnedBy: undefined,
-        allowMissing: true,
-      },
-    });
-    expect(callGatewayMock).toHaveBeenNthCalledWith(2, {
-      method: "sessions.resolve",
-      params: {
-        key: "current",
-        spawnedBy: undefined,
-      },
-    });
-    expect(callGatewayMock).toHaveBeenNthCalledWith(3, {
-      method: "sessions.resolve",
-      params: {
-        sessionId: "current",
-        spawnedBy: undefined,
-        includeGlobal: true,
-        includeUnknown: true,
-        allowMissing: true,
-      },
-    });
-    expect(callGatewayMock).toHaveBeenNthCalledWith(4, {
-      method: "sessions.resolve",
-      params: {
-        sessionId: "current",
-        spawnedBy: undefined,
-        includeGlobal: true,
-        includeUnknown: true,
-      },
-    });
-  });
+      const result = await resolveSessionReference({
+        sessionKey: "current",
+        alias: "main",
+        mainKey: "main",
+        requesterInternalKey: "agent:main:subagent:child",
+        restrictToSpawned: false,
+      });
+      expectResolvedSessionReference(result, {
+        key: "agent:ops:main",
+        displayKey: "agent:ops:main",
+        resolvedViaSessionId: true,
+      });
+      expect(callGatewayMock).toHaveBeenNthCalledWith(1, {
+        method: "sessions.resolve",
+        params: {
+          key: "current",
+          spawnedBy: undefined,
+          allowMissing: true,
+        },
+      });
+      expect(callGatewayMock).toHaveBeenNthCalledWith(2, {
+        method: "sessions.resolve",
+        params: {
+          key: "current",
+          spawnedBy: undefined,
+        },
+      });
+      expect(callGatewayMock).toHaveBeenNthCalledWith(3, {
+        method: "sessions.resolve",
+        params: {
+          sessionId: "current",
+          spawnedBy: undefined,
+          includeGlobal: true,
+          includeUnknown: true,
+          allowMissing: true,
+        },
+      });
+      expect(callGatewayMock).toHaveBeenNthCalledWith(4, {
+        method: "sessions.resolve",
+        params: {
+          sessionId: "current",
+          spawnedBy: undefined,
+          includeGlobal: true,
+          includeUnknown: true,
+        },
+      });
+    },
+  );
 
   it("does not compatibility-retry unrelated gateway failures", async () => {
     callGatewayMock.mockRejectedValueOnce(new Error("gateway timeout")).mockResolvedValueOnce({});

--- a/src/agents/tools/sessions-resolution.ts
+++ b/src/agents/tools/sessions-resolution.ts
@@ -8,6 +8,7 @@ import {
   GATEWAY_CLIENT_IDS,
   normalizeGatewayClientId,
 } from "../../../packages/gateway-protocol/src/client-info.js";
+import { messageReportsUnexpectedProperty } from "../../../packages/gateway-protocol/src/validation-errors.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { GatewayClientRequestError } from "../../gateway/client.js";
@@ -223,7 +224,7 @@ async function callGatewayResolveSession(
       error instanceof GatewayClientRequestError &&
       error.gatewayCode === "INVALID_REQUEST" &&
       error.message.includes("invalid sessions.resolve params") &&
-      error.message.includes("unexpected property 'allowMissing'");
+      messageReportsUnexpectedProperty(error.message, "allowMissing");
     if (!olderGatewayRejectedProbe) {
       throw error;
     }

--- a/src/channels/plugins/config-schema.test.ts
+++ b/src/channels/plugins/config-schema.test.ts
@@ -237,7 +237,7 @@ describe("buildJsonChannelConfigSchema", () => {
 
     expect(result.runtime?.safeParse({})).toEqual({
       success: false,
-      issues: [{ path: ["100001"], message: "must have required property '100001'" }],
+      issues: [{ path: ["100001"], message: 'must have required property "100001"' }],
     });
   });
 });

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -1464,7 +1464,7 @@ describe("GatewayClient connect auth payload", () => {
       connectId: firstConnect.id,
       failureDetails: {},
       failureMessage:
-        "invalid connect params: at /auth: unexpected property 'approvalRuntimeToken'",
+        'invalid connect params: at /auth: unexpected property "approvalRuntimeToken"',
     });
     expectRecordFields(
       retriedAuth,

--- a/src/gateway/server.auth.default-token.suite.ts
+++ b/src/gateway/server.auth.default-token.suite.ts
@@ -620,7 +620,7 @@ export function registerDefaultAuthTokenSuite(): void {
         device: deviceWithoutNonce,
       });
       expect(res.ok).toBe(false);
-      expect(res.error?.message ?? "").toContain("must have required property 'nonce'");
+      expect(res.error?.message ?? "").toContain('must have required property "nonce"');
       await new Promise<void>((resolve) => {
         ws.once("close", () => resolve());
       });

--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -455,7 +455,7 @@ test("lists and patches session store via sessions.* RPC", async () => {
     expect(rejected.ok, field).toBe(false);
     expect(rejected.error, field).toMatchObject({
       code: "INVALID_REQUEST",
-      message: expect.stringContaining(`unexpected property '${field}'`),
+      message: expect.stringContaining(`unexpected property ${JSON.stringify(field)}`),
     });
   }
 

--- a/src/plugins/config-schema.test.ts
+++ b/src/plugins/config-schema.test.ts
@@ -135,7 +135,7 @@ describe("buildJsonPluginConfigSchema", () => {
     expect(result.safeParse?.({})).toEqual({
       success: false,
       error: {
-        issues: [{ path: ["100001"], message: "must have required property '100001'" }],
+        issues: [{ path: ["100001"], message: 'must have required property "100001"' }],
       },
     });
   });

--- a/src/plugins/contracts/session-actions.contract.test.ts
+++ b/src/plugins/contracts/session-actions.contract.test.ts
@@ -469,7 +469,7 @@ describe("plugin session actions", () => {
     });
     await expectValidationError("bad-ok", { includes: "/ok: must be boolean" });
     await expectValidationError("error-shaped-success", {
-      includes: "unexpected property 'error'",
+      includes: 'unexpected property "error"',
     });
     await expectValidationError("bad-error-details", {
       exact: "plugin session action details must be JSON-compatible",
@@ -478,10 +478,10 @@ describe("plugin session actions", () => {
       includes: "/continueAgent: must be boolean",
     });
     await expectValidationError("mixed-branch-fields", {
-      includes: "unexpected property 'continueAgent'",
+      includes: 'unexpected property "continueAgent"',
     });
     await expectValidationError("unknown-success-field", {
-      includes: "unexpected property 'extra'",
+      includes: 'unexpected property "extra"',
     });
     const throwsSecret = await callValidationAction("throws-secret");
     const throwsSecretError = requireHookError(throwsSecret);

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -446,6 +446,7 @@ export type PluginHookAfterCompactionEvent = {
   sessionFile?: string;
   /** Physical session generation replaced by this compaction, when it rotated. */
   previousSessionId?: string;
+  reason?: string;
 };
 
 export type PluginHookInboundClaimResult = {

--- a/src/plugins/schema-validator.test.ts
+++ b/src/plugins/schema-validator.test.ts
@@ -241,6 +241,38 @@ describe("schema validator", () => {
     ).toThrow("invalid schema");
   });
 
+  it("escapes embedded quotes/backslashes in required-property messages", () => {
+    const weird = 'weird"key\\path';
+    const result = expectValidationFailure({
+      cacheKey: "schema-validator.test.required-escape",
+      schema: {
+        type: "object",
+        properties: { [weird]: { type: "string" } },
+        required: [weird],
+      },
+      value: {},
+    });
+
+    const message = result.errors.map((entry) => entry.message).join("\n");
+    expect(message).toContain(`must have required property ${JSON.stringify(weird)}`);
+  });
+
+  it("escapes embedded quotes/backslashes in additional-property messages", () => {
+    const weird = 'weird"key\\path';
+    const result = expectValidationFailure({
+      cacheKey: "schema-validator.test.additional-escape",
+      schema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      value: { [weird]: "x" },
+    });
+
+    const message = result.errors.map((entry) => entry.message).join("\n");
+    expect(message).toContain(JSON.stringify(weird));
+  });
+
   it("rejects invalid JSON Schema constraint keyword values", () => {
     for (const [cacheKey, schema] of [
       [
@@ -2015,7 +2047,9 @@ describe("schema validator", () => {
       throw new Error("expected terminal sanitization validation issue");
     }
     expect(issue.path).toContain("\n");
-    expect(issue.message).toContain("\n");
+    expect(issue.message).toContain("\\n");
+    expect(issue.message).not.toContain("\n");
+    expect(issue.message).not.toContain("\x1b");
     expect(issue.text).toContain("\\n");
     expect(issue.text).toContain("\\t");
     expect(issue.text).not.toContain("\n");

--- a/src/plugins/schema-validator.ts
+++ b/src/plugins/schema-validator.ts
@@ -274,7 +274,7 @@ function formatRequiredMessage(error: TypeBoxValidationError): string | null {
   if (!missingProperty) {
     return null;
   }
-  return `must have required property '${missingProperty}'`;
+  return `must have required property ${JSON.stringify(missingProperty)}`;
 }
 
 function formatAdditionalPropertiesMessage(error: TypeBoxValidationError): string | null {
@@ -282,7 +282,7 @@ function formatAdditionalPropertiesMessage(error: TypeBoxValidationError): strin
   if (additionalProperties.length === 0) {
     return null;
   }
-  const quoted = additionalProperties.map((entry) => `"${entry}"`).join(", ");
+  const quoted = additionalProperties.map((entry) => JSON.stringify(entry)).join(", ");
   return `must not have additional properties: ${quoted}`;
 }
 

--- a/ui/src/lib/sessions/usage.test.ts
+++ b/ui/src/lib/sessions/usage.test.ts
@@ -28,32 +28,41 @@ describe("buildSessionUsageDateParams", () => {
 });
 
 describe("requestSessionsUsage", () => {
-  it("retries older gateways with the legacy UTC offset", async () => {
-    const result = { sessions: [] };
-    const request = vi
-      .fn()
-      .mockRejectedValueOnce(
-        new GatewayRequestError({
-          code: "INVALID_REQUEST",
-          message: "invalid sessions.usage params: at root: unexpected property 'timeZone'",
-        }),
-      )
-      .mockResolvedValueOnce(result);
-    const params = {
-      range: "all",
-      mode: "specific",
-      timeZone: "Europe/Vienna",
-      utcOffset: "UTC+2",
-    };
+  it.each([
+    [
+      "legacy single-quoted",
+      "invalid sessions.usage params: at root: unexpected property 'timeZone'",
+    ],
+    ["JSON-quoted", 'invalid sessions.usage params: at root: unexpected property "timeZone"'],
+  ])(
+    "retries older gateways with the legacy UTC offset (%s rejection)",
+    async (_label, message) => {
+      const result = { sessions: [] };
+      const request = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new GatewayRequestError({
+            code: "INVALID_REQUEST",
+            message,
+          }),
+        )
+        .mockResolvedValueOnce(result);
+      const params = {
+        range: "all",
+        mode: "specific",
+        timeZone: "Europe/Vienna",
+        utcOffset: "UTC+2",
+      };
 
-    await expect(requestSessionsUsage({ request } as never, params)).resolves.toBe(result);
-    expect(request).toHaveBeenNthCalledWith(1, "sessions.usage", params);
-    expect(request).toHaveBeenNthCalledWith(2, "sessions.usage", {
-      range: "all",
-      mode: "specific",
-      utcOffset: "UTC+2",
-    });
-  });
+      await expect(requestSessionsUsage({ request } as never, params)).resolves.toBe(result);
+      expect(request).toHaveBeenNthCalledWith(1, "sessions.usage", params);
+      expect(request).toHaveBeenNthCalledWith(2, "sessions.usage", {
+        range: "all",
+        mode: "specific",
+        utcOffset: "UTC+2",
+      });
+    },
+  );
 
   it("does not retry unrelated invalid usage parameters", async () => {
     const error = new GatewayRequestError({

--- a/ui/src/lib/sessions/usage.ts
+++ b/ui/src/lib/sessions/usage.ts
@@ -1,3 +1,4 @@
+import { messageReportsUnexpectedProperty } from "../../../../packages/gateway-protocol/src/validation-errors.js";
 import type { SessionUsageTimeSeries } from "../../../../src/shared/session-usage-timeseries-types.js";
 import type { SessionsUsageResult } from "../../../../src/shared/usage-types.js";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
@@ -56,7 +57,7 @@ function isOlderGatewayWithoutUsageTimeZone(
     error instanceof GatewayRequestError &&
     error.gatewayCode === "INVALID_REQUEST" &&
     error.message.includes("invalid sessions.usage params:") &&
-    error.message.includes("unexpected property 'timeZone'")
+    messageReportsUnexpectedProperty(error.message, "timeZone")
   );
 }
 


### PR DESCRIPTION
Closes #81925

## What Problem This Solves

Fixes an issue where voice-channel sessions return HTTP 500 when the context engine runs compaction under memory pressure, and where open-weight JSON tool-calling models get stuck in an unrecoverable retry loop against OpenClaw's schema validators.

Two coupled defects:

1. When compaction is a legitimate no-op (`{ok:true, compacted:false}`), OpenClaw emits `before_compaction` but never `after_compaction`. A plugin observer that pairs the two waits forever. The voice plugin waits out its 3s timeout, falls back to `tool-result-truncation`, and only recovers after about three attempts (roughly 2.5 minutes), long after the client has already 500'd.
2. Schema-validation error messages wrap property names in single quotes (`unexpected property 'sessionTarget'`). Models trained on JSON tool calls copy the trailing `'` back into their next attempt, re-emit the same malformed key, and re-trigger the identical error.

## Why This Change Was Made

**No-op `after_compaction`, all three surfaces.** `before_compaction` fires unconditionally once the engine owns compaction, but `after_compaction` was gated on `result.compacted === true` on three independent paths: `compact.queued.ts` (engine-owned queued), `compaction-session-execution.ts` (native direct, reached from `compactEmbeddedAgentSessionDirect`, where the `!containsRealConversationMessages(...)` early return skipped the after-hook entirely), and `run/compaction-runtime.ts` (timeout-recovery and overflow-recovery). Fixing one would still hang on the others. All three now emit `after_compaction` whenever compaction completes (`result.ok`), with `compactedCount: 0` and a `reason` discriminator on the no-op path: the engine paths forward the engine's own skip reason (default `policy_skipped`), the native path reports `no_real_conversation_messages`. `reason?: string` is an additive, backward-compatible field on the `after_compaction` hook contract. The `!result.ok` guard is preserved, so genuine failures and aborts still do not emit a success `after_compaction`.

**Property-name delimiters, all four branches.** `formatValidationErrors` (`unexpected property` and `must have required property`) and `schema-validator.ts` (`must have required property` plus the `additionalProperties` list) now format every property name through `JSON.stringify(name)` instead of hand-written quotes. That emits a real JSON string token, so the delimiter matches JSON tool-call syntax and a name containing `"`, `\`, or a control character is properly escaped. A model that copies the token back always gets a clean, parseable JSON key.

**Version-fallback detectors, all five surfaces.** Five internal callers strip an additive request field and retry when an older gateway rejects it, recognizing that rejection by the validator's `unexpected property '<name>'` text: `cron-tool.ts` (`cron.list` compact), `gateway.ts` (`connect` identity token and `node.invoke` turn source), `sessions-resolution.ts` (`sessions.resolve` allowMissing), and `ui/src/lib/sessions/usage.ts` (`sessions.usage` timeZone). Switching the producer to double quotes without touching them would silently break the mixed-version fallback they exist to provide. All five now route through one shared `messageReportsUnexpectedProperty(message, name, requestContext?)` helper co-located with the producer in `validation-errors.ts`, which accepts both the legacy single-quoted and the new `JSON.stringify` wording. `context-engine/registry.ts` already matched single, double, and backtick quotes, so it needed no change.

Non-goal: no change to when compaction decides to skip, only to the hook lifecycle around that decision.

### Rebase note

Rebased onto `main`@`1e0a42432d`, which had moved the native compaction body out of `compact.ts` into `compaction-session-execution.ts` (`compact.ts` is now a thin facade over `direct-compaction.ts`). The fix moved with it; behavior is unchanged. Two structural constraints from `main` are respected:

- Keeping production LOC flat in an already large file. `compaction-session-execution.ts` is 618 lines, so instead of appending a second after-hook call site the fix hoists the shared compaction hook context once (`hookBase` / `afterHookBase`) and routes the native no-op through `runSkippedCompactionHooks`; the file line count is unchanged. `afterCompactionSkipFields` (leaf module `compaction-skip.ts`) carries the engine-owned skip payload fields so `compact.queued.ts` and `run/compaction-runtime.ts` stop duplicating the compacted and no-op branches.
- The `max-lines` lint ceiling on `packages/gateway-protocol/src/index.test.ts`, which the previous head exceeded. The new delimiter and matcher tests now live in a dedicated `packages/gateway-protocol/src/validation-errors.test.ts` next to the module they cover, so `index.test.ts` stays under the limit.

## User Impact

Voice channels no longer 500 on a no-op compaction: a plugin observer that pairs `before_compaction` with `after_compaction` now always sees its matching `after`, with `compactedCount` 0 and a `reason` explaining the skip. JSON tool-calling models that read a validation error now get a property token that parses as a JSON string, so they can correct the key instead of looping on the same malformed one. Mixed-version deployments keep working: the dashboard and agent tools still detect an older gateway rejecting an additive field, in either wording.

## Evidence

- `node scripts/run-vitest.mjs packages/gateway-protocol/src/validation-errors.test.ts packages/gateway-protocol/src/index.test.ts src/plugins/schema-validator.test.ts src/agents/tools/cron-tool.test.ts src/agents/tools/gateway.test.ts src/agents/tools/sessions-resolution.test.ts ui/src/lib/sessions/usage.test.ts`: 4 shards passed, 351 tests passed.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compact.hooks.test.ts src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test.ts src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts`: 3 files passed, 144 tests passed. `run.overflow-compaction.test.ts` needs more than the 120s `beforeAll` harness budget on this machine and is covered by the CI `checks-node-compact-*` shards.
- `node scripts/check-max-lines-ratchet.mjs`: OK.
- `./node_modules/.bin/oxfmt --check` over all 28 changed files: clean. `./node_modules/.bin/oxlint` over the same files: clean.
- Full CI on head `1f20a4df20`: 86 checks green, 0 failures, including `check-lint` (the `max-lines` failure on the previous head) and every `checks-node-compact-*` shard. `src/gateway/server.sessions.store-rpc.test.ts` asserted the old single-quoted wording on `sessions.patch` rejections and is updated to the JSON-quoted token; the local heavy-check lock was held by sibling worktrees for that file, so its proof is the green `checks-node-compact-small-7` shard.
- Regression coverage: engine-skip no-op, engine default `policy_skipped` reason, native-skip paired observer, timeout-recovery no-op, overflow-recovery no-op, JSON-token escaping on both validator paths, and each of the five version-fallback detectors parametrized over both wordings.

## Real behavior proof
Behavior addressed: on a legitimate no-op compaction the runtime emitted `before_compaction` with no matching `after_compaction`, so a plugin observer that pairs the two waited forever and timed out; and the schema validators wrapped property names in single quotes, so a JSON tool-calling model that copied the reported property token back emitted a malformed key and re-triggered the identical error.
Real environment tested: the real production runtime, driven through `node` with the tsx ESM loader, in a pristine `main` worktree checked out at `1e0a42432d0a6b6574316fed93fe9ff14e5c6230` and in the PR worktree at head `1f20a4df2013c1d8fe2d6d1afa4c857bcdf777f8`. Driver 1 calls the real `compactEmbeddedAgentSessionDirect` from `src/agents/embedded-agent-runner/compact.ts` end to end against a real `SessionManager` transcript on disk in an isolated `OPENCLAW_STATE_DIR`, with real model resolution, the real hook bus, and a real `registerInternalHook` voice-style paired observer on `session:compact:before` / `session:compact:after`. Driver 2 calls the real `formatValidationErrors` from `packages/gateway-protocol/src/validation-errors.ts` and the real `validateJsonSchemaValue` from `src/plugins/schema-validator.ts`. Driver 3 calls the real `requestSessionsUsage` from `ui/src/lib/sessions/usage.ts` against a gateway that rejects the additive `timeZone` field in each wording.
Exact steps or command run after this patch: `node --import tsx .proof-1.ts`, `node --import tsx .proof-2.ts`, and `node --import tsx .proof-3.ts` from the worktree root. Driver 1 registers the paired observer, writes a heartbeat-only transcript through the real `SessionManager`, and calls the real `compactEmbeddedAgentSessionDirect` on it. Driver 2 feeds a property name carrying an embedded quote and backslash into both real validators and parses the token a JSON model would copy back. Driver 3 drives the real `requestSessionsUsage` against a gateway rejecting `timeZone` in the legacy single-quoted and the new JSON-quoted wording. The identical three drivers were run first in the pristine `main` worktree, on identical inputs.
Evidence after fix:
```
=== 1. no-op compaction, real compactEmbeddedAgentSessionDirect ===

# BEFORE (pristine main 1e0a42432d)
voice-observer  <- session:compact:before  sessionKey=voice:proof
compaction result           = {"ok":true,"compacted":false,"reason":"no real conversation messages"}
before_compaction observed  = 1
after_compaction observed   = 0
observer pending balance    = 1
voice-observer  => UNPAIRED, observer still waiting for after_compaction (hangs, then 500s)

# AFTER (this patch, identical inputs, head 1f20a4df20)
voice-observer  <- session:compact:before  sessionKey=voice:proof
voice-observer  <- session:compact:after   sessionKey=voice:proof compactedCount=0 reason="no_real_conversation_messages"
compaction result           = {"ok":true,"compacted":false,"reason":"no real conversation messages"}
before_compaction observed  = 1
after_compaction observed   = 1
observer pending balance    = 0
voice-observer  => paired, observer completes

=== 2. property-name delimiters, real validators ===
property name supplied by the caller: "evil\"key\\path"

# BEFORE (pristine main 1e0a42432d)
gateway rpc validator message   = at root: unexpected property 'evil"key\path'
plugin action validator message = must have required property 'evil"key\path'
token a JSON tool-calling model copies back = 'evil"key\path'
token parses back to the original key       = false (unparseable, model re-emits a malformed key and loops)

# AFTER (this patch, identical inputs, head 1f20a4df20)
gateway rpc validator message   = at root: unexpected property "evil\"key\\path"
plugin action validator message = must have required property "evil\"key\\path"
token a JSON tool-calling model copies back = "evil\"key\\path"
token parses back to the original key       = true ("evil\"key\\path")

=== 3. version-fallback detector, real requestSessionsUsage ===

# BEFORE (pristine main 1e0a42432d)
legacy gateway (single-quoted wording)
  requests the dashboard sent  : 2
  additive timeZone field      : stripped, call retried
  dashboard outcome            : usage returned
newer gateway (JSON-quoted wording)
  requests the dashboard sent  : 1
  additive timeZone field      : never stripped
  dashboard outcome            : threw invalid sessions.usage params: at root: unexpected property "timeZone"

# AFTER (this patch, identical inputs, head 1f20a4df20)
legacy gateway (single-quoted wording)
  requests the dashboard sent  : 2
  additive timeZone field      : stripped, call retried
  dashboard outcome            : usage returned
newer gateway (JSON-quoted wording)
  requests the dashboard sent  : 2
  additive timeZone field      : stripped, call retried
  dashboard outcome            : usage returned
```
Observed result after fix: the real no-op compaction path now delivers `after_compaction` with `compactedCount` 0 and `reason` `no_real_conversation_messages` to the paired observer, returning its pending balance to 0 instead of stranding it at 1; for a property name carrying an embedded quote and backslash, both the gateway formatter and the plugin schema-validator now emit a token that parses back to the original key, where pristine `main` emitted an unparseable single-quoted token; and the dashboard now strips the additive `timeZone` field and retries against a gateway that rejects it in the JSON-quoted wording, where pristine `main` rethrew and left the usage view broken.
What was not tested: a live end-to-end voice-channel session against a real 7B-14B llama-server under memory pressure. No live provider HTTP request is made, because the no-op compaction returns before any model call, which is exactly the path under proof. A full build was not run; CI covers lint, types, and the full suite.
