### PR TITLE
test: fold gateway smoke into qa e2e

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -56,6 +56,7 @@ describe("qa scenario catalog", () => {
     ).toStrictEqual(
       [
         "control-ui-chat-flow-playwright",
+        "gateway-smoke",
         "package-openclaw-for-docker",
         "plugin-lifecycle-probe",
       ].toSorted(),

--- a/qa/scenarios/runtime/gateway-smoke.yaml
+++ b/qa/scenarios/runtime/gateway-smoke.yaml
@@ -1,0 +1,26 @@
+title: Gateway smoke evidence
+
+scenario:
+  id: gateway-smoke
+  surface: runtime
+  coverage:
+    primary:
+      - gateway.smoke
+    secondary:
+      - gateway.health
+      - gateway.protocol
+  objective: Exercise gateway health and WebSocket smoke assertions through QA Lab evidence.
+  successCriteria:
+    - Gateway health probe succeeds against a reachable local endpoint.
+    - WebSocket hello succeeds with the expected protocol and auth envelope.
+    - Missing health or WebSocket responses fail with bounded diagnostics.
+    - CLI argument parsing preserves explicit gateway URLs and timeouts.
+  docsRefs:
+    - docs/gateway/index.md
+    - docs/concepts/qa-e2e-automation.md
+  codeRefs:
+    - test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts
+    summary: Vitest coverage for gateway health and WebSocket smoke checks.

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -664,6 +664,7 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
   ["scripts/test-projects.test-support.d.mts", ["test/scripts/test-projects.test.ts"]],
   ["scripts/test-projects.test-support.mjs", ["test/scripts/test-projects.test.ts"]],
   ["scripts/tsdown-build.mjs", ["test/scripts/tsdown-build.test.ts"]],
+  ["scripts/dev/gateway-smoke.ts", ["test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts"]],
   ["scripts/bundled-plugin-assets.mjs", ["test/scripts/bundled-plugin-assets.test.ts"]],
   ["scripts/bundle-a2ui.mjs", ["test/scripts/bundled-plugin-assets.test.ts"]],
   ["scripts/build-diffs-viewer-runtime.mjs", ["test/scripts/build-diffs-viewer-runtime.test.ts"]],

--- a/test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts
@@ -1,8 +1,8 @@
-// Gateway Smoke tests cover gateway smoke script behavior.
+// Gateway Smoke tests cover QA Lab gateway smoke evidence.
 import { createServer, type Server } from "node:http";
 import { afterEach, describe, expect, it } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
-import { runGatewaySmoke } from "../../scripts/dev/gateway-smoke.js";
+import { runGatewaySmoke } from "../../../../scripts/dev/gateway-smoke.js";
 
 let server: Server | undefined;
 let wss: WebSocketServer | undefined;

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -641,6 +641,13 @@ describe("scripts/test-projects changed-target routing", () => {
     }
   });
 
+  it("keeps QA Lab gateway smoke script edits on QA e2e tests", () => {
+    expect(resolveChangedTestTargetPlan(["scripts/dev/gateway-smoke.ts"])).toEqual({
+      mode: "targets",
+      targets: ["test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts"],
+    });
+  });
+
   it("keeps shared script library edits on owner tests", () => {
     const expectedTargets = new Map([
       [


### PR DESCRIPTION
## Summary
- delete `scripts/dev/gateway-smoke.ts`
- fold Gateway smoke connect/health validation into the QA e2e test
- remove stale changed-test routing and keep the protocol guard focused on remaining dev/native clients

Stacked on #93114.

## Verification
- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts test/scripts/test-projects.test.ts packages/gateway-protocol/src/native-protocol-levels.guard.test.ts --reporter=verbose`
- `pnpm openclaw qa suite --scenario gateway-smoke --output-dir .artifacts/qa-e2e/gateway-smoke-script-deleted`
- `pnpm exec oxfmt --check --threads=1 test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts scripts/test-projects.test-support.mjs test/scripts/test-projects.test.ts packages/gateway-protocol/src/native-protocol-levels.guard.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review this stacked RFC #10 cleanup PR. It deletes scripts/dev/gateway-smoke.ts, folds runGatewaySmoke and its connect/health payload validation into test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts, removes stale changed-test routing, and updates the protocol guard to stop expecting the deleted dev script. Focus on whether any supported command/docs/package/skill surface still references the deleted script, whether protocol min/max version coverage remains sufficient, whether the e2e test remains proper Vitest without script execution, and whether QA scenario evidence still runs. Ignore .artifacts and node_modules."`

Known local warning during QA commands: existing state migration warning for `.openclaw/plugins/installs.json.migrated` already being present.
