### PR TITLE
fix(mcp): move blocked stdio env warning from per-spawn resolver to config-write time

### DIFF
--- a/src/agents/mcp-config-shared.ts
+++ b/src/agents/mcp-config-shared.ts
@@ -31,7 +31,7 @@ const MCP_EXPLICIT_CREDENTIAL_ENV_KEYS = new Set([
   "REDIS_URL",
 ]);
 
-function isDangerousMcpStdioEnvVarName(rawKey: string): boolean {
+export function isDangerousMcpStdioEnvVarName(rawKey: string): boolean {
   if (isDangerousHostEnvVarName(rawKey)) {
     return true;
   }

--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -68,6 +68,7 @@ describe("resolveMcpTransportConfig", () => {
       },
     });
 
+    // Blocked keys are silently dropped at runtime.
     expect(resolved).toEqual({
       kind: "stdio",
       transportType: "stdio",
@@ -86,21 +87,7 @@ describe("resolveMcpTransportConfig", () => {
       requestTimeoutMs: 60_000,
       supportsParallelToolCalls: false,
     });
-    expect(logWarn).toHaveBeenCalledWith(
-      'bundle-mcp: server "probe": env "NODE_OPTIONS" is blocked for stdio startup safety and was ignored.',
-    );
-    expect(logWarn).toHaveBeenCalledWith(
-      'bundle-mcp: server "probe": env "LD_PRELOAD" is blocked for stdio startup safety and was ignored.',
-    );
-    expect(logWarn).toHaveBeenCalledWith(
-      'bundle-mcp: server "probe": env "BASH_ENV" is blocked for stdio startup safety and was ignored.',
-    );
-    expect(logWarn).toHaveBeenCalledWith(
-      'bundle-mcp: server "probe": env "ANSIBLE_CONFIG" is blocked for stdio startup safety and was ignored.',
-    );
-    expect(logWarn).toHaveBeenCalledWith(
-      'bundle-mcp: server "probe": env "TF_CLI_CONFIG_FILE" is blocked for stdio startup safety and was ignored.',
-    );
+    expect(logWarn).not.toHaveBeenCalled();
   });
 
   it("uses an explicit empty stdio env when all configured env keys are blocked", () => {
@@ -126,17 +113,21 @@ describe("resolveMcpTransportConfig", () => {
     });
   });
 
-  it("sanitizes config-controlled names in stdio env warnings", () => {
-    resolveMcpTransportConfig("probe\nWARN forged\u001b[31m", {
+  it("silently drops blocked env keys regardless of key formatting", () => {
+    const resolved = resolveMcpTransportConfig("probe", {
       command: "node",
       env: {
-        "LD_PRELOAD\nWARN forged\u001b[31m": "/tmp/pwn.so",
+        LD_PRELOAD: "/tmp/pwn.so",
+        GITHUB_TOKEN: "token",
       },
     });
 
-    expect(logWarn).toHaveBeenCalledWith(
-      'bundle-mcp: server "probeWARN forged": env "LD_PRELOADWARN forged" is blocked for stdio startup safety and was ignored.',
+    expect(resolved).toEqual(
+      expect.objectContaining({
+        env: { GITHUB_TOKEN: "token" },
+      }),
     );
+    expect(logWarn).not.toHaveBeenCalled();
   });
 
   it("resolves SSE config by default", () => {

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -204,13 +204,9 @@ export function resolveMcpTransportConfig(
   const requestedTransport = getRequestedTransport(rawServer);
   const requestedTransportAlias = requestedTransport ? "" : getRequestedTransportAlias(rawServer);
   const effectiveTransport = requestedTransport || requestedTransportAlias;
-  const stdioLaunch = resolveStdioMcpServerLaunchConfig(rawServer, {
-    onDroppedEnv: (key) => {
-      logWarn(
-        `bundle-mcp: server "${logServerName}": env "${sanitizeForLog(key)}" is blocked for stdio startup safety and was ignored.`,
-      );
-    },
-  });
+  // Blocked env keys are silently dropped at runtime — the operator is warned
+  // once at config-write time (see setConfiguredMcpServer).
+  const stdioLaunch = resolveStdioMcpServerLaunchConfig(rawServer);
   if (stdioLaunch.ok) {
     // A command-bearing server is always treated as stdio even when HTTP-ish
     // aliases are present, matching existing MCP config precedence.

--- a/src/config/mcp-config.test.ts
+++ b/src/config/mcp-config.test.ts
@@ -9,6 +9,12 @@ import {
   unsetConfiguredMcpServer,
 } from "./mcp-config.js";
 
+const mockedLogWarn = vi.fn();
+
+vi.mock("../logger.js", () => ({
+  logWarn: (...args: unknown[]) => mockedLogWarn(...args),
+}));
+
 function validationOk(raw: unknown) {
   return { ok: true as const, config: raw, warnings: [] };
 }
@@ -153,6 +159,72 @@ describe("config mcp config", () => {
           "X-Debug": true,
         },
       });
+    });
+  });
+
+  it("warns once when saving a stdio server with blocked env keys", async () => {
+    mockedLogWarn.mockClear();
+    await withMcpConfigHome({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "blocked-env",
+        server: {
+          command: "python",
+          args: ["server.py"],
+          env: {
+            PYTHONPATH: "/tmp/workspace",
+            NODE_OPTIONS: "--require=./evil.js",
+            PYTHONUNBUFFERED: "1",
+          },
+        },
+      });
+
+      expect(setResult.ok).toBe(true);
+      expect(mockedLogWarn).toHaveBeenCalledTimes(2);
+      expect(mockedLogWarn).toHaveBeenCalledWith(
+        'bundle-mcp: server "blocked-env": env "PYTHONPATH" is blocked for stdio startup safety and will be ignored at runtime. Remove it from the config or handle it inside the server script.',
+      );
+      expect(mockedLogWarn).toHaveBeenCalledWith(
+        'bundle-mcp: server "blocked-env": env "NODE_OPTIONS" is blocked for stdio startup safety and will be ignored at runtime. Remove it from the config or handle it inside the server script.',
+      );
+    });
+  });
+
+  it("does not warn for stdio servers with no blocked env keys", async () => {
+    mockedLogWarn.mockClear();
+    await withMcpConfigHome({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "clean-env",
+        server: {
+          command: "node",
+          args: ["server.js"],
+          env: {
+            PYTHONUNBUFFERED: "1",
+            GITHUB_TOKEN: "token",
+          },
+        },
+      });
+
+      expect(setResult.ok).toBe(true);
+      expect(mockedLogWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not warn for HTTP servers with blocked env keys", async () => {
+    mockedLogWarn.mockClear();
+    await withMcpConfigHome({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "http-server",
+        server: {
+          url: "https://mcp.example.com/sse",
+          env: {
+            PYTHONPATH: "/tmp/workspace",
+          },
+        },
+      });
+
+      expect(setResult.ok).toBe(true);
+      // env is only checked for stdio servers (with a command field).
+      expect(mockedLogWarn).not.toHaveBeenCalled();
     });
   });
 

--- a/src/config/mcp-config.test.ts
+++ b/src/config/mcp-config.test.ts
@@ -228,6 +228,29 @@ describe("config mcp config", () => {
     });
   });
 
+  it("sanitizes server names in blocked-env warnings", async () => {
+    mockedLogWarn.mockClear();
+    await withMcpConfigHome({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        // Server name with newline and ANSI escape that must be stripped.
+        name: "bad\nWARN forged[31m",
+        server: {
+          command: "node",
+          args: ["server.js"],
+          env: { LD_PRELOAD: "/tmp/pwn.so" },
+        },
+      });
+
+      expect(setResult.ok).toBe(true);
+      expect(mockedLogWarn).toHaveBeenCalledTimes(1);
+      const warnMsg = mockedLogWarn.mock.calls[0][0] as string;
+      expect(warnMsg).toContain('server "badWARN forged"');
+      expect(warnMsg).toContain("LD_PRELOAD");
+      expect(warnMsg).not.toContain("\n");
+      expect(warnMsg).not.toContain("");
+    });
+  });
+
   it("canonicalizes CLI-native HTTP type aliases when saving MCP config", async () => {
     await withMcpConfigHome({}, async () => {
       const setResult = await setConfiguredMcpServer({

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -1,3 +1,4 @@
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 // Normalizes MCP server config for runtime launch and validation.
 import { isDangerousMcpStdioEnvVarName, isMcpConfigRecord } from "../agents/mcp-config-shared.js";
 import { logWarn } from "../logger.js";
@@ -201,7 +202,7 @@ function warnBlockedMcpStdioEnvKeys(serverName: string, server: Record<string, u
   for (const key of Object.keys(server.env)) {
     if (isDangerousMcpStdioEnvVarName(key)) {
       logWarn(
-        `bundle-mcp: server "${serverName}": env "${key}" is blocked for stdio startup safety and will be ignored at runtime. Remove it from the config or handle it inside the server script.`,
+        `bundle-mcp: server "${sanitizeForLog(serverName)}": env "${sanitizeForLog(key)}" is blocked for stdio startup safety and will be ignored at runtime. Remove it from the config or handle it inside the server script.`,
       );
     }
   }

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -1,4 +1,6 @@
 // Normalizes MCP server config for runtime launch and validation.
+import { isDangerousMcpStdioEnvVarName, isMcpConfigRecord } from "../agents/mcp-config-shared.js";
+import { logWarn } from "../logger.js";
 import { isRecord } from "../utils.js";
 import { readSourceConfigSnapshot } from "./io.js";
 import {
@@ -188,6 +190,23 @@ export async function updateConfiguredMcpServer(params: {
   };
 }
 
+function warnBlockedMcpStdioEnvKeys(serverName: string, server: Record<string, unknown>): void {
+  // Only stdio servers with a command and env block are relevant.
+  if (typeof server.command !== "string" || !server.command.trim()) {
+    return;
+  }
+  if (!isMcpConfigRecord(server.env)) {
+    return;
+  }
+  for (const key of Object.keys(server.env)) {
+    if (isDangerousMcpStdioEnvVarName(key)) {
+      logWarn(
+        `bundle-mcp: server "${serverName}": env "${key}" is blocked for stdio startup safety and will be ignored at runtime. Remove it from the config or handle it inside the server script.`,
+      );
+    }
+  }
+}
+
 export async function setConfiguredMcpServer(params: {
   name: string;
   server: unknown;
@@ -208,6 +227,11 @@ export async function setConfiguredMcpServer(params: {
   const next = structuredClone(loaded.config);
   const servers = normalizeConfiguredMcpServers(next.mcp?.servers);
   servers[name] = canonicalizeConfiguredMcpServer(params.server);
+
+  // Warn once about blocked stdio env keys at config-write time instead of
+  // repeating the warning on every spawn / probe / status / doctor call.
+  warnBlockedMcpStdioEnvKeys(name, servers[name]);
+
   next.mcp = {
     ...next.mcp,
     servers,


### PR DESCRIPTION
## Summary

Fixes #92474 by moving the blocked stdio env warning from the per-spawn runtime resolver to the config-write time, where it fires once instead of on every probe/spawn/status/doctor call.

## Root cause

The runtime safety filter (`toMcpEnvRecord` → `isDangerousMcpStdioEnvVarName`) correctly drops blocked env keys (PYTHONPATH, NODE_OPTIONS, LD_PRELOAD, etc.) but previously logged a warning via `onDroppedEnv` callback every time the resolver ran — on every spawn, probe, status, and doctor call — flooding the gateway journal with repeated identical messages.

## Changes

- Export `isDangerousMcpStdioEnvVarName` from `mcp-config-shared.ts` so the config layer can use it
- Remove per-call `logWarn` from `resolveMcpTransportConfig` — runtime now silently drops blocked env keys
- Add `warnBlockedMcpStdioEnvKeys` in `setConfiguredMcpServer` to warn once at config-write time
- Add regression tests: blocked env keys (warns), clean env (no warn), HTTP server (no warn for env)

## Real behavior proof

Behavior addressed: Blocked stdio env key warning now fires once at config-write time instead of on every MCP operation.

Real environment tested: Local OpenClaw checkout on Linux, current branch.

Exact steps or command run after this patch:

```
openclaw mcp set test-server '{command:python,args:[server.py],env:{PYTHONPATH:/tmp/test,PYTHONUNBUFFERED:1}}'
```

Evidence after fix:

```
[bundle-mcp] server "test-server": env "PYTHONPATH" is blocked for stdio startup safety
and will be ignored at runtime. Remove it from the config or handle it inside the server script.
```

Subsequent operations produce **no** blocked-env warnings:

```
$ openclaw mcp list
MCP servers: test-server       ← no blocked warnings

$ openclaw mcp probe test-server
McpError: Connection closed    ← python not installed, but no PYTHONPATH block warning
```

Observed result after fix: warning appears exactly once (at `mcp set`), then never again.

What was not tested: A running gateway over multiple chat turns (the log flooding reported in #92474 requires a live MCP server with repeated spawns).

## Tests

- `node scripts/run-vitest.mjs src/agents/mcp-transport-config.test.ts` — 9 passed
- `node scripts/run-vitest.mjs src/config/mcp-config.test.ts` — 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)