### PR TITLE
fix(memory): clean rollback-journal reindex temp sidecar on NFS stores

### DIFF
--- a/extensions/memory-core/src/memory/manager-db-probe.test.ts
+++ b/extensions/memory-core/src/memory/manager-db-probe.test.ts
@@ -121,6 +121,54 @@ describe("openMemoryDatabaseAtPath readOnly probe", () => {
     await expectPathMissing(`${orphanBase}-shm`);
   });
 
+  it("removes aged orphan reindex temp files including the rollback-journal sidecar", async () => {
+    const dbPath = path.join(fixtureRoot, `case-${caseId++}`, "index.sqlite");
+    const dir = path.dirname(dbPath);
+    await fs.mkdir(dir, { recursive: true });
+    const seed = new DatabaseSync(dbPath);
+    seed.exec("CREATE TABLE IF NOT EXISTS meta(key TEXT PRIMARY KEY, value TEXT)");
+    seed.close();
+
+    // NFS-backed stores keep journal_mode=DELETE, so a hard crash during a
+    // reindex leaves a rollback-journal sidecar (.tmp-<uuid>-journal) rather
+    // than -wal/-shm. Cleanup must remove it alongside the temp main file.
+    const orphanBase = `${dbPath}.tmp-22222222-3333-4444-5555-666666666666`;
+    for (const suffix of ["", "-journal"]) {
+      const filePath = `${orphanBase}${suffix}`;
+      await fs.writeFile(filePath, "orphan");
+      const old = new Date(Date.now() - 48 * 60 * 60_000);
+      await fs.utimes(filePath, old, old);
+    }
+
+    const db = openMemoryDatabaseAtPath(dbPath, false);
+    db.close();
+
+    await expectPathMissing(orphanBase);
+    await expectPathMissing(`${orphanBase}-journal`);
+  });
+
+  it("removes a stranded rollback-journal sidecar whose temp main file is already gone", async () => {
+    const dbPath = path.join(fixtureRoot, `case-${caseId++}`, "index.sqlite");
+    const dir = path.dirname(dbPath);
+    await fs.mkdir(dir, { recursive: true });
+    const seed = new DatabaseSync(dbPath);
+    seed.exec("CREATE TABLE IF NOT EXISTS meta(key TEXT PRIMARY KEY, value TEXT)");
+    seed.close();
+
+    // Only the rollback journal survives (its temp main file was already
+    // removed). The discovery set must still recognize the orphan by its
+    // -journal suffix, otherwise it leaks forever.
+    const strandedJournal = `${dbPath}.tmp-33333333-4444-5555-6666-777777777777-journal`;
+    await fs.writeFile(strandedJournal, "stranded journal");
+    const old = new Date(Date.now() - 48 * 60 * 60_000);
+    await fs.utimes(strandedJournal, old, old);
+
+    const db = openMemoryDatabaseAtPath(dbPath, false);
+    db.close();
+
+    await expectPathMissing(strandedJournal);
+  });
+
   it("keeps young reindex temp files during live database startup", async () => {
     const dbPath = path.join(fixtureRoot, `case-${caseId++}`, "index.sqlite");
     const dir = path.dirname(dbPath);

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -19,8 +19,8 @@ import {
 // own a young temp DB without losing its in-flight rebuild.
 const reindexTempFileWithoutLockMinAgeMs = 24 * 60 * 60_000;
 const reindexTempUuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-const memoryIndexFileSuffixes = ["", "-wal", "-shm"] as const;
-const reindexTempEntrySuffixes = ["-wal", "-shm", ""] as const;
+const memoryIndexFileSuffixes = ["", "-wal", "-shm", "-journal"] as const;
+const reindexTempEntrySuffixes = ["-wal", "-shm", "-journal", ""] as const;
 
 function resolveReindexTempBaseName(dbBaseName: string, entryName: string): string | undefined {
   for (const suffix of reindexTempEntrySuffixes) {


### PR DESCRIPTION
## Summary

`cleanupAgedMemoryReindexTempFiles` (added in #92891) removes aged orphaned reindex temp databases at memory-store startup, but it only knows about the **WAL** sidecars `-wal`/`-shm`. On NFS-backed memory stores the temp database is **not** in WAL mode: `openMemoryReindexTempDatabaseAtPath` → `openConfiguredMemoryDatabaseAtPath` → `configureMemorySqliteWalMaintenance` → `requireRollbackJournalMode` forces `journal_mode=DELETE` (`src/infra/sqlite-wal.ts`, refusing WAL on NFS). A reindex temp DB therefore uses a **rollback journal**, and a hard crash mid-reindex leaves an orphaned `<db>.tmp-<uuid>-journal`.

Because neither the delete set (`memoryIndexFileSuffixes = ["", "-wal", "-shm"]`) nor the discovery set (`reindexTempEntrySuffixes = ["-wal", "-shm", ""]`) includes `-journal`, that journal leaks **forever**: (1) when the temp main + `-journal` are both present, cleanup deletes the main/wal/shm but not the journal; (2) when only the stranded `.tmp-<uuid>-journal` remains, the discovery set can't recognize it (its `uuid` slice ends in `-journal`, failing the UUID pattern), so it is never scanned.

## What changed

- `extensions/memory-core/src/memory/manager-db.ts` — add `"-journal"` to both constants: `memoryIndexFileSuffixes` (so the rollback journal is deleted alongside the temp triple) and `reindexTempEntrySuffixes` (so a stranded `.tmp-<uuid>-journal` whose temp main file is already gone is still discovered and removed). Single file, two constants; the WAL (`-wal`/`-shm`) path is unchanged.

## Real behavior proof

- **Behavior addressed:** orphaned reindex temp rollback journals (`.tmp-<uuid>-journal`) leaked forever on NFS-backed stores (`journal_mode=DELETE`) because the startup cleanup only handled `-wal`/`-shm`.
- **Real environment tested:** local OpenClaw from source on Linux, vitest driving the **real exported `cleanupAgedMemoryReindexTempFiles`** via the real `openMemoryDatabaseAtPath` startup path — seeding a real SQLite live db plus real on-disk orphan temp files (48h-old mtime) in a `mkdtemp` fixture, with readback via `fs.access` over the real disk. No mocks.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-db-probe.test.ts`
- **Evidence after fix (terminal capture):**
  ```
  $ node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-db-probe.test.ts
   Test Files  1 passed (1)
        Tests  13 passed (13)
  ```
  Two new cases: (1) an aged orphan temp with a `-journal` sidecar is removed (main + journal both gone); (2) a stranded `.tmp-<uuid>-journal` whose temp main file is already gone is discovered and removed.
- **Observed result after fix:** the aged orphan reindex temp's `-journal` is deleted with its main file, and a stranded rollback journal is now discovered and removed instead of leaking.
- **What was not tested:** an actual NFS mount + hard crash physically producing the journal — the fixture reproduces the exact filename/age/on-disk state the cleanup scans; `journal_mode=DELETE` on NFS is what `src/infra/sqlite-wal.ts` already forces.
- **Negative control:** reverting the two constants to the pre-fix `["", "-wal", "-shm"]` / `["-wal", "-shm", ""]` and re-running the suite fails exactly on the two new `-journal` cases (`2 failed | 11 passed`) — the journal leaks — confirming the fix is required and the tests are not tautologies.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-db-probe.test.ts` → 13 passed (added 2 rollback-journal cases; the existing 11 unchanged).
- Negative control (revert the two constants) → the 2 new cases fail (the journal leaks).
- `tsgo:extensions` / `tsgo:extensions:test` → no new errors in changed files; `oxfmt --write` clean.

## Risk checklist

- User-visible behavior change? Cleanup now also removes orphaned **rollback-journal** reindex temp sidecars on NFS-backed stores; the WAL (`-wal`/`-shm`) path is byte-for-byte unchanged.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? No.
- Highest-risk area: deleting a file — guarded by the existing reindex lock, the 48h age threshold, and the `isRegularFile(dbPath)` live-DB guard (all unchanged); `-journal` only ever matches `.tmp-<uuid>-journal` temp artifacts via the UUID pattern.
