### PR TITLE
fix(tui): keep parent stdin paused after exit

### DIFF
--- a/src/tui/tui-launch.test.ts
+++ b/src/tui/tui-launch.test.ts
@@ -135,6 +135,19 @@ describe("launchTuiCli", () => {
     expect(options.stdio).toBe("inherit");
   });
 
+  it("keeps parent stdin paused after the relaunched TUI exits", async () => {
+    const child = createChildProcess();
+    spawnMock.mockImplementation((_cmd: string, _args: string[], _opts: SpawnOptions) => {
+      queueMicrotask(() => child.emit("exit", 0, null));
+      return child;
+    });
+
+    await launchTuiCli({ deliver: false });
+
+    expect(process.stdin.pause).toHaveBeenCalledOnce();
+    expect(process.stdin.resume).not.toHaveBeenCalled();
+  });
+
   it("launches compiled CLI shapes without repeating the current command", async () => {
     process.argv[1] = "setup";
     const child = createChildProcess();

--- a/src/tui/tui-launch.test.ts
+++ b/src/tui/tui-launch.test.ts
@@ -1,10 +1,12 @@
 // Covers TUI launch argument and environment construction.
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 const detachMock = vi.hoisted(() => vi.fn());
+let pauseSpy: MockInstance;
+let resumeSpy: MockInstance;
 
 vi.mock("node:child_process", () => ({
   spawn: spawnMock,
@@ -42,8 +44,8 @@ describe("launchTuiCli", () => {
     process.execArgv.length = 0;
     spawnMock.mockReset();
     detachMock.mockReset();
-    vi.spyOn(process.stdin, "pause").mockImplementation(() => process.stdin);
-    vi.spyOn(process.stdin, "resume").mockImplementation(() => process.stdin);
+    pauseSpy = vi.spyOn(process.stdin, "pause").mockImplementation(() => process.stdin);
+    resumeSpy = vi.spyOn(process.stdin, "resume").mockImplementation(() => process.stdin);
     vi.spyOn(process.stdin, "isPaused").mockReturnValue(false);
   });
 
@@ -144,8 +146,8 @@ describe("launchTuiCli", () => {
 
     await launchTuiCli({ deliver: false });
 
-    expect(process.stdin.pause).toHaveBeenCalledOnce();
-    expect(process.stdin.resume).not.toHaveBeenCalled();
+    expect(pauseSpy).toHaveBeenCalledOnce();
+    expect(resumeSpy).not.toHaveBeenCalled();
   });
 
   it("launches compiled CLI shapes without repeating the current command", async () => {

--- a/src/tui/tui-launch.ts
+++ b/src/tui/tui-launch.ts
@@ -96,10 +96,8 @@ export async function launchTuiCli(
             : {}),
         }
       : process.env;
-  const stdinWasPaused =
-    typeof process.stdin.isPaused === "function" ? process.stdin.isPaused() : false;
-
-  // Pause parent stdin while the child owns the terminal, then restore the previous state.
+  // Pause parent stdin while the inherited-stdio child owns the terminal.
+  // Keep it paused afterward so setup/container parents with stdin_open can exit.
   process.stdin.pause();
 
   await new Promise<void>((resolve, reject) => {
@@ -126,9 +124,5 @@ export async function launchTuiCli(
       }
       resolve();
     });
-  }).finally(() => {
-    if (!stdinWasPaused) {
-      process.stdin.resume();
-    }
   });
 }

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -541,10 +541,10 @@ describe("finalizeSetupWizard", () => {
     ).rejects.toThrow("TUI exited with code 1");
 
     expect(restoreTerminalState).toHaveBeenCalledWith("pre-setup tui", {
-      resumeStdinIfPaused: true,
+      resumeStdinIfPaused: false,
     });
     expect(restoreTerminalState).toHaveBeenCalledWith("post-setup tui", {
-      resumeStdinIfPaused: true,
+      resumeStdinIfPaused: false,
     });
   });
 

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -529,7 +529,7 @@ export async function finalizeSetupWizard(
     });
 
     if (hatchChoice === "tui") {
-      restoreTerminalState("pre-setup tui", { resumeStdinIfPaused: true });
+      restoreTerminalState("pre-setup tui", { resumeStdinIfPaused: false });
       try {
         await launchTuiCli({
           local: true,
@@ -538,7 +538,7 @@ export async function finalizeSetupWizard(
           timeoutMs: HATCH_TUI_TIMEOUT_MS,
         });
       } finally {
-        restoreTerminalState("post-setup tui", { resumeStdinIfPaused: true });
+        restoreTerminalState("post-setup tui", { resumeStdinIfPaused: false });
       }
       launchedTui = true;
     } else if (hatchChoice === "web") {


### PR DESCRIPTION
## Summary

- Keep the parent CLI stdin stream paused after an inherited-stdio TUI child exits so `/exit` does not leave the parent process/container alive.
- Stop onboarding finalize cleanup from resuming stdin around the post-setup TUI handoff.
- Add focused regression coverage for the parent-stdin lifecycle.

## Verification

- Pre-fix clean-head PTY reproduction: parent script called `launchTuiCli`, child exited 0, output printed `launch returned`, then timed out waiting for parent exit with status 124.
- Azure Crabbox real PTY reproduction (`run_aa5f98a89a2c`, lease `cbx_5c205da5a519`): same parent/child PTY proof printed `launch returned` and exited 0 while the PTY master remained open.
- `node scripts/run-vitest.mjs src/tui/tui-launch.test.ts src/wizard/setup.finalize.test.ts` -> 23 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts` -> 13 tests passed.
- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed` -> passed typecheck, lint, guards, and import-cycle checks.
- `git diff --check` -> passed.
- Trusted autoreview -> `autoreview clean: no accepted/actionable findings reported`.

## Real behavior proof

Behavior or issue addressed: Bare/inherited-stdio TUI `/exit` can return from the child while the parent process remains alive because parent stdin was resumed.
Real environment tested: Azure Crabbox Linux PTY using `@lydell/node-pty`, preserving the PTY master open after the child TUI process exits.
Exact steps or command run after this patch: Ran a PTY reproduction that imports `src/tui/tui-launch.ts`, marks parent stdin flowing with `process.stdin.resume()`, launches an inherited-stdio child entry that exits 0 for `tui`, and waits up to 4 seconds for the parent to exit.
Evidence after fix (copied live console output):

```text
PTY output:
launch returned
PTY result: {"exitCode":0,"signal":0,"timedOut":false}
```

Observed result after fix: Parent process exits after the TUI child exits, so the container/PTY is not kept alive by a resumed stdin stream.
What was not tested: Full Docker interactive package lane was not run; the focused PTY proof covers the inherited-stdio lifecycle that caused the observed Docker hang.
