### PR TITLE
fix(agents): skip bootstrap seeding in inherited nested workspaces (#83593)

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -480,6 +480,84 @@ describe("ensureAgentWorkspace", () => {
     await expectCompletedWithoutBootstrap(tempDir);
   });
 
+  it("does not re-seed an existing directory nested under an ancestor workspace marker", async () => {
+    // A nested git worktree or relocated agent subdir under an established workspace is
+    // inherited project content, not a new workspace, so a session/subagent run must not
+    // recreate bootstrap templates the user removed or relocated there (#83593).
+    const parent = await makeTempWorkspace("openclaw-workspace-");
+    const markerPath = path.join(parent, ...WORKSPACE_STATE_PATH_SEGMENTS);
+    await fs.mkdir(path.dirname(markerPath), { recursive: true });
+    await fs.writeFile(
+      markerPath,
+      JSON.stringify({ version: 1, setupCompletedAt: new Date().toISOString() }),
+    );
+    // Nested dir with existing content (a git worktree) but no bootstrap files.
+    const nested = path.join(parent, "github", "project");
+    await fs.mkdir(path.join(nested, ".git"), { recursive: true });
+    await fs.writeFile(path.join(nested, ".git", "HEAD"), "ref: refs/heads/main\n");
+
+    await ensureAgentWorkspace({ dir: nested, ensureBootstrapFiles: true });
+
+    for (const name of [
+      DEFAULT_AGENTS_FILENAME,
+      DEFAULT_SOUL_FILENAME,
+      DEFAULT_TOOLS_FILENAME,
+      DEFAULT_IDENTITY_FILENAME,
+      DEFAULT_USER_FILENAME,
+      DEFAULT_HEARTBEAT_FILENAME,
+      DEFAULT_BOOTSTRAP_FILENAME,
+    ]) {
+      await expectPathMissing(path.join(nested, name));
+    }
+    await expectPathMissing(path.join(nested, ...WORKSPACE_STATE_PATH_SEGMENTS));
+  });
+
+  it("still seeds a brand-new secondary-agent directory nested under a workspace marker", async () => {
+    // Regression guard: a freshly created secondary agent whose workspace resolves under
+    // `agents.defaults.workspace` is empty (brand new), so it must still receive starter
+    // files even though an ancestor owns the workspace marker (#83593).
+    const parent = await makeTempWorkspace("openclaw-workspace-");
+    const markerPath = path.join(parent, ...WORKSPACE_STATE_PATH_SEGMENTS);
+    await fs.mkdir(path.dirname(markerPath), { recursive: true });
+    await fs.writeFile(
+      markerPath,
+      JSON.stringify({ version: 1, setupCompletedAt: new Date().toISOString() }),
+    );
+    const nested = path.join(parent, "bravo");
+    await fs.mkdir(nested, { recursive: true });
+
+    await ensureAgentWorkspace({ dir: nested, ensureBootstrapFiles: true });
+
+    await expect(fs.access(path.join(nested, DEFAULT_AGENTS_FILENAME))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(nested, DEFAULT_TOOLS_FILENAME))).resolves.toBeUndefined();
+  });
+
+  it("still repairs a nested workspace that owns its marker even under an ancestor marker", async () => {
+    // A real secondary-agent workspace nested under `agents.defaults.workspace` has its OWN
+    // `.openclaw/workspace-state.json`. Even with an ancestor marker it must keep the normal
+    // seeding/repair path, so a required file removed after setup (TOOLS.md) is restored (#83593).
+    const parent = await makeTempWorkspace("openclaw-workspace-");
+    const parentMarker = path.join(parent, ...WORKSPACE_STATE_PATH_SEGMENTS);
+    await fs.mkdir(path.dirname(parentMarker), { recursive: true });
+    await fs.writeFile(
+      parentMarker,
+      JSON.stringify({ version: 1, setupCompletedAt: new Date().toISOString() }),
+    );
+    // Established nested agent workspace: own marker + existing AGENTS.md, but TOOLS.md is gone.
+    const nested = path.join(parent, "bravo");
+    const nestedMarker = path.join(nested, ...WORKSPACE_STATE_PATH_SEGMENTS);
+    await fs.mkdir(path.dirname(nestedMarker), { recursive: true });
+    await fs.writeFile(
+      nestedMarker,
+      JSON.stringify({ version: 1, setupCompletedAt: new Date().toISOString() }),
+    );
+    await fs.writeFile(path.join(nested, DEFAULT_AGENTS_FILENAME), "# agents\n");
+
+    await ensureAgentWorkspace({ dir: nested, ensureBootstrapFiles: true });
+
+    await expect(fs.access(path.join(nested, DEFAULT_TOOLS_FILENAME))).resolves.toBeUndefined();
+  });
+
   it("skips configured optional bootstrap files without skipping required files", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
 

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -458,6 +458,23 @@ function resolveWorkspaceStatePath(dir: string): string {
   return path.join(dir, WORKSPACE_STATE_DIRNAME, WORKSPACE_STATE_FILENAME);
 }
 
+// True when `dir` sits inside an already-established OpenClaw workspace: one of its
+// ancestors owns a `.openclaw/workspace-state.json` marker. The seeding guard combines
+// this with a non-empty-content check to skip re-seeding inherited project content
+// (#83593). The walk starts at the parent so a dir's own marker never affects its seeding.
+async function hasAncestorWorkspaceMarker(dir: string): Promise<boolean> {
+  let current = path.resolve(dir);
+  let parent = path.dirname(current);
+  while (parent !== current) {
+    if (await pathExists(resolveWorkspaceStatePath(parent))) {
+      return true;
+    }
+    current = parent;
+    parent = path.dirname(current);
+  }
+  return false;
+}
+
 export function resolveWorkspaceAttestationPath(dir: string): string {
   return resolveWorkspaceAttestationPathInStateDir(dir, resolveStateDir());
 }
@@ -846,6 +863,23 @@ export async function ensureAgentWorkspace(params?: {
     if (hasContentEvidence) {
       await maybeWriteWorkspaceAttestation(attestationPath, dir);
     }
+    return { dir };
+  }
+
+  // A non-empty directory nested inside an existing OpenClaw workspace (an ancestor owns
+  // `.openclaw/workspace-state.json`) that is NOT itself a workspace (no marker of its own)
+  // is inherited project content: a nested git worktree or relocated files. Re-seeding
+  // bootstrap templates there recreates files the user removed/relocated and litters the
+  // parent workspace (#83593). Directories with their own marker keep the normal
+  // seeding/repair path, and empty dirs still seed, so real nested agent workspaces (e.g. a
+  // secondary agent under `agents.defaults.workspace`) keep their starter files and repair.
+  const nestedUnderWorkspace = await hasAncestorWorkspaceMarker(dir);
+  const ownsWorkspaceMarker = await pathExists(resolveWorkspaceStatePath(dir));
+  if (
+    nestedUnderWorkspace &&
+    !ownsWorkspaceMarker &&
+    (await hasSkipBootstrapWorkspaceContentEvidence(dir))
+  ) {
     return { dir };
   }
 


### PR DESCRIPTION
## Summary

`ensureAgentWorkspace` re-seeds bootstrap templates (`SOUL.md`, `USER.md`, `IDENTITY.md`, `HEARTBEAT.md`, …) into directories nested **inside** an already-established OpenClaw workspace, because it only consulted the directory's *own* `.openclaw/workspace-state.json` marker — never an ancestor's. As reported in #83593, spawning a subagent (or starting a session in a nested git worktree) recreates bootstrap files the user intentionally relocated under the real workspace root, littering the parent workspace.

`resolveAgentWorkspaceDir` legitimately places secondary-agent workspaces at `path.join(agents.defaults.workspace, agentId)` — i.e. *inside* the established workspace — which is the structural root of the bug.

### Fix

Before seeding, skip only when the directory (a) is nested under an **ancestor** workspace marker, (b) does **not** own a workspace marker of its own, and (c) already holds non-trivial content (`hasSkipBootstrapWorkspaceContentEvidence`). That precisely targets inherited project content — a nested git worktree or relocated files.

- A directory that **owns** its `.openclaw/workspace-state.json` (a real secondary-agent workspace) keeps the normal seeding/repair path, so a required file removed after setup is still restored.
- An **empty** directory still seeds, so a freshly created secondary agent under `agents.defaults.workspace` keeps its starter files.
- Real workspace **roots** have no ancestor marker and are unaffected.

This matches the maintainer review's "narrow workspace-boundary fix … preserving documented starter-file creation for real workspace roots and required setup files," and avoids the two earlier closed attempts' pitfalls — no broad `isBrandNewWorkspace` gate, no hardcoded subdir names.

### Changes

- `src/agents/workspace.ts`: add `hasAncestorWorkspaceMarker(dir)` (walks ancestors for `.openclaw/workspace-state.json`); add the seeding guard in `ensureAgentWorkspace` (ancestor marker + no own marker + existing content).
- `src/agents/workspace.test.ts`: three regression tests — inherited content under a marker is **not** re-seeded; a brand-new nested secondary-agent dir **still** seeds; a nested workspace that **owns** its marker still repairs a missing required file under an ancestor marker.

## Real behavior proof

- Behavior addressed: a subagent/session run recreates bootstrap files (`SOUL.md`, `USER.md`, `IDENTITY.md`, `HEARTBEAT.md`, `AGENTS.md`, `TOOLS.md`) inside a directory nested under an already-established OpenClaw workspace (#83593).
- Real environment tested: macOS (Darwin 25.x), Node 22, driving the real exported `ensureAgentWorkspace` from `src/agents/workspace.ts` against real on-disk directories under an isolated `OPENCLAW_HOME`, reproducing the nested-workspace seeding path a subagent run hits. Branch cut from current `origin/main`.
- Exact steps or command run after this patch: created an established workspace at `<parent>/.openclaw/workspace-state.json`; created a nested project directory `<parent>/github/my-project` containing `.git/` and `README.md` (no marker of its own); invoked `ensureAgentWorkspace({ dir: nested, ensureBootstrapFiles: true })`; then listed the nested directory. Ran it on this branch (with the fix) and again with `src/agents/workspace.ts` reverted to `origin/main` (without the fix).
- Before evidence (without the fix, on `origin/main`): the nested project directory is littered with generated bootstrap files —
  ```
  nested dir BEFORE ensureAgentWorkspace: .git README.md
  nested dir AFTER  ensureAgentWorkspace: .git .openclaw AGENTS.md HEARTBEAT.md IDENTITY.md README.md SOUL.md TOOLS.md USER.md
  ```
- Evidence after fix: the same real run, on this branch, leaves the nested project directory exactly as it was —
  ```
  nested dir BEFORE ensureAgentWorkspace: .git README.md
  nested dir AFTER  ensureAgentWorkspace: .git README.md
  ```
- Observed result after fix: the nested project directory is left untouched — `ensureAgentWorkspace` no longer writes `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, or a nested `.openclaw/` into it. A brand-new (empty) nested directory, and a nested directory that owns its own marker, both still seed/repair, so freshly created and established secondary agents are unaffected.
- What was not tested: a live Telegram/macOS end-to-end subagent spawn through a model. The reproduction above drives the exact production `ensureAgentWorkspace` filesystem path the subagent flow uses; the reporter's original root-level symptom is separately addressed by the existing cwd/workspace split, so this targets the remaining source-reproducible nested case.

## Automated checks (supplemental)

- `src/agents/workspace.test.ts`: 49/49, including three new regression tests covering the ancestor-marker boundary (inherited content skipped; brand-new nested still seeded; own-marker nested still repaired).
- `src/agents/subagent-spawn.workspace.test.ts`, `spawned-context.test.ts`, `bootstrap-files.test.ts`, `attempt.cwd-split.test.ts`, `attempt.spawn-workspace.sessions-spawn.test.ts`: all green.
- `oxfmt --check`, `oxlint`, `tsgo:core`, `tsgo:core:test`: clean.

Fixes #83593
