### PR TITLE
feat(cron): add edit dry-run preview

### DIFF
--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const callGatewayFromCli = vi.fn();
+const writeJson = vi.fn();
 
 vi.mock("../gateway-rpc.js", async () => {
   const actual = await vi.importActual<typeof import("../gateway-rpc.js")>("../gateway-rpc.js");
@@ -10,6 +11,19 @@ vi.mock("../gateway-rpc.js", async () => {
     ...actual,
     callGatewayFromCli: (...args: Parameters<typeof actual.callGatewayFromCli>) =>
       callGatewayFromCli(...args),
+  };
+});
+
+vi.mock("../../runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("../../runtime.js")>("../../runtime.js");
+  return {
+    ...actual,
+    defaultRuntime: {
+      ...actual.defaultRuntime,
+      writeJson: (value: unknown) => writeJson(value),
+      error: vi.fn(),
+      exit: vi.fn(),
+    },
   };
 });
 
@@ -26,6 +40,7 @@ describe("cron edit command", () => {
   beforeEach(() => {
     callGatewayFromCli.mockReset();
     callGatewayFromCli.mockResolvedValue({ ok: true });
+    writeJson.mockReset();
   });
 
   it("documents that --best-effort-deliver implies announce mode when used alone (#83908)", () => {
@@ -198,6 +213,103 @@ describe("cron edit command", () => {
           },
         },
       },
+    );
+  });
+
+  it("previews cron.update params and skips update when --dry-run is used", async () => {
+    callGatewayFromCli.mockImplementation(async (method: string) => {
+      if (method === "cron.get") {
+        return {
+          id: "job-1",
+          name: "old-name",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          payload: { kind: "agentTurn", message: "old message" },
+        };
+      }
+      return { ok: true };
+    });
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", "--name", "new-name", "--disable", "--dry-run"], {
+      from: "user",
+    });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith("cron.get", expect.anything(), {
+      id: "job-1",
+    });
+    expect(callGatewayFromCli).not.toHaveBeenCalledWith(
+      "cron.update",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(callGatewayFromCli).not.toHaveBeenCalledWith(
+      "cron.status",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(writeJson).toHaveBeenCalledWith({
+      id: "job-1",
+      dryRun: true,
+      patch: {
+        name: "new-name",
+        enabled: false,
+      },
+      before: {
+        name: "old-name",
+        enabled: true,
+      },
+      after: {
+        name: "new-name",
+        enabled: false,
+      },
+      diff: [
+        { field: "name", before: "old-name", after: "new-name" },
+        { field: "enabled", before: true, after: false },
+      ],
+    });
+  });
+
+  it("keeps space-separated --tools parsing in dry-run previews", async () => {
+    callGatewayFromCli.mockImplementation(async (method: string) => {
+      if (method === "cron.get") {
+        return {
+          id: "job-1",
+          name: "agent job",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          payload: { kind: "agentTurn", message: "old message" },
+        };
+      }
+      return { ok: true };
+    });
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", "--tools", "exec read write", "--dry-run"], {
+      from: "user",
+    });
+
+    expect(callGatewayFromCli).not.toHaveBeenCalledWith(
+      "cron.update",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        patch: {
+          payload: {
+            kind: "agentTurn",
+            toolsAllow: ["exec", "read", "write"],
+          },
+        },
+        after: {
+          payload: {
+            kind: "agentTurn",
+            message: "old message",
+            toolsAllow: ["exec", "read", "write"],
+          },
+        },
+      }),
     );
   });
 });

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -38,6 +38,109 @@ const assignIf = (
   }
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function cloneJsonRecord(value: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+function mergeRecordPreview(
+  existing: unknown,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...(isRecord(existing) ? cloneJsonRecord(existing) : {}),
+    ...cloneJsonRecord(patch),
+  };
+}
+
+function applyCronEditDryRunPatchPreview(
+  existing: CronJob,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const after = cloneJsonRecord(existing as unknown as Record<string, unknown>);
+  for (const field of [
+    "name",
+    "description",
+    "enabled",
+    "deleteAfterRun",
+    "sessionTarget",
+    "wakeMode",
+    "agentId",
+    "sessionKey",
+  ]) {
+    if (Object.hasOwn(patch, field)) {
+      after[field] = patch[field];
+    }
+  }
+  if (isRecord(patch.schedule)) {
+    const nextSchedule = cloneJsonRecord(patch.schedule);
+    if (
+      nextSchedule.kind === "cron" &&
+      !Object.hasOwn(nextSchedule, "staggerMs") &&
+      existing.schedule.kind === "cron" &&
+      existing.schedule.staggerMs !== undefined
+    ) {
+      nextSchedule.staggerMs = existing.schedule.staggerMs;
+    }
+    after.schedule = nextSchedule;
+  }
+  if (isRecord(patch.payload)) {
+    const existingPayload = existing.payload;
+    after.payload =
+      isRecord(existingPayload) && existingPayload.kind === patch.payload.kind
+        ? mergeRecordPreview(existingPayload, patch.payload)
+        : cloneJsonRecord(patch.payload);
+  }
+  if (isRecord(patch.delivery)) {
+    after.delivery = mergeRecordPreview(existing.delivery, patch.delivery);
+  }
+  if (Object.hasOwn(patch, "failureAlert")) {
+    after.failureAlert =
+      patch.failureAlert === false || !isRecord(patch.failureAlert)
+        ? patch.failureAlert
+        : mergeRecordPreview(existing.failureAlert, patch.failureAlert);
+  }
+  return after;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
+  }
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .filter((key) => value[key] !== undefined)
+      .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "undefined";
+}
+
+function buildCronEditDryRunPreview(existing: CronJob, patch: Record<string, unknown>) {
+  const after = applyCronEditDryRunPatchPreview(existing, patch);
+  const beforeRecord = existing as unknown as Record<string, unknown>;
+  const changedFields = Object.keys(patch).filter(
+    (field) => stableJson(beforeRecord[field]) !== stableJson(after[field]),
+  );
+  const before = Object.fromEntries(changedFields.map((field) => [field, beforeRecord[field]]));
+  const afterChanged = Object.fromEntries(changedFields.map((field) => [field, after[field]]));
+  return {
+    dryRun: true,
+    patch,
+    before,
+    after: afterChanged,
+    diff: changedFields.map((field) => ({
+      field,
+      before: beforeRecord[field],
+      after: after[field],
+    })),
+  };
+}
+
 async function loadCronJobForEditSchedulePatch(
   opts: Record<string, unknown>,
   id: string,
@@ -87,10 +190,7 @@ export function registerCronEditCommand(cron: Command) {
       .option("--session-key <key>", "Set session key for job routing")
       .option("--clear-session-key", "Unset session key", false)
       .option("--wake <mode>", "Wake mode (now|next-heartbeat)")
-      .option(
-        "--at <when>",
-        "Set one-shot time (ISO, offset-less uses --tz) or duration like 20m",
-      )
+      .option("--at <when>", "Set one-shot time (ISO, offset-less uses --tz) or duration like 20m")
       .option("--every <duration>", "Set interval duration like 10m")
       .option("--cron <expr>", "Set cron expression")
       .option(
@@ -154,6 +254,7 @@ export function registerCronEditCommand(cron: Command) {
         "--failure-alert-account-id <id>",
         "Account ID for failure alert channel (multi-account setups)",
       )
+      .option("--dry-run", "Preview the cron.update patch without applying it", false)
       .action(async (id, opts) => {
         try {
           const sessionTarget =
@@ -524,6 +625,15 @@ export function registerCronEditCommand(cron: Command) {
               failureAlert.accountId = accountId ? accountId : undefined;
             }
             patch.failureAlert = failureAlert;
+          }
+
+          if (opts.dryRun) {
+            const existing = await readCronJobForEdit(opts, String(id));
+            defaultRuntime.writeJson({
+              id,
+              ...buildCronEditDryRunPreview(existing, patch),
+            });
+            return;
           }
 
           const res = await callGatewayFromCli("cron.update", opts, {


### PR DESCRIPTION
## Summary

Clean replacement for #59597.

- Adds explicit `cron edit --dry-run`.
- Builds the same `cron.update` patch as normal `cron edit`, then fetches the existing job and prints a JSON preview.
- The preview includes `patch`, changed-field `before` / `after`, and a `diff` array.
- Does not call `cron.update` and does not run the post-update scheduler warning path.
- Keeps default `cron edit` behavior unchanged for existing scripts.

## Scope Boundary

This deliberately avoids the old PR's default UI/workflow changes. There is no confirmation prompt, no default stderr diff before real edits, and no gateway API addition.

## Real Behavior Proof

Targeted test run:

```text
$ npx -y -p node@24 -p pnpm@11.2.2 pnpm exec node scripts/test-projects.mjs src/cli/cron-cli/register.cron-edit.test.ts
Test Files  1 passed (1)
Tests       9 passed (9)
[test] passed 1 Vitest shard
```

Covered cases:

- `cron edit --dry-run` calls `cron.get`, outputs preview JSON, and skips `cron.update`.
- Dry-run skips `cron.status` / scheduler warning checks.
- PowerShell-friendly space-separated `--tools "exec read write"` still routes through `parseCronToolsAllow`.

## Related

- Replaces #59597
- Closes #59453