### PR TITLE
simplify QA evidence profile and mappings/coverage shape

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -371,7 +371,6 @@ describe("qa cli runtime", () => {
                     path: "qa/scenarios/channels/dm-chat-baseline.yaml",
                   },
                 },
-                profile: "smoke-ci",
                 coverage: [
                   {
                     id: "channels.dm",
@@ -442,8 +441,8 @@ describe("qa cli runtime", () => {
       expect(suiteArgs.scenarioIds).not.toContain("thinking-slash-model-remap");
       expect(process.env.OPENCLAW_QA_PROFILE).toBe("release");
       const evidence = JSON.parse(await fs.readFile(suiteEvidencePath, "utf8")) as {
+        profile?: unknown;
         scorecard?: {
-          profile?: unknown;
           run?: { evidenceEntryCount?: unknown };
           features?: { fulfilled?: unknown };
           categoryReports?: Array<{
@@ -453,12 +452,15 @@ describe("qa cli runtime", () => {
           }>;
         };
       };
+      expect(evidence.profile).toBe("smoke-ci");
       expect(evidence.scorecard).toMatchObject({
-        profile: "smoke-ci",
         run: {
           evidenceEntryCount: 1,
         },
       });
+      expect(evidence.scorecard).not.toHaveProperty("kind");
+      expect(evidence.scorecard).not.toHaveProperty("taxonomy");
+      expect(evidence.scorecard).not.toHaveProperty("profile");
       expect(evidence.scorecard?.features?.fulfilled).toBe(1);
       expect(evidence.scorecard?.categoryReports?.[0]).toMatchObject({
         id: "agent-runtime-and-provider-execution.agent-turn-execution",

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -371,17 +371,13 @@ describe("qa cli runtime", () => {
                     path: "qa/scenarios/channels/dm-chat-baseline.yaml",
                   },
                 },
-                mapping: {
-                  profile: "smoke-ci",
-                  coverage: [
-                    {
-                      id: "channels.dm",
-                      role: "primary",
-                      surfaceIds: ["dm"],
-                      categoryIds: ["agent-runtime-and-provider-execution.agent-turn-execution"],
-                    },
-                  ],
-                },
+                profile: "smoke-ci",
+                coverage: [
+                  {
+                    id: "channels.dm",
+                    role: "primary",
+                  },
+                ],
                 execution: {
                   runner: "host",
                   environment: {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -686,7 +686,6 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
   }
   await attachQaProfileScorecardEvidenceToFile({
     evidencePath,
-    taxonomyReport: scorecardReport,
     profile,
     filters: {
       surface: opts.surface,

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -71,7 +71,7 @@ import { resolveQaScenarioPackScenarioIds } from "./scenario-packs.js";
 import { attachQaProfileScorecardEvidenceToFile } from "./scorecard-evidence.js";
 import {
   readQaScorecardTaxonomyReport,
-  type QaScorecardCategoryMappingReport,
+  type QaScorecardCategoryCoverageReport,
 } from "./scorecard-taxonomy.js";
 import { runQaFlowSuiteFromRuntime, runQaSuite } from "./suite-launch.runtime.js";
 import { scenarioMatchesQaProviderLane } from "./suite-planning.js";
@@ -713,7 +713,7 @@ function defaultQaRunProfileProviderMode(profile: string): QaProviderModeInput {
 }
 
 function qaScorecardCategoryMatchesRunProfile(
-  category: QaScorecardCategoryMappingReport,
+  category: QaScorecardCategoryCoverageReport,
   opts: { profile: string; surface?: string; category?: string },
 ): boolean {
   if (!category.profiles.includes(opts.profile)) {

--- a/extensions/qa-lab/src/coverage-report.test.ts
+++ b/extensions/qa-lab/src/coverage-report.test.ts
@@ -121,7 +121,7 @@ describe("qa coverage report", () => {
     expect(inventory.scorecardTaxonomy.taxonomyFulfillmentPercent).toBeGreaterThan(0);
     expect(inventory.scorecardTaxonomy.evidenceRefCount).toBeGreaterThan(0);
     expect(inventory.scorecardTaxonomy.scenarioCoverageIdCount).toBeGreaterThan(0);
-    expect(inventory.scorecardTaxonomy.unmappedCoverageIdCount).toBe(0);
+    expect(inventory.scorecardTaxonomy.unknownCoverageIdCount).toBe(0);
     expect(inventory.scorecardTaxonomy.validationIssues.length).toBeGreaterThan(0);
     expect(
       inventory.scorecardTaxonomy.validationIssues.every(
@@ -210,7 +210,7 @@ describe("qa coverage report", () => {
       "- browser-automation-and-exec-sandbox-tools.tool-invocation-and-execution (browser-automation-and-exec-sandbox-tools / Tool Invocation and Execution; partial): profiles: release, smoke-ci; coverage IDs:",
     );
     expect(report).toContain("primary:playwright:ui/src/ui/e2e/chat-flow.e2e.test.ts (ui.control)");
-    expect(report).not.toContain("### Unmapped Scenario Coverage IDs");
+    expect(report).not.toContain("### Unknown Scenario Coverage IDs");
   });
 
   it("renders Playwright matches as qa suite targets", () => {
@@ -292,7 +292,7 @@ describe("qa coverage report", () => {
     });
 
     expect(report.fulfilledFeatureCount).toBe(0);
-    expect(report.categories[0]?.mappingStatus).toBe("missing");
+    expect(report.categories[0]?.coverageStatus).toBe("missing");
     expect(report.validationIssues.map((issue) => issue.code)).toEqual([
       "coverage-id-not-found",
       "coverage-id-missing-primary-evidence",
@@ -320,7 +320,7 @@ describe("qa coverage report", () => {
     expect(report.validationIssues).toStrictEqual([]);
     expect(report.fulfilledCategoryCount).toBe(1);
     expect(report.fulfilledFeatureCount).toBe(1);
-    expect(report.categories[0]?.mappingStatus).toBe("mapped");
+    expect(report.categories[0]?.coverageStatus).toBe("covered");
     expect(report.categories[0]?.scenarioRefs).toStrictEqual([
       "qa/scenarios/ui/control-ui-chat-flow-playwright.yaml",
     ]);
@@ -422,7 +422,7 @@ describe("qa coverage report", () => {
     });
 
     expect(report.fulfilledFeatureCount).toBe(0);
-    expect(report.categories[0]?.mappingStatus).toBe("partial");
+    expect(report.categories[0]?.coverageStatus).toBe("partial");
     expect(report.validationIssues.map((issue) => issue.code)).toEqual([
       "coverage-id-not-found",
       "coverage-id-missing-primary-evidence",

--- a/extensions/qa-lab/src/coverage-report.ts
+++ b/extensions/qa-lab/src/coverage-report.ts
@@ -333,7 +333,7 @@ function pushScorecardTaxonomyLines(lines: string[], report: QaScorecardTaxonomy
   );
   lines.push(`- Evidence refs: ${report.evidenceRefCount}`);
   lines.push(`- Scenario coverage IDs: ${report.scenarioCoverageIdCount}`);
-  lines.push(`- Unmapped scenario coverage IDs: ${report.unmappedCoverageIdCount}`);
+  lines.push(`- Unknown scenario coverage IDs: ${report.unknownCoverageIdCount}`);
   lines.push(`- Validation warnings: ${report.validationIssueCount}`, "");
 
   if (report.profiles.length > 0) {
@@ -346,7 +346,7 @@ function pushScorecardTaxonomyLines(lines: string[], report: QaScorecardTaxonomy
   }
 
   if (report.categories.length > 0) {
-    lines.push("### Category Mapping", "");
+    lines.push("### Category Coverage", "");
     for (const category of report.categories) {
       const coverageIds =
         category.coverageIds.length > 0 ? category.coverageIds.join(", ") : "none";
@@ -361,7 +361,7 @@ function pushScorecardTaxonomyLines(lines: string[], report: QaScorecardTaxonomy
           : "none";
       const profiles = category.profiles.length > 0 ? category.profiles.join(", ") : "none";
       lines.push(
-        `- ${category.id} (${category.taxonomySurfaceId} / ${category.taxonomyCategoryName}; ${category.mappingStatus}): profiles: ${profiles}; coverage IDs: ${coverageIds}; evidence: ${evidence}`,
+        `- ${category.id} (${category.taxonomySurfaceId} / ${category.taxonomyCategoryName}; ${category.coverageStatus}): profiles: ${profiles}; coverage IDs: ${coverageIds}; evidence: ${evidence}`,
       );
     }
     lines.push("");
@@ -376,9 +376,9 @@ function pushScorecardTaxonomyLines(lines: string[], report: QaScorecardTaxonomy
     lines.push("");
   }
 
-  if (report.unmappedCoverageIds.length > 0) {
-    lines.push("### Unmapped Scenario Coverage IDs", "");
-    lines.push(report.unmappedCoverageIds.join(", "));
+  if (report.unknownCoverageIds.length > 0) {
+    lines.push("### Unknown Scenario Coverage IDs", "");
+    lines.push(report.unknownCoverageIds.join(", "));
     lines.push("");
   }
 }

--- a/extensions/qa-lab/src/evidence-summary.test.ts
+++ b/extensions/qa-lab/src/evidence-summary.test.ts
@@ -47,6 +47,7 @@ describe("evidence summary", () => {
     expect(validateQaEvidenceSummaryJson(evidence)).toEqual(evidence);
     expect(evidence.kind).toBe(QA_EVIDENCE_SUMMARY_KIND);
     expect(evidence.schemaVersion).toBe(QA_EVIDENCE_SUMMARY_SCHEMA_VERSION);
+    expect(evidence.profile).toBeUndefined();
     expect(evidence.entries).toHaveLength(1);
     expect(evidence.entries[0]).toMatchObject({
       test: {
@@ -57,7 +58,6 @@ describe("evidence summary", () => {
           path: "qa/scenarios/channels/dm-chat-baseline.yaml",
         },
       },
-      profile: "smoke-ci",
       coverage: [
         {
           id: "channels.dm",
@@ -148,6 +148,7 @@ describe("evidence summary", () => {
     });
 
     expect(validateQaEvidenceSummaryJson(evidence)).toEqual(evidence);
+    expect(evidence.profile).toBeUndefined();
     expect(evidence.entries).toEqual([
       expect.objectContaining({
         test: {
@@ -155,7 +156,6 @@ describe("evidence summary", () => {
           id: "telegram-canary",
           title: "Telegram canary",
         },
-        profile: "release",
         coverage: [
           {
             id: "channels.telegram.live",
@@ -277,6 +277,7 @@ describe("evidence summary", () => {
     });
 
     expect(validateQaEvidenceSummaryJson(evidence)).toEqual(evidence);
+    expect(evidence.profile).toBeUndefined();
     expect(evidence.entries).toEqual([
       expect.objectContaining({
         test: {
@@ -287,7 +288,6 @@ describe("evidence summary", () => {
             path: "src/agents/agent-runner.e2e.test.ts",
           },
         },
-        profile: "smoke-ci",
         coverage: [
           {
             id: "runtime.agent-runner",
@@ -361,6 +361,7 @@ describe("evidence summary", () => {
     });
 
     expect(validateQaEvidenceSummaryJson(evidence)).toEqual(evidence);
+    expect(evidence.profile).toBeUndefined();
     expect(evidence.entries[0]).toMatchObject({
       test: {
         kind: "playwright-test",
@@ -370,7 +371,6 @@ describe("evidence summary", () => {
           path: "ui/control-ui.e2e.test.ts",
         },
       },
-      profile: "smoke-ci",
       coverage: [
         {
           id: "control-ui.browser",
@@ -437,7 +437,7 @@ describe("evidence summary", () => {
       scenarioResults: [{ name: "DM baseline conversation", status: "pass" }],
     });
 
-    expect(evidence.entries[0]?.profile).toBe("experimental-profile");
+    expect(evidence.profile).toBe("experimental-profile");
   });
 
   it("keeps mock non-OpenAI model refs attributed to their model provider", () => {

--- a/extensions/qa-lab/src/evidence-summary.test.ts
+++ b/extensions/qa-lab/src/evidence-summary.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./evidence-summary.js";
 
 describe("evidence summary", () => {
-  it("builds taxonomy-mapped QA suite evidence entries from catalog metadata", () => {
+  it("builds QA suite evidence entries from catalog metadata", () => {
     const evidence = buildQaSuiteEvidenceSummary({
       artifactPaths: [
         { kind: "summary", path: "qa-suite-summary.json" },
@@ -57,34 +57,28 @@ describe("evidence summary", () => {
           path: "qa/scenarios/channels/dm-chat-baseline.yaml",
         },
       },
-      mapping: {
-        profile: "smoke-ci",
-        coverage: [
-          {
-            id: "channels.dm",
-            role: "primary",
-            surfaceIds: ["dm"],
-            categoryIds: ["channels.dm"],
-          },
-          {
-            id: "channels.qa-channel",
-            role: "secondary",
-            surfaceIds: ["dm"],
-            categoryIds: [],
-          },
-        ],
-        refs: [
-          {
-            kind: "docs",
-            path: "docs/channels/qa-channel.md",
-          },
-          {
-            kind: "code",
-            path: "extensions/qa-channel/src/gateway.ts",
-          },
-        ],
-        runtimeParityTier: "standard",
-      },
+      profile: "smoke-ci",
+      coverage: [
+        {
+          id: "channels.dm",
+          role: "primary",
+        },
+        {
+          id: "channels.qa-channel",
+          role: "secondary",
+        },
+      ],
+      refs: [
+        {
+          kind: "docs",
+          path: "docs/channels/qa-channel.md",
+        },
+        {
+          kind: "code",
+          path: "extensions/qa-channel/src/gateway.ts",
+        },
+      ],
+      runtimeParityTier: "standard",
       execution: {
         runner: "host",
         provider: {
@@ -161,23 +155,17 @@ describe("evidence summary", () => {
           id: "telegram-canary",
           title: "Telegram canary",
         },
-        mapping: {
-          profile: "release",
-          coverage: [
-            {
-              id: "channels.telegram.live",
-              role: "live-transport",
-              surfaceIds: ["channels.telegram"],
-              categoryIds: ["channels.telegram.live"],
-            },
-            {
-              id: "channels.telegram.canary",
-              role: "live-transport-coverage",
-              surfaceIds: ["channels.telegram"],
-              categoryIds: ["channels.telegram.live"],
-            },
-          ],
-        },
+        profile: "release",
+        coverage: [
+          {
+            id: "channels.telegram.live",
+            role: "live-transport",
+          },
+          {
+            id: "channels.telegram.canary",
+            role: "live-transport-coverage",
+          },
+        ],
         execution: expect.objectContaining({
           runner: "crabbox",
           provider: {
@@ -276,8 +264,6 @@ describe("evidence summary", () => {
           title: "Agent runner boundary integration tests",
           sourcePath: "src/agents/agent-runner.e2e.test.ts",
           primaryCoverageIds: ["runtime.agent-runner", "runtime.delivery"],
-          surfaceIds: ["agent-runtime-and-provider-execution"],
-          categoryIds: ["agent-runtime-and-provider-execution.agent-turn-execution"],
           codeRefs: ["src/agents/agent-runner.ts"],
         },
       ],
@@ -301,29 +287,23 @@ describe("evidence summary", () => {
             path: "src/agents/agent-runner.e2e.test.ts",
           },
         },
-        mapping: {
-          profile: "smoke-ci",
-          coverage: [
-            {
-              id: "runtime.agent-runner",
-              role: "primary",
-              surfaceIds: ["agent-runtime-and-provider-execution"],
-              categoryIds: ["agent-runtime-and-provider-execution.agent-turn-execution"],
-            },
-            {
-              id: "runtime.delivery",
-              role: "primary",
-              surfaceIds: ["agent-runtime-and-provider-execution"],
-              categoryIds: ["agent-runtime-and-provider-execution.agent-turn-execution"],
-            },
-          ],
-          refs: [
-            {
-              kind: "code",
-              path: "src/agents/agent-runner.ts",
-            },
-          ],
-        },
+        profile: "smoke-ci",
+        coverage: [
+          {
+            id: "runtime.agent-runner",
+            role: "primary",
+          },
+          {
+            id: "runtime.delivery",
+            role: "primary",
+          },
+        ],
+        refs: [
+          {
+            kind: "code",
+            path: "src/agents/agent-runner.ts",
+          },
+        ],
         execution: expect.objectContaining({
           runner: "vitest",
           provider: expect.objectContaining({
@@ -366,8 +346,6 @@ describe("evidence summary", () => {
           title: "Control UI browser workflow",
           sourcePath: "ui/control-ui.e2e.test.ts",
           primaryCoverageIds: ["control-ui.browser"],
-          surfaceIds: ["browser-control-ui-and-webchat"],
-          categoryIds: ["browser-control-ui-and-webchat.browser-ui"],
           docsRefs: ["docs/concepts/qa-e2e-automation.md"],
           codeRefs: ["ui/"],
         },
@@ -392,26 +370,23 @@ describe("evidence summary", () => {
           path: "ui/control-ui.e2e.test.ts",
         },
       },
-      mapping: {
-        coverage: [
-          {
-            id: "control-ui.browser",
-            role: "primary",
-            surfaceIds: ["browser-control-ui-and-webchat"],
-            categoryIds: ["browser-control-ui-and-webchat.browser-ui"],
-          },
-        ],
-        refs: [
-          {
-            kind: "docs",
-            path: "docs/concepts/qa-e2e-automation.md",
-          },
-          {
-            kind: "code",
-            path: "ui/",
-          },
-        ],
-      },
+      profile: "smoke-ci",
+      coverage: [
+        {
+          id: "control-ui.browser",
+          role: "primary",
+        },
+      ],
+      refs: [
+        {
+          kind: "docs",
+          path: "docs/concepts/qa-e2e-automation.md",
+        },
+        {
+          kind: "code",
+          path: "ui/",
+        },
+      ],
       execution: {
         runner: "playwright",
         artifacts: [
@@ -439,7 +414,7 @@ describe("evidence summary", () => {
     });
   });
 
-  it("carries profile env values without hardcoding taxonomy mapping ids", () => {
+  it("carries profile env values without hardcoding taxonomy coverage ids", () => {
     const evidence = buildQaSuiteEvidenceSummary({
       artifactPaths: [{ kind: "summary", path: "qa-suite-summary.json" }],
       scenarioDefinitions: [
@@ -462,7 +437,7 @@ describe("evidence summary", () => {
       scenarioResults: [{ name: "DM baseline conversation", status: "pass" }],
     });
 
-    expect(evidence.entries[0]?.mapping.profile).toBe("experimental-profile");
+    expect(evidence.entries[0]?.profile).toBe("experimental-profile");
   });
 
   it("keeps mock non-OpenAI model refs attributed to their model provider", () => {

--- a/extensions/qa-lab/src/evidence-summary.ts
+++ b/extensions/qa-lab/src/evidence-summary.ts
@@ -124,14 +124,6 @@ const qaEvidenceScorecardCategorySchema = z
 
 const qaEvidenceScorecardSchema = z
   .object({
-    kind: z.literal("openclaw.qa.scorecard"),
-    profile: qaEvidenceProfileIdSchema,
-    taxonomy: z
-      .object({
-        path: nullableStringSchema,
-        title: nullableStringSchema,
-      })
-      .strict(),
     filters: z
       .object({
         surface: nullableStringSchema,
@@ -179,7 +171,6 @@ const qaEvidenceResultSchema = z
 export const qaEvidenceSummaryEntrySchema = z
   .object({
     test: qaEvidenceTestSchema,
-    profile: qaEvidenceProfileIdSchema,
     coverage: z.array(qaEvidenceCoverageSchema),
     refs: z.array(qaEvidenceRefSchema).optional(),
     runtimeParityTier: nonEmptyStringSchema.optional(),
@@ -194,6 +185,7 @@ export const qaEvidenceSummarySchema = z
     schemaVersion: z.literal(QA_EVIDENCE_SUMMARY_SCHEMA_VERSION),
     generatedAt: nonEmptyStringSchema,
     entries: z.array(qaEvidenceSummaryEntrySchema),
+    profile: qaEvidenceProfileIdSchema.optional(),
     scorecard: qaEvidenceScorecardSchema.optional(),
   })
   .strict();
@@ -350,7 +342,6 @@ function uniqueSortedStrings(values: readonly (string | undefined)[]) {
 
 function resolveQaEvidenceProfile(params: {
   env?: NodeJS.ProcessEnv;
-  fallback: QaEvidenceProfile;
   explicit?: QaEvidenceProfile;
 }) {
   if (params.explicit) {
@@ -373,7 +364,7 @@ function resolveQaEvidenceProfile(params: {
     return normalized;
   }
 
-  return params.fallback;
+  return undefined;
 }
 
 function resolveQaEvidenceRunner(params: { env?: NodeJS.ProcessEnv; fallback?: string }) {
@@ -499,12 +490,14 @@ function resultForEvidence(
 function buildQaEvidenceSummary(params: {
   entries: QaEvidenceSummaryEntry[];
   generatedAt: string;
+  profile?: QaEvidenceProfile;
 }): QaEvidenceSummaryJson {
   return qaEvidenceSummarySchema.parse({
     kind: QA_EVIDENCE_SUMMARY_KIND,
     schemaVersion: QA_EVIDENCE_SUMMARY_SCHEMA_VERSION,
     generatedAt: params.generatedAt,
     entries: params.entries,
+    profile: params.profile,
   });
 }
 
@@ -514,10 +507,12 @@ export function validateQaEvidenceSummaryJson(summary: unknown): QaEvidenceSumma
 
 export function attachQaEvidenceScorecard(params: {
   summary: QaEvidenceSummaryJson;
+  profile: QaEvidenceProfile;
   scorecard: QaEvidenceScorecardJson;
 }): QaEvidenceSummaryJson {
   return validateQaEvidenceSummaryJson({
     ...params.summary,
+    profile: params.profile,
     scorecard: params.scorecard,
   });
 }
@@ -535,7 +530,6 @@ export function buildQaSuiteEvidenceSummary(
   const runner = resolveQaEvidenceRunner({ env: params.env, fallback: params.runner });
   const profile = resolveQaEvidenceProfile({
     env: params.env,
-    fallback: provider.live ? "release" : "smoke-ci",
     explicit: params.profile,
   });
   const channelDriver = resolveQaEvidenceChannelDriver({
@@ -563,7 +557,6 @@ export function buildQaSuiteEvidenceSummary(
         title: scenario?.title ?? result.name,
         source: scenario?.sourcePath ? { path: scenario.sourcePath } : undefined,
       },
-      profile,
       coverage: buildQaEvidenceCoverage({
         primaryCoverageIds,
         secondaryCoverageIds: coverageIds.filter(
@@ -587,7 +580,7 @@ export function buildQaSuiteEvidenceSummary(
       result: resultForEvidence(result, timing),
     };
   });
-  return buildQaEvidenceSummary({ generatedAt: params.generatedAt, entries });
+  return buildQaEvidenceSummary({ generatedAt: params.generatedAt, entries, profile });
 }
 
 function buildTestRunnerEvidenceSummary(
@@ -607,7 +600,6 @@ function buildTestRunnerEvidenceSummary(
   });
   const profile = resolveQaEvidenceProfile({
     env: params.env,
-    fallback: provider.live ? "release" : "smoke-ci",
     explicit: params.profile,
   });
   const targetById = new Map(params.targets.map((target) => [target.id, target]));
@@ -632,7 +624,6 @@ function buildTestRunnerEvidenceSummary(
         title: target?.title ?? result.title ?? fallbackId,
         source: sourcePath ? { path: sourcePath } : undefined,
       },
-      profile,
       coverage: buildQaEvidenceCoverage({
         primaryCoverageIds: target?.primaryCoverageIds ?? [],
         secondaryCoverageIds: target?.secondaryCoverageIds ?? [],
@@ -648,7 +639,7 @@ function buildTestRunnerEvidenceSummary(
       result: resultForEvidence(result, timing),
     };
   });
-  return buildQaEvidenceSummary({ generatedAt: params.generatedAt, entries });
+  return buildQaEvidenceSummary({ generatedAt: params.generatedAt, entries, profile });
 }
 
 export function buildVitestEvidenceSummary(
@@ -691,7 +682,6 @@ export function buildLiveTransportEvidenceSummary(
   const runner = resolveQaEvidenceRunner({ env: params.env, fallback: params.runner });
   const profile = resolveQaEvidenceProfile({
     env: params.env,
-    fallback: "release",
     explicit: params.profile,
   });
   const channelDriver = resolveQaEvidenceChannelDriver({
@@ -720,7 +710,6 @@ export function buildLiveTransportEvidenceSummary(
         id: testId,
         title: check.title,
       },
-      profile,
       coverage,
       execution: {
         runner,
@@ -743,5 +732,5 @@ export function buildLiveTransportEvidenceSummary(
       result: resultForEvidence(check, timing),
     };
   });
-  return buildQaEvidenceSummary({ generatedAt: params.generatedAt, entries });
+  return buildQaEvidenceSummary({ generatedAt: params.generatedAt, entries, profile });
 }

--- a/extensions/qa-lab/src/evidence-summary.ts
+++ b/extensions/qa-lab/src/evidence-summary.ts
@@ -5,6 +5,8 @@ import { getQaProvider, type QaProviderMode } from "./providers/index.js";
 
 export const QA_EVIDENCE_SUMMARY_KIND = "openclaw.qa.evidence-summary";
 export const QA_EVIDENCE_FILENAME = "qa-evidence.json";
+// v2 was introduced on this PR series and has no stable external readers yet.
+// Keep the version while the pre-release evidence shape settles.
 export const QA_EVIDENCE_SUMMARY_SCHEMA_VERSION = 2;
 
 const qaEvidenceStatusSchema = z.enum(["pass", "fail", "blocked", "skipped"]);

--- a/extensions/qa-lab/src/evidence-summary.ts
+++ b/extensions/qa-lab/src/evidence-summary.ts
@@ -96,17 +96,6 @@ const qaEvidenceRefSchema = z
 const qaEvidenceCoverageSchema = qaEvidenceIdSchema
   .extend({
     role: nonEmptyStringSchema,
-    surfaceIds: z.array(nonEmptyStringSchema),
-    categoryIds: z.array(nonEmptyStringSchema),
-  })
-  .strict();
-
-const qaEvidenceMappingSchema = z
-  .object({
-    profile: qaEvidenceProfileIdSchema,
-    coverage: z.array(qaEvidenceCoverageSchema),
-    refs: z.array(qaEvidenceRefSchema).optional(),
-    runtimeParityTier: nonEmptyStringSchema.optional(),
   })
   .strict();
 
@@ -190,7 +179,10 @@ const qaEvidenceResultSchema = z
 export const qaEvidenceSummaryEntrySchema = z
   .object({
     test: qaEvidenceTestSchema,
-    mapping: qaEvidenceMappingSchema,
+    profile: qaEvidenceProfileIdSchema,
+    coverage: z.array(qaEvidenceCoverageSchema),
+    refs: z.array(qaEvidenceRefSchema).optional(),
+    runtimeParityTier: nonEmptyStringSchema.optional(),
     execution: qaEvidenceExecutionSchema,
     result: qaEvidenceResultSchema,
   })
@@ -268,8 +260,6 @@ type QaEvidenceTestTargetInput = {
   sourcePath: string;
   primaryCoverageIds?: readonly string[];
   secondaryCoverageIds?: readonly string[];
-  surfaceIds: readonly string[];
-  categoryIds: readonly string[];
   docsRefs?: readonly string[];
   codeRefs?: readonly string[];
 };
@@ -321,16 +311,10 @@ function buildQaEvidenceRefs(params: {
 function buildQaEvidenceCoverage(params: {
   primaryCoverageIds?: readonly string[];
   secondaryCoverageIds?: readonly string[];
-  surfaceIds?: readonly string[];
-  categoryIds?: readonly string[];
 }) {
-  const surfaceIds = uniqueSortedStrings(params.surfaceIds ?? []);
-  const categoryIds = uniqueSortedStrings(params.categoryIds ?? []);
   const buildCoverage = (id: string, role: "primary" | "secondary") => ({
     id,
     role,
-    surfaceIds,
-    categoryIds: role === "primary" ? categoryIds : [],
   });
   return [
     ...uniqueSortedStrings(params.primaryCoverageIds ?? []).map((id) =>
@@ -565,9 +549,6 @@ export function buildQaSuiteEvidenceSummary(
       ...(scenario?.coverage?.primary ?? []),
       ...(scenario?.coverage?.secondary ?? []),
     ]);
-    const surfaceIds = uniqueSortedStrings(
-      scenario?.surfaces && scenario.surfaces.length > 0 ? scenario.surfaces : [scenario?.surface],
-    );
     const runtimeParityTier = scenario?.runtimeParityTier;
     const testId = scenario?.id ?? `scenario-${index + 1}`;
     const refs = buildQaEvidenceRefs({
@@ -582,19 +563,15 @@ export function buildQaSuiteEvidenceSummary(
         title: scenario?.title ?? result.name,
         source: scenario?.sourcePath ? { path: scenario.sourcePath } : undefined,
       },
-      mapping: {
-        profile,
-        coverage: buildQaEvidenceCoverage({
-          primaryCoverageIds,
-          secondaryCoverageIds: coverageIds.filter(
-            (coverageId) => !primaryCoverageIds.includes(coverageId),
-          ),
-          surfaceIds,
-          categoryIds: uniqueSortedStrings([scenario?.category, ...primaryCoverageIds]),
-        }),
-        refs: refs.length > 0 ? refs : undefined,
-        runtimeParityTier,
-      },
+      profile,
+      coverage: buildQaEvidenceCoverage({
+        primaryCoverageIds,
+        secondaryCoverageIds: coverageIds.filter(
+          (coverageId) => !primaryCoverageIds.includes(coverageId),
+        ),
+      }),
+      refs: refs.length > 0 ? refs : undefined,
+      runtimeParityTier,
       execution: {
         runner,
         environment,
@@ -655,16 +632,12 @@ function buildTestRunnerEvidenceSummary(
         title: target?.title ?? result.title ?? fallbackId,
         source: sourcePath ? { path: sourcePath } : undefined,
       },
-      mapping: {
-        profile,
-        coverage: buildQaEvidenceCoverage({
-          primaryCoverageIds: target?.primaryCoverageIds ?? [],
-          secondaryCoverageIds: target?.secondaryCoverageIds ?? [],
-          surfaceIds: target?.surfaceIds ?? [],
-          categoryIds: target?.categoryIds ?? [],
-        }),
-        refs: refs.length > 0 ? refs : undefined,
-      },
+      profile,
+      coverage: buildQaEvidenceCoverage({
+        primaryCoverageIds: target?.primaryCoverageIds ?? [],
+        secondaryCoverageIds: target?.secondaryCoverageIds ?? [],
+      }),
+      refs: refs.length > 0 ? refs : undefined,
       execution: {
         runner,
         environment,
@@ -728,22 +701,16 @@ export function buildLiveTransportEvidenceSummary(
   const entries = params.checks.map((check): QaEvidenceSummaryEntry => {
     const testId = check.id;
     const liveCoverageId = `channels.${params.transportId}.live`;
-    const channelSurfaceId = `channels.${params.transportId}`;
-    const categoryIds = [liveCoverageId];
     const coverage = [
       {
         id: liveCoverageId,
         role: "live-transport",
-        surfaceIds: [channelSurfaceId],
-        categoryIds,
       },
       ...uniqueSortedStrings(check.coverageIds ?? [])
         .filter((coverageId) => coverageId !== liveCoverageId)
         .map((coverageId) => ({
           id: coverageId,
           role: "live-transport-coverage",
-          surfaceIds: [channelSurfaceId],
-          categoryIds,
         })),
     ];
     const timing = timingForRttResult(check);
@@ -753,10 +720,8 @@ export function buildLiveTransportEvidenceSummary(
         id: testId,
         title: check.title,
       },
-      mapping: {
-        profile,
-        coverage,
-      },
+      profile,
+      coverage,
       execution: {
         runner,
         environment,

--- a/extensions/qa-lab/src/live-transports/whatsapp/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/cli.runtime.test.ts
@@ -56,7 +56,6 @@ function makeEvidenceSummary(status: "pass" | "fail" | "blocked" | "skipped") {
           id: "whatsapp-mention-gating",
           title: "WhatsApp mention gating",
         },
-        profile: "release",
         coverage: [],
         execution: {
           runner: "host",

--- a/extensions/qa-lab/src/live-transports/whatsapp/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/cli.runtime.test.ts
@@ -56,7 +56,8 @@ function makeEvidenceSummary(status: "pass" | "fail" | "blocked" | "skipped") {
           id: "whatsapp-mention-gating",
           title: "WhatsApp mention gating",
         },
-        mapping: { profile: "release", coverage: [] },
+        profile: "release",
+        coverage: [],
         execution: {
           runner: "host",
           environment: { ref: null, os: "darwin", nodeVersion: "v24.0.0" },

--- a/extensions/qa-lab/src/scorecard-evidence.ts
+++ b/extensions/qa-lab/src/scorecard-evidence.ts
@@ -7,10 +7,7 @@ import {
   type QaEvidenceSummaryEntry,
   type QaEvidenceSummaryJson,
 } from "./evidence-summary.js";
-import type {
-  QaScorecardCategoryCoverageReport,
-  QaScorecardTaxonomyReport,
-} from "./scorecard-taxonomy.js";
+import type { QaScorecardCategoryCoverageReport } from "./scorecard-taxonomy.js";
 import { readQaScorecardFeatureCoverageByCategory } from "./scorecard-taxonomy.js";
 
 type QaProfileScorecardFilters = {
@@ -68,8 +65,6 @@ function categoryFeatureCoverageIds(params: {
 
 export function buildQaProfileScorecardEvidence(params: {
   evidence: QaEvidenceSummaryJson;
-  taxonomyReport: QaScorecardTaxonomyReport;
-  profile: string;
   filters: QaProfileScorecardFilters;
   categories: readonly QaScorecardCategoryCoverageReport[];
   featureCoverageByCategoryId?: ReadonlyMap<string, readonly (readonly string[])[]>;
@@ -134,12 +129,6 @@ export function buildQaProfileScorecardEvidence(params: {
     (category) => category.status === "missing",
   ).length;
   return {
-    kind: "openclaw.qa.scorecard",
-    profile: params.profile,
-    taxonomy: {
-      path: params.taxonomyReport.taxonomyPath,
-      title: params.taxonomyReport.title,
-    },
     filters: {
       surface: nullableFilter(params.filters.surface),
       category: nullableFilter(params.filters.category),
@@ -166,7 +155,6 @@ export function buildQaProfileScorecardEvidence(params: {
 
 export async function attachQaProfileScorecardEvidenceToFile(params: {
   evidencePath: string;
-  taxonomyReport: QaScorecardTaxonomyReport;
   profile: string;
   filters: QaProfileScorecardFilters;
   categories: readonly QaScorecardCategoryCoverageReport[];
@@ -176,13 +164,15 @@ export async function attachQaProfileScorecardEvidenceToFile(params: {
   );
   const scorecard = buildQaProfileScorecardEvidence({
     evidence,
-    taxonomyReport: params.taxonomyReport,
-    profile: params.profile,
     filters: params.filters,
     categories: params.categories,
     featureCoverageByCategoryId: readQaScorecardFeatureCoverageByCategory(),
   });
-  const nextEvidence = attachQaEvidenceScorecard({ summary: evidence, scorecard });
+  const nextEvidence = attachQaEvidenceScorecard({
+    summary: evidence,
+    profile: params.profile,
+    scorecard,
+  });
   await fs.writeFile(params.evidencePath, `${JSON.stringify(nextEvidence, null, 2)}\n`, "utf8");
   return scorecard;
 }

--- a/extensions/qa-lab/src/scorecard-evidence.ts
+++ b/extensions/qa-lab/src/scorecard-evidence.ts
@@ -8,7 +8,7 @@ import {
   type QaEvidenceSummaryJson,
 } from "./evidence-summary.js";
 import type {
-  QaScorecardCategoryMappingReport,
+  QaScorecardCategoryCoverageReport,
   QaScorecardTaxonomyReport,
 } from "./scorecard-taxonomy.js";
 import { readQaScorecardFeatureCoverageByCategory } from "./scorecard-taxonomy.js";
@@ -18,7 +18,7 @@ type QaProfileScorecardFilters = {
   category?: string;
 };
 
-type EvidenceCoverageRole = QaEvidenceSummaryEntry["mapping"]["coverage"][number]["role"];
+type EvidenceCoverageRole = QaEvidenceSummaryEntry["coverage"][number]["role"];
 
 function uniqueSortedStrings(values: Iterable<string | undefined>) {
   return [
@@ -41,9 +41,7 @@ function coverageIdsForRole(
 ) {
   return new Set(
     entries.flatMap((entry) =>
-      entry.mapping.coverage
-        .filter((coverage) => coverage.role === role)
-        .map((coverage) => coverage.id),
+      entry.coverage.filter((coverage) => coverage.role === role).map((coverage) => coverage.id),
     ),
   );
 }
@@ -59,7 +57,7 @@ function statusForCategory(params: { featureCount: number; fulfilledFeatureCount
 }
 
 function categoryFeatureCoverageIds(params: {
-  category: QaScorecardCategoryMappingReport;
+  category: QaScorecardCategoryCoverageReport;
   featureCoverageByCategoryId?: ReadonlyMap<string, readonly (readonly string[])[]>;
 }) {
   const features = params.featureCoverageByCategoryId?.get(params.category.id);
@@ -73,7 +71,7 @@ export function buildQaProfileScorecardEvidence(params: {
   taxonomyReport: QaScorecardTaxonomyReport;
   profile: string;
   filters: QaProfileScorecardFilters;
-  categories: readonly QaScorecardCategoryMappingReport[];
+  categories: readonly QaScorecardCategoryCoverageReport[];
   featureCoverageByCategoryId?: ReadonlyMap<string, readonly (readonly string[])[]>;
 }): QaEvidenceScorecardJson {
   const primaryCoverageIds = coverageIdsForRole(params.evidence.entries, "primary");
@@ -171,7 +169,7 @@ export async function attachQaProfileScorecardEvidenceToFile(params: {
   taxonomyReport: QaScorecardTaxonomyReport;
   profile: string;
   filters: QaProfileScorecardFilters;
-  categories: readonly QaScorecardCategoryMappingReport[];
+  categories: readonly QaScorecardCategoryCoverageReport[];
 }) {
   const evidence = validateQaEvidenceSummaryJson(
     JSON.parse(await fs.readFile(params.evidencePath, "utf8")),

--- a/extensions/qa-lab/src/scorecard-taxonomy.ts
+++ b/extensions/qa-lab/src/scorecard-taxonomy.ts
@@ -109,11 +109,11 @@ export type QaScorecardEvidenceReport = {
   scenarioRefs: string[];
 };
 
-export type QaScorecardCategoryMappingReport = {
+export type QaScorecardCategoryCoverageReport = {
   id: string;
   taxonomySurfaceId: string;
   taxonomyCategoryName: string;
-  mappingStatus: "mapped" | "partial" | "missing";
+  coverageStatus: "covered" | "partial" | "missing";
   profiles: string[];
   coverageIds: string[];
   fulfilledCoverageIds: string[];
@@ -145,11 +145,11 @@ export type QaScorecardTaxonomyReport = {
   taxonomyFulfillmentPercent: number;
   evidenceRefCount: number;
   scenarioCoverageIdCount: number;
-  unmappedCoverageIdCount: number;
-  unmappedCoverageIds: string[];
+  unknownCoverageIdCount: number;
+  unknownCoverageIds: string[];
   validationIssueCount: number;
   validationIssues: QaScorecardValidationIssue[];
-  categories: QaScorecardCategoryMappingReport[];
+  categories: QaScorecardCategoryCoverageReport[];
 };
 
 type MaturityCategoryRef = {
@@ -414,7 +414,7 @@ export function buildQaScorecardTaxonomyReport(params: {
 }): QaScorecardTaxonomyReport {
   const maturityRefs = buildMaturityRefs(params.taxonomy);
   const issues: QaScorecardValidationIssue[] = [];
-  const categories: QaScorecardCategoryMappingReport[] = [];
+  const categories: QaScorecardCategoryCoverageReport[] = [];
   const primaryScenarioRefsByCoverageId = collectScenarioEvidenceByCoverageId({
     scenarios: params.scenarios,
     role: "primary",
@@ -578,11 +578,11 @@ export function buildQaScorecardTaxonomyReport(params: {
     const missingCoverageIds = required
       ? category.coverageIds.filter((coverageId) => !coverageIdsWithAnyEvidence.has(coverageId))
       : [];
-    const mappingStatus =
+    const coverageStatus =
       required &&
       category.features.length > 0 &&
       fulfilledFeatureCountForCategory === category.features.length
-        ? "mapped"
+        ? "covered"
         : evidenceReports.length > 0
           ? "partial"
           : "missing";
@@ -591,7 +591,7 @@ export function buildQaScorecardTaxonomyReport(params: {
       id: category.id,
       taxonomySurfaceId: category.surfaceId,
       taxonomyCategoryName: category.categoryName,
-      mappingStatus,
+      coverageStatus,
       profiles: profileIds,
       coverageIds: category.coverageIds,
       fulfilledCoverageIds: uniqueSorted(fulfilledCoverageIds),
@@ -608,9 +608,9 @@ export function buildQaScorecardTaxonomyReport(params: {
 
   const requiredCategories = categories.filter((category) => category.profiles.length > 0);
   const fulfilledCategoryCount = requiredCategories.filter(
-    (category) => category.mappingStatus === "mapped",
+    (category) => category.coverageStatus === "covered",
   ).length;
-  const unmappedCoverageIds = allScenarioCoverageIds.filter(
+  const unknownCoverageIds = allScenarioCoverageIds.filter(
     (coverageId) => !maturityRefs.coverageIds.has(coverageId),
   );
 
@@ -634,8 +634,8 @@ export function buildQaScorecardTaxonomyReport(params: {
     taxonomyFulfillmentPercent: percent(fulfilledFeatureCount, requiredFeatureCount),
     evidenceRefCount: categories.reduce((count, category) => count + category.evidence.length, 0),
     scenarioCoverageIdCount: allScenarioCoverageIds.length,
-    unmappedCoverageIdCount: unmappedCoverageIds.length,
-    unmappedCoverageIds,
+    unknownCoverageIdCount: unknownCoverageIds.length,
+    unknownCoverageIds,
     validationIssueCount: issues.length,
     validationIssues: issues,
     categories,

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -163,11 +163,19 @@ function mergeQaEvidenceSummaries(params: {
   evidenceSummaries: readonly QaEvidenceSummaryJson[];
   generatedAt: string;
 }) {
+  const profiles = [
+    ...new Set(
+      params.evidenceSummaries
+        .map((summary) => summary.profile?.trim())
+        .filter((profile): profile is string => Boolean(profile)),
+    ),
+  ];
   return validateQaEvidenceSummaryJson({
     kind: QA_EVIDENCE_SUMMARY_KIND,
     schemaVersion: QA_EVIDENCE_SUMMARY_SCHEMA_VERSION,
     generatedAt: params.generatedAt,
     entries: params.evidenceSummaries.flatMap((summary) => summary.entries),
+    profile: profiles.length === 1 ? profiles[0] : undefined,
   });
 }
 

--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -102,7 +102,6 @@ describe("qa test file scenario runner", () => {
           path: "ui/src/ui/e2e/chat-flow.e2e.test.ts",
         },
       },
-      profile: "smoke-ci",
       coverage: [
         {
           id: "ui.control",
@@ -177,7 +176,6 @@ describe("qa test file scenario runner", () => {
           path: "extensions/qa-lab/src/coverage-report.test.ts",
         },
       },
-      profile: "smoke-ci",
       coverage: [
         {
           id: "qa.coverage",

--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -102,32 +102,27 @@ describe("qa test file scenario runner", () => {
           path: "ui/src/ui/e2e/chat-flow.e2e.test.ts",
         },
       },
-      mapping: {
-        coverage: [
-          {
-            id: "ui.control",
-            role: "primary",
-            surfaceIds: ["control-ui"],
-            categoryIds: ["browser-control-ui-and-webchat.browser-ui"],
-          },
-          {
-            id: "ui.streaming",
-            role: "secondary",
-            surfaceIds: ["control-ui"],
-            categoryIds: [],
-          },
-        ],
-        refs: [
-          {
-            kind: "docs",
-            path: "docs/concepts/qa-e2e-automation.md",
-          },
-          {
-            kind: "code",
-            path: "ui/src/ui/e2e/chat-flow.e2e.test.ts",
-          },
-        ],
-      },
+      profile: "smoke-ci",
+      coverage: [
+        {
+          id: "ui.control",
+          role: "primary",
+        },
+        {
+          id: "ui.streaming",
+          role: "secondary",
+        },
+      ],
+      refs: [
+        {
+          kind: "docs",
+          path: "docs/concepts/qa-e2e-automation.md",
+        },
+        {
+          kind: "code",
+          path: "ui/src/ui/e2e/chat-flow.e2e.test.ts",
+        },
+      ],
       execution: {
         runner: "playwright",
         artifacts: [
@@ -182,18 +177,17 @@ describe("qa test file scenario runner", () => {
           path: "extensions/qa-lab/src/coverage-report.test.ts",
         },
       },
-      mapping: {
-        coverage: [
-          {
-            id: "qa.coverage",
-            role: "primary",
-          },
-          {
-            id: "qa.reporting",
-            role: "secondary",
-          },
-        ],
-      },
+      profile: "smoke-ci",
+      coverage: [
+        {
+          id: "qa.coverage",
+          role: "primary",
+        },
+        {
+          id: "qa.reporting",
+          role: "secondary",
+        },
+      ],
       execution: {
         runner: "vitest",
         artifacts: [

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -271,6 +271,7 @@ function buildTestFileEvidence(params: {
     kind: QA_EVIDENCE_SUMMARY_KIND,
     schemaVersion: QA_EVIDENCE_SUMMARY_SCHEMA_VERSION,
     generatedAt: params.generatedAt,
+    profile: evidence.profile,
     entries: evidence.entries,
   });
 }

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -2,7 +2,6 @@ import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { toRepoRelativePath } from "./cli-paths.js";
 import { QaSuiteArtifactError } from "./errors.js";
 import {
@@ -159,16 +158,12 @@ function runQaScenarioCommand(
 }
 
 function buildScenarioEvidenceTarget(scenario: QaTestFileScenario) {
-  const surfaces =
-    scenario.surfaces && scenario.surfaces.length > 0 ? scenario.surfaces : [scenario.surface];
   return {
     id: scenario.id,
     title: scenario.title,
     sourcePath: scenario.execution.path,
     primaryCoverageIds: scenario.coverage?.primary ?? [],
     secondaryCoverageIds: scenario.coverage?.secondary ?? [],
-    surfaceIds: surfaces,
-    categoryIds: uniqueStrings([scenario.category].filter(Boolean) as string[]),
     docsRefs: scenario.docsRefs,
     codeRefs: scenario.codeRefs,
   };

--- a/test/scripts/mantis-build-telegram-evidence.test.ts
+++ b/test/scripts/mantis-build-telegram-evidence.test.ts
@@ -35,10 +35,7 @@ function makeTelegramOutput({ includeReport = true, summary = {} } = {}) {
             id: "telegram-status-command",
             title: "Telegram status command reply",
           },
-          mapping: {
-            profile: "release",
-            coverage: [],
-          },
+          coverage: [],
           execution: {
             runner: "host",
             environment: {


### PR DESCRIPTION
## Summary

- simplify `qa-evidence.json` entries by replacing the nested `mapping` object with direct `profile`, `coverage`, `refs`, and `runtimeParityTier` fields
- drop redundant per-entry `surfaceIds` and `categoryIds`; taxonomy category/feature fulfillment is derived from coverage IDs in `taxonomy.yaml`
- rename stale coverage-report mapping language to coverage language (`coverageStatus`, `unknownCoverageIds`, `Category Coverage`)

## Schema note

This intentionally keeps `schemaVersion: 2`. The v2 QA evidence artifact was introduced very recently on `main`, has not shipped as a stable external contract, and this follow-up makes that v2 shape representative before it becomes a real consumer contract.

## Verification

- `node scripts/run-vitest.mjs extensions/qa-lab/src/evidence-summary.test.ts extensions/qa-lab/src/coverage-report.test.ts extensions/qa-lab/src/test-file-scenario-runner.test.ts extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/live-transports/whatsapp/cli.runtime.test.ts`
- `pnpm check:test-types`
- `pnpm exec oxlint extensions/qa-lab/src/evidence-summary.ts extensions/qa-lab/src/scorecard-evidence.ts extensions/qa-lab/src/scorecard-taxonomy.ts extensions/qa-lab/src/coverage-report.ts extensions/qa-lab/src/test-file-scenario-runner.ts extensions/qa-lab/src/cli.runtime.ts extensions/qa-lab/src/evidence-summary.test.ts extensions/qa-lab/src/coverage-report.test.ts extensions/qa-lab/src/test-file-scenario-runner.test.ts extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/live-transports/whatsapp/cli.runtime.test.ts`
- `pnpm exec oxfmt --check extensions/qa-lab/src/evidence-summary.ts extensions/qa-lab/src/scorecard-evidence.ts extensions/qa-lab/src/scorecard-taxonomy.ts extensions/qa-lab/src/coverage-report.ts extensions/qa-lab/src/test-file-scenario-runner.ts extensions/qa-lab/src/cli.runtime.ts extensions/qa-lab/src/evidence-summary.test.ts extensions/qa-lab/src/coverage-report.test.ts extensions/qa-lab/src/test-file-scenario-runner.test.ts extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/live-transports/whatsapp/cli.runtime.test.ts`
- `node scripts/run-node.mjs qa coverage --json`
- `git diff --check`

## Review

- Autoreview reported one schema-version finding. I rejected it because this keeps the intended pre-release v2 evidence contract and notes that explicitly above.
