### PR TITLE
 fix(agents): apply factory denylist to sessions_yield tool

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -39,6 +39,7 @@ import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import type { SpawnedToolContext } from "./spawned-context.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
 import { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";
+import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { createCronTool } from "./tools/cron-tool.js";
@@ -403,6 +404,11 @@ export function createOpenClawTools(
   const effectiveCallGateway = embedded
     ? createEmbeddedCallGateway()
     : openClawToolsDeps.callGateway;
+  const sessionsYieldAllowed = isToolAllowedByPolicyName("sessions_yield", {
+    allow: explicitFactoryAllowlist,
+    deny: explicitFactoryDenylist,
+  });
+  const sessionsYieldDenied = !sessionsYieldAllowed;
   const includeUpdatePlanTool = shouldIncludeUpdatePlanToolForOpenClawTools({
     config: resolvedConfig,
     agentSessionKey: options?.agentSessionKey,
@@ -532,10 +538,14 @@ export function createOpenClawTools(
           }),
         ]
       : []),
-    createSessionsYieldTool({
-      sessionId: options?.sessionId,
-      onYield: options?.onYield,
-    }),
+    ...(sessionsYieldDenied
+      ? []
+      : [
+          createSessionsYieldTool({
+            sessionId: options?.sessionId,
+            onYield: options?.onYield,
+          }),
+        ]),
     createSubagentsTool({
       agentSessionKey: options?.agentSessionKey,
     }),

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -404,11 +404,9 @@ export function createOpenClawTools(
   const effectiveCallGateway = embedded
     ? createEmbeddedCallGateway()
     : openClawToolsDeps.callGateway;
-  const sessionsYieldAllowed = isToolAllowedByPolicyName("sessions_yield", {
-    allow: explicitFactoryAllowlist,
+  const sessionsYieldDenied = !isToolAllowedByPolicyName("sessions_yield", {
     deny: explicitFactoryDenylist,
   });
-  const sessionsYieldDenied = !sessionsYieldAllowed;
   const includeUpdatePlanTool = shouldIncludeUpdatePlanToolForOpenClawTools({
     config: resolvedConfig,
     agentSessionKey: options?.agentSessionKey,

--- a/src/agents/openclaw-tools.tts-config.test.ts
+++ b/src/agents/openclaw-tools.tts-config.test.ts
@@ -541,4 +541,45 @@ describe("createOpenClawTools sessions_yield denylist", () => {
       testing.setDepsForTest();
     }
   });
+
+  it("keeps sessions_yield when alsoAllow is set with unrelated tools", () => {
+    testing.setDepsForTest({
+      config: {
+        tools: { alsoAllow: ["skill_workshop"] },
+      } as OpenClawConfig,
+    });
+
+    try {
+      const toolNames = createOpenClawTools({
+        disableMessageTool: true,
+        disablePluginTools: true,
+      }).map((t) => t.name);
+
+      expect(toolNames).toContain("sessions_yield");
+    } finally {
+      testing.setDepsForTest();
+    }
+  });
+
+  it("still excludes sessions_yield when alsoAllow and deny both set", () => {
+    testing.setDepsForTest({
+      config: {
+        tools: {
+          alsoAllow: ["skill_workshop"],
+          deny: ["sessions_yield"],
+        },
+      } as OpenClawConfig,
+    });
+
+    try {
+      const toolNames = createOpenClawTools({
+        disableMessageTool: true,
+        disablePluginTools: true,
+      }).map((t) => t.name);
+
+      expect(toolNames).not.toContain("sessions_yield");
+    } finally {
+      testing.setDepsForTest();
+    }
+  });
 });

--- a/src/agents/openclaw-tools.tts-config.test.ts
+++ b/src/agents/openclaw-tools.tts-config.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => {
     createImageGenerateToolOptions: vi.fn(),
     createMusicGenerateToolOptions: vi.fn(),
     createVideoGenerateToolOptions: vi.fn(),
+    createSessionsYieldToolOptions: vi.fn(),
     textToSpeech: vi.fn(async () => ({
       success: true,
       audioPath: "/tmp/openclaw/tts-config-test.opus",
@@ -461,5 +462,83 @@ describe("createOpenClawTools cron context wiring", () => {
       },
       selfRemoveOnlyJobId: "job-current",
     });
+  });
+});
+
+describe("createOpenClawTools sessions_yield denylist", () => {
+  beforeEach(() => {
+    mocks.createSessionsYieldToolOptions.mockClear();
+  });
+
+  it("includes sessions_yield by default", () => {
+    testing.setDepsForTest({ config: {} });
+
+    try {
+      const toolNames = createOpenClawTools({
+        disableMessageTool: true,
+        disablePluginTools: true,
+      }).map((t) => t.name);
+
+      expect(toolNames).toContain("sessions_yield");
+    } finally {
+      testing.setDepsForTest();
+    }
+  });
+
+  it("excludes sessions_yield when denied via tools.deny", () => {
+    testing.setDepsForTest({
+      config: {
+        tools: { deny: ["sessions_yield"] },
+      } as OpenClawConfig,
+    });
+
+    try {
+      const toolNames = createOpenClawTools({
+        disableMessageTool: true,
+        disablePluginTools: true,
+      }).map((t) => t.name);
+
+      expect(toolNames).not.toContain("sessions_yield");
+    } finally {
+      testing.setDepsForTest();
+    }
+  });
+
+  it("excludes sessions_yield when denied via group:sessions pattern", () => {
+    testing.setDepsForTest({
+      config: {
+        tools: { deny: ["group:sessions"] },
+      } as OpenClawConfig,
+    });
+
+    try {
+      const toolNames = createOpenClawTools({
+        disableMessageTool: true,
+        disablePluginTools: true,
+      }).map((t) => t.name);
+
+      expect(toolNames).not.toContain("sessions_yield");
+    } finally {
+      testing.setDepsForTest();
+    }
+  });
+
+  it("excludes sessions_yield when denied via wildcard pattern", () => {
+    testing.setDepsForTest({
+      config: {
+        tools: { deny: ["sessions_*"] },
+      } as OpenClawConfig,
+    });
+
+    try {
+      const toolNames = createOpenClawTools({
+        disableMessageTool: true,
+        disablePluginTools: true,
+      }).map((t) => t.name);
+
+      expect(toolNames).not.toContain("sessions_yield");
+    } finally {
+      testing.setDepsForTest();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **Problem**: `sessions_yield` tool is constructed with an active `onYield` callback even when explicitly denied via `tools.deny`. Agents can invoke it mid-task as if it were always available, bypassing tool policy.
- **Solution**: Gate `createSessionsYieldTool` against `explicitFactoryDenylist` using the same pattern already used for the `message` tool. When `tools.deny` contains `sessions_yield`, the tool is not constructed and never appears in effective tool surfaces.
- **What changed**: 2 files — `src/agents/openclaw-tools.ts` (use `isToolAllowedByPolicyName` instead of literal `includes`, supporting `group:sessions` and wildcard patterns) and test file (+93 lines for 4 tests).
- **What did NOT change**: The downstream filtering in `applyEmbeddedAttemptToolsAllow` (attempt-tool-construction-plan.ts:94) — fixing both gaps is preferred, but the factory-level gate alone prevents construction and is the narrower, safer fix.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related to #83981 (factory-level gate; downstream filtering gap not addressed)
- [x] This PR fixes a bug or regression

## Motivation

`sessions_yield` was constructed unconditionally — no check against `explicitFactoryDenylist`. This means users who configure `tools.deny: ["sessions_yield"]` expect the tool to be unavailable, but it remains callable. The `message` tool already has this protection; `sessions_yield` was simply missed.

## Real behavior proof

- **Behavior addressed**: `sessions_yield` tool no longer constructed when denied via `tools.deny`.
- **Real environment tested**: Real Linux (4.19.112, Node v22.22.0), branch `fix/sessions-yield-denylist-83981` (5a3d97184), build OK.
- **Exact steps or command run after this patch**:
  ```bash
  pnpm build
  node scripts/run-vitest.mjs src/agents/openclaw-tools.tts-config.test.ts --run --reporter=verbose
  ```
- **Evidence after fix**:

  Runtime proof — effective tool catalog with and without `tools.deny: ["sessions_yield"]`:

  ```console
  $ npx vitest run src/agents/openclaw-tools.proof.test.ts --config test/vitest/vitest.agents.config.ts --reporter=verbose

  === Effective Tool Catalog ===

  --- WITHOUT deny (all tools) ---
    agents_list
    create_goal
    cron
    gateway
    get_goal
    image_generate
    nodes
    session_status
    sessions_history
    sessions_list
    sessions_send
    sessions_spawn
    sessions_yield            ← present
    skill_workshop
    subagents
    tts
    update_goal
    video_generate
    web_fetch
    web_search

  --- WITH tools.deny: ["sessions_yield"] ---
    agents_list
    create_goal
    cron
    gateway
    get_goal
    image_generate
    nodes
    session_status
    sessions_history
    sessions_list
    sessions_send
    sessions_spawn
    skill_workshop
    subagents
    tts
    update_goal
    video_generate
    web_fetch
    web_search
                                  ← sessions_yield absent

  sessions_yield in no-deny: true
  sessions_yield in deny:    false
  ✓ sessions_yield denylist - real proof output > shows effective tool catalog with and without deny 621ms
  ```

  Unit tests (all 14 pass):
  ```console
  $ node scripts/run-vitest.mjs src/agents/openclaw-tools.tts-config.test.ts --run --reporter=verbose

   ✓ createOpenClawTools sessions_yield denylist > includes sessions_yield by default  203ms
   ✓ createOpenClawTools sessions_yield denylist > excludes sessions_yield when denied via tools.deny  214ms
   ✓ createOpenClawTools sessions_yield denylist > excludes sessions_yield when denied via group:sessions pattern  200ms
   ✓ createOpenClawTools sessions_yield denylist > excludes sessions_yield when denied via wildcard pattern  185ms

   Test Files  1 passed (1)
        Tests  14 passed (14)

  $ git log --oneline -1
  a1243e278 [AI] fix(agents): use denylist-only check for sessions_yield gate

  Environment: Linux 4.19.112, Node v22.22.0, OpenClaw 2026.6.2
  Build: OK
  ```
- **Observed result after fix**:
  1. Default (no deny): `sessions_yield` present in tools array (unchanged behavior) — verified via runtime proof, tool catalog shows 20 tools including `sessions_yield`
  2. `tools.deny: ["sessions_yield"]`: `sessions_yield` absent (exact match) — verified via runtime proof, tool catalog shows 19 tools with `sessions_yield` removed
  3. `tools.deny: ["group:sessions"]`: `sessions_yield` absent (group expansion) — verified via unit tests
  4. `tools.deny: ["sessions_*"]`: `sessions_yield` absent (wildcard glob) — verified via unit tests
  The gate uses `isToolAllowedByPolicyName` which applies `expandToolGroups`, `compileGlobPatterns`, and `normalizeToolName` — the same policy matching used throughout the tool runtime.
- **What was not tested**: The downstream filtering gap in `applyEmbeddedAttemptToolsAllow` (attempt-tool-construction-plan.ts:94) where deny-only config with no explicit allow bypasses filtering. Live E2E with a real agent. Runtime proof covers the factory-level tool catalog at construction time (the primary gate this PR addresses).

## Root Cause

Two gaps combined (per martingarramon's analysis on #83981):
1. **Factory denylist not applied** (`openclaw-tools.ts:535`): `explicitFactoryDenylist` is built from `tools.deny` but `createSessionsYieldTool` is called unconditionally.
2. **Allow-undefined bypass** (`attempt-tool-construction-plan.ts:94`): When no `tools.allow` is configured, `toolsAllow` is `undefined` and the function returns all tools unfiltered.

This PR fixes gap 1 (factory-level gate) using `isToolAllowedByPolicyName` which supports `group:sessions`, `sessions_*` wildcard patterns, and case normalization — not just literal `sessions_yield`. Gap 2 remains but is less impactful when gap 1 is closed.

## Regression Test Plan

Four new tests in `src/agents/openclaw-tools.tts-config.test.ts`:
1. Default inclusion: verify `sessions_yield` present when no deny configured
2. Exact name deny: verify `sessions_yield` absent when `tools.deny: ["sessions_yield"]`
3. Group pattern deny: verify `sessions_yield` absent when `tools.deny: ["group:sessions"]`
4. Wildcard pattern deny: verify `sessions_yield` absent when `tools.deny: ["sessions_*"]`

All 14 tests pass.

## User-visible / Behavior Changes

Users who configure `tools.deny: ["sessions_yield"]` will now properly have the tool excluded from agent tool surfaces.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? Yes — tool policy now correctly enforced for `sessions_yield`
- [x] Data access scope changed? No

## Repro + Verification

### Environment

- Branch: `fix/sessions-yield-denylist-83981`
- Base: `origin/main`

### Steps

1. Configure `tools.deny: ["sessions_yield"]` in `openclaw.json`
2. Restart gateway
3. Check effective tool catalog for agent

### Expected

`sessions_yield` does not appear in effective tool list.

### Actual (before fix)

Agent can invoke `sessions_yield` despite deny config.

## Human Verification

- **Verified scenarios**: Default include (runtime catalog shows `sessions_yield` present), exact-name deny (runtime catalog shows `sessions_yield` absent), group:sessions pattern, sessions_* wildcard pattern.
- **Edge cases checked**: Empty denylist (default preserved), `group:sessions` expansion covers all session tools, wildcard glob `sessions_*` matches prefix.
- **What you did NOT verify**: E2E with real agent invocation. Downstream filtering gap (gap 2).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- [x] Backward compatible? Yes — default behavior unchanged
- [x] Config/env changes? No
- [x] Migration needed? No

## AI Assistance

- **AI-assisted**: Yes
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: "fix #83981 — sessions_yield tool bypasses tool policy denylist"

## Risks and Mitigations

None. The gate follows the exact pattern proven by the `message` tool. When deny is not set, behavior is identical to before.

---

Related to #83981
