### PR TITLE
fix(doctor): import default-agent auth profiles into sqlite

### DIFF
--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -442,6 +442,82 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     expect(fs.existsSync(authPath)).toBe(true);
     expect(fs.existsSync(`${authPath}.sqlite-import.464.bak`)).toBe(false);
   });
+
+  it("imports default-agent config auth profiles into sqlite when no legacy files exist", async () => {
+    const state = await makeTestState();
+    const cfg = {
+      auth: {
+        profiles: {
+          "openai:default": {
+            provider: "openai",
+            mode: "api_key",
+            key: "sk-config",
+          },
+          "anthropic:default": {
+            provider: "anthropic",
+            mode: "token",
+            token: {
+              source: "env",
+              provider: "default",
+              id: "ANTHROPIC_TOKEN",
+            },
+          },
+          "router:default": {
+            provider: "router",
+            mode: "api_key",
+            displayName: "routing only",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg,
+      prompter: makePrompter(true),
+      now: () => 465,
+    });
+
+    const authPath = `${state.agentDir()}/auth-profiles.json`;
+    expect(result.detected).toEqual([authPath]);
+    expect(result.configChanged).toBe(true);
+    expect(result.warnings).toStrictEqual([]);
+    expect(cfg.auth?.profiles?.["openai:default"]).toEqual({
+      provider: "openai",
+      mode: "api_key",
+    });
+    expect(cfg.auth?.profiles?.["anthropic:default"]).toEqual({
+      provider: "anthropic",
+      mode: "token",
+    });
+    expect(cfg.auth?.profiles?.["router:default"]).toEqual({
+      provider: "router",
+      mode: "api_key",
+      displayName: "routing only",
+    });
+    expect(loadPersistedAuthProfileStore(state.agentDir())).toMatchObject({
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-config",
+        },
+        "anthropic:default": {
+          type: "token",
+          provider: "anthropic",
+          tokenRef: {
+            source: "env",
+            provider: "default",
+            id: "ANTHROPIC_TOKEN",
+          },
+        },
+      },
+    });
+    expect(
+      loadPersistedAuthProfileStore(state.agentDir())?.profiles["router:default"],
+    ).toBeUndefined();
+    expect(fs.existsSync(authPath)).toBe(false);
+    expect(fs.existsSync(`${authPath}.sqlite-import.465.bak`)).toBe(false);
+  });
 });
 
 describe("maybeRepairLegacyFlatAuthProfileStores", () => {

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -518,6 +518,53 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     expect(fs.existsSync(authPath)).toBe(false);
     expect(fs.existsSync(`${authPath}.sqlite-import.465.bak`)).toBe(false);
   });
+
+  it("preserves default-agent JSON auth profiles over config fallback", async () => {
+    const state = await makeTestState();
+    const authPath = await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-json",
+        },
+      },
+    });
+    const cfg = {
+      auth: {
+        profiles: {
+          "openai:default": {
+            provider: "openai",
+            mode: "api_key",
+            key: "sk-config",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg,
+      prompter: makePrompter(true),
+      now: () => 466,
+    });
+
+    expect(result.detected).toEqual([authPath]);
+    expect(result.configChanged).toBeUndefined();
+    expect(result.warnings).toStrictEqual([]);
+    expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles["openai:default"]).toEqual({
+      type: "api_key",
+      provider: "openai",
+      key: "sk-json",
+    });
+    expect(cfg.auth?.profiles?.["openai:default"]).toEqual({
+      provider: "openai",
+      mode: "api_key",
+      key: "sk-config",
+    });
+    expect(fs.existsSync(authPath)).toBe(false);
+    expect(fs.existsSync(`${authPath}.sqlite-import.466.bak`)).toBe(true);
+  });
 });
 
 describe("maybeRepairLegacyFlatAuthProfileStores", () => {

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -468,6 +468,10 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
             displayName: "routing only",
           },
         },
+        order: {
+          openai: ["openai:default"],
+          anthropic: ["anthropic:default"],
+        },
       },
     } as OpenClawConfig;
 
@@ -494,6 +498,10 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       mode: "api_key",
       displayName: "routing only",
     });
+    expect(cfg.auth?.order).toEqual({
+      openai: ["openai:default"],
+      anthropic: ["anthropic:default"],
+    });
     expect(loadPersistedAuthProfileStore(state.agentDir())).toMatchObject({
       profiles: {
         "openai:default": {
@@ -515,22 +523,21 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     expect(
       loadPersistedAuthProfileStore(state.agentDir())?.profiles["router:default"],
     ).toBeUndefined();
+    expect(loadPersistedAuthProfileStore(state.agentDir())?.order).toBeUndefined();
     expect(fs.existsSync(authPath)).toBe(false);
     expect(fs.existsSync(`${authPath}.sqlite-import.465.bak`)).toBe(false);
   });
 
-  it("preserves default-agent JSON auth profiles over config fallback", async () => {
+  it("imports default-agent config auth profiles when only legacy state exists", async () => {
     const state = await makeTestState();
-    const authPath = await writeLegacyAuthProfilesJson(state, {
-      version: 1,
-      profiles: {
-        "openai:default": {
-          type: "api_key",
-          provider: "openai",
-          key: "sk-json",
-        },
-      },
-    });
+    const statePath = await state.writeText(
+      "agents/main/agent/auth-state.json",
+      `${JSON.stringify({
+        version: 1,
+        order: { openai: ["openai:default"] },
+        lastGood: { openai: "openai:default" },
+      })}\n`,
+    );
     const cfg = {
       auth: {
         profiles: {
@@ -546,24 +553,301 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
       cfg,
       prompter: makePrompter(true),
-      now: () => 466,
+      now: () => 467,
+    });
+
+    const authPath = `${state.agentDir()}/auth-profiles.json`;
+    expect(result.detected.toSorted()).toEqual([authPath, statePath].toSorted());
+    expect(result.configChanged).toBe(true);
+    expect(result.warnings).toStrictEqual([]);
+    expect(cfg.auth?.profiles?.["openai:default"]).toEqual({
+      provider: "openai",
+      mode: "api_key",
+    });
+    expect(loadPersistedAuthProfileStore(state.agentDir())).toMatchObject({
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-config",
+        },
+      },
+      order: { openai: ["openai:default"] },
+      lastGood: { openai: "openai:default" },
+    });
+    expect(fs.existsSync(statePath)).toBe(false);
+    expect(fs.existsSync(`${statePath}.sqlite-import.467.bak`)).toBe(true);
+    expect(fs.existsSync(authPath)).toBe(false);
+    expect(fs.existsSync(`${authPath}.sqlite-import.467.bak`)).toBe(false);
+  });
+
+  it("infers config credential provider and mode before stripping config", async () => {
+    const cases: Array<{ profileId: string; cfg: OpenClawConfig; now: number }> = [
+      {
+        profileId: "openai:default",
+        cfg: {
+          auth: { profiles: { "openai:default": { key: "sk-config" } } },
+        } as unknown as OpenClawConfig,
+        now: 468,
+      },
+      {
+        profileId: "work",
+        cfg: {
+          auth: { profiles: { work: { key: "sk-config" } } },
+          agents: { defaults: { model: { primary: "openai/gpt-5.5@work" } } },
+        } as unknown as OpenClawConfig,
+        now: 470,
+      },
+      {
+        profileId: "ordered",
+        cfg: {
+          auth: {
+            profiles: { ordered: { key: "sk-config" } },
+            order: { openai: ["ordered"] },
+          },
+        } as unknown as OpenClawConfig,
+        now: 474,
+      },
+    ];
+
+    for (const entry of cases) {
+      const state = await makeTestState();
+      const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+        cfg: entry.cfg,
+        prompter: makePrompter(true),
+        now: () => entry.now,
+      });
+
+      const authPath = `${state.agentDir()}/auth-profiles.json`;
+      expect(result.detected).toEqual([authPath]);
+      expect(result.configChanged).toBe(true);
+      expect(result.warnings).toStrictEqual([]);
+      expect(entry.cfg.auth?.profiles?.[entry.profileId]).toEqual({
+        provider: "openai",
+        mode: "api_key",
+      });
+      expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles[entry.profileId]).toEqual({
+        type: "api_key",
+        provider: "openai",
+        key: "sk-config",
+      });
+      expect(fs.existsSync(authPath)).toBe(false);
+      expect(fs.existsSync(`${authPath}.sqlite-import.${entry.now}.bak`)).toBe(false);
+    }
+  });
+
+  it("imports missing config credentials while preserving legacy JSON precedence", async () => {
+    const state = await makeTestState();
+    const authPath = await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-json",
+        },
+        "openai:work": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-work",
+        },
+      },
+      order: {
+        openai: ["openai:work"],
+      },
+    });
+    const cfg = {
+      auth: {
+        profiles: {
+          "openai:default": {
+            provider: "openai",
+            mode: "api_key",
+            key: "sk-config",
+          },
+          "anthropic:default": {
+            provider: "anthropic",
+            mode: "api_key",
+            key: "sk-anthropic",
+          },
+        },
+        order: {
+          openai: ["openai:default"],
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg,
+      prompter: makePrompter(true),
+      now: () => 471,
     });
 
     expect(result.detected).toEqual([authPath]);
-    expect(result.configChanged).toBeUndefined();
+    expect(result.configChanged).toBe(true);
     expect(result.warnings).toStrictEqual([]);
-    expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles["openai:default"]).toEqual({
-      type: "api_key",
-      provider: "openai",
-      key: "sk-json",
+    expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles).toMatchObject({
+      "openai:default": {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-json",
+      },
+      "openai:work": {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-work",
+      },
+      "anthropic:default": {
+        type: "api_key",
+        provider: "anthropic",
+        key: "sk-anthropic",
+      },
     });
     expect(cfg.auth?.profiles?.["openai:default"]).toEqual({
       provider: "openai",
       mode: "api_key",
-      key: "sk-config",
+    });
+    expect(cfg.auth?.profiles?.["anthropic:default"]).toEqual({
+      provider: "anthropic",
+      mode: "api_key",
+    });
+    expect(loadPersistedAuthProfileStore(state.agentDir())).toMatchObject({
+      order: {
+        openai: ["openai:work"],
+      },
     });
     expect(fs.existsSync(authPath)).toBe(false);
-    expect(fs.existsSync(`${authPath}.sqlite-import.466.bak`)).toBe(true);
+    expect(fs.existsSync(`${authPath}.sqlite-import.471.bak`)).toBe(true);
+  });
+
+  it("imports default-agent config api key alias SecretRefs as key refs", async () => {
+    const cases = [
+      {
+        profileId: "openai:api-key-object",
+        profile: {
+          provider: "openai",
+          apiKey: {
+            source: "env",
+            provider: "default",
+            id: "OPENAI_API_KEY",
+          },
+        },
+      },
+      {
+        profileId: "openai:api-key-template",
+        profile: {
+          provider: "openai",
+          mode: "api_key",
+          apiKey: "${OPENAI_API_KEY}",
+        },
+      },
+      {
+        profileId: "openai:api-key-legacy-field",
+        profile: {
+          provider: "openai",
+          api_key: {
+            source: "env",
+            provider: "default",
+            id: "OPENAI_API_KEY",
+          },
+        },
+      },
+    ];
+
+    for (const entry of cases) {
+      const state = await makeTestState();
+      const cfg = {
+        auth: {
+          profiles: {
+            [entry.profileId]: entry.profile,
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+        cfg,
+        prompter: makePrompter(true),
+        now: () => 473,
+      });
+
+      expect(result.configChanged).toBe(true);
+      expect(result.warnings).toStrictEqual([]);
+      expect(cfg.auth?.profiles?.[entry.profileId]).toEqual({
+        provider: "openai",
+        mode: "api_key",
+      });
+      expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles[entry.profileId]).toEqual({
+        type: "api_key",
+        provider: "openai",
+        keyRef: {
+          source: "env",
+          provider: "default",
+          id: "OPENAI_API_KEY",
+        },
+      });
+    }
+  });
+
+  it("uses config credentials only when same-id sqlite credentials are incomplete", async () => {
+    const cases = [
+      {
+        existing: {
+          type: "api_key" as const,
+          provider: "openai",
+          key: "sk-sqlite",
+        },
+        expectedKey: "sk-sqlite",
+      },
+      {
+        existing: {
+          type: "api_key" as const,
+          provider: "openai",
+        },
+        expectedKey: "sk-config",
+      },
+    ];
+
+    for (const entry of cases) {
+      const state = await makeTestState();
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            "openai:default": entry.existing,
+          },
+        },
+        state.agentDir(),
+        { syncExternalCli: false },
+      );
+      const cfg = {
+        auth: {
+          profiles: {
+            "openai:default": {
+              provider: "openai",
+              mode: "api_key",
+              key: "sk-config",
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+        cfg,
+        prompter: makePrompter(true),
+        now: () => 469,
+      });
+
+      expect(result.configChanged).toBe(true);
+      expect(result.warnings).toStrictEqual([]);
+      expect(cfg.auth?.profiles?.["openai:default"]).toEqual({
+        provider: "openai",
+        mode: "api_key",
+      });
+      expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles["openai:default"]).toEqual({
+        type: "api_key",
+        provider: "openai",
+        key: entry.expectedKey,
+      });
+    }
   });
 });
 

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -598,6 +598,14 @@ function hasImportableAuthProfileStore(store: AuthProfileStore | null): store is
   return Boolean(store && (Object.keys(store.profiles).length > 0 || hasAuthProfileState(store)));
 }
 
+function hasLegacyAuthProfileSource(candidate: AuthProfileSqliteMigrationCandidate): boolean {
+  return (
+    fs.existsSync(candidate.authPath) ||
+    fs.existsSync(candidate.statePath) ||
+    fs.existsSync(candidate.legacyPath)
+  );
+}
+
 function backupAuthProfileJson(pathname: string, suffix: string, now: () => number): string {
   const backupPath = `${pathname}.${suffix}.${now()}.bak`;
   fs.copyFileSync(pathname, backupPath);
@@ -641,9 +649,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   const configStore = coerceLegacyConfigAuthProfileStore(params.cfg);
   const detected = candidates.filter(
     (candidate) =>
-      fs.existsSync(candidate.authPath) ||
-      fs.existsSync(candidate.statePath) ||
-      fs.existsSync(candidate.legacyPath) ||
+      hasLegacyAuthProfileSource(candidate) ||
       (configStore && isDefaultAgentCandidate(candidate, params.cfg, env)),
   );
   const result: LegacyFlatAuthProfileRepairResult = {
@@ -737,7 +743,11 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         ? maybeCanonicalStore
         : null;
       const configCanonicalStore =
-        configStore && isDefaultAgentCandidate(candidate, params.cfg, env) ? configStore : null;
+        configStore &&
+        isDefaultAgentCandidate(candidate, params.cfg, env) &&
+        !hasLegacyAuthProfileSource(candidate)
+          ? configStore
+          : null;
       const legacyStore = loadLegacyAuthProfileStore(candidate.agentDir);
       const rawState = fs.existsSync(candidate.statePath)
         ? loadJsonFile(candidate.statePath)

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -65,6 +65,12 @@ type AwsSdkAuthProfileMarkerStore = {
   profiles: AwsSdkProfileMarker[];
 };
 
+type RawAuthProfileImportStore = {
+  version: number;
+  profiles: Record<string, Record<string, unknown>>;
+  order?: Record<string, string[]>;
+};
+
 export type LegacyFlatAuthProfileRepairResult = {
   detected: string[];
   changes: string[];
@@ -294,11 +300,13 @@ function collectAuthProfileStateProfileIds(state: AuthProfileState): string[] {
 }
 
 function coerceLegacyConfigAuthProfileStore(cfg: OpenClawConfig): AuthProfileStore | null {
-  const profiles = isRecord(cfg.auth?.profiles) ? cfg.auth.profiles : null;
+  const cfgRecord: Record<string, unknown> = cfg;
+  const auth = isRecord(cfgRecord.auth) ? cfgRecord.auth : null;
+  const profiles = auth && isRecord(auth.profiles) ? auth.profiles : null;
   if (!profiles) {
     return null;
   }
-  const store: Record<string, unknown> = { version: AUTH_STORE_VERSION, profiles: {} };
+  const store: RawAuthProfileImportStore = { version: AUTH_STORE_VERSION, profiles: {} };
   for (const [profileId, raw] of Object.entries(profiles)) {
     if (!isRecord(raw)) {
       continue;
@@ -350,8 +358,8 @@ function coerceLegacyConfigAuthProfileStore(cfg: OpenClawConfig): AuthProfileSto
     }
     store.profiles[profileId] = next;
   }
-  if (isRecord(cfg.auth?.order)) {
-    const state = coerceAuthProfileState({ order: cfg.auth.order });
+  if (auth && isRecord(auth.order)) {
+    const state = coerceAuthProfileState({ order: auth.order });
     if (state.order) {
       store.order = state.order;
     }

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -293,6 +293,104 @@ function collectAuthProfileStateProfileIds(state: AuthProfileState): string[] {
   return [...profileIds];
 }
 
+function coerceLegacyConfigAuthProfileStore(cfg: OpenClawConfig): AuthProfileStore | null {
+  const profiles = isRecord(cfg.auth?.profiles) ? cfg.auth.profiles : null;
+  if (!profiles) {
+    return null;
+  }
+  const store: Record<string, unknown> = { version: AUTH_STORE_VERSION, profiles: {} };
+  for (const [profileId, raw] of Object.entries(profiles)) {
+    if (!isRecord(raw)) {
+      continue;
+    }
+    const mode = readNonEmptyString(raw.mode) ?? readNonEmptyString(raw.type);
+    if (mode !== "api_key" && mode !== "token" && mode !== "oauth") {
+      continue;
+    }
+    const provider = readNonEmptyString(raw.provider) ?? extractProviderFromProfileId(profileId);
+    if (!provider || !isSafeLegacyProviderKey(provider)) {
+      continue;
+    }
+    const next: Record<string, unknown> = { ...raw, provider, mode };
+    if (mode === "api_key") {
+      const keyRef = coerceSecretRef(raw.keyRef) ?? coerceSecretRef(raw.key);
+      const key =
+        readNonEmptyString(raw.key) ??
+        readNonEmptyString(raw.apiKey) ??
+        readNonEmptyString(raw["api_key"]);
+      if (keyRef) {
+        next.keyRef = keyRef;
+        delete next.key;
+        delete next.apiKey;
+        delete next["api_key"];
+      } else if (key) {
+        next.key = key;
+        delete next.keyRef;
+      } else {
+        continue;
+      }
+    } else if (mode === "token") {
+      const tokenRef = coerceSecretRef(raw.tokenRef) ?? coerceSecretRef(raw.token);
+      const token = readNonEmptyString(raw.token);
+      if (tokenRef) {
+        next.tokenRef = tokenRef;
+        delete next.token;
+      } else if (token) {
+        next.token = token;
+        delete next.tokenRef;
+      } else {
+        continue;
+      }
+    } else if (
+      !readNonEmptyString(raw.access) ||
+      !readNonEmptyString(raw.refresh) ||
+      typeof raw.expires !== "number"
+    ) {
+      continue;
+    }
+    store.profiles[profileId] = next;
+  }
+  if (isRecord(cfg.auth?.order)) {
+    const state = coerceAuthProfileState({ order: cfg.auth.order });
+    if (state.order) {
+      store.order = state.order;
+    }
+  }
+  const canonicalStore = coercePersistedAuthProfileStore(store);
+  return canonicalStore && Object.keys(canonicalStore.profiles).length > 0 ? canonicalStore : null;
+}
+
+function isDefaultAgentCandidate(
+  candidate: AuthProfileSqliteMigrationCandidate,
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  return path.resolve(candidate.agentDir ?? "") === path.resolve(resolveDefaultAgentDir(cfg, env));
+}
+
+function stripImportedConfigAuthProfileCredentials(
+  cfg: OpenClawConfig,
+  store: AuthProfileStore,
+): boolean {
+  const profiles = ensureConfigAuthProfiles(cfg);
+  let changed = false;
+  for (const [profileId, credential] of Object.entries(store.profiles)) {
+    const current = profiles[profileId];
+    if (!current) {
+      continue;
+    }
+    const metadata: AuthProfileConfig = {
+      provider: current.provider || credential.provider,
+      mode: credential.type,
+      ...(current.email ? { email: current.email } : {}),
+      ...(current.displayName ? { displayName: current.displayName } : {}),
+    };
+    profiles[profileId] = metadata;
+    changed = true;
+  }
+  return changed;
+}
+
 function mergeImportedAuthProfiles(params: {
   store: AuthProfileStore;
   profiles: AuthProfileStore["profiles"];
@@ -532,17 +630,32 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   const loadMigratedStore =
     params.deps?.loadPersistedAuthProfileStore ?? loadPersistedAuthProfileStore;
   const candidates = listAuthProfileSqliteMigrationCandidates(params.cfg, env);
+  const configStore = coerceLegacyConfigAuthProfileStore(params.cfg);
   const detected = candidates.filter(
     (candidate) =>
       fs.existsSync(candidate.authPath) ||
       fs.existsSync(candidate.statePath) ||
-      fs.existsSync(candidate.legacyPath),
+      fs.existsSync(candidate.legacyPath) ||
+      (configStore && isDefaultAgentCandidate(candidate, params.cfg, env)),
   );
   const result: LegacyFlatAuthProfileRepairResult = {
     detected: detected.flatMap((candidate) =>
-      [candidate.authPath, candidate.statePath, candidate.legacyPath].filter((pathname) =>
-        fs.existsSync(pathname),
-      ),
+      [
+        candidate.authPath,
+        candidate.statePath,
+        candidate.legacyPath,
+        ...(configStore && isDefaultAgentCandidate(candidate, params.cfg, env)
+          ? [candidate.authPath]
+          : []),
+      ]
+        .filter((pathname, index, entries) => entries.indexOf(pathname) === index)
+        .filter(
+          (pathname) =>
+            fs.existsSync(pathname) ||
+            (configStore &&
+              isDefaultAgentCandidate(candidate, params.cfg, env) &&
+              pathname === candidate.authPath),
+        ),
     ),
     changes: [],
     warnings: [],
@@ -615,12 +728,20 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
       const canonicalStore = hasImportableAuthProfileStore(maybeCanonicalStore)
         ? maybeCanonicalStore
         : null;
+      const configCanonicalStore =
+        configStore && isDefaultAgentCandidate(candidate, params.cfg, env) ? configStore : null;
       const legacyStore = loadLegacyAuthProfileStore(candidate.agentDir);
       const rawState = fs.existsSync(candidate.statePath)
         ? loadJsonFile(candidate.statePath)
         : null;
       const state = coerceAuthProfileState(rawState);
-      if (!canonicalStore && !legacyStore && !hasAuthProfileState(state) && !awsSdkMarkerStore) {
+      if (
+        !canonicalStore &&
+        !configCanonicalStore &&
+        !legacyStore &&
+        !hasAuthProfileState(state) &&
+        !awsSdkMarkerStore
+      ) {
         result.warnings.push(
           `Left auth profile JSON in place for ${shortenHomePath(candidate.authPath)} because no importable auth profiles or state were found.`,
         );
@@ -666,15 +787,33 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
           existingState,
         });
       }
+      if (configCanonicalStore) {
+        for (const profileId of Object.keys(configCanonicalStore.profiles)) {
+          importedProfileIds.add(profileId);
+        }
+        next = mergeImportedAuthProfiles({
+          store: next,
+          profiles: configCanonicalStore.profiles,
+          existingProfileIds,
+        });
+        next = mergeImportedAuthProfileState({
+          store: next,
+          state: coerceAuthProfileState(configCanonicalStore),
+          existingState,
+        });
+      }
       if (hasAuthProfileState(state)) {
         next = mergeImportedAuthProfileState({ store: next, state, existingState });
       }
 
-      if (canonicalStore || legacyStore || hasAuthProfileState(state)) {
+      if (canonicalStore || configCanonicalStore || legacyStore || hasAuthProfileState(state)) {
         const stateProfileIds = [
           ...collectAuthProfileStateProfileIds(state),
           ...(canonicalStore
             ? collectAuthProfileStateProfileIds(coerceAuthProfileState(canonicalStore))
+            : []),
+          ...(configCanonicalStore
+            ? collectAuthProfileStateProfileIds(coerceAuthProfileState(configCanonicalStore))
             : []),
         ];
         saveAuthProfileStore(next, candidate.agentDir, {
@@ -694,6 +833,12 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
           );
           continue;
         }
+        if (
+          configCanonicalStore &&
+          stripImportedConfigAuthProfileCredentials(params.cfg, configCanonicalStore)
+        ) {
+          result.configChanged = true;
+        }
       }
 
       const backups: string[] = [];
@@ -711,8 +856,12 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
       if (fs.existsSync(candidate.legacyPath)) {
         backups.push(backupAndRemoveAuthProfileJson(candidate.legacyPath, "sqlite-import", now));
       }
+      const backupText =
+        backups.length > 0
+          ? `backup${backups.length === 1 ? "" : "s"}: ${backups.map(shortenHomePath).join(", ")}`
+          : "no legacy JSON backup needed";
       result.changes.push(
-        `Migrated auth profile JSON for ${shortenHomePath(candidate.authPath)} into SQLite (backup${backups.length === 1 ? "" : "s"}: ${backups.map(shortenHomePath).join(", ")}).`,
+        `Migrated auth profile JSON for ${shortenHomePath(candidate.authPath)} into SQLite (${backupText}).`,
       );
       if (awsSdkMarkerStore) {
         result.changes.push(

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -1,6 +1,7 @@
 /** Doctor repairs for legacy auth profile JSON stores and OpenAI provider-id migrations. */
 import fs from "node:fs";
 import path from "node:path";
+import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveAgentDir, resolveDefaultAgentDir, listAgentIds } from "../agents/agent-scope.js";
@@ -26,6 +27,7 @@ import type {
   AuthProfileState,
   AuthProfileStore,
 } from "../agents/auth-profiles/types.js";
+import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { AuthProfileConfig } from "../config/types.auth.js";
@@ -94,6 +96,86 @@ function extractProviderFromProfileId(profileId: string): string | undefined {
     return undefined;
   }
   return readNonEmptyString(profileId.slice(0, colon));
+}
+
+function extractProviderFromModelRef(modelRef: string): string | undefined {
+  const { model } = splitTrailingAuthProfile(modelRef);
+  const slash = model.indexOf("/");
+  if (slash <= 0) {
+    return undefined;
+  }
+  return readNonEmptyString(model.slice(0, slash));
+}
+
+function collectLegacyConfigAuthProfileProviderHints(
+  cfg: OpenClawConfig,
+): ReadonlyMap<string, string> {
+  const hints = new Map<string, string>();
+  const conflicted = new Set<string>();
+  const addHint = (profileId: string, provider: string): void => {
+    const existing = hints.get(profileId);
+    if (existing && existing !== provider) {
+      hints.delete(profileId);
+      conflicted.add(profileId);
+      return;
+    }
+    if (!conflicted.has(profileId)) {
+      hints.set(profileId, provider);
+    }
+  };
+  const addModelHints = (models: unknown): void => {
+    if (!isRecord(models)) {
+      return;
+    }
+    for (const [modelRef, rawModel] of Object.entries(models)) {
+      const provider = extractProviderFromModelRef(modelRef);
+      if (!provider || !isSafeLegacyProviderKey(provider) || !isRecord(rawModel)) {
+        continue;
+      }
+      const agentRuntime = isRecord(rawModel.agentRuntime) ? rawModel.agentRuntime : null;
+      const authProfileId = agentRuntime
+        ? readNonEmptyString(agentRuntime.authProfileId)
+        : undefined;
+      if (authProfileId) {
+        addHint(authProfileId, provider);
+      }
+    }
+  };
+
+  for (const { value } of collectConfiguredModelRefs(cfg)) {
+    const { profile } = splitTrailingAuthProfile(value);
+    const provider = extractProviderFromModelRef(value);
+    if (profile && provider && isSafeLegacyProviderKey(provider)) {
+      addHint(profile, provider);
+    }
+  }
+
+  const root: Record<string, unknown> = cfg;
+  const auth = isRecord(root.auth) ? root.auth : null;
+  const order = auth && isRecord(auth.order) ? auth.order : null;
+  if (order) {
+    for (const [provider, profileIds] of Object.entries(order)) {
+      if (!isSafeLegacyProviderKey(provider) || !Array.isArray(profileIds)) {
+        continue;
+      }
+      for (const profileId of profileIds) {
+        const normalizedProfileId = readNonEmptyString(profileId);
+        if (normalizedProfileId) {
+          addHint(normalizedProfileId, provider);
+        }
+      }
+    }
+  }
+  const agents = isRecord(root.agents) ? root.agents : null;
+  const defaults = agents && isRecord(agents.defaults) ? agents.defaults : null;
+  addModelHints(defaults?.models);
+  const agentList = agents && Array.isArray(agents.list) ? agents.list : [];
+  for (const agent of agentList) {
+    if (isRecord(agent)) {
+      addModelHints(agent.models);
+    }
+  }
+  return hints;
 }
 
 function inferLegacyCredentialType(
@@ -299,6 +381,41 @@ function collectAuthProfileStateProfileIds(state: AuthProfileState): string[] {
   return [...profileIds];
 }
 
+function inferLegacyConfigAuthProfileMode(
+  raw: Record<string, unknown>,
+): AuthProfileCredential["type"] | undefined {
+  const explicit = readNonEmptyString(raw.mode) ?? readNonEmptyString(raw.type);
+  if (explicit === "api_key" || explicit === "token" || explicit === "oauth") {
+    return explicit;
+  }
+  if (
+    readNonEmptyString(raw.key) ||
+    readNonEmptyString(raw.apiKey) ||
+    readNonEmptyString(raw["api_key"]) ||
+    coerceSecretRef(raw.keyRef) ||
+    coerceSecretRef(raw.key) ||
+    coerceSecretRef(raw.apiKey) ||
+    coerceSecretRef(raw["api_key"])
+  ) {
+    return "api_key";
+  }
+  if (
+    readNonEmptyString(raw.token) ||
+    coerceSecretRef(raw.tokenRef) ||
+    coerceSecretRef(raw.token)
+  ) {
+    return "token";
+  }
+  if (
+    readNonEmptyString(raw.access) &&
+    readNonEmptyString(raw.refresh) &&
+    typeof raw.expires === "number"
+  ) {
+    return "oauth";
+  }
+  return undefined;
+}
+
 function coerceLegacyConfigAuthProfileStore(cfg: OpenClawConfig): AuthProfileStore | null {
   const cfgRecord: Record<string, unknown> = cfg;
   const auth = isRecord(cfgRecord.auth) ? cfgRecord.auth : null;
@@ -306,22 +423,30 @@ function coerceLegacyConfigAuthProfileStore(cfg: OpenClawConfig): AuthProfileSto
   if (!profiles) {
     return null;
   }
+  const providerHints = collectLegacyConfigAuthProfileProviderHints(cfg);
   const store: RawAuthProfileImportStore = { version: AUTH_STORE_VERSION, profiles: {} };
   for (const [profileId, raw] of Object.entries(profiles)) {
     if (!isRecord(raw)) {
       continue;
     }
-    const mode = readNonEmptyString(raw.mode) ?? readNonEmptyString(raw.type);
+    const mode = inferLegacyConfigAuthProfileMode(raw);
     if (mode !== "api_key" && mode !== "token" && mode !== "oauth") {
       continue;
     }
-    const provider = readNonEmptyString(raw.provider) ?? extractProviderFromProfileId(profileId);
+    const provider =
+      readNonEmptyString(raw.provider) ??
+      extractProviderFromProfileId(profileId) ??
+      providerHints.get(profileId);
     if (!provider || !isSafeLegacyProviderKey(provider)) {
       continue;
     }
     const next: Record<string, unknown> = { ...raw, provider, mode };
     if (mode === "api_key") {
-      const keyRef = coerceSecretRef(raw.keyRef) ?? coerceSecretRef(raw.key);
+      const keyRef =
+        coerceSecretRef(raw.keyRef) ??
+        coerceSecretRef(raw.key) ??
+        coerceSecretRef(raw.apiKey) ??
+        coerceSecretRef(raw["api_key"]);
       const key =
         readNonEmptyString(raw.key) ??
         readNonEmptyString(raw.apiKey) ??
@@ -358,12 +483,6 @@ function coerceLegacyConfigAuthProfileStore(cfg: OpenClawConfig): AuthProfileSto
     }
     store.profiles[profileId] = next;
   }
-  if (auth && isRecord(auth.order)) {
-    const state = coerceAuthProfileState({ order: auth.order });
-    if (state.order) {
-      store.order = state.order;
-    }
-  }
   const canonicalStore = coercePersistedAuthProfileStore(store);
   return canonicalStore && Object.keys(canonicalStore.profiles).length > 0 ? canonicalStore : null;
 }
@@ -399,14 +518,39 @@ function stripImportedConfigAuthProfileCredentials(
   return changed;
 }
 
+function hasUsableAuthProfileCredential(credential: AuthProfileCredential): boolean {
+  if (credential.type === "api_key") {
+    return Boolean(readNonEmptyString(credential.key) || credential.keyRef);
+  }
+  if (credential.type === "token") {
+    return Boolean(readNonEmptyString(credential.token) || credential.tokenRef);
+  }
+  return (
+    Boolean(readNonEmptyString(credential.access)) &&
+    Boolean(readNonEmptyString(credential.refresh)) &&
+    typeof credential.expires === "number"
+  );
+}
+
 function mergeImportedAuthProfiles(params: {
   store: AuthProfileStore;
   profiles: AuthProfileStore["profiles"];
   existingProfileIds: ReadonlySet<string>;
+  replaceExistingWithoutCredential?: boolean;
 }): AuthProfileStore {
   const profiles = { ...params.store.profiles };
   for (const [profileId, credential] of Object.entries(params.profiles)) {
     if (!params.existingProfileIds.has(profileId)) {
+      profiles[profileId] = credential;
+      continue;
+    }
+    const existing = profiles[profileId];
+    if (
+      params.replaceExistingWithoutCredential &&
+      existing &&
+      !hasUsableAuthProfileCredential(existing) &&
+      hasUsableAuthProfileCredential(credential)
+    ) {
       profiles[profileId] = credential;
     }
   }
@@ -743,11 +887,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         ? maybeCanonicalStore
         : null;
       const configCanonicalStore =
-        configStore &&
-        isDefaultAgentCandidate(candidate, params.cfg, env) &&
-        !hasLegacyAuthProfileSource(candidate)
-          ? configStore
-          : null;
+        configStore && isDefaultAgentCandidate(candidate, params.cfg, env) ? configStore : null;
       const legacyStore = loadLegacyAuthProfileStore(candidate.agentDir);
       const rawState = fs.existsSync(candidate.statePath)
         ? loadJsonFile(candidate.statePath)
@@ -809,15 +949,13 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         for (const profileId of Object.keys(configCanonicalStore.profiles)) {
           importedProfileIds.add(profileId);
         }
+        // Config imports fill missing SQLite credentials only; when both exist,
+        // the canonical per-agent SQLite store wins over legacy config secrets.
         next = mergeImportedAuthProfiles({
           store: next,
           profiles: configCanonicalStore.profiles,
-          existingProfileIds,
-        });
-        next = mergeImportedAuthProfileState({
-          store: next,
-          state: coerceAuthProfileState(configCanonicalStore),
-          existingState,
+          existingProfileIds: new Set(Object.keys(next.profiles)),
+          replaceExistingWithoutCredential: true,
         });
       }
       if (hasAuthProfileState(state)) {


### PR DESCRIPTION
## Summary
- Import legacy default-agent `auth.profiles` credentials into the per-agent SQLite auth store when no per-agent JSON files exist.
- Strip migrated config credential fields back to metadata-only entries and mark the config changed so doctor does not repeat the import or leave secrets in config.
- Metadata-only config profiles remain metadata-only and are not converted into usable credentials.

## Root Cause (full chain)
Symptom: After a 2026.6.1 -> 2026.6.6 upgrade, the default agent can start with an empty auth SQLite store and provider auth fails.
Layer 1: The SQLite migration candidate detector only considered per-agent `auth-profiles.json`, `auth-state.json`, or legacy `auth.json` files.
Layer 2: The default agent's shipped legacy setup could keep static auth under global `openclaw.json auth.profiles`, with no per-agent JSON source file.
Layer 3: Runtime auth now reads the per-agent SQLite store and does not reconstruct provider credentials from global config.
Root cause: Doctor migration skipped the only legacy credential source for the default agent, then runtime correctly consumed the empty canonical store.
Missing guardrail: No regression test covered a default-agent upgrade where global config had importable auth profile credentials but per-agent auth JSON files were absent.

## Fix
- Build a doctor-only import store from legacy secret-bearing `auth.profiles` entries for the default agent.
- Reuse the existing persisted auth-profile coercion path for imported credentials.
- After SQLite verification succeeds, replace migrated config entries with metadata-only `provider`/`mode`/label fields and set `configChanged`.

## Compatibility
| Scenario | Before | After |
|----------|--------|-------|
| Per-agent legacy JSON exists | Imported into SQLite with backups | Same behavior |
| Default agent has legacy config credential fields only | No migration candidate, empty store remains | Importable credentials are written to SQLite |
| Metadata-only `auth.profiles` entry | Not a runtime credential | Still not imported as a credential |
| Existing SQLite profile id | Existing SQLite credential wins | Preserved by existing import merge rules |

## Real behavior proof
**Behavior addressed:** Default-agent config auth credentials with no per-agent JSON are migrated into the canonical SQLite store.
**Real environment tested:** Node v22.22.0 on Linux, branch head after rebasing on current `origin/main`.
**Exact steps or command run after this patch:** Called the actual doctor migration and auth-store load functions from source via `node --import tsx`.
**Evidence after fix:**

```text
{
  "configChanged": true,
  "detected": [
    "auth-profiles.json"
  ],
  "changes": 1,
  "warnings": [],
  "profiles": [
    "openai:default"
  ],
  "configProfileAfter": {
    "provider": "openai",
    "mode": "api_key"
  },
  "routerImported": false,
  "openai": {
    "type": "api_key",
    "provider": "openai",
    "key": "sk-config"
  }
}
```

**Observed result after fix:** The default agent's SQLite store contains the migrated `openai:default` credential, the source config is metadata-only afterward, and metadata-only `router:default` is not imported.
**What was not tested:** A live 2026.6.1-to-2026.6.6 upgrade on a user's machine; the proof uses the production doctor migration and SQLite auth-store code with an isolated temporary state directory.

## Regression Test Proof
Before applying the implementation, the same production probe returned no migration candidate and no profile:

```text
{
  "detected": [],
  "changes": 0,
  "warnings": [],
  "profiles": []
}
```

After the implementation, `node scripts/run-vitest.mjs src/commands/doctor-auth-flat-profiles.test.ts` includes the regression case `imports default-agent config auth profiles into sqlite when no legacy files exist` and passes.

## Verification
- `node scripts/run-vitest.mjs src/commands/doctor-auth-flat-profiles.test.ts`
- `node scripts/run-vitest.mjs src/agents/auth-profiles.sqlite-store.test.ts src/agents/model-auth.profiles.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` initially reported config cleanup risk; patch was updated to strip imported config credentials and set `configChanged`. A rerun timed out without a final verdict, so the fixed behavior is covered by the regression test and production proof above.

## User-visible / Behavior Changes
Running `openclaw doctor --fix` can now recover default-agent auth from legacy config credentials into SQLite instead of leaving the default agent with an empty canonical store.

## Security Impact
- New permissions? No
- Secrets handling changed? Yes, legacy config credential fields are moved into the auth SQLite store and stripped back to metadata after successful verification.
- New network calls? No

## Maintainer Crabbox Proof
**Behavior addressed:** Default-agent legacy `auth.profiles` credentials with no per-agent auth JSON are migrated into the canonical per-agent SQLite auth store.

**Real environment tested:** Crabbox remote Linux, provider `azure`, lease `cbx_41eb92450583`, run `run_1b6eb2db526c`.

**Exact steps or command run after this patch:** Ran a Crabbox before/after harness that cloned GitHub `openclaw/openclaw@main` and PR #93156 head, then called the production `maybeMigrateAuthProfileJsonStoresToSqlite` function with an isolated 2026.6.1-style config-only default-agent auth state.

**Evidence before fix (`origin/main` `caab3434612c835889bfff061935ec73ccd2430b`):**

```text
REPRO_ASSERT before: origin/main leaves config-only default auth unmigrated
detected: []
sqliteExists: false
profiles: {}
configProfilesAfter.openai:default: { provider: "openai", mode: "api_key", key: "<redacted>" }
```

**Evidence after fix (PR head `7e1b18bfee521b665ba227e10eb85764148f4073`):**

```text
REPRO_ASSERT after: fixed head migrates SQLite auth and strips config metadata
detected: ["<state>/.openclaw/agents/main/agent/auth-profiles.json"]
warnings: []
configChanged: true
sqliteExists: true
sqliteBytes: 4096
profiles.openai:default: { type: "api_key", provider: "openai", key: "<redacted>" }
profiles.anthropic:default: { type: "token", provider: "anthropic", tokenRef: { source: "env", provider: "default", id: "ANTHROPIC_TOKEN" } }
configProfilesAfter.openai:default: { provider: "openai", mode: "api_key" }
configProfilesAfter.anthropic:default: { provider: "anthropic", mode: "token" }
```

**Observed result after fix:** The PR head migrates usable default-agent auth into SQLite, strips legacy config credentials back to metadata, keeps metadata-only router auth out of SQLite, and emits no warnings.

Closes #93145