### PR TITLE
fix(gateway): reject unknown agent slugs on OpenAI-compatible endpoints

### DIFF
--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -9,7 +9,7 @@ import { resolveAgentDir } from "../agents/agent-scope.js";
 import { createConfigIO, resetConfigRuntimeState } from "../config/config.js";
 import type { MemoryEmbeddingProviderAdapter } from "../plugins/memory-embedding-providers.js";
 import { startOpenAiCompatGatewayServer } from "./openai-compatible-http.test-helpers.js";
-import { getFreePort, installGatewayTestHooks, testState } from "./test-helpers.js";
+import { getFreePort, installGatewayTestHooks, testState, writeGatewayConfig } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
@@ -278,6 +278,16 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
   });
 
   it("supports base64 encoding and agent-scoped auth/config resolution", async () => {
+    await writeGatewayConfig({
+      agents: {
+        list: [{ id: "main", default: true }, { id: "beta" }],
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+          models: { "openai/gpt-5.4": {} },
+        },
+      },
+    });
+
     const res = await postEmbeddings(
       {
         model: "openclaw/beta",

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -291,7 +291,14 @@ export async function handleOpenAiEmbeddingsHttpRequest(
     return true;
   }
 
-  const agentId = resolveAgentIdForRequest({ req, model: requestModel });
+  const agentResult = resolveAgentIdForRequest({ req, model: requestModel });
+  if ("error" in agentResult) {
+    sendJson(res, agentResult.error.status, {
+      error: { message: agentResult.error.message, type: "invalid_request_error" },
+    });
+    return true;
+  }
+  const agentId = agentResult.agentId;
   const agentDir = resolveAgentDir(cfg, agentId);
   const memorySearch = resolveMemorySearchConfig(cfg, agentId);
   const configuredProvider = memorySearch?.provider ?? "openai";

--- a/src/gateway/http-utils.agent-id.test.ts
+++ b/src/gateway/http-utils.agent-id.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests agent id resolution and roster validation for gateway OpenAI-compatible requests.
+ */
+import type { IncomingMessage } from "node:http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const loadConfigMock = vi.fn();
+
+vi.mock("../config/io.js", () => ({
+  getRuntimeConfig: () => loadConfigMock(),
+}));
+
+import { resolveAgentIdForRequest } from "./http-utils.js";
+
+function createReq(headers: Record<string, string> = {}): IncomingMessage {
+  return { headers } as IncomingMessage;
+}
+
+function createConfig(agentIds: string[]): OpenClawConfig {
+  return {
+    agents: {
+      list: agentIds.map((id) => ({ id })),
+      defaults: {
+        model: { primary: "openai/gpt-5.4" },
+      },
+    },
+  } satisfies OpenClawConfig;
+}
+
+describe("resolveAgentIdForRequest", () => {
+  beforeEach(() => {
+    loadConfigMock.mockReset().mockReturnValue(createConfig(["main", "beta"]));
+  });
+
+  it("resolves to the default agent when no explicit target is provided", () => {
+    const result = resolveAgentIdForRequest({ req: createReq(), model: undefined });
+    expect(result).toEqual({ agentId: "main" });
+  });
+
+  it("resolves openclaw/default to the default agent", () => {
+    const result = resolveAgentIdForRequest({ req: createReq(), model: "openclaw/default" });
+    expect(result).toEqual({ agentId: "main" });
+  });
+
+  it("resolves openclaw to the default agent", () => {
+    const result = resolveAgentIdForRequest({ req: createReq(), model: "openclaw" });
+    expect(result).toEqual({ agentId: "main" });
+  });
+
+  it("resolves a known agent from the model field", () => {
+    const result = resolveAgentIdForRequest({ req: createReq(), model: "openclaw/beta" });
+    expect(result).toEqual({ agentId: "beta" });
+  });
+
+  it("returns an error for an unknown agent in the model field", () => {
+    const result = resolveAgentIdForRequest({ req: createReq(), model: "openclaw/unknown" });
+    expect(result).toEqual({ error: { status: 404, message: "Unknown agent 'unknown'." } });
+  });
+
+  it("resolves a known agent from the x-openclaw-agent-id header", () => {
+    const result = resolveAgentIdForRequest({
+      req: createReq({ "x-openclaw-agent-id": "beta" }),
+      model: "openclaw",
+    });
+    expect(result).toEqual({ agentId: "beta" });
+  });
+
+  it("returns an error for an unknown agent in the x-openclaw-agent-id header", () => {
+    const result = resolveAgentIdForRequest({
+      req: createReq({ "x-openclaw-agent-id": "unknown" }),
+      model: "openclaw",
+    });
+    expect(result).toEqual({ error: { status: 404, message: "Unknown agent 'unknown'." } });
+  });
+
+  it("returns an error for an unknown agent in the x-openclaw-agent header", () => {
+    const result = resolveAgentIdForRequest({
+      req: createReq({ "x-openclaw-agent": "unknown" }),
+      model: "openclaw",
+    });
+    expect(result).toEqual({ error: { status: 404, message: "Unknown agent 'unknown'." } });
+  });
+
+  it("prioritizes the header over the model field", () => {
+    const result = resolveAgentIdForRequest({
+      req: createReq({ "x-openclaw-agent-id": "beta" }),
+      model: "openclaw/main",
+    });
+    expect(result).toEqual({ agentId: "beta" });
+  });
+});

--- a/src/gateway/http-utils.request-context.test.ts
+++ b/src/gateway/http-utils.request-context.test.ts
@@ -18,39 +18,56 @@ function createReq(headers: Record<string, string> = {}): IncomingMessage {
 const tokenAuth = { mode: "token" as const };
 const noneAuth = { mode: "none" as const };
 
+function requireContext(
+  result:
+    | { agentId: string; sessionKey: string; messageChannel: string }
+    | { error: { status: number; message: string } },
+): { agentId: string; sessionKey: string; messageChannel: string } {
+  if ("error" in result) {
+    throw new Error(`unexpected error: ${result.error.message}`);
+  }
+  return result;
+}
+
 describe("resolveGatewayRequestContext", () => {
   it("uses normalized x-openclaw-message-channel when enabled", () => {
-    const result = resolveGatewayRequestContext({
-      req: createReq({ "x-openclaw-message-channel": " Custom-Channel " }),
-      model: "openclaw",
-      sessionPrefix: "openai",
-      defaultMessageChannel: "webchat",
-      useMessageChannelHeader: true,
-    });
+    const result = requireContext(
+      resolveGatewayRequestContext({
+        req: createReq({ "x-openclaw-message-channel": " Custom-Channel " }),
+        model: "openclaw",
+        sessionPrefix: "openai",
+        defaultMessageChannel: "webchat",
+        useMessageChannelHeader: true,
+      }),
+    );
 
     expect(result.messageChannel).toBe("custom-channel");
   });
 
   it("uses default messageChannel when header support is disabled", () => {
-    const result = resolveGatewayRequestContext({
-      req: createReq({ "x-openclaw-message-channel": "custom-channel" }),
-      model: "openclaw",
-      sessionPrefix: "openresponses",
-      defaultMessageChannel: "webchat",
-      useMessageChannelHeader: false,
-    });
+    const result = requireContext(
+      resolveGatewayRequestContext({
+        req: createReq({ "x-openclaw-message-channel": "custom-channel" }),
+        model: "openclaw",
+        sessionPrefix: "openresponses",
+        defaultMessageChannel: "webchat",
+        useMessageChannelHeader: false,
+      }),
+    );
 
     expect(result.messageChannel).toBe("webchat");
   });
 
   it("includes session prefix and user in generated session key", () => {
-    const result = resolveGatewayRequestContext({
-      req: createReq(),
-      model: "openclaw",
-      user: "alice",
-      sessionPrefix: "openresponses",
-      defaultMessageChannel: "webchat",
-    });
+    const result = requireContext(
+      resolveGatewayRequestContext({
+        req: createReq(),
+        model: "openclaw",
+        user: "alice",
+        sessionPrefix: "openresponses",
+        defaultMessageChannel: "webchat",
+      }),
+    );
 
     expect(result.sessionKey).toContain("openresponses-user:alice");
   });

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -6,7 +6,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { modelKey, parseModelRef, resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { createModelVisibilityPolicy } from "../agents/model-visibility-policy.js";
 import { getRuntimeConfig } from "../config/io.js";
@@ -131,19 +131,40 @@ export async function resolveOpenAiCompatModelOverride(params: {
   return { modelOverride: raw };
 }
 
+function isExplicitNonDefaultModelSelection(model: string | undefined): boolean {
+  const raw = model?.trim();
+  if (!raw) {
+    return false;
+  }
+  const lowered = normalizeLowercaseStringOrEmpty(raw);
+  return lowered !== OPENCLAW_MODEL_ID && lowered !== OPENCLAW_DEFAULT_MODEL_ID;
+}
+
 /** Resolves the request agent from headers, model alias, or the configured default. */
 export function resolveAgentIdForRequest(params: {
   req: IncomingMessage;
   model: string | undefined;
-}): string {
+}): { agentId: string } | { error: { status: number; message: string } } {
   const cfg = getRuntimeConfig();
+  const roster = new Set(listAgentIds(cfg));
+
   const fromHeader = resolveAgentIdFromHeader(params.req);
   if (fromHeader) {
-    return fromHeader;
+    if (!roster.has(fromHeader)) {
+      return { error: { status: 404, message: `Unknown agent '${fromHeader}'.` } };
+    }
+    return { agentId: fromHeader };
   }
 
   const fromModel = resolveAgentIdFromModel(params.model, cfg);
-  return fromModel ?? resolveDefaultAgentId(cfg);
+  if (fromModel && isExplicitNonDefaultModelSelection(params.model)) {
+    if (!roster.has(fromModel)) {
+      return { error: { status: 404, message: `Unknown agent '${fromModel}'.` } };
+    }
+    return { agentId: fromModel };
+  }
+
+  return { agentId: fromModel ?? resolveDefaultAgentId(cfg) };
 }
 
 function resolveSessionKey(params: {
@@ -170,8 +191,14 @@ export function resolveGatewayRequestContext(params: {
   sessionPrefix: string;
   defaultMessageChannel: string;
   useMessageChannelHeader?: boolean;
-}): { agentId: string; sessionKey: string; messageChannel: string } {
-  const agentId = resolveAgentIdForRequest({ req: params.req, model: params.model });
+}):
+  | { agentId: string; sessionKey: string; messageChannel: string }
+  | { error: { status: number; message: string } } {
+  const agentResult = resolveAgentIdForRequest({ req: params.req, model: params.model });
+  if ("error" in agentResult) {
+    return agentResult;
+  }
+  const { agentId } = agentResult;
   const sessionKey = resolveSessionKey({
     req: params.req,
     agentId,

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -1,8 +1,6 @@
 // OpenAI-compatible HTTP tests cover chat completions, streaming, tool calls,
 // session context, auth scopes, and provider error mapping.
-import fs from "node:fs/promises";
 import http from "node:http";
-import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createClientToolNameConflictError } from "../agents/agent-tool-definition-adapter.js";
 import {
@@ -22,6 +20,7 @@ import {
   startGatewayServerWithRetries,
   testState,
   withGatewayServer,
+  writeGatewayConfig,
 } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
@@ -65,15 +64,6 @@ async function startTokenServer(port: number, opts?: { openAiChatCompletionsEnab
     controlUiEnabled: false,
     openAiChatCompletionsEnabled: opts?.openAiChatCompletionsEnabled ?? true,
   });
-}
-
-async function writeGatewayConfig(config: Record<string, unknown>) {
-  const configPath = process.env.OPENCLAW_CONFIG_PATH;
-  if (!configPath) {
-    throw new Error("OPENCLAW_CONFIG_PATH is required for gateway config tests");
-  }
-  await fs.mkdir(path.dirname(configPath), { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
 }
 
 async function postChatCompletions(port: number, body: unknown, headers?: Record<string, string>) {
@@ -210,6 +200,18 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(getFirstAgentCall()?.messageChannel).toBe("webchat");
         await res.text();
       }
+
+      await writeGatewayConfig({
+        agents: {
+          list: [{ id: "main", default: true }, { id: "beta" }],
+          defaults: {
+            model: { primary: "openai/gpt-5.4" },
+            models: {
+              "openai/gpt-5.4": {},
+            },
+          },
+        },
+      });
 
       await expectAgentSessionKeyMatch({
         body: { model: "openclaw", messages: [{ role: "user", content: "hi" }] },

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -962,7 +962,7 @@ export async function handleOpenAiHttpRequest(
         }
       : undefined;
 
-  const { agentId, sessionKey, messageChannel } = resolveGatewayRequestContext({
+  const resolvedContext = resolveGatewayRequestContext({
     req,
     model,
     user,
@@ -970,6 +970,13 @@ export async function handleOpenAiHttpRequest(
     defaultMessageChannel: "webchat",
     useMessageChannelHeader: true,
   });
+  if ("error" in resolvedContext) {
+    sendJson(res, resolvedContext.error.status, {
+      error: { message: resolvedContext.error.message, type: "invalid_request_error" },
+    });
+    return true;
+  }
+  const { agentId, sessionKey, messageChannel } = resolvedContext;
   const { modelOverride, errorMessage: modelError } = await resolveOpenAiCompatModelOverride({
     req,
     agentId,

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1,8 +1,6 @@
 // OpenAI Responses HTTP tests cover response creation, streaming, tool calls,
 // response-session lookup, limits, auth scopes, and provider error mapping.
-import fs from "node:fs/promises";
 import http from "node:http";
-import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createClientToolNameConflictError } from "../agents/agent-tool-definition-adapter.js";
 import { FailoverError } from "../agents/failover-error.js";
@@ -15,6 +13,7 @@ import {
   getFreePort,
   installGatewayTestHooks,
   startGatewayServerWithRetries,
+  writeGatewayConfig,
 } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
@@ -89,15 +88,6 @@ async function startTokenServer(port: number, opts?: { openResponsesEnabled?: bo
       ? { ...serverOpts, openResponsesEnabled: true }
       : { ...serverOpts, openResponsesEnabled: opts.openResponsesEnabled },
   );
-}
-
-async function writeGatewayConfig(config: Record<string, unknown>) {
-  const configPath = process.env.OPENCLAW_CONFIG_PATH;
-  if (!configPath) {
-    throw new Error("OPENCLAW_CONFIG_PATH is required for gateway config tests");
-  }
-  await fs.mkdir(path.dirname(configPath), { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
 }
 
 async function postResponses(port: number, body: unknown, headers?: Record<string, string>) {
@@ -298,6 +288,16 @@ describe("OpenResponses HTTP API (e2e)", () => {
       );
       expect(agentCommand).toHaveBeenCalledTimes(0);
       await ensureResponseConsumed(resInvalidModel);
+
+      await writeGatewayConfig({
+        agents: {
+          list: [{ id: "main", default: true }, { id: "beta" }],
+          defaults: {
+            model: { primary: "openai/gpt-5.4" },
+            models: { "openai/gpt-5.4": {} },
+          },
+        },
+      });
 
       mockAgentOnce([{ text: "hello" }]);
       const resHeader = await postResponses(

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -477,7 +477,14 @@ export async function handleOpenResponsesHttpRequest(
   const stream = Boolean(payload.stream);
   const model = payload.model;
   const user = payload.user;
-  const agentId = resolveAgentIdForRequest({ req, model });
+  const agentResult = resolveAgentIdForRequest({ req, model });
+  if ("error" in agentResult) {
+    sendJson(res, agentResult.error.status, {
+      error: { message: agentResult.error.message, type: "invalid_request_error" },
+    });
+    return true;
+  }
+  const agentId = agentResult.agentId;
   const { modelOverride, errorMessage: modelError } = await resolveOpenAiCompatModelOverride({
     req,
     agentId,
@@ -632,6 +639,12 @@ export async function handleOpenResponsesHttpRequest(
     defaultMessageChannel: "webchat",
     useMessageChannelHeader: true,
   });
+  if ("error" in resolved) {
+    sendJson(res, resolved.error.status, {
+      error: { message: resolved.error.message, type: "invalid_request_error" },
+    });
+    return true;
+  }
   const responseSessionScope = createResponseSessionScope({
     req,
     auth: opts.auth,

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -195,6 +195,18 @@ async function persistTestSessionConfig(): Promise<void> {
   lastSyncedSessionConfigJson = serializeGatewayTestSessionConfig();
 }
 
+export async function writeGatewayConfig(config: Record<string, unknown>): Promise<void> {
+  const configPath = process.env.OPENCLAW_CONFIG_PATH;
+  if (!configPath) {
+    throw new Error("OPENCLAW_CONFIG_PATH is required for gateway config tests");
+  }
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+  // Tests mutate config on disk while the gateway server runs in the same process.
+  // Clear the pinned runtime snapshot so the next handler load sees the new file.
+  resetConfigRuntimeState();
+}
+
 export async function writeSessionStore(params: {
   entries: Record<string, Partial<SessionEntry>>;
   storePath?: string;

--- a/src/gateway/test-helpers.ts
+++ b/src/gateway/test-helpers.ts
@@ -33,5 +33,6 @@ export {
   trackConnectChallengeNonce,
   waitForSystemEvent,
   withGatewayServer,
+  writeGatewayConfig,
   writeSessionStore,
 } from "./test-helpers.server.js";


### PR DESCRIPTION
## Summary

Closes #92504.

`resolveAgentIdForRequest` previously returned normalized header- or model-selected agent IDs directly and fell back to the default agent when no explicit target was supplied. It never checked whether the selected agent actually exists in the configured roster, so well-formed but unknown values such as `x-openclaw-agent-id: beta` or `model: openclaw/beta` silently ran under `agents.defaults`.

This change:

- Validates explicit non-default agent selections against `listAgentIds(cfg)`.
- Returns a structured `404 invalid_request_error` when an explicit agent is unknown.
- Keeps default routing unchanged when no explicit target is supplied (`openclaw`, `openclaw/default`, omitted `model`, or non-`openclaw` model values).
- Propagates the new error shape through chat-completions, responses, and embeddings handlers.
- Adds regression tests for `resolveAgentIdForRequest` and updates existing endpoint tests to seed a `beta` agent before asserting beta routing.

## Verification

```bash
node scripts/run-vitest.mjs src/gateway/http-utils.agent-id.test.ts src/gateway/http-utils.request-context.test.ts src/gateway/http-utils.model-override.test.ts --run
node scripts/run-vitest.mjs src/gateway/openai-http.test.ts --run
node scripts/run-vitest.mjs src/gateway/openresponses-http.test.ts --run
node scripts/run-vitest.mjs src/gateway/embeddings-http.test.ts --run
```

All passed locally. `git diff --check` clean.