### PR TITLE
feat(gateway): accept thinkingLevel/reasoningLevel at sessions.create (operator.write)

### DIFF
--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -243,6 +243,11 @@ export const SessionsCreateParamsSchema = Type.Object(
     agentId: Type.Optional(NonEmptyString),
     label: Type.Optional(SessionLabelString),
     model: Type.Optional(NonEmptyString),
+    // Apply the session's reasoning effort + reasoning toggle at create time so a
+    // caller with only operator.write (e.g. a flyway seat) can set them without the
+    // operator.admin scope that sessions.patch requires. Validated like the patch.
+    thinkingLevel: Type.Optional(NonEmptyString),
+    reasoningLevel: Type.Optional(NonEmptyString),
     parentSessionKey: Type.Optional(NonEmptyString),
     emitCommandHooks: Type.Optional(Type.Boolean()),
     task: Type.Optional(Type.String()),

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1496,30 +1496,45 @@ export const sessionsHandlers: GatewayRequestHandlers = {
             mainKey: cfg.session?.mainKey,
           })
       : buildDashboardSessionKey(agentId);
+    const requestedModel = normalizeOptionalString(p.model);
+    const requestedThinkingLevel = normalizeOptionalString(p.thinkingLevel);
+    const requestedReasoningLevel = normalizeOptionalString(p.reasoningLevel);
     const target = resolveGatewaySessionStoreTarget({ cfg, key, agentId });
     const targetAgentId = target.agentId;
     const created = await updateSessionStore(target.storePath, async (store) => {
+      const inheritedSelection =
+        canonicalParentSessionKey && !requestedModel
+          ? inheritSessionRuntimeSelection(parentSessionEntry)
+          : {};
+      const patchStore =
+        Object.keys(inheritedSelection).length > 0
+          ? {
+              ...store,
+              [target.canonicalKey]: {
+                ...store[target.canonicalKey],
+                ...inheritedSelection,
+              },
+            }
+          : store;
       const patched = await applySessionsPatchToStore({
         cfg,
-        store,
+        store: patchStore,
         storeKey: target.canonicalKey,
         agentId: targetAgentId,
         patch: {
           key: target.canonicalKey,
           label: normalizeOptionalString(p.label),
-          model: normalizeOptionalString(p.model),
+          model: requestedModel,
+          ...(requestedThinkingLevel ? { thinkingLevel: requestedThinkingLevel } : {}),
+          ...(requestedReasoningLevel ? { reasoningLevel: requestedReasoningLevel } : {}),
         },
         loadGatewayModelCatalog: context.loadGatewayModelCatalog,
       });
       if (!patched.ok || !canonicalParentSessionKey) {
         return patched;
       }
-      const inheritedSelection = normalizeOptionalString(p.model)
-        ? {}
-        : inheritSessionRuntimeSelection(parentSessionEntry);
       const nextEntry: SessionEntry = {
         ...patched.entry,
-        ...inheritedSelection,
         parentSessionKey: canonicalParentSessionKey,
       };
       store[target.canonicalKey] = nextEntry;

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -89,6 +89,111 @@ test("sessions.create stores dashboard session model and parent linkage, and cre
   expect(header.id).toBe(created.payload?.sessionId);
 });
 
+test("sessions.create applies thinkingLevel + reasoningLevel at create (operator.write, no admin patch)", async () => {
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent", {
+        providerOverride: "openai",
+        modelOverride: "gpt-test-a",
+        thinkingLevel: "off",
+        reasoningLevel: "off",
+      }),
+    },
+  });
+  const created = await directSessionReq<{
+    key?: string;
+    entry?: {
+      providerOverride?: string;
+      modelOverride?: string;
+      thinkingLevel?: string;
+      reasoningLevel?: string;
+    };
+  }>("sessions.create", {
+    agentId: "ops",
+    parentSessionKey: "main",
+    thinkingLevel: "high",
+    reasoningLevel: "on",
+  });
+
+  expect(created.ok).toBe(true);
+  expect(created.payload?.entry?.providerOverride).toBe("openai");
+  expect(created.payload?.entry?.modelOverride).toBe("gpt-test-a");
+  expect(created.payload?.entry?.thinkingLevel).toBe("high");
+  expect(created.payload?.entry?.reasoningLevel).toBe("on");
+
+  const rawStore = readSessionStore(storePath);
+  const key = created.payload?.key as string;
+  expect(rawStore[key]?.thinkingLevel).toBe("high");
+  expect(rawStore[key]?.reasoningLevel).toBe("on");
+});
+
+test("sessions.create validates thinkingLevel against inherited parent model", async () => {
+  const { storePath } = await createSessionStoreDir();
+  agentDiscoveryMock.enabled = true;
+  agentDiscoveryMock.models = [
+    { id: "no-reason", name: "No Reason", provider: "openai", reasoning: false },
+  ];
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent", {
+        providerOverride: "openai",
+        modelOverride: "no-reason",
+      }),
+    },
+  });
+
+  const created = await directSessionReq("sessions.create", {
+    agentId: "ops",
+    parentSessionKey: "main",
+    thinkingLevel: "high",
+  });
+
+  expect(created.ok).toBe(false);
+  expect((created.error as { message?: string } | undefined)?.message ?? "").toContain(
+    'thinkingLevel "high" is not supported for openai/no-reason',
+  );
+  const storeKeys = Object.keys(readSessionStore(storePath));
+  expect(storeKeys).toHaveLength(1);
+  expect(storeKeys.some((key) => key.startsWith("agent:ops:dashboard:"))).toBe(false);
+});
+
+test("sessions.create treats omitted thinkingLevel as inherited state, not explicit patch input", async () => {
+  const { storePath } = await createSessionStoreDir();
+  agentDiscoveryMock.enabled = true;
+  agentDiscoveryMock.models = [
+    { id: "no-reason", name: "No Reason", provider: "openai", reasoning: false },
+  ];
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent", {
+        providerOverride: "openai",
+        modelOverride: "no-reason",
+        thinkingLevel: "high",
+      }),
+    },
+  });
+
+  const created = await directSessionReq<{
+    key?: string;
+    entry?: {
+      modelOverride?: string;
+      thinkingLevel?: string;
+    };
+  }>("sessions.create", {
+    agentId: "ops",
+    parentSessionKey: "main",
+  });
+
+  expect(created.ok).toBe(true);
+  expect(created.payload?.entry?.modelOverride).toBe("no-reason");
+  expect(created.payload?.entry?.thinkingLevel).toBe("off");
+
+  const rawStore = readSessionStore(storePath);
+  const key = created.payload?.key as string;
+  expect(rawStore[key]?.thinkingLevel).toBe("off");
+});
+
 test("sessions.create inherits parent runtime model selection when model is omitted", async () => {
   const { storePath } = await createSessionStoreDir();
   await writeSessionStore({


### PR DESCRIPTION
## Summary

`sessions.create` now accepts `thinkingLevel` and `reasoningLevel`, applying them to the new session entry using the same validators `sessions.patch` already uses.

## Motivation

`sessions.patch` requires `operator.admin`, so a client that only holds `operator.write` (e.g. a CLI / flyway seat) cannot set a session's reasoning effort — the only path is a post-create patch, which silently no-ops without admin. `sessions.create` is already `operator.write` and already accepts `model`; adding the two thinking fields there lets a normal client set reasoning effort at create time, with no admin scope required.

## Changes

- `packages/gateway-protocol/src/schema/sessions.ts` — add `thinkingLevel` + `reasoningLevel` to `SessionsCreateParamsSchema`.
- `src/gateway/server-methods/sessions.ts` — pass both through to the create patch alongside the existing `model` handling (validated via `applySessionsPatchToStore`; `undefined` is a no-op).
- `src/gateway/server.sessions.create.test.ts` — tests for apply / inherited-validation / omitted-as-inherited behavior.

Validated identically to `sessions.patch` (`normalizeThinkLevel` / `normalizeReasoningLevel`). Opening as a draft pending your CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
