### PR TITLE
[codex] Fix /btw Codex runtime side-question routing

### DIFF
--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -297,7 +297,6 @@ function markdownTableColumnCount(row: string): number {
 }
 
 function findRichMarkdownTableLineIndexes(
-  markdown: string,
   lines: readonly string[],
   fenceSpans: readonly RichMarkdownFenceSpan[],
 ): Set<number> {
@@ -336,7 +335,7 @@ function preserveTelegramRichMarkdownLineBreaks(markdown: string): string {
 
   const fenceSpans = parseRichMarkdownFenceSpans(markdown);
   const lines = markdown.split("\n");
-  const tableLineIndexes = findRichMarkdownTableLineIndexes(markdown, lines, fenceSpans);
+  const tableLineIndexes = findRichMarkdownTableLineIndexes(lines, fenceSpans);
   const out: string[] = [];
   let offset = 0;
   for (let index = 0; index < lines.length; index += 1) {

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -641,6 +641,65 @@ describe("runBtwSideQuestion", () => {
     expect(registerProviderStreamForModelMock).not.toHaveBeenCalled();
   });
 
+  it("reselects the Codex hook after resolving legacy openai-codex route state", async () => {
+    const codexSideQuestionMock = vi.fn().mockResolvedValue({ text: "Codex side answer." });
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex test harness",
+      supports: (ctx) =>
+        ctx.provider === "openai"
+          ? { supported: true, priority: 100 }
+          : { supported: false, reason: "openai only" },
+      runAttempt: vi.fn(),
+      runSideQuestion: codexSideQuestionMock,
+    });
+    resolveModelWithRegistryMock.mockReturnValue({
+      provider: "openai",
+      id: "gpt-5.5",
+      api: "openai-responses",
+    });
+    resolveSessionAuthProfileOverrideMock.mockResolvedValue("openai-codex:user@example.test");
+
+    const result = await runSideQuestion({
+      cfg: {
+        auth: {
+          order: {
+            openai: ["openai-codex:user@example.test"],
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": {
+                agentRuntime: { id: "codex" },
+              },
+            },
+          },
+        },
+      } as never,
+      provider: "openai-codex",
+      model: "gpt-5.5",
+      sessionKey: DEFAULT_SESSION_KEY,
+    });
+
+    expect(result).toEqual({ text: "Codex side answer." });
+    expect(codexSideQuestionMock).toHaveBeenCalledTimes(1);
+    const sideQuestionParams = mockArg(codexSideQuestionMock, 0, 0) as {
+      provider?: string;
+      authProfileId?: string;
+    };
+    expect(sideQuestionParams.provider).toBe("openai");
+    expect(sideQuestionParams.authProfileId).toBe("openai-codex:user@example.test");
+    const authArgs = mockArg(resolveSessionAuthProfileOverrideMock, 0, 0) as {
+      provider?: string;
+      acceptedProviderIds?: string[];
+    };
+    expect(authArgs.provider).toBe("openai");
+    expect(authArgs.acceptedProviderIds).toEqual(["openai"]);
+    expect(streamSimpleMock).not.toHaveBeenCalled();
+    expect(registerProviderStreamForModelMock).not.toHaveBeenCalled();
+  });
+
   it("does not fall back to the direct provider call when Codex lacks BTW support", async () => {
     registerAgentHarness({
       id: "codex",

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -31,6 +31,7 @@ import { resolveModelWithRegistry } from "./embedded-agent-runner/model.js";
 import { getActiveEmbeddedRunSnapshot } from "./embedded-agent-runner/runs.js";
 import { resolveEmbeddedAgentStreamFn } from "./embedded-agent-runner/stream-resolution.js";
 import { resolveAvailableAgentHarnessPolicy, selectAgentHarness } from "./harness/selection.js";
+import type { AgentHarness } from "./harness/types.js";
 import {
   resolveImageSanitizationLimits,
   type ImageSanitizationLimits,
@@ -319,15 +320,17 @@ async function resolveRuntimeModel(params: {
   if (!model) {
     throw new Error(`Unknown model: ${params.provider}/${params.model}`);
   }
+  const runtimeProvider = model.provider;
+  const runtimeModelId = model.id;
 
   const authProfileId = await resolveSessionAuthProfileOverride({
     cfg: params.cfg,
-    provider: params.provider,
+    provider: runtimeProvider,
     acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
-      provider: params.provider,
+      provider: runtimeProvider,
       harnessRuntime: resolveAvailableAgentHarnessPolicy({
-        provider: params.provider,
-        modelId: params.model,
+        provider: runtimeProvider,
+        modelId: runtimeModelId,
         config: params.cfg,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
@@ -465,33 +468,50 @@ export async function runBtwSideQuestion(
     agentId: sessionAgentId,
     sessionKey: params.sessionKey,
   });
-  if (harness.runSideQuestion) {
-    const { model, authProfileId, authProfileIdSource } = await resolveRuntimeModel({
-      cfg: params.cfg,
-      provider: params.provider,
-      model: params.model,
-      agentId: sessionAgentId,
-      agentDir: params.agentDir,
-      workspaceDir,
-      sessionEntry: params.sessionEntry,
-      sessionStore: params.sessionStore,
-      sessionKey: params.sessionKey,
-      storePath: params.storePath,
-      isNewSession: params.isNewSession,
-    });
-    const result = await harness.runSideQuestion({
+  let runtimeSelection: Awaited<ReturnType<typeof resolveRuntimeModel>> | undefined;
+  const resolveRuntimeSelection = async () => {
+    if (!runtimeSelection) {
+      runtimeSelection = await resolveRuntimeModel({
+        cfg: params.cfg,
+        provider: params.provider,
+        model: params.model,
+        agentId: sessionAgentId,
+        agentDir: params.agentDir,
+        workspaceDir,
+        sessionEntry: params.sessionEntry,
+        sessionStore: params.sessionStore,
+        sessionKey: params.sessionKey,
+        storePath: params.storePath,
+        isNewSession: params.isNewSession,
+      });
+    }
+    return runtimeSelection;
+  };
+  const runHarnessSideQuestion = async (
+    selectedHarness: AgentHarness,
+    runtime: Awaited<ReturnType<typeof resolveRuntimeModel>>,
+  ): Promise<ReplyPayload | undefined> => {
+    if (!selectedHarness.runSideQuestion) {
+      throw new Error(
+        `Selected agent harness "${selectedHarness.id}" does not support /btw side questions.`,
+      );
+    }
+    const result = await selectedHarness.runSideQuestion({
       ...params,
-      provider: model.provider,
-      model: model.id,
-      runtimeModel: model,
+      provider: runtime.model.provider,
+      model: runtime.model.id,
+      runtimeModel: runtime.model,
       sessionId,
       sessionFile,
       agentId: sessionAgentId,
       workspaceDir,
-      authProfileId,
-      authProfileIdSource,
+      authProfileId: runtime.authProfileId,
+      authProfileIdSource: runtime.authProfileIdSource,
     });
     return { text: result.text };
+  };
+  if (harness.runSideQuestion) {
+    return runHarnessSideQuestion(harness, await resolveRuntimeSelection());
   }
   if (harness.id === "codex") {
     throw new Error(`Selected agent harness "${harness.id}" does not support /btw side questions.`);
@@ -522,6 +542,23 @@ export async function runBtwSideQuestion(
   }
   if (messages.length === 0 && !inFlightPrompt?.trim()) {
     throw new Error("No active session context.");
+  }
+
+  const runtimeSelectionForHarness = await resolveRuntimeSelection();
+  const runtimeHarness = selectAgentHarness({
+    provider: runtimeSelectionForHarness.model.provider,
+    modelId: runtimeSelectionForHarness.model.id,
+    config: params.cfg,
+    agentId: sessionAgentId,
+    sessionKey: params.sessionKey,
+  });
+  if (runtimeHarness.runSideQuestion) {
+    return runHarnessSideQuestion(runtimeHarness, runtimeSelectionForHarness);
+  }
+  if (runtimeHarness.id === "codex") {
+    throw new Error(
+      `Selected agent harness "${runtimeHarness.id}" does not support /btw side questions.`,
+    );
   }
 
   const fallbackPolicy = resolveAvailableAgentHarnessPolicy({
@@ -588,19 +625,7 @@ export async function runBtwSideQuestion(
     });
   }
 
-  const { model, authProfileId, authProfileIdSource } = await resolveRuntimeModel({
-    cfg: params.cfg,
-    provider: params.provider,
-    model: params.model,
-    agentId: sessionAgentId,
-    agentDir: params.agentDir,
-    workspaceDir,
-    sessionEntry: params.sessionEntry,
-    sessionStore: params.sessionStore,
-    sessionKey: params.sessionKey,
-    storePath: params.storePath,
-    isNewSession: params.isNewSession,
-  });
+  const { model, authProfileId, authProfileIdSource } = runtimeSelectionForHarness;
   let externalCliAuthScope = resolveExternalCliAuthOverlayScopeFromSelection({
     provider: model.provider,
     cfg: params.cfg,


### PR DESCRIPTION
Closes #88902.

Resolves `/btw` to the canonical runtime model before committing to a side-question route, then reselects the harness with the canonical provider/model. This lets stale legacy `openai-codex` route state use the Codex side-question handling instead of falling into the public OpenAI Responses path.

Adds regression coverage for the stale `openai-codex` route-state case and carries the current-main Telegram unused-parameter cleanup needed for `check-prod-types` while #93185 is still open.

## Real behavior proof
Behavior addressed: stale legacy `openai-codex` `/btw` route state now reselects the Codex side-question harness after resolving to canonical `openai/gpt-5.5`.

Real environment tested: local OpenClaw source checkout on macOS with the real harness selection registry and a temporary Codex proof harness registered for canonical OpenAI routes.

Exact steps or command run after this patch: ran a local `node --import tsx` smoke that registers the Codex harness, checks stale `openai-codex/gpt-5.5` selection, then checks canonical `openai/gpt-5.5` selection. Also ran the focused `/btw` regression shard, adjacent command/auth/Codex side-question shards, and `pnpm tsgo:prod` after the rebase.

Evidence after fix:
```text
OpenClaw /btw harness reselection proof
stale route input: openai-codex/gpt-5.5 -> harness=openclaw, sideQuestion=false
canonical runtime route: openai/gpt-5.5 -> harness=codex, sideQuestion=true
canonical hook output: Codex hook received openai/gpt-5.5

[test] passed 1 Vitest shard in 40.17s
[test] passed 3 Vitest shards in 55.80s
pnpm tsgo:prod exited 0
```

Observed result after fix: once the runtime model is canonicalized, the side-question path reaches the Codex harness hook with `openai/gpt-5.5` instead of using the direct OpenAI Responses fallback, and production TypeScript typechecking is green.

What was not tested: live Telegram delivery and live Codex OAuth/account execution were not run.
