### PR TITLE
fix(process): default killProcessTree to direct-pid kill, opt-in group-kill via detached:true (fixes #76259)

### DIFF
--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -14,11 +14,13 @@ export type KillProcessTreeOptions = {
  * Best-effort process-tree termination with graceful shutdown.
  * - Windows: use taskkill /T to include descendants. Sends SIGTERM-equivalent
  *   first (without /F), then force-kills if process survives.
- * - Unix: send SIGTERM to process group first, wait grace period, then SIGKILL.
+ * - Unix: send SIGTERM to the process, wait grace period, then SIGKILL.
  *
- * When the child was spawned with `detached: false`, pass `detached: false` to
- * skip the Unix `process.kill(-pid, ...)` group-kill. That avoids signaling the
- * gateway's own process group.
+ * By default, Unix kills use direct `process.kill(pid, ...)` only. Pass
+ * `detached: true` to opt into `process.kill(-pid, ...)` group-kill, which
+ * targets the entire process group. Group-kill is only safe when the child
+ * was spawned with `detached: true` and is its own process group leader;
+ * otherwise it signals the caller's own group — including the gateway.
  */
 export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): void {
   if (!Number.isFinite(pid) || pid <= 0) {
@@ -35,7 +37,7 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
     return;
   }
 
-  const useGroupKill = opts?.detached !== false;
+  const useGroupKill = opts?.detached === true;
   if (opts?.force === true) {
     signalProcessTreeUnix(pid, "SIGKILL", useGroupKill);
     return;
@@ -68,7 +70,7 @@ export function signalProcessTree(
     return;
   }
 
-  signalProcessTreeUnix(pid, signal, opts?.detached !== false);
+  signalProcessTreeUnix(pid, signal, opts?.detached === true);
 }
 
 function normalizeGraceMs(value?: number): number {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -498,7 +498,7 @@ export async function runCommandWithTimeout(
             // Fall through to Node's direct child kill as a last resort.
           }
         }
-        terminateProcessTree(child.pid, { graceMs: COMMAND_PROCESS_TREE_KILL_GRACE_MS });
+        terminateProcessTree(child.pid, { graceMs: COMMAND_PROCESS_TREE_KILL_GRACE_MS, detached: true });
         return;
       }
       if (process.platform === "win32" && typeof child.pid === "number" && child.pid > 0) {

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -90,9 +90,6 @@ describe("killProcessTree", () => {
 
   it("on Unix sends SIGTERM first and skips SIGKILL when process exits", async () => {
     killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
-      if (pid === -3333 && signal === 0) {
-        throw new Error("ESRCH");
-      }
       if (pid === 3333 && signal === 0) {
         throw new Error("ESRCH");
       }
@@ -104,15 +101,14 @@ describe("killProcessTree", () => {
 
       await vi.advanceTimersByTimeAsync(10);
 
-      expect(killSpy).toHaveBeenCalledWith(-3333, "SIGTERM");
-      expect(killSpy).not.toHaveBeenCalledWith(-3333, "SIGKILL");
+      expect(killSpy).toHaveBeenCalledWith(3333, "SIGTERM");
       expect(killSpy).not.toHaveBeenCalledWith(3333, "SIGKILL");
     });
   });
 
   it("on Unix sends SIGKILL after grace period when process is still alive", async () => {
     killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
-      if (pid === -4444 && signal === 0) {
+      if (pid === 4444 && signal === 0) {
         return true;
       }
       return true;
@@ -123,8 +119,8 @@ describe("killProcessTree", () => {
 
       await vi.advanceTimersByTimeAsync(5);
 
-      expect(killSpy).toHaveBeenCalledWith(-4444, "SIGTERM");
-      expect(killSpy).toHaveBeenCalledWith(-4444, "SIGKILL");
+      expect(killSpy).toHaveBeenCalledWith(4444, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(4444, "SIGKILL");
     });
   });
 
@@ -136,8 +132,8 @@ describe("killProcessTree", () => {
       await vi.advanceTimersByTimeAsync(60_000);
 
       expect(killSpy).toHaveBeenCalledTimes(1);
-      expect(killSpy).toHaveBeenCalledWith(-4949, "SIGKILL");
-      expect(killSpy).not.toHaveBeenCalledWith(-4949, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(4949, "SIGKILL");
+      expect(killSpy).not.toHaveBeenCalledWith(4949, "SIGTERM");
     });
   });
 
@@ -153,7 +149,7 @@ describe("killProcessTree", () => {
     }) as typeof process.kill);
 
     await withMockedPlatform("linux", async () => {
-      killProcessTree(4545, { graceMs: 5 });
+      killProcessTree(4545, { graceMs: 5, detached: true });
 
       await vi.advanceTimersByTimeAsync(5);
 
@@ -184,11 +180,30 @@ describe("killProcessTree", () => {
     });
   });
 
-  it("on Unix uses group kill by default (detached:true preserved as the existing behavior)", async () => {
+  it("on Unix uses group kill when detached:true is explicit", async () => {
     killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
-      if (pid === -6666 && signal === 0) {
+      if (pid === -7777 && signal === 0) {
         throw new Error("ESRCH");
       }
+      if (pid === 7777 && signal === 0) {
+        throw new Error("ESRCH");
+      }
+      return true;
+    }) as typeof process.kill);
+
+    await withMockedPlatform("linux", async () => {
+      killProcessTree(7777, { graceMs: 10, detached: true });
+      await vi.advanceTimersByTimeAsync(10);
+
+      // Explicit detached:true opts into group kill — safe when the child
+      // was spawned detached and is its own process group leader.
+      expect(killSpy).toHaveBeenCalledWith(-7777, "SIGTERM");
+      expect(killSpy).not.toHaveBeenCalledWith(-7777, "SIGKILL");
+    });
+  });
+
+  it("on Unix uses direct pid kill by default (group kill requires explicit detached:true, #76259)", async () => {
+    killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
       if (pid === 6666 && signal === 0) {
         throw new Error("ESRCH");
       }
@@ -199,7 +214,12 @@ describe("killProcessTree", () => {
       killProcessTree(6666, { graceMs: 10 });
       await vi.advanceTimersByTimeAsync(10);
 
-      expect(killSpy).toHaveBeenCalledWith(-6666, "SIGTERM");
+      // Default is safe: direct pid kill only. Group kill (`-pid`) would
+      // SIGTERM the gateway's own process group when the child was not spawned
+      // detached. Callers must pass `detached: true` to opt into group kill.
+      expect(killSpy).toHaveBeenCalledWith(6666, "SIGTERM");
+      expect(killSpy).not.toHaveBeenCalledWith(-6666, "SIGTERM");
+      expect(killSpy).not.toHaveBeenCalledWith(-6666, "SIGKILL");
     });
   });
 
@@ -212,8 +232,23 @@ describe("killProcessTree", () => {
       await vi.advanceTimersByTimeAsync(60_000);
 
       expect(killSpy).toHaveBeenCalledTimes(1);
-      expect(killSpy).toHaveBeenCalledWith(-7777, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(7777, "SIGTERM");
+      expect(killSpy).not.toHaveBeenCalledWith(-7777, "SIGTERM");
       expect(killSpy).not.toHaveBeenCalledWith(-7777, "SIGKILL");
+    });
+  });
+
+  it("on Unix signalProcessTree uses group kill when detached:true is explicit", async () => {
+    killSpy.mockImplementation(() => true);
+
+    await withMockedPlatform("linux", async () => {
+      signalProcessTree(7788, "SIGTERM", { detached: true });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(killSpy).toHaveBeenCalledTimes(1);
+      expect(killSpy).toHaveBeenCalledWith(-7788, "SIGTERM");
+      expect(killSpy).not.toHaveBeenCalledWith(7788, "SIGTERM");
     });
   });
 


### PR DESCRIPTION
## Real behavior proof

- **Behavior addressed:** `killProcessTree` defaults to Unix group-kill (`process.kill(-pid, ...)`) which sends SIGTERM to the caller's own process group when the child was not spawned detached. This kills the gateway on macOS when a timed-out agent CLI child shares the gateway's process group.
- **Environment tested:** macOS Darwin 26.4.1, node v24, OpenClaw local build from upstream/main
- **Steps run after the patch:**
  1. Applied the two-line default-swap in `packages/agent-core/src/harness/env/kill-tree.ts` (`opts?.detached !== false` → `opts?.detached === true`) and added `detached: true` to the `terminateProcessTree` call in `src/process/exec.ts:501`
  2. Ran `kill-tree.test.ts` (13 tests) and `exec.test.ts` (12 tests)
  3. Ran `pnpm build` to verify compilation

- **Evidence after fix:**

```
$ grep -n 'useGroupKill' packages/agent-core/src/harness/env/kill-tree.ts
40:  const useGroupKill = opts?.detached === true;

$ grep -n 'terminateProcessTree' src/process/exec.ts
501:        terminateProcessTree(child.pid, { graceMs: COMMAND_PROCESS_TREE_KILL_GRACE_MS, detached: true });

$ npx vitest run src/process/kill-tree.test.ts src/process/exec.test.ts
 ✓  process  src/process/kill-tree.test.ts (13 tests) 12ms
 ✓  process  src/process/exec.test.ts (12 tests) 147ms
 Test Files  2 passed (2)
      Tests  25 passed (25)

$ pnpm build
✓ built in 506ms
```

- **Observed result after fix:** `killProcessTree` now defaults to direct `process.kill(pid, ...)` — safe when the child shares the caller's process group. Group-kill (`process.kill(-pid, ...)`) is opt-in via `detached: true`, which `exec.ts` passes explicitly when the child was spawned detached. All 25 tests pass. Build succeeds.
- **What was not tested:** Live macOS gateway restart scenario (requires a running gateway + Telegram dispatch). The test suite validates the signal-targeting logic with mocked `process.kill`.
