### PR TITLE
[codex] fix(telegram): drop unused rich markdown parameter

### DIFF
--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -297,7 +297,6 @@ function markdownTableColumnCount(row: string): number {
 }
 
 function findRichMarkdownTableLineIndexes(
-  markdown: string,
   lines: readonly string[],
   fenceSpans: readonly RichMarkdownFenceSpan[],
 ): Set<number> {
@@ -336,7 +335,7 @@ function preserveTelegramRichMarkdownLineBreaks(markdown: string): string {
 
   const fenceSpans = parseRichMarkdownFenceSpans(markdown);
   const lines = markdown.split("\n");
-  const tableLineIndexes = findRichMarkdownTableLineIndexes(markdown, lines, fenceSpans);
+  const tableLineIndexes = findRichMarkdownTableLineIndexes(lines, fenceSpans);
   const out: string[] = [];
   let offset = 0;
   for (let index = 0; index < lines.length; index += 1) {


### PR DESCRIPTION
## Summary
- Remove the unused `markdown` parameter from `findRichMarkdownTableLineIndexes`.
- Keep the table line detection behavior unchanged while restoring `tsgo:extensions` cleanliness.

## Verification
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `git diff --check`

## Real behavior proof
Behavior or issue addressed:
Current main trips production type checking with `extensions/telegram/src/rich-message.ts(300,3): error TS6133: 'markdown' is declared but its value is never read.`

Real environment tested:
Local OpenClaw checkout on macOS, branch `codex/telegram-rich-unused-param`, Node `v25.9.0`, using the repository `run-tsgo.mjs` wrapper against `tsconfig.extensions.json`.

Exact steps or command run after this patch:
```sh
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
git diff --check
```

Evidence before fix:
GitHub Actions `check-prod-types` on a PR rebased to current main reported:
```text
extensions/telegram/src/rich-message.ts(300,3): error TS6133: 'markdown' is declared but its value is never read.
```

Evidence after fix:
Terminal output copied from the local checkout:
```text
$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
(exit 0; no TypeScript diagnostics)

$ git diff --check
(exit 0)
```

Observed result after fix:
The extensions TypeScript project now accepts `extensions/telegram/src/rich-message.ts`; the unused `markdown` parameter is gone and the call site passes only the values used by the helper.

What was not tested:
Live Telegram message sending; this patch only removes an unused helper parameter and does not alter rich-message parsing logic.
