### PR TITLE
fix(ui): preserve live tool stream order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 - **Agent terminal failures:** surface a safe interactive reply when an agent run ends without visible output, while preserving completed message-tool delivery and heartbeat-specific guidance. (#99304) Thanks @moeedahmed.
 - **MCP loopback tool results:** preserve schema-valid text, image, and embedded-resource content through HTTP tool calls while rendering malformed or protocol-incompatible blocks as safe text. (#100336) Thanks @tzy-17.
 - **Control UI tool-result images:** render direct image content blocks from Gateway history and make the delayed-send scroll E2E setup deterministic. (#100295) Thanks @lzyyzznl.
+- **Control UI live tool ordering:** keep assistant stream text before its matching tool card when browser and Gateway timestamps disagree. (#93184) Thanks @Pick-cat.
 - **Plugin approval diagnostics:** distinguish request validation rejections, expired wait decisions, and unavailable Gateways while keeping approval failures fail-closed. (#100337) Thanks @tzy-17.
 - **IRC Unicode messages:** split outbound PRIVMSG payloads on UTF-16 code-point boundaries so emoji cannot be cut into lone surrogates. (#96572) Thanks @llagy009.
 - **OpenAI realtime voice greetings:** prevent server VAD from creating a second outbound greeting while an explicit greeting response owns the turn, without disabling caller interruption. (#86285) Thanks @giodl73-repo.

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -1510,4 +1510,70 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await closeBrowserContext(context);
     }
   });
+
+  it("keeps live assistant stream text before the matching tool card", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+
+      const prompt = "stream before tool";
+      await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+
+      const sendRequest = await gateway.waitForRequest("chat.send");
+      const params = requireRecord(sendRequest.params);
+      const runId = requireString(params.idempotencyKey, "chat send idempotency key");
+
+      await gateway.emitGatewayEvent("chat", {
+        message: {
+          content: [{ text: "I will inspect the file.", type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+        runId,
+        sessionKey: "main",
+        state: "delta",
+      });
+      await page.getByText("I will inspect the file.").waitFor({ timeout: 10_000 });
+
+      await gateway.emitGatewayEvent("agent", {
+        data: {
+          args: { path: "README.md" },
+          name: "read",
+          phase: "start",
+          toolCallId: "call-read",
+        },
+        runId,
+        seq: 1,
+        sessionKey: "main",
+        stream: "tool",
+        ts: Date.now() - 10_000,
+      });
+      await page.locator(".chat-bubble--tool-shell").waitFor({ timeout: 10_000 });
+
+      const visibleOrder = await page.locator(".chat-thread").evaluate((thread: Element) => {
+        return Array.from(thread.querySelectorAll(".chat-group")).flatMap((group: Element) => {
+          const text = group.textContent ?? "";
+          if (text.includes("I will inspect the file.")) {
+            return ["assistant stream"];
+          }
+          if (group.querySelector(".chat-bubble--tool-shell")) {
+            return ["tool card"];
+          }
+          return [];
+        });
+      });
+
+      expect(visibleOrder).toEqual(["assistant stream", "tool card"]);
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
 });

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -1532,6 +1532,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       const runId = requireString(params.idempotencyKey, "chat send idempotency key");
 
       await gateway.emitGatewayEvent("chat", {
+        deltaText: "I will inspect the file.",
         message: {
           content: [{ text: "I will inspect the file.", type: "text" }],
           role: "assistant",
@@ -1545,9 +1546,9 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
 
       await gateway.emitGatewayEvent("agent", {
         data: {
-          args: { path: "README.md" },
           name: "read",
-          phase: "start",
+          phase: "result",
+          result: "file contents",
           toolCallId: "call-read",
         },
         runId,
@@ -1556,7 +1557,8 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         stream: "tool",
         ts: Date.now() - 10_000,
       });
-      await page.locator(".chat-bubble--tool-shell").waitFor({ timeout: 10_000 });
+      const toolBubble = page.locator('[data-message-id^="tool:assistant:call-read"]');
+      await toolBubble.waitFor({ timeout: 10_000 });
 
       const visibleOrder = await page.locator(".chat-thread").evaluate((thread: Element) => {
         return Array.from(thread.querySelectorAll(".chat-group")).flatMap((group: Element) => {
@@ -1564,7 +1566,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
           if (text.includes("I will inspect the file.")) {
             return ["assistant stream"];
           }
-          if (group.querySelector(".chat-bubble--tool-shell")) {
+          if (group.querySelector('[data-message-id^="tool:assistant:call-read"]')) {
             return ["tool card"];
           }
           return [];

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -791,6 +791,95 @@ describe("buildChatItems", () => {
     expect(streamItems).toHaveLength(1);
   });
 
+  it("keeps a live tool card after the stream segment that introduced it", () => {
+    const items = buildChatItems(
+      createProps({
+        streamSegments: [{ text: "I will inspect the file.", ts: 2_000, toolCallId: "call-read" }],
+        toolMessages: [
+          {
+            role: "toolResult",
+            toolCallId: "call-read",
+            toolName: "read",
+            content: "file contents",
+            timestamp: 1_000,
+          },
+        ],
+      }),
+    );
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      kind: "stream",
+      text: "I will inspect the file.",
+    });
+    expect(messageRecord(requireGroup(items[1])).toolCallId).toBe("call-read");
+  });
+
+  it("keeps same-millisecond stream segments interleaved with their matching tool cards", () => {
+    const items = buildChatItems(
+      createProps({
+        streamSegments: [
+          { text: "First tool.", ts: 2_000, toolCallId: "call-read" },
+          { text: "First tool. Second tool.", ts: 2_000, toolCallId: "call-list" },
+        ],
+        toolMessages: [
+          {
+            role: "toolResult",
+            toolCallId: "call-read",
+            toolName: "read",
+            content: "file contents",
+            timestamp: 1_000,
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call-list",
+            toolName: "list",
+            content: "file list",
+            timestamp: 1_000,
+          },
+        ],
+      }),
+    );
+
+    expect(items).toHaveLength(4);
+    expect(items[0]).toMatchObject({ kind: "stream", text: "First tool." });
+    expect(messageRecord(requireGroup(items[1])).toolCallId).toBe("call-read");
+    expect(items[2]).toMatchObject({ kind: "stream", text: "Second tool." });
+    expect(messageRecord(requireGroup(items[3])).toolCallId).toBe("call-list");
+  });
+
+  it("keeps a live tool card ordered with its stream segment when a keyed preamble precedes it", () => {
+    const items = buildChatItems(
+      createProps({
+        streamSegments: [
+          { text: "Checking workspace", ts: 1_500, itemId: "preamble-1" },
+          { text: "I will inspect the file.", ts: 2_000, toolCallId: "call-read" },
+        ],
+        toolMessages: [
+          {
+            role: "toolResult",
+            toolCallId: "call-read",
+            toolName: "read",
+            content: "file contents",
+            timestamp: 1_000,
+          },
+        ],
+      }),
+    );
+
+    expect(items).toHaveLength(3);
+    expect(items[0]).toMatchObject({
+      kind: "stream",
+      text: "Checking workspace",
+      startedAt: 1_500,
+    });
+    expect(items[1]).toMatchObject({
+      kind: "stream",
+      text: "I will inspect the file.",
+    });
+    expect(messageRecord(requireGroup(items[2])).toolCallId).toBe("call-read");
+  });
+
   it("suppresses metadata-only history messages before grouping", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -848,12 +848,16 @@ describe("buildChatItems", () => {
     expect(messageRecord(requireGroup(items[3])).toolCallId).toBe("call-list");
   });
 
-  it("keeps a live tool card ordered with its stream segment when a keyed preamble precedes it", () => {
+  it("keeps a live tool card after its stream segment when an unkeyed preamble shifts indexes", () => {
     const items = buildChatItems(
       createProps({
         streamSegments: [
-          { text: "Checking workspace", ts: 1_500, itemId: "preamble-1" },
-          { text: "I will inspect the file.", ts: 2_000, toolCallId: "call-read" },
+          { text: "Checking workspace", ts: 1_500 },
+          {
+            text: "Checking workspace I will inspect the file.",
+            ts: 2_000,
+            toolCallId: "call-read",
+          },
         ],
         toolMessages: [
           {

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -693,9 +693,10 @@ function sortChatItemsByVisibleTime(
       return {
         item,
         index,
+        predecessorKey,
         timestamp:
-          timestamp != null && predecessorTimestamp != null && timestamp <= predecessorTimestamp
-            ? predecessorTimestamp
+          timestamp != null && predecessorTimestamp != null
+            ? Math.max(timestamp, predecessorTimestamp)
             : timestamp,
       };
     })
@@ -711,6 +712,12 @@ function sortChatItemsByVisibleTime(
       }
       if (a.timestamp !== b.timestamp) {
         return a.timestamp - b.timestamp;
+      }
+      if (a.predecessorKey === b.item.key) {
+        return 1;
+      }
+      if (b.predecessorKey === a.item.key) {
+        return -1;
       }
       return a.index - b.index;
     })
@@ -977,6 +984,17 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   const segments = props.streamSegments ?? [];
   const keyedSegments = segments.filter(streamSegmentHasItemId);
   const indexedSegments = segments.filter((segment) => !streamSegmentHasItemId(segment));
+  const toolItems = tools.map((message, index) => ({
+    key: messageKey(message, index + history.length),
+    message,
+  }));
+  const toolKeysByCallId = new Map<string, string>();
+  for (const tool of toolItems) {
+    const toolCallId = asRecord(tool.message)?.toolCallId;
+    if (typeof toolCallId === "string" && toolCallId.trim()) {
+      toolKeysByCallId.set(toolCallId.trim(), tool.key);
+    }
+  }
   const maxLen = Math.max(indexedSegments.length, tools.length);
   let previousAccumulatedStreamText: string | null = null;
   const toolStreamPredecessors = new Map<string, string>();
@@ -1001,27 +1019,20 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
           isStreaming: false,
         });
         const toolCallId = segment.toolCallId?.trim();
-        if (toolCallId) {
-          const matchingToolIndex = tools.findIndex((tool, toolIndex) => {
-            if (toolIndex < i) {
-              return false;
-            }
-            return asRecord(tool)?.toolCallId === toolCallId;
-          });
-          if (matchingToolIndex >= 0) {
-            toolStreamPredecessors.set(
-              messageKey(tools[matchingToolIndex], matchingToolIndex + history.length),
-              streamKey,
-            );
-          }
+        const toolKey = toolCallId ? toolKeysByCallId.get(toolCallId) : undefined;
+        if (toolKey) {
+          // Gateway and browser clocks can disagree. Keep the assistant text that
+          // introduced a tool causally before its card even when timestamps do not.
+          toolStreamPredecessors.set(toolKey, streamKey);
         }
       }
     }
-    if (i < tools.length && props.showToolCalls) {
+    const tool = toolItems[i];
+    if (tool && props.showToolCalls) {
       items.push({
         kind: "message",
-        key: messageKey(tools[i], i + history.length),
-        message: tools[i],
+        key: tool.key,
+        message: tool.message,
       });
     }
   }

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -674,9 +674,31 @@ function timestampAfterVisibleItems(items: ChatItem[], desiredTimestamp: number)
     : desiredTimestamp;
 }
 
-function sortChatItemsByVisibleTime(items: ChatItem[]): ChatItem[] {
+function sortChatItemsByVisibleTime(
+  items: ChatItem[],
+  toolStreamPredecessors: ReadonlyMap<string, string>,
+): ChatItem[] {
+  const timestampsByKey = new Map<string, number>();
+  for (const item of items) {
+    const timestamp = chatItemTimestamp(item);
+    if (timestamp != null) {
+      timestampsByKey.set(item.key, timestamp);
+    }
+  }
   return items
-    .map((item, index) => ({ item, index, timestamp: chatItemTimestamp(item) }))
+    .map((item, index) => {
+      const timestamp = chatItemTimestamp(item);
+      const predecessorKey = toolStreamPredecessors.get(item.key);
+      const predecessorTimestamp = predecessorKey ? timestampsByKey.get(predecessorKey) : null;
+      return {
+        item,
+        index,
+        timestamp:
+          timestamp != null && predecessorTimestamp != null && timestamp <= predecessorTimestamp
+            ? predecessorTimestamp
+            : timestamp,
+      };
+    })
     .toSorted((a, b) => {
       if (a.timestamp == null && b.timestamp == null) {
         return a.index - b.index;
@@ -957,6 +979,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   const indexedSegments = segments.filter((segment) => !streamSegmentHasItemId(segment));
   const maxLen = Math.max(indexedSegments.length, tools.length);
   let previousAccumulatedStreamText: string | null = null;
+  const toolStreamPredecessors = new Map<string, string>();
   for (let i = 0; i < maxLen; i++) {
     if (i < indexedSegments.length) {
       const segment = indexedSegments[i];
@@ -969,13 +992,29 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
         previousAccumulatedStreamText = text;
       }
       if (visibleText.length > 0) {
+        const streamKey = `stream-seg:${props.sessionKey}:${i}`;
         items.push({
           kind: "stream",
-          key: `stream-seg:${props.sessionKey}:${i}`,
+          key: streamKey,
           text: visibleText,
           startedAt: segment.ts,
           isStreaming: false,
         });
+        const toolCallId = segment.toolCallId?.trim();
+        if (toolCallId) {
+          const matchingToolIndex = tools.findIndex((tool, toolIndex) => {
+            if (toolIndex < i) {
+              return false;
+            }
+            return asRecord(tool)?.toolCallId === toolCallId;
+          });
+          if (matchingToolIndex >= 0) {
+            toolStreamPredecessors.set(
+              messageKey(tools[matchingToolIndex], matchingToolIndex + history.length),
+              streamKey,
+            );
+          }
+        }
       }
     }
     if (i < tools.length && props.showToolCalls) {
@@ -1048,7 +1087,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   return annotateToolTurnOutcome(
     groupMessages(
       collapseSequentialDuplicateMessages(
-        coalesceToolActivityMessages(sortChatItemsByVisibleTime(items)),
+        coalesceToolActivityMessages(sortChatItemsByVisibleTime(items, toolStreamPredecessors)),
       ),
     ),
   );


### PR DESCRIPTION
Fixes #92122.

## What Problem This Solves

During a live WebChat turn, a tool event can carry an older timestamp than the assistant stream segment that introduced the call. Timestamp-only sorting then renders the tool card before its causal assistant text; refreshing later restores the persisted order.

## Why This Change Was Made

The projection now carries the existing `toolCallId` into each live stream item, maps matching stream predecessors once, and adds one causal tie-break: a matching tool card cannot sort before the stream segment that introduced it. All unrelated history, stream, and tool entries retain timestamp/stable ordering. This keeps ownership in the renderer and avoids producer, Gateway, or transport changes.

## User Impact

Live assistant text stays before the tool card it introduced, including clock-skewed events. Other transcript ordering remains unchanged.

## Evidence

- Unit coverage includes older tool timestamps, same-millisecond calls, multiple call pairs, and an unkeyed preamble that shifts insertion indexes.
- Real-Chromium Control UI E2E injects assistant text followed by a matching tool result whose timestamp is 10 seconds older, then reads the rendered chat-thread order.
- Exact-head sanitized AWS Crabbox run `run_1d307fac3a57` passed all 66 `chat-thread.test.ts` assertions and all 23 `chat-flow.e2e.test.ts` browser scenarios on `9ba103f9dad6e88c81344ad8dfe0756c0f8780f5`.
- Contributor before/after screenshots reproduce the inverted `main` order and corrected order: https://github.com/user-attachments/assets/4bb440cf-027e-45d3-85b3-6938e713acc8 and https://github.com/user-attachments/assets/05d2eaef-3623-414d-a67d-4984bd4f2576
- Fresh autoreview found no accepted/actionable defects.

