### PR TITLE
fix: keep Discord status reactions active in tool-only replies

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1587,6 +1587,50 @@ describe("processDiscordMessage session routing", () => {
     expect(emojis).toContain(DEFAULT_EMOJIS.done);
   });
 
+  it("keeps explicit message-tool-only Discord status reactions active across tool execution", async () => {
+    vi.useFakeTimers();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onToolStart?.({
+        name: "exec",
+        phase: "start",
+        args: { command: "echo hi" },
+      });
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1_000);
+      });
+      return createNoQueuedDispatchResult();
+    });
+    const ctx = await createBaseContext({
+      shouldRequireMention: false,
+      effectiveWasMentioned: false,
+      ackReactionScope: "all",
+      cfg: {
+        messages: {
+          ackReaction: "👀",
+          ackReactionScope: "all",
+          groupChat: { visibleReplies: "message_tool" },
+          statusReactions: {
+            enabled: true,
+            timing: { debounceMs: 0 },
+          },
+        },
+        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+      },
+      route: BASE_CHANNEL_ROUTE,
+    });
+
+    const runPromise = runProcessDiscordMessage(ctx);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runAllTimersAsync();
+    await runPromise;
+
+    expect(getLastDispatchReplyOptions()?.sourceReplyDeliveryMode).toBe("message_tool_only");
+    const emojis = getReactionEmojis();
+    expect(emojis).toContain("👀");
+    expect(emojis).toContain(DEFAULT_EMOJIS.tool);
+    expect(emojis).toContain(DEFAULT_EMOJIS.done);
+  });
+
   it("suppresses Discord reactions for room events even when status reactions are explicit", async () => {
     vi.useFakeTimers();
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -981,9 +981,16 @@ async function processDiscordMessageInner(
         queuedDeliveryCorrelations: isRoomEvent ? [{ begin: beginDeliveryCorrelation }] : undefined,
         suppressTyping: isRoomEvent ? true : undefined,
         allowProgressCallbacksWhenSourceDeliverySuppressed:
-          sourceRepliesAreToolOnly && draftPreview.draftStream && draftPreview.isProgressMode
+          sourceRepliesAreToolOnly &&
+          ((draftPreview.draftStream && draftPreview.isProgressMode) || statusReactionsActive)
             ? true
             : undefined,
+        suppressDefaultToolProgressMessages:
+          sourceRepliesAreToolOnly && statusReactionsActive
+            ? true
+            : draftPreview.suppressDefaultToolProgressMessages
+              ? true
+              : undefined,
         disableBlockStreaming: sourceRepliesAreToolOnly
           ? true
           : (draftPreview.disableBlockStreamingForDraft ??
@@ -1001,9 +1008,6 @@ async function processDiscordMessageInner(
           ? () => draftPreview.handleAssistantMessageBoundary()
           : undefined,
         onModelSelected,
-        suppressDefaultToolProgressMessages: draftPreview.suppressDefaultToolProgressMessages
-          ? true
-          : undefined,
         commentaryProgressEnabled: draftPreview.isProgressMode
           ? draftPreview.commentaryProgressEnabled
           : undefined,


### PR DESCRIPTION
## Summary
- keep Discord status-reaction lifecycle callbacks active for explicit `message_tool_only` replies
- treat Discord status reactions as quiet channel-owned progress so verbose tool-summary text stays suppressed
- add a regression test covering tool execution reactions in always-on guild replies

## Testing
- NODE_OPTIONS=--max-old-space-size=8192 pnpm vitest run extensions/discord/src/monitor/message-handler.process.test.ts -t "keeps explicit message-tool-only Discord status reactions active across tool execution" *(initial run failed before expectation fix; subsequent targeted runs in this workspace stalled after rolldown plugin timing output)*
- pnpm exec tsx -e "import './extensions/discord/src/monitor/message-handler.process.ts'; console.log('tsx-import-ok')"