### PR TITLE
fix(cache): stable tool result aggregate truncation

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -344,6 +344,25 @@ describe("estimateToolResultReductionPotential", () => {
     );
   });
 
+  it("matches live prompt aggregate quantum in reduction estimates", () => {
+    const messages: AgentMessage[] = [
+      makeToolResult("x".repeat(5_000), "call_1"),
+      makeToolResult("y".repeat(5_000), "call_2"),
+      makeToolResult("z".repeat(5_000), "call_3"),
+    ];
+
+    const estimate = estimateToolResultReductionPotential({
+      messages,
+      contextWindowTokens: 128_000,
+      maxCharsOverride: 12_000,
+      aggregateMaxCharsOverride: 12_000,
+    });
+
+    expect(estimate.aggregateBudgetChars).toBe(12_000);
+    expect(estimate.totalToolResultChars).toBe(15_000);
+    expect(estimate.aggregateReducibleChars).toBeGreaterThan(3_000);
+  });
+
   it("lets tiny caps drive aggregate recovery estimates without the old floor", () => {
     const medium = "alpha beta gamma delta epsilon ".repeat(600);
     const messages: AgentMessage[] = [
@@ -429,6 +448,39 @@ describe("truncateOversizedToolResultsInMessages", () => {
     }
   });
 
+  it("reduces aggregate overflow in coarse chunks to avoid repeated cache-prefix churn", () => {
+    const messages: AgentMessage[] = [
+      makeUserMessage("hello"),
+      makeAssistantMessage("calling tools"),
+      makeToolResult("x".repeat(5_000), "call_1"),
+      makeToolResult("y".repeat(5_000), "call_2"),
+      makeToolResult("z".repeat(5_000), "call_3"),
+    ];
+
+    const { messages: result, truncatedCount } = truncateOversizedToolResultsInMessages(
+      messages,
+      128_000,
+      12_000,
+      12_000,
+    );
+
+    const totalChars = result.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+
+    // The aggregate budget is 12k and the total input is 15k. Instead of shaving
+    // exactly the 3k overflow and leaving the next appended tool result to rewrite
+    // old history again, live truncation reduces by one coarse quantum
+    // (12k * 0.2 = 2.4k, rounded overflow => 4.8k).
+    expect(truncatedCount).toBe(1);
+    expect(totalChars).toBeLessThanOrEqual(10_200);
+    expect(totalChars).toBeLessThan(12_000);
+    expect(getToolResultTextLength(result[3])).toBe(5_000);
+    expect(getToolResultTextLength(result[4])).toBe(5_000);
+  });
+
   it("bounds aggregate tool-result text in prompt history without rewriting callers", () => {
     // Live replay truncates cloned tool-result messages; the source array keeps
     // full content for UI and transcript persistence.
@@ -464,6 +516,38 @@ describe("truncateOversizedToolResultsInMessages", () => {
 });
 
 describe("truncateOversizedToolResultsInSession", () => {
+  it("uses exact aggregate shaving for persisted session recovery", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+    sm.appendMessage(makeUserMessage("hello"));
+    sm.appendMessage(makeAssistantMessage("calling tools"));
+    sm.appendMessage(makeToolResult("x".repeat(5_000), "call_1"));
+    sm.appendMessage(makeToolResult("y".repeat(5_000), "call_2"));
+    sm.appendMessage(makeToolResult("z".repeat(5_000), "call_3"));
+    const sessionFile = sm.getSessionFile()!;
+
+    const result = await truncateOversizedToolResultsInSession({
+      sessionFile,
+      contextWindowTokens: 128_000,
+      maxCharsOverride: 12_000,
+      aggregateMaxCharsOverride: 12_000,
+    });
+
+    expect(result.truncated).toBe(true);
+    const afterBranch = SessionManager.open(sessionFile).getBranch();
+    const totalChars = afterBranch.reduce(
+      (sum, entry) =>
+        sum +
+        (entry.type === "message" && entry.message.role === "toolResult"
+          ? getToolResultTextLength(entry.message)
+          : 0),
+      0,
+    );
+
+    expect(totalChars).toBeLessThanOrEqual(12_000);
+    expect(totalChars).toBeGreaterThan(10_200);
+  });
+
   it("readably truncates aggregate medium tool results in a session file", async () => {
     // Persisted truncation rewrites JSONL directly and emits the transcript
     // update event instead of reopening through SessionManager internals.

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -53,6 +53,7 @@ const XL_CONTEXT_TOOL_RESULT_TOKENS = 200_000;
  */
 const MIN_KEEP_CHARS = 2_000;
 const RECOVERY_MIN_KEEP_CHARS = 0;
+const AGGREGATE_REDUCTION_QUANTUM_RATIO = 0.2;
 
 type ToolResultTruncationOptions = {
   suffix?: string | ((truncatedChars: number) => string);
@@ -360,6 +361,7 @@ export function truncateOversizedToolResultsInMessages(
     maxChars,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
+    aggregateReductionQuantumRatio: AGGREGATE_REDUCTION_QUANTUM_RATIO,
   });
   if (plan.replacements.length === 0) {
     return { messages, truncatedCount: 0 };
@@ -412,6 +414,7 @@ function buildAggregateToolResultReplacements(params: {
   branch: ToolResultBranchEntry[];
   aggregateBudgetChars: number;
   minKeepChars?: number;
+  aggregateReductionQuantumRatio?: number;
 }): ToolResultReplacement[] {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
   const candidates = params.branch
@@ -451,7 +454,18 @@ function buildAggregateToolResultReplacements(params: {
     return [];
   }
 
-  let remainingReduction = totalChars - params.aggregateBudgetChars;
+  const aggregateOverflowChars = totalChars - params.aggregateBudgetChars;
+  // Live prompt projection and its matching pressure estimate use a coarse
+  // reduction quantum to avoid shaving exactly the current overflow on every
+  // appended tool result. Persisted recovery paths leave the ratio undefined so
+  // session/transcript rewrites still perform the minimum exact reduction.
+  const aggregateReductionQuantumChars =
+    params.aggregateReductionQuantumRatio !== undefined
+      ? Math.max(1, Math.ceil(params.aggregateBudgetChars * params.aggregateReductionQuantumRatio))
+      : 1;
+  let remainingReduction =
+    Math.ceil(aggregateOverflowChars / aggregateReductionQuantumChars) *
+    aggregateReductionQuantumChars;
   const replacements: Array<{ entryId: string; message: AgentMessage }> = [];
 
   // Spend aggregate reduction on older entries first so fresh tool output stays intact.
@@ -569,6 +583,7 @@ function buildToolResultReplacementPlan(params: {
   maxChars: number;
   aggregateBudgetChars: number;
   minKeepChars?: number;
+  aggregateReductionQuantumRatio?: number;
 }): {
   replacements: ToolResultReplacement[];
   oversizedReplacementCount: number;
@@ -594,6 +609,7 @@ function buildToolResultReplacementPlan(params: {
     branch: oversizedTrimmedBranch,
     aggregateBudgetChars: params.aggregateBudgetChars,
     minKeepChars,
+    aggregateReductionQuantumRatio: params.aggregateReductionQuantumRatio,
   });
   const aggregateReducibleChars = calculateReplacementReduction(
     oversizedTrimmedBranch,
@@ -648,6 +664,7 @@ export function estimateToolResultReductionPotential(params: {
     maxChars,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
+    aggregateReductionQuantumRatio: AGGREGATE_REDUCTION_QUANTUM_RATIO,
   });
   const maxReducibleChars = plan.oversizedReducibleChars + plan.aggregateReducibleChars;
 

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -653,11 +653,12 @@ describe("repairSessionFileIfNeeded", () => {
   it("inserts missing code-mode tool results before replay repair has to synthesize them", async () => {
     const { file } = await createTempSessionPath();
     const { header, message } = buildSessionHeaderAndMessage();
+    const sourceEntryTimestamp = "2026-06-15T14:16:00.000Z";
     const toolCallAssistant = {
       type: "message",
       id: "msg-asst-process",
       parentId: "msg-1",
-      timestamp: new Date().toISOString(),
+      timestamp: sourceEntryTimestamp,
       message: {
         role: "assistant",
         provider: "openai",
@@ -707,6 +708,7 @@ describe("repairSessionFileIfNeeded", () => {
     expect(inserted.message.toolCallId).toBe("call_process|fc_1");
     expect(inserted.message.toolName).toBe("process");
     expect(inserted.message.isError).toBe(true);
+    expect(inserted.message.timestamp).toBe(Date.parse(sourceEntryTimestamp));
     expect(inserted.message.content[0].text).toBe("aborted");
     expect(JSON.parse(lines[4])).toEqual(deliveryMirror);
   });

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -322,10 +322,12 @@ function makeSyntheticToolResultEntry(params: {
   toolCallId: string;
   toolName?: string;
 }): SessionMessageEntry {
+  const parentMessageTimestamp = readSessionEntrySourceTimestamp(params.parent);
   const message = makeMissingToolResult({
     toolCallId: params.toolCallId,
     toolName: params.toolName,
     text: "aborted",
+    sourceTimestamp: parentMessageTimestamp,
   });
   return {
     type: "message",
@@ -334,6 +336,17 @@ function makeSyntheticToolResultEntry(params: {
     timestamp: new Date().toISOString(),
     message: message as unknown as SessionMessageEntry["message"],
   };
+}
+
+function readSessionEntrySourceTimestamp(entry: SessionMessageEntry): number | undefined {
+  if (typeof entry.message.timestamp === "number" && Number.isFinite(entry.message.timestamp)) {
+    return entry.message.timestamp;
+  }
+  if (typeof entry.timestamp === "string") {
+    const timestamp = Date.parse(entry.timestamp);
+    return Number.isFinite(timestamp) ? timestamp : undefined;
+  }
+  return undefined;
 }
 
 function insertMissingCodeModeToolResults(entries: unknown[]): {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -37,6 +37,10 @@ import { makeMissingToolResult, sanitizeToolCallInputs } from "./session-transcr
 import type { SessionManager } from "./sessions/index.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-id.js";
 
+function readFiniteTimestamp(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
 /**
  * Truncate oversized text content blocks in a tool result message.
  * Returns the original message if under the limit, or a new message with
@@ -705,16 +709,17 @@ export function installSessionToolResultGuard(
       return;
     }
     if (allowSyntheticToolResults) {
-      for (const [id, name] of pendingState.entries()) {
+      for (const [id, entry] of pendingState.entries()) {
         const synthetic = makeMissingToolResult({
           toolCallId: id,
-          toolName: name,
+          toolName: entry.name,
           text: missingToolResultText,
+          sourceTimestamp: entry.timestamp,
         });
         const flushed = applyBeforeWriteHook(
           persistToolResult(persistMessage(synthetic), {
             toolCallId: id,
-            toolName: name,
+            toolName: entry.name,
             isSynthetic: true,
           }),
         );
@@ -858,7 +863,17 @@ export function installSessionToolResultGuard(
     }
 
     if (toolCalls.length > 0) {
-      pendingState.trackToolCalls(toolCalls);
+      const assistantTimestamp = readFiniteTimestamp(
+        (finalMessage as { timestamp?: unknown }).timestamp,
+      );
+      pendingState.trackToolCalls(
+        toolCalls.map((call) => {
+          if (assistantTimestamp === undefined) {
+            return call;
+          }
+          return { id: call.id, name: call.name, timestamp: assistantTimestamp };
+        }),
+      );
     }
     if (isUserAgentMessage(finalMessage)) {
       void opts?.onUserMessagePersisted?.(finalMessage);

--- a/src/agents/session-tool-result-state.ts
+++ b/src/agents/session-tool-result-state.ts
@@ -3,11 +3,12 @@
  * The state object decides when dropped or reordered messages need synthetic
  * tool results flushed.
  */
-type PendingToolCall = { id: string; name?: string };
+type PendingToolCall = { id: string; name?: string; timestamp?: number };
+type PendingToolCallEntry = { name?: string; timestamp?: number };
 
 type PendingToolCallState = {
   size: () => number;
-  entries: () => IterableIterator<[string, string | undefined]>;
+  entries: () => IterableIterator<[string, PendingToolCallEntry]>;
   getToolName: (id: string) => string | undefined;
   delete: (id: string) => void;
   clear: () => void;
@@ -20,12 +21,12 @@ type PendingToolCallState = {
 
 /** Tracks pending tool calls so sanitized transcript repair can flush in order. */
 export function createPendingToolCallState(): PendingToolCallState {
-  const pending = new Map<string, string | undefined>();
+  const pending = new Map<string, PendingToolCallEntry>();
 
   return {
     size: () => pending.size,
     entries: () => pending.entries(),
-    getToolName: (id: string) => pending.get(id),
+    getToolName: (id: string) => pending.get(id)?.name,
     delete: (id: string) => {
       pending.delete(id);
     },
@@ -34,7 +35,10 @@ export function createPendingToolCallState(): PendingToolCallState {
     },
     trackToolCalls: (calls: PendingToolCall[]) => {
       for (const call of calls) {
-        pending.set(call.id, call.name);
+        pending.set(call.id, {
+          ...(call.name !== undefined ? { name: call.name } : {}),
+          ...(call.timestamp !== undefined ? { timestamp: call.timestamp } : {}),
+        });
       }
     },
     getPendingIds: () => Array.from(pending.keys()),

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -91,6 +91,7 @@ describe("sanitizeToolUseResultPairing", () => {
       {
         role: "assistant",
         content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+        timestamp: 12345,
       },
       { role: "user", content: "user message that should come after tool use" },
     ]);
@@ -102,6 +103,11 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(result.added).toHaveLength(1);
     expect(result.messages.map((m) => m.role)).toEqual(["assistant", "toolResult", "user"]);
     expect(result.added[0]?.content).toEqual([{ type: "text", text: "aborted" }]);
+    const repeated = repairToolUseResultPairing(input, {
+      missingToolResultText: "aborted",
+    });
+    expect(result.added[0]?.timestamp).toBe(12345);
+    expect(repeated.added[0]?.timestamp).toBe(result.added[0]?.timestamp);
   });
 
   it("keeps matched parallel tool results and synthesizes only missing siblings", () => {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -151,6 +151,10 @@ const DEFAULT_MISSING_TOOL_RESULT_TEXT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
 const SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY = "openclawSyntheticMissingToolResult";
 
+function readFiniteTimestamp(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
 function makeMissingToolResult(params: {
   toolCallId: string;
   toolName?: string;
@@ -160,6 +164,7 @@ function makeMissingToolResult(params: {
   // sends this repaired history to real models. Other providers keep the older,
   // explicit OpenClaw diagnostic text unless the caller opts in.
   text?: string;
+  sourceTimestamp?: unknown;
 }): Extract<AgentMessage, { role: "toolResult" }> {
   return {
     role: "toolResult",
@@ -173,7 +178,7 @@ function makeMissingToolResult(params: {
     ],
     details: { [SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY]: true },
     isError: true,
-    timestamp: Date.now(),
+    timestamp: readFiniteTimestamp(params.sourceTimestamp) ?? 0,
   } as Extract<AgentMessage, { role: "toolResult" }>;
 }
 
@@ -715,6 +720,7 @@ export function repairToolUseResultPairing(
             toolCallId: call.id,
             toolName: call.name,
             text: options?.missingToolResultText,
+            sourceTimestamp: readFiniteTimestamp((msg as { timestamp?: unknown }).timestamp),
           });
           added.push(missing);
           changed = true;


### PR DESCRIPTION
## Summary

- Reduces prompt-cache churn during long tool-heavy agent runs by making live tool-result prompt projection less eager to rewrite old prefix content.
- Changes live aggregate tool-result reduction from exact byte shaving to coarse 20% budget quanta, creating a stateless hysteresis band while preserving the existing oldest-first truncation strategy.
- Keeps persisted/session recovery paths on exact shaving so durable transcript rewrites still minimize data loss and on-disk diffs.
- Replaces non-deterministic `Date.now()` timestamps on synthetic missing tool-result placeholders with deterministic numeric timestamps derived from the source assistant/tool-use message, with `0` as the fallback when no source timestamp exists.
- Preserves the `ToolResultMessage.timestamp: number` contract for runtime and persisted synthetic repair messages.
- Intended outcome: repeated tool-loop requests should preserve provider prompt-cache prefixes more often, especially when total tool-result text hovers near the aggregate cap.
- Out of scope: redesigning transcript repair ordering, changing provider payload schemas, disabling synthetic missing tool results, or adding persistent per-message projection caches.
- Reviewers should focus on whether the 20% live-projection quantum is the right minimal cache-stability tradeoff, and whether deriving synthetic repair timestamps from source turns is the right contract-preserving stabilization layer.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #15409  
Related #58036

Was this requested by a maintainer or owner?

No maintainer request. This was prompted by live OpenClaw cache-trace investigation showing repeated prefix-cache invalidation during tool-heavy sessions.

## Real behavior proof

Behavior or issue addressed:

- During long active tool loops, live prompt assembly could repeatedly rewrite older tool-result projections as new tool results were appended near the aggregate cap.
- That changed serialized prompt prefixes between adjacent model calls and reduced provider prompt-cache reuse.
- Synthetic missing tool-result repair also used `timestamp: Date.now()`, creating non-deterministic transcript bytes when placeholders were regenerated.
- Current PR head verified: `b2278f63ee87805e60b188e8407a3bcb23c05017`.

Real environment tested:

- Local OpenClaw gateway on NixOS, OpenClaw `2026.6.5`, after rebuild/switch and gateway restart.
- Running process inspected from `/proc`:

  ```text
  /nix/store/jb0rvygwwcvhc98v637rlfj17bnch7ln-openclaw-gateway-2026.6.5/lib/openclaw/dist/index.js gateway --port 18789
  ```

- Cache tracing source: `/home/ltrump/.openclaw/logs/cache-trace.jsonl`.
- Controlled proof session: `agent:main:tui-fa8b100b-b024-40d1-a589-6fd489022a47`.
- Main controlled proof run: `17d7842f-dbd7-4a20-86bc-24454f17485b`.
- The local Nix-packaged gateway dist was inspected and matched the current PR head behavior before collecting traces.

Exact steps or command run after this patch:

1. Rebuilt/switched the local OpenClaw gateway and restarted it.
2. Verified the running process path with `ps` and `/proc/<pid>/exe`.
3. Inspected the running dist chunks with `rg`:

   ```bash
   rg -n "AGGREGATE_REDUCTION_QUANTUM_RATIO|aggregateReductionQuantumRatio|aggregateReductionQuantumChars" \
     /nix/store/jb0rvygwwcvhc98v637rlfj17bnch7ln-openclaw-gateway-2026.6.5/lib/openclaw/dist/tool-result-truncation-*.js

   rg -n "readFiniteTimestamp|timestamp: readFiniteTimestamp|sourceTimestamp" \
     /nix/store/jb0rvygwwcvhc98v637rlfj17bnch7ln-openclaw-gateway-2026.6.5/lib/openclaw/dist/session-transcript-repair-*.js \
     /nix/store/jb0rvygwwcvhc98v637rlfj17bnch7ln-openclaw-gateway-2026.6.5/lib/openclaw/dist/compaction-successor-transcript-*.js
   ```

4. Ran a controlled cache-trace workload in a fresh TUI session:
   - generated `/home/ltrump/.openclaw/workspace/tmp/cache-proof-large.txt`, about 4.74 MB;
   - performed 14 sequential `read` tool calls on different offsets, each `limit=2000`;
   - forced one LLM turn between tool calls so each appended result created a new prompt assembly;
   - then performed 6 sequential small `exec` tool calls.
5. Parsed `/home/ltrump/.openclaw/logs/cache-trace.jsonl` for `stream:context` transitions, aggregate tool-result size, common-prefix preservation, synthetic missing tool-result timestamps, and provider `cacheRead` values.

Evidence after fix:

- Running dist verification showed live/estimate quantum opt-in and deterministic synthetic timestamps:

  ```text
  tool-result-truncation-CSLN3t54.js:
    const AGGREGATE_REDUCTION_QUANTUM_RATIO = 0.2;
    aggregateReductionQuantumRatio: AGGREGATE_REDUCTION_QUANTUM_RATIO   # 2 occurrences
    aggregateReductionQuantumRatio: params.aggregateReductionQuantumRatio # 1 occurrence
    const aggregateReductionQuantumChars = params.aggregateReductionQuantumRatio !== void 0 ? ... : 1;

  session-transcript-repair-B17NYGhL.js:
    function readFiniteTimestamp(value)
    timestamp: readFiniteTimestamp(params.sourceTimestamp) ?? 0
    sourceTimestamp: readFiniteTimestamp(msg.timestamp)
    no timestamp: Date.now() hit in this chunk

  compaction-successor-transcript-DOYIvTa2.js:
    const parentEntryTimestamp = typeof params.parent.timestamp === "string" ? Date.parse(params.parent.timestamp) : void 0;
    const parentMessageTimestamp = readFiniteTimestamp(params.parent.message?.timestamp) ?? readFiniteTimestamp(parentEntryTimestamp);
    sourceTimestamp: parentMessageTimestamp
    sourceTimestamp: entry.timestamp
    const assistantTimestamp = readFiniteTimestamp(finalMessage.timestamp);
  ```

- Which paths use the 20% aggregate quantum:
  - `truncateOversizedToolResultsInMessages()` uses `aggregateReductionQuantumRatio: AGGREGATE_REDUCTION_QUANTUM_RATIO` because it is the live prompt-projection path. It does not rewrite the session file, and it is the path that directly affects provider prompt-cache prefix stability during tool loops.
  - `estimateToolResultReductionPotential()` also uses the same ratio so pressure/possible-reduction estimates match the live projection behavior that will actually run.

- Which paths intentionally do **not** use the quantum:
  - `truncateOversizedToolResultsInExistingSessionManager()` / session-manager recovery paths leave `aggregateReductionQuantumRatio` undefined.
  - `truncateOversizedToolResultsInSession()` persisted session-file recovery paths leave `aggregateReductionQuantumRatio` undefined.
  - With the ratio undefined, `buildAggregateToolResultReplacements()` uses a 1-char quantum, i.e. exact shaving.
  - Reason: persisted recovery mutates durable session/transcript state, so it should make the minimum necessary reduction to recover from pressure/overflow. The cache-stability hysteresis band is only needed for transient live prompt projections and their matching estimates.

- Redacted runtime log excerpt from `cache-trace.jsonl`, controlled aggregate trace from run `17d7842f-dbd7-4a20-86bc-24454f17485b`:

  ```text
  seq 13  toolTotal 258,954
  seq 14  toolTotal 310,700
  seq 15  toolTotal 362,446
  seq 16  toolTotal 414,192
  seq 17  toolTotal 465,938
  seq 18  toolTotal 414,634  <-- aggregate quantum reduction after appending another ~51.7k read result
  seq 19  toolTotal 466,380
  seq 20  toolTotal 415,076  <-- aggregate quantum reduction again
  seq 21  toolTotal 466,822
  seq 22  toolTotal 415,518  <-- aggregate quantum reduction again
  ```

  With `toolResultMaxChars = 128000`, the aggregate budget is approximately `128000 * 4 = 512000` chars. At `seq 17 -> seq 18`, exact overflow would have been only a few thousand chars:

  ```text
  465,938 + ~51,746 ~= 517,684
  517,684 - 512,000 ~= 5,684
  ```

  Instead, aggregate tool-result text dropped to `414,634`, implying a reduction of about `103k` chars:

  ```text
  517,684 - 414,634 ~= 103,050
  ```

  That matches the configured 20% live projection quantum:

  ```text
  512,000 * 0.2 = 102,400
  ```

  This confirms the running gateway used chunked aggregate reduction rather than exact byte shaving for live prompt projection.

- Prefix stability after the read-heavy phase:

  ```text
  seq 23 -> seq 24: common prefix 31/31, lost 0
  seq 24 -> seq 25: common prefix 33/33, lost 0
  seq 25 -> seq 26: common prefix 35/35, lost 0
  seq 26 -> seq 27: common prefix 37/37, lost 0
  seq 27 -> seq 28: common prefix 39/39, lost 0
  ```

  These are the 6 small `exec` appends after the aggregate quantum reductions. They preserved the full previous prefix, which is the intended hysteresis behavior.

- Redacted runtime log excerpt, provider cache-read evidence from the same controlled session:

  ```text
  session: agent:main:tui-fa8b100b-b024-40d1-a589-6fd489022a47
  runId: 17d7842f-dbd7-4a20-86bc-24454f17485b
  cacheRead: 1,641,621
  note: stable cache inputs
  ```

- Redacted runtime log excerpt, deterministic synthetic timestamp trace over the current-head trace window:

  ```text
  synthetic missing toolResults observed: 185
  unique synthetic toolCallIds: 13
  unstable timestamp groups: 0
  fallback 0 cases: 63
  ```

- Overall cache-trace summary for the current-head proof window:

  ```text
  records: 225
  stream:context: 104
  cache:result: 14
  cache hits: 12
  hit rate: 85.7%
  max cacheRead: 2,820,096
  controlled proof run cacheRead: 1,641,621
  ```

Observed result after fix:

- Live prompt projection used 20% aggregate quantum reductions when the controlled read-heavy workload crossed the aggregate cap.
- The reduction size was about `103k`, matching a `~512k * 20%` quantum, instead of exact overflow shaving of only a few thousand chars.
- After the quantum reductions, subsequent small tool-result appends preserved the full previous prefix across all checked transitions.
- Synthetic missing tool-result placeholders kept stable numeric timestamps: no synthetic toolCallId had multiple observed timestamp values across the trace window.
- The controlled run produced provider cache reuse with `cacheRead=1,641,621` and `note: stable cache inputs`.

What was not tested:

- Full provider billing/cache behavior across every supported provider.
- A long statistical A/B comparison against an unpatched gateway under identical workload.
- Maintainer-hosted production deployment. The runtime proof is from a local NixOS gateway whose running dist was inspected and matched the current PR head behavior.

Proof limitations or environment constraints:

- Live logs were summarized/redacted to avoid exposing private session content.
- Cache-trace fingerprints are diagnostic and can differ from provider-projected payloads; therefore the proof combines runtime dist inspection, controlled workload deltas, and provider `cacheRead` fields.

Before evidence:

- Before the aggregate reduction change, sessions with total tool-result text near the aggregate cap showed repeated old tool-result rewrites as new tool results were appended.
- Example observed pattern: old tool-result projections at stable message indices changed lengths between adjacent prompt assemblies, breaking the common prefix far before the newly appended messages.
- Before the timestamp change, `makeMissingToolResult()` emitted:

  ```ts
  timestamp: Date.now(),
  ```

## Tests and validation

Which commands did you run?

```bash
node scripts/run-vitest.mjs src/agents/session-transcript-repair.test.ts src/agents/session-tool-result-guard.test.ts src/agents/session-file-repair.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts src/agents/embedded-agent-runner/tool-result-truncation.test.ts
pnpm lint --threads=8
pnpm tsgo:prod
pnpm tsgo:core:test
```

Result:

```text
Focused Vitest: 274 tests passed
pnpm lint --threads=8: 0 warnings, 0 errors
pnpm tsgo:prod: passed
pnpm tsgo:core:test: passed after rebasing onto origin/main, which includes d012d29e6f test(protocol): narrow literal union schemas
```

Additional source/runtime checks:

```bash
grep -n "AGGREGATE_REDUCTION_QUANTUM_RATIO\|aggregateReductionQuantum" <running-dist>/tool-result-truncation-*.js
grep -n "timestamp: Date.now()" src/agents/session-transcript-repair.ts src/agents/session-tool-result-guard.ts || true
python analyze /home/ltrump/.openclaw/logs/cache-trace.jsonl
```

What regression coverage was added or updated?

- Added unit coverage for live aggregate tool-result truncation using coarse chunk reduction.
- Added unit coverage that persisted/session recovery paths use exact aggregate shaving instead of the live prompt quantum.
- Added/updated transcript repair coverage showing synthetic missing tool results inherit a stable source timestamp.
- Kept embedded-agent expectations aligned with the `ToolResultMessage.timestamp: number` contract.

What failed before this fix, if known?

- The previous aggregate truncation behavior reduced exactly `totalChars - aggregateBudgetChars` in all paths.
- That meant small appended tool results could repeatedly force older live prompt tool-result projections to be rewritten by small amounts across adjacent prompt assemblies.
- Synthetic missing tool-result repair also added `Date.now()`, making regenerated placeholders non-deterministic.

If no test was added, why not?

- Tests were added/updated for both the aggregate reduction behavior and the deterministic timestamp propagation behavior.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Live prompt tool-result projection: chunked aggregate reductions may truncate more text than the exact overflow amount when the aggregate cap is exceeded.
- Synthetic transcript repair: synthetic missing tool results now use source/fallback deterministic timestamps instead of wall-clock insertion time.

How is that risk mitigated?

- The aggregate quantum only applies after aggregate tool-result text already exceeds the configured aggregate budget.
- The quantum is bounded by the aggregate budget (`20%`) and preserves the existing oldest-first truncation strategy.
- Persisted/session recovery paths intentionally keep exact shaving to minimize durable data loss.
- The synthetic repair marker remains available through `details.openclawSyntheticMissingToolResult`, and message ordering/content fields are unchanged.
- Synthetic tool results continue to include a numeric `timestamp`, preserving the shared message contract.
- Existing tool-result truncation and transcript repair tests pass, with additional coverage for the new behavior.

## Current review state

What is the next action?

Maintainer review and CI on the force-pushed current head.

What is still waiting on author, maintainer, CI, or external proof?

- CI on current PR head `b2278f63ee87805e60b188e8407a3bcb23c05017`.
- Maintainer judgment on whether `20%` is the right default live prompt-projection quantum ratio.
- Maintainer judgment on the deterministic source/fallback timestamp approach for synthetic missing tool results.

Which bot or reviewer comments were addressed?

- ClawSweeper proof concern: addressed with exact current-head hash, running dist inspection, controlled runtime trace, provider cacheRead evidence, and explicit path split for quantum vs exact shaving.
- ClawSweeper P1 timestamp contract concern: addressed by preserving numeric timestamps and deriving them deterministically from source assistant/tool-use turns, with fallback `0` instead of `Date.now()`.
- ClawSweeper P2 path concern: addressed by limiting the 20% aggregate quantum to live prompt projection and matching estimates, while keeping persisted recovery paths on exact shaving.
- ClawSweeper P2 lint concern in the aggregate truncation test: addressed by removing unnecessary non-null assertions.
