### PR TITLE
fix(memory-core): report active dreaming phases in status

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -235,9 +235,10 @@ function formatDreamingSummary(cfg: OpenClawConfig): string {
   const remSummary = rem.enabled
     ? `rem=${formatCron(rem.cron)} · limit=${rem.limit} · lookbackDays=${rem.lookbackDays} · minPatternStrength=${rem.minPatternStrength}`
     : null;
-  const deepSummary = deep.enabled
-    ? `${formatCron(deep.cron)} · limit=${deep.limit} · minScore=${deep.minScore} · minRecallCount=${deep.minRecallCount} · minUniqueQueries=${deep.minUniqueQueries} · recencyHalfLifeDays=${deep.recencyHalfLifeDays} · maxAgeDays=${deep.maxAgeDays ?? "none"} · maxPromotedSnippetTokens=${deep.maxPromotedSnippetTokens}`
-    : null;
+  const hasLighterPhase = light.enabled || rem.enabled;
+  const deepLabel = hasLighterPhase ? "deep=" : "";
+  const deepDetails = `${formatCron(deep.cron)} · limit=${deep.limit} · minScore=${deep.minScore} · minRecallCount=${deep.minRecallCount} · minUniqueQueries=${deep.minUniqueQueries} · recencyHalfLifeDays=${deep.recencyHalfLifeDays} · maxAgeDays=${deep.maxAgeDays ?? "none"} · maxPromotedSnippetTokens=${deep.maxPromotedSnippetTokens}`;
+  const deepSummary = deep.enabled ? `${deepLabel}${deepDetails}` : null;
   const phases = [lightSummary, remSummary, deepSummary].filter(Boolean);
   return phases.length > 0 ? phases.join(" · ") : "off";
 }

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import type { MemoryEmbeddingProbeResult } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
   resolveMemoryDreamingConfig,
+  resolveMemoryLightDreamingConfig,
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
@@ -223,12 +224,22 @@ async function createHistoricalRemHarnessWorkspace(params: {
 
 function formatDreamingSummary(cfg: OpenClawConfig): string {
   const pluginConfig = resolveMemoryPluginConfig(cfg);
-  const dreaming = resolveShortTermPromotionDreamingConfig({ pluginConfig, cfg });
-  if (!dreaming.enabled) {
-    return "off";
-  }
-  const timezone = dreaming.timezone ? ` (${dreaming.timezone})` : "";
-  return `${dreaming.cron}${timezone} · limit=${dreaming.limit} · minScore=${dreaming.minScore} · minRecallCount=${dreaming.minRecallCount} · minUniqueQueries=${dreaming.minUniqueQueries} · recencyHalfLifeDays=${dreaming.recencyHalfLifeDays} · maxAgeDays=${dreaming.maxAgeDays ?? "none"} · maxPromotedSnippetTokens=${dreaming.maxPromotedSnippetTokens}`;
+  const light = resolveMemoryLightDreamingConfig({ pluginConfig, cfg });
+  const deep = resolveShortTermPromotionDreamingConfig({ pluginConfig, cfg });
+  const rem = resolveMemoryRemDreamingConfig({ pluginConfig, cfg });
+  const timezone = deep.timezone ?? light.timezone ?? rem.timezone;
+  const formatCron = (cron: string) => (timezone ? `${cron} (${timezone})` : cron);
+  const lightSummary = light.enabled
+    ? `light=${formatCron(light.cron)} · limit=${light.limit} · lookbackDays=${light.lookbackDays}`
+    : null;
+  const remSummary = rem.enabled
+    ? `rem=${formatCron(rem.cron)} · limit=${rem.limit} · lookbackDays=${rem.lookbackDays} · minPatternStrength=${rem.minPatternStrength}`
+    : null;
+  const deepSummary = deep.enabled
+    ? `${formatCron(deep.cron)} · limit=${deep.limit} · minScore=${deep.minScore} · minRecallCount=${deep.minRecallCount} · minUniqueQueries=${deep.minUniqueQueries} · recencyHalfLifeDays=${deep.recencyHalfLifeDays} · maxAgeDays=${deep.maxAgeDays ?? "none"} · maxPromotedSnippetTokens=${deep.maxPromotedSnippetTokens}`
+    : null;
+  const phases = [lightSummary, remSummary, deepSummary].filter(Boolean);
+  return phases.length > 0 ? phases.join(" · ") : "off";
 }
 
 function formatAuditCounts(audit: ShortTermAuditSummary): string {

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -836,6 +836,63 @@ describe("memory cli", () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it("labels deep dreaming when multiple phases are active during status", async () => {
+    getRuntimeConfig.mockReturnValue({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                frequency: "15 2 * * *",
+                timezone: "UTC",
+                phases: {
+                  light: {
+                    enabled: true,
+                    limit: 5,
+                    lookbackDays: 1,
+                  },
+                  deep: {
+                    enabled: true,
+                    limit: 7,
+                    minScore: 0.72,
+                    minRecallCount: 4,
+                    minUniqueQueries: 2,
+                    recencyHalfLifeDays: 10,
+                    maxAgeDays: 45,
+                    maxPromotedSnippetTokens: 512,
+                  },
+                  rem: {
+                    enabled: true,
+                    limit: 2,
+                    lookbackDays: 14,
+                    minPatternStrength: 0.67,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus(),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status"]);
+
+    expectLogged(log, "Dreaming: light=15 2 * * * (UTC) · limit=5 · lookbackDays=1");
+    expectLogged(log, "rem=15 2 * * * (UTC) · limit=2 · lookbackDays=14 · minPatternStrength=0.67");
+    expectLogged(log, "deep=15 2 * * * (UTC) · limit=7 · minScore=0.72");
+    expectLogged(log, "minRecallCount=4");
+    expectLogged(log, "maxPromotedSnippetTokens=512");
+    expect(close).toHaveBeenCalled();
+  });
+
   it("preserves deep dreaming diagnostics during status", async () => {
     getRuntimeConfig.mockReturnValue({
       plugins: {

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -746,6 +746,149 @@ describe("memory cli", () => {
     });
   });
 
+  it("reports light-only dreaming as active during status", async () => {
+    getRuntimeConfig.mockReturnValue({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                frequency: "5 * * * *",
+                timezone: "UTC",
+                phases: {
+                  light: {
+                    enabled: true,
+                    limit: 4,
+                    lookbackDays: 2,
+                  },
+                  deep: {
+                    enabled: false,
+                  },
+                  rem: {
+                    enabled: false,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus(),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status"]);
+
+    expectLogged(log, "Dreaming: light=5 * * * * (UTC) · limit=4 · lookbackDays=2");
+    expect(close).toHaveBeenCalled();
+  });
+
+  it("reports rem-only dreaming as active during status", async () => {
+    getRuntimeConfig.mockReturnValue({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                frequency: "0 6 * * 0",
+                timezone: "UTC",
+                phases: {
+                  light: {
+                    enabled: false,
+                  },
+                  deep: {
+                    enabled: false,
+                  },
+                  rem: {
+                    enabled: true,
+                    limit: 3,
+                    lookbackDays: 9,
+                    minPatternStrength: 0.81,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus(),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status"]);
+
+    expectLogged(
+      log,
+      "Dreaming: rem=0 6 * * 0 (UTC) · limit=3 · lookbackDays=9 · minPatternStrength=0.81",
+    );
+    expect(close).toHaveBeenCalled();
+  });
+
+  it("preserves deep dreaming diagnostics during status", async () => {
+    getRuntimeConfig.mockReturnValue({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                frequency: "0 4 * * *",
+                timezone: "UTC",
+                phases: {
+                  light: {
+                    enabled: false,
+                  },
+                  deep: {
+                    enabled: true,
+                    limit: 6,
+                    minScore: 0.88,
+                    minRecallCount: 5,
+                    minUniqueQueries: 3,
+                    recencyHalfLifeDays: 12,
+                    maxAgeDays: 30,
+                    maxPromotedSnippetTokens: 640,
+                  },
+                  rem: {
+                    enabled: false,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus(),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status"]);
+
+    expectLogged(log, "Dreaming: 0 4 * * * (UTC) · limit=6 · minScore=0.88");
+    expectLogged(log, "minRecallCount=5");
+    expectLogged(log, "minUniqueQueries=3");
+    expectLogged(log, "recencyHalfLifeDays=12");
+    expectLogged(log, "maxAgeDays=30");
+    expectLogged(log, "maxPromotedSnippetTokens=640");
+    expect(close).toHaveBeenCalled();
+  });
+
   it("repairs invalid recall metadata and stale locks with status --fix", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await shortTermTesting.writeRawRecallStore(workspaceDir, {


### PR DESCRIPTION
## Summary

- Fix `memory status` so it reports active light-only and REM-only dreaming instead of deriving the `Dreaming` line solely from the deep promotion config.
- Keep the existing deep-only status detail intact, including the current promotion thresholds and limits, to avoid the compatibility regression that blocked the prior replacement PR.
- Add focused CLI regression coverage for light-only, REM-only, and deep-detail-preservation status output.

What problem does this PR solve?
`openclaw memory status` could print `Dreaming: off` when global dreaming was enabled but only the light or REM phase was active.

Why does this matter now?
`#67868` is still open, source-reproducible on current `main`, and the last replacement PR was self-closed after ClawSweeper flagged missing REM coverage and dropped deep diagnostics.

What is the intended outcome?
Operators should see truthful phase-aware dreaming status without losing the existing deep promotion detail they already rely on.

What is intentionally out of scope?
No scheduler, config-schema, or dreaming execution changes. This only touches status formatting and regression coverage.

What does success look like?
Light-only and REM-only configs show active dreaming in `memory status`, deep-only configs keep their detailed thresholds, and the focused memory-core suites stay green.

What should reviewers focus on?
The `formatDreamingSummary` contract in `extensions/memory-core/src/cli.runtime.ts` and the new regression cases in `extensions/memory-core/src/cli.test.ts`.

## Linked context

Closes #67868

Related #92979
Related #67910
Related #67923
Related #67882

Was this requested by a maintainer or owner?
No direct maintainer request. This is a replacement for previously closed attempts on the same issue.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
  `memory status` incorrectly printed `Dreaming: off` for light-only and REM-only dreaming configs.
- Real environment tested:
  Local `main` checkout on macOS with an isolated temporary `HOME`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, temp workspace, and temp `OPENCLAW_CONFIG_PATH`.
- Exact steps or command run after this patch:
  `HOME="$HOME_DIR" OPENCLAW_HOME="$HOME_DIR/.openclaw" OPENCLAW_STATE_DIR="$STATE_DIR" OPENCLAW_CONFIG_PATH="$TMPROOT/light.json" pnpm openclaw memory status --agent main`
  `HOME="$HOME_DIR" OPENCLAW_HOME="$HOME_DIR/.openclaw" OPENCLAW_STATE_DIR="$STATE_DIR" OPENCLAW_CONFIG_PATH="$TMPROOT/rem.json" pnpm openclaw memory status --agent main`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
LIGHT
Memory Search (main)
Provider: openai (requested: openai)
Model: openai
Sources: memory
Indexed: 0/0 files · 0 chunks
Dirty: yes
Store: /tmp/openclaw-memory-status-proof.1QCdHp/state/memory/main.sqlite
Workspace: /tmp/openclaw-memory-status-proof.1QCdHp/workspace
Dreaming: light=5 * * * * (UTC) · limit=4 · lookbackDays=2
```

```text
REM
Memory Search (main)
Provider: openai (requested: openai)
Model: openai
Sources: memory
Indexed: 0/0 files · 0 chunks
Dirty: yes
Store: /tmp/openclaw-memory-status-proof.1QCdHp/state/memory/main.sqlite
Workspace: /tmp/openclaw-memory-status-proof.1QCdHp/workspace
Dreaming: rem=0 6 * * 0 (UTC) · limit=3 · lookbackDays=9 · minPatternStrength=0.81
```

- Observed result after fix:
  Both isolated runs now show active dreaming with the expected phase-specific summary instead of `Dreaming: off`.
- What was not tested:
  No live background cron sweep or Dream Diary execution was run; this PR does not change dreaming execution.
- Proof limitations or environment constraints:
  The proof uses isolated temporary state rather than an existing long-lived gateway workspace, because the issue is a status-formatting bug and the formatter is fully config-driven.
- Before evidence (optional but encouraged):
  Focused Vitest coverage on current main failed with `Dreaming: off` for both light-only and REM-only configs before this patch.

## Tests and validation

- `pnpm test -- extensions/memory-core/src/cli.test.ts -t "dreaming"`
- `pnpm test -- extensions/memory-core/src/cli.test.ts extensions/memory-core/src/dreaming.test.ts extensions/memory-core/src/dreaming-phases.test.ts`
- `git diff --check`

What regression coverage was added or updated?
Added status assertions for light-only, REM-only, and deep-detail-preservation cases in `extensions/memory-core/src/cli.test.ts`.

What failed before this fix, if known?
The new light-only and REM-only status tests failed on current main because the formatter still returned `Dreaming: off`.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
Yes

Did config, environment, or migration behavior change? (`Yes/No`)
No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
No

What is the highest-risk area?
The `memory status` text contract for deep-only dreaming output.

How is that risk mitigated?
The formatter keeps the existing deep-only detail, and the new regression test asserts those deep diagnostics still appear.

## Current review state

What is the next action?
Maintainer review plus normal CI.

What is still waiting on author, maintainer, CI, or external proof?
CI has not run yet on GitHub. Author-side proof and focused tests are included above.

Which bot or reviewer comments were addressed?
This replacement explicitly addresses the gaps called out on #92979: REM coverage, preserved deep diagnostics, and real `memory status` output.
