### PR TITLE
fix: resolve gateway token SecretRef against service env

### DIFF
--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -872,6 +872,64 @@ describe("maybeRepairGatewayServiceConfig", () => {
     expect(mocks.install).toHaveBeenCalledTimes(1);
   });
 
+  it("resolves SecretRef-managed gateway tokens against the service command environment", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+      },
+      async () => {
+        mocks.readCommand.mockResolvedValue({
+          programArguments: gatewayProgramArguments,
+          environment: {
+            OPENCLAW_GATEWAY_TOKEN: "service-env-token",
+          },
+          environmentValueSources: {
+            OPENCLAW_GATEWAY_TOKEN: "file",
+          },
+        });
+        mocks.resolveGatewayAuthTokenForService.mockImplementation(
+          async (_cfg: OpenClawConfig, env: NodeJS.ProcessEnv) => {
+            return env.OPENCLAW_GATEWAY_TOKEN
+              ? { token: env.OPENCLAW_GATEWAY_TOKEN }
+              : {
+                  unavailableReason: "gateway.auth.token SecretRef is configured but unresolved",
+                };
+          },
+        );
+        mocks.auditGatewayServiceConfig.mockResolvedValue({
+          ok: true,
+          issues: [],
+        });
+        mocks.buildGatewayInstallPlan.mockResolvedValue({
+          programArguments: gatewayProgramArguments,
+          workingDirectory: "/tmp",
+          environment: {},
+        });
+
+        const cfg: OpenClawConfig = {
+          gateway: {
+            auth: {
+              mode: "token",
+              token: "${OPENCLAW_GATEWAY_TOKEN}",
+            },
+          },
+        };
+
+        await runRepair(cfg);
+
+        expect(mocks.resolveGatewayAuthTokenForService).toHaveBeenCalledWith(
+          cfg,
+          expect.objectContaining({ OPENCLAW_GATEWAY_TOKEN: "service-env-token" }),
+          { allowExecSecretRefs: false },
+        );
+        expectNoNoteContaining(
+          "Unable to verify gateway service token drift",
+          "Gateway service config",
+        );
+      },
+    );
+  });
+
   it("falls back to embedded service token when config and env tokens are missing", async () => {
     await withEnvAsync(
       {

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -396,15 +396,25 @@ export async function maybeRepairGatewayServiceConfig(
       ].join("\n")
     : null;
 
-  const tokenRefConfigured = Boolean(
-    resolveSecretInputRef({
-      value: cfg.gateway?.auth?.token,
-      defaults: cfg.secrets?.defaults,
-    }).ref,
+  const gatewayTokenRef = resolveSecretInputRef({
+    value: cfg.gateway?.auth?.token,
+    defaults: cfg.secrets?.defaults,
+  }).ref;
+  const tokenRefConfigured = Boolean(gatewayTokenRef);
+  const gatewayTokenResolutionEnv =
+    gatewayTokenRef?.source === "env"
+      ? {
+          ...process.env,
+          ...command.environment,
+        }
+      : process.env;
+  const gatewayTokenResolution = await resolveGatewayAuthTokenForService(
+    cfg,
+    gatewayTokenResolutionEnv,
+    {
+      allowExecSecretRefs: options.allowExecSecretRefs === true,
+    },
   );
-  const gatewayTokenResolution = await resolveGatewayAuthTokenForService(cfg, process.env, {
-    allowExecSecretRefs: options.allowExecSecretRefs === true,
-  });
   if (gatewayTokenResolution.unavailableReason) {
     note(
       `Unable to verify gateway service token drift: ${gatewayTokenResolution.unavailableReason}`,


### PR DESCRIPTION
## Summary
- resolve env-backed gateway auth SecretRefs against the resolved systemd service command environment during doctor service drift checks
- keep plaintext, missing-token, and exec SecretRef behavior unchanged
- add regression coverage for OPENCLAW_GATEWAY_TOKEN loaded from the gateway service environment file

## Validation
- ./node_modules/.bin/oxfmt --write --threads=1 src/commands/doctor-gateway-services.ts src/commands/doctor-gateway-services.test.ts
- git diff --check
- node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/doctor-gateway-services.test.ts