### PR TITLE
fix(doctor): repair null agents.list[].workspace values

### DIFF
--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -187,6 +187,39 @@ describe("normalizeCompatibilityConfigValues", () => {
     );
   });
 
+  it("removes null workspace values from agents.list entries", () => {
+    const res = normalizeCompatibilityConfigValues({
+      agents: {
+        list: [
+          { id: "main", workspace: null as unknown as string },
+          { id: "beta", workspace: "/beta" },
+          { id: "gamma" },
+        ],
+      },
+    });
+
+    expect(res.config.agents?.list).toEqual([
+      { id: "main" },
+      { id: "beta", workspace: "/beta" },
+      { id: "gamma" },
+    ]);
+    expect(res.changes).toContain("Removed null workspace value from agents.list entry.");
+  });
+
+  it("does not alter agents.list when no workspace is null", () => {
+    const res = normalizeCompatibilityConfigValues({
+      agents: {
+        list: [{ id: "main", workspace: "/main" }, { id: "beta" }],
+      },
+    });
+
+    expect(res.config.agents?.list).toEqual([
+      { id: "main", workspace: "/main" },
+      { id: "beta" },
+    ]);
+    expect(res.changes.some((change) => change.includes("workspace"))).toBe(false);
+  });
+
   it("removes bindings for missing configured agents", () => {
     const res = normalizeCompatibilityConfigValues({
       agents: {

--- a/src/commands/doctor/shared/legacy-config-core-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-core-migrate.ts
@@ -10,6 +10,40 @@ import {
   normalizeLegacyOpenAICodexModelsAddMetadata,
 } from "./legacy-config-core-normalizers.js";
 
+function repairNullAgentWorkspaces(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
+  const agents = cfg.agents?.list;
+  if (!Array.isArray(agents)) {
+    return cfg;
+  }
+
+  let repaired = 0;
+  const nextAgents = agents.map((agent) => {
+    if (agent && typeof agent === "object" && (agent as Record<string, unknown>).workspace === null) {
+      repaired += 1;
+      const { workspace: _workspace, ...rest } = agent as Record<string, unknown>;
+      return rest;
+    }
+    return agent;
+  });
+
+  if (repaired === 0) {
+    return cfg;
+  }
+
+  changes.push(
+    `Removed null workspace value${repaired === 1 ? "" : "s"} from agents.list entr${
+      repaired === 1 ? "y" : "ies"
+    }.`,
+  );
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      list: nextAgents as typeof agents,
+    },
+  };
+}
+
 function pruneBindingsForMissingAgents(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
   const agents = cfg.agents?.list;
   const bindings = cfg.bindings;
@@ -71,6 +105,7 @@ export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
   }
   next = normalizeLegacyCommandsConfig(next, changes);
   next = normalizeLegacyOpenAICodexModelsAddMetadata(next, changes);
+  next = repairNullAgentWorkspaces(next, changes);
   next = pruneBindingsForMissingAgents(next, changes);
 
   return { config: next, changes };


### PR DESCRIPTION
## Summary

Fixes #77718.

A literal null `workspace` field in an `agents.list` entry still failed Zod schema validation at startup (workspace is optional but must be a string when present). Because `openclaw doctor --fix` never normalized the malformed field, users hit a crash loop that could only be recovered by manually editing `openclaw.json`.

This change adds a narrow compatibility migration in the core doctor pipeline that removes null `workspace` values from `agents.list` entries. The existing runtime fallback path (`agents.defaults.workspace` → default-agent workspace → stateDir-derived per-agent workspace) then supplies a valid workspace directory.

## Changes

- `src/commands/doctor/shared/legacy-config-core-migrate.ts`
  - New `repairNullAgentWorkspaces` migration step.
  - Called before binding pruning in `normalizeCompatibilityConfigValues`.

- `src/commands/doctor-legacy-config.migrations.test.ts`
  - Regression test: null workspace is removed.
  - Regression test: non-null / omitted workspaces are left untouched.

## Verification

```bash
node scripts/run-vitest.mjs src/commands/doctor-legacy-config.migrations.test.ts --run
node scripts/run-vitest.mjs src/config/config.schema-regressions.test.ts --run
node scripts/run-vitest.mjs src/gateway/server-startup-config.recovery.test.ts --run
```

All passed locally. `git diff --check` clean.

## Real behavior proof

**Behavior addressed:** `agents.list[].workspace: null` causes `openclaw config validate` to fail and blocks gateway startup until the field is manually removed.

**Real environment tested:** Local source checkout on branch `fix/doctor-null-agent-workspace`, Linux, Node 22, isolated with `--profile dev` and `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1`.

**Exact steps or command run after this patch:**

1. Create a minimal config with a literal null workspace:

```bash
mkdir -p /tmp/oc-proof/home/.openclaw-dev/.openclaw /tmp/oc-proof/home/.openclaw-dev/state
cat > /tmp/oc-proof/home/.openclaw-dev/.openclaw/openclaw.json <<'JSON'
{
  "agents": {
    "list": [
      { "id": "alpha", "workspace": null }
    ],
    "defaults": {}
  }
}
JSON
```

2. Validate the config before repair:

```bash
OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 \
OPENCLAW_HOME=/tmp/oc-proof/home \
OPENCLAW_CONFIG_PATH=/tmp/oc-proof/home/.openclaw-dev/.openclaw/openclaw.json \
OPENCLAW_STATE_DIR=/tmp/oc-proof/home/.openclaw-dev/state \
  node --import tsx src/entry.ts --dev config validate
```

3. Run doctor repair non-interactively:

```bash
OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 \
OPENCLAW_HOME=/tmp/oc-proof/home \
OPENCLAW_CONFIG_PATH=/tmp/oc-proof/home/.openclaw-dev/.openclaw/openclaw.json \
OPENCLAW_STATE_DIR=/tmp/oc-proof/home/.openclaw-dev/state \
  node --import tsx src/entry.ts --dev doctor --fix --non-interactive --yes
```

4. Validate the config after repair:

```bash
OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 \
OPENCLAW_HOME=/tmp/oc-proof/home \
OPENCLAW_CONFIG_PATH=/tmp/oc-proof/home/.openclaw-dev/.openclaw/openclaw.json \
OPENCLAW_STATE_DIR=/tmp/oc-proof/home/.openclaw-dev/state \
  node --import tsx src/entry.ts --dev config validate
```

**Evidence after fix:**

Before repair, validation fails with the null workspace error:

```text
OpenClaw config is invalid: $OPENCLAW_HOME/.openclaw-dev/.openclaw/openclaw.json
  × agents.list.0.workspace: Invalid input: expected string, received null

Run `openclaw --profile dev doctor --fix` to repair, or fix the keys above manually.
Inspect with openclaw --profile dev config validate.
```

Doctor reports the specific repair:

```text
◇  Doctor changes ───────────────────────────────────────╮
│                                                        │
│  Removed null workspace value from agents.list entry.  │
│                                                        │
├────────────────────────────────────────────────────────╯
```

After repair, validation passes:

```text
Config valid: $OPENCLAW_HOME/.openclaw-dev/.openclaw/openclaw.json
```

The repaired config no longer contains the null `workspace` field:

```json
{
  "agents": {
    "list": [
      { "id": "alpha" }
    ],
    "defaults": {}
  }
}
```

**Observed result after fix:** `openclaw doctor --fix` removes the literal null `workspace` field from `agents.list`, and the repaired config passes schema validation. The existing runtime/workspace fallback can then supply a valid per-agent workspace directory on gateway startup.

**What was not tested:** Live message dispatch or external channel integration; this change only affects config normalization.