### PR TITLE
test(macos): cover root CLI command parsing

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -368,7 +368,7 @@ enum ExecApprovalsStore {
                 tempURL.path,
                 targetURL.path,
                 nil,
-                copyfile_flags_t(COPYFILE_EXCL))
+                copyfile_flags_t(COPYFILE_DATA | COPYFILE_EXCL))
             if copied == -1 {
                 if errno == EEXIST {
                     try? FileManager().removeItem(at: tempURL)

--- a/apps/macos/Sources/OpenClawMacCLI/EntryPoint.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/EntryPoint.swift
@@ -1,39 +1,26 @@
 import Foundation
 
-private struct RootCommand {
-    var name: String
-    var args: [String]
-}
-
 @main
 struct OpenClawMacCLI {
     static func main() async {
         let args = Array(CommandLine.arguments.dropFirst())
-        let command = parseRootCommand(args)
-        switch command?.name {
-        case nil:
+        switch rootCommandAction(for: args) {
+        case .usage:
             printUsage()
-        case "-h", "--help", "help":
-            printUsage()
-        case "connect":
-            await runConnect(command?.args ?? [])
-        case "configure-remote":
-            runConfigureRemote(command?.args ?? [])
-        case "discover":
-            await runDiscover(command?.args ?? [])
-        case "wizard":
-            await runWizardCommand(command?.args ?? [])
-        default:
+        case let .connect(commandArgs):
+            await runConnect(commandArgs)
+        case let .configureRemote(commandArgs):
+            runConfigureRemote(commandArgs)
+        case let .discover(commandArgs):
+            await runDiscover(commandArgs)
+        case let .wizard(commandArgs):
+            await runWizardCommand(commandArgs)
+        case let .unknown(exitCode):
             fputs("openclaw-mac: unknown command\n", stderr)
             printUsage()
-            exit(1)
+            exit(exitCode)
         }
     }
-}
-
-private func parseRootCommand(_ args: [String]) -> RootCommand? {
-    guard let first = args.first else { return nil }
-    return RootCommand(name: first, args: Array(args.dropFirst()))
 }
 
 private func printUsage() {

--- a/apps/macos/Sources/OpenClawMacCLI/RootCommandParser.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/RootCommandParser.swift
@@ -1,0 +1,36 @@
+struct RootCommand: Equatable {
+    var name: String
+    var args: [String]
+}
+
+enum RootCommandAction: Equatable {
+    case usage
+    case connect([String])
+    case configureRemote([String])
+    case discover([String])
+    case wizard([String])
+    case unknown(exitCode: Int32)
+}
+
+func parseRootCommand(_ args: [String]) -> RootCommand? {
+    guard let first = args.first else { return nil }
+    return RootCommand(name: first, args: Array(args.dropFirst()))
+}
+
+func rootCommandAction(for args: [String]) -> RootCommandAction {
+    let command = parseRootCommand(args)
+    switch command?.name {
+    case nil, "-h", "--help", "help":
+        return .usage
+    case "connect":
+        return .connect(command?.args ?? [])
+    case "configure-remote":
+        return .configureRemote(command?.args ?? [])
+    case "discover":
+        return .discover(command?.args ?? [])
+    case "wizard":
+        return .wizard(command?.args ?? [])
+    default:
+        return .unknown(exitCode: 1)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/RootCommandParserTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/RootCommandParserTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import OpenClawMacCLI
+
+struct RootCommandParserTests {
+    @Test func `empty args parse no command and show usage`() {
+        #expect(parseRootCommand([]) == nil)
+        #expect(rootCommandAction(for: []) == .usage)
+    }
+
+    @Test func `single command parses with empty trailing args`() throws {
+        let command = try #require(parseRootCommand(["connect"]))
+        #expect(command.name == "connect")
+        #expect(command.args == [])
+    }
+
+    @Test func `root parser splits command from trailing arguments`() throws {
+        let command = try #require(parseRootCommand(["connect", "--url", "ws://127.0.0.1:18789", "--json"]))
+        #expect(command.name == "connect")
+        #expect(command.args == ["--url", "ws://127.0.0.1:18789", "--json"])
+    }
+
+    @Test func `help aliases show usage`() {
+        for alias in ["-h", "--help", "help"] {
+            #expect(rootCommandAction(for: [alias]) == .usage)
+        }
+    }
+
+    @Test func `known commands dispatch with trailing arguments`() {
+        #expect(rootCommandAction(for: ["connect", "--json"]) == .connect(["--json"]))
+        #expect(rootCommandAction(for: ["configure-remote", "--ssh-target", "alice@gateway.local"]) ==
+            .configureRemote([
+                "--ssh-target",
+                "alice@gateway.local",
+            ]))
+        #expect(rootCommandAction(for: ["discover", "--include-local"]) == .discover(["--include-local"]))
+        #expect(rootCommandAction(for: ["wizard", "--mode", "local"]) == .wizard(["--mode", "local"]))
+    }
+
+    @Test func `unknown command dispatches to nonzero exit action`() {
+        #expect(rootCommandAction(for: ["Connect"]) == .unknown(exitCode: 1))
+        #expect(rootCommandAction(for: ["bogus", "--json"]) == .unknown(exitCode: 1))
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -46,6 +46,17 @@ public enum NodePresenceAliveReason: String, Codable, Sendable {
     case connect = "connect"
 }
 
+public enum SessionFileKind: String, Codable, Sendable {
+    case modified = "modified"
+    case read = "read"
+}
+
+public enum SessionFileRelevance: String, Codable, Sendable {
+    case modified = "modified"
+    case read = "read"
+    case mixed = "mixed"
+}
+
 public struct ConnectParams: Codable, Sendable {
     public let minprotocol: Int
     public let maxprotocol: Int

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -297,7 +297,6 @@ function markdownTableColumnCount(row: string): number {
 }
 
 function findRichMarkdownTableLineIndexes(
-  markdown: string,
   lines: readonly string[],
   fenceSpans: readonly RichMarkdownFenceSpan[],
 ): Set<number> {
@@ -336,7 +335,7 @@ function preserveTelegramRichMarkdownLineBreaks(markdown: string): string {
 
   const fenceSpans = parseRichMarkdownFenceSpans(markdown);
   const lines = markdown.split("\n");
-  const tableLineIndexes = findRichMarkdownTableLineIndexes(markdown, lines, fenceSpans);
+  const tableLineIndexes = findRichMarkdownTableLineIndexes(lines, fenceSpans);
   const out: string[] = [];
   let offset = 0;
   for (let index = 0; index < lines.length; index += 1) {

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -235,13 +235,35 @@ function swiftInitializerParam(params: {
 }
 
 function emitEnum(name: string, schema: JsonSchema): string {
-  const cases = schema.enum ?? [];
+  const cases = stringEnumValues(schema);
   return [
     `public enum ${name}: String, Codable, Sendable {`,
     ...cases.map((value) => `    case ${safeName(value)} = "${value}"`),
     "}",
     "",
   ].join("\n");
+}
+
+function stringEnumValues(schema: JsonSchema): string[] {
+  if (schema.type === "string" && schema.enum) {
+    return schema.enum;
+  }
+  const branches = schema.anyOf ?? schema.oneOf;
+  if (!branches?.length) {
+    return [];
+  }
+  const values: string[] = [];
+  for (const branch of branches) {
+    if (branch.type !== "string" || typeof branch.const !== "string") {
+      return [];
+    }
+    values.push(branch.const);
+  }
+  return values;
+}
+
+function isStringEnumSchema(schema: JsonSchema): boolean {
+  return stringEnumValues(schema).length > 0;
 }
 
 function emitStruct(name: string, schema: JsonSchema): string {
@@ -606,7 +628,7 @@ async function generate() {
     if (name === "GatewayFrame") {
       continue;
     }
-    if (schema.type === "string" && schema.enum) {
+    if (isStringEnumSchema(schema)) {
       parts.push(emitEnum(name, schema));
     }
   }


### PR DESCRIPTION
Closes #83879.

Adds a small root-command parser/dispatch helper for the macOS CLI and covers usage/help, known-command argument forwarding, and unknown-command dispatch.

Also refreshes the Swift protocol generator so current literal-union schemas emit the Swift enums required by the macOS package, fixes the exec approvals legacy migration copy path exposed by the macOS IPC shard, and carries the current-main Telegram unused-parameter cleanup needed for `check-prod-types` while #93185 is still open.

## Real behavior proof
Behavior addressed: the macOS root CLI parser and help dispatch path are covered and still produce the expected root usage output.

Real environment tested: local OpenClaw source checkout on macOS, running the Swift package CLI, macOS IPC test shard, protocol guard, and production typecheck.

Exact steps or command run after this patch: ran `swift run --package-path apps/macos openclaw-mac --help`, focused parser tests, the macOS IPC filter that includes the parser and approvals migration tests, the native protocol guard, and `pnpm tsgo:prod`.

Evidence after fix:
```text
openclaw-mac

Usage:
  openclaw-mac connect [--url <ws://host:port>] [--token <token>] [--password <password>]
  openclaw-mac configure-remote --ssh-target <user@host[:port]> [--local-port <port>]
  openclaw-mac discover [--timeout <ms>] [--json] [--include-local]
  openclaw-mac wizard [--url <ws://host:port>] [--token <token>] [--password <password>]

✔ Suite RootCommandParserTests passed after 0.001 seconds.
✔ Test run with 587 tests in 114 suites passed after 2.625 seconds.
[test] passed 1 Vitest shard in 6.79s
pnpm tsgo:prod exited 0
```

Observed result after fix: root help dispatch prints the macOS CLI usage, the new parser tests pass, the broader macOS IPC shard passes with the generated protocol and approvals migration fixes in place, and production TypeScript typechecking is green.

What was not tested: packaged app notarization or installer flows were not run.
