### PR TITLE
test: probe temp helper CI warning

### DIFF
--- a/test/scripts/temp-helper-warning-probe.test.ts
+++ b/test/scripts/temp-helper-warning-probe.test.ts
@@ -1,0 +1,15 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("temp helper warning probe", () => {
+  it("intentionally creates a bare temp dir for CI warning validation", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-temp-helper-warning-probe-"));
+    try {
+      expect(fs.existsSync(tempDir)).toBe(true);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a temporary test file that intentionally creates a bare temp directory with `fs.mkdtempSync(path.join(os.tmpdir(), ...))`.
- This PR is intentionally shaped to validate the report-only temp helper warning added by #87298.
- After we confirm the CI annotation shape, this PR should be updated to use `test/helpers/temp-dir.ts` so the warning disappears.

## Expected CI behavior
- `scripts/report-test-temp-creations.mjs` should emit a GitHub warning on `test/scripts/temp-helper-warning-probe.test.ts:8`.
- The test itself should pass; the goal is warning validation, not a failing test.

## Local verification
- `node scripts/report-test-temp-creations.mjs --base origin/main --head HEAD --json`
- `GITHUB_ACTIONS=true node scripts/report-test-temp-creations.mjs --base origin/main --head HEAD`
- `pnpm exec vitest run test/scripts/temp-helper-warning-probe.test.ts`
- `git diff --check origin/main...HEAD`