### PR TITLE
fix(gateway): archive legacy-root stale transcript files on reset/delete

### DIFF
--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -118,6 +118,30 @@ function canonicalizePathForComparison(filePath: string): string {
   }
 }
 
+// Stale sessionFile values may point to legacy transcript files under the
+// OpenClaw-owned global sessions directory (e.g. ~/.openclaw/sessions/ from
+// before the per-agent filing overhaul). resolveSessionFilePath silently
+// normalizes those to a generated path for the current sessionId, so the raw
+// legacy file is never archived. Include the raw stale path as a candidate
+// only when it resolves under the known legacy root, with realpath-based
+// canonicalization to prevent symlink escape.
+function pushRawStaleLegacyCandidate(
+  sessionFile: string,
+  candidates: string[],
+  legacyDir: string,
+): void {
+  const trimmed = sessionFile.trim();
+  if (!trimmed) {
+    return;
+  }
+  const canonicalLegacyDir = canonicalizePathForComparison(legacyDir);
+  const resolved = canonicalizePathForComparison(trimmed);
+  const relative = path.relative(canonicalLegacyDir, resolved);
+  if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+    candidates.push(resolved);
+  }
+}
+
 export function resolveSessionTranscriptCandidates(
   sessionId: string,
   storePath: string | undefined,
@@ -126,6 +150,8 @@ export function resolveSessionTranscriptCandidates(
 ): string[] {
   const candidates: string[] = [];
   const sessionFileState = classifySessionTranscriptCandidate(sessionId, sessionFile);
+  const home = resolveRequiredHomeDir(process.env, os.homedir);
+  const legacyDir = path.join(home, ".openclaw", "sessions");
   const pushCandidate = (resolve: () => string): void => {
     try {
       candidates.push(resolve());
@@ -146,11 +172,14 @@ export function resolveSessionTranscriptCandidates(
       pushCandidate(() =>
         resolveSessionFilePath(sessionId, { sessionFile }, { sessionsDir, agentId }),
       );
+      pushRawStaleLegacyCandidate(sessionFile, candidates, legacyDir);
     }
   } else if (sessionFile) {
     if (agentId) {
       if (sessionFileState !== "stale") {
         pushCandidate(() => resolveSessionFilePath(sessionId, { sessionFile }, { agentId }));
+      } else {
+        pushRawStaleLegacyCandidate(sessionFile, candidates, legacyDir);
       }
     } else {
       const trimmed = sessionFile.trim();
@@ -164,13 +193,12 @@ export function resolveSessionTranscriptCandidates(
     pushCandidate(() => resolveSessionTranscriptPath(sessionId, agentId));
     if (sessionFile && sessionFileState === "stale") {
       pushCandidate(() => resolveSessionFilePath(sessionId, { sessionFile }, { agentId }));
+      pushRawStaleLegacyCandidate(sessionFile, candidates, legacyDir);
     }
   }
 
   // Keep the legacy global sessions directory as a final candidate so tagged
   // upgrades can still find transcripts created before per-agent paths.
-  const home = resolveRequiredHomeDir(process.env, os.homedir);
-  const legacyDir = path.join(home, ".openclaw", "sessions");
   pushCandidate(() => resolveSessionTranscriptPathInDir(sessionId, legacyDir));
 
   return uniqueStrings(candidates);

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -2454,45 +2454,53 @@ describe("archiveSessionTranscripts", () => {
   });
 
   test("archives legacy-root stale transcript on reset", () => {
-    const oldSessionId = "22222222-2222-4222-8222-222222222222";
-    const currentSessionId = "11111111-1111-4111-8111-111111111111";
-    const legacyDir = path.join(tmpDir, ".openclaw", "sessions");
-    fs.mkdirSync(legacyDir, { recursive: true });
-    const stalePath = path.join(legacyDir, `${oldSessionId}.jsonl`);
-    fs.writeFileSync(stalePath, '{"type":"session"}\n', "utf-8");
+    withArchiveHome(() => {
+      const oldSessionId = "22222222-2222-4222-8222-222222222222";
+      const currentSessionId = "11111111-1111-4111-8111-111111111111";
+      const agentStorePath = path.join(tmpDir, "agents", "test-agent", "sessions", "sessions.json");
+      fs.mkdirSync(path.dirname(agentStorePath), { recursive: true });
+      const legacyDir = path.join(tmpDir, ".openclaw", "sessions");
+      fs.mkdirSync(legacyDir, { recursive: true });
+      const stalePath = path.join(legacyDir, `${oldSessionId}.jsonl`);
+      fs.writeFileSync(stalePath, '{"type":"session"}\n', "utf-8");
 
-    const archived = archiveSessionTranscripts({
-      sessionId: currentSessionId,
-      storePath,
-      sessionFile: stalePath,
-      reason: "reset",
+      const archived = archiveSessionTranscripts({
+        sessionId: currentSessionId,
+        storePath: agentStorePath,
+        sessionFile: stalePath,
+        reason: "reset",
+      });
+
+      expect(archived).toHaveLength(1);
+      expect(archived[0]).toContain(".reset.");
+      expect(fs.existsSync(stalePath)).toBe(false);
+      expect(fs.existsSync(archived[0])).toBe(true);
     });
-
-    expect(archived).toHaveLength(1);
-    expect(archived[0]).toContain(".reset.");
-    expect(fs.existsSync(stalePath)).toBe(false);
-    expect(fs.existsSync(archived[0])).toBe(true);
   });
 
   test("archives legacy-root stale transcript on delete", () => {
-    const oldSessionId = "22222222-2222-4222-8222-222222222222";
-    const currentSessionId = "11111111-1111-4111-8111-111111111111";
-    const legacyDir = path.join(tmpDir, ".openclaw", "sessions");
-    fs.mkdirSync(legacyDir, { recursive: true });
-    const stalePath = path.join(legacyDir, `${oldSessionId}.jsonl`);
-    fs.writeFileSync(stalePath, '{"type":"session"}\n', "utf-8");
+    withArchiveHome(() => {
+      const oldSessionId = "22222222-2222-4222-8222-222222222222";
+      const currentSessionId = "11111111-1111-4111-8111-111111111111";
+      const agentStorePath = path.join(tmpDir, "agents", "test-agent", "sessions", "sessions.json");
+      fs.mkdirSync(path.dirname(agentStorePath), { recursive: true });
+      const legacyDir = path.join(tmpDir, ".openclaw", "sessions");
+      fs.mkdirSync(legacyDir, { recursive: true });
+      const stalePath = path.join(legacyDir, `${oldSessionId}.jsonl`);
+      fs.writeFileSync(stalePath, '{"type":"session"}\n', "utf-8");
 
-    const archived = archiveSessionTranscripts({
-      sessionId: currentSessionId,
-      storePath,
-      sessionFile: stalePath,
-      reason: "deleted",
+      const archived = archiveSessionTranscripts({
+        sessionId: currentSessionId,
+        storePath: agentStorePath,
+        sessionFile: stalePath,
+        reason: "deleted",
+      });
+
+      expect(archived).toHaveLength(1);
+      expect(archived[0]).toContain(".deleted.");
+      expect(fs.existsSync(stalePath)).toBe(false);
+      expect(fs.existsSync(archived[0])).toBe(true);
     });
-
-    expect(archived).toHaveLength(1);
-    expect(archived[0]).toContain(".deleted.");
-    expect(fs.existsSync(stalePath)).toBe(false);
-    expect(fs.existsSync(archived[0])).toBe(true);
   });
 
   test("does not archive stale transcript outside legacy root", () => {

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -2526,29 +2526,31 @@ describe("archiveSessionTranscripts", () => {
   });
 
   test("does not archive symlink under legacy root that resolves outside", () => {
-    const oldSessionId = "22222222-2222-4222-8222-222222222222";
-    const currentSessionId = "11111111-1111-4111-8111-111111111111";
-    const legacyDir = path.join(tmpDir, ".openclaw", "sessions");
-    fs.mkdirSync(legacyDir, { recursive: true });
-    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-symlink-target-"));
-    try {
-      const targetPath = path.join(outsideDir, "target.jsonl");
-      fs.writeFileSync(targetPath, '{"type":"session"}\n', "utf-8");
-      const symlinkPath = path.join(legacyDir, `${oldSessionId}.jsonl`);
-      fs.symlinkSync(targetPath, symlinkPath);
+    withArchiveHome(() => {
+      const oldSessionId = "22222222-2222-4222-8222-222222222222";
+      const currentSessionId = "11111111-1111-4111-8111-111111111111";
+      const legacyDir = path.join(tmpDir, ".openclaw", "sessions");
+      fs.mkdirSync(legacyDir, { recursive: true });
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-symlink-target-"));
+      try {
+        const targetPath = path.join(outsideDir, "target.jsonl");
+        fs.writeFileSync(targetPath, '{"type":"session"}\n', "utf-8");
+        const symlinkPath = path.join(legacyDir, `${oldSessionId}.jsonl`);
+        fs.symlinkSync(targetPath, symlinkPath);
 
-      const archived = archiveSessionTranscripts({
-        sessionId: currentSessionId,
-        storePath,
-        sessionFile: symlinkPath,
-        reason: "reset",
-      });
+        const archived = archiveSessionTranscripts({
+          sessionId: currentSessionId,
+          storePath,
+          sessionFile: symlinkPath,
+          reason: "reset",
+        });
 
-      expect(archived).toStrictEqual([]);
-      expect(fs.existsSync(targetPath)).toBe(true);
-    } finally {
-      fs.rmSync(outsideDir, { recursive: true, force: true });
-    }
+        expect(archived).toStrictEqual([]);
+        expect(fs.existsSync(targetPath)).toBe(true);
+      } finally {
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
+    });
   });
 });
 

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -2363,6 +2363,18 @@ describe("resolveSessionTranscriptCandidates safety", () => {
     );
     expect(candidates).toContain(path.resolve(staleSessionFile));
   });
+
+  test("includes stale sessionFile under legacy transcript root", () => {
+    vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
+    const storePath = "/tmp/openclaw/agents/main/sessions/sessions.json";
+    const sessionId = "11111111-1111-4111-8111-111111111111";
+    const legacyStalePath =
+      "/srv/openclaw-home/.openclaw/sessions/22222222-2222-4222-8222-222222222222.jsonl";
+
+    const candidates = resolveSessionTranscriptCandidates(sessionId, storePath, legacyStalePath);
+
+    expect(candidates.map((value) => path.resolve(value))).toContain(path.resolve(legacyStalePath));
+  });
 });
 
 describe("archiveSessionTranscripts", () => {
@@ -2439,6 +2451,96 @@ describe("archiveSessionTranscripts", () => {
       expect(archived[0]).toContain(".deleted.");
       expect(fs.existsSync(transcriptPath)).toBe(false);
     });
+  });
+
+  test("archives legacy-root stale transcript on reset", () => {
+    const oldSessionId = "22222222-2222-4222-8222-222222222222";
+    const currentSessionId = "11111111-1111-4111-8111-111111111111";
+    const legacyDir = path.join(tmpDir, ".openclaw", "sessions");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    const stalePath = path.join(legacyDir, `${oldSessionId}.jsonl`);
+    fs.writeFileSync(stalePath, '{"type":"session"}\n', "utf-8");
+
+    const archived = archiveSessionTranscripts({
+      sessionId: currentSessionId,
+      storePath,
+      sessionFile: stalePath,
+      reason: "reset",
+    });
+
+    expect(archived).toHaveLength(1);
+    expect(archived[0]).toContain(".reset.");
+    expect(fs.existsSync(stalePath)).toBe(false);
+    expect(fs.existsSync(archived[0])).toBe(true);
+  });
+
+  test("archives legacy-root stale transcript on delete", () => {
+    const oldSessionId = "22222222-2222-4222-8222-222222222222";
+    const currentSessionId = "11111111-1111-4111-8111-111111111111";
+    const legacyDir = path.join(tmpDir, ".openclaw", "sessions");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    const stalePath = path.join(legacyDir, `${oldSessionId}.jsonl`);
+    fs.writeFileSync(stalePath, '{"type":"session"}\n', "utf-8");
+
+    const archived = archiveSessionTranscripts({
+      sessionId: currentSessionId,
+      storePath,
+      sessionFile: stalePath,
+      reason: "deleted",
+    });
+
+    expect(archived).toHaveLength(1);
+    expect(archived[0]).toContain(".deleted.");
+    expect(fs.existsSync(stalePath)).toBe(false);
+    expect(fs.existsSync(archived[0])).toBe(true);
+  });
+
+  test("does not archive stale transcript outside legacy root", () => {
+    const oldSessionId = "22222222-2222-4222-8222-222222222222";
+    const currentSessionId = "11111111-1111-4111-8111-111111111111";
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-outside-root-"));
+    try {
+      const outsidePath = path.join(outsideDir, `${oldSessionId}.jsonl`);
+      fs.writeFileSync(outsidePath, '{"type":"session"}\n', "utf-8");
+
+      const archived = archiveSessionTranscripts({
+        sessionId: currentSessionId,
+        storePath,
+        sessionFile: outsidePath,
+        reason: "reset",
+      });
+
+      expect(archived).toStrictEqual([]);
+      expect(fs.existsSync(outsidePath)).toBe(true);
+    } finally {
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not archive symlink under legacy root that resolves outside", () => {
+    const oldSessionId = "22222222-2222-4222-8222-222222222222";
+    const currentSessionId = "11111111-1111-4111-8111-111111111111";
+    const legacyDir = path.join(tmpDir, ".openclaw", "sessions");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-symlink-target-"));
+    try {
+      const targetPath = path.join(outsideDir, "target.jsonl");
+      fs.writeFileSync(targetPath, '{"type":"session"}\n', "utf-8");
+      const symlinkPath = path.join(legacyDir, `${oldSessionId}.jsonl`);
+      fs.symlinkSync(targetPath, symlinkPath);
+
+      const archived = archiveSessionTranscripts({
+        sessionId: currentSessionId,
+        storePath,
+        sessionFile: symlinkPath,
+        reason: "reset",
+      });
+
+      expect(archived).toStrictEqual([]);
+      expect(fs.existsSync(targetPath)).toBe(true);
+    } finally {
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
Fixes #91868.

## Summary

When a stale legacy transcript path such as `~/.openclaw/sessions/<old-uuid>.jsonl` is stored in session state, `resolveSessionFilePath()` silently normalizes it to a generated path for the *current* sessionId. The legacy file therefore never appears in `resolveSessionTranscriptCandidates()` and is never archived by `/clear` or `/reset`, so it keeps getting re-attached to later prompts.

This PR adds a small containment-checked helper (`pushRawStaleLegacyCandidate`) that appends the raw stale path as an archive candidate only when it resolves under the OpenClaw-owned legacy transcript root (`~/.openclaw/sessions/`), with `fs.realpathSync`-based canonicalization to prevent symlink escape. It also adds archive-flow regression tests proving the legacy file is actually renamed on both `reset` and `deleted`, while outside-root and symlink-escape paths stay untouched.

Thanks to @Pandah97 in #92751 for identifying the same fix location; this change provides the archive-flow proof requested by ClawSweeper.

## Verification

```bash
pnpm test src/gateway/session-utils.fs.test.ts --run
pnpm test src/gateway/session-transcript-files.fs.archive-events.test.ts --run
```

- `session-utils.fs.test.ts`: 364 tests pass (includes new archive-flow regression tests).
- `session-transcript-files.fs.archive-events.test.ts`: 20 tests pass (no regressions).

## Real behavior proof

**Behavior addressed:** After `/clear` or `/reset`, stale legacy `~/.openclaw/sessions/<old-uuid>.jsonl` transcripts persist and are re-attached.

**Real environment tested:** Local Linux checkout, Node v22.22.0, pnpm 11.2.2.

**Exact steps or command run after this patch:**

```bash
cd /home/0668000780/开源社区提交2/openclaw
node /tmp/repro-91868.mjs
```

**Evidence after fix:**

```
=== Scenario 1: legacy-root stale file (should be archived) ===
archived: ['/tmp/.../.openclaw/sessions/22222222-2222-1222-8222-222222222222.jsonl.reset.2026-06-15T06-12-04.656Z']
original exists: false
archive exists: true

=== Scenario 2: outside-root stale file (should NOT be archived) ===
archived: []
original exists: true

=== Scenario 3: symlink under legacy root pointing outside (should NOT be archived) ===
archived: []
target exists: true
```

**Observed result after fix:** Legacy-root stale `.jsonl` files are renamed to `.jsonl.reset.<ts>` / `.jsonl.deleted.<ts>`; outside-root and symlink-escape files are left untouched.

**What was not tested:** Production `/clear` or `/reset` live command dispatch; behavior is covered by the archive-flow regression tests added in `session-utils.fs.test.ts`.