### PR TITLE
fix(cron): fail closed on unavailable-tool self-debug in cron delivery

### DIFF
--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -6,6 +6,7 @@ import {
   pickLastDeliverablePayload,
   pickLastNonEmptyTextFromPayloads,
   pickSummaryFromPayloads,
+  resolveCronPayloadOutcome,
 } from "./helpers.js";
 
 type TextPayload = { text?: string | undefined; isError?: boolean | undefined };
@@ -226,5 +227,47 @@ describe("isHeartbeatOnlyResponse", () => {
         ACK_MAX,
       ),
     ).toBe(false);
+  });
+});
+
+describe("resolveCronPayloadOutcome unavailable-tool self-debug", () => {
+  it("marks fatal when final visible text apologises about an unavailable tool", () => {
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [{ text: "Tool process not found", isError: true }],
+      finalAssistantVisibleText:
+        "I can't use the tool \"process\" here because it isn't available. I need to stop retrying it and answer without that tool.",
+    });
+    expect(outcome.hasFatalErrorPayload).toBe(true);
+    // The error text uses the last error payload, not the self-debug apology.
+    expect(outcome.embeddedRunError).toContain("Tool process not found");
+    expect(outcome.outputText).toContain("Tool process not found");
+  });
+
+  it("does not mark fatal for normal deliverable assistant text", () => {
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [{ text: "Here is the summary you asked for.", isError: false }],
+      finalAssistantVisibleText: "Here is the summary you asked for.",
+    });
+    expect(outcome.hasFatalErrorPayload).toBe(false);
+  });
+
+  it("does not mark fatal when there are no tool error payloads", () => {
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [{ text: "Some output from a successful action" }],
+      finalAssistantVisibleText:
+        "I can't use the tool \"process\" here because it isn't available.",
+    });
+    expect(outcome.hasFatalErrorPayload).toBe(false);
+  });
+
+  it("does not mark fatal when successful payload exists after the last error", () => {
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "Tool process not found", isError: true },
+        { text: "Here is the real answer after recovering.", isError: false },
+      ],
+      finalAssistantVisibleText: "Here is the real answer after recovering.",
+    });
+    expect(outcome.hasFatalErrorPayload).toBe(false);
   });
 });

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -217,6 +217,12 @@ function isCronToolWarning(text: string | undefined): boolean {
   return normalizeOptionalString(text)?.startsWith("⚠️ 🛠️ ") === true;
 }
 
+/** Detects canned model self-debug output from repeated unavailable-tool attempts. */
+const UNAVAILABLE_TOOL_SELF_DEBUG_RE = /I can't use the tool/i;
+function isUnavailableToolSelfDebugText(text: string | undefined): boolean {
+  return UNAVAILABLE_TOOL_SELF_DEBUG_RE.test(normalizeOptionalString(text) ?? "");
+}
+
 function isNonTerminalToolErrorWarning(payload: object | undefined): boolean {
   return Boolean(payload && getReplyPayloadMetadata(payload)?.nonTerminalToolErrorWarning);
 }
@@ -294,6 +300,16 @@ export function resolveCronPayloadOutcome(params: {
     !hasStructuredDeliveryPayloads &&
     errorPayloads.length > 0 &&
     errorPayloads.every((payload) => isCronToolWarning(payload?.text));
+  // Self-debug text about unavailable tools (e.g. "I can't use the tool 'process'
+  // here because it isn't available") should not be delivered as normal cron output.
+  // Treat repeated unavailable-tool errors followed only by self-debug text as fatal.
+  const hasFatalUnavailableToolSelfDebug =
+    !params.runLevelError &&
+    params.failureSignal?.fatalForCron !== true &&
+    errorPayloads.length > 0 &&
+    normalizedFinalAssistantVisibleText !== undefined &&
+    isUnavailableToolSelfDebugText(normalizedFinalAssistantVisibleText) &&
+    !hasSuccessfulPayloadAfterLastError;
   // Structured error payloads are fatal unless later successful output or a
   // known non-terminal warning proves the agent recovered.
   const hasFatalStructuredErrorPayload =
@@ -330,7 +346,10 @@ export function resolveCronPayloadOutcome(params: {
   const failureSignal = normalizeCronFailureSignal(params.failureSignal);
   const runLevelError = formatCronRunLevelError(params.runLevelError);
   const hasFatalErrorPayload =
-    hasFatalStructuredErrorPayload || failureSignal !== undefined || runLevelError !== undefined;
+    hasFatalStructuredErrorPayload ||
+    failureSignal !== undefined ||
+    runLevelError !== undefined ||
+    hasFatalUnavailableToolSelfDebug;
   const structuredErrorText = hasFatalStructuredErrorPayload
     ? (lastErrorPayloadText ?? "cron isolated run returned an error payload")
     : undefined;
@@ -339,7 +358,8 @@ export function resolveCronPayloadOutcome(params: {
   const fatalDeliveryText =
     structuredErrorText ??
     failureSignal?.message ??
-    (shouldUseRunLevelErrorPayload ? runLevelError : undefined);
+    (shouldUseRunLevelErrorPayload ? runLevelError : undefined) ??
+    (hasFatalUnavailableToolSelfDebug ? normalizedFinalAssistantVisibleText : undefined);
   const fatalDeliveryPayload = fatalDeliveryText
     ? ({ text: fatalDeliveryText, isError: true } satisfies DeliveryPayload)
     : undefined;
@@ -358,7 +378,9 @@ export function resolveCronPayloadOutcome(params: {
       ? structuredErrorText
       : failureSignal
         ? formatCronFailureSignal(failureSignal)
-        : runLevelError,
+        : hasFatalUnavailableToolSelfDebug
+          ? `cron classifier: unavailable-tool self-debug: ${normalizedFinalAssistantVisibleText}`
+          : runLevelError,
     pendingPresentationWarningError: hasPendingPresentationWarning
       ? lastErrorPayloadText
       : undefined,


### PR DESCRIPTION
## Summary

Fixes #92535.

An isolated cron agent run can treat an internal unavailable-tool continuation failure as a successful final assistant response, then announce canned self-debug text to Telegram or other channels. The observed user-visible payload was:

```
I can't use the tool "process" here because it isn't available. I need to stop retrying it and answer without that tool.
```

This is internal tool/runtime failure text escaping through the cron delivery path. The fix detects the self-debug pattern in the final assistant visible text and marks the run as fatal, using the error payload text as the delivery output instead.

## Changes

- **`src/cron/isolated-agent/helpers.ts`**: Added `isUnavailableToolSelfDebugText()` to detect the known "I can't use the tool..." self-debug pattern. Added `hasFatalUnavailableToolSelfDebug` to `resolveCronPayloadOutcome` that marks the run as fatal when self-debug text is the only terminal output after tool errors.

- **`src/cron/isolated-agent/helpers.test.ts`**: Added 4 regression tests covering self-debug detection, normal text passthrough, no-error-payload passthrough, and successful-recovery passthrough.

## Real behavior proof

- **Behavior addressed**: Prevents canned "I can't use the tool..." self-debug text from being delivered as normal cron completion output when the agent hit repeated unavailable-tool errors.
- **Real environment tested**: Linux 4.19.112-2.el8.x86_64, Node v22.19.0, local OpenClaw source checkout.
- **Exact steps or command run after this patch**:
  - `pnpm test src/cron/isolated-agent/helpers.test.ts --run`
- **Evidence after fix**:
  Terminal output from regression tests:
  ```text
  ✓ resolveCronPayloadOutcome unavailable-tool self-debug > marks fatal when final visible text apologises about an unavailable tool
  ✓ resolveCronPayloadOutcome unavailable-tool self-debug > does not mark fatal for normal deliverable assistant text
  ✓ resolveCronPayloadOutcome unavailable-tool self-debug > does not mark fatal when there are no tool error payloads
  ✓ resolveCronPayloadOutcome unavailable-tool self-debug > does not mark fatal when successful payload exists after the last error
  ```
  All 29 helpers tests pass (25 existing + 4 new regression).
  360 cron isolated agent tests pass.
- **Observed result after fix**: When `finalAssistantVisibleText` matches the self-debug pattern and there are tool error payloads with no successful recovery, `hasFatalErrorPayload` is `true`, `embeddedRunError` contains the error payload text, and the self-debug apology is not delivered as normal output.
- **What was not tested**: Live Telegram roundtrip; Discord channel delivery; other non-cron background task runtimes (ACP, subagent) where similar self-debug could appear.

## Verification

- `pnpm test src/cron/isolated-agent/helpers.test.ts --run` — 29 passed (25 existing + 4 new)
- `pnpm test src/cron/isolated-agent/ --run` — 360 passed
