### PR TITLE
feat(attribution): parameterize OpenRouter `X-OpenRouter-Title` per deployment

### DIFF
--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -26,7 +26,7 @@ import { ModelRegistry } from "./model-registry.js";
 import type { ResourceLoader } from "./resource-loader.js";
 import { createAgentSession } from "./sdk.js";
 import { SessionManager } from "./session-manager.js";
-import { SettingsManager } from "./settings-manager.js";
+import { SettingsManager, type Settings } from "./settings-manager.js";
 import { createSyntheticSourceInfo } from "./source-info.js";
 
 const testModel: Model = {
@@ -87,13 +87,16 @@ function createResourceLoaderWithHandlers(
   };
 }
 
-async function createSessionAndStreamModel(model: Model): Promise<SimpleStreamOptions> {
+async function createSessionAndStreamModel(
+  model: Model,
+  settingsOverride: Partial<Settings> = {},
+): Promise<SimpleStreamOptions> {
   streamMocks.streamSimple.mockClear();
   const { session } = await createAgentSession({
     model,
     resourceLoader: createEmptyResourceLoader(),
     sessionManager: SessionManager.inMemory(),
-    settingsManager: SettingsManager.inMemory(),
+    settingsManager: SettingsManager.inMemory(settingsOverride),
     modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
   });
 
@@ -145,6 +148,72 @@ describe("createAgentSession attribution headers", () => {
       "HTTP-Referer": "https://openclaw.ai",
       "X-OpenRouter-Title": "OpenClaw",
       "X-OpenRouter-Categories": "cli-agent",
+    });
+  });
+
+  it("honors settings.appAttribution.openrouterTitle when set on OpenRouter", async () => {
+    // Per-agent attribution: an operator can group spend in the OpenRouter
+    // dashboard by setting `appAttribution.openrouterTitle` in agent settings,
+    // without provisioning per-agent API keys. See issue #92672.
+    const providerOptions = await createSessionAndStreamModel(
+      {
+        ...testModel,
+        provider: "openrouter",
+        baseUrl: "https://example.test",
+      },
+      {
+        appAttribution: { openrouterTitle: "darojaai-architect" },
+      },
+    );
+
+    expect(providerOptions.headers).toMatchObject({
+      "HTTP-Referer": "https://openclaw.ai",
+      "X-OpenRouter-Title": "darojaai-architect",
+      "X-OpenRouter-Categories": "cli-agent",
+    });
+  });
+
+  it("honors settings.appAttribution.httpReferer when set on OpenRouter", async () => {
+    const providerOptions = await createSessionAndStreamModel(
+      {
+        ...testModel,
+        provider: "openrouter",
+        baseUrl: "https://example.test",
+      },
+      {
+        appAttribution: {
+          openrouterTitle: "rag-research-tool",
+          httpReferer: "https://github.com/DarojaAI/linux-desktop-seed",
+        },
+      },
+    );
+
+    expect(providerOptions.headers).toMatchObject({
+      "HTTP-Referer": "https://github.com/DarojaAI/linux-desktop-seed",
+      "X-OpenRouter-Title": "rag-research-tool",
+    });
+  });
+
+  it("falls back to OpenClaw defaults when appAttribution values are invalid", async () => {
+    // Empty string, oversize, and control-character values must not break
+    // attribution; we fall back to the OpenClaw defaults.
+    const providerOptions = await createSessionAndStreamModel(
+      {
+        ...testModel,
+        provider: "openrouter",
+        baseUrl: "https://example.test",
+      },
+      {
+        appAttribution: {
+          openrouterTitle: "<script>alert(1)</script>",
+          httpReferer: "not-a-url",
+        },
+      },
+    );
+
+    expect(providerOptions.headers).toMatchObject({
+      "HTTP-Referer": "https://openclaw.ai",
+      "X-OpenRouter-Title": "OpenClaw",
     });
   });
 

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -181,9 +181,17 @@ function getAttributionHeaders(
   const baseUrl = (model as { baseUrl?: string }).baseUrl ?? "";
 
   if (model.provider === "openrouter" || baseUrl.includes("openrouter.ai")) {
+    // Per-deployment overrides from `settings.appAttribution.*` allow operators
+    // to attribute spend in the OpenRouter dashboard without provisioning
+    // per-agent API keys. The OpenClaw defaults remain the fallback so this
+    // change is fully backward-compatible: existing deployments continue to
+    // send `X-OpenRouter-Title: OpenClaw` and `HTTP-Referer: https://openclaw.ai`.
+    const overrides = settingsManager.getAppAttribution();
+    const openrouterTitle = sanitizeOpenRouterTitle(overrides.openrouterTitle);
+    const httpReferer = sanitizeHttpReferer(overrides.httpReferer);
     return {
-      "HTTP-Referer": "https://openclaw.ai",
-      "X-OpenRouter-Title": "OpenClaw",
+      "HTTP-Referer": httpReferer,
+      "X-OpenRouter-Title": openrouterTitle,
       "X-OpenRouter-Categories": "cli-agent",
     };
   }
@@ -200,6 +208,39 @@ function getAttributionHeaders(
   }
 
   return undefined;
+}
+
+/**
+ * Validates and sanitizes a user-supplied `X-OpenRouter-Title` value.
+ *
+ * OpenRouter's app-attribution dashboard groups spend by the `X-OpenRouter-Title`
+ * header. We accept any non-empty 1-50 character printable string. Invalid input
+ * falls back to the OpenClaw default so a misconfiguration cannot break
+ * downstream attribution.
+ */
+function sanitizeOpenRouterTitle(value: string | undefined): string {
+  if (typeof value !== "string") return "OpenClaw";
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > 50) return "OpenClaw";
+  // Reject control characters and HTML/script-injection vectors
+  if (/[\u0000-\u001f\u007f<>"'`\\]/.test(trimmed)) return "OpenClaw";
+  return trimmed;
+}
+
+/**
+ * Validates and sanitizes a user-supplied `HTTP-Referer` value.
+ *
+ * Must be either a valid http(s) URL or a URL-prefixed identifier
+ * (e.g. `"https://github.com/<org>/<repo>"`). Falls back to the
+ * OpenClaw default if invalid.
+ */
+function sanitizeHttpReferer(value: string | undefined): string {
+  if (typeof value !== "string") return "https://openclaw.ai";
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > 200) return "https://openclaw.ai";
+  // Must start with http:// or https://
+  if (!/^https?:\/\//.test(trimmed)) return "https://openclaw.ai";
+  return trimmed;
 }
 
 /**

--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -118,6 +118,45 @@ export interface Settings {
   warnings?: WarningSettings;
   sessionDir?: string; // Custom session storage directory (same format as --session-dir CLI flag)
   httpIdleTimeoutMs?: number; // HTTP header/body idle timeout in milliseconds; 0 disables it
+  /**
+   * Per-deployment app-attribution overrides sent to provider request headers.
+   *
+   * When set, the gateway substitutes these values into the vendor-documented
+   * attribution headers (currently `X-OpenRouter-Title`, `HTTP-Referer`) instead
+   * of the OpenClaw defaults. Use this to attribute per-agent spend in the
+   * OpenRouter dashboard without provisioning per-agent API keys — all agents
+   * still share one key, but the per-request `X-OpenRouter-Title` groups spend
+   * on the dashboard.
+   *
+   * @example
+   * ```json
+   * { "appAttribution": { "openrouterTitle": "darojaai-architect" } }
+   * ```
+   */
+  appAttribution?: AppAttributionSettings;
+}
+
+/**
+ * App-attribution header overrides.
+ *
+ * Each field is a per-deployment value sent to the named provider's
+ * vendor-documented attribution header. When omitted, the OpenClaw
+ * defaults apply (see `provider-attribution.ts`).
+ */
+export interface AppAttributionSettings {
+  /**
+   * Value for the `X-OpenRouter-Title` request header.
+   * Defaults to `"OpenClaw"` when unset. Must be a non-empty string
+   * of 1-50 characters. Used by the OpenRouter dashboard to group
+   * spend by application.
+   */
+  openrouterTitle?: string;
+  /**
+   * Value for the `HTTP-Referer` request header.
+   * Defaults to `"https://openclaw.ai"` when unset. Must be a valid
+   * URL or URL-prefixed identifier (e.g. `"https://github.com/<org>/<repo>"`).
+   */
+  httpReferer?: string;
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
@@ -792,6 +831,23 @@ export class SettingsManager {
       maxRetries: this.settings.retry?.provider?.maxRetries,
       maxRetryDelayMs: this.settings.retry?.provider?.maxRetryDelayMs ?? 60000,
     };
+  }
+
+  /**
+   * Per-deployment app-attribution header overrides.
+   *
+   * Returns the user-configured `appAttribution` block from settings, or
+   * an empty object if no overrides are set. The OpenClaw defaults
+   * (`X-OpenRouter-Title: OpenClaw`, `HTTP-Referer: https://openclaw.ai`)
+   * are applied by the attribution layer when these are unset, so a
+   * returned empty object means "use the OpenClaw defaults".
+   *
+   * Use this from the SDK seam (`getAttributionHeaders` in `sdk.ts`) to
+   * parameterize the attribution headers per agent or per deployment
+   * without provisioning per-agent API keys.
+   */
+  getAppAttribution(): AppAttributionSettings {
+    return this.settings.appAttribution ?? {};
   }
 
   getHideThinkingBlock(): boolean {


### PR DESCRIPTION
## Summary
Adds `settings.appAttribution.{openrouterTitle,httpReferer}` so operators can attribute spend in the OpenRouter dashboard per agent or per deployment, without provisioning per-agent API keys. The OpenClaw defaults (`X-OpenRouter-Title: OpenClaw`, `HTTP-Referer: https://openclaw.ai`) remain the fallback when no override is set, so this is fully backward-compatible.

## Use case
A single repo-level OpenRouter key shared by N agents, with each agent's `settings.json` setting its own `openrouterTitle`. The OpenRouter dashboard then groups spend by that title, giving per-agent visibility into a single key.

## Changes
- `src/agents/sessions/settings-manager.ts`: new `AppAttributionSettings` interface (`openrouterTitle`, `httpReferer`) and `getAppAttribution()` getter on `SettingsManager`.
- `src/agents/sessions/sdk.ts`: `getAttributionHeaders()` reads the override and substitutes into `X-OpenRouter-Title` / `HTTP-Referer` for OpenRouter routes. New `sanitizeOpenRouterTitle` / `sanitizeHttpReferer` helpers validate input and fall back to OpenClaw defaults on invalid values.
- `src/agents/sessions/sdk.test.ts`: 3 new tests covering per-deployment title, per-deployment referer, and invalid-input fallback. Test helper extended to accept a settings override.

## Validation
- 34/34 tests pass in `src/agents/sessions/sdk.test.ts`
- 66/66 tests pass in `src/agents/provider-attribution.test.ts` (no regressions)
- Pre-existing `tsgo` errors in `src/config/io.ts` and `src/secrets/config-io.ts` confirmed unrelated to this change (verified by stashing this branch and re-running `tsgo` on the base).

## Backward compatibility
Zero behavior change for existing deployments. `appAttribution` is an opt-in settings block. When unset (the default), the attribution layer continues to send `X-OpenRouter-Title: OpenClaw` and `HTTP-Referer: https://openclaw.ai` exactly as today.

## Related
- Closes the per-agent attribution use case in #92672 (DarojaAI deployments, ~16 agents on one OpenRouter key, currently invisible per-agent in the dashboard)
- DarojaAI/linux-desktop-seed#830 (per-agent spend attribution tracking issue)