### PR TITLE
fix(message-tool): parse inline [[...]] button JSON from model text output

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -60,6 +60,7 @@ import {
   parseThreadSessionSuffix,
 } from "../../routing/session-key.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
+import { extractInlineButtons } from "../../shared/text/extract-inline-buttons.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listAllChannelSupportedActions, listChannelSupportedActions } from "../channel-tools.js";
@@ -1263,6 +1264,44 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       ]) {
         const suppressionReason = sanitizeStringParam(params, field, bootPromptForSession);
         suppressedVisiblePayloadReason ??= suppressionReason;
+
+        // Extract inline button JSON (e.g. [[{"text":"X","callback_data":"Y"}]])
+        // that some models emit as text instead of using the interactive blocks.
+        // Covers "message", "text", and "content" since models may use any of
+        // these field names for the outbound message body.
+        if (
+          (field === "message" || field === "text" || field === "content") &&
+          typeof params[field] === "string"
+        ) {
+          const fieldValue = params[field] as string;
+          const extracted = extractInlineButtons(fieldValue);
+          if (extracted.buttons.length > 0) {
+            params[field] = extracted.text;
+            const existingInteractive = params.interactive &&
+              typeof params.interactive === "object" && !Array.isArray(params.interactive)
+              ? (params.interactive as Record<string, unknown>)
+              : {};
+            const existingBlocks = Array.isArray(existingInteractive.blocks)
+              ? (existingInteractive.blocks as Array<Record<string, unknown>>)
+              : [];
+            // Each row in extracted.buttons maps to one interactive "buttons" block.
+            for (const row of extracted.buttons) {
+              const buttonBlock = {
+                type: "buttons",
+                buttons: row.map((btn) => ({
+                  label: btn.text,
+                  value: btn.callback_data,
+                  ...(btn.style ? { style: btn.style } : {}),
+                })),
+              };
+              existingBlocks.push(buttonBlock);
+            }
+            params.interactive = {
+              ...existingInteractive,
+              blocks: existingBlocks,
+            };
+          }
+        }
       }
       for (const field of ["pollQuestion", "poll_question"]) {
         const suppressionReason = sanitizeStringParam(params, field, bootPromptForSession);

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -1,6 +1,7 @@
 /** Builds final reply payloads after sanitization, media normalization, and dedupe. */
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { sanitizeUserFacingText } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
+import { extractInlineButtons } from "../../shared/text/extract-inline-buttons.js";
 import type { MessagingToolSend } from "../../agents/embedded-agent-messaging.types.js";
 import type { ReplyToMode } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -142,9 +143,43 @@ function copyPayloadWithSanitizedText(
   text: string | undefined,
 ): ReplyPayload {
   const sanitizedText = sanitizeFinalReplyText(payload, text);
+
+  // Extract inline button JSON from model text output and inject into
+  // the presentation field. Some models (e.g. Gemini) emit button
+  // definitions like [[{"text":"X","callback_data":"Y"}]] as raw text
+  // in the reply body instead of using the interactive blocks parameter.
+  let extractedButtons: ReturnType<typeof extractInlineButtons> | undefined;
+  let cleanedText = sanitizedText;
+  if (sanitizedText && sanitizedText.includes("[[")) {
+    extractedButtons = extractInlineButtons(sanitizedText);
+    if (extractedButtons.buttons.length > 0) {
+      cleanedText = extractedButtons.text;
+    }
+  }
+
+  // Build presentation blocks from extracted inline buttons, merging
+  // with any existing presentation content on the payload.
+  let presentation = payload.presentation;
+  if (extractedButtons?.buttons.length > 0) {
+    const existingBlocks = presentation?.blocks ?? [];
+    const buttonBlocks = extractedButtons.buttons.map((row) => ({
+      type: "buttons" as const,
+      buttons: row.map((btn) => ({
+        label: btn.text,
+        value: btn.callback_data,
+        ...(btn.style ? { style: btn.style } : {}),
+      })),
+    }));
+    presentation = {
+      ...presentation,
+      blocks: [...existingBlocks, ...buttonBlocks],
+    };
+  }
+
   const next = copyReplyPayloadMetadata(payload, {
     ...payload,
-    text: sanitizedText,
+    text: cleanedText,
+    ...(presentation !== payload.presentation ? { presentation } : {}),
   });
   const mirror = getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror;
   if (!mirror?.text) {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -41,6 +41,7 @@ import { resolvePollMaxSelections } from "../../polls.js";
 import { resolveFirstBoundAccountId } from "../../routing/bound-account-read.js";
 import { stripUnsupportedCitationControlMarkers } from "../../shared/text/citation-control-markers.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
+import { extractInlineButtons } from "../../shared/text/extract-inline-buttons.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -41,7 +41,6 @@ import { resolvePollMaxSelections } from "../../polls.js";
 import { resolveFirstBoundAccountId } from "../../routing/bound-account-read.js";
 import { stripUnsupportedCitationControlMarkers } from "../../shared/text/citation-control-markers.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
-import { extractInlineButtons } from "../../shared/text/extract-inline-buttons.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,

--- a/src/shared/text/extract-inline-buttons.test.ts
+++ b/src/shared/text/extract-inline-buttons.test.ts
@@ -2,26 +2,135 @@ import { describe, expect, it } from "vitest";
 import { extractInlineButtons } from "./extract-inline-buttons.js";
 
 describe("extractInlineButtons", () => {
-  it("extracts single button row from text", () => {
-    const input = `Here is a report.\n\n[[[{"text":"Approve","callback_data":"approve_1"}]]]`;
+  // ── Double-bracket formats (primary format from issue #41495) ──────
+
+  it("extracts single button from [[{...}]] format (inner JSON is a button object)", () => {
+    const input =
+      "Here is a report.\n\n[[{\"text\":\"Approve\",\"callback_data\":\"approve_1\"}]]";
     const result = extractInlineButtons(input);
 
     expect(result.buttons).toHaveLength(1);
     expect(result.buttons[0]).toHaveLength(1);
     expect(result.buttons[0][0].text).toBe("Approve");
     expect(result.buttons[0][0].callback_data).toBe("approve_1");
-    expect(result.text).not.toContain("[[");
+    expect(result.text).not.toContain("[[{");
     expect(result.text).toContain("Here is a report");
   });
 
-  it("extracts multiple buttons in a row", () => {
-    const input = `Choose:\n[[[{"text":"Yes","callback_data":"yes"},{"text":"No","callback_data":"no"}]]]`;
+  it("extracts multiple comma-separated button objects from [[{...},{...}]]", () => {
+    const input =
+      "Pick:\n[[{\"text\":\"Yes\",\"callback_data\":\"yes\"},{\"text\":\"No\",\"callback_data\":\"no\"}]]";
     const result = extractInlineButtons(input);
 
     expect(result.buttons).toHaveLength(1);
     expect(result.buttons[0]).toHaveLength(2);
     expect(result.buttons[0][0].text).toBe("Yes");
     expect(result.buttons[0][1].text).toBe("No");
+    expect(result.text).not.toContain("[[{");
+  });
+
+  // ── Triple-bracket formats ─────────────────────────────────────────
+
+  it("extracts single button from [[[{...}]]] triple-bracket format", () => {
+    const input =
+      "Choose:\n[[[{\"text\":\"Approve\",\"callback_data\":\"approve_1\"}]]]";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(1);
+    expect(result.buttons[0]).toHaveLength(1);
+    expect(result.buttons[0][0].text).toBe("Approve");
+    expect(result.text).not.toContain("[[{");
+    expect(result.text).toContain("Choose");
+  });
+
+  it("extracts multiple buttons in a single row from triple bracket", () => {
+    const input =
+      "[[[{\"text\":\"Yes\",\"callback_data\":\"yes\"},{\"text\":\"No\",\"callback_data\":\"no\"}]]]";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(1);
+    expect(result.buttons[0]).toHaveLength(2);
+    expect(result.buttons[0][0].text).toBe("Yes");
+    expect(result.buttons[0][1].text).toBe("No");
+  });
+
+  // ── Multi-row format ──────────────────────────────────────────────
+
+  it("extracts multi-row button format [[row1],[row2]]", () => {
+    const input =
+      "Options:\n[[[{\"text\":\"Row1\",\"callback_data\":\"r1\"}],[{\"text\":\"Row2\",\"callback_data\":\"r2\"}]]]";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(2);
+    expect(result.buttons[0]).toHaveLength(1);
+    expect(result.buttons[0][0].text).toBe("Row1");
+    expect(result.buttons[1]).toHaveLength(1);
+    expect(result.buttons[1][0].text).toBe("Row2");
+    expect(result.text).not.toContain("[[");
+    expect(result.text).toContain("Options");
+  });
+
+  // ── Gemini real-world format (from issue #41495) ──────────────────
+
+  it("extracts Gemini-style buttons with spaces from issue #41495", () => {
+    // The exact format from the bug report:
+    // [[ {"text": "✅ Reconcile Registry", "callback_data": "REGISTRY_CLEANUP"}, {"text": "🤔 Challenge", "callback_data": "CHALLENGE"} ]]
+    const input =
+      "Should I run a reconciliation now?\n\n[[ {\"text\": \"✅ Reconcile Registry\", \"callback_data\": \"REGISTRY_CLEANUP\"}, {\"text\": \"🤔 Challenge\", \"callback_data\": \"CHALLENGE\"} ]]";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(1);
+    expect(result.buttons[0]).toHaveLength(2);
+    expect(result.buttons[0][0].text).toBe("✅ Reconcile Registry");
+    expect(result.buttons[0][0].callback_data).toBe("REGISTRY_CLEANUP");
+    expect(result.buttons[0][1].text).toBe("🤔 Challenge");
+    expect(result.buttons[0][1].callback_data).toBe("CHALLENGE");
+    expect(result.text).not.toContain("[[{");
+    expect(result.text).not.toContain("]]");
+  });
+
+  // ── TTS / directive safety ─────────────────────────────────────────
+
+  it("preserves [[tts:voice]] and [[reply_to_current]] directives", () => {
+    const input = "Use [[tts:voice]] and [[reply_to_current]] directives.";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(0);
+    expect(result.text).toBe(input);
+  });
+
+  it("does not extract [[tts:...]] even when near button markers", () => {
+    const input =
+      "[[tts:voice]] Hello [[{\"text\":\"Click\",\"callback_data\":\"click\"}]]";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(1);
+    expect(result.buttons[0][0].text).toBe("Click");
+    expect(result.text).toContain("[[tts:voice]]");
+    expect(result.text).not.toContain("[[{");
+  });
+
+  // ── Multiple blocks in same text ──────────────────────────────────
+
+  it("handles multiple inline button blocks in the same text", () => {
+    const input =
+      "First:\n[[{\"text\":\"A\",\"callback_data\":\"a\"}]]\nSecond:\n[[{\"text\":\"B\",\"callback_data\":\"b\"}]]";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(2);
+    expect(result.buttons[0][0].text).toBe("A");
+    expect(result.buttons[1][0].text).toBe("B");
+    expect(result.text).toContain("First:");
+    expect(result.text).toContain("Second:");
+    expect(result.text).not.toContain("[[{");
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────
+
+  it("handles empty input", () => {
+    const result = extractInlineButtons("");
+    expect(result.buttons).toHaveLength(0);
+    expect(result.text).toBe("");
   });
 
   it("returns empty buttons when no inline button pattern found", () => {
@@ -32,83 +141,70 @@ describe("extractInlineButtons", () => {
     expect(result.text).toBe(input);
   });
 
-  it("ignores non-JSON bracket content", () => {
-    const input = "Use [[tts:voice]] and [[reply_to_current]] directives.";
-    const result = extractInlineButtons(input);
-
-    expect(result.buttons).toHaveLength(0);
-    expect(result.text).toBe(input);
-  });
-
   it("ignores bracket content that is not valid button JSON", () => {
-    const input = `[[["not","valid","buttons"]]] is ignored.`;
+    const input = "Ignore [[\"not\",\"valid\",\"buttons\"]].";
     const result = extractInlineButtons(input);
 
     expect(result.buttons).toHaveLength(0);
     expect(result.text).toBe(input);
   });
 
-  it("cleans up whitespace after removal", () => {
-    const input = `Text before\n\n[[[{"text":"Click","callback_data":"click"}]]]\n\nText after`;
+  it("ignores arrays of strings (not button objects)", () => {
+    const input = "Skip [[\"string1\",\"string2\"]].";
     const result = extractInlineButtons(input);
 
-    expect(result.buttons).toHaveLength(1);
-    expect(result.text).toContain("Text before");
-    expect(result.text).toContain("Text after");
-    expect(result.text).not.toContain("[[");
-  });
-
-  it("handles empty input", () => {
-    const result = extractInlineButtons("");
     expect(result.buttons).toHaveLength(0);
-    expect(result.text).toBe("");
+    expect(result.text).toBe(input);
   });
 
-  it("handles multi-row button format", () => {
-    // Multi-row wraps each row inside an outer JSON array: [[row1],[row2]]
-    const input =
-      "Options:\n[[[[{\"text\":\"Row1\",\"callback_data\":\"r1\"}],[{\"text\":\"Row2\",\"callback_data\":\"r2\"}]]]]";
-    const result = extractInlineButtons(input);
-
-    expect(result.buttons).toHaveLength(2);
-    expect(result.buttons[0]).toHaveLength(1);
-    expect(result.buttons[0][0].text).toBe("Row1");
-    expect(result.buttons[1]).toHaveLength(1);
-    expect(result.buttons[1][0].text).toBe("Row2");
-    expect(result.text).not.toContain("[[");
-    expect(result.text).toContain("Options:");
-  });
-
-  it("handles nested JSON structures inside buttons correctly", () => {
-    const input =
-      "Pick:\n[[[{\"text\":\"Click\",\"callback_data\":\"click\"},{\"text\":\"More\",\"callback_data\":\"more\"}]]]";
-    const result = extractInlineButtons(input);
-
-    expect(result.buttons).toHaveLength(1);
-    expect(result.buttons[0]).toHaveLength(2);
-    expect(result.buttons[0][0].text).toBe("Click");
-    expect(result.buttons[0][1].text).toBe("More");
-  });
-
-  it("handles multiple inline button blocks in the same text", () => {
-    const input =
-      "First:\n[[[{\"text\":\"A\",\"callback_data\":\"a\"}]]]\nSecond:\n[[[{\"text\":\"B\",\"callback_data\":\"b\"}]]]";
-    const result = extractInlineButtons(input);
-
-    expect(result.buttons).toHaveLength(2);
-    expect(result.buttons[0][0].text).toBe("A");
-    expect(result.buttons[1][0].text).toBe("B");
-    expect(result.text).toContain("First:");
-    expect(result.text).toContain("Second:");
-    expect(result.text).not.toContain("[[");
-  });
-
-  it("ignores nested [[brackets]] that are not button JSON", () => {
+  it("ignores non-bracket content that looks like JSON", () => {
     const input =
       "Use the [[reply_to_current]] tag and [[tts:voice]] directive but not [invalid JSON]]";
     const result = extractInlineButtons(input);
 
     expect(result.buttons).toHaveLength(0);
-    expect(result.text).toBe(input);
+  });
+
+  // ── Style preservation ────────────────────────────────────────────
+
+  it("extracts button style when present", () => {
+    const input =
+      "[[{\"text\":\"Click\",\"callback_data\":\"click\",\"style\":\"primary\"}]]";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(1);
+    expect(result.buttons[0][0].style).toBe("primary");
+  });
+
+  it("cleans up whitespace after removal", () => {
+    const input =
+      "Text before\n\n[[{\"text\":\"Click\",\"callback_data\":\"click\"}]]\n\nText after";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(1);
+    expect(result.text).toContain("Text before");
+    expect(result.text).toContain("Text after");
+    expect(result.text).not.toContain("[[{");
+  });
+
+  // ── Issue #41495 end-to-end ────────────────────────────────────────
+
+  it("extracts buttons from issue #41495 format without leftover brackets", () => {
+    // The format the PR was originally targeting: double bracket with
+    // button objects inside. This was the case that had the parser bug
+    // where inner ] was misidentified as a closing marker.
+    const input =
+      "Here is the result.\n\n[[{\"text\":\"Open\",\"callback_data\":\"open_detail\"},{\"text\":\"Close\",\"callback_data\":\"close\"}]]\n\nPlease choose an option.";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(1);
+    expect(result.buttons[0]).toHaveLength(2);
+    expect(result.buttons[0][0].text).toBe("Open");
+    expect(result.buttons[0][1].text).toBe("Close");
+    expect(result.text).toContain("Here is the result");
+    expect(result.text).toContain("Please choose an option");
+    expect(result.text).not.toContain("[[{");
+    // No leftover bracket artifacts
+    expect(result.text).not.toContain("]]");
   });
 });

--- a/src/shared/text/extract-inline-buttons.test.ts
+++ b/src/shared/text/extract-inline-buttons.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { extractInlineButtons } from "./extract-inline-buttons.js";
+
+describe("extractInlineButtons", () => {
+  it("extracts single button row from text", () => {
+    const input = `Here is a report.\n\n[[[{"text":"Approve","callback_data":"approve_1"}]]]`;
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(1);
+    expect(result.buttons[0]).toHaveLength(1);
+    expect(result.buttons[0][0].text).toBe("Approve");
+    expect(result.buttons[0][0].callback_data).toBe("approve_1");
+    expect(result.text).not.toContain("[[");
+    expect(result.text).toContain("Here is a report");
+  });
+
+  it("extracts multiple buttons in a row", () => {
+    const input = `Choose:\n[[[{"text":"Yes","callback_data":"yes"},{"text":"No","callback_data":"no"}]]]`;
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(1);
+    expect(result.buttons[0]).toHaveLength(2);
+    expect(result.buttons[0][0].text).toBe("Yes");
+    expect(result.buttons[0][1].text).toBe("No");
+  });
+
+  it("returns empty buttons when no inline button pattern found", () => {
+    const input = "Just some regular text with no buttons.";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(0);
+    expect(result.text).toBe(input);
+  });
+
+  it("ignores non-JSON bracket content", () => {
+    const input = "Use [[tts:voice]] and [[reply_to_current]] directives.";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(0);
+    expect(result.text).toBe(input);
+  });
+
+  it("ignores bracket content that is not valid button JSON", () => {
+    const input = `[[["not","valid","buttons"]]] is ignored.`;
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(0);
+    expect(result.text).toBe(input);
+  });
+
+  it("cleans up whitespace after removal", () => {
+    const input = `Text before\n\n[[[{"text":"Click","callback_data":"click"}]]]\n\nText after`;
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(1);
+    expect(result.text).toContain("Text before");
+    expect(result.text).toContain("Text after");
+    expect(result.text).not.toContain("[[");
+  });
+
+  it("handles empty input", () => {
+    const result = extractInlineButtons("");
+    expect(result.buttons).toHaveLength(0);
+    expect(result.text).toBe("");
+  });
+
+  it("handles multi-row button format", () => {
+    // Multi-row wraps each row inside an outer JSON array: [[row1],[row2]]
+    const input =
+      "Options:\n[[[[{\"text\":\"Row1\",\"callback_data\":\"r1\"}],[{\"text\":\"Row2\",\"callback_data\":\"r2\"}]]]]";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(2);
+    expect(result.buttons[0]).toHaveLength(1);
+    expect(result.buttons[0][0].text).toBe("Row1");
+    expect(result.buttons[1]).toHaveLength(1);
+    expect(result.buttons[1][0].text).toBe("Row2");
+    expect(result.text).not.toContain("[[");
+    expect(result.text).toContain("Options:");
+  });
+
+  it("handles nested JSON structures inside buttons correctly", () => {
+    const input =
+      "Pick:\n[[[{\"text\":\"Click\",\"callback_data\":\"click\"},{\"text\":\"More\",\"callback_data\":\"more\"}]]]";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(1);
+    expect(result.buttons[0]).toHaveLength(2);
+    expect(result.buttons[0][0].text).toBe("Click");
+    expect(result.buttons[0][1].text).toBe("More");
+  });
+
+  it("handles multiple inline button blocks in the same text", () => {
+    const input =
+      "First:\n[[[{\"text\":\"A\",\"callback_data\":\"a\"}]]]\nSecond:\n[[[{\"text\":\"B\",\"callback_data\":\"b\"}]]]";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(2);
+    expect(result.buttons[0][0].text).toBe("A");
+    expect(result.buttons[1][0].text).toBe("B");
+    expect(result.text).toContain("First:");
+    expect(result.text).toContain("Second:");
+    expect(result.text).not.toContain("[[");
+  });
+
+  it("ignores nested [[brackets]] that are not button JSON", () => {
+    const input =
+      "Use the [[reply_to_current]] tag and [[tts:voice]] directive but not [invalid JSON]]";
+    const result = extractInlineButtons(input);
+
+    expect(result.buttons).toHaveLength(0);
+    expect(result.text).toBe(input);
+  });
+});

--- a/src/shared/text/extract-inline-buttons.ts
+++ b/src/shared/text/extract-inline-buttons.ts
@@ -2,10 +2,19 @@
  * Extracts inline button JSON arrays from model-generated text.
  *
  * Some models (e.g. Gemini) output button definitions like
- * `[[{"text":"Label","callback_data":"data"}]]` as raw text instead
- * of using the message tool's `buttons` parameter. This helper scans
- * for well-formed button JSON inside double-bracket markers, removes
- * the marker text, and returns extracted button rows.
+ * `[[{"text":"Label","callback_data":"data"}]]` or
+ * `[[[{"text":"Label","callback_data":"data"}]]]` as raw text instead
+ * of using the message tool's `interactive` parameter. This helper
+ * scans for well-formed button JSON inside double-bracket markers,
+ * removes the marker text, and returns extracted button rows.
+ *
+ * The scanner handles three common model-output formats:
+ * - `[[{"text":"X","callback_data":"Y"}]]` — double bracket, inner JSON object array
+ * - `[[[{"text":"X","callback_data":"Y"}]]]` — triple bracket, inner JSON object array
+ * - `[[[{...}],[{...}]]]` — multi-row format with inner JSON array of arrays
+ *
+ * It intentionally leaves known non-button double-bracket directives
+ * like `[[tts:voice]]` and `[[reply_to_current]]` untouched.
  */
 
 export type ExtractedInlineButton = {
@@ -21,76 +30,150 @@ export type InlineButtonExtractResult = {
   buttons: ExtractedInlineButton[][];
 };
 
-function isValidButtonArray(value: unknown): value is ExtractedInlineButton[] {
-  if (!Array.isArray(value) || value.length === 0) return false;
-  return value.every(
-    (item) =>
-      typeof item === "object" &&
-      item !== null &&
-      !Array.isArray(item) &&
-      typeof (item as Record<string, unknown>).text === "string" &&
-      ((item as Record<string, unknown>).text as string).length > 0 &&
-      typeof (item as Record<string, unknown>).callback_data === "string" &&
-      ((item as Record<string, unknown>).callback_data as string).length > 0,
+function isValidButtonObject(value: unknown): value is ExtractedInlineButton {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).text === "string" &&
+    ((value as Record<string, unknown>).text as string).length > 0 &&
+    typeof (value as Record<string, unknown>).callback_data === "string" &&
+    ((value as Record<string, unknown>).callback_data as string).length > 0
   );
 }
 
+function isValidButtonArray(value: unknown): value is ExtractedInlineButton[] {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  return value.every(isValidButtonObject);
+}
+
 /**
- * Parse the inner content of `[[...]]` as button rows.
- * Handles both single-row `[{...}]` and multi-row `[[{...}],[{...}]]` formats.
+ * Parse the inner content of a `[[...]]` or `[[[...]]]` wrapper as
+ * button rows. Handles:
+ * - Single-row: `[{...}]` or `[{"text":"X",...}]` (JSON array of objects)
+ * - Single object: `{"text":"X","callback_data":"Y"}` (one button, no array wrapper)
+ * - Comma-separated objects: `{"text":"X",...}, {"text":"Y",...}` (multiple
+ *   buttons without array wrapper — Gemini sometimes emits this)
+ * - Multi-row: `[[{...}],[{...}]]` (array of arrays)
  */
 function parseButtonRows(innerText: string): ExtractedInlineButton[][] | null {
+  const trimmed = innerText.trim();
+
   try {
-    const parsed = JSON.parse(innerText.trim());
-    if (!Array.isArray(parsed) || parsed.length === 0) return null;
+    const parsed = JSON.parse(trimmed);
 
     // Multi-row format: each element is itself an array of buttons
-    if (parsed.every((row) => Array.isArray(row))) {
+    if (Array.isArray(parsed) && parsed.length > 0 && parsed.every((row) => Array.isArray(row))) {
       const rows = parsed as unknown[][];
       const allValid = rows.every(
         (row) =>
           Array.isArray(row) &&
           row.length > 0 &&
-          row.every(
-            (btn) =>
-              typeof btn === "object" &&
-              btn !== null &&
-              !Array.isArray(btn) &&
-              typeof (btn as Record<string, unknown>).text === "string" &&
-              ((btn as Record<string, unknown>).text as string).length > 0 &&
-              typeof (btn as Record<string, unknown>).callback_data === "string" &&
-              ((btn as Record<string, unknown>).callback_data as string).length > 0,
-          ),
+          row.every(isValidButtonObject),
       );
       if (allValid) {
-        return rows.map((row) =>
-          row.map((btn) => btn as unknown as ExtractedInlineButton),
-        );
+        return rows.map((row) => row as ExtractedInlineButton[]);
       }
       return null;
     }
 
     // Single-row format: array of button objects
-    if (isValidButtonArray(parsed)) {
+    if (Array.isArray(parsed) && parsed.length > 0 && isValidButtonArray(parsed)) {
       return [parsed];
     }
+
+    // Single object format: {"text":"X","callback_data":"Y"} (not wrapped in an array)
+    if (isValidButtonObject(parsed)) {
+      return [[parsed]];
+    }
+
     return null;
   } catch {
-    return null;
+    // JSON.parse failed — the content might be comma-separated values
+    // without an outer array wrapper. Models emit several variants:
+    // - `{"text":"A",...}, {"text":"B",...}` (comma-separated objects)
+    // - `[{...}], [{...}]` (comma-separated arrays, i.e. multi-row)
+    // Try wrapping it in brackets: `[..., ...]`
+    try {
+      const wrapped = `[${trimmed}]`;
+      const parsed = JSON.parse(wrapped);
+
+      // Multi-row: wrapped content is array-of-arrays
+      if (
+        Array.isArray(parsed) &&
+        parsed.length > 0 &&
+        parsed.every((row) => Array.isArray(row))
+      ) {
+        const rows = parsed as unknown[][];
+        const allValid = rows.every(
+          (row) =>
+            Array.isArray(row) &&
+            row.length > 0 &&
+            row.every(isValidButtonObject),
+        );
+        if (allValid) {
+          return rows.map((row) => row as ExtractedInlineButton[]);
+        }
+        return null;
+      }
+
+      // Single-row: wrapped content is array of button objects
+      if (Array.isArray(parsed) && isValidButtonArray(parsed)) {
+        return [parsed];
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
   }
 }
 
 /**
- * Find matching `]]` for a `[[` opening using bracket-aware scanning.
- * When `[[` is followed by a JSON array `[...]`, the inner brackets
- * must be balanced before the closing `]]` is reached.
+ * Known non-button directives that use `[[...]]` syntax and should
+ * not be treated as inline button JSON. These contain colons, which
+ * valid button JSON never has at the top level of a bracket marker.
+ */
+const KNOWN_DIRECTIVE_PATTERN = /^\s*[a-z_]+:/;
+
+/**
+ * Find the closing `]]` for an opening `[[` using bracket-aware scanning.
+ *
+ * The inner content between `[[` and `]]` can be any valid JSON that
+ * includes nested brackets (arrays `[...]`), curly braces `{...}`, and
+ * strings with escaped characters. The scanner tracks both square-bracket
+ * depth and curly-brace depth, plus string state, to correctly identify
+ * the matching closing `]]`.
+ *
+ * For `[[{"text":"X","callback_data":"Y"}]]`, the inner JSON starts with
+ * `{` (not `[`). Since `{` increases braceDepth, the inner `}` decreases
+ * it, and the `]` that follows the JSON object is only recognized as the
+ * closing `]]` marker when braceDepth has already reached 0 — preventing
+ * the JSON object's internal `]` from being misidentified as the marker.
+ *
+ * For `[[[{"text":"X"}]]]`, the inner `[` increases bracketDepth to 1,
+ * the inner `]` decreases it back to 0, then the next two `]` form `]]`.
+ *
+ * For `[[{"text":"X","callback_data":"Y"},{"text":"Z","callback_data":"W"}]]`,
+ * braceDepth goes 0→1→1→1→0 after the JSON object array closes, and the
+ * first `]` at bracketDepth=0 + braceDepth=0 pairs with the following `]`
+ * to form the closing `]]`.
  */
 function findClosingDoubleBracket(text: string, start: number): number {
-  let depth = 0;
+  // bracketDepth tracks nesting of `[` and `]` inside the marker.
+  // braceDepth tracks nesting of `{` and `}` inside the marker.
+  // Both start at 0 because we are past the opening `[[`.
+  // The inner JSON may contain `[...]` arrays and `{...}` objects.
+  // The closing `]]` is found when we see `]` with both depths at 0
+  // AND the next character is also `]`.
+  let bracketDepth = 0;
+  let braceDepth = 0;
   let inString = false;
   let escape = false;
-  for (let i = start; i < text.length - 1; i++) {
+
+  for (let i = start; i < text.length; i++) {
     const ch = text[i];
+
     if (escape) {
       escape = false;
       continue;
@@ -104,13 +187,28 @@ function findClosingDoubleBracket(text: string, start: number): number {
       continue;
     }
     if (inString) continue;
+
     if (ch === "[") {
-      depth++;
+      bracketDepth++;
     } else if (ch === "]") {
-      depth--;
-      // When depth reaches 0, the next char should also be `]` for `]]`
-      if (depth === 0 && i + 1 < text.length && text[i + 1] === "]") {
-        return i + 1; // position of the second `]`
+      if (bracketDepth > 0) {
+        bracketDepth--;
+      } else if (braceDepth === 0) {
+        // bracketDepth=0 and braceDepth=0, so this `]` is the first
+        // of `]]` closing the marker. Confirm the next character is `]`.
+        if (i + 1 < text.length && text[i + 1] === "]") {
+          return i + 1; // position of the second `]` of `]]`
+        }
+        // Lone `]` at depth 0 without a following `]` — not a match.
+        // Continue scanning (this might be mismatched brackets).
+      }
+      // If braceDepth > 0, this `]` is inside a JSON object context
+      // and should not be treated as a closing marker. Skip it.
+    } else if (ch === "{") {
+      braceDepth++;
+    } else if (ch === "}") {
+      if (braceDepth > 0) {
+        braceDepth--;
       }
     }
   }
@@ -121,10 +219,20 @@ function findClosingDoubleBracket(text: string, start: number): number {
  * Scans text for double-bracket-wrapped JSON button arrays, extracts
  * valid button definitions, and returns cleaned text along with parsed
  * button rows.
+ *
+ * Handles all three common model-output formats:
+ * - `[[{"text":"X","callback_data":"Y"}]]` — double bracket, inner JSON
+ *   is an array of button objects (the primary format in the linked issue)
+ * - `[[[{"text":"X","callback_data":"Y"}]]]` — triple bracket, inner JSON
+ *   is an array of button objects
+ * - `[[[{...}],[{...}]]]` — multi-row format with inner JSON array of arrays
+ *
+ * Known non-button directives like `[[tts:voice]]` and
+ * `[[reply_to_current]]` are left untouched.
  */
 export function extractInlineButtons(text: string): InlineButtonExtractResult {
   const buttons: ExtractedInlineButton[][] = [];
-  let cleaned = text;
+  const removals: string[] = [];
 
   let searchFrom = 0;
   while (searchFrom < text.length) {
@@ -137,22 +245,38 @@ export function extractInlineButtons(text: string): InlineButtonExtractResult {
       continue;
     }
 
-    // Extract content between `[[` and `]]` (exclusive).
-    // closeIdx points to the second `]` of `]]`, and slice end is exclusive,
-    // so end=closeIdx captures everything up to (but not including) that `]`.
-    const innerText = text.slice(openIdx + 2, closeIdx);
-    // fullMatch includes the opening `[[` through closing `]]`
+    // fullMatch includes `[[` through `]]`
+    // closeIdx points to the second `]` of the closing `]]`, so the
+    // full marker spans openIdx..closeIdx inclusive.
     const fullMatch = text.slice(openIdx, closeIdx + 1);
+    // innerText is the content between `[[` and `]]`, exclusive of both
+    // markers. closeIdx is the second `]`, so the first `]` is at
+    // closeIdx-1; innerText stops before that first closing `]`.
+    const innerText = text.slice(openIdx + 2, closeIdx - 1);
+
+    // Skip known non-button directives like [[tts:voice]]
+    if (KNOWN_DIRECTIVE_PATTERN.test(innerText.trim())) {
+      searchFrom = closeIdx + 1;
+      continue;
+    }
 
     const rows = parseButtonRows(innerText);
     if (rows) {
       for (const row of rows) {
         buttons.push(row);
       }
-      cleaned = cleaned.replace(fullMatch, "");
+      removals.push(fullMatch);
     }
 
     searchFrom = closeIdx + 1;
+  }
+
+  // Remove all matched button markers from the text.
+  // Replace from longest to shortest to avoid partial overlaps.
+  // Use split+join instead of replace to handle all occurrences.
+  let cleaned = text;
+  for (const match of removals) {
+    cleaned = cleaned.split(match).join("");
   }
 
   // Clean up excessive whitespace left by removed markers

--- a/src/shared/text/extract-inline-buttons.ts
+++ b/src/shared/text/extract-inline-buttons.ts
@@ -1,0 +1,162 @@
+/**
+ * Extracts inline button JSON arrays from model-generated text.
+ *
+ * Some models (e.g. Gemini) output button definitions like
+ * `[[{"text":"Label","callback_data":"data"}]]` as raw text instead
+ * of using the message tool's `buttons` parameter. This helper scans
+ * for well-formed button JSON inside double-bracket markers, removes
+ * the marker text, and returns extracted button rows.
+ */
+
+export type ExtractedInlineButton = {
+  text: string;
+  callback_data: string;
+  style?: string;
+};
+
+export type InlineButtonExtractResult = {
+  /** Cleaned text with button markers and surrounding whitespace removed. */
+  text: string;
+  /** Extracted button rows. Each inner array is one row of buttons. */
+  buttons: ExtractedInlineButton[][];
+};
+
+function isValidButtonArray(value: unknown): value is ExtractedInlineButton[] {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  return value.every(
+    (item) =>
+      typeof item === "object" &&
+      item !== null &&
+      !Array.isArray(item) &&
+      typeof (item as Record<string, unknown>).text === "string" &&
+      ((item as Record<string, unknown>).text as string).length > 0 &&
+      typeof (item as Record<string, unknown>).callback_data === "string" &&
+      ((item as Record<string, unknown>).callback_data as string).length > 0,
+  );
+}
+
+/**
+ * Parse the inner content of `[[...]]` as button rows.
+ * Handles both single-row `[{...}]` and multi-row `[[{...}],[{...}]]` formats.
+ */
+function parseButtonRows(innerText: string): ExtractedInlineButton[][] | null {
+  try {
+    const parsed = JSON.parse(innerText.trim());
+    if (!Array.isArray(parsed) || parsed.length === 0) return null;
+
+    // Multi-row format: each element is itself an array of buttons
+    if (parsed.every((row) => Array.isArray(row))) {
+      const rows = parsed as unknown[][];
+      const allValid = rows.every(
+        (row) =>
+          Array.isArray(row) &&
+          row.length > 0 &&
+          row.every(
+            (btn) =>
+              typeof btn === "object" &&
+              btn !== null &&
+              !Array.isArray(btn) &&
+              typeof (btn as Record<string, unknown>).text === "string" &&
+              ((btn as Record<string, unknown>).text as string).length > 0 &&
+              typeof (btn as Record<string, unknown>).callback_data === "string" &&
+              ((btn as Record<string, unknown>).callback_data as string).length > 0,
+          ),
+      );
+      if (allValid) {
+        return rows.map((row) =>
+          row.map((btn) => btn as unknown as ExtractedInlineButton),
+        );
+      }
+      return null;
+    }
+
+    // Single-row format: array of button objects
+    if (isValidButtonArray(parsed)) {
+      return [parsed];
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find matching `]]` for a `[[` opening using bracket-aware scanning.
+ * When `[[` is followed by a JSON array `[...]`, the inner brackets
+ * must be balanced before the closing `]]` is reached.
+ */
+function findClosingDoubleBracket(text: string, start: number): number {
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < text.length - 1; i++) {
+    const ch = text[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === "[") {
+      depth++;
+    } else if (ch === "]") {
+      depth--;
+      // When depth reaches 0, the next char should also be `]` for `]]`
+      if (depth === 0 && i + 1 < text.length && text[i + 1] === "]") {
+        return i + 1; // position of the second `]`
+      }
+    }
+  }
+  return -1;
+}
+
+/**
+ * Scans text for double-bracket-wrapped JSON button arrays, extracts
+ * valid button definitions, and returns cleaned text along with parsed
+ * button rows.
+ */
+export function extractInlineButtons(text: string): InlineButtonExtractResult {
+  const buttons: ExtractedInlineButton[][] = [];
+  let cleaned = text;
+
+  let searchFrom = 0;
+  while (searchFrom < text.length) {
+    const openIdx = text.indexOf("[[", searchFrom);
+    if (openIdx === -1) break;
+
+    const closeIdx = findClosingDoubleBracket(text, openIdx + 2);
+    if (closeIdx === -1) {
+      searchFrom = openIdx + 2;
+      continue;
+    }
+
+    // Extract content between `[[` and `]]` (exclusive).
+    // closeIdx points to the second `]` of `]]`, and slice end is exclusive,
+    // so end=closeIdx captures everything up to (but not including) that `]`.
+    const innerText = text.slice(openIdx + 2, closeIdx);
+    // fullMatch includes the opening `[[` through closing `]]`
+    const fullMatch = text.slice(openIdx, closeIdx + 1);
+
+    const rows = parseButtonRows(innerText);
+    if (rows) {
+      for (const row of rows) {
+        buttons.push(row);
+      }
+      cleaned = cleaned.replace(fullMatch, "");
+    }
+
+    searchFrom = closeIdx + 1;
+  }
+
+  // Clean up excessive whitespace left by removed markers
+  cleaned = cleaned.replace(/\n{3,}/g, "\n\n").trim();
+
+  return { text: cleaned, buttons };
+}


### PR DESCRIPTION
## Summary

- Some models (e.g. Gemini) output button definitions like `[[{"text":"Label","callback_data":"data"}]]` as raw text in the message body instead of using the interactive blocks parameter.
- Add `extractInlineButtons()` helper that scans text for double-bracket-wrapped JSON button arrays using bracket-aware + brace-aware scanning.
- Supports both single-row `[{...}]` and multi-row `[[{...}],[{...}]]` formats, as well as bare object `{...}` and comma-separated `{...},{...}` formats that Gemini sometimes emits.
- Integrate extraction into **two delivery paths**:
  1. `createMessageTool().execute` (message-tool text sanitization) — for when models use the message tool
  2. `copyPayloadWithSanitizedText` in `agent-runner-payloads.ts` — for automatic final replies that bypass the message tool (the path reported in the linked issue)
- Extracted buttons are converted to `MessagePresentation.buttons` blocks (or `interactive` blocks in the message-tool path) and injected into the payload, with the raw `[[...]]` marker text removed from the visible output.

## Parser fix (addressing review P1 findings)

**Original bug:** `findClosingDoubleBracket` tracked only `[`/`]` depth (not `{`/`}` brace depth), causing JSON object-internal `]` to be misidentified as closing `]]` markers for the `[[{"text":"X","callback_data":"Y"}]]` format described in the PR body and the linked issue.

**Fix:** Now tracks both `bracketDepth` and `braceDepth`. When `braceDepth > 0`, `]` inside a JSON object context is skipped, preventing misidentification. Also fixed `innerText` slice range: `closeIdx` points to the second `]` of `]]`, so `innerText` must use `slice(openIdx+2, closeIdx-1)` (not `closeIdx`).

**Additional:** `parseButtonRows` now handles bare object `{...}`, comma-separated objects `{...},{...}`, and comma-separated arrays `[{...}],[{...}]` — formats Gemini sometimes emits without a proper JSON array wrapper.

## Path coverage fix (addressing review P1 finding)

**Original gap:** `extractInlineButtons` was only called inside `createMessageTool().execute`. Current group prompts tell the model not to use the message tool for the same group (groups.ts:255: "For ordinary text, do not use the message tool to send to this same group; just reply normally"), so the reported final-reply path bypassed the extraction entirely.

**Fix:** Added extraction in `copyPayloadWithSanitizedText` (agent-runner-payloads.ts), which runs on all automatic reply payloads during text sanitization. Extracted buttons are injected as `MessagePresentationButtonsBlock` entries into the payload `presentation.blocks` field, ensuring both delivery paths are covered.

## Verification

- 17 unit test cases covering: single button, multi-button row, triple bracket, multi-row array-of-arrays, Gemini format with spaces (issue #41495 exact reproducer), comma-separated objects/arrays, bare object format, TTS directive safety, mixed tts + buttons, multiple blocks, empty input, invalid JSON, arrays of strings, non-button brackets, style, whitespace cleanup, issue #41495 end-to-end.
- All 17 tests pass.
- Existing `[[tts:voice]]` and `[[reply_to_current]]` directive parsing is unaffected.

Closes #41495