### PR TITLE
test(reply): preserve telegram dedupe fallback

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -107,6 +107,16 @@ describe("buildReplyPayloads media filter integration", () => {
           },
           source: "test",
         },
+        {
+          pluginId: "telegram",
+          plugin: createChannelTestPluginBase({ id: "telegram" }),
+          source: "test",
+        },
+        {
+          pluginId: "discord",
+          plugin: createChannelTestPluginBase({ id: "discord" }),
+          source: "test",
+        },
       ]),
     );
   });

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -5,6 +5,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { isMessagingToolDuplicate } from "../../agents/embedded-agent-helpers.js";
 import type { MessagingToolSend } from "../../agents/embedded-agent-messaging.types.js";
+import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { getLoadedChannelPluginForRead } from "../../channels/plugins/registry-loaded-read.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -188,8 +189,7 @@ function targetsMatchForDedupe(params: {
   targetKey: string;
   targetThreadId?: string;
 }): boolean {
-  const pluginMatch = getLoadedChannelPluginForRead(params.provider)?.outbound
-    ?.targetsMatchForReplySuppression;
+  const pluginMatch = getChannelPlugin(params.provider)?.outbound?.targetsMatchForReplySuppression;
   if (pluginMatch) {
     return pluginMatch({
       originTarget: params.originTarget,
@@ -214,8 +214,7 @@ function resolveOriginThreadIdForPayload(params: {
     return originThreadId;
   }
   const replyToId = normalizeThreadIdForComparison(params.replyToId);
-  const resolveReplyTransport = getLoadedChannelPluginForRead(params.provider)?.threading
-    ?.resolveReplyTransport;
+  const resolveReplyTransport = getChannelPlugin(params.provider)?.threading?.resolveReplyTransport;
   if (!replyToId || !params.config || !resolveReplyTransport) {
     return originThreadId;
   }
@@ -326,7 +325,7 @@ export function getMatchingMessagingToolReplyTargets(params: {
     // that encode the thread/topic inside the target string carry their own
     // matcher and must still run it.
     const hasPluginThreadMatcher = Boolean(
-      getLoadedChannelPluginForRead(provider)?.outbound?.targetsMatchForReplySuppression,
+      getChannelPlugin(provider)?.outbound?.targetsMatchForReplySuppression,
     );
     if (!hasPluginThreadMatcher && (originRoute.threadId != null || targetRoute.threadId != null)) {
       return false;

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -1,5 +1,5 @@
 // Tests reply payload helper behavior and delivery metadata.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
@@ -25,6 +25,17 @@ function targetsMatchTelegramReplySuppression(params: {
     (originTopic === undefined || originTopic === params.targetThreadId)
   );
 }
+
+vi.mock("../../channels/plugins/bundled.js", () => ({
+  getBundledChannelPlugin: (channel: string) =>
+    channel === "telegram"
+      ? {
+          outbound: {
+            targetsMatchForReplySuppression: targetsMatchTelegramReplySuppression,
+          },
+        }
+      : undefined,
+}));
 
 describe("filterMessagingToolMediaDuplicates", () => {
   it("strips mediaUrl when it matches sentMediaUrls", () => {
@@ -251,7 +262,7 @@ describe("shouldDedupeMessagingToolRepliesForRoute", () => {
     ).toBe(true);
   });
 
-  it("uses generic route matching when the active plugin registry omits telegram", () => {
+  it("matches telegram replies even when the active plugin registry omits telegram", () => {
     resetPluginRuntimeStateForTest();
     setActivePluginRegistry(createTestRegistry([]));
 
@@ -263,7 +274,7 @@ describe("shouldDedupeMessagingToolRepliesForRoute", () => {
           { tool: "message", provider: "telegram", to: "-100123", threadId: "77" },
         ],
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Restore the Telegram bundled-fallback dedupe behavior that #90943 intentionally preserved.
- Restore the omitted-active-registry Telegram unit coverage.
- Fix the `agent-runner-payloads.test.ts` flake by seeding lightweight `telegram` and `discord` channel fixtures in that integration suite, avoiding cold bundled channel runtime loads from tests that only need generic route-dedupe fixtures.

Root cause: #93104 fixed the CI timeout by changing runtime lookup behavior, but recent provenance showed that reverted intentional behavior from #90943: Telegram topic suppression must still work through bundled fallback when the active registry omits Telegram. The correct deflake is to make the agent-runner payload integration suite install the provider ids it uses instead of falling through to bundled channel loading.

Refs #93104 and #91587.

## Verification

- Inspected `c67dc59b02` / #90943 and confirmed the commit explicitly preserved Telegram topic suppression through the plugin matcher path.
- Cold local repro with lightweight fixtures: first target-dedupe call was about 0.45s, subsequent calls were sub-millisecond.
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-payloads-dedupe.ts src/auto-reply/reply/reply-payloads.test.ts`
- `node scripts/run-oxlint.mjs src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-payloads-dedupe.ts src/auto-reply/reply/reply-payloads.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-payloads.test.ts src/auto-reply/reply/followup-delivery.test.ts -- --reporter=dot` (105 passed)
- `node scripts/run-vitest.mjs --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/abort.test.ts src/auto-reply/reply/acp-projector.test.ts src/auto-reply/reply/acp-stream-settings.test.ts src/auto-reply/reply/agent-runner-cli-dispatch.test.ts src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/agent-runner-helpers.test.ts src/auto-reply/reply/agent-runner-memory.dedup.test.ts src/auto-reply/reply/agent-runner-memory.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/agent-runner-reminder-guard.test.ts src/auto-reply/reply/agent-runner-runtime-config.test.ts src/auto-reply/reply/agent-runner-session-reset.test.ts src/auto-reply/reply/agent-runner-usage-line.test.ts src/auto-reply/reply/agent-runner-utils.secret-resolution.test.ts src/auto-reply/reply/agent-runner-utils.test.ts src/auto-reply/reply/agent-runner.final-media-runreplyagent.test.ts src/auto-reply/reply/agent-runner.media-paths.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts src/auto-reply/reply/bash-command.stop.test.ts src/auto-reply/reply/block-reply-pipeline.test.ts src/auto-reply/reply/block-streaming.test.ts -- --reporter=dot` (486 passed)
