### PR TITLE
fix(gateway): guard fast-path startup migrations

### DIFF
--- a/src/cli/command-bootstrap.ts
+++ b/src/cli/command-bootstrap.ts
@@ -1,4 +1,5 @@
 // Shared command preflight: config readiness plus optional plugin registry activation.
+import type { ConfigFileSnapshot } from "../config/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import type { CliPluginRegistryPolicy } from "./command-catalog.js";
@@ -18,6 +19,7 @@ export async function ensureCliCommandBootstrap(params: {
   suppressDoctorStdout?: boolean;
   skipConfigGuard?: boolean;
   allowInvalid?: boolean;
+  beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
   loadPlugins?: boolean;
   pluginRegistry?: CliPluginRegistryPolicy;
 }) {
@@ -27,6 +29,9 @@ export async function ensureCliCommandBootstrap(params: {
       runtime: params.runtime,
       commandPath: params.commandPath,
       ...(params.allowInvalid ? { allowInvalid: true } : {}),
+      ...(params.beforeStateMigrations
+        ? { beforeStateMigrations: params.beforeStateMigrations }
+        : {}),
       ...(params.suppressDoctorStdout ? { suppressDoctorStdout: true } : {}),
     });
   }

--- a/src/cli/command-execution-startup.ts
+++ b/src/cli/command-execution-startup.ts
@@ -1,4 +1,5 @@
 // CLI startup context, banner/log presentation, and bootstrap orchestration.
+import type { ConfigFileSnapshot } from "../config/types.js";
 import { routeLogsToStderr } from "../logging/console.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
@@ -65,6 +66,7 @@ export async function ensureCliExecutionBootstrap(params: {
   commandPath: string[];
   startupPolicy: CliStartupPolicy;
   allowInvalid?: boolean;
+  beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
   loadPlugins?: boolean;
   skipConfigGuard?: boolean;
 }) {
@@ -73,6 +75,9 @@ export async function ensureCliExecutionBootstrap(params: {
     commandPath: params.commandPath,
     suppressDoctorStdout: params.startupPolicy.suppressDoctorStdout,
     allowInvalid: params.allowInvalid,
+    ...(params.beforeStateMigrations
+      ? { beforeStateMigrations: params.beforeStateMigrations }
+      : {}),
     loadPlugins: params.loadPlugins ?? params.startupPolicy.loadPlugins,
     pluginRegistry: params.startupPolicy.pluginRegistry,
     skipConfigGuard: params.skipConfigGuard ?? params.startupPolicy.skipConfigGuard,

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -339,6 +339,13 @@ describe("command-path-policy", () => {
     expect(resolveCliNetworkProxyPolicy(argv)).toBe("default");
   });
 
+  it("resolves gateway runs after root options with values", () => {
+    const argv = ["node", "openclaw", "--log-level", "debug", "gateway", "run"];
+
+    expect(resolveCliCatalogCommandPath(argv)).toEqual(["gateway"]);
+    expect(resolveCliNetworkProxyPolicy(argv)).toBe("default");
+  });
+
   it("does not let gateway run option values spoof bypass subcommands", () => {
     for (const argv of [
       ["node", "openclaw", "gateway", "--token", "status"],

--- a/src/cli/dotenv.ts
+++ b/src/cli/dotenv.ts
@@ -4,11 +4,14 @@ import { resolveStateDir } from "../config/paths.js";
 import { loadGlobalRuntimeDotEnvFiles, loadWorkspaceDotEnvFile } from "../infra/dotenv.js";
 
 /** Load `.env` files for normal CLI commands without overriding existing process env. */
-export function loadCliDotEnv(opts?: { quiet?: boolean }) {
+export function loadCliDotEnv(opts?: { loadGlobalEnv?: boolean; quiet?: boolean }) {
   const quiet = opts?.quiet ?? true;
   const cwdEnvPath = path.join(process.cwd(), ".env");
   loadWorkspaceDotEnvFile(cwdEnvPath, { quiet });
 
+  if (opts?.loadGlobalEnv === false) {
+    return;
+  }
   // Then load the global fallback set without overriding any env vars that
   // were already set or loaded from CWD. This includes the Ubuntu fresh-install
   // gateway.env compatibility path.

--- a/src/cli/gateway-cli/future-config-guard.ts
+++ b/src/cli/gateway-cli/future-config-guard.ts
@@ -1,4 +1,9 @@
 import {
+  cloneEnvWithPlatformSemantics,
+  createConfigRuntimeEnv,
+} from "../../config/config-env-vars.js";
+import {
+  ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV,
   formatFutureConfigActionBlock,
   resolveFutureConfigActionBlock,
 } from "../../config/future-version-guard.js";
@@ -12,24 +17,41 @@ export type GatewayRunPreBootstrapOptions = Pick<GatewayRunOpts, "force" | "rese
 type GatewayRunFutureConfigGuardParams = {
   opts: GatewayRunPreBootstrapOptions;
   snapshot?: ConfigFileSnapshot | null;
-  config?: Pick<OpenClawConfig, "meta"> | null;
+  config?: Pick<OpenClawConfig, "env" | "meta"> | null;
 };
 
 function resolveGatewayRunFutureConfigBlock(params: GatewayRunFutureConfigGuardParams) {
+  const processServiceMode = Boolean(process.env.OPENCLAW_SERVICE_MARKER?.trim());
+  const candidateConfig =
+    params.config ??
+    (params.snapshot?.valid ? (params.snapshot.sourceConfig ?? params.snapshot.config) : undefined);
+  const candidateServiceMode =
+    !params.opts.reset &&
+    Boolean(
+      candidateConfig
+        ? createConfigRuntimeEnv(candidateConfig, process.env).OPENCLAW_SERVICE_MARKER?.trim()
+        : undefined,
+    );
+  const serviceMode = processServiceMode || candidateServiceMode;
   // Reset runs before service/force startup, while ordinary startup now runs state migrations.
   const futureAction = params.opts.reset
     ? { action: "reset the dev gateway state", exitCode: 1 }
-    : process.env.OPENCLAW_SERVICE_MARKER?.trim()
+    : serviceMode
       ? { action: "start the gateway service", exitCode: 78 }
       : params.opts.force
         ? { action: "force-kill gateway port listeners", exitCode: 1 }
         : { action: "run automatic gateway startup migrations", exitCode: 1 };
+  const guardEnv = serviceMode ? cloneEnvWithPlatformSemantics(process.env) : process.env;
+  if (serviceMode) {
+    delete guardEnv[ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV];
+  }
   const block = resolveFutureConfigActionBlock({
     action: futureAction.action,
     snapshot: params.snapshot,
     config: params.config,
+    env: guardEnv,
   });
-  return block ? { block, exitCode: futureAction.exitCode } : null;
+  return block ? { block, exitCode: futureAction.exitCode, serviceMode } : null;
 }
 
 export function isGatewayRunFutureConfigAllowed(
@@ -44,6 +66,9 @@ export function enforceGatewayRunFutureConfigGuard(
   const resolved = resolveGatewayRunFutureConfigBlock(params);
   if (!resolved) {
     return true;
+  }
+  if (resolved.serviceMode) {
+    delete process.env[ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV];
   }
   params.runtime.error(formatFutureConfigActionBlock(resolved.block));
   params.runtime.exit(resolved.exitCode);

--- a/src/cli/gateway-cli/future-config-guard.ts
+++ b/src/cli/gateway-cli/future-config-guard.ts
@@ -1,0 +1,51 @@
+import {
+  formatFutureConfigActionBlock,
+  resolveFutureConfigActionBlock,
+} from "../../config/future-version-guard.js";
+// Gateway-specific future-config actions shared by pre-bootstrap and runtime startup.
+import type { ConfigFileSnapshot, OpenClawConfig } from "../../config/types.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import type { GatewayRunOpts } from "./run-options.js";
+
+export type GatewayRunPreBootstrapOptions = Pick<GatewayRunOpts, "force" | "reset">;
+
+type GatewayRunFutureConfigGuardParams = {
+  opts: GatewayRunPreBootstrapOptions;
+  snapshot?: ConfigFileSnapshot | null;
+  config?: Pick<OpenClawConfig, "meta"> | null;
+};
+
+function resolveGatewayRunFutureConfigBlock(params: GatewayRunFutureConfigGuardParams) {
+  // Reset runs before service/force startup, while ordinary startup now runs state migrations.
+  const futureAction = params.opts.reset
+    ? { action: "reset the dev gateway state", exitCode: 1 }
+    : process.env.OPENCLAW_SERVICE_MARKER?.trim()
+      ? { action: "start the gateway service", exitCode: 78 }
+      : params.opts.force
+        ? { action: "force-kill gateway port listeners", exitCode: 1 }
+        : { action: "run automatic gateway startup migrations", exitCode: 1 };
+  const block = resolveFutureConfigActionBlock({
+    action: futureAction.action,
+    snapshot: params.snapshot,
+    config: params.config,
+  });
+  return block ? { block, exitCode: futureAction.exitCode } : null;
+}
+
+export function isGatewayRunFutureConfigAllowed(
+  params: GatewayRunFutureConfigGuardParams,
+): boolean {
+  return resolveGatewayRunFutureConfigBlock(params) === null;
+}
+
+export function enforceGatewayRunFutureConfigGuard(
+  params: GatewayRunFutureConfigGuardParams & { runtime: RuntimeEnv },
+): boolean {
+  const resolved = resolveGatewayRunFutureConfigBlock(params);
+  if (!resolved) {
+    return true;
+  }
+  params.runtime.error(formatFutureConfigActionBlock(resolved.block));
+  params.runtime.exit(resolved.exitCode);
+  return false;
+}

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -469,6 +469,15 @@ export async function applyFinalGatewayRunConfigEnv(params: {
   const preparedSnapshot = preparedGatewayRunBootstrapSnapshot;
   preparedGatewayRunBootstrapSnapshot = undefined;
   if (!params.snapshot.valid) {
+    restoreAppliedGatewayRunConfigEnvironment(false);
+    if (preparedSnapshot) {
+      params.runtime.error(
+        "Refusing to start the gateway because the final config read became invalid. Retry startup after fixing the config.",
+      );
+      params.runtime.exit(1);
+      return false;
+    }
+    await pinGatewayRunRuntimePaths();
     return true;
   }
   const invocationDestructiveOverride = resolveInvocationDestructiveOverride();

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -1,0 +1,682 @@
+// Gateway startup checks that must run before shared CLI bootstrap can migrate state.
+import { ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV } from "../../config/future-version-guard.js";
+import type { ConfigFileSnapshot } from "../../config/types.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import type { GatewayRunPreBootstrapOptions } from "./future-config-guard.js";
+import { enforceGatewayRunFutureConfigGuard } from "./future-config-guard.js";
+import { getGatewayRunRuntimeHooks } from "./runtime-hooks.js";
+
+type GatewayRunGuardParams = {
+  opts: GatewayRunPreBootstrapOptions;
+  runtime: RuntimeEnv;
+};
+
+type GatewayRunEnvironmentSelection = {
+  after: Record<string, string | undefined>;
+  before: Record<string, string | undefined>;
+};
+
+type PreparedGatewayRunReset = {
+  selectionEnvironment: Record<string, string | undefined>;
+  selectionSignature: string;
+  snapshot: ConfigFileSnapshot;
+};
+
+let selectedGatewayRunEnvironment: GatewayRunEnvironmentSelection | undefined;
+let appliedGatewayRunConfigEnvironment: GatewayRunEnvironmentSelection | undefined;
+let lastGuardedGatewayRunSnapshot: ConfigFileSnapshot | undefined;
+let preparedGatewayRunBootstrapSnapshot: ConfigFileSnapshot | undefined;
+let preparedGatewayRunReset: PreparedGatewayRunReset | undefined;
+let gatewayRunTargetSelectedByConfig = false;
+
+async function pinGatewayRunRuntimePaths(): Promise<void> {
+  const [{ pinRuntimePaths }, { pinConfigDir }] = await Promise.all([
+    import("../../config/paths.js"),
+    import("../../utils.js"),
+  ]);
+  pinRuntimePaths(process.env);
+  pinConfigDir(process.env);
+}
+
+const GATEWAY_CONFIG_SELECTION_ENV_KEYS = new Set([
+  "ANDROID_DATA",
+  "HOME",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "OPENCLAW_AGENT_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_HOME",
+  "OPENCLAW_INCLUDE_ROOTS",
+  "OPENCLAW_NIX_MODE",
+  "OPENCLAW_OAUTH_DIR",
+  "OPENCLAW_PACKAGE_DIR",
+  "OPENCLAW_PROFILE",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_TEST_FAST",
+  "OPENCLAW_WORKSPACE_DIR",
+  "PI_CODING_AGENT_DIR",
+  "PREFIX",
+  "USERPROFILE",
+]);
+
+const GATEWAY_RESET_SELECTION_ENV_KEYS = new Set([
+  ...GATEWAY_CONFIG_SELECTION_ENV_KEYS,
+  "OPENCLAW_PROFILE",
+  "OPENCLAW_WORKSPACE_DIR",
+]);
+
+function resolveGatewayConfigSelectionSignature(env: NodeJS.ProcessEnv): string {
+  return JSON.stringify([...GATEWAY_CONFIG_SELECTION_ENV_KEYS].map((key) => [key, env[key]]));
+}
+
+function snapshotGatewayConfigSelectionEnvironment(
+  env: NodeJS.ProcessEnv,
+): Record<string, string | undefined> {
+  return Object.fromEntries([...GATEWAY_CONFIG_SELECTION_ENV_KEYS].map((key) => [key, env[key]]));
+}
+
+function restoreGatewayConfigSelectionEnvironment(
+  snapshot: Record<string, string | undefined>,
+): void {
+  for (const key of GATEWAY_CONFIG_SELECTION_ENV_KEYS) {
+    const value = snapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function resolveGatewayRunDotEnvPaths(params: {
+  env: NodeJS.ProcessEnv;
+  join: (...paths: string[]) => string;
+  resolve: (path: string) => string;
+  resolveConfigDir: (env: NodeJS.ProcessEnv) => string;
+  resolveStateDir: (env: NodeJS.ProcessEnv) => string;
+}): { additionalEnvPaths?: string[]; stateEnvPath: string } {
+  const stateEnvPath = params.join(params.resolveStateDir(params.env), ".env");
+  const configEnvPath = params.join(params.resolveConfigDir(params.env), ".env");
+  return params.resolve(stateEnvPath) === params.resolve(configEnvPath)
+    ? { stateEnvPath }
+    : { additionalEnvPaths: [configEnvPath], stateEnvPath };
+}
+
+function resolveInvocationDestructiveOverride(): string | undefined {
+  if (process.env.OPENCLAW_SERVICE_MARKER?.trim()) {
+    delete process.env[ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV];
+    return undefined;
+  }
+  return process.env[ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV];
+}
+
+function applyInvocationDestructiveOverride(value: string | undefined): void {
+  if (process.env.OPENCLAW_SERVICE_MARKER?.trim() || value === undefined) {
+    delete process.env[ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV];
+  } else {
+    process.env[ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV] = value;
+  }
+}
+
+function restoreGatewayEnvChanges(params: {
+  before: Record<string, string | undefined>;
+  after: Record<string, string | undefined>;
+  preservedKeys?: ReadonlySet<string>;
+}): void {
+  const keys = new Set([...Object.keys(params.before), ...Object.keys(params.after)]);
+  for (const key of keys) {
+    const preservedKey = process.platform === "win32" ? key.toUpperCase() : key;
+    if (params.preservedKeys?.has(preservedKey)) {
+      continue;
+    }
+    if (params.before[key] === params.after[key] || process.env[key] !== params.after[key]) {
+      continue;
+    }
+    const previous = params.before[key];
+    if (previous === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = previous;
+    }
+  }
+}
+
+function restoreSupersededGatewaySelectionEnv(params: {
+  beforeCurrentPass: Record<string, string | undefined>;
+  environmentSelection?: GatewayRunEnvironmentSelection;
+}): void {
+  restoreGatewayEnvChanges({
+    before: params.beforeCurrentPass,
+    after: { ...process.env },
+    preservedKeys: GATEWAY_CONFIG_SELECTION_ENV_KEYS,
+  });
+  if (params.environmentSelection) {
+    // Remove only values introduced by the early selection phase. Later mutations such as
+    // managed-proxy env differ from the recorded after-snapshot and remain intact.
+    restoreGatewayEnvChanges({
+      before: params.environmentSelection.before,
+      after: params.environmentSelection.after,
+      preservedKeys: GATEWAY_CONFIG_SELECTION_ENV_KEYS,
+    });
+  }
+}
+
+function restoreAppliedGatewayRunConfigEnvironment(preserveSelection = true): void {
+  const applied = appliedGatewayRunConfigEnvironment;
+  appliedGatewayRunConfigEnvironment = undefined;
+  if (!applied) {
+    return;
+  }
+  restoreGatewayEnvChanges({
+    before: applied.before,
+    after: applied.after,
+    ...(preserveSelection ? { preservedKeys: GATEWAY_CONFIG_SELECTION_ENV_KEYS } : {}),
+  });
+}
+
+async function readGuardedGatewayRunConfig(
+  params: GatewayRunGuardParams,
+): Promise<ConfigFileSnapshot | null> {
+  const { readConfigFileSnapshot } = await import("../../config/config.js");
+  const snapshot = await readConfigFileSnapshot({ isolateEnv: true, observe: false });
+  return enforceGatewayRunFutureConfigGuard({
+    opts: params.opts,
+    runtime: params.runtime,
+    snapshot,
+  })
+    ? snapshot
+    : null;
+}
+
+async function isSameGatewayRunConfigSnapshot(
+  expected: ConfigFileSnapshot,
+  current: ConfigFileSnapshot,
+  options: { allowPathChange?: boolean } = {},
+): Promise<boolean> {
+  const { hashRuntimeConfigValue } = await import("../../config/runtime-snapshot.js");
+  return (
+    (options.allowPathChange || current.path === expected.path) &&
+    current.exists === expected.exists &&
+    (current.hash ?? current.raw) === (expected.hash ?? expected.raw) &&
+    hashRuntimeConfigValue(current.sourceConfig) === hashRuntimeConfigValue(expected.sourceConfig)
+  );
+}
+
+function resolveGatewayConfigSelectionDeclarationSignature(
+  entries: Record<string, string>,
+): string {
+  const normalized = new Map(
+    Object.entries(entries).map(([key, value]) => [key.toUpperCase(), value]),
+  );
+  return JSON.stringify(
+    [...GATEWAY_CONFIG_SELECTION_ENV_KEYS].map((key) => [key, normalized.get(key)]),
+  );
+}
+
+async function recoverGuardedGatewayRunConfig(
+  params: GatewayRunGuardParams & { restoreSuspicious: boolean },
+): Promise<ConfigFileSnapshot | null> {
+  const { readConfigFileSnapshot } = await import("../../config/config.js");
+  let recoveryAllowed = true;
+  const recoveredSnapshot = await readConfigFileSnapshot({
+    isolateEnv: true,
+    recoverSuspicious: true,
+    allowSuspiciousRecovery: (config, current) => {
+      recoveryAllowed = enforceGatewayRunFutureConfigGuard({
+        opts: params.opts,
+        runtime: params.runtime,
+        config: current,
+      });
+      if (recoveryAllowed) {
+        recoveryAllowed = enforceGatewayRunFutureConfigGuard({
+          opts: params.opts,
+          runtime: params.runtime,
+          config,
+        });
+      }
+      return params.restoreSuspicious && recoveryAllowed;
+    },
+  });
+  if (!recoveryAllowed) {
+    return null;
+  }
+  // Recovery can select a different config, so enforce the same guard again before migrations.
+  return enforceGatewayRunFutureConfigGuard({
+    opts: params.opts,
+    runtime: params.runtime,
+    snapshot: recoveredSnapshot,
+  })
+    ? recoveredSnapshot
+    : null;
+}
+
+async function guardGatewayRunSelectedConfig(
+  params: GatewayRunGuardParams & {
+    environmentSelection?: GatewayRunEnvironmentSelection;
+    recoverSuspicious: boolean;
+    restoreSuspicious: boolean;
+  },
+): Promise<boolean> {
+  lastGuardedGatewayRunSnapshot = undefined;
+  const [
+    path,
+    { applyConfigEnvVars, isConfigRuntimeEnvVarAllowed },
+    { loadGlobalRuntimeDotEnvFiles },
+    { normalizeEnv },
+    { normalizeStateDirEnv, resolveStateDir },
+    { resolveConfigDir },
+  ] = await Promise.all([
+    import("node:path"),
+    import("../../config/env-vars.js"),
+    import("../../infra/dotenv-global.js"),
+    import("../../infra/env.js"),
+    import("../../config/paths.js"),
+    import("../../utils.js"),
+  ]);
+  const invocationDestructiveOverride = resolveInvocationDestructiveOverride();
+  if (params.environmentSelection) {
+    restoreAppliedGatewayRunConfigEnvironment();
+    restoreGatewayEnvChanges({
+      before: params.environmentSelection.before,
+      after: params.environmentSelection.after,
+      preservedKeys: GATEWAY_CONFIG_SELECTION_ENV_KEYS,
+    });
+  }
+  const applyTrustedGatewayEnv = () => {
+    normalizeStateDirEnv(process.env);
+    const loaded = loadGlobalRuntimeDotEnvFiles({
+      ...(gatewayRunTargetSelectedByConfig ? { entryFilter: isConfigRuntimeEnvVarAllowed } : {}),
+      quiet: true,
+      ...resolveGatewayRunDotEnvPaths({
+        env: process.env,
+        join: path.join,
+        resolve: path.resolve,
+        resolveConfigDir,
+        resolveStateDir,
+      }),
+    });
+    normalizeStateDirEnv(process.env);
+    normalizeEnv();
+    applyInvocationDestructiveOverride(invocationDestructiveOverride);
+    return loaded;
+  };
+  const applySelectedConfigEnv = (snapshot: ConfigFileSnapshot) => {
+    restoreAppliedGatewayRunConfigEnvironment(params.opts.reset !== true);
+    if (snapshot.valid && params.opts.reset !== true) {
+      const envBeforeApply = { ...process.env };
+      applyConfigEnvVars(snapshot.sourceConfig, process.env);
+      normalizeStateDirEnv(process.env);
+      normalizeEnv();
+      appliedGatewayRunConfigEnvironment = {
+        before: envBeforeApply,
+        after: { ...process.env },
+      };
+    }
+    applyInvocationDestructiveOverride(invocationDestructiveOverride);
+  };
+  for (;;) {
+    const envBeforeTrustedApply = { ...process.env };
+    const trustedSelectionSignature = resolveGatewayConfigSelectionSignature(process.env);
+    const trustedEnvLoad = applyTrustedGatewayEnv();
+    if (resolveGatewayConfigSelectionSignature(process.env) !== trustedSelectionSignature) {
+      const stateEnvSelectedTarget = trustedEnvLoad.stateEnvAppliedKeys.some((key) =>
+        GATEWAY_CONFIG_SELECTION_ENV_KEYS.has(key.toUpperCase()),
+      );
+      if (stateEnvSelectedTarget) {
+        const fallbackSelectorKeys = new Set(
+          trustedEnvLoad.gatewayEnvAppliedKeys
+            .map((key) => key.toUpperCase())
+            .filter((key) => GATEWAY_CONFIG_SELECTION_ENV_KEYS.has(key)),
+        );
+        restoreGatewayEnvChanges({
+          before: envBeforeTrustedApply,
+          after: { ...process.env },
+          preservedKeys: new Set(
+            [...GATEWAY_CONFIG_SELECTION_ENV_KEYS].filter((key) => !fallbackSelectorKeys.has(key)),
+          ),
+        });
+      }
+      // A trusted dotenv selected another state/config target. Keep only its selectors so
+      // credentials from the superseded dotenv cannot win over the selected target's dotenv.
+      restoreSupersededGatewaySelectionEnv({
+        beforeCurrentPass: envBeforeTrustedApply,
+        environmentSelection: params.environmentSelection,
+      });
+      continue;
+    }
+    const snapshot = await readGuardedGatewayRunConfig(params);
+    if (!snapshot) {
+      return false;
+    }
+    if (!snapshot.valid) {
+      // Invalid config source is untrusted. In particular, applying its env block could let an
+      // off-root $include self-authorize OPENCLAW_INCLUDE_ROOTS on the next read. Only explicit dev
+      // reset may proceed as the recovery path; ordinary startup skips mutation-capable bootstrap.
+      if (params.opts.reset) {
+        lastGuardedGatewayRunSnapshot = snapshot;
+      }
+      return params.opts.reset === true;
+    }
+    const selectionSignature = resolveGatewayConfigSelectionSignature(process.env);
+    applySelectedConfigEnv(snapshot);
+    // Only selection inputs survive a selection hop. Reload credentials once the final config and
+    // state dotenv are stable so a superseded profile cannot contaminate the selected gateway.
+    if (resolveGatewayConfigSelectionSignature(process.env) !== selectionSignature) {
+      // Config-selected roots have only config-level trust. Their dotenv files must keep the same
+      // blocked-key boundary instead of becoming operator-trusted sources on the next pass.
+      gatewayRunTargetSelectedByConfig = true;
+      restoreSupersededGatewaySelectionEnv({
+        beforeCurrentPass: envBeforeTrustedApply,
+        environmentSelection: params.environmentSelection,
+      });
+      continue;
+    }
+    if (!params.recoverSuspicious) {
+      lastGuardedGatewayRunSnapshot = snapshot;
+      return true;
+    }
+    // Recovery writes audit/config state, so run it only after config and state selection is stable.
+    const recoveredSnapshot = await recoverGuardedGatewayRunConfig(params);
+    if (!recoveredSnapshot) {
+      return false;
+    }
+    if (recoveredSnapshot.path !== snapshot.path || recoveredSnapshot.hash !== snapshot.hash) {
+      // Recovery replaced the selected config. Discard every env mutation from the old selection
+      // chain before converging again so rejected credentials cannot survive into the backup.
+      restoreSupersededGatewaySelectionEnv({
+        beforeCurrentPass: envBeforeTrustedApply,
+        environmentSelection: params.environmentSelection,
+      });
+      continue;
+    }
+    const envBeforeRecoveredApply = { ...process.env };
+    const recoveredSelectionSignature = resolveGatewayConfigSelectionSignature(process.env);
+    applySelectedConfigEnv(recoveredSnapshot);
+    if (resolveGatewayConfigSelectionSignature(process.env) === recoveredSelectionSignature) {
+      lastGuardedGatewayRunSnapshot = recoveredSnapshot;
+      return true;
+    }
+    restoreSupersededGatewaySelectionEnv({
+      beforeCurrentPass: envBeforeRecoveredApply,
+      environmentSelection: params.environmentSelection,
+    });
+    gatewayRunTargetSelectedByConfig = true;
+  }
+}
+
+export async function guardGatewayRunReset(params: GatewayRunGuardParams): Promise<boolean> {
+  gatewayRunTargetSelectedByConfig = false;
+  const envBeforeGuard = { ...process.env };
+  try {
+    return await guardGatewayRunSelectedConfig({
+      ...params,
+      recoverSuspicious: true,
+      restoreSuspicious: false,
+    });
+  } finally {
+    // Config being deleted cannot authorize or retarget its own reset. Restore its env layer first,
+    // then retain only invocation/trusted selectors through deletion and recreation.
+    restoreAppliedGatewayRunConfigEnvironment(false);
+    // Reset keeps only the selected config/state target. Credentials and other env from the
+    // config being deleted must not survive into the replacement config or gateway runtime.
+    restoreGatewayEnvChanges({
+      before: envBeforeGuard,
+      after: { ...process.env },
+      preservedKeys: GATEWAY_RESET_SELECTION_ENV_KEYS,
+    });
+  }
+}
+
+export async function recheckGatewayRunReset(params: GatewayRunGuardParams): Promise<boolean> {
+  const expected = preparedGatewayRunReset;
+  preparedGatewayRunReset = undefined;
+  const rejectDrift = async () => {
+    if (expected) {
+      restoreGatewayConfigSelectionEnvironment(expected.selectionEnvironment);
+      await pinGatewayRunRuntimePaths();
+    }
+    params.runtime.error(
+      "Refusing to reset the dev gateway state because the selected config or state target changed during startup. Retry the reset so the new target can be validated.",
+    );
+    params.runtime.exit(1);
+    return false;
+  };
+  if (
+    !expected ||
+    resolveGatewayConfigSelectionSignature(process.env) !== expected.selectionSignature
+  ) {
+    return await rejectDrift();
+  }
+  if (!(await guardGatewayRunReset(params))) {
+    return false;
+  }
+  const current = lastGuardedGatewayRunSnapshot;
+  if (
+    resolveGatewayConfigSelectionSignature(process.env) !== expected.selectionSignature ||
+    !current ||
+    !(await isSameGatewayRunConfigSnapshot(expected.snapshot, current))
+  ) {
+    return await rejectDrift();
+  }
+  return true;
+}
+
+export async function applyFinalGatewayRunConfigEnv(params: {
+  lowerPrecedenceEnv?: Readonly<Record<string, string>>;
+  runtime: RuntimeEnv;
+  snapshot: ConfigFileSnapshot;
+}): Promise<boolean> {
+  const preparedSnapshot = preparedGatewayRunBootstrapSnapshot;
+  preparedGatewayRunBootstrapSnapshot = undefined;
+  if (!params.snapshot.valid) {
+    return true;
+  }
+  const invocationDestructiveOverride = resolveInvocationDestructiveOverride();
+  const envBeforeApply = { ...process.env };
+  const selectionSignature = resolveGatewayConfigSelectionSignature(process.env);
+  const [
+    { applyConfigEnvVars, collectConfigRuntimeEnvVars },
+    { normalizeEnv },
+    { normalizeStateDirEnv },
+  ] = await Promise.all([
+    import("../../config/env-vars.js"),
+    import("../../infra/env.js"),
+    import("../../config/paths.js"),
+  ]);
+  const finalConfigEnv = collectConfigRuntimeEnvVars(params.snapshot.sourceConfig);
+  if (
+    preparedSnapshot &&
+    resolveGatewayConfigSelectionDeclarationSignature(
+      collectConfigRuntimeEnvVars(preparedSnapshot.sourceConfig),
+    ) !== resolveGatewayConfigSelectionDeclarationSignature(finalConfigEnv)
+  ) {
+    params.runtime.error(
+      "Refusing to start the gateway because the final config read changed config or state selection. Retry startup so the selected target can be validated.",
+    );
+    params.runtime.exit(1);
+    return false;
+  }
+  restoreAppliedGatewayRunConfigEnvironment();
+  const finalConfigEnvKeys = new Set(Object.keys(finalConfigEnv).map((key) => key.toUpperCase()));
+  for (const [key, value] of Object.entries(params.lowerPrecedenceEnv ?? {})) {
+    if (finalConfigEnvKeys.has(key.toUpperCase()) && process.env[key] === value) {
+      delete process.env[key];
+    }
+  }
+  applyConfigEnvVars(params.snapshot.sourceConfig, process.env);
+  normalizeStateDirEnv(process.env);
+  normalizeEnv();
+  applyInvocationDestructiveOverride(invocationDestructiveOverride);
+  appliedGatewayRunConfigEnvironment = {
+    before: envBeforeApply,
+    after: { ...process.env },
+  };
+  if (resolveGatewayConfigSelectionSignature(process.env) === selectionSignature) {
+    return true;
+  }
+  appliedGatewayRunConfigEnvironment = undefined;
+  restoreGatewayEnvChanges({ before: envBeforeApply, after: { ...process.env } });
+  params.runtime.error(
+    "Refusing to start the gateway because the final config read changed config or state selection. Retry startup so the selected target can be validated.",
+  );
+  params.runtime.exit(1);
+  return false;
+}
+
+export function clearGatewayRunConfigEnvironment(): void {
+  restoreAppliedGatewayRunConfigEnvironment();
+}
+
+export async function reloadTrustedGatewayRunEnvironment(params: {
+  runtime: RuntimeEnv;
+}): Promise<boolean> {
+  const [
+    path,
+    { isConfigRuntimeEnvVarAllowed },
+    { loadGlobalRuntimeDotEnvFiles },
+    { normalizeEnv },
+    { normalizeStateDirEnv, resolveStateDir },
+    { resolveConfigDir },
+  ] = await Promise.all([
+    import("node:path"),
+    import("../../config/env-vars.js"),
+    import("../../infra/dotenv-global.js"),
+    import("../../infra/env.js"),
+    import("../../config/paths.js"),
+    import("../../utils.js"),
+  ]);
+  const envBeforeReload = { ...process.env };
+  const selectionSignature = resolveGatewayConfigSelectionSignature(process.env);
+  const invocationDestructiveOverride = resolveInvocationDestructiveOverride();
+  normalizeStateDirEnv(process.env);
+  loadGlobalRuntimeDotEnvFiles({
+    ...(gatewayRunTargetSelectedByConfig ? { entryFilter: isConfigRuntimeEnvVarAllowed } : {}),
+    quiet: true,
+    ...resolveGatewayRunDotEnvPaths({
+      env: process.env,
+      join: path.join,
+      resolve: path.resolve,
+      resolveConfigDir,
+      resolveStateDir,
+    }),
+  });
+  normalizeStateDirEnv(process.env);
+  normalizeEnv();
+  applyInvocationDestructiveOverride(invocationDestructiveOverride);
+  if (resolveGatewayConfigSelectionSignature(process.env) !== selectionSignature) {
+    // Runtime modules already derived process-stable paths before startup mutations. A replacement
+    // dotenv cannot select another target without splitting the running gateway across state dirs.
+    restoreGatewayEnvChanges({ before: envBeforeReload, after: { ...process.env } });
+    applyInvocationDestructiveOverride(invocationDestructiveOverride);
+    await pinGatewayRunRuntimePaths();
+    params.runtime.error(
+      "Refusing to start the gateway because trusted dotenv reload after startup mutations changed config or state selection. Retry startup so the selected target can be validated.",
+    );
+    params.runtime.exit(1);
+    return false;
+  }
+  await pinGatewayRunRuntimePaths();
+  return true;
+}
+
+export async function selectGatewayRunEnvironment(params: GatewayRunGuardParams): Promise<boolean> {
+  gatewayRunTargetSelectedByConfig = false;
+  preparedGatewayRunBootstrapSnapshot = undefined;
+  preparedGatewayRunReset = undefined;
+  restoreAppliedGatewayRunConfigEnvironment(params.opts.reset !== true);
+  const envBeforeGuard = { ...process.env };
+  selectedGatewayRunEnvironment = undefined;
+  let guarded: boolean;
+  try {
+    guarded = await guardGatewayRunSelectedConfig({
+      ...params,
+      recoverSuspicious: false,
+      restoreSuspicious: false,
+    });
+  } finally {
+    if (params.opts.reset) {
+      restoreAppliedGatewayRunConfigEnvironment(false);
+      restoreGatewayEnvChanges({
+        before: envBeforeGuard,
+        after: { ...process.env },
+        preservedKeys: GATEWAY_RESET_SELECTION_ENV_KEYS,
+      });
+    }
+  }
+  selectedGatewayRunEnvironment = {
+    before: envBeforeGuard,
+    after: { ...process.env },
+  };
+  await pinGatewayRunRuntimePaths();
+  return guarded;
+}
+
+export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams): Promise<boolean> {
+  preparedGatewayRunReset = undefined;
+  // Stop the early proxy before recovery can select another config/state target. Its lifecycle
+  // restores the underlying env snapshot so the selected target's trusted dotenv can replace it.
+  await getGatewayRunRuntimeHooks().releaseManagedProxy?.();
+  const environmentSelection = selectedGatewayRunEnvironment;
+  selectedGatewayRunEnvironment = undefined;
+  if (!environmentSelection) {
+    gatewayRunTargetSelectedByConfig = false;
+  }
+  const guarded = params.opts.reset
+    ? await guardGatewayRunReset(params)
+    : await guardGatewayRunSelectedConfig({
+        ...params,
+        environmentSelection,
+        recoverSuspicious: true,
+        restoreSuspicious: true,
+      });
+  await pinGatewayRunRuntimePaths();
+  // Dev reset deletes the state directory before recreating config. Migrating first would
+  // archive legacy state and then delete its imported SQLite rows.
+  const shouldBootstrap = guarded && !params.opts.reset;
+  preparedGatewayRunBootstrapSnapshot = shouldBootstrap ? lastGuardedGatewayRunSnapshot : undefined;
+  if (guarded && params.opts.reset && lastGuardedGatewayRunSnapshot) {
+    preparedGatewayRunReset = {
+      selectionEnvironment: snapshotGatewayConfigSelectionEnvironment(process.env),
+      selectionSignature: resolveGatewayConfigSelectionSignature(process.env),
+      snapshot: lastGuardedGatewayRunSnapshot,
+    };
+  }
+  return shouldBootstrap;
+}
+
+export async function recheckGatewayRunBootstrap(
+  params: GatewayRunGuardParams & { snapshot?: ConfigFileSnapshot },
+): Promise<boolean> {
+  const expected = preparedGatewayRunBootstrapSnapshot;
+  if (!expected) {
+    params.runtime.error(
+      "Refusing to run automatic gateway startup migrations without a prepared config snapshot. Retry startup.",
+    );
+    params.runtime.exit(1);
+    return false;
+  }
+  const current = params.snapshot
+    ? enforceGatewayRunFutureConfigGuard({
+        opts: params.opts,
+        runtime: params.runtime,
+        snapshot: params.snapshot,
+      })
+      ? params.snapshot
+      : null
+    : await readGuardedGatewayRunConfig(params);
+  if (!current) {
+    return false;
+  }
+  if (
+    await isSameGatewayRunConfigSnapshot(expected, current, {
+      allowPathChange: params.snapshot !== undefined,
+    })
+  ) {
+    return true;
+  }
+  params.runtime.error(
+    "Refusing to run automatic gateway startup migrations because the selected config changed during startup. Retry startup so the new config can be validated.",
+  );
+  params.runtime.exit(1);
+  return false;
+}

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -478,10 +478,12 @@ export async function applyFinalGatewayRunConfigEnv(params: {
     { applyConfigEnvVars, collectConfigRuntimeEnvVars },
     { normalizeEnv },
     { normalizeStateDirEnv },
+    { clearShellEnvAppliedKeys },
   ] = await Promise.all([
     import("../../config/env-vars.js"),
     import("../../infra/env.js"),
     import("../../config/paths.js"),
+    import("../../infra/shell-env.js"),
   ]);
   const finalConfigEnv = collectConfigRuntimeEnvVars(params.snapshot.sourceConfig);
   if (
@@ -497,13 +499,10 @@ export async function applyFinalGatewayRunConfigEnv(params: {
     return false;
   }
   restoreAppliedGatewayRunConfigEnvironment();
-  const finalConfigEnvKeys = new Set(Object.keys(finalConfigEnv).map((key) => key.toUpperCase()));
-  for (const [key, value] of Object.entries(params.lowerPrecedenceEnv ?? {})) {
-    if (finalConfigEnvKeys.has(key.toUpperCase()) && process.env[key] === value) {
-      delete process.env[key];
-    }
-  }
-  applyConfigEnvVars(params.snapshot.sourceConfig, process.env);
+  applyConfigEnvVars(params.snapshot.sourceConfig, process.env, {
+    lowerPrecedenceEnv: params.lowerPrecedenceEnv,
+    onLowerPrecedenceKeysReplaced: clearShellEnvAppliedKeys,
+  });
   normalizeStateDirEnv(process.env);
   normalizeEnv();
   applyInvocationDestructiveOverride(invocationDestructiveOverride);

--- a/src/cli/gateway-cli/run-command.ts
+++ b/src/cli/gateway-cli/run-command.ts
@@ -8,7 +8,11 @@ function formatModeChoices(modes: readonly string[]): string {
   return modes.map((mode) => `"${mode}"`).join("|");
 }
 
-export function addGatewayRunCommand(cmd: Command): Command {
+type GatewayRunCommandHooks = {
+  beforeRun?: (opts: { reset?: boolean }) => Promise<void> | void;
+};
+
+export function addGatewayRunCommand(cmd: Command, hooks: GatewayRunCommandHooks = {}): Command {
   return cmd
     .option("--port <port>", "Port for the gateway WebSocket")
     .option(
@@ -56,6 +60,8 @@ export function addGatewayRunCommand(cmd: Command): Command {
     .option("--raw-stream-path <path>", "Raw stream jsonl path")
     .action(async (opts, command) => {
       const { resolveGatewayRunOptions, runGatewayCommand } = await import("./run.js");
-      await runGatewayCommand(resolveGatewayRunOptions(opts, command));
+      const resolved = resolveGatewayRunOptions(opts, command);
+      await hooks.beforeRun?.(resolved);
+      await runGatewayCommand(resolved);
     });
 }

--- a/src/cli/gateway-cli/run-command.ts
+++ b/src/cli/gateway-cli/run-command.ts
@@ -1,5 +1,8 @@
 // Gateway run command option registration and lazy handoff to runtime startup.
 import type { Command } from "commander";
+import type { GatewayRunOpts } from "./run-options.js";
+import { resolveGatewayRunOptions } from "./run-options.js";
+import { getGatewayRunRuntimeHooks } from "./runtime-hooks.js";
 
 const GATEWAY_AUTH_MODES = ["none", "token", "password", "trusted-proxy"] as const;
 const GATEWAY_TAILSCALE_MODES = ["off", "serve", "funnel"] as const;
@@ -9,7 +12,7 @@ function formatModeChoices(modes: readonly string[]): string {
 }
 
 type GatewayRunCommandHooks = {
-  beforeRun?: (opts: { reset?: boolean }) => Promise<void> | void;
+  beforeRun?: (opts: Pick<GatewayRunOpts, "force" | "reset">) => Promise<void> | void;
 };
 
 export function addGatewayRunCommand(cmd: Command, hooks: GatewayRunCommandHooks = {}): Command {
@@ -59,9 +62,9 @@ export function addGatewayRunCommand(cmd: Command, hooks: GatewayRunCommandHooks
     .option("--raw-stream", "Log raw model stream events to jsonl", false)
     .option("--raw-stream-path <path>", "Raw stream jsonl path")
     .action(async (opts, command) => {
-      const { resolveGatewayRunOptions, runGatewayCommand } = await import("./run.js");
       const resolved = resolveGatewayRunOptions(opts, command);
       await hooks.beforeRun?.(resolved);
-      await runGatewayCommand(resolved);
+      const { runGatewayCommand } = await import("./run.js");
+      await runGatewayCommand(resolved, getGatewayRunRuntimeHooks());
     });
 }

--- a/src/cli/gateway-cli/run-options.ts
+++ b/src/cli/gateway-cli/run-options.ts
@@ -1,0 +1,72 @@
+// Source-aware gateway run option resolution shared by pre-action and runtime startup.
+import type { Command } from "commander";
+import { inheritOptionFromParent } from "../command-options.js";
+
+export type GatewayRunOpts = {
+  port?: unknown;
+  bind?: unknown;
+  token?: unknown;
+  auth?: unknown;
+  password?: unknown;
+  passwordFile?: unknown;
+  tailscale?: unknown;
+  tailscaleResetOnExit?: boolean;
+  allowUnconfigured?: boolean;
+  force?: boolean;
+  verbose?: boolean;
+  cliBackendLogs?: boolean;
+  /** @deprecated Use cliBackendLogs. */
+  claudeCliLogs?: boolean;
+  wsLog?: unknown;
+  compact?: boolean;
+  rawStream?: boolean;
+  rawStreamPath?: unknown;
+  dev?: boolean;
+  reset?: boolean;
+};
+
+const GATEWAY_RUN_VALUE_KEYS = [
+  "port",
+  "bind",
+  "token",
+  "auth",
+  "password",
+  "passwordFile",
+  "tailscale",
+  "wsLog",
+  "rawStreamPath",
+] as const;
+
+const GATEWAY_RUN_BOOLEAN_KEYS = [
+  "tailscaleResetOnExit",
+  "allowUnconfigured",
+  "dev",
+  "reset",
+  "force",
+  "verbose",
+  "cliBackendLogs",
+  "claudeCliLogs",
+  "compact",
+  "rawStream",
+] as const;
+
+export function resolveGatewayRunOptions(opts: GatewayRunOpts, command?: Command): GatewayRunOpts {
+  const resolved: GatewayRunOpts = { ...opts };
+
+  for (const key of GATEWAY_RUN_VALUE_KEYS) {
+    const inherited = inheritOptionFromParent(command, key);
+    if (key === "wsLog") {
+      // wsLog has a child default ("auto"), so prefer inherited parent CLI value when present.
+      resolved[key] = inherited ?? resolved[key];
+      continue;
+    }
+    resolved[key] = resolved[key] ?? inherited;
+  }
+
+  for (const key of GATEWAY_RUN_BOOLEAN_KEYS) {
+    const inherited = inheritOptionFromParent<boolean>(command, key);
+    resolved[key] = Boolean(resolved[key] || inherited);
+  }
+
+  return resolved;
+}

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -7,6 +7,7 @@ import { SUPERVISOR_HINT_ENV_VARS } from "../../infra/supervisor-markers.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { withTempSecretFiles } from "../../test-utils/secret-file-fixture.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
+import { installGatewayRunRuntimeHooks } from "./runtime-hooks.js";
 
 const startGatewayServer = vi.fn(async (_port: number, _opts?: unknown) => ({
   close: vi.fn(async () => {}),
@@ -27,19 +28,43 @@ const runGatewayLoop = vi.fn(async ({ start }: { start: GatewayLoopStart }) => {
   await start();
 });
 const normalizeStateDirEnv = vi.fn((_env?: NodeJS.ProcessEnv) => undefined);
+const pinConfigDir = vi.fn((_env?: NodeJS.ProcessEnv) => undefined);
+const pinRuntimePaths = vi.fn((_env?: NodeJS.ProcessEnv) => undefined);
+const loadGlobalRuntimeDotEnvFiles = vi.fn((_opts?: unknown) => undefined);
 const beforeRun = vi.fn(async () => {
   callOrder.push("bootstrap");
 });
 const callOrder = vi.hoisted(() => [] as string[]);
+const refreshManagedProxy = vi.fn(async () => {
+  callOrder.push("proxy");
+});
+const loadShellEnvFallback = vi.fn((_opts?: unknown) => {
+  callOrder.push("shell-env");
+});
+const resolveShellEnvExpectedKeys = vi.fn((_env?: NodeJS.ProcessEnv) => ["OPENCLAW_GATEWAY_TOKEN"]);
+const resolveShellEnvFallbackTimeoutMs = vi.fn((_env?: NodeJS.ProcessEnv) => 15_000);
+const shouldDeferShellEnvFallback = vi.fn((_env?: NodeJS.ProcessEnv) => false);
+const shouldEnableShellEnvFallback = vi.fn((_env?: NodeJS.ProcessEnv) => false);
 const gatewayLogMessages = vi.hoisted(() => [] as string[]);
 const configState = vi.hoisted(() => ({
   cfg: {} as Record<string, unknown>,
-  snapshot: { exists: false } as Record<string, unknown>,
+  snapshot: { config: {}, exists: false, sourceConfig: {}, valid: true } as Record<string, unknown>,
 }));
 const readBestEffortConfig = vi.fn(async () => configState.cfg);
-const readConfigFileSnapshotWithPluginMetadata = vi.fn(async () => ({
-  snapshot: configState.snapshot,
-}));
+type ConfigSnapshotReadOptionsStub = {
+  isolateEnv?: boolean;
+  lowerPrecedenceEnv?: Readonly<Record<string, string>>;
+  recoverSuspicious?: boolean;
+  allowSuspiciousRecovery?: (
+    candidate: Record<string, unknown>,
+    current: Record<string, unknown>,
+  ) => boolean | Promise<boolean>;
+};
+const readConfigFileSnapshotWithPluginMetadata = vi.fn(
+  async (_options?: ConfigSnapshotReadOptionsStub) => ({
+    snapshot: configState.snapshot,
+  }),
+);
 const writeDiagnosticStabilityBundleForFailureSync = vi.fn((_reason: string, _error: unknown) => ({
   status: "written" as const,
   message: "wrote stability bundle: /tmp/openclaw-stability.json",
@@ -66,14 +91,41 @@ vi.mock("../../config/config.js", () => ({
   getConfigPath: () => "/tmp/openclaw-test-missing-config.json",
   readBestEffortConfig: () => readBestEffortConfig(),
   readConfigFileSnapshot: async () => configState.snapshot,
-  readConfigFileSnapshotWithPluginMetadata: () => readConfigFileSnapshotWithPluginMetadata(),
+  readConfigFileSnapshotWithPluginMetadata: (options?: ConfigSnapshotReadOptionsStub) =>
+    readConfigFileSnapshotWithPluginMetadata(options),
 }));
 
 vi.mock("../../config/paths.js", () => ({
   CONFIG_PATH: "/tmp/openclaw-test-missing-config.json",
   normalizeStateDirEnv: (env?: NodeJS.ProcessEnv) => normalizeStateDirEnv(env),
+  pinRuntimePaths: (env?: NodeJS.ProcessEnv) => pinRuntimePaths(env),
   resolveStateDir: () => "/tmp",
   resolveGatewayPort: (cfg?: { gateway?: { port?: number } }) => cfg?.gateway?.port ?? 18789,
+}));
+
+vi.mock("../../utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../utils.js")>()),
+  pinConfigDir: (env?: NodeJS.ProcessEnv) => pinConfigDir(env),
+}));
+
+vi.mock("../../infra/dotenv-global.js", () => ({
+  loadGlobalRuntimeDotEnvFiles: (opts?: unknown) =>
+    loadGlobalRuntimeDotEnvFiles(opts) ?? {
+      gatewayEnvAppliedKeys: [],
+      stateEnvAppliedKeys: [],
+    },
+}));
+
+vi.mock("../../config/shell-env-expected-keys.js", () => ({
+  resolveShellEnvExpectedKeys: (env?: NodeJS.ProcessEnv) => resolveShellEnvExpectedKeys(env),
+}));
+
+vi.mock("../../infra/shell-env.js", () => ({
+  loadShellEnvFallback: (opts?: unknown) => loadShellEnvFallback(opts),
+  resolveShellEnvFallbackTimeoutMs: (env?: NodeJS.ProcessEnv) =>
+    resolveShellEnvFallbackTimeoutMs(env),
+  shouldDeferShellEnvFallback: (env?: NodeJS.ProcessEnv) => shouldDeferShellEnvFallback(env),
+  shouldEnableShellEnvFallback: (env?: NodeJS.ProcessEnv) => shouldEnableShellEnvFallback(env),
 }));
 
 vi.mock("../../gateway/auth.js", () => ({
@@ -226,7 +278,7 @@ describe("gateway run option collisions", () => {
   beforeEach(() => {
     resetRuntimeCapture();
     configState.cfg = {};
-    configState.snapshot = { exists: false };
+    configState.snapshot = { config: {}, exists: false, sourceConfig: {}, valid: true };
     netState.autoBindHost = "127.0.0.1";
     netState.container = false;
     readBestEffortConfig.mockClear();
@@ -244,12 +296,28 @@ describe("gateway run option collisions", () => {
     ensureDevGatewayConfig.mockClear();
     runGatewayLoop.mockClear();
     normalizeStateDirEnv.mockReset();
+    pinConfigDir.mockClear();
+    pinRuntimePaths.mockClear();
+    loadGlobalRuntimeDotEnvFiles.mockReset();
     beforeRun.mockClear();
+    refreshManagedProxy.mockClear();
+    loadShellEnvFallback.mockClear();
+    resolveShellEnvExpectedKeys.mockClear();
+    resolveShellEnvFallbackTimeoutMs.mockClear();
+    shouldDeferShellEnvFallback.mockReset();
+    shouldDeferShellEnvFallback.mockReturnValue(false);
+    shouldEnableShellEnvFallback.mockReset();
+    shouldEnableShellEnvFallback.mockReturnValue(false);
     callOrder.length = 0;
   });
 
   async function runGatewayCli(argv: string[]) {
     await sharedProgram.parseAsync(argv, { from: "user" });
+  }
+
+  async function prepareGatewayReset() {
+    const { prepareGatewayRunBootstrap } = await import("./pre-bootstrap.js");
+    return await prepareGatewayRunBootstrap({ opts: { reset: true }, runtime: defaultRuntime });
   }
 
   function callArg(mock: { mock: { calls: unknown[][] } }, index = 0, argIndex = 0): unknown {
@@ -286,7 +354,166 @@ describe("gateway run option collisions", () => {
     await runGatewayCli(["gateway", "--allow-unconfigured"]);
 
     expect(beforeRun).toHaveBeenCalledOnce();
-    expect(callOrder).toEqual(["bootstrap", "normalize", "start"]);
+    expect(callOrder).toEqual(["bootstrap", "normalize", "normalize", "start"]);
+  });
+
+  it("refreshes the managed proxy from the final accepted config before gateway startup", async () => {
+    const finalConfig = {
+      gateway: { mode: "local" },
+      proxy: { enabled: true, proxyUrl: "http://127.0.0.1:29876" },
+    };
+    configState.snapshot = {
+      exists: true,
+      valid: true,
+      path: "/tmp/openclaw.json",
+      config: finalConfig,
+      parsed: finalConfig,
+      sourceConfig: finalConfig,
+    };
+    const uninstall = installGatewayRunRuntimeHooks({ refreshManagedProxy });
+    try {
+      await runGatewayCli(["gateway"]);
+    } finally {
+      uninstall();
+    }
+
+    expect(refreshManagedProxy).toHaveBeenCalledWith(finalConfig.proxy);
+    const refreshOrder = refreshManagedProxy.mock.invocationCallOrder[0] ?? 0;
+    const startOrder = startGatewayServer.mock.invocationCallOrder[0] ?? 0;
+    expect(startOrder).toBeGreaterThan(refreshOrder);
+  });
+
+  it("loads configured shell env fallback before final proxy refresh and gateway startup", async () => {
+    await withEnvAsync({ OPENCLAW_GATEWAY_TOKEN: undefined }, async () => {
+      const finalConfig = {
+        env: {
+          shellEnv: { enabled: true, timeoutMs: 1234 },
+          vars: { OPENCLAW_GATEWAY_TOKEN: "config-token" },
+        },
+        gateway: {
+          auth: { mode: "token", token: "${OPENCLAW_GATEWAY_TOKEN}" },
+          mode: "local",
+        },
+        proxy: { enabled: true, proxyUrl: "http://127.0.0.1:29876" },
+      };
+      configState.cfg = finalConfig;
+      configState.snapshot = {
+        exists: true,
+        valid: true,
+        path: "/tmp/openclaw.json",
+        config: finalConfig,
+        parsed: finalConfig,
+        sourceConfig: finalConfig,
+      };
+      readConfigFileSnapshotWithPluginMetadata.mockImplementationOnce(async () => {
+        expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("shell-token");
+        return {
+          snapshot: {
+            ...configState.snapshot,
+            config: {
+              ...finalConfig,
+              gateway: {
+                ...finalConfig.gateway,
+                auth: { mode: "token", token: "config-token" },
+              },
+            },
+          },
+        };
+      });
+      loadShellEnvFallback.mockImplementationOnce((opts?: unknown) => {
+        callOrder.push("shell-env");
+        (opts as { env: NodeJS.ProcessEnv }).env.OPENCLAW_GATEWAY_TOKEN = "shell-token";
+      });
+      const uninstall = installGatewayRunRuntimeHooks({ refreshManagedProxy });
+      try {
+        await runGatewayCli(["gateway"]);
+      } finally {
+        uninstall();
+      }
+
+      expect(loadShellEnvFallback).toHaveBeenCalledWith({
+        enabled: true,
+        env: process.env,
+        expectedKeys: ["OPENCLAW_GATEWAY_TOKEN"],
+        logger: expect.any(Object),
+        timeoutMs: 1234,
+      });
+      expect(readConfigFileSnapshotWithPluginMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lowerPrecedenceEnv: { OPENCLAW_GATEWAY_TOKEN: "shell-token" },
+        }),
+      );
+      expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("config-token");
+      const shellEnvOrder = loadShellEnvFallback.mock.invocationCallOrder[0] ?? 0;
+      const finalConfigReadOrder =
+        readConfigFileSnapshotWithPluginMetadata.mock.invocationCallOrder[0] ?? 0;
+      const refreshOrder = refreshManagedProxy.mock.invocationCallOrder[0] ?? 0;
+      const startOrder = startGatewayServer.mock.invocationCallOrder[0] ?? 0;
+      expect(finalConfigReadOrder).toBeGreaterThan(shellEnvOrder);
+      expect(refreshOrder).toBeGreaterThan(shellEnvOrder);
+      expect(startOrder).toBeGreaterThan(refreshOrder);
+    });
+  });
+
+  it("replaces config-derived env when the final startup snapshot changes in place", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_PROXY_URL: undefined,
+        OPENCLAW_RAW_STREAM: undefined,
+      },
+      async () => {
+        const oldConfig = {
+          env: {
+            vars: {
+              OPENCLAW_GATEWAY_TOKEN: "old-token",
+              OPENCLAW_PROXY_URL: "http://127.0.0.1:19876",
+              OPENCLAW_RAW_STREAM: "1",
+            },
+          },
+          gateway: { mode: "local" },
+        };
+        const newConfig = {
+          env: { vars: { OPENCLAW_GATEWAY_TOKEN: "new-token" } },
+          gateway: { mode: "local" },
+        };
+        configState.snapshot = {
+          config: oldConfig,
+          exists: true,
+          hash: "old",
+          path: "/tmp/openclaw.json",
+          sourceConfig: oldConfig,
+          valid: true,
+        };
+        const { prepareGatewayRunBootstrap, selectGatewayRunEnvironment } =
+          await import("./pre-bootstrap.js");
+        await selectGatewayRunEnvironment({ opts: {}, runtime: defaultRuntime });
+        await prepareGatewayRunBootstrap({ opts: {}, runtime: defaultRuntime });
+        expect(pinRuntimePaths).toHaveBeenCalledWith(process.env);
+        expect(pinConfigDir).toHaveBeenCalledWith(process.env);
+        expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("old-token");
+        expect(process.env.OPENCLAW_PROXY_URL).toBe("http://127.0.0.1:19876");
+
+        configState.snapshot = {
+          config: newConfig,
+          exists: true,
+          hash: "new",
+          path: "/tmp/openclaw.json",
+          sourceConfig: newConfig,
+          valid: true,
+        };
+        readConfigFileSnapshotWithPluginMetadata.mockImplementationOnce(async () => {
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+          expect(process.env.OPENCLAW_PROXY_URL).toBeUndefined();
+          return { snapshot: configState.snapshot };
+        });
+        await runGatewayCli(["gateway", "--raw-stream"]);
+
+        expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("new-token");
+        expect(process.env.OPENCLAW_PROXY_URL).toBeUndefined();
+        expect(process.env.OPENCLAW_RAW_STREAM).toBe("1");
+      },
+    );
   });
 
   it("forwards parent-captured options to `gateway run` subcommand", async () => {
@@ -317,7 +544,7 @@ describe("gateway run option collisions", () => {
     expect(setGatewayWsLogStyle).toHaveBeenCalledWith("full");
     expect(gatewayStartOptions().auth?.token).toBe("tok_run");
     expect(normalizeStateDirEnv).toHaveBeenCalledWith(process.env);
-    expect(callOrder).toEqual(["bootstrap", "normalize", "start"]);
+    expect(callOrder).toEqual(["bootstrap", "normalize", "normalize", "start"]);
   });
 
   it("marks service-mode gateway descendants with the live gateway pid", async () => {
@@ -333,6 +560,64 @@ describe("gateway run option collisions", () => {
       },
     );
     expect(normalizeStateDirEnv).toHaveBeenCalledWith(process.env);
+  });
+
+  it("marks descendants when the final config supplies the service marker", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_SERVICE_MARKER: undefined,
+        [GATEWAY_SERVICE_RUNTIME_PID_ENV]: undefined,
+      },
+      async () => {
+        const finalConfig = {
+          env: { vars: { OPENCLAW_SERVICE_MARKER: "openclaw" } },
+          gateway: { mode: "local" },
+        };
+        configState.snapshot = {
+          config: finalConfig,
+          exists: true,
+          path: "/tmp/openclaw.json",
+          sourceConfig: finalConfig,
+          valid: true,
+        };
+
+        await runGatewayCli(["gateway"]);
+
+        expect(process.env.OPENCLAW_SERVICE_MARKER).toBe("openclaw");
+        expect(process.env[GATEWAY_SERVICE_RUNTIME_PID_ENV]).toBe(String(process.pid));
+      },
+    );
+  });
+
+  it("rechecks future config after the final config enters service mode", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1",
+        OPENCLAW_SERVICE_MARKER: undefined,
+      },
+      async () => {
+        const finalConfig = {
+          env: { vars: { OPENCLAW_SERVICE_MARKER: "openclaw" } },
+          gateway: { mode: "local" },
+          meta: { lastTouchedVersion: "9999.1.1" },
+        };
+        configState.cfg = finalConfig;
+        configState.snapshot = {
+          config: finalConfig,
+          exists: true,
+          path: "/tmp/openclaw.json",
+          sourceConfig: finalConfig,
+          valid: true,
+        };
+
+        await expect(runGatewayCli(["gateway"])).rejects.toThrow("__exit__:78");
+
+        expect(process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBeUndefined();
+        expect(process.env.OPENCLAW_SERVICE_MARKER).toBeUndefined();
+        expect(startGatewayServer).not.toHaveBeenCalled();
+        expect(runtimeErrors.join("\n")).toContain("start the gateway service");
+      },
+    );
   });
 
   it("blocks --force port cleanup from an older binary with newer config", async () => {
@@ -378,6 +663,243 @@ describe("gateway run option collisions", () => {
     expect(runtimeErrors.join("\n")).toContain("Refusing to start the gateway service");
   });
 
+  it("blocks dev reset from an older binary before deleting state", async () => {
+    configState.snapshot = {
+      exists: true,
+      valid: true,
+      config: { meta: { lastTouchedVersion: "9999.1.1" } },
+      sourceConfig: { meta: { lastTouchedVersion: "9999.1.1" } },
+    };
+
+    await expect(prepareGatewayReset()).rejects.toThrow("__exit__:1");
+
+    expect(ensureDevGatewayConfig).not.toHaveBeenCalled();
+    expect(startGatewayServer).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain("Refusing to reset the dev gateway state");
+  });
+
+  it("does not retain targets or credentials from the config deleted by dev reset", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_CONFIG_PATH: undefined,
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_PROFILE: undefined,
+        OPENCLAW_STATE_DIR: undefined,
+        OPENCLAW_WORKSPACE_DIR: undefined,
+      },
+      async () => {
+        configState.snapshot = {
+          exists: true,
+          valid: true,
+          config: { gateway: { mode: "local" } },
+          sourceConfig: {
+            env: {
+              vars: {
+                OPENCLAW_CONFIG_PATH: "/tmp/openclaw-reset/openclaw.json",
+                OPENCLAW_GATEWAY_TOKEN: "old-token",
+                OPENCLAW_HOME: "/tmp/openclaw-reset-home",
+                OPENCLAW_STATE_DIR: "/tmp/openclaw-reset",
+              },
+            },
+            gateway: { mode: "local" },
+          },
+        };
+        ensureDevGatewayConfig.mockImplementationOnce(async () => {
+          expect(process.env.OPENCLAW_CONFIG_PATH).toBeUndefined();
+          expect(process.env.OPENCLAW_HOME).toBeUndefined();
+          expect(process.env.OPENCLAW_PROFILE).toBe("dev");
+          expect(process.env.OPENCLAW_STATE_DIR).toBeUndefined();
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+          expect(process.env.OPENCLAW_WORKSPACE_DIR).toBe("/tmp/openclaw-reset-workspace");
+          configState.snapshot = {
+            exists: true,
+            valid: true,
+            config: { gateway: { mode: "local" } },
+            sourceConfig: { gateway: { mode: "local" } },
+          };
+        });
+        loadGlobalRuntimeDotEnvFiles.mockImplementation(() => {
+          process.env.OPENCLAW_GATEWAY_TOKEN ??= "trusted-token";
+          process.env.OPENCLAW_PROFILE ??= "dev";
+          process.env.OPENCLAW_WORKSPACE_DIR ??= "/tmp/openclaw-reset-workspace";
+        });
+
+        await prepareGatewayReset();
+        await runGatewayCli(["gateway", "run", "--allow-unconfigured", "--dev", "--reset"]);
+
+        expect(ensureDevGatewayConfig).toHaveBeenCalledWith({ reset: true });
+        expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("trusted-token");
+        expect(loadGlobalRuntimeDotEnvFiles).toHaveBeenCalled();
+      },
+    );
+  });
+
+  it("refuses dev reset if trusted dotenv retargets after pre-bootstrap", async () => {
+    await withEnvAsync({ OPENCLAW_STATE_DIR: "/tmp/openclaw-reset-original" }, async () => {
+      configState.snapshot = {
+        config: { gateway: { mode: "local" } },
+        exists: true,
+        path: "/tmp/openclaw-reset-original/openclaw.json",
+        sourceConfig: { gateway: { mode: "local" } },
+        valid: true,
+      };
+      await prepareGatewayReset();
+      loadGlobalRuntimeDotEnvFiles.mockImplementation(() => {
+        process.env.OPENCLAW_STATE_DIR = "/tmp/openclaw-reset-retargeted";
+        return {
+          gatewayEnvAppliedKeys: [],
+          stateEnvAppliedKeys: ["OPENCLAW_STATE_DIR"],
+        };
+      });
+
+      await expect(
+        runGatewayCli(["gateway", "run", "--allow-unconfigured", "--dev", "--reset"]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(ensureDevGatewayConfig).not.toHaveBeenCalled();
+      expect(process.env.OPENCLAW_STATE_DIR).toBe("/tmp/openclaw-reset-original");
+      expect(runtimeErrors.join("\n")).toContain(
+        "selected config or state target changed during startup",
+      );
+    });
+  });
+
+  it.each([
+    "OPENCLAW_AGENT_DIR",
+    "OPENCLAW_INCLUDE_ROOTS",
+    "OPENCLAW_NIX_MODE",
+    "OPENCLAW_OAUTH_DIR",
+    "OPENCLAW_PACKAGE_DIR",
+    "OPENCLAW_PROFILE",
+    "OPENCLAW_STATE_DIR",
+    "OPENCLAW_WORKSPACE_DIR",
+    "PI_CODING_AGENT_DIR",
+  ])("blocks trusted dotenv selector drift for %s after startup mutations", async (selector) => {
+    await withEnvAsync({ [selector]: "/tmp/openclaw-reset-value" }, async () => {
+      loadGlobalRuntimeDotEnvFiles.mockImplementation(() => {
+        process.env[selector] = "/tmp/openclaw-reset-retargeted";
+      });
+      const { reloadTrustedGatewayRunEnvironment } = await import("./pre-bootstrap.js");
+
+      await expect(reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime })).rejects.toThrow(
+        "__exit__:1",
+      );
+
+      expect(process.env[selector]).toBe("/tmp/openclaw-reset-value");
+      expect(runtimeErrors.join("\n")).toContain(
+        "trusted dotenv reload after startup mutations changed config or state selection",
+      );
+    });
+  });
+
+  it("blocks a future-version late recovery candidate before gateway startup", async () => {
+    readConfigFileSnapshotWithPluginMetadata.mockImplementationOnce(async (options) => {
+      await options?.allowSuspiciousRecovery?.(
+        {
+          gateway: { mode: "local" },
+          meta: { lastTouchedVersion: "9999.1.1" },
+        },
+        { gateway: { mode: "local" } },
+      );
+      return { snapshot: configState.snapshot };
+    });
+
+    await expect(runGatewayCli(["gateway", "run", "--allow-unconfigured"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(startGatewayServer).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain("run automatic gateway startup migrations");
+  });
+
+  it("blocks a future-version current config before suspicious recovery", async () => {
+    let recoveryAllowed: boolean | undefined;
+    readConfigFileSnapshotWithPluginMetadata.mockImplementationOnce(async (options) => {
+      recoveryAllowed = await options?.allowSuspiciousRecovery?.(
+        { gateway: { mode: "local" } },
+        {
+          gateway: { mode: "local" },
+          meta: { lastTouchedVersion: "9999.1.1" },
+        },
+      );
+      return { snapshot: configState.snapshot };
+    });
+
+    await expect(runGatewayCli(["gateway", "run", "--allow-unconfigured"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(recoveryAllowed).toBe(false);
+    expect(startGatewayServer).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain("run automatic gateway startup migrations");
+  });
+
+  it("blocks a final startup snapshot that changes guarded config selection", async () => {
+    await withEnvAsync({ OPENCLAW_STATE_DIR: undefined }, async () => {
+      configState.snapshot = {
+        exists: true,
+        valid: true,
+        config: { gateway: { mode: "local" } },
+        sourceConfig: {
+          env: { vars: { OPENCLAW_STATE_DIR: "/tmp/openclaw-late-selection" } },
+          gateway: { mode: "local" },
+        },
+      };
+
+      await expect(runGatewayCli(["gateway", "run"])).rejects.toThrow("__exit__:1");
+
+      expect(process.env.OPENCLAW_STATE_DIR).toBeUndefined();
+      expect(startGatewayServer).not.toHaveBeenCalled();
+      expect(runtimeErrors.join("\n")).toContain(
+        "final config read changed config or state selection",
+      );
+    });
+  });
+
+  it("blocks a final startup snapshot that changes an already-selected config selector", async () => {
+    await withEnvAsync({ OPENCLAW_STATE_DIR: undefined }, async () => {
+      const guardedConfig = {
+        env: { vars: { OPENCLAW_STATE_DIR: "/tmp/openclaw-guarded-state" } },
+        gateway: { mode: "local" },
+      };
+      configState.snapshot = {
+        config: guardedConfig,
+        exists: true,
+        hash: "guarded",
+        path: "/tmp/openclaw.json",
+        sourceConfig: guardedConfig,
+        valid: true,
+      };
+      const { prepareGatewayRunBootstrap, selectGatewayRunEnvironment } =
+        await import("./pre-bootstrap.js");
+      await selectGatewayRunEnvironment({ opts: {}, runtime: defaultRuntime });
+      await prepareGatewayRunBootstrap({ opts: {}, runtime: defaultRuntime });
+      expect(process.env.OPENCLAW_STATE_DIR).toBe("/tmp/openclaw-guarded-state");
+
+      const finalConfig = {
+        env: { vars: { OPENCLAW_STATE_DIR: "/tmp/openclaw-final-state" } },
+        gateway: { mode: "local" },
+      };
+      configState.snapshot = {
+        config: finalConfig,
+        exists: true,
+        hash: "final",
+        path: "/tmp/openclaw.json",
+        sourceConfig: finalConfig,
+        valid: true,
+      };
+
+      await expect(runGatewayCli(["gateway", "run"])).rejects.toThrow("__exit__:1");
+
+      expect(process.env.OPENCLAW_STATE_DIR).toBe("/tmp/openclaw-guarded-state");
+      expect(startGatewayServer).not.toHaveBeenCalled();
+      expect(runtimeErrors.join("\n")).toContain(
+        "final config read changed config or state selection",
+      );
+    });
+  });
+
   it.each([
     ["--cli-backend-logs", "generic flag"],
     ["--claude-cli-logs", "deprecated alias"],
@@ -396,7 +918,12 @@ describe("gateway run option collisions", () => {
     });
 
     expect(readConfigFileSnapshotWithPluginMetadata).toHaveBeenCalledTimes(1);
-    expect(readBestEffortConfig).not.toHaveBeenCalled();
+    expect(readConfigFileSnapshotWithPluginMetadata).toHaveBeenCalledWith({
+      isolateEnv: true,
+      recoverSuspicious: true,
+      allowSuspiciousRecovery: expect.any(Function),
+    });
+    expect(readBestEffortConfig).toHaveBeenCalledOnce();
     const options = gatewayStartOptions();
     expect(options.bind).toBe("loopback");
     expect(options.startupConfigSnapshotRead).toEqual({ snapshot: configState.snapshot });
@@ -520,7 +1047,7 @@ describe("gateway run option collisions", () => {
       `Config write audit: ${path.join("/tmp", "logs", "config-audit.jsonl")}`,
     );
     expect(startGatewayServer).not.toHaveBeenCalled();
-    expect(readBestEffortConfig).not.toHaveBeenCalled();
+    expect(readBestEffortConfig).toHaveBeenCalledOnce();
   });
 
   it("blocks invalid startup config without automatic recovery", async () => {
@@ -545,6 +1072,23 @@ describe("gateway run option collisions", () => {
     );
     expect(readConfigFileSnapshotWithPluginMetadata).toHaveBeenCalledOnce();
     expect(startGatewayServer).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicit dev reset as the recovery path for invalid config", async () => {
+    configState.snapshot = {
+      exists: true,
+      valid: false,
+      path: "/tmp/openclaw-test-missing-config.json",
+      config: {},
+      parsed: null,
+      issues: [{ path: "<root>", message: "JSON5 parse failed" }],
+      legacyIssues: [],
+    };
+
+    await prepareGatewayReset();
+    await runGatewayCli(["gateway", "--dev", "--reset", "--allow-unconfigured"]);
+
+    expect(ensureDevGatewayConfig).toHaveBeenCalledWith({ reset: true });
   });
 
   it("passes invalid startup snapshot through when explicitly allowed", async () => {

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -27,6 +27,9 @@ const runGatewayLoop = vi.fn(async ({ start }: { start: GatewayLoopStart }) => {
   await start();
 });
 const normalizeStateDirEnv = vi.fn((_env?: NodeJS.ProcessEnv) => undefined);
+const beforeRun = vi.fn(async () => {
+  callOrder.push("bootstrap");
+});
 const callOrder = vi.hoisted(() => [] as string[]);
 const gatewayLogMessages = vi.hoisted(() => [] as string[]);
 const configState = vi.hoisted(() => ({
@@ -216,8 +219,8 @@ describe("gateway run option collisions", () => {
     ({ addGatewayRunCommand } = await import("./run-command.js"));
     sharedProgram = new Command();
     sharedProgram.exitOverride();
-    const gateway = addGatewayRunCommand(sharedProgram.command("gateway"));
-    addGatewayRunCommand(gateway.command("run"));
+    const gateway = addGatewayRunCommand(sharedProgram.command("gateway"), { beforeRun });
+    addGatewayRunCommand(gateway.command("run"), { beforeRun });
   });
 
   beforeEach(() => {
@@ -241,6 +244,7 @@ describe("gateway run option collisions", () => {
     ensureDevGatewayConfig.mockClear();
     runGatewayLoop.mockClear();
     normalizeStateDirEnv.mockReset();
+    beforeRun.mockClear();
     callOrder.length = 0;
   });
 
@@ -270,6 +274,21 @@ describe("gateway run option collisions", () => {
     expect(gatewayStartOptions().auth?.mode).toBe(mode);
   }
 
+  it("runs the fast-path bootstrap hook before gateway startup", async () => {
+    normalizeStateDirEnv.mockImplementation((_env?: NodeJS.ProcessEnv) => {
+      callOrder.push("normalize");
+    });
+    startGatewayServer.mockImplementationOnce(async (_port: number, _opts?: unknown) => {
+      callOrder.push("start");
+      return { close: vi.fn(async () => {}) };
+    });
+
+    await runGatewayCli(["gateway", "--allow-unconfigured"]);
+
+    expect(beforeRun).toHaveBeenCalledOnce();
+    expect(callOrder).toEqual(["bootstrap", "normalize", "start"]);
+  });
+
   it("forwards parent-captured options to `gateway run` subcommand", async () => {
     normalizeStateDirEnv.mockImplementation((_env?: NodeJS.ProcessEnv) => {
       callOrder.push("normalize");
@@ -298,7 +317,7 @@ describe("gateway run option collisions", () => {
     expect(setGatewayWsLogStyle).toHaveBeenCalledWith("full");
     expect(gatewayStartOptions().auth?.token).toBe("tok_run");
     expect(normalizeStateDirEnv).toHaveBeenCalledWith(process.env);
-    expect(callOrder).toEqual(["normalize", "start"]);
+    expect(callOrder).toEqual(["bootstrap", "normalize", "start"]);
   });
 
   it("marks service-mode gateway descendants with the live gateway pid", async () => {

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -992,6 +992,37 @@ describe("gateway run option collisions", () => {
     expect(runtimeErrors.join("\n")).toContain("run automatic gateway startup migrations");
   });
 
+  it("blocks a future-version service-mode late recovery candidate before restore", async () => {
+    let recoveryAllowed: boolean | undefined;
+    await withEnvAsync(
+      {
+        OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1",
+        OPENCLAW_SERVICE_MARKER: undefined,
+      },
+      async () => {
+        readConfigFileSnapshotWithPluginMetadata.mockImplementationOnce(async (options) => {
+          recoveryAllowed = await options?.allowSuspiciousRecovery?.(
+            {
+              env: { vars: { OPENCLAW_SERVICE_MARKER: "gateway" } },
+              gateway: { mode: "local" },
+              meta: { lastTouchedVersion: "9999.1.1" },
+            },
+            { gateway: { mode: "local" } },
+          );
+          return { snapshot: configState.snapshot };
+        });
+
+        await expect(runGatewayCli(["gateway", "run", "--allow-unconfigured"])).rejects.toThrow(
+          "__exit__:78",
+        );
+      },
+    );
+
+    expect(recoveryAllowed).toBe(false);
+    expect(startGatewayServer).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain("start the gateway service");
+  });
+
   it("blocks a future-version current config before suspicious recovery", async () => {
     let recoveryAllowed: boolean | undefined;
     readConfigFileSnapshotWithPluginMetadata.mockImplementationOnce(async (options) => {

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -515,6 +515,125 @@ describe("gateway run option collisions", () => {
     });
   });
 
+  it("uses config env shell fallback controls without mutating the live env during planning", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_LOAD_SHELL_ENV: undefined,
+        OPENCLAW_SHELL_ENV_TIMEOUT_MS: undefined,
+      },
+      async () => {
+        const finalConfig = {
+          env: {
+            vars: {
+              OPENCLAW_LOAD_SHELL_ENV: "1",
+              OPENCLAW_SHELL_ENV_TIMEOUT_MS: "4321",
+            },
+          },
+          gateway: { auth: { mode: "none" }, mode: "local" },
+        };
+        configState.snapshot = {
+          config: finalConfig,
+          exists: true,
+          parsed: finalConfig,
+          path: "/tmp/openclaw.json",
+          sourceConfig: finalConfig,
+          valid: true,
+        };
+        shouldEnableShellEnvFallback.mockImplementationOnce(
+          (env?: NodeJS.ProcessEnv) => env?.OPENCLAW_LOAD_SHELL_ENV === "1",
+        );
+        resolveShellEnvFallbackTimeoutMs.mockImplementationOnce((env?: NodeJS.ProcessEnv) =>
+          Number(env?.OPENCLAW_SHELL_ENV_TIMEOUT_MS),
+        );
+
+        await runGatewayCli(["gateway"]);
+
+        expect(loadShellEnvFallback).toHaveBeenCalledWith(
+          expect.objectContaining({ enabled: true, timeoutMs: 4321 }),
+        );
+        expect(process.env.OPENCLAW_LOAD_SHELL_ENV).toBe("1");
+        expect(process.env.OPENCLAW_SHELL_ENV_TIMEOUT_MS).toBe("4321");
+      },
+    );
+  });
+
+  it("honors config env shell fallback deferral", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_DEFER_SHELL_ENV_FALLBACK: undefined,
+        OPENCLAW_LOAD_SHELL_ENV: undefined,
+      },
+      async () => {
+        const finalConfig = {
+          env: {
+            vars: {
+              OPENCLAW_DEFER_SHELL_ENV_FALLBACK: "1",
+              OPENCLAW_LOAD_SHELL_ENV: "1",
+            },
+          },
+          gateway: { auth: { mode: "none" }, mode: "local" },
+        };
+        configState.snapshot = {
+          config: finalConfig,
+          exists: true,
+          parsed: finalConfig,
+          path: "/tmp/openclaw.json",
+          sourceConfig: finalConfig,
+          valid: true,
+        };
+        shouldEnableShellEnvFallback.mockImplementationOnce(
+          (env?: NodeJS.ProcessEnv) => env?.OPENCLAW_LOAD_SHELL_ENV === "1",
+        );
+        shouldDeferShellEnvFallback.mockImplementationOnce(
+          (env?: NodeJS.ProcessEnv) => env?.OPENCLAW_DEFER_SHELL_ENV_FALLBACK === "1",
+        );
+
+        await runGatewayCli(["gateway"]);
+
+        expect(resolveShellEnvExpectedKeys).not.toHaveBeenCalled();
+        expect(loadShellEnvFallback).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it("ignores shell fallback controls from invalid config", async () => {
+    const { clearGatewayRunConfigEnvironment } = await import("./pre-bootstrap.js");
+    clearGatewayRunConfigEnvironment();
+    await withEnvAsync(
+      {
+        OPENCLAW_DEFER_SHELL_ENV_FALLBACK: undefined,
+        OPENCLAW_LOAD_SHELL_ENV: "1",
+      },
+      async () => {
+        const invalidConfig = {
+          env: { vars: { OPENCLAW_DEFER_SHELL_ENV_FALLBACK: "1" } },
+          gateway: { mode: "local" },
+        };
+        configState.snapshot = {
+          config: invalidConfig,
+          exists: true,
+          issues: [{ path: "gateway", message: "invalid" }],
+          parsed: invalidConfig,
+          path: "/tmp/openclaw.json",
+          sourceConfig: invalidConfig,
+          valid: false,
+        };
+        shouldEnableShellEnvFallback.mockImplementation(
+          (env?: NodeJS.ProcessEnv) => env?.OPENCLAW_LOAD_SHELL_ENV === "1",
+        );
+        shouldDeferShellEnvFallback.mockImplementation(
+          (env?: NodeJS.ProcessEnv) => env?.OPENCLAW_DEFER_SHELL_ENV_FALLBACK === "1",
+        );
+
+        await runGatewayCli(["gateway", "--allow-unconfigured"]);
+
+        expect(loadShellEnvFallback).toHaveBeenCalledOnce();
+        expect(startGatewayServer).toHaveBeenCalledOnce();
+      },
+    );
+  });
+
   it("replaces config-derived env when the final startup snapshot changes in place", async () => {
     await withEnvAsync(
       {

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -933,6 +933,26 @@ describe("gateway run option collisions", () => {
     expect(runtimeErrors.join("\n")).toContain("Refusing to reset the dev gateway state");
   });
 
+  it("blocks dev reset when parseable future-version metadata is schema-invalid", async () => {
+    configState.snapshot = {
+      config: {},
+      exists: true,
+      issues: [{ message: "unknown newer field", path: "gateway.newerField" }],
+      parsed: { gateway: { newerField: true }, meta: { lastTouchedVersion: "9999.1.1" } },
+      sourceConfig: {
+        gateway: { newerField: true },
+        meta: { lastTouchedVersion: "9999.1.1" },
+      },
+      valid: false,
+    };
+
+    await expect(prepareGatewayReset()).rejects.toThrow("__exit__:1");
+
+    expect(ensureDevGatewayConfig).not.toHaveBeenCalled();
+    expect(startGatewayServer).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain("Refusing to reset the dev gateway state");
+  });
+
   it("does not retain targets or credentials from the config deleted by dev reset", async () => {
     await withEnvAsync(
       {

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -41,6 +41,7 @@ const refreshManagedProxy = vi.fn(async () => {
 const loadShellEnvFallback = vi.fn((_opts?: unknown) => {
   callOrder.push("shell-env");
 });
+const clearShellEnvAppliedKeys = vi.fn((_keys: readonly string[]) => undefined);
 const resolveShellEnvExpectedKeys = vi.fn((_env?: NodeJS.ProcessEnv) => ["OPENCLAW_GATEWAY_TOKEN"]);
 const resolveShellEnvFallbackTimeoutMs = vi.fn((_env?: NodeJS.ProcessEnv) => 15_000);
 const shouldDeferShellEnvFallback = vi.fn((_env?: NodeJS.ProcessEnv) => false);
@@ -121,6 +122,7 @@ vi.mock("../../config/shell-env-expected-keys.js", () => ({
 }));
 
 vi.mock("../../infra/shell-env.js", () => ({
+  clearShellEnvAppliedKeys: (keys: readonly string[]) => clearShellEnvAppliedKeys(keys),
   loadShellEnvFallback: (opts?: unknown) => loadShellEnvFallback(opts),
   resolveShellEnvFallbackTimeoutMs: (env?: NodeJS.ProcessEnv) =>
     resolveShellEnvFallbackTimeoutMs(env),
@@ -302,6 +304,7 @@ describe("gateway run option collisions", () => {
     beforeRun.mockClear();
     refreshManagedProxy.mockClear();
     loadShellEnvFallback.mockClear();
+    clearShellEnvAppliedKeys.mockClear();
     resolveShellEnvExpectedKeys.mockClear();
     resolveShellEnvFallbackTimeoutMs.mockClear();
     shouldDeferShellEnvFallback.mockReset();
@@ -396,7 +399,6 @@ describe("gateway run option collisions", () => {
         },
         proxy: { enabled: true, proxyUrl: "http://127.0.0.1:29876" },
       };
-      configState.cfg = finalConfig;
       configState.snapshot = {
         exists: true,
         valid: true,
@@ -405,21 +407,30 @@ describe("gateway run option collisions", () => {
         parsed: finalConfig,
         sourceConfig: finalConfig,
       };
-      readConfigFileSnapshotWithPluginMetadata.mockImplementationOnce(async () => {
-        expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("shell-token");
-        return {
-          snapshot: {
-            ...configState.snapshot,
-            config: {
-              ...finalConfig,
-              gateway: {
-                ...finalConfig.gateway,
-                auth: { mode: "token", token: "config-token" },
+      readConfigFileSnapshotWithPluginMetadata
+        .mockImplementationOnce(async (options) => {
+          expect(options?.lowerPrecedenceEnv).toBeUndefined();
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+          return { snapshot: configState.snapshot };
+        })
+        .mockImplementationOnce(async (options) => {
+          expect(options?.lowerPrecedenceEnv).toEqual({
+            OPENCLAW_GATEWAY_TOKEN: "shell-token",
+          });
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("shell-token");
+          return {
+            snapshot: {
+              ...configState.snapshot,
+              config: {
+                ...finalConfig,
+                gateway: {
+                  ...finalConfig.gateway,
+                  auth: { mode: "token", token: "config-token" },
+                },
               },
             },
-          },
-        };
-      });
+          };
+        });
       loadShellEnvFallback.mockImplementationOnce((opts?: unknown) => {
         callOrder.push("shell-env");
         (opts as { env: NodeJS.ProcessEnv }).env.OPENCLAW_GATEWAY_TOKEN = "shell-token";
@@ -443,15 +454,64 @@ describe("gateway run option collisions", () => {
           lowerPrecedenceEnv: { OPENCLAW_GATEWAY_TOKEN: "shell-token" },
         }),
       );
+      expect(readConfigFileSnapshotWithPluginMetadata).toHaveBeenCalledTimes(2);
       expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("config-token");
       const shellEnvOrder = loadShellEnvFallback.mock.invocationCallOrder[0] ?? 0;
-      const finalConfigReadOrder =
+      const initialConfigReadOrder =
         readConfigFileSnapshotWithPluginMetadata.mock.invocationCallOrder[0] ?? 0;
+      const finalConfigReadOrder =
+        readConfigFileSnapshotWithPluginMetadata.mock.invocationCallOrder[1] ?? 0;
       const refreshOrder = refreshManagedProxy.mock.invocationCallOrder[0] ?? 0;
       const startOrder = startGatewayServer.mock.invocationCallOrder[0] ?? 0;
+      expect(shellEnvOrder).toBeGreaterThan(initialConfigReadOrder);
       expect(finalConfigReadOrder).toBeGreaterThan(shellEnvOrder);
       expect(refreshOrder).toBeGreaterThan(shellEnvOrder);
       expect(startOrder).toBeGreaterThan(refreshOrder);
+    });
+  });
+
+  it("removes shell fallback values when the final accepted config disables fallback", async () => {
+    await withEnvAsync({ OPENCLAW_GATEWAY_TOKEN: undefined }, async () => {
+      const enabledConfig = {
+        env: { shellEnv: { enabled: true } },
+        gateway: { auth: { mode: "none" }, mode: "local" },
+      };
+      const disabledConfig = {
+        gateway: { auth: { mode: "none" }, mode: "local" },
+      };
+      const snapshot = (config: Record<string, unknown>) => ({
+        config,
+        exists: true,
+        parsed: config,
+        path: "/tmp/openclaw.json",
+        sourceConfig: config,
+        valid: true,
+      });
+      readConfigFileSnapshotWithPluginMetadata
+        .mockResolvedValueOnce({ snapshot: snapshot(enabledConfig) })
+        .mockImplementationOnce(async (options) => {
+          expect(options?.lowerPrecedenceEnv).toEqual({
+            OPENCLAW_GATEWAY_TOKEN: "shell-token",
+          });
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("shell-token");
+          return { snapshot: snapshot(disabledConfig) };
+        })
+        .mockImplementationOnce(async (options) => {
+          expect(options?.lowerPrecedenceEnv).toBeUndefined();
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+          return { snapshot: snapshot(disabledConfig) };
+        });
+      loadShellEnvFallback.mockImplementationOnce((opts?: unknown) => {
+        (opts as { env: NodeJS.ProcessEnv }).env.OPENCLAW_GATEWAY_TOKEN = "shell-token";
+      });
+
+      await runGatewayCli(["gateway"]);
+
+      expect(readConfigFileSnapshotWithPluginMetadata).toHaveBeenCalledTimes(3);
+      expect(loadShellEnvFallback).toHaveBeenCalledOnce();
+      expect(clearShellEnvAppliedKeys).toHaveBeenCalledWith(["OPENCLAW_GATEWAY_TOKEN"]);
+      expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+      expect(startGatewayServer).toHaveBeenCalledOnce();
     });
   });
 
@@ -923,7 +983,8 @@ describe("gateway run option collisions", () => {
       recoverSuspicious: true,
       allowSuspiciousRecovery: expect.any(Function),
     });
-    expect(readBestEffortConfig).toHaveBeenCalledOnce();
+    expect(resolveShellEnvExpectedKeys).not.toHaveBeenCalled();
+    expect(readBestEffortConfig).not.toHaveBeenCalled();
     const options = gatewayStartOptions();
     expect(options.bind).toBe("loopback");
     expect(options.startupConfigSnapshotRead).toEqual({ snapshot: configState.snapshot });
@@ -1047,7 +1108,7 @@ describe("gateway run option collisions", () => {
       `Config write audit: ${path.join("/tmp", "logs", "config-audit.jsonl")}`,
     );
     expect(startGatewayServer).not.toHaveBeenCalled();
-    expect(readBestEffortConfig).toHaveBeenCalledOnce();
+    expect(readBestEffortConfig).not.toHaveBeenCalled();
   });
 
   it("blocks invalid startup config without automatic recovery", async () => {

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -456,6 +456,7 @@ describe("gateway run option collisions", () => {
       );
       expect(readConfigFileSnapshotWithPluginMetadata).toHaveBeenCalledTimes(2);
       expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("config-token");
+      expect(clearShellEnvAppliedKeys).toHaveBeenCalledWith(["OPENCLAW_GATEWAY_TOKEN"]);
       const shellEnvOrder = loadShellEnvFallback.mock.invocationCallOrder[0] ?? 0;
       const initialConfigReadOrder =
         readConfigFileSnapshotWithPluginMetadata.mock.invocationCallOrder[0] ?? 0;
@@ -467,6 +468,38 @@ describe("gateway run option collisions", () => {
       expect(finalConfigReadOrder).toBeGreaterThan(shellEnvOrder);
       expect(refreshOrder).toBeGreaterThan(shellEnvOrder);
       expect(startOrder).toBeGreaterThan(refreshOrder);
+    });
+  });
+
+  it("lets config env aliases replace canonical shell fallback values", async () => {
+    await withEnvAsync({ ZAI_API_KEY: undefined, Z_AI_API_KEY: undefined }, async () => {
+      const finalConfig = {
+        env: {
+          shellEnv: { enabled: true },
+          vars: { Z_AI_API_KEY: "config-key" },
+        },
+        gateway: { auth: { mode: "none" }, mode: "local" },
+      };
+      configState.snapshot = {
+        config: finalConfig,
+        exists: true,
+        parsed: finalConfig,
+        path: "/tmp/openclaw.json",
+        sourceConfig: finalConfig,
+        valid: true,
+      };
+      resolveShellEnvExpectedKeys
+        .mockReturnValueOnce(["ZAI_API_KEY"])
+        .mockReturnValueOnce(["ZAI_API_KEY"]);
+      loadShellEnvFallback.mockImplementationOnce((opts?: unknown) => {
+        (opts as { env: NodeJS.ProcessEnv }).env.ZAI_API_KEY = "shell-key";
+      });
+
+      await runGatewayCli(["gateway"]);
+
+      expect(process.env.Z_AI_API_KEY).toBe("config-key");
+      expect(process.env.ZAI_API_KEY).toBe("config-key");
+      expect(clearShellEnvAppliedKeys).toHaveBeenCalledWith(["ZAI_API_KEY"]);
     });
   });
 

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConfigFileSnapshot } from "../../config/types.js";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../../daemon/constants.js";
 import { SUPERVISOR_HINT_ENV_VARS } from "../../infra/supervisor-markers.js";
 import { withEnvAsync } from "../../test-utils/env.js";
@@ -665,6 +666,48 @@ describe("gateway run option collisions", () => {
         expect(startGatewayServer).toHaveBeenCalledOnce();
       },
     );
+  });
+
+  it("rejects an invalid final config after a prepared config selected runtime paths", async () => {
+    const selectedStateDir = "/tmp/openclaw-prepared-selected-state";
+    await withEnvAsync({ OPENCLAW_STATE_DIR: undefined }, async () => {
+      const selectedConfig = {
+        env: { vars: { OPENCLAW_STATE_DIR: selectedStateDir } },
+        gateway: { mode: "local" },
+      };
+      configState.snapshot = {
+        config: selectedConfig,
+        exists: true,
+        parsed: selectedConfig,
+        path: "/tmp/openclaw.json",
+        sourceConfig: selectedConfig,
+        valid: true,
+      };
+      const {
+        applyFinalGatewayRunConfigEnv,
+        prepareGatewayRunBootstrap,
+        selectGatewayRunEnvironment,
+      } = await import("./pre-bootstrap.js");
+
+      expect(await selectGatewayRunEnvironment({ opts: {}, runtime: defaultRuntime })).toBe(true);
+      expect(await prepareGatewayRunBootstrap({ opts: {}, runtime: defaultRuntime })).toBe(true);
+      expect(process.env.OPENCLAW_STATE_DIR).toBe(selectedStateDir);
+
+      const invalidSnapshot = {
+        ...configState.snapshot,
+        issues: [{ message: "invalid", path: "gateway" }],
+        valid: false,
+      };
+      await expect(
+        applyFinalGatewayRunConfigEnv({
+          runtime: defaultRuntime,
+          snapshot: invalidSnapshot as ConfigFileSnapshot,
+        }),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(runtimeErrors.join("\n")).toContain("final config read became invalid");
+      expect(startGatewayServer).not.toHaveBeenCalled();
+    });
   });
 
   it("replaces config-derived env when the final startup snapshot changes in place", async () => {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -303,22 +303,24 @@ type GatewayRunShellEnvFallbackPlan =
 async function resolveGatewayRunShellEnvFallbackPlan(
   cfg: OpenClawConfig,
 ): Promise<GatewayRunShellEnvFallbackPlan> {
+  const { createConfigRuntimeEnv } = await import("../../config/env-vars.js");
   const {
     resolveShellEnvFallbackTimeoutMs,
     shouldDeferShellEnvFallback,
     shouldEnableShellEnvFallback,
   } = await import("../../infra/shell-env.js");
+  const planEnv = createConfigRuntimeEnv(cfg, process.env);
   const enabled =
-    (shouldEnableShellEnvFallback(process.env) || cfg.env?.shellEnv?.enabled === true) &&
-    !shouldDeferShellEnvFallback(process.env);
+    (shouldEnableShellEnvFallback(planEnv) || cfg.env?.shellEnv?.enabled === true) &&
+    !shouldDeferShellEnvFallback(planEnv);
   if (!enabled) {
     return { enabled: false };
   }
   const { resolveShellEnvExpectedKeys } = await import("../../config/shell-env-expected-keys.js");
   return {
     enabled: true,
-    expectedKeys: resolveShellEnvExpectedKeys(process.env),
-    timeoutMs: cfg.env?.shellEnv?.timeoutMs ?? resolveShellEnvFallbackTimeoutMs(process.env),
+    expectedKeys: resolveShellEnvExpectedKeys(planEnv),
+    timeoutMs: cfg.env?.shellEnv?.timeoutMs ?? resolveShellEnvFallbackTimeoutMs(planEnv),
   };
 }
 
@@ -379,7 +381,9 @@ async function readGatewayStartupConfigWithShellEnv(params: {
         opts: params.opts,
         startupTrace: params.startupTrace,
       });
-      const plan = await resolveGatewayRunShellEnvFallbackPlan(startupConfig.cfg);
+      const plan = await resolveGatewayRunShellEnvFallbackPlan(
+        startupConfig.snapshot?.valid === true ? startupConfig.cfg : {},
+      );
       const planSignature = gatewayRunShellEnvFallbackPlanSignature(plan);
       if (!plan.enabled) {
         if (Object.keys(lowerPrecedenceEnv).length === 0) {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -546,6 +546,21 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
   void maybeLogPendingControlUiBuild(cfg).catch((err: unknown) => {
     gatewayLog.warn(`Control UI asset check failed: ${String(err)}`);
   });
+  // Gateway fast path skips ensureCliExecutionBootstrap, so the normal state migration
+  // preflight never runs. Without this the scheduler loads 0 jobs from empty SQLite.
+  try {
+    const { repairLegacyCronStoreWithoutPrompt } =
+      await import("../../commands/doctor/cron/index.js");
+    const cronMigration = await repairLegacyCronStoreWithoutPrompt({ cfg });
+    for (const change of cronMigration.changes) {
+      gatewayLog.info(change);
+    }
+    for (const warning of cronMigration.warnings) {
+      gatewayLog.warn(warning);
+    }
+  } catch (err) {
+    gatewayLog.warn(`Cron store migration check failed: ${formatErrorMessage(err)}`);
+  }
   const portOverride = parsePort(opts.port);
   if (opts.port !== undefined && portOverride === null) {
     defaultRuntime.error(formatInvalidPortOption("--port"));

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -546,21 +546,6 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
   void maybeLogPendingControlUiBuild(cfg).catch((err: unknown) => {
     gatewayLog.warn(`Control UI asset check failed: ${String(err)}`);
   });
-  // Gateway fast path skips ensureCliExecutionBootstrap, so the normal state migration
-  // preflight never runs. Without this the scheduler loads 0 jobs from empty SQLite.
-  try {
-    const { repairLegacyCronStoreWithoutPrompt } =
-      await import("../../commands/doctor/cron/index.js");
-    const cronMigration = await repairLegacyCronStoreWithoutPrompt({ cfg });
-    for (const change of cronMigration.changes) {
-      gatewayLog.info(change);
-    }
-    for (const warning of cronMigration.warnings) {
-      gatewayLog.warn(warning);
-    }
-  } catch (err) {
-    gatewayLog.warn(`Cron store migration check failed: ${formatErrorMessage(err)}`);
-  }
   const portOverride = parsePort(opts.port);
   if (opts.port !== undefined && portOverride === null) {
     defaultRuntime.error(formatInvalidPortOption("--port"));

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -58,6 +58,7 @@ const gatewayLog = createSubsystemLogger("gateway");
 const SUPERVISED_GATEWAY_LOCK_RETRY_MS = 5000;
 const SUPERVISED_GATEWAY_LOCK_RETRY_TIMEOUT_MS = 30_000;
 const SUPERVISED_GATEWAY_HEALTH_PROBE_TIMEOUT_MS = 1000;
+const GATEWAY_SHELL_ENV_CONVERGENCE_MAX_READS = 4;
 
 type Awaitable<T> = T | Promise<T>;
 type GatewayRunLogger = Pick<ReturnType<typeof createSubsystemLogger>, "info" | "warn">;
@@ -291,54 +292,119 @@ async function readGatewayStartupConfig(params: {
   };
 }
 
-async function loadGatewayRunShellEnvFallback(
+type GatewayRunShellEnvFallbackPlan =
+  | { enabled: false }
+  | {
+      enabled: true;
+      expectedKeys: string[];
+      timeoutMs: number;
+    };
+
+async function resolveGatewayRunShellEnvFallbackPlan(
   cfg: OpenClawConfig,
-): Promise<Record<string, string>> {
-  const [
-    { resolveShellEnvExpectedKeys },
-    {
-      loadShellEnvFallback,
-      resolveShellEnvFallbackTimeoutMs,
-      shouldDeferShellEnvFallback,
-      shouldEnableShellEnvFallback,
-    },
-  ] = await Promise.all([
-    import("../../config/shell-env-expected-keys.js"),
-    import("../../infra/shell-env.js"),
-  ]);
-  const enabled = shouldEnableShellEnvFallback(process.env) || cfg.env?.shellEnv?.enabled === true;
-  if (!enabled || shouldDeferShellEnvFallback(process.env)) {
-    return {};
+): Promise<GatewayRunShellEnvFallbackPlan> {
+  const {
+    resolveShellEnvFallbackTimeoutMs,
+    shouldDeferShellEnvFallback,
+    shouldEnableShellEnvFallback,
+  } = await import("../../infra/shell-env.js");
+  const enabled =
+    (shouldEnableShellEnvFallback(process.env) || cfg.env?.shellEnv?.enabled === true) &&
+    !shouldDeferShellEnvFallback(process.env);
+  if (!enabled) {
+    return { enabled: false };
   }
-  const expectedKeys = resolveShellEnvExpectedKeys(process.env);
-  const valuesBeforeLoad = new Map(expectedKeys.map((key) => [key, process.env[key]]));
+  const { resolveShellEnvExpectedKeys } = await import("../../config/shell-env-expected-keys.js");
+  return {
+    enabled: true,
+    expectedKeys: resolveShellEnvExpectedKeys(process.env),
+    timeoutMs: cfg.env?.shellEnv?.timeoutMs ?? resolveShellEnvFallbackTimeoutMs(process.env),
+  };
+}
+
+async function loadGatewayRunShellEnvFallback(
+  plan: Extract<GatewayRunShellEnvFallbackPlan, { enabled: true }>,
+): Promise<Record<string, string>> {
+  const { loadShellEnvFallback } = await import("../../infra/shell-env.js");
+  const valuesBeforeLoad = new Map(plan.expectedKeys.map((key) => [key, process.env[key]]));
   loadShellEnvFallback({
     enabled: true,
     env: process.env,
-    expectedKeys,
+    expectedKeys: plan.expectedKeys,
     logger: gatewayLog,
-    timeoutMs: cfg.env?.shellEnv?.timeoutMs ?? resolveShellEnvFallbackTimeoutMs(process.env),
+    timeoutMs: plan.timeoutMs,
   });
   return Object.fromEntries(
-    expectedKeys.flatMap((key) => {
+    plan.expectedKeys.flatMap((key) => {
       const value = process.env[key];
       return value !== undefined && value !== valuesBeforeLoad.get(key) ? [[key, value]] : [];
     }),
   );
 }
 
-async function loadGatewayRunShellEnvForFinalConfig(
-  startupTrace: ReturnType<typeof createGatewayCliStartupTrace>,
-): Promise<{
-  lowerPrecedenceEnv: Readonly<Record<string, string>>;
-}> {
-  const { readBestEffortConfig } = await import("../../config/config.js");
-  const preliminaryConfig = await startupTrace.measure("cli.config-shell-env", () =>
-    readBestEffortConfig({ isolateEnv: true, observe: false }),
+async function clearGatewayRunShellEnvFallback(
+  values: Readonly<Record<string, string>>,
+): Promise<void> {
+  const keys = Object.keys(values);
+  if (keys.length === 0) {
+    return;
+  }
+  for (const [key, value] of Object.entries(values)) {
+    if (process.env[key] === value) {
+      delete process.env[key];
+    }
+  }
+  const { clearShellEnvAppliedKeys } = await import("../../infra/shell-env.js");
+  clearShellEnvAppliedKeys(keys);
+}
+
+function gatewayRunShellEnvFallbackPlanSignature(plan: GatewayRunShellEnvFallbackPlan): string {
+  return JSON.stringify(plan);
+}
+
+async function readGatewayStartupConfigWithShellEnv(params: {
+  opts: GatewayRunOpts;
+  startupTrace: ReturnType<typeof createGatewayCliStartupTrace>;
+}): Promise<
+  Awaited<ReturnType<typeof readGatewayStartupConfig>> & {
+    lowerPrecedenceEnv: Readonly<Record<string, string>>;
+  }
+> {
+  let lowerPrecedenceEnv: Record<string, string> = {};
+  let loadedPlanSignature: string | undefined;
+  try {
+    for (let readCount = 0; readCount < GATEWAY_SHELL_ENV_CONVERGENCE_MAX_READS; readCount += 1) {
+      const startupConfig = await readGatewayStartupConfig({
+        lowerPrecedenceEnv,
+        opts: params.opts,
+        startupTrace: params.startupTrace,
+      });
+      const plan = await resolveGatewayRunShellEnvFallbackPlan(startupConfig.cfg);
+      const planSignature = gatewayRunShellEnvFallbackPlanSignature(plan);
+      if (!plan.enabled) {
+        if (Object.keys(lowerPrecedenceEnv).length === 0) {
+          return { ...startupConfig, lowerPrecedenceEnv };
+        }
+        await clearGatewayRunShellEnvFallback(lowerPrecedenceEnv);
+        lowerPrecedenceEnv = {};
+        loadedPlanSignature = undefined;
+        continue;
+      }
+      if (loadedPlanSignature === planSignature) {
+        return { ...startupConfig, lowerPrecedenceEnv };
+      }
+      await clearGatewayRunShellEnvFallback(lowerPrecedenceEnv);
+      lowerPrecedenceEnv = await loadGatewayRunShellEnvFallback(plan);
+      loadedPlanSignature = planSignature;
+    }
+  } catch (err) {
+    await clearGatewayRunShellEnvFallback(lowerPrecedenceEnv);
+    throw err;
+  }
+  await clearGatewayRunShellEnvFallback(lowerPrecedenceEnv);
+  throw new Error(
+    "Gateway shell environment fallback settings changed repeatedly during startup. Retry startup.",
   );
-  return {
-    lowerPrecedenceEnv: await loadGatewayRunShellEnvFallback(preliminaryConfig),
-  };
 }
 
 function isGatewayLockError(err: unknown): err is GatewayLockError {
@@ -564,12 +630,11 @@ export async function runGatewayCommand(opts: GatewayRunOpts, hooks: GatewayRunR
   }
 
   gatewayLog.info("loading configuration…");
-  const shellEnvForFinalConfig = await loadGatewayRunShellEnvForFinalConfig(startupTrace);
-  const { cfg, snapshot, startupConfigSnapshotRead } = await readGatewayStartupConfig({
-    ...shellEnvForFinalConfig,
-    opts,
-    startupTrace,
-  });
+  const { cfg, lowerPrecedenceEnv, snapshot, startupConfigSnapshotRead } =
+    await readGatewayStartupConfigWithShellEnv({
+      opts,
+      startupTrace,
+    });
   if (
     !enforceGatewayRunFutureConfigGuard({
       opts,
@@ -583,7 +648,7 @@ export async function runGatewayCommand(opts: GatewayRunOpts, hooks: GatewayRunR
     const { applyFinalGatewayRunConfigEnv } = await import("./pre-bootstrap.js");
     if (
       !(await applyFinalGatewayRunConfigEnv({
-        lowerPrecedenceEnv: shellEnvForFinalConfig.lowerPrecedenceEnv,
+        lowerPrecedenceEnv,
         runtime: defaultRuntime,
         snapshot,
       }))

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -6,7 +6,6 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import type { Command } from "commander";
 import type {
   ConfigFileSnapshot,
   GatewayAuthMode,
@@ -14,6 +13,7 @@ import type {
   GatewayTailscaleMode,
   ReadConfigFileSnapshotWithPluginMetadataResult,
 } from "../../config/config.js";
+import { ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV } from "../../config/future-version-guard.js";
 import {
   CONFIG_PATH,
   normalizeStateDirEnv,
@@ -41,62 +41,19 @@ import { withDiagnosticPhase } from "../../logging/diagnostic-phase.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
-import { inheritOptionFromParent } from "../command-options.js";
 import { formatInvalidConfigPort, formatInvalidPortOption } from "../error-format.js";
 import { withProgress } from "../progress.js";
 import { parsePort } from "../shared/parse-port.js";
+import {
+  enforceGatewayRunFutureConfigGuard,
+  isGatewayRunFutureConfigAllowed,
+} from "./future-config-guard.js";
 import { installQaParentWatchdog } from "./qa-parent-watchdog.js";
 import { runGatewayLoop } from "./run-loop.js";
-
-type GatewayRunOpts = {
-  port?: unknown;
-  bind?: unknown;
-  token?: unknown;
-  auth?: unknown;
-  password?: unknown;
-  passwordFile?: unknown;
-  tailscale?: unknown;
-  tailscaleResetOnExit?: boolean;
-  allowUnconfigured?: boolean;
-  force?: boolean;
-  verbose?: boolean;
-  cliBackendLogs?: boolean;
-  /** @deprecated Use cliBackendLogs. */
-  claudeCliLogs?: boolean;
-  wsLog?: unknown;
-  compact?: boolean;
-  rawStream?: boolean;
-  rawStreamPath?: unknown;
-  dev?: boolean;
-  reset?: boolean;
-};
+import type { GatewayRunOpts } from "./run-options.js";
+import type { GatewayRunRuntimeHooks } from "./runtime-hooks.js";
 
 const gatewayLog = createSubsystemLogger("gateway");
-
-const GATEWAY_RUN_VALUE_KEYS = [
-  "port",
-  "bind",
-  "token",
-  "auth",
-  "password",
-  "passwordFile",
-  "tailscale",
-  "wsLog",
-  "rawStreamPath",
-] as const;
-
-const GATEWAY_RUN_BOOLEAN_KEYS = [
-  "tailscaleResetOnExit",
-  "allowUnconfigured",
-  "dev",
-  "reset",
-  "force",
-  "verbose",
-  "cliBackendLogs",
-  "claudeCliLogs",
-  "compact",
-  "rawStream",
-] as const;
 
 const SUPERVISED_GATEWAY_LOCK_RETRY_MS = 5000;
 const SUPERVISED_GATEWAY_LOCK_RETRY_TIMEOUT_MS = 30_000;
@@ -287,6 +244,8 @@ function getGatewayStartGuardErrors(params: {
 }
 
 async function readGatewayStartupConfig(params: {
+  lowerPrecedenceEnv: Readonly<Record<string, string>>;
+  opts: GatewayRunOpts;
   startupTrace: ReturnType<typeof createGatewayCliStartupTrace>;
 }): Promise<{
   cfg: OpenClawConfig;
@@ -294,10 +253,35 @@ async function readGatewayStartupConfig(params: {
   startupConfigSnapshotRead?: ReadConfigFileSnapshotWithPluginMetadataResult;
 }> {
   const { readConfigFileSnapshotWithPluginMetadata } = await import("../../config/config.js");
+  let blockedRecoveryConfig: OpenClawConfig | null = null;
   const snapshotRead: ReadConfigFileSnapshotWithPluginMetadataResult | null =
     await params.startupTrace.measure("cli.config-snapshot", () =>
-      readConfigFileSnapshotWithPluginMetadata({ recoverSuspicious: true }).catch(() => null),
+      readConfigFileSnapshotWithPluginMetadata({
+        isolateEnv: true,
+        ...(Object.keys(params.lowerPrecedenceEnv).length > 0
+          ? { lowerPrecedenceEnv: params.lowerPrecedenceEnv }
+          : {}),
+        recoverSuspicious: true,
+        allowSuspiciousRecovery: (config, current) => {
+          const blockedConfig = [current, config].find(
+            (candidate) =>
+              !isGatewayRunFutureConfigAllowed({ opts: params.opts, config: candidate }),
+          );
+          if (!blockedConfig) {
+            return true;
+          }
+          blockedRecoveryConfig = blockedConfig;
+          return false;
+        },
+      }).catch(() => null),
     );
+  if (blockedRecoveryConfig) {
+    enforceGatewayRunFutureConfigGuard({
+      opts: params.opts,
+      runtime: defaultRuntime,
+      config: blockedRecoveryConfig,
+    });
+  }
   const snapshot: ConfigFileSnapshot | null = snapshotRead?.snapshot ?? null;
   const cfg = snapshot?.config ?? {};
   return {
@@ -307,25 +291,54 @@ async function readGatewayStartupConfig(params: {
   };
 }
 
-export function resolveGatewayRunOptions(opts: GatewayRunOpts, command?: Command): GatewayRunOpts {
-  const resolved: GatewayRunOpts = { ...opts };
-
-  for (const key of GATEWAY_RUN_VALUE_KEYS) {
-    const inherited = inheritOptionFromParent(command, key);
-    if (key === "wsLog") {
-      // wsLog has a child default ("auto"), so prefer inherited parent CLI value when present.
-      resolved[key] = inherited ?? resolved[key];
-      continue;
-    }
-    resolved[key] = resolved[key] ?? inherited;
+async function loadGatewayRunShellEnvFallback(
+  cfg: OpenClawConfig,
+): Promise<Record<string, string>> {
+  const [
+    { resolveShellEnvExpectedKeys },
+    {
+      loadShellEnvFallback,
+      resolveShellEnvFallbackTimeoutMs,
+      shouldDeferShellEnvFallback,
+      shouldEnableShellEnvFallback,
+    },
+  ] = await Promise.all([
+    import("../../config/shell-env-expected-keys.js"),
+    import("../../infra/shell-env.js"),
+  ]);
+  const enabled = shouldEnableShellEnvFallback(process.env) || cfg.env?.shellEnv?.enabled === true;
+  if (!enabled || shouldDeferShellEnvFallback(process.env)) {
+    return {};
   }
+  const expectedKeys = resolveShellEnvExpectedKeys(process.env);
+  const valuesBeforeLoad = new Map(expectedKeys.map((key) => [key, process.env[key]]));
+  loadShellEnvFallback({
+    enabled: true,
+    env: process.env,
+    expectedKeys,
+    logger: gatewayLog,
+    timeoutMs: cfg.env?.shellEnv?.timeoutMs ?? resolveShellEnvFallbackTimeoutMs(process.env),
+  });
+  return Object.fromEntries(
+    expectedKeys.flatMap((key) => {
+      const value = process.env[key];
+      return value !== undefined && value !== valuesBeforeLoad.get(key) ? [[key, value]] : [];
+    }),
+  );
+}
 
-  for (const key of GATEWAY_RUN_BOOLEAN_KEYS) {
-    const inherited = inheritOptionFromParent<boolean>(command, key);
-    resolved[key] = Boolean(resolved[key] || inherited);
-  }
-
-  return resolved;
+async function loadGatewayRunShellEnvForFinalConfig(
+  startupTrace: ReturnType<typeof createGatewayCliStartupTrace>,
+): Promise<{
+  lowerPrecedenceEnv: Readonly<Record<string, string>>;
+}> {
+  const { readBestEffortConfig } = await import("../../config/config.js");
+  const preliminaryConfig = await startupTrace.measure("cli.config-shell-env", () =>
+    readBestEffortConfig({ isolateEnv: true, observe: false }),
+  );
+  return {
+    lowerPrecedenceEnv: await loadGatewayRunShellEnvFallback(preliminaryConfig),
+  };
 }
 
 function isGatewayLockError(err: unknown): err is GatewayLockError {
@@ -477,12 +490,11 @@ async function maybeWriteGatewayStartupFailureBundle(err: unknown): Promise<void
   }
 }
 
-export async function runGatewayCommand(opts: GatewayRunOpts) {
+export async function runGatewayCommand(opts: GatewayRunOpts, hooks: GatewayRunRuntimeHooks = {}) {
   normalizeStateDirEnv(process.env);
+  const { clearGatewayRunConfigEnvironment } = await import("./pre-bootstrap.js");
+  clearGatewayRunConfigEnvironment();
   installQaParentWatchdog();
-  if (process.env.OPENCLAW_SERVICE_MARKER?.trim()) {
-    process.env[GATEWAY_SERVICE_RUNTIME_PID_ENV] = String(process.pid);
-  }
   const isDevProfile = normalizeOptionalLowercaseString(process.env.OPENCLAW_PROFILE) === "dev";
   const devMode = Boolean(opts.dev) || isDevProfile;
   if (opts.reset && !devMode) {
@@ -490,7 +502,6 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
     defaultRuntime.exit(1);
     return;
   }
-
   setVerbose(Boolean(opts.verbose));
   if (opts.cliBackendLogs || opts.claudeCliLogs) {
     setConsoleSubsystemFilter(["agent/cli-backend"]);
@@ -533,16 +544,79 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
   setConsoleTimestampPrefix(true);
 
   if (devMode) {
+    if (opts.reset) {
+      // Recheck immediately before full reset; gateway module loading above can take seconds.
+      const { recheckGatewayRunReset } = await import("./pre-bootstrap.js");
+      if (!(await recheckGatewayRunReset({ opts, runtime: defaultRuntime }))) {
+        return;
+      }
+    }
     const { ensureDevGatewayConfig } = await import("./dev.js");
     await startupTrace.measure("cli.dev-config", () =>
       ensureDevGatewayConfig({ reset: Boolean(opts.reset) }),
     );
+    if (opts.reset) {
+      const { reloadTrustedGatewayRunEnvironment } = await import("./pre-bootstrap.js");
+      if (!(await reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime }))) {
+        return;
+      }
+    }
   }
 
   gatewayLog.info("loading configuration…");
+  const shellEnvForFinalConfig = await loadGatewayRunShellEnvForFinalConfig(startupTrace);
   const { cfg, snapshot, startupConfigSnapshotRead } = await readGatewayStartupConfig({
+    ...shellEnvForFinalConfig,
+    opts,
     startupTrace,
   });
+  if (
+    !enforceGatewayRunFutureConfigGuard({
+      opts,
+      runtime: defaultRuntime,
+      snapshot,
+    })
+  ) {
+    return;
+  }
+  if (snapshot) {
+    const { applyFinalGatewayRunConfigEnv } = await import("./pre-bootstrap.js");
+    if (
+      !(await applyFinalGatewayRunConfigEnv({
+        lowerPrecedenceEnv: shellEnvForFinalConfig.lowerPrecedenceEnv,
+        runtime: defaultRuntime,
+        snapshot,
+      }))
+    ) {
+      return;
+    }
+    const finalConfigEnteredServiceMode = Boolean(process.env.OPENCLAW_SERVICE_MARKER?.trim());
+    const clearRejectedFinalConfigEnv = () => {
+      clearGatewayRunConfigEnvironment();
+      if (finalConfigEnteredServiceMode) {
+        delete process.env[ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV];
+      }
+    };
+    let finalConfigAllowed: boolean;
+    try {
+      finalConfigAllowed = enforceGatewayRunFutureConfigGuard({
+        opts,
+        runtime: defaultRuntime,
+        snapshot,
+      });
+    } catch (err) {
+      clearRejectedFinalConfigEnv();
+      throw err;
+    }
+    if (!finalConfigAllowed) {
+      clearRejectedFinalConfigEnv();
+      return;
+    }
+  }
+  if (process.env.OPENCLAW_SERVICE_MARKER?.trim()) {
+    process.env[GATEWAY_SERVICE_RUNTIME_PID_ENV] = String(process.pid);
+  }
+  await hooks.refreshManagedProxy?.(cfg.proxy);
   void maybeLogPendingControlUiBuild(cfg).catch((err: unknown) => {
     gatewayLog.warn(`Control UI asset check failed: ${String(err)}`);
   });
@@ -555,28 +629,6 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
   const port = portOverride ?? resolveGatewayPort(cfg);
   if (!Number.isFinite(port) || port <= 0 || port > 65_535) {
     defaultRuntime.error(formatInvalidConfigPort("gateway.port"));
-    defaultRuntime.exit(1);
-    return;
-  }
-  const { formatFutureConfigActionBlock, resolveFutureConfigActionBlock } =
-    await import("../../config/future-version-guard.js");
-  const futureStartupBlock = resolveFutureConfigActionBlock({
-    action: "start the gateway service",
-    snapshot,
-  });
-  if (futureStartupBlock && process.env.OPENCLAW_SERVICE_MARKER?.trim()) {
-    defaultRuntime.error(formatFutureConfigActionBlock(futureStartupBlock));
-    defaultRuntime.exit(78);
-    return;
-  }
-  const futureForceBlock = opts.force
-    ? resolveFutureConfigActionBlock({
-        action: "force-kill gateway port listeners",
-        snapshot,
-      })
-    : null;
-  if (futureForceBlock) {
-    defaultRuntime.error(formatFutureConfigActionBlock(futureForceBlock));
     defaultRuntime.exit(1);
     return;
   }

--- a/src/cli/gateway-cli/runtime-hooks.ts
+++ b/src/cli/gateway-cli/runtime-hooks.ts
@@ -1,0 +1,22 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+export type GatewayRunRuntimeHooks = {
+  releaseManagedProxy?: () => Promise<void> | void;
+  refreshManagedProxy?: (config: OpenClawConfig["proxy"]) => Promise<void> | void;
+};
+
+let activeGatewayRunRuntimeHooks: GatewayRunRuntimeHooks = {};
+
+export function getGatewayRunRuntimeHooks(): GatewayRunRuntimeHooks {
+  return activeGatewayRunRuntimeHooks;
+}
+
+export function installGatewayRunRuntimeHooks(hooks: GatewayRunRuntimeHooks): () => void {
+  const previous = activeGatewayRunRuntimeHooks;
+  activeGatewayRunRuntimeHooks = hooks;
+  return () => {
+    if (activeGatewayRunRuntimeHooks === hooks) {
+      activeGatewayRunRuntimeHooks = previous;
+    }
+  };
+}

--- a/src/cli/gateway-run-argv.ts
+++ b/src/cli/gateway-run-argv.ts
@@ -1,5 +1,5 @@
 // Fast-path argv parser for `openclaw gateway ...` without full Commander registration.
-import { isValueToken } from "../infra/cli-root-options.js";
+import { consumeRootOptionToken, isValueToken } from "../infra/cli-root-options.js";
 
 const GATEWAY_RUN_VALUE_FLAGS = new Set([
   "--port",
@@ -47,6 +47,23 @@ export function consumeGatewayRunOptionToken(args: ReadonlyArray<string>, index:
   return isValueToken(args[index + 1]) ? 2 : 0;
 }
 
+function consumeGatewayRunPreBootstrapOptionToken(
+  args: ReadonlyArray<string>,
+  index: number,
+): number {
+  const consumed = consumeGatewayRunOptionToken(args, index);
+  if (consumed > 0) {
+    return consumed;
+  }
+  const arg = args[index];
+  if (arg && GATEWAY_RUN_VALUE_FLAGS.has(arg) && args[index + 1] !== undefined) {
+    // Commander will reject option-looking required values later. Consume them here so malformed
+    // input cannot accidentally enable a destructive flag before parsing reaches that error.
+    return 2;
+  }
+  return 0;
+}
+
 /** Return how many root fast-path tokens are consumed before the `gateway` command. */
 export function consumeGatewayFastPathRootOptionToken(
   args: ReadonlyArray<string>,
@@ -79,7 +96,7 @@ export function resolveGatewayCatalogCommandPath(argv: string[]): string[] | nul
       break;
     }
     if (!sawGateway) {
-      const consumed = consumeGatewayFastPathRootOptionToken(args, index);
+      const consumed = consumeRootOptionToken(args, index);
       if (consumed > 0) {
         index += consumed - 1;
         continue;
@@ -106,4 +123,61 @@ export function resolveGatewayCatalogCommandPath(argv: string[]): string[] | nul
   }
 
   return sawGateway ? ["gateway"] : null;
+}
+
+/** Resolve destructive gateway-run flags before Commander registration. */
+export function resolveGatewayRunPreBootstrapOptions(
+  argv: string[],
+): { force: boolean; reset: boolean } | null {
+  const args = argv.slice(2);
+  let force = false;
+  let reset = false;
+  let sawGateway = false;
+  let sawRun = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg || arg === "--") {
+      break;
+    }
+    if (!sawGateway) {
+      const consumed = consumeRootOptionToken(args, index);
+      if (consumed > 0) {
+        index += consumed - 1;
+        continue;
+      }
+      if (arg.startsWith("-")) {
+        continue;
+      }
+      if (arg !== "gateway") {
+        return null;
+      }
+      sawGateway = true;
+      continue;
+    }
+    if (!sawRun && arg === "run") {
+      sawRun = true;
+      continue;
+    }
+    const consumed = consumeGatewayRunPreBootstrapOptionToken(args, index);
+    if (consumed > 0) {
+      if (arg === "--force") {
+        force = true;
+      } else if (arg === "--reset") {
+        reset = true;
+      }
+      index += consumed - 1;
+      continue;
+    }
+    if (arg === "--force") {
+      force = true;
+    } else if (arg === "--reset") {
+      reset = true;
+    }
+    if (!arg.startsWith("-")) {
+      return null;
+    }
+  }
+
+  return sawGateway ? { force, reset } : null;
 }

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { withSuppressedNotes } from "../../../packages/terminal-core/src/note.js";
 import { readConfigFileSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import { resolveLegacyStateDirs, resolveOAuthDir, resolveStateDir } from "../../config/paths.js";
+import type { ConfigFileSnapshot } from "../../config/types.js";
 import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { shouldMigrateStateFromPath } from "../argv.js";
@@ -179,6 +180,7 @@ export async function ensureConfigReady(params: {
   commandPath?: string[];
   suppressDoctorStdout?: boolean;
   allowInvalid?: boolean;
+  beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
 }): Promise<void> {
   const commandPath = params.commandPath ?? [];
   let preflightSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>> | null = null;
@@ -191,6 +193,9 @@ export async function ensureConfigReady(params: {
         migrateState: true,
         migrateLegacyConfig: false,
         invalidConfigNote: false,
+        ...(params.beforeStateMigrations
+          ? { beforeStateMigrations: params.beforeStateMigrations }
+          : {}),
       });
     return !params.suppressDoctorStdout
       ? (await runDoctorConfigPreflight()).snapshot

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -13,6 +13,9 @@ const emitCliBannerMock = vi.fn();
 const ensureConfigReadyMock = vi.fn(async () => {});
 const ensurePluginRegistryLoadedMock = vi.fn();
 const routeLogsToStderrMock = vi.fn();
+const prepareGatewayRunBootstrapMock = vi.fn(async () => true);
+const recheckGatewayRunBootstrapMock = vi.fn(async () => true);
+const reloadTrustedGatewayRunEnvironmentMock = vi.fn(async () => true);
 
 const runtimeMock = {
   log: vi.fn(),
@@ -48,6 +51,12 @@ vi.mock("./config-guard.js", () => ({
 
 vi.mock("../plugin-registry.js", () => ({
   ensurePluginRegistryLoaded: ensurePluginRegistryLoadedMock,
+}));
+
+vi.mock("../gateway-cli/pre-bootstrap.js", () => ({
+  prepareGatewayRunBootstrap: prepareGatewayRunBootstrapMock,
+  recheckGatewayRunBootstrap: recheckGatewayRunBootstrapMock,
+  reloadTrustedGatewayRunEnvironment: reloadTrustedGatewayRunEnvironmentMock,
 }));
 
 let registerPreActionHooks: typeof import("./preaction.js").registerPreActionHooks;
@@ -129,6 +138,16 @@ describe("registerPreActionHooks", () => {
     programLocal
       .command("status")
       .option("--json")
+      .action(() => {});
+    const gateway = programLocal
+      .command("gateway")
+      .option("--force")
+      .option("--reset")
+      .action(() => {});
+    gateway
+      .command("run")
+      .option("--force")
+      .option("--reset")
       .action(() => {});
     programLocal
       .command("backup")
@@ -238,6 +257,59 @@ describe("registerPreActionHooks", () => {
     });
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
     processTitleSetSpy.mockRestore();
+  });
+
+  it("runs gateway pre-bootstrap before full-CLI gateway bootstrap", async () => {
+    prepareGatewayRunBootstrapMock.mockResolvedValueOnce(false);
+    const gatewayRunCommand = resolveActionCommand(["gateway", "run"]);
+    gatewayRunCommand.setOptionValueWithSource("force", true, "cli");
+    try {
+      await runPreAction({
+        parseArgv: ["gateway", "run"],
+        processArgv: [
+          "node",
+          "openclaw",
+          "--log-level",
+          "debug",
+          "gateway",
+          "run",
+          "--raw-stream-path",
+          "--reset",
+          "--force",
+        ],
+      });
+    } finally {
+      gatewayRunCommand.setOptionValueWithSource("force", false, "default");
+    }
+
+    expect(prepareGatewayRunBootstrapMock).toHaveBeenCalledWith({
+      opts: { force: true, reset: false },
+      runtime: runtimeMock,
+    });
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+  });
+
+  it("passes the gateway config recheck to the state migration boundary", async () => {
+    await runPreAction({
+      parseArgv: ["gateway", "run"],
+      processArgv: ["node", "openclaw", "gateway", "run"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        beforeStateMigrations: expect.any(Function),
+        commandPath: ["gateway", "run"],
+      }),
+    );
+    const beforeStateMigrations = ensureConfigReadyMock.mock.calls[0]?.[0]?.beforeStateMigrations;
+    await beforeStateMigrations?.();
+    expect(recheckGatewayRunBootstrapMock).toHaveBeenCalledWith({
+      opts: { force: false, reset: false },
+      runtime: runtimeMock,
+    });
+    expect(reloadTrustedGatewayRunEnvironmentMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+    });
   });
 
   it("loads plugins for text local agent runs", async () => {

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -1,5 +1,6 @@
 // Global Commander pre-action hook: startup presentation, config guard, logging, and plugin preflight.
 import type { Command } from "commander";
+import type { ConfigFileSnapshot } from "../../config/types.js";
 import { setVerbose } from "../../globals.js";
 import type { LogLevel } from "../../logging/levels.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -96,6 +97,17 @@ function isGuidedConfigCommandPath(commandPath: string[]): boolean {
   );
 }
 
+function isGatewayRunAction(actionCommand: Command): boolean {
+  if (actionCommand.name() === "gateway") {
+    return actionCommand.parent?.parent === null;
+  }
+  return (
+    actionCommand.name() === "run" &&
+    actionCommand.parent?.name() === "gateway" &&
+    actionCommand.parent.parent?.parent === null
+  );
+}
+
 /** Register global pre-action bootstrap hooks for every non-help command invocation. */
 export function registerPreActionHooks(program: Command, programVersion: string) {
   program.hook("preAction", async (_thisCommand, actionCommand) => {
@@ -130,12 +142,39 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     ) {
       return;
     }
+    let beforeStateMigrations: ((snapshot?: ConfigFileSnapshot) => Promise<boolean>) | undefined;
+    if (isGatewayRunAction(actionCommand)) {
+      const { prepareGatewayRunBootstrap, recheckGatewayRunBootstrap } =
+        await import("../gateway-cli/pre-bootstrap.js");
+      const { resolveGatewayRunOptions } = await import("../gateway-cli/run-options.js");
+      const resolvedOptions = resolveGatewayRunOptions(actionCommand.opts(), actionCommand);
+      const opts = {
+        force: resolvedOptions.force === true,
+        reset: resolvedOptions.reset === true,
+      };
+      const shouldBootstrap = await prepareGatewayRunBootstrap({ opts, runtime: defaultRuntime });
+      if (!shouldBootstrap) {
+        return;
+      }
+      beforeStateMigrations = (snapshot) =>
+        recheckGatewayRunBootstrap({
+          opts,
+          runtime: defaultRuntime,
+          ...(snapshot ? { snapshot } : {}),
+        });
+    }
     await ensureCliExecutionBootstrap({
       runtime: defaultRuntime,
       commandPath,
       startupPolicy,
       allowInvalid: shouldAllowInvalidConfigForAction(actionCommand, commandPath),
+      ...(beforeStateMigrations ? { beforeStateMigrations } : {}),
       skipConfigGuard: shouldBypassConfigGuardForCommandPath(commandPath),
     });
+    if (beforeStateMigrations) {
+      const { reloadTrustedGatewayRunEnvironment } =
+        await import("../gateway-cli/pre-bootstrap.js");
+      await reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime });
+    }
   });
 }

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -922,7 +922,6 @@ describe("runCli exit behavior", () => {
   });
 
   it("blocks a future service-mode candidate before pre-bootstrap suspicious recovery", async () => {
-    let recoveryAllowed: boolean | undefined;
     const currentSnapshot = {
       exists: true,
       valid: true,
@@ -930,7 +929,7 @@ describe("runCli exit behavior", () => {
     };
     readConfigFileSnapshotMock.mockImplementation(async (options) => {
       if (options?.recoverSuspicious) {
-        recoveryAllowed = await options.allowSuspiciousRecovery?.(
+        await options.allowSuspiciousRecovery?.(
           {
             env: { vars: { OPENCLAW_SERVICE_MARKER: "gateway" } },
             gateway: { mode: "local" },

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -172,7 +172,8 @@ vi.mock("./dotenv.js", () => ({
   loadCliDotEnv: loadDotEnvMock,
 }));
 
-vi.mock("../infra/env.js", () => ({
+vi.mock("../infra/env.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/env.js")>()),
   isTruthyEnvValue: (value?: string) =>
     typeof value === "string" && ["1", "on", "true", "yes"].includes(value.trim().toLowerCase()),
   normalizeEnv: normalizeEnvMock,
@@ -2083,6 +2084,39 @@ describe("runCli exit behavior", () => {
     const finalStartOrder = startProxyMock.mock.invocationCallOrder[1] ?? 0;
     expect(finalEnvironmentReadOrder).toBeGreaterThan(earlyStopOrder);
     expect(finalStartOrder).toBeGreaterThan(earlyStopOrder);
+  });
+
+  it("removes early proxy signal handlers when the final config disables the proxy", async () => {
+    const earlyHandle = makeProxyHandle();
+    const earlyProxy = { enabled: true, proxyUrl: "http://127.0.0.1:19876" };
+    const finalProxy = { enabled: false };
+    loadConfigMock.mockReturnValueOnce({ proxy: earlyProxy });
+    startProxyMock.mockResolvedValueOnce(earlyHandle).mockResolvedValueOnce(null);
+    const processOnceSpy = vi.spyOn(process, "once");
+    const processOffSpy = vi.spyOn(process, "off");
+    commanderParseAsyncMock.mockImplementationOnce(async () => {
+      const sigtermHandler = processOnceSpy.mock.calls.find(([event]) => event === "SIGTERM")?.[1];
+      const sigintHandler = processOnceSpy.mock.calls.find(([event]) => event === "SIGINT")?.[1];
+      const exitHandler = processOnceSpy.mock.calls.find(([event]) => event === "exit")?.[1];
+
+      await getGatewayRunRuntimeHooks().refreshManagedProxy?.(finalProxy);
+
+      expect(processOffSpy).toHaveBeenCalledWith("SIGTERM", sigtermHandler);
+      expect(processOffSpy).toHaveBeenCalledWith("SIGINT", sigintHandler);
+      expect(processOffSpy).toHaveBeenCalledWith("exit", exitHandler);
+    });
+
+    try {
+      await runCli(["node", "openclaw", "gateway", "run"]);
+    } finally {
+      processOffSpy.mockRestore();
+      processOnceSpy.mockRestore();
+    }
+
+    expect(startProxyMock).toHaveBeenNthCalledWith(1, earlyProxy);
+    expect(startProxyMock).toHaveBeenNthCalledWith(2, finalProxy);
+    expect(stopProxyMock).toHaveBeenCalledOnce();
+    expect(stopProxyMock).toHaveBeenCalledWith(earlyHandle);
   });
 
   it("starts the managed proxy for metadata-owned plugin commands by default", async () => {

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -1,20 +1,40 @@
 // Run main exit tests cover process exit behavior for CLI failures.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import process from "node:process";
 import { CommanderError } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { loggingState } from "../logging/state.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { getGatewayRunRuntimeHooks } from "./gateway-cli/runtime-hooks.js";
 import type { RootHelpRenderOptions } from "./program/root-help.js";
 import { runCli, shouldStartProxyForCli } from "./run-main.js";
 
 type ConfigSnapshotStub = {
   exists: boolean;
+  hash?: string;
+  path?: string;
+  raw?: string | null;
   valid: boolean;
   sourceConfig: Record<string, unknown>;
+};
+
+type ConfigSnapshotReadOptionsStub = {
+  isolateEnv?: boolean;
+  observe?: boolean;
+  recoverSuspicious?: boolean;
+  allowSuspiciousRecovery?: (
+    candidate: Record<string, unknown>,
+    current: Record<string, unknown>,
+  ) => boolean | Promise<boolean>;
 };
 
 const tryRouteCliMock = vi.hoisted(() => vi.fn());
 const loadDotEnvMock = vi.hoisted(() => vi.fn());
 const normalizeEnvMock = vi.hoisted(() => vi.fn());
+const pinConfigDirMock = vi.hoisted(() => vi.fn());
+const pinRuntimePathsMock = vi.hoisted(() => vi.fn());
 const ensurePathMock = vi.hoisted(() => vi.fn());
 const assertRuntimeMock = vi.hoisted(() => vi.fn());
 const closeActiveMemorySearchManagersMock = vi.hoisted(() => vi.fn(async () => {}));
@@ -46,7 +66,7 @@ const restoreTerminalStateMock = vi.hoisted(() => vi.fn());
 const hasEnvHttpProxyAgentConfiguredMock = vi.hoisted(() => vi.fn(() => false));
 const ensureGlobalUndiciEnvProxyDispatcherMock = vi.hoisted(() => vi.fn());
 const readConfigFileSnapshotMock = vi.hoisted(() =>
-  vi.fn<() => Promise<ConfigSnapshotStub>>(async () => ({
+  vi.fn<(options?: ConfigSnapshotReadOptionsStub) => Promise<ConfigSnapshotStub>>(async () => ({
     exists: true,
     valid: true,
     sourceConfig: { gateway: { mode: "local" } },
@@ -156,6 +176,16 @@ vi.mock("../infra/env.js", () => ({
   isTruthyEnvValue: (value?: string) =>
     typeof value === "string" && ["1", "on", "true", "yes"].includes(value.trim().toLowerCase()),
   normalizeEnv: normalizeEnvMock,
+}));
+
+vi.mock("../config/paths.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/paths.js")>()),
+  pinRuntimePaths: pinRuntimePathsMock,
+}));
+
+vi.mock("../utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils.js")>()),
+  pinConfigDir: pinConfigDirMock,
 }));
 
 vi.mock("../infra/path-env.js", () => ({
@@ -472,6 +502,7 @@ describe("runCli exit behavior", () => {
   it("configures the gateway foreground fast path with the standard CLI bootstrap", async () => {
     await runCli(["node", "openclaw", "gateway", "--force"]);
 
+    expect(readConfigFileSnapshotMock.mock.calls).toEqual([[{ isolateEnv: true, observe: false }]]);
     const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
       | { beforeRun?: (opts: { reset?: boolean }) => Promise<void> }
       | undefined;
@@ -479,15 +510,1107 @@ describe("runCli exit behavior", () => {
 
     expect(ensureCliExecutionBootstrapMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        beforeStateMigrations: expect.any(Function),
         commandPath: ["gateway"],
         loadPlugins: false,
       }),
     );
-    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({ recoverSuspicious: true });
-    const recoveryOrder = readConfigFileSnapshotMock.mock.invocationCallOrder[0] ?? 0;
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({
+      isolateEnv: true,
+      recoverSuspicious: true,
+      allowSuspiciousRecovery: expect.any(Function),
+    });
+    const recoveryOrder = readConfigFileSnapshotMock.mock.invocationCallOrder[2] ?? 0;
     const bootstrapOrder = ensureCliExecutionBootstrapMock.mock.invocationCallOrder[0] ?? 0;
     expect(recoveryOrder).toBeGreaterThan(0);
     expect(bootstrapOrder).toBeGreaterThan(recoveryOrder);
+  });
+
+  it("rechecks the effective guarded config before automatic startup migrations", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      hash: "guarded",
+      path: "/tmp/openclaw.json",
+      raw: "{}",
+      valid: true,
+      sourceConfig: {
+        cron: { store: "/tmp/included-a.json" },
+        gateway: { mode: "local" },
+      },
+    });
+    await runCli(["node", "openclaw", "gateway"]);
+    const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+      | { beforeRun?: (opts: { reset?: boolean }) => Promise<void> }
+      | undefined;
+    await hooks?.beforeRun?.({});
+    const beforeStateMigrations = (
+      ensureCliExecutionBootstrapMock.mock.calls[0]?.[0] as
+        | { beforeStateMigrations?: () => Promise<boolean> }
+        | undefined
+    )?.beforeStateMigrations;
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      hash: "guarded",
+      path: "/tmp/openclaw.json",
+      raw: "{}",
+      valid: true,
+      sourceConfig: {
+        cron: { store: "/tmp/included-b.json" },
+        gateway: { mode: "local" },
+      },
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${String(code)}`);
+    }) as typeof process.exit);
+    try {
+      await expect(beforeStateMigrations?.()).rejects.toThrow("exit:1");
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("changed during startup"));
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    {
+      name: "automatic startup migrations",
+      flags: [],
+      marker: undefined,
+      override: undefined,
+      expectedAction: "run automatic gateway startup migrations",
+      expectedExitCode: 1,
+    },
+    {
+      name: "service-mode startup",
+      flags: [],
+      marker: "gateway",
+      override: "1",
+      expectedAction: "start the gateway service",
+      expectedExitCode: 78,
+    },
+    {
+      name: "forced port cleanup",
+      flags: ["--force"],
+      marker: undefined,
+      override: undefined,
+      expectedAction: "force-kill gateway port listeners",
+      expectedExitCode: 1,
+    },
+    {
+      name: "dev reset",
+      flags: ["--dev", "--reset"],
+      marker: undefined,
+      override: undefined,
+      expectedAction: "reset the dev gateway state",
+      expectedExitCode: 1,
+    },
+    {
+      name: "forced dev reset",
+      flags: ["--dev", "--reset", "--force"],
+      marker: undefined,
+      override: undefined,
+      expectedAction: "reset the dev gateway state",
+      expectedExitCode: 1,
+    },
+  ])("blocks future-config $name before gateway bootstrap", async (params) => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: true,
+      sourceConfig: { meta: { lastTouchedVersion: "9999.1.1" } },
+    });
+    const previousMarker = process.env.OPENCLAW_SERVICE_MARKER;
+    const previousOverride = process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS;
+    if (params.marker) {
+      process.env.OPENCLAW_SERVICE_MARKER = params.marker;
+    } else {
+      delete process.env.OPENCLAW_SERVICE_MARKER;
+    }
+    if (params.override) {
+      process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS = params.override;
+    } else {
+      delete process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS;
+    }
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${String(code)}`);
+    }) as typeof process.exit);
+    try {
+      await expect(runCli(["node", "openclaw", "gateway", ...params.flags])).rejects.toThrow(
+        `exit:${params.expectedExitCode}`,
+      );
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(params.expectedAction));
+      expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+      expect(readConfigFileSnapshotMock.mock.calls).toEqual([
+        [{ isolateEnv: true, observe: false }],
+      ]);
+      if (params.marker) {
+        expect(process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBeUndefined();
+      }
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+      if (previousMarker === undefined) {
+        delete process.env.OPENCLAW_SERVICE_MARKER;
+      } else {
+        process.env.OPENCLAW_SERVICE_MARKER = previousMarker;
+      }
+      if (previousOverride === undefined) {
+        delete process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS;
+      } else {
+        process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS = previousOverride;
+      }
+    }
+  });
+
+  it("revokes the destructive override when selected config enters service mode", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: true,
+      sourceConfig: {
+        env: { vars: { OPENCLAW_SERVICE_MARKER: "gateway" } },
+        meta: { lastTouchedVersion: "9999.1.1" },
+      },
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${String(code)}`);
+    }) as typeof process.exit);
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1",
+          OPENCLAW_SERVICE_MARKER: undefined,
+        },
+        async () => {
+          await runCli(["node", "openclaw", "gateway"]);
+          expect(process.env.OPENCLAW_SERVICE_MARKER).toBe("gateway");
+          expect(process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBeUndefined();
+
+          const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+            | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
+            | undefined;
+          await expect(hooks?.beforeRun?.({})).rejects.toThrow("exit:1");
+          expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+        },
+      );
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("guards the config selected by trusted global dotenv before the default config", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-global-selection-"));
+    const stateDir = path.join(homeDir, ".openclaw");
+    const selectedConfigPath = path.join(stateDir, "selected.json");
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      path.join(stateDir, ".env"),
+      [
+        `OPENCLAW_CONFIG_PATH=${selectedConfigPath}`,
+        "OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1",
+        "",
+      ].join("\n"),
+    );
+    try {
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: undefined,
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_HOME: homeDir,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+        async () => {
+          readConfigFileSnapshotMock.mockImplementation(async () =>
+            process.env.OPENCLAW_CONFIG_PATH === selectedConfigPath
+              ? {
+                  exists: true,
+                  valid: true,
+                  sourceConfig: { gateway: { mode: "local" } },
+                }
+              : {
+                  exists: true,
+                  valid: true,
+                  sourceConfig: { meta: { lastTouchedVersion: "9999.1.1" } },
+                },
+          );
+
+          await runCli(["node", "openclaw", "gateway"]);
+
+          expect(process.env.OPENCLAW_CONFIG_PATH).toBe(selectedConfigPath);
+          expect(process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBeUndefined();
+          expect(readConfigFileSnapshotMock).toHaveBeenCalledOnce();
+        },
+      );
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads state dotenv before a custom config-root fallback", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-config-env-"));
+    const stateDir = path.join(homeDir, ".openclaw");
+    const configDir = path.join(homeDir, "profile");
+    const configPath = path.join(configDir, "openclaw.json");
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(path.join(stateDir, ".env"), "OPENCLAW_GATEWAY_TOKEN=state-token\n");
+    await fs.writeFile(
+      path.join(configDir, ".env"),
+      [
+        "OPENCLAW_GATEWAY_PASSWORD=config-root-password",
+        "OPENCLAW_GATEWAY_TOKEN=config-root-token",
+        "",
+      ].join("\n"),
+    );
+    try {
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_GATEWAY_PASSWORD: undefined,
+          OPENCLAW_GATEWAY_TOKEN: undefined,
+          OPENCLAW_HOME: homeDir,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+        async () => {
+          await runCli(["node", "openclaw", "gateway"]);
+
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("state-token");
+          expect(process.env.OPENCLAW_GATEWAY_PASSWORD).toBe("config-root-password");
+        },
+      );
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads and repins a legacy state dotenv after automatic state migration", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-legacy-env-"));
+    const legacyStateDir = path.join(homeDir, ".clawdbot");
+    const newStateDir = path.join(homeDir, ".openclaw");
+    await fs.mkdir(legacyStateDir, { recursive: true });
+    await fs.writeFile(path.join(legacyStateDir, ".env"), "OPENCLAW_GATEWAY_TOKEN=legacy-token\n");
+    try {
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_GATEWAY_TOKEN: undefined,
+          OPENCLAW_HOME: homeDir,
+          OPENCLAW_STATE_DIR: undefined,
+          OPENCLAW_TEST_FAST: undefined,
+        },
+        async () => {
+          ensureCliExecutionBootstrapMock.mockImplementationOnce(async () => {
+            await fs.rename(legacyStateDir, newStateDir);
+          });
+          await runCli(["node", "openclaw", "gateway"]);
+          const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+            | { beforeRun?: (opts: { reset?: boolean }) => Promise<void> }
+            | undefined;
+          await hooks?.beforeRun?.({});
+
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("legacy-token");
+          await expect(fs.access(path.join(newStateDir, ".env"))).resolves.toBeUndefined();
+          const bootstrapOrder = ensureCliExecutionBootstrapMock.mock.invocationCallOrder[0] ?? 0;
+          const finalPinOrder = pinRuntimePathsMock.mock.invocationCallOrder.at(-1) ?? 0;
+          expect(finalPinOrder).toBeGreaterThan(bootstrapOrder);
+        },
+      );
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks a future-config recovery candidate before destructive gateway reset", async () => {
+    const currentSnapshot = {
+      exists: true,
+      valid: true,
+      sourceConfig: { gateway: { mode: "local" } },
+    };
+    readConfigFileSnapshotMock.mockImplementation(async (options) => {
+      if (options?.recoverSuspicious) {
+        await options?.allowSuspiciousRecovery?.(
+          {
+            meta: { lastTouchedVersion: "9999.1.1" },
+            gateway: { mode: "local" },
+          },
+          currentSnapshot.sourceConfig,
+        );
+      }
+      return currentSnapshot;
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${String(code)}`);
+    }) as typeof process.exit);
+    try {
+      await runCli(["node", "openclaw", "gateway", "--dev", "--reset"]);
+      const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+        | { beforeRun?: (opts: { reset?: boolean }) => Promise<void> }
+        | undefined;
+      await expect(hooks?.beforeRun?.({ reset: true })).rejects.toThrow("exit:1");
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Refusing to reset the dev gateway state"),
+      );
+      expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("blocks a future current config before pre-bootstrap suspicious recovery", async () => {
+    const currentSnapshot = {
+      exists: true,
+      valid: true,
+      sourceConfig: { gateway: { mode: "local" } },
+    };
+    readConfigFileSnapshotMock.mockImplementation(async (options) => {
+      if (options?.recoverSuspicious) {
+        await options.allowSuspiciousRecovery?.(
+          { gateway: { mode: "local" } },
+          {
+            meta: { lastTouchedVersion: "9999.1.1" },
+            gateway: { mode: "local" },
+          },
+        );
+      }
+      return currentSnapshot;
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${String(code)}`);
+    }) as typeof process.exit);
+    try {
+      await runCli(["node", "openclaw", "gateway"]);
+      const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+        | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
+        | undefined;
+      await expect(hooks?.beforeRun?.({})).rejects.toThrow("exit:1");
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("run automatic gateway startup migrations"),
+      );
+      expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("re-guards config env path selection until the gateway config is stable", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-selection-"));
+    try {
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_HOME: homeDir,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+        async () => {
+          readConfigFileSnapshotMock.mockImplementation(async () => {
+            if (process.env.OPENCLAW_CONFIG_PATH === "/tmp/openclaw-chain-c.json") {
+              return {
+                exists: true,
+                valid: true,
+                sourceConfig: { meta: { lastTouchedVersion: "9999.1.1" } },
+              };
+            }
+            if (process.env.OPENCLAW_STATE_DIR === "/tmp/openclaw-chain-b") {
+              return {
+                exists: true,
+                valid: true,
+                sourceConfig: {
+                  env: { vars: { OPENCLAW_CONFIG_PATH: "/tmp/openclaw-chain-c.json" } },
+                  gateway: { mode: "local" },
+                },
+              };
+            }
+            return {
+              exists: true,
+              valid: true,
+              sourceConfig: {
+                env: { vars: { OPENCLAW_STATE_DIR: "/tmp/openclaw-chain-b" } },
+                gateway: { mode: "local" },
+              },
+            };
+          });
+          const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+          const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+            throw new Error(`exit:${String(code)}`);
+          }) as typeof process.exit);
+          try {
+            await expect(runCli(["node", "openclaw", "gateway"])).rejects.toThrow("exit:1");
+            expect(errorSpy).toHaveBeenCalledWith(
+              expect.stringContaining("run automatic gateway startup migrations"),
+            );
+            expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+            expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(3);
+          } finally {
+            exitSpy.mockRestore();
+            errorSpy.mockRestore();
+          }
+        },
+      );
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("re-guards config changes to Termux home selectors", async () => {
+    await withEnvAsync({ ANDROID_DATA: undefined, PREFIX: undefined }, async () => {
+      readConfigFileSnapshotMock.mockImplementation(async () =>
+        process.env.ANDROID_DATA === "/data" &&
+        process.env.PREFIX === "/data/data/com.termux/files/usr"
+          ? {
+              exists: true,
+              valid: true,
+              sourceConfig: { meta: { lastTouchedVersion: "9999.1.1" } },
+            }
+          : {
+              exists: true,
+              valid: true,
+              sourceConfig: {
+                env: {
+                  vars: {
+                    ANDROID_DATA: "/data",
+                    PREFIX: "/data/data/com.termux/files/usr",
+                  },
+                },
+                gateway: { mode: "local" },
+              },
+            },
+      );
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+        throw new Error(`exit:${String(code)}`);
+      }) as typeof process.exit);
+      try {
+        await expect(runCli(["node", "openclaw", "gateway"])).rejects.toThrow("exit:1");
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("run automatic gateway startup migrations"),
+        );
+        expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(2);
+      } finally {
+        exitSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
+    });
+  });
+
+  it("drops credentials from configs superseded during state selection", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_STATE_DIR: undefined,
+      },
+      async () => {
+        readConfigFileSnapshotMock.mockImplementation(async () =>
+          process.env.OPENCLAW_STATE_DIR === "/tmp/openclaw-selected-state"
+            ? {
+                exists: true,
+                valid: true,
+                sourceConfig: {
+                  env: { vars: { OPENCLAW_GATEWAY_TOKEN: "selected-token" } },
+                  gateway: { mode: "local" },
+                },
+              }
+            : {
+                exists: true,
+                valid: true,
+                sourceConfig: {
+                  env: {
+                    vars: {
+                      OPENCLAW_GATEWAY_TOKEN: "superseded-token",
+                      OPENCLAW_STATE_DIR: "/tmp/openclaw-selected-state",
+                    },
+                  },
+                  gateway: { mode: "local" },
+                },
+              },
+        );
+        await runCli(["node", "openclaw", "gateway"]);
+
+        const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+          | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
+          | undefined;
+        await hooks?.beforeRun?.({});
+
+        expect(process.env.OPENCLAW_STATE_DIR).toBe("/tmp/openclaw-selected-state");
+        expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("selected-token");
+        expect(ensureCliExecutionBootstrapMock).toHaveBeenCalledOnce();
+      },
+    );
+  });
+
+  it("re-guards config selection from a newly selected state dotenv", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-dotenv-"));
+    const futureConfigPath = path.join(stateDir, "future.json");
+    await fs.writeFile(
+      path.join(stateDir, ".env"),
+      [
+        `OPENCLAW_CONFIG_PATH=${futureConfigPath}`,
+        "OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1",
+        "",
+      ].join("\n"),
+    );
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_HOME: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+          OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: undefined,
+        },
+        async () => {
+          readConfigFileSnapshotMock.mockImplementation(async () => {
+            if (process.env.OPENCLAW_CONFIG_PATH === futureConfigPath) {
+              return {
+                exists: true,
+                valid: true,
+                sourceConfig: { meta: { lastTouchedVersion: "9999.1.1" } },
+              };
+            }
+            return {
+              exists: true,
+              valid: true,
+              sourceConfig: {
+                env: { vars: { OPENCLAW_STATE_DIR: stateDir } },
+                gateway: { mode: "local" },
+              },
+            };
+          });
+          const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+          const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+            throw new Error(`exit:${String(code)}`);
+          }) as typeof process.exit);
+          try {
+            await expect(runCli(["node", "openclaw", "gateway"])).rejects.toThrow("exit:1");
+            expect(errorSpy).toHaveBeenCalledWith(
+              expect.stringContaining("run automatic gateway startup migrations"),
+            );
+            expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+            expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(2);
+            expect(process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBeUndefined();
+          } finally {
+            exitSpy.mockRestore();
+            errorSpy.mockRestore();
+          }
+        },
+      );
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("re-inspects recovery after recovery changes config selection", async () => {
+    await withEnvAsync({ OPENCLAW_CONFIG_PATH: undefined }, async () => {
+      const selectedConfigPath = "/tmp/openclaw-recovered-selection.json";
+      const currentSnapshot = {
+        exists: true,
+        valid: true,
+        sourceConfig: { gateway: { mode: "local" } },
+      };
+      let recoveryReads = 0;
+      readConfigFileSnapshotMock.mockImplementation(async (options) => {
+        if (!options?.recoverSuspicious) {
+          return currentSnapshot;
+        }
+        recoveryReads += 1;
+        if (recoveryReads === 1) {
+          const recoveredSnapshot = {
+            exists: true,
+            valid: true,
+            sourceConfig: {
+              env: { vars: { OPENCLAW_CONFIG_PATH: selectedConfigPath } },
+              gateway: { mode: "local" },
+            },
+          };
+          await options.allowSuspiciousRecovery?.(
+            recoveredSnapshot.sourceConfig,
+            currentSnapshot.sourceConfig,
+          );
+          return recoveredSnapshot;
+        }
+        await options.allowSuspiciousRecovery?.(
+          {
+            meta: { lastTouchedVersion: "9999.1.1" },
+            gateway: { mode: "local" },
+          },
+          currentSnapshot.sourceConfig,
+        );
+        return currentSnapshot;
+      });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+        throw new Error(`exit:${String(code)}`);
+      }) as typeof process.exit);
+      try {
+        await runCli(["node", "openclaw", "gateway"]);
+        const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+          | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
+          | undefined;
+        await expect(hooks?.beforeRun?.({})).rejects.toThrow("exit:1");
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("run automatic gateway startup migrations"),
+        );
+        expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+        expect(recoveryReads).toBe(2);
+      } finally {
+        exitSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
+    });
+  });
+
+  it("discards env from a config replaced by suspicious recovery", async () => {
+    await withEnvAsync(
+      { OPENCLAW_GATEWAY_TOKEN: undefined, OPENCLAW_PROXY_ACTIVE: undefined },
+      async () => {
+        const clobberedSnapshot = {
+          exists: true,
+          valid: true,
+          sourceConfig: {
+            env: { vars: { OPENCLAW_GATEWAY_TOKEN: "discarded-token" } },
+            gateway: { mode: "local" },
+          },
+          hash: "clobbered",
+          path: "/tmp/openclaw.json",
+        };
+        const recoveredSnapshot = {
+          exists: true,
+          valid: true,
+          sourceConfig: { gateway: { mode: "local" } },
+          hash: "recovered",
+          path: "/tmp/openclaw.json",
+        };
+        const initialSnapshot = {
+          exists: true,
+          valid: true,
+          sourceConfig: { gateway: { mode: "local" } },
+          hash: "initial",
+          path: "/tmp/openclaw.json",
+        };
+        let currentSnapshot = initialSnapshot;
+        let recovered = false;
+        readConfigFileSnapshotMock.mockImplementation(async (options) => {
+          if (!options?.recoverSuspicious) {
+            return recovered ? recoveredSnapshot : currentSnapshot;
+          }
+          recovered = true;
+          await options.allowSuspiciousRecovery?.(
+            recoveredSnapshot.sourceConfig,
+            currentSnapshot.sourceConfig,
+          );
+          return recoveredSnapshot;
+        });
+        await runCli(["node", "openclaw", "gateway"]);
+
+        currentSnapshot = clobberedSnapshot;
+        process.env.OPENCLAW_PROXY_ACTIVE = "1";
+        const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+          | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
+          | undefined;
+        await hooks?.beforeRun?.({});
+
+        expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+        expect(process.env.OPENCLAW_PROXY_ACTIVE).toBe("1");
+        expect(ensureCliExecutionBootstrapMock).toHaveBeenCalledOnce();
+      },
+    );
+  });
+
+  it("does not apply environment variables from invalid config snapshots", async () => {
+    await withEnvAsync({ OPENCLAW_INCLUDE_ROOTS: undefined }, async () => {
+      readConfigFileSnapshotMock.mockResolvedValue({
+        exists: true,
+        valid: false,
+        sourceConfig: {
+          env: { vars: { OPENCLAW_INCLUDE_ROOTS: "/tmp/openclaw-includes" } },
+          gateway: { mode: "local" },
+        },
+      });
+
+      await runCli(["node", "openclaw", "gateway"]);
+      const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+        | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
+        | undefined;
+      await hooks?.beforeRun?.({});
+
+      expect(process.env.OPENCLAW_INCLUDE_ROOTS).toBeUndefined();
+      expect(readConfigFileSnapshotMock.mock.calls).toEqual([
+        [{ isolateEnv: true, observe: false }],
+        [{ isolateEnv: true, observe: false }],
+      ]);
+      expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("loads selected state dotenv before config env and environment normalization", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-selected-env-"));
+    const stateDir = path.join(homeDir, "state");
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(path.join(stateDir, ".env"), "OPENCLAW_GATEWAY_TOKEN=state-token\n");
+    try {
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_GATEWAY_TOKEN: undefined,
+          OPENCLAW_HOME: homeDir,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+        async () => {
+          readConfigFileSnapshotMock.mockResolvedValue({
+            exists: true,
+            valid: true,
+            sourceConfig: {
+              env: {
+                vars: {
+                  OPENCLAW_GATEWAY_TOKEN: "config-token",
+                  OPENCLAW_STATE_DIR: stateDir,
+                },
+              },
+              gateway: { mode: "local" },
+            },
+          });
+          let tokenAtNormalize: string | undefined;
+          normalizeEnvMock.mockImplementation(() => {
+            tokenAtNormalize = process.env.OPENCLAW_GATEWAY_TOKEN;
+          });
+
+          await runCli(["node", "openclaw", "gateway"]);
+
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("state-token");
+          expect(tokenAtNormalize).toBe("state-token");
+        },
+      );
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("drops credentials from a trusted dotenv superseded by state selection", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-dotenv-hop-"));
+    const defaultStateDir = path.join(homeDir, ".openclaw");
+    const selectedStateDir = path.join(homeDir, "selected-state");
+    await fs.mkdir(defaultStateDir, { recursive: true });
+    await fs.mkdir(selectedStateDir, { recursive: true });
+    await fs.writeFile(
+      path.join(defaultStateDir, ".env"),
+      [
+        `OPENCLAW_STATE_DIR=${selectedStateDir}`,
+        "OPENCLAW_GATEWAY_TOKEN=superseded-token",
+        "",
+      ].join("\n"),
+    );
+    await fs.writeFile(
+      path.join(selectedStateDir, ".env"),
+      "OPENCLAW_GATEWAY_TOKEN=selected-token\n",
+    );
+    try {
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_GATEWAY_TOKEN: undefined,
+          OPENCLAW_HOME: homeDir,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+        async () => {
+          await runCli(["node", "openclaw", "gateway"]);
+
+          expect(process.env.OPENCLAW_STATE_DIR).toBe(selectedStateDir);
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("selected-token");
+        },
+      );
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("drops gateway.env selectors when the default state dotenv selects a custom state", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-fallback-hop-"));
+    const defaultStateDir = path.join(homeDir, ".openclaw");
+    const selectedStateDir = path.join(homeDir, "selected-state");
+    const gatewayEnvDir = path.join(homeDir, ".config", "openclaw");
+    await fs.mkdir(defaultStateDir, { recursive: true });
+    await fs.mkdir(selectedStateDir, { recursive: true });
+    await fs.mkdir(gatewayEnvDir, { recursive: true });
+    await fs.writeFile(
+      path.join(defaultStateDir, ".env"),
+      `OPENCLAW_STATE_DIR=${selectedStateDir}\n`,
+    );
+    await fs.writeFile(
+      path.join(gatewayEnvDir, "gateway.env"),
+      [
+        "OPENCLAW_CONFIG_PATH=/tmp/wrong-openclaw.json",
+        "OPENCLAW_GATEWAY_TOKEN=fallback-token",
+        "",
+      ].join("\n"),
+    );
+    await fs.writeFile(
+      path.join(selectedStateDir, ".env"),
+      [
+        "OPENCLAW_GATEWAY_TOKEN=selected-token",
+        "OPENCLAW_INCLUDE_ROOTS=/tmp/untrusted-include-root",
+        "NODE_OPTIONS=--require /tmp/untrusted.js",
+        "",
+      ].join("\n"),
+    );
+    try {
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_GATEWAY_TOKEN: undefined,
+          OPENCLAW_HOME: homeDir,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+        async () => {
+          await runCli(["node", "openclaw", "gateway"]);
+
+          expect(process.env.OPENCLAW_STATE_DIR).toBe(selectedStateDir);
+          expect(process.env.OPENCLAW_CONFIG_PATH).toBeUndefined();
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("selected-token");
+        },
+      );
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves gateway.env selectors when the compatibility fallback selects the target", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-fallback-select-"));
+    const selectedStateDir = path.join(homeDir, "selected-state");
+    const gatewayEnvDir = path.join(homeDir, ".config", "openclaw");
+    await fs.mkdir(selectedStateDir, { recursive: true });
+    await fs.mkdir(gatewayEnvDir, { recursive: true });
+    await fs.writeFile(
+      path.join(gatewayEnvDir, "gateway.env"),
+      [`OPENCLAW_STATE_DIR=${selectedStateDir}`, "OPENCLAW_GATEWAY_TOKEN=fallback-token", ""].join(
+        "\n",
+      ),
+    );
+    await fs.writeFile(
+      path.join(selectedStateDir, ".env"),
+      "OPENCLAW_GATEWAY_TOKEN=selected-token\n",
+    );
+    try {
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_GATEWAY_TOKEN: undefined,
+          OPENCLAW_HOME: homeDir,
+          OPENCLAW_INCLUDE_ROOTS: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+          NODE_OPTIONS: undefined,
+        },
+        async () => {
+          await runCli(["node", "openclaw", "gateway"]);
+
+          expect(process.env.OPENCLAW_STATE_DIR).toBe(selectedStateDir);
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("selected-token");
+          expect(process.env.OPENCLAW_INCLUDE_ROOTS).toBeUndefined();
+          expect(process.env.NODE_OPTIONS).toBeUndefined();
+        },
+      );
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("drops old state dotenv credentials when config selects another state", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-config-state-hop-"));
+    const defaultStateDir = path.join(homeDir, ".openclaw");
+    const selectedStateDir = path.join(homeDir, "selected-state");
+    await fs.mkdir(defaultStateDir, { recursive: true });
+    await fs.mkdir(selectedStateDir, { recursive: true });
+    await fs.writeFile(
+      path.join(defaultStateDir, ".env"),
+      "OPENCLAW_GATEWAY_TOKEN=superseded-token\n",
+    );
+    await fs.writeFile(
+      path.join(selectedStateDir, ".env"),
+      "OPENCLAW_GATEWAY_TOKEN=selected-token\n",
+    );
+    try {
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_GATEWAY_TOKEN: undefined,
+          OPENCLAW_HOME: homeDir,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+        async () => {
+          readConfigFileSnapshotMock.mockImplementation(async () => ({
+            exists: true,
+            valid: true,
+            sourceConfig:
+              process.env.OPENCLAW_STATE_DIR === selectedStateDir
+                ? { gateway: { mode: "local" } }
+                : {
+                    env: { vars: { OPENCLAW_STATE_DIR: selectedStateDir } },
+                    gateway: { mode: "local" },
+                  },
+          }));
+
+          await runCli(["node", "openclaw", "gateway"]);
+
+          expect(process.env.OPENCLAW_STATE_DIR).toBe(selectedStateDir);
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("selected-token");
+        },
+      );
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("drops early target credentials when a later guard selects another state", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-late-state-hop-"));
+    const defaultStateDir = path.join(homeDir, ".openclaw");
+    const selectedStateDir = path.join(homeDir, "selected-state");
+    await fs.mkdir(defaultStateDir, { recursive: true });
+    await fs.mkdir(selectedStateDir, { recursive: true });
+    await fs.writeFile(path.join(defaultStateDir, ".env"), "OPENCLAW_GATEWAY_TOKEN=early-token\n");
+    await fs.writeFile(
+      path.join(selectedStateDir, ".env"),
+      "OPENCLAW_GATEWAY_TOKEN=selected-token\n",
+    );
+    try {
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_GATEWAY_TOKEN: undefined,
+          OPENCLAW_HOME: homeDir,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+        async () => {
+          let selectLateState = false;
+          readConfigFileSnapshotMock.mockImplementation(async () => ({
+            exists: true,
+            valid: true,
+            sourceConfig:
+              selectLateState && process.env.OPENCLAW_STATE_DIR !== selectedStateDir
+                ? {
+                    env: { vars: { OPENCLAW_STATE_DIR: selectedStateDir } },
+                    gateway: { mode: "local" },
+                  }
+                : { gateway: { mode: "local" } },
+          }));
+
+          await runCli(["node", "openclaw", "gateway"]);
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("early-token");
+
+          selectLateState = true;
+          const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+            | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
+            | undefined;
+          await hooks?.beforeRun?.({});
+
+          expect(process.env.OPENCLAW_STATE_DIR).toBe(selectedStateDir);
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("selected-token");
+          expect(ensureCliExecutionBootstrapMock).toHaveBeenCalledOnce();
+        },
+      );
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("drops normalized credentials from an early config replaced by a later guard", async () => {
+    await withEnvAsync({ ZAI_API_KEY: undefined, Z_AI_API_KEY: undefined }, async () => {
+      let useReplacement = false;
+      readConfigFileSnapshotMock.mockImplementation(async () => ({
+        exists: true,
+        valid: true,
+        sourceConfig: {
+          env: {
+            vars: {
+              Z_AI_API_KEY: useReplacement ? "replacement-key" : "superseded-key",
+            },
+          },
+          gateway: { mode: "local" },
+        },
+      }));
+      normalizeEnvMock.mockImplementation(() => {
+        if (!process.env.ZAI_API_KEY?.trim() && process.env.Z_AI_API_KEY?.trim()) {
+          process.env.ZAI_API_KEY = process.env.Z_AI_API_KEY;
+        }
+      });
+
+      await runCli(["node", "openclaw", "gateway"]);
+      expect(process.env.ZAI_API_KEY).toBe("superseded-key");
+
+      useReplacement = true;
+      const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+        | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
+        | undefined;
+      await hooks?.beforeRun?.({});
+
+      expect(process.env.Z_AI_API_KEY).toBe("replacement-key");
+      expect(process.env.ZAI_API_KEY).toBe("replacement-key");
+    });
+  });
+
+  it("does not let gateway.env authorize automatic mutations of a selected future config", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-global-env-"));
+    const gatewayEnvDir = path.join(homeDir, ".config", "openclaw");
+    const futureConfigPath = path.join(homeDir, "future.json");
+    await fs.mkdir(gatewayEnvDir, { recursive: true });
+    await fs.writeFile(
+      path.join(gatewayEnvDir, "gateway.env"),
+      "OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1\n",
+    );
+    try {
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: undefined,
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_HOME: homeDir,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+        async () => {
+          readConfigFileSnapshotMock.mockImplementation(async () =>
+            process.env.OPENCLAW_CONFIG_PATH === futureConfigPath
+              ? {
+                  exists: true,
+                  valid: true,
+                  sourceConfig: { meta: { lastTouchedVersion: "9999.1.1" } },
+                }
+              : {
+                  exists: true,
+                  valid: true,
+                  sourceConfig: {
+                    env: { vars: { OPENCLAW_CONFIG_PATH: futureConfigPath } },
+                    gateway: { mode: "local" },
+                  },
+                },
+          );
+          const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+          const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+            throw new Error(`exit:${String(code)}`);
+          }) as typeof process.exit);
+          try {
+            await expect(runCli(["node", "openclaw", "gateway"])).rejects.toThrow("exit:1");
+            expect(errorSpy).toHaveBeenCalledWith(
+              expect.stringContaining("run automatic gateway startup migrations"),
+            );
+            expect(process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBeUndefined();
+          } finally {
+            exitSpy.mockRestore();
+            errorSpy.mockRestore();
+          }
+        },
+      );
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
   });
 
   it("does not treat gateway option values as bootstrap command paths", async () => {
@@ -506,7 +1629,7 @@ describe("runCli exit behavior", () => {
     );
   });
 
-  it("skips state migration before destructive gateway dev resets", async () => {
+  it("guards then skips state migration before destructive gateway dev resets", async () => {
     await runCli(["node", "openclaw", "gateway", "--dev", "--reset"]);
 
     const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
@@ -514,8 +1637,86 @@ describe("runCli exit behavior", () => {
       | undefined;
     await hooks?.beforeRun?.({ reset: true });
 
-    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({ isolateEnv: true, observe: false });
     expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+  });
+
+  it("retains selected config paths and invocation reset targets", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_CONFIG_PATH: "/tmp/openclaw-invocation/openclaw.json",
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_HOME: "/tmp/openclaw-invocation-home",
+        OPENCLAW_INCLUDE_ROOTS: undefined,
+        OPENCLAW_PROFILE: undefined,
+        OPENCLAW_STATE_DIR: "/tmp/openclaw-invocation-state",
+        OPENCLAW_TEST_FAST: "1",
+        OPENCLAW_WORKSPACE_DIR: "/tmp/openclaw-invocation-workspace",
+      },
+      async () => {
+        readConfigFileSnapshotMock.mockResolvedValue({
+          exists: true,
+          valid: true,
+          sourceConfig: {
+            env: {
+              vars: {
+                OPENCLAW_CONFIG_PATH: "/tmp/openclaw-reset/openclaw.json",
+                OPENCLAW_GATEWAY_TOKEN: "old-token",
+                OPENCLAW_HOME: "/tmp/openclaw-reset-home",
+                OPENCLAW_INCLUDE_ROOTS: "/tmp/openclaw-reset-includes",
+                OPENCLAW_PROFILE: "config-dev",
+                OPENCLAW_STATE_DIR: "/tmp/openclaw-reset",
+                OPENCLAW_TEST_FAST: "0",
+                OPENCLAW_WORKSPACE_DIR: "/tmp/openclaw-reset-workspace",
+              },
+            },
+            gateway: { mode: "local" },
+          },
+        });
+        await runCli(["node", "openclaw", "gateway", "--dev", "--reset"]);
+
+        const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+          | { beforeRun?: (opts: { reset?: boolean }) => Promise<void> }
+          | undefined;
+        await hooks?.beforeRun?.({ reset: true });
+
+        expect(process.env.OPENCLAW_CONFIG_PATH).toBe("/tmp/openclaw-invocation/openclaw.json");
+        expect(process.env.OPENCLAW_HOME).toBe("/tmp/openclaw-invocation-home");
+        expect(process.env.OPENCLAW_PROFILE).toBeUndefined();
+        expect(process.env.OPENCLAW_STATE_DIR).toBe("/tmp/openclaw-invocation-state");
+        expect(process.env.OPENCLAW_TEST_FAST).toBe("1");
+        expect(process.env.OPENCLAW_WORKSPACE_DIR).toBe("/tmp/openclaw-invocation-workspace");
+        expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+        expect(process.env.OPENCLAW_INCLUDE_ROOTS).toBeUndefined();
+        expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it("does not let config env authorize or retarget an explicit reset", async () => {
+    await withEnvAsync(
+      { OPENCLAW_PROFILE: undefined, OPENCLAW_WORKSPACE_DIR: undefined },
+      async () => {
+        readConfigFileSnapshotMock.mockResolvedValue({
+          exists: true,
+          valid: true,
+          sourceConfig: {
+            env: {
+              vars: {
+                OPENCLAW_PROFILE: "dev",
+                OPENCLAW_WORKSPACE_DIR: "/tmp/openclaw-config-workspace",
+              },
+            },
+            gateway: { mode: "local" },
+          },
+        });
+
+        await runCli(["node", "openclaw", "gateway", "--reset"]);
+
+        expect(process.env.OPENCLAW_PROFILE).toBeUndefined();
+        expect(process.env.OPENCLAW_WORKSPACE_DIR).toBeUndefined();
+      },
+    );
   });
 
   it("honors banner suppression on the gateway foreground fast path", async () => {
@@ -733,6 +1934,90 @@ describe("runCli exit behavior", () => {
     await runCli(["node", "openclaw", "plugins", "marketplace", "list"]);
 
     expect(startProxyMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it.each([
+    ["fast path", ["node", "openclaw", "gateway", "run"]],
+    [
+      "full Commander path with root options",
+      ["node", "openclaw", "--log-level", "debug", "gateway", "run"],
+    ],
+  ])("loads trusted dotenv and isolates %s gateway proxy config reads", async (_name, argv) => {
+    if (_name === "full Commander path with root options") {
+      tryRouteCliMock.mockResolvedValueOnce(true);
+    }
+    await runCli(argv);
+
+    expect(loadDotEnvMock).toHaveBeenCalledWith({ loadGlobalEnv: false, quiet: true });
+    expect(loadConfigMock).toHaveBeenCalledWith({ isolateEnv: true, observe: false });
+    expect(startProxyMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("validates the runtime before selecting gateway config", async () => {
+    await runCli(["node", "openclaw", "gateway", "run"]);
+
+    const runtimeGuardOrder = assertRuntimeMock.mock.invocationCallOrder[0] ?? 0;
+    const configReadOrder = readConfigFileSnapshotMock.mock.invocationCallOrder[0] ?? 0;
+    expect(runtimeGuardOrder).toBeGreaterThan(0);
+    expect(configReadOrder).toBeGreaterThan(runtimeGuardOrder);
+  });
+
+  it("re-pins runtime paths after selecting gateway config", async () => {
+    await runCli(["node", "openclaw", "gateway", "run"]);
+
+    expect(pinRuntimePathsMock).toHaveBeenCalledWith(process.env);
+    expect(pinConfigDirMock).toHaveBeenCalledWith(process.env);
+    const configReadOrder = readConfigFileSnapshotMock.mock.invocationCallOrder[0] ?? 0;
+    const pinOrder = pinRuntimePathsMock.mock.invocationCallOrder[0] ?? 0;
+    expect(pinOrder).toBeGreaterThan(configReadOrder);
+  });
+
+  it("selects gateway config env before starting its managed proxy", async () => {
+    await withEnvAsync({ OPENCLAW_TEST_PROXY_SELECTION: undefined }, async () => {
+      readConfigFileSnapshotMock.mockResolvedValue({
+        exists: true,
+        valid: true,
+        sourceConfig: {
+          env: { vars: { OPENCLAW_TEST_PROXY_SELECTION: "selected" } },
+          gateway: { mode: "local" },
+        },
+      });
+      loadConfigMock.mockImplementationOnce(() => ({
+        proxy: { selected: process.env.OPENCLAW_TEST_PROXY_SELECTION },
+      }));
+
+      await runCli(["node", "openclaw", "gateway", "run"]);
+
+      expect(startProxyMock).toHaveBeenCalledWith({ selected: "selected" });
+    });
+  });
+
+  it("replaces the early managed proxy with the final accepted gateway config", async () => {
+    const earlyHandle = makeProxyHandle();
+    const finalHandle = makeProxyHandle();
+    const earlyProxy = { enabled: true, proxyUrl: "http://127.0.0.1:19876" };
+    const finalProxy = { enabled: true, proxyUrl: "http://127.0.0.1:29876" };
+    loadConfigMock.mockReturnValueOnce({ proxy: earlyProxy });
+    startProxyMock.mockResolvedValueOnce(earlyHandle).mockResolvedValueOnce(finalHandle);
+    commanderParseAsyncMock.mockImplementationOnce(async () => {
+      const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+        | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
+        | undefined;
+      await hooks?.beforeRun?.({});
+      await getGatewayRunRuntimeHooks().refreshManagedProxy?.(finalProxy);
+    });
+
+    await runCli(["node", "openclaw", "gateway", "run"]);
+
+    expect(startProxyMock).toHaveBeenNthCalledWith(1, earlyProxy);
+    expect(startProxyMock).toHaveBeenNthCalledWith(2, finalProxy);
+    expect(stopProxyMock).toHaveBeenNthCalledWith(1, earlyHandle);
+    expect(stopProxyMock).toHaveBeenNthCalledWith(2, finalHandle);
+    const earlyStopOrder = stopProxyMock.mock.invocationCallOrder[0] ?? 0;
+    const finalEnvironmentReadOrder = readConfigFileSnapshotMock.mock.invocationCallOrder[1] ?? 0;
+    const finalStartOrder = startProxyMock.mock.invocationCallOrder[1] ?? 0;
+    expect(finalEnvironmentReadOrder).toBeGreaterThan(earlyStopOrder);
+    expect(finalStartOrder).toBeGreaterThan(earlyStopOrder);
   });
 
   it("starts the managed proxy for metadata-owned plugin commands by default", async () => {

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -663,7 +663,7 @@ describe("runCli exit behavior", () => {
     }
   });
 
-  it("revokes the destructive override when selected config enters service mode", async () => {
+  it("blocks and revokes the destructive override when selected config declares service mode", async () => {
     readConfigFileSnapshotMock.mockResolvedValue({
       exists: true,
       valid: true,
@@ -683,14 +683,9 @@ describe("runCli exit behavior", () => {
           OPENCLAW_SERVICE_MARKER: undefined,
         },
         async () => {
-          await runCli(["node", "openclaw", "gateway"]);
-          expect(process.env.OPENCLAW_SERVICE_MARKER).toBe("gateway");
+          await expect(runCli(["node", "openclaw", "gateway"])).rejects.toThrow("exit:78");
+          expect(process.env.OPENCLAW_SERVICE_MARKER).toBeUndefined();
           expect(process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBeUndefined();
-
-          const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
-            | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
-            | undefined;
-          await expect(hooks?.beforeRun?.({})).rejects.toThrow("exit:1");
           expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
         },
       );
@@ -698,6 +693,30 @@ describe("runCli exit behavior", () => {
       exitSpy.mockRestore();
       errorSpy.mockRestore();
     }
+  });
+
+  it("ignores service mode declared by an invalid selected config", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: false,
+      sourceConfig: {
+        env: { vars: { OPENCLAW_SERVICE_MARKER: "gateway" } },
+        meta: { lastTouchedVersion: "9999.1.1" },
+      },
+    });
+
+    await withEnvAsync(
+      {
+        OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1",
+        OPENCLAW_SERVICE_MARKER: undefined,
+      },
+      async () => {
+        await runCli(["node", "openclaw", "gateway"]);
+
+        expect(process.env.OPENCLAW_SERVICE_MARKER).toBeUndefined();
+        expect(process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBe("1");
+      },
+    );
   });
 
   it("guards the config selected by trusted global dotenv before the default config", async () => {
@@ -894,6 +913,52 @@ describe("runCli exit behavior", () => {
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("run automatic gateway startup migrations"),
       );
+      expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("blocks a future service-mode candidate before pre-bootstrap suspicious recovery", async () => {
+    let recoveryAllowed: boolean | undefined;
+    const currentSnapshot = {
+      exists: true,
+      valid: true,
+      sourceConfig: { gateway: { mode: "local" } },
+    };
+    readConfigFileSnapshotMock.mockImplementation(async (options) => {
+      if (options?.recoverSuspicious) {
+        recoveryAllowed = await options.allowSuspiciousRecovery?.(
+          {
+            env: { vars: { OPENCLAW_SERVICE_MARKER: "gateway" } },
+            gateway: { mode: "local" },
+            meta: { lastTouchedVersion: "9999.1.1" },
+          },
+          { gateway: { mode: "local" } },
+        );
+      }
+      return currentSnapshot;
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${String(code)}`);
+    }) as typeof process.exit);
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1",
+          OPENCLAW_SERVICE_MARKER: undefined,
+        },
+        async () => {
+          await runCli(["node", "openclaw", "gateway"]);
+          const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+            | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
+            | undefined;
+          await expect(hooks?.beforeRun?.({})).rejects.toThrow("exit:78");
+        },
+      );
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("start the gateway service"));
       expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
     } finally {
       exitSpy.mockRestore();

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -58,6 +58,7 @@ const runCrestodianMock = vi.hoisted(() =>
 );
 const commanderParseAsyncMock = vi.hoisted(() => vi.fn(async () => {}));
 const addGatewayRunCommandMock = vi.hoisted(() => vi.fn((command: unknown) => command));
+const ensureCliExecutionBootstrapMock = vi.hoisted(() => vi.fn(async () => {}));
 const emitCliBannerMock = vi.hoisted(() => vi.fn());
 const enableConsoleCaptureMock = vi.hoisted(() => vi.fn());
 const progressDoneMock = vi.hoisted(() => vi.fn());
@@ -123,6 +124,10 @@ vi.mock("./route.js", () => ({
 
 vi.mock("./gateway-cli/run-command.js", () => ({
   addGatewayRunCommand: addGatewayRunCommandMock,
+}));
+
+vi.mock("./command-execution-startup.js", () => ({
+  ensureCliExecutionBootstrap: ensureCliExecutionBootstrapMock,
 }));
 
 vi.mock("../version.js", () => ({
@@ -462,6 +467,55 @@ describe("runCli exit behavior", () => {
     const parseOrder = commanderParseAsyncMock.mock.invocationCallOrder[0] ?? 0;
     expect(captureOrder).toBeGreaterThan(0);
     expect(parseOrder).toBeGreaterThan(captureOrder);
+  });
+
+  it("configures the gateway foreground fast path with the standard CLI bootstrap", async () => {
+    await runCli(["node", "openclaw", "gateway", "--force"]);
+
+    const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+      | { beforeRun?: (opts: { reset?: boolean }) => Promise<void> }
+      | undefined;
+    await hooks?.beforeRun?.({});
+
+    expect(ensureCliExecutionBootstrapMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandPath: ["gateway"],
+        loadPlugins: false,
+      }),
+    );
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({ recoverSuspicious: true });
+    const recoveryOrder = readConfigFileSnapshotMock.mock.invocationCallOrder[0] ?? 0;
+    const bootstrapOrder = ensureCliExecutionBootstrapMock.mock.invocationCallOrder[0] ?? 0;
+    expect(recoveryOrder).toBeGreaterThan(0);
+    expect(bootstrapOrder).toBeGreaterThan(recoveryOrder);
+  });
+
+  it("does not treat gateway option values as bootstrap command paths", async () => {
+    await runCli(["node", "openclaw", "gateway", "--raw-stream-path", "status"]);
+
+    const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+      | { beforeRun?: (opts: { reset?: boolean }) => Promise<void> }
+      | undefined;
+    await hooks?.beforeRun?.({});
+
+    expect(ensureCliExecutionBootstrapMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandPath: ["gateway"],
+        loadPlugins: false,
+      }),
+    );
+  });
+
+  it("skips state migration before destructive gateway dev resets", async () => {
+    await runCli(["node", "openclaw", "gateway", "--dev", "--reset"]);
+
+    const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+      | { beforeRun?: (opts: { reset?: boolean }) => Promise<void> }
+      | undefined;
+    await hooks?.beforeRun?.({ reset: true });
+
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
   });
 
   it("honors banner suppression on the gateway foreground fast path", async () => {

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -1,6 +1,7 @@
 // Run main tests cover CLI main entrypoint behavior and process error handling.
 import { describe, expect, it } from "vitest";
 import type { PluginManifestCommandAliasRegistry } from "../plugins/manifest-command-aliases.js";
+import { resolveGatewayRunPreBootstrapOptions } from "./gateway-run-argv.js";
 import {
   resolvePrecomputedSubcommandHelpFastPath,
   rewriteUpdateFlagArgv,
@@ -72,6 +73,32 @@ describe("isGatewayRunFastPathArgv", () => {
     expect(isGatewayRunFastPathArgv(["node", "openclaw", "gateway", "--help"])).toBe(false);
     expect(isGatewayRunFastPathArgv(["node", "openclaw", "gateway", "--port"])).toBe(false);
     expect(isGatewayRunFastPathArgv(["node", "openclaw", "gateway", "--unknown"])).toBe(false);
+  });
+});
+
+describe("resolveGatewayRunPreBootstrapOptions", () => {
+  it("resolves destructive gateway flags across fast and full Commander paths", () => {
+    expect(
+      resolveGatewayRunPreBootstrapOptions(["node", "openclaw", "gateway", "run", "--force"]),
+    ).toEqual({ force: true, reset: false });
+    expect(
+      resolveGatewayRunPreBootstrapOptions([
+        "node",
+        "openclaw",
+        "--log-level",
+        "debug",
+        "gateway",
+        "run",
+        "--force",
+        "--reset",
+      ]),
+    ).toEqual({ force: true, reset: true });
+  });
+
+  it("does not treat malformed required option values as destructive flags", () => {
+    expect(
+      resolveGatewayRunPreBootstrapOptions(["node", "openclaw", "gateway", "--token", "--force"]),
+    ).toEqual({ force: false, reset: false });
   });
 });
 

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -601,7 +601,22 @@ export async function runCli(argv: string[] = process.argv) {
     }
     return await bestEffortConfigPromise;
   };
+  const uninstallProxySignalHandlers = () => {
+    if (onSigterm) {
+      process.off("SIGTERM", onSigterm);
+      onSigterm = null;
+    }
+    if (onSigint) {
+      process.off("SIGINT", onSigint);
+      onSigint = null;
+    }
+    if (onExit) {
+      process.off("exit", onExit);
+      onExit = null;
+    }
+  };
   const stopStartedProxy = async () => {
+    uninstallProxySignalHandlers();
     const handle = proxyHandle;
     proxyHandle = null;
     if (handle) {
@@ -619,12 +634,6 @@ export async function runCli(argv: string[] = process.argv) {
       return;
     }
     const shutdown = (exitCode: number) => {
-      if (onSigterm) {
-        process.off("SIGTERM", onSigterm);
-      }
-      if (onSigint) {
-        process.off("SIGINT", onSigint);
-      }
       void stopStartedProxy().finally(() => {
         process.exit(exitCode);
       });
@@ -988,15 +997,6 @@ export async function runCli(argv: string[] = process.argv) {
     }
   } finally {
     uninstallGatewayRunRuntimeHooks?.();
-    if (onSigterm) {
-      process.off("SIGTERM", onSigterm);
-    }
-    if (onSigint) {
-      process.off("SIGINT", onSigint);
-    }
-    if (onExit) {
-      process.off("exit", onExit);
-    }
     await stopStartedProxy();
     await disposeCliAgentHarnesses();
     await closeCliMemoryManagers();

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -23,6 +23,7 @@ import { maybeRunCliInContainer, parseCliContainerArgs } from "./container-targe
 import {
   consumeGatewayFastPathRootOptionToken,
   consumeGatewayRunOptionToken,
+  resolveGatewayCatalogCommandPath,
 } from "./gateway-run-argv.js";
 import { hasJsonOutputFlag, withConsoleLogsRoutedToStderrForJson } from "./json-output-mode.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
@@ -173,6 +174,9 @@ async function tryRunGatewayRunFastPath(
     { emitCliBanner },
     { resolveCliStartupPolicy },
     { enableConsoleCapture },
+    { ensureCliExecutionBootstrap },
+    { defaultRuntime },
+    { readConfigFileSnapshot },
   ] = await startupTrace.measure("gateway-run-imports", () =>
     Promise.all([
       import("commander"),
@@ -181,11 +185,15 @@ async function tryRunGatewayRunFastPath(
       import("./banner.js"),
       import("./command-startup-policy.js"),
       loadLoggingModule(),
+      import("./command-execution-startup.js"),
+      import("../runtime.js"),
+      import("../config/config.js"),
     ]),
   );
-  const invocation = resolveCliArgvInvocation(argv);
+  const commandPath = resolveGatewayCatalogCommandPath(argv) ?? ["gateway"];
   const startupPolicy = resolveCliStartupPolicy({
-    commandPath: invocation.commandPath,
+    argv,
+    commandPath,
     jsonOutputMode: hasJsonOutputFlag(argv),
     routeMode: true,
   });
@@ -200,11 +208,31 @@ async function tryRunGatewayRunFastPath(
     process.exitCode = typeof err.exitCode === "number" ? err.exitCode : 1;
     throw err;
   });
+  const beforeRun = async (opts: { reset?: boolean }) => {
+    // Dev reset deletes the state directory before recreating config. Migrating first would
+    // archive legacy state and then delete its imported SQLite rows.
+    if (opts.reset) {
+      return;
+    }
+    await startupTrace.measure("gateway-run-config-recovery", () =>
+      readConfigFileSnapshot({ recoverSuspicious: true }),
+    );
+    await startupTrace.measure("gateway-run-bootstrap", () =>
+      ensureCliExecutionBootstrap({
+        runtime: defaultRuntime,
+        commandPath,
+        startupPolicy,
+        loadPlugins: false,
+      }),
+    );
+  };
   const gateway = addGatewayRunCommand(
     program.command("gateway").description("Run, inspect, and query the WebSocket Gateway"),
+    { beforeRun },
   );
   addGatewayRunCommand(
     gateway.command("run").description("Run the WebSocket Gateway (foreground)"),
+    { beforeRun },
   );
   enableConsoleCapture();
   try {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -24,6 +24,7 @@ import {
   consumeGatewayFastPathRootOptionToken,
   consumeGatewayRunOptionToken,
   resolveGatewayCatalogCommandPath,
+  resolveGatewayRunPreBootstrapOptions,
 } from "./gateway-run-argv.js";
 import { hasJsonOutputFlag, withConsoleLogsRoutedToStderrForJson } from "./json-output-mode.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
@@ -160,6 +161,14 @@ export function isGatewayRunFastPathArgv(argv: string[]): boolean {
   return sawGateway;
 }
 
+function isGatewayRunInvocationArgv(argv: string[]): boolean {
+  const commandPath = resolveGatewayCatalogCommandPath(argv);
+  return (
+    commandPath?.length === 1 ||
+    (commandPath?.length === 2 && commandPath[0] === "gateway" && commandPath[1] === "run")
+  );
+}
+
 async function tryRunGatewayRunFastPath(
   argv: string[],
   startupTrace: ReturnType<typeof createGatewayCliMainStartupTrace>,
@@ -176,7 +185,6 @@ async function tryRunGatewayRunFastPath(
     { enableConsoleCapture },
     { ensureCliExecutionBootstrap },
     { defaultRuntime },
-    { readConfigFileSnapshot },
   ] = await startupTrace.measure("gateway-run-imports", () =>
     Promise.all([
       import("commander"),
@@ -187,7 +195,6 @@ async function tryRunGatewayRunFastPath(
       loadLoggingModule(),
       import("./command-execution-startup.js"),
       import("../runtime.js"),
-      import("../config/config.js"),
     ]),
   );
   const commandPath = resolveGatewayCatalogCommandPath(argv) ?? ["gateway"];
@@ -208,23 +215,36 @@ async function tryRunGatewayRunFastPath(
     process.exitCode = typeof err.exitCode === "number" ? err.exitCode : 1;
     throw err;
   });
-  const beforeRun = async (opts: { reset?: boolean }) => {
-    // Dev reset deletes the state directory before recreating config. Migrating first would
-    // archive legacy state and then delete its imported SQLite rows.
-    if (opts.reset) {
+  const beforeRun = async (opts: { force?: boolean; reset?: boolean }) => {
+    let beforeStateMigrations: ((snapshot?: ConfigFileSnapshot) => Promise<boolean>) | undefined;
+    const shouldBootstrap = await startupTrace.measure("gateway-run-pre-bootstrap", async () => {
+      const { prepareGatewayRunBootstrap, recheckGatewayRunBootstrap } =
+        await import("./gateway-cli/pre-bootstrap.js");
+      const prepared = await prepareGatewayRunBootstrap({ opts, runtime: defaultRuntime });
+      if (prepared) {
+        beforeStateMigrations = (snapshot) =>
+          recheckGatewayRunBootstrap({
+            opts,
+            runtime: defaultRuntime,
+            ...(snapshot ? { snapshot } : {}),
+          });
+      }
+      return prepared;
+    });
+    if (!shouldBootstrap) {
       return;
     }
-    await startupTrace.measure("gateway-run-config-recovery", () =>
-      readConfigFileSnapshot({ recoverSuspicious: true }),
-    );
-    await startupTrace.measure("gateway-run-bootstrap", () =>
-      ensureCliExecutionBootstrap({
+    await startupTrace.measure("gateway-run-bootstrap", async () => {
+      await ensureCliExecutionBootstrap({
         runtime: defaultRuntime,
         commandPath,
         startupPolicy,
         loadPlugins: false,
-      }),
-    );
+        ...(beforeStateMigrations ? { beforeStateMigrations } : {}),
+      });
+      const { reloadTrustedGatewayRunEnvironment } = await import("./gateway-cli/pre-bootstrap.js");
+      await reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime });
+    });
   };
   const gateway = addGatewayRunCommand(
     program.command("gateway").description("Run, inspect, and query the WebSocket Gateway"),
@@ -530,17 +550,31 @@ export async function runCli(argv: string[] = process.argv) {
   const normalizedArgv = normalizeRootHelpTargetArgv(parsedProfile.argv);
   const normalizedInvocation = resolveCliArgvInvocation(normalizedArgv);
   const isHelpOrVersionInvocation = normalizedInvocation.hasHelpOrVersion;
+  const isGatewayRunInvocation = isGatewayRunInvocationArgv(normalizedArgv);
   startupTrace.mark("argv");
 
-  if (!isHelpOrVersionInvocation && shouldLoadCliDotEnv()) {
+  // Enforce the minimum supported runtime before gateway selection can read or recover config.
+  assertSupportedRuntime();
+
+  if (!isHelpOrVersionInvocation && (isGatewayRunInvocation || shouldLoadCliDotEnv())) {
     await startupTrace.measure("dotenv", async () => {
       if (isRemoteAgentDispatchInvocation(normalizedArgv, normalizedInvocation.primary)) {
         const { loadGatewayDispatchCliDotEnv } = await import("./gateway-dispatch-dotenv.js");
         await loadGatewayDispatchCliDotEnv({ quiet: true });
       } else {
         const { loadCliDotEnv } = await import("./dotenv.js");
-        loadCliDotEnv({ quiet: true });
+        loadCliDotEnv({ loadGlobalEnv: !isGatewayRunInvocation, quiet: true });
       }
+    });
+  }
+  if (!isHelpOrVersionInvocation && isGatewayRunInvocation) {
+    await startupTrace.measure("gateway-run-select-environment", async () => {
+      const [{ selectGatewayRunEnvironment }, { defaultRuntime }] = await Promise.all([
+        import("./gateway-cli/pre-bootstrap.js"),
+        import("../runtime.js"),
+      ]);
+      const opts = resolveGatewayRunPreBootstrapOptions(normalizedArgv) ?? {};
+      await selectGatewayRunEnvironment({ opts, runtime: defaultRuntime });
     });
   }
   normalizeEnv();
@@ -548,18 +582,21 @@ export async function runCli(argv: string[] = process.argv) {
     ensureOpenClawCliOnPath();
   }
 
-  // Enforce the minimum supported runtime before doing any work.
-  assertSupportedRuntime();
-
   // Activate operator-managed proxy routing for network-capable commands.
   // Local Gateway/control-plane commands keep direct loopback access while
   // runtime, provider, plugin, update, and manifest/metadata-owned plugin commands route egress.
   let proxyHandle: ProxyHandle | null = null;
+  let onSigterm: (() => void) | null = null;
+  let onSigint: (() => void) | null = null;
+  let onExit: (() => void) | null = null;
   let bestEffortConfigPromise: Promise<OpenClawConfig> | null = null;
+  const isolateProxyConfigEnv = isGatewayRunInvocation;
   const readBestEffortCliConfig = async (): Promise<OpenClawConfig> => {
     if (!bestEffortConfigPromise) {
       bestEffortConfigPromise = import("../config/io.js").then(({ readBestEffortConfig }) =>
-        readBestEffortConfig(),
+        readBestEffortConfig(
+          isolateProxyConfigEnv ? { isolateEnv: true, observe: false } : undefined,
+        ),
       );
     }
     return await bestEffortConfigPromise;
@@ -577,20 +614,10 @@ export async function runCli(argv: string[] = process.argv) {
     proxyHandle = null;
     handle?.kill("SIGTERM");
   };
-  if (!isHelpOrVersionInvocation && shouldStartProxyForCli(normalizedArgv)) {
-    const config = await readBestEffortCliConfig();
-    const unownedPrimary = await resolveUnownedCliPrimary({ argv: normalizedArgv, config });
-    if (unownedPrimary) {
-      throw new Error(await resolveUnownedCliPrimaryMessage({ primary: unownedPrimary, config }));
+  const installProxySignalHandlers = () => {
+    if (!proxyHandle || onSigterm || onSigint || onExit) {
+      return;
     }
-    const { startProxy } = await loadProxyLifecycleModule();
-    proxyHandle = await startProxy(config?.proxy ?? undefined);
-  }
-
-  let onSigterm: (() => void) | null = null;
-  let onSigint: (() => void) | null = null;
-  let onExit: (() => void) | null = null;
-  if (proxyHandle) {
     const shutdown = (exitCode: number) => {
       if (onSigterm) {
         process.off("SIGTERM", onSigterm);
@@ -608,6 +635,29 @@ export async function runCli(argv: string[] = process.argv) {
     process.once("SIGTERM", onSigterm);
     process.once("SIGINT", onSigint);
     process.once("exit", onExit);
+  };
+  const replaceStartedProxy = async (config: OpenClawConfig["proxy"]) => {
+    await stopStartedProxy();
+    const { startProxy } = await loadProxyLifecycleModule();
+    proxyHandle = await startProxy(config);
+    installProxySignalHandlers();
+  };
+  if (!isHelpOrVersionInvocation && shouldStartProxyForCli(normalizedArgv)) {
+    const config = await readBestEffortCliConfig();
+    const unownedPrimary = await resolveUnownedCliPrimary({ argv: normalizedArgv, config });
+    if (unownedPrimary) {
+      throw new Error(await resolveUnownedCliPrimaryMessage({ primary: unownedPrimary, config }));
+    }
+    await replaceStartedProxy(config?.proxy ?? undefined);
+  }
+
+  let uninstallGatewayRunRuntimeHooks: (() => void) | null = null;
+  if (!isHelpOrVersionInvocation && isGatewayRunInvocation) {
+    const { installGatewayRunRuntimeHooks } = await import("./gateway-cli/runtime-hooks.js");
+    uninstallGatewayRunRuntimeHooks = installGatewayRunRuntimeHooks({
+      releaseManagedProxy: stopStartedProxy,
+      refreshManagedProxy: replaceStartedProxy,
+    });
   }
 
   try {
@@ -937,6 +987,7 @@ export async function runCli(argv: string[] = process.argv) {
       stopStartupProgress();
     }
   } finally {
+    uninstallGatewayRunRuntimeHooks?.();
     if (onSigterm) {
       process.off("SIGTERM", onSigterm);
     }

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -83,13 +83,13 @@ describe("runDoctorConfigPreflight state migration", () => {
     });
   });
 
-  it("limits invalid-config preflight to config-independent state migration", async () => {
+  it("still migrates cron storage while limiting other invalid-config state migration", async () => {
     vi.clearAllMocks();
     readConfigFileSnapshot.mockResolvedValueOnce({
       exists: true,
       valid: false,
-      config: {},
-      sourceConfig: {},
+      config: { cron: { store: "/tmp/legacy-cron.json" } },
+      sourceConfig: { cron: { store: "/tmp/legacy-cron.json" } },
       legacyIssues: [],
       warnings: [],
       issues: [{ path: "gateway", message: "invalid" }],
@@ -101,7 +101,9 @@ describe("runDoctorConfigPreflight state migration", () => {
     });
 
     expect(autoMigrateLegacyState).not.toHaveBeenCalled();
-    expect(repairLegacyCronStoreWithoutPrompt).not.toHaveBeenCalled();
+    expect(repairLegacyCronStoreWithoutPrompt).toHaveBeenCalledWith({
+      cfg: { cron: { store: "/tmp/legacy-cron.json" } },
+    });
     expect(autoMigrateLegacyTaskStateSidecars).toHaveBeenCalledWith({ env: process.env });
     expect(note).toHaveBeenCalledWith("- task-imported", "Doctor changes");
   });

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -140,7 +140,7 @@ describe("runDoctorConfigPreflight state migration", () => {
     });
   });
 
-  it("still migrates cron storage while limiting other invalid-config state migration", async () => {
+  it("limits invalid-config preflight to config-independent state migration", async () => {
     readConfigFileSnapshot.mockResolvedValueOnce({
       exists: true,
       valid: false,
@@ -157,9 +157,7 @@ describe("runDoctorConfigPreflight state migration", () => {
     });
 
     expect(autoMigrateLegacyState).not.toHaveBeenCalled();
-    expect(repairLegacyCronStoreWithoutPrompt).toHaveBeenCalledWith({
-      cfg: { cron: { store: "/tmp/legacy-cron.json" } },
-    });
+    expect(repairLegacyCronStoreWithoutPrompt).not.toHaveBeenCalled();
     expect(autoMigrateLegacyTaskStateSidecars).toHaveBeenCalledWith({ env: process.env });
     expect(note).toHaveBeenCalledWith("- task-imported", "Doctor changes");
   });

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -1,5 +1,5 @@
 // Doctor config preflight tests cover state migration preflight behavior before config repair.
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const autoMigrateLegacyStateDir = vi.hoisted(() =>
   vi.fn(async () => ({ migrated: false, skipped: false, changes: [], warnings: [] })),
@@ -47,6 +47,65 @@ vi.mock("../../packages/terminal-core/src/note.js", () => ({ note }));
 const { runDoctorConfigPreflight } = await import("./doctor-config-preflight.js");
 
 describe("runDoctorConfigPreflight state migration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runs the startup guard immediately before the first state mutation", async () => {
+    const beforeStateMigrations = vi.fn(async () => true);
+
+    await runDoctorConfigPreflight({
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+      beforeStateMigrations,
+    });
+
+    expect(beforeStateMigrations).toHaveBeenCalledTimes(2);
+    const guardOrder = beforeStateMigrations.mock.invocationCallOrder[0] ?? 0;
+    const firstMutationOrder = autoMigrateLegacyStateDir.mock.invocationCallOrder[0] ?? 0;
+    expect(firstMutationOrder).toBeGreaterThan(guardOrder);
+    const configGuardOrder = beforeStateMigrations.mock.invocationCallOrder[1] ?? 0;
+    const configMutationOrder = repairLegacyCronStoreWithoutPrompt.mock.invocationCallOrder[0] ?? 0;
+    expect(configMutationOrder).toBeGreaterThan(configGuardOrder);
+    expect(beforeStateMigrations.mock.calls[1]?.[0]).toMatchObject({
+      valid: true,
+      sourceConfig: { gateway: { mode: "local", port: 19091 } },
+    });
+  });
+
+  it("skips every state migration stage when the startup guard rejects", async () => {
+    await runDoctorConfigPreflight({
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+      beforeStateMigrations: async () => false,
+    });
+
+    expect(autoMigrateLegacyStateDir).not.toHaveBeenCalled();
+    expect(repairLegacyCronStoreWithoutPrompt).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyState).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyTaskStateSidecars).not.toHaveBeenCalled();
+    expect(readConfigFileSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it("skips config-dependent migrations when the fresh snapshot guard rejects", async () => {
+    const beforeStateMigrations = vi
+      .fn<(snapshot?: Record<string, unknown>) => Promise<boolean>>()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    await runDoctorConfigPreflight({
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+      beforeStateMigrations,
+    });
+
+    expect(autoMigrateLegacyStateDir).toHaveBeenCalledOnce();
+    expect(beforeStateMigrations).toHaveBeenCalledTimes(2);
+    expect(repairLegacyCronStoreWithoutPrompt).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyState).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyTaskStateSidecars).not.toHaveBeenCalled();
+  });
+
   it("runs full state migrations after reading the config snapshot", async () => {
     await runDoctorConfigPreflight({
       migrateLegacyConfig: false,
@@ -68,8 +127,6 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("passes explicit corrupt-target recovery to state migrations", async () => {
-    vi.clearAllMocks();
-
     await runDoctorConfigPreflight({
       migrateLegacyConfig: false,
       invalidConfigNote: false,
@@ -84,7 +141,6 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("still migrates cron storage while limiting other invalid-config state migration", async () => {
-    vi.clearAllMocks();
     readConfigFileSnapshot.mockResolvedValueOnce({
       exists: true,
       valid: false,

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -8,7 +8,7 @@ import {
   recoverConfigFromLastKnownGood,
 } from "../config/io.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
-import type { LegacyConfigIssue } from "../config/types.js";
+import type { ConfigFileSnapshot, LegacyConfigIssue } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { resolveHomeDir } from "../utils.js";
@@ -129,10 +129,19 @@ export async function runDoctorConfigPreflight(
     repairPrefixedConfig?: boolean;
     recoverCorruptTargetStore?: boolean;
     invalidConfigNote?: string | false;
+    beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
   } = {},
 ): Promise<DoctorConfigPreflightResult> {
-  if (options.migrateState !== false) {
-    const { autoMigrateLegacyStateDir } = await loadDoctorStateMigrations();
+  const stateMigrations =
+    options.migrateState !== false ? await loadDoctorStateMigrations() : undefined;
+  // The gateway uses this last-moment guard to ensure its prepared config did not change before
+  // any automatic migration mutates state. A rejected guard skips every state migration stage.
+  const stateMigrationsAllowed =
+    stateMigrations === undefined ||
+    options.beforeStateMigrations === undefined ||
+    (await options.beforeStateMigrations());
+  if (stateMigrations && stateMigrationsAllowed) {
+    const { autoMigrateLegacyStateDir } = stateMigrations;
     const stateDirResult = await autoMigrateLegacyStateDir({ env: process.env });
     noteStateMigrationResult(stateDirResult);
   }
@@ -180,12 +189,16 @@ export async function runDoctorConfigPreflight(
   }
 
   const baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
-  if (options.migrateState !== false) {
+  const configStateMigrationsAllowed =
+    stateMigrations !== undefined &&
+    stateMigrationsAllowed &&
+    (options.beforeStateMigrations === undefined ||
+      (await options.beforeStateMigrations(snapshot)));
+  if (stateMigrations && configStateMigrationsAllowed) {
     const { repairLegacyCronStoreWithoutPrompt } = await loadDoctorCron();
     const cronResult = await repairLegacyCronStoreWithoutPrompt({ cfg: baseConfig });
     noteStateMigrationResult(cronResult);
-    const { autoMigrateLegacyState, autoMigrateLegacyTaskStateSidecars } =
-      await loadDoctorStateMigrations();
+    const { autoMigrateLegacyState, autoMigrateLegacyTaskStateSidecars } = stateMigrations;
     const stateResult = snapshot.valid
       ? await autoMigrateLegacyState({
           cfg: baseConfig,

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -195,18 +195,21 @@ export async function runDoctorConfigPreflight(
     (options.beforeStateMigrations === undefined ||
       (await options.beforeStateMigrations(snapshot)));
   if (stateMigrations && configStateMigrationsAllowed) {
-    const { repairLegacyCronStoreWithoutPrompt } = await loadDoctorCron();
-    const cronResult = await repairLegacyCronStoreWithoutPrompt({ cfg: baseConfig });
-    noteStateMigrationResult(cronResult);
     const { autoMigrateLegacyState, autoMigrateLegacyTaskStateSidecars } = stateMigrations;
-    const stateResult = snapshot.valid
-      ? await autoMigrateLegacyState({
+    if (snapshot.valid) {
+      const { repairLegacyCronStoreWithoutPrompt } = await loadDoctorCron();
+      const cronResult = await repairLegacyCronStoreWithoutPrompt({ cfg: baseConfig });
+      noteStateMigrationResult(cronResult);
+      noteStateMigrationResult(
+        await autoMigrateLegacyState({
           cfg: baseConfig,
           env: process.env,
           recoverCorruptTargetStore: options.recoverCorruptTargetStore,
-        })
-      : await autoMigrateLegacyTaskStateSidecars({ env: process.env });
-    noteStateMigrationResult(stateResult);
+        }),
+      );
+    } else {
+      noteStateMigrationResult(await autoMigrateLegacyTaskStateSidecars({ env: process.env }));
+    }
   }
 
   return {

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -181,11 +181,9 @@ export async function runDoctorConfigPreflight(
 
   const baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
   if (options.migrateState !== false) {
-    if (snapshot.valid) {
-      const { repairLegacyCronStoreWithoutPrompt } = await loadDoctorCron();
-      const cronResult = await repairLegacyCronStoreWithoutPrompt({ cfg: baseConfig });
-      noteStateMigrationResult(cronResult);
-    }
+    const { repairLegacyCronStoreWithoutPrompt } = await loadDoctorCron();
+    const cronResult = await repairLegacyCronStoreWithoutPrompt({ cfg: baseConfig });
+    noteStateMigrationResult(cronResult);
     const { autoMigrateLegacyState, autoMigrateLegacyTaskStateSidecars } =
       await loadDoctorStateMigrations();
     const stateResult = snapshot.valid

--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -16,7 +16,6 @@ import {
   collectLegacyWhatsAppCrontabHealthWarning,
   maybeRepairLegacyCronStore,
   noteLegacyWhatsAppCrontabHealthCheck,
-  repairLegacyCronStoreWithoutPrompt,
 } from "./index.js";
 
 type TerminalNote = (message: string, title?: string) => void;
@@ -1057,34 +1056,5 @@ describe("legacy WhatsApp crontab health check", () => {
     ).resolves.toBeUndefined();
 
     expect(noteMock).not.toHaveBeenCalled();
-  });
-});
-
-describe("repairLegacyCronStoreWithoutPrompt", () => {
-  it("migrates legacy JSON cron store to SQLite and returns a change summary", async () => {
-    const storePath = await makeTempStorePath();
-    await writeCronStore(storePath, [createLegacyCronJob()]);
-
-    const result = await repairLegacyCronStoreWithoutPrompt({
-      cfg: createCronConfig(storePath),
-    });
-
-    expect(result.changes).toHaveLength(1);
-    expect(result.changes[0]).toContain("Cron store migrated to SQLite");
-    expect(result.warnings).toHaveLength(0);
-    const jobs = await readPersistedJobs(storePath);
-    expect(jobs).toHaveLength(1);
-  });
-
-  it("returns empty result when no legacy store exists", async () => {
-    const storePath = await makeTempStorePath();
-    await writeCurrentCronStore(storePath, [createCurrentCronJob()]);
-
-    const result = await repairLegacyCronStoreWithoutPrompt({
-      cfg: createCronConfig(storePath),
-    });
-
-    expect(result.changes).toHaveLength(0);
-    expect(result.warnings).toHaveLength(0);
   });
 });

--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -16,6 +16,7 @@ import {
   collectLegacyWhatsAppCrontabHealthWarning,
   maybeRepairLegacyCronStore,
   noteLegacyWhatsAppCrontabHealthCheck,
+  repairLegacyCronStoreWithoutPrompt,
 } from "./index.js";
 
 type TerminalNote = (message: string, title?: string) => void;
@@ -1056,5 +1057,34 @@ describe("legacy WhatsApp crontab health check", () => {
     ).resolves.toBeUndefined();
 
     expect(noteMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("repairLegacyCronStoreWithoutPrompt", () => {
+  it("migrates legacy JSON cron store to SQLite and returns a change summary", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCronStore(storePath, [createLegacyCronJob()]);
+
+    const result = await repairLegacyCronStoreWithoutPrompt({
+      cfg: createCronConfig(storePath),
+    });
+
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toContain("Cron store migrated to SQLite");
+    expect(result.warnings).toHaveLength(0);
+    const jobs = await readPersistedJobs(storePath);
+    expect(jobs).toHaveLength(1);
+  });
+
+  it("returns empty result when no legacy store exists", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCurrentCronStore(storePath, [createCurrentCronJob()]);
+
+    const result = await repairLegacyCronStoreWithoutPrompt({
+      cfg: createCronConfig(storePath),
+    });
+
+    expect(result.changes).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
   });
 });

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -216,7 +216,7 @@ async function applyLegacyCronStoreRepair(params: {
 export async function repairLegacyCronStoreWithoutPrompt(params: {
   cfg: OpenClawConfig;
 }): Promise<LegacyCronRepairResult> {
-  const storePath = resolveCronJobsStorePath(params.cfg.cron?.store);
+  const storePath = resolveCronJobsStorePath(normalizeOptionalString(params.cfg.cron?.store));
   let state: LegacyCronRepairState | null;
   try {
     state = await loadLegacyCronRepairState({

--- a/src/config/config-env-vars.ts
+++ b/src/config/config-env-vars.ts
@@ -5,10 +5,21 @@ import {
   normalizeEnvVarKey,
 } from "../infra/host-env-security.js";
 import { containsEnvVarReference } from "./env-substitution.js";
+import { ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV } from "./future-version-guard.js";
 import type { OpenClawConfig } from "./types.js";
 
 function isBlockedConfigEnvVar(key: string): boolean {
-  return isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key);
+  return (
+    key.toUpperCase() === ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV ||
+    key.toUpperCase() === "OPENCLAW_INCLUDE_ROOTS" ||
+    isDangerousHostEnvVarName(key) ||
+    isDangerousHostEnvOverrideVarName(key)
+  );
+}
+
+/** Returns whether a config-controlled environment entry is safe to apply at runtime. */
+export function isConfigRuntimeEnvVarAllowed(key: string, value: string): boolean {
+  return Boolean(value.trim()) && !isBlockedConfigEnvVar(key) && !containsEnvVarReference(value);
 }
 
 function collectConfigEnvVarsByTarget(cfg?: OpenClawConfig): Record<string, string> {
@@ -28,10 +39,7 @@ function collectConfigEnvVarsByTarget(cfg?: OpenClawConfig): Record<string, stri
       if (!key) {
         continue;
       }
-      if (isBlockedConfigEnvVar(key)) {
-        continue;
-      }
-      if (containsEnvVarReference(value)) {
+      if (!isConfigRuntimeEnvVarAllowed(key, value)) {
         continue;
       }
       entries[key] = value;
@@ -49,10 +57,7 @@ function collectConfigEnvVarsByTarget(cfg?: OpenClawConfig): Record<string, stri
     if (!key) {
       continue;
     }
-    if (isBlockedConfigEnvVar(key)) {
-      continue;
-    }
-    if (containsEnvVarReference(value)) {
+    if (!isConfigRuntimeEnvVarAllowed(key, value)) {
       continue;
     }
     entries[key] = value;
@@ -86,10 +91,18 @@ export function createConfigRuntimeEnv(
 export function applyConfigEnvVars(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,
+  options: { lowerPrecedenceEnv?: Readonly<Record<string, string>> } = {},
 ): void {
   const entries = collectConfigRuntimeEnvVars(cfg);
+  const lowerPrecedenceEnv = new Map(
+    Object.entries(options.lowerPrecedenceEnv ?? {}).map(([key, value]) => [
+      key.toUpperCase(),
+      value,
+    ]),
+  );
   for (const [key, value] of Object.entries(entries)) {
-    if (env[key]?.trim()) {
+    const currentValue = env[key];
+    if (currentValue?.trim() && lowerPrecedenceEnv.get(key.toUpperCase()) !== currentValue) {
       continue;
     }
     // Skip values containing unresolved ${VAR} references — applyConfigEnvVars runs

--- a/src/config/config-env-vars.ts
+++ b/src/config/config-env-vars.ts
@@ -1,3 +1,8 @@
+import {
+  expandEnvNormalizationKeys,
+  normalizeZaiEnv,
+  resolveEnvNormalizationKeys,
+} from "../infra/env.js";
 // Defines environment-variable config metadata and preservation rules.
 import {
   isDangerousHostEnvOverrideVarName,
@@ -150,18 +155,61 @@ export function createConfigRuntimeEnv(
 export function applyConfigEnvVars(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,
-  options: { lowerPrecedenceEnv?: Readonly<Record<string, string>> } = {},
+  options: {
+    lowerPrecedenceEnv?: Readonly<Record<string, string>>;
+    onLowerPrecedenceKeysReplaced?: (keys: readonly string[]) => void;
+  } = {},
 ): void {
   const entries = collectConfigRuntimeEnvVars(cfg);
+  const lowerPrecedenceEntries = Object.entries(options.lowerPrecedenceEnv ?? {});
+  const normalizeKey = (key: string) => (process.platform === "win32" ? key.toUpperCase() : key);
   const lowerPrecedenceEnv = new Map(
-    Object.entries(options.lowerPrecedenceEnv ?? {}).map(([key, value]) => [
-      key.toUpperCase(),
-      value,
-    ]),
+    lowerPrecedenceEntries.map(([key, value]) => [normalizeKey(key), value]),
   );
+  const configEnvKeys = expandEnvNormalizationKeys(Object.keys(entries));
+  const configValuesByKey = new Map<string, Set<string>>();
   for (const [key, value] of Object.entries(entries)) {
+    for (const normalizedKey of resolveEnvNormalizationKeys(key)) {
+      const values = configValuesByKey.get(normalizedKey) ?? new Set<string>();
+      values.add(value);
+      configValuesByKey.set(normalizedKey, values);
+    }
+  }
+  const higherPrecedenceValues = new Map<string, string>();
+  for (const key of Object.keys(entries)) {
+    const normalizedKeys = resolveEnvNormalizationKeys(key);
+    const winningValue = normalizedKeys
+      .map((normalizedKey) => [normalizedKey, env[normalizedKey]] as const)
+      .find(
+        ([normalizedKey, currentValue]) =>
+          currentValue?.trim() &&
+          lowerPrecedenceEnv.get(normalizedKey) !== currentValue &&
+          !configValuesByKey.get(normalizedKey)?.has(currentValue),
+      )?.[1];
+    if (winningValue !== undefined) {
+      for (const normalizedKey of normalizedKeys) {
+        higherPrecedenceValues.set(normalizedKey, winningValue);
+      }
+    }
+  }
+  const replacedLowerPrecedenceKeys: string[] = [];
+  for (const [key, value] of lowerPrecedenceEntries) {
+    if (configEnvKeys.has(normalizeKey(key)) && env[key] === value) {
+      delete env[key];
+      replacedLowerPrecedenceKeys.push(key);
+    }
+  }
+  if (replacedLowerPrecedenceKeys.length > 0) {
+    options.onLowerPrecedenceKeysReplaced?.(replacedLowerPrecedenceKeys);
+  }
+  for (const [key, value] of Object.entries(entries)) {
+    const higherPrecedenceValue = higherPrecedenceValues.get(normalizeKey(key));
+    if (higherPrecedenceValue !== undefined) {
+      env[key] = higherPrecedenceValue;
+      continue;
+    }
     const currentValue = env[key];
-    if (currentValue?.trim() && lowerPrecedenceEnv.get(key.toUpperCase()) !== currentValue) {
+    if (currentValue?.trim() && lowerPrecedenceEnv.get(normalizeKey(key)) !== currentValue) {
       continue;
     }
     // Skip values containing unresolved ${VAR} references — applyConfigEnvVars runs
@@ -173,4 +221,5 @@ export function applyConfigEnvVars(
     }
     env[key] = value;
   }
+  normalizeZaiEnv(env);
 }

--- a/src/config/config-env-vars.ts
+++ b/src/config/config-env-vars.ts
@@ -66,6 +66,65 @@ function collectConfigEnvVarsByTarget(cfg?: OpenClawConfig): Record<string, stri
   return entries;
 }
 
+function findCaseInsensitiveEnvKey(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  if (Object.hasOwn(env, key)) {
+    return key;
+  }
+  const upperKey = key.toUpperCase();
+  return Object.keys(env).find((candidate) => candidate.toUpperCase() === upperKey);
+}
+
+export function cloneEnvWithPlatformSemantics(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const cloned = { ...env } as NodeJS.ProcessEnv;
+  if (process.platform !== "win32") {
+    return cloned;
+  }
+  // A plain spread loses Windows process.env's case-insensitive lookup and assignment semantics.
+  return new Proxy(cloned, {
+    deleteProperty(target, property) {
+      if (typeof property !== "string") {
+        return Reflect.deleteProperty(target, property);
+      }
+      const key = findCaseInsensitiveEnvKey(target, property);
+      return key ? Reflect.deleteProperty(target, key) : true;
+    },
+    get(target, property, receiver) {
+      if (typeof property !== "string") {
+        return Reflect.get(target, property, receiver);
+      }
+      const key = findCaseInsensitiveEnvKey(target, property);
+      return key ? target[key] : Reflect.get(target, property, receiver);
+    },
+    getOwnPropertyDescriptor(target, property) {
+      if (typeof property !== "string") {
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      }
+      const key = findCaseInsensitiveEnvKey(target, property);
+      if (!key) {
+        return undefined;
+      }
+      return {
+        configurable: true,
+        enumerable: true,
+        value: target[key],
+        writable: true,
+      };
+    },
+    has(target, property) {
+      return typeof property === "string"
+        ? findCaseInsensitiveEnvKey(target, property) !== undefined
+        : Reflect.has(target, property);
+    },
+    set(target, property, value) {
+      if (typeof property !== "string") {
+        return Reflect.set(target, property, value);
+      }
+      target[findCaseInsensitiveEnvKey(target, property) ?? property] = value as string | undefined;
+      return true;
+    },
+  });
+}
+
 /** Collects config env vars safe to inject into runtime process environments. */
 export function collectConfigRuntimeEnvVars(cfg?: OpenClawConfig): Record<string, string> {
   return collectConfigEnvVarsByTarget(cfg);
@@ -82,7 +141,7 @@ export function createConfigRuntimeEnv(
   cfg: OpenClawConfig,
   baseEnv: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
-  const env = { ...baseEnv };
+  const env = cloneEnvWithPlatformSemantics(baseEnv);
   applyConfigEnvVars(cfg, env);
   return env;
 }

--- a/src/config/config.env-vars.test.ts
+++ b/src/config/config.env-vars.test.ts
@@ -1,7 +1,7 @@
 // Covers environment-variable config metadata and parsing.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { resolveConfigEnvVars } from "./env-substitution.js";
 import {
@@ -78,6 +78,21 @@ describe("config env vars", () => {
       expect(merged.OPENROUTER_API_KEY).toBe("config-key");
       expect(process.env.OPENROUTER_API_KEY).toBeUndefined();
     });
+  });
+
+  it("preserves Windows case-insensitive env precedence in merged runtime env", () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      const merged = createConfigRuntimeEnv(
+        { env: { vars: { OPENCLAW_LOAD_SHELL_ENV: "1" } } } as OpenClawConfig,
+        { OpenClaw_Load_Shell_Env: "0" },
+      );
+
+      expect(merged.OPENCLAW_LOAD_SHELL_ENV).toBe("0");
+      expect(Object.keys(merged)).toEqual(["OpenClaw_Load_Shell_Env"]);
+    } finally {
+      platformSpy.mockRestore();
+    }
   });
 
   it("blocks dangerous startup env vars from config env", async () => {

--- a/src/config/config.env-vars.test.ts
+++ b/src/config/config.env-vars.test.ts
@@ -44,6 +44,60 @@ describe("config env vars", () => {
     expect(changedEnv.OPENROUTER_API_KEY).toBe("changed-key");
   });
 
+  it("applies config env above normalized lower-precedence aliases", () => {
+    const onLowerPrecedenceKeysReplaced = vi.fn();
+    const env = { ZAI_API_KEY: "shell-key" };
+
+    applyConfigEnvVars({ env: { vars: { Z_AI_API_KEY: "config-key" } } } as OpenClawConfig, env, {
+      lowerPrecedenceEnv: { ZAI_API_KEY: "shell-key" },
+      onLowerPrecedenceKeysReplaced,
+    });
+
+    expect(env).toEqual({
+      ZAI_API_KEY: "config-key",
+      Z_AI_API_KEY: "config-key",
+    });
+    expect(onLowerPrecedenceKeysReplaced).toHaveBeenCalledWith(["ZAI_API_KEY"]);
+  });
+
+  it("preserves a higher-precedence normalized alias", () => {
+    const env = {
+      ZAI_API_KEY: "shell-key",
+      Z_AI_API_KEY: "invocation-key",
+    };
+
+    applyConfigEnvVars({ env: { vars: { ZAI_API_KEY: "config-key" } } } as OpenClawConfig, env, {
+      lowerPrecedenceEnv: { ZAI_API_KEY: "shell-key" },
+    });
+
+    expect(env).toEqual({
+      ZAI_API_KEY: "invocation-key",
+      Z_AI_API_KEY: "invocation-key",
+    });
+  });
+
+  it("mirrors a higher-precedence canonical value into a config-declared alias", () => {
+    const env = { ZAI_API_KEY: "invocation-key" };
+
+    applyConfigEnvVars({ env: { vars: { Z_AI_API_KEY: "config-key" } } } as OpenClawConfig, env);
+
+    expect(env).toEqual({
+      ZAI_API_KEY: "invocation-key",
+      Z_AI_API_KEY: "invocation-key",
+    });
+  });
+
+  it.runIf(process.platform !== "win32")("keeps unrelated POSIX env casing distinct", () => {
+    const env = { FOO: "host-key" };
+
+    applyConfigEnvVars({ env: { vars: { foo: "config-key" } } } as OpenClawConfig, env);
+
+    expect(env).toEqual({
+      FOO: "host-key",
+      foo: "config-key",
+    });
+  });
+
   it("applies env vars from env.vars when missing", async () => {
     await withEnvOverride({ GROQ_API_KEY: undefined }, async () => {
       applyConfigEnvVars({ env: { vars: { GROQ_API_KEY: "gsk-config" } } } as OpenClawConfig);

--- a/src/config/config.env-vars.test.ts
+++ b/src/config/config.env-vars.test.ts
@@ -29,6 +29,21 @@ describe("config env vars", () => {
     });
   });
 
+  it("overrides only exact lower-precedence env values", () => {
+    const config = {
+      env: { vars: { OPENROUTER_API_KEY: "config-key" } },
+    } as OpenClawConfig;
+    const lowerPrecedenceEnv = { OPENROUTER_API_KEY: "shell-key" };
+    const shellEnv = { OPENROUTER_API_KEY: "shell-key" };
+    const changedEnv = { OPENROUTER_API_KEY: "changed-key" };
+
+    applyConfigEnvVars(config, shellEnv, { lowerPrecedenceEnv });
+    applyConfigEnvVars(config, changedEnv, { lowerPrecedenceEnv });
+
+    expect(shellEnv.OPENROUTER_API_KEY).toBe("config-key");
+    expect(changedEnv.OPENROUTER_API_KEY).toBe("changed-key");
+  });
+
   it("applies env vars from env.vars when missing", async () => {
     await withEnvOverride({ GROQ_API_KEY: undefined }, async () => {
       applyConfigEnvVars({ env: { vars: { GROQ_API_KEY: "gsk-config" } } } as OpenClawConfig);
@@ -72,6 +87,9 @@ describe("config env vars", () => {
         SHELL: undefined,
         HOME: undefined,
         ZDOTDIR: undefined,
+        OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: undefined,
+        OPENCLAW_INCLUDE_ROOTS: undefined,
+        openclaw_allow_older_binary_destructive_actions: undefined,
         OPENROUTER_API_KEY: undefined,
       },
       async () => {
@@ -82,6 +100,9 @@ describe("config env vars", () => {
               SHELL: "/tmp/evil-shell",
               HOME: "/tmp/evil-home",
               ZDOTDIR: "/tmp/evil-zdotdir",
+              OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1",
+              OPENCLAW_INCLUDE_ROOTS: "/tmp/evil-include-root",
+              openclaw_allow_older_binary_destructive_actions: "1",
               OPENROUTER_API_KEY: "config-key",
             },
           },
@@ -91,6 +112,9 @@ describe("config env vars", () => {
         expect(entries.SHELL).toBeUndefined();
         expect(entries.HOME).toBeUndefined();
         expect(entries.ZDOTDIR).toBeUndefined();
+        expect(entries.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBeUndefined();
+        expect(entries.OPENCLAW_INCLUDE_ROOTS).toBeUndefined();
+        expect(entries.openclaw_allow_older_binary_destructive_actions).toBeUndefined();
         expect(entries.OPENROUTER_API_KEY).toBe("config-key");
 
         applyConfigEnvVars(config as OpenClawConfig);
@@ -98,6 +122,9 @@ describe("config env vars", () => {
         expect(process.env.SHELL).toBeUndefined();
         expect(process.env.HOME).toBeUndefined();
         expect(process.env.ZDOTDIR).toBeUndefined();
+        expect(process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBeUndefined();
+        expect(process.env.OPENCLAW_INCLUDE_ROOTS).toBeUndefined();
+        expect(process.env.openclaw_allow_older_binary_destructive_actions).toBeUndefined();
         expect(process.env.OPENROUTER_API_KEY).toBe("config-key");
       },
     );
@@ -217,11 +244,13 @@ describe("config env vars", () => {
 
   it("drops dangerous and empty values from the state-dir .env file", async () => {
     await withTempHome(async (_home) => {
-      await writeStateDirDotEnv("NODE_OPTIONS=--require /tmp/evil.js\nEMPTY=\nVALID=ok\n", {
-        env: process.env,
-      });
+      await writeStateDirDotEnv(
+        "NODE_OPTIONS=--require /tmp/evil.js\nOPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1\nEMPTY=\nVALID=ok\n",
+        { env: process.env },
+      );
       const vars = readStateDirDotEnvVars(process.env);
       expect(vars.NODE_OPTIONS).toBeUndefined();
+      expect(vars.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBeUndefined();
       expect(vars.EMPTY).toBeUndefined();
       expect(vars.VALID).toBe("ok");
     });

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -3,5 +3,6 @@ export {
   applyConfigEnvVars,
   collectConfigRuntimeEnvVars,
   createConfigRuntimeEnv,
+  isConfigRuntimeEnvVarAllowed,
 } from "./config-env-vars.js";
 export { collectDurableServiceEnvVars, readStateDirDotEnvVars } from "./state-dir-dotenv.js";

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -1,6 +1,7 @@
 // Public facade for config env var collection and durable state-dir dotenv reads.
 export {
   applyConfigEnvVars,
+  cloneEnvWithPlatformSemantics,
   collectConfigRuntimeEnvVars,
   createConfigRuntimeEnv,
   isConfigRuntimeEnvVarAllowed,

--- a/src/config/io.best-effort.test.ts
+++ b/src/config/io.best-effort.test.ts
@@ -80,6 +80,77 @@ describe("readBestEffortConfig", () => {
     });
   });
 
+  it("resolves config env above normalized lower-precedence aliases in isolated snapshots", async () => {
+    await withTempHome(async (home) => {
+      const previousCanonical = process.env.ZAI_API_KEY;
+      const previousLegacy = process.env.Z_AI_API_KEY;
+      process.env.ZAI_API_KEY = "shell-token";
+      delete process.env.Z_AI_API_KEY;
+      try {
+        await writeOpenClawConfig(home, {
+          env: { vars: { Z_AI_API_KEY: "config-token" } },
+          gateway: { auth: { mode: "token", token: "${ZAI_API_KEY}" }, mode: "local" },
+        });
+
+        const snapshot = await readConfigFileSnapshot({
+          isolateEnv: true,
+          lowerPrecedenceEnv: { ZAI_API_KEY: "shell-token" },
+          observe: false,
+        });
+
+        expect(snapshot.config.gateway?.auth?.token).toBe("config-token");
+        expect(process.env.ZAI_API_KEY).toBe("shell-token");
+        expect(process.env.Z_AI_API_KEY).toBeUndefined();
+      } finally {
+        if (previousCanonical === undefined) {
+          delete process.env.ZAI_API_KEY;
+        } else {
+          process.env.ZAI_API_KEY = previousCanonical;
+        }
+        if (previousLegacy === undefined) {
+          delete process.env.Z_AI_API_KEY;
+        } else {
+          process.env.Z_AI_API_KEY = previousLegacy;
+        }
+      }
+    });
+  });
+
+  it("resolves config aliases from a higher-precedence canonical value in isolated snapshots", async () => {
+    await withTempHome(async (home) => {
+      const previousCanonical = process.env.ZAI_API_KEY;
+      const previousLegacy = process.env.Z_AI_API_KEY;
+      process.env.ZAI_API_KEY = "invocation-token";
+      delete process.env.Z_AI_API_KEY;
+      try {
+        await writeOpenClawConfig(home, {
+          env: { vars: { Z_AI_API_KEY: "config-token" } },
+          gateway: { auth: { mode: "token", token: "${Z_AI_API_KEY}" }, mode: "local" },
+        });
+
+        const snapshot = await readConfigFileSnapshot({
+          isolateEnv: true,
+          observe: false,
+        });
+
+        expect(snapshot.config.gateway?.auth?.token).toBe("invocation-token");
+        expect(process.env.ZAI_API_KEY).toBe("invocation-token");
+        expect(process.env.Z_AI_API_KEY).toBeUndefined();
+      } finally {
+        if (previousCanonical === undefined) {
+          delete process.env.ZAI_API_KEY;
+        } else {
+          process.env.ZAI_API_KEY = previousCanonical;
+        }
+        if (previousLegacy === undefined) {
+          delete process.env.Z_AI_API_KEY;
+        } else {
+          process.env.Z_AI_API_KEY = previousLegacy;
+        }
+      }
+    });
+  });
+
   it("can read best-effort config without applying env vars or recording observation", async () => {
     await withTempHome(async (home) => {
       const key = "OPENCLAW_ISOLATED_BEST_EFFORT_CONFIG_TEST";

--- a/src/config/io.best-effort.test.ts
+++ b/src/config/io.best-effort.test.ts
@@ -1,6 +1,6 @@
 // Covers best-effort config IO reads and warning behavior.
 import fs from "node:fs/promises";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   readBestEffortConfig,
   readBestEffortConfigSnapshot,
@@ -24,6 +24,123 @@ describe("readBestEffortConfig", () => {
       await readConfigFileSnapshot();
 
       await expect(fs.stat(healthPath)).resolves.toMatchObject({ isFile: expect.any(Function) });
+    });
+  });
+
+  it("can read snapshots without applying config env vars to the process", async () => {
+    await withTempHome(async (home) => {
+      const key = "OPENCLAW_ISOLATED_CONFIG_READ_TEST";
+      const previous = process.env[key];
+      delete process.env[key];
+      try {
+        await writeOpenClawConfig(home, {
+          env: { vars: { [key]: "from-config" } },
+          gateway: { mode: "local" },
+        });
+
+        await readConfigFileSnapshot({ isolateEnv: true, observe: false });
+
+        expect(process.env[key]).toBeUndefined();
+      } finally {
+        if (previous === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = previous;
+        }
+      }
+    });
+  });
+
+  it("resolves config env above exact lower-precedence values in isolated snapshots", async () => {
+    await withTempHome(async (home) => {
+      const key = "OPENCLAW_GATEWAY_TOKEN";
+      const previous = process.env[key];
+      process.env[key] = "shell-token";
+      try {
+        await writeOpenClawConfig(home, {
+          env: { vars: { [key]: "config-token" } },
+          gateway: { auth: { mode: "token", token: `\${${key}}` }, mode: "local" },
+        });
+
+        const snapshot = await readConfigFileSnapshot({
+          isolateEnv: true,
+          lowerPrecedenceEnv: { [key]: "shell-token" },
+          observe: false,
+        });
+
+        expect(snapshot.config.gateway?.auth?.token).toBe("config-token");
+        expect(process.env[key]).toBe("shell-token");
+      } finally {
+        if (previous === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = previous;
+        }
+      }
+    });
+  });
+
+  it("can read best-effort config without applying env vars or recording observation", async () => {
+    await withTempHome(async (home) => {
+      const key = "OPENCLAW_ISOLATED_BEST_EFFORT_CONFIG_TEST";
+      const previous = process.env[key];
+      delete process.env[key];
+      try {
+        await writeOpenClawConfig(home, {
+          env: { vars: { [key]: "from-config" } },
+          gateway: { mode: "local" },
+        });
+
+        const config = await readBestEffortConfig({ isolateEnv: true, observe: false });
+
+        expect(config.gateway?.mode).toBe("local");
+        expect(process.env[key]).toBeUndefined();
+        await expect(fs.stat(`${home}/.openclaw/logs/config-health.json`)).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      } finally {
+        if (previous === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = previous;
+        }
+      }
+    });
+  });
+
+  it("preserves Windows case-insensitive env lookup in isolated reads", async () => {
+    await withTempHome(async (home) => {
+      const mixedCaseKey = "OpenClaw_Config_Path";
+      const customConfigPath = `${home}/custom-openclaw.json`;
+      const previousMixedCasePath = process.env[mixedCaseKey];
+      const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      delete process.env.OPENCLAW_CONFIG_PATH;
+      process.env[mixedCaseKey] = customConfigPath;
+      try {
+        await fs.writeFile(
+          customConfigPath,
+          `${JSON.stringify({ gateway: { mode: "local" } }, null, 2)}\n`,
+          "utf-8",
+        );
+
+        const snapshot = await readConfigFileSnapshot({ isolateEnv: true, observe: false });
+
+        expect(snapshot.exists).toBe(true);
+        expect(snapshot.path).toBe(customConfigPath);
+      } finally {
+        platformSpy.mockRestore();
+        if (previousMixedCasePath === undefined) {
+          delete process.env[mixedCaseKey];
+        } else {
+          process.env[mixedCaseKey] = previousMixedCasePath;
+        }
+        if (previousConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+        }
+      }
     });
   });
 

--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -548,6 +548,87 @@ describe("config observe recovery", () => {
     });
   });
 
+  it("does not auto-restore backup candidates rejected by the caller", async () => {
+    await withSuiteHome(async (home) => {
+      const { io, configPath } = createTestConfigIO(home);
+      await seedConfigBackup(configPath, recoverableTelegramConfig);
+      const clobbered = await writeConfigRaw(configPath, {
+        meta: { lastTouchedVersion: "2026.5.28" },
+      });
+      const allowSuspiciousRecovery = vi.fn(() => false);
+
+      const snapshot = await io.readConfigFileSnapshot({
+        recoverSuspicious: true,
+        allowSuspiciousRecovery,
+      });
+      await io.readConfigFileSnapshot({ recoverSuspicious: true, allowSuspiciousRecovery });
+
+      expect(snapshot.valid).toBe(true);
+      expect(snapshot.config.gateway?.mode).toBeUndefined();
+      expect(allowSuspiciousRecovery).toHaveBeenCalledTimes(2);
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(clobbered.raw);
+      await expect(listClobberFiles(configPath)).resolves.toHaveLength(0);
+    });
+  });
+
+  it("passes the resolved backup candidate to caller recovery policy", async () => {
+    await withSuiteHome(async (home) => {
+      const { io, configPath } = createTestConfigIO(home);
+      await fsp.mkdir(path.dirname(configPath), { recursive: true });
+      await fsp.writeFile(
+        path.join(path.dirname(configPath), "future-meta.json5"),
+        '{ meta: { lastTouchedVersion: "9999.1.1" } }\n',
+        "utf-8",
+      );
+      await seedConfigBackup(configPath, {
+        $include: "./future-meta.json5",
+        gateway: { mode: "local" },
+      });
+      const clobbered = await writeConfigRaw(configPath, {});
+      let candidateVersion: string | undefined;
+      let currentConfig: Record<string, unknown> | undefined;
+
+      await io.readConfigFileSnapshot({
+        recoverSuspicious: true,
+        allowSuspiciousRecovery: (candidate, current) => {
+          candidateVersion = candidate.meta?.lastTouchedVersion;
+          currentConfig = current;
+          return false;
+        },
+      });
+
+      expect(candidateVersion).toBe("9999.1.1");
+      expect(currentConfig).toBeDefined();
+      expect(currentConfig?.meta).toBeUndefined();
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(clobbered.raw);
+    });
+  });
+
+  it("does not inspect caller policy for backup candidates ineligible for restoration", async () => {
+    await withSuiteHome(async (home) => {
+      const { io, configPath } = createTestConfigIO(home);
+      await seedConfigBackup(configPath, {
+        meta: { lastTouchedVersion: "9999.1.1" },
+        channels: {
+          telegram: {
+            enabled: true,
+            allowFrom: Array.from({ length: 60 }, (_, index) => `telegram-user-${index}`),
+          },
+        },
+      });
+      const clobbered = await writeConfigRaw(configPath, {});
+      const allowSuspiciousRecovery = vi.fn(() => false);
+
+      await io.readConfigFileSnapshot({
+        recoverSuspicious: true,
+        allowSuspiciousRecovery,
+      });
+
+      expect(allowSuspiciousRecovery).not.toHaveBeenCalled();
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(clobbered.raw);
+    });
+  });
+
   it("validates backup candidates without leaking their env into live state", async () => {
     await withSuiteHome(async (home) => {
       const env = {} as NodeJS.ProcessEnv;
@@ -585,18 +666,20 @@ describe("config observe recovery", () => {
     });
   });
 
-  it("records copyFile failure instead of falsely claiming restore succeeded", async () => {
+  it("records writeFile failure instead of falsely claiming restore succeeded", async () => {
     await withSuiteHome(async (home) => {
       const { deps, configPath, auditPath, warn } = makeDeps(home);
       await seedConfigBackup(configPath, recoverableTelegramConfig);
       const clobbered = await writeClobberedUpdateChannel(configPath);
 
       const copyError = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      const writeFile = deps.fs.promises.writeFile.bind(deps.fs.promises);
       const failingFs: ObserveRecoveryDeps["fs"] = {
         ...deps.fs,
         promises: {
           ...deps.fs.promises,
-          copyFile: () => Promise.reject(copyError),
+          writeFile: (target, data, options) =>
+            target === configPath ? Promise.reject(copyError) : writeFile(target, data, options),
         },
       };
       const recovered = await maybeRecoverSuspiciousConfigRead({
@@ -619,17 +702,21 @@ describe("config observe recovery", () => {
     });
   });
 
-  it("sync recovery records copyFileSync failure instead of falsely claiming restore succeeded", async () => {
+  it("sync recovery records writeFileSync failure instead of falsely claiming restore succeeded", async () => {
     await withSuiteHome(async (home) => {
       const { deps, configPath, auditPath, warn } = makeDeps(home);
       await seedConfigBackup(configPath, recoverableTelegramConfig);
       const clobbered = await writeClobberedUpdateChannel(configPath);
 
       const copyError = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      const writeFileSync = deps.fs.writeFileSync.bind(deps.fs);
       const failingFs: ObserveRecoveryDeps["fs"] = {
         ...deps.fs,
-        copyFileSync: () => {
-          throw copyError;
+        writeFileSync: (target, data, options) => {
+          if (target === configPath) {
+            throw copyError;
+          }
+          return writeFileSync(target, data, options);
         },
       };
       const recovered = maybeRecoverSuspiciousConfigReadSync({
@@ -653,18 +740,20 @@ describe("config observe recovery", () => {
     });
   });
 
-  it("retries recovery on next launch after a failed copyFile restore", async () => {
+  it("retries recovery on next launch after a failed writeFile restore", async () => {
     await withSuiteHome(async (home) => {
       const { deps, configPath, auditPath, warn } = makeDeps(home);
       await seedConfigBackup(configPath, recoverableTelegramConfig);
       const clobbered = await writeClobberedUpdateChannel(configPath);
 
       const copyError = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      const writeFile = deps.fs.promises.writeFile.bind(deps.fs.promises);
       const failingFs: ObserveRecoveryDeps["fs"] = {
         ...deps.fs,
         promises: {
           ...deps.fs.promises,
-          copyFile: () => Promise.reject(copyError),
+          writeFile: (target, data, options) =>
+            target === configPath ? Promise.reject(copyError) : writeFile(target, data, options),
         },
       };
       await maybeRecoverSuspiciousConfigRead({
@@ -694,17 +783,21 @@ describe("config observe recovery", () => {
     });
   });
 
-  it("sync recovery retries on next launch after a failed copyFileSync restore", async () => {
+  it("sync recovery retries on next launch after a failed writeFileSync restore", async () => {
     await withSuiteHome(async (home) => {
       const { deps, configPath, auditPath, warn } = makeDeps(home);
       await seedConfigBackup(configPath, recoverableTelegramConfig);
       const clobbered = await writeClobberedUpdateChannel(configPath);
 
       const copyError = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      const writeFileSync = deps.fs.writeFileSync.bind(deps.fs);
       const failingFs: ObserveRecoveryDeps["fs"] = {
         ...deps.fs,
-        copyFileSync: () => {
-          throw copyError;
+        writeFileSync: (target, data, options) => {
+          if (target === configPath) {
+            throw copyError;
+          }
+          return writeFileSync(target, data, options);
         },
       };
       maybeRecoverSuspiciousConfigReadSync({
@@ -731,6 +824,56 @@ describe("config observe recovery", () => {
       const retryEvents = await readObserveEvents(auditPath);
       expect(retryEvents).toHaveLength(2);
       expect(retryEvents[1]?.restoredFromBackup).toBe(true);
+    });
+  });
+
+  it("restores the exact async backup bytes approved by validation", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath } = makeDeps(home);
+      await seedConfigBackup(configPath, recoverableTelegramConfig);
+      const backupPath = `${configPath}.bak`;
+      const approvedRaw = await fsp.readFile(backupPath, "utf-8");
+      const replacementRaw = `${JSON.stringify({ gateway: { mode: "remote" } }, null, 2)}\n`;
+      const clobbered = await writeClobberedUpdateChannel(configPath);
+
+      await maybeRecoverSuspiciousConfigRead({
+        deps,
+        configPath,
+        raw: clobbered.raw,
+        parsed: clobbered.parsed,
+        validateBackup: async () => {
+          await fsp.writeFile(backupPath, replacementRaw, "utf-8");
+          return true;
+        },
+      });
+
+      await expect(fsp.readFile(backupPath, "utf-8")).resolves.toBe(replacementRaw);
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(approvedRaw);
+    });
+  });
+
+  it("restores the exact sync backup bytes approved by validation", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath } = makeDeps(home);
+      await seedConfigBackup(configPath, recoverableTelegramConfig);
+      const backupPath = `${configPath}.bak`;
+      const approvedRaw = await fsp.readFile(backupPath, "utf-8");
+      const replacementRaw = `${JSON.stringify({ gateway: { mode: "remote" } }, null, 2)}\n`;
+      const clobbered = await writeClobberedUpdateChannel(configPath);
+
+      maybeRecoverSuspiciousConfigReadSync({
+        deps,
+        configPath,
+        raw: clobbered.raw,
+        parsed: clobbered.parsed,
+        validateBackupSync: () => {
+          fs.writeFileSync(backupPath, replacementRaw, "utf-8");
+          return true;
+        },
+      });
+
+      await expect(fsp.readFile(backupPath, "utf-8")).resolves.toBe(replacementRaw);
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(approvedRaw);
     });
   });
 

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -135,6 +135,7 @@ type ConfigReadRecoveryParams = {
   parsed: unknown;
   validateBackup?: (backup: { raw: string; parsed: unknown }) => Promise<boolean>;
   validateBackupSync?: (backup: { raw: string; parsed: unknown }) => boolean;
+  allowBackupRecovery?: () => Promise<boolean>;
 };
 
 type ConfigReadRecoveryResult = {
@@ -724,6 +725,9 @@ export async function maybeRecoverSuspiciousConfigRead(
   if (!backup?.gatewayMode) {
     return returnOriginalConfigRead(params);
   }
+  if (params.allowBackupRecovery && !(await params.allowBackupRecovery())) {
+    return returnOriginalConfigRead(params);
+  }
 
   const clobberedPath = await persistBoundedClobberedConfigSnapshot({
     deps: params.deps,
@@ -735,7 +739,10 @@ export async function maybeRecoverSuspiciousConfigRead(
   let restoredFromBackup = false;
   let restoreError: unknown;
   try {
-    await params.deps.fs.promises.copyFile(backupPath, params.configPath);
+    await params.deps.fs.promises.writeFile(params.configPath, backupRaw, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
     await params.deps.fs.promises.chmod?.(params.configPath, 0o600).catch(() => {});
     restoredFromBackup = true;
   } catch (error) {
@@ -842,7 +849,10 @@ export function maybeRecoverSuspiciousConfigReadSync(
   let restoredFromBackup = false;
   let restoreError: unknown;
   try {
-    params.deps.fs.copyFileSync(backupPath, params.configPath);
+    params.deps.fs.writeFileSync(params.configPath, backupRaw, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
     try {
       params.deps.fs.chmodSync?.(params.configPath, 0o600);
     } catch {}
@@ -993,7 +1003,10 @@ export async function recoverConfigFromLastKnownGood(params: {
     raw: snapshot.raw,
     observedAt: now,
   });
-  await deps.fs.promises.copyFile(lastGoodPath, snapshot.path);
+  await deps.fs.promises.writeFile(snapshot.path, backupRaw, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
   await deps.fs.promises.chmod?.(snapshot.path, 0o600).catch(() => {});
   const issueSummary = formatConfigIssueSummary([...snapshot.issues, ...snapshot.legacyIssues]);
   deps.logger.warn(

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1010,6 +1010,7 @@ export type ConfigIoDeps = {
   fs?: typeof fs;
   json5?: typeof JSON5;
   env?: NodeJS.ProcessEnv;
+  lowerPrecedenceEnv?: Readonly<Record<string, string>>;
   homedir?: () => string;
   configPath?: string;
   logger?: Pick<typeof console, "error" | "warn">;
@@ -1021,7 +1022,13 @@ export type ConfigIoDeps = {
 export type ConfigSnapshotReadOptions = {
   measure?: ConfigSnapshotReadMeasure;
   observe?: boolean;
+  isolateEnv?: boolean;
+  lowerPrecedenceEnv?: Readonly<Record<string, string>>;
   recoverSuspicious?: boolean;
+  allowSuspiciousRecovery?: (
+    candidate: OpenClawConfig,
+    current: OpenClawConfig,
+  ) => boolean | Promise<boolean>;
   skipPluginValidation?: boolean;
   preservedLegacyRootKeys?: readonly string[];
   suppressFutureVersionWarning?: boolean;
@@ -1086,6 +1093,7 @@ function normalizeDeps(overrides: ConfigIoDeps = {}): Required<ConfigIoDeps> {
     fs: overrides.fs ?? fs,
     json5: overrides.json5 ?? JSON5,
     env,
+    lowerPrecedenceEnv: overrides.lowerPrecedenceEnv ?? {},
     homedir: overrides.homedir ?? (() => resolveRequiredHomeDir(env, os.homedir)),
     configPath: overrides.configPath ?? "",
     logger: overrides.logger ?? console,
@@ -1187,7 +1195,11 @@ async function recoverConfigFromJsonRootSuffixWithDeps(params: {
   } catch {
     return false;
   }
-  const readResolution = resolveConfigForRead(resolved, params.deps.env);
+  const readResolution = resolveConfigForRead(
+    resolved,
+    params.deps.env,
+    params.deps.lowerPrecedenceEnv,
+  );
   const validated = validateConfigObjectWithPlugins(
     stripShippedPluginInstallConfigRecords(readResolution.resolvedConfigRaw),
     {
@@ -1345,10 +1357,11 @@ function resolveConfigIncludesForRead(
 function resolveConfigForRead(
   resolvedIncludes: unknown,
   env: NodeJS.ProcessEnv,
+  lowerPrecedenceEnv: Readonly<Record<string, string>> = {},
 ): ConfigReadResolution {
   // Apply config.env to process.env BEFORE substitution so ${VAR} can reference config-defined vars.
   if (resolvedIncludes && typeof resolvedIncludes === "object" && "env" in resolvedIncludes) {
-    applyConfigEnvVars(resolvedIncludes as OpenClawConfig, env);
+    applyConfigEnvVars(resolvedIncludes as OpenClawConfig, env, { lowerPrecedenceEnv });
   }
 
   // Collect missing env var references as warnings instead of throwing,
@@ -1366,6 +1379,65 @@ function resolveConfigForRead(
 
 function snapshotEnv(env: NodeJS.ProcessEnv): Record<string, string | undefined> {
   return { ...env };
+}
+
+function findCaseInsensitiveEnvKey(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  if (Object.hasOwn(env, key)) {
+    return key;
+  }
+  const upperKey = key.toUpperCase();
+  return Object.keys(env).find((candidate) => candidate.toUpperCase() === upperKey);
+}
+
+function cloneEnvForIsolatedRead(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const cloned = { ...env } as NodeJS.ProcessEnv;
+  if (process.platform !== "win32") {
+    return cloned;
+  }
+  // A plain spread loses Windows process.env's case-insensitive lookup and assignment semantics.
+  return new Proxy(cloned, {
+    deleteProperty(target, property) {
+      if (typeof property !== "string") {
+        return Reflect.deleteProperty(target, property);
+      }
+      const key = findCaseInsensitiveEnvKey(target, property);
+      return key ? Reflect.deleteProperty(target, key) : true;
+    },
+    get(target, property, receiver) {
+      if (typeof property !== "string") {
+        return Reflect.get(target, property, receiver);
+      }
+      const key = findCaseInsensitiveEnvKey(target, property);
+      return key ? target[key] : Reflect.get(target, property, receiver);
+    },
+    getOwnPropertyDescriptor(target, property) {
+      if (typeof property !== "string") {
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      }
+      const key = findCaseInsensitiveEnvKey(target, property);
+      if (!key) {
+        return undefined;
+      }
+      return {
+        configurable: true,
+        enumerable: true,
+        value: target[key],
+        writable: true,
+      };
+    },
+    has(target, property) {
+      return typeof property === "string"
+        ? findCaseInsensitiveEnvKey(target, property) !== undefined
+        : Reflect.has(target, property);
+    },
+    set(target, property, value) {
+      if (typeof property !== "string") {
+        return Reflect.set(target, property, value);
+      }
+      target[findCaseInsensitiveEnvKey(target, property) ?? property] = value as string | undefined;
+      return true;
+    },
+  });
 }
 
 export function restoreEnvChangesIfUnchanged(params: {
@@ -1440,8 +1512,9 @@ function createConfigFileSnapshot(params: {
 async function finalizeReadConfigSnapshotInternalResult(
   deps: Required<ConfigIoDeps>,
   result: ReadConfigFileSnapshotInternalResult,
+  options?: { observe?: boolean },
 ): Promise<ReadConfigFileSnapshotInternalResult> {
-  if (deps.observe) {
+  if (deps.observe && options?.observe !== false) {
     await observeConfigSnapshot(deps, result.snapshot);
   }
   return result;
@@ -1606,7 +1679,7 @@ export function createConfigIO(
       ...deps,
       env,
     });
-    const readResolution = resolveConfigForRead(resolvedIncludes, env);
+    const readResolution = resolveConfigForRead(resolvedIncludes, env, deps.lowerPrecedenceEnv);
     return coerceConfig(
       migrateAndStripShippedPluginInstallConfigRecords(readResolution.resolvedConfigRaw, {
         persist: false,
@@ -1669,12 +1742,12 @@ export function createConfigIO(
     return false;
   }
 
-  function validateSuspiciousRecoveryBackup(parsed: unknown): boolean {
+  function resolveSuspiciousRecoveryBackupCandidate(parsed: unknown): OpenClawConfig | null {
     try {
-      const candidateEnv = { ...deps.env } as NodeJS.ProcessEnv;
+      const candidateEnv = cloneEnvForIsolatedRead(deps.env);
       const candidateDeps = { ...deps, env: candidateEnv };
       const resolved = resolveConfigIncludesForRead(parsed, configPath, candidateDeps);
-      const readResolution = resolveConfigForRead(resolved, candidateEnv);
+      const readResolution = resolveConfigForRead(resolved, candidateEnv, deps.lowerPrecedenceEnv);
       const installMigration = migrateAndStripShippedPluginInstallConfigRecords(
         readResolution.resolvedConfigRaw,
         {
@@ -1706,15 +1779,16 @@ export function createConfigIO(
         });
         return pluginMetadataSnapshot;
       };
-      return validateConfigObjectWithPlugins(validationConfigRaw, {
+      const validated = validateConfigObjectWithPlugins(validationConfigRaw, {
         env: candidateEnv,
         pluginValidation: overrides.pluginValidation,
         loadPluginMetadataSnapshot: loadValidationPluginMetadataSnapshot,
         sourceRaw: parsed,
         preservedLegacyRootKeys: overrides.preservedLegacyRootKeys,
-      }).ok;
+      });
+      return validated.ok ? coerceConfig(effectiveConfigRaw) : null;
     } catch {
-      return false;
+      return null;
     }
   }
 
@@ -1743,6 +1817,7 @@ export function createConfigIO(
       const readResolution = resolveConfigForRead(
         resolveConfigIncludesForRead(parsed, configPath, deps),
         deps.env,
+        deps.lowerPrecedenceEnv,
       );
       const resolvedConfig = readResolution.resolvedConfigRaw;
       const installMigration = migrateAndStripShippedPluginInstallConfigRecords(resolvedConfig, {
@@ -1862,7 +1937,8 @@ export function createConfigIO(
           configPath,
           raw,
           parsed,
-          validateBackupSync: (backup) => validateSuspiciousRecoveryBackup(backup.parsed),
+          validateBackupSync: (backup) =>
+            resolveSuspiciousRecoveryBackupCandidate(backup.parsed) !== null,
         });
         if (recovery.raw !== raw) {
           restoreEnvChangesIfUnchanged({
@@ -1911,7 +1987,14 @@ export function createConfigIO(
   }
 
   async function readConfigFileSnapshotInternal(
-    options: { recoverSuspicious?: boolean; skipSuspiciousRecovery?: boolean } = {},
+    options: {
+      recoverSuspicious?: boolean;
+      skipSuspiciousRecovery?: boolean;
+      allowSuspiciousRecovery?: (
+        candidate: OpenClawConfig,
+        current: OpenClawConfig,
+      ) => boolean | Promise<boolean>;
+    } = {},
   ): Promise<ReadConfigFileSnapshotInternalResult> {
     maybeLoadDotEnvForConfig(deps.env);
     const envBeforeRead = snapshotEnv(deps.env);
@@ -2019,7 +2102,7 @@ export function createConfigIO(
       }
 
       const readResolution = await deps.measure("config.snapshot.read.env", () =>
-        resolveConfigForRead(resolved, deps.env),
+        resolveConfigForRead(resolved, deps.env, deps.lowerPrecedenceEnv),
       );
       fallbackEnvSnapshotForRestore = readResolution.envSnapshotForRestore;
 
@@ -2106,19 +2189,36 @@ export function createConfigIO(
       if (!deps.suppressFutureVersionWarning) {
         warnIfConfigFromFuture(validated.config, deps.logger);
       }
+      let callerRejectedSuspiciousRecovery = false;
       if (
         options.recoverSuspicious === true &&
         deps.observe &&
         !options.skipSuspiciousRecovery &&
         !containsConfigIncludeDirective(effectiveParsed)
       ) {
+        const allowSuspiciousRecovery = options.allowSuspiciousRecovery;
+        let recoveryCandidate: OpenClawConfig | null = null;
         const recovery = await deps.measure("config.snapshot.read.recover-suspicious", () =>
           maybeRecoverSuspiciousConfigReadWithDeps({
             deps,
             configPath,
             raw,
             parsed: effectiveParsed,
-            validateBackup: async (backup) => validateSuspiciousRecoveryBackup(backup.parsed),
+            validateBackup: async (backup) => {
+              recoveryCandidate = resolveSuspiciousRecoveryBackupCandidate(backup.parsed);
+              return recoveryCandidate !== null;
+            },
+            ...(allowSuspiciousRecovery
+              ? {
+                  allowBackupRecovery: async () => {
+                    const allowed =
+                      recoveryCandidate !== null &&
+                      (await allowSuspiciousRecovery(recoveryCandidate, validated.config));
+                    callerRejectedSuspiciousRecovery = !allowed;
+                    return allowed;
+                  },
+                }
+              : {}),
           }),
         );
         if (recovery.raw !== raw) {
@@ -2142,27 +2242,31 @@ export function createConfigIO(
         ),
       );
       return await deps.measure("config.snapshot.read.observe", () =>
-        finalizeReadConfigSnapshotInternalResult(deps, {
-          snapshot: createConfigFileSnapshot({
-            path: configPath,
-            exists: true,
-            raw: snapshotRaw,
-            parsed: snapshotParsed,
-            // Use resolvedConfigRaw (after $include and ${ENV} substitution but BEFORE runtime defaults)
-            // for config set/unset operations (issue #6070)
-            sourceConfig: coerceConfig(effectiveConfigRaw),
-            valid: true,
-            runtimeConfig: snapshotConfig,
-            hash: snapshotHash,
-            issues: [],
-            warnings: [...validated.warnings, ...envVarWarnings],
-            legacyIssues: [],
-          }),
-          envSnapshotForRestore: readResolution.envSnapshotForRestore,
-          includeFileHashesForWrite,
-          includeFileTargetsForWrite,
-          pluginMetadataSnapshot,
-        }),
+        finalizeReadConfigSnapshotInternalResult(
+          deps,
+          {
+            snapshot: createConfigFileSnapshot({
+              path: configPath,
+              exists: true,
+              raw: snapshotRaw,
+              parsed: snapshotParsed,
+              // Use resolvedConfigRaw (after $include and ${ENV} substitution but BEFORE runtime defaults)
+              // for config set/unset operations (issue #6070)
+              sourceConfig: coerceConfig(effectiveConfigRaw),
+              valid: true,
+              runtimeConfig: snapshotConfig,
+              hash: snapshotHash,
+              issues: [],
+              warnings: [...validated.warnings, ...envVarWarnings],
+              legacyIssues: [],
+            }),
+            envSnapshotForRestore: readResolution.envSnapshotForRestore,
+            includeFileHashesForWrite,
+            includeFileTargetsForWrite,
+            pluginMetadataSnapshot,
+          },
+          { observe: !callerRejectedSuspiciousRecovery },
+        ),
       );
     } catch (err) {
       const nodeErr = err as NodeJS.ErrnoException;
@@ -2210,6 +2314,7 @@ export function createConfigIO(
   ): Promise<ConfigFileSnapshot> {
     const result = await readConfigFileSnapshotInternal({
       recoverSuspicious: options.recoverSuspicious === true,
+      allowSuspiciousRecovery: options.allowSuspiciousRecovery,
     });
     return result.snapshot;
   }
@@ -2219,6 +2324,7 @@ export function createConfigIO(
   ): Promise<ReadConfigFileSnapshotWithPluginMetadataResult> {
     const result = await readConfigFileSnapshotInternal({
       recoverSuspicious: options.recoverSuspicious === true,
+      allowSuspiciousRecovery: options.allowSuspiciousRecovery,
     });
     return {
       snapshot: result.snapshot,
@@ -2330,7 +2436,7 @@ export function createConfigIO(
         return coerceConfig(parsedRes.parsed);
       }
 
-      const readResolution = resolveConfigForRead(resolved, deps.env);
+      const readResolution = resolveConfigForRead(resolved, deps.env, deps.lowerPrecedenceEnv);
       return coerceConfig(stripShippedPluginInstallConfigRecords(readResolution.resolvedConfigRaw));
     } catch {
       return {};
@@ -2785,11 +2891,15 @@ export function getRuntimeConfig(options?: {
 }
 
 export async function readBestEffortConfig(options?: {
+  isolateEnv?: boolean;
+  observe?: boolean;
   skipPluginValidation?: boolean;
 }): Promise<OpenClawConfig> {
-  return await createConfigIO(
-    options?.skipPluginValidation ? { pluginValidation: "skip" } : {},
-  ).readBestEffortConfig();
+  return await createConfigIO({
+    ...(options?.isolateEnv ? { env: cloneEnvForIsolatedRead(process.env) } : {}),
+    ...(options?.observe === false ? { observe: false } : {}),
+    ...(options?.skipPluginValidation ? { pluginValidation: "skip" } : {}),
+  }).readBestEffortConfig();
 }
 
 export async function readBestEffortConfigSnapshot(options?: {
@@ -2810,6 +2920,8 @@ export async function readConfigFileSnapshot(
   return await createConfigIO({
     ...(options.measure ? { measure: options.measure } : {}),
     ...(options.observe === false ? { observe: false } : {}),
+    ...(options.isolateEnv ? { env: cloneEnvForIsolatedRead(process.env) } : {}),
+    ...(options.lowerPrecedenceEnv ? { lowerPrecedenceEnv: options.lowerPrecedenceEnv } : {}),
     ...(options.skipPluginValidation ? { pluginValidation: "skip" } : {}),
     ...(options.suppressFutureVersionWarning ? { suppressFutureVersionWarning: true } : {}),
     ...(options.preservedLegacyRootKeys
@@ -2817,17 +2929,29 @@ export async function readConfigFileSnapshot(
       : {}),
   }).readConfigFileSnapshot({
     recoverSuspicious: options.recoverSuspicious === true,
+    allowSuspiciousRecovery: options.allowSuspiciousRecovery,
   });
 }
 
-export async function readConfigFileSnapshotWithPluginMetadata(options?: {
-  measure?: ConfigSnapshotReadMeasure;
-  recoverSuspicious?: boolean;
-}): Promise<ReadConfigFileSnapshotWithPluginMetadataResult> {
-  return await createConfigIO(
-    options?.measure ? { measure: options.measure } : {},
-  ).readConfigFileSnapshotWithPluginMetadata({
+export async function readConfigFileSnapshotWithPluginMetadata(
+  options?: Pick<
+    ConfigSnapshotReadOptions,
+    | "allowSuspiciousRecovery"
+    | "isolateEnv"
+    | "lowerPrecedenceEnv"
+    | "measure"
+    | "observe"
+    | "recoverSuspicious"
+  >,
+): Promise<ReadConfigFileSnapshotWithPluginMetadataResult> {
+  return await createConfigIO({
+    ...(options?.measure ? { measure: options.measure } : {}),
+    ...(options?.observe === false ? { observe: false } : {}),
+    ...(options?.isolateEnv ? { env: cloneEnvForIsolatedRead(process.env) } : {}),
+    ...(options?.lowerPrecedenceEnv ? { lowerPrecedenceEnv: options.lowerPrecedenceEnv } : {}),
+  }).readConfigFileSnapshotWithPluginMetadata({
     recoverSuspicious: options?.recoverSuspicious === true,
+    allowSuspiciousRecovery: options?.allowSuspiciousRecovery,
   });
 }
 

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -43,7 +43,7 @@ import {
   containsEnvVarReference,
   resolveConfigEnvVars,
 } from "./env-substitution.js";
-import { applyConfigEnvVars } from "./env-vars.js";
+import { applyConfigEnvVars, cloneEnvWithPlatformSemantics } from "./env-vars.js";
 import {
   ConfigIncludeError,
   hashConfigIncludeRaw,
@@ -1381,65 +1381,6 @@ function snapshotEnv(env: NodeJS.ProcessEnv): Record<string, string | undefined>
   return { ...env };
 }
 
-function findCaseInsensitiveEnvKey(env: NodeJS.ProcessEnv, key: string): string | undefined {
-  if (Object.hasOwn(env, key)) {
-    return key;
-  }
-  const upperKey = key.toUpperCase();
-  return Object.keys(env).find((candidate) => candidate.toUpperCase() === upperKey);
-}
-
-function cloneEnvForIsolatedRead(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const cloned = { ...env } as NodeJS.ProcessEnv;
-  if (process.platform !== "win32") {
-    return cloned;
-  }
-  // A plain spread loses Windows process.env's case-insensitive lookup and assignment semantics.
-  return new Proxy(cloned, {
-    deleteProperty(target, property) {
-      if (typeof property !== "string") {
-        return Reflect.deleteProperty(target, property);
-      }
-      const key = findCaseInsensitiveEnvKey(target, property);
-      return key ? Reflect.deleteProperty(target, key) : true;
-    },
-    get(target, property, receiver) {
-      if (typeof property !== "string") {
-        return Reflect.get(target, property, receiver);
-      }
-      const key = findCaseInsensitiveEnvKey(target, property);
-      return key ? target[key] : Reflect.get(target, property, receiver);
-    },
-    getOwnPropertyDescriptor(target, property) {
-      if (typeof property !== "string") {
-        return Reflect.getOwnPropertyDescriptor(target, property);
-      }
-      const key = findCaseInsensitiveEnvKey(target, property);
-      if (!key) {
-        return undefined;
-      }
-      return {
-        configurable: true,
-        enumerable: true,
-        value: target[key],
-        writable: true,
-      };
-    },
-    has(target, property) {
-      return typeof property === "string"
-        ? findCaseInsensitiveEnvKey(target, property) !== undefined
-        : Reflect.has(target, property);
-    },
-    set(target, property, value) {
-      if (typeof property !== "string") {
-        return Reflect.set(target, property, value);
-      }
-      target[findCaseInsensitiveEnvKey(target, property) ?? property] = value as string | undefined;
-      return true;
-    },
-  });
-}
-
 export function restoreEnvChangesIfUnchanged(params: {
   env: NodeJS.ProcessEnv;
   before: Record<string, string | undefined>;
@@ -1744,7 +1685,7 @@ export function createConfigIO(
 
   function resolveSuspiciousRecoveryBackupCandidate(parsed: unknown): OpenClawConfig | null {
     try {
-      const candidateEnv = cloneEnvForIsolatedRead(deps.env);
+      const candidateEnv = cloneEnvWithPlatformSemantics(deps.env);
       const candidateDeps = { ...deps, env: candidateEnv };
       const resolved = resolveConfigIncludesForRead(parsed, configPath, candidateDeps);
       const readResolution = resolveConfigForRead(resolved, candidateEnv, deps.lowerPrecedenceEnv);
@@ -2896,7 +2837,7 @@ export async function readBestEffortConfig(options?: {
   skipPluginValidation?: boolean;
 }): Promise<OpenClawConfig> {
   return await createConfigIO({
-    ...(options?.isolateEnv ? { env: cloneEnvForIsolatedRead(process.env) } : {}),
+    ...(options?.isolateEnv ? { env: cloneEnvWithPlatformSemantics(process.env) } : {}),
     ...(options?.observe === false ? { observe: false } : {}),
     ...(options?.skipPluginValidation ? { pluginValidation: "skip" } : {}),
   }).readBestEffortConfig();
@@ -2920,7 +2861,7 @@ export async function readConfigFileSnapshot(
   return await createConfigIO({
     ...(options.measure ? { measure: options.measure } : {}),
     ...(options.observe === false ? { observe: false } : {}),
-    ...(options.isolateEnv ? { env: cloneEnvForIsolatedRead(process.env) } : {}),
+    ...(options.isolateEnv ? { env: cloneEnvWithPlatformSemantics(process.env) } : {}),
     ...(options.lowerPrecedenceEnv ? { lowerPrecedenceEnv: options.lowerPrecedenceEnv } : {}),
     ...(options.skipPluginValidation ? { pluginValidation: "skip" } : {}),
     ...(options.suppressFutureVersionWarning ? { suppressFutureVersionWarning: true } : {}),
@@ -2947,7 +2888,7 @@ export async function readConfigFileSnapshotWithPluginMetadata(
   return await createConfigIO({
     ...(options?.measure ? { measure: options.measure } : {}),
     ...(options?.observe === false ? { observe: false } : {}),
-    ...(options?.isolateEnv ? { env: cloneEnvForIsolatedRead(process.env) } : {}),
+    ...(options?.isolateEnv ? { env: cloneEnvWithPlatformSemantics(process.env) } : {}),
     ...(options?.lowerPrecedenceEnv ? { lowerPrecedenceEnv: options.lowerPrecedenceEnv } : {}),
   }).readConfigFileSnapshotWithPluginMetadata({
     recoverSuspicious: options?.recoverSuspicious === true,

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1769,7 +1769,7 @@ export function createConfigIO(
         const defaultAgentId = resolveDefaultAgentId(metadataConfig);
         pluginMetadataSnapshot = resolvePluginMetadataSnapshot({
           config: metadataConfig,
-          workspaceDir: resolveAgentWorkspaceDir(metadataConfig, defaultAgentId),
+          workspaceDir: resolveAgentWorkspaceDir(metadataConfig, defaultAgentId, candidateEnv),
           env: candidateEnv,
           allowWorkspaceScopedCurrent: true,
           pluginIdScope: createConfigValidationMetadataPluginIdScope({
@@ -1875,7 +1875,7 @@ export function createConfigIO(
         const defaultAgentId = resolveDefaultAgentId(metadataConfig);
         pluginMetadataSnapshot = resolvePluginMetadataSnapshot({
           config: metadataConfig,
-          workspaceDir: resolveAgentWorkspaceDir(metadataConfig, defaultAgentId),
+          workspaceDir: resolveAgentWorkspaceDir(metadataConfig, defaultAgentId, deps.env),
           env: deps.env,
           allowWorkspaceScopedCurrent: true,
           pluginIdScope: createConfigValidationMetadataPluginIdScope({
@@ -2143,7 +2143,7 @@ export function createConfigIO(
         const defaultAgentId = resolveDefaultAgentId(metadataConfig);
         pluginMetadataSnapshot = resolvePluginMetadataSnapshot({
           config: metadataConfig,
-          workspaceDir: resolveAgentWorkspaceDir(metadataConfig, defaultAgentId),
+          workspaceDir: resolveAgentWorkspaceDir(metadataConfig, defaultAgentId, deps.env),
           env: deps.env,
           allowWorkspaceScopedCurrent: true,
           pluginIdScope: createConfigValidationMetadataPluginIdScope({

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -4,8 +4,11 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
+  CONFIG_PATH,
   DEFAULT_GATEWAY_PORT,
+  isNixMode,
   normalizeStateDirEnv,
+  pinRuntimePaths,
   resolveDefaultConfigCandidates,
   resolveConfigPathCandidate,
   resolveConfigPath,
@@ -14,6 +17,7 @@ import {
   resolveOAuthDir,
   resolveOAuthPath,
   resolveStateDir,
+  STATE_DIR,
 } from "./paths.js";
 
 function envWith(overrides: Record<string, string | undefined>): NodeJS.ProcessEnv {
@@ -165,6 +169,37 @@ describe("state + config path candidates", () => {
 
     expect(normalized).toBe(path.resolve("relative-state"));
     expect(resolveStateDir(env, () => "/srv/other-home")).toBe(normalized);
+  });
+
+  it("re-pins exported runtime paths after startup environment selection", () => {
+    const originalConfigPath = CONFIG_PATH;
+    const originalNixMode = isNixMode;
+    const originalStateDir = STATE_DIR;
+    const selectedStateDir = path.resolve("/tmp/openclaw-selected-runtime-state");
+    const selectedConfigPath = path.join(selectedStateDir, "selected.json");
+    try {
+      const pinned = pinRuntimePaths({
+        OPENCLAW_CONFIG_PATH: selectedConfigPath,
+        OPENCLAW_NIX_MODE: "1",
+        OPENCLAW_STATE_DIR: selectedStateDir,
+        OPENCLAW_TEST_FAST: "1",
+      });
+
+      expect(pinned).toEqual({
+        configPath: selectedConfigPath,
+        stateDir: selectedStateDir,
+      });
+      expect(CONFIG_PATH).toBe(selectedConfigPath);
+      expect(isNixMode).toBe(true);
+      expect(STATE_DIR).toBe(selectedStateDir);
+    } finally {
+      pinRuntimePaths({
+        OPENCLAW_CONFIG_PATH: originalConfigPath,
+        OPENCLAW_NIX_MODE: originalNixMode ? "1" : undefined,
+        OPENCLAW_STATE_DIR: originalStateDir,
+        OPENCLAW_TEST_FAST: "1",
+      });
+    }
   });
 
   it("uses OPENCLAW_HOME for default state/config locations", () => {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -17,7 +17,7 @@ export function resolveIsNixMode(env: NodeJS.ProcessEnv = process.env): boolean 
   return env.OPENCLAW_NIX_MODE === "1";
 }
 
-export const isNixMode = resolveIsNixMode();
+export let isNixMode = resolveIsNixMode();
 
 // Support the remaining legacy pre-rebrand state dir.
 const LEGACY_STATE_DIRNAMES = [".clawdbot"] as const;
@@ -146,7 +146,7 @@ export function resolveIncludeRoots(
   return roots;
 }
 
-export const STATE_DIR = resolveStateDir();
+export let STATE_DIR = resolveStateDir();
 
 /**
  * Config file path (JSON or JSON5).
@@ -229,7 +229,24 @@ export function resolveConfigPath(
   return path.join(stateDir, CONFIG_FILENAME);
 }
 
-export const CONFIG_PATH = resolveConfigPathCandidate();
+export let CONFIG_PATH = resolveConfigPathCandidate();
+
+/**
+ * Re-pins process-stable runtime paths after an early startup selector changes the environment.
+ *
+ * Gateway startup must call this before importing runtime modules that derive their own constants
+ * from these live bindings, otherwise one process can split reads and writes across two targets.
+ */
+export function pinRuntimePaths(env: NodeJS.ProcessEnv = process.env): {
+  configPath: string;
+  stateDir: string;
+} {
+  normalizeStateDirEnv(env);
+  isNixMode = resolveIsNixMode(env);
+  STATE_DIR = resolveStateDir(env);
+  CONFIG_PATH = resolveConfigPathCandidate(env);
+  return { configPath: CONFIG_PATH, stateDir: STATE_DIR };
+}
 
 /**
  * Resolve default config path candidates across default locations.

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -8,11 +8,16 @@ import {
   normalizeEnvVarKey,
 } from "../infra/host-env-security.js";
 import { collectConfigServiceEnvVars } from "./config-env-vars.js";
+import { ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV } from "./future-version-guard.js";
 import { resolveStateDir } from "./paths.js";
 import type { OpenClawConfig } from "./types.js";
 
 function isBlockedServiceEnvVar(key: string): boolean {
-  return isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key);
+  return (
+    key.toUpperCase() === ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV ||
+    isDangerousHostEnvVarName(key) ||
+    isDangerousHostEnvOverrideVarName(key)
+  );
 }
 
 function unwrapMatchingLiteralQuotes(value: string): string {

--- a/src/infra/dotenv-global.ts
+++ b/src/infra/dotenv-global.ts
@@ -22,7 +22,15 @@ type LoadedDotEnvFile = {
   entries: DotEnvEntry[];
 };
 
+type GlobalRuntimeDotEnvOptions = {
+  additionalEnvPaths?: string[];
+  entryFilter?: (key: string, value: string) => boolean;
+  quiet?: boolean;
+  stateEnvPath?: string;
+};
+
 function readGlobalRuntimeDotEnvFile(params: {
+  entryFilter?: (key: string, value: string) => boolean;
   filePath: string;
   quiet?: boolean;
 }): LoadedDotEnvFile | null {
@@ -52,17 +60,18 @@ function readGlobalRuntimeDotEnvFile(params: {
   const entries: DotEnvEntry[] = [];
   for (const [rawKey, value] of Object.entries(parsed)) {
     const key = normalizeEnvVarKey(rawKey, { portable: true });
-    if (key) {
+    if (key && (params.entryFilter?.(key, value) ?? true)) {
       entries.push({ key, value });
     }
   }
   return { filePath: params.filePath, entries };
 }
 
-function loadParsedDotEnvFiles(files: LoadedDotEnvFile[]) {
+function loadParsedDotEnvFiles(files: LoadedDotEnvFile[]): Map<string, string[]> {
   const preExistingKeys = new Set(Object.keys(process.env));
   const conflicts = new Map<string, { keptPath: string; ignoredPath: string; keys: Set<string> }>();
   const firstSeen = new Map<string, { value: string; filePath: string }>();
+  const appliedKeysByFile = new Map<string, string[]>();
 
   for (const file of files) {
     for (const { key, value } of file.entries) {
@@ -91,6 +100,12 @@ function loadParsedDotEnvFiles(files: LoadedDotEnvFile[]) {
       firstSeen.set(key, { value, filePath: file.filePath });
       if (process.env[key] === undefined) {
         process.env[key] = value;
+        const appliedKeys = appliedKeysByFile.get(file.filePath);
+        if (appliedKeys) {
+          appliedKeys.push(key);
+        } else {
+          appliedKeysByFile.set(file.filePath, [key]);
+        }
       }
     }
   }
@@ -105,12 +120,14 @@ function loadParsedDotEnvFiles(files: LoadedDotEnvFile[]) {
       { keptPath: conflict.keptPath, ignoredPath: conflict.ignoredPath, keys },
     );
   }
+  return appliedKeysByFile;
 }
 
 /** Load global runtime dotenv files into `process.env` with first-wins precedence. */
-export function loadGlobalRuntimeDotEnvFiles(opts?: { quiet?: boolean; stateEnvPath?: string }) {
+export function loadGlobalRuntimeDotEnvFiles(opts?: GlobalRuntimeDotEnvOptions) {
   const quiet = opts?.quiet ?? true;
   const stateEnvPath = opts?.stateEnvPath ?? path.join(resolveConfigDir(process.env), ".env");
+  const globalEnvPaths = [...new Set([stateEnvPath, ...(opts?.additionalEnvPaths ?? [])])];
   const defaultStateEnvPath = path.join(
     resolveRequiredHomeDir(process.env, os.homedir),
     ".openclaw",
@@ -119,20 +136,30 @@ export function loadGlobalRuntimeDotEnvFiles(opts?: { quiet?: boolean; stateEnvP
   const hasExplicitNonDefaultStateDir =
     process.env.OPENCLAW_STATE_DIR?.trim() !== undefined &&
     path.resolve(stateEnvPath) !== path.resolve(defaultStateEnvPath);
-  const parsedFiles = [readGlobalRuntimeDotEnvFile({ filePath: stateEnvPath, quiet })];
+  const globalEnvs = globalEnvPaths.map((filePath) =>
+    readGlobalRuntimeDotEnvFile({ entryFilter: opts?.entryFilter, filePath, quiet }),
+  );
+  const parsedFiles = [...globalEnvs];
+  let gatewayEnv: LoadedDotEnvFile | null = null;
   if (!hasExplicitNonDefaultStateDir) {
-    parsedFiles.push(
-      readGlobalRuntimeDotEnvFile({
-        filePath: path.join(
-          resolveRequiredHomeDir(process.env, os.homedir),
-          ".config",
-          "openclaw",
-          "gateway.env",
-        ),
-        quiet,
-      }),
-    );
+    gatewayEnv = readGlobalRuntimeDotEnvFile({
+      entryFilter: opts?.entryFilter,
+      filePath: path.join(
+        resolveRequiredHomeDir(process.env, os.homedir),
+        ".config",
+        "openclaw",
+        "gateway.env",
+      ),
+      quiet,
+    });
+    parsedFiles.push(gatewayEnv);
   }
   const parsed = parsedFiles.filter((file): file is LoadedDotEnvFile => file !== null);
-  loadParsedDotEnvFiles(parsed);
+  const appliedKeysByFile = loadParsedDotEnvFiles(parsed);
+  return {
+    stateEnvAppliedKeys: globalEnvs.flatMap((file) =>
+      file ? (appliedKeysByFile.get(file.filePath) ?? []) : [],
+    ),
+    gatewayEnvAppliedKeys: gatewayEnv ? (appliedKeysByFile.get(gatewayEnv.filePath) ?? []) : [],
+  };
 }

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -690,6 +690,33 @@ describe("loadCliDotEnv", () => {
     });
   });
 
+  it("can defer global dotenv while loading only workspace env", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ base, cwdDir }) => {
+        process.env.HOME = base;
+        const defaultStateDir = path.join(base, ".openclaw");
+        process.env.OPENCLAW_STATE_DIR = defaultStateDir;
+        await writeEnvFile(path.join(cwdDir, ".env"), "BAZ=from-workspace\n");
+        await writeEnvFile(path.join(defaultStateDir, ".env"), "FOO=from-global\n");
+        await writeEnvFile(
+          path.join(base, ".config", "openclaw", "gateway.env"),
+          "BAR=from-gateway\n",
+        );
+
+        vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
+        delete process.env.FOO;
+        delete process.env.BAR;
+        delete process.env.BAZ;
+
+        loadCliDotEnv({ loadGlobalEnv: false, quiet: true });
+
+        expect(process.env.FOO).toBeUndefined();
+        expect(process.env.BAR).toBeUndefined();
+        expect(process.env.BAZ).toBe("from-workspace");
+      });
+    });
+  });
+
   it("does not load gateway.env when OPENCLAW_STATE_DIR is explicitly set", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ base, cwdDir }) => {

--- a/src/infra/env.ts
+++ b/src/infra/env.ts
@@ -5,6 +5,7 @@ import type { SubsystemLogger } from "../logging/subsystem.js";
 let log: SubsystemLogger | null = null;
 let logPromise: Promise<SubsystemLogger> | null = null;
 const loggedEnv = new Set<string>();
+const ENV_NORMALIZATION_KEY_GROUPS = [["ZAI_API_KEY", "Z_AI_API_KEY"]] as const;
 
 async function getLog(): Promise<SubsystemLogger> {
   if (!log) {
@@ -59,10 +60,31 @@ export function logAcceptedEnvOption(option: AcceptedEnvOption): void {
 }
 
 /** Normalizes the legacy Z_AI_API_KEY spelling into the canonical ZAI_API_KEY env var. */
-export function normalizeZaiEnv(): void {
-  if (!process.env.ZAI_API_KEY?.trim() && process.env.Z_AI_API_KEY?.trim()) {
-    process.env.ZAI_API_KEY = process.env.Z_AI_API_KEY;
+export function normalizeZaiEnv(env: NodeJS.ProcessEnv = process.env): void {
+  if (!env.ZAI_API_KEY?.trim() && env.Z_AI_API_KEY?.trim()) {
+    env.ZAI_API_KEY = env.Z_AI_API_KEY;
   }
+}
+
+/** Expands env keys to include aliases that process-wide normalization treats as equivalent. */
+export function expandEnvNormalizationKeys(keys: Iterable<string>): Set<string> {
+  const expanded = new Set<string>();
+  for (const key of keys) {
+    for (const normalizedKey of resolveEnvNormalizationKeys(key)) {
+      expanded.add(normalizedKey);
+    }
+  }
+  return expanded;
+}
+
+/** Resolves one env key to its canonical-first runtime normalization group. */
+export function resolveEnvNormalizationKeys(key: string): readonly string[] {
+  const normalizedKey = process.platform === "win32" ? key.toUpperCase() : key;
+  return (
+    ENV_NORMALIZATION_KEY_GROUPS.find((group) =>
+      group.some((candidate) => candidate === normalizedKey),
+    ) ?? [normalizedKey]
+  );
 }
 
 /** Interprets common human/operator truthy env strings. */
@@ -94,5 +116,5 @@ export function isVitestRuntimeEnv(env: NodeJS.ProcessEnv = process.env): boolea
 
 /** Applies process-wide env normalization before runtime configuration is read. */
 export function normalizeEnv(): void {
-  normalizeZaiEnv();
+  normalizeZaiEnv(process.env);
 }

--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
 import {
+  clearShellEnvAppliedKeys,
   getShellEnvAppliedKeys,
   getShellPathFromLoginShell,
   loadShellEnvFallback,
@@ -394,6 +395,22 @@ describe("shell env fallback", () => {
       error: "boom",
     });
     expect(getShellEnvAppliedKeys()).toStrictEqual([]);
+  });
+
+  it("clears only discarded shell-applied keys", () => {
+    loadShellEnvFallback({
+      enabled: true,
+      env: {},
+      expectedKeys: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
+      exec: (() =>
+        Buffer.from(
+          "OPENAI_API_KEY=openai-shell\0ANTHROPIC_API_KEY=anthropic-shell\0",
+        )) as Parameters<typeof loadShellEnvFallback>[0]["exec"],
+    });
+
+    clearShellEnvAppliedKeys(["OPENAI_API_KEY"]);
+
+    expect(getShellEnvAppliedKeys()).toEqual(["ANTHROPIC_API_KEY"]);
   });
 
   it("resolves PATH via login shell and caches it", () => {

--- a/src/infra/shell-env.ts
+++ b/src/infra/shell-env.ts
@@ -328,3 +328,8 @@ export function resetShellPathCacheForTests(): void {
 export function getShellEnvAppliedKeys(): string[] {
   return [...lastAppliedKeys];
 }
+
+export function clearShellEnvAppliedKeys(keys: readonly string[]): void {
+  const removed = new Set(keys);
+  lastAppliedKeys = lastAppliedKeys.filter((key) => !removed.has(key));
+}

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,7 +6,9 @@ import { MAX_TIMER_TIMEOUT_MS } from "./shared/number-coercion.js";
 import { withTempDir } from "./test-helpers/temp-dir.js";
 import { withEnv } from "./test-utils/env.js";
 import {
+  CONFIG_DIR,
   ensureDir,
+  pinConfigDir,
   resolveConfigDir,
   resolveHomeDir,
   resolveUserPath,
@@ -80,6 +82,25 @@ describe("resolveConfigDir", () => {
     } as NodeJS.ProcessEnv;
 
     expect(resolveConfigDir(env)).toBe(path.resolve("/tmp/openclaw-home", "profiles", "dev"));
+  });
+
+  it("re-pins the exported configuration root after startup environment selection", () => {
+    const originalConfigDir = CONFIG_DIR;
+    const selectedConfigDir = path.resolve("/tmp/openclaw-selected-config-root");
+    try {
+      expect(
+        pinConfigDir({
+          OPENCLAW_STATE_DIR: selectedConfigDir,
+          OPENCLAW_TEST_FAST: "1",
+        }),
+      ).toBe(selectedConfigDir);
+      expect(CONFIG_DIR).toBe(selectedConfigDir);
+    } finally {
+      pinConfigDir({
+        OPENCLAW_STATE_DIR: originalConfigDir,
+        OPENCLAW_TEST_FAST: "1",
+      });
+    }
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -211,8 +211,14 @@ export function displayString(input: string): string {
   return shortenHomeInString(input);
 }
 
-// Configuration root; can be overridden via OPENCLAW_STATE_DIR.
-export const CONFIG_DIR = resolveConfigDir();
+// Gateway startup re-pins this live binding after config/state selection converges so modules
+// imported during early CLI bootstrap cannot keep using the superseded configuration root.
+export let CONFIG_DIR = resolveConfigDir();
+
+export function pinConfigDir(env: NodeJS.ProcessEnv = process.env): string {
+  CONFIG_DIR = resolveConfigDir(env);
+  return CONFIG_DIR;
+}
 /**
  * Check if a file or directory exists at the given path.
  */


### PR DESCRIPTION
### Summary

- Run the shared CLI startup bootstrap for both gateway foreground entry paths, so state and cron migrations complete before the server and scheduler load.
- Converge the selected config, state directory, dotenv sources, config env, and shell fallback before startup controls are evaluated, with explicit source precedence and late-drift rejection.
- Guard every startup mutation boundary: state migration, doctor/cron repair, suspicious-config recovery, future-version reset, and managed-proxy refresh.
- Keep invalid config from supplying service markers, include roots, selectors, destructive overrides, or migration paths; preserve valid invocation/trusted-env selectors across reset and migration.
- Add focused regression coverage for fast-path bootstrap, env alias precedence, runtime path repinning, recovery/reset guards, proxy hook cleanup, and cron migration timing.

### Why this shape

The original direct cron-repair call fixed the immediate symptom but left the gateway fast path bypassing the shared startup contract. Review found that the same split path could apply or act on config-derived startup state before validation and could retain superseded env/proxy state. This repair moves the behavior to the shared gateway startup boundary and makes the selected runtime state explicit before any config-dependent mutation.

### Verification

- Changed-surface tests: 431 passed across 6 shards.
- Isolated config I/O regressions: 6 passed, 5 skipped.
- `src/cli/run-main.exit.test.ts`: 132 passed.
- `src/cli/gateway-cli/run.option-collisions.test.ts`: 55 passed.
- Changed-file oxlint and oxfmt checks, `git diff --check`, privacy scan, and CLI bootstrap import guard: passed.
- Direct local tsdown build with a 12 GB Node heap: passed.
- Fresh exhaustive full-branch autoreview: clean.

Proof gaps: the full `src/config/io.best-effort.test.ts` file is blocked locally by the shared checkout missing `@openclaw/llm-core`; the standard build wrapper is blocked because this shell lacks `pnpm`; Testbox is blocked because `blacksmith` is unavailable; default Crabbox selected Azure and is blocked by expired Azure CLI authentication. No live macOS LaunchAgent upgrade proof was run.

### Release note

Gateway foreground startup now runs guarded state/config migrations before loading scheduler state, so legacy cron jobs are available on the first post-upgrade gateway start instead of requiring a second restart or manual doctor command.

Fixes #93032
