### PR TITLE
fix(imessage): honor disabled reply actions

### DIFF
--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -121,6 +121,30 @@ describe("sendMessageIMessage receipts", () => {
     expect(result.receipt.sentAt).toBeGreaterThan(0);
   });
 
+  it("drops reply metadata from text sends when reply actions are disabled", async () => {
+    const client = createClient({ guid: "p:0/imsg-plain" });
+
+    const result = await sendMessageIMessage("chat_id:42", "hello", {
+      config: {
+        channels: {
+          imessage: {
+            actions: { reply: false },
+            accounts: { default: {} },
+          },
+        },
+      },
+      client,
+      replyToId: "reply-1",
+    });
+
+    const sendParams = getClientMocks(client).request.mock.calls[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(sendParams).not.toHaveProperty("reply_to");
+    expect(result.receipt.replyToId).toBeUndefined();
+    expect(result.receipt.parts[0]?.replyToId).toBeUndefined();
+  });
+
   it("passes the default RPC send transport", async () => {
     const client = createClient({ guid: "p:0/imsg-transport-default" });
 
@@ -296,6 +320,35 @@ describe("sendMessageIMessage receipts", () => {
     ]);
     expect(result.receipt.replyToId).toBe("p:0/reply-guid");
     expect(result.receipt.parts.map((part) => part.kind)).toEqual(["voice"]);
+    expect(client["request"]).not.toHaveBeenCalled();
+  });
+
+  it("drops reply metadata from media sends when reply actions are disabled", async () => {
+    const client = createClient({ message_id: 12345 });
+    const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/plain-media-guid" });
+
+    const result = await sendMessageIMessage("chat_guid:chat-1", "", {
+      config: {
+        channels: {
+          imessage: {
+            actions: { reply: false },
+            accounts: { default: {} },
+          },
+        },
+      },
+      client,
+      mediaUrl: "/tmp/image.png",
+      replyToId: "p:0/reply-guid",
+      resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+      runCliJson,
+    });
+
+    expect(result.messageId).toBe("p:0/plain-media-guid");
+    expect(runCliJson.mock.calls).toEqual([
+      [["send-attachment", "--chat", "chat-1", "--file", "/tmp/image.png", "--transport", "auto"]],
+    ]);
+    expect(result.receipt.replyToId).toBeUndefined();
+    expect(result.receipt.parts[0]?.replyToId).toBeUndefined();
     expect(client["request"]).not.toHaveBeenCalled();
   });
 

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -4,6 +4,7 @@ import { constants, accessSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
+import { createActionGate } from "openclaw/plugin-sdk/channel-actions";
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
@@ -948,7 +949,8 @@ export async function sendMessageIMessage(
     throw new Error("iMessage send requires text or media");
   }
   const echoText = resolveOutboundEchoText(message, filePath ? mediaContentType : undefined);
-  const resolvedReplyToId = sanitizeReplyToId(opts.replyToId);
+  const replyActionsEnabled = createActionGate(account.config.actions)("reply");
+  const resolvedReplyToId = replyActionsEnabled ? sanitizeReplyToId(opts.replyToId) : undefined;
   const runCliJson =
     opts.runCliJson ??
     ((args: readonly string[]) => runIMessageCliJson(cliPath, dbPath, args, timeoutMs));


### PR DESCRIPTION
## Summary

Fixes #92142 by making the iMessage sender honor `channels.imessage.actions.reply === false` before preserving outbound reply metadata.

When reply actions are disabled, `sendMessageIMessage` now drops `replyToId` before it can become the `imsg` RPC `reply_to` parameter or `send-attachment --reply-to`. That lets final iMessage responses degrade to normal top-level sends on SIP-enabled macOS setups instead of entering the SIP-gated threaded reply path.

## Root cause

Final delivery passes `payload.replyToId` into the iMessage sender for text and media replies. The sender previously sanitized and reused that value unconditionally, so `actions.reply: false` disabled advertised/private reply actions but not the lower-level final delivery metadata.

## Changes

- Gate resolved iMessage reply metadata with the existing `createActionGate(account.config.actions)("reply")` helper.
- Add regression coverage for disabled reply actions on text sends and media attachment sends.

## Verification

- `node scripts/run-vitest.mjs extensions/imessage/src/send.test.ts` passed: 43 tests.
- `pnpm --silent exec oxfmt --check extensions/imessage/src/send.ts extensions/imessage/src/send.test.ts` passed.
- `git diff --check -- extensions/imessage/src/send.ts extensions/imessage/src/send.test.ts` passed.

## Duplicate PRs

This maintainer PR supersedes #92170 and #92920. Both contributor PRs target the same issue and same sender line; this PR keeps the maintainer-owned fix while borrowing the stronger sender-boundary test shape.