### PR TITLE
feat(cron): add add dry-run preview

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -138,8 +138,8 @@ One-shot jobs delete after success by default. Use `--keep-after-run` to preserv
 Preview a create request without saving it by passing `--dry-run`:
 
 ```bash
-openclaw cron add --at 2026-07-01T09:00:00Z --message "Run quarterly check" --dry-run
-openclaw cron add --at 2026-07-01T09:00:00Z --message "Run quarterly check" --dry-run --json
+openclaw cron add --name quarterly-check --at 2026-07-01T09:00:00Z --message "Run quarterly check" --dry-run
+openclaw cron add --name quarterly-check --at 2026-07-01T09:00:00Z --message "Run quarterly check" --dry-run --json
 ```
 
 The preview prints the `cron.add` params that would be sent to the gateway and returns before creating a job or checking scheduler status.

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -135,6 +135,15 @@ reported as pre-model cron failures.
 One-shot jobs delete after success by default. Use `--keep-after-run` to preserve them.
 </Note>
 
+Preview a create request without saving it by passing `--dry-run`:
+
+```bash
+openclaw cron add --at 2026-07-01T09:00:00Z --message "Run quarterly check" --dry-run
+openclaw cron add --at 2026-07-01T09:00:00Z --message "Run quarterly check" --dry-run --json
+```
+
+The preview prints the `cron.add` params that would be sent to the gateway and returns before creating a job or checking scheduler status.
+
 ### Recurring jobs
 
 Recurring jobs use exponential retry backoff after consecutive errors: 30s, 1m, 5m, 15m, 60m. The schedule returns to normal after the next successful run.

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -462,6 +462,68 @@ describe("cron cli", () => {
     expect(params?.delivery?.mode).toBe("announce");
   });
 
+  it("dry-runs cron add as pure params JSON without gateway calls", async () => {
+    await runCronCommand([
+      "cron",
+      "add",
+      "--name",
+      "Tools",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--agent",
+      "main",
+      "--message",
+      "hello",
+      "--tools",
+      "exec read write",
+      "--dry-run",
+      "--json",
+    ]);
+
+    expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.add")).toBe(false);
+    expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.status")).toBe(false);
+    expect(defaultRuntime.error).not.toHaveBeenCalled();
+    const payload = JSON.parse(stdoutText()) as CronAddParams;
+    expect(payload).toMatchObject({
+      name: "Tools",
+      agentId: "main",
+      sessionTarget: "isolated",
+      payload: {
+        kind: "agentTurn",
+        message: "hello",
+        toolsAllow: ["exec", "read", "write"],
+      },
+    });
+    expect(stdoutText()).not.toContain("dry-run");
+  });
+
+  it("prints the cron add dry-run note outside stdout JSON", async () => {
+    await runCronCommand([
+      "cron",
+      "add",
+      "--name",
+      "Preview",
+      "--every",
+      "10m",
+      "--session",
+      "isolated",
+      "--agent",
+      "main",
+      "--message",
+      "hello",
+      "--dry-run",
+    ]);
+
+    expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.add")).toBe(false);
+    expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.status")).toBe(false);
+    expectRuntimeErrorContaining("cron.add dry-run: no job created");
+    const payload = JSON.parse(stdoutText()) as CronAddParams;
+    expect(payload.name).toBe("Preview");
+    expect(payload.schedule).toEqual({ kind: "every", everyMs: 600000 });
+  });
+
   it("accepts positional cron create name with webhook delivery", async () => {
     const params = await runCronAddAndGetParams([
       "Webhook reminder",

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -141,6 +141,7 @@ export function registerCronAddCommand(cron: Command) {
       .option("--thread-id <id>", "Telegram forum topic thread id")
       .option("--account <id>", "Channel account id for delivery (multi-account setups)")
       .option("--best-effort-deliver", "Do not fail the job if delivery fails", false)
+      .option("--dry-run", "Preview cron.add params without creating the job", false)
       .option("--json", "Output JSON", false)
       .action(
         async (
@@ -385,6 +386,16 @@ export function registerCronAddCommand(cron: Command) {
                   }
                 : undefined,
             };
+
+            if (opts.dryRun) {
+              if (!opts.json) {
+                defaultRuntime.error(
+                  "cron.add dry-run: no job created; previewing cron.add params.",
+                );
+              }
+              printCronJson(params);
+              return;
+            }
 
             const res = await callGatewayFromCli("cron.add", opts, params);
             printCronJson(res);


### PR DESCRIPTION
## Summary

Clean replacement for #59490 / #59452.

- Adds `cron add --dry-run`.
- Builds the exact params that normal `cron add` would send to `cron.add`.
- Prints those params as JSON and returns before any gateway RPC.
- `--dry-run --json` keeps stdout pure JSON.
- Does not call `cron.add` and does not call `cron.status`, so the scheduler warning path is not triggered.
- Documents the new preview flag in `docs/cli/cron.md`.

## Behavior

Default `cron add` behavior is unchanged. The dry-run path is explicit and does not add a gateway API; it reuses existing CLI parameter construction.

For non-JSON dry-runs, a short dry-run note is written to stderr while stdout remains the JSON params preview.

## Real Behavior Proof

- Behavior or issue addressed: `cron add --dry-run` previews the params normal `cron add` would send to `cron.add`, keeps `--dry-run --json` stdout as pure JSON, and returns before gateway RPC or scheduler-warning calls.
- Real environment tested: Windows PowerShell in the OpenClaw repo, Node.js v24.13.0, branch head `5cf84b0f6644560f52436a2180dd2d79088139a5`.
- Exact steps or command run after this patch: `node scripts/test-projects.mjs src/cli/cron-cli.test.ts`; `node node_modules/oxfmt/bin/oxfmt --check --threads=1 --config .oxfmtrc.jsonc docs/cli/cron.md`; `node scripts/check-docs-mdx.mjs docs/cli/cron.md`; `node openclaw.mjs cron add --name codex-dry-run-proof --at 2026-07-01T09:00:00Z --message "Dry run proof" --no-deliver --agent main --dry-run --json`; `node openclaw.mjs cron add --name codex-dry-run-proof --at 2026-07-01T09:00:00Z --message "Dry run proof" --no-deliver --agent main --dry-run`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output below shows real `node openclaw.mjs cron add --dry-run` JSON and non-JSON runs plus targeted cron CLI test and docs-check output.
- Observed result after fix: Dry-run JSON mode prints only the constructed params JSON; human mode prints the same params JSON and a dry-run note; tests assert `cron.add` and `cron.status` are not called and `--tools "exec read write"` parsing is preserved.
- What was not tested: No known gaps for the CLI params-preview scope; a real Gateway mutation was intentionally not performed because dry-run must not call the gateway.
- Proof limitations or environment constraints: This is intentionally a CLI-only params preview, not server-owned validation or next-fire calculation.

Runtime used for verification:

```text
$ node -v
v24.13.0
```

Targeted CLI test run:

```text
$ node scripts/test-projects.mjs src/cli/cron-cli.test.ts
Test Files  1 passed (1)
Tests       94 passed (94)
[test] passed 1 Vitest shard
```

Docs checks:

```text
$ node node_modules/oxfmt/bin/oxfmt --check --threads=1 --config .oxfmtrc.jsonc docs/cli/cron.md
Checking formatting...

All matched files use the correct format.
Finished in 586ms on 1 files using 1 threads.

$ node scripts/check-docs-mdx.mjs docs/cli/cron.md
Docs MDX check passed (1 files, 421ms).
```

Real CLI dry-run, JSON mode:

```text
$ node openclaw.mjs cron add --name codex-dry-run-proof --at 2026-07-01T09:00:00Z --message "Dry run proof" --no-deliver --agent main --dry-run --json
{
  "name": "codex-dry-run-proof",
  "enabled": true,
  "agentId": "main",
  "schedule": {
    "kind": "at",
    "at": "2026-07-01T09:00:00.000Z"
  },
  "sessionTarget": "isolated",
  "wakeMode": "now",
  "payload": {
    "kind": "agentTurn",
    "message": "Dry run proof"
  },
  "delivery": {
    "mode": "none",
    "channel": "last"
  }
}
```

Real CLI dry-run, human mode:

```text
$ node openclaw.mjs cron add --name codex-dry-run-proof --at 2026-07-01T09:00:00Z --message "Dry run proof" --no-deliver --agent main --dry-run
{
  "name": "codex-dry-run-proof",
  "enabled": true,
  "agentId": "main",
  "schedule": {
    "kind": "at",
    "at": "2026-07-01T09:00:00.000Z"
  },
  "sessionTarget": "isolated",
  "wakeMode": "now",
  "payload": {
    "kind": "agentTurn",
    "message": "Dry run proof"
  },
  "delivery": {
    "mode": "none",
    "channel": "last"
  }
}
cron.add dry-run: no job created; previewing cron.add params.
```

Covered cases:

- `cron add --dry-run --json` outputs the params object as pure JSON.
- `cron.add` is not called.
- `cron.status` / scheduler warning is not called.
- Space-separated `--tools "exec read write"` still uses `parseCronToolsAllow`.

## Related

- Related issue: #59452
- Replacement for #59490
