### PR TITLE
fix(agents): preserve prompt-released session metadata

### DIFF
--- a/extensions/codex/src/app-server/session-history.test.ts
+++ b/extensions/codex/src/app-server/session-history.test.ts
@@ -1,0 +1,133 @@
+// Codex tests cover mirrored session-history branch selection.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
+import { afterEach, describe, expect, it } from "vitest";
+import { readCodexMirroredSessionHistoryMessages } from "./session-history.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function writeSession(records: unknown[]): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-session-history-"));
+  tempDirs.push(dir);
+  const sessionFile = path.join(dir, "session.jsonl");
+  const header = {
+    type: "session",
+    version: CURRENT_SESSION_VERSION,
+    id: "codex-session",
+    timestamp: "2026-06-15T00:00:00.000Z",
+    cwd: dir,
+  };
+  await fs.writeFile(
+    sessionFile,
+    [header, ...records].map((record) => JSON.stringify(record)).join("\n") + "\n",
+  );
+  return sessionFile;
+}
+
+function messageEntry(params: {
+  id: string;
+  parentId: string | null;
+  role: "user" | "assistant";
+  content: string;
+}) {
+  return {
+    type: "message",
+    id: params.id,
+    parentId: params.parentId,
+    timestamp: "2026-06-15T00:00:00.000Z",
+    message: {
+      role: params.role,
+      content: params.content,
+      timestamp: 1,
+    },
+  };
+}
+
+describe("readCodexMirroredSessionHistoryMessages", () => {
+  it("replays only the branch selected by a leaf control", async () => {
+    const sessionFile = await writeSession([
+      messageEntry({ id: "root", parentId: null, role: "user", content: "root prompt" }),
+      messageEntry({
+        id: "active",
+        parentId: "root",
+        role: "assistant",
+        content: "active answer",
+      }),
+      messageEntry({
+        id: "inactive",
+        parentId: "root",
+        role: "assistant",
+        content: "inactive answer",
+      }),
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "inactive",
+        targetId: "active",
+      },
+    ]);
+
+    await expect(readCodexMirroredSessionHistoryMessages(sessionFile)).resolves.toMatchObject([
+      { role: "user", content: "root prompt" },
+      { role: "assistant", content: "active answer" },
+    ]);
+  });
+
+  it("honors explicit navigation to an empty branch", async () => {
+    const sessionFile = await writeSession([
+      messageEntry({ id: "old", parentId: null, role: "user", content: "old prompt" }),
+      {
+        type: "leaf",
+        id: "empty-leaf",
+        parentId: "old",
+        targetId: null,
+        appendParentId: "old",
+      },
+    ]);
+
+    await expect(readCodexMirroredSessionHistoryMessages(sessionFile)).resolves.toEqual([]);
+  });
+
+  it("keeps visible history when continuation rows use a disjoint append cursor", async () => {
+    const sessionFile = await writeSession([
+      messageEntry({ id: "visible", parentId: null, role: "user", content: "visible prompt" }),
+      messageEntry({
+        id: "inactive",
+        parentId: "visible",
+        role: "assistant",
+        content: "inactive answer",
+      }),
+      {
+        type: "metadata",
+        id: "append-metadata",
+        parentId: "inactive",
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "inactive",
+        targetId: "visible",
+        appendParentId: "append-metadata",
+      },
+      messageEntry({
+        id: "continued",
+        parentId: "append-metadata",
+        role: "assistant",
+        content: "continued answer",
+      }),
+    ]);
+
+    await expect(readCodexMirroredSessionHistoryMessages(sessionFile)).resolves.toMatchObject([
+      { role: "user", content: "visible prompt" },
+      { role: "assistant", content: "continued answer" },
+    ]);
+  });
+});

--- a/extensions/codex/src/app-server/session-history.test.ts
+++ b/extensions/codex/src/app-server/session-history.test.ts
@@ -130,4 +130,33 @@ describe("readCodexMirroredSessionHistoryMessages", () => {
       { role: "assistant", content: "continued answer" },
     ]);
   });
+
+  it("keeps visible history when a continuation references the leaf marker", async () => {
+    const sessionFile = await writeSession([
+      messageEntry({ id: "visible", parentId: null, role: "user", content: "visible prompt" }),
+      messageEntry({
+        id: "inactive",
+        parentId: "visible",
+        role: "assistant",
+        content: "inactive answer",
+      }),
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "inactive",
+        targetId: "visible",
+      },
+      messageEntry({
+        id: "continued",
+        parentId: "active-leaf",
+        role: "assistant",
+        content: "continued answer",
+      }),
+    ]);
+
+    await expect(readCodexMirroredSessionHistoryMessages(sessionFile)).resolves.toMatchObject([
+      { role: "user", content: "visible prompt" },
+      { role: "assistant", content: "continued answer" },
+    ]);
+  });
 });

--- a/extensions/codex/src/app-server/session-history.ts
+++ b/extensions/codex/src/app-server/session-history.ts
@@ -9,6 +9,7 @@ import {
   buildSessionContext,
   migrateSessionEntries,
   parseSessionEntries,
+  selectSessionTranscriptLeafControlledPath,
 } from "openclaw/plugin-sdk/agent-sessions";
 import { sanitizeCodexHistoryImagePayloads } from "./image-payload-sanitizer.js";
 
@@ -36,8 +37,10 @@ export async function readCodexMirroredSessionHistoryMessages(
     const sessionEntries = entries.filter(
       (entry): entry is SessionEntry => entry.type !== "session",
     );
+    const selectedEntries =
+      selectSessionTranscriptLeafControlledPath(sessionEntries) ?? sessionEntries;
     return sanitizeCodexHistoryImagePayloads(
-      buildSessionContext(sessionEntries).messages,
+      buildSessionContext(selectedEntries).messages,
       "codex mirrored history",
     );
   } catch (error) {

--- a/extensions/codex/src/app-server/session-history.ts
+++ b/extensions/codex/src/app-server/session-history.ts
@@ -9,7 +9,6 @@ import {
   buildSessionContext,
   migrateSessionEntries,
   parseSessionEntries,
-  selectSessionTranscriptLeafControlledPath,
 } from "openclaw/plugin-sdk/agent-sessions";
 import { sanitizeCodexHistoryImagePayloads } from "./image-payload-sanitizer.js";
 
@@ -37,10 +36,8 @@ export async function readCodexMirroredSessionHistoryMessages(
     const sessionEntries = entries.filter(
       (entry): entry is SessionEntry => entry.type !== "session",
     );
-    const selectedEntries =
-      selectSessionTranscriptLeafControlledPath(sessionEntries) ?? sessionEntries;
     return sanitizeCodexHistoryImagePayloads(
-      buildSessionContext(selectedEntries).messages,
+      buildSessionContext(sessionEntries).messages,
       "codex mirrored history",
     );
   } catch (error) {

--- a/packages/agent-core/src/harness/session/jsonl-storage.test.ts
+++ b/packages/agent-core/src/harness/session/jsonl-storage.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import { ok, type FileSystem } from "../types.js";
 import { JsonlSessionStorage, loadJsonlSessionMetadata } from "./jsonl-storage.js";
+import { Session } from "./session.js";
 
 type JsonlStorageFs = Pick<
   FileSystem,
@@ -54,5 +55,144 @@ describe("JsonlSessionStorage timestamps", () => {
     await expect(JsonlSessionStorage.open(fs, "/sessions/invalid-entry.jsonl")).rejects.toThrow(
       "line 2 has invalid timestamp",
     );
+  });
+
+  it("uses a leaf control's opaque append parent for the next entry", async () => {
+    let content = [
+      {
+        type: "session",
+        version: 3,
+        id: "session-1",
+        timestamp: "2026-06-15T00:00:00.000Z",
+        cwd: "/repo",
+      },
+      {
+        type: "custom",
+        id: "active-root",
+        parentId: null,
+        timestamp: "2026-06-15T00:00:01.000Z",
+        customType: "root",
+      },
+      {
+        type: "metadata",
+        id: "plugin-metadata",
+        parentId: null,
+        timestamp: "2026-06-15T00:00:02.000Z",
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "inactive-tail",
+        timestamp: "2026-06-15T00:00:03.000Z",
+        targetId: "active-root",
+        appendParentId: "plugin-metadata",
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join("\n");
+    content += "\n";
+    const fs: JsonlStorageFs = {
+      ...createReadOnlyFs(content),
+      readTextFile: async () => ok(content),
+      appendFile: async (_path, appended) => {
+        content += String(appended);
+        return ok(undefined);
+      },
+    };
+    const storage = await JsonlSessionStorage.open(fs, "/sessions/session.jsonl");
+    const session = new Session(storage);
+
+    expect(await session.getLeafId()).toBe("active-root");
+    const entryId = await session.appendCustomEntry("continued");
+    const entry = await session.getEntry(entryId);
+
+    expect(entry).toMatchObject({ parentId: "plugin-metadata" });
+    expect((await storage.getPathToRoot(entryId)).map((pathEntry) => pathEntry.id)).toEqual([
+      "active-root",
+      entryId,
+    ]);
+    expect(content.trim().split(/\r?\n/).at(-1)).toContain('"parentId":"plugin-metadata"');
+  });
+
+  it("does not let opaque rows replace the selected visible leaf", async () => {
+    const content = [
+      {
+        type: "session",
+        version: 3,
+        id: "session-1",
+        timestamp: "2026-06-15T00:00:00.000Z",
+        cwd: "/repo",
+      },
+      {
+        type: "custom",
+        id: "active-root",
+        parentId: null,
+        timestamp: "2026-06-15T00:00:01.000Z",
+        customType: "active",
+      },
+      {
+        type: "custom",
+        id: "inactive-root",
+        parentId: null,
+        timestamp: "2026-06-15T00:00:02.000Z",
+        customType: "inactive",
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "inactive-root",
+        timestamp: "2026-06-15T00:00:03.000Z",
+        targetId: "active-root",
+      },
+      {
+        type: "metadata",
+        id: "plugin-metadata",
+        parentId: "inactive-root",
+        timestamp: "2026-06-15T00:00:04.000Z",
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join("\n");
+    const storage = await JsonlSessionStorage.open(
+      createReadOnlyFs(`${content}\n`),
+      "/sessions/session.jsonl",
+    );
+    const session = new Session(storage);
+
+    expect(await session.getLeafId()).toBe("active-root");
+    expect((await session.getBranch()).map((entry) => entry.id)).toEqual(["active-root"]);
+  });
+
+  it("rejects a leaf control with a missing append parent", async () => {
+    const content = [
+      {
+        type: "session",
+        version: 3,
+        id: "session-1",
+        timestamp: "2026-06-15T00:00:00.000Z",
+        cwd: "/repo",
+      },
+      {
+        type: "custom",
+        id: "active-root",
+        parentId: null,
+        timestamp: "2026-06-15T00:00:01.000Z",
+        customType: "active",
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "active-root",
+        timestamp: "2026-06-15T00:00:02.000Z",
+        targetId: "active-root",
+        appendParentId: "missing",
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join("\n");
+
+    await expect(
+      JsonlSessionStorage.open(createReadOnlyFs(`${content}\n`), "/sessions/session.jsonl"),
+    ).rejects.toThrow("Append parent missing not found");
   });
 });

--- a/packages/agent-core/src/harness/session/jsonl-storage.test.ts
+++ b/packages/agent-core/src/harness/session/jsonl-storage.test.ts
@@ -114,6 +114,72 @@ describe("JsonlSessionStorage timestamps", () => {
     expect(content.trim().split(/\r?\n/).at(-1)).toContain('"parentId":"plugin-metadata"');
   });
 
+  it("keeps a terminal side append off the visible branch", async () => {
+    let content = [
+      {
+        type: "session",
+        version: 3,
+        id: "session-1",
+        timestamp: "2026-06-15T00:00:00.000Z",
+        cwd: "/repo",
+      },
+      {
+        type: "custom",
+        id: "active-root",
+        parentId: null,
+        timestamp: "2026-06-15T00:00:01.000Z",
+        customType: "active",
+      },
+      {
+        type: "custom",
+        id: "side-one",
+        parentId: "active-root",
+        timestamp: "2026-06-15T00:00:02.000Z",
+        customType: "side",
+      },
+      {
+        type: "leaf",
+        id: "side-leaf",
+        parentId: "side-one",
+        timestamp: "2026-06-15T00:00:03.000Z",
+        targetId: "active-root",
+        appendParentId: "side-one",
+        appendMode: "side",
+      },
+      {
+        type: "custom",
+        id: "side-two",
+        parentId: "side-one",
+        timestamp: "2026-06-15T00:00:04.000Z",
+        customType: "side",
+        appendMode: "side",
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join("\n");
+    content += "\n";
+    const fs: JsonlStorageFs = {
+      ...createReadOnlyFs(content),
+      readTextFile: async () => ok(content),
+      appendFile: async (_path, appended) => {
+        content += String(appended);
+        return ok(undefined);
+      },
+    };
+    const storage = await JsonlSessionStorage.open(fs, "/sessions/session.jsonl");
+    const session = new Session(storage);
+
+    expect(await storage.getLeafId()).toBe("active-root");
+    expect(await storage.getAppendParentId()).toBe("side-two");
+    const entryId = await session.appendCustomEntry("continued");
+
+    expect(await storage.getEntry(entryId)).toMatchObject({ parentId: "side-two" });
+    expect((await storage.getPathToRoot(entryId)).map((entry) => entry.id)).toEqual([
+      "active-root",
+      entryId,
+    ]);
+  });
+
   it("does not let opaque rows replace the selected visible leaf", async () => {
     const content = [
       {

--- a/packages/agent-core/src/harness/session/jsonl-storage.ts
+++ b/packages/agent-core/src/harness/session/jsonl-storage.ts
@@ -2,7 +2,11 @@
 import type { FileSystem, JsonlSessionMetadata, SessionTreeEntry } from "../types.js";
 import { SessionError, toError } from "../types.js";
 import { getFileSystemResultOrThrow } from "./repo-utils.js";
-import { BaseSessionStorage, leafIdAfterEntry } from "./storage-base.js";
+import {
+  appendParentIdAfterEntry,
+  BaseSessionStorage,
+  leafIdUpdateAfterEntry,
+} from "./storage-base.js";
 import { parseSessionTimestampMs } from "./timestamps.js";
 
 type JsonlSessionStorageFileSystem = Pick<
@@ -113,6 +117,14 @@ function parseEntryLine(line: string, filePath: string, lineNumber: number): Ses
   if (parsed.type === "leaf" && parsed.targetId !== null && typeof parsed.targetId !== "string") {
     throw invalidEntry(filePath, lineNumber, "has invalid targetId");
   }
+  if (
+    parsed.type === "leaf" &&
+    parsed.appendParentId !== undefined &&
+    parsed.appendParentId !== null &&
+    typeof parsed.appendParentId !== "string"
+  ) {
+    throw invalidEntry(filePath, lineNumber, "has invalid appendParentId");
+  }
   return parsed as unknown as SessionTreeEntry;
 }
 
@@ -149,6 +161,7 @@ async function loadJsonlStorage(
   header: SessionHeader;
   entries: SessionTreeEntry[];
   leafId: string | null;
+  appendParentId: string | null;
 }> {
   const content = getFileSystemResultOrThrow(
     await fs.readTextFile(filePath),
@@ -162,12 +175,17 @@ async function loadJsonlStorage(
   const header = parseHeaderLine(lines[0], filePath);
   const entries: SessionTreeEntry[] = [];
   let leafId: string | null = null;
+  let appendParentId: string | null = null;
   for (let i = 1; i < lines.length; i++) {
     const entry = parseEntryLine(lines[i], filePath, i + 1);
     entries.push(entry);
-    leafId = leafIdAfterEntry(entry);
+    const leafUpdate = leafIdUpdateAfterEntry(entry);
+    if (leafUpdate !== undefined) {
+      leafId = leafUpdate;
+    }
+    appendParentId = appendParentIdAfterEntry(entry);
   }
-  return { header, entries, leafId };
+  return { header, entries, leafId, appendParentId };
 }
 
 /** Append-only JSONL-backed storage for one session tree. */
@@ -181,8 +199,9 @@ export class JsonlSessionStorage extends BaseSessionStorage<JsonlSessionMetadata
     header: SessionHeader,
     entries: SessionTreeEntry[],
     leafId: string | null,
+    appendParentId: string | null,
   ) {
-    super(headerToSessionMetadata(header, filePath), entries, leafId);
+    super(headerToSessionMetadata(header, filePath), entries, leafId, appendParentId);
     this.fs = fs;
     this.filePath = filePath;
   }
@@ -192,7 +211,14 @@ export class JsonlSessionStorage extends BaseSessionStorage<JsonlSessionMetadata
     filePath: string,
   ): Promise<JsonlSessionStorage> {
     const loaded = await loadJsonlStorage(fs, filePath);
-    return new JsonlSessionStorage(fs, filePath, loaded.header, loaded.entries, loaded.leafId);
+    return new JsonlSessionStorage(
+      fs,
+      filePath,
+      loaded.header,
+      loaded.entries,
+      loaded.leafId,
+      loaded.appendParentId,
+    );
   }
 
   /** Create a new JSONL file with a session header and no entries. */
@@ -217,7 +243,7 @@ export class JsonlSessionStorage extends BaseSessionStorage<JsonlSessionMetadata
       await fs.writeFile(filePath, `${JSON.stringify(header)}\n`),
       `Failed to create session ${filePath}`,
     );
-    return new JsonlSessionStorage(fs, filePath, header, [], null);
+    return new JsonlSessionStorage(fs, filePath, header, [], null, null);
   }
 
   override async setLeafId(leafId: string | null): Promise<void> {
@@ -230,6 +256,7 @@ export class JsonlSessionStorage extends BaseSessionStorage<JsonlSessionMetadata
   }
 
   override async appendEntry(entry: SessionTreeEntry): Promise<void> {
+    this.validateEntryForAppend(entry);
     getFileSystemResultOrThrow(
       await this.fs.appendFile(this.filePath, `${JSON.stringify(entry)}\n`),
       `Failed to append session entry ${entry.id}`,

--- a/packages/agent-core/src/harness/session/jsonl-storage.ts
+++ b/packages/agent-core/src/harness/session/jsonl-storage.ts
@@ -125,6 +125,9 @@ function parseEntryLine(line: string, filePath: string, lineNumber: number): Ses
   ) {
     throw invalidEntry(filePath, lineNumber, "has invalid appendParentId");
   }
+  if (parsed.appendMode !== undefined && parsed.appendMode !== "side") {
+    throw invalidEntry(filePath, lineNumber, "has invalid appendMode");
+  }
   return parsed as unknown as SessionTreeEntry;
 }
 

--- a/packages/agent-core/src/harness/session/memory-storage.test.ts
+++ b/packages/agent-core/src/harness/session/memory-storage.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import type { SessionTreeEntry } from "../types.js";
 import { InMemorySessionStorage } from "./memory-storage.js";
+import { Session } from "./session.js";
 
 const rootEntry: SessionTreeEntry = {
   type: "custom",
@@ -85,5 +86,46 @@ describe("InMemorySessionStorage", () => {
       "replacement",
     ]);
     expect((await storage.getPathToRoot(leafEntry.id)).map((entry) => entry.id)).toEqual(["root"]);
+  });
+
+  it("honors an explicit root append parent after a visible leaf selection", async () => {
+    const storage = new InMemorySessionStorage({
+      entries: [
+        rootEntry,
+        {
+          type: "leaf",
+          id: "leaf-1",
+          parentId: "root",
+          timestamp: "2026-01-01T00:00:01.000Z",
+          targetId: "root",
+          appendParentId: null,
+        },
+      ],
+    });
+    const session = new Session(storage);
+
+    const entryId = await session.appendCustomEntry("new-root");
+
+    expect(await session.getEntry(entryId)).toMatchObject({ parentId: null });
+    expect((await storage.getPathToRoot(entryId)).map((entry) => entry.id)).toEqual([
+      "root",
+      entryId,
+    ]);
+  });
+
+  it("rejects a leaf entry with a missing append parent before recording it", async () => {
+    const storage = new InMemorySessionStorage({ entries: [rootEntry] });
+
+    await expect(
+      storage.appendEntry({
+        type: "leaf",
+        id: "leaf-1",
+        parentId: "root",
+        timestamp: "2026-01-01T00:00:01.000Z",
+        targetId: "root",
+        appendParentId: "missing",
+      }),
+    ).rejects.toThrow("Append parent missing not found");
+    expect(await storage.getEntries()).toEqual([rootEntry]);
   });
 });

--- a/packages/agent-core/src/harness/session/memory-storage.test.ts
+++ b/packages/agent-core/src/harness/session/memory-storage.test.ts
@@ -113,6 +113,62 @@ describe("InMemorySessionStorage", () => {
     ]);
   });
 
+  it("keeps marked side ancestry separate from the next active append", async () => {
+    const sideOne: SessionTreeEntry = {
+      type: "custom",
+      id: "side-one",
+      parentId: "root",
+      timestamp: "2026-01-01T00:00:01.000Z",
+      customType: "side",
+    };
+    const sideTwo: SessionTreeEntry = {
+      type: "custom",
+      id: "side-two",
+      parentId: sideOne.id,
+      timestamp: "2026-01-01T00:00:03.000Z",
+      appendMode: "side",
+      customType: "side",
+    };
+    const storage = new InMemorySessionStorage({
+      entries: [
+        rootEntry,
+        sideOne,
+        {
+          type: "leaf",
+          id: "first-leaf",
+          parentId: sideOne.id,
+          timestamp: "2026-01-01T00:00:02.000Z",
+          targetId: "root",
+          appendParentId: sideOne.id,
+          appendMode: "side",
+        },
+        sideTwo,
+        {
+          type: "leaf",
+          id: "second-leaf",
+          parentId: sideTwo.id,
+          timestamp: "2026-01-01T00:00:04.000Z",
+          targetId: "root",
+          appendParentId: sideTwo.id,
+          appendMode: "side",
+        },
+      ],
+    });
+    const session = new Session(storage);
+
+    expect((await storage.getPathToRoot(sideTwo.id)).map((entry) => entry.id)).toEqual([
+      "root",
+      sideOne.id,
+      sideTwo.id,
+    ]);
+
+    const nextEntryId = await session.appendCustomEntry("active");
+    expect((await storage.getPathToRoot(nextEntryId)).map((entry) => entry.id)).toEqual([
+      "root",
+      nextEntryId,
+    ]);
+  });
+
   it("rejects a leaf entry with a missing append parent before recording it", async () => {
     const storage = new InMemorySessionStorage({ entries: [rootEntry] });
 

--- a/packages/agent-core/src/harness/session/memory-storage.test.ts
+++ b/packages/agent-core/src/harness/session/memory-storage.test.ts
@@ -60,4 +60,30 @@ describe("InMemorySessionStorage", () => {
       targetId: "root",
     });
   });
+
+  it("traverses descendants of leaf markers through the selected target", async () => {
+    const leafEntry: SessionTreeEntry = {
+      type: "leaf",
+      id: "leaf-1",
+      parentId: "child",
+      timestamp: "2026-01-01T00:00:02.000Z",
+      targetId: "root",
+    };
+    const replacementEntry: SessionTreeEntry = {
+      type: "custom",
+      id: "replacement",
+      parentId: leafEntry.id,
+      timestamp: "2026-01-01T00:00:03.000Z",
+      customType: "replacement",
+    };
+    const storage = new InMemorySessionStorage({
+      entries: [rootEntry, childEntry, leafEntry, replacementEntry],
+    });
+
+    expect((await storage.getPathToRoot(replacementEntry.id)).map((entry) => entry.id)).toEqual([
+      "root",
+      "replacement",
+    ]);
+    expect((await storage.getPathToRoot(leafEntry.id)).map((entry) => entry.id)).toEqual(["root"]);
+  });
 });

--- a/packages/agent-core/src/harness/session/memory-storage.test.ts
+++ b/packages/agent-core/src/harness/session/memory-storage.test.ts
@@ -143,19 +143,12 @@ describe("InMemorySessionStorage", () => {
           appendMode: "side",
         },
         sideTwo,
-        {
-          type: "leaf",
-          id: "second-leaf",
-          parentId: sideTwo.id,
-          timestamp: "2026-01-01T00:00:04.000Z",
-          targetId: "root",
-          appendParentId: sideTwo.id,
-          appendMode: "side",
-        },
       ],
     });
     const session = new Session(storage);
 
+    expect(await storage.getLeafId()).toBe("root");
+    expect(await storage.getAppendParentId()).toBe(sideTwo.id);
     expect((await storage.getPathToRoot(sideTwo.id)).map((entry) => entry.id)).toEqual([
       "root",
       sideOne.id,

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -122,6 +122,10 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
     return this.storage.getLeafId();
   }
 
+  private getAppendParentId(): Promise<string | null> {
+    return this.storage.getAppendParentId?.() ?? this.storage.getLeafId();
+  }
+
   getEntry(id: string): Promise<SessionTreeEntry | undefined> {
     return this.storage.getEntry(id);
   }
@@ -157,7 +161,7 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
     return this.appendTypedEntry({
       type: "message",
       id: await this.storage.createEntryId(),
-      parentId: await this.storage.getLeafId(),
+      parentId: await this.getAppendParentId(),
       timestamp: new Date().toISOString(),
       message,
     } satisfies MessageEntry);
@@ -167,7 +171,7 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
     return this.appendTypedEntry({
       type: "thinking_level_change",
       id: await this.storage.createEntryId(),
-      parentId: await this.storage.getLeafId(),
+      parentId: await this.getAppendParentId(),
       timestamp: new Date().toISOString(),
       thinkingLevel,
     } satisfies ThinkingLevelChangeEntry);
@@ -177,7 +181,7 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
     return this.appendTypedEntry({
       type: "model_change",
       id: await this.storage.createEntryId(),
-      parentId: await this.storage.getLeafId(),
+      parentId: await this.getAppendParentId(),
       timestamp: new Date().toISOString(),
       provider,
       modelId,
@@ -194,7 +198,7 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
     return this.appendTypedEntry({
       type: "compaction",
       id: await this.storage.createEntryId(),
-      parentId: await this.storage.getLeafId(),
+      parentId: await this.getAppendParentId(),
       timestamp: new Date().toISOString(),
       summary,
       firstKeptEntryId,
@@ -209,7 +213,7 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
     return this.appendTypedEntry({
       type: "custom",
       id: await this.storage.createEntryId(),
-      parentId: await this.storage.getLeafId(),
+      parentId: await this.getAppendParentId(),
       timestamp: new Date().toISOString(),
       customType,
       data,
@@ -226,7 +230,7 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
     return this.appendTypedEntry({
       type: "custom_message",
       id: await this.storage.createEntryId(),
-      parentId: await this.storage.getLeafId(),
+      parentId: await this.getAppendParentId(),
       timestamp: new Date().toISOString(),
       customType,
       content,
@@ -243,7 +247,7 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
     return this.appendTypedEntry({
       type: "label",
       id: await this.storage.createEntryId(),
-      parentId: await this.storage.getLeafId(),
+      parentId: await this.getAppendParentId(),
       timestamp: new Date().toISOString(),
       targetId,
       label,
@@ -254,7 +258,7 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
     return this.appendTypedEntry({
       type: "session_info",
       id: await this.storage.createEntryId(),
-      parentId: await this.storage.getLeafId(),
+      parentId: await this.getAppendParentId(),
       timestamp: new Date().toISOString(),
       name: name.trim(),
     } satisfies SessionInfoEntry);

--- a/packages/agent-core/src/harness/session/storage-base.ts
+++ b/packages/agent-core/src/harness/session/storage-base.ts
@@ -44,6 +44,9 @@ function generateEntryId(byId: { has(id: string): boolean }): string {
 
 /** Return the visible-leaf update represented by one session tree entry. */
 export function leafIdUpdateAfterEntry(entry: SessionTreeEntry): string | null | undefined {
+  if (entry.type !== "leaf" && isSideAppendEntry(entry)) {
+    return undefined;
+  }
   switch (entry.type) {
     case "leaf":
       return entry.targetId;

--- a/packages/agent-core/src/harness/session/storage-base.ts
+++ b/packages/agent-core/src/harness/session/storage-base.ts
@@ -137,14 +137,24 @@ export abstract class BaseSessionStorage<
     if (!current) {
       throw new SessionError("not_found", `Entry ${leafId} not found`);
     }
+    const seen = new Set<string>();
     while (current) {
-      path.unshift(current);
-      if (!current.parentId) {
+      if (seen.has(current.id)) {
+        throw new SessionError("invalid_session", `Cycle found at entry ${current.id}`);
+      }
+      seen.add(current.id);
+      if (current.type !== "leaf") {
+        path.unshift(current);
+      }
+      // Leaf rows are control records. Descendants written by older appenders
+      // may point at the marker, but their visible ancestry starts at its target.
+      const parentId = current.type === "leaf" ? current.targetId : current.parentId;
+      if (!parentId) {
         break;
       }
-      const parent = this.byId.get(current.parentId);
+      const parent = this.byId.get(parentId);
       if (!parent) {
-        throw new SessionError("invalid_session", `Entry ${current.parentId} not found`);
+        throw new SessionError("invalid_session", `Entry ${parentId} not found`);
       }
       current = parent;
     }

--- a/packages/agent-core/src/harness/session/storage-base.ts
+++ b/packages/agent-core/src/harness/session/storage-base.ts
@@ -38,17 +38,71 @@ function generateEntryId(byId: { has(id: string): boolean }): string {
   return uuidv7();
 }
 
-/** Return the effective branch leaf after applying a session tree entry. */
-export function leafIdAfterEntry(entry: SessionTreeEntry): string | null {
-  return entry.type === "leaf" ? entry.targetId : entry.id;
+/** Return the visible-leaf update represented by one session tree entry. */
+export function leafIdUpdateAfterEntry(entry: SessionTreeEntry): string | null | undefined {
+  switch (entry.type) {
+    case "leaf":
+      return entry.targetId;
+    case "message":
+    case "thinking_level_change":
+    case "model_change":
+    case "compaction":
+    case "branch_summary":
+    case "custom":
+    case "custom_message":
+    case "label":
+    case "session_info":
+      return entry.id;
+    default:
+      // JSONL transcripts may contain parent-linked plugin rows that advance
+      // the raw append cursor without selecting a model-visible branch.
+      return undefined;
+  }
+}
+
+/** Return the raw parent for the next append after applying a tree entry. */
+export function appendParentIdAfterEntry(entry: SessionTreeEntry): string | null {
+  return entry.type === "leaf"
+    ? entry.appendParentId === undefined
+      ? entry.targetId
+      : entry.appendParentId
+    : entry.id;
 }
 
 function resolveLeafId(entries: readonly SessionTreeEntry[]): string | null {
   let leafId: string | null = null;
   for (const entry of entries) {
-    leafId = leafIdAfterEntry(entry);
+    const update = leafIdUpdateAfterEntry(entry);
+    if (update !== undefined) {
+      leafId = update;
+    }
   }
   return leafId;
+}
+
+function resolveAppendParentId(entries: readonly SessionTreeEntry[]): string | null {
+  let appendParentId: string | null = null;
+  for (const entry of entries) {
+    appendParentId = appendParentIdAfterEntry(entry);
+  }
+  return appendParentId;
+}
+
+function buildLogicalParentsById(entries: readonly SessionTreeEntry[]): Map<string, string | null> {
+  const logicalParentsById = new Map<string, string | null>();
+  let leafId: string | null = null;
+  let appendParentId: string | null = null;
+  for (const entry of entries) {
+    const leafUpdate = leafIdUpdateAfterEntry(entry);
+    if (leafUpdate === entry.id && entry.parentId === appendParentId && leafId !== appendParentId) {
+      logicalParentsById.set(entry.id, leafId);
+    }
+    if (leafUpdate !== undefined) {
+      leafId = leafUpdate;
+    }
+    appendParentId = appendParentIdAfterEntry(entry);
+  }
+  return logicalParentsById;
 }
 
 export abstract class BaseSessionStorage<
@@ -58,20 +112,28 @@ export abstract class BaseSessionStorage<
   private readonly entries: SessionTreeEntry[];
   private readonly byId: Map<string, SessionTreeEntry>;
   private readonly labelsById: Map<string, string>;
+  private readonly logicalParentsById: Map<string, string | null>;
   private leafId: string | null;
+  private appendParentId: string | null;
 
   protected constructor(
     metadata: TMetadata,
     entries: SessionTreeEntry[],
     leafId: string | null = resolveLeafId(entries),
+    appendParentId: string | null = resolveAppendParentId(entries),
   ) {
     this.metadata = metadata;
     this.entries = entries;
     this.byId = new Map(entries.map((entry) => [entry.id, entry]));
     this.labelsById = buildLabelsById(entries);
+    this.logicalParentsById = buildLogicalParentsById(entries);
     this.leafId = leafId;
+    this.appendParentId = appendParentId;
     if (this.leafId !== null && !this.byId.has(this.leafId)) {
       throw new SessionError("invalid_session", `Entry ${this.leafId} not found`);
+    }
+    if (this.appendParentId !== null && !this.byId.has(this.appendParentId)) {
+      throw new SessionError("invalid_session", `Append parent ${this.appendParentId} not found`);
     }
   }
 
@@ -86,6 +148,13 @@ export abstract class BaseSessionStorage<
     return this.leafId;
   }
 
+  async getAppendParentId(): Promise<string | null> {
+    if (this.appendParentId !== null && !this.byId.has(this.appendParentId)) {
+      throw new SessionError("invalid_session", `Append parent ${this.appendParentId} not found`);
+    }
+    return this.appendParentId;
+  }
+
   protected createLeafEntry(leafId: string | null): LeafEntry {
     if (leafId !== null && !this.byId.has(leafId)) {
       throw new SessionError("not_found", `Entry ${leafId} not found`);
@@ -93,7 +162,7 @@ export abstract class BaseSessionStorage<
     return {
       type: "leaf",
       id: generateEntryId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
       targetId: leafId,
     };
@@ -103,13 +172,39 @@ export abstract class BaseSessionStorage<
     return generateEntryId(this.byId);
   }
 
+  protected validateEntryForAppend(entry: SessionTreeEntry): void {
+    const leafId = leafIdUpdateAfterEntry(entry);
+    const leafIsNewEntry = entry.type !== "leaf" && leafId === entry.id;
+    if (leafId !== undefined && leafId !== null && !leafIsNewEntry && !this.byId.has(leafId)) {
+      throw new SessionError("not_found", `Entry ${leafId} not found`);
+    }
+
+    const appendParentId = appendParentIdAfterEntry(entry);
+    const appendParentIsNewEntry = entry.type !== "leaf" && appendParentId === entry.id;
+    if (appendParentId !== null && !appendParentIsNewEntry && !this.byId.has(appendParentId)) {
+      throw new SessionError("not_found", `Append parent ${appendParentId} not found`);
+    }
+  }
+
   protected recordEntry(entry: SessionTreeEntry): void {
     // Leaf and label entries are append-only state changes; keep derived indexes
     // synchronized here so memory and JSONL storage expose identical behavior.
+    this.validateEntryForAppend(entry);
+    const leafId = leafIdUpdateAfterEntry(entry);
+    if (
+      leafId === entry.id &&
+      entry.parentId === this.appendParentId &&
+      this.leafId !== this.appendParentId
+    ) {
+      this.logicalParentsById.set(entry.id, this.leafId);
+    }
     this.entries.push(entry);
     this.byId.set(entry.id, entry);
     updateLabelCache(this.labelsById, entry);
-    this.leafId = leafIdAfterEntry(entry);
+    if (leafId !== undefined) {
+      this.leafId = leafId;
+    }
+    this.appendParentId = appendParentIdAfterEntry(entry);
   }
 
   async getEntry(id: string): Promise<SessionTreeEntry | undefined> {
@@ -148,7 +243,12 @@ export abstract class BaseSessionStorage<
       }
       // Leaf rows are control records. Descendants written by older appenders
       // may point at the marker, but their visible ancestry starts at its target.
-      const parentId = current.type === "leaf" ? current.targetId : current.parentId;
+      const parentId =
+        current.type === "leaf"
+          ? current.targetId
+          : this.logicalParentsById.has(current.id)
+            ? (this.logicalParentsById.get(current.id) ?? null)
+            : current.parentId;
       if (!parentId) {
         break;
       }

--- a/packages/agent-core/src/harness/session/storage-base.ts
+++ b/packages/agent-core/src/harness/session/storage-base.ts
@@ -28,6 +28,10 @@ function buildLabelsById(entries: SessionTreeEntry[]): Map<string, string> {
   return labelsById;
 }
 
+function isSideAppendEntry(entry: SessionTreeEntry): boolean {
+  return entry.appendMode === "side";
+}
+
 function generateEntryId(byId: { has(id: string): boolean }): string {
   for (let i = 0; i < 100; i++) {
     const id = uuidv7().slice(0, 8);
@@ -94,7 +98,12 @@ function buildLogicalParentsById(entries: readonly SessionTreeEntry[]): Map<stri
   let appendParentId: string | null = null;
   for (const entry of entries) {
     const leafUpdate = leafIdUpdateAfterEntry(entry);
-    if (leafUpdate === entry.id && entry.parentId === appendParentId && leafId !== appendParentId) {
+    if (
+      leafUpdate === entry.id &&
+      !isSideAppendEntry(entry) &&
+      entry.parentId === appendParentId &&
+      leafId !== appendParentId
+    ) {
       logicalParentsById.set(entry.id, leafId);
     }
     if (leafUpdate !== undefined) {
@@ -193,6 +202,7 @@ export abstract class BaseSessionStorage<
     const leafId = leafIdUpdateAfterEntry(entry);
     if (
       leafId === entry.id &&
+      !isSideAppendEntry(entry) &&
       entry.parentId === this.appendParentId &&
       this.leafId !== this.appendParentId
     ) {

--- a/packages/agent-core/src/harness/types.ts
+++ b/packages/agent-core/src/harness/types.ts
@@ -448,6 +448,8 @@ export interface SessionInfoEntry extends SessionTreeEntryBase {
 export interface LeafEntry extends SessionTreeEntryBase {
   type: "leaf";
   targetId: string | null;
+  /** Raw parent for the next append when it differs from the visible leaf. */
+  appendParentId?: string | null;
 }
 
 /** All persisted session tree entry variants. */
@@ -483,6 +485,7 @@ export interface JsonlSessionMetadata extends SessionMetadata {
 export interface SessionStorage<TMetadata extends SessionMetadata = SessionMetadata> {
   getMetadata(): Promise<TMetadata>;
   getLeafId(): Promise<string | null>;
+  getAppendParentId?(): Promise<string | null>;
   /** Persist a leaf entry that records the active session-tree leaf. */
   setLeafId(leafId: string | null): Promise<void>;
   createEntryId(): Promise<string>;

--- a/packages/agent-core/src/harness/types.ts
+++ b/packages/agent-core/src/harness/types.ts
@@ -374,6 +374,8 @@ export interface SessionTreeEntryBase {
   parentId: string | null;
   /** ISO timestamp string used for persistence and sorting. */
   timestamp: string;
+  /** This row consumes the raw side cursor instead of the visible leaf. */
+  appendMode?: "side";
 }
 
 /** Persisted transcript message entry. */

--- a/src/agents/btw-transcript.ts
+++ b/src/agents/btw-transcript.ts
@@ -7,6 +7,10 @@ import {
   resolveSessionFilePathOptions,
   type SessionEntry as StoredSessionEntry,
 } from "../config/sessions.js";
+import {
+  scanSessionTranscriptTree,
+  type SessionTranscriptTree,
+} from "../config/sessions/transcript-tree.js";
 import { diagnosticLogger as diag } from "../logging/diagnostic.js";
 import {
   buildSessionContext,
@@ -44,35 +48,17 @@ function readSessionEntryId(entry: AgentSessionEntry): string | undefined {
   return typeof id === "string" && id.trim().length > 0 ? id : undefined;
 }
 
-function readSessionEntryParentId(entry: AgentSessionEntry): string | null | undefined {
-  const parentId = (entry as { parentId?: unknown }).parentId;
-  if (parentId === null) {
-    return null;
-  }
-  return typeof parentId === "string" && parentId.trim().length > 0 ? parentId : undefined;
-}
-
-// Parent links mark fork-aware transcripts. Without them, the flat session
-// context builder preserves the legacy append-only transcript behavior.
-function hasParentLinkedEntries(entries: AgentSessionEntry[]): boolean {
-  return entries.some((entry) => Boolean(readSessionEntryId(entry) && "parentId" in entry));
-}
-
 // Reconstructs the selected branch from leaf to root. Missing links or cycles
 // mean the snapshot cannot be trusted, so callers fall back to a safe branch.
 function buildSessionBranchEntries(
-  entries: AgentSessionEntry[],
-  leafId: string | undefined,
+  tree: SessionTranscriptTree<AgentSessionEntry>,
+  leafId: string | null | undefined,
 ): AgentSessionEntry[] | undefined {
+  if (leafId === null) {
+    return [];
+  }
   if (!leafId) {
     return undefined;
-  }
-  const byId = new Map<string, AgentSessionEntry>();
-  for (const entry of entries) {
-    const id = readSessionEntryId(entry);
-    if (id) {
-      byId.set(id, entry);
-    }
   }
   const branch: AgentSessionEntry[] = [];
   const seen = new Set<string>();
@@ -82,24 +68,20 @@ function buildSessionBranchEntries(
       return undefined;
     }
     seen.add(currentId);
-    const entry = byId.get(currentId);
-    if (!entry) {
+    const node = tree.byId.get(currentId);
+    if (!node) {
       return undefined;
     }
-    branch.push(entry);
-    currentId = readSessionEntryParentId(entry) ?? undefined;
+    if ((node.entry as { type?: unknown }).type !== "leaf") {
+      branch.push(
+        node.entry.parentId === node.parentId
+          ? node.entry
+          : ({ ...node.entry, parentId: node.parentId } as AgentSessionEntry),
+      );
+    }
+    currentId = node.parentId ?? undefined;
   }
   return branch.toReversed();
-}
-
-function readDefaultLeafId(entries: AgentSessionEntry[]): string | undefined {
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    const id = readSessionEntryId(entries[index]);
-    if (id) {
-      return id;
-    }
-  }
-  return undefined;
 }
 
 function isTrailingUserMessage(entry: AgentSessionEntry | undefined): boolean {
@@ -127,24 +109,27 @@ export async function readBtwTranscriptMessages(params: {
     const sessionEntries = entries.filter(
       (entry): entry is AgentSessionEntry => entry.type !== "session",
     );
-    if (!hasParentLinkedEntries(sessionEntries)) {
+    const tree = scanSessionTranscriptTree(sessionEntries);
+    if (!tree.hasLeafUpdate) {
       return buildSessionContext(sessionEntries).messages;
     }
 
-    let branchEntries = params.snapshotLeafId
-      ? buildSessionBranchEntries(sessionEntries, params.snapshotLeafId)
+    const hasSnapshotLeaf = params.snapshotLeafId !== undefined;
+    let branchEntries = hasSnapshotLeaf
+      ? buildSessionBranchEntries(tree, params.snapshotLeafId)
       : undefined;
-    if (params.snapshotLeafId && !branchEntries) {
+    if (hasSnapshotLeaf && branchEntries === undefined) {
       diag.debug(
         `btw snapshot leaf unavailable: sessionId=${params.sessionId} leaf=${params.snapshotLeafId}`,
       );
     }
-    branchEntries ??= buildSessionBranchEntries(sessionEntries, readDefaultLeafId(sessionEntries));
-    if (!params.snapshotLeafId && isTrailingUserMessage(branchEntries?.at(-1))) {
+    branchEntries ??= buildSessionBranchEntries(tree, tree.leafId);
+    if (!hasSnapshotLeaf && isTrailingUserMessage(branchEntries?.at(-1))) {
       // Auto-selecting the newest branch must not include the current user turn
       // that triggered BTW handoff; the subagent should continue from its parent.
-      const parentId = readSessionEntryParentId(branchEntries!.at(-1)!);
-      branchEntries = parentId ? (buildSessionBranchEntries(sessionEntries, parentId) ?? []) : [];
+      const trailingId = readSessionEntryId(branchEntries!.at(-1)!);
+      const parentId = trailingId ? tree.byId.get(trailingId)?.parentId : null;
+      branchEntries = parentId ? (buildSessionBranchEntries(tree, parentId) ?? []) : [];
     }
     const sessionContext = buildSessionContext(branchEntries ?? sessionEntries);
     return Array.isArray(sessionContext.messages) ? sessionContext.messages : [];

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -1482,6 +1482,144 @@ describe("runBtwSideQuestion", () => {
     );
   });
 
+  it("honors an explicitly empty active run snapshot", async () => {
+    const userEntry = createTranscriptEntry({
+      id: "user-seed",
+      message: createUserTranscriptMessage(),
+    });
+    const assistantEntry = createTranscriptEntry({
+      id: "assistant-seed",
+      parentId: "user-seed",
+      message: createAssistantTranscriptMessage([{ type: "text", text: "seed answer" }]),
+    });
+    mockTranscriptEntries([userEntry, assistantEntry]);
+    getActiveEmbeddedRunSnapshotMock.mockReturnValue({
+      transcriptLeafId: null,
+    });
+
+    await expect(runMathSideQuestion()).rejects.toThrow("No active session context.");
+
+    expect(buildSessionContextMock).toHaveBeenCalledTimes(1);
+    expect(buildSessionContextMock).toHaveBeenCalledWith([]);
+  });
+
+  it("uses the branch selected by a terminal transcript leaf control", async () => {
+    const userEntry = createTranscriptEntry({
+      id: "user-seed",
+      message: createUserTranscriptMessage(),
+    });
+    const assistantEntry = createTranscriptEntry({
+      id: "assistant-seed",
+      parentId: "user-seed",
+      message: createAssistantTranscriptMessage([{ type: "text", text: "seed answer" }]),
+    });
+    const sideEntry = createTranscriptEntry({
+      id: "side-delivery",
+      parentId: "assistant-seed",
+      message: createAssistantTranscriptMessage([{ type: "text", text: "side delivery" }]),
+    });
+    const leafEntry = {
+      type: "leaf",
+      id: "active-leaf",
+      parentId: "side-delivery",
+      targetId: "assistant-seed",
+    };
+    mockTranscriptEntries([userEntry, assistantEntry, sideEntry, leafEntry]);
+    mockDoneAnswer(MATH_ANSWER);
+
+    const result = await runMathSideQuestion();
+
+    expect(buildSessionContextMock).toHaveBeenCalledTimes(1);
+    expect(buildSessionContextMock).toHaveBeenCalledWith([userEntry, assistantEntry]);
+    expect(result).toEqual({ text: MATH_ANSWER });
+  });
+
+  it("keeps parentless history addressed by a terminal leaf control", async () => {
+    const userEntry = {
+      type: "message",
+      id: "user-seed",
+      message: createUserTranscriptMessage(),
+    };
+    const assistantEntry = {
+      type: "message",
+      id: "assistant-seed",
+      message: createAssistantTranscriptMessage([{ type: "text", text: "seed answer" }]),
+    };
+    const sideEntry = createTranscriptEntry({
+      id: "side-delivery",
+      parentId: "assistant-seed",
+      message: createAssistantTranscriptMessage([{ type: "text", text: "side delivery" }]),
+    });
+    const leafEntry = {
+      type: "leaf",
+      id: "active-leaf",
+      parentId: "side-delivery",
+      targetId: "assistant-seed",
+    };
+    mockTranscriptEntries([userEntry, assistantEntry, sideEntry, leafEntry]);
+    mockDoneAnswer(MATH_ANSWER);
+
+    const result = await runMathSideQuestion();
+
+    expect(buildSessionContextMock).toHaveBeenCalledWith([
+      { ...userEntry, parentId: null },
+      { ...assistantEntry, parentId: "user-seed" },
+    ]);
+    expect(result).toEqual({ text: MATH_ANSWER });
+  });
+
+  it("keeps visible history after continuing from a disjoint opaque append cursor", async () => {
+    const userEntry = createTranscriptEntry({
+      id: "user-seed",
+      message: createUserTranscriptMessage(),
+    });
+    const assistantEntry = createTranscriptEntry({
+      id: "assistant-seed",
+      parentId: "user-seed",
+      message: createAssistantTranscriptMessage([{ type: "text", text: "seed answer" }]),
+    });
+    const sideEntry = createTranscriptEntry({
+      id: "side-delivery",
+      parentId: "assistant-seed",
+      message: createAssistantTranscriptMessage([{ type: "text", text: "side delivery" }]),
+    });
+    const metadataEntry = {
+      type: "metadata",
+      id: "plugin-metadata",
+      parentId: "side-delivery",
+    };
+    const leafEntry = {
+      type: "leaf",
+      id: "active-leaf",
+      parentId: "side-delivery",
+      targetId: "assistant-seed",
+      appendParentId: "plugin-metadata",
+    };
+    const continuationEntry = createTranscriptEntry({
+      id: "assistant-continuation",
+      parentId: "plugin-metadata",
+      message: createAssistantTranscriptMessage([{ type: "text", text: "continued answer" }]),
+    });
+    mockTranscriptEntries([
+      userEntry,
+      assistantEntry,
+      sideEntry,
+      metadataEntry,
+      leafEntry,
+      continuationEntry,
+    ]);
+    mockDoneAnswer(MATH_ANSWER);
+
+    const result = await runMathSideQuestion();
+
+    expect(buildSessionContextMock).toHaveBeenCalledWith([
+      userEntry,
+      assistantEntry,
+      { ...continuationEntry, parentId: "assistant-seed" },
+    ]);
+    expect(result).toEqual({ text: MATH_ANSWER });
+  });
+
   it("returns the BTW answer without appending transcript custom entries", async () => {
     mockDoneAnswer(MATH_ANSWER);
 

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -204,6 +204,65 @@ describe("loadCliSessionHistoryMessages", () => {
     }
   });
 
+  it("loads only the branch selected by transcript leaf controls", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
+    const sessionFile = createSessionTranscript({
+      rootDir: stateDir,
+      sessionId: "session-leaf-control",
+      messages: ["active root"],
+    });
+    fs.appendFileSync(
+      sessionFile,
+      [
+        {
+          type: "message",
+          id: "side-entry",
+          parentId: "msg-0",
+          timestamp: new Date(2).toISOString(),
+          message: { role: "assistant", content: "side delivery", timestamp: 2 },
+        },
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "side-entry",
+          timestamp: new Date(3).toISOString(),
+          targetId: "msg-0",
+        },
+        {
+          type: "message",
+          id: "active-tail",
+          parentId: "msg-0",
+          timestamp: new Date(4).toISOString(),
+          message: { role: "assistant", content: "active tail", timestamp: 4 },
+        },
+        {
+          type: "metadata",
+          id: "opaque-after-active-tail",
+          parentId: "side-entry",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+
+    try {
+      await withCliSessionState(stateDir, async () => {
+        const history = await loadCliSessionHistoryMessages({
+          sessionId: "session-leaf-control",
+          sessionFile,
+          sessionKey: "agent:main:main",
+          agentId: "main",
+        });
+        expect(history).toHaveLength(2);
+        expectMessageFields(history[0], { role: "user", content: "active root" });
+        expectMessageFields(history[1], { role: "assistant", content: "active tail" });
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps complete history for context-engine snapshots", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
     const sessionFile = createSessionTranscript({

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -8,6 +8,7 @@ import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
 } from "../../config/sessions/paths.js";
+import { selectSessionTranscriptLeafControlledPath } from "../../config/sessions/transcript-tree.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
@@ -329,7 +330,8 @@ async function loadCliSessionEntries(params: {
     }
     const entries = parseSessionEntries(await fsp.readFile(realSessionFile, "utf-8"));
     migrateSessionEntries(entries);
-    return entries.filter((entry) => entry.type !== "session");
+    const sessionEntries = entries.filter((entry) => entry.type !== "session");
+    return selectSessionTranscriptLeafControlledPath(sessionEntries) ?? sessionEntries;
   } catch {
     return [];
   }

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -11,7 +11,7 @@ import {
   captureCompactionCheckpointSnapshotAsync,
   cleanupCompactionCheckpointSnapshot,
   persistSessionCompactionCheckpoint,
-  readSessionLeafIdFromTranscriptAsync,
+  readSessionLeafStateFromTranscriptAsync,
   resolveSessionCompactionCheckpointReason,
   type CapturedCompactionCheckpointSnapshot,
 } from "../../gateway/session-compaction-checkpoints.js";
@@ -452,10 +452,13 @@ export async function compactEmbeddedAgentSession(
           }
           if (params.config && params.sessionKey && checkpointSnapshot) {
             try {
-              const postLeafId =
-                postCompactionLeafId ??
-                (await readSessionLeafIdFromTranscriptAsync(postCompactionSessionFile)) ??
-                undefined;
+              const transcriptState =
+                await readSessionLeafStateFromTranscriptAsync(postCompactionSessionFile);
+              const postLeafId = postCompactionLeafId ?? transcriptState?.leafId ?? undefined;
+              const postEntryId =
+                transcriptState && transcriptState.leafId === postLeafId
+                  ? transcriptState.entryId
+                  : postLeafId;
               const storedCheckpoint = await persistSessionCompactionCheckpoint({
                 cfg: params.config,
                 sessionKey: params.sessionKey,
@@ -470,7 +473,7 @@ export async function compactEmbeddedAgentSession(
                 tokensAfter: result.result?.tokensAfter,
                 postSessionFile: postCompactionSessionFile,
                 postLeafId,
-                postEntryId: postLeafId,
+                postEntryId,
               });
               checkpointSnapshotRetained = storedCheckpoint !== null;
             } catch (err) {

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -12,6 +12,7 @@ import {
   cleanupCompactionCheckpointSnapshot,
   persistSessionCompactionCheckpoint,
   readSessionLeafStateFromTranscriptAsync,
+  resolveCompactionCheckpointTranscriptPosition,
   resolveSessionCompactionCheckpointReason,
   type CapturedCompactionCheckpointSnapshot,
 } from "../../gateway/session-compaction-checkpoints.js";
@@ -454,11 +455,10 @@ export async function compactEmbeddedAgentSession(
             try {
               const transcriptState =
                 await readSessionLeafStateFromTranscriptAsync(postCompactionSessionFile);
-              const postLeafId = postCompactionLeafId ?? transcriptState?.leafId ?? undefined;
-              const postEntryId =
-                transcriptState && transcriptState.leafId === postLeafId
-                  ? transcriptState.entryId
-                  : postLeafId;
+              const checkpointPosition = resolveCompactionCheckpointTranscriptPosition({
+                preferredLeafId: postCompactionLeafId,
+                transcriptState,
+              });
               const storedCheckpoint = await persistSessionCompactionCheckpoint({
                 cfg: params.config,
                 sessionKey: params.sessionKey,
@@ -472,8 +472,8 @@ export async function compactEmbeddedAgentSession(
                 tokensBefore: result.result?.tokensBefore,
                 tokensAfter: result.result?.tokensAfter,
                 postSessionFile: postCompactionSessionFile,
-                postLeafId,
-                postEntryId,
+                postLeafId: checkpointPosition.leafId,
+                postEntryId: checkpointPosition.entryId,
               });
               checkpointSnapshotRetained = storedCheckpoint !== null;
             } catch (err) {

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -11,6 +11,7 @@ import {
   captureCompactionCheckpointSnapshotAsync,
   cleanupCompactionCheckpointSnapshot,
   persistSessionCompactionCheckpoint,
+  readSessionLeafStateFromTranscriptAsync,
   resolveSessionCompactionCheckpointReason,
   type CapturedCompactionCheckpointSnapshot,
 } from "../../gateway/session-compaction-checkpoints.js";
@@ -1504,6 +1505,13 @@ async function compactEmbeddedAgentSessionDirectOnce(
           });
           if (params.config && params.sessionKey && checkpointSnapshot) {
             try {
+              const transcriptState =
+                await readSessionLeafStateFromTranscriptAsync(activeSessionFile);
+              const checkpointPostLeafId = activePostLeafId ?? transcriptState?.leafId ?? undefined;
+              const checkpointPostEntryId =
+                transcriptState && transcriptState.leafId === checkpointPostLeafId
+                  ? transcriptState.entryId
+                  : checkpointPostLeafId;
               const storedCheckpoint = await persistSessionCompactionCheckpoint({
                 cfg: params.config,
                 sessionKey: params.sessionKey,
@@ -1517,8 +1525,8 @@ async function compactEmbeddedAgentSessionDirectOnce(
                 tokensBefore: observedTokenCount ?? result.tokensBefore,
                 tokensAfter,
                 postSessionFile: activeSessionFile,
-                postLeafId: activePostLeafId,
-                postEntryId: activePostLeafId,
+                postLeafId: checkpointPostLeafId,
+                postEntryId: checkpointPostEntryId,
                 createdAt: compactStartedAt,
               });
               checkpointSnapshotRetained = storedCheckpoint !== null;

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -12,6 +12,7 @@ import {
   cleanupCompactionCheckpointSnapshot,
   persistSessionCompactionCheckpoint,
   readSessionLeafStateFromTranscriptAsync,
+  resolveCompactionCheckpointTranscriptPosition,
   resolveSessionCompactionCheckpointReason,
   type CapturedCompactionCheckpointSnapshot,
 } from "../../gateway/session-compaction-checkpoints.js";
@@ -1507,11 +1508,10 @@ async function compactEmbeddedAgentSessionDirectOnce(
             try {
               const transcriptState =
                 await readSessionLeafStateFromTranscriptAsync(activeSessionFile);
-              const checkpointPostLeafId = activePostLeafId ?? transcriptState?.leafId ?? undefined;
-              const checkpointPostEntryId =
-                transcriptState && transcriptState.leafId === checkpointPostLeafId
-                  ? transcriptState.entryId
-                  : checkpointPostLeafId;
+              const checkpointPosition = resolveCompactionCheckpointTranscriptPosition({
+                preferredLeafId: activePostLeafId,
+                transcriptState,
+              });
               const storedCheckpoint = await persistSessionCompactionCheckpoint({
                 cfg: params.config,
                 sessionKey: params.sessionKey,
@@ -1525,8 +1525,8 @@ async function compactEmbeddedAgentSessionDirectOnce(
                 tokensBefore: observedTokenCount ?? result.tokensBefore,
                 tokensAfter,
                 postSessionFile: activeSessionFile,
-                postLeafId: checkpointPostLeafId,
-                postEntryId: checkpointPostEntryId,
+                postLeafId: checkpointPosition.leafId,
+                postEntryId: checkpointPosition.entryId,
                 createdAt: compactStartedAt,
               });
               checkpointSnapshotRetained = storedCheckpoint !== null;

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -2554,6 +2554,42 @@ describe("embedded attempt session lock lifecycle", () => {
     await controller.dispose();
   });
 
+  it("keeps non-message events with message payloads opaque", async () => {
+    const sessionFile = await createTempSessionFile();
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+    await controller.releaseForPrompt();
+
+    const event = {
+      type: "metadata",
+      id: "message-shaped-metadata",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: { role: "assistant", provider: "openclaw", model: "delivery-mirror" },
+      payload: { source: "plugin" },
+    };
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () => {
+        await appendSessionTranscriptEvent({ transcriptPath: sessionFile, event });
+      },
+    );
+
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      { type: "prompt_released_opaque", record: event },
+    ]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
   it("validates opaque events migrated by a nested message publication", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-migrated-"));
     tempDirs.push(dir);

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -2393,6 +2393,43 @@ describe("embedded attempt session lock lifecycle", () => {
     await controller.dispose();
   });
 
+  it("preserves a created first-turn header when the owned append throws", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-failed-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "failed-first-turn.jsonl");
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+    await controller.releaseForPrompt();
+
+    await expect(
+      withOwnedSessionTranscriptWrites(
+        {
+          sessionFile,
+          withSessionWriteLock: (operation, options) =>
+            controller.withSessionWriteLock(operation, options),
+        },
+        async () =>
+          await appendSessionTranscriptMessage({
+            transcriptPath: sessionFile,
+            sessionId: "failed-first-turn",
+            cwd: dir,
+            message: { role: "assistant", content: "blocked" },
+            prepareMessageAfterIdempotencyCheck: () => {
+              throw new Error("expected append failure");
+            },
+          }),
+      ),
+    ).rejects.toThrow("expected append failure");
+
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
   it("rejects unowned rows added beside a blocked first-turn append", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-blocked-"));
     tempDirs.push(dir);

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -2823,6 +2823,268 @@ describe("embedded attempt session lock lifecycle", () => {
     await controller.dispose();
   });
 
+  it("drains unawaited nested publications before publishing the parent fence", async () => {
+    const sessionFile = await createTempSessionFile();
+    const mergedIds: string[] = [];
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: (entries) => {
+        for (const entry of entries) {
+          if (entry.type !== "prompt_released_opaque") {
+            mergedIds.push(entry.id);
+          }
+        }
+      },
+    });
+    await controller.releaseForPrompt();
+
+    let releaseNestedWrite!: () => void;
+    const nestedWriteCanFinish = new Promise<void>((resolve) => {
+      releaseNestedWrite = resolve;
+    });
+    let markNestedWriteStarted!: () => void;
+    const nestedWriteStarted = new Promise<void>((resolve) => {
+      markNestedWriteStarted = resolve;
+    });
+    let parentSettled = false;
+    const parentWrite = controller
+      .withSessionWriteLock(
+        async () => {
+          await fs.appendFile(
+            sessionFile,
+            `${JSON.stringify({
+              type: "message",
+              id: "parent-publication",
+              parentId: null,
+              timestamp: new Date().toISOString(),
+              message: {
+                role: "assistant",
+                provider: "anthropic",
+                model: "sonnet-4.6",
+              },
+            })}\n`,
+            "utf8",
+          );
+          void controller.withSessionWriteLock(
+            async () => {
+              markNestedWriteStarted();
+              await nestedWriteCanFinish;
+              await controller.withSessionWriteLock(
+                async () => {
+                  await fs.appendFile(
+                    sessionFile,
+                    `${JSON.stringify({
+                      type: "message",
+                      id: "unawaited-nested",
+                      parentId: null,
+                      timestamp: new Date().toISOString(),
+                      message: {
+                        role: "assistant",
+                        provider: "anthropic",
+                        model: "sonnet-4.6",
+                      },
+                    })}\n`,
+                    "utf8",
+                  );
+                  return "unawaited-nested";
+                },
+                {
+                  publishOwnedWrite: true,
+                  resolvePublishedEntries: (id) => [{ kind: "id", id }],
+                },
+              );
+            },
+            { publishOwnedWrite: true },
+          );
+          await nestedWriteStarted;
+          return "parent-publication";
+        },
+        {
+          publishOwnedWrite: true,
+          resolvePublishedEntries: (id) => [{ kind: "id", id }],
+        },
+      )
+      .finally(() => {
+        parentSettled = true;
+      });
+
+    await nestedWriteStarted;
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    const settledBeforeNestedWrite = parentSettled;
+    releaseNestedWrite();
+    await parentWrite;
+
+    expect(settledBeforeNestedWrite).toBe(false);
+    expect(mergedIds).toEqual(["parent-publication", "unawaited-nested"]);
+    await expect(controller.withSessionWriteLock(() => "next write")).resolves.toBe("next write");
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
+  it("drains unawaited publications started from an ordinary lock scope", async () => {
+    const sessionFile = await createTempSessionFile();
+    const mergedIds: string[] = [];
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: (entries) => {
+        for (const entry of entries) {
+          if (entry.type !== "prompt_released_opaque") {
+            mergedIds.push(entry.id);
+          }
+        }
+      },
+    });
+    await controller.releaseForPrompt();
+
+    let releasePublication!: () => void;
+    const publicationCanFinish = new Promise<void>((resolve) => {
+      releasePublication = resolve;
+    });
+    let markPublicationStarted!: () => void;
+    const publicationStarted = new Promise<void>((resolve) => {
+      markPublicationStarted = resolve;
+    });
+    let outerSettled = false;
+    const outerWrite = controller
+      .withSessionWriteLock(async () => {
+        void controller.withSessionWriteLock(
+          async () => {
+            markPublicationStarted();
+            await publicationCanFinish;
+            await fs.appendFile(
+              sessionFile,
+              `${JSON.stringify({
+                type: "message",
+                id: "ordinary-scope-publication",
+                parentId: null,
+                timestamp: new Date().toISOString(),
+                message: {
+                  role: "assistant",
+                  provider: "anthropic",
+                  model: "sonnet-4.6",
+                },
+              })}\n`,
+              "utf8",
+            );
+            return "ordinary-scope-publication";
+          },
+          {
+            publishOwnedWrite: true,
+            resolvePublishedEntries: (id) => [{ kind: "id", id }],
+          },
+        );
+        await publicationStarted;
+      })
+      .finally(() => {
+        outerSettled = true;
+      });
+
+    await publicationStarted;
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    const settledBeforePublication = outerSettled;
+    releasePublication();
+    await outerWrite;
+
+    expect(settledBeforePublication).toBe(false);
+    expect(mergedIds).toEqual(["ordinary-scope-publication"]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
+  it("reacquires the lock for inherited publications that start during fence merge", async () => {
+    const sessionFile = await createTempSessionFile();
+    const mergedIds: string[] = [];
+    let markFirstMergeStarted!: () => void;
+    const firstMergeStarted = new Promise<void>((resolve) => {
+      markFirstMergeStarted = resolve;
+    });
+    let releaseFirstMerge!: () => void;
+    const firstMergeCanFinish = new Promise<void>((resolve) => {
+      releaseFirstMerge = resolve;
+    });
+    let mergeCount = 0;
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: async (entries) => {
+        mergeCount += 1;
+        if (mergeCount === 1) {
+          markFirstMergeStarted();
+          await firstMergeCanFinish;
+        }
+        for (const entry of entries) {
+          if (entry.type !== "prompt_released_opaque") {
+            mergedIds.push(entry.id);
+          }
+        }
+      },
+    });
+    await controller.releaseForPrompt();
+
+    const appendOwnedAssistant = async (id: string): Promise<string> => {
+      await fs.appendFile(
+        sessionFile,
+        `${JSON.stringify({
+          type: "message",
+          id,
+          parentId: null,
+          timestamp: new Date().toISOString(),
+          message: {
+            role: "assistant",
+            provider: "anthropic",
+            model: "sonnet-4.6",
+          },
+        })}\n`,
+        "utf8",
+      );
+      return id;
+    };
+
+    let lateWriteRan = false;
+    let lateWrite!: Promise<string>;
+    const parentWrite = controller.withSessionWriteLock(
+      async () => {
+        lateWrite = (async () => {
+          await firstMergeStarted;
+          return await controller.withSessionWriteLock(
+            async () => {
+              lateWriteRan = true;
+              return await appendOwnedAssistant("late-inherited");
+            },
+            {
+              publishOwnedWrite: true,
+              resolvePublishedEntries: (id) => [{ kind: "id", id }],
+            },
+          );
+        })();
+        return await appendOwnedAssistant("parent-publication");
+      },
+      {
+        publishOwnedWrite: true,
+        resolvePublishedEntries: (id) => [{ kind: "id", id }],
+      },
+    );
+
+    await firstMergeStarted;
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(lateWriteRan).toBe(false);
+    releaseFirstMerge();
+    await expect(parentWrite).resolves.toBe("parent-publication");
+    await expect(lateWrite).resolves.toBe("late-inherited");
+
+    expect(mergedIds).toEqual(["parent-publication", "late-inherited"]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
   it("rejects interleaved assistant rows and stops already-queued publications", async () => {
     const sessionFile = await createTempSessionFile();
     const mergePromptReleasedSessionEntries = vi.fn();

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -3366,37 +3366,70 @@ describe("embedded attempt session lock lifecycle", () => {
       return id;
     };
 
-    await controller.withSessionWriteLock(async () => {
-      const firstWrite = controller.withSessionWriteLock(
-        async () => {
-          markFirstWriteStarted();
-          await firstWriteCanFinish;
-          await appendAssistant("interleaved-external");
-          return await appendAssistant("owned-entry");
-        },
-        {
-          publishOwnedWrite: true,
-          resolvePublishedEntries: (id) => [{ kind: "id", id }],
-        },
-      );
-      await firstWriteStarted;
-      const secondWrite = controller.withSessionWriteLock(
-        async () => {
-          secondWriteRan = true;
-          return await appendAssistant("queued-entry");
-        },
-        {
-          publishOwnedWrite: true,
-          resolvePublishedEntries: (id) => [{ kind: "id", id }],
-        },
-      );
-      releaseFirstWrite();
-      const results = await Promise.allSettled([firstWrite, secondWrite]);
-      expect(results.map((result) => result.status)).toEqual(["rejected", "rejected"]);
-    });
+    await expect(
+      controller.withSessionWriteLock(async () => {
+        const firstWrite = controller.withSessionWriteLock(
+          async () => {
+            markFirstWriteStarted();
+            await firstWriteCanFinish;
+            await appendAssistant("interleaved-external");
+            return await appendAssistant("owned-entry");
+          },
+          {
+            publishOwnedWrite: true,
+            resolvePublishedEntries: (id) => [{ kind: "id", id }],
+          },
+        );
+        await firstWriteStarted;
+        const secondWrite = controller.withSessionWriteLock(
+          async () => {
+            secondWriteRan = true;
+            return await appendAssistant("queued-entry");
+          },
+          {
+            publishOwnedWrite: true,
+            resolvePublishedEntries: (id) => [{ kind: "id", id }],
+          },
+        );
+        releaseFirstWrite();
+        const results = await Promise.allSettled([firstWrite, secondWrite]);
+        expect(results.map((result) => result.status)).toEqual(["rejected", "rejected"]);
+      }),
+    ).rejects.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
 
     expect(secondWriteRan).toBe(false);
     expect(mergePromptReleasedSessionEntries).not.toHaveBeenCalled();
+    expect(controller.hasSessionTakeover()).toBe(true);
+    await controller.dispose();
+  });
+
+  it("preserves an outer failure when a nested publication detects takeover", async () => {
+    const sessionFile = await createTempSessionFile();
+    const outerFailure = new Error("outer operation failed");
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: vi.fn(),
+    });
+    await controller.releaseForPrompt();
+
+    await expect(
+      controller.withSessionWriteLock(async () => {
+        const nestedPublication = controller.withSessionWriteLock(
+          async () => {
+            await fs.appendFile(sessionFile, '{"type":"message","id":"external"}\n', "utf8");
+            return "owned";
+          },
+          {
+            publishOwnedWrite: true,
+            resolvePublishedEntries: (id) => [{ kind: "id", id }],
+          },
+        );
+        const [nestedResult] = await Promise.allSettled([nestedPublication]);
+        expect(nestedResult.status).toBe("rejected");
+        throw outerFailure;
+      }),
+    ).rejects.toBe(outerFailure);
     expect(controller.hasSessionTakeover()).toBe(true);
     await controller.dispose();
   });

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -857,7 +857,8 @@ describe("embedded attempt session lock lifecycle", () => {
       acquireSessionWriteLock,
       lockOptions: { ...lockOptions, sessionFile },
       mergePromptReleasedSessionEntries: (entries) =>
-        staleManager.mergePromptReleasedSessionEntries(entries),
+        staleManager.mergePromptReleasedSessionEntries(entries, { persistLeaf: true }),
+      reloadPromptReleasedSessionFile: () => staleManager.setSessionFile(sessionFile),
     });
 
     await controller.releaseForPrompt();
@@ -882,6 +883,14 @@ describe("embedded attempt session lock lifecycle", () => {
       ].join("\n") + "\n",
       "utf8",
     );
+    await controller.withSessionWriteLock(() => undefined);
+
+    const reopenedBeforeReply = SessionManager.open(sessionFile, dir, dir);
+    expect(
+      reopenedBeforeReply.buildSessionContext().messages.map((message) => message.role),
+    ).toEqual(["user"]);
+    expect(reopenedBeforeReply.getSessionName()).toBe("first turn");
+
     await controller.withSessionWriteLock(() => {
       staleManager.appendMessage({
         role: "assistant",
@@ -912,6 +921,238 @@ describe("embedded attempt session lock lifecycle", () => {
       type: "custom",
       customType: "model-snapshot",
     });
+  });
+
+  it("persists the restored leaf before returning from a prompt-released merge", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-leaf-fence-"));
+    tempDirs.push(dir);
+    const initialManager = SessionManager.create(dir, dir);
+    initialManager.appendMessage({ role: "user", content: "question", timestamp: 1 });
+    const baseAnswerId = initialManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "base answer" }],
+      api: "messages",
+      provider: "anthropic",
+      model: "sonnet-4.6",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+    const sessionFile = initialManager.getSessionFile();
+    if (!sessionFile) {
+      throw new Error("expected persisted session file");
+    }
+    const staleManager = SessionManager.open(sessionFile, dir, dir);
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: (entries) =>
+        staleManager.mergePromptReleasedSessionEntries(entries, { persistLeaf: true }),
+      reloadPromptReleasedSessionFile: () => staleManager.setSessionFile(sessionFile),
+    });
+    await controller.releaseForPrompt();
+    await fs.appendFile(
+      sessionFile,
+      `${JSON.stringify({
+        type: "message",
+        id: "side-delivery",
+        parentId: baseAnswerId,
+        timestamp: new Date().toISOString(),
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "side delivery" }],
+          provider: "openclaw",
+          model: "delivery-mirror",
+        },
+      })}\n`,
+      "utf8",
+    );
+
+    await controller.withSessionWriteLock(() => undefined);
+
+    const records = (await fs.readFile(sessionFile, "utf8"))
+      .trim()
+      .split("\n")
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            type?: string;
+            parentId?: string | null;
+            targetId?: string | null;
+            appendParentId?: string | null;
+            appendMode?: string;
+          },
+      );
+    expect(records.at(-1)).toMatchObject({
+      type: "leaf",
+      parentId: "side-delivery",
+      targetId: baseAnswerId,
+      appendParentId: "side-delivery",
+      appendMode: "side",
+    });
+    const reopened = SessionManager.open(sessionFile, dir, dir);
+    expect(reopened.getLeafId()).toBe(baseAnswerId);
+    expect(JSON.stringify(reopened.buildSessionContext())).not.toContain("side delivery");
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
+  it("publishes the restoring leaf for every active session fence", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-shared-leaf-"));
+    tempDirs.push(dir);
+    const initialManager = SessionManager.create(dir, dir);
+    initialManager.appendMessage({ role: "user", content: "question", timestamp: 1 });
+    const baseAnswerId = initialManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "base answer" }],
+      api: "messages",
+      provider: "anthropic",
+      model: "sonnet-4.6",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+    const sessionFile = initialManager.getSessionFile();
+    if (!sessionFile) {
+      throw new Error("expected persisted session file");
+    }
+    const firstManager = SessionManager.open(sessionFile, dir, dir);
+    const secondManager = SessionManager.open(sessionFile, dir, dir);
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: (entries) =>
+        firstManager.mergePromptReleasedSessionEntries(entries, { persistLeaf: true }),
+      reloadPromptReleasedSessionFile: () => firstManager.setSessionFile(sessionFile),
+    });
+    await firstController.releaseForPrompt();
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: (entries) =>
+        secondManager.mergePromptReleasedSessionEntries(entries, { persistLeaf: true }),
+      reloadPromptReleasedSessionFile: () => secondManager.setSessionFile(sessionFile),
+    });
+    await secondController.releaseForPrompt();
+
+    await fs.appendFile(
+      sessionFile,
+      `${JSON.stringify({
+        type: "message",
+        id: "shared-side-delivery",
+        parentId: baseAnswerId,
+        timestamp: new Date().toISOString(),
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "side delivery" }],
+          provider: "openclaw",
+          model: "delivery-mirror",
+        },
+      })}\n`,
+      "utf8",
+    );
+    await firstController.withSessionWriteLock(() => undefined);
+    const recordsAfterFirstMerge = (await fs.readFile(sessionFile, "utf8")).trim().split("\n");
+
+    await secondController.withSessionWriteLock(() => undefined);
+
+    const recordsAfterSecondMerge = (await fs.readFile(sessionFile, "utf8")).trim().split("\n");
+    expect(recordsAfterSecondMerge).toHaveLength(recordsAfterFirstMerge.length);
+    expect(JSON.parse(recordsAfterSecondMerge.at(-1) ?? "{}")).toMatchObject({
+      type: "leaf",
+      targetId: baseAnswerId,
+      appendParentId: "shared-side-delivery",
+      appendMode: "side",
+    });
+    expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(secondController.hasSessionTakeover()).toBe(false);
+    await firstController.dispose();
+    await secondController.dispose();
+  });
+
+  it("reloads a trusted first-turn rewrite for every active session fence", async () => {
+    const dir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-attempt-session-shared-rewrite-"),
+    );
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "shared-first-turn",
+        timestamp: new Date().toISOString(),
+        cwd: dir,
+      })}\n`,
+      "utf8",
+    );
+    const firstManager = SessionManager.open(sessionFile, dir, dir);
+    const firstUserId = firstManager.appendMessage({
+      role: "user",
+      content: "first prepared question",
+      timestamp: 1,
+    });
+    const secondManager = SessionManager.open(sessionFile, dir, dir);
+    secondManager.appendMessage({
+      role: "user",
+      content: "stale prepared question",
+      timestamp: 1,
+    });
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: (entries) =>
+        firstManager.mergePromptReleasedSessionEntries(entries, { persistLeaf: true }),
+      reloadPromptReleasedSessionFile: () => firstManager.setSessionFile(sessionFile),
+    });
+    await firstController.releaseForPrompt();
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: (entries) =>
+        secondManager.mergePromptReleasedSessionEntries(entries, { persistLeaf: true }),
+      reloadPromptReleasedSessionFile: () => secondManager.setSessionFile(sessionFile),
+    });
+    await secondController.releaseForPrompt();
+    await fs.appendFile(
+      sessionFile,
+      `${JSON.stringify({
+        type: "session_info",
+        id: "shared-session-info",
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        name: "shared first turn",
+      })}\n`,
+      "utf8",
+    );
+
+    await firstController.withSessionWriteLock(() => undefined);
+    await secondController.withSessionWriteLock(() => undefined);
+
+    expect(secondManager.getLeafId()).toBe(firstUserId);
+    expect(secondManager.getSessionName()).toBe("shared first turn");
+    expect(secondManager.buildSessionContext().messages).toMatchObject([
+      { role: "user", content: "first prepared question" },
+    ]);
+    expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(secondController.hasSessionTakeover()).toBe(false);
+    await firstController.dispose();
+    await secondController.dispose();
   });
 
   it("preserves globally resolved metadata when a stale manager appends the reply branch", async () => {
@@ -949,7 +1190,8 @@ describe("embedded attempt session lock lifecycle", () => {
       acquireSessionWriteLock,
       lockOptions: { ...lockOptions, sessionFile },
       mergePromptReleasedSessionEntries: (entries) =>
-        staleManager.mergePromptReleasedSessionEntries(entries),
+        staleManager.mergePromptReleasedSessionEntries(entries, { persistLeaf: true }),
+      reloadPromptReleasedSessionFile: () => staleManager.setSessionFile(sessionFile),
     });
 
     await controller.releaseForPrompt();
@@ -1039,7 +1281,8 @@ describe("embedded attempt session lock lifecycle", () => {
       acquireSessionWriteLock,
       lockOptions: { ...lockOptions, sessionFile },
       mergePromptReleasedSessionEntries: (entries) =>
-        staleManager.mergePromptReleasedSessionEntries(entries),
+        staleManager.mergePromptReleasedSessionEntries(entries, { persistLeaf: true }),
+      reloadPromptReleasedSessionFile: () => staleManager.setSessionFile(sessionFile),
     });
 
     await controller.releaseForPrompt();
@@ -3264,7 +3507,8 @@ describe("embedded attempt session lock lifecycle", () => {
       acquireSessionWriteLock,
       lockOptions: { ...lockOptions, sessionFile },
       mergePromptReleasedSessionEntries: (entries) =>
-        staleManager.mergePromptReleasedSessionEntries(entries),
+        staleManager.mergePromptReleasedSessionEntries(entries, { persistLeaf: true }),
+      reloadPromptReleasedSessionFile: () => staleManager.setSessionFile(sessionFile),
     });
     await controller.releaseForPrompt();
 

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -1,9 +1,10 @@
 // Coverage for embedded attempt session-file ownership and write locks.
-import { appendFileSync } from "node:fs";
+import { appendFileSync, writeFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveSessionTranscriptPathInDir } from "../../../config/sessions/paths.js";
 import {
   appendSessionTranscriptEvent,
   appendSessionTranscriptMessage,
@@ -13,6 +14,7 @@ import {
   runWithOwnedSessionTranscriptWritePublication,
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
+import { appendExactAssistantMessageToSessionTranscript } from "../../../config/sessions/transcript.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import {
   SessionWriteLockStaleError,
@@ -2246,6 +2248,347 @@ describe("embedded attempt session lock lifecycle", () => {
     await controller.dispose();
   });
 
+  it("validates owned first-turn writes that create the transcript header", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-new-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "new-session.jsonl");
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+    await controller.releaseForPrompt();
+
+    const appended = await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () =>
+        await appendSessionTranscriptMessage({
+          transcriptPath: sessionFile,
+          sessionId: "new-session",
+          cwd: dir,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "first-turn delivery" }],
+            provider: "openclaw",
+            model: "delivery-mirror",
+          },
+        }),
+    );
+
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      expect.objectContaining({ type: "message", id: appended.messageId }),
+    ]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
+  it("validates first-turn exact assistant appends through the production facade", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-facade-"));
+    tempDirs.push(dir);
+    const sessionId = "facade-session";
+    const sessionKey = "facade";
+    const storePath = path.join(dir, "sessions.json");
+    const sessionFile = resolveSessionTranscriptPathInDir(sessionId, dir);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId,
+          chatType: "direct",
+          channel: "discord",
+          spawnedCwd: dir,
+        },
+      }),
+      "utf8",
+    );
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+    await controller.releaseForPrompt();
+
+    const result = await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        sessionKey,
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () =>
+        await appendExactAssistantMessageToSessionTranscript({
+          sessionKey,
+          storePath,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "first-turn delivery" }],
+            api: "openai-responses",
+            provider: "openclaw",
+            model: "delivery-mirror",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                total: 0,
+              },
+            },
+            stopReason: "stop",
+            timestamp: Date.now(),
+          },
+        }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      expect.objectContaining({ type: "message" }),
+    ]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
+  it("accepts header-only initialization when a first-turn append is blocked", async () => {
+    const sessionFile = await createTempSessionFile();
+    await fs.writeFile(sessionFile, "", "utf8");
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+    await controller.releaseForPrompt();
+
+    await expect(
+      withOwnedSessionTranscriptWrites(
+        {
+          sessionFile,
+          withSessionWriteLock: (operation, options) =>
+            controller.withSessionWriteLock(operation, options),
+        },
+        async () =>
+          await appendSessionTranscriptMessage({
+            transcriptPath: sessionFile,
+            sessionId: "blocked-session",
+            message: { role: "assistant", content: "blocked" },
+            prepareMessageAfterIdempotencyCheck: () => undefined,
+          }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([]);
+    expect(await fs.readFile(sessionFile, "utf8")).toContain('"type":"session"');
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
+  it("rejects unowned rows added beside a blocked first-turn append", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-blocked-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "blocked-external.jsonl");
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: vi.fn(),
+    });
+    await controller.releaseForPrompt();
+
+    await expect(
+      withOwnedSessionTranscriptWrites(
+        {
+          sessionFile,
+          withSessionWriteLock: (operation, options) =>
+            controller.withSessionWriteLock(operation, options),
+        },
+        async () =>
+          await appendSessionTranscriptMessage({
+            transcriptPath: sessionFile,
+            sessionId: "blocked-session",
+            message: { role: "assistant", content: "blocked" },
+            prepareMessageAfterIdempotencyCheck: () => {
+              appendFileSync(
+                sessionFile,
+                `${JSON.stringify({ type: "message", id: "external" })}\n`,
+                "utf8",
+              );
+              return undefined;
+            },
+          }),
+      ),
+    ).rejects.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+
+    expect(controller.hasSessionTakeover()).toBe(true);
+    await controller.dispose();
+  });
+
+  it("rejects a first-turn header changed before the owned message is published", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-header-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "changed-header.jsonl");
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: vi.fn(),
+    });
+    await controller.releaseForPrompt();
+
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "first-turn delivery" }],
+      provider: "openclaw",
+      model: "delivery-mirror",
+    } as const;
+    await expect(
+      withOwnedSessionTranscriptWrites(
+        {
+          sessionFile,
+          withSessionWriteLock: (operation, options) =>
+            controller.withSessionWriteLock(operation, options),
+        },
+        async () =>
+          await appendSessionTranscriptMessage({
+            transcriptPath: sessionFile,
+            sessionId: "expected-session",
+            cwd: dir,
+            message,
+            prepareMessageAfterIdempotencyCheck: (candidate) => {
+              writeFileSync(
+                sessionFile,
+                `${JSON.stringify({
+                  type: "session",
+                  version: 3,
+                  id: "replaced-session",
+                  timestamp: new Date().toISOString(),
+                  cwd: "/tmp/replaced",
+                })}\n`,
+                "utf8",
+              );
+              return candidate;
+            },
+          }),
+      ),
+    ).rejects.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+
+    expect(controller.hasSessionTakeover()).toBe(true);
+    await controller.dispose();
+  });
+
+  it("distinguishes a published session event from an implicit new header", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-event-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "session-event.jsonl");
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+    await controller.releaseForPrompt();
+
+    const event = { type: "session", sessionId: "published-session-event" };
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () =>
+        await appendSessionTranscriptEvent({
+          transcriptPath: sessionFile,
+          event,
+        }),
+    );
+
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      { type: "prompt_released_opaque", record: event },
+    ]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
+  it("validates opaque events migrated by a nested message publication", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-migrated-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "migrated-event.jsonl");
+    const existingMessageId = "existing-user";
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 1,
+          id: "migrated-event",
+          timestamp: new Date().toISOString(),
+          cwd: dir,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: existingMessageId,
+          timestamp: new Date().toISOString(),
+          message: { role: "user", content: "existing prompt" },
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+    await controller.releaseForPrompt();
+
+    const sessionKey = "agent:main:migrated-event";
+    const appended = await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        sessionKey,
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () =>
+        await runWithOwnedSessionTranscriptWritePublication(
+          { sessionFile, sessionKey },
+          async () => {
+            await appendSessionTranscriptEvent({
+              transcriptPath: sessionFile,
+              event: { type: "metadata", payload: { source: "plugin" } },
+            });
+            return await appendSessionTranscriptMessage({
+              transcriptPath: sessionFile,
+              message: {
+                role: "assistant",
+                content: [{ type: "text", text: "after metadata" }],
+                provider: "anthropic",
+                model: "sonnet-4.6",
+              },
+            });
+          },
+        ),
+    );
+
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      expect.objectContaining({
+        type: "prompt_released_opaque",
+        record: expect.objectContaining({ type: "metadata" }),
+      }),
+      expect.objectContaining({ type: "message", id: appended.messageId }),
+    ]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
   it("validates owned transcript entries larger than the benign external read limit", async () => {
     const sessionFile = await createTempSessionFile();
     const mergePromptReleasedSessionEntries = vi.fn();
@@ -2339,6 +2682,9 @@ describe("embedded attempt session lock lifecycle", () => {
       lockOptions: { ...lockOptions, sessionFile },
       mergePromptReleasedSessionEntries: (entries) => {
         for (const entry of entries) {
+          if (entry.type === "prompt_released_opaque") {
+            continue;
+          }
           if (mergedIds.includes(entry.id)) {
             throw new Error(`duplicate merged entry ${entry.id}`);
           }
@@ -2384,7 +2730,7 @@ describe("embedded attempt session lock lifecycle", () => {
         },
         {
           publishOwnedWrite: true,
-          resolvePublishedEntryIds: (id) => [id],
+          resolvePublishedEntries: (id) => [{ kind: "id", id }],
         },
       );
       await firstWriteStarted;
@@ -2392,7 +2738,7 @@ describe("embedded attempt session lock lifecycle", () => {
         () => appendOwnedAssistant("owned-second"),
         {
           publishOwnedWrite: true,
-          resolvePublishedEntryIds: (id) => [id],
+          resolvePublishedEntries: (id) => [{ kind: "id", id }],
         },
       );
       releaseFirstWrite();
@@ -2452,7 +2798,7 @@ describe("embedded attempt session lock lifecycle", () => {
         },
         {
           publishOwnedWrite: true,
-          resolvePublishedEntryIds: (id) => [id],
+          resolvePublishedEntries: (id) => [{ kind: "id", id }],
         },
       );
       await firstWriteStarted;
@@ -2463,7 +2809,7 @@ describe("embedded attempt session lock lifecycle", () => {
         },
         {
           publishOwnedWrite: true,
-          resolvePublishedEntryIds: (id) => [id],
+          resolvePublishedEntries: (id) => [{ kind: "id", id }],
         },
       );
       releaseFirstWrite();
@@ -2518,7 +2864,7 @@ describe("embedded attempt session lock lifecycle", () => {
       },
       {
         publishOwnedWrite: true,
-        resolvePublishedEntryIds: (id) => [id],
+        resolvePublishedEntries: (id) => [{ kind: "id", id }],
       },
     );
 
@@ -2570,39 +2916,86 @@ describe("embedded attempt session lock lifecycle", () => {
     await controller.dispose();
   });
 
-  it("rejects owned transcript events the active manager cannot replay", async () => {
-    const sessionFile = await createTempSessionFile();
-    const mergePromptReleasedSessionEntries = vi.fn();
+  it("preserves opaque owned transcript events across a stale-manager rewrite", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-opaque-"));
+    tempDirs.push(dir);
+    const staleManager = SessionManager.create(dir, dir);
+    staleManager.appendMessage({ role: "user", content: "question", timestamp: 1 });
+    const sessionFile = staleManager.getSessionFile();
+    if (!sessionFile) {
+      throw new Error("expected persisted session file");
+    }
     const controller = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock,
       lockOptions: { ...lockOptions, sessionFile },
-      mergePromptReleasedSessionEntries,
+      mergePromptReleasedSessionEntries: (entries) =>
+        staleManager.mergePromptReleasedSessionEntries(entries),
     });
     await controller.releaseForPrompt();
 
-    await expect(
-      withOwnedSessionTranscriptWrites(
-        {
-          sessionFile,
-          withSessionWriteLock: (operation, options) =>
-            controller.withSessionWriteLock(operation, options),
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () =>
+        await appendSessionTranscriptEvent({
+          transcriptPath: sessionFile,
+          event: {
+            type: "metadata",
+            payload: { source: "plugin" },
+          },
+        }),
+    );
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () =>
+        await appendSessionTranscriptEvent({
+          transcriptPath: sessionFile,
+          event: 42,
+        }),
+    );
+    await controller.withSessionWriteLock(() => {
+      staleManager.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "answer" }],
+        api: "messages",
+        provider: "anthropic",
+        model: "sonnet-4.6",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
         },
-        async () =>
-          await appendSessionTranscriptEvent({
-            transcriptPath: sessionFile,
-            event: {
-              type: "metadata",
-              id: "owned-metadata",
-              parentId: null,
-              timestamp: new Date().toISOString(),
-              data: { source: "plugin" },
-            },
-          }),
-      ),
-    ).rejects.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+        stopReason: "stop",
+        timestamp: 2,
+      });
+    });
 
-    expect(mergePromptReleasedSessionEntries).not.toHaveBeenCalled();
-    expect(controller.hasSessionTakeover()).toBe(true);
+    const records = (await fs.readFile(sessionFile, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as unknown);
+    expect(records).toContainEqual({
+      type: "metadata",
+      payload: { source: "plugin" },
+    });
+    expect(records).toContain(42);
+    const reopened = SessionManager.open(sessionFile, dir, dir);
+    expect(reopened.getEntries()).toHaveLength(2);
+    expect(reopened.buildSessionContext().messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+    expect(controller.hasSessionTakeover()).toBe(false);
     await controller.dispose();
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -739,7 +739,7 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(2);
   });
 
-  it("allows session control entries while the prompt lock is released", async () => {
+  it("allows globally resolved session metadata while the prompt lock is released", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});
     const acquireSessionWriteLockLocal = vi.fn(async () => ({ release }));
@@ -753,25 +753,10 @@ describe("embedded attempt session lock lifecycle", () => {
       sessionFile,
       [
         JSON.stringify({
-          type: "model_change",
-          id: "model-change",
-          parentId: null,
-          timestamp: new Date().toISOString(),
-          provider: "openai",
-          modelId: "gpt-5.1",
-        }),
-        JSON.stringify({
-          type: "thinking_level_change",
-          id: "thinking-change",
-          parentId: "model-change",
-          timestamp: new Date().toISOString(),
-          thinkingLevel: "high",
-        }),
-        JSON.stringify({
           type: "custom",
           customType: "model-snapshot",
           id: "model-snapshot",
-          parentId: "thinking-change",
+          parentId: null,
           timestamp: new Date().toISOString(),
           data: { provider: "openai", modelId: "gpt-5.1" },
         }),
@@ -790,6 +775,12 @@ describe("embedded attempt session lock lifecycle", () => {
           timestamp: new Date().toISOString(),
           name: "session title",
         }),
+        JSON.stringify({
+          type: "session_info",
+          id: "session-info-clear",
+          parentId: "session-info",
+          timestamp: new Date().toISOString(),
+        }),
       ].join("\n") + "\n",
       "utf8",
     );
@@ -801,9 +792,90 @@ describe("embedded attempt session lock lifecycle", () => {
     await cleanupLock.release();
   });
 
+  it("preserves globally resolved metadata when a stale manager appends the reply branch", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-metadata-"));
+    tempDirs.push(dir);
+    const initialManager = SessionManager.create(dir, dir);
+    initialManager.appendMessage({
+      role: "user",
+      content: "question",
+      timestamp: 1,
+    });
+    const rootId = initialManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "first answer" }],
+      api: "messages",
+      provider: "anthropic",
+      model: "sonnet-4.6",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+    const sessionFile = initialManager.getSessionFile();
+    if (!sessionFile) {
+      throw new Error("expected persisted session file");
+    }
+    const staleManager = SessionManager.open(sessionFile, dir, dir);
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    const metadataManager = SessionManager.open(sessionFile, dir, dir);
+    const customId = metadataManager.appendCustomEntry("model-snapshot", {
+      provider: "openai",
+      modelId: "gpt-5.1",
+    });
+    metadataManager.appendLabelChange(rootId, "runtime setting");
+    metadataManager.appendSessionInfo("session title");
+
+    await controller.withSessionWriteLock(() => {
+      staleManager.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "answer" }],
+        api: "messages",
+        provider: "anthropic",
+        model: "sonnet-4.6",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 3,
+      });
+    });
+
+    const reopened = SessionManager.open(sessionFile, dir, dir);
+    expect(reopened.getSessionName()).toBe("session title");
+    expect(reopened.getLabel(rootId)).toBe("runtime setting");
+    expect(reopened.getEntry(customId)).toMatchObject({
+      type: "custom",
+      customType: "model-snapshot",
+    });
+    expect(reopened.buildSessionContext().messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "assistant",
+    ]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+
+    const cleanupLock = await controller.acquireForCleanup();
+    await cleanupLock.release();
+  });
+
   it.each([
-    ["model_change without provider", { type: "model_change", modelId: "gpt-5.1" }],
-    ["thinking_level_change without thinkingLevel", { type: "thinking_level_change" }],
     ["custom without customType", { type: "custom", data: { provider: "openai" } }],
     ["custom with empty customType", { type: "custom", customType: "" }],
     ["label without targetId", { type: "label", label: "runtime setting" }],
@@ -843,6 +915,21 @@ describe("embedded attempt session lock lifecycle", () => {
   );
 
   it.each([
+    [
+      "model_change",
+      {
+        type: "model_change",
+        provider: "openai",
+        modelId: "gpt-5.1",
+      },
+    ],
+    [
+      "thinking_level_change",
+      {
+        type: "thinking_level_change",
+        thinkingLevel: "high",
+      },
+    ],
     [
       "message",
       {

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -4,7 +4,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { appendSessionTranscriptMessage } from "../../../config/sessions/transcript-append.js";
+import {
+  appendSessionTranscriptEvent,
+  appendSessionTranscriptMessage,
+} from "../../../config/sessions/transcript-append.js";
 import {
   runWithOwnedSessionTranscriptWriteLock,
   runWithOwnedSessionTranscriptWritePublication,
@@ -1039,69 +1042,57 @@ describe("embedded attempt session lock lifecycle", () => {
 
     await controller.releaseForPrompt();
     const sessionKey = "agent:main:delivery-side-branch";
-    await withOwnedSessionTranscriptWrites(
+    const deliveryId = await withOwnedSessionTranscriptWrites(
       {
         sessionFile,
         sessionKey,
         withSessionWriteLock: (operation, options) =>
           controller.withSessionWriteLock(operation, options),
       },
-      async () =>
-        await runWithOwnedSessionTranscriptWritePublication(
-          { sessionFile, sessionKey },
-          async () => {
-            await fs.appendFile(
-              sessionFile,
-              [
-                JSON.stringify({
-                  type: "message",
-                  id: "delivery-mirror",
-                  parentId: null,
-                  timestamp: new Date().toISOString(),
-                  message: {
-                    role: "assistant",
-                    content: [{ type: "text", text: "mirrored delivery" }],
-                    api: "messages",
-                    provider: "openclaw",
-                    model: "delivery-mirror",
-                    usage: {
-                      input: 0,
-                      output: 0,
-                      cacheRead: 0,
-                      cacheWrite: 0,
-                      totalTokens: 0,
-                      cost: {
-                        input: 0,
-                        output: 0,
-                        cacheRead: 0,
-                        cacheWrite: 0,
-                        total: 0,
-                      },
-                    },
-                    stopReason: "stop",
-                    timestamp: 3,
-                  },
-                }),
-                JSON.stringify({
-                  type: "label",
-                  id: "delivery-label",
-                  parentId: "delivery-mirror",
-                  timestamp: new Date().toISOString(),
-                  targetId: "delivery-mirror",
-                  label: "delivered",
-                }),
-                JSON.stringify({
-                  type: "session_info",
-                  id: "session-info",
-                  parentId: "delivery-label",
-                  timestamp: new Date().toISOString(),
-                  name: "delivery session",
-                }),
-              ].join("\n") + "\n",
-              "utf8",
-            );
+      async () => {
+        const delivery = await appendSessionTranscriptMessage({
+          transcriptPath: sessionFile,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "owned plugin delivery" }],
+            api: "messages",
+            provider: "anthropic",
+            model: "sonnet-4.6",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "stop",
+            timestamp: 3,
           },
-        ),
+        });
+        await appendSessionTranscriptEvent({
+          transcriptPath: sessionFile,
+          event: {
+            type: "label",
+            id: "delivery-label",
+            parentId: delivery.messageId,
+            timestamp: new Date().toISOString(),
+            targetId: delivery.messageId,
+            label: "delivered",
+          },
+        });
+        await appendSessionTranscriptEvent({
+          transcriptPath: sessionFile,
+          event: {
+            type: "session_info",
+            id: "session-info",
+            parentId: "delivery-label",
+            timestamp: new Date().toISOString(),
+            name: "delivery session",
+          },
+        });
+        return delivery.messageId;
+      },
     );
 
     await controller.withSessionWriteLock(() => {
@@ -1130,11 +1121,11 @@ describe("embedded attempt session lock lifecycle", () => {
     ).rewriteFile();
 
     const reopened = SessionManager.open(sessionFile, dir, dir);
-    expect(reopened.getEntry("delivery-mirror")).toMatchObject({
+    expect(reopened.getEntry(deliveryId)).toMatchObject({
       type: "message",
-      message: expect.objectContaining({ model: "delivery-mirror" }),
+      message: expect.objectContaining({ model: "sonnet-4.6" }),
     });
-    expect(reopened.getLabel("delivery-mirror")).toBe("delivered");
+    expect(reopened.getLabel(deliveryId)).toBe("delivered");
     expect(reopened.getSessionName()).toBe("delivery session");
     expect(reopened.buildSessionContext().messages.map((message) => message.role)).toEqual([
       "user",
@@ -2145,7 +2136,7 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(firstController.hasSessionTakeover()).toBe(false);
   });
 
-  it("allows post-prompt writes after the prompt context publishes an owned transcript write", async () => {
+  it("retains owned transcript publications until every active fence consumes them", async () => {
     const sessionFile = await createTempSessionFile();
     const releases: string[] = [];
     const acquireSessionWriteLockLocal2 = vi.fn(async () => ({
@@ -2176,29 +2167,27 @@ describe("embedded attempt session lock lifecycle", () => {
         },
         run,
       );
-    await promptActiveSession(
-      async () =>
-        await runWithOwnedSessionTranscriptWritePublication(
-          { sessionFile, sessionKey: "agent:main:slack:channel:456" },
-          async () => {
-            await fs.appendFile(
-              sessionFile,
-              `${JSON.stringify({
-                type: "message",
-                id: "same-process",
-                parentId: null,
-                timestamp: new Date().toISOString(),
-                message: {
+    const publishedIds: string[] = [];
+    await promptActiveSession(async () => {
+      for (let index = 0; index < 70; index += 1) {
+        const appended = await appendSessionTranscriptMessage({
+          transcriptPath: sessionFile,
+          message:
+            index === 0
+              ? {
+                  role: "user",
+                  content: [{ type: "text", text: "owned user publication" }],
+                }
+              : {
                   role: "assistant",
-                  provider: "openclaw",
-                  model: "delivery-mirror",
+                  content: [{ type: "text", text: `owned publication ${index}` }],
+                  provider: "anthropic",
+                  model: "sonnet-4.6",
                 },
-              })}\n`,
-              "utf8",
-            );
-          },
-        ),
-    );
+        });
+        publishedIds.push(appended.messageId);
+      }
+    });
     await secondController.releaseForPrompt();
 
     await expect(
@@ -2209,11 +2198,286 @@ describe("embedded attempt session lock lifecycle", () => {
     ).resolves.toBe("post-write");
 
     expect(firstController.hasSessionTakeover()).toBe(false);
-    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
-      expect.objectContaining({ type: "message", id: "same-process" }),
-    ]);
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith(
+      publishedIds.map((id) => expect.objectContaining({ type: "message", id })),
+    );
     expect(acquireSessionWriteLockLocal2).toHaveBeenCalledTimes(3);
     expect(releases).toEqual(["release", "release", "release"]);
+  });
+
+  it("serializes concurrent nested owned transcript publications", async () => {
+    const sessionFile = await createTempSessionFile();
+    const mergedIds: string[] = [];
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: (entries) => {
+        for (const entry of entries) {
+          if (mergedIds.includes(entry.id)) {
+            throw new Error(`duplicate merged entry ${entry.id}`);
+          }
+          mergedIds.push(entry.id);
+        }
+      },
+    });
+    await controller.releaseForPrompt();
+
+    let releaseFirstWrite!: () => void;
+    const firstWriteCanFinish = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    let markFirstWriteStarted!: () => void;
+    const firstWriteStarted = new Promise<void>((resolve) => {
+      markFirstWriteStarted = resolve;
+    });
+    const appendOwnedAssistant = async (id: string): Promise<string> => {
+      await fs.appendFile(
+        sessionFile,
+        `${JSON.stringify({
+          type: "message",
+          id,
+          parentId: null,
+          timestamp: new Date().toISOString(),
+          message: {
+            role: "assistant",
+            provider: "anthropic",
+            model: "sonnet-4.6",
+          },
+        })}\n`,
+        "utf8",
+      );
+      return id;
+    };
+
+    await controller.withSessionWriteLock(async () => {
+      const firstWrite = controller.withSessionWriteLock(
+        async () => {
+          markFirstWriteStarted();
+          await firstWriteCanFinish;
+          return await appendOwnedAssistant("owned-first");
+        },
+        {
+          publishOwnedWrite: true,
+          resolvePublishedEntryIds: (id) => [id],
+        },
+      );
+      await firstWriteStarted;
+      const secondWrite = controller.withSessionWriteLock(
+        () => appendOwnedAssistant("owned-second"),
+        {
+          publishOwnedWrite: true,
+          resolvePublishedEntryIds: (id) => [id],
+        },
+      );
+      releaseFirstWrite();
+      await Promise.all([firstWrite, secondWrite]);
+    });
+
+    expect(mergedIds).toEqual(["owned-first", "owned-second"]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
+  it("rejects interleaved assistant rows and stops already-queued publications", async () => {
+    const sessionFile = await createTempSessionFile();
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+    await controller.releaseForPrompt();
+
+    let releaseFirstWrite!: () => void;
+    const firstWriteCanFinish = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    let markFirstWriteStarted!: () => void;
+    const firstWriteStarted = new Promise<void>((resolve) => {
+      markFirstWriteStarted = resolve;
+    });
+    let secondWriteRan = false;
+    const appendAssistant = async (id: string): Promise<string> => {
+      await fs.appendFile(
+        sessionFile,
+        `${JSON.stringify({
+          type: "message",
+          id,
+          parentId: null,
+          timestamp: new Date().toISOString(),
+          message: {
+            role: "assistant",
+            provider: "anthropic",
+            model: "sonnet-4.6",
+          },
+        })}\n`,
+        "utf8",
+      );
+      return id;
+    };
+
+    await controller.withSessionWriteLock(async () => {
+      const firstWrite = controller.withSessionWriteLock(
+        async () => {
+          markFirstWriteStarted();
+          await firstWriteCanFinish;
+          await appendAssistant("interleaved-external");
+          return await appendAssistant("owned-entry");
+        },
+        {
+          publishOwnedWrite: true,
+          resolvePublishedEntryIds: (id) => [id],
+        },
+      );
+      await firstWriteStarted;
+      const secondWrite = controller.withSessionWriteLock(
+        async () => {
+          secondWriteRan = true;
+          return await appendAssistant("queued-entry");
+        },
+        {
+          publishOwnedWrite: true,
+          resolvePublishedEntryIds: (id) => [id],
+        },
+      );
+      releaseFirstWrite();
+      const results = await Promise.allSettled([firstWrite, secondWrite]);
+      expect(results.map((result) => result.status)).toEqual(["rejected", "rejected"]);
+    });
+
+    expect(secondWriteRan).toBe(false);
+    expect(mergePromptReleasedSessionEntries).not.toHaveBeenCalled();
+    expect(controller.hasSessionTakeover()).toBe(true);
+    await controller.dispose();
+  });
+
+  it("deactivates publication contexts inherited by delayed descendants", async () => {
+    const sessionFile = await createTempSessionFile();
+    const acquireSessionWriteLockLocal = vi.fn(async () => ({
+      release: vi.fn(async () => {}),
+    }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: vi.fn(),
+    });
+    await controller.releaseForPrompt();
+
+    let releaseDelayedWrite!: () => void;
+    const delayedWriteCanStart = new Promise<void>((resolve) => {
+      releaseDelayedWrite = resolve;
+    });
+    let delayedWrite!: Promise<string>;
+    await controller.withSessionWriteLock(
+      async () => {
+        delayedWrite = delayedWriteCanStart.then(() =>
+          controller.withSessionWriteLock(() => "delayed-write"),
+        );
+        await fs.appendFile(
+          sessionFile,
+          `${JSON.stringify({
+            type: "message",
+            id: "publication-entry",
+            parentId: null,
+            timestamp: new Date().toISOString(),
+            message: {
+              role: "assistant",
+              provider: "anthropic",
+              model: "sonnet-4.6",
+            },
+          })}\n`,
+          "utf8",
+        );
+        return "publication-entry";
+      },
+      {
+        publishOwnedWrite: true,
+        resolvePublishedEntryIds: (id) => [id],
+      },
+    );
+
+    releaseDelayedWrite();
+    await expect(delayedWrite).resolves.toBe("delayed-write");
+    expect(acquireSessionWriteLockLocal).toHaveBeenCalledTimes(3);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
+  it("publishes the transcript event id returned by serialization", async () => {
+    const sessionFile = await createTempSessionFile();
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+    await controller.releaseForPrompt();
+
+    const toJSON = vi.fn(() => ({
+      type: "custom",
+      id: "serialized-owned-event",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      customType: "plugin-event",
+      data: { source: "plugin" },
+    }));
+    await expect(
+      withOwnedSessionTranscriptWrites(
+        {
+          sessionFile,
+          withSessionWriteLock: (operation, options) =>
+            controller.withSessionWriteLock(operation, options),
+        },
+        async () =>
+          await appendSessionTranscriptEvent({
+            transcriptPath: sessionFile,
+            event: { toJSON },
+          }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(toJSON).toHaveBeenCalledTimes(1);
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      expect.objectContaining({ type: "custom", id: "serialized-owned-event" }),
+    ]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
+  it("rejects owned transcript events the active manager cannot replay", async () => {
+    const sessionFile = await createTempSessionFile();
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+    await controller.releaseForPrompt();
+
+    await expect(
+      withOwnedSessionTranscriptWrites(
+        {
+          sessionFile,
+          withSessionWriteLock: (operation, options) =>
+            controller.withSessionWriteLock(operation, options),
+        },
+        async () =>
+          await appendSessionTranscriptEvent({
+            transcriptPath: sessionFile,
+            event: {
+              type: "metadata",
+              id: "owned-metadata",
+              parentId: null,
+              timestamp: new Date().toISOString(),
+              data: { source: "plugin" },
+            },
+          }),
+      ),
+    ).rejects.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+
+    expect(mergePromptReleasedSessionEntries).not.toHaveBeenCalled();
+    expect(controller.hasSessionTakeover()).toBe(true);
+    await controller.dispose();
   });
 
   it("allows prompt-stream announcement writes from another controller but still rejects external edits", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -743,9 +743,11 @@ describe("embedded attempt session lock lifecycle", () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});
     const acquireSessionWriteLockLocal = vi.fn(async () => ({ release }));
+    const mergePromptReleasedSessionEntries = vi.fn();
     const controller = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock: acquireSessionWriteLockLocal,
       lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
     });
 
     await controller.releaseForPrompt();
@@ -787,9 +789,124 @@ describe("embedded attempt session lock lifecycle", () => {
 
     await expect(controller.withSessionWriteLock(() => "late-write")).resolves.toBe("late-write");
     expect(controller.hasSessionTakeover()).toBe(false);
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      expect.objectContaining({ type: "custom", id: "model-snapshot" }),
+      expect.objectContaining({ type: "label", id: "label-change" }),
+      expect.objectContaining({ type: "session_info", id: "session-info" }),
+      expect.objectContaining({ type: "session_info", id: "session-info-clear" }),
+    ]);
 
     const cleanupLock = await controller.acquireForCleanup();
     await cleanupLock.release();
+  });
+
+  it("rejects global metadata when the active session manager cannot resync", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: vi.fn(async () => ({ release })),
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await fs.appendFile(
+      sessionFile,
+      `${JSON.stringify({
+        type: "session_info",
+        id: "session-info",
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        name: "session title",
+      })}\n`,
+      "utf8",
+    );
+
+    await expect(controller.withSessionWriteLock(() => "late-write")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
+  it("preserves an unflushed first user turn while merging global metadata", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-first-turn-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "first-turn",
+        timestamp: new Date().toISOString(),
+        cwd: dir,
+      })}\n`,
+      "utf8",
+    );
+    const staleManager = SessionManager.open(sessionFile, dir, dir);
+    staleManager.appendMessage({
+      role: "user",
+      content: "question",
+      timestamp: 1,
+    });
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: (entries) =>
+        staleManager.mergePromptReleasedSessionEntries(entries),
+    });
+
+    await controller.releaseForPrompt();
+    await fs.appendFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "custom",
+          id: "model-snapshot",
+          parentId: null,
+          timestamp: new Date().toISOString(),
+          customType: "model-snapshot",
+          data: { provider: "openai", modelId: "gpt-5.1" },
+        }),
+        JSON.stringify({
+          type: "session_info",
+          id: "session-info",
+          parentId: "model-snapshot",
+          timestamp: new Date().toISOString(),
+          name: "first turn",
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    await controller.withSessionWriteLock(() => {
+      staleManager.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "answer" }],
+        api: "messages",
+        provider: "anthropic",
+        model: "sonnet-4.6",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 2,
+      });
+    });
+
+    const reopened = SessionManager.open(sessionFile, dir, dir);
+    expect(reopened.buildSessionContext().messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+    expect(reopened.getSessionName()).toBe("first turn");
+    expect(reopened.getEntry("model-snapshot")).toMatchObject({
+      type: "custom",
+      customType: "model-snapshot",
+    });
   });
 
   it("preserves globally resolved metadata when a stale manager appends the reply branch", async () => {
@@ -826,6 +943,8 @@ describe("embedded attempt session lock lifecycle", () => {
     const controller = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock,
       lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: (entries) =>
+        staleManager.mergePromptReleasedSessionEntries(entries),
     });
 
     await controller.releaseForPrompt();
@@ -856,6 +975,11 @@ describe("embedded attempt session lock lifecycle", () => {
         timestamp: 3,
       });
     });
+    (
+      staleManager as unknown as {
+        rewriteFile: () => void;
+      }
+    ).rewriteFile();
 
     const reopened = SessionManager.open(sessionFile, dir, dir);
     expect(reopened.getSessionName()).toBe("session title");
@@ -864,6 +988,154 @@ describe("embedded attempt session lock lifecycle", () => {
       type: "custom",
       customType: "model-snapshot",
     });
+    expect(reopened.buildSessionContext().messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "assistant",
+    ]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+
+    const cleanupLock = await controller.acquireForCleanup();
+    await cleanupLock.release();
+  });
+
+  it("preserves mixed delivery and metadata side branches across a stale-manager rewrite", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-session-delivery-"));
+    tempDirs.push(dir);
+    const initialManager = SessionManager.create(dir, dir);
+    initialManager.appendMessage({
+      role: "user",
+      content: "question",
+      timestamp: 1,
+    });
+    initialManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "first answer" }],
+      api: "messages",
+      provider: "anthropic",
+      model: "sonnet-4.6",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+    const sessionFile = initialManager.getSessionFile();
+    if (!sessionFile) {
+      throw new Error("expected persisted session file");
+    }
+    const staleManager = SessionManager.open(sessionFile, dir, dir);
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries: (entries) =>
+        staleManager.mergePromptReleasedSessionEntries(entries),
+    });
+
+    await controller.releaseForPrompt();
+    const sessionKey = "agent:main:delivery-side-branch";
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        sessionKey,
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () =>
+        await runWithOwnedSessionTranscriptWritePublication(
+          { sessionFile, sessionKey },
+          async () => {
+            await fs.appendFile(
+              sessionFile,
+              [
+                JSON.stringify({
+                  type: "message",
+                  id: "delivery-mirror",
+                  parentId: null,
+                  timestamp: new Date().toISOString(),
+                  message: {
+                    role: "assistant",
+                    content: [{ type: "text", text: "mirrored delivery" }],
+                    api: "messages",
+                    provider: "openclaw",
+                    model: "delivery-mirror",
+                    usage: {
+                      input: 0,
+                      output: 0,
+                      cacheRead: 0,
+                      cacheWrite: 0,
+                      totalTokens: 0,
+                      cost: {
+                        input: 0,
+                        output: 0,
+                        cacheRead: 0,
+                        cacheWrite: 0,
+                        total: 0,
+                      },
+                    },
+                    stopReason: "stop",
+                    timestamp: 3,
+                  },
+                }),
+                JSON.stringify({
+                  type: "label",
+                  id: "delivery-label",
+                  parentId: "delivery-mirror",
+                  timestamp: new Date().toISOString(),
+                  targetId: "delivery-mirror",
+                  label: "delivered",
+                }),
+                JSON.stringify({
+                  type: "session_info",
+                  id: "session-info",
+                  parentId: "delivery-label",
+                  timestamp: new Date().toISOString(),
+                  name: "delivery session",
+                }),
+              ].join("\n") + "\n",
+              "utf8",
+            );
+          },
+        ),
+    );
+
+    await controller.withSessionWriteLock(() => {
+      staleManager.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "current answer" }],
+        api: "messages",
+        provider: "anthropic",
+        model: "sonnet-4.6",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 4,
+      });
+    });
+    (
+      staleManager as unknown as {
+        rewriteFile: () => void;
+      }
+    ).rewriteFile();
+
+    const reopened = SessionManager.open(sessionFile, dir, dir);
+    expect(reopened.getEntry("delivery-mirror")).toMatchObject({
+      type: "message",
+      message: expect.objectContaining({ model: "delivery-mirror" }),
+    });
+    expect(reopened.getLabel("delivery-mirror")).toBe("delivered");
+    expect(reopened.getSessionName()).toBe("delivery session");
     expect(reopened.buildSessionContext().messages.map((message) => message.role)).toEqual([
       "user",
       "assistant",
@@ -1001,9 +1273,11 @@ describe("embedded attempt session lock lifecycle", () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});
     const acquireSessionWriteLockLocal11 = vi.fn(async () => ({ release }));
+    const mergePromptReleasedSessionEntries = vi.fn();
     const controller = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock: acquireSessionWriteLockLocal11,
       lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
     });
 
     await controller.releaseForPrompt();
@@ -1022,7 +1296,68 @@ describe("embedded attempt session lock lifecycle", () => {
     await cleanupLock.release();
 
     expect(controller.hasSessionTakeover()).toBe(false);
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      expect.objectContaining({
+        type: "message",
+        message: expect.objectContaining({ model: "delivery-mirror" }),
+      }),
+    ]);
     expect(release).toHaveBeenCalledTimes(3);
+  });
+
+  it("allows mixed delivery mirror and global metadata appends", async () => {
+    const sessionFile = await createTempSessionFile();
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: vi.fn(async () => ({ release: vi.fn(async () => {}) })),
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+
+    await controller.releaseForPrompt();
+    await fs.appendFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "message",
+          id: "delivery-mirror",
+          parentId: null,
+          timestamp: new Date().toISOString(),
+          message: {
+            role: "assistant",
+            provider: "openclaw",
+            model: "delivery-mirror",
+          },
+        }),
+        JSON.stringify({
+          type: "label",
+          id: "delivery-label",
+          parentId: "delivery-mirror",
+          timestamp: new Date().toISOString(),
+          targetId: "delivery-mirror",
+          label: "delivered",
+        }),
+        JSON.stringify({
+          type: "session_info",
+          id: "session-info",
+          parentId: "delivery-label",
+          timestamp: new Date().toISOString(),
+          name: "session title",
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    await expect(controller.withSessionWriteLock(() => "late-write")).resolves.toBe("late-write");
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      expect.objectContaining({ type: "message", id: "delivery-mirror" }),
+      expect.objectContaining({
+        type: "label",
+        id: "delivery-label",
+        targetId: "delivery-mirror",
+      }),
+      expect.objectContaining({ type: "session_info", id: "session-info" }),
+    ]);
   });
 
   it("allows delivery mirror appends that migrate legacy linear transcripts", async () => {
@@ -1038,9 +1373,11 @@ describe("embedded attempt session lock lifecycle", () => {
     );
     const release = vi.fn(async () => {});
     const acquireSessionWriteLockLocal10 = vi.fn(async () => ({ release }));
+    const mergePromptReleasedSessionEntries = vi.fn();
     const controller = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock: acquireSessionWriteLockLocal10,
       lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
     });
 
     await controller.releaseForPrompt();
@@ -1053,12 +1390,90 @@ describe("embedded attempt session lock lifecycle", () => {
         model: "delivery-mirror",
       },
     });
+    await fs.appendFile(
+      sessionFile,
+      `${JSON.stringify({
+        type: "session_info",
+        id: "session-info",
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        name: "migrated title",
+      })}\n`,
+      "utf8",
+    );
 
     await expect(controller.withSessionWriteLock(() => "late-write")).resolves.toBe("late-write");
     const cleanupLock = await controller.acquireForCleanup();
     await cleanupLock.release();
 
     await expect(fs.readFile(sessionFile, "utf8")).resolves.toContain('"parentId"');
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      expect.objectContaining({
+        type: "message",
+        message: expect.objectContaining({ model: "delivery-mirror" }),
+      }),
+      expect.objectContaining({ type: "session_info", id: "session-info" }),
+    ]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
+  it("allows parentless delivery mirrors appended to large legacy linear transcripts", async () => {
+    const sessionFile = await createTempSessionFile();
+    await fs.appendFile(
+      sessionFile,
+      `${JSON.stringify({
+        type: "message",
+        id: "large-legacy-user",
+        timestamp: new Date().toISOString(),
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "x".repeat(8 * 1024 * 1024) }],
+        },
+      })}\n`,
+      "utf8",
+    );
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+
+    await controller.releaseForPrompt();
+    const sessionKey = "agent:main:large-linear-delivery";
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        sessionKey,
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () =>
+        await runWithOwnedSessionTranscriptWritePublication(
+          { sessionFile, sessionKey },
+          async () =>
+            await appendSessionTranscriptMessage({
+              transcriptPath: sessionFile,
+              message: {
+                role: "assistant",
+                content: [{ type: "text", text: "mirrored large transcript delivery" }],
+                provider: "openclaw",
+                model: "delivery-mirror",
+              },
+            }),
+        ),
+    );
+
+    const lastLine = (await fs.readFile(sessionFile, "utf8")).trimEnd().split("\n").at(-1);
+    expect(lastLine).toBeDefined();
+    expect(JSON.parse(lastLine ?? "{}")).not.toHaveProperty("parentId");
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      expect.objectContaining({
+        type: "message",
+        parentId: null,
+        message: expect.objectContaining({ model: "delivery-mirror" }),
+      }),
+    ]);
     expect(controller.hasSessionTakeover()).toBe(false);
   });
 
@@ -1738,9 +2153,11 @@ describe("embedded attempt session lock lifecycle", () => {
         releases.push("release");
       }),
     }));
+    const mergePromptReleasedSessionEntries = vi.fn();
     const firstController = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock: acquireSessionWriteLockLocal2,
       lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
     });
 
     await firstController.releaseForPrompt();
@@ -1764,7 +2181,21 @@ describe("embedded attempt session lock lifecycle", () => {
         await runWithOwnedSessionTranscriptWritePublication(
           { sessionFile, sessionKey: "agent:main:slack:channel:456" },
           async () => {
-            await fs.appendFile(sessionFile, '{"type":"message","id":"same-process"}\n', "utf8");
+            await fs.appendFile(
+              sessionFile,
+              `${JSON.stringify({
+                type: "message",
+                id: "same-process",
+                parentId: null,
+                timestamp: new Date().toISOString(),
+                message: {
+                  role: "assistant",
+                  provider: "openclaw",
+                  model: "delivery-mirror",
+                },
+              })}\n`,
+              "utf8",
+            );
           },
         ),
     );
@@ -1778,6 +2209,9 @@ describe("embedded attempt session lock lifecycle", () => {
     ).resolves.toBe("post-write");
 
     expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      expect.objectContaining({ type: "message", id: "same-process" }),
+    ]);
     expect(acquireSessionWriteLockLocal2).toHaveBeenCalledTimes(3);
     expect(releases).toEqual(["release", "release", "release"]);
   });

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -2205,6 +2205,132 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(releases).toEqual(["release", "release", "release"]);
   });
 
+  it("validates nested owned publications with the persisted entry ids", async () => {
+    const sessionFile = await createTempSessionFile();
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+    await controller.releaseForPrompt();
+
+    const sessionKey = "agent:main:nested-publication";
+    const appended = await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        sessionKey,
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () =>
+        await runWithOwnedSessionTranscriptWritePublication(
+          { sessionFile, sessionKey },
+          async () =>
+            await appendSessionTranscriptMessage({
+              transcriptPath: sessionFile,
+              message: {
+                role: "assistant",
+                content: [{ type: "text", text: "nested owned publication" }],
+                provider: "anthropic",
+                model: "sonnet-4.6",
+              },
+            }),
+        ),
+    );
+
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      expect.objectContaining({ type: "message", id: appended.messageId }),
+    ]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
+  it("validates owned transcript entries larger than the benign external read limit", async () => {
+    const sessionFile = await createTempSessionFile();
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+    await controller.releaseForPrompt();
+
+    const appended = await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () =>
+        await appendSessionTranscriptMessage({
+          transcriptPath: sessionFile,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "x".repeat(1024 * 1024 + 1) }],
+            provider: "anthropic",
+            model: "sonnet-4.6",
+          },
+        }),
+    );
+
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      expect.objectContaining({ type: "message", id: appended.messageId }),
+    ]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
+  it("validates large owned entries after migrating a large linear transcript", async () => {
+    const sessionFile = await createTempSessionFile();
+    await fs.appendFile(
+      sessionFile,
+      `${JSON.stringify({
+        type: "message",
+        id: "large-linear-user",
+        timestamp: new Date().toISOString(),
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "x".repeat(7 * 1024 * 1024) }],
+        },
+      })}\n`,
+      "utf8",
+    );
+    const mergePromptReleasedSessionEntries = vi.fn();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+      mergePromptReleasedSessionEntries,
+    });
+    await controller.releaseForPrompt();
+
+    const appended = await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () =>
+        await appendSessionTranscriptMessage({
+          transcriptPath: sessionFile,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "y".repeat(3 * 1024 * 1024) }],
+            provider: "anthropic",
+            model: "sonnet-4.6",
+          },
+        }),
+    );
+
+    const persisted = await fs.readFile(sessionFile, "utf8");
+    expect(persisted).toContain('"parentId"');
+    expect(mergePromptReleasedSessionEntries).toHaveBeenCalledWith([
+      expect.objectContaining({ type: "message", id: appended.messageId }),
+    ]);
+    expect(controller.hasSessionTakeover()).toBe(false);
+    await controller.dispose();
+  });
+
   it("serializes concurrent nested owned transcript publications", async () => {
     const sessionFile = await createTempSessionFile();
     const mergedIds: string[] = [];

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -739,6 +739,177 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(2);
   });
 
+  it("allows session control entries while the prompt lock is released", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await fs.appendFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "model_change",
+          id: "model-change",
+          parentId: null,
+          timestamp: new Date().toISOString(),
+          provider: "openai",
+          modelId: "gpt-5.1",
+        }),
+        JSON.stringify({
+          type: "thinking_level_change",
+          id: "thinking-change",
+          parentId: "model-change",
+          timestamp: new Date().toISOString(),
+          thinkingLevel: "high",
+        }),
+        JSON.stringify({
+          type: "custom",
+          customType: "model-snapshot",
+          id: "model-snapshot",
+          parentId: "thinking-change",
+          timestamp: new Date().toISOString(),
+          data: { provider: "openai", modelId: "gpt-5.1" },
+        }),
+        JSON.stringify({
+          type: "label",
+          id: "label-change",
+          parentId: "model-snapshot",
+          timestamp: new Date().toISOString(),
+          targetId: "model-change",
+          label: "runtime setting",
+        }),
+        JSON.stringify({
+          type: "session_info",
+          id: "session-info",
+          parentId: "label-change",
+          timestamp: new Date().toISOString(),
+          name: "session title",
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    await expect(controller.withSessionWriteLock(() => "late-write")).resolves.toBe("late-write");
+    expect(controller.hasSessionTakeover()).toBe(false);
+
+    const cleanupLock = await controller.acquireForCleanup();
+    await cleanupLock.release();
+  });
+
+  it.each([
+    ["model_change without provider", { type: "model_change", modelId: "gpt-5.1" }],
+    ["thinking_level_change without thinkingLevel", { type: "thinking_level_change" }],
+    ["custom without customType", { type: "custom", data: { provider: "openai" } }],
+    ["custom with empty customType", { type: "custom", customType: "" }],
+    ["label without targetId", { type: "label", label: "runtime setting" }],
+    ["label with non-string label", { type: "label", targetId: "model-change", label: 42 }],
+    ["session_info with non-string name", { type: "session_info", name: 42 }],
+  ])(
+    "rejects malformed session control entries while the prompt lock is released: %s",
+    async (_, entry) => {
+      const sessionFile = await createTempSessionFile();
+      const release = vi.fn(async () => {});
+      const acquireSessionWriteLockLocal = vi.fn(async () => ({ release }));
+      const controller = await createEmbeddedAttemptSessionLockController({
+        acquireSessionWriteLock: acquireSessionWriteLockLocal,
+        lockOptions: { ...lockOptions, sessionFile },
+      });
+
+      await controller.releaseForPrompt();
+      await fs.appendFile(
+        sessionFile,
+        `${JSON.stringify({
+          id: "malformed-control-entry",
+          parentId: null,
+          timestamp: new Date().toISOString(),
+          ...entry,
+        })}\n`,
+        "utf8",
+      );
+
+      await expect(controller.withSessionWriteLock(() => "late-write")).rejects.toBeInstanceOf(
+        EmbeddedAttemptSessionTakeoverError,
+      );
+      expect(controller.hasSessionTakeover()).toBe(true);
+
+      const cleanupLock = await controller.acquireForCleanup();
+      await cleanupLock.release();
+    },
+  );
+
+  it.each([
+    [
+      "message",
+      {
+        type: "message",
+        message: { role: "user", content: [{ type: "text", text: "concurrent user input" }] },
+      },
+    ],
+    [
+      "custom_message",
+      {
+        type: "custom_message",
+        customType: "extension-context",
+        content: "prompt-affecting extension content",
+        display: false,
+      },
+    ],
+    [
+      "compaction",
+      {
+        type: "compaction",
+        summary: "Compacted context that would affect the next prompt.",
+        firstKeptEntryId: "root",
+        tokensBefore: 42,
+      },
+    ],
+    [
+      "branch_summary",
+      {
+        type: "branch_summary",
+        fromId: "root",
+        summary: "Branch summary that would affect the next prompt.",
+      },
+    ],
+    ["leaf", { type: "leaf", targetId: null }],
+  ])(
+    "rejects prompt-affecting session entries while the prompt lock is released: %s",
+    async (_, entry) => {
+      const sessionFile = await createTempSessionFile();
+      const release = vi.fn(async () => {});
+      const acquireSessionWriteLockLocal = vi.fn(async () => ({ release }));
+      const controller = await createEmbeddedAttemptSessionLockController({
+        acquireSessionWriteLock: acquireSessionWriteLockLocal,
+        lockOptions: { ...lockOptions, sessionFile },
+      });
+
+      await controller.releaseForPrompt();
+      await fs.appendFile(
+        sessionFile,
+        `${JSON.stringify({
+          id: "prompt-affecting-entry",
+          parentId: null,
+          timestamp: new Date().toISOString(),
+          ...entry,
+        })}\n`,
+        "utf8",
+      );
+
+      await expect(controller.withSessionWriteLock(() => "late-write")).rejects.toBeInstanceOf(
+        EmbeddedAttemptSessionTakeoverError,
+      );
+      expect(controller.hasSessionTakeover()).toBe(true);
+
+      const cleanupLock = await controller.acquireForCleanup();
+      await cleanupLock.release();
+    },
+  );
+
   it("allows delivery mirror appends while the prompt lock is released", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -1686,32 +1686,43 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
   }
 
-  async function runWithRetainedLock<T>(
+  async function runWithPhysicalWriteLockScope<T>(
     run: () => Promise<T>,
-    releaseRetainedUse: () => void,
+    release: () => Promise<void> | void,
   ): Promise<T> {
     const scope = createActiveWriteLockScope();
-    let operationSucceeded = false;
+    let outcome: { ok: true; value: T } | { ok: false; error: unknown };
     try {
-      const result = await activeWriteLock.run(scope.state, run);
-      operationSucceeded = true;
-      return result;
+      outcome = { ok: true, value: await activeWriteLock.run(scope.state, run) };
+    } catch (error) {
+      outcome = { ok: false, error };
     } finally {
       try {
         await drainWriteLockScope(scope.state.scope);
-        if (operationSucceeded && takeoverDetected) {
-          throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
-        }
       } finally {
         scope.state.active = false;
         scope.state.scope.active = false;
         try {
-          releaseRetainedUse();
+          await release();
         } finally {
           scope.complete();
         }
       }
     }
+    if (!outcome.ok) {
+      throw outcome.error;
+    }
+    if (takeoverDetected) {
+      throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+    }
+    return outcome.value;
+  }
+
+  async function runWithRetainedLock<T>(
+    run: () => Promise<T>,
+    releaseRetainedUse: () => void,
+  ): Promise<T> {
+    return await runWithPhysicalWriteLockScope(run, releaseRetainedUse);
   }
 
   async function runPublishingOwnedSessionFileWrite<T>(
@@ -1856,28 +1867,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       return await runWithRetainedLock(runLockedOperation, releaseRetainedUse ?? (() => {}));
     }
 
-    const scope = createActiveWriteLockScope();
-    let operationSucceeded = false;
-    try {
-      const result = await activeWriteLock.run(scope.state, runLockedOperation);
-      operationSucceeded = true;
-      return result;
-    } finally {
-      try {
-        await drainWriteLockScope(scope.state.scope);
-        if (operationSucceeded && takeoverDetected) {
-          throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
-        }
-      } finally {
-        scope.state.active = false;
-        scope.state.scope.active = false;
-        try {
-          await lock.release();
-        } finally {
-          scope.complete();
-        }
-      }
-    }
+    return await runWithPhysicalWriteLockScope(runLockedOperation, () => lock.release());
   }
 
   return {

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -27,11 +27,72 @@ import { resolveEmbeddedSessionFileKey } from "../session-file-key.js";
 
 type SessionLock = Awaited<ReturnType<typeof acquireSessionWriteLock>>;
 type AcquireSessionWriteLock = typeof acquireSessionWriteLock;
-type ActiveWriteLockState = {
+type PhysicalWriteLockScope = {
   active: boolean;
-  publishingOwnedWrite: boolean;
-  publishedEntries?: OwnedSessionTranscriptPublishedEntry[];
+  completion: Promise<void>;
+  pendingOperations: Set<Promise<void>>;
 };
+type ActiveWriteLockState =
+  | {
+      active: boolean;
+      scope: PhysicalWriteLockScope;
+      publishingOwnedWrite: false;
+    }
+  | {
+      active: boolean;
+      scope: PhysicalWriteLockScope;
+      publishingOwnedWrite: true;
+      acceptingNestedPublications: boolean;
+      pendingNestedPublications: Set<Promise<void>>;
+      publishedEntries?: OwnedSessionTranscriptPublishedEntry[];
+    };
+type RootWriteLockState = Extract<ActiveWriteLockState, { publishingOwnedWrite: false }>;
+
+function createActiveWriteLockScope(): {
+  state: RootWriteLockState;
+  complete: () => void;
+} {
+  let complete!: () => void;
+  const completion = new Promise<void>((resolve) => {
+    complete = resolve;
+  });
+  return {
+    state: {
+      active: true,
+      scope: {
+        active: true,
+        completion,
+        pendingOperations: new Set(),
+      },
+      publishingOwnedWrite: false,
+    },
+    complete,
+  };
+}
+
+function trackWriteLockOperation<T>(
+  scope: PhysicalWriteLockScope,
+  operation: Promise<T>,
+  additionalSet?: Set<Promise<void>>,
+): Promise<T> {
+  const settlement = operation.then(
+    () => undefined,
+    () => undefined,
+  );
+  scope.pendingOperations.add(settlement);
+  additionalSet?.add(settlement);
+  void settlement.finally(() => {
+    scope.pendingOperations.delete(settlement);
+    additionalSet?.delete(settlement);
+  });
+  return operation;
+}
+
+async function drainWriteLockScope(scope: PhysicalWriteLockScope): Promise<void> {
+  while (scope.pendingOperations.size > 0) {
+    await Promise.all(scope.pendingOperations);
+  }
+}
 
 type LockOptions = {
   sessionFile: string;
@@ -284,64 +345,96 @@ function classifyPromptReleasedSessionLines(
   }
   const entries: PromptReleasedSessionEntry[] = [];
   const publishedEntries: OwnedSessionTranscriptPublishedEntry[] = [];
+  const remainingExpectedEntries = options?.expectedPublishedEntries
+    ? [...options.expectedPublishedEntries]
+    : undefined;
   let hasGlobalMetadata = false;
   let hasOpaqueEntries = false;
   let expectedParentId = options?.initialParentId ?? null;
   for (const line of lines) {
-    const expectedPublishedEntry = options?.expectedPublishedEntries?.[publishedEntries.length];
-    if (expectedPublishedEntry?.kind === "serialized") {
-      if (expectedPublishedEntry.serialized === line) {
-        try {
-          const exactEntry = JSON.parse(line) as unknown;
-          if (isJsonRecord(exactEntry)) {
-            expectedParentId = normalizeTranscriptEntryId(exactEntry.id) ?? expectedParentId;
+    const matchExpectedEntry = (
+      id: string | undefined,
+    ): OwnedSessionTranscriptPublishedEntry | undefined => {
+      if (!remainingExpectedEntries) {
+        if (id) {
+          expectedParentId = id;
+          return { kind: "id", id };
+        }
+        return { kind: "serialized", serialized: line };
+      }
+      let matchIndex = remainingExpectedEntries.findIndex(
+        (entry) => entry.kind === "serialized" && entry.serialized === line,
+      );
+      let migratedParentId: string | undefined;
+      if (matchIndex < 0 && id) {
+        matchIndex = remainingExpectedEntries.findIndex(
+          (entry) => entry.kind === "id" && entry.id === id,
+        );
+      }
+      if (matchIndex < 0) {
+        matchIndex = remainingExpectedEntries.findIndex((entry) => {
+          if (entry.kind !== "serialized") {
+            return false;
           }
-        } catch {
-          return undefined;
-        }
-      } else {
-        const lineMatch = lineMatchesLinearTranscriptMigration({
-          previousLine: expectedPublishedEntry.serialized,
-          currentLine: line,
-          expectedParentId,
+          const lineMatch = lineMatchesLinearTranscriptMigration({
+            previousLine: entry.serialized,
+            currentLine: line,
+            expectedParentId,
+          });
+          if (!lineMatch.ok) {
+            return false;
+          }
+          migratedParentId = lineMatch.nextPreviousId;
+          return true;
         });
-        if (!lineMatch.ok) {
-          return undefined;
-        }
-        expectedParentId = lineMatch.nextPreviousId ?? expectedParentId;
       }
-    }
-    const publishIdentity = (id: string): OwnedSessionTranscriptPublishedEntry => {
-      if (expectedPublishedEntry?.kind === "serialized") {
-        return expectedPublishedEntry;
+      if (matchIndex < 0) {
+        return undefined;
       }
-      expectedParentId = id;
-      return { kind: "id", id };
+      const [matchedEntry] = remainingExpectedEntries.splice(matchIndex, 1);
+      if (migratedParentId) {
+        expectedParentId = migratedParentId;
+      } else if (id) {
+        expectedParentId = id;
+      }
+      return matchedEntry;
     };
     const transcriptEntry = parsePromptReleasedMessageLine(line, options);
     if (transcriptEntry) {
+      const publishedEntry = matchExpectedEntry(transcriptEntry.id);
+      if (!publishedEntry) {
+        return undefined;
+      }
       entries.push(transcriptEntry);
-      publishedEntries.push(publishIdentity(transcriptEntry.id));
+      publishedEntries.push(publishedEntry);
       continue;
     }
     const metadataEntry = parsePromptReleasedGlobalMetadataLine(line);
     if (metadataEntry) {
+      const publishedEntry = matchExpectedEntry(metadataEntry.id);
+      if (!publishedEntry) {
+        return undefined;
+      }
       entries.push(metadataEntry);
-      publishedEntries.push(publishIdentity(metadataEntry.id));
+      publishedEntries.push(publishedEntry);
       hasGlobalMetadata = true;
       continue;
     }
     const opaqueEntry = options?.allowAnyMessage ? parsePromptReleasedOpaqueLine(line) : undefined;
-    if (!opaqueEntry) {
+    const opaqueId =
+      opaqueEntry && isJsonRecord(opaqueEntry.record)
+        ? normalizeTranscriptEntryId(opaqueEntry.record.id)
+        : undefined;
+    const publishedEntry = opaqueEntry ? matchExpectedEntry(opaqueId) : undefined;
+    if (!opaqueEntry || !publishedEntry) {
       return undefined;
     }
     entries.push(opaqueEntry);
-    publishedEntries.push(
-      expectedPublishedEntry?.kind === "serialized"
-        ? expectedPublishedEntry
-        : { kind: "serialized", serialized: line },
-    );
+    publishedEntries.push(publishedEntry);
     hasOpaqueEntries = true;
+  }
+  if (remainingExpectedEntries?.length) {
+    return undefined;
   }
   if (hasOpaqueEntries) {
     return { kind: "opaque", entries, publishedEntries };
@@ -354,6 +447,24 @@ function classifyPromptReleasedSessionLines(
     entries: entries as SessionMessageEntry[],
     publishedEntries,
   };
+}
+
+function haveSamePublishedEntries(
+  actual: readonly OwnedSessionTranscriptPublishedEntry[],
+  expected: readonly OwnedSessionTranscriptPublishedEntry[],
+): boolean {
+  if (actual.length !== expected.length) {
+    return false;
+  }
+  const unmatched = [...expected];
+  for (const entry of actual) {
+    const matchIndex = unmatched.findIndex((candidate) => isDeepStrictEqual(candidate, entry));
+    if (matchIndex < 0) {
+      return false;
+    }
+    unmatched.splice(matchIndex, 1);
+  }
+  return true;
 }
 
 function normalizeTranscriptEntryId(value: unknown): string | undefined {
@@ -549,10 +660,7 @@ async function classifyOwnedSessionFileInitialization(params: {
     return undefined;
   }
   const lines = normalizeStringEntries(text.split("\n"));
-  const expectedHeader =
-    params.expectedPublishedEntries[0]?.kind === "header"
-      ? params.expectedPublishedEntries[0]
-      : undefined;
+  const expectedHeader = params.expectedPublishedEntries.find((entry) => entry.kind === "header");
   if (expectedHeader) {
     if (lines[0] !== expectedHeader.serialized) {
       return undefined;
@@ -560,7 +668,7 @@ async function classifyOwnedSessionFileInitialization(params: {
     lines.shift();
   }
   const remainingExpectedEntries = expectedHeader
-    ? params.expectedPublishedEntries.slice(1)
+    ? params.expectedPublishedEntries.filter((entry) => entry !== expectedHeader)
     : params.expectedPublishedEntries;
   const change = classifyPromptReleasedSessionLines(lines, {
     allowAnyMessage: true,
@@ -1110,7 +1218,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
     if (
       options?.expectedPublishedEntries &&
-      !isDeepStrictEqual(change.publishedEntries, [...options.expectedPublishedEntries])
+      !haveSamePublishedEntries(change.publishedEntries, options.expectedPublishedEntries)
     ) {
       return undefined;
     }
@@ -1154,7 +1262,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     if (retainedLockUseCount === 0) {
       return true;
     }
-    if (activeWriteLock.getStore()?.active === true) {
+    if (activeWriteLock.getStore()?.scope.active === true) {
       return false;
     }
     await new Promise<void>((resolve) => {
@@ -1503,18 +1611,18 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     run: () => Promise<T>,
     releaseRetainedUse: () => void,
   ): Promise<T> {
+    const scope = createActiveWriteLockScope();
     try {
-      const activeLockState: ActiveWriteLockState = {
-        active: true,
-        publishingOwnedWrite: false,
-      };
-      try {
-        return await activeWriteLock.run(activeLockState, run);
-      } finally {
-        activeLockState.active = false;
-      }
+      return await activeWriteLock.run(scope.state, run);
     } finally {
-      releaseRetainedUse();
+      await drainWriteLockScope(scope.state.scope);
+      scope.state.active = false;
+      scope.state.scope.active = false;
+      try {
+        releaseRetainedUse();
+      } finally {
+        scope.complete();
+      }
     }
   }
 
@@ -1524,71 +1632,161 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     resolvePublishedEntriesAfterFailure?: () => readonly OwnedSessionTranscriptPublishedEntry[],
   ): Promise<T> {
     const parentLockState = activeWriteLock.getStore();
-    if (parentLockState?.publishingOwnedWrite) {
-      let nestedEntries: readonly OwnedSessionTranscriptPublishedEntry[] | undefined;
-      try {
-        const result = await run();
-        nestedEntries = resolvePublishedEntries?.(result);
-        return result;
-      } catch (error) {
-        nestedEntries = resolvePublishedEntriesAfterFailure?.();
-        throw error;
-      } finally {
-        if (nestedEntries !== undefined) {
-          parentLockState.publishedEntries ??= [];
-          parentLockState.publishedEntries.push(...nestedEntries);
-        }
-      }
+    if (!parentLockState?.active || !parentLockState.scope.active) {
+      throw new Error("owned session publication requires an active session write lock");
     }
-    let releaseQueue!: () => void;
-    const currentQueueEntry = new Promise<void>((resolve) => {
-      releaseQueue = resolve;
-    });
-    const previousQueueEntry = ownedPublicationQueue.catch(() => undefined);
-    ownedPublicationQueue = previousQueueEntry.then(() => currentQueueEntry);
-    await previousQueueEntry;
-    try {
-      if (takeoverDetected) {
-        throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
-      }
-      const beforeWrite = await captureOwnedSessionFileWriteStart();
-      const publicationLockState: ActiveWriteLockState = {
-        active: parentLockState?.active ?? true,
-        publishingOwnedWrite: true,
-        publishedEntries: undefined,
-      };
-      try {
-        return await activeWriteLock.run(publicationLockState, async () => {
-          let ownEntries: readonly OwnedSessionTranscriptPublishedEntry[] | undefined;
-          try {
-            const result = await run();
-            ownEntries = resolvePublishedEntries?.(result);
-            return result;
-          } catch (error) {
-            ownEntries = resolvePublishedEntriesAfterFailure?.();
-            throw error;
-          } finally {
-            const nestedEntries = publicationLockState.publishedEntries;
-            const expectedPublishedEntries =
-              nestedEntries === undefined
-                ? ownEntries
-                : ownEntries === undefined
-                  ? nestedEntries
-                  : [...nestedEntries, ...ownEntries];
-            await publishOwnedSessionFileFence(beforeWrite, expectedPublishedEntries);
+    if (parentLockState?.publishingOwnedWrite && parentLockState.acceptingNestedPublications) {
+      const nestedPublication = (async () => {
+        let nestedEntries: readonly OwnedSessionTranscriptPublishedEntry[] | undefined;
+        try {
+          const result = await run();
+          nestedEntries = resolvePublishedEntries?.(result);
+          return result;
+        } catch (error) {
+          nestedEntries = resolvePublishedEntriesAfterFailure?.();
+          throw error;
+        } finally {
+          if (nestedEntries !== undefined) {
+            parentLockState.publishedEntries ??= [];
+            parentLockState.publishedEntries.push(...nestedEntries);
           }
-        });
+        }
+      })();
+      return await trackWriteLockOperation(
+        parentLockState.scope,
+        nestedPublication,
+        parentLockState.pendingNestedPublications,
+      );
+    }
+    const publication = (async () => {
+      let releaseQueue!: () => void;
+      const currentQueueEntry = new Promise<void>((resolve) => {
+        releaseQueue = resolve;
+      });
+      const previousQueueEntry = ownedPublicationQueue.catch(() => undefined);
+      ownedPublicationQueue = previousQueueEntry.then(() => currentQueueEntry);
+      await previousQueueEntry;
+      try {
+        if (takeoverDetected) {
+          throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+        }
+        const beforeWrite = await captureOwnedSessionFileWriteStart();
+        const publicationLockState: ActiveWriteLockState = {
+          active: true,
+          scope: parentLockState.scope,
+          publishingOwnedWrite: true,
+          acceptingNestedPublications: true,
+          pendingNestedPublications: new Set(),
+          publishedEntries: undefined,
+        };
+        try {
+          return await activeWriteLock.run(publicationLockState, async () => {
+            let ownEntries: readonly OwnedSessionTranscriptPublishedEntry[] | undefined;
+            try {
+              const result = await run();
+              ownEntries = resolvePublishedEntries?.(result);
+              return result;
+            } catch (error) {
+              ownEntries = resolvePublishedEntriesAfterFailure?.();
+              throw error;
+            } finally {
+              // Nested transcript callbacks inherit this publication owner.
+              // Drain them before freezing the expected fence entry set.
+              while (publicationLockState.pendingNestedPublications.size > 0) {
+                await Promise.all(publicationLockState.pendingNestedPublications);
+              }
+              publicationLockState.acceptingNestedPublications = false;
+              publicationLockState.active = false;
+              const nestedEntries = publicationLockState.publishedEntries;
+              const expectedPublishedEntries =
+                nestedEntries === undefined
+                  ? ownEntries
+                  : ownEntries === undefined
+                    ? nestedEntries
+                    : [...nestedEntries, ...ownEntries];
+              await publishOwnedSessionFileFence(beforeWrite, expectedPublishedEntries);
+            }
+          });
+        } finally {
+          publicationLockState.active = false;
+        }
       } finally {
-        publicationLockState.active = false;
+        releaseQueue();
       }
+    })();
+    return await trackWriteLockOperation(parentLockState.scope, publication);
+  }
+
+  async function runInheritedWriteLockOperation<T>(
+    state: ActiveWriteLockState,
+    run: () => Promise<T> | T,
+  ): Promise<T> {
+    const operation = (async () => await run())();
+    return await trackWriteLockOperation(state.scope, operation);
+  }
+
+  async function withSessionWriteLock<T>(
+    run: () => Promise<T> | T,
+    options?: OwnedSessionTranscriptWriteOptions<T>,
+  ): Promise<T> {
+    if (takeoverDetected) {
+      throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+    }
+    const inheritedLockState = activeWriteLock.getStore();
+    if (inheritedLockState && (!inheritedLockState.active || !inheritedLockState.scope.active)) {
+      await inheritedLockState.scope.completion;
+      return await activeWriteLock.exit(() => withSessionWriteLock(run, options));
+    }
+    if (inheritedLockState?.active === true) {
+      if (options?.publishOwnedWrite !== true) {
+        return await runInheritedWriteLockOperation(inheritedLockState, run);
+      }
+      return await runPublishingOwnedSessionFileWrite(
+        run,
+        options.resolvePublishedEntries,
+        options.resolvePublishedEntriesAfterFailure,
+      );
+    }
+    const { lock, owned, releaseRetainedUse } = await acquireWriteLock();
+    const runLockedOperation = async () => {
+      await assertSessionFileFence();
+      if (options?.publishOwnedWrite === true) {
+        return await runPublishingOwnedSessionFileWrite(
+          run,
+          options.resolvePublishedEntries,
+          options.resolvePublishedEntriesAfterFailure,
+        );
+      }
+      const beforeWrite = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+      try {
+        return await run();
+      } finally {
+        await refreshSessionFileFence(beforeWrite);
+      }
+    };
+    if (!owned) {
+      return await runWithRetainedLock(runLockedOperation, releaseRetainedUse ?? (() => {}));
+    }
+
+    const scope = createActiveWriteLockScope();
+    try {
+      return await activeWriteLock.run(scope.state, runLockedOperation);
     } finally {
-      releaseQueue();
+      await drainWriteLockScope(scope.state.scope);
+      scope.state.active = false;
+      scope.state.scope.active = false;
+      try {
+        await lock.release();
+      } finally {
+        scope.complete();
+      }
     }
   }
 
   return {
     canAdvanceSessionEntryCache(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean {
-      if (takeoverDetected || activeWriteLock.getStore()?.active !== true) {
+      const state = activeWriteLock.getStore();
+      if (takeoverDetected || state?.active !== true || !state.scope.active) {
         return false;
       }
       const fingerprint: SessionFileFingerprint = { exists: true, ...snapshot };
@@ -1598,7 +1796,8 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       );
     },
     publishOwnedSessionFileSnapshot(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean {
-      if (takeoverDetected || activeWriteLock.getStore()?.active !== true) {
+      const state = activeWriteLock.getStore();
+      if (takeoverDetected || state?.active !== true || !state.scope.active) {
         return false;
       }
       const fingerprint: SessionFileFingerprint = { exists: true, ...snapshot };
@@ -1697,62 +1896,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       }
     },
     waitForSessionEvents: waitForSessionEventQueue,
-    async withSessionWriteLock<T>(
-      run: () => Promise<T> | T,
-      options?: OwnedSessionTranscriptWriteOptions<T>,
-    ): Promise<T> {
-      if (takeoverDetected) {
-        throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
-      }
-      if (activeWriteLock.getStore()?.active === true) {
-        if (options?.publishOwnedWrite !== true) {
-          return await run();
-        }
-        return await runPublishingOwnedSessionFileWrite(
-          run,
-          options.resolvePublishedEntries,
-          options.resolvePublishedEntriesAfterFailure,
-        );
-      }
-      const { lock, owned, releaseRetainedUse } = await acquireWriteLock();
-      try {
-        const runLockedOperation = async () => {
-          await assertSessionFileFence();
-          const runWithLock = async () => {
-            if (options?.publishOwnedWrite === true) {
-              return await runPublishingOwnedSessionFileWrite(
-                run,
-                options.resolvePublishedEntries,
-                options.resolvePublishedEntriesAfterFailure,
-              );
-            }
-            const beforeWrite = await readSessionFileFingerprint(params.lockOptions.sessionFile);
-            try {
-              return await run();
-            } finally {
-              await refreshSessionFileFence(beforeWrite);
-            }
-          };
-          return await runWithLock();
-        };
-        if (owned) {
-          const activeLockState: ActiveWriteLockState = {
-            active: true,
-            publishingOwnedWrite: false,
-          };
-          try {
-            return await activeWriteLock.run(activeLockState, runLockedOperation);
-          } finally {
-            activeLockState.active = false;
-          }
-        }
-        return await runWithRetainedLock(runLockedOperation, releaseRetainedUse ?? (() => {}));
-      } finally {
-        if (owned) {
-          await lock.release();
-        }
-      }
-    },
+    withSessionWriteLock,
     async acquireForCleanup(cleanupParams?: { session?: unknown }): Promise<SessionLock> {
       if (cleanupParams?.session) {
         await waitForSessionEventQueue(cleanupParams.session);

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -14,12 +14,14 @@ import {
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
 import { resolveGlobalSingleton } from "../../../shared/global-singleton.js";
+import { isTranscriptOnlyOpenClawAssistantMessage } from "../../../shared/transcript-only-openclaw-assistant.js";
 import { isSessionWriteLockAcquireError } from "../../session-write-lock-error.js";
 import type { acquireSessionWriteLock } from "../../session-write-lock.js";
 import type {
   CustomEntry,
   LabelEntry,
   PromptReleasedOpaqueEntry,
+  PromptReleasedSessionMergeResult,
   SessionInfoEntry,
   SessionMessageEntry,
 } from "../../sessions/session-manager.js";
@@ -126,7 +128,6 @@ type SessionFileFingerprint =
 
 export type TrustedSessionFileSnapshot = Extract<SessionFileFingerprint, { exists: true }>;
 
-const TRANSCRIPT_ONLY_OPENCLAW_ASSISTANT_MODELS = new Set(["delivery-mirror", "gateway-injected"]);
 const MAX_BENIGN_SESSION_FENCE_ADVANCE_BYTES = 1024 * 1024;
 const MAX_BENIGN_SESSION_FENCE_REWRITE_BYTES = 8 * 1024 * 1024;
 const MAX_BENIGN_SESSION_FENCE_REWRITE_RESULT_BYTES =
@@ -203,7 +204,8 @@ function parsePromptReleasedMessageLine(
       parsed.timestamp.trim().length === 0 ||
       (parsed.parentId !== undefined &&
         parsed.parentId !== null &&
-        typeof parsed.parentId !== "string")
+        typeof parsed.parentId !== "string") ||
+      (parsed.appendMode !== undefined && parsed.appendMode !== "side")
     ) {
       return undefined;
     }
@@ -211,11 +213,7 @@ function parsePromptReleasedMessageLine(
     if (!isJsonRecord(message)) {
       return undefined;
     }
-    const isOpenClawTranscriptOnlyAssistant =
-      message.role === "assistant" &&
-      message.provider === "openclaw" &&
-      typeof message.model === "string" &&
-      TRANSCRIPT_ONLY_OPENCLAW_ASSISTANT_MODELS.has(message.model);
+    const isOpenClawTranscriptOnlyAssistant = isTranscriptOnlyOpenClawAssistantMessage(message);
     if (
       typeof message.role !== "string" ||
       (!options?.allowAnyMessage && !isOpenClawTranscriptOnlyAssistant)
@@ -228,6 +226,7 @@ function parsePromptReleasedMessageLine(
       parentId: parsed.parentId ?? null,
       timestamp: parsed.timestamp,
       message: message as unknown as SessionMessageEntry["message"],
+      ...(parsed.appendMode === "side" ? { appendMode: parsed.appendMode } : {}),
     };
   } catch {
     return undefined;
@@ -793,6 +792,7 @@ type OwnedSessionFileWrite = {
   generation: number;
   fingerprint: SessionFileFingerprint;
   publishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[];
+  requiresReload?: true;
 };
 
 type OwnedSessionFileWriteHistory = {
@@ -1009,12 +1009,14 @@ function recordOwnedSessionFileWrite(
   sessionFileKey: string,
   fingerprint: SessionFileFingerprint,
   publishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[],
+  requiresReload?: true,
 ): number {
   ownedSessionFileWriteGeneration += 1;
   const state = {
     generation: ownedSessionFileWriteGeneration,
     fingerprint,
     ...(publishedEntries ? { publishedEntries: [...publishedEntries] } : {}),
+    ...(requiresReload ? { requiresReload } : {}),
   };
   const history = resolveOwnedSessionFileWriteHistory(sessionFileKey);
   history.writes.push(state);
@@ -1137,7 +1139,8 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   lockOptions: LockOptions;
   mergePromptReleasedSessionEntries?: (
     entries: readonly PromptReleasedSessionEntry[],
-  ) => Promise<void> | void;
+  ) => Promise<PromptReleasedSessionMergeResult | void> | PromptReleasedSessionMergeResult | void;
+  reloadPromptReleasedSessionFile?: () => Promise<void> | void;
 }): Promise<EmbeddedAttemptSessionLockController> {
   const acquireLock = async (): Promise<SessionLock> =>
     await params.acquireSessionWriteLock({
@@ -1200,7 +1203,9 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   ): Promise<
     | {
         snapshot: SessionFileFenceSnapshot;
-        publishedEntries: OwnedSessionTranscriptPublishedEntry[];
+        publishedEntries?: OwnedSessionTranscriptPublishedEntry[];
+        postMergePublishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[];
+        requiresReload?: true;
       }
     | undefined
   > {
@@ -1222,21 +1227,53 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     ) {
       return undefined;
     }
+    let mergeResult: PromptReleasedSessionMergeResult | void;
     try {
-      await params.mergePromptReleasedSessionEntries(change.entries);
+      mergeResult = await params.mergePromptReleasedSessionEntries(change.entries);
     } catch (error) {
       takeoverDetected = true;
       throw error;
     }
     const refreshedSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
-    if (!sameSessionFileFingerprint(current, refreshedSnapshot.fingerprint)) {
+    const expectedFingerprint = mergeResult?.sessionFileSnapshot
+      ? { exists: true as const, ...mergeResult.sessionFileSnapshot }
+      : current;
+    if (!sameSessionFileFingerprint(expectedFingerprint, refreshedSnapshot.fingerprint)) {
       takeoverDetected = true;
       throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
     }
     return {
       snapshot: refreshedSnapshot,
-      publishedEntries: change.publishedEntries,
+      publishedEntries: mergeResult?.requiresReload
+        ? undefined
+        : mergeResult?.publishedEntries
+          ? [...change.publishedEntries, ...mergeResult.publishedEntries]
+          : change.publishedEntries,
+      ...(mergeResult?.publishedEntries
+        ? { postMergePublishedEntries: mergeResult.publishedEntries }
+        : {}),
+      ...(mergeResult?.requiresReload ? { requiresReload: true as const } : {}),
     };
+  }
+
+  async function reloadPromptReleasedSessionFile(
+    expectedFingerprint: SessionFileFingerprint,
+  ): Promise<SessionFileFenceSnapshot | undefined> {
+    if (!params.reloadPromptReleasedSessionFile) {
+      return undefined;
+    }
+    try {
+      await params.reloadPromptReleasedSessionFile();
+    } catch (error) {
+      takeoverDetected = true;
+      throw error;
+    }
+    const snapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
+    if (!sameSessionFileFingerprint(expectedFingerprint, snapshot.fingerprint)) {
+      takeoverDetected = true;
+      throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+    }
+    return snapshot;
   }
 
   function beginRetainedLockUse(): () => void {
@@ -1350,6 +1387,17 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       const unseenOwnedWrites = ownedWriteHistory.filter(
         (write) => write.generation > fenceGeneration,
       );
+      if (unseenOwnedWrites.some((write) => write.requiresReload)) {
+        const reloadedSnapshot = await reloadPromptReleasedSessionFile(current);
+        if (!reloadedSnapshot) {
+          takeoverDetected = true;
+          throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+        }
+        fenceFingerprint = reloadedSnapshot.fingerprint;
+        fenceSnapshot = reloadedSnapshot;
+        setFenceGeneration(ownedWrite.generation);
+        return;
+      }
       const canValidateExactEntries = unseenOwnedWrites.every(
         (write) => write.publishedEntries !== undefined,
       );
@@ -1365,9 +1413,19 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         takeoverDetected = true;
         throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
       }
-      fenceFingerprint = current;
+      const mergedFingerprint = mergedChange?.snapshot.fingerprint ?? current;
+      const mergedGeneration =
+        mergedChange && !sameSessionFileFingerprint(current, mergedFingerprint)
+          ? recordOwnedSessionFileWrite(
+              sessionFileFenceKey,
+              mergedFingerprint,
+              mergedChange.postMergePublishedEntries,
+              mergedChange.requiresReload,
+            )
+          : ownedWrite.generation;
+      fenceFingerprint = mergedFingerprint;
       fenceSnapshot = mergedChange?.snapshot ?? { fingerprint: current };
-      setFenceGeneration(ownedWrite.generation);
+      setFenceGeneration(mergedGeneration);
       return;
     }
 
@@ -1404,8 +1462,12 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       fenceSnapshot = mergedChange.snapshot;
       fenceFingerprint = mergedChange.snapshot.fingerprint;
       setFenceGeneration(
-        trustSessionFileState(sessionFileFenceKey, mergedChange.snapshot.fingerprint) ??
-          fenceGeneration,
+        recordOwnedSessionFileWrite(
+          sessionFileFenceKey,
+          mergedChange.snapshot.fingerprint,
+          mergedChange.publishedEntries,
+          mergedChange.requiresReload,
+        ),
       );
       return;
     }
@@ -1463,10 +1525,18 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       takeoverDetected = true;
       throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
     }
-    const publishedEntries = expectedPublishedEntries ?? mergedChange?.publishedEntries;
-    const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, current, publishedEntries);
+    const publishedEntries = mergedChange
+      ? mergedChange.publishedEntries
+      : expectedPublishedEntries;
+    const publishedFingerprint = mergedChange?.snapshot.fingerprint ?? current;
+    const generation = recordOwnedSessionFileWrite(
+      sessionFileFenceKey,
+      publishedFingerprint,
+      publishedEntries,
+      mergedChange?.requiresReload,
+    );
     if (fenceActive) {
-      fenceFingerprint = current;
+      fenceFingerprint = publishedFingerprint;
       fenceSnapshot =
         mergedChange?.snapshot ??
         (await readSessionFileFenceSnapshot(params.lockOptions.sessionFile));

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -135,6 +135,7 @@ function parsePromptReleasedMessageLine(
     const parsed = JSON.parse(line) as unknown;
     if (
       !isJsonRecord(parsed) ||
+      parsed.type !== "message" ||
       typeof parsed.id !== "string" ||
       parsed.id.trim().length === 0 ||
       typeof parsed.timestamp !== "string" ||

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -1520,16 +1520,24 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   async function runPublishingOwnedSessionFileWrite<T>(
     run: () => Promise<T> | T,
     resolvePublishedEntries?: (result: T) => readonly OwnedSessionTranscriptPublishedEntry[],
+    resolvePublishedEntriesAfterFailure?: () => readonly OwnedSessionTranscriptPublishedEntry[],
   ): Promise<T> {
     const parentLockState = activeWriteLock.getStore();
     if (parentLockState?.publishingOwnedWrite) {
-      const result = await run();
-      const nestedEntries = resolvePublishedEntries?.(result);
-      if (nestedEntries !== undefined) {
-        parentLockState.publishedEntries ??= [];
-        parentLockState.publishedEntries.push(...nestedEntries);
+      let nestedEntries: readonly OwnedSessionTranscriptPublishedEntry[] | undefined;
+      try {
+        const result = await run();
+        nestedEntries = resolvePublishedEntries?.(result);
+        return result;
+      } catch (error) {
+        nestedEntries = resolvePublishedEntriesAfterFailure?.();
+        throw error;
+      } finally {
+        if (nestedEntries !== undefined) {
+          parentLockState.publishedEntries ??= [];
+          parentLockState.publishedEntries.push(...nestedEntries);
+        }
       }
-      return result;
     }
     let releaseQueue!: () => void;
     const currentQueueEntry = new Promise<void>((resolve) => {
@@ -1550,19 +1558,22 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       };
       try {
         return await activeWriteLock.run(publicationLockState, async () => {
-          let expectedPublishedEntries: readonly OwnedSessionTranscriptPublishedEntry[] | undefined;
+          let ownEntries: readonly OwnedSessionTranscriptPublishedEntry[] | undefined;
           try {
             const result = await run();
-            const ownEntries = resolvePublishedEntries?.(result);
+            ownEntries = resolvePublishedEntries?.(result);
+            return result;
+          } catch (error) {
+            ownEntries = resolvePublishedEntriesAfterFailure?.();
+            throw error;
+          } finally {
             const nestedEntries = publicationLockState.publishedEntries;
-            expectedPublishedEntries =
+            const expectedPublishedEntries =
               nestedEntries === undefined
                 ? ownEntries
                 : ownEntries === undefined
                   ? nestedEntries
                   : [...nestedEntries, ...ownEntries];
-            return result;
-          } finally {
             await publishOwnedSessionFileFence(beforeWrite, expectedPublishedEntries);
           }
         });
@@ -1696,7 +1707,11 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         if (options?.publishOwnedWrite !== true) {
           return await run();
         }
-        return await runPublishingOwnedSessionFileWrite(run, options.resolvePublishedEntries);
+        return await runPublishingOwnedSessionFileWrite(
+          run,
+          options.resolvePublishedEntries,
+          options.resolvePublishedEntriesAfterFailure,
+        );
       }
       const { lock, owned, releaseRetainedUse } = await acquireWriteLock();
       try {
@@ -1704,7 +1719,11 @@ export async function createEmbeddedAttemptSessionLockController(params: {
           await assertSessionFileFence();
           const runWithLock = async () => {
             if (options?.publishOwnedWrite === true) {
-              return await runPublishingOwnedSessionFileWrite(run, options.resolvePublishedEntries);
+              return await runPublishingOwnedSessionFileWrite(
+                run,
+                options.resolvePublishedEntries,
+                options.resolvePublishedEntriesAfterFailure,
+              );
             }
             const beforeWrite = await readSessionFileFingerprint(params.lockOptions.sessionFile);
             try {

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -14,6 +14,12 @@ import {
 import { resolveGlobalSingleton } from "../../../shared/global-singleton.js";
 import { isSessionWriteLockAcquireError } from "../../session-write-lock-error.js";
 import type { acquireSessionWriteLock } from "../../session-write-lock.js";
+import type {
+  CustomEntry,
+  LabelEntry,
+  SessionInfoEntry,
+  SessionMessageEntry,
+} from "../../sessions/session-manager.js";
 import { resolveEmbeddedSessionFileKey } from "../session-file-key.js";
 
 type SessionLock = Awaited<ReturnType<typeof acquireSessionWriteLock>>;
@@ -120,24 +126,42 @@ function isJsonRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function isTranscriptOnlyOpenClawAssistantLine(line: string): boolean {
+function parseTranscriptOnlyOpenClawAssistantLine(line: string): SessionMessageEntry | undefined {
   try {
     const parsed = JSON.parse(line) as unknown;
-    if (!isJsonRecord(parsed)) {
-      return false;
+    if (
+      !isJsonRecord(parsed) ||
+      typeof parsed.id !== "string" ||
+      parsed.id.trim().length === 0 ||
+      typeof parsed.timestamp !== "string" ||
+      parsed.timestamp.trim().length === 0 ||
+      (parsed.parentId !== undefined &&
+        parsed.parentId !== null &&
+        typeof parsed.parentId !== "string")
+    ) {
+      return undefined;
     }
     const message = parsed.message;
     if (!isJsonRecord(message)) {
-      return false;
+      return undefined;
     }
-    return (
+    const isTranscriptOnlyAssistant =
       message.role === "assistant" &&
       message.provider === "openclaw" &&
       typeof message.model === "string" &&
-      TRANSCRIPT_ONLY_OPENCLAW_ASSISTANT_MODELS.has(message.model)
-    );
+      TRANSCRIPT_ONLY_OPENCLAW_ASSISTANT_MODELS.has(message.model);
+    if (!isTranscriptOnlyAssistant) {
+      return undefined;
+    }
+    return {
+      type: "message",
+      id: parsed.id,
+      parentId: parsed.parentId ?? null,
+      timestamp: parsed.timestamp,
+      message: message as unknown as SessionMessageEntry["message"],
+    };
   } catch {
-    return false;
+    return undefined;
   }
 }
 
@@ -151,36 +175,97 @@ function hasSessionEntryBase(record: Record<string, unknown>): boolean {
   );
 }
 
-function isPromptReleasedGlobalMetadataLine(line: string): boolean {
+export type PromptReleasedSessionMetadataEntry = CustomEntry | LabelEntry | SessionInfoEntry;
+
+export type PromptReleasedSessionEntry = SessionMessageEntry | PromptReleasedSessionMetadataEntry;
+
+function parsePromptReleasedGlobalMetadataLine(
+  line: string,
+): PromptReleasedSessionMetadataEntry | undefined {
   try {
     const parsed = JSON.parse(line) as unknown;
     if (!isJsonRecord(parsed) || !hasSessionEntryBase(parsed)) {
-      return false;
+      return undefined;
     }
+    const base = {
+      id: parsed.id as string,
+      parentId: parsed.parentId as string | null,
+      timestamp: parsed.timestamp as string,
+    };
     // These records are resolved globally rather than through the active branch.
     // Accepting them keeps an in-flight reply alive without losing branch-scoped
     // model or thinking state when the active SessionManager is stale.
     switch (parsed.type) {
       case "custom":
-        return typeof parsed.customType === "string" && parsed.customType.trim().length > 0;
+        return typeof parsed.customType === "string" && parsed.customType.trim().length > 0
+          ? {
+              ...base,
+              type: "custom",
+              customType: parsed.customType,
+              ...(Object.hasOwn(parsed, "data") ? { data: parsed.data } : {}),
+            }
+          : undefined;
       case "label":
-        return (
-          typeof parsed.targetId === "string" &&
+        return typeof parsed.targetId === "string" &&
           parsed.targetId.trim().length > 0 &&
           (parsed.label === undefined || typeof parsed.label === "string")
-        );
+          ? {
+              ...base,
+              type: "label",
+              targetId: parsed.targetId,
+              label: parsed.label,
+            }
+          : undefined;
       case "session_info":
-        return parsed.name === undefined || typeof parsed.name === "string";
+        return parsed.name === undefined || typeof parsed.name === "string"
+          ? {
+              ...base,
+              type: "session_info",
+              ...(typeof parsed.name === "string" ? { name: parsed.name } : {}),
+            }
+          : undefined;
       default:
-        return false;
+        return undefined;
     }
   } catch {
-    return false;
+    return undefined;
   }
 }
 
-function isBenignPromptReleasedSessionLine(line: string): boolean {
-  return isTranscriptOnlyOpenClawAssistantLine(line) || isPromptReleasedGlobalMetadataLine(line);
+type PromptReleasedSessionChange =
+  | {
+      kind: "transcript-only";
+      entries: SessionMessageEntry[];
+    }
+  | {
+      kind: "global-metadata";
+      entries: PromptReleasedSessionEntry[];
+    };
+
+function classifyPromptReleasedSessionLines(
+  lines: string[],
+): PromptReleasedSessionChange | undefined {
+  if (lines.length === 0) {
+    return undefined;
+  }
+  const entries: PromptReleasedSessionEntry[] = [];
+  let hasGlobalMetadata = false;
+  for (const line of lines) {
+    const transcriptEntry = parseTranscriptOnlyOpenClawAssistantLine(line);
+    if (transcriptEntry) {
+      entries.push(transcriptEntry);
+      continue;
+    }
+    const metadataEntry = parsePromptReleasedGlobalMetadataLine(line);
+    if (!metadataEntry) {
+      return undefined;
+    }
+    entries.push(metadataEntry);
+    hasGlobalMetadata = true;
+  }
+  return hasGlobalMetadata
+    ? { kind: "global-metadata", entries }
+    : { kind: "transcript-only", entries: entries as SessionMessageEntry[] };
 }
 
 function normalizeTranscriptEntryId(value: unknown): string | undefined {
@@ -323,17 +408,17 @@ async function readSessionFileDigest(sessionFile: string): Promise<string | unde
   });
 }
 
-async function sessionFenceAdvanceIsBenign(params: {
+async function classifySessionFenceAdvance(params: {
   sessionFile: string;
   previous: SessionFileFenceSnapshot | undefined;
   current: SessionFileFingerprint;
-}): Promise<boolean> {
+}): Promise<PromptReleasedSessionChange | undefined> {
   if (
     !params.previous?.fingerprint.exists ||
     !params.current.exists ||
     !sameSessionFileIdentity(params.previous.fingerprint, params.current)
   ) {
-    return false;
+    return undefined;
   }
   const text = await readAppendedSessionFileText({
     sessionFile: params.sessionFile,
@@ -341,10 +426,10 @@ async function sessionFenceAdvanceIsBenign(params: {
     current: params.current,
   });
   if (!text?.endsWith("\n")) {
-    return false;
+    return undefined;
   }
   const lines = normalizeStringEntries(text.split("\n"));
-  return lines.length > 0 && lines.every(isBenignPromptReleasedSessionLine);
+  return classifyPromptReleasedSessionLines(lines);
 }
 
 async function sessionFenceCtimeDriftIsBenign(params: {
@@ -374,11 +459,11 @@ async function sessionFenceCtimeDriftIsBenign(params: {
   }
 }
 
-async function sessionFenceRewriteIsBenign(params: {
+async function classifySessionFenceRewrite(params: {
   sessionFile: string;
   previous: SessionFileFenceSnapshot | undefined;
   current: SessionFileFingerprint;
-}): Promise<boolean> {
+}): Promise<PromptReleasedSessionChange | undefined> {
   if (
     !params.previous?.fingerprint.exists ||
     !params.current.exists ||
@@ -387,21 +472,21 @@ async function sessionFenceRewriteIsBenign(params: {
     params.current.size > BigInt(MAX_BENIGN_SESSION_FENCE_REWRITE_RESULT_BYTES) ||
     params.current.size > MAX_SAFE_FILE_OFFSET
   ) {
-    return false;
+    return undefined;
   }
   let currentText: string;
   try {
     currentText = await fs.readFile(params.sessionFile, "utf8");
   } catch {
-    return false;
+    return undefined;
   }
   if (!currentText.endsWith("\n")) {
-    return false;
+    return undefined;
   }
   const previousLines = splitSessionFileLines(params.previous.text);
   const currentLines = splitSessionFileLines(currentText);
   if (currentLines.length <= previousLines.length) {
-    return false;
+    return undefined;
   }
   let expectedParentId: string | null = null;
   for (let index = 0; index < previousLines.length; index += 1) {
@@ -411,12 +496,20 @@ async function sessionFenceRewriteIsBenign(params: {
       expectedParentId,
     });
     if (!lineMatch.ok) {
-      return false;
+      return undefined;
     }
     expectedParentId = lineMatch.nextPreviousId ?? expectedParentId;
   }
   const appendedLines = currentLines.slice(previousLines.length);
-  return appendedLines.every(isBenignPromptReleasedSessionLine);
+  return classifyPromptReleasedSessionLines(appendedLines);
+}
+
+async function classifySessionFenceChange(params: {
+  sessionFile: string;
+  previous: SessionFileFenceSnapshot | undefined;
+  current: SessionFileFingerprint;
+}): Promise<PromptReleasedSessionChange | undefined> {
+  return (await classifySessionFenceAdvance(params)) ?? (await classifySessionFenceRewrite(params));
 }
 
 type OwnedSessionFileWrite = {
@@ -727,6 +820,9 @@ export type EmbeddedAttemptSessionLockController = {
 export async function createEmbeddedAttemptSessionLockController(params: {
   acquireSessionWriteLock: AcquireSessionWriteLock;
   lockOptions: LockOptions;
+  mergePromptReleasedSessionEntries?: (
+    entries: readonly PromptReleasedSessionEntry[],
+  ) => Promise<void> | void;
 }): Promise<EmbeddedAttemptSessionLockController> {
   const acquireLock = async (): Promise<SessionLock> =>
     await params.acquireSessionWriteLock({
@@ -749,6 +845,35 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   let heldLockDrainOwner: symbol | undefined;
   const heldLockDrainWaiters = new Set<() => void>();
   const sessionFileFenceKey = resolveSessionFileFenceKey(params.lockOptions.sessionFile);
+
+  async function mergePromptReleasedSessionChange(
+    previous: SessionFileFenceSnapshot | undefined,
+    current: SessionFileFingerprint,
+  ): Promise<SessionFileFenceSnapshot | undefined> {
+    if (!params.mergePromptReleasedSessionEntries) {
+      return undefined;
+    }
+    const change = await classifySessionFenceChange({
+      sessionFile: params.lockOptions.sessionFile,
+      previous,
+      current,
+    });
+    if (!change) {
+      return undefined;
+    }
+    try {
+      await params.mergePromptReleasedSessionEntries(change.entries);
+    } catch (error) {
+      takeoverDetected = true;
+      throw error;
+    }
+    const refreshedSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
+    if (!sameSessionFileFingerprint(current, refreshedSnapshot.fingerprint)) {
+      takeoverDetected = true;
+      throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+    }
+    return refreshedSnapshot;
+  }
 
   function beginRetainedLockUse(): () => void {
     retainedLockUseCount += 1;
@@ -857,8 +982,9 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       ownedWrite.generation > fenceGeneration &&
       sameSessionFileFingerprint(ownedWrite.fingerprint, current)
     ) {
+      const mergedSnapshot = await mergePromptReleasedSessionChange(fenceSnapshot, current);
       fenceFingerprint = current;
-      fenceSnapshot = { fingerprint: current };
+      fenceSnapshot = mergedSnapshot ?? { fingerprint: current };
       fenceGeneration = ownedWrite.generation;
       return;
     }
@@ -876,43 +1002,33 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       return;
     }
 
-    if (
-      (await sessionFenceAdvanceIsBenign({
-        sessionFile: params.lockOptions.sessionFile,
-        previous: fenceSnapshot,
-        current,
-      })) ||
-      (await sessionFenceRewriteIsBenign({
-        sessionFile: params.lockOptions.sessionFile,
-        previous: fenceSnapshot,
-        current,
-      }))
-    ) {
+    const changeKind = await classifySessionFenceChange({
+      sessionFile: params.lockOptions.sessionFile,
+      previous: fenceSnapshot,
+      current,
+    });
+    if (changeKind?.kind === "transcript-only" && !params.mergePromptReleasedSessionEntries) {
       fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
       fenceFingerprint = fenceSnapshot.fingerprint;
       fenceGeneration = trustSessionFileState(sessionFileFenceKey, current) ?? fenceGeneration;
       return;
     }
+    if (changeKind && params.mergePromptReleasedSessionEntries) {
+      const refreshedSnapshot = await mergePromptReleasedSessionChange(fenceSnapshot, current);
+      if (!refreshedSnapshot) {
+        takeoverDetected = true;
+        throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+      }
+      fenceSnapshot = refreshedSnapshot;
+      fenceFingerprint = refreshedSnapshot.fingerprint;
+      fenceGeneration =
+        trustSessionFileState(sessionFileFenceKey, refreshedSnapshot.fingerprint) ??
+        fenceGeneration;
+      return;
+    }
 
     takeoverDetected = true;
     throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
-  }
-
-  async function publishOwnedSessionFileWriteIfChanged(
-    beforeWrite: SessionFileFingerprint,
-  ): Promise<{
-    fingerprint: SessionFileFingerprint;
-    generation: number;
-  } | null> {
-    const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
-    if (sameSessionFileFingerprint(beforeWrite, fingerprint)) {
-      return null;
-    }
-    if (!isTrustedSessionFileState(sessionFileFenceKey, beforeWrite)) {
-      return null;
-    }
-    const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, fingerprint);
-    return { fingerprint, generation };
   }
 
   async function refreshSessionFileFence(beforeWrite: SessionFileFingerprint): Promise<void> {
@@ -926,15 +1042,41 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
   }
 
-  async function publishOwnedSessionFileFence(beforeWrite: SessionFileFingerprint): Promise<void> {
+  async function captureOwnedSessionFileWriteStart(): Promise<SessionFileFenceSnapshot> {
+    const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+    const currentFenceSnapshot = fenceSnapshot;
+    if (
+      currentFenceSnapshot &&
+      sameSessionFileFingerprint(currentFenceSnapshot.fingerprint, fingerprint)
+    ) {
+      return currentFenceSnapshot;
+    }
+    return { fingerprint };
+  }
+
+  async function publishOwnedSessionFileFence(
+    beforeWrite: SessionFileFenceSnapshot,
+  ): Promise<void> {
     if (takeoverDetected) {
       return;
     }
-    const ownedWrite = await publishOwnedSessionFileWriteIfChanged(beforeWrite);
-    if (ownedWrite && fenceActive) {
-      fenceFingerprint = ownedWrite.fingerprint;
-      fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
-      fenceGeneration = ownedWrite.generation;
+    const current = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+    if (sameSessionFileFingerprint(beforeWrite.fingerprint, current)) {
+      return;
+    }
+    const beforeWriteIsTrusted =
+      (fenceActive && sameSessionFileFingerprint(fenceFingerprint, beforeWrite.fingerprint)) ||
+      isTrustedSessionFileState(sessionFileFenceKey, beforeWrite.fingerprint);
+    if (!beforeWriteIsTrusted) {
+      return;
+    }
+    const mergedSnapshot = await mergePromptReleasedSessionChange(beforeWrite, current);
+    const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, current);
+    if (fenceActive) {
+      fenceFingerprint = current;
+      fenceSnapshot =
+        mergedSnapshot ?? (await readSessionFileFenceSnapshot(params.lockOptions.sessionFile));
+      fenceGeneration = generation;
     }
   }
 
@@ -1209,7 +1351,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         if (options?.publishOwnedWrite !== true) {
           return await run();
         }
-        const beforeWrite = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+        const beforeWrite = await captureOwnedSessionFileWriteStart();
         try {
           return await run();
         } finally {
@@ -1220,16 +1362,20 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       try {
         const runLockedOperation = async () => {
           await assertSessionFileFence();
-          const beforeWrite = await readSessionFileFingerprint(params.lockOptions.sessionFile);
           const runWithLock = async () => {
+            if (options?.publishOwnedWrite === true) {
+              const beforeWrite = await captureOwnedSessionFileWriteStart();
+              try {
+                return await run();
+              } finally {
+                await publishOwnedSessionFileFence(beforeWrite);
+              }
+            }
+            const beforeWrite = await readSessionFileFingerprint(params.lockOptions.sessionFile);
             try {
               return await run();
             } finally {
-              if (options?.publishOwnedWrite === true) {
-                await publishOwnedSessionFileFence(beforeWrite);
-              } else {
-                await refreshSessionFileFence(beforeWrite);
-              }
+              await refreshSessionFileFence(beforeWrite);
             }
           };
           return await runWithLock();

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -1691,16 +1691,25 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     releaseRetainedUse: () => void,
   ): Promise<T> {
     const scope = createActiveWriteLockScope();
+    let operationSucceeded = false;
     try {
-      return await activeWriteLock.run(scope.state, run);
+      const result = await activeWriteLock.run(scope.state, run);
+      operationSucceeded = true;
+      return result;
     } finally {
-      await drainWriteLockScope(scope.state.scope);
-      scope.state.active = false;
-      scope.state.scope.active = false;
       try {
-        releaseRetainedUse();
+        await drainWriteLockScope(scope.state.scope);
+        if (operationSucceeded && takeoverDetected) {
+          throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+        }
       } finally {
-        scope.complete();
+        scope.state.active = false;
+        scope.state.scope.active = false;
+        try {
+          releaseRetainedUse();
+        } finally {
+          scope.complete();
+        }
       }
     }
   }
@@ -1848,16 +1857,25 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
 
     const scope = createActiveWriteLockScope();
+    let operationSucceeded = false;
     try {
-      return await activeWriteLock.run(scope.state, runLockedOperation);
+      const result = await activeWriteLock.run(scope.state, runLockedOperation);
+      operationSucceeded = true;
+      return result;
     } finally {
-      await drainWriteLockScope(scope.state.scope);
-      scope.state.active = false;
-      scope.state.scope.active = false;
       try {
-        await lock.release();
+        await drainWriteLockScope(scope.state.scope);
+        if (operationSucceeded && takeoverDetected) {
+          throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+        }
       } finally {
-        scope.complete();
+        scope.state.active = false;
+        scope.state.scope.active = false;
+        try {
+          await lock.release();
+        } finally {
+          scope.complete();
+        }
       }
     }
   }

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -20,8 +20,6 @@ import type { acquireSessionWriteLock } from "../../session-write-lock.js";
 import type {
   CustomEntry,
   LabelEntry,
-  PromptReleasedOpaqueEntry,
-  PromptReleasedSessionMergeResult,
   SessionInfoEntry,
   SessionMessageEntry,
 } from "../../sessions/session-manager.js";
@@ -243,12 +241,23 @@ function hasSessionEntryBase(record: Record<string, unknown>): boolean {
   );
 }
 
-export type PromptReleasedSessionMetadataEntry = CustomEntry | LabelEntry | SessionInfoEntry;
+type PromptReleasedSessionMetadataEntry = CustomEntry | LabelEntry | SessionInfoEntry;
 
-export type PromptReleasedSessionEntry =
+type PromptReleasedOpaqueEntry = {
+  type: "prompt_released_opaque";
+  record: unknown;
+};
+
+type PromptReleasedSessionEntry =
   | SessionMessageEntry
   | PromptReleasedSessionMetadataEntry
   | PromptReleasedOpaqueEntry;
+
+type PromptReleasedSessionMergeResult = {
+  sessionFileSnapshot: OwnedSessionTranscriptCacheSnapshot;
+  publishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[];
+  requiresReload?: true;
+};
 
 function parsePromptReleasedGlobalMetadataLine(
   line: string,

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -8,6 +8,7 @@ import fs from "node:fs/promises";
 import { isDeepStrictEqual } from "node:util";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import {
+  type OwnedSessionTranscriptWriteOptions,
   type OwnedSessionTranscriptCacheSnapshot,
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
@@ -26,6 +27,7 @@ type SessionLock = Awaited<ReturnType<typeof acquireSessionWriteLock>>;
 type AcquireSessionWriteLock = typeof acquireSessionWriteLock;
 type ActiveWriteLockState = {
   active: boolean;
+  publishingOwnedWrite: boolean;
 };
 
 type LockOptions = {
@@ -33,10 +35,6 @@ type LockOptions = {
   timeoutMs: number;
   staleMs: number;
   maxHoldMs: number;
-};
-
-type SessionWriteLockRunOptions = {
-  publishOwnedWrite?: boolean;
 };
 
 type SessionFileWriteAppendValidator<T> = (result: T, appendedText: string) => boolean;
@@ -126,7 +124,10 @@ function isJsonRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseTranscriptOnlyOpenClawAssistantLine(line: string): SessionMessageEntry | undefined {
+function parsePromptReleasedMessageLine(
+  line: string,
+  options?: { allowAnyMessage?: boolean },
+): SessionMessageEntry | undefined {
   try {
     const parsed = JSON.parse(line) as unknown;
     if (
@@ -145,12 +146,15 @@ function parseTranscriptOnlyOpenClawAssistantLine(line: string): SessionMessageE
     if (!isJsonRecord(message)) {
       return undefined;
     }
-    const isTranscriptOnlyAssistant =
+    const isOpenClawTranscriptOnlyAssistant =
       message.role === "assistant" &&
       message.provider === "openclaw" &&
       typeof message.model === "string" &&
       TRANSCRIPT_ONLY_OPENCLAW_ASSISTANT_MODELS.has(message.model);
-    if (!isTranscriptOnlyAssistant) {
+    if (
+      typeof message.role !== "string" ||
+      (!options?.allowAnyMessage && !isOpenClawTranscriptOnlyAssistant)
+    ) {
       return undefined;
     }
     return {
@@ -244,6 +248,7 @@ type PromptReleasedSessionChange =
 
 function classifyPromptReleasedSessionLines(
   lines: string[],
+  options?: { allowAnyMessage?: boolean },
 ): PromptReleasedSessionChange | undefined {
   if (lines.length === 0) {
     return undefined;
@@ -251,7 +256,7 @@ function classifyPromptReleasedSessionLines(
   const entries: PromptReleasedSessionEntry[] = [];
   let hasGlobalMetadata = false;
   for (const line of lines) {
-    const transcriptEntry = parseTranscriptOnlyOpenClawAssistantLine(line);
+    const transcriptEntry = parsePromptReleasedMessageLine(line, options);
     if (transcriptEntry) {
       entries.push(transcriptEntry);
       continue;
@@ -412,6 +417,7 @@ async function classifySessionFenceAdvance(params: {
   sessionFile: string;
   previous: SessionFileFenceSnapshot | undefined;
   current: SessionFileFingerprint;
+  allowAnyMessage?: boolean;
 }): Promise<PromptReleasedSessionChange | undefined> {
   if (
     !params.previous?.fingerprint.exists ||
@@ -429,7 +435,7 @@ async function classifySessionFenceAdvance(params: {
     return undefined;
   }
   const lines = normalizeStringEntries(text.split("\n"));
-  return classifyPromptReleasedSessionLines(lines);
+  return classifyPromptReleasedSessionLines(lines, params);
 }
 
 async function sessionFenceCtimeDriftIsBenign(params: {
@@ -463,6 +469,7 @@ async function classifySessionFenceRewrite(params: {
   sessionFile: string;
   previous: SessionFileFenceSnapshot | undefined;
   current: SessionFileFingerprint;
+  allowAnyMessage?: boolean;
 }): Promise<PromptReleasedSessionChange | undefined> {
   if (
     !params.previous?.fingerprint.exists ||
@@ -501,13 +508,14 @@ async function classifySessionFenceRewrite(params: {
     expectedParentId = lineMatch.nextPreviousId ?? expectedParentId;
   }
   const appendedLines = currentLines.slice(previousLines.length);
-  return classifyPromptReleasedSessionLines(appendedLines);
+  return classifyPromptReleasedSessionLines(appendedLines, params);
 }
 
 async function classifySessionFenceChange(params: {
   sessionFile: string;
   previous: SessionFileFenceSnapshot | undefined;
   current: SessionFileFingerprint;
+  allowAnyMessage?: boolean;
 }): Promise<PromptReleasedSessionChange | undefined> {
   return (await classifySessionFenceAdvance(params)) ?? (await classifySessionFenceRewrite(params));
 }
@@ -515,6 +523,12 @@ async function classifySessionFenceChange(params: {
 type OwnedSessionFileWrite = {
   generation: number;
   fingerprint: SessionFileFingerprint;
+  entryIds?: readonly string[];
+};
+
+type OwnedSessionFileWriteHistory = {
+  activeFenceGenerations: Map<symbol, number>;
+  writes: OwnedSessionFileWrite[];
 };
 
 type TrustedSessionFileState = {
@@ -527,7 +541,7 @@ type TrustedSessionFileState = {
 // only fingerprints that changed while OpenClaw held the write lock so the
 // takeover fence can distinguish those locked in-process writes from unowned
 // external file changes.
-const ownedSessionFileWrites = new Map<string, OwnedSessionFileWrite>();
+const ownedSessionFileWrites = new Map<string, OwnedSessionFileWriteHistory>();
 const trustedSessionFileStates = new Map<string, TrustedSessionFileState>();
 let ownedSessionFileWriteGeneration = 0;
 
@@ -692,18 +706,50 @@ export function resetEmbeddedAttemptSessionFileOwnersForTest(): void {
     }
   }
   sessionFileOwnerState.owners.clear();
+  ownedSessionFileWrites.clear();
+  trustedSessionFileStates.clear();
+  ownedSessionFileWriteGeneration = 0;
+}
+
+function resolveOwnedSessionFileWriteHistory(sessionFileKey: string): OwnedSessionFileWriteHistory {
+  const existing = ownedSessionFileWrites.get(sessionFileKey);
+  if (existing) {
+    return existing;
+  }
+  const created = {
+    activeFenceGenerations: new Map<symbol, number>(),
+    writes: [],
+  };
+  ownedSessionFileWrites.set(sessionFileKey, created);
+  return created;
+}
+
+function pruneOwnedSessionFileWriteHistory(
+  sessionFileKey: string,
+  history: OwnedSessionFileWriteHistory,
+): void {
+  if (history.activeFenceGenerations.size === 0) {
+    ownedSessionFileWrites.delete(sessionFileKey);
+    return;
+  }
+  const oldestFenceGeneration = Math.min(...history.activeFenceGenerations.values());
+  history.writes = history.writes.filter((write) => write.generation > oldestFenceGeneration);
 }
 
 function recordOwnedSessionFileWrite(
   sessionFileKey: string,
   fingerprint: SessionFileFingerprint,
+  entryIds?: readonly string[],
 ): number {
   ownedSessionFileWriteGeneration += 1;
   const state = {
     generation: ownedSessionFileWriteGeneration,
     fingerprint,
+    ...(entryIds ? { entryIds: [...entryIds] } : {}),
   };
-  ownedSessionFileWrites.set(sessionFileKey, state);
+  const history = resolveOwnedSessionFileWriteHistory(sessionFileKey);
+  history.writes.push(state);
+  pruneOwnedSessionFileWriteHistory(sessionFileKey, history);
   trustedSessionFileStates.set(sessionFileKey, state);
   return ownedSessionFileWriteGeneration;
 }
@@ -810,7 +856,7 @@ export type EmbeddedAttemptSessionLockController = {
   waitForSessionEvents(session: unknown): Promise<void>;
   withSessionWriteLock<T>(
     run: () => Promise<T> | T,
-    options?: SessionWriteLockRunOptions,
+    options?: OwnedSessionTranscriptWriteOptions<T>,
   ): Promise<T>;
   acquireForCleanup(params?: { session?: unknown }): Promise<SessionLock>;
   hasSessionTakeover(): boolean;
@@ -834,6 +880,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
 
   let heldLock: SessionLock | undefined = await acquireLock();
   const activeWriteLock = new AsyncLocalStorage<ActiveWriteLockState>();
+  let ownedPublicationQueue: Promise<void> = Promise.resolve();
   let fenceFingerprint: SessionFileFingerprint | undefined;
   let fenceSnapshot: SessionFileFenceSnapshot | undefined;
   let fenceGeneration = 0;
@@ -845,11 +892,47 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   let heldLockDrainOwner: symbol | undefined;
   const heldLockDrainWaiters = new Set<() => void>();
   const sessionFileFenceKey = resolveSessionFileFenceKey(params.lockOptions.sessionFile);
+  const controllerFenceId = Symbol(sessionFileFenceKey);
+
+  function setFenceGeneration(generation: number): void {
+    fenceGeneration = generation;
+    if (!fenceActive) {
+      return;
+    }
+    const history = resolveOwnedSessionFileWriteHistory(sessionFileFenceKey);
+    history.activeFenceGenerations.set(controllerFenceId, generation);
+    pruneOwnedSessionFileWriteHistory(sessionFileFenceKey, history);
+  }
+
+  function activateFence(generation: number): void {
+    fenceActive = true;
+    setFenceGeneration(generation);
+  }
+
+  function deactivateFence(): void {
+    if (!fenceActive) {
+      return;
+    }
+    fenceActive = false;
+    const history = ownedSessionFileWrites.get(sessionFileFenceKey);
+    if (!history) {
+      return;
+    }
+    history.activeFenceGenerations.delete(controllerFenceId);
+    pruneOwnedSessionFileWriteHistory(sessionFileFenceKey, history);
+  }
 
   async function mergePromptReleasedSessionChange(
     previous: SessionFileFenceSnapshot | undefined,
     current: SessionFileFingerprint,
-  ): Promise<SessionFileFenceSnapshot | undefined> {
+    options?: { expectedEntryIds?: readonly string[] },
+  ): Promise<
+    | {
+        snapshot: SessionFileFenceSnapshot;
+        entryIds: string[];
+      }
+    | undefined
+  > {
     if (!params.mergePromptReleasedSessionEntries) {
       return undefined;
     }
@@ -857,8 +940,18 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       sessionFile: params.lockOptions.sessionFile,
       previous,
       current,
+      allowAnyMessage: options?.expectedEntryIds !== undefined,
     });
     if (!change) {
+      return undefined;
+    }
+    if (
+      options?.expectedEntryIds &&
+      !isDeepStrictEqual(
+        change.entries.map((entry) => entry.id),
+        [...options.expectedEntryIds],
+      )
+    ) {
       return undefined;
     }
     try {
@@ -872,7 +965,10 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       takeoverDetected = true;
       throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
     }
-    return refreshedSnapshot;
+    return {
+      snapshot: refreshedSnapshot,
+      entryIds: change.entries.map((entry) => entry.id),
+    };
   }
 
   function beginRetainedLockUse(): () => void {
@@ -976,16 +1072,34 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       return;
     }
 
-    const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
+    const ownedWriteHistory = ownedSessionFileWrites.get(sessionFileFenceKey)?.writes ?? [];
+    const ownedWrite = ownedWriteHistory.at(-1);
     if (
       ownedWrite &&
       ownedWrite.generation > fenceGeneration &&
       sameSessionFileFingerprint(ownedWrite.fingerprint, current)
     ) {
-      const mergedSnapshot = await mergePromptReleasedSessionChange(fenceSnapshot, current);
+      const unseenOwnedWrites = ownedWriteHistory.filter(
+        (write) => write.generation > fenceGeneration,
+      );
+      const canValidateExactEntries = unseenOwnedWrites.every(
+        (write) => write.entryIds !== undefined,
+      );
+      const expectedEntryIds = canValidateExactEntries
+        ? unseenOwnedWrites.flatMap((write) => write.entryIds ?? [])
+        : undefined;
+      const mergedChange = await mergePromptReleasedSessionChange(
+        fenceSnapshot,
+        current,
+        expectedEntryIds ? { expectedEntryIds } : undefined,
+      );
+      if (params.mergePromptReleasedSessionEntries && !mergedChange) {
+        takeoverDetected = true;
+        throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+      }
       fenceFingerprint = current;
-      fenceSnapshot = mergedSnapshot ?? { fingerprint: current };
-      fenceGeneration = ownedWrite.generation;
+      fenceSnapshot = mergedChange?.snapshot ?? { fingerprint: current };
+      setFenceGeneration(ownedWrite.generation);
       return;
     }
 
@@ -998,7 +1112,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     ) {
       fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
       fenceFingerprint = fenceSnapshot.fingerprint;
-      fenceGeneration = recordTrustedSessionFileState(sessionFileFenceKey, current);
+      setFenceGeneration(recordTrustedSessionFileState(sessionFileFenceKey, current));
       return;
     }
 
@@ -1010,20 +1124,21 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     if (changeKind?.kind === "transcript-only" && !params.mergePromptReleasedSessionEntries) {
       fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
       fenceFingerprint = fenceSnapshot.fingerprint;
-      fenceGeneration = trustSessionFileState(sessionFileFenceKey, current) ?? fenceGeneration;
+      setFenceGeneration(trustSessionFileState(sessionFileFenceKey, current) ?? fenceGeneration);
       return;
     }
     if (changeKind && params.mergePromptReleasedSessionEntries) {
-      const refreshedSnapshot = await mergePromptReleasedSessionChange(fenceSnapshot, current);
-      if (!refreshedSnapshot) {
+      const mergedChange = await mergePromptReleasedSessionChange(fenceSnapshot, current);
+      if (!mergedChange) {
         takeoverDetected = true;
         throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
       }
-      fenceSnapshot = refreshedSnapshot;
-      fenceFingerprint = refreshedSnapshot.fingerprint;
-      fenceGeneration =
-        trustSessionFileState(sessionFileFenceKey, refreshedSnapshot.fingerprint) ??
-        fenceGeneration;
+      fenceSnapshot = mergedChange.snapshot;
+      fenceFingerprint = mergedChange.snapshot.fingerprint;
+      setFenceGeneration(
+        trustSessionFileState(sessionFileFenceKey, mergedChange.snapshot.fingerprint) ??
+          fenceGeneration,
+      );
       return;
     }
 
@@ -1056,6 +1171,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
 
   async function publishOwnedSessionFileFence(
     beforeWrite: SessionFileFenceSnapshot,
+    expectedEntryIds?: readonly string[],
   ): Promise<void> {
     if (takeoverDetected) {
       return;
@@ -1070,13 +1186,23 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     if (!beforeWriteIsTrusted) {
       return;
     }
-    const mergedSnapshot = await mergePromptReleasedSessionChange(beforeWrite, current);
-    const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, current);
+    const mergedChange = await mergePromptReleasedSessionChange(
+      beforeWrite,
+      current,
+      expectedEntryIds ? { expectedEntryIds } : undefined,
+    );
+    if (params.mergePromptReleasedSessionEntries && !mergedChange) {
+      takeoverDetected = true;
+      throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+    }
+    const publishedEntryIds = expectedEntryIds ?? mergedChange?.entryIds;
+    const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, current, publishedEntryIds);
     if (fenceActive) {
       fenceFingerprint = current;
       fenceSnapshot =
-        mergedSnapshot ?? (await readSessionFileFenceSnapshot(params.lockOptions.sessionFile));
-      fenceGeneration = generation;
+        mergedChange?.snapshot ??
+        (await readSessionFileFenceSnapshot(params.lockOptions.sessionFile));
+      setFenceGeneration(generation);
     }
   }
 
@@ -1112,7 +1238,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     if (fenceActive) {
       fenceFingerprint = fingerprint;
       fenceSnapshot = { fingerprint };
-      fenceGeneration = generation;
+      setFenceGeneration(generation);
     }
   }
 
@@ -1138,15 +1264,15 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       // turns do not wait for the maxHoldMs watchdog.
       try {
         const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
-        const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
+        const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey)?.writes.at(-1);
         const trustedGeneration = trustSessionFileState(sessionFileFenceKey, fingerprint);
         fenceFingerprint = fingerprint;
         fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
-        fenceGeneration =
+        const releasedFenceGeneration =
           ownedWrite && sameSessionFileFingerprint(ownedWrite.fingerprint, fingerprint)
             ? ownedWrite.generation
             : (trustedGeneration ?? fenceGeneration);
-        fenceActive = true;
+        activateFence(releasedFenceGeneration);
       } finally {
         await lock.release();
       }
@@ -1218,7 +1344,10 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     releaseRetainedUse: () => void,
   ): Promise<T> {
     try {
-      const activeLockState: ActiveWriteLockState = { active: true };
+      const activeLockState: ActiveWriteLockState = {
+        active: true,
+        publishingOwnedWrite: false,
+      };
       try {
         return await activeWriteLock.run(activeLockState, run);
       } finally {
@@ -1226,6 +1355,49 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       }
     } finally {
       releaseRetainedUse();
+    }
+  }
+
+  async function runPublishingOwnedSessionFileWrite<T>(
+    run: () => Promise<T> | T,
+    resolvePublishedEntryIds?: (result: T) => readonly string[],
+  ): Promise<T> {
+    const parentLockState = activeWriteLock.getStore();
+    if (parentLockState?.publishingOwnedWrite) {
+      return await run();
+    }
+    let releaseQueue!: () => void;
+    const currentQueueEntry = new Promise<void>((resolve) => {
+      releaseQueue = resolve;
+    });
+    const previousQueueEntry = ownedPublicationQueue.catch(() => undefined);
+    ownedPublicationQueue = previousQueueEntry.then(() => currentQueueEntry);
+    await previousQueueEntry;
+    try {
+      if (takeoverDetected) {
+        throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+      }
+      const beforeWrite = await captureOwnedSessionFileWriteStart();
+      const publicationLockState: ActiveWriteLockState = {
+        active: parentLockState?.active ?? true,
+        publishingOwnedWrite: true,
+      };
+      try {
+        return await activeWriteLock.run(publicationLockState, async () => {
+          let expectedEntryIds: readonly string[] | undefined;
+          try {
+            const result = await run();
+            expectedEntryIds = resolvePublishedEntryIds?.(result);
+            return result;
+          } finally {
+            await publishOwnedSessionFileFence(beforeWrite, expectedEntryIds);
+          }
+        });
+      } finally {
+        publicationLockState.active = false;
+      }
+    } finally {
+      releaseQueue();
     }
   }
 
@@ -1253,7 +1425,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       if (fenceActive) {
         fenceFingerprint = current;
         fenceSnapshot = { fingerprint: current };
-        fenceGeneration = generation;
+        setFenceGeneration(generation);
       }
       return true;
     },
@@ -1266,7 +1438,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       if (!sameSessionFileFingerprint(fingerprint, current)) {
         return false;
       }
-      fenceGeneration = recordTrustedSessionFileState(sessionFileFenceKey, current);
+      setFenceGeneration(recordTrustedSessionFileState(sessionFileFenceKey, current));
       if (fenceActive) {
         fenceFingerprint = current;
         fenceSnapshot = { fingerprint: current };
@@ -1295,14 +1467,14 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         // User-message persistence occurs before the prompt fence activates.
         // The retained session lock owns that write, so publish its exact state
         // for the next attempt before release establishes the active fence.
-        fenceGeneration = recordTrustedSessionFileState(sessionFileFenceKey, fingerprint);
+        setFenceGeneration(recordTrustedSessionFileState(sessionFileFenceKey, fingerprint));
         return;
       }
       if (
         !sameSessionFileFingerprint(beforeWrite, fingerprint) &&
         isTrustedSessionFileState(sessionFileFenceKey, beforeWrite ?? { exists: false })
       ) {
-        fenceGeneration = recordOwnedSessionFileWrite(sessionFileFenceKey, fingerprint);
+        setFenceGeneration(recordOwnedSessionFileWrite(sessionFileFenceKey, fingerprint));
       }
       fenceFingerprint = fingerprint;
       fenceSnapshot = { fingerprint };
@@ -1342,7 +1514,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     waitForSessionEvents: waitForSessionEventQueue,
     async withSessionWriteLock<T>(
       run: () => Promise<T> | T,
-      options?: SessionWriteLockRunOptions,
+      options?: OwnedSessionTranscriptWriteOptions<T>,
     ): Promise<T> {
       if (takeoverDetected) {
         throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
@@ -1351,12 +1523,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         if (options?.publishOwnedWrite !== true) {
           return await run();
         }
-        const beforeWrite = await captureOwnedSessionFileWriteStart();
-        try {
-          return await run();
-        } finally {
-          await publishOwnedSessionFileFence(beforeWrite);
-        }
+        return await runPublishingOwnedSessionFileWrite(run, options.resolvePublishedEntryIds);
       }
       const { lock, owned, releaseRetainedUse } = await acquireWriteLock();
       try {
@@ -1364,12 +1531,10 @@ export async function createEmbeddedAttemptSessionLockController(params: {
           await assertSessionFileFence();
           const runWithLock = async () => {
             if (options?.publishOwnedWrite === true) {
-              const beforeWrite = await captureOwnedSessionFileWriteStart();
-              try {
-                return await run();
-              } finally {
-                await publishOwnedSessionFileFence(beforeWrite);
-              }
+              return await runPublishingOwnedSessionFileWrite(
+                run,
+                options.resolvePublishedEntryIds,
+              );
             }
             const beforeWrite = await readSessionFileFingerprint(params.lockOptions.sessionFile);
             try {
@@ -1381,7 +1546,10 @@ export async function createEmbeddedAttemptSessionLockController(params: {
           return await runWithLock();
         };
         if (owned) {
-          const activeLockState: ActiveWriteLockState = { active: true };
+          const activeLockState: ActiveWriteLockState = {
+            active: true,
+            publishingOwnedWrite: false,
+          };
           try {
             return await activeWriteLock.run(activeLockState, runLockedOperation);
           } finally {
@@ -1421,7 +1589,11 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       return takeoverDetected;
     },
     async dispose(): Promise<void> {
-      await disposeHeldLockAfterRetainedIdle();
+      try {
+        await disposeHeldLockAfterRetainedIdle();
+      } finally {
+        deactivateFence();
+      }
     },
   };
 }
@@ -1435,7 +1607,7 @@ export function installPromptSubmissionLockRelease(params: {
   sessionKey?: string;
   withSessionWriteLock?: <T>(
     run: () => Promise<T> | T,
-    options?: SessionWriteLockRunOptions,
+    options?: OwnedSessionTranscriptWriteOptions<T>,
   ) => Promise<T>;
   canAdvanceSessionEntryCache?: (snapshot: OwnedSessionTranscriptCacheSnapshot) => boolean;
   publishSessionFileSnapshot?: (snapshot: OwnedSessionTranscriptCacheSnapshot) => boolean;

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -141,7 +141,7 @@ function isTranscriptOnlyOpenClawAssistantLine(line: string): boolean {
   }
 }
 
-function hasSessionControlEntryBase(record: Record<string, unknown>): boolean {
+function hasSessionEntryBase(record: Record<string, unknown>): boolean {
   return (
     typeof record.id === "string" &&
     record.id.trim().length > 0 &&
@@ -151,21 +151,16 @@ function hasSessionControlEntryBase(record: Record<string, unknown>): boolean {
   );
 }
 
-function isPromptReleasedSessionControlLine(line: string): boolean {
+function isPromptReleasedGlobalMetadataLine(line: string): boolean {
   try {
     const parsed = JSON.parse(line) as unknown;
-    if (!isJsonRecord(parsed) || !hasSessionControlEntryBase(parsed)) {
+    if (!isJsonRecord(parsed) || !hasSessionEntryBase(parsed)) {
       return false;
     }
-    // These records are out-of-band session metadata/settings. They do not add
-    // user/assistant/tool content to the prompt transcript, so accepting their
-    // append while the provider lock is released keeps an in-flight reply alive
-    // without masking real conversational takeovers.
+    // These records are resolved globally rather than through the active branch.
+    // Accepting them keeps an in-flight reply alive without losing branch-scoped
+    // model or thinking state when the active SessionManager is stale.
     switch (parsed.type) {
-      case "model_change":
-        return typeof parsed.provider === "string" && typeof parsed.modelId === "string";
-      case "thinking_level_change":
-        return typeof parsed.thinkingLevel === "string";
       case "custom":
         return typeof parsed.customType === "string" && parsed.customType.trim().length > 0;
       case "label":
@@ -185,7 +180,7 @@ function isPromptReleasedSessionControlLine(line: string): boolean {
 }
 
 function isBenignPromptReleasedSessionLine(line: string): boolean {
-  return isTranscriptOnlyOpenClawAssistantLine(line) || isPromptReleasedSessionControlLine(line);
+  return isTranscriptOnlyOpenClawAssistantLine(line) || isPromptReleasedGlobalMetadataLine(line);
 }
 
 function normalizeTranscriptEntryId(value: unknown): string | undefined {

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -141,6 +141,53 @@ function isTranscriptOnlyOpenClawAssistantLine(line: string): boolean {
   }
 }
 
+function hasSessionControlEntryBase(record: Record<string, unknown>): boolean {
+  return (
+    typeof record.id === "string" &&
+    record.id.trim().length > 0 &&
+    (record.parentId === null || typeof record.parentId === "string") &&
+    typeof record.timestamp === "string" &&
+    record.timestamp.trim().length > 0
+  );
+}
+
+function isPromptReleasedSessionControlLine(line: string): boolean {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (!isJsonRecord(parsed) || !hasSessionControlEntryBase(parsed)) {
+      return false;
+    }
+    // These records are out-of-band session metadata/settings. They do not add
+    // user/assistant/tool content to the prompt transcript, so accepting their
+    // append while the provider lock is released keeps an in-flight reply alive
+    // without masking real conversational takeovers.
+    switch (parsed.type) {
+      case "model_change":
+        return typeof parsed.provider === "string" && typeof parsed.modelId === "string";
+      case "thinking_level_change":
+        return typeof parsed.thinkingLevel === "string";
+      case "custom":
+        return typeof parsed.customType === "string" && parsed.customType.trim().length > 0;
+      case "label":
+        return (
+          typeof parsed.targetId === "string" &&
+          parsed.targetId.trim().length > 0 &&
+          (parsed.label === undefined || typeof parsed.label === "string")
+        );
+      case "session_info":
+        return parsed.name === undefined || typeof parsed.name === "string";
+      default:
+        return false;
+    }
+  } catch {
+    return false;
+  }
+}
+
+function isBenignPromptReleasedSessionLine(line: string): boolean {
+  return isTranscriptOnlyOpenClawAssistantLine(line) || isPromptReleasedSessionControlLine(line);
+}
+
 function normalizeTranscriptEntryId(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
@@ -302,7 +349,7 @@ async function sessionFenceAdvanceIsBenign(params: {
     return false;
   }
   const lines = normalizeStringEntries(text.split("\n"));
-  return lines.length > 0 && lines.every(isTranscriptOnlyOpenClawAssistantLine);
+  return lines.length > 0 && lines.every(isBenignPromptReleasedSessionLine);
 }
 
 async function sessionFenceCtimeDriftIsBenign(params: {
@@ -374,7 +421,7 @@ async function sessionFenceRewriteIsBenign(params: {
     expectedParentId = lineMatch.nextPreviousId ?? expectedParentId;
   }
   const appendedLines = currentLines.slice(previousLines.length);
-  return appendedLines.every(isTranscriptOnlyOpenClawAssistantLine);
+  return appendedLines.every(isBenignPromptReleasedSessionLine);
 }
 
 type OwnedSessionFileWrite = {

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -28,6 +28,7 @@ type AcquireSessionWriteLock = typeof acquireSessionWriteLock;
 type ActiveWriteLockState = {
   active: boolean;
   publishingOwnedWrite: boolean;
+  publishedEntryIds?: string[];
 };
 
 type LockOptions = {
@@ -343,13 +344,14 @@ async function readAppendedSessionFileText(params: {
   sessionFile: string;
   previous: Extract<SessionFileFingerprint, { exists: true }>;
   current: Extract<SessionFileFingerprint, { exists: true }>;
+  maxBytes?: number;
 }): Promise<string | undefined> {
   if (params.current.size <= params.previous.size || params.previous.size > MAX_SAFE_FILE_OFFSET) {
     return undefined;
   }
   const appendedBytes = params.current.size - params.previous.size;
   if (
-    appendedBytes > BigInt(MAX_BENIGN_SESSION_FENCE_ADVANCE_BYTES) ||
+    (params.maxBytes !== undefined && appendedBytes > BigInt(params.maxBytes)) ||
     appendedBytes > MAX_SAFE_FILE_OFFSET
   ) {
     return undefined;
@@ -430,6 +432,9 @@ async function classifySessionFenceAdvance(params: {
     sessionFile: params.sessionFile,
     previous: params.previous.fingerprint,
     current: params.current,
+    // Exact IDs come from the lock owner. Replaying the persisted entry needs
+    // its full payload, so only unowned benign classification uses the size cap.
+    ...(params.allowAnyMessage ? {} : { maxBytes: MAX_BENIGN_SESSION_FENCE_ADVANCE_BYTES }),
   });
   if (!text?.endsWith("\n")) {
     return undefined;
@@ -476,7 +481,8 @@ async function classifySessionFenceRewrite(params: {
     !params.current.exists ||
     !params.previous.text ||
     !sameSessionFileIdentity(params.previous.fingerprint, params.current) ||
-    params.current.size > BigInt(MAX_BENIGN_SESSION_FENCE_REWRITE_RESULT_BYTES) ||
+    (!params.allowAnyMessage &&
+      params.current.size > BigInt(MAX_BENIGN_SESSION_FENCE_REWRITE_RESULT_BYTES)) ||
     params.current.size > MAX_SAFE_FILE_OFFSET
   ) {
     return undefined;
@@ -1364,7 +1370,13 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   ): Promise<T> {
     const parentLockState = activeWriteLock.getStore();
     if (parentLockState?.publishingOwnedWrite) {
-      return await run();
+      const result = await run();
+      const nestedEntryIds = resolvePublishedEntryIds?.(result);
+      if (nestedEntryIds !== undefined) {
+        parentLockState.publishedEntryIds ??= [];
+        parentLockState.publishedEntryIds.push(...nestedEntryIds);
+      }
+      return result;
     }
     let releaseQueue!: () => void;
     const currentQueueEntry = new Promise<void>((resolve) => {
@@ -1381,13 +1393,21 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       const publicationLockState: ActiveWriteLockState = {
         active: parentLockState?.active ?? true,
         publishingOwnedWrite: true,
+        publishedEntryIds: undefined,
       };
       try {
         return await activeWriteLock.run(publicationLockState, async () => {
           let expectedEntryIds: readonly string[] | undefined;
           try {
             const result = await run();
-            expectedEntryIds = resolvePublishedEntryIds?.(result);
+            const ownEntryIds = resolvePublishedEntryIds?.(result);
+            const nestedEntryIds = publicationLockState.publishedEntryIds;
+            expectedEntryIds =
+              nestedEntryIds === undefined
+                ? ownEntryIds
+                : ownEntryIds === undefined
+                  ? nestedEntryIds
+                  : [...nestedEntryIds, ...ownEntryIds];
             return result;
           } finally {
             await publishOwnedSessionFileFence(beforeWrite, expectedEntryIds);

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -8,6 +8,7 @@ import fs from "node:fs/promises";
 import { isDeepStrictEqual } from "node:util";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import {
+  type OwnedSessionTranscriptPublishedEntry,
   type OwnedSessionTranscriptWriteOptions,
   type OwnedSessionTranscriptCacheSnapshot,
   withOwnedSessionTranscriptWrites,
@@ -18,6 +19,7 @@ import type { acquireSessionWriteLock } from "../../session-write-lock.js";
 import type {
   CustomEntry,
   LabelEntry,
+  PromptReleasedOpaqueEntry,
   SessionInfoEntry,
   SessionMessageEntry,
 } from "../../sessions/session-manager.js";
@@ -28,7 +30,7 @@ type AcquireSessionWriteLock = typeof acquireSessionWriteLock;
 type ActiveWriteLockState = {
   active: boolean;
   publishingOwnedWrite: boolean;
-  publishedEntryIds?: string[];
+  publishedEntries?: OwnedSessionTranscriptPublishedEntry[];
 };
 
 type LockOptions = {
@@ -182,7 +184,10 @@ function hasSessionEntryBase(record: Record<string, unknown>): boolean {
 
 export type PromptReleasedSessionMetadataEntry = CustomEntry | LabelEntry | SessionInfoEntry;
 
-export type PromptReleasedSessionEntry = SessionMessageEntry | PromptReleasedSessionMetadataEntry;
+export type PromptReleasedSessionEntry =
+  | SessionMessageEntry
+  | PromptReleasedSessionMetadataEntry
+  | PromptReleasedOpaqueEntry;
 
 function parsePromptReleasedGlobalMetadataLine(
   line: string,
@@ -237,41 +242,117 @@ function parsePromptReleasedGlobalMetadataLine(
   }
 }
 
+function parsePromptReleasedOpaqueLine(line: string): PromptReleasedOpaqueEntry | undefined {
+  try {
+    const record = JSON.parse(line) as unknown;
+    return !isJsonRecord(record) || record.type !== "message"
+      ? { type: "prompt_released_opaque", record }
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 type PromptReleasedSessionChange =
   | {
       kind: "transcript-only";
       entries: SessionMessageEntry[];
+      publishedEntries: OwnedSessionTranscriptPublishedEntry[];
     }
   | {
       kind: "global-metadata";
       entries: PromptReleasedSessionEntry[];
+      publishedEntries: OwnedSessionTranscriptPublishedEntry[];
+    }
+  | {
+      kind: "opaque";
+      entries: PromptReleasedSessionEntry[];
+      publishedEntries: OwnedSessionTranscriptPublishedEntry[];
     };
 
 function classifyPromptReleasedSessionLines(
   lines: string[],
-  options?: { allowAnyMessage?: boolean },
+  options?: {
+    allowAnyMessage?: boolean;
+    expectedPublishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[];
+    initialParentId?: string | null;
+  },
 ): PromptReleasedSessionChange | undefined {
   if (lines.length === 0) {
     return undefined;
   }
   const entries: PromptReleasedSessionEntry[] = [];
+  const publishedEntries: OwnedSessionTranscriptPublishedEntry[] = [];
   let hasGlobalMetadata = false;
+  let hasOpaqueEntries = false;
+  let expectedParentId = options?.initialParentId ?? null;
   for (const line of lines) {
+    const expectedPublishedEntry = options?.expectedPublishedEntries?.[publishedEntries.length];
+    if (expectedPublishedEntry?.kind === "serialized") {
+      if (expectedPublishedEntry.serialized === line) {
+        try {
+          const exactEntry = JSON.parse(line) as unknown;
+          if (isJsonRecord(exactEntry)) {
+            expectedParentId = normalizeTranscriptEntryId(exactEntry.id) ?? expectedParentId;
+          }
+        } catch {
+          return undefined;
+        }
+      } else {
+        const lineMatch = lineMatchesLinearTranscriptMigration({
+          previousLine: expectedPublishedEntry.serialized,
+          currentLine: line,
+          expectedParentId,
+        });
+        if (!lineMatch.ok) {
+          return undefined;
+        }
+        expectedParentId = lineMatch.nextPreviousId ?? expectedParentId;
+      }
+    }
+    const publishIdentity = (id: string): OwnedSessionTranscriptPublishedEntry => {
+      if (expectedPublishedEntry?.kind === "serialized") {
+        return expectedPublishedEntry;
+      }
+      expectedParentId = id;
+      return { kind: "id", id };
+    };
     const transcriptEntry = parsePromptReleasedMessageLine(line, options);
     if (transcriptEntry) {
       entries.push(transcriptEntry);
+      publishedEntries.push(publishIdentity(transcriptEntry.id));
       continue;
     }
     const metadataEntry = parsePromptReleasedGlobalMetadataLine(line);
-    if (!metadataEntry) {
+    if (metadataEntry) {
+      entries.push(metadataEntry);
+      publishedEntries.push(publishIdentity(metadataEntry.id));
+      hasGlobalMetadata = true;
+      continue;
+    }
+    const opaqueEntry = options?.allowAnyMessage ? parsePromptReleasedOpaqueLine(line) : undefined;
+    if (!opaqueEntry) {
       return undefined;
     }
-    entries.push(metadataEntry);
-    hasGlobalMetadata = true;
+    entries.push(opaqueEntry);
+    publishedEntries.push(
+      expectedPublishedEntry?.kind === "serialized"
+        ? expectedPublishedEntry
+        : { kind: "serialized", serialized: line },
+    );
+    hasOpaqueEntries = true;
   }
-  return hasGlobalMetadata
-    ? { kind: "global-metadata", entries }
-    : { kind: "transcript-only", entries: entries as SessionMessageEntry[] };
+  if (hasOpaqueEntries) {
+    return { kind: "opaque", entries, publishedEntries };
+  }
+  if (hasGlobalMetadata) {
+    return { kind: "global-metadata", entries, publishedEntries };
+  }
+  return {
+    kind: "transcript-only",
+    entries: entries as SessionMessageEntry[],
+    publishedEntries,
+  };
 }
 
 function normalizeTranscriptEntryId(value: unknown): string | undefined {
@@ -420,6 +501,7 @@ async function classifySessionFenceAdvance(params: {
   previous: SessionFileFenceSnapshot | undefined;
   current: SessionFileFingerprint;
   allowAnyMessage?: boolean;
+  expectedPublishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[];
 }): Promise<PromptReleasedSessionChange | undefined> {
   if (
     !params.previous?.fingerprint.exists ||
@@ -441,6 +523,64 @@ async function classifySessionFenceAdvance(params: {
   }
   const lines = normalizeStringEntries(text.split("\n"));
   return classifyPromptReleasedSessionLines(lines, params);
+}
+
+async function classifyOwnedSessionFileInitialization(params: {
+  sessionFile: string;
+  previous: SessionFileFenceSnapshot | undefined;
+  current: SessionFileFingerprint;
+  expectedPublishedEntries: readonly OwnedSessionTranscriptPublishedEntry[];
+}): Promise<PromptReleasedSessionChange | undefined> {
+  if (
+    !params.current.exists ||
+    (params.previous?.fingerprint.exists === true && params.previous.fingerprint.size > 0n) ||
+    params.current.size > MAX_SAFE_FILE_OFFSET
+  ) {
+    return undefined;
+  }
+  let text: string;
+  try {
+    text = await fs.readFile(params.sessionFile, "utf8");
+  } catch {
+    return undefined;
+  }
+  if (!text.endsWith("\n")) {
+    return undefined;
+  }
+  const lines = normalizeStringEntries(text.split("\n"));
+  const expectedHeader =
+    params.expectedPublishedEntries[0]?.kind === "header"
+      ? params.expectedPublishedEntries[0]
+      : undefined;
+  if (expectedHeader) {
+    if (lines[0] !== expectedHeader.serialized) {
+      return undefined;
+    }
+    lines.shift();
+  }
+  const remainingExpectedEntries = expectedHeader
+    ? params.expectedPublishedEntries.slice(1)
+    : params.expectedPublishedEntries;
+  const change = classifyPromptReleasedSessionLines(lines, {
+    allowAnyMessage: true,
+    expectedPublishedEntries: remainingExpectedEntries,
+  });
+  if (!change && lines.length > 0) {
+    return undefined;
+  }
+  const resolvedChange =
+    change ??
+    ({
+      kind: "transcript-only",
+      entries: [],
+      publishedEntries: [],
+    } satisfies PromptReleasedSessionChange);
+  return expectedHeader
+    ? {
+        ...resolvedChange,
+        publishedEntries: [expectedHeader, ...resolvedChange.publishedEntries],
+      }
+    : resolvedChange;
 }
 
 async function sessionFenceCtimeDriftIsBenign(params: {
@@ -475,6 +615,7 @@ async function classifySessionFenceRewrite(params: {
   previous: SessionFileFenceSnapshot | undefined;
   current: SessionFileFingerprint;
   allowAnyMessage?: boolean;
+  expectedPublishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[];
 }): Promise<PromptReleasedSessionChange | undefined> {
   if (
     !params.previous?.fingerprint.exists ||
@@ -514,22 +655,35 @@ async function classifySessionFenceRewrite(params: {
     expectedParentId = lineMatch.nextPreviousId ?? expectedParentId;
   }
   const appendedLines = currentLines.slice(previousLines.length);
-  return classifyPromptReleasedSessionLines(appendedLines, params);
+  return classifyPromptReleasedSessionLines(appendedLines, {
+    ...params,
+    initialParentId: expectedParentId,
+  });
 }
 
 async function classifySessionFenceChange(params: {
   sessionFile: string;
   previous: SessionFileFenceSnapshot | undefined;
   current: SessionFileFingerprint;
-  allowAnyMessage?: boolean;
+  expectedPublishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[];
 }): Promise<PromptReleasedSessionChange | undefined> {
-  return (await classifySessionFenceAdvance(params)) ?? (await classifySessionFenceRewrite(params));
+  const allowAnyMessage = params.expectedPublishedEntries !== undefined;
+  return (
+    (params.expectedPublishedEntries
+      ? await classifyOwnedSessionFileInitialization({
+          ...params,
+          expectedPublishedEntries: params.expectedPublishedEntries,
+        })
+      : undefined) ??
+    (await classifySessionFenceAdvance({ ...params, allowAnyMessage })) ??
+    (await classifySessionFenceRewrite({ ...params, allowAnyMessage }))
+  );
 }
 
 type OwnedSessionFileWrite = {
   generation: number;
   fingerprint: SessionFileFingerprint;
-  entryIds?: readonly string[];
+  publishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[];
 };
 
 type OwnedSessionFileWriteHistory = {
@@ -745,13 +899,13 @@ function pruneOwnedSessionFileWriteHistory(
 function recordOwnedSessionFileWrite(
   sessionFileKey: string,
   fingerprint: SessionFileFingerprint,
-  entryIds?: readonly string[],
+  publishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[],
 ): number {
   ownedSessionFileWriteGeneration += 1;
   const state = {
     generation: ownedSessionFileWriteGeneration,
     fingerprint,
-    ...(entryIds ? { entryIds: [...entryIds] } : {}),
+    ...(publishedEntries ? { publishedEntries: [...publishedEntries] } : {}),
   };
   const history = resolveOwnedSessionFileWriteHistory(sessionFileKey);
   history.writes.push(state);
@@ -931,11 +1085,13 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   async function mergePromptReleasedSessionChange(
     previous: SessionFileFenceSnapshot | undefined,
     current: SessionFileFingerprint,
-    options?: { expectedEntryIds?: readonly string[] },
+    options?: {
+      expectedPublishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[];
+    },
   ): Promise<
     | {
         snapshot: SessionFileFenceSnapshot;
-        entryIds: string[];
+        publishedEntries: OwnedSessionTranscriptPublishedEntry[];
       }
     | undefined
   > {
@@ -946,17 +1102,14 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       sessionFile: params.lockOptions.sessionFile,
       previous,
       current,
-      allowAnyMessage: options?.expectedEntryIds !== undefined,
+      expectedPublishedEntries: options?.expectedPublishedEntries,
     });
     if (!change) {
       return undefined;
     }
     if (
-      options?.expectedEntryIds &&
-      !isDeepStrictEqual(
-        change.entries.map((entry) => entry.id),
-        [...options.expectedEntryIds],
-      )
+      options?.expectedPublishedEntries &&
+      !isDeepStrictEqual(change.publishedEntries, [...options.expectedPublishedEntries])
     ) {
       return undefined;
     }
@@ -973,7 +1126,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
     return {
       snapshot: refreshedSnapshot,
-      entryIds: change.entries.map((entry) => entry.id),
+      publishedEntries: change.publishedEntries,
     };
   }
 
@@ -1089,15 +1242,15 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         (write) => write.generation > fenceGeneration,
       );
       const canValidateExactEntries = unseenOwnedWrites.every(
-        (write) => write.entryIds !== undefined,
+        (write) => write.publishedEntries !== undefined,
       );
-      const expectedEntryIds = canValidateExactEntries
-        ? unseenOwnedWrites.flatMap((write) => write.entryIds ?? [])
+      const expectedPublishedEntries = canValidateExactEntries
+        ? unseenOwnedWrites.flatMap((write) => write.publishedEntries ?? [])
         : undefined;
       const mergedChange = await mergePromptReleasedSessionChange(
         fenceSnapshot,
         current,
-        expectedEntryIds ? { expectedEntryIds } : undefined,
+        expectedPublishedEntries ? { expectedPublishedEntries } : undefined,
       );
       if (params.mergePromptReleasedSessionEntries && !mergedChange) {
         takeoverDetected = true;
@@ -1177,7 +1330,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
 
   async function publishOwnedSessionFileFence(
     beforeWrite: SessionFileFenceSnapshot,
-    expectedEntryIds?: readonly string[],
+    expectedPublishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[],
   ): Promise<void> {
     if (takeoverDetected) {
       return;
@@ -1195,14 +1348,14 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     const mergedChange = await mergePromptReleasedSessionChange(
       beforeWrite,
       current,
-      expectedEntryIds ? { expectedEntryIds } : undefined,
+      expectedPublishedEntries ? { expectedPublishedEntries } : undefined,
     );
     if (params.mergePromptReleasedSessionEntries && !mergedChange) {
       takeoverDetected = true;
       throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
     }
-    const publishedEntryIds = expectedEntryIds ?? mergedChange?.entryIds;
-    const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, current, publishedEntryIds);
+    const publishedEntries = expectedPublishedEntries ?? mergedChange?.publishedEntries;
+    const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, current, publishedEntries);
     if (fenceActive) {
       fenceFingerprint = current;
       fenceSnapshot =
@@ -1366,15 +1519,15 @@ export async function createEmbeddedAttemptSessionLockController(params: {
 
   async function runPublishingOwnedSessionFileWrite<T>(
     run: () => Promise<T> | T,
-    resolvePublishedEntryIds?: (result: T) => readonly string[],
+    resolvePublishedEntries?: (result: T) => readonly OwnedSessionTranscriptPublishedEntry[],
   ): Promise<T> {
     const parentLockState = activeWriteLock.getStore();
     if (parentLockState?.publishingOwnedWrite) {
       const result = await run();
-      const nestedEntryIds = resolvePublishedEntryIds?.(result);
-      if (nestedEntryIds !== undefined) {
-        parentLockState.publishedEntryIds ??= [];
-        parentLockState.publishedEntryIds.push(...nestedEntryIds);
+      const nestedEntries = resolvePublishedEntries?.(result);
+      if (nestedEntries !== undefined) {
+        parentLockState.publishedEntries ??= [];
+        parentLockState.publishedEntries.push(...nestedEntries);
       }
       return result;
     }
@@ -1393,24 +1546,24 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       const publicationLockState: ActiveWriteLockState = {
         active: parentLockState?.active ?? true,
         publishingOwnedWrite: true,
-        publishedEntryIds: undefined,
+        publishedEntries: undefined,
       };
       try {
         return await activeWriteLock.run(publicationLockState, async () => {
-          let expectedEntryIds: readonly string[] | undefined;
+          let expectedPublishedEntries: readonly OwnedSessionTranscriptPublishedEntry[] | undefined;
           try {
             const result = await run();
-            const ownEntryIds = resolvePublishedEntryIds?.(result);
-            const nestedEntryIds = publicationLockState.publishedEntryIds;
-            expectedEntryIds =
-              nestedEntryIds === undefined
-                ? ownEntryIds
-                : ownEntryIds === undefined
-                  ? nestedEntryIds
-                  : [...nestedEntryIds, ...ownEntryIds];
+            const ownEntries = resolvePublishedEntries?.(result);
+            const nestedEntries = publicationLockState.publishedEntries;
+            expectedPublishedEntries =
+              nestedEntries === undefined
+                ? ownEntries
+                : ownEntries === undefined
+                  ? nestedEntries
+                  : [...nestedEntries, ...ownEntries];
             return result;
           } finally {
-            await publishOwnedSessionFileFence(beforeWrite, expectedEntryIds);
+            await publishOwnedSessionFileFence(beforeWrite, expectedPublishedEntries);
           }
         });
       } finally {
@@ -1543,7 +1696,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         if (options?.publishOwnedWrite !== true) {
           return await run();
         }
-        return await runPublishingOwnedSessionFileWrite(run, options.resolvePublishedEntryIds);
+        return await runPublishingOwnedSessionFileWrite(run, options.resolvePublishedEntries);
       }
       const { lock, owned, releaseRetainedUse } = await acquireWriteLock();
       try {
@@ -1551,10 +1704,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
           await assertSessionFileFence();
           const runWithLock = async () => {
             if (options?.publishOwnedWrite === true) {
-              return await runPublishingOwnedSessionFileWrite(
-                run,
-                options.resolvePublishedEntryIds,
-              );
+              return await runPublishingOwnedSessionFileWrite(run, options.resolvePublishedEntries);
             }
             const beforeWrite = await readSessionFileFingerprint(params.lockOptions.sessionFile);
             try {

--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
@@ -180,47 +180,26 @@ export function stripSessionsYieldArtifacts(activeSession: {
 
   const sessionManager = activeSession.sessionManager as
     | {
-        fileEntries?: Array<{
-          type?: string;
-          id?: string;
-          parentId?: string | null;
-          message?: { role?: string; stopReason?: string };
-          customType?: string;
-        }>;
-        byId?: Map<string, { id: string }>;
-        leafId?: string | null;
-        rewriteFile?: () => void;
+        removeTrailingEntries?: (
+          predicate: (entry: {
+            type?: string;
+            message?: { role?: string; stopReason?: string };
+            customType?: string;
+          }) => boolean,
+        ) => number;
       }
     | undefined;
-  const fileEntries = sessionManager?.fileEntries;
-  const byId = sessionManager?.byId;
-  if (!fileEntries || !byId) {
+  if (typeof sessionManager?.removeTrailingEntries !== "function") {
     return;
   }
 
-  let changed = false;
-  while (fileEntries.length > 1) {
-    const last = fileEntries.at(-1);
-    if (!last || last.type === "session") {
-      break;
-    }
+  sessionManager.removeTrailingEntries((entry) => {
     const isYieldAbortAssistant =
-      last.type === "message" &&
-      last.message?.role === "assistant" &&
-      last.message?.stopReason === "aborted";
+      entry.type === "message" &&
+      entry.message?.role === "assistant" &&
+      entry.message?.stopReason === "aborted";
     const isYieldInterruptMessage =
-      last.type === "custom_message" && last.customType === SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE;
-    if (!isYieldAbortAssistant && !isYieldInterruptMessage) {
-      break;
-    }
-    fileEntries.pop();
-    if (last.id) {
-      byId.delete(last.id);
-    }
-    sessionManager.leafId = last.parentId ?? null;
-    changed = true;
-  }
-  if (changed) {
-    sessionManager.rewriteFile?.();
-  }
+      entry.type === "custom_message" && entry.customType === SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE;
+    return isYieldAbortAssistant || isYieldInterruptMessage;
+  });
 }

--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
@@ -1,6 +1,7 @@
 /**
  * Handles sessions-yield interruption, persistence, and artifact cleanup.
  */
+import { isTranscriptOnlyOpenClawAssistantMessage } from "../../../shared/transcript-only-openclaw-assistant.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { log } from "../logger.js";
 import { resolveEmbeddedAbortSettleTimeoutMs } from "./attempt.abort-settle-timeout.js";
@@ -183,9 +184,24 @@ export function stripSessionsYieldArtifacts(activeSession: {
         removeTrailingEntries?: (
           predicate: (entry: {
             type?: string;
-            message?: { role?: string; stopReason?: string };
+            message?: {
+              role?: string;
+              stopReason?: string;
+              provider?: string;
+              model?: string;
+            };
             customType?: string;
           }) => boolean,
+          options?: {
+            preserveTrailing?: (entry: {
+              type?: string;
+              message?: {
+                role?: string;
+                provider?: string;
+                model?: string;
+              };
+            }) => boolean;
+          },
         ) => number;
       }
     | undefined;
@@ -193,13 +209,23 @@ export function stripSessionsYieldArtifacts(activeSession: {
     return;
   }
 
-  sessionManager.removeTrailingEntries((entry) => {
-    const isYieldAbortAssistant =
-      entry.type === "message" &&
-      entry.message?.role === "assistant" &&
-      entry.message?.stopReason === "aborted";
-    const isYieldInterruptMessage =
-      entry.type === "custom_message" && entry.customType === SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE;
-    return isYieldAbortAssistant || isYieldInterruptMessage;
-  });
+  sessionManager.removeTrailingEntries(
+    (entry) => {
+      const isYieldAbortAssistant =
+        entry.type === "message" &&
+        entry.message?.role === "assistant" &&
+        entry.message?.stopReason === "aborted";
+      const isYieldInterruptMessage =
+        entry.type === "custom_message" &&
+        entry.customType === SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE;
+      return isYieldAbortAssistant || isYieldInterruptMessage;
+    },
+    {
+      preserveTrailing: (entry) =>
+        entry.type === "custom" ||
+        entry.type === "label" ||
+        entry.type === "session_info" ||
+        (entry.type === "message" && isTranscriptOnlyOpenClawAssistantMessage(entry.message)),
+    },
+  );
 }

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -59,6 +59,7 @@ type SessionManagerMocks = {
   appendCustomEntry: UnknownMock;
   flushPendingToolResults: UnknownMock;
   clearPendingToolResults: UnknownMock;
+  removeTrailingEntries: UnknownMock;
 };
 type AttemptSpawnWorkspaceHoisted = {
   spawnSubagentDirectMock: UnknownMock;
@@ -208,6 +209,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     appendCustomEntry: vi.fn(),
     flushPendingToolResults: vi.fn(),
     clearPendingToolResults: vi.fn(),
+    removeTrailingEntries: vi.fn(() => 0),
   };
   return {
     spawnSubagentDirectMock,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -21,6 +21,7 @@ import { resolveQuotaSuspensionEntryMaintenance } from "../../../config/sessions
 import {
   bindOwnedSessionTranscriptWrites,
   type OwnedSessionTranscriptCacheSnapshot,
+  type OwnedSessionTranscriptWriteOptions,
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
@@ -2139,7 +2140,7 @@ export async function runEmbeddedAttempt(
         sessionLockController.publishOwnedSessionFileSnapshot(snapshot),
       withSessionWriteLock: <T>(
         operation: () => Promise<T> | T,
-        options?: { publishOwnedWrite?: boolean },
+        options?: OwnedSessionTranscriptWriteOptions<T>,
       ) => sessionLockController.withSessionWriteLock(operation, options),
     };
     const withOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T): Promise<T> =>

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2113,7 +2113,13 @@ export async function runEmbeddedAttempt(
         if (!sessionManager) {
           throw new Error("session manager unavailable during prompt-released entry merge");
         }
-        sessionManager.mergePromptReleasedSessionEntries(entries);
+        return sessionManager.mergePromptReleasedSessionEntries(entries, { persistLeaf: true });
+      },
+      reloadPromptReleasedSessionFile: () => {
+        if (!sessionManager) {
+          throw new Error("session manager unavailable during prompt-released file reload");
+        }
+        sessionManager.setSessionFile(params.sessionFile);
       },
     });
     releaseRetainedSessionLock = () => sessionLockController.dispose();

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2115,11 +2115,18 @@ export async function runEmbeddedAttempt(
       timeoutMs: sessionWriteLockOptions.maxHoldMs,
       signal: params.abortSignal,
     });
+    let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
     const sessionLockController = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock,
       lockOptions: {
         sessionFile: params.sessionFile,
         ...sessionWriteLockOptions,
+      },
+      mergePromptReleasedSessionEntries: (entries) => {
+        if (!sessionManager) {
+          throw new Error("session manager unavailable during prompt-released entry merge");
+        }
+        sessionManager.mergePromptReleasedSessionEntries(entries);
       },
     });
     releaseRetainedSessionLock = () => sessionLockController.dispose();
@@ -2141,7 +2148,6 @@ export async function runEmbeddedAttempt(
       );
     armExternalAbortSignal();
 
-    let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
     let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
     let removeToolResultContextGuard: (() => void) | undefined;
     let trajectoryRecorder: ReturnType<typeof createTrajectoryRuntimeRecorder> | null = null;

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -700,42 +700,20 @@ function removeTrailingMidTurnPrecheckAssistantError(params: {
   sessionManager: ReturnType<typeof guardSessionManager>;
 }): void {
   const messages = params.activeSession.agent.state.messages;
-  if (isMidTurnPrecheckAssistantError(messages.at(-1))) {
+  const removedActiveError = isMidTurnPrecheckAssistantError(messages.at(-1));
+  if (removedActiveError) {
     params.activeSession.agent.state.messages = messages.slice(0, -1);
   }
 
-  const mutableSessionManager = params.sessionManager as unknown as {
-    fileEntries?: Array<{
-      type?: string;
-      id?: string;
-      parentId?: string | null;
-      message?: AgentMessage;
-    }>;
-    byId?: Map<string, unknown>;
-    leafId?: string | null;
-    rewriteFile?: () => void;
-  };
-  const lastEntry = mutableSessionManager.fileEntries?.at(-1);
-  if (lastEntry?.type !== "message" || !isMidTurnPrecheckAssistantError(lastEntry.message)) {
-    if (isMidTurnPrecheckAssistantError(params.activeSession.agent.state.messages.at(-1))) {
-      log.warn(
-        "[context-overflow-midturn-precheck] removed synthetic assistant error from active session but could not locate matching persisted SessionManager entry",
-      );
-    }
-    return;
-  }
-  if (typeof mutableSessionManager.rewriteFile !== "function") {
+  const removedPersistedError =
+    params.sessionManager.removeTrailingEntries(
+      (entry) => entry.type === "message" && isMidTurnPrecheckAssistantError(entry.message),
+    ) > 0;
+  if (removedActiveError && !removedPersistedError) {
     log.warn(
-      "[context-overflow-midturn-precheck] removed synthetic assistant error from active session but SessionManager rewrite hook is unavailable",
+      "[context-overflow-midturn-precheck] removed synthetic assistant error from active session but could not locate matching persisted SessionManager entry",
     );
-    return;
   }
-  mutableSessionManager.fileEntries?.pop();
-  if (lastEntry.id) {
-    mutableSessionManager.byId?.delete(lastEntry.id);
-  }
-  mutableSessionManager.leafId = lastEntry.parentId ?? null;
-  mutableSessionManager.rewriteFile();
 }
 
 function collectAttemptExplicitToolAllowlistSources(params: {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -67,6 +67,7 @@ import {
 import { getPluginToolMeta } from "../../../plugins/tools.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { annotateInterSessionPromptText } from "../../../sessions/input-provenance.js";
+import { isTranscriptOnlyOpenClawAssistantMessage } from "../../../shared/transcript-only-openclaw-assistant.js";
 import { resolveSkillsPromptForRun } from "../../../skills/loading/workspace.js";
 import { resolveEmbeddedRunSkillEntries } from "../../../skills/runtime/embedded-run-entries.js";
 import {
@@ -708,6 +709,13 @@ function removeTrailingMidTurnPrecheckAssistantError(params: {
   const removedPersistedError =
     params.sessionManager.removeTrailingEntries(
       (entry) => entry.type === "message" && isMidTurnPrecheckAssistantError(entry.message),
+      {
+        preserveTrailing: (entry) =>
+          entry.type === "custom" ||
+          entry.type === "label" ||
+          entry.type === "session_info" ||
+          (entry.type === "message" && isTranscriptOnlyOpenClawAssistantMessage(entry.message)),
+      },
     ) > 0;
   if (removedActiveError && !removedPersistedError) {
     log.warn(

--- a/src/agents/embedded-agent-runner/session-manager-init.test.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.test.ts
@@ -71,6 +71,63 @@ describe("prepareSessionManagerForRun", () => {
     expect(await fs.readFile(sessionFile, "utf-8")).toBe("");
   });
 
+  it("clears the append parent when resetting a real user-only manager", async () => {
+    const sessionFile = await makeTempFile();
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "old-session",
+          timestamp: "2026-05-27T00:00:00.000Z",
+          cwd: "/old/cwd",
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "old-user",
+          parentId: null,
+          timestamp: "2026-05-27T00:00:01.000Z",
+          message: { role: "user", content: "old prompt" },
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const sessionManager = SessionManager.open(sessionFile, path.dirname(sessionFile), "/old/cwd");
+
+    await prepareSessionManagerForRun({
+      sessionManager,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "new-session",
+      cwd: "/tmp/task-repo",
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "response" }],
+      api: "messages",
+      provider: "anthropic",
+      model: "sonnet-4.6",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+
+    const entries = (await fs.readFile(sessionFile, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { type: string; parentId?: string | null });
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toEqual(expect.objectContaining({ type: "message", parentId: null }));
+  });
+
   it("rewrites forked transcript headers with copied assistant messages to the runtime cwd", async () => {
     // Forked sessions keep copied assistant context but rewrite the session
     // header to the child run id and active workspace cwd.

--- a/src/agents/embedded-agent-runner/session-manager-init.test.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.test.ts
@@ -211,6 +211,85 @@ describe("prepareSessionManagerForRun", () => {
     expect(JSON.parse(assistantLine ?? "{}")).toEqual(assistantEntry);
   });
 
+  it("preserves a forked empty branch and its opaque append cursor", async () => {
+    const sessionFile = await makeTempFile();
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "forked-session",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: "/old/cwd",
+          parentSession: "/sessions/parent.jsonl",
+        }),
+        JSON.stringify({
+          type: "metadata",
+          id: "plugin-metadata",
+          parentId: null,
+        }),
+        JSON.stringify({
+          type: "leaf",
+          id: "empty-leaf",
+          parentId: "plugin-metadata",
+          targetId: null,
+          appendParentId: "plugin-metadata",
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const sessionManager = SessionManager.open(sessionFile, path.dirname(sessionFile), "/old/cwd");
+
+    await prepareSessionManagerForRun({
+      sessionManager,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "child-session",
+      cwd: "/tmp/task-repo",
+    });
+
+    const userId = sessionManager.appendMessage({
+      role: "user",
+      content: "continued",
+      timestamp: Date.now(),
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [],
+      api: "responses",
+      provider: "openai",
+      model: "gpt-test",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+
+    const records = (await fs.readFile(sessionFile, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records[0]).toMatchObject({
+      type: "session",
+      id: "child-session",
+      cwd: "/tmp/task-repo",
+      parentSession: "/sessions/parent.jsonl",
+    });
+    expect(records.some((record) => record.id === "plugin-metadata")).toBe(true);
+    expect(records.some((record) => record.id === "empty-leaf")).toBe(true);
+    expect(records.find((record) => record.id === userId)).toMatchObject({
+      type: "message",
+      parentId: "plugin-metadata",
+    });
+  });
+
   it("does not truncate an existing transcript with a corrupted header", async () => {
     // A corrupt header may still be followed by useful transcript entries; fail
     // closed instead of truncating unknown persisted user data.

--- a/src/agents/embedded-agent-runner/session-manager-init.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.ts
@@ -5,7 +5,12 @@ import fs from "node:fs/promises";
 import { serializeJsonlLine, writeJsonlLines } from "../../config/sessions/transcript-jsonl.js";
 import { invalidateSessionFileRepairCache } from "../session-file-repair.js";
 
-type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
+type SessionHeaderEntry = {
+  type: "session";
+  id?: string;
+  cwd?: string;
+  parentSession?: string;
+};
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -77,7 +82,11 @@ export async function prepareSessionManagerForRun(params: {
   }
 
   if (params.hadSessionFile && header && !hasAssistant) {
-    if (sm.wasRecoveredFromCorruptHeader?.()) {
+    const preservesForkedBranch =
+      typeof header.parentSession === "string" && header.parentSession.length > 0;
+    if (sm.wasRecoveredFromCorruptHeader?.() || preservesForkedBranch) {
+      // Fork transcripts can intentionally select a user-only or empty branch.
+      // Keep their copied tree so the first run appends at the preserved cursor.
       header.id = params.sessionId;
       header.cwd = params.cwd;
       sm.sessionId = params.sessionId;

--- a/src/agents/embedded-agent-runner/session-manager-init.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.ts
@@ -58,6 +58,8 @@ export async function prepareSessionManagerForRun(params: {
     labelsById?: Map<string, unknown>;
     leafId?: string | null;
     wasRecoveredFromCorruptHeader?: () => boolean;
+    clearPreservedOpaqueFileEntries?: () => void;
+    getSerializedFileLinesForRewrite?: () => string[];
     syncSnapshotAfterHeaderRewrite?: (expectedContent?: string) => void;
   };
 
@@ -82,7 +84,7 @@ export async function prepareSessionManagerForRun(params: {
       sm.cwd = params.cwd;
       const content = await writeJsonlLines(
         params.sessionFile,
-        sm.fileEntries.map(serializeJsonlLine),
+        sm.getSerializedFileLinesForRewrite?.() ?? sm.fileEntries.map(serializeJsonlLine),
         {
           mode: 0o600,
         },
@@ -101,6 +103,7 @@ export async function prepareSessionManagerForRun(params: {
     sm.sessionId = params.sessionId;
     sm.cwd = params.cwd;
     sm.fileEntries = [header];
+    sm.clearPreservedOpaqueFileEntries?.();
     sm.byId?.clear?.();
     sm.labelsById?.clear?.();
     sm.leafId = null;
@@ -120,7 +123,7 @@ export async function prepareSessionManagerForRun(params: {
     }
     const content = await writeJsonlLines(
       params.sessionFile,
-      sm.fileEntries.map(serializeJsonlLine),
+      sm.getSerializedFileLinesForRewrite?.() ?? sm.fileEntries.map(serializeJsonlLine),
       {
         mode: 0o600,
       },

--- a/src/agents/embedded-agent-runner/transcript-file-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.test.ts
@@ -1189,6 +1189,85 @@ describe("readTranscriptFileState", () => {
     ]);
   });
 
+  it("preserves marked side ancestry without capturing the next active append", async () => {
+    const root = await makeRoot("openclaw-transcript-state-side-append-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: root,
+        },
+        {
+          type: "message",
+          id: "active-root",
+          parentId: null,
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "assistant", content: "active" },
+        },
+        {
+          type: "message",
+          id: "side-one",
+          parentId: "active-root",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          message: { role: "assistant", content: "first side delivery" },
+        },
+        {
+          type: "leaf",
+          id: "first-leaf",
+          parentId: "side-one",
+          timestamp: "2026-06-15T00:00:03.000Z",
+          targetId: "active-root",
+          appendParentId: "side-one",
+          appendMode: "side",
+        },
+        {
+          type: "message",
+          id: "side-two",
+          parentId: "side-one",
+          timestamp: "2026-06-15T00:00:04.000Z",
+          appendMode: "side",
+          message: { role: "assistant", content: "second side delivery" },
+        },
+        {
+          type: "leaf",
+          id: "second-leaf",
+          parentId: "side-two",
+          timestamp: "2026-06-15T00:00:05.000Z",
+          targetId: "active-root",
+          appendParentId: "side-two",
+          appendMode: "side",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getBranch("side-two").map((entry) => entry.id)).toEqual([
+      "active-root",
+      "side-one",
+      "side-two",
+    ]);
+    expect(state.getBranch().map((entry) => entry.id)).toEqual(["active-root"]);
+
+    const nextUser = state.appendMessage({
+      role: "user",
+      content: "next question",
+      timestamp: Date.now(),
+    });
+    expect(state.getBranch(nextUser.id).map((entry) => entry.id)).toEqual([
+      "active-root",
+      nextUser.id,
+    ]);
+  });
+
   it("keeps a terminal leaf control's opaque append parent", async () => {
     const root = await makeRoot("openclaw-transcript-state-opaque-append-parent-");
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/agents/embedded-agent-runner/transcript-file-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.test.ts
@@ -970,6 +970,68 @@ describe("readTranscriptFileState", () => {
     ).not.toThrow();
   });
 
+  it("applies leaf controls to active state and marker-linked descendants", async () => {
+    const root = await makeRoot("openclaw-transcript-state-leaf-");
+    const sessionFile = path.join(root, "session.jsonl");
+    const header = {
+      type: "session",
+      version: 3,
+      id: "session-1",
+      timestamp: "2026-05-16T00:00:00.000Z",
+      cwd: root,
+    };
+    const rootEntry = {
+      type: "message",
+      id: "root-user",
+      parentId: null,
+      timestamp: "2026-05-16T00:00:01.000Z",
+      message: { role: "user", content: "root question" },
+    };
+    const abandonedEntry = {
+      type: "message",
+      id: "abandoned-assistant",
+      parentId: rootEntry.id,
+      timestamp: "2026-05-16T00:00:02.000Z",
+      message: { role: "assistant", content: "abandoned answer" },
+    };
+    const leafEntry = {
+      type: "leaf",
+      id: "leaf-1",
+      parentId: abandonedEntry.id,
+      timestamp: "2026-05-16T00:00:03.000Z",
+      targetId: rootEntry.id,
+    };
+    await fs.writeFile(
+      sessionFile,
+      [header, rootEntry, abandonedEntry, leafEntry]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const selectedState = await readTranscriptFileState(sessionFile);
+    expect(selectedState.getLeafId()).toBe(rootEntry.id);
+    expect(selectedState.getBranch().map((entry) => entry.id)).toEqual([rootEntry.id]);
+
+    const replacementEntry = {
+      type: "message",
+      id: "replacement-assistant",
+      parentId: leafEntry.id,
+      timestamp: "2026-05-16T00:00:04.000Z",
+      message: { role: "assistant", content: "replacement answer" },
+    };
+    await fs.appendFile(sessionFile, `${JSON.stringify(replacementEntry)}\n`, "utf8");
+
+    const reopened = await readTranscriptFileState(sessionFile);
+    expect(reopened.getEntries().find((entry) => entry.id === replacementEntry.id)).toEqual(
+      expect.objectContaining({ parentId: rootEntry.id }),
+    );
+    expect(reopened.getBranch().map((entry) => entry.id)).toEqual([
+      rootEntry.id,
+      replacementEntry.id,
+    ]);
+  });
+
   it("keeps legacy roots that are missing tree metadata", async () => {
     const root = await makeRoot("openclaw-transcript-state-legacy-root-");
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/agents/embedded-agent-runner/transcript-file-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.test.ts
@@ -1132,6 +1132,63 @@ describe("readTranscriptFileState", () => {
     ]);
   });
 
+  it("keeps parentless canonical ancestry through rewrite replay", async () => {
+    const root = await makeRoot("openclaw-transcript-state-parentless-leaf-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: root,
+        },
+        {
+          type: "message",
+          id: "user-1",
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "user", content: "question", timestamp: 1 },
+        },
+        {
+          type: "message",
+          id: "assistant-1",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          message: { role: "assistant", content: "answer", timestamp: 2 },
+        },
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "assistant-1",
+          timestamp: "2026-06-15T00:00:03.000Z",
+          targetId: "assistant-1",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+    expect(state.getBranch().map((entry) => entry.id)).toEqual(["user-1", "assistant-1"]);
+
+    rewriteTranscriptEntriesInState({
+      state,
+      replacements: [
+        {
+          entryId: "user-1",
+          message: { role: "user", content: "rewritten question", timestamp: 3 },
+        },
+      ],
+    });
+
+    expect(state.buildSessionContext().messages).toMatchObject([
+      { role: "user", content: "rewritten question" },
+      { role: "assistant", content: "answer" },
+    ]);
+  });
+
   it("keeps a terminal leaf control's opaque append parent", async () => {
     const root = await makeRoot("openclaw-transcript-state-opaque-append-parent-");
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/agents/embedded-agent-runner/transcript-file-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.test.ts
@@ -1233,15 +1233,6 @@ describe("readTranscriptFileState", () => {
           appendMode: "side",
           message: { role: "assistant", content: "second side delivery" },
         },
-        {
-          type: "leaf",
-          id: "second-leaf",
-          parentId: "side-two",
-          timestamp: "2026-06-15T00:00:05.000Z",
-          targetId: "active-root",
-          appendParentId: "side-two",
-          appendMode: "side",
-        },
       ]
         .map((entry) => JSON.stringify(entry))
         .join("\n") + "\n",
@@ -1256,6 +1247,9 @@ describe("readTranscriptFileState", () => {
       "side-two",
     ]);
     expect(state.getBranch().map((entry) => entry.id)).toEqual(["active-root"]);
+    expect(state.getLeafId()).toBe("active-root");
+    expect(state.getAppendParentId()).toBe("side-two");
+    expect(state.getAppendMode()).toBe("side");
 
     const nextUser = state.appendMessage({
       role: "user",

--- a/src/agents/embedded-agent-runner/transcript-file-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.test.ts
@@ -4,7 +4,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { readTranscriptFileState } from "./transcript-file-state.js";
+import {
+  persistTranscriptStateMutation,
+  readTranscriptFileState,
+} from "./transcript-file-state.js";
 import { rewriteTranscriptEntriesInState } from "./transcript-rewrite.js";
 
 const roots: string[] = [];
@@ -460,6 +463,54 @@ describe("readTranscriptFileState", () => {
     ]);
   });
 
+  it("canonicalizes opaque append parents before a legacy migration rewrite", async () => {
+    const root = await makeRoot("openclaw-transcript-state-v1-opaque-parent-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 1,
+          id: "session-1",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: root,
+        },
+        {
+          type: "message",
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "assistant", content: "legacy active" },
+        },
+        {
+          type: "metadata",
+          id: "plugin-metadata",
+          parentId: "missing-before-migration",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+    const activeLeafId = state.getLeafId();
+    const appended = state.appendMessage({
+      role: "user",
+      content: "continued",
+      timestamp: Date.now(),
+    });
+    await persistTranscriptStateMutation({
+      sessionFile,
+      state,
+      appendedEntries: [appended],
+    });
+
+    expect(state.migrated).toBe(true);
+    expect(appended.parentId).toBe(activeLeafId);
+    const reopened = await readTranscriptFileState(sessionFile);
+    expect(reopened.getBranch().map((entry) => entry.id)).toEqual([activeLeafId, appended.id]);
+  });
+
   it("preserves legacy compaction keep indexes across JSON-valid non-object rows", async () => {
     const root = await makeRoot("openclaw-transcript-state-v1-compaction-null-row-");
     const sessionFile = path.join(root, "session.jsonl");
@@ -844,6 +895,55 @@ describe("readTranscriptFileState", () => {
     expect(state.getBranch().map((entry) => entry.id)).toEqual(["user-1"]);
   });
 
+  it("breaks cycles between canonical and opaque rows", async () => {
+    const root = await makeRoot("openclaw-transcript-state-canonical-opaque-cycle-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: root,
+        },
+        {
+          type: "message",
+          id: "active-entry",
+          parentId: "opaque-cycle",
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "user", content: "kept through cycle" },
+        },
+        {
+          type: "metadata",
+          id: "opaque-cycle",
+          parentId: "active-entry",
+          payload: { source: "plugin" },
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getBranch().map((entry) => ({ id: entry.id, parentId: entry.parentId }))).toEqual([
+      { id: "active-entry", parentId: null },
+    ]);
+    expect(state.buildSessionContext().messages).toMatchObject([
+      { role: "user", content: "kept through cycle" },
+    ]);
+    const appended = state.appendMessage({
+      role: "user",
+      content: "continued",
+      timestamp: Date.now(),
+    });
+    expect(appended.parentId).toBe("opaque-cycle");
+    expect(state.getBranch().map((entry) => entry.id)).toEqual(["active-entry", appended.id]);
+  });
+
   it("drops missing parents reached through rejected rows before rewrite replay", async () => {
     const root = await makeRoot("openclaw-transcript-state-rejected-missing-parent-");
     const sessionFile = path.join(root, "session.jsonl");
@@ -1030,6 +1130,141 @@ describe("readTranscriptFileState", () => {
       rootEntry.id,
       replacementEntry.id,
     ]);
+  });
+
+  it("keeps a terminal leaf control's opaque append parent", async () => {
+    const root = await makeRoot("openclaw-transcript-state-opaque-append-parent-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: root,
+        },
+        {
+          type: "message",
+          id: "active-root",
+          parentId: null,
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "assistant", content: "active" },
+        },
+        {
+          type: "metadata",
+          id: "plugin-metadata",
+          parentId: null,
+          payload: { source: "plugin" },
+        },
+        {
+          type: "message",
+          id: "side-delivery",
+          parentId: "active-root",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          message: { role: "assistant", content: "side delivery" },
+        },
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "side-delivery",
+          timestamp: "2026-06-15T00:00:03.000Z",
+          targetId: "active-root",
+          appendParentId: "plugin-metadata",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+    const appended = state.appendMessage({
+      role: "user",
+      content: "continued",
+      timestamp: Date.now(),
+    });
+    await persistTranscriptStateMutation({
+      sessionFile,
+      state,
+      appendedEntries: [appended],
+    });
+    const persisted = (await fs.readFile(sessionFile, "utf8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(state.getLeafId()).toBe(appended.id);
+    expect(appended.parentId).toBe("plugin-metadata");
+    expect(state.getBranch().map((entry) => entry.id)).toEqual(["active-root", appended.id]);
+    expect(persisted.at(-1)).toMatchObject({ id: appended.id, parentId: "plugin-metadata" });
+  });
+
+  it("ignores leaf controls with dangling target or append references", async () => {
+    const root = await makeRoot("openclaw-transcript-state-invalid-leaf-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: root,
+        },
+        {
+          type: "message",
+          id: "active-root",
+          parentId: null,
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "assistant", content: "active" },
+        },
+        {
+          type: "metadata",
+          id: "plugin-metadata",
+          parentId: "active-root",
+          payload: { source: "plugin" },
+        },
+        {
+          type: "leaf",
+          id: "missing-target",
+          parentId: "plugin-metadata",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          targetId: "missing",
+        },
+        {
+          type: "leaf",
+          id: "missing-append",
+          parentId: "missing-target",
+          timestamp: "2026-06-15T00:00:03.000Z",
+          targetId: "active-root",
+          appendParentId: "missing",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+    const appended = state.appendMessage({
+      role: "user",
+      content: "continued",
+      timestamp: Date.now(),
+    });
+    await persistTranscriptStateMutation({
+      sessionFile,
+      state,
+      appendedEntries: [appended],
+    });
+
+    expect(appended.parentId).toBe("plugin-metadata");
+    expect(state.getBranch().map((entry) => entry.id)).toEqual(["active-root", appended.id]);
+    const reopened = await readTranscriptFileState(sessionFile);
+    expect(reopened.getLeafId()).toBe(appended.id);
+    expect(reopened.getBranch().map((entry) => entry.id)).toEqual(["active-root", appended.id]);
   });
 
   it("keeps legacy roots that are missing tree metadata", async () => {

--- a/src/agents/embedded-agent-runner/transcript-file-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.ts
@@ -4,6 +4,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import { appendRegularFile } from "../../infra/fs-safe.js";
 import { privateFileStore } from "../../infra/private-file-store.js";
@@ -36,6 +37,7 @@ export type TranscriptLeafControlEntry = {
   timestamp: string;
   targetId: string | null;
   appendParentId?: string | null;
+  appendMode?: "side";
 };
 
 export type TranscriptPersistedEntry = SessionEntry | TranscriptLeafControlEntry;
@@ -293,6 +295,7 @@ function parseLeafControlEntry(entry: unknown):
       parentId: string | null;
       targetId: string | null;
       appendParentId?: string | null;
+      appendMode?: "side";
     }
   | undefined {
   if (!isRecord(entry) || entry.type !== "leaf") {
@@ -303,6 +306,7 @@ function parseLeafControlEntry(entry: unknown):
     parentId?: unknown;
     targetId?: unknown;
     appendParentId?: unknown;
+    appendMode?: unknown;
     timestamp?: unknown;
   };
   if (
@@ -314,7 +318,8 @@ function parseLeafControlEntry(entry: unknown):
     (candidate.targetId !== null && typeof candidate.targetId !== "string") ||
     (candidate.appendParentId !== undefined &&
       candidate.appendParentId !== null &&
-      typeof candidate.appendParentId !== "string")
+      typeof candidate.appendParentId !== "string") ||
+    (candidate.appendMode !== undefined && candidate.appendMode !== "side")
   ) {
     return undefined;
   }
@@ -323,6 +328,7 @@ function parseLeafControlEntry(entry: unknown):
     parentId: candidate.parentId ?? null,
     targetId: candidate.targetId,
     ...(candidate.appendParentId !== undefined ? { appendParentId: candidate.appendParentId } : {}),
+    ...(candidate.appendMode === "side" ? { appendMode: candidate.appendMode } : {}),
   };
 }
 
@@ -515,7 +521,9 @@ function readableSessionState(fileEntries: FileEntry[]): ReadableSessionState {
     const hasSerializedParent = Object.hasOwn(rawRecord, "parentId");
     if (
       !hasSerializedParent ||
-      (entry.parentId === effectiveAppendParentId && effectiveLeafId !== effectiveAppendParentId)
+      (!isSessionTranscriptSideAppendEntry(rawRecord) &&
+        entry.parentId === effectiveAppendParentId &&
+        effectiveLeafId !== effectiveAppendParentId)
     ) {
       logicalParentsById.set(entry.id, effectiveLeafId);
     }
@@ -877,7 +885,11 @@ export class TranscriptFileState {
   }
 
   private appendEntry<T extends SessionEntry>(entry: T): T {
-    if (entry.parentId === this.appendParentId && this.leafId !== this.appendParentId) {
+    if (
+      !isSessionTranscriptSideAppendEntry(entry) &&
+      entry.parentId === this.appendParentId &&
+      this.leafId !== this.appendParentId
+    ) {
       this.logicalParentsById.set(entry.id, this.leafId);
     }
     this.entries.push(entry);

--- a/src/agents/embedded-agent-runner/transcript-file-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.ts
@@ -336,6 +336,7 @@ type ReadableSessionState = {
   entries: SessionEntry[];
   leafId: string | null;
   appendParentId: string | null;
+  appendMode?: "side";
   opaqueParentsById: Map<string, string | null>;
   logicalParentsById: Map<string, string | null>;
 };
@@ -354,6 +355,7 @@ function readableSessionState(fileEntries: FileEntry[]): ReadableSessionState {
   const rejectedAncestorsByAcceptedId = new Map<string, string[]>();
   let effectiveLeafId: string | null = null;
   let effectiveAppendParentId: string | null = null;
+  let effectiveAppendMode: "side" | undefined;
   const acceptedPath = (leafId: string | null | undefined): SessionEntry[] => {
     const pathLocal: SessionEntry[] = [];
     let id = leafId ?? null;
@@ -483,6 +485,7 @@ function readableSessionState(fileEntries: FileEntry[]): ReadableSessionState {
         resolvedTargetId !== null && acceptedIds.has(resolvedTargetId) ? resolvedTargetId : null;
       effectiveAppendParentId =
         leafEntry.appendParentId === undefined ? effectiveLeafId : leafEntry.appendParentId;
+      effectiveAppendMode = leafEntry.appendMode;
       continue;
     }
     if (rawType === "leaf") {
@@ -533,11 +536,13 @@ function readableSessionState(fileEntries: FileEntry[]): ReadableSessionState {
     acceptedEntryById.set(repaired.id, repaired);
     effectiveLeafId = repaired.id;
     effectiveAppendParentId = repaired.id;
+    effectiveAppendMode = isSessionTranscriptSideAppendEntry(rawRecord) ? "side" : undefined;
   }
   return {
     entries,
     leafId: effectiveLeafId,
     appendParentId: effectiveAppendParentId,
+    ...(effectiveAppendMode ? { appendMode: effectiveAppendMode } : {}),
     opaqueParentsById: rejectedParentById,
     logicalParentsById,
   };
@@ -585,12 +590,14 @@ export class TranscriptFileState {
   private readonly logicalParentsById = new Map<string, string | null>();
   private leafId: string | null = null;
   private appendParentId: string | null = null;
+  private appendMode: "side" | undefined;
 
   constructor(params: {
     header: SessionHeader | null;
     entries: SessionEntry[];
     leafId?: string | null;
     appendParentId?: string | null;
+    appendMode?: "side";
     opaqueParentsById?: ReadonlyMap<string, string | null>;
     logicalParentsById?: ReadonlyMap<string, string | null>;
     migrated?: boolean;
@@ -605,6 +612,7 @@ export class TranscriptFileState {
       this.logicalParentsById.set(id, parentId);
     }
     this.rebuildIndex(params.leafId, params.appendParentId);
+    this.appendMode = params.appendMode;
   }
 
   private resolveCanonicalParentId(parentId: string | null): string | null {
@@ -670,6 +678,10 @@ export class TranscriptFileState {
     return this.appendParentId;
   }
 
+  getAppendMode(): "side" | undefined {
+    return this.appendMode;
+  }
+
   getLeafEntry(): SessionEntry | undefined {
     return this.leafId ? this.byId.get(this.leafId) : undefined;
   }
@@ -717,12 +729,14 @@ export class TranscriptFileState {
     }
     this.leafId = branchFromId;
     this.appendParentId = branchFromId;
+    this.appendMode = undefined;
   }
 
   /** Clear the active leaf so the next append starts a root branch. */
   resetLeaf(): void {
     this.leafId = null;
     this.appendParentId = null;
+    this.appendMode = undefined;
   }
 
   appendMessage(message: SessionMessageEntry["message"]): SessionMessageEntry {
@@ -855,6 +869,7 @@ export class TranscriptFileState {
   appendLeafControl(params: {
     targetId: string | null;
     appendParentId: string | null;
+    appendMode?: "side";
   }): TranscriptLeafControlEntry {
     if (params.targetId !== null && !this.byId.has(params.targetId)) {
       throw new Error(`Entry ${params.targetId} not found`);
@@ -877,10 +892,12 @@ export class TranscriptFileState {
       ...(params.appendParentId !== params.targetId
         ? { appendParentId: params.appendParentId }
         : {}),
+      ...(params.appendMode ? { appendMode: params.appendMode } : {}),
     };
     this.opaqueParentsById.set(entry.id, params.targetId);
     this.leafId = params.targetId;
     this.appendParentId = params.appendParentId;
+    this.appendMode = params.appendMode;
     return entry;
   }
 
@@ -896,6 +913,7 @@ export class TranscriptFileState {
     this.byId.set(entry.id, entry);
     this.leafId = entry.id;
     this.appendParentId = entry.id;
+    this.appendMode = isSessionTranscriptSideAppendEntry(entry) ? "side" : undefined;
     if (entry.type === "label") {
       if (entry.label) {
         this.labelsById.set(entry.targetId, entry.label);
@@ -926,6 +944,7 @@ export async function readTranscriptFileState(sessionFile: string): Promise<Tran
     entries: readable.entries,
     leafId: readable.leafId,
     appendParentId: migrated ? readable.leafId : readable.appendParentId,
+    ...(!migrated && readable.appendMode ? { appendMode: readable.appendMode } : {}),
     opaqueParentsById: readable.opaqueParentsById,
     logicalParentsById: readable.logicalParentsById,
     migrated,

--- a/src/agents/embedded-agent-runner/transcript-file-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.ts
@@ -29,6 +29,17 @@ type SessionInfoEntry = Extract<SessionEntry, { type: "session_info" }>;
 type SessionMessageEntry = Extract<SessionEntry, { type: "message" }>;
 type ThinkingLevelChangeEntry = Extract<SessionEntry, { type: "thinking_level_change" }>;
 
+export type TranscriptLeafControlEntry = {
+  type: "leaf";
+  id: string;
+  parentId: string | null;
+  timestamp: string;
+  targetId: string | null;
+  appendParentId?: string | null;
+};
+
+export type TranscriptPersistedEntry = SessionEntry | TranscriptLeafControlEntry;
+
 const sessionEntryTypes = new Set<string>([
   "branch_summary",
   "compaction",
@@ -276,9 +287,14 @@ function isSessionEntry(entry: FileEntry): entry is SessionEntry {
   return false;
 }
 
-function parseLeafControlEntry(
-  entry: unknown,
-): { id: string; targetId: string | null } | undefined {
+function parseLeafControlEntry(entry: unknown):
+  | {
+      id: string;
+      parentId: string | null;
+      targetId: string | null;
+      appendParentId?: string | null;
+    }
+  | undefined {
   if (!isRecord(entry) || entry.type !== "leaf") {
     return undefined;
   }
@@ -286,6 +302,7 @@ function parseLeafControlEntry(
     id?: unknown;
     parentId?: unknown;
     targetId?: unknown;
+    appendParentId?: unknown;
     timestamp?: unknown;
   };
   if (
@@ -294,16 +311,27 @@ function parseLeafControlEntry(
       candidate.parentId !== null &&
       !isString(candidate.parentId)) ||
     (candidate.timestamp !== undefined && !isString(candidate.timestamp)) ||
-    (candidate.targetId !== null && typeof candidate.targetId !== "string")
+    (candidate.targetId !== null && typeof candidate.targetId !== "string") ||
+    (candidate.appendParentId !== undefined &&
+      candidate.appendParentId !== null &&
+      typeof candidate.appendParentId !== "string")
   ) {
     return undefined;
   }
-  return { id: candidate.id, targetId: candidate.targetId };
+  return {
+    id: candidate.id,
+    parentId: candidate.parentId ?? null,
+    targetId: candidate.targetId,
+    ...(candidate.appendParentId !== undefined ? { appendParentId: candidate.appendParentId } : {}),
+  };
 }
 
 type ReadableSessionState = {
   entries: SessionEntry[];
   leafId: string | null;
+  appendParentId: string | null;
+  opaqueParentsById: Map<string, string | null>;
+  logicalParentsById: Map<string, string | null>;
 };
 
 // Keep every readable entry while repairing links through rejected rows. This
@@ -314,9 +342,12 @@ function readableSessionState(fileEntries: FileEntry[]): ReadableSessionState {
   const acceptedEntryById = new Map<string, SessionEntry>();
   const rejectedIds = new Set<string>();
   const rejectedParentById = new Map<string, string | null>();
+  const logicalParentsById = new Map<string, string | null>();
+  const invalidLeafIds = new Set<string>();
   const firstReadableDescendantByRejectedId = new Map<string, string>();
   const rejectedAncestorsByAcceptedId = new Map<string, string[]>();
   let effectiveLeafId: string | null = null;
+  let effectiveAppendParentId: string | null = null;
   const acceptedPath = (leafId: string | null | undefined): SessionEntry[] => {
     const pathLocal: SessionEntry[] = [];
     let id = leafId ?? null;
@@ -415,22 +446,61 @@ function readableSessionState(fileEntries: FileEntry[]): ReadableSessionState {
     if (!isRecord(rawEntry)) {
       continue;
     }
+    const rawRecord = rawEntry as unknown as Record<string, unknown>;
     const entry = rawEntry as FileEntry;
-    const id = rawEntry.id;
-    const leafEntry = parseLeafControlEntry(rawEntry);
+    const id = rawRecord.id;
+    const rawType = rawRecord.type;
+    const rawParentId = rawRecord.parentId;
+    const leafEntry = parseLeafControlEntry(rawRecord);
     if (leafEntry) {
       rejectedIds.add(leafEntry.id);
+      const targetIsKnown =
+        leafEntry.targetId === null ||
+        acceptedIds.has(leafEntry.targetId) ||
+        (rejectedParentById.has(leafEntry.targetId) && !invalidLeafIds.has(leafEntry.targetId));
+      const appendParentIsKnown =
+        leafEntry.appendParentId === undefined ||
+        leafEntry.appendParentId === null ||
+        acceptedIds.has(leafEntry.appendParentId) ||
+        (rejectedParentById.has(leafEntry.appendParentId) &&
+          !invalidLeafIds.has(leafEntry.appendParentId));
+      if (!targetIsKnown || !appendParentIsKnown) {
+        // Ignore corrupt navigation state, but keep the marker transparent so
+        // descendants can still repair through the serialized raw branch.
+        invalidLeafIds.add(leafEntry.id);
+        rejectedParentById.set(leafEntry.id, leafEntry.parentId);
+        continue;
+      }
       rejectedParentById.set(leafEntry.id, leafEntry.targetId);
       const resolvedTargetId = resolveRejectedParent(leafEntry.targetId);
       effectiveLeafId =
         resolvedTargetId !== null && acceptedIds.has(resolvedTargetId) ? resolvedTargetId : null;
+      effectiveAppendParentId =
+        leafEntry.appendParentId === undefined ? effectiveLeafId : leafEntry.appendParentId;
+      continue;
+    }
+    if (rawType === "leaf") {
+      if (isString(id)) {
+        rejectedIds.add(id);
+        invalidLeafIds.add(id);
+        rejectedParentById.set(id, isString(rawParentId) ? rawParentId : null);
+      }
       continue;
     }
     if (!isSessionEntry(entry)) {
       if (isString(id)) {
         rejectedIds.add(id);
-        const parentId = rawEntry.parentId;
-        rejectedParentById.set(id, isString(parentId) ? parentId : null);
+        rejectedParentById.set(id, isString(rawParentId) ? rawParentId : null);
+        const isParentLinkedOpaque =
+          typeof rawType === "string" &&
+          rawType !== "session" &&
+          !id.startsWith("__openclaw_invalid_jsonl_slot_") &&
+          !sessionEntryTypes.has(rawType) &&
+          Object.hasOwn(rawRecord, "parentId") &&
+          (rawParentId === null || isString(rawParentId));
+        if (isParentLinkedOpaque) {
+          effectiveAppendParentId = id;
+        }
       }
       continue;
     }
@@ -442,13 +512,23 @@ function readableSessionState(fileEntries: FileEntry[]): ReadableSessionState {
     if (acceptedIds.has(entry.id)) {
       continue;
     }
+    if (entry.parentId === effectiveAppendParentId && effectiveLeafId !== effectiveAppendParentId) {
+      logicalParentsById.set(entry.id, effectiveLeafId);
+    }
     const repaired = repairEntryLinks(entry);
     entries.push(repaired);
     acceptedIds.add(repaired.id);
     acceptedEntryById.set(repaired.id, repaired);
     effectiveLeafId = repaired.id;
+    effectiveAppendParentId = repaired.id;
   }
-  return { entries, leafId: effectiveLeafId };
+  return {
+    entries,
+    leafId: effectiveLeafId,
+    appendParentId: effectiveAppendParentId,
+    opaqueParentsById: rejectedParentById,
+    logicalParentsById,
+  };
 }
 
 function sessionHeaderVersion(header: SessionHeader | null): number {
@@ -465,7 +545,7 @@ function generateEntryId(byId: { has(id: string): boolean }): string {
   return randomUUID();
 }
 
-function serializeTranscriptFileEntries(entries: FileEntry[]): string {
+function serializeTranscriptFileEntries(entries: readonly unknown[]): string {
   return `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
 }
 
@@ -489,28 +569,55 @@ export class TranscriptFileState {
   private readonly byId = new Map<string, SessionEntry>();
   private readonly labelsById = new Map<string, string>();
   private readonly labelTimestampsById = new Map<string, string>();
+  private readonly opaqueParentsById = new Map<string, string | null>();
+  private readonly logicalParentsById = new Map<string, string | null>();
   private leafId: string | null = null;
+  private appendParentId: string | null = null;
 
   constructor(params: {
     header: SessionHeader | null;
     entries: SessionEntry[];
     leafId?: string | null;
+    appendParentId?: string | null;
+    opaqueParentsById?: ReadonlyMap<string, string | null>;
+    logicalParentsById?: ReadonlyMap<string, string | null>;
     migrated?: boolean;
   }) {
     this.header = params.header;
     this.entries = [...params.entries];
     this.migrated = params.migrated === true;
-    this.rebuildIndex(params.leafId);
+    for (const [id, parentId] of params.opaqueParentsById ?? []) {
+      this.opaqueParentsById.set(id, parentId);
+    }
+    for (const [id, parentId] of params.logicalParentsById ?? []) {
+      this.logicalParentsById.set(id, parentId);
+    }
+    this.rebuildIndex(params.leafId, params.appendParentId);
   }
 
-  private rebuildIndex(leafId?: string | null): void {
+  private resolveCanonicalParentId(parentId: string | null): string | null {
+    const seen = new Set<string>();
+    let currentId = parentId;
+    while (currentId !== null && this.opaqueParentsById.has(currentId)) {
+      if (seen.has(currentId)) {
+        return null;
+      }
+      seen.add(currentId);
+      currentId = this.opaqueParentsById.get(currentId) ?? null;
+    }
+    return currentId;
+  }
+
+  private rebuildIndex(leafId?: string | null, appendParentId?: string | null): void {
     this.byId.clear();
     this.labelsById.clear();
     this.labelTimestampsById.clear();
     this.leafId = null;
+    this.appendParentId = null;
     for (const entry of this.entries) {
       this.byId.set(entry.id, entry);
       this.leafId = entry.id;
+      this.appendParentId = entry.id;
       if (entry.type === "label") {
         if (entry.label) {
           this.labelsById.set(entry.targetId, entry.label);
@@ -523,6 +630,11 @@ export class TranscriptFileState {
     }
     if (leafId !== undefined) {
       this.leafId = leafId;
+    }
+    if (appendParentId !== undefined) {
+      this.appendParentId = appendParentId;
+    } else if (leafId !== undefined) {
+      this.appendParentId = leafId;
     }
   }
 
@@ -542,6 +654,10 @@ export class TranscriptFileState {
     return this.leafId;
   }
 
+  getAppendParentId(): string | null {
+    return this.appendParentId;
+  }
+
   getLeafEntry(): SessionEntry | undefined {
     return this.leafId ? this.byId.get(this.leafId) : undefined;
   }
@@ -552,17 +668,34 @@ export class TranscriptFileState {
 
   getBranch(fromId?: string): SessionEntry[] {
     const branch: SessionEntry[] = [];
-    let current = (fromId ?? this.leafId) ? this.byId.get((fromId ?? this.leafId)!) : undefined;
-    while (current) {
-      branch.push(current);
-      current = current.parentId ? this.byId.get(current.parentId) : undefined;
+    const seen = new Set<string>();
+    let currentId = fromId ?? this.leafId;
+    while (currentId && !seen.has(currentId)) {
+      const current = this.byId.get(currentId);
+      if (!current) {
+        break;
+      }
+      seen.add(current.id);
+      const resolvedParentId = this.logicalParentsById.has(current.id)
+        ? (this.logicalParentsById.get(current.id) ?? null)
+        : this.resolveCanonicalParentId(current.parentId);
+      const parentId =
+        resolvedParentId === current.id || (resolvedParentId && seen.has(resolvedParentId))
+          ? null
+          : resolvedParentId;
+      branch.push(
+        parentId === current.parentId ? current : ({ ...current, parentId } as SessionEntry),
+      );
+      currentId = parentId;
     }
     branch.reverse();
     return branch;
   }
 
   buildSessionContext(): SessionContext {
-    return buildSessionContext(this.entries, this.leafId, this.byId);
+    const entries = this.getBranch();
+    const leafId = entries.at(-1)?.id ?? null;
+    return buildSessionContext(entries, leafId, new Map(entries.map((entry) => [entry.id, entry])));
   }
 
   /** Move the active leaf to an existing entry without appending a row. */
@@ -571,18 +704,20 @@ export class TranscriptFileState {
       throw new Error(`Entry ${branchFromId} not found`);
     }
     this.leafId = branchFromId;
+    this.appendParentId = branchFromId;
   }
 
   /** Clear the active leaf so the next append starts a root branch. */
   resetLeaf(): void {
     this.leafId = null;
+    this.appendParentId = null;
   }
 
   appendMessage(message: SessionMessageEntry["message"]): SessionMessageEntry {
     return this.appendEntry({
       type: "message",
       id: generateEntryId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
       message,
     });
@@ -592,7 +727,7 @@ export class TranscriptFileState {
     return this.appendEntry({
       type: "thinking_level_change",
       id: generateEntryId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
       thinkingLevel,
     });
@@ -602,7 +737,7 @@ export class TranscriptFileState {
     return this.appendEntry({
       type: "model_change",
       id: generateEntryId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
       provider,
       modelId,
@@ -619,7 +754,7 @@ export class TranscriptFileState {
     return this.appendEntry({
       type: "compaction",
       id: generateEntryId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
       summary,
       firstKeptEntryId,
@@ -635,7 +770,7 @@ export class TranscriptFileState {
       customType,
       data,
       id: generateEntryId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
     });
   }
@@ -644,7 +779,7 @@ export class TranscriptFileState {
     return this.appendEntry({
       type: "session_info",
       id: generateEntryId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
       name: name.trim(),
     });
@@ -663,7 +798,7 @@ export class TranscriptFileState {
       display,
       details,
       id: generateEntryId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
     });
   }
@@ -675,7 +810,7 @@ export class TranscriptFileState {
     return this.appendEntry({
       type: "label",
       id: generateEntryId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
       targetId,
       label,
@@ -692,6 +827,7 @@ export class TranscriptFileState {
       throw new Error(`Entry ${branchFromId} not found`);
     }
     this.leafId = branchFromId;
+    this.appendParentId = branchFromId;
     return this.appendEntry({
       type: "branch_summary",
       id: generateEntryId(this.byId),
@@ -704,10 +840,46 @@ export class TranscriptFileState {
     });
   }
 
+  appendLeafControl(params: {
+    targetId: string | null;
+    appendParentId: string | null;
+  }): TranscriptLeafControlEntry {
+    if (params.targetId !== null && !this.byId.has(params.targetId)) {
+      throw new Error(`Entry ${params.targetId} not found`);
+    }
+    if (
+      params.appendParentId !== null &&
+      !this.byId.has(params.appendParentId) &&
+      !this.opaqueParentsById.has(params.appendParentId)
+    ) {
+      throw new Error(`Entry ${params.appendParentId} not found`);
+    }
+    const entry: TranscriptLeafControlEntry = {
+      type: "leaf",
+      id: generateEntryId({
+        has: (id) => this.byId.has(id) || this.opaqueParentsById.has(id),
+      }),
+      parentId: this.appendParentId,
+      timestamp: new Date().toISOString(),
+      targetId: params.targetId,
+      ...(params.appendParentId !== params.targetId
+        ? { appendParentId: params.appendParentId }
+        : {}),
+    };
+    this.opaqueParentsById.set(entry.id, params.targetId);
+    this.leafId = params.targetId;
+    this.appendParentId = params.appendParentId;
+    return entry;
+  }
+
   private appendEntry<T extends SessionEntry>(entry: T): T {
+    if (entry.parentId === this.appendParentId && this.leafId !== this.appendParentId) {
+      this.logicalParentsById.set(entry.id, this.leafId);
+    }
     this.entries.push(entry);
     this.byId.set(entry.id, entry);
     this.leafId = entry.id;
+    this.appendParentId = entry.id;
     if (entry.type === "label") {
       if (entry.label) {
         this.labelsById.set(entry.targetId, entry.label);
@@ -737,6 +909,9 @@ export async function readTranscriptFileState(sessionFile: string): Promise<Tran
     header,
     entries: readable.entries,
     leafId: readable.leafId,
+    appendParentId: migrated ? readable.leafId : readable.appendParentId,
+    opaqueParentsById: readable.opaqueParentsById,
+    logicalParentsById: readable.logicalParentsById,
     migrated,
   });
 }
@@ -744,7 +919,7 @@ export async function readTranscriptFileState(sessionFile: string): Promise<Tran
 /** Rewrite the full transcript through the private-file store. */
 export async function writeTranscriptFileAtomic(
   filePath: string,
-  entries: Array<SessionHeader | SessionEntry>,
+  entries: Array<SessionHeader | TranscriptPersistedEntry>,
 ): Promise<void> {
   await privateFileStore(path.dirname(filePath)).writeText(
     path.basename(filePath),
@@ -756,15 +931,19 @@ export async function writeTranscriptFileAtomic(
 export async function persistTranscriptStateMutation(params: {
   sessionFile: string;
   state: TranscriptFileState;
-  appendedEntries: SessionEntry[];
+  appendedEntries: TranscriptPersistedEntry[];
 }): Promise<void> {
   if (params.appendedEntries.length === 0 && !params.state.migrated) {
     return;
   }
   if (params.state.migrated) {
+    const appendedLeafControls = params.appendedEntries.filter(
+      (entry): entry is TranscriptLeafControlEntry => entry.type === "leaf",
+    );
     await writeTranscriptFileAtomic(params.sessionFile, [
       ...(params.state.header ? [params.state.header] : []),
       ...params.state.entries,
+      ...appendedLeafControls,
     ]);
     return;
   }

--- a/src/agents/embedded-agent-runner/transcript-file-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.ts
@@ -276,9 +276,39 @@ function isSessionEntry(entry: FileEntry): entry is SessionEntry {
   return false;
 }
 
+function parseLeafControlEntry(
+  entry: unknown,
+): { id: string; targetId: string | null } | undefined {
+  if (!isRecord(entry) || entry.type !== "leaf") {
+    return undefined;
+  }
+  const candidate = entry as {
+    id?: unknown;
+    parentId?: unknown;
+    targetId?: unknown;
+    timestamp?: unknown;
+  };
+  if (
+    !isString(candidate.id) ||
+    (candidate.parentId !== undefined &&
+      candidate.parentId !== null &&
+      !isString(candidate.parentId)) ||
+    (candidate.timestamp !== undefined && !isString(candidate.timestamp)) ||
+    (candidate.targetId !== null && typeof candidate.targetId !== "string")
+  ) {
+    return undefined;
+  }
+  return { id: candidate.id, targetId: candidate.targetId };
+}
+
+type ReadableSessionState = {
+  entries: SessionEntry[];
+  leafId: string | null;
+};
+
 // Keep every readable entry while repairing links through rejected rows. This
 // preserves usable branches from partially written or migrated transcripts.
-function readableSessionEntries(fileEntries: FileEntry[]): SessionEntry[] {
+function readableSessionState(fileEntries: FileEntry[]): ReadableSessionState {
   const entries: SessionEntry[] = [];
   const acceptedIds = new Set<string>();
   const acceptedEntryById = new Map<string, SessionEntry>();
@@ -286,6 +316,7 @@ function readableSessionEntries(fileEntries: FileEntry[]): SessionEntry[] {
   const rejectedParentById = new Map<string, string | null>();
   const firstReadableDescendantByRejectedId = new Map<string, string>();
   const rejectedAncestorsByAcceptedId = new Map<string, string[]>();
+  let effectiveLeafId: string | null = null;
   const acceptedPath = (leafId: string | null | undefined): SessionEntry[] => {
     const pathLocal: SessionEntry[] = [];
     let id = leafId ?? null;
@@ -386,6 +417,15 @@ function readableSessionEntries(fileEntries: FileEntry[]): SessionEntry[] {
     }
     const entry = rawEntry as FileEntry;
     const id = rawEntry.id;
+    const leafEntry = parseLeafControlEntry(rawEntry);
+    if (leafEntry) {
+      rejectedIds.add(leafEntry.id);
+      rejectedParentById.set(leafEntry.id, leafEntry.targetId);
+      const resolvedTargetId = resolveRejectedParent(leafEntry.targetId);
+      effectiveLeafId =
+        resolvedTargetId !== null && acceptedIds.has(resolvedTargetId) ? resolvedTargetId : null;
+      continue;
+    }
     if (!isSessionEntry(entry)) {
       if (isString(id)) {
         rejectedIds.add(id);
@@ -406,8 +446,9 @@ function readableSessionEntries(fileEntries: FileEntry[]): SessionEntry[] {
     entries.push(repaired);
     acceptedIds.add(repaired.id);
     acceptedEntryById.set(repaired.id, repaired);
+    effectiveLeafId = repaired.id;
   }
-  return entries;
+  return { entries, leafId: effectiveLeafId };
 }
 
 function sessionHeaderVersion(header: SessionHeader | null): number {
@@ -453,15 +494,16 @@ export class TranscriptFileState {
   constructor(params: {
     header: SessionHeader | null;
     entries: SessionEntry[];
+    leafId?: string | null;
     migrated?: boolean;
   }) {
     this.header = params.header;
     this.entries = [...params.entries];
     this.migrated = params.migrated === true;
-    this.rebuildIndex();
+    this.rebuildIndex(params.leafId);
   }
 
-  private rebuildIndex(): void {
+  private rebuildIndex(leafId?: string | null): void {
     this.byId.clear();
     this.labelsById.clear();
     this.labelTimestampsById.clear();
@@ -478,6 +520,9 @@ export class TranscriptFileState {
           this.labelTimestampsById.delete(entry.targetId);
         }
       }
+    }
+    if (leafId !== undefined) {
+      this.leafId = leafId;
     }
   }
 
@@ -687,8 +732,13 @@ export async function readTranscriptFileState(sessionFile: string): Promise<Tran
   migrateSessionEntries(fileEntries);
   const header =
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;
-  const entries = readableSessionEntries(fileEntries);
-  return new TranscriptFileState({ header, entries, migrated });
+  const readable = readableSessionState(fileEntries);
+  return new TranscriptFileState({
+    header,
+    entries: readable.entries,
+    leafId: readable.leafId,
+    migrated,
+  });
 }
 
 /** Rewrite the full transcript through the private-file store. */

--- a/src/agents/embedded-agent-runner/transcript-file-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.ts
@@ -512,7 +512,11 @@ function readableSessionState(fileEntries: FileEntry[]): ReadableSessionState {
     if (acceptedIds.has(entry.id)) {
       continue;
     }
-    if (entry.parentId === effectiveAppendParentId && effectiveLeafId !== effectiveAppendParentId) {
+    const hasSerializedParent = Object.hasOwn(rawRecord, "parentId");
+    if (
+      !hasSerializedParent ||
+      (entry.parentId === effectiveAppendParentId && effectiveLeafId !== effectiveAppendParentId)
+    ) {
       logicalParentsById.set(entry.id, effectiveLeafId);
     }
     const repaired = repairEntryLinks(entry);

--- a/src/agents/embedded-agent-runner/transcript-file-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.ts
@@ -534,9 +534,13 @@ function readableSessionState(fileEntries: FileEntry[]): ReadableSessionState {
     entries.push(repaired);
     acceptedIds.add(repaired.id);
     acceptedEntryById.set(repaired.id, repaired);
-    effectiveLeafId = repaired.id;
     effectiveAppendParentId = repaired.id;
-    effectiveAppendMode = isSessionTranscriptSideAppendEntry(rawRecord) ? "side" : undefined;
+    if (isSessionTranscriptSideAppendEntry(rawRecord)) {
+      effectiveAppendMode = "side";
+    } else {
+      effectiveLeafId = repaired.id;
+      effectiveAppendMode = undefined;
+    }
   }
   return {
     entries,
@@ -911,9 +915,13 @@ export class TranscriptFileState {
     }
     this.entries.push(entry);
     this.byId.set(entry.id, entry);
-    this.leafId = entry.id;
     this.appendParentId = entry.id;
-    this.appendMode = isSessionTranscriptSideAppendEntry(entry) ? "side" : undefined;
+    if (isSessionTranscriptSideAppendEntry(entry)) {
+      this.appendMode = "side";
+    } else {
+      this.leafId = entry.id;
+      this.appendMode = undefined;
+    }
     if (entry.type === "label") {
       if (entry.label) {
         this.labelsById.set(entry.targetId, entry.label);

--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -397,6 +397,178 @@ describe("rewriteTranscriptEntriesInSessionFile", () => {
     }
   });
 
+  it("rewrites a guarded side branch and restores the active navigation state", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-transcript-rewrite-side-"));
+    const sessionFile = path.join(dir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-side-rewrite",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: dir,
+        },
+        {
+          type: "message",
+          id: "active-root",
+          parentId: null,
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "user", content: "active root", timestamp: 1 },
+        },
+        {
+          type: "message",
+          id: "side-mirror",
+          parentId: "active-root",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          message: {
+            role: "assistant",
+            content: createTextContent("source reply before rewrite"),
+            timestamp: 2,
+          },
+        },
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "side-mirror",
+          timestamp: "2026-06-15T00:00:03.000Z",
+          targetId: "active-root",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+
+    const result = await rewriteTranscriptEntriesInSessionFile({
+      sessionFile,
+      sessionKey: "agent:main:test",
+      request: {
+        allowedRewriteSuffixEntryIds: ["side-mirror"],
+        replacements: [
+          {
+            entryId: "side-mirror",
+            message: asAppendMessage({
+              role: "assistant",
+              content: createTextContent("source reply after rewrite"),
+              timestamp: 2,
+            }) as AgentMessage,
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({ changed: true, rewrittenEntries: 1 });
+    const records = (await fs.readFile(sessionFile, "utf-8"))
+      .trim()
+      .split("\n")
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            type?: string;
+            id?: string;
+            parentId?: string | null;
+            targetId?: string | null;
+            message?: AgentMessage;
+          },
+      );
+    const rewrittenSideEntry = records.findLast(
+      (entry) =>
+        entry.type === "message" &&
+        JSON.stringify(entry.message).includes("source reply after rewrite"),
+    );
+    expect(rewrittenSideEntry).toMatchObject({ parentId: "active-root" });
+    expect(records.at(-1)).toMatchObject({
+      type: "leaf",
+      parentId: rewrittenSideEntry?.id,
+      targetId: "active-root",
+    });
+
+    const reopened = SessionManager.open(sessionFile, dir, dir);
+    expect(getBranchMessages(reopened).map(getMessageContent)).toEqual(["active root"]);
+    const nextId = reopened.appendMessage(
+      asAppendMessage({ role: "user", content: "active continuation", timestamp: 3 }),
+    );
+    expect(reopened.getEntry(nextId)).toMatchObject({ parentId: "active-root" });
+  });
+
+  it("rejects a rewrite batch split across active and side branches", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-transcript-rewrite-mixed-"));
+    const sessionFile = path.join(dir, "session.jsonl");
+    const records = [
+      {
+        type: "session",
+        version: 3,
+        id: "session-mixed-rewrite",
+        timestamp: "2026-06-15T00:00:00.000Z",
+        cwd: dir,
+      },
+      {
+        type: "message",
+        id: "root",
+        parentId: null,
+        timestamp: "2026-06-15T00:00:01.000Z",
+        message: { role: "user", content: "root", timestamp: 1 },
+      },
+      {
+        type: "message",
+        id: "active-mirror",
+        parentId: "root",
+        timestamp: "2026-06-15T00:00:02.000Z",
+        message: { role: "assistant", content: createTextContent("active"), timestamp: 2 },
+      },
+      {
+        type: "message",
+        id: "side-mirror",
+        parentId: "root",
+        timestamp: "2026-06-15T00:00:03.000Z",
+        message: { role: "assistant", content: createTextContent("side"), timestamp: 3 },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "side-mirror",
+        timestamp: "2026-06-15T00:00:04.000Z",
+        targetId: "active-mirror",
+      },
+    ];
+    const original = records.map((entry) => JSON.stringify(entry)).join("\n") + "\n";
+    await fs.writeFile(sessionFile, original, "utf-8");
+
+    const result = await rewriteTranscriptEntriesInSessionFile({
+      sessionFile,
+      sessionKey: "agent:main:test",
+      request: {
+        allowedRewriteSuffixEntryIds: ["active-mirror", "side-mirror"],
+        replacements: [
+          {
+            entryId: "active-mirror",
+            message: asAppendMessage({
+              role: "assistant",
+              content: createTextContent("active rewritten"),
+              timestamp: 2,
+            }) as AgentMessage,
+          },
+          {
+            entryId: "side-mirror",
+            message: asAppendMessage({
+              role: "assistant",
+              content: createTextContent("side rewritten"),
+              timestamp: 3,
+            }) as AgentMessage,
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({
+      changed: false,
+      reason: "rewrite targets span multiple branches",
+    });
+    expect(await fs.readFile(sessionFile, "utf-8")).toBe(original);
+  });
+
   it("emits transcript updates when the active branch changes without opening a manager", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-transcript-rewrite-"));
     const sessionManager = SessionManager.create(dir, dir);

--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -434,6 +434,8 @@ describe("rewriteTranscriptEntriesInSessionFile", () => {
           parentId: "side-mirror",
           timestamp: "2026-06-15T00:00:03.000Z",
           targetId: "active-root",
+          appendParentId: "side-mirror",
+          appendMode: "side",
         },
       ]
         .map((entry) => JSON.stringify(entry))
@@ -470,6 +472,8 @@ describe("rewriteTranscriptEntriesInSessionFile", () => {
             id?: string;
             parentId?: string | null;
             targetId?: string | null;
+            appendParentId?: string | null;
+            appendMode?: "side";
             message?: AgentMessage;
           },
       );
@@ -483,6 +487,8 @@ describe("rewriteTranscriptEntriesInSessionFile", () => {
       type: "leaf",
       parentId: rewrittenSideEntry?.id,
       targetId: "active-root",
+      appendParentId: "side-mirror",
+      appendMode: "side",
     });
 
     const reopened = SessionManager.open(sessionFile, dir, dir);
@@ -491,6 +497,7 @@ describe("rewriteTranscriptEntriesInSessionFile", () => {
       asAppendMessage({ role: "user", content: "active continuation", timestamp: 3 }),
     );
     expect(reopened.getEntry(nextId)).toMatchObject({ parentId: "active-root" });
+    expect(reopened.getEntry(nextId)).not.toHaveProperty("appendMode");
   });
 
   it("rejects a rewrite batch split across active and side branches", async () => {

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -21,6 +21,7 @@ import {
   persistTranscriptStateMutation,
   readTranscriptFileState,
   type TranscriptFileState,
+  type TranscriptPersistedEntry,
 } from "./transcript-file-state.js";
 import {
   persistRuntimeTranscriptStateMutation,
@@ -261,7 +262,7 @@ export function rewriteTranscriptEntriesInState(params: {
   state: TranscriptFileState;
   replacements: TranscriptRewriteReplacement[];
   allowedRewriteSuffixEntryIds?: string[];
-}): TranscriptRewriteResult & { appendedEntries: SessionBranchEntry[] } {
+}): TranscriptRewriteResult & { appendedEntries: TranscriptPersistedEntry[] } {
   const replacementsById = new Map(
     params.replacements
       .filter((replacement) => replacement.entryId.trim().length > 0)
@@ -277,7 +278,57 @@ export function rewriteTranscriptEntriesInState(params: {
     };
   }
 
-  const branch = params.state.getBranch();
+  const originalLeafId = params.state.getLeafId();
+  const originalAppendParentId = params.state.getAppendParentId();
+  const activeBranch = params.state.getBranch();
+  const allEntries = params.state.getEntries();
+  let branch = activeBranch;
+  let restoreOriginalNavigation = false;
+  const replacementIdsOnBranch = (candidate: readonly SessionBranchEntry[]): Set<string> =>
+    new Set(
+      candidate
+        .filter((entry) => entry.type === "message" && replacementsById.has(entry.id))
+        .map((entry) => entry.id),
+    );
+  const activeReplacementIds = replacementIdsOnBranch(activeBranch);
+  if (activeReplacementIds.size > 0 && activeReplacementIds.size < replacementsById.size) {
+    return {
+      changed: false,
+      bytesFreed: 0,
+      rewrittenEntries: 0,
+      reason: "rewrite targets span multiple branches",
+      appendedEntries: [],
+    };
+  }
+  const activeBranchHasEveryReplacement = activeReplacementIds.size === replacementsById.size;
+  if (!activeBranchHasEveryReplacement && params.allowedRewriteSuffixEntryIds) {
+    const allowedIds = new Set(params.allowedRewriteSuffixEntryIds);
+    const sideBranch = allEntries
+      .toReversed()
+      .filter((entry) => allowedIds.has(entry.id))
+      .map((entry) => params.state.getBranch(entry.id))
+      .find((candidate) => replacementIdsOnBranch(candidate).size === replacementsById.size);
+    if (sideBranch) {
+      branch = sideBranch;
+      restoreOriginalNavigation = true;
+    }
+  }
+  if (
+    !activeBranchHasEveryReplacement &&
+    !restoreOriginalNavigation &&
+    activeReplacementIds.size === 0 &&
+    params.replacements.some((replacement) =>
+      allEntries.some((entry) => entry.id === replacement.entryId),
+    )
+  ) {
+    return {
+      changed: false,
+      bytesFreed: 0,
+      rewrittenEntries: 0,
+      reason: "rewrite targets span multiple branches",
+      appendedEntries: [],
+    };
+  }
   if (branch.length === 0) {
     return {
       changed: false,
@@ -351,7 +402,7 @@ export function rewriteTranscriptEntriesInState(params: {
     params.state.branch(firstMatchedEntry.parentId);
   }
 
-  const appendedEntries: SessionBranchEntry[] = [];
+  const appendedEntries: TranscriptPersistedEntry[] = [];
   const rewrittenEntryIds = new Map<string, string>();
   for (let index = matchedIndices[0]; index < branch.length; index++) {
     const entry = branch[index];
@@ -366,6 +417,14 @@ export function rewriteTranscriptEntriesInState(params: {
         : params.state.appendMessage(replacement);
     rewrittenEntryIds.set(entry.id, newEntry.id);
     appendedEntries.push(newEntry);
+  }
+  if (restoreOriginalNavigation) {
+    appendedEntries.push(
+      params.state.appendLeafControl({
+        targetId: originalLeafId,
+        appendParentId: originalAppendParentId,
+      }),
+    );
   }
 
   return {

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -280,6 +280,7 @@ export function rewriteTranscriptEntriesInState(params: {
 
   const originalLeafId = params.state.getLeafId();
   const originalAppendParentId = params.state.getAppendParentId();
+  const originalAppendMode = params.state.getAppendMode();
   const activeBranch = params.state.getBranch();
   const allEntries = params.state.getEntries();
   let branch = activeBranch;
@@ -423,6 +424,7 @@ export function rewriteTranscriptEntriesInState(params: {
       params.state.appendLeafControl({
         targetId: originalLeafId,
         appendParentId: originalAppendParentId,
+        ...(originalAppendMode ? { appendMode: originalAppendMode } : {}),
       }),
     );
   }

--- a/src/agents/embedded-agent-runner/transcript-runtime-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-runtime-state.ts
@@ -12,6 +12,7 @@ import {
   persistTranscriptStateMutation,
   readTranscriptFileState,
   type TranscriptFileState,
+  type TranscriptPersistedEntry,
   writeTranscriptFileAtomic,
 } from "./transcript-file-state.js";
 
@@ -60,7 +61,7 @@ export async function readRuntimeTranscriptState(
  * Persists an append or migration rewrite for a resolved runtime transcript.
  */
 export async function persistRuntimeTranscriptStateMutation(params: {
-  appendedEntries: SessionEntry[];
+  appendedEntries: TranscriptPersistedEntry[];
   state: TranscriptFileState;
   target: RuntimeTranscriptTarget;
 }): Promise<void> {

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -70,6 +70,7 @@ describe("SessionManager.open", () => {
     const sessionManager = SessionManager.open(sessionFile, dir, "/tmp/task-repo");
 
     expect(sessionManager.getEntries()).toEqual([userEntry, assistantEntry]);
+    expect(sessionManager.getChildren(userEntry.id)).toEqual([assistantEntry]);
     expect(await fs.readFile(sessionFile, "utf8")).toContain("important question");
     expect(await fs.readFile(sessionFile, "utf8")).toContain("important answer");
     await expect(fs.readFile(sessionFile, "utf8")).resolves.not.toBe(originalTranscript);
@@ -1360,6 +1361,263 @@ describe("SessionManager.open", () => {
     expect(sessionManager.getEntries()).toEqual([assistantEntry]);
   });
 
+  it("bridges parent-linked opaque rows without exposing them as session entries", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const userEntry = {
+      type: "message",
+      id: "user-1",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: { role: "user", content: "question" },
+    };
+    const metadata = {
+      type: "metadata",
+      id: "metadata-1",
+      parentId: userEntry.id,
+      payload: { source: "plugin" },
+    };
+    await fs.writeFile(
+      sessionFile,
+      [buildSessionHeader(dir, "session-1"), userEntry, metadata]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    expect(sessionManager.getLeafEntry()).toEqual(userEntry);
+    const assistantId = sessionManager.appendMessage(buildAssistantMessage("answer"));
+    const assistantEntry = sessionManager.getEntry(assistantId);
+
+    expect(assistantEntry).toEqual(expect.objectContaining({ parentId: userEntry.id }));
+    const persistedAssistant = (await fs.readFile(sessionFile, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null })
+      .find((entry) => entry.id === assistantId);
+    expect(persistedAssistant).toEqual(expect.objectContaining({ parentId: metadata.id }));
+    expect(sessionManager.getEntries()).toEqual([userEntry, assistantEntry]);
+    expect(sessionManager.getBranch()).toEqual([
+      userEntry,
+      expect.objectContaining({ id: assistantId, parentId: userEntry.id }),
+    ]);
+    expect(sessionManager.buildSessionContext().messages).toMatchObject([
+      { role: "user", content: "question" },
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+    ]);
+
+    sessionManager.branch(metadata.id);
+    expect(sessionManager.getLeafId()).toBe(userEntry.id);
+    sessionManager.branch(assistantId);
+    const branchedFile = sessionManager.createBranchedSession(assistantId);
+    expect(branchedFile).toBeDefined();
+    expect(
+      SessionManager.open(branchedFile!, dir, dir).buildSessionContext().messages,
+    ).toMatchObject([
+      { role: "user", content: "question" },
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+    ]);
+  });
+
+  it("repairs compaction boundaries that point through opaque rows", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const userEntry = {
+      type: "message",
+      id: "user-1",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: { role: "user", content: "question" },
+    };
+    const metadata = {
+      type: "metadata",
+      id: "metadata-1",
+      parentId: userEntry.id,
+      payload: { source: "plugin" },
+    };
+    const assistantEntry = {
+      type: "message",
+      id: "assistant-1",
+      parentId: metadata.id,
+      timestamp: "2026-06-04T00:00:02.000Z",
+      message: buildAssistantMessage("answer"),
+    };
+    const compactionEntry = {
+      type: "compaction",
+      id: "compaction-1",
+      parentId: assistantEntry.id,
+      timestamp: "2026-06-04T00:00:03.000Z",
+      summary: "summary",
+      firstKeptEntryId: metadata.id,
+      tokensBefore: 200,
+    };
+    await fs.writeFile(
+      sessionFile,
+      [buildSessionHeader(dir, "session-1"), userEntry, metadata, assistantEntry, compactionEntry]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+
+    expect(sessionManager.getEntry(compactionEntry.id)).toEqual(
+      expect.objectContaining({ firstKeptEntryId: userEntry.id }),
+    );
+    expect(sessionManager.buildSessionContext().messages).toMatchObject([
+      { role: "compactionSummary", summary: "summary" },
+      { role: "user", content: "question" },
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+    ]);
+  });
+
+  it("repairs opaque compaction boundaries on the active branch", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const opaqueRoot = { type: "metadata", id: "opaque-root", parentId: null };
+    const branchAUser = {
+      type: "message",
+      id: "branch-a-user",
+      parentId: opaqueRoot.id,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: { role: "user", content: "branch a" },
+    };
+    const branchBUser = {
+      type: "message",
+      id: "branch-b-user",
+      parentId: opaqueRoot.id,
+      timestamp: "2026-06-04T00:00:02.000Z",
+      message: { role: "user", content: "branch b" },
+    };
+    const branchBAssistant = {
+      type: "message",
+      id: "branch-b-assistant",
+      parentId: branchBUser.id,
+      timestamp: "2026-06-04T00:00:03.000Z",
+      message: buildAssistantMessage("branch b answer"),
+    };
+    const compactionEntry = {
+      type: "compaction",
+      id: "compaction-1",
+      parentId: branchBAssistant.id,
+      timestamp: "2026-06-04T00:00:04.000Z",
+      summary: "summary",
+      firstKeptEntryId: opaqueRoot.id,
+      tokensBefore: 200,
+    };
+    await fs.writeFile(
+      sessionFile,
+      [
+        buildSessionHeader(dir, "session-1"),
+        opaqueRoot,
+        branchAUser,
+        branchBUser,
+        branchBAssistant,
+        compactionEntry,
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+
+    expect(sessionManager.getEntry(compactionEntry.id)).toEqual(
+      expect.objectContaining({ firstKeptEntryId: branchBUser.id }),
+    );
+    expect(sessionManager.buildSessionContext().messages).toMatchObject([
+      { role: "compactionSummary", summary: "summary" },
+      { role: "user", content: "branch b" },
+      { role: "assistant", content: [{ type: "text", text: "branch b answer" }] },
+    ]);
+  });
+
+  it("does not use session events as append parents", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const userEntry = {
+      type: "message",
+      id: "user-1",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: { role: "user", content: "question" },
+    };
+    const sessionEvent = {
+      type: "session",
+      id: "event-1",
+      parentId: userEntry.id,
+      sessionId: "external-session-event",
+    };
+    await fs.writeFile(
+      sessionFile,
+      [buildSessionHeader(dir, "session-1"), userEntry, sessionEvent]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    const assistantId = sessionManager.appendMessage(buildAssistantMessage("answer"));
+
+    expect(sessionManager.getEntry(assistantId)).toEqual(
+      expect.objectContaining({ parentId: userEntry.id }),
+    );
+    expect(sessionManager.buildSessionContext().messages).toMatchObject([
+      { role: "user", content: "question" },
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+    ]);
+  });
+
+  it("repairs descendants linked through persisted leaf records", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const rootEntry = {
+      type: "message",
+      id: "root-user",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: { role: "user", content: "root question" },
+    };
+    const abandonedEntry = {
+      type: "message",
+      id: "abandoned-assistant",
+      parentId: rootEntry.id,
+      timestamp: "2026-06-04T00:00:02.000Z",
+      message: buildAssistantMessage("abandoned answer"),
+    };
+    const leafEntry = {
+      type: "leaf",
+      id: "leaf-1",
+      parentId: abandonedEntry.id,
+      timestamp: "2026-06-04T00:00:03.000Z",
+      targetId: rootEntry.id,
+    };
+    const replacementEntry = {
+      type: "message",
+      id: "replacement-assistant",
+      parentId: leafEntry.id,
+      timestamp: "2026-06-04T00:00:04.000Z",
+      message: buildAssistantMessage("replacement answer"),
+    };
+    await fs.writeFile(
+      sessionFile,
+      [buildSessionHeader(dir, "session-1"), rootEntry, abandonedEntry, leafEntry, replacementEntry]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const reopened = SessionManager.open(sessionFile, dir, dir);
+    expect(reopened.getEntry(replacementEntry.id)).toEqual(
+      expect.objectContaining({ parentId: rootEntry.id }),
+    );
+    expect(reopened.buildSessionContext().messages).toMatchObject([
+      { role: "user", content: "root question" },
+      { role: "assistant", content: [{ type: "text", text: "replacement answer" }] },
+    ]);
+  });
+
   it("preserves trailing opaque rows when cleanup removes the preceding entry", async () => {
     const dir = await makeTempDir();
     const sessionManager = SessionManager.create(dir, dir);
@@ -1371,18 +1629,9 @@ describe("SessionManager.open", () => {
       { type: "prompt_released_opaque", record: metadata },
     ]);
 
-    const mutableManager = sessionManager as unknown as {
-      fileEntries: Array<{ id?: string }>;
-      byId: Map<string, unknown>;
-      leafId: string | null;
-      rewriteFile: () => void;
-    };
-    mutableManager.fileEntries.pop();
-    mutableManager.byId.delete(temporaryErrorId);
-    mutableManager.leafId = baseAnswerId;
-    mutableManager.rewriteFile();
+    expect(sessionManager.removeTrailingEntries((entry) => entry.id === temporaryErrorId)).toBe(1);
+    expect(sessionManager.getLeafId()).toBe(baseAnswerId);
     const replacementId = sessionManager.appendMessage(buildAssistantMessage("replacement answer"));
-    mutableManager.rewriteFile();
 
     const sessionFile = sessionManager.getSessionFile();
     expect(sessionFile).toBeDefined();

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -1758,6 +1758,111 @@ describe("SessionManager.open", () => {
     );
   });
 
+  it("persists the active leaf immediately after merging prompt-released side rows", async () => {
+    const dir = await makeTempDir();
+    const sessionManager = SessionManager.create(dir, dir);
+    sessionManager.appendMessage({ role: "user", content: "question", timestamp: 1 });
+    const baseAnswerId = sessionManager.appendMessage(buildAssistantMessage("base answer"));
+    const sideEntry = {
+      type: "message" as const,
+      id: "side-delivery",
+      parentId: baseAnswerId,
+      timestamp: "2026-06-15T00:00:03.000Z",
+      message: buildAssistantMessage("side delivery"),
+    };
+    const sessionFile = sessionManager.getSessionFile();
+    expect(sessionFile).toBeDefined();
+    await fs.appendFile(sessionFile!, `${JSON.stringify(sideEntry)}\n`, "utf8");
+
+    const mergeResult = sessionManager.mergePromptReleasedSessionEntries([sideEntry], {
+      persistLeaf: true,
+    });
+
+    expect(mergeResult?.publishedEntries).toEqual([{ kind: "id", id: expect.any(String) }]);
+    const records = (await fs.readFile(sessionFile!, "utf8"))
+      .trim()
+      .split("\n")
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            type?: string;
+            id?: string;
+            parentId?: string | null;
+            targetId?: string | null;
+            appendParentId?: string | null;
+            appendMode?: string;
+          },
+      );
+    expect(records.at(-1)).toMatchObject({
+      type: "leaf",
+      parentId: sideEntry.id,
+      targetId: baseAnswerId,
+      appendParentId: sideEntry.id,
+      appendMode: "side",
+    });
+
+    const nextSideEntry = {
+      ...sideEntry,
+      id: "next-side-delivery",
+      parentId: records.at(-1)?.appendParentId ?? records.at(-1)?.targetId ?? null,
+      appendMode: "side" as const,
+      timestamp: "2026-06-15T00:00:04.000Z",
+      message: buildAssistantMessage("next side delivery"),
+    };
+    await fs.appendFile(sessionFile!, `${JSON.stringify(nextSideEntry)}\n`, "utf8");
+    sessionManager.mergePromptReleasedSessionEntries([nextSideEntry], {
+      persistLeaf: true,
+    });
+
+    const finalRecords = (await fs.readFile(sessionFile!, "utf8"))
+      .trim()
+      .split("\n")
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            type?: string;
+            id?: string;
+            parentId?: string | null;
+            targetId?: string | null;
+            appendParentId?: string | null;
+            appendMode?: string;
+          },
+      );
+    expect(finalRecords.find((record) => record.id === nextSideEntry.id)?.parentId).toBe(
+      sideEntry.id,
+    );
+    expect(finalRecords.at(-1)).toMatchObject({
+      type: "leaf",
+      parentId: nextSideEntry.id,
+      targetId: baseAnswerId,
+      appendParentId: nextSideEntry.id,
+      appendMode: "side",
+    });
+
+    const reopened = SessionManager.open(sessionFile!, dir, dir);
+    expect(reopened.getLeafId()).toBe(baseAnswerId);
+    expect(JSON.stringify(reopened.buildSessionContext())).not.toContain("side delivery");
+    expect(
+      reopened
+        .getBranch(nextSideEntry.id)
+        .map((entry) => entry.id)
+        .slice(-2),
+    ).toEqual([sideEntry.id, nextSideEntry.id]);
+
+    const nextUserId = reopened.appendMessage({
+      role: "user",
+      content: "next question",
+      timestamp: 3,
+    });
+    expect(
+      reopened
+        .getBranch(nextUserId)
+        .map((entry) => entry.id)
+        .slice(-2),
+    ).toEqual([baseAnswerId, nextUserId]);
+    expect(JSON.stringify(reopened.buildSessionContext())).not.toContain("side delivery");
+  });
+
   it("applies merged leaf controls across separate callbacks", async () => {
     const dir = await makeTempDir();
     const sessionManager = SessionManager.create(dir, dir);

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -1809,8 +1809,9 @@ describe("SessionManager.open", () => {
       timestamp: "2026-06-15T00:00:04.000Z",
       message: buildAssistantMessage("next side delivery"),
     };
+    const reopenedForNextMerge = SessionManager.open(sessionFile!, dir, dir);
     await fs.appendFile(sessionFile!, `${JSON.stringify(nextSideEntry)}\n`, "utf8");
-    sessionManager.mergePromptReleasedSessionEntries([nextSideEntry], {
+    reopenedForNextMerge.mergePromptReleasedSessionEntries([nextSideEntry], {
       persistLeaf: true,
     });
 
@@ -1832,10 +1833,9 @@ describe("SessionManager.open", () => {
       sideEntry.id,
     );
     expect(finalRecords.at(-1)).toMatchObject({
-      type: "leaf",
-      parentId: nextSideEntry.id,
-      targetId: baseAnswerId,
-      appendParentId: nextSideEntry.id,
+      type: "message",
+      id: nextSideEntry.id,
+      parentId: sideEntry.id,
       appendMode: "side",
     });
 

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
+import { isTranscriptOnlyOpenClawAssistantMessage } from "../../shared/transcript-only-openclaw-assistant.js";
 import { prepareSessionManagerForRun } from "../embedded-agent-runner/session-manager-init.js";
 import { repairSessionFileIfNeeded } from "../session-file-repair.js";
 import {
@@ -1630,12 +1631,41 @@ describe("SessionManager.open", () => {
     sessionManager.appendMessage({ role: "user", content: "question", timestamp: 1 });
     const baseAnswerId = sessionManager.appendMessage(buildAssistantMessage("base answer"));
     const temporaryErrorId = sessionManager.appendMessage(buildAssistantMessage("temporary error"));
-    const metadata = { type: "metadata", payload: { source: "plugin" } };
+    const opaqueMetadata = { type: "metadata", payload: { source: "plugin" } };
+    const globalMetadata = {
+      type: "custom" as const,
+      id: "plugin-state",
+      parentId: temporaryErrorId,
+      timestamp: "2026-06-04T00:00:04.000Z",
+      customType: "plugin-state",
+      data: { source: "plugin" },
+    };
+    const deliveryEntry = {
+      type: "message" as const,
+      id: "delivery-mirror",
+      parentId: globalMetadata.id,
+      timestamp: "2026-06-04T00:00:05.000Z",
+      message: {
+        ...buildAssistantMessage("mirrored delivery"),
+        provider: "openclaw",
+        model: "delivery-mirror",
+      },
+    };
     sessionManager.mergePromptReleasedSessionEntries([
-      { type: "prompt_released_opaque", record: metadata },
+      { type: "prompt_released_opaque", record: opaqueMetadata },
+      globalMetadata,
+      deliveryEntry,
     ]);
 
-    expect(sessionManager.removeTrailingEntries((entry) => entry.id === temporaryErrorId)).toBe(1);
+    expect(
+      sessionManager.removeTrailingEntries((entry) => entry.id === temporaryErrorId, {
+        preserveTrailing: (entry) =>
+          entry.type === "custom" ||
+          entry.type === "label" ||
+          entry.type === "session_info" ||
+          (entry.type === "message" && isTranscriptOnlyOpenClawAssistantMessage(entry.message)),
+      }),
+    ).toBe(1);
     expect(sessionManager.getLeafId()).toBe(baseAnswerId);
     const replacementId = sessionManager.appendMessage(buildAssistantMessage("replacement answer"));
 
@@ -1644,19 +1674,19 @@ describe("SessionManager.open", () => {
     const records = (await fs.readFile(sessionFile!, "utf8"))
       .trim()
       .split("\n")
-      .map((line) => JSON.parse(line) as unknown);
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
     const metadataIndex = records.findIndex(
-      (record) => JSON.stringify(record) === JSON.stringify(metadata),
+      (record) => JSON.stringify(record) === JSON.stringify(opaqueMetadata),
     );
-    const replacementIndex = records.findIndex(
-      (record) =>
-        typeof record === "object" &&
-        record !== null &&
-        "id" in record &&
-        record.id === replacementId,
-    );
+    const globalMetadataIndex = records.findIndex((record) => record.id === globalMetadata.id);
+    const deliveryIndex = records.findIndex((record) => record.id === deliveryEntry.id);
+    const replacementIndex = records.findIndex((record) => record.id === replacementId);
     expect(metadataIndex).toBeGreaterThan(-1);
-    expect(replacementIndex).toBeGreaterThan(metadataIndex);
+    expect(globalMetadataIndex).toBeGreaterThan(metadataIndex);
+    expect(deliveryIndex).toBeGreaterThan(globalMetadataIndex);
+    expect(replacementIndex).toBeGreaterThan(deliveryIndex);
+    expect(records[globalMetadataIndex]?.parentId).toBe(baseAnswerId);
+    expect(records[deliveryIndex]?.parentId).toBe(globalMetadata.id);
     expect(SessionManager.open(sessionFile!, dir, dir).buildSessionContext().messages).toHaveLength(
       3,
     );

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -1662,6 +1662,114 @@ describe("SessionManager.open", () => {
     );
   });
 
+  it("keeps merged messages downstream of parent-linked opaque events", async () => {
+    const dir = await makeTempDir();
+    const sessionManager = SessionManager.create(dir, dir);
+    sessionManager.appendMessage({ role: "user", content: "question", timestamp: 1 });
+    const baseAnswerId = sessionManager.appendMessage(buildAssistantMessage("base answer"));
+    const metadata = {
+      type: "metadata",
+      id: "plugin-metadata",
+      parentId: baseAnswerId,
+      payload: { source: "plugin" },
+    };
+    const deliveryEntry = {
+      type: "message" as const,
+      id: "plugin-delivery",
+      parentId: baseAnswerId,
+      timestamp: "2026-06-04T00:00:03.000Z",
+      message: buildAssistantMessage("plugin delivery"),
+    };
+
+    sessionManager.mergePromptReleasedSessionEntries([
+      { type: "prompt_released_opaque", record: metadata },
+    ]);
+    sessionManager.mergePromptReleasedSessionEntries([deliveryEntry]);
+    (
+      sessionManager as unknown as {
+        rewriteFile: () => void;
+      }
+    ).rewriteFile();
+
+    const sessionFile = sessionManager.getSessionFile();
+    expect(sessionFile).toBeDefined();
+    const records = (await fs.readFile(sessionFile!, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null });
+    expect(records.find((record) => record.id === deliveryEntry.id)?.parentId).toBe(metadata.id);
+
+    const reopened = SessionManager.open(sessionFile!, dir, dir);
+    expect(reopened.getBranch(deliveryEntry.id).map((entry) => entry.id)).toEqual([
+      expect.any(String),
+      baseAnswerId,
+      deliveryEntry.id,
+    ]);
+    const branchedFile = reopened.createBranchedSession(deliveryEntry.id);
+    expect(branchedFile).toBeDefined();
+    const branchedRecords = (await fs.readFile(branchedFile!, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null });
+    expect(branchedRecords).toContainEqual(metadata);
+    expect(branchedRecords.find((record) => record.id === deliveryEntry.id)?.parentId).toBe(
+      metadata.id,
+    );
+  });
+
+  it("applies merged leaf controls across separate callbacks", async () => {
+    const dir = await makeTempDir();
+    const sessionManager = SessionManager.create(dir, dir);
+    sessionManager.appendMessage({ role: "user", content: "question", timestamp: 1 });
+    const baseAnswerId = sessionManager.appendMessage(buildAssistantMessage("base answer"));
+    const metadata = {
+      type: "metadata",
+      id: "plugin-metadata",
+      parentId: baseAnswerId,
+      payload: { source: "plugin" },
+    };
+    const leafEntry = {
+      type: "leaf",
+      id: "plugin-leaf",
+      parentId: metadata.id,
+      timestamp: "2026-06-04T00:00:03.000Z",
+      targetId: baseAnswerId,
+    };
+    const deliveryEntry = {
+      type: "message" as const,
+      id: "plugin-delivery",
+      parentId: leafEntry.id,
+      timestamp: "2026-06-04T00:00:04.000Z",
+      message: buildAssistantMessage("plugin delivery"),
+    };
+
+    sessionManager.mergePromptReleasedSessionEntries([
+      { type: "prompt_released_opaque", record: metadata },
+    ]);
+    sessionManager.mergePromptReleasedSessionEntries([
+      { type: "prompt_released_opaque", record: leafEntry },
+    ]);
+    sessionManager.mergePromptReleasedSessionEntries([deliveryEntry]);
+    (
+      sessionManager as unknown as {
+        rewriteFile: () => void;
+      }
+    ).rewriteFile();
+
+    const sessionFile = sessionManager.getSessionFile();
+    expect(sessionFile).toBeDefined();
+    const records = (await fs.readFile(sessionFile!, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null });
+    expect(records.find((record) => record.id === deliveryEntry.id)?.parentId).toBe(baseAnswerId);
+    expect(
+      SessionManager.open(sessionFile!, dir, dir)
+        .getBranch(deliveryEntry.id)
+        .map((entry) => entry.id),
+    ).toEqual([expect.any(String), baseAnswerId, deliveryEntry.id]);
+  });
+
   it("removes leaf controls that target regenerated labels when branching", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "session.jsonl");

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -1896,6 +1896,47 @@ describe("SessionManager.open", () => {
     });
   });
 
+  it("reopens parentless canonical rows as one visible branch", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        buildSessionHeader(dir, "session-1"),
+        {
+          type: "message",
+          id: "user-1",
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "user", content: "question", timestamp: 1 },
+        },
+        {
+          type: "message",
+          id: "assistant-1",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          message: buildAssistantMessage("answer"),
+        },
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "assistant-1",
+          timestamp: "2026-06-15T00:00:03.000Z",
+          targetId: "assistant-1",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const reopened = SessionManager.open(sessionFile, dir, dir);
+
+    expect(reopened.getBranch().map((entry) => entry.id)).toEqual(["user-1", "assistant-1"]);
+    expect(reopened.buildSessionContext().messages).toMatchObject([
+      { role: "user", content: "question" },
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+    ]);
+  });
+
   it("ignores persisted leaf controls with dangling references", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "session.jsonl");

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -1726,10 +1726,21 @@ describe("SessionManager.open", () => {
     const records = (await fs.readFile(sessionFile!, "utf8"))
       .trim()
       .split("\n")
-      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null });
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            type?: string;
+            id?: string;
+            parentId?: string | null;
+            targetId?: string | null;
+          },
+      );
     expect(records.find((record) => record.id === deliveryEntry.id)?.parentId).toBe(metadata.id);
+    expect(records.at(-1)).toMatchObject({ type: "leaf", targetId: baseAnswerId });
 
     const reopened = SessionManager.open(sessionFile!, dir, dir);
+    expect(reopened.getLeafId()).toBe(baseAnswerId);
+    expect(JSON.stringify(reopened.buildSessionContext())).not.toContain("plugin delivery");
     expect(reopened.getBranch(deliveryEntry.id).map((entry) => entry.id)).toEqual([
       expect.any(String),
       baseAnswerId,
@@ -1791,13 +1802,216 @@ describe("SessionManager.open", () => {
     const records = (await fs.readFile(sessionFile!, "utf8"))
       .trim()
       .split("\n")
-      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null });
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            type?: string;
+            id?: string;
+            parentId?: string | null;
+            targetId?: string | null;
+          },
+      );
     expect(records.find((record) => record.id === deliveryEntry.id)?.parentId).toBe(baseAnswerId);
-    expect(
-      SessionManager.open(sessionFile!, dir, dir)
-        .getBranch(deliveryEntry.id)
-        .map((entry) => entry.id),
-    ).toEqual([expect.any(String), baseAnswerId, deliveryEntry.id]);
+    expect(records.at(-1)).toMatchObject({ type: "leaf", targetId: baseAnswerId });
+    const reopened = SessionManager.open(sessionFile!, dir, dir);
+    expect(reopened.getLeafId()).toBe(baseAnswerId);
+    expect(JSON.stringify(reopened.buildSessionContext())).not.toContain("plugin delivery");
+    expect(reopened.getBranch(deliveryEntry.id).map((entry) => entry.id)).toEqual([
+      expect.any(String),
+      baseAnswerId,
+      deliveryEntry.id,
+    ]);
+  });
+
+  it("round-trips a visible leaf with a distinct opaque append parent", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const baseAnswer = {
+      type: "message",
+      id: "base-answer",
+      parentId: null,
+      timestamp: "2026-06-15T00:00:01.000Z",
+      message: buildAssistantMessage("base answer"),
+    };
+    const metadata = {
+      type: "metadata",
+      id: "plugin-metadata",
+      parentId: null,
+      payload: { source: "plugin" },
+    };
+    await fs.writeFile(
+      sessionFile,
+      [buildSessionHeader(dir, "session-1"), baseAnswer, metadata]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    sessionManager.mergePromptReleasedSessionEntries([
+      {
+        type: "message",
+        id: "side-delivery",
+        parentId: baseAnswer.id,
+        timestamp: "2026-06-15T00:00:02.000Z",
+        message: buildAssistantMessage("side delivery"),
+      },
+    ]);
+    (
+      sessionManager as unknown as {
+        rewriteFile: () => void;
+      }
+    ).rewriteFile();
+
+    const rewritten = (await fs.readFile(sessionFile, "utf-8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(rewritten.at(-1)).toMatchObject({
+      type: "leaf",
+      targetId: baseAnswer.id,
+      appendParentId: metadata.id,
+    });
+
+    const reopened = SessionManager.open(sessionFile, dir, dir);
+    expect(reopened.getLeafId()).toBe(baseAnswer.id);
+    const nextId = reopened.appendMessage(buildAssistantMessage("active continuation"));
+    const records = (await fs.readFile(sessionFile, "utf-8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null });
+    expect(records.find((entry) => entry.id === nextId)?.parentId).toBe(metadata.id);
+    expect(reopened.getBranch(nextId).map((entry) => entry.id)).toEqual([baseAnswer.id, nextId]);
+    const branchedFile = reopened.createBranchedSession(nextId);
+    expect(branchedFile).toBeDefined();
+    const branchedRecords = (await fs.readFile(branchedFile!, "utf-8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null });
+    expect(branchedRecords.find((entry) => entry.id === metadata.id)).toMatchObject({
+      parentId: baseAnswer.id,
+    });
+    expect(branchedRecords.find((entry) => entry.id === nextId)).toMatchObject({
+      parentId: metadata.id,
+    });
+  });
+
+  it("ignores persisted leaf controls with dangling references", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        buildSessionHeader(dir, "session-1"),
+        {
+          type: "message",
+          id: "active-root",
+          parentId: null,
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: buildAssistantMessage("active"),
+        },
+        {
+          type: "metadata",
+          id: "plugin-metadata",
+          parentId: "active-root",
+          payload: { source: "plugin" },
+        },
+        {
+          type: "leaf",
+          id: "missing-target",
+          parentId: "plugin-metadata",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          targetId: "missing",
+        },
+        {
+          type: "leaf",
+          id: "missing-append",
+          parentId: "missing-target",
+          timestamp: "2026-06-15T00:00:03.000Z",
+          targetId: "active-root",
+          appendParentId: "missing",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+
+    const reopened = SessionManager.open(sessionFile, dir, dir);
+    expect(reopened.getLeafId()).toBe("active-root");
+    const nextId = reopened.appendMessage(buildAssistantMessage("continued"));
+    const records = (await fs.readFile(sessionFile, "utf-8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null });
+    expect(records.find((entry) => entry.id === nextId)?.parentId).toBe("plugin-metadata");
+    expect(reopened.buildSessionContext().messages).toMatchObject([
+      { role: "assistant", content: [{ type: "text", text: "active" }] },
+      { role: "assistant", content: [{ type: "text", text: "continued" }] },
+    ]);
+  });
+
+  it("ignores dangling leaf controls merged while a prompt is released", async () => {
+    const dir = await makeTempDir();
+    const sessionManager = SessionManager.create(dir, dir);
+    const baseAnswerId = sessionManager.appendMessage(buildAssistantMessage("base answer"));
+    const metadata = {
+      type: "metadata",
+      id: "plugin-metadata",
+      parentId: baseAnswerId,
+      payload: { source: "plugin" },
+    };
+    sessionManager.mergePromptReleasedSessionEntries([
+      { type: "prompt_released_opaque", record: metadata },
+    ]);
+    sessionManager.mergePromptReleasedSessionEntries([
+      {
+        type: "prompt_released_opaque",
+        record: {
+          type: "leaf",
+          id: "missing-target",
+          parentId: metadata.id,
+          timestamp: "2026-06-15T00:00:02.000Z",
+          targetId: "missing",
+        },
+      },
+    ]);
+    sessionManager.mergePromptReleasedSessionEntries([
+      {
+        type: "prompt_released_opaque",
+        record: {
+          type: "leaf",
+          id: "missing-append",
+          parentId: "missing-target",
+          timestamp: "2026-06-15T00:00:03.000Z",
+          targetId: baseAnswerId,
+          appendParentId: "missing",
+        },
+      },
+    ]);
+    sessionManager.mergePromptReleasedSessionEntries([
+      {
+        type: "message",
+        id: "side-delivery",
+        parentId: baseAnswerId,
+        timestamp: "2026-06-15T00:00:04.000Z",
+        message: buildAssistantMessage("side delivery"),
+      },
+    ]);
+    (
+      sessionManager as unknown as {
+        rewriteFile: () => void;
+      }
+    ).rewriteFile();
+
+    expect(sessionManager.getLeafId()).toBe(baseAnswerId);
+    const sessionFile = sessionManager.getSessionFile();
+    expect(sessionFile).toBeDefined();
+    const records = (await fs.readFile(sessionFile!, "utf-8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null });
+    expect(records.find((entry) => entry.id === "side-delivery")?.parentId).toBe(metadata.id);
   });
 
   it("removes leaf controls that target regenerated labels when branching", async () => {

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -1322,6 +1322,91 @@ describe("SessionManager.open", () => {
     }
   });
 
+  it("preserves opaque transcript rows during embedded header normalization", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const metadata = { type: "metadata", payload: { source: "plugin" } };
+    const assistantEntry = {
+      type: "message",
+      id: "assistant-1",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: { role: "assistant", content: "carried context" },
+    };
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify(buildSessionHeader(dir, "original-session")),
+        JSON.stringify(metadata),
+        JSON.stringify(assistantEntry),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    await prepareSessionManagerForRun({
+      sessionManager,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "run-session",
+      cwd: "/tmp/task-repo",
+    });
+
+    const records = (await fs.readFile(sessionFile, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as unknown);
+    expect(records).toContainEqual(metadata);
+    expect(sessionManager.getEntries()).toEqual([assistantEntry]);
+  });
+
+  it("preserves trailing opaque rows when cleanup removes the preceding entry", async () => {
+    const dir = await makeTempDir();
+    const sessionManager = SessionManager.create(dir, dir);
+    sessionManager.appendMessage({ role: "user", content: "question", timestamp: 1 });
+    const baseAnswerId = sessionManager.appendMessage(buildAssistantMessage("base answer"));
+    const temporaryErrorId = sessionManager.appendMessage(buildAssistantMessage("temporary error"));
+    const metadata = { type: "metadata", payload: { source: "plugin" } };
+    sessionManager.mergePromptReleasedSessionEntries([
+      { type: "prompt_released_opaque", record: metadata },
+    ]);
+
+    const mutableManager = sessionManager as unknown as {
+      fileEntries: Array<{ id?: string }>;
+      byId: Map<string, unknown>;
+      leafId: string | null;
+      rewriteFile: () => void;
+    };
+    mutableManager.fileEntries.pop();
+    mutableManager.byId.delete(temporaryErrorId);
+    mutableManager.leafId = baseAnswerId;
+    mutableManager.rewriteFile();
+    const replacementId = sessionManager.appendMessage(buildAssistantMessage("replacement answer"));
+    mutableManager.rewriteFile();
+
+    const sessionFile = sessionManager.getSessionFile();
+    expect(sessionFile).toBeDefined();
+    const records = (await fs.readFile(sessionFile!, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as unknown);
+    const metadataIndex = records.findIndex(
+      (record) => JSON.stringify(record) === JSON.stringify(metadata),
+    );
+    const replacementIndex = records.findIndex(
+      (record) =>
+        typeof record === "object" &&
+        record !== null &&
+        "id" in record &&
+        record.id === replacementId,
+    );
+    expect(metadataIndex).toBeGreaterThan(-1);
+    expect(replacementIndex).toBeGreaterThan(metadataIndex);
+    expect(SessionManager.open(sessionFile!, dir, dir).buildSessionContext().messages).toHaveLength(
+      3,
+    );
+  });
+
   it("keeps the warm cache after prepareSessionManagerForRun rewrites then appends", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "session.jsonl");

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -1412,6 +1412,12 @@ describe("SessionManager.open", () => {
     sessionManager.branch(assistantId);
     const branchedFile = sessionManager.createBranchedSession(assistantId);
     expect(branchedFile).toBeDefined();
+    const branchedRecords = (await fs.readFile(branchedFile!, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null });
+    expect(branchedRecords).toContainEqual(metadata);
+    expect(branchedRecords.find((record) => record.id === assistantId)?.parentId).toBe(metadata.id);
     expect(
       SessionManager.open(branchedFile!, dir, dir).buildSessionContext().messages,
     ).toMatchObject([
@@ -1654,6 +1660,87 @@ describe("SessionManager.open", () => {
     expect(SessionManager.open(sessionFile!, dir, dir).buildSessionContext().messages).toHaveLength(
       3,
     );
+  });
+
+  it("removes leaf controls that target regenerated labels when branching", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const rootEntry = {
+      type: "message",
+      id: "root-user",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: { role: "user", content: "root question" },
+    };
+    const labelEntry = {
+      type: "label",
+      id: "label-1",
+      parentId: rootEntry.id,
+      timestamp: "2026-06-04T00:00:02.000Z",
+      targetId: rootEntry.id,
+      label: "selected",
+    };
+    const abandonedEntry = {
+      type: "message",
+      id: "abandoned-assistant",
+      parentId: labelEntry.id,
+      timestamp: "2026-06-04T00:00:03.000Z",
+      message: buildAssistantMessage("abandoned answer"),
+    };
+    const leafEntry = {
+      type: "leaf",
+      id: "leaf-1",
+      parentId: abandonedEntry.id,
+      timestamp: "2026-06-04T00:00:04.000Z",
+      targetId: labelEntry.id,
+    };
+    const replacementEntry = {
+      type: "message",
+      id: "replacement-assistant",
+      parentId: leafEntry.id,
+      timestamp: "2026-06-04T00:00:05.000Z",
+      message: buildAssistantMessage("replacement answer"),
+    };
+    await fs.writeFile(
+      sessionFile,
+      [
+        buildSessionHeader(dir, "session-1"),
+        rootEntry,
+        labelEntry,
+        abandonedEntry,
+        leafEntry,
+        replacementEntry,
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    const branchedFile = sessionManager.createBranchedSession(replacementEntry.id);
+    expect(branchedFile).toBeDefined();
+    const branchedRecords = (await fs.readFile(branchedFile!, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(branchedRecords.some((record) => record.type === "leaf")).toBe(false);
+    expect(branchedRecords.find((record) => record.id === replacementEntry.id)?.parentId).toBe(
+      rootEntry.id,
+    );
+    expect(branchedRecords).toContainEqual(
+      expect.objectContaining({
+        type: "label",
+        targetId: rootEntry.id,
+        label: labelEntry.label,
+      }),
+    );
+    expect(
+      SessionManager.open(branchedFile!, dir, dir).buildSessionContext().messages,
+    ).toMatchObject([
+      { role: "user", content: "root question" },
+      { role: "assistant", content: [{ type: "text", text: "replacement answer" }] },
+    ]);
   });
 
   it("keeps the warm cache after prepareSessionManagerForRun rewrites then appends", async () => {

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -1619,6 +1619,8 @@ export class SessionManager {
           this.opaqueParentsById.set(leafEntry.id, leafState.leafId);
           this.leafId = leafState.leafId;
           this.appendParentId = leafState.appendParentId;
+          this.promptReleasedSideBranchParentId =
+            leafState.appendMode === "side" ? leafState.appendParentId : undefined;
           opaqueIndex += 1;
           continue;
         }
@@ -1626,6 +1628,9 @@ export class SessionManager {
         if (link) {
           this.opaqueParentsById.set(link.id, link.parentId);
           this.appendParentId = link.id;
+          if (this.promptReleasedSideBranchParentId !== undefined) {
+            this.promptReleasedSideBranchParentId = link.id;
+          }
         }
         opaqueIndex += 1;
       }
@@ -1643,8 +1648,13 @@ export class SessionManager {
         this.logicalParentsById.set(entry.id, this.leafId);
       }
       this.byId.set(entry.id, entry);
-      this.leafId = entry.id;
       this.appendParentId = entry.id;
+      if (isSessionTranscriptSideAppendEntry(entry)) {
+        this.promptReleasedSideBranchParentId = entry.id;
+      } else {
+        this.leafId = entry.id;
+        this.promptReleasedSideBranchParentId = undefined;
+      }
       if (entry.type === "label") {
         if (entry.label) {
           this.labelsById.set(entry.targetId, entry.label);
@@ -2133,7 +2143,8 @@ export class SessionManager {
         : this.promptReleasedSideBranchParentId;
     let persistedLeafId = this.leafId;
     let persistedAppendParentId = this.appendParentId;
-    let persistedAppendMode: "active" | "side" = "active";
+    let persistedAppendMode: "active" | "side" =
+      this.promptReleasedSideBranchParentId === undefined ? "active" : "side";
     let sawPersistedStateUpdate = false;
     let rawTailId: string | null = null;
     for (const sourceEntry of entries) {
@@ -2185,9 +2196,13 @@ export class SessionManager {
       this.fileEntries.push(entry);
       this.byId.set(entry.id, entry);
       sideBranchParentId = entry.id;
-      persistedLeafId = entry.id;
       persistedAppendParentId = entry.id;
-      persistedAppendMode = "active";
+      if (isSessionTranscriptSideAppendEntry(entry)) {
+        persistedAppendMode = "side";
+      } else {
+        persistedLeafId = entry.id;
+        persistedAppendMode = "active";
+      }
       sawPersistedStateUpdate = true;
       rawTailId = entry.id;
       if (entry.type === "label") {

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -980,6 +980,38 @@ type PreservedOpaqueFileEntry = {
   record: unknown;
 };
 
+function parseParentLinkedOpaqueEntry(
+  record: unknown,
+): { id: string; parentId: string | null } | undefined {
+  if (
+    !isJsonRecord(record) ||
+    record.type === "session" ||
+    record.type === "leaf" ||
+    typeof record.id !== "string" ||
+    record.id.length === 0 ||
+    (record.parentId !== null && typeof record.parentId !== "string")
+  ) {
+    return undefined;
+  }
+  return { id: record.id, parentId: record.parentId };
+}
+
+function parseOpaqueLeafEntry(
+  record: unknown,
+): { id: string; targetId: string | null } | undefined {
+  if (
+    !isJsonRecord(record) ||
+    record.type !== "leaf" ||
+    typeof record.id !== "string" ||
+    record.id.length === 0
+  ) {
+    return undefined;
+  }
+  return record.targetId === null || typeof record.targetId === "string"
+    ? { id: record.id, targetId: record.targetId }
+    : undefined;
+}
+
 function partitionSessionFileEntries(entries: readonly FileEntry[]): {
   fileEntries: FileEntry[];
   opaqueEntries: PreservedOpaqueFileEntry[];
@@ -1331,9 +1363,11 @@ export class SessionManager {
   private fileEntries: FileEntry[] = [];
   private opaqueFileEntries: PreservedOpaqueFileEntry[] = [];
   private byId: Map<string, SessionEntry> = new Map();
+  private opaqueParentsById: Map<string, string | null> = new Map();
   private labelsById: Map<string, string> = new Map();
   private labelTimestampsById: Map<string, string> = new Map();
   private leafId: string | null = null;
+  private appendParentId: string | null = null;
   private recoveredCorruptHeader = false;
   private sessionFileSnapshot: SessionFileSnapshot | undefined;
 
@@ -1443,8 +1477,10 @@ export class SessionManager {
     this.fileEntries = [header];
     this.opaqueFileEntries = [];
     this.byId.clear();
+    this.opaqueParentsById.clear();
     this.labelsById.clear();
     this.leafId = null;
+    this.appendParentId = null;
     this.flushed = false;
 
     if (this.shouldPersist) {
@@ -1456,15 +1492,43 @@ export class SessionManager {
 
   private buildIndex(): void {
     this.byId.clear();
+    this.opaqueParentsById.clear();
     this.labelsById.clear();
     this.labelTimestampsById.clear();
     this.leafId = null;
-    for (const entry of this.fileEntries) {
+    this.appendParentId = null;
+    let opaqueIndex = 0;
+    for (let index = 0; index <= this.fileEntries.length; index += 1) {
+      while (this.opaqueFileEntries[opaqueIndex]?.index === index) {
+        const opaqueRecord = this.opaqueFileEntries[opaqueIndex]?.record;
+        const leafEntry = parseOpaqueLeafEntry(opaqueRecord);
+        if (leafEntry) {
+          const canonicalLeafId =
+            leafEntry.targetId === null
+              ? null
+              : this.byId.has(leafEntry.targetId)
+                ? leafEntry.targetId
+                : this.resolveCanonicalParentId(leafEntry.targetId);
+          this.opaqueParentsById.set(leafEntry.id, canonicalLeafId);
+          this.leafId = canonicalLeafId;
+          this.appendParentId = canonicalLeafId;
+          opaqueIndex += 1;
+          continue;
+        }
+        const link = parseParentLinkedOpaqueEntry(opaqueRecord);
+        if (link) {
+          this.opaqueParentsById.set(link.id, link.parentId);
+          this.appendParentId = link.id;
+        }
+        opaqueIndex += 1;
+      }
+      const entry = this.fileEntries[index];
       if (!isIndexedSessionEntry(entry)) {
         continue;
       }
       this.byId.set(entry.id, entry);
       this.leafId = entry.id;
+      this.appendParentId = entry.id;
       if (entry.type === "label") {
         if (entry.label) {
           this.labelsById.set(entry.targetId, entry.label);
@@ -1477,10 +1541,95 @@ export class SessionManager {
     }
   }
 
-  private getPersistedFileEntries(): unknown[] {
-    // Tail cleanup removes canonical entries before rewriting. Clamp opaque
-    // anchors now so later appends stay after records that the rewrite moved
-    // to the new tail instead of crossing them on the next full rewrite.
+  private resolveCanonicalParentId(parentId: string | null): string | null {
+    const seen = new Set<string>();
+    let currentId = parentId;
+    while (currentId && !this.byId.has(currentId)) {
+      if (seen.has(currentId)) {
+        return null;
+      }
+      seen.add(currentId);
+      currentId = this.opaqueParentsById.get(currentId) ?? null;
+    }
+    return currentId;
+  }
+
+  private normalizeEntryParent(entry: SessionEntry): SessionEntry {
+    const parentId = this.resolveCanonicalParentId(entry.parentId);
+    let normalized = parentId === entry.parentId ? entry : { ...entry, parentId };
+    if (
+      normalized.type === "compaction" &&
+      !this.byId.has(normalized.firstKeptEntryId) &&
+      this.opaqueParentsById.has(normalized.firstKeptEntryId)
+    ) {
+      const resolvedFirstKeptParent = this.resolveCanonicalParentId(normalized.firstKeptEntryId);
+      const firstKeptEntryId =
+        resolvedFirstKeptParent ??
+        this.findFirstCanonicalDescendantOnBranch(
+          normalized.firstKeptEntryId,
+          normalized.parentId,
+        ) ??
+        this.findFirstCanonicalDescendant(normalized.firstKeptEntryId) ??
+        parentId;
+      if (firstKeptEntryId && firstKeptEntryId !== normalized.firstKeptEntryId) {
+        normalized = { ...normalized, firstKeptEntryId };
+      }
+    }
+    return normalized;
+  }
+
+  private findFirstCanonicalDescendantOnBranch(
+    opaqueId: string,
+    leafId: string | null,
+  ): string | undefined {
+    const seen = new Set<string>();
+    let currentId = leafId;
+    let firstCanonicalDescendant: string | undefined;
+    while (currentId && !seen.has(currentId)) {
+      if (currentId === opaqueId) {
+        return firstCanonicalDescendant;
+      }
+      seen.add(currentId);
+      const entry = this.byId.get(currentId);
+      if (entry) {
+        firstCanonicalDescendant = entry.id;
+        currentId = entry.parentId;
+      } else {
+        currentId = this.opaqueParentsById.get(currentId) ?? null;
+      }
+    }
+    return undefined;
+  }
+
+  private findFirstCanonicalDescendant(opaqueId: string): string | undefined {
+    for (const entry of this.fileEntries) {
+      if (!isIndexedSessionEntry(entry)) {
+        continue;
+      }
+      const seen = new Set<string>();
+      let parentId = entry.parentId;
+      while (parentId && this.opaqueParentsById.has(parentId) && !seen.has(parentId)) {
+        if (parentId === opaqueId) {
+          return entry.id;
+        }
+        seen.add(parentId);
+        parentId = this.opaqueParentsById.get(parentId) ?? null;
+      }
+    }
+    return undefined;
+  }
+
+  private resolveBranchTargetId(branchFromId: string): string | null | undefined {
+    if (this.byId.has(branchFromId)) {
+      return branchFromId;
+    }
+    if (!this.opaqueParentsById.has(branchFromId)) {
+      return undefined;
+    }
+    return this.resolveCanonicalParentId(branchFromId);
+  }
+
+  private clampOpaqueFileEntryIndexes(): void {
     let previousOpaqueIndex = 0;
     for (const opaqueEntry of this.opaqueFileEntries) {
       opaqueEntry.index = Math.max(
@@ -1489,6 +1638,13 @@ export class SessionManager {
       );
       previousOpaqueIndex = opaqueEntry.index;
     }
+  }
+
+  private getPersistedFileEntries(): unknown[] {
+    // Tail cleanup removes canonical entries before rewriting. Clamp opaque
+    // anchors now so later appends stay after records that the rewrite moved
+    // to the new tail instead of crossing them on the next full rewrite.
+    this.clampOpaqueFileEntryIndexes();
 
     const entries: unknown[] = [];
     let opaqueIndex = 0;
@@ -1515,6 +1671,8 @@ export class SessionManager {
 
   clearPreservedOpaqueFileEntries(): void {
     this.opaqueFileEntries = [];
+    this.opaqueParentsById.clear();
+    this.appendParentId = null;
   }
 
   private writeFullFile(): string {
@@ -1558,6 +1716,35 @@ export class SessionManager {
 
   getSessionFile(): string | undefined {
     return this.sessionFile;
+  }
+
+  /**
+   * Remove matching entries from the canonical tail and rewrite once.
+   * Opaque records stay in file order, while the next append keeps the raw
+   * parent of the oldest removed entry so branch/control links remain intact.
+   */
+  removeTrailingEntries(predicate: (entry: SessionEntry) => boolean): number {
+    let removedParentId: string | null | undefined;
+    let removedCount = 0;
+    while (this.fileEntries.length > 1) {
+      const entry = this.fileEntries.at(-1);
+      if (!isIndexedSessionEntry(entry) || !predicate(entry)) {
+        break;
+      }
+      this.fileEntries.pop();
+      removedParentId = entry.parentId;
+      removedCount += 1;
+    }
+    if (removedCount === 0) {
+      return 0;
+    }
+
+    this.clampOpaqueFileEntryIndexes();
+    this.buildIndex();
+    this.leafId = this.resolveCanonicalParentId(removedParentId ?? null);
+    this.appendParentId = removedParentId ?? null;
+    this.rewriteFile();
+    return removedCount;
   }
 
   persist(entry: SessionEntry, options?: AppendPersistenceOptions): void {
@@ -1652,6 +1839,10 @@ export class SessionManager {
           index: this.fileEntries.length,
           record: sourceEntry.record,
         });
+        const link = parseParentLinkedOpaqueEntry(sourceEntry.record);
+        if (link) {
+          this.opaqueParentsById.set(link.id, link.parentId);
+        }
         continue;
       }
       if (this.byId.has(sourceEntry.id)) {
@@ -1686,6 +1877,7 @@ export class SessionManager {
     this.fileEntries.push(entry);
     this.byId.set(entry.id, entry);
     this.leafId = entry.id;
+    this.appendParentId = entry.id;
     this.persist(entry, options);
   }
 
@@ -1704,7 +1896,7 @@ export class SessionManager {
     const entry: SessionMessageEntry = {
       type: "message",
       id: generateId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
       message,
     };
@@ -1720,7 +1912,7 @@ export class SessionManager {
     const entry: ThinkingLevelChangeEntry = {
       type: "thinking_level_change",
       id: generateId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
       thinkingLevel,
     };
@@ -1733,7 +1925,7 @@ export class SessionManager {
     const entry: ModelChangeEntry = {
       type: "model_change",
       id: generateId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
       provider,
       modelId,
@@ -1753,7 +1945,7 @@ export class SessionManager {
     const entry: CompactionEntry = {
       type: "compaction",
       id: generateId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
       summary,
       firstKeptEntryId,
@@ -1774,7 +1966,7 @@ export class SessionManager {
       customType,
       data,
       id: generateId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
     };
     this.appendEntry(entry, { invalidateSerializedPrefixCache: true });
@@ -1786,7 +1978,7 @@ export class SessionManager {
     const entry: SessionInfoEntry = {
       type: "session_info",
       id: generateId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
       name: name.trim(),
     };
@@ -1829,7 +2021,7 @@ export class SessionManager {
       display,
       details,
       id: generateId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
     };
     this.appendEntry(entry, { invalidateSerializedPrefixCache: true });
@@ -1845,11 +2037,12 @@ export class SessionManager {
   }
 
   getLeafEntry(): SessionEntry | undefined {
-    return this.leafId ? this.byId.get(this.leafId) : undefined;
+    return this.leafId ? this.getEntry(this.leafId) : undefined;
   }
 
   getEntry(id: string): SessionEntry | undefined {
-    return this.byId.get(id);
+    const entry = this.byId.get(id);
+    return entry ? this.normalizeEntryParent(entry) : undefined;
   }
 
   /**
@@ -1858,8 +2051,8 @@ export class SessionManager {
   getChildren(parentId: string): SessionEntry[] {
     const children: SessionEntry[] = [];
     for (const entry of this.byId.values()) {
-      if (entry.parentId === parentId) {
-        children.push(entry);
+      if (this.resolveCanonicalParentId(entry.parentId) === parentId) {
+        children.push(this.normalizeEntryParent(entry));
       }
     }
     return children;
@@ -1884,7 +2077,7 @@ export class SessionManager {
     const entry: LabelEntry = {
       type: "label",
       id: generateId(this.byId),
-      parentId: this.leafId,
+      parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
       targetId,
       label,
@@ -1908,10 +2101,17 @@ export class SessionManager {
   getBranch(fromId?: string): SessionEntry[] {
     const path: SessionEntry[] = [];
     const startId = fromId ?? this.leafId;
-    let current = startId ? this.byId.get(startId) : undefined;
-    while (current) {
-      path.unshift(current);
-      current = current.parentId ? this.byId.get(current.parentId) : undefined;
+    const seen = new Set<string>();
+    let currentId = startId;
+    while (currentId && !seen.has(currentId)) {
+      seen.add(currentId);
+      const current = this.byId.get(currentId);
+      if (current) {
+        path.unshift(this.normalizeEntryParent(current));
+        currentId = current.parentId;
+      } else {
+        currentId = this.opaqueParentsById.get(currentId) ?? null;
+      }
     }
     return path;
   }
@@ -1921,7 +2121,7 @@ export class SessionManager {
    * Uses tree traversal from current leaf.
    */
   buildSessionContext(): SessionContext {
-    return buildSessionContext(this.getEntries(), this.leafId, this.byId);
+    return buildCoreSessionContext(this.getBranch() as CoreSessionTreeEntry[]) as SessionContext;
   }
 
   /**
@@ -1938,7 +2138,9 @@ export class SessionManager {
    * change the leaf pointer. Entries cannot be modified or deleted.
    */
   getEntries(): SessionEntry[] {
-    return this.fileEntries.filter((e): e is SessionEntry => e.type !== "session");
+    return this.fileEntries
+      .filter((entry): entry is SessionEntry => entry.type !== "session")
+      .map((entry) => this.normalizeEntryParent(entry));
   }
 
   /**
@@ -1961,10 +2163,11 @@ export class SessionManager {
     // Build tree
     for (const entry of entries) {
       const node = nodeMap.get(entry.id)!;
-      if (entry.parentId === null || entry.parentId === entry.id) {
+      const parentId = this.resolveCanonicalParentId(entry.parentId);
+      if (parentId === null || parentId === entry.id) {
         roots.push(node);
       } else {
-        const parent = nodeMap.get(entry.parentId);
+        const parent = nodeMap.get(parentId);
         if (parent) {
           parent.children.push(node);
         } else {
@@ -1999,10 +2202,12 @@ export class SessionManager {
    * are not modified or deleted.
    */
   branch(branchFromId: string): void {
-    if (!this.byId.has(branchFromId)) {
+    const branchTargetId = this.resolveBranchTargetId(branchFromId);
+    if (branchTargetId === undefined) {
       throw new Error(`Entry ${branchFromId} not found`);
     }
-    this.leafId = branchFromId;
+    this.leafId = branchTargetId;
+    this.appendParentId = branchTargetId;
   }
 
   /**
@@ -2012,6 +2217,7 @@ export class SessionManager {
    */
   resetLeaf(): void {
     this.leafId = null;
+    this.appendParentId = null;
   }
 
   /**
@@ -2025,16 +2231,18 @@ export class SessionManager {
     details?: unknown,
     fromHook?: boolean,
   ): string {
-    if (branchFromId !== null && !this.byId.has(branchFromId)) {
+    const branchTargetId = branchFromId === null ? null : this.resolveBranchTargetId(branchFromId);
+    if (branchTargetId === undefined) {
       throw new Error(`Entry ${branchFromId} not found`);
     }
-    this.leafId = branchFromId;
+    this.leafId = branchTargetId;
+    this.appendParentId = branchTargetId;
     const entry: BranchSummaryEntry = {
       type: "branch_summary",
       id: generateId(this.byId),
-      parentId: branchFromId,
+      parentId: branchTargetId,
       timestamp: new Date().toISOString(),
-      fromId: branchFromId ?? "root",
+      fromId: branchTargetId ?? "root",
       summary,
       details,
       fromHook,

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -26,7 +26,10 @@ import {
   serializeJsonlLine,
   writeJsonlEntriesSync,
 } from "../../config/sessions/transcript-jsonl.js";
-import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
+import {
+  isSessionTranscriptSideAppendEntry,
+  selectSessionTranscriptLeafControlledPath,
+} from "../../config/sessions/transcript-tree.js";
 import {
   canAdvanceOwnedSessionEntryCache,
   type OwnedSessionTranscriptCacheSnapshot,
@@ -136,19 +139,19 @@ export interface SessionInfoEntry extends SessionEntryBase {
   name?: string;
 }
 
-export interface PromptReleasedOpaqueEntry {
+interface PromptReleasedOpaqueEntry {
   type: "prompt_released_opaque";
   record: unknown;
 }
 
-export type PromptReleasedSessionEntry =
+type PromptReleasedSessionEntry =
   | SessionMessageEntry
   | CustomEntry
   | LabelEntry
   | SessionInfoEntry
   | PromptReleasedOpaqueEntry;
 
-export type PromptReleasedSessionMergeResult = {
+type PromptReleasedSessionMergeResult = {
   sessionFileSnapshot: OwnedSessionTranscriptCacheSnapshot;
   publishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[];
   requiresReload?: true;
@@ -379,6 +382,13 @@ export function buildSessionContext(
   leafId?: string | null,
   byIdInput?: Map<string, SessionEntry>,
 ): SessionContext {
+  if (leafId === undefined) {
+    const selectedEntries = selectSessionTranscriptLeafControlledPath(entries);
+    if (selectedEntries !== undefined) {
+      entries = selectedEntries;
+      byIdInput = undefined;
+    }
+  }
   let byId = byIdInput;
   // Build uuid index if not available
   if (!byId) {

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -26,8 +26,11 @@ import {
   serializeJsonlLine,
   writeJsonlEntriesSync,
 } from "../../config/sessions/transcript-jsonl.js";
+import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
 import {
   canAdvanceOwnedSessionEntryCache,
+  type OwnedSessionTranscriptCacheSnapshot,
+  type OwnedSessionTranscriptPublishedEntry,
   publishOwnedSessionFileSnapshot,
 } from "../../config/sessions/transcript-write-context.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
@@ -63,6 +66,8 @@ export interface SessionEntryBase {
   id: string;
   parentId: string | null;
   timestamp: string;
+  /** This row consumes the raw side cursor instead of the visible leaf. */
+  appendMode?: "side";
 }
 
 export interface SessionMessageEntry extends SessionEntryBase {
@@ -142,6 +147,12 @@ export type PromptReleasedSessionEntry =
   | LabelEntry
   | SessionInfoEntry
   | PromptReleasedOpaqueEntry;
+
+export type PromptReleasedSessionMergeResult = {
+  sessionFileSnapshot: OwnedSessionTranscriptCacheSnapshot;
+  publishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[];
+  requiresReload?: true;
+};
 
 /**
  * Custom message entry for extensions to inject messages into LLM context.
@@ -980,6 +991,16 @@ type PreservedOpaqueFileEntry = {
   record: unknown;
 };
 
+type SessionLeafControl = {
+  type: "leaf";
+  id: string;
+  parentId: string | null;
+  timestamp: string;
+  targetId: string | null;
+  appendParentId?: string | null;
+  appendMode?: "side";
+};
+
 function parseParentLinkedOpaqueEntry(
   record: unknown,
 ): { id: string; parentId: string | null } | undefined {
@@ -1002,6 +1023,7 @@ function parseOpaqueLeafEntry(record: unknown):
       parentId: string | null;
       targetId: string | null;
       appendParentId?: string | null;
+      appendMode?: "side";
     }
   | undefined {
   if (
@@ -1023,11 +1045,15 @@ function parseOpaqueLeafEntry(record: unknown):
   ) {
     return undefined;
   }
+  if (record.appendMode !== undefined && record.appendMode !== "side") {
+    return undefined;
+  }
   return {
     id: record.id,
     parentId: record.parentId,
     targetId: record.targetId,
     ...(record.appendParentId !== undefined ? { appendParentId: record.appendParentId } : {}),
+    ...(record.appendMode === "side" ? { appendMode: record.appendMode } : {}),
   };
 }
 
@@ -1537,7 +1563,7 @@ export class SessionManager {
 
   private resolveOpaqueLeafControl(
     leafEntry: ReturnType<typeof parseOpaqueLeafEntry>,
-  ): { leafId: string | null; appendParentId: string | null } | undefined {
+  ): { leafId: string | null; appendParentId: string | null; appendMode?: "side" } | undefined {
     if (!leafEntry) {
       return undefined;
     }
@@ -1558,6 +1584,7 @@ export class SessionManager {
         leafEntry.appendParentId === undefined
           ? leafId
           : this.resolveOpaqueAppendParentId(leafEntry.appendParentId),
+      ...(leafEntry.appendMode ? { appendMode: leafEntry.appendMode } : {}),
     };
   }
 
@@ -1609,7 +1636,9 @@ export class SessionManager {
       const hasSerializedParent = Object.hasOwn(entry, "parentId");
       if (
         !hasSerializedParent ||
-        (entry.parentId === this.appendParentId && this.leafId !== this.appendParentId)
+        (!isSessionTranscriptSideAppendEntry(entry) &&
+          entry.parentId === this.appendParentId &&
+          this.leafId !== this.appendParentId)
       ) {
         this.logicalParentsById.set(entry.id, this.leafId);
       }
@@ -1729,7 +1758,36 @@ export class SessionManager {
     }
   }
 
-  private getPersistedFileEntries(): unknown[] {
+  private createLeafControl(
+    parentId: string | null,
+    appendParentId: string | null = this.appendParentId,
+    appendMode?: "side",
+  ): SessionLeafControl {
+    return {
+      type: "leaf",
+      id: generateId({
+        has: (id) => this.byId.has(id) || this.opaqueParentsById.has(id),
+      }),
+      parentId,
+      timestamp: new Date().toISOString(),
+      targetId: this.leafId,
+      ...(appendParentId !== this.leafId ? { appendParentId } : {}),
+      ...(appendMode ? { appendMode } : {}),
+    };
+  }
+
+  private rememberLeafControl(leafEntry: SessionLeafControl): void {
+    this.opaqueFileEntries.push({
+      index: this.fileEntries.length,
+      record: leafEntry,
+    });
+    this.opaqueParentsById.set(leafEntry.id, this.leafId);
+  }
+
+  private getPersistedFileEntries(
+    leafAppendParentId: string | null = this.appendParentId,
+    leafAppendMode?: "side",
+  ): unknown[] {
     // Tail cleanup removes canonical entries before rewriting. Clamp opaque
     // anchors now so later appends stay after records that the rewrite moved
     // to the new tail instead of crossing them on the next full rewrite.
@@ -1784,21 +1842,8 @@ export class SessionManager {
     if (persistedLeafId !== this.leafId || persistedAppendParentId !== this.appendParentId) {
       // Full rewrites preserve side branches in file order. Encode the active
       // branch explicitly so reopening does not adopt the serialized side tail.
-      const leafEntry = {
-        type: "leaf",
-        id: generateId({
-          has: (id) => this.byId.has(id) || this.opaqueParentsById.has(id),
-        }),
-        parentId: rawTailId,
-        timestamp: new Date().toISOString(),
-        targetId: this.leafId,
-        ...(this.appendParentId !== this.leafId ? { appendParentId: this.appendParentId } : {}),
-      };
-      this.opaqueFileEntries.push({
-        index: this.fileEntries.length,
-        record: leafEntry,
-      });
-      this.opaqueParentsById.set(leafEntry.id, this.leafId);
+      const leafEntry = this.createLeafControl(rawTailId, leafAppendParentId, leafAppendMode);
+      this.rememberLeafControl(leafEntry);
       entries.push(leafEntry);
     }
     return entries;
@@ -1816,21 +1861,33 @@ export class SessionManager {
     this.promptReleasedSideBranchParentId = undefined;
   }
 
-  private writeFullFile(): string {
+  private writeFullFile(
+    leafAppendParentId: string | null = this.appendParentId,
+    leafAppendMode?: "side",
+  ): string {
     if (!this.sessionFile) {
       return "";
     }
-    return writeJsonlEntriesSync(this.sessionFile, this.getPersistedFileEntries());
+    return writeJsonlEntriesSync(
+      this.sessionFile,
+      this.getPersistedFileEntries(leafAppendParentId, leafAppendMode),
+    );
   }
 
-  private rewriteFile(): void {
+  private rewriteFile(options?: {
+    publishSnapshot?: boolean;
+    leafAppendParentId?: string | null;
+    leafAppendMode?: "side";
+  }): void {
     if (!this.shouldPersist || !this.sessionFile) {
       return;
     }
-    const content = this.writeFullFile();
+    const leafAppendParentId =
+      options?.leafAppendParentId === undefined ? this.appendParentId : options.leafAppendParentId;
+    const content = this.writeFullFile(leafAppendParentId, options?.leafAppendMode);
     const rememberedWrite = rememberWrittenSessionEntries(this.sessionFile, content);
     this.sessionFileSnapshot = rememberedWrite.snapshot;
-    if (rememberedWrite.verifiedWrite) {
+    if (rememberedWrite.verifiedWrite && options?.publishSnapshot !== false) {
       publishRememberedSessionFileSnapshot(this.sessionFile, rememberedWrite.snapshot);
     }
   }
@@ -1974,7 +2031,11 @@ export class SessionManager {
     return removedEntries.length;
   }
 
-  persist(entry: SessionEntry, options?: AppendPersistenceOptions): void {
+  private persistRecord(
+    entry: unknown,
+    options?: AppendPersistenceOptions,
+    publishSnapshot = true,
+  ): void {
     if (!this.shouldPersist || !this.sessionFile) {
       return;
     }
@@ -1993,7 +2054,7 @@ export class SessionManager {
       this.flushed = true;
       const rememberedWrite = rememberWrittenSessionEntries(this.sessionFile, content);
       this.sessionFileSnapshot = rememberedWrite.snapshot;
-      if (rememberedWrite.verifiedWrite) {
+      if (rememberedWrite.verifiedWrite && publishSnapshot) {
         publishRememberedSessionFileSnapshot(this.sessionFile, rememberedWrite.snapshot);
       }
     } else {
@@ -2028,10 +2089,14 @@ export class SessionManager {
         invalidateSerializedPrefixCache,
       );
       this.sessionFileSnapshot = rememberedAppend.snapshot;
-      if (rememberedAppend.ownedAppendVerified) {
+      if (rememberedAppend.ownedAppendVerified && publishSnapshot) {
         publishRememberedSessionFileSnapshot(this.sessionFile, rememberedAppend.snapshot);
       }
     }
+  }
+
+  persist(entry: SessionEntry, options?: AppendPersistenceOptions): void {
+    this.persistRecord(entry, options);
   }
 
   /**
@@ -2058,11 +2123,19 @@ export class SessionManager {
    * Attach them as a side branch so rewrites retain external state without
    * moving the prepared reply branch or adding delivery mirrors to its context.
    */
-  mergePromptReleasedSessionEntries(entries: readonly PromptReleasedSessionEntry[]): void {
+  mergePromptReleasedSessionEntries(
+    entries: readonly PromptReleasedSessionEntry[],
+    options?: { persistLeaf?: boolean },
+  ): PromptReleasedSessionMergeResult | undefined {
     let sideBranchParentId =
       this.promptReleasedSideBranchParentId === undefined
         ? this.leafId
         : this.promptReleasedSideBranchParentId;
+    let persistedLeafId = this.leafId;
+    let persistedAppendParentId = this.appendParentId;
+    let persistedAppendMode: "active" | "side" = "active";
+    let sawPersistedStateUpdate = false;
+    let rawTailId: string | null = null;
     for (const sourceEntry of entries) {
       if (sourceEntry.type === "prompt_released_opaque") {
         this.opaqueFileEntries.push({
@@ -2071,6 +2144,7 @@ export class SessionManager {
         });
         const leafEntry = parseOpaqueLeafEntry(sourceEntry.record);
         if (leafEntry) {
+          rawTailId = leafEntry.id;
           const leafState = this.resolveOpaqueLeafControl(leafEntry);
           if (!leafState) {
             this.invalidLeafControlIds.add(leafEntry.id);
@@ -2082,12 +2156,19 @@ export class SessionManager {
           }
           this.opaqueParentsById.set(leafEntry.id, leafState.leafId);
           sideBranchParentId = leafState.appendParentId;
+          persistedLeafId = leafState.leafId;
+          persistedAppendParentId = leafState.appendParentId;
+          persistedAppendMode = leafState.appendMode === "side" ? "side" : "active";
+          sawPersistedStateUpdate = true;
           continue;
         }
         const link = parseParentLinkedOpaqueEntry(sourceEntry.record);
         if (link) {
           this.opaqueParentsById.set(link.id, link.parentId);
           sideBranchParentId = link.id;
+          persistedAppendParentId = link.id;
+          sawPersistedStateUpdate = true;
+          rawTailId = link.id;
         }
         continue;
       }
@@ -2104,6 +2185,11 @@ export class SessionManager {
       this.fileEntries.push(entry);
       this.byId.set(entry.id, entry);
       sideBranchParentId = entry.id;
+      persistedLeafId = entry.id;
+      persistedAppendParentId = entry.id;
+      persistedAppendMode = "active";
+      sawPersistedStateUpdate = true;
+      rawTailId = entry.id;
       if (entry.type === "label") {
         if (entry.label) {
           this.labelsById.set(entry.targetId, entry.label);
@@ -2118,10 +2204,55 @@ export class SessionManager {
     if (this.sessionFile) {
       this.sessionFileSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
     }
+    if (
+      options?.persistLeaf !== true ||
+      !this.shouldPersist ||
+      !this.sessionFile ||
+      !sawPersistedStateUpdate ||
+      (persistedLeafId === this.leafId &&
+        persistedAppendParentId === sideBranchParentId &&
+        persistedAppendMode === "side")
+    ) {
+      return undefined;
+    }
+
+    const hasAssistant = this.fileEntries.some(
+      (entry) => entry.type === "message" && entry.message.role === "assistant",
+    );
+    if (!this.flushed || !hasAssistant) {
+      this.rewriteFile({
+        publishSnapshot: false,
+        leafAppendParentId: sideBranchParentId,
+        leafAppendMode: "side",
+      });
+      this.flushed = true;
+      if (!this.sessionFileSnapshot) {
+        throw new Error(`Unable to snapshot restored session file: ${this.sessionFile}`);
+      }
+      // The rewrite can materialize an unflushed user turn as well as the leaf,
+      // so peer controllers must reload the trusted final file instead of
+      // attempting to replay an append-only entry delta.
+      return { sessionFileSnapshot: this.sessionFileSnapshot, requiresReload: true };
+    }
+
+    const leafEntry = this.createLeafControl(rawTailId, sideBranchParentId, "side");
+    this.persistRecord(leafEntry, undefined, false);
+    this.rememberLeafControl(leafEntry);
+    if (!this.sessionFileSnapshot) {
+      throw new Error(`Unable to snapshot restored session file: ${this.sessionFile}`);
+    }
+    return {
+      sessionFileSnapshot: this.sessionFileSnapshot,
+      publishedEntries: [{ kind: "id", id: leafEntry.id }],
+    };
   }
 
   private appendEntry(entry: SessionEntry, options?: AppendPersistenceOptions): void {
-    if (entry.parentId === this.appendParentId && this.leafId !== this.appendParentId) {
+    if (
+      !isSessionTranscriptSideAppendEntry(entry) &&
+      entry.parentId === this.appendParentId &&
+      this.leafId !== this.appendParentId
+    ) {
       this.logicalParentsById.set(entry.id, this.leafId);
     }
     this.fileEntries.push(entry);

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -130,6 +130,12 @@ export interface SessionInfoEntry extends SessionEntryBase {
   name?: string;
 }
 
+export type PromptReleasedSessionEntry =
+  | SessionMessageEntry
+  | CustomEntry
+  | LabelEntry
+  | SessionInfoEntry;
+
 /**
  * Custom message entry for extensions to inject messages into LLM context.
  * Use customType to identify your extension's entries.
@@ -1491,6 +1497,42 @@ export class SessionManager {
     this.sessionFileSnapshot = rememberedWrite.snapshot;
     if (rememberedWrite.verifiedWrite) {
       publishRememberedSessionFileSnapshot(this.sessionFile, rememberedWrite.snapshot);
+    }
+  }
+
+  /**
+   * Preserve entries appended while the active prompt released its file lock.
+   * Attach them as a side branch so rewrites retain external state without
+   * moving the prepared reply branch or adding delivery mirrors to its context.
+   */
+  mergePromptReleasedSessionEntries(entries: readonly PromptReleasedSessionEntry[]): void {
+    let sideBranchParentId = this.leafId;
+    for (const sourceEntry of entries) {
+      if (this.byId.has(sourceEntry.id)) {
+        throw new Error(`Entry ${sourceEntry.id} already exists`);
+      }
+      if (sourceEntry.type === "label" && !this.byId.has(sourceEntry.targetId)) {
+        throw new Error(`Entry ${sourceEntry.targetId} not found`);
+      }
+      const entry: PromptReleasedSessionEntry = {
+        ...sourceEntry,
+        parentId: sideBranchParentId,
+      };
+      this.fileEntries.push(entry);
+      this.byId.set(entry.id, entry);
+      sideBranchParentId = entry.id;
+      if (entry.type === "label") {
+        if (entry.label) {
+          this.labelsById.set(entry.targetId, entry.label);
+          this.labelTimestampsById.set(entry.targetId, entry.timestamp);
+        } else {
+          this.labelsById.delete(entry.targetId);
+          this.labelTimestampsById.delete(entry.targetId);
+        }
+      }
+    }
+    if (this.sessionFile) {
+      this.sessionFileSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
     }
   }
 

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -382,18 +382,20 @@ export function buildSessionContext(
   leafId?: string | null,
   byIdInput?: Map<string, SessionEntry>,
 ): SessionContext {
+  let contextEntries = entries;
+  let contextById = byIdInput;
   if (leafId === undefined) {
     const selectedEntries = selectSessionTranscriptLeafControlledPath(entries);
     if (selectedEntries !== undefined) {
-      entries = selectedEntries;
-      byIdInput = undefined;
+      contextEntries = selectedEntries;
+      contextById = undefined;
     }
   }
-  let byId = byIdInput;
+  let byId = contextById;
   // Build uuid index if not available
   if (!byId) {
     byId = new Map<string, SessionEntry>();
-    for (const entry of entries) {
+    for (const entry of contextEntries) {
       byId.set(entry.id, entry);
     }
   }
@@ -409,7 +411,7 @@ export function buildSessionContext(
   }
   if (!leaf) {
     // Fallback to last entry (when leafId is undefined)
-    leaf = entries[entries.length - 1];
+    leaf = contextEntries[contextEntries.length - 1];
   }
 
   if (!leaf) {

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -23,6 +23,7 @@ import {
   appendJsonlEntrySync,
   appendSerializedJsonlEntrySync,
   serializeJsonlEntry,
+  serializeJsonlLine,
   writeJsonlEntriesSync,
 } from "../../config/sessions/transcript-jsonl.js";
 import {
@@ -130,11 +131,17 @@ export interface SessionInfoEntry extends SessionEntryBase {
   name?: string;
 }
 
+export interface PromptReleasedOpaqueEntry {
+  type: "prompt_released_opaque";
+  record: unknown;
+}
+
 export type PromptReleasedSessionEntry =
   | SessionMessageEntry
   | CustomEntry
   | LabelEntry
-  | SessionInfoEntry;
+  | SessionInfoEntry
+  | PromptReleasedOpaqueEntry;
 
 /**
  * Custom message entry for extensions to inject messages into LLM context.
@@ -241,7 +248,10 @@ function generateId(byId: { has(id: string): boolean }): string {
 }
 
 /** Migrate v1 → v2: add id/parentId tree structure. Mutates in place. */
-function migrateV1ToV2(entries: FileEntry[]): void {
+function migrateV1ToV2(
+  entries: FileEntry[],
+  entriesByOriginalIndex?: readonly (FileEntry | undefined)[],
+): void {
   const ids = new Set<string>();
   let prevId: string | null = null;
 
@@ -260,7 +270,8 @@ function migrateV1ToV2(entries: FileEntry[]): void {
     if (entry.type === "compaction") {
       const comp = entry as CompactionEntry & { firstKeptEntryIndex?: number };
       if (typeof comp.firstKeptEntryIndex === "number") {
-        const targetEntry = entries[comp.firstKeptEntryIndex];
+        const targetEntry =
+          entriesByOriginalIndex?.[comp.firstKeptEntryIndex] ?? entries[comp.firstKeptEntryIndex];
         if (targetEntry && targetEntry.type !== "session") {
           comp.firstKeptEntryId = targetEntry.id;
         }
@@ -292,7 +303,10 @@ function migrateV2ToV3(entries: FileEntry[]): void {
  * Run all necessary migrations to bring entries to current version.
  * Mutates entries in place. Returns true if any migration was applied.
  */
-function migrateToCurrentVersion(entries: FileEntry[]): boolean {
+function migrateToCurrentVersion(
+  entries: FileEntry[],
+  entriesByOriginalIndex?: readonly (FileEntry | undefined)[],
+): boolean {
   const header = entries.find((e) => e.type === "session");
   const version = header?.version ?? 1;
 
@@ -301,7 +315,7 @@ function migrateToCurrentVersion(entries: FileEntry[]): boolean {
   }
 
   if (version < 2) {
-    migrateV1ToV2(entries);
+    migrateV1ToV2(entries, entriesByOriginalIndex);
   }
   if (version < 3) {
     migrateV2ToV3(entries);
@@ -933,6 +947,77 @@ function hasReadableSessionHeader(entries: FileEntry[]): boolean {
   return header?.type === "session" && typeof (header as { id?: unknown }).id === "string";
 }
 
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSessionEntryType(type: unknown): boolean {
+  switch (type) {
+    case "message":
+    case "thinking_level_change":
+    case "model_change":
+    case "compaction":
+    case "branch_summary":
+    case "custom":
+    case "custom_message":
+    case "label":
+    case "session_info":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isIndexedSessionEntry(entry: unknown): entry is SessionEntry {
+  if (!isJsonRecord(entry)) {
+    return false;
+  }
+  return isSessionEntryType(entry.type) && typeof entry.id === "string" && entry.id.length > 0;
+}
+
+type PreservedOpaqueFileEntry = {
+  index: number;
+  record: unknown;
+};
+
+function partitionSessionFileEntries(entries: readonly FileEntry[]): {
+  fileEntries: FileEntry[];
+  opaqueEntries: PreservedOpaqueFileEntry[];
+  fileEntriesByOriginalIndex: Array<FileEntry | undefined>;
+} {
+  const fileEntries: FileEntry[] = [];
+  const opaqueEntries: PreservedOpaqueFileEntry[] = [];
+  const fileEntriesByOriginalIndex: Array<FileEntry | undefined> = [];
+  const header = entries.find(
+    (entry) => isJsonRecord(entry) && entry.type === "session" && typeof entry.id === "string",
+  ) as SessionHeader | undefined;
+  const acceptsLegacyEntries = (header?.version ?? 1) < 2;
+  let hasHeader = false;
+  for (const [originalIndex, entry] of entries.entries()) {
+    if (
+      !hasHeader &&
+      isJsonRecord(entry) &&
+      entry.type === "session" &&
+      typeof entry.id === "string"
+    ) {
+      fileEntries.push(entry as unknown as SessionHeader);
+      fileEntriesByOriginalIndex[originalIndex] = entry;
+      hasHeader = true;
+      continue;
+    }
+    if (
+      isIndexedSessionEntry(entry) ||
+      (acceptsLegacyEntries && isJsonRecord(entry) && isSessionEntryType(entry.type))
+    ) {
+      fileEntries.push(entry);
+      fileEntriesByOriginalIndex[originalIndex] = entry;
+      continue;
+    }
+    opaqueEntries.push({ index: fileEntries.length, record: entry });
+  }
+  return { fileEntries, opaqueEntries, fileEntriesByOriginalIndex };
+}
+
 function buildCorruptSessionBackupPath(filePath: string): string {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   return `${filePath}.corrupt-${timestamp}-${randomUUID().slice(0, 8)}.jsonl`;
@@ -1244,6 +1329,7 @@ export class SessionManager {
   private shouldPersist: boolean;
   private flushed = false;
   private fileEntries: FileEntry[] = [];
+  private opaqueFileEntries: PreservedOpaqueFileEntry[] = [];
   private byId: Map<string, SessionEntry> = new Map();
   private labelsById: Map<string, string> = new Map();
   private labelTimestampsById: Map<string, string> = new Map();
@@ -1294,7 +1380,9 @@ export class SessionManager {
     this.sessionFileSnapshot = undefined;
     this.recoveredCorruptHeader = false;
     if (existsSync(this.sessionFile)) {
-      this.fileEntries = loaded.entries;
+      const partitioned = partitionSessionFileEntries(loaded.entries);
+      this.fileEntries = partitioned.fileEntries;
+      this.opaqueFileEntries = partitioned.opaqueEntries;
       this.sessionFileSnapshot = loaded.snapshot;
 
       // If file was empty or corrupted (no valid header), truncate and start fresh
@@ -1302,9 +1390,12 @@ export class SessionManager {
       if (this.fileEntries.length === 0) {
         const recoveredEntries = recoverCorruptSessionEntries(this.sessionFile, this.cwd);
         if (recoveredEntries && hasReadableSessionHeader(recoveredEntries)) {
-          this.fileEntries = recoveredEntries;
+          const recovered = partitionSessionFileEntries(recoveredEntries);
+          this.fileEntries = recovered.fileEntries;
+          this.opaqueFileEntries = recovered.opaqueEntries;
           const header = this.fileEntries.find((e) => e.type === "session");
           this.sessionId = header?.id ?? createSessionId();
+          migrateToCurrentVersion(this.fileEntries, recovered.fileEntriesByOriginalIndex);
           this.buildIndex();
           this.rewriteFile();
           this.recoveredCorruptHeader = true;
@@ -1323,7 +1414,7 @@ export class SessionManager {
       const header = this.fileEntries.find((e) => e.type === "session");
       this.sessionId = header?.id ?? createSessionId();
 
-      if (migrateToCurrentVersion(this.fileEntries)) {
+      if (migrateToCurrentVersion(this.fileEntries, partitioned.fileEntriesByOriginalIndex)) {
         this.rewriteFile();
       }
 
@@ -1350,6 +1441,7 @@ export class SessionManager {
       parentSession: options?.parentSession,
     };
     this.fileEntries = [header];
+    this.opaqueFileEntries = [];
     this.byId.clear();
     this.labelsById.clear();
     this.leafId = null;
@@ -1368,7 +1460,7 @@ export class SessionManager {
     this.labelTimestampsById.clear();
     this.leafId = null;
     for (const entry of this.fileEntries) {
-      if (entry.type === "session") {
+      if (!isIndexedSessionEntry(entry)) {
         continue;
       }
       this.byId.set(entry.id, entry);
@@ -1385,11 +1477,58 @@ export class SessionManager {
     }
   }
 
+  private getPersistedFileEntries(): unknown[] {
+    // Tail cleanup removes canonical entries before rewriting. Clamp opaque
+    // anchors now so later appends stay after records that the rewrite moved
+    // to the new tail instead of crossing them on the next full rewrite.
+    let previousOpaqueIndex = 0;
+    for (const opaqueEntry of this.opaqueFileEntries) {
+      opaqueEntry.index = Math.max(
+        previousOpaqueIndex,
+        Math.min(opaqueEntry.index, this.fileEntries.length),
+      );
+      previousOpaqueIndex = opaqueEntry.index;
+    }
+
+    const entries: unknown[] = [];
+    let opaqueIndex = 0;
+    for (let index = 0; index <= this.fileEntries.length; index += 1) {
+      while (this.opaqueFileEntries[opaqueIndex]?.index === index) {
+        entries.push(this.opaqueFileEntries[opaqueIndex]?.record);
+        opaqueIndex += 1;
+      }
+      const entry = this.fileEntries[index];
+      if (entry) {
+        entries.push(entry);
+      }
+    }
+    while (opaqueIndex < this.opaqueFileEntries.length) {
+      entries.push(this.opaqueFileEntries[opaqueIndex]?.record);
+      opaqueIndex += 1;
+    }
+    return entries;
+  }
+
+  getSerializedFileLinesForRewrite(): string[] {
+    return this.getPersistedFileEntries().map(serializeJsonlLine);
+  }
+
+  clearPreservedOpaqueFileEntries(): void {
+    this.opaqueFileEntries = [];
+  }
+
+  private writeFullFile(): string {
+    if (!this.sessionFile) {
+      return "";
+    }
+    return writeJsonlEntriesSync(this.sessionFile, this.getPersistedFileEntries());
+  }
+
   private rewriteFile(): void {
     if (!this.shouldPersist || !this.sessionFile) {
       return;
     }
-    const content = writeJsonlEntriesSync(this.sessionFile, this.fileEntries);
+    const content = this.writeFullFile();
     const rememberedWrite = rememberWrittenSessionEntries(this.sessionFile, content);
     this.sessionFileSnapshot = rememberedWrite.snapshot;
     if (rememberedWrite.verifiedWrite) {
@@ -1436,7 +1575,7 @@ export class SessionManager {
     }
 
     if (!this.flushed) {
-      const content = writeJsonlEntriesSync(this.sessionFile, this.fileEntries);
+      const content = this.writeFullFile();
       this.flushed = true;
       const rememberedWrite = rememberWrittenSessionEntries(this.sessionFile, content);
       this.sessionFileSnapshot = rememberedWrite.snapshot;
@@ -1508,6 +1647,13 @@ export class SessionManager {
   mergePromptReleasedSessionEntries(entries: readonly PromptReleasedSessionEntry[]): void {
     let sideBranchParentId = this.leafId;
     for (const sourceEntry of entries) {
+      if (sourceEntry.type === "prompt_released_opaque") {
+        this.opaqueFileEntries.push({
+          index: this.fileEntries.length,
+          record: sourceEntry.record,
+        });
+        continue;
+      }
       if (this.byId.has(sourceEntry.id)) {
         throw new Error(`Entry ${sourceEntry.id} already exists`);
       }
@@ -1957,6 +2103,7 @@ export class SessionManager {
       }
 
       this.fileEntries = [header, ...pathWithoutLabels, ...labelEntries];
+      this.opaqueFileEntries = [];
       this.sessionId = newSessionId;
       this.sessionFile = newSessionFile;
       this.sessionFileSnapshot = undefined;
@@ -1996,6 +2143,7 @@ export class SessionManager {
       parentId = labelEntry.id;
     }
     this.fileEntries = [header, ...pathWithoutLabels, ...labelEntries];
+    this.opaqueFileEntries = [];
     this.sessionId = newSessionId;
     this.buildIndex();
     return undefined;

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -2253,6 +2253,77 @@ export class SessionManager {
     return entry.id;
   }
 
+  private collectBranchedSessionPath(leafId: string): {
+    entries: SessionEntry[];
+    opaqueEntries: PreservedOpaqueFileEntry[];
+    tailId: string | null;
+    usedIds: Set<string>;
+  } {
+    type BranchNode =
+      | { type: "entry"; entry: SessionEntry }
+      | { type: "opaque"; id: string; record: Record<string, unknown> };
+
+    const opaqueById = new Map<string, Record<string, unknown>>();
+    for (const opaqueEntry of this.opaqueFileEntries) {
+      const leafEntry = parseOpaqueLeafEntry(opaqueEntry.record);
+      const link = leafEntry ?? parseParentLinkedOpaqueEntry(opaqueEntry.record);
+      if (link && isJsonRecord(opaqueEntry.record)) {
+        opaqueById.set(link.id, opaqueEntry.record);
+      }
+    }
+
+    const reversedNodes: BranchNode[] = [];
+    const seen = new Set<string>();
+    let currentId: string | null = leafId;
+    while (currentId && !seen.has(currentId)) {
+      seen.add(currentId);
+      const entry = this.byId.get(currentId);
+      if (entry) {
+        reversedNodes.push({ type: "entry", entry });
+        currentId = entry.parentId;
+        continue;
+      }
+      const record = opaqueById.get(currentId);
+      if (!record || !this.opaqueParentsById.has(currentId)) {
+        break;
+      }
+      reversedNodes.push({ type: "opaque", id: currentId, record });
+      currentId = this.opaqueParentsById.get(currentId) ?? null;
+    }
+
+    const entries: SessionEntry[] = [];
+    const opaqueEntries: PreservedOpaqueFileEntry[] = [];
+    const usedIds = new Set<string>();
+    let tailId: string | null = null;
+    for (const node of reversedNodes.toReversed()) {
+      if (node.type === "entry") {
+        if (node.entry.type === "label") {
+          continue;
+        }
+        const branchEntry: SessionEntry =
+          node.entry.parentId === tailId
+            ? node.entry
+            : ({ ...node.entry, parentId: tailId } as SessionEntry);
+        entries.push(branchEntry);
+        usedIds.add(branchEntry.id);
+        tailId = branchEntry.id;
+        continue;
+      }
+      if (parseOpaqueLeafEntry(node.record)) {
+        // A fork already materializes one selected path. Drop navigation-only
+        // leaf markers so regenerated labels cannot leave dangling targetIds.
+        continue;
+      }
+      opaqueEntries.push({
+        index: entries.length + 1,
+        record: { ...node.record, parentId: tailId },
+      });
+      usedIds.add(node.id);
+      tailId = node.id;
+    }
+    return { entries, opaqueEntries, tailId, usedIds };
+  }
+
   /**
    * Create a new session file containing only the path from root to the specified leaf.
    * Useful for extracting a single conversation path from a branched session.
@@ -2260,13 +2331,10 @@ export class SessionManager {
    */
   createBranchedSession(leafId: string): string | undefined {
     const previousSessionFile = this.sessionFile;
-    const path = this.getBranch(leafId);
-    if (path.length === 0) {
+    const branchPath = this.collectBranchedSessionPath(leafId);
+    if (branchPath.entries.length === 0) {
       throw new Error(`Entry ${leafId} not found`);
     }
-
-    // Filter out LabelEntry from path - we'll recreate them from the resolved map
-    const pathWithoutLabels = path.filter((e) => e.type !== "label");
 
     const newSessionId = createSessionId();
     const timestamp = new Date().toISOString();
@@ -2283,7 +2351,7 @@ export class SessionManager {
     };
 
     // Collect labels for entries in the path
-    const pathEntryIds = new Set(pathWithoutLabels.map((e) => e.id));
+    const pathEntryIds = new Set(branchPath.entries.map((entry) => entry.id));
     const labelsToWrite: Array<{ targetId: string; label: string; timestamp: string }> = [];
     for (const [targetId, label] of this.labelsById) {
       if (pathEntryIds.has(targetId)) {
@@ -2293,25 +2361,24 @@ export class SessionManager {
 
     if (this.shouldPersist) {
       // Build label entries
-      const lastEntryId = pathWithoutLabels[pathWithoutLabels.length - 1]?.id || null;
-      let parentId = lastEntryId;
+      let parentId = branchPath.tailId;
       const labelEntries: LabelEntry[] = [];
       for (const { targetId, label, timestamp: labelTimestamp } of labelsToWrite) {
         const labelEntry: LabelEntry = {
           type: "label",
-          id: generateId(new Set(pathEntryIds)),
+          id: generateId(branchPath.usedIds),
           parentId,
           timestamp: labelTimestamp,
           targetId,
           label,
         };
-        pathEntryIds.add(labelEntry.id);
+        branchPath.usedIds.add(labelEntry.id);
         labelEntries.push(labelEntry);
         parentId = labelEntry.id;
       }
 
-      this.fileEntries = [header, ...pathWithoutLabels, ...labelEntries];
-      this.opaqueFileEntries = [];
+      this.fileEntries = [header, ...branchPath.entries, ...labelEntries];
+      this.opaqueFileEntries = branchPath.opaqueEntries;
       this.sessionId = newSessionId;
       this.sessionFile = newSessionFile;
       this.sessionFileSnapshot = undefined;
@@ -2337,21 +2404,22 @@ export class SessionManager {
 
     // In-memory mode: replace current session with the path + labels
     const labelEntries: LabelEntry[] = [];
-    let parentId = pathWithoutLabels[pathWithoutLabels.length - 1]?.id || null;
+    let parentId = branchPath.tailId;
     for (const { targetId, label, timestamp: labelTimestamp } of labelsToWrite) {
       const labelEntry: LabelEntry = {
         type: "label",
-        id: generateId(new Set([...pathEntryIds, ...labelEntries.map((e) => e.id)])),
+        id: generateId(branchPath.usedIds),
         parentId,
         timestamp: labelTimestamp,
         targetId,
         label,
       };
+      branchPath.usedIds.add(labelEntry.id);
       labelEntries.push(labelEntry);
       parentId = labelEntry.id;
     }
-    this.fileEntries = [header, ...pathWithoutLabels, ...labelEntries];
-    this.opaqueFileEntries = [];
+    this.fileEntries = [header, ...branchPath.entries, ...labelEntries];
+    this.opaqueFileEntries = branchPath.opaqueEntries;
     this.sessionId = newSessionId;
     this.buildIndex();
     return undefined;

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -1606,7 +1606,11 @@ export class SessionManager {
       if (!isIndexedSessionEntry(entry)) {
         continue;
       }
-      if (entry.parentId === this.appendParentId && this.leafId !== this.appendParentId) {
+      const hasSerializedParent = Object.hasOwn(entry, "parentId");
+      if (
+        !hasSerializedParent ||
+        (entry.parentId === this.appendParentId && this.leafId !== this.appendParentId)
+      ) {
         this.logicalParentsById.set(entry.id, this.leafId);
       }
       this.byId.set(entry.id, entry);

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -1368,6 +1368,9 @@ export class SessionManager {
   private labelTimestampsById: Map<string, string> = new Map();
   private leafId: string | null = null;
   private appendParentId: string | null = null;
+  // Owned writes can publish in separate callbacks while one prompt is released.
+  // Ordinary appends/navigation clear this cursor before the next prompt.
+  private promptReleasedSideBranchParentId: string | null | undefined;
   private recoveredCorruptHeader = false;
   private sessionFileSnapshot: SessionFileSnapshot | undefined;
 
@@ -1481,6 +1484,7 @@ export class SessionManager {
     this.labelsById.clear();
     this.leafId = null;
     this.appendParentId = null;
+    this.promptReleasedSideBranchParentId = undefined;
     this.flushed = false;
 
     if (this.shouldPersist) {
@@ -1490,6 +1494,13 @@ export class SessionManager {
     return this.sessionFile;
   }
 
+  private resolveOpaqueLeafTargetId(targetId: string | null): string | null {
+    if (targetId === null || this.byId.has(targetId)) {
+      return targetId;
+    }
+    return this.resolveCanonicalParentId(targetId);
+  }
+
   private buildIndex(): void {
     this.byId.clear();
     this.opaqueParentsById.clear();
@@ -1497,18 +1508,14 @@ export class SessionManager {
     this.labelTimestampsById.clear();
     this.leafId = null;
     this.appendParentId = null;
+    this.promptReleasedSideBranchParentId = undefined;
     let opaqueIndex = 0;
     for (let index = 0; index <= this.fileEntries.length; index += 1) {
       while (this.opaqueFileEntries[opaqueIndex]?.index === index) {
         const opaqueRecord = this.opaqueFileEntries[opaqueIndex]?.record;
         const leafEntry = parseOpaqueLeafEntry(opaqueRecord);
         if (leafEntry) {
-          const canonicalLeafId =
-            leafEntry.targetId === null
-              ? null
-              : this.byId.has(leafEntry.targetId)
-                ? leafEntry.targetId
-                : this.resolveCanonicalParentId(leafEntry.targetId);
+          const canonicalLeafId = this.resolveOpaqueLeafTargetId(leafEntry.targetId);
           this.opaqueParentsById.set(leafEntry.id, canonicalLeafId);
           this.leafId = canonicalLeafId;
           this.appendParentId = canonicalLeafId;
@@ -1673,6 +1680,7 @@ export class SessionManager {
     this.opaqueFileEntries = [];
     this.opaqueParentsById.clear();
     this.appendParentId = null;
+    this.promptReleasedSideBranchParentId = undefined;
   }
 
   private writeFullFile(): string {
@@ -1832,16 +1840,29 @@ export class SessionManager {
    * moving the prepared reply branch or adding delivery mirrors to its context.
    */
   mergePromptReleasedSessionEntries(entries: readonly PromptReleasedSessionEntry[]): void {
-    let sideBranchParentId = this.leafId;
+    let sideBranchParentId =
+      this.promptReleasedSideBranchParentId === undefined
+        ? this.leafId
+        : this.promptReleasedSideBranchParentId;
     for (const sourceEntry of entries) {
       if (sourceEntry.type === "prompt_released_opaque") {
         this.opaqueFileEntries.push({
           index: this.fileEntries.length,
           record: sourceEntry.record,
         });
+        const leafEntry = parseOpaqueLeafEntry(sourceEntry.record);
+        if (leafEntry) {
+          this.opaqueParentsById.set(
+            leafEntry.id,
+            this.resolveOpaqueLeafTargetId(leafEntry.targetId),
+          );
+          sideBranchParentId = leafEntry.targetId;
+          continue;
+        }
         const link = parseParentLinkedOpaqueEntry(sourceEntry.record);
         if (link) {
           this.opaqueParentsById.set(link.id, link.parentId);
+          sideBranchParentId = link.id;
         }
         continue;
       }
@@ -1868,6 +1889,7 @@ export class SessionManager {
         }
       }
     }
+    this.promptReleasedSideBranchParentId = sideBranchParentId;
     if (this.sessionFile) {
       this.sessionFileSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
     }
@@ -1878,6 +1900,7 @@ export class SessionManager {
     this.byId.set(entry.id, entry);
     this.leafId = entry.id;
     this.appendParentId = entry.id;
+    this.promptReleasedSideBranchParentId = undefined;
     this.persist(entry, options);
   }
 
@@ -2208,6 +2231,7 @@ export class SessionManager {
     }
     this.leafId = branchTargetId;
     this.appendParentId = branchTargetId;
+    this.promptReleasedSideBranchParentId = undefined;
   }
 
   /**
@@ -2218,6 +2242,7 @@ export class SessionManager {
   resetLeaf(): void {
     this.leafId = null;
     this.appendParentId = null;
+    this.promptReleasedSideBranchParentId = undefined;
   }
 
   /**

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -1727,32 +1727,112 @@ export class SessionManager {
   }
 
   /**
-   * Remove matching entries from the canonical tail and rewrite once.
-   * Opaque records stay in file order, while the next append keeps the raw
-   * parent of the oldest removed entry so branch/control links remain intact.
+   * Remove matching entries near the canonical tail and rewrite once.
+   * Declared trailing metadata can survive above the removed entries; all
+   * surviving canonical/opaque children are reparented to the retained branch.
    */
-  removeTrailingEntries(predicate: (entry: SessionEntry) => boolean): number {
-    let removedParentId: string | null | undefined;
-    let removedCount = 0;
-    while (this.fileEntries.length > 1) {
-      const entry = this.fileEntries.at(-1);
+  removeTrailingEntries(
+    predicate: (entry: SessionEntry) => boolean,
+    options?: { preserveTrailing?: (entry: SessionEntry) => boolean },
+  ): number {
+    let preservedStart = this.fileEntries.length;
+    while (preservedStart > 1) {
+      const entry = this.fileEntries[preservedStart - 1];
+      if (!isIndexedSessionEntry(entry) || !options?.preserveTrailing?.(entry)) {
+        break;
+      }
+      preservedStart -= 1;
+    }
+
+    let removeStart = preservedStart;
+    while (removeStart > 1) {
+      const entry = this.fileEntries[removeStart - 1];
       if (!isIndexedSessionEntry(entry) || !predicate(entry)) {
         break;
       }
-      this.fileEntries.pop();
-      removedParentId = entry.parentId;
-      removedCount += 1;
+      removeStart -= 1;
     }
-    if (removedCount === 0) {
+    if (removeStart === preservedStart) {
       return 0;
     }
 
+    const shiftOpaqueIndexesAfterRemoval = (start: number, count: number): void => {
+      for (const opaqueEntry of this.opaqueFileEntries) {
+        const removedBeforeOpaque = Math.max(0, Math.min(count, opaqueEntry.index - start));
+        opaqueEntry.index -= removedBeforeOpaque;
+      }
+    };
+    const removedCount = preservedStart - removeStart;
+    shiftOpaqueIndexesAfterRemoval(removeStart, removedCount);
+    const removedEntries = this.fileEntries.splice(removeStart, removedCount) as SessionEntry[];
+    const removedParentById = new Map(
+      removedEntries.map((entry) => [entry.id, entry.parentId] as const),
+    );
+    for (let index = removeStart; index < this.fileEntries.length; ) {
+      const entry = this.fileEntries[index];
+      if (
+        isIndexedSessionEntry(entry) &&
+        entry.type === "label" &&
+        removedParentById.has(entry.targetId)
+      ) {
+        removedParentById.set(entry.id, entry.parentId);
+        shiftOpaqueIndexesAfterRemoval(index, 1);
+        this.fileEntries.splice(index, 1);
+        continue;
+      }
+      index += 1;
+    }
+
+    const resolveRetainedParentId = (parentId: string | null): string | null => {
+      const seen = new Set<string>();
+      let currentId = parentId;
+      while (currentId && removedParentById.has(currentId) && !seen.has(currentId)) {
+        seen.add(currentId);
+        currentId = removedParentById.get(currentId) ?? null;
+      }
+      return currentId;
+    };
+    const replacementParentId = resolveRetainedParentId(removedEntries[0]?.parentId ?? null);
+    this.fileEntries = this.fileEntries.map((entry) => {
+      if (!isIndexedSessionEntry(entry)) {
+        return entry;
+      }
+      const parentId = resolveRetainedParentId(entry.parentId);
+      return parentId === entry.parentId ? entry : ({ ...entry, parentId } as SessionEntry);
+    });
+    this.opaqueFileEntries = this.opaqueFileEntries.map((opaqueEntry) => {
+      if (!isJsonRecord(opaqueEntry.record)) {
+        return opaqueEntry;
+      }
+      const record = opaqueEntry.record;
+      const parentId =
+        record.parentId === null || typeof record.parentId === "string"
+          ? resolveRetainedParentId(record.parentId)
+          : undefined;
+      const leafEntry = parseOpaqueLeafEntry(record);
+      const targetId = leafEntry ? resolveRetainedParentId(leafEntry.targetId) : undefined;
+      if (
+        (parentId === undefined || parentId === record.parentId) &&
+        (targetId === undefined || targetId === leafEntry?.targetId)
+      ) {
+        return opaqueEntry;
+      }
+      return {
+        ...opaqueEntry,
+        record: {
+          ...record,
+          ...(parentId !== undefined ? { parentId } : {}),
+          ...(targetId !== undefined ? { targetId } : {}),
+        },
+      };
+    });
+
     this.clampOpaqueFileEntryIndexes();
     this.buildIndex();
-    this.leafId = this.resolveCanonicalParentId(removedParentId ?? null);
-    this.appendParentId = removedParentId ?? null;
+    this.leafId = this.resolveCanonicalParentId(replacementParentId);
+    this.appendParentId = replacementParentId;
     this.rewriteFile();
-    return removedCount;
+    return removedEntries.length;
   }
 
   persist(entry: SessionEntry, options?: AppendPersistenceOptions): void {

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -996,20 +996,39 @@ function parseParentLinkedOpaqueEntry(
   return { id: record.id, parentId: record.parentId };
 }
 
-function parseOpaqueLeafEntry(
-  record: unknown,
-): { id: string; targetId: string | null } | undefined {
+function parseOpaqueLeafEntry(record: unknown):
+  | {
+      id: string;
+      parentId: string | null;
+      targetId: string | null;
+      appendParentId?: string | null;
+    }
+  | undefined {
   if (
     !isJsonRecord(record) ||
     record.type !== "leaf" ||
     typeof record.id !== "string" ||
-    record.id.length === 0
+    record.id.length === 0 ||
+    (record.parentId !== null && typeof record.parentId !== "string")
   ) {
     return undefined;
   }
-  return record.targetId === null || typeof record.targetId === "string"
-    ? { id: record.id, targetId: record.targetId }
-    : undefined;
+  if (record.targetId !== null && typeof record.targetId !== "string") {
+    return undefined;
+  }
+  if (
+    record.appendParentId !== undefined &&
+    record.appendParentId !== null &&
+    typeof record.appendParentId !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    id: record.id,
+    parentId: record.parentId,
+    targetId: record.targetId,
+    ...(record.appendParentId !== undefined ? { appendParentId: record.appendParentId } : {}),
+  };
 }
 
 function partitionSessionFileEntries(entries: readonly FileEntry[]): {
@@ -1364,6 +1383,8 @@ export class SessionManager {
   private opaqueFileEntries: PreservedOpaqueFileEntry[] = [];
   private byId: Map<string, SessionEntry> = new Map();
   private opaqueParentsById: Map<string, string | null> = new Map();
+  private logicalParentsById: Map<string, string | null> = new Map();
+  private invalidLeafControlIds: Set<string> = new Set();
   private labelsById: Map<string, string> = new Map();
   private labelTimestampsById: Map<string, string> = new Map();
   private leafId: string | null = null;
@@ -1451,11 +1472,15 @@ export class SessionManager {
       const header = this.fileEntries.find((e) => e.type === "session");
       this.sessionId = header?.id ?? createSessionId();
 
-      if (migrateToCurrentVersion(this.fileEntries, partitioned.fileEntriesByOriginalIndex)) {
+      const migrated = migrateToCurrentVersion(
+        this.fileEntries,
+        partitioned.fileEntriesByOriginalIndex,
+      );
+      this.buildIndex();
+      if (migrated) {
         this.rewriteFile();
       }
 
-      this.buildIndex();
       this.flushed = true;
     } else {
       const explicitPath = this.sessionFile;
@@ -1481,6 +1506,8 @@ export class SessionManager {
     this.opaqueFileEntries = [];
     this.byId.clear();
     this.opaqueParentsById.clear();
+    this.logicalParentsById.clear();
+    this.invalidLeafControlIds.clear();
     this.labelsById.clear();
     this.leafId = null;
     this.appendParentId = null;
@@ -1501,9 +1528,44 @@ export class SessionManager {
     return this.resolveCanonicalParentId(targetId);
   }
 
+  private resolveOpaqueAppendParentId(parentId: string | null): string | null {
+    if (parentId === null || this.byId.has(parentId) || this.opaqueParentsById.has(parentId)) {
+      return parentId;
+    }
+    return this.resolveCanonicalParentId(parentId);
+  }
+
+  private resolveOpaqueLeafControl(
+    leafEntry: ReturnType<typeof parseOpaqueLeafEntry>,
+  ): { leafId: string | null; appendParentId: string | null } | undefined {
+    if (!leafEntry) {
+      return undefined;
+    }
+    const isKnownReference = (id: string | null): boolean =>
+      id === null ||
+      this.byId.has(id) ||
+      (this.opaqueParentsById.has(id) && !this.invalidLeafControlIds.has(id));
+    if (
+      !isKnownReference(leafEntry.targetId) ||
+      (leafEntry.appendParentId !== undefined && !isKnownReference(leafEntry.appendParentId))
+    ) {
+      return undefined;
+    }
+    const leafId = this.resolveOpaqueLeafTargetId(leafEntry.targetId);
+    return {
+      leafId,
+      appendParentId:
+        leafEntry.appendParentId === undefined
+          ? leafId
+          : this.resolveOpaqueAppendParentId(leafEntry.appendParentId),
+    };
+  }
+
   private buildIndex(): void {
     this.byId.clear();
     this.opaqueParentsById.clear();
+    this.logicalParentsById.clear();
+    this.invalidLeafControlIds.clear();
     this.labelsById.clear();
     this.labelTimestampsById.clear();
     this.leafId = null;
@@ -1515,10 +1577,21 @@ export class SessionManager {
         const opaqueRecord = this.opaqueFileEntries[opaqueIndex]?.record;
         const leafEntry = parseOpaqueLeafEntry(opaqueRecord);
         if (leafEntry) {
-          const canonicalLeafId = this.resolveOpaqueLeafTargetId(leafEntry.targetId);
-          this.opaqueParentsById.set(leafEntry.id, canonicalLeafId);
-          this.leafId = canonicalLeafId;
-          this.appendParentId = canonicalLeafId;
+          const leafState = this.resolveOpaqueLeafControl(leafEntry);
+          if (!leafState) {
+            // Ignore invalid controls while keeping their marker transparent
+            // for canonical descendants serialized after the opaque row.
+            this.invalidLeafControlIds.add(leafEntry.id);
+            this.opaqueParentsById.set(
+              leafEntry.id,
+              this.resolveOpaqueAppendParentId(leafEntry.parentId),
+            );
+            opaqueIndex += 1;
+            continue;
+          }
+          this.opaqueParentsById.set(leafEntry.id, leafState.leafId);
+          this.leafId = leafState.leafId;
+          this.appendParentId = leafState.appendParentId;
           opaqueIndex += 1;
           continue;
         }
@@ -1532,6 +1605,9 @@ export class SessionManager {
       const entry = this.fileEntries[index];
       if (!isIndexedSessionEntry(entry)) {
         continue;
+      }
+      if (entry.parentId === this.appendParentId && this.leafId !== this.appendParentId) {
+        this.logicalParentsById.set(entry.id, this.leafId);
       }
       this.byId.set(entry.id, entry);
       this.leafId = entry.id;
@@ -1562,7 +1638,9 @@ export class SessionManager {
   }
 
   private normalizeEntryParent(entry: SessionEntry): SessionEntry {
-    const parentId = this.resolveCanonicalParentId(entry.parentId);
+    const parentId = this.logicalParentsById.has(entry.id)
+      ? (this.logicalParentsById.get(entry.id) ?? null)
+      : this.resolveCanonicalParentId(entry.parentId);
     let normalized = parentId === entry.parentId ? entry : { ...entry, parentId };
     if (
       normalized.type === "compaction" &&
@@ -1669,6 +1747,56 @@ export class SessionManager {
       entries.push(this.opaqueFileEntries[opaqueIndex]?.record);
       opaqueIndex += 1;
     }
+    let persistedLeafId: string | null = null;
+    let persistedAppendParentId: string | null = null;
+    let rawTailId: string | null = null;
+    for (const entry of entries) {
+      const leafEntry = parseOpaqueLeafEntry(entry);
+      if (leafEntry) {
+        rawTailId = leafEntry.id;
+        if (this.invalidLeafControlIds.has(leafEntry.id)) {
+          continue;
+        }
+        const targetId = this.resolveOpaqueLeafTargetId(leafEntry.targetId);
+        persistedLeafId = targetId;
+        persistedAppendParentId =
+          leafEntry.appendParentId === undefined
+            ? targetId
+            : this.resolveOpaqueAppendParentId(leafEntry.appendParentId);
+        continue;
+      }
+      if (isIndexedSessionEntry(entry)) {
+        persistedLeafId = entry.id;
+        persistedAppendParentId = entry.id;
+        rawTailId = entry.id;
+        continue;
+      }
+      const opaqueLink = parseParentLinkedOpaqueEntry(entry);
+      if (opaqueLink) {
+        persistedAppendParentId = opaqueLink.id;
+        rawTailId = opaqueLink.id;
+      }
+    }
+    if (persistedLeafId !== this.leafId || persistedAppendParentId !== this.appendParentId) {
+      // Full rewrites preserve side branches in file order. Encode the active
+      // branch explicitly so reopening does not adopt the serialized side tail.
+      const leafEntry = {
+        type: "leaf",
+        id: generateId({
+          has: (id) => this.byId.has(id) || this.opaqueParentsById.has(id),
+        }),
+        parentId: rawTailId,
+        timestamp: new Date().toISOString(),
+        targetId: this.leafId,
+        ...(this.appendParentId !== this.leafId ? { appendParentId: this.appendParentId } : {}),
+      };
+      this.opaqueFileEntries.push({
+        index: this.fileEntries.length,
+        record: leafEntry,
+      });
+      this.opaqueParentsById.set(leafEntry.id, this.leafId);
+      entries.push(leafEntry);
+    }
     return entries;
   }
 
@@ -1679,6 +1807,7 @@ export class SessionManager {
   clearPreservedOpaqueFileEntries(): void {
     this.opaqueFileEntries = [];
     this.opaqueParentsById.clear();
+    this.invalidLeafControlIds.clear();
     this.appendParentId = null;
     this.promptReleasedSideBranchParentId = undefined;
   }
@@ -1811,9 +1940,14 @@ export class SessionManager {
           : undefined;
       const leafEntry = parseOpaqueLeafEntry(record);
       const targetId = leafEntry ? resolveRetainedParentId(leafEntry.targetId) : undefined;
+      const appendParentId =
+        leafEntry?.appendParentId !== undefined
+          ? resolveRetainedParentId(leafEntry.appendParentId)
+          : undefined;
       if (
         (parentId === undefined || parentId === record.parentId) &&
-        (targetId === undefined || targetId === leafEntry?.targetId)
+        (targetId === undefined || targetId === leafEntry?.targetId) &&
+        (appendParentId === undefined || appendParentId === leafEntry?.appendParentId)
       ) {
         return opaqueEntry;
       }
@@ -1823,6 +1957,7 @@ export class SessionManager {
           ...record,
           ...(parentId !== undefined ? { parentId } : {}),
           ...(targetId !== undefined ? { targetId } : {}),
+          ...(appendParentId !== undefined ? { appendParentId } : {}),
         },
       };
     });
@@ -1932,11 +2067,17 @@ export class SessionManager {
         });
         const leafEntry = parseOpaqueLeafEntry(sourceEntry.record);
         if (leafEntry) {
-          this.opaqueParentsById.set(
-            leafEntry.id,
-            this.resolveOpaqueLeafTargetId(leafEntry.targetId),
-          );
-          sideBranchParentId = leafEntry.targetId;
+          const leafState = this.resolveOpaqueLeafControl(leafEntry);
+          if (!leafState) {
+            this.invalidLeafControlIds.add(leafEntry.id);
+            this.opaqueParentsById.set(
+              leafEntry.id,
+              this.resolveOpaqueAppendParentId(leafEntry.parentId),
+            );
+            continue;
+          }
+          this.opaqueParentsById.set(leafEntry.id, leafState.leafId);
+          sideBranchParentId = leafState.appendParentId;
           continue;
         }
         const link = parseParentLinkedOpaqueEntry(sourceEntry.record);
@@ -1976,6 +2117,9 @@ export class SessionManager {
   }
 
   private appendEntry(entry: SessionEntry, options?: AppendPersistenceOptions): void {
+    if (entry.parentId === this.appendParentId && this.leafId !== this.appendParentId) {
+      this.logicalParentsById.set(entry.id, this.leafId);
+    }
     this.fileEntries.push(entry);
     this.byId.set(entry.id, entry);
     this.leafId = entry.id;
@@ -2154,8 +2298,9 @@ export class SessionManager {
   getChildren(parentId: string): SessionEntry[] {
     const children: SessionEntry[] = [];
     for (const entry of this.byId.values()) {
-      if (this.resolveCanonicalParentId(entry.parentId) === parentId) {
-        children.push(this.normalizeEntryParent(entry));
+      const normalizedEntry = this.normalizeEntryParent(entry);
+      if (normalizedEntry.parentId === parentId) {
+        children.push(normalizedEntry);
       }
     }
     return children;
@@ -2210,8 +2355,9 @@ export class SessionManager {
       seen.add(currentId);
       const current = this.byId.get(currentId);
       if (current) {
-        path.unshift(this.normalizeEntryParent(current));
-        currentId = current.parentId;
+        const normalizedCurrent = this.normalizeEntryParent(current);
+        path.unshift(normalizedCurrent);
+        currentId = normalizedCurrent.parentId;
       } else {
         currentId = this.opaqueParentsById.get(currentId) ?? null;
       }
@@ -2385,7 +2531,21 @@ export class SessionManager {
       const entry = this.byId.get(currentId);
       if (entry) {
         reversedNodes.push({ type: "entry", entry });
-        currentId = entry.parentId;
+        if (this.logicalParentsById.has(entry.id)) {
+          let physicalId = entry.parentId;
+          while (physicalId && !seen.has(physicalId)) {
+            const physicalRecord = opaqueById.get(physicalId);
+            if (!physicalRecord || !this.opaqueParentsById.has(physicalId)) {
+              break;
+            }
+            seen.add(physicalId);
+            reversedNodes.push({ type: "opaque", id: physicalId, record: physicalRecord });
+            physicalId = this.opaqueParentsById.get(physicalId) ?? null;
+          }
+          currentId = this.logicalParentsById.get(entry.id) ?? null;
+        } else {
+          currentId = entry.parentId;
+        }
         continue;
       }
       const record = opaqueById.get(currentId);

--- a/src/agents/sessions/session-migrate-id-dedup.test.ts
+++ b/src/agents/sessions/session-migrate-id-dedup.test.ts
@@ -119,6 +119,11 @@ describe("v1 session migration id assignment", () => {
 
     expect(kept).toBeDefined();
     expect(compaction).toMatchObject({ firstKeptEntryId: kept?.id });
-    expect(readFileSync(file, "utf8").trim().split("\n").map(JSON.parse)).toContain(null);
+    expect(
+      readFileSync(file, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as unknown),
+    ).toContain(null);
   });
 });

--- a/src/agents/sessions/session-migrate-id-dedup.test.ts
+++ b/src/agents/sessions/session-migrate-id-dedup.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -67,5 +67,58 @@ describe("v1 session migration id assignment", () => {
     expect(new Set(ids).size).toBe(ids.length);
     expect(messages[1].parentId).toBe(messages[0].id);
     expect(messages[1].parentId).not.toBe(messages[1].id);
+  });
+
+  it("preserves compaction indexes across opaque rows", () => {
+    const dir = mkdtempSync(join(tmpdir(), "oc-v1mig-compaction-"));
+    const file = join(dir, "session.jsonl");
+    const keptMessage = {
+      type: "message",
+      timestamp: "2026-01-01T00:00:02.000Z",
+      message: { role: "user", content: "kept" },
+    };
+    writeFileSync(
+      file,
+      [
+        {
+          type: "session",
+          version: 1,
+          id: "v1-header-id",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          cwd: "/tmp/cwd",
+        },
+        {
+          type: "message",
+          timestamp: "2026-01-01T00:00:01.000Z",
+          message: { role: "user", content: "prelude" },
+        },
+        null,
+        keptMessage,
+        {
+          type: "compaction",
+          timestamp: "2026-01-01T00:00:03.000Z",
+          summary: "summary",
+          firstKeptEntryIndex: 3,
+          tokensBefore: 200,
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+    );
+
+    const sm = SessionManager.open(file, dir);
+    const kept = sm
+      .getEntries()
+      .find(
+        (entry) =>
+          entry.type === "message" &&
+          entry.message.role === "user" &&
+          entry.message.content === "kept",
+      );
+    const compaction = sm.getEntries().find((entry) => entry.type === "compaction");
+
+    expect(kept).toBeDefined();
+    expect(compaction).toMatchObject({ firstKeptEntryId: kept?.id });
+    expect(readFileSync(file, "utf8").trim().split("\n").map(JSON.parse)).toContain(null);
   });
 });

--- a/src/auto-reply/reply/commands-core.test.ts
+++ b/src/auto-reply/reply/commands-core.test.ts
@@ -153,4 +153,69 @@ describe("emitResetCommandHooks", () => {
     expect(event.reason).toBe("new");
     expect(ctx.sessionId).toBe("prev-session");
   });
+
+  it("keeps leaf-controlled side branches out of before_reset hooks", async () => {
+    fsMocks.readFile.mockResolvedValueOnce(
+      [
+        {
+          type: "message",
+          id: "active-root",
+          parentId: null,
+          message: { role: "user", content: "active root" },
+        },
+        {
+          type: "message",
+          id: "side-entry",
+          parentId: "active-root",
+          message: { role: "assistant", content: "side delivery" },
+        },
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "side-entry",
+          targetId: "active-root",
+        },
+        {
+          type: "message",
+          id: "active-tail",
+          parentId: "active-root",
+          message: { role: "assistant", content: "active tail" },
+        },
+        {
+          type: "metadata",
+          id: "opaque-after-active-tail",
+          parentId: "side-entry",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n"),
+    );
+
+    await emitResetCommandHooks({
+      action: "new",
+      ctx: {} as HandleCommandsParams["ctx"],
+      cfg: {} as HandleCommandsParams["cfg"],
+      command: {
+        surface: "discord",
+        senderId: "rai",
+        channel: "discord",
+        from: "discord:rai",
+        to: "discord:bot",
+        resetHookTriggered: false,
+      } as HandleCommandsParams["command"],
+      sessionKey: "agent:main:main",
+      previousSessionEntry: {
+        sessionId: "prev-session",
+        sessionFile: "/tmp/prev-session.jsonl",
+      } as HandleCommandsParams["previousSessionEntry"],
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    await vi.waitFor(() => expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1));
+    const [event] = firstBeforeResetCall();
+    expect(event.messages).toEqual([
+      { role: "user", content: "active root" },
+      { role: "assistant", content: "active tail" },
+    ]);
+  });
 });

--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -359,7 +359,7 @@ describe("buildExportSessionReply", () => {
             rawEntries[0],
             rawEntries[1],
             { ...rawEntries[2], parentId: "active-tail" },
-            rawEntries[3],
+            { ...rawEntries[3], parentId: "active-tail" },
           ],
           leafId: "replacement",
           hasLeafControl: true,

--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -265,12 +265,201 @@ describe("buildExportSessionReply", () => {
           header: null,
           entries: [],
           leafId: null,
+          hasLeafControl: false,
           systemPrompt: "system prompt",
           tools: [],
         }),
       ).toString("base64"),
     );
     expect(html).toContain('const base64 = document.getElementById("session-data").textContent;');
+  });
+
+  it("exports the active target selected by a terminal leaf control", async () => {
+    const entries = [
+      {
+        type: "message",
+        id: "active-tail",
+        parentId: null,
+        timestamp: "2026-06-15T00:00:01.000Z",
+        message: { role: "assistant", content: "active" },
+      },
+      {
+        type: "message",
+        id: "inactive-tail",
+        parentId: "active-tail",
+        timestamp: "2026-06-15T00:00:02.000Z",
+        message: { role: "assistant", content: "side delivery" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "inactive-tail",
+        timestamp: "2026-06-15T00:00:03.000Z",
+        targetId: "active-tail",
+      },
+    ];
+    hoisted.sessionTranscriptContent = entries.map((entry) => JSON.stringify(entry)).join("\n");
+
+    await buildExportSessionReply(makeParams());
+
+    expect(writtenHtml()).toContain(
+      Buffer.from(
+        JSON.stringify({
+          header: null,
+          entries: [entries[0], entries[1], { ...entries[2], parentId: "active-tail" }],
+          leafId: "active-tail",
+          hasLeafControl: true,
+          systemPrompt: "system prompt",
+          tools: [],
+        }),
+      ).toString("base64"),
+    );
+  });
+
+  it("normalizes a leaf control parent before exporting its active descendant", async () => {
+    const rawEntries = [
+      {
+        type: "message",
+        id: "active-tail",
+        parentId: null,
+        timestamp: "2026-06-15T00:00:01.000Z",
+        message: { role: "assistant", content: "active" },
+      },
+      {
+        type: "message",
+        id: "inactive-tail",
+        parentId: "active-tail",
+        timestamp: "2026-06-15T00:00:02.000Z",
+        message: { role: "assistant", content: "side delivery" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "inactive-tail",
+        timestamp: "2026-06-15T00:00:03.000Z",
+        targetId: "active-tail",
+      },
+      {
+        type: "message",
+        id: "replacement",
+        parentId: "active-leaf",
+        timestamp: "2026-06-15T00:00:04.000Z",
+        message: { role: "assistant", content: "replacement" },
+      },
+    ];
+    hoisted.sessionTranscriptContent = rawEntries.map((entry) => JSON.stringify(entry)).join("\n");
+
+    await buildExportSessionReply(makeParams());
+
+    expect(writtenHtml()).toContain(
+      Buffer.from(
+        JSON.stringify({
+          header: null,
+          entries: [
+            rawEntries[0],
+            rawEntries[1],
+            { ...rawEntries[2], parentId: "active-tail" },
+            rawEntries[3],
+          ],
+          leafId: "replacement",
+          hasLeafControl: true,
+          systemPrompt: "system prompt",
+          tools: [],
+        }),
+      ).toString("base64"),
+    );
+  });
+
+  it("normalizes parentless history addressed by a leaf control", async () => {
+    const rawEntries = [
+      {
+        type: "message",
+        id: "active-root",
+        timestamp: "2026-06-15T00:00:01.000Z",
+        message: { role: "user", content: "root" },
+      },
+      {
+        type: "message",
+        id: "active-tail",
+        timestamp: "2026-06-15T00:00:02.000Z",
+        message: { role: "assistant", content: "active" },
+      },
+      {
+        type: "message",
+        id: "inactive-tail",
+        parentId: "active-tail",
+        timestamp: "2026-06-15T00:00:03.000Z",
+        message: { role: "assistant", content: "side delivery" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "inactive-tail",
+        timestamp: "2026-06-15T00:00:04.000Z",
+        targetId: "active-tail",
+      },
+    ];
+    hoisted.sessionTranscriptContent = rawEntries.map((entry) => JSON.stringify(entry)).join("\n");
+
+    await buildExportSessionReply(makeParams());
+
+    expect(writtenHtml()).toContain(
+      Buffer.from(
+        JSON.stringify({
+          header: null,
+          entries: [
+            { ...rawEntries[0], parentId: null },
+            { ...rawEntries[1], parentId: "active-root" },
+            rawEntries[2],
+            { ...rawEntries[3], parentId: "active-tail" },
+          ],
+          leafId: "active-tail",
+          hasLeafControl: true,
+          systemPrompt: "system prompt",
+          tools: [],
+        }),
+      ).toString("base64"),
+    );
+  });
+
+  it("preserves an explicitly empty branch selected by a terminal leaf control", async () => {
+    const entries = [
+      {
+        type: "message",
+        id: "inactive-tail",
+        parentId: null,
+        timestamp: "2026-06-15T00:00:01.000Z",
+        message: { role: "assistant", content: "inactive" },
+      },
+      {
+        type: "leaf",
+        id: "empty-leaf",
+        parentId: "inactive-tail",
+        timestamp: "2026-06-15T00:00:02.000Z",
+        targetId: null,
+      },
+      {
+        type: "metadata",
+        id: "opaque-after-leaf",
+        parentId: "inactive-tail",
+      },
+    ];
+    hoisted.sessionTranscriptContent = entries.map((entry) => JSON.stringify(entry)).join("\n");
+
+    await buildExportSessionReply(makeParams());
+
+    expect(writtenHtml()).toContain(
+      Buffer.from(
+        JSON.stringify({
+          header: null,
+          entries: [entries[0], { ...entries[1], parentId: null }, entries[2]],
+          leafId: null,
+          hasLeafControl: true,
+          systemPrompt: "system prompt",
+          tools: [],
+        }),
+      ).toString("base64"),
+    );
   });
 
   it("suffixes colliding default export filenames instead of overwriting", async () => {

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -9,6 +9,7 @@ import {
   type SessionEntry as AgentSessionEntry,
   type SessionHeader,
 } from "../../agents/sessions/session-manager.js";
+import { scanSessionTranscriptTree } from "../../config/sessions/transcript-tree.js";
 import { pathExists } from "../../infra/fs-safe.js";
 import type { ReplyPayload } from "../types.js";
 import {
@@ -26,6 +27,7 @@ interface SessionData {
   header: SessionHeader | null;
   entries: AgentSessionEntry[];
   leafId: string | null;
+  hasLeafControl: boolean;
   systemPrompt?: string;
   tools?: Array<{ name: string; description?: string; parameters?: unknown }>;
 }
@@ -240,6 +242,7 @@ async function readSessionDataFromTranscript(sessionFile: string): Promise<{
   header: SessionHeader | null;
   entries: AgentSessionEntry[];
   leafId: string | null;
+  hasLeafControl: boolean;
   warnings: SessionExportWarningSummary[];
 }> {
   const raw = await fsp.readFile(sessionFile, "utf-8");
@@ -247,12 +250,26 @@ async function readSessionDataFromTranscript(sessionFile: string): Promise<{
   migrateSessionEntries(fileEntries);
   const header =
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;
-  const entries = fileEntries.filter(
+  const rawEntries = fileEntries.filter(
     (entry): entry is AgentSessionEntry => entry.type !== "session",
   );
-  const lastEntry = entries.at(-1);
-  const leafId = typeof lastEntry?.id === "string" ? lastEntry.id : null;
-  return { header, entries, leafId, warnings: summarizeSessionExportWarnings(warnings) };
+  const tree = scanSessionTranscriptTree(rawEntries);
+  const hasLeafControl = tree.hasLeafControl;
+  const entries = hasLeafControl
+    ? rawEntries.map((entry) => {
+        const node = tree.byId.get(entry.id);
+        return node && entry.parentId !== node.parentId
+          ? ({ ...entry, parentId: node.parentId } as AgentSessionEntry)
+          : entry;
+      })
+    : rawEntries;
+  return {
+    header,
+    entries,
+    leafId: tree.leafId,
+    hasLeafControl,
+    warnings: summarizeSessionExportWarnings(warnings),
+  };
 }
 
 export async function buildExportSessionReply(params: HandleCommandsParams): Promise<ReplyPayload> {
@@ -274,7 +291,8 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
   }
 
   // 2. Load session entries
-  const { entries, header, leafId, warnings } = await readSessionDataFromTranscript(sessionFile);
+  const { entries, header, leafId, hasLeafControl, warnings } =
+    await readSessionDataFromTranscript(sessionFile);
 
   // 3. Build full system prompt
   const { systemPrompt, tools } = await resolveCommandsSystemPromptBundle({
@@ -287,6 +305,7 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
     header,
     entries,
     leafId,
+    hasLeafControl,
     systemPrompt,
     tools: tools.map((t) => ({
       name: t.name,

--- a/src/auto-reply/reply/commands-reset-hooks.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.ts
@@ -1,6 +1,7 @@
 // Emits reset hooks and cleanup work around session reset commands.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { selectSessionTranscriptLeafControlledPath } from "../../config/sessions/transcript-tree.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -17,21 +18,31 @@ function loadRouteReplyRuntime() {
 export type ResetCommandAction = "new" | "reset";
 
 function parseTranscriptMessages(content: string): unknown[] {
-  const messages: unknown[] = [];
+  const entries: unknown[] = [];
   for (const line of content.split("\n")) {
     if (!line.trim()) {
       continue;
     }
     try {
       const entry = JSON.parse(line);
-      if (entry.type === "message" && entry.message) {
-        messages.push(entry.message);
-      }
+      entries.push(entry);
     } catch {
       // Skip malformed lines from partially-written transcripts.
     }
   }
-  return messages;
+  const selectedEntries = selectSessionTranscriptLeafControlledPath(entries) ?? entries;
+  return selectedEntries.flatMap((entry) => {
+    if (
+      entry &&
+      typeof entry === "object" &&
+      !Array.isArray(entry) &&
+      (entry as { type?: unknown }).type === "message" &&
+      (entry as { message?: unknown }).message
+    ) {
+      return [(entry as { message: unknown }).message];
+    }
+    return [];
+  });
 }
 
 async function findLatestArchivedTranscript(sessionFile: string): Promise<string | undefined> {

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -13,7 +13,15 @@
     bytes[i] = binary.charCodeAt(i);
   }
   const data = JSON.parse(new TextDecoder("utf-8").decode(bytes));
-  const { header, entries, leafId: defaultLeafId, systemPrompt, tools, renderedTools } = data;
+  const {
+    header,
+    entries,
+    leafId: defaultLeafId,
+    hasLeafControl = false,
+    systemPrompt,
+    tools,
+    renderedTools,
+  } = data;
 
   // ============================================================
   // URL PARAMETER HANDLING
@@ -1952,6 +1960,9 @@
     } else {
       navigateTo(leafId, "none");
     }
+  } else if (hasLeafControl) {
+    // A null leaf selected by a control record is an intentional empty branch.
+    navigateTo(null, "none");
   } else if (entries.length > 0) {
     // Fallback: use last entry if no leafId
     navigateTo(entries[entries.length - 1].id, "none");

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -13,6 +13,8 @@ type SessionEntry = {
   message?: unknown;
   summary?: string;
   content?: unknown;
+  targetId?: string | null;
+  appendParentId?: string | null;
   display?: boolean;
   customType?: string;
   provider?: string;
@@ -23,7 +25,8 @@ type SessionEntry = {
 type SessionData = {
   header: { id: string; timestamp: string };
   entries: SessionEntry[];
-  leafId: string;
+  leafId: string | null;
+  hasLeafControl?: boolean;
   systemPrompt: string;
   tools: unknown[];
 };
@@ -209,6 +212,36 @@ describe("export html sidebar trigger affordance", () => {
 });
 
 describe("export html security hardening", () => {
+  it("renders an explicitly selected empty branch without inactive messages", async () => {
+    const session: SessionData = {
+      header: { id: "session-empty", timestamp: now() },
+      entries: [
+        {
+          id: "inactive-tail",
+          parentId: null,
+          timestamp: now(),
+          type: "message",
+          message: { role: "assistant", content: "inactive history" },
+        },
+        {
+          id: "empty-leaf",
+          parentId: "inactive-tail",
+          timestamp: now(),
+          type: "leaf",
+          targetId: null,
+        },
+      ],
+      leafId: null,
+      hasLeafControl: true,
+      systemPrompt: "",
+      tools: [],
+    };
+
+    const { document } = await renderTemplate(session);
+    const messages = requireElement(document.getElementById("messages"), "messages root missing");
+    expect(messages.textContent).not.toContain("inactive history");
+  });
+
   it("escapes raw HTML from markdown blocks", async () => {
     const attack = "<img src=x onerror=alert(1)>";
     const session: SessionData = {

--- a/src/auto-reply/reply/session-fork.runtime.test.ts
+++ b/src/auto-reply/reply/session-fork.runtime.test.ts
@@ -387,6 +387,7 @@ describe("forkSessionFromParentRuntime", () => {
         timestamp: "2026-06-15T00:00:03.000Z",
         targetId: "active-root",
         appendParentId: "plugin-metadata",
+        appendMode: "side",
       },
     ];
     await fs.writeFile(
@@ -423,6 +424,12 @@ describe("forkSessionFromParentRuntime", () => {
       targetId: "active-root",
       label: "selected",
     });
+    expect(forkedRecords.at(-1)).toMatchObject({
+      type: "leaf",
+      targetId: "active-root",
+      appendParentId: "plugin-metadata",
+      appendMode: "side",
+    });
     const reopened = SessionManager.open(fork.sessionFile, sessionsDir);
     reopened.appendMessage({ role: "user", content: "continued", timestamp: Date.now() });
     const records = (await fs.readFile(fork.sessionFile, "utf-8"))
@@ -430,6 +437,11 @@ describe("forkSessionFromParentRuntime", () => {
       .split(/\r?\n/)
       .map((line) => JSON.parse(line) as Record<string, unknown>);
     expect(records.at(-1)).toMatchObject({ type: "message", parentId: "plugin-metadata" });
+    expect(records.at(-1)).not.toHaveProperty("appendMode");
+    expect(reopened.buildSessionContext().messages).toMatchObject([
+      { role: "assistant", content: "active root" },
+      { role: "user", content: "continued" },
+    ]);
   });
 
   it("keeps parentless visible history with a disjoint append cursor", async () => {

--- a/src/auto-reply/reply/session-fork.runtime.test.ts
+++ b/src/auto-reply/reply/session-fork.runtime.test.ts
@@ -2,7 +2,9 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { afterEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../../agents/sessions/session-manager.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import {
   forkSessionFromParentRuntime,
@@ -270,6 +272,20 @@ describe("forkSessionFromParentRuntime", () => {
         targetId: "user-1",
         label: "start",
       },
+      {
+        type: "message",
+        id: "delivery-side-branch",
+        parentId: "label-1",
+        timestamp: "2026-05-01T00:00:04.000Z",
+        message: { role: "assistant", content: "side delivery" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "delivery-side-branch",
+        timestamp: "2026-05-01T00:00:05.000Z",
+        targetId: "label-1",
+      },
     ];
     await fs.writeFile(
       parentSessionFile,
@@ -308,11 +324,446 @@ describe("forkSessionFromParentRuntime", () => {
       "message",
       "message",
       "label",
+      "leaf",
     ]);
-    const forkedLabel = forkedEntries.at(-1);
+    const forkedLabel = forkedEntries.find((entry) => entry.type === "label");
     expect(forkedLabel?.type).toBe("label");
     expect(forkedLabel?.targetId).toBe("user-1");
     expect(forkedLabel?.label).toBe("start");
+    expect(forkedEntries.at(-1)).toMatchObject({
+      type: "leaf",
+      targetId: "label-1",
+      appendParentId: "label-1",
+    });
+    expect(raw).not.toContain("side delivery");
+  });
+
+  it("keeps opaque append-parent metadata on the active fork branch", async () => {
+    const root = await makeRoot("openclaw-parent-fork-opaque-");
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir);
+    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
+    const parentSessionId = "parent-opaque";
+    const entries = [
+      {
+        type: "session",
+        version: 3,
+        id: parentSessionId,
+        timestamp: "2026-06-15T00:00:00.000Z",
+        cwd: root,
+      },
+      {
+        type: "message",
+        id: "active-root",
+        parentId: null,
+        timestamp: "2026-06-15T00:00:01.000Z",
+        message: { role: "assistant", content: "active root" },
+      },
+      {
+        type: "label",
+        id: "active-label",
+        parentId: "active-root",
+        timestamp: "2026-06-15T00:00:01.500Z",
+        targetId: "active-root",
+        label: "selected",
+      },
+      {
+        type: "message",
+        id: "side-delivery",
+        parentId: "active-root",
+        timestamp: "2026-06-15T00:00:02.000Z",
+        message: { role: "assistant", content: "side delivery" },
+      },
+      {
+        type: "metadata",
+        id: "plugin-metadata",
+        parentId: "side-delivery",
+        payload: { source: "plugin" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "side-delivery",
+        timestamp: "2026-06-15T00:00:03.000Z",
+        targetId: "active-root",
+        appendParentId: "plugin-metadata",
+      },
+    ];
+    await fs.writeFile(
+      parentSessionFile,
+      `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+      "utf-8",
+    );
+
+    const fork = await forkSessionFromParentRuntime({
+      parentEntry: {
+        sessionId: parentSessionId,
+        sessionFile: parentSessionFile,
+        updatedAt: Date.now(),
+      },
+      agentId: "main",
+      sessionsDir,
+    });
+
+    if (!fork) {
+      throw new Error("expected forked session");
+    }
+    const raw = await fs.readFile(fork.sessionFile, "utf-8");
+    expect(raw).toContain('"id":"active-root"');
+    expect(raw).toContain('"id":"plugin-metadata"');
+    expect(raw).not.toContain("side delivery");
+    const forkedRecords = raw
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(forkedRecords.find((entry) => entry.id === "plugin-metadata")).toMatchObject({
+      parentId: "active-root",
+    });
+    expect(forkedRecords.find((entry) => entry.type === "label")).toMatchObject({
+      targetId: "active-root",
+      label: "selected",
+    });
+    const reopened = SessionManager.open(fork.sessionFile, sessionsDir);
+    reopened.appendMessage({ role: "user", content: "continued", timestamp: Date.now() });
+    const records = (await fs.readFile(fork.sessionFile, "utf-8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records.at(-1)).toMatchObject({ type: "message", parentId: "plugin-metadata" });
+  });
+
+  it("keeps parentless visible history with a disjoint append cursor", async () => {
+    const root = await makeRoot("openclaw-parent-fork-disjoint-");
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir);
+    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
+    await fs.writeFile(
+      parentSessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "parent-disjoint",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: root,
+        },
+        {
+          type: "message",
+          id: "visible-user",
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "user", content: "visible question" },
+        },
+        {
+          type: "message",
+          id: "visible-assistant",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          message: { role: "assistant", content: "visible answer" },
+        },
+        {
+          type: "metadata",
+          id: "append-root",
+          parentId: null,
+          payload: { source: "plugin" },
+        },
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "append-root",
+          timestamp: "2026-06-15T00:00:03.000Z",
+          targetId: "visible-assistant",
+          appendParentId: "append-root",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+
+    const fork = await forkSessionFromParentRuntime({
+      parentEntry: {
+        sessionId: "parent-disjoint",
+        sessionFile: parentSessionFile,
+        updatedAt: Date.now(),
+      },
+      agentId: "main",
+      sessionsDir,
+    });
+
+    if (!fork) {
+      throw new Error("expected forked session");
+    }
+    const reopened = SessionManager.open(fork.sessionFile, sessionsDir);
+    expect(reopened.buildSessionContext().messages).toHaveLength(2);
+    reopened.appendMessage({ role: "user", content: "continued", timestamp: Date.now() });
+    const raw = await fs.readFile(fork.sessionFile, "utf-8");
+    expect(raw).toContain("visible question");
+    expect(raw).toContain("visible answer");
+    expect(raw).toContain('"id":"append-root"');
+    const records = raw
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records.at(-1)).toMatchObject({ type: "message", parentId: "append-root" });
+  });
+
+  it("keeps an explicit empty visible branch separate from its opaque append parent", async () => {
+    const root = await makeRoot("openclaw-parent-fork-empty-opaque-");
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir);
+    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
+    await fs.writeFile(
+      parentSessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "parent-empty-opaque",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: root,
+        },
+        {
+          type: "message",
+          id: "inactive-root",
+          parentId: null,
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "user", content: "inactive history" },
+        },
+        {
+          type: "leaf",
+          id: "empty-leaf",
+          parentId: "inactive-root",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          targetId: null,
+          appendParentId: null,
+        },
+        {
+          type: "metadata",
+          id: "plugin-metadata",
+          parentId: "inactive-root",
+          payload: { source: "plugin" },
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+
+    const fork = await forkSessionFromParentRuntime({
+      parentEntry: {
+        sessionId: "parent-empty-opaque",
+        sessionFile: parentSessionFile,
+        updatedAt: Date.now(),
+      },
+      agentId: "main",
+      sessionsDir,
+    });
+
+    if (!fork) {
+      throw new Error("expected forked session");
+    }
+    const reopened = SessionManager.open(fork.sessionFile, sessionsDir);
+    expect(reopened.buildSessionContext().messages).toEqual([]);
+    const continuedId = reopened.appendMessage({
+      role: "user",
+      content: "continued",
+      timestamp: Date.now(),
+    });
+    reopened.appendMessage({
+      role: "assistant",
+      content: "done",
+      api: "responses",
+      provider: "openai",
+      model: "gpt-test",
+      timestamp: Date.now(),
+    } as unknown as AssistantMessage);
+    const records = (await fs.readFile(fork.sessionFile, "utf-8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records.some((record) => record.id === "inactive-root")).toBe(false);
+    expect(records.find((record) => record.id === continuedId)).toMatchObject({
+      type: "message",
+      parentId: "plugin-metadata",
+    });
+  });
+
+  it("keeps a reachable branch suffix when an older parent is missing", async () => {
+    const root = await makeRoot("openclaw-parent-fork-missing-ancestor-");
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir);
+    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
+    await fs.writeFile(
+      parentSessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "parent-missing-ancestor",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: root,
+        },
+        {
+          type: "message",
+          id: "reachable-tail",
+          parentId: "missing-parent",
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "assistant", content: "reachable tail" },
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+
+    const fork = await forkSessionFromParentRuntime({
+      parentEntry: {
+        sessionId: "parent-missing-ancestor",
+        sessionFile: parentSessionFile,
+        updatedAt: Date.now(),
+      },
+      agentId: "main",
+      sessionsDir,
+    });
+
+    if (!fork) {
+      throw new Error("expected forked session");
+    }
+    const raw = await fs.readFile(fork.sessionFile, "utf-8");
+    expect(raw).toContain("reachable tail");
+    expect(raw).not.toContain("missing-parent");
+  });
+
+  it("keeps visible history when the next append explicitly starts a root branch", async () => {
+    const root = await makeRoot("openclaw-parent-fork-root-append-");
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir);
+    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
+    await fs.writeFile(
+      parentSessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "parent-root-append",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: root,
+        },
+        {
+          type: "message",
+          id: "visible-root",
+          parentId: null,
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "assistant", content: "visible history" },
+        },
+        {
+          type: "leaf",
+          id: "root-append-control",
+          parentId: "inactive-tail",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          targetId: "visible-root",
+          appendParentId: null,
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+
+    const fork = await forkSessionFromParentRuntime({
+      parentEntry: {
+        sessionId: "parent-root-append",
+        sessionFile: parentSessionFile,
+        updatedAt: Date.now(),
+      },
+      agentId: "main",
+      sessionsDir,
+    });
+
+    if (!fork) {
+      throw new Error("expected forked session");
+    }
+    const reopened = SessionManager.open(fork.sessionFile, sessionsDir);
+    expect(reopened.buildSessionContext().messages).toHaveLength(1);
+    reopened.appendMessage({ role: "user", content: "new root", timestamp: Date.now() });
+    const records = (await fs.readFile(fork.sessionFile, "utf-8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records.at(-1)).toMatchObject({ type: "message", parentId: null });
+  });
+
+  it("preserves supported current-version linear transcripts", async () => {
+    const root = await makeRoot("openclaw-parent-fork-linear-");
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir);
+    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
+    await fs.writeFile(
+      parentSessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "parent-linear",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: root,
+        },
+        {
+          type: "message",
+          id: "linear-user",
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "user", content: "hello" },
+        },
+        {
+          type: "message",
+          id: "linear-assistant",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          message: { role: "assistant", content: "hi" },
+        },
+        {
+          type: "metadata",
+          id: "linear-metadata",
+          parentId: "linear-assistant",
+          payload: { source: "plugin" },
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+
+    const fork = await forkSessionFromParentRuntime({
+      parentEntry: {
+        sessionId: "parent-linear",
+        sessionFile: parentSessionFile,
+        updatedAt: Date.now(),
+      },
+      agentId: "main",
+      sessionsDir,
+    });
+
+    if (!fork) {
+      throw new Error("expected forked session");
+    }
+    const records = (await fs.readFile(fork.sessionFile, "utf-8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records.slice(1)).toMatchObject([
+      { id: "linear-user", parentId: null },
+      { id: "linear-assistant", parentId: "linear-user" },
+      { id: "linear-metadata", parentId: "linear-assistant" },
+    ]);
+    const reopened = SessionManager.open(fork.sessionFile, sessionsDir);
+    expect(reopened.buildSessionContext().messages).toHaveLength(2);
+    reopened.appendMessage({ role: "user", content: "continued", timestamp: Date.now() });
+    const continuedRecords = (await fs.readFile(fork.sessionFile, "utf-8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(continuedRecords.at(-1)).toMatchObject({
+      type: "message",
+      parentId: "linear-metadata",
+    });
   });
 
   it("creates a header-only child when the parent has no entries", async () => {

--- a/src/auto-reply/reply/session-fork.runtime.ts
+++ b/src/auto-reply/reply/session-fork.runtime.ts
@@ -32,6 +32,7 @@ type ForkSourceTranscript = {
   sessionDir: string;
   leafId: string | null;
   appendParentId: string | null;
+  appendMode?: "side";
   preserveLeafControl: boolean;
   branchEntries: unknown[];
   labelsToWrite: Array<{ targetId: string; label: string; timestamp: string }>;
@@ -201,12 +202,14 @@ async function readForkSourceTranscript(
       isRecord(entry) && typeof entry.id === "string" ? [entry.id] : [],
     ),
   );
-  const lastLeafUpdateEntry = tree.nodes.findLast((node) => node.leafId !== undefined)?.entry;
+  const lastLeafUpdateNode = tree.nodes.findLast((node) => node.leafId !== undefined);
+  const lastLeafUpdateEntry = lastLeafUpdateNode?.entry;
   return {
     cwd: header?.cwd ?? process.cwd(),
     sessionDir: path.dirname(parentSessionFile),
     leafId,
     appendParentId: mergedPath.appendParentId,
+    ...(lastLeafUpdateNode?.appendMode ? { appendMode: lastLeafUpdateNode.appendMode } : {}),
     preserveLeafControl: isSessionTranscriptLeafControl(lastLeafUpdateEntry),
     branchEntries,
     labelsToWrite: collectBranchLabels({ allEntries: entries, pathEntryIds }),
@@ -300,6 +303,7 @@ async function writeBranchedSession(params: {
         timestamp,
         targetId: params.source.leafId,
         appendParentId: params.source.appendParentId,
+        ...(params.source.appendMode ? { appendMode: params.source.appendMode } : {}),
       }
     : null;
   const entries = [header, ...pathEntries, ...labelEntries, ...(leafEntry ? [leafEntry] : [])];

--- a/src/auto-reply/reply/session-fork.runtime.ts
+++ b/src/auto-reply/reply/session-fork.runtime.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import {
   migrateSessionEntries,
   parseSessionEntries,
-  type FileEntry,
   type SessionEntry as AgentSessionEntry,
   type SessionHeader,
 } from "../../agents/sessions/session-manager.js";
@@ -14,6 +13,12 @@ import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
 } from "../../config/sessions/paths.js";
+import {
+  isSessionTranscriptLeafControl,
+  mergeSessionTranscriptVisiblePathWithOpaqueAppendPath,
+  scanSessionTranscriptTree,
+  selectSessionTranscriptTreePathNodes,
+} from "../../config/sessions/transcript-tree.js";
 import {
   resolveFreshSessionTotalTokens,
   type SessionEntry as StoreSessionEntry,
@@ -26,7 +31,9 @@ type ForkSourceTranscript = {
   cwd: string;
   sessionDir: string;
   leafId: string | null;
-  branchEntries: AgentSessionEntry[];
+  appendParentId: string | null;
+  preserveLeafControl: boolean;
+  branchEntries: unknown[];
   labelsToWrite: Array<{ targetId: string; label: string; timestamp: string }>;
 };
 
@@ -108,30 +115,8 @@ export async function resolveParentForkTokenCountRuntime(params: {
   return maxPositiveTokenCount(cachedTokens, byteEstimateTokens);
 }
 
-function isSessionEntry(entry: FileEntry): entry is AgentSessionEntry {
-  return (
-    entry.type !== "session" &&
-    typeof (entry as { id?: unknown }).id === "string" &&
-    (typeof (entry as { timestamp?: unknown }).timestamp === "string" ||
-      typeof (entry as { timestamp?: unknown }).timestamp === "number")
-  );
-}
-
-function buildEntryIndex(entries: AgentSessionEntry[]): Map<string, AgentSessionEntry> {
-  return new Map(entries.map((entry) => [entry.id, entry]));
-}
-
-function readBranch(params: {
-  byId: Map<string, AgentSessionEntry>;
-  leafId: string | null;
-}): AgentSessionEntry[] {
-  const branchEntries: AgentSessionEntry[] = [];
-  let current = params.leafId ? params.byId.get(params.leafId) : undefined;
-  while (current) {
-    branchEntries.unshift(current);
-    current = current.parentId ? params.byId.get(current.parentId) : undefined;
-  }
-  return branchEntries;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function generateEntryId(existingIds: Set<string>): string {
@@ -147,15 +132,31 @@ function generateEntryId(existingIds: Set<string>): string {
   return id;
 }
 
+function hasAssistantEntry(entries: unknown[]): boolean {
+  return entries.some(
+    (entry) =>
+      isRecord(entry) &&
+      entry.type === "message" &&
+      isRecord(entry.message) &&
+      entry.message.role === "assistant",
+  );
+}
+
 function collectBranchLabels(params: {
-  allEntries: AgentSessionEntry[];
+  allEntries: unknown[];
   pathEntryIds: Set<string>;
 }): Array<{ targetId: string; label: string; timestamp: string }> {
   const labelsToWrite: Array<{ targetId: string; label: string; timestamp: string }> = [];
   for (const entry of params.allEntries) {
+    if (!isRecord(entry)) {
+      continue;
+    }
     if (
       entry.type === "label" &&
-      entry.label &&
+      typeof entry.label === "string" &&
+      typeof entry.targetId === "string" &&
+      typeof entry.id === "string" &&
+      !params.pathEntryIds.has(entry.id) &&
       params.pathEntryIds.has(entry.targetId) &&
       typeof entry.timestamp === "string"
     ) {
@@ -177,17 +178,36 @@ async function readForkSourceTranscript(
   migrateSessionEntries(fileEntries);
   const header =
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;
-  const entries = fileEntries.filter(isSessionEntry);
-  const byId = buildEntryIndex(entries);
-  const leafId = entries.at(-1)?.id ?? null;
-  const branchEntries = readBranch({ byId, leafId });
+  const entries = fileEntries.filter((entry) => entry.type !== "session");
+  const tree = scanSessionTranscriptTree(entries);
+  const leafId = tree.leafId;
+  const appendParentId = tree.appendParentId;
+  const visiblePath = selectSessionTranscriptTreePathNodes(tree, leafId);
+  const appendPath = selectSessionTranscriptTreePathNodes(tree, appendParentId);
+  const mergedPath = mergeSessionTranscriptVisiblePathWithOpaqueAppendPath({
+    visiblePath,
+    appendPath,
+    appendParentId,
+  });
+  const branchEntries = mergedPath.nodes.flatMap((node) => {
+    if (!isRecord(node.entry)) {
+      return [];
+    }
+    const parentId = node.selectedParentId;
+    return [node.entry.parentId === parentId ? node.entry : { ...node.entry, parentId }];
+  });
   const pathEntryIds = new Set(
-    branchEntries.filter((entry) => entry.type !== "label").map((entry) => entry.id),
+    branchEntries.flatMap((entry) =>
+      isRecord(entry) && typeof entry.id === "string" ? [entry.id] : [],
+    ),
   );
+  const lastLeafUpdateEntry = tree.nodes.findLast((node) => node.leafId !== undefined)?.entry;
   return {
     cwd: header?.cwd ?? process.cwd(),
     sessionDir: path.dirname(parentSessionFile),
     leafId,
+    appendParentId: mergedPath.appendParentId,
+    preserveLeafControl: isSessionTranscriptLeafControl(lastLeafUpdateEntry),
     branchEntries,
     labelsToWrite: collectBranchLabels({ allEntries: entries, pathEntryIds }),
   };
@@ -250,12 +270,19 @@ async function writeBranchedSession(params: {
   const timestamp = new Date().toISOString();
   const fileTimestamp = timestamp.replace(/[:.]/g, "-");
   const sessionFile = path.join(params.source.sessionDir, `${fileTimestamp}_${sessionId}.jsonl`);
-  const pathWithoutLabels = params.source.branchEntries.filter((entry) => entry.type !== "label");
-  const pathEntryIds = new Set(pathWithoutLabels.map((entry) => entry.id));
+  const pathEntries = params.source.branchEntries;
+  const pathEntryIds = new Set(
+    pathEntries.flatMap((entry) =>
+      isRecord(entry) && typeof entry.id === "string" ? [entry.id] : [],
+    ),
+  );
+  const lastPathEntry = pathEntries.at(-1);
+  const lastPathEntryId =
+    isRecord(lastPathEntry) && typeof lastPathEntry.id === "string" ? lastPathEntry.id : null;
   const labelEntries = buildBranchLabelEntries({
     labelsToWrite: params.source.labelsToWrite,
     pathEntryIds,
-    lastEntryId: pathWithoutLabels.at(-1)?.id ?? null,
+    lastEntryId: lastPathEntryId,
   });
   const header = {
     type: "session",
@@ -265,22 +292,23 @@ async function writeBranchedSession(params: {
     cwd: params.source.cwd,
     parentSession: params.parentSessionFile,
   } satisfies SessionHeader;
-  const entries = [header, ...pathWithoutLabels, ...labelEntries];
-  const hasAssistant = entries.some(
-    (entry) => entry.type === "message" && entry.message.role === "assistant",
-  );
-  if (hasAssistant) {
-    await fs.mkdir(path.dirname(sessionFile), { recursive: true });
-    await fs.writeFile(
-      sessionFile,
-      `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
-      {
-        encoding: "utf-8",
-        mode: 0o600,
-        flag: "wx",
-      },
-    );
-  }
+  const leafEntry = params.source.preserveLeafControl
+    ? {
+        type: "leaf",
+        id: generateEntryId(pathEntryIds),
+        parentId: labelEntries.at(-1)?.id ?? lastPathEntryId,
+        timestamp,
+        targetId: params.source.leafId,
+        appendParentId: params.source.appendParentId,
+      }
+    : null;
+  const entries = [header, ...pathEntries, ...labelEntries, ...(leafEntry ? [leafEntry] : [])];
+  await fs.mkdir(path.dirname(sessionFile), { recursive: true });
+  await fs.writeFile(sessionFile, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+    flag: "wx",
+  });
   return { sessionId, sessionFile };
 }
 
@@ -303,7 +331,9 @@ export async function forkSessionFromParentRuntime(params: {
     if (!source) {
       return null;
     }
-    return source.leafId
+    const shouldPersistBranch =
+      source.preserveLeafControl || hasAssistantEntry(source.branchEntries);
+    return shouldPersistBranch
       ? await writeBranchedSession({ parentSessionFile, source })
       : await writeForkHeaderOnly({
           parentSessionFile,

--- a/src/commands/doctor-session-transcripts.test.ts
+++ b/src/commands/doctor-session-transcripts.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../agents/sessions/session-manager.js";
 
 const note = vi.hoisted(() => vi.fn());
 
@@ -147,6 +148,257 @@ describe("doctor session transcript repair", () => {
     expect(message).toContain("legacy state");
     expect(message).toContain('Run "openclaw doctor --fix"');
     expect(countNonEmptyLines(await fs.readFile(filePath, "utf-8"))).toBe(3);
+  });
+
+  it("repairs supported current-version linear transcripts", async () => {
+    const filePath = await writeTranscript([
+      { type: "session", version: 3, id: "session-linear", timestamp: "2026-06-15T00:00:00Z" },
+      {
+        type: "message",
+        id: "runtime-user",
+        timestamp: "2026-06-15T00:00:01Z",
+        message: {
+          role: "user",
+          content:
+            "visible ask\n\n<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nsecret\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        },
+      },
+      {
+        type: "message",
+        id: "plain-user",
+        timestamp: "2026-06-15T00:00:02Z",
+        message: { role: "user", content: "visible ask" },
+      },
+    ]);
+
+    const result = await repairBrokenSessionTranscriptFile({ filePath, shouldRepair: true });
+
+    expect(result.repaired).toBe(true);
+    const records = (await fs.readFile(filePath, "utf-8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line));
+    expect(records.map((entry) => entry.id)).toEqual(["session-linear", "plain-user"]);
+  });
+
+  it("repairs the branch selected by a terminal leaf control", async () => {
+    const filePath = await writeTranscript([
+      { type: "session", version: 3, id: "session-1", timestamp: "2026-06-15T00:00:00Z" },
+      {
+        type: "message",
+        id: "parent",
+        parentId: null,
+        message: { role: "assistant", content: "previous" },
+      },
+      {
+        type: "message",
+        id: "runtime-user",
+        parentId: "parent",
+        message: {
+          role: "user",
+          content:
+            "visible ask\n\n<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nsecret\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        },
+      },
+      {
+        type: "message",
+        id: "runtime-assistant",
+        parentId: "runtime-user",
+        message: { role: "assistant", content: "stale" },
+      },
+      {
+        type: "message",
+        id: "active-user",
+        parentId: "parent",
+        message: { role: "user", content: "visible ask" },
+      },
+      {
+        type: "message",
+        id: "active-assistant",
+        parentId: "active-user",
+        message: { role: "assistant", content: "answer" },
+      },
+      {
+        type: "message",
+        id: "side-delivery",
+        parentId: "active-assistant",
+        message: { role: "assistant", content: "side delivery" },
+      },
+      {
+        type: "metadata",
+        id: "plugin-metadata",
+        parentId: "runtime-assistant",
+        payload: { source: "plugin" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "side-delivery",
+        targetId: "active-assistant",
+        appendParentId: "plugin-metadata",
+      },
+      {
+        type: "metadata",
+        id: "post-leaf-metadata",
+        parentId: "plugin-metadata",
+        payload: { phase: "after-leaf" },
+      },
+    ]);
+
+    const result = await repairBrokenSessionTranscriptFile({ filePath, shouldRepair: true });
+
+    expect(result.repaired).toBe(true);
+    const repaired = await fs.readFile(filePath, "utf-8");
+    expect(repaired).toContain("answer");
+    expect(repaired).toContain("plugin-metadata");
+    expect(repaired).toContain("post-leaf-metadata");
+    expect(repaired).not.toContain("side delivery");
+    expect(repaired).not.toContain("secret");
+    const repairedRecords = repaired
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line));
+    expect(repairedRecords.find((entry) => entry.id === "plugin-metadata")).toMatchObject({
+      parentId: "active-assistant",
+    });
+    const reopened = SessionManager.open(filePath, path.dirname(filePath));
+    reopened.appendMessage({ role: "user", content: "continued", timestamp: Date.now() });
+    const records = (await fs.readFile(filePath, "utf-8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line));
+    expect(records.at(-1)).toMatchObject({ type: "message", parentId: "post-leaf-metadata" });
+  });
+
+  it("preserves parentless visible history and a disjoint append cursor", async () => {
+    const filePath = await writeTranscript([
+      { type: "session", version: 3, id: "session-disjoint", timestamp: "2026-06-15T00:00:00Z" },
+      {
+        type: "message",
+        id: "visible-parent",
+        message: { role: "assistant", content: "previous" },
+      },
+      {
+        type: "message",
+        id: "active-user",
+        message: { role: "user", content: "visible ask" },
+      },
+      {
+        type: "message",
+        id: "active-assistant",
+        message: { role: "assistant", content: "answer" },
+      },
+      {
+        type: "message",
+        id: "runtime-user",
+        parentId: "visible-parent",
+        message: {
+          role: "user",
+          content:
+            "visible ask\n\n<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nsecret\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        },
+      },
+      {
+        type: "message",
+        id: "runtime-assistant",
+        parentId: "runtime-user",
+        message: { role: "assistant", content: "stale" },
+      },
+      {
+        type: "metadata",
+        id: "append-root",
+        parentId: null,
+        payload: { source: "plugin" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "append-root",
+        targetId: "active-assistant",
+        appendParentId: "append-root",
+      },
+    ]);
+
+    const result = await repairBrokenSessionTranscriptFile({ filePath, shouldRepair: true });
+
+    expect(result.repaired).toBe(true);
+    const repaired = await fs.readFile(filePath, "utf-8");
+    expect(repaired).toContain("previous");
+    expect(repaired).toContain("answer");
+    expect(repaired).toContain('"id":"append-root"');
+    expect(repaired).not.toContain("stale");
+    const reopened = SessionManager.open(filePath, path.dirname(filePath));
+    expect(reopened.buildSessionContext().messages).toHaveLength(3);
+    reopened.appendMessage({ role: "user", content: "continued", timestamp: Date.now() });
+    const records = (await fs.readFile(filePath, "utf-8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line));
+    expect(records.at(-1)).toMatchObject({ type: "message", parentId: "append-root" });
+  });
+
+  it("preserves an explicit root append cursor while repairing the visible branch", async () => {
+    const filePath = await writeTranscript([
+      { type: "session", version: 3, id: "session-root", timestamp: "2026-06-15T00:00:00Z" },
+      {
+        type: "message",
+        id: "parent",
+        parentId: null,
+        message: { role: "assistant", content: "previous" },
+      },
+      {
+        type: "message",
+        id: "runtime-user",
+        parentId: "parent",
+        message: {
+          role: "user",
+          content:
+            "visible ask\n\n<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nsecret\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        },
+      },
+      {
+        type: "message",
+        id: "runtime-assistant",
+        parentId: "runtime-user",
+        message: { role: "assistant", content: "stale" },
+      },
+      {
+        type: "message",
+        id: "active-user",
+        parentId: "parent",
+        message: { role: "user", content: "visible ask" },
+      },
+      {
+        type: "message",
+        id: "active-assistant",
+        parentId: "active-user",
+        message: { role: "assistant", content: "answer" },
+      },
+      {
+        type: "leaf",
+        id: "root-append-control",
+        parentId: "runtime-assistant",
+        targetId: "active-assistant",
+        appendParentId: null,
+      },
+    ]);
+
+    const result = await repairBrokenSessionTranscriptFile({ filePath, shouldRepair: true });
+
+    expect(result.repaired).toBe(true);
+    const reopened = SessionManager.open(filePath, path.dirname(filePath));
+    expect(reopened.buildSessionContext().messages).toHaveLength(3);
+    reopened.appendMessage({ role: "user", content: "new root", timestamp: Date.now() });
+    const records = (await fs.readFile(filePath, "utf-8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line));
+    expect(records.at(-2)).toMatchObject({
+      type: "leaf",
+      targetId: "active-assistant",
+      appendParentId: null,
+    });
+    expect(records.at(-1)).toMatchObject({ type: "message", parentId: null });
   });
 
   it("rewrites legacy OpenAI Codex transcript metadata only during doctor repair", async () => {

--- a/src/commands/doctor-session-transcripts.ts
+++ b/src/commands/doctor-session-transcripts.ts
@@ -9,6 +9,13 @@ import {
 } from "../agents/internal-runtime-context.js";
 import { resolveAgentSessionDirs } from "../agents/session-dirs.js";
 import { resolveStateDir } from "../config/paths.js";
+import {
+  isSessionTranscriptLeafControl,
+  mergeSessionTranscriptTreePaths,
+  mergeSessionTranscriptVisiblePathWithOpaqueAppendPath,
+  scanSessionTranscriptTree,
+  selectSessionTranscriptTreePathNodes,
+} from "../config/sessions/transcript-tree.js";
 import { shortenHomePath } from "../utils.js";
 
 type TranscriptEntry = Record<string, unknown> & {
@@ -27,6 +34,13 @@ type TranscriptRepairResult = {
   legacyOpenAICodexEntries: number;
   backupPath?: string;
   reason?: string;
+};
+
+type ActiveTranscriptPath = {
+  entries: TranscriptEntry[];
+  entriesToPersist: TranscriptEntry[];
+  terminalLeafControl: TranscriptEntry | null;
+  appendParentId: string | null;
 };
 
 const LEGACY_OPENAI_CODEX_PROVIDER_ID = "openai-codex";
@@ -64,6 +78,10 @@ function getMessage(entry: TranscriptEntry): Record<string, unknown> | null {
   return entry.message && typeof entry.message === "object" && !Array.isArray(entry.message)
     ? (entry.message as Record<string, unknown>)
     : null;
+}
+
+function withSelectedParent(entry: TranscriptEntry, parentId: string | null): TranscriptEntry {
+  return entry.parentId === parentId ? entry : { ...entry, parentId };
 }
 
 function normalizeLegacyOpenAICodexTranscriptMetadata(entries: TranscriptEntry[]): number {
@@ -106,36 +124,65 @@ function textFromContent(content: unknown): string | null {
   return text || null;
 }
 
-function selectActivePath(entries: TranscriptEntry[]): TranscriptEntry[] | null {
+function selectActivePath(entries: TranscriptEntry[]): ActiveTranscriptPath | null {
   const sessionEntries = entries.filter((entry) => entry.type !== "session");
-  const leaf = sessionEntries.at(-1);
-  const leafId = leaf ? getEntryId(leaf) : null;
-  if (!leaf || !leafId) {
+  const tree = scanSessionTranscriptTree(sessionEntries);
+  if (!tree.hasExplicitLeafUpdate) {
+    const byId = new Map<string, TranscriptEntry>();
+    for (const entry of sessionEntries) {
+      const id = getEntryId(entry);
+      if (id) {
+        byId.set(id, entry);
+      }
+    }
+    const active: TranscriptEntry[] = [];
+    const seen = new Set<string>();
+    let current = sessionEntries.at(-1);
+    while (current) {
+      const id = getEntryId(current);
+      if (!id || seen.has(id)) {
+        return null;
+      }
+      seen.add(id);
+      active.unshift(current);
+      const parentId = getParentId(current);
+      current = parentId ? byId.get(parentId) : undefined;
+    }
+    return active.length > 0
+      ? {
+          entries: active,
+          entriesToPersist: active,
+          terminalLeafControl: null,
+          appendParentId: getEntryId(active.at(-1) ?? {}),
+        }
+      : null;
+  }
+  if (!tree.hasLeafUpdate) {
     return null;
   }
-
-  const byId = new Map<string, TranscriptEntry>();
-  for (const entry of sessionEntries) {
-    const id = getEntryId(entry);
-    if (id) {
-      byId.set(id, entry);
-    }
-  }
-
-  const active: TranscriptEntry[] = [];
-  const seen = new Set<string>();
-  let current: TranscriptEntry | undefined = leaf;
-  while (current) {
-    const id = getEntryId(current);
-    if (!id || seen.has(id)) {
-      return null;
-    }
-    seen.add(id);
-    active.unshift(current);
-    const parentId = getParentId(current);
-    current = parentId ? byId.get(parentId) : undefined;
-  }
-  return active;
+  const visiblePath = selectSessionTranscriptTreePathNodes(tree, tree.leafId);
+  const appendPath = selectSessionTranscriptTreePathNodes(tree, tree.appendParentId);
+  const visibleEntries = mergeSessionTranscriptTreePaths([visiblePath]).map((node) =>
+    withSelectedParent(node.entry, node.selectedParentId),
+  );
+  const persistedPath = mergeSessionTranscriptVisiblePathWithOpaqueAppendPath({
+    visiblePath,
+    appendPath,
+    appendParentId: tree.appendParentId,
+  });
+  const entriesToPersist = persistedPath.nodes.map((node) =>
+    withSelectedParent(node.entry, node.selectedParentId),
+  );
+  const lastLeafUpdateEntry = tree.nodes.findLast((node) => node.leafId !== undefined)?.entry;
+  const terminalLeafControl = isSessionTranscriptLeafControl(lastLeafUpdateEntry)
+    ? lastLeafUpdateEntry
+    : null;
+  return {
+    entries: visibleEntries,
+    entriesToPersist,
+    terminalLeafControl,
+    appendParentId: persistedPath.appendParentId,
+  };
 }
 
 function hasBrokenPromptRewriteBranch(entries: TranscriptEntry[], activePath: TranscriptEntry[]) {
@@ -181,7 +228,7 @@ function hasBrokenPromptRewriteBranch(entries: TranscriptEntry[], activePath: Tr
 async function writeActiveTranscript(params: {
   filePath: string;
   entries: TranscriptEntry[];
-  activePath: TranscriptEntry[];
+  activePath: ActiveTranscriptPath;
 }): Promise<string> {
   const header = params.entries.find((entry) => entry.type === "session");
   if (!header) {
@@ -191,7 +238,21 @@ async function writeActiveTranscript(params: {
     .toISOString()
     .replace(/[:.]/g, "-")}.bak`;
   await fs.copyFile(params.filePath, backupPath);
-  const next = [header, ...params.activePath].map((entry) => JSON.stringify(entry)).join("\n");
+  const lastPersistedId = getEntryId(params.activePath.entriesToPersist.at(-1) ?? {});
+  const terminalLeafControl = params.activePath.terminalLeafControl
+    ? {
+        ...params.activePath.terminalLeafControl,
+        parentId: lastPersistedId,
+        appendParentId: params.activePath.appendParentId,
+      }
+    : null;
+  const next = [
+    header,
+    ...params.activePath.entriesToPersist,
+    ...(terminalLeafControl ? [terminalLeafControl] : []),
+  ]
+    .map((entry) => JSON.stringify(entry))
+    .join("\n");
   await fs.writeFile(params.filePath, `${next}\n`, "utf-8");
   return backupPath;
 }
@@ -243,14 +304,14 @@ export async function repairBrokenSessionTranscriptFile(params: {
         reason: "no active branch",
       };
     }
-    const broken = hasBrokenPromptRewriteBranch(entries, activePath);
+    const broken = hasBrokenPromptRewriteBranch(entries, activePath.entries);
     if (!broken && legacyOpenAICodexEntries === 0) {
       return {
         filePath: params.filePath,
         broken: false,
         repaired: false,
         originalEntries: entries.length,
-        activeEntries: activePath.length,
+        activeEntries: activePath.entries.length,
         legacyOpenAICodexEntries,
       };
     }
@@ -260,7 +321,7 @@ export async function repairBrokenSessionTranscriptFile(params: {
         broken: true,
         repaired: false,
         originalEntries: entries.length,
-        activeEntries: activePath.length,
+        activeEntries: activePath.entries.length,
         legacyOpenAICodexEntries,
       };
     }
@@ -276,7 +337,7 @@ export async function repairBrokenSessionTranscriptFile(params: {
       broken: true,
       repaired: true,
       originalEntries: entries.length,
-      activeEntries: activePath.length,
+      activeEntries: activePath.entries.length,
       legacyOpenAICodexEntries,
       backupPath,
     };

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -36,23 +36,53 @@ type TranscriptLeafInfo = {
   nonSessionEntryCount: number;
 };
 
+type TranscriptLineInfo = {
+  isNonSessionEntry: boolean;
+  hasParentLinkedEntry: boolean;
+  leafUpdate?: { leafId: string | null };
+};
+
 async function yieldTranscriptAppendScan(): Promise<void> {
   await new Promise<void>((resolve) => {
     setImmediate(resolve);
   });
 }
 
-function lineParentLinkedEntryId(line: string): string | undefined {
+function readTranscriptLineInfo(line: string): TranscriptLineInfo {
   if (!line.trim()) {
-    return undefined;
+    return { isNonSessionEntry: false, hasParentLinkedEntry: false };
   }
   try {
-    const parsed = JSON.parse(line) as { type?: unknown; id?: unknown; parentId?: unknown };
-    return parsed.type !== "session" && typeof parsed.id === "string" && "parentId" in parsed
-      ? parsed.id
-      : undefined;
+    const parsed = JSON.parse(line) as {
+      type?: unknown;
+      id?: unknown;
+      parentId?: unknown;
+      targetId?: unknown;
+    };
+    if (parsed.type === "session") {
+      return { isNonSessionEntry: false, hasParentLinkedEntry: false };
+    }
+    const entryId = typeof parsed.id === "string" ? parsed.id : undefined;
+    if (!entryId || !("parentId" in parsed)) {
+      return { isNonSessionEntry: true, hasParentLinkedEntry: false };
+    }
+    if (parsed.type === "leaf") {
+      const targetId = parsed.targetId;
+      return targetId === null || typeof targetId === "string"
+        ? {
+            isNonSessionEntry: true,
+            hasParentLinkedEntry: true,
+            leafUpdate: { leafId: targetId },
+          }
+        : { isNonSessionEntry: true, hasParentLinkedEntry: true };
+    }
+    return {
+      isNonSessionEntry: true,
+      hasParentLinkedEntry: true,
+      leafUpdate: { leafId: entryId },
+    };
   } catch {
-    return undefined;
+    return { isNonSessionEntry: false, hasParentLinkedEntry: false };
   }
 }
 
@@ -91,26 +121,30 @@ async function readTranscriptLeafInfo(transcriptPath: string): Promise<Transcrip
       const lines = text.split(/\r?\n/);
       carry = lines.pop() ?? "";
       for (const line of lines) {
-        if (lineHasNonSessionEntry(line)) {
+        const lineInfo = readTranscriptLineInfo(line);
+        if (lineInfo.isNonSessionEntry) {
           nonSessionEntryCount += 1;
         }
-        const id = lineParentLinkedEntryId(line);
-        if (id) {
-          leafId = id;
+        if (lineInfo.hasParentLinkedEntry) {
           hasParentLinkedEntries = true;
+        }
+        if (lineInfo.leafUpdate) {
+          leafId = lineInfo.leafUpdate.leafId ?? undefined;
         }
       }
       // Large transcripts are scanned cooperatively so appends do not monopolize the event loop.
       await yieldTranscriptAppendScan();
     }
     const tail = carry + decoder.end();
-    if (lineHasNonSessionEntry(tail)) {
+    const tailInfo = readTranscriptLineInfo(tail);
+    if (tailInfo.isNonSessionEntry) {
       nonSessionEntryCount += 1;
     }
-    const id = lineParentLinkedEntryId(tail);
-    if (id) {
-      leafId = id;
+    if (tailInfo.hasParentLinkedEntry) {
       hasParentLinkedEntries = true;
+    }
+    if (tailInfo.leafUpdate) {
+      leafId = tailInfo.leafUpdate.leafId ?? undefined;
     }
     return {
       ...(leafId ? { leafId } : {}),
@@ -119,18 +153,6 @@ async function readTranscriptLeafInfo(transcriptPath: string): Promise<Transcrip
     };
   } finally {
     await handle.close();
-  }
-}
-
-function lineHasNonSessionEntry(line: string): boolean {
-  if (!line.trim()) {
-    return false;
-  }
-  try {
-    const parsed = JSON.parse(line) as { type?: unknown };
-    return parsed.type !== "session";
-  } catch {
-    return false;
   }
 }
 
@@ -298,6 +320,8 @@ export async function appendSessionTranscriptMessage<TMessage>(
           ...(publishedHeader ? [{ kind: "header" as const, serialized: publishedHeader }] : []),
           ...(result?.appended === true ? [{ kind: "id" as const, id: result.messageId }] : []),
         ],
+        resolvePublishedEntriesAfterFailure: () =>
+          publishedHeader ? [{ kind: "header", serialized: publishedHeader }] : [],
       },
     );
   }

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -2,7 +2,6 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { StringDecoder } from "node:string_decoder";
 import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import {
@@ -21,11 +20,14 @@ import {
   writeJsonlEntry,
   writeJsonlLines,
 } from "./transcript-jsonl.js";
-import { streamSessionTranscriptLinesReverse } from "./transcript-stream.js";
+import {
+  streamSessionTranscriptLines,
+  streamSessionTranscriptLinesReverse,
+} from "./transcript-stream.js";
+import { isCanonicalSessionTranscriptEntry } from "./transcript-tree.js";
 import { resolveOwnedSessionTranscriptWriteLockRunner } from "./transcript-write-context.js";
 import { CURRENT_SESSION_VERSION } from "./version.js";
 
-const TRANSCRIPT_APPEND_SCAN_CHUNK_BYTES = 64 * 1024;
 const SESSION_MANAGER_APPEND_MAX_BYTES = 8 * 1024 * 1024;
 
 const transcriptAppendQueues = new Map<string, Promise<void>>();
@@ -39,14 +41,13 @@ type TranscriptLeafInfo = {
 type TranscriptLineInfo = {
   isNonSessionEntry: boolean;
   hasParentLinkedEntry: boolean;
-  leafUpdate?: { leafId: string | null };
+  entryId?: string;
+  leafControl?: {
+    targetId: string | null;
+    appendParentId?: string | null;
+  };
+  invalidLeafControl?: boolean;
 };
-
-async function yieldTranscriptAppendScan(): Promise<void> {
-  await new Promise<void>((resolve) => {
-    setImmediate(resolve);
-  });
-}
 
 function readTranscriptLineInfo(line: string): TranscriptLineInfo {
   if (!line.trim()) {
@@ -58,28 +59,55 @@ function readTranscriptLineInfo(line: string): TranscriptLineInfo {
       id?: unknown;
       parentId?: unknown;
       targetId?: unknown;
+      appendParentId?: unknown;
     };
     if (parsed.type === "session") {
       return { isNonSessionEntry: false, hasParentLinkedEntry: false };
     }
-    const entryId = typeof parsed.id === "string" ? parsed.id : undefined;
-    if (!entryId || !("parentId" in parsed)) {
+    const entryId = normalizeEntryId(parsed.id);
+    if (!entryId) {
       return { isNonSessionEntry: true, hasParentLinkedEntry: false };
     }
+    if (!("parentId" in parsed)) {
+      return {
+        isNonSessionEntry: true,
+        hasParentLinkedEntry: false,
+        ...(isCanonicalSessionTranscriptEntry(parsed) ? { entryId } : {}),
+      };
+    }
     if (parsed.type === "leaf") {
-      const targetId = parsed.targetId;
-      return targetId === null || typeof targetId === "string"
-        ? {
-            isNonSessionEntry: true,
-            hasParentLinkedEntry: true,
-            leafUpdate: { leafId: targetId },
-          }
-        : { isNonSessionEntry: true, hasParentLinkedEntry: true };
+      const targetId = parsed.targetId === null ? null : normalizeEntryId(parsed.targetId);
+      const appendParentId =
+        parsed.appendParentId === undefined
+          ? undefined
+          : parsed.appendParentId === null
+            ? null
+            : normalizeEntryId(parsed.appendParentId);
+      if (
+        (parsed.targetId !== null && targetId === undefined) ||
+        (parsed.appendParentId !== undefined && appendParentId === undefined)
+      ) {
+        return {
+          isNonSessionEntry: true,
+          hasParentLinkedEntry: true,
+          entryId,
+          invalidLeafControl: true,
+        };
+      }
+      return {
+        isNonSessionEntry: true,
+        hasParentLinkedEntry: true,
+        entryId,
+        leafControl: {
+          targetId: targetId ?? null,
+          ...(appendParentId !== undefined ? { appendParentId } : {}),
+        },
+      };
     }
     return {
       isNonSessionEntry: true,
       hasParentLinkedEntry: true,
-      leafUpdate: { leafId: entryId },
+      entryId,
     };
   } catch {
     return { isNonSessionEntry: false, hasParentLinkedEntry: false };
@@ -103,57 +131,102 @@ function generateEntryId(existingIds: Set<string>): string {
   return id;
 }
 
-async function readTranscriptLeafInfo(transcriptPath: string): Promise<TranscriptLeafInfo> {
-  const handle = await fs.open(transcriptPath, "r");
-  try {
-    const decoder = new StringDecoder("utf8");
-    const buffer = Buffer.allocUnsafe(TRANSCRIPT_APPEND_SCAN_CHUNK_BYTES);
-    let carry = "";
-    let leafId: string | undefined;
-    let hasParentLinkedEntries = false;
-    let nonSessionEntryCount = 0;
-    while (true) {
-      const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
-      if (bytesRead <= 0) {
-        break;
-      }
-      const text = carry + decoder.write(buffer.subarray(0, bytesRead));
-      const lines = text.split(/\r?\n/);
-      carry = lines.pop() ?? "";
-      for (const line of lines) {
-        const lineInfo = readTranscriptLineInfo(line);
-        if (lineInfo.isNonSessionEntry) {
-          nonSessionEntryCount += 1;
-        }
-        if (lineInfo.hasParentLinkedEntry) {
-          hasParentLinkedEntries = true;
-        }
-        if (lineInfo.leafUpdate) {
-          leafId = lineInfo.leafUpdate.leafId ?? undefined;
-        }
-      }
-      // Large transcripts are scanned cooperatively so appends do not monopolize the event loop.
-      await yieldTranscriptAppendScan();
+async function validateTranscriptLeafControlReferences(params: {
+  transcriptPath: string;
+  leafControlId: string;
+  leafControl: NonNullable<TranscriptLineInfo["leafControl"]>;
+}): Promise<boolean> {
+  const referenceIds = new Set(
+    [params.leafControl.targetId, params.leafControl.appendParentId].filter(
+      (id): id is string => typeof id === "string",
+    ),
+  );
+  if (referenceIds.size === 0) {
+    return true;
+  }
+
+  for await (const line of streamSessionTranscriptLines(params.transcriptPath)) {
+    const lineInfo = readTranscriptLineInfo(line);
+    if (lineInfo.entryId === params.leafControlId) {
+      break;
     }
-    const tail = carry + decoder.end();
-    const tailInfo = readTranscriptLineInfo(tail);
-    if (tailInfo.isNonSessionEntry) {
+    if (!lineInfo.entryId || !referenceIds.has(lineInfo.entryId)) {
+      continue;
+    }
+    if (
+      lineInfo.invalidLeafControl ||
+      (lineInfo.leafControl &&
+        !(await validateTranscriptLeafControlReferences({
+          transcriptPath: params.transcriptPath,
+          leafControlId: lineInfo.entryId,
+          leafControl: lineInfo.leafControl,
+        })))
+    ) {
+      return false;
+    }
+    referenceIds.delete(lineInfo.entryId);
+    if (referenceIds.size === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function resolveTranscriptLeafIdFromTrailingControls(
+  transcriptPath: string,
+): Promise<string | undefined> {
+  for await (const line of streamSessionTranscriptLinesReverse(transcriptPath)) {
+    const lineInfo = readTranscriptLineInfo(line);
+    if (!lineInfo.entryId || lineInfo.invalidLeafControl) {
+      continue;
+    }
+    if (!lineInfo.leafControl) {
+      return lineInfo.entryId;
+    }
+    const valid = await validateTranscriptLeafControlReferences({
+      transcriptPath,
+      leafControlId: lineInfo.entryId,
+      leafControl: lineInfo.leafControl,
+    });
+    if (valid) {
+      const { targetId, appendParentId } = lineInfo.leafControl;
+      return (appendParentId === undefined ? targetId : appendParentId) ?? undefined;
+    }
+  }
+  return undefined;
+}
+
+async function readTranscriptLeafInfo(transcriptPath: string): Promise<TranscriptLeafInfo> {
+  let leafId: string | undefined;
+  let hasParentLinkedEntries = false;
+  let nonSessionEntryCount = 0;
+  let hasTrailingLeafControl = false;
+  for await (const line of streamSessionTranscriptLines(transcriptPath)) {
+    const lineInfo = readTranscriptLineInfo(line);
+    if (lineInfo.isNonSessionEntry) {
       nonSessionEntryCount += 1;
     }
-    if (tailInfo.hasParentLinkedEntry) {
+    if (lineInfo.hasParentLinkedEntry) {
       hasParentLinkedEntries = true;
     }
-    if (tailInfo.leafUpdate) {
-      leafId = tailInfo.leafUpdate.leafId ?? undefined;
+    if (!lineInfo.entryId) {
+      continue;
     }
-    return {
-      ...(leafId ? { leafId } : {}),
-      hasParentLinkedEntries,
-      nonSessionEntryCount,
-    };
-  } finally {
-    await handle.close();
+    if (lineInfo.invalidLeafControl || lineInfo.leafControl) {
+      hasTrailingLeafControl = true;
+      continue;
+    }
+    leafId = lineInfo.entryId;
+    hasTrailingLeafControl = false;
   }
+  if (hasTrailingLeafControl) {
+    leafId = await resolveTranscriptLeafIdFromTrailingControls(transcriptPath);
+  }
+  return {
+    ...(leafId ? { leafId } : {}),
+    hasParentLinkedEntries,
+    nonSessionEntryCount,
+  };
 }
 
 async function migrateLinearTranscriptToParentLinked(transcriptPath: string): Promise<{

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -11,6 +11,7 @@ import {
 import { redactTranscriptMessage } from "../../agents/transcript-redact.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { redactSecrets } from "../../logging/redact.js";
+import { isTranscriptOnlyOpenClawAssistantMessage } from "../../shared/transcript-only-openclaw-assistant.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {
   appendJsonlEntry,
@@ -34,6 +35,7 @@ const transcriptAppendQueues = new Map<string, Promise<void>>();
 
 type TranscriptLeafInfo = {
   leafId?: string;
+  appendMode: "active" | "side";
   hasParentLinkedEntries: boolean;
   nonSessionEntryCount: number;
 };
@@ -42,9 +44,12 @@ type TranscriptLineInfo = {
   isNonSessionEntry: boolean;
   hasParentLinkedEntry: boolean;
   entryId?: string;
+  isCanonicalEntry?: boolean;
+  appendMode?: "side";
   leafControl?: {
     targetId: string | null;
     appendParentId?: string | null;
+    appendMode?: "side";
   };
   invalidLeafControl?: boolean;
 };
@@ -60,6 +65,7 @@ function readTranscriptLineInfo(line: string): TranscriptLineInfo {
       parentId?: unknown;
       targetId?: unknown;
       appendParentId?: unknown;
+      appendMode?: unknown;
     };
     if (parsed.type === "session") {
       return { isNonSessionEntry: false, hasParentLinkedEntry: false };
@@ -69,10 +75,14 @@ function readTranscriptLineInfo(line: string): TranscriptLineInfo {
       return { isNonSessionEntry: true, hasParentLinkedEntry: false };
     }
     if (!("parentId" in parsed)) {
+      const isCanonicalEntry = isCanonicalSessionTranscriptEntry(parsed);
       return {
         isNonSessionEntry: true,
         hasParentLinkedEntry: false,
-        ...(isCanonicalSessionTranscriptEntry(parsed) ? { entryId } : {}),
+        ...(isCanonicalEntry ? { entryId, isCanonicalEntry: true as const } : {}),
+        ...(isCanonicalEntry && parsed.appendMode === "side"
+          ? { appendMode: parsed.appendMode }
+          : {}),
       };
     }
     if (parsed.type === "leaf") {
@@ -85,7 +95,8 @@ function readTranscriptLineInfo(line: string): TranscriptLineInfo {
             : normalizeEntryId(parsed.appendParentId);
       if (
         (parsed.targetId !== null && targetId === undefined) ||
-        (parsed.appendParentId !== undefined && appendParentId === undefined)
+        (parsed.appendParentId !== undefined && appendParentId === undefined) ||
+        (parsed.appendMode !== undefined && parsed.appendMode !== "side")
       ) {
         return {
           isNonSessionEntry: true,
@@ -101,13 +112,19 @@ function readTranscriptLineInfo(line: string): TranscriptLineInfo {
         leafControl: {
           targetId: targetId ?? null,
           ...(appendParentId !== undefined ? { appendParentId } : {}),
+          ...(parsed.appendMode === "side" ? { appendMode: parsed.appendMode } : {}),
         },
       };
     }
+    const isCanonicalEntry = isCanonicalSessionTranscriptEntry(parsed);
     return {
       isNonSessionEntry: true,
       hasParentLinkedEntry: true,
       entryId,
+      ...(isCanonicalEntry ? { isCanonicalEntry: true as const } : {}),
+      ...(isCanonicalEntry && parsed.appendMode === "side"
+        ? { appendMode: parsed.appendMode }
+        : {}),
     };
   } catch {
     return { isNonSessionEntry: false, hasParentLinkedEntry: false };
@@ -174,14 +191,17 @@ async function validateTranscriptLeafControlReferences(params: {
 
 async function resolveTranscriptLeafIdFromTrailingControls(
   transcriptPath: string,
-): Promise<string | undefined> {
+): Promise<{ leafId?: string; appendMode: "active" | "side" }> {
   for await (const line of streamSessionTranscriptLinesReverse(transcriptPath)) {
     const lineInfo = readTranscriptLineInfo(line);
     if (!lineInfo.entryId || lineInfo.invalidLeafControl) {
       continue;
     }
     if (!lineInfo.leafControl) {
-      return lineInfo.entryId;
+      return {
+        leafId: lineInfo.entryId,
+        appendMode: lineInfo.appendMode === "side" ? "side" : "active",
+      };
     }
     const valid = await validateTranscriptLeafControlReferences({
       transcriptPath,
@@ -189,11 +209,15 @@ async function resolveTranscriptLeafIdFromTrailingControls(
       leafControl: lineInfo.leafControl,
     });
     if (valid) {
-      const { targetId, appendParentId } = lineInfo.leafControl;
-      return (appendParentId === undefined ? targetId : appendParentId) ?? undefined;
+      const { targetId, appendParentId, appendMode } = lineInfo.leafControl;
+      const leafId = (appendParentId === undefined ? targetId : appendParentId) ?? undefined;
+      return {
+        ...(leafId ? { leafId } : {}),
+        appendMode: appendMode === "side" ? "side" : "active",
+      };
     }
   }
-  return undefined;
+  return { appendMode: "active" };
 }
 
 async function readTranscriptLeafInfo(transcriptPath: string): Promise<TranscriptLeafInfo> {
@@ -201,6 +225,7 @@ async function readTranscriptLeafInfo(transcriptPath: string): Promise<Transcrip
   let hasParentLinkedEntries = false;
   let nonSessionEntryCount = 0;
   let hasTrailingLeafControl = false;
+  let appendMode: "active" | "side" = "active";
   for await (const line of streamSessionTranscriptLines(transcriptPath)) {
     const lineInfo = readTranscriptLineInfo(line);
     if (lineInfo.isNonSessionEntry) {
@@ -213,17 +238,26 @@ async function readTranscriptLeafInfo(transcriptPath: string): Promise<Transcrip
       continue;
     }
     if (lineInfo.invalidLeafControl || lineInfo.leafControl) {
+      if (lineInfo.leafControl) {
+        appendMode = lineInfo.leafControl.appendMode === "side" ? "side" : "active";
+      }
       hasTrailingLeafControl = true;
       continue;
     }
     leafId = lineInfo.entryId;
+    if (lineInfo.isCanonicalEntry) {
+      appendMode = lineInfo.appendMode === "side" ? "side" : "active";
+    }
     hasTrailingLeafControl = false;
   }
   if (hasTrailingLeafControl) {
-    leafId = await resolveTranscriptLeafIdFromTrailingControls(transcriptPath);
+    const resolvedLeaf = await resolveTranscriptLeafIdFromTrailingControls(transcriptPath);
+    leafId = resolvedLeaf.leafId;
+    appendMode = resolvedLeaf.appendMode;
   }
   return {
     ...(leafId ? { leafId } : {}),
+    appendMode,
     hasParentLinkedEntries,
     nonSessionEntryCount,
   };
@@ -496,6 +530,7 @@ async function appendSessionTranscriptMessageLocked<TMessage>(
     () => ({
       hasParentLinkedEntries: false,
       nonSessionEntryCount: 0,
+      appendMode: "active",
     }),
   );
   const hasLinearEntries = !leafInfo.hasParentLinkedEntries && leafInfo.nonSessionEntryCount > 0;
@@ -506,6 +541,7 @@ async function appendSessionTranscriptMessageLocked<TMessage>(
     const migrated = await migrateLinearTranscriptToParentLinked(params.transcriptPath);
     leafInfo = {
       ...(migrated.leafId ? { leafId: migrated.leafId } : {}),
+      appendMode: "active",
       hasParentLinkedEntries: Boolean(migrated.leafId),
       nonSessionEntryCount: leafInfo.nonSessionEntryCount,
     };
@@ -521,6 +557,9 @@ async function appendSessionTranscriptMessageLocked<TMessage>(
     ...(shouldRawAppend ? {} : { parentId: leafInfo.leafId ?? null }),
     timestamp: resolveTimestampMsToIsoString(now),
     message: finalMessage,
+    ...(leafInfo.appendMode === "side" && isTranscriptOnlyOpenClawAssistantMessage(finalMessage)
+      ? { appendMode: "side" as const }
+      : {}),
   };
   await appendJsonlEntry(params.transcriptPath, entry);
   return { messageId, message: finalMessage, appended: true };

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -15,6 +15,8 @@ import { redactSecrets } from "../../logging/redact.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {
   appendJsonlEntry,
+  appendSerializedJsonlEntry,
+  serializeJsonlEntry,
   serializeJsonlLine,
   writeJsonlEntry,
   writeJsonlLines,
@@ -278,10 +280,15 @@ export async function appendSessionTranscriptMessage<TMessage>(
     // Active prompt-stream writes must acquire the session lock before joining
     // the append FIFO; otherwise a hook that already owns the lock can deadlock
     // behind the prompt append it is blocking.
-    return await activeLockRunner(() =>
-      withTranscriptAppendQueue(params.transcriptPath, () =>
-        appendSessionTranscriptMessageLocked(params),
-      ),
+    return await activeLockRunner(
+      () =>
+        withTranscriptAppendQueue(params.transcriptPath, () =>
+          appendSessionTranscriptMessageLocked(params),
+        ),
+      {
+        publishOwnedWrite: true,
+        resolvePublishedEntryIds: (result) => (result?.appended === true ? [result.messageId] : []),
+      },
     );
   }
   return await withTranscriptAppendQueue(params.transcriptPath, () =>
@@ -303,13 +310,19 @@ export async function appendSessionTranscriptEvent(
     sessionFile: params.transcriptPath,
   });
   if (activeLockRunner) {
-    return await activeLockRunner(() =>
-      withTranscriptAppendQueue(params.transcriptPath, () =>
-        appendSessionTranscriptEventLocked(params),
-      ),
+    await activeLockRunner(
+      () =>
+        withTranscriptAppendQueue(params.transcriptPath, () =>
+          appendSessionTranscriptEventLocked(params),
+        ),
+      {
+        publishOwnedWrite: true,
+        resolvePublishedEntryIds: (result) => (result.entryId ? [result.entryId] : []),
+      },
     );
+    return;
   }
-  return await withTranscriptAppendQueue(params.transcriptPath, () =>
+  await withTranscriptAppendQueue(params.transcriptPath, () =>
     withSessionTranscriptWriteLock(params, () => appendSessionTranscriptEventLocked(params)),
   );
 }
@@ -332,9 +345,20 @@ async function withSessionTranscriptWriteLock<T>(
 
 async function appendSessionTranscriptEventLocked(
   params: AppendSessionTranscriptEventParams,
-): Promise<void> {
+): Promise<{ entryId?: string }> {
   await fs.mkdir(path.dirname(params.transcriptPath), { recursive: true });
-  await appendJsonlEntry(params.transcriptPath, params.event);
+  const serializedEvent = serializeJsonlEntry(params.event);
+  await appendSerializedJsonlEntry(params.transcriptPath, serializedEvent);
+  try {
+    const persisted = JSON.parse(serializedEvent) as unknown;
+    const entryId =
+      persisted && typeof persisted === "object" && !Array.isArray(persisted)
+        ? (persisted as { id?: unknown }).id
+        : undefined;
+    return typeof entryId === "string" && entryId.trim().length > 0 ? { entryId } : {};
+  } catch {
+    return {};
+  }
 }
 
 async function appendSessionTranscriptMessageLocked<TMessage>(

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -184,10 +184,10 @@ async function migrateLinearTranscriptToParentLinked(transcriptPath: string): Pr
 async function ensureTranscriptHeader(
   transcriptPath: string,
   params: { sessionId?: string; cwd?: string } = {},
-): Promise<void> {
+): Promise<string | undefined> {
   const stat = await fs.stat(transcriptPath).catch(() => null);
   if (stat?.isFile() && stat.size > 0) {
-    return;
+    return undefined;
   }
   await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
   const header = createSessionTranscriptHeader(params);
@@ -195,6 +195,7 @@ async function ensureTranscriptHeader(
     mode: 0o600,
     flag: stat?.isFile() ? "w" : "wx",
   });
+  return serializeJsonlLine(header);
 }
 
 async function resolveTranscriptAppendQueueKey(transcriptPath: string): Promise<string> {
@@ -280,14 +281,23 @@ export async function appendSessionTranscriptMessage<TMessage>(
     // Active prompt-stream writes must acquire the session lock before joining
     // the append FIFO; otherwise a hook that already owns the lock can deadlock
     // behind the prompt append it is blocking.
+    let publishedHeader: string | undefined;
     return await activeLockRunner(
       () =>
         withTranscriptAppendQueue(params.transcriptPath, () =>
-          appendSessionTranscriptMessageLocked(params),
+          appendSessionTranscriptMessageLocked({
+            ...params,
+            onHeaderCreated: (header) => {
+              publishedHeader = header;
+            },
+          }),
         ),
       {
         publishOwnedWrite: true,
-        resolvePublishedEntryIds: (result) => (result?.appended === true ? [result.messageId] : []),
+        resolvePublishedEntries: (result) => [
+          ...(publishedHeader ? [{ kind: "header" as const, serialized: publishedHeader }] : []),
+          ...(result?.appended === true ? [{ kind: "id" as const, id: result.messageId }] : []),
+        ],
       },
     );
   }
@@ -317,7 +327,9 @@ export async function appendSessionTranscriptEvent(
         ),
       {
         publishOwnedWrite: true,
-        resolvePublishedEntryIds: (result) => (result.entryId ? [result.entryId] : []),
+        resolvePublishedEntries: (result) => [
+          { kind: "serialized", serialized: result.serializedEntry },
+        ],
       },
     );
     return;
@@ -345,30 +357,26 @@ async function withSessionTranscriptWriteLock<T>(
 
 async function appendSessionTranscriptEventLocked(
   params: AppendSessionTranscriptEventParams,
-): Promise<{ entryId?: string }> {
+): Promise<{ serializedEntry: string }> {
   await fs.mkdir(path.dirname(params.transcriptPath), { recursive: true });
   const serializedEvent = serializeJsonlEntry(params.event);
   await appendSerializedJsonlEntry(params.transcriptPath, serializedEvent);
-  try {
-    const persisted = JSON.parse(serializedEvent) as unknown;
-    const entryId =
-      persisted && typeof persisted === "object" && !Array.isArray(persisted)
-        ? (persisted as { id?: unknown }).id
-        : undefined;
-    return typeof entryId === "string" && entryId.trim().length > 0 ? { entryId } : {};
-  } catch {
-    return {};
-  }
+  return { serializedEntry: serializedEvent.slice(0, -1) };
 }
 
 async function appendSessionTranscriptMessageLocked<TMessage>(
-  params: AppendSessionTranscriptMessageParams<TMessage>,
+  params: AppendSessionTranscriptMessageParams<TMessage> & {
+    onHeaderCreated?: (serializedHeader: string) => void;
+  },
 ): Promise<AppendSessionTranscriptMessageResult<TMessage> | undefined> {
   const now = params.now ?? Date.now();
-  await ensureTranscriptHeader(params.transcriptPath, {
+  const serializedHeader = await ensureTranscriptHeader(params.transcriptPath, {
     ...(params.sessionId ? { sessionId: params.sessionId } : {}),
     ...(params.cwd ? { cwd: params.cwd } : {}),
   });
+  if (serializedHeader) {
+    params.onHeaderCreated?.(serializedHeader);
+  }
   const idempotencyKey = readMessageIdempotencyKey(params.message);
   const existing =
     idempotencyKey && params.idempotencyLookup === "scan"

--- a/src/config/sessions/transcript-jsonl.ts
+++ b/src/config/sessions/transcript-jsonl.ts
@@ -84,7 +84,13 @@ export async function writeJsonlLines(
 }
 
 export async function appendJsonlEntry(filePath: string, entry: unknown): Promise<void> {
-  const serializedEntry = serializeJsonlEntry(entry);
+  await appendSerializedJsonlEntry(filePath, serializeJsonlEntry(entry));
+}
+
+export async function appendSerializedJsonlEntry(
+  filePath: string,
+  serializedEntry: string,
+): Promise<void> {
   const handle = await fs.open(filePath, "a+", 0o600);
   try {
     const stat = await handle.stat();

--- a/src/config/sessions/transcript-tree.test.ts
+++ b/src/config/sessions/transcript-tree.test.ts
@@ -300,18 +300,12 @@ describe("session transcript tree helpers", () => {
         appendMode: "side",
       },
       { type: "custom", id: "side-two", parentId: "side-one", appendMode: "side" },
-      {
-        type: "leaf",
-        id: "second-leaf",
-        parentId: "side-two",
-        targetId: "visible",
-        appendParentId: "side-two",
-        appendMode: "side",
-      },
     ];
 
     const tree = scanSessionTranscriptTree(entries);
 
+    expect(tree.leafId).toBe("visible");
+    expect(tree.appendParentId).toBe("side-two");
     expect(tree.byId.get("side-two")?.parentId).toBe("side-one");
     expect(selectSessionTranscriptLeafControlledPath(entries)).toEqual([entries[0]]);
   });

--- a/src/config/sessions/transcript-tree.test.ts
+++ b/src/config/sessions/transcript-tree.test.ts
@@ -152,6 +152,53 @@ describe("session transcript tree helpers", () => {
     ).toEqual([activeRoot, activeTail]);
   });
 
+  it("normalizes continuations parented to an omitted leaf marker", () => {
+    const activeRoot = { type: "message", id: "active-root", parentId: null };
+    const sideEntry = { type: "message", id: "side-entry", parentId: "active-root" };
+    const leafControl = {
+      type: "leaf",
+      id: "active-leaf",
+      parentId: "side-entry",
+      targetId: "active-root",
+    };
+    const activeTail = { type: "message", id: "active-tail", parentId: "active-leaf" };
+    const entries = [activeRoot, sideEntry, leafControl, activeTail];
+
+    const tree = scanSessionTranscriptTree(entries);
+
+    expect(tree.byId.get("active-tail")?.parentId).toBe("active-root");
+    expect(selectSessionTranscriptLeafControlledPath(entries)).toEqual([
+      activeRoot,
+      { ...activeTail, parentId: "active-root" },
+    ]);
+  });
+
+  it("normalizes parentless continuations after chained leaf markers", () => {
+    const activeRoot = { type: "message", id: "active-root", parentId: null };
+    const firstLeaf = {
+      type: "leaf",
+      id: "first-leaf",
+      parentId: "active-root",
+      targetId: "active-root",
+    };
+    const secondLeaf = {
+      type: "leaf",
+      id: "second-leaf",
+      parentId: "first-leaf",
+      targetId: "first-leaf",
+    };
+    const activeTail = { type: "message", id: "active-tail" };
+    const entries = [activeRoot, firstLeaf, secondLeaf, activeTail];
+
+    const tree = scanSessionTranscriptTree(entries);
+
+    expect(tree.byId.get("active-tail")?.parentId).toBe("active-root");
+    expect(selectSessionTranscriptLeafControlledPath(entries)).toEqual([
+      activeRoot,
+      { ...activeTail, parentId: "active-root" },
+    ]);
+  });
+
   it("keeps the reachable active suffix when an older parent is missing", () => {
     const activeTail = { type: "message", id: "active-tail", parentId: "missing-parent" };
     const leafControl = {
@@ -293,6 +340,7 @@ describe("session transcript tree helpers", () => {
     expect(tree.appendParentId).toBe("child");
     expect(tree.hasLeafControl).toBe(false);
     expect(tree.byId.get("missing-target")?.parentId).toBe("root");
+    expect(tree.byId.get("child")?.parentId).toBe("root");
     expect(selectSessionTranscriptTreePathNodes(tree, tree.leafId).map((node) => node.id)).toEqual([
       "root",
       "child",

--- a/src/config/sessions/transcript-tree.test.ts
+++ b/src/config/sessions/transcript-tree.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSessionTranscriptLeafControl,
+  mergeSessionTranscriptVisiblePathWithOpaqueAppendPath,
+  parseSessionTranscriptTreeEntry,
+  readSessionTranscriptLeafUpdate,
+  resolveSessionTranscriptAppendParentId,
+  resolveSessionTranscriptLeafId,
+  scanSessionTranscriptTree,
+  selectSessionTranscriptLeafControlledPath,
+  selectSessionTranscriptTreePathNodes,
+} from "./transcript-tree.js";
+
+describe("session transcript tree helpers", () => {
+  it("recognizes only valid leaf controls", () => {
+    expect(
+      isSessionTranscriptLeafControl({
+        type: "leaf",
+        id: "leaf-control",
+        parentId: "old-tail",
+        targetId: null,
+      }),
+    ).toBe(true);
+    expect(
+      isSessionTranscriptLeafControl({
+        type: "leaf",
+        id: "leaf-control",
+        parentId: "old-tail",
+      }),
+    ).toBe(false);
+  });
+
+  it("treats leaf controls as navigation to their target", () => {
+    const leaf = {
+      type: "leaf",
+      id: "leaf-control",
+      parentId: "inactive-tail",
+      targetId: "active-tail",
+    };
+
+    expect(parseSessionTranscriptTreeEntry(leaf)).toEqual({
+      id: "leaf-control",
+      parentId: "active-tail",
+      leafId: "active-tail",
+      appendParentId: "active-tail",
+    });
+    expect(readSessionTranscriptLeafUpdate(leaf)).toBe("active-tail");
+  });
+
+  it("resolves a distinct opaque append parent from a leaf control", () => {
+    const entries = [
+      { type: "message", id: "active-tail", parentId: null },
+      { type: "metadata", id: "plugin-metadata", parentId: "active-tail" },
+      {
+        type: "leaf",
+        id: "leaf-control",
+        parentId: "inactive-tail",
+        targetId: "active-tail",
+        appendParentId: "plugin-metadata",
+      },
+    ];
+
+    expect(resolveSessionTranscriptLeafId(entries)).toBe("active-tail");
+    expect(resolveSessionTranscriptAppendParentId(entries)).toBe("plugin-metadata");
+    expect(selectSessionTranscriptLeafControlledPath(entries)).toEqual(entries.slice(0, 1));
+  });
+
+  it("does not let later opaque rows replace the visible leaf", () => {
+    const activeRoot = { type: "message", id: "active-root", parentId: null };
+    const sideEntry = { type: "message", id: "side-entry", parentId: "active-root" };
+    const leafControl = {
+      type: "leaf",
+      id: "leaf-control",
+      parentId: "side-entry",
+      targetId: "active-root",
+    };
+    const metadata = { type: "metadata", id: "plugin-metadata", parentId: "side-entry" };
+    const entries = [activeRoot, sideEntry, leafControl, metadata];
+
+    expect(resolveSessionTranscriptLeafId(entries)).toBe("active-root");
+    expect(resolveSessionTranscriptAppendParentId(entries)).toBe("plugin-metadata");
+    expect(selectSessionTranscriptLeafControlledPath(entries)).toEqual([activeRoot]);
+  });
+
+  it("resolves the last valid leaf update in file order", () => {
+    expect(
+      resolveSessionTranscriptLeafId([
+        { type: "message", id: "active-tail", parentId: null },
+        { type: "message", id: "inactive-tail", parentId: "active-tail" },
+        {
+          type: "leaf",
+          id: "leaf-control",
+          parentId: "inactive-tail",
+          targetId: "active-tail",
+        },
+      ]),
+    ).toBe("active-tail");
+  });
+
+  it("supports explicit navigation to an empty branch", () => {
+    const entries = [
+      { type: "message", id: "old-tail", parentId: null },
+      {
+        type: "leaf",
+        id: "leaf-control",
+        parentId: "old-tail",
+        targetId: null,
+        appendParentId: "old-tail",
+      },
+    ];
+
+    expect(resolveSessionTranscriptLeafId(entries)).toBeNull();
+    expect(resolveSessionTranscriptAppendParentId(entries)).toBe("old-tail");
+    expect(selectSessionTranscriptLeafControlledPath(entries)).toEqual([]);
+  });
+
+  it("keeps visible history when the next append starts at the root", () => {
+    const activeRoot = { type: "message", id: "active-root", parentId: null };
+    const leafControl = {
+      type: "leaf",
+      id: "leaf-control",
+      parentId: "inactive-tail",
+      targetId: "active-root",
+      appendParentId: null,
+    };
+
+    expect(selectSessionTranscriptLeafControlledPath([activeRoot, leafControl])).toEqual([
+      activeRoot,
+    ]);
+  });
+
+  it("selects the active path after side rows and later active appends", () => {
+    const activeRoot = { type: "message", id: "active-root", parentId: null };
+    const sideEntry = { type: "message", id: "side-entry", parentId: "active-root" };
+    const leafControl = {
+      type: "leaf",
+      id: "leaf-control",
+      parentId: "side-entry",
+      targetId: "active-root",
+    };
+    const activeTail = { type: "message", id: "active-tail", parentId: "active-root" };
+    const unlinkedMetadata = { type: "metadata", id: "unlinked-metadata" };
+
+    expect(
+      selectSessionTranscriptLeafControlledPath([
+        activeRoot,
+        sideEntry,
+        leafControl,
+        activeTail,
+        unlinkedMetadata,
+      ]),
+    ).toEqual([activeRoot, activeTail]);
+  });
+
+  it("keeps the reachable active suffix when an older parent is missing", () => {
+    const activeTail = { type: "message", id: "active-tail", parentId: "missing-parent" };
+    const leafControl = {
+      type: "leaf",
+      id: "leaf-control",
+      parentId: "inactive-tail",
+      targetId: "active-tail",
+    };
+
+    expect(selectSessionTranscriptLeafControlledPath([activeTail, leafControl])).toEqual([
+      activeTail,
+    ]);
+  });
+
+  it("normalizes parentless canonical rows before applying a leaf control", () => {
+    const entries = [
+      { type: "message", id: "root", message: { role: "user", content: "root" } },
+      {
+        type: "message",
+        id: "active",
+        message: { role: "assistant", content: "active" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "side",
+        targetId: "active",
+      },
+    ];
+
+    const tree = scanSessionTranscriptTree(entries);
+
+    expect(tree.byId.get("root")?.parentId).toBeNull();
+    expect(tree.byId.get("active")?.parentId).toBe("root");
+    expect(selectSessionTranscriptLeafControlledPath(entries)).toEqual([
+      { ...entries[0], parentId: null },
+      { ...entries[1], parentId: "root" },
+    ]);
+  });
+
+  it("selects visible and disjoint append paths independently", () => {
+    const entries = [
+      { type: "custom", id: "visible", parentId: null },
+      { type: "metadata", id: "append-root", parentId: null },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "append-root",
+        targetId: "visible",
+        appendParentId: "append-root",
+      },
+    ];
+
+    const tree = scanSessionTranscriptTree(entries);
+
+    expect(selectSessionTranscriptTreePathNodes(tree, tree.leafId).map((node) => node.id)).toEqual([
+      "visible",
+    ]);
+    expect(
+      selectSessionTranscriptTreePathNodes(tree, tree.appendParentId).map((node) => node.id),
+    ).toEqual(["append-root"]);
+  });
+
+  it("keeps the selected history when a canonical row uses a disjoint raw cursor", () => {
+    const entries = [
+      { type: "custom", id: "visible", parentId: null },
+      { type: "custom", id: "inactive", parentId: null },
+      { type: "metadata", id: "append-root", parentId: "inactive" },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "inactive",
+        targetId: "visible",
+        appendParentId: "append-root",
+      },
+      { type: "custom", id: "continued", parentId: "append-root" },
+    ];
+
+    const tree = scanSessionTranscriptTree(entries);
+
+    expect(tree.byId.get("continued")?.parentId).toBe("visible");
+    expect(selectSessionTranscriptLeafControlledPath(entries)).toEqual([
+      entries[0],
+      { ...entries[4], parentId: "visible" },
+    ]);
+  });
+
+  it("copies only the opaque suffix of a disjoint append path", () => {
+    const entries = [
+      { type: "custom", id: "visible", parentId: null },
+      { type: "custom", id: "inactive", parentId: null },
+      { type: "metadata", id: "append-metadata", parentId: "inactive" },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "inactive",
+        targetId: "visible",
+        appendParentId: "append-metadata",
+      },
+    ];
+    const tree = scanSessionTranscriptTree(entries);
+    const merged = mergeSessionTranscriptVisiblePathWithOpaqueAppendPath({
+      visiblePath: selectSessionTranscriptTreePathNodes(tree, tree.leafId),
+      appendPath: selectSessionTranscriptTreePathNodes(tree, tree.appendParentId),
+      appendParentId: tree.appendParentId,
+    });
+
+    expect(merged.nodes.map((node) => [node.id, node.selectedParentId])).toEqual([
+      ["visible", null],
+      ["append-metadata", "visible"],
+    ]);
+    expect(merged.appendParentId).toBe("append-metadata");
+  });
+
+  it("ignores leaf controls with dangling references", () => {
+    const root = { type: "custom", id: "root", parentId: null };
+    const missingTarget = {
+      type: "leaf",
+      id: "missing-target",
+      parentId: "root",
+      targetId: "missing",
+    };
+    const child = {
+      type: "custom",
+      id: "child",
+      parentId: "missing-target",
+    };
+    const missingAppendParent = {
+      type: "leaf",
+      id: "missing-append",
+      parentId: "child",
+      targetId: "child",
+      appendParentId: "missing",
+    };
+
+    const tree = scanSessionTranscriptTree([root, missingTarget, child, missingAppendParent]);
+
+    expect(tree.leafId).toBe("child");
+    expect(tree.appendParentId).toBe("child");
+    expect(tree.hasLeafControl).toBe(false);
+    expect(tree.byId.get("missing-target")?.parentId).toBe("root");
+    expect(selectSessionTranscriptTreePathNodes(tree, tree.leafId).map((node) => node.id)).toEqual([
+      "root",
+      "child",
+    ]);
+    expect(selectSessionTranscriptLeafControlledPath([root, missingTarget])).toBeUndefined();
+  });
+});

--- a/src/config/sessions/transcript-tree.test.ts
+++ b/src/config/sessions/transcript-tree.test.ts
@@ -273,6 +273,7 @@ describe("session transcript tree helpers", () => {
         parentId: "inactive",
         targetId: "visible",
         appendParentId: "append-root",
+        appendMode: "side",
       },
       { type: "custom", id: "continued", parentId: "append-root" },
     ];
@@ -284,6 +285,35 @@ describe("session transcript tree helpers", () => {
       entries[0],
       { ...entries[4], parentId: "visible" },
     ]);
+  });
+
+  it("preserves side ancestry after an explicit side append leaf", () => {
+    const entries = [
+      { type: "custom", id: "visible", parentId: null },
+      { type: "custom", id: "side-one", parentId: "visible" },
+      {
+        type: "leaf",
+        id: "first-leaf",
+        parentId: "side-one",
+        targetId: "visible",
+        appendParentId: "side-one",
+        appendMode: "side",
+      },
+      { type: "custom", id: "side-two", parentId: "side-one", appendMode: "side" },
+      {
+        type: "leaf",
+        id: "second-leaf",
+        parentId: "side-two",
+        targetId: "visible",
+        appendParentId: "side-two",
+        appendMode: "side",
+      },
+    ];
+
+    const tree = scanSessionTranscriptTree(entries);
+
+    expect(tree.byId.get("side-two")?.parentId).toBe("side-one");
+    expect(selectSessionTranscriptLeafControlledPath(entries)).toEqual([entries[0]]);
   });
 
   it("copies only the opaque suffix of a disjoint append path", () => {

--- a/src/config/sessions/transcript-tree.ts
+++ b/src/config/sessions/transcript-tree.ts
@@ -1,0 +1,335 @@
+// Transcript tree helpers keep append-only leaf controls consistent across readers.
+type TranscriptRecord = Record<string, unknown>;
+
+export type SessionTranscriptTreeEntry = {
+  id: string;
+  parentId: string | null;
+  leafId: string | null | undefined;
+  appendParentId: string | null;
+};
+
+export type SessionTranscriptTreeNode<T> = SessionTranscriptTreeEntry & {
+  entry: T;
+  index: number;
+};
+
+export type SessionTranscriptTree<T> = {
+  nodes: SessionTranscriptTreeNode<T>[];
+  byId: Map<string, SessionTranscriptTreeNode<T>>;
+  leafId: string | null;
+  appendParentId: string | null;
+  hasLeafControl: boolean;
+  hasLeafUpdate: boolean;
+  hasExplicitLeafUpdate: boolean;
+  hasInvalidLeafControl: boolean;
+};
+
+function isRecord(value: unknown): value is TranscriptRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function isCanonicalSessionEntryType(value: unknown): boolean {
+  switch (value) {
+    case "message":
+    case "thinking_level_change":
+    case "model_change":
+    case "compaction":
+    case "branch_summary":
+    case "custom":
+    case "custom_message":
+    case "label":
+    case "session_info":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function isCanonicalSessionTranscriptEntry(
+  record: unknown,
+): record is TranscriptRecord & { type: string } {
+  return isRecord(record) && isCanonicalSessionEntryType(record.type);
+}
+
+export function isSessionTranscriptLeafControl(
+  record: unknown,
+): record is TranscriptRecord & { type: "leaf" } {
+  return (
+    isRecord(record) &&
+    record.type === "leaf" &&
+    parseSessionTranscriptTreeEntry(record) !== undefined
+  );
+}
+
+/**
+ * Parse one parent-linked transcript row.
+ *
+ * Leaf rows are navigation controls: they select targetId as the active leaf,
+ * and descendants that reference the marker continue through that same target.
+ */
+export function parseSessionTranscriptTreeEntry(
+  record: unknown,
+): SessionTranscriptTreeEntry | undefined {
+  if (!isRecord(record) || record.type === "session" || !Object.hasOwn(record, "parentId")) {
+    return undefined;
+  }
+  const id = readNonEmptyString(record.id);
+  const parentId =
+    record.parentId === null ? null : (readNonEmptyString(record.parentId) ?? undefined);
+  if (!id || parentId === undefined) {
+    return undefined;
+  }
+  if (record.type === "leaf") {
+    const targetId =
+      record.targetId === null ? null : (readNonEmptyString(record.targetId) ?? undefined);
+    const appendParentId =
+      record.appendParentId === undefined
+        ? targetId
+        : record.appendParentId === null
+          ? null
+          : (readNonEmptyString(record.appendParentId) ?? undefined);
+    return targetId === undefined || appendParentId === undefined
+      ? undefined
+      : { id, parentId: targetId, leafId: targetId, appendParentId };
+  }
+  return {
+    id,
+    parentId,
+    leafId: isCanonicalSessionTranscriptEntry(record) ? id : undefined,
+    appendParentId: id,
+  };
+}
+
+function parseParentlessCanonicalEntry(
+  record: unknown,
+  parentId: string | null,
+): SessionTranscriptTreeEntry | undefined {
+  if (!isCanonicalSessionTranscriptEntry(record) || Object.hasOwn(record, "parentId")) {
+    return undefined;
+  }
+  const id = readNonEmptyString(record.id);
+  return id ? { id, parentId, leafId: id, appendParentId: id } : undefined;
+}
+
+/**
+ * Resolve transcript navigation state in file order.
+ *
+ * Current-version transcripts can contain parentless canonical rows written by
+ * older appenders. Treat those rows as a linear continuation of the current
+ * append cursor so a later leaf control can still address their full history.
+ */
+export function scanSessionTranscriptTree<T>(entries: readonly T[]): SessionTranscriptTree<T> {
+  const nodes: SessionTranscriptTreeNode<T>[] = [];
+  const byId = new Map<string, SessionTranscriptTreeNode<T>>();
+  let leafId: string | null = null;
+  let appendParentId: string | null = null;
+  let hasLeafControl = false;
+  let hasLeafUpdate = false;
+  let hasExplicitLeafUpdate = false;
+  let hasInvalidLeafControl = false;
+  const invalidLeafControlIds = new Set<string>();
+
+  for (const [index, entry] of entries.entries()) {
+    const explicitTreeEntry = parseSessionTranscriptTreeEntry(entry);
+    const isKnownLeafReference = (id: string | null): boolean =>
+      id === null || (byId.has(id) && !invalidLeafControlIds.has(id));
+    const invalidLeafControl =
+      explicitTreeEntry?.leafId !== undefined &&
+      isSessionTranscriptLeafControl(entry) &&
+      (!isKnownLeafReference(explicitTreeEntry.leafId) ||
+        !isKnownLeafReference(explicitTreeEntry.appendParentId));
+    if (invalidLeafControl) {
+      hasInvalidLeafControl = true;
+      invalidLeafControlIds.add(explicitTreeEntry.id);
+      const rawParentId = (entry as TranscriptRecord).parentId as string | null;
+      const node: SessionTranscriptTreeNode<T> = {
+        ...explicitTreeEntry,
+        parentId: rawParentId,
+        leafId: undefined,
+        appendParentId,
+        entry,
+        index,
+      };
+      // Invalid controls are transparent structural markers. Descendants can
+      // repair through their raw parent, but navigation state does not change.
+      nodes.push(node);
+      byId.set(node.id, node);
+      continue;
+    }
+    let treeEntry: SessionTranscriptTreeEntry | undefined =
+      explicitTreeEntry ?? parseParentlessCanonicalEntry(entry, leafId);
+    if (
+      treeEntry &&
+      explicitTreeEntry &&
+      isCanonicalSessionTranscriptEntry(entry) &&
+      treeEntry.parentId === appendParentId &&
+      leafId !== appendParentId
+    ) {
+      // The raw cursor can belong to plugin metadata or an inactive branch.
+      // Preserve that physical append link while keeping visible ancestry on
+      // the leaf selected when the canonical row was written.
+      treeEntry = { ...treeEntry, parentId: leafId };
+    }
+    if (!treeEntry) {
+      continue;
+    }
+    const node: SessionTranscriptTreeNode<T> = { ...treeEntry, entry, index };
+    nodes.push(node);
+    byId.set(node.id, node);
+    appendParentId = node.appendParentId;
+    if (node.leafId !== undefined) {
+      leafId = node.leafId;
+      hasLeafUpdate = true;
+      if (explicitTreeEntry) {
+        hasExplicitLeafUpdate = true;
+      }
+    }
+    if (isSessionTranscriptLeafControl(entry)) {
+      hasLeafControl = true;
+    }
+  }
+
+  return {
+    nodes,
+    byId,
+    leafId,
+    appendParentId,
+    hasLeafControl,
+    hasLeafUpdate,
+    hasExplicitLeafUpdate,
+    hasInvalidLeafControl,
+  };
+}
+
+/** Select one normalized path, retaining a reachable suffix after missing ancestors. */
+export function selectSessionTranscriptTreePathNodes<T>(
+  tree: SessionTranscriptTree<T>,
+  leafId: string | null,
+): SessionTranscriptTreeNode<T>[] {
+  if (leafId === null) {
+    return [];
+  }
+  const path: SessionTranscriptTreeNode<T>[] = [];
+  const seen = new Set<string>();
+  let currentId: string | null = leafId;
+  while (currentId) {
+    if (seen.has(currentId)) {
+      return [];
+    }
+    seen.add(currentId);
+    const current = tree.byId.get(currentId);
+    if (!current) {
+      break;
+    }
+    if (!isSessionTranscriptLeafControl(current.entry)) {
+      path.unshift(current);
+    }
+    currentId = current.parentId;
+  }
+  return path;
+}
+
+/** Merge normalized paths in original file order and expose their retained parent links. */
+export function mergeSessionTranscriptTreePaths<T>(
+  paths: Array<SessionTranscriptTreeNode<T>[]>,
+): Array<SessionTranscriptTreeNode<T> & { selectedParentId: string | null }> {
+  const selectedById = new Map<
+    string,
+    SessionTranscriptTreeNode<T> & { selectedParentId: string | null }
+  >();
+  for (const path of paths) {
+    let selectedParentId: string | null = null;
+    for (const node of path) {
+      selectedById.set(node.id, { ...node, selectedParentId });
+      selectedParentId = node.id;
+    }
+  }
+  return [...selectedById.values()].toSorted((left, right) => left.index - right.index);
+}
+
+/**
+ * Build a copy-safe branch from the visible path and the opaque append suffix.
+ *
+ * Hidden canonical append ancestors must not leak into forks or repairs. Keep
+ * only opaque cursor records after the last canonical ancestor and reparent
+ * that suffix onto the selected visible path.
+ */
+export function mergeSessionTranscriptVisiblePathWithOpaqueAppendPath<T>(params: {
+  visiblePath: SessionTranscriptTreeNode<T>[];
+  appendPath: SessionTranscriptTreeNode<T>[];
+  appendParentId: string | null;
+}): {
+  nodes: Array<SessionTranscriptTreeNode<T> & { selectedParentId: string | null }>;
+  appendParentId: string | null;
+} {
+  const nodes = mergeSessionTranscriptTreePaths([params.visiblePath]);
+  const selectedIds = new Set(nodes.map((node) => node.id));
+  const opaqueSuffix: SessionTranscriptTreeNode<T>[] = [];
+  for (let index = params.appendPath.length - 1; index >= 0; index -= 1) {
+    const node = params.appendPath[index];
+    if (!node || selectedIds.has(node.id) || isCanonicalSessionTranscriptEntry(node.entry)) {
+      break;
+    }
+    opaqueSuffix.unshift(node);
+  }
+
+  let selectedParentId = nodes.at(-1)?.id ?? null;
+  for (const node of opaqueSuffix) {
+    nodes.push({ ...node, selectedParentId });
+    selectedIds.add(node.id);
+    selectedParentId = node.id;
+  }
+
+  return {
+    nodes,
+    appendParentId:
+      params.appendParentId === null
+        ? null
+        : selectedIds.has(params.appendParentId)
+          ? params.appendParentId
+          : (nodes.at(-1)?.id ?? null),
+  };
+}
+
+/** Return the leaf update represented by one transcript row, if any. */
+export function readSessionTranscriptLeafUpdate(record: unknown): string | null | undefined {
+  return parseSessionTranscriptTreeEntry(record)?.leafId;
+}
+
+/** Resolve the active leaf after applying transcript rows in file order. */
+export function resolveSessionTranscriptLeafId(entries: readonly unknown[]): string | null {
+  return scanSessionTranscriptTree(entries).leafId;
+}
+
+/** Resolve the raw parent for the next append after applying rows in file order. */
+export function resolveSessionTranscriptAppendParentId(entries: readonly unknown[]): string | null {
+  return scanSessionTranscriptTree(entries).appendParentId;
+}
+
+/**
+ * Select the effective branch only when the transcript contains leaf controls.
+ *
+ * Legacy flat readers can keep their existing behavior when this returns
+ * undefined. Once navigation controls exist, returning the selected path keeps
+ * side branches out of prompts and hooks even after later active-branch appends.
+ */
+export function selectSessionTranscriptLeafControlledPath<T>(
+  entries: readonly T[],
+): T[] | undefined {
+  const tree = scanSessionTranscriptTree(entries);
+  if (!tree.hasLeafControl) {
+    return undefined;
+  }
+  return selectSessionTranscriptTreePathNodes(tree, tree.leafId).map((node) => {
+    if (!isRecord(node.entry) || node.entry.parentId === node.parentId) {
+      return node.entry;
+    }
+    // Consumers rebuild context from the selected entries, so preserve the
+    // logical ancestry normalized while scanning disjoint append cursors.
+    return Object.assign({}, node.entry, { parentId: node.parentId }) as T;
+  });
+}

--- a/src/config/sessions/transcript-tree.ts
+++ b/src/config/sessions/transcript-tree.ts
@@ -115,6 +115,28 @@ function parseParentlessCanonicalEntry(
   return id ? { id, parentId, leafId: id, appendParentId: id } : undefined;
 }
 
+function resolveCanonicalParentId<T>(
+  parentId: string | null,
+  byId: ReadonlyMap<string, SessionTranscriptTreeNode<T>>,
+): string | null {
+  const seen = new Set<string>();
+  let currentId = parentId;
+  while (currentId !== null) {
+    if (seen.has(currentId)) {
+      return currentId;
+    }
+    seen.add(currentId);
+    const parent = byId.get(currentId);
+    if (!parent || !isSessionTranscriptLeafControl(parent.entry)) {
+      return currentId;
+    }
+    // Leaf controls are omitted from selected paths, so descendants must point
+    // through the marker to its normalized visible parent.
+    currentId = parent.parentId;
+  }
+  return null;
+}
+
 /**
  * Resolve transcript navigation state in file order.
  *
@@ -162,17 +184,18 @@ export function scanSessionTranscriptTree<T>(entries: readonly T[]): SessionTran
     }
     let treeEntry: SessionTranscriptTreeEntry | undefined =
       explicitTreeEntry ?? parseParentlessCanonicalEntry(entry, leafId);
-    if (
-      treeEntry &&
-      explicitTreeEntry &&
-      isCanonicalSessionTranscriptEntry(entry) &&
-      treeEntry.parentId === appendParentId &&
-      leafId !== appendParentId
-    ) {
-      // The raw cursor can belong to plugin metadata or an inactive branch.
-      // Preserve that physical append link while keeping visible ancestry on
-      // the leaf selected when the canonical row was written.
-      treeEntry = { ...treeEntry, parentId: leafId };
+    if (treeEntry && isCanonicalSessionTranscriptEntry(entry)) {
+      const logicalParentId =
+        explicitTreeEntry && treeEntry.parentId === appendParentId && leafId !== appendParentId
+          ? leafId
+          : treeEntry.parentId;
+      const normalizedParentId = resolveCanonicalParentId(logicalParentId, byId);
+      if (normalizedParentId !== treeEntry.parentId) {
+        // The raw cursor can belong to plugin metadata, an inactive branch, or
+        // an omitted leaf marker. Keep physical append state separate from the
+        // visible ancestry consumed by context builders.
+        treeEntry = { ...treeEntry, parentId: normalizedParentId };
+      }
     }
     if (!treeEntry) {
       continue;

--- a/src/config/sessions/transcript-tree.ts
+++ b/src/config/sessions/transcript-tree.ts
@@ -6,6 +6,7 @@ export type SessionTranscriptTreeEntry = {
   parentId: string | null;
   leafId: string | null | undefined;
   appendParentId: string | null;
+  appendMode?: "side";
 };
 
 export type SessionTranscriptTreeNode<T> = SessionTranscriptTreeEntry & {
@@ -55,6 +56,10 @@ export function isCanonicalSessionTranscriptEntry(
   return isRecord(record) && isCanonicalSessionEntryType(record.type);
 }
 
+export function isSessionTranscriptSideAppendEntry(record: unknown): boolean {
+  return isCanonicalSessionTranscriptEntry(record) && record.appendMode === "side";
+}
+
 export function isSessionTranscriptLeafControl(
   record: unknown,
 ): record is TranscriptRecord & { type: "leaf" } {
@@ -92,15 +97,24 @@ export function parseSessionTranscriptTreeEntry(
         : record.appendParentId === null
           ? null
           : (readNonEmptyString(record.appendParentId) ?? undefined);
-    return targetId === undefined || appendParentId === undefined
+    const appendMode =
+      record.appendMode === undefined ? undefined : record.appendMode === "side" ? "side" : null;
+    return targetId === undefined || appendParentId === undefined || appendMode === null
       ? undefined
-      : { id, parentId: targetId, leafId: targetId, appendParentId };
+      : {
+          id,
+          parentId: targetId,
+          leafId: targetId,
+          appendParentId,
+          ...(appendMode ? { appendMode } : {}),
+        };
   }
   return {
     id,
     parentId,
     leafId: isCanonicalSessionTranscriptEntry(record) ? id : undefined,
     appendParentId: id,
+    ...(record.appendMode === "side" ? { appendMode: record.appendMode } : {}),
   };
 }
 
@@ -112,7 +126,15 @@ function parseParentlessCanonicalEntry(
     return undefined;
   }
   const id = readNonEmptyString(record.id);
-  return id ? { id, parentId, leafId: id, appendParentId: id } : undefined;
+  return id
+    ? {
+        id,
+        parentId,
+        leafId: id,
+        appendParentId: id,
+        ...(record.appendMode === "side" ? { appendMode: record.appendMode } : {}),
+      }
+    : undefined;
 }
 
 function resolveCanonicalParentId<T>(
@@ -186,7 +208,10 @@ export function scanSessionTranscriptTree<T>(entries: readonly T[]): SessionTran
       explicitTreeEntry ?? parseParentlessCanonicalEntry(entry, leafId);
     if (treeEntry && isCanonicalSessionTranscriptEntry(entry)) {
       const logicalParentId =
-        explicitTreeEntry && treeEntry.parentId === appendParentId && leafId !== appendParentId
+        explicitTreeEntry &&
+        treeEntry.appendMode !== "side" &&
+        treeEntry.parentId === appendParentId &&
+        leafId !== appendParentId
           ? leafId
           : treeEntry.parentId;
       const normalizedParentId = resolveCanonicalParentId(logicalParentId, byId);

--- a/src/config/sessions/transcript-tree.ts
+++ b/src/config/sessions/transcript-tree.ts
@@ -112,7 +112,8 @@ export function parseSessionTranscriptTreeEntry(
   return {
     id,
     parentId,
-    leafId: isCanonicalSessionTranscriptEntry(record) ? id : undefined,
+    leafId:
+      isCanonicalSessionTranscriptEntry(record) && record.appendMode !== "side" ? id : undefined,
     appendParentId: id,
     ...(record.appendMode === "side" ? { appendMode: record.appendMode } : {}),
   };
@@ -130,7 +131,7 @@ function parseParentlessCanonicalEntry(
     ? {
         id,
         parentId,
-        leafId: id,
+        leafId: record.appendMode === "side" ? undefined : id,
         appendParentId: id,
         ...(record.appendMode === "side" ? { appendMode: record.appendMode } : {}),
       }

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -9,8 +9,13 @@ type OwnedSessionTranscriptWriteContext = {
   publishSessionFileSnapshot?: (snapshot: OwnedSessionTranscriptCacheSnapshot) => boolean;
   withSessionWriteLock: <T>(
     run: () => Promise<T> | T,
-    options?: { publishOwnedWrite?: boolean },
+    options?: OwnedSessionTranscriptWriteOptions<T>,
   ) => Promise<T>;
+};
+
+export type OwnedSessionTranscriptWriteOptions<T> = {
+  publishOwnedWrite?: boolean;
+  resolvePublishedEntryIds?: (result: T) => readonly string[];
 };
 
 export type OwnedSessionTranscriptCacheSnapshot = {
@@ -134,7 +139,7 @@ async function runWithOwnedSessionTranscriptWriteContext<T>(
     sessionKey?: string;
   },
   run: () => Promise<T> | T,
-  options?: { publishOwnedWrite?: boolean },
+  options?: OwnedSessionTranscriptWriteOptions<T>,
 ): Promise<T> {
   const context = ownedTranscriptWriteContext.getStore();
   if (!context || !contextMatches({ context, ...params })) {

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -16,6 +16,7 @@ type OwnedSessionTranscriptWriteContext = {
 export type OwnedSessionTranscriptWriteOptions<T> = {
   publishOwnedWrite?: boolean;
   resolvePublishedEntries?: (result: T) => readonly OwnedSessionTranscriptPublishedEntry[];
+  resolvePublishedEntriesAfterFailure?: () => readonly OwnedSessionTranscriptPublishedEntry[];
 };
 
 export type OwnedSessionTranscriptPublishedEntry =

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -15,8 +15,13 @@ type OwnedSessionTranscriptWriteContext = {
 
 export type OwnedSessionTranscriptWriteOptions<T> = {
   publishOwnedWrite?: boolean;
-  resolvePublishedEntryIds?: (result: T) => readonly string[];
+  resolvePublishedEntries?: (result: T) => readonly OwnedSessionTranscriptPublishedEntry[];
 };
+
+export type OwnedSessionTranscriptPublishedEntry =
+  | { kind: "id"; id: string }
+  | { kind: "header"; serialized: string }
+  | { kind: "serialized"; serialized: string };
 
 export type OwnedSessionTranscriptCacheSnapshot = {
   dev: bigint;

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -285,7 +285,7 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     );
 
     expect(result.ok).toBe(true);
-    expect(events).toEqual(["lock", "lock", "lock"]);
+    expect(events).toEqual(["lock", "lock"]);
   });
 
   it("keeps matching owned transcript appends locked from bound callbacks", async () => {

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -13,6 +13,7 @@ import {
   appendSessionTranscriptEvent,
   appendSessionTranscriptMessage,
 } from "./transcript-append.js";
+import { selectSessionTranscriptLeafControlledPath } from "./transcript-tree.js";
 import {
   bindOwnedSessionTranscriptWrites,
   withOwnedSessionTranscriptWrites,
@@ -1465,6 +1466,112 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null })
       .find((entry) => entry.id === appended.messageId);
     expect(appendedEntry?.parentId).toBe(metadata.id);
+  });
+
+  it("marks transcript-only messages that consume a side append cursor", async () => {
+    const sessionFile = resolveSessionTranscriptPathInDir(
+      "side-append-mode-transcript-session",
+      fixture.sessionsDir(),
+    );
+    const activeEntry = {
+      type: "message",
+      id: "active-entry",
+      parentId: null,
+      timestamp: "2026-05-30T12:00:00.000Z",
+      message: { role: "user", content: "active question" },
+    };
+    const sideEntry = {
+      type: "message",
+      id: "side-entry",
+      parentId: activeEntry.id,
+      timestamp: "2026-05-30T12:00:01.000Z",
+      message: { role: "assistant", content: "first side delivery" },
+    };
+    fs.writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "side-append-mode-transcript-session",
+          timestamp: "2026-05-30T12:00:00.000Z",
+          cwd: fixture.sessionsDir(),
+        },
+        activeEntry,
+        sideEntry,
+        {
+          type: "leaf",
+          id: "side-leaf",
+          parentId: sideEntry.id,
+          timestamp: "2026-05-30T12:00:02.000Z",
+          targetId: activeEntry.id,
+          appendParentId: sideEntry.id,
+          appendMode: "side",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+    );
+
+    const appended = await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: {
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: "second side delivery",
+      },
+    });
+
+    const appendedEntry = fs
+      .readFileSync(sessionFile, "utf8")
+      .trim()
+      .split("\n")
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            id?: string;
+            parentId?: string | null;
+            appendMode?: string;
+          },
+      )
+      .find((entry) => entry.id === appended.messageId);
+    expect(appendedEntry).toMatchObject({
+      parentId: sideEntry.id,
+      appendMode: "side",
+    });
+
+    fs.appendFileSync(
+      sessionFile,
+      `${JSON.stringify({
+        type: "leaf",
+        id: "restored-side-leaf",
+        parentId: appended.messageId,
+        timestamp: "2026-05-30T12:00:04.000Z",
+        targetId: activeEntry.id,
+        appendParentId: appended.messageId,
+        appendMode: "side",
+      })}\n`,
+      "utf8",
+    );
+    const nextUser = await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: { role: "user", content: "next question" },
+    });
+    const finalRecords = fs
+      .readFileSync(sessionFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(finalRecords.find((entry) => entry.id === nextUser.messageId)).toMatchObject({
+      parentId: appended.messageId,
+    });
+    expect(finalRecords.find((entry) => entry.id === nextUser.messageId)).not.toHaveProperty(
+      "appendMode",
+    );
+    expect(
+      selectSessionTranscriptLeafControlledPath(finalRecords)?.map((entry) => entry.id),
+    ).toEqual([activeEntry.id, nextUser.messageId]);
   });
 
   it("ignores dangling leaf references when choosing the direct append parent", async () => {

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -1541,19 +1541,6 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       appendMode: "side",
     });
 
-    fs.appendFileSync(
-      sessionFile,
-      `${JSON.stringify({
-        type: "leaf",
-        id: "restored-side-leaf",
-        parentId: appended.messageId,
-        timestamp: "2026-05-30T12:00:04.000Z",
-        targetId: activeEntry.id,
-        appendParentId: appended.messageId,
-        appendMode: "side",
-      })}\n`,
-      "utf8",
-    );
     const nextUser = await appendSessionTranscriptMessage({
       transcriptPath: sessionFile,
       message: { role: "user", content: "next question" },

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -1411,6 +1411,237 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     expect(appendedEntry?.parentId).toBe(rootEntry.id);
   });
 
+  it("appends after an explicit opaque append parent on a leaf control", async () => {
+    const sessionFile = resolveSessionTranscriptPathInDir(
+      "leaf-append-parent-transcript-session",
+      fixture.sessionsDir(),
+    );
+    const rootEntry = {
+      type: "message",
+      id: "root-user",
+      parentId: null,
+      timestamp: "2026-05-30T12:00:00.000Z",
+      message: { role: "user", content: "root question" },
+    };
+    const metadata = {
+      type: "metadata",
+      id: "plugin-metadata",
+      parentId: rootEntry.id,
+    };
+    fs.writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "leaf-append-parent-transcript-session",
+          timestamp: "2026-05-30T12:00:00.000Z",
+          cwd: fixture.sessionsDir(),
+        },
+        rootEntry,
+        metadata,
+        {
+          type: "leaf",
+          id: "leaf-1",
+          parentId: metadata.id,
+          timestamp: "2026-05-30T12:00:02.000Z",
+          targetId: rootEntry.id,
+          appendParentId: metadata.id,
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+    );
+
+    const appended = await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: { role: "assistant", content: "replacement answer" },
+    });
+
+    const appendedEntry = fs
+      .readFileSync(sessionFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null })
+      .find((entry) => entry.id === appended.messageId);
+    expect(appendedEntry?.parentId).toBe(metadata.id);
+  });
+
+  it("ignores dangling leaf references when choosing the direct append parent", async () => {
+    const sessionFile = resolveSessionTranscriptPathInDir(
+      "invalid-leaf-append-parent-transcript-session",
+      fixture.sessionsDir(),
+    );
+    const rootEntry = {
+      type: "message",
+      id: "root-user",
+      parentId: null,
+      timestamp: "2026-05-30T12:00:00.000Z",
+      message: { role: "user", content: "root question" },
+    };
+    const metadata = {
+      type: "metadata",
+      id: "plugin-metadata",
+      parentId: rootEntry.id,
+    };
+    fs.writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "invalid-leaf-append-parent-transcript-session",
+          timestamp: "2026-05-30T12:00:00.000Z",
+          cwd: fixture.sessionsDir(),
+        },
+        rootEntry,
+        metadata,
+        {
+          type: "leaf",
+          id: "missing-target",
+          parentId: metadata.id,
+          timestamp: "2026-05-30T12:00:01.000Z",
+          targetId: "missing",
+        },
+        {
+          type: "leaf",
+          id: "missing-append",
+          parentId: "missing-target",
+          timestamp: "2026-05-30T12:00:02.000Z",
+          targetId: rootEntry.id,
+          appendParentId: "missing",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+    );
+
+    const appended = await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: { role: "assistant", content: "replacement answer" },
+    });
+
+    const appendedEntry = fs
+      .readFileSync(sessionFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null })
+      .find((entry) => entry.id === appended.messageId);
+    expect(appendedEntry?.parentId).toBe(metadata.id);
+  });
+
+  it("rejects append targets that reference an earlier invalid leaf control", async () => {
+    const sessionFile = resolveSessionTranscriptPathInDir(
+      "nested-invalid-leaf-append-parent-transcript-session",
+      fixture.sessionsDir(),
+    );
+    const rootEntry = {
+      type: "message",
+      id: "root-user",
+      parentId: null,
+      timestamp: "2026-05-30T12:00:00.000Z",
+      message: { role: "user", content: "root question" },
+    };
+    fs.writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "nested-invalid-leaf-append-parent-transcript-session",
+          timestamp: "2026-05-30T12:00:00.000Z",
+          cwd: fixture.sessionsDir(),
+        },
+        rootEntry,
+        {
+          type: "leaf",
+          id: "invalid-leaf",
+          parentId: rootEntry.id,
+          timestamp: "2026-05-30T12:00:01.000Z",
+          targetId: "missing",
+        },
+        {
+          type: "leaf",
+          id: "nested-invalid-leaf",
+          parentId: "invalid-leaf",
+          timestamp: "2026-05-30T12:00:02.000Z",
+          targetId: "invalid-leaf",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+    );
+
+    const appended = await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: { role: "assistant", content: "replacement answer" },
+    });
+
+    const appendedEntry = fs
+      .readFileSync(sessionFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null })
+      .find((entry) => entry.id === appended.messageId);
+    expect(appendedEntry?.parentId).toBe(rootEntry.id);
+  });
+
+  it("recognizes parentless canonical rows selected by a later leaf control", async () => {
+    const sessionFile = resolveSessionTranscriptPathInDir(
+      "parentless-leaf-target-transcript-session",
+      fixture.sessionsDir(),
+    );
+    const activeEntry = {
+      type: "message",
+      id: "active-entry",
+      timestamp: "2026-05-30T12:00:00.000Z",
+      message: { role: "user", content: "active question" },
+    };
+    const sideEntry = {
+      type: "message",
+      id: "side-entry",
+      parentId: activeEntry.id,
+      timestamp: "2026-05-30T12:00:01.000Z",
+      message: { role: "assistant", content: "side delivery" },
+    };
+    fs.writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "parentless-leaf-target-transcript-session",
+          timestamp: "2026-05-30T12:00:00.000Z",
+          cwd: fixture.sessionsDir(),
+        },
+        activeEntry,
+        sideEntry,
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: sideEntry.id,
+          timestamp: "2026-05-30T12:00:02.000Z",
+          targetId: activeEntry.id,
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+    );
+
+    const appended = await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: { role: "assistant", content: "active replacement" },
+    });
+
+    const appendedEntry = fs
+      .readFileSync(sessionFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null })
+      .find((entry) => entry.id === appended.messageId);
+    expect(appendedEntry?.parentId).toBe(activeEntry.id);
+  });
+
   it("redacts structured message content before transcript persistence", async () => {
     const sessionFile = resolveSessionTranscriptPathInDir(
       "redacted-transcript-session",

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -1353,6 +1353,64 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     expect(message?.timestamp).toBe("2026-05-30T12:00:00.000Z");
   });
 
+  it("appends after the target selected by a leaf control record", async () => {
+    const sessionFile = resolveSessionTranscriptPathInDir(
+      "leaf-target-transcript-session",
+      fixture.sessionsDir(),
+    );
+    const rootEntry = {
+      type: "message",
+      id: "root-user",
+      parentId: null,
+      timestamp: "2026-05-30T12:00:00.000Z",
+      message: { role: "user", content: "root question" },
+    };
+    const abandonedEntry = {
+      type: "message",
+      id: "abandoned-assistant",
+      parentId: rootEntry.id,
+      timestamp: "2026-05-30T12:00:01.000Z",
+      message: { role: "assistant", content: "abandoned answer" },
+    };
+    const leafEntry = {
+      type: "leaf",
+      id: "leaf-1",
+      parentId: abandonedEntry.id,
+      timestamp: "2026-05-30T12:00:02.000Z",
+      targetId: rootEntry.id,
+    };
+    fs.writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "leaf-target-transcript-session",
+          timestamp: "2026-05-30T12:00:00.000Z",
+          cwd: fixture.sessionsDir(),
+        },
+        rootEntry,
+        abandonedEntry,
+        leafEntry,
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+    );
+
+    const appended = await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: { role: "assistant", content: "replacement answer" },
+    });
+
+    const appendedEntry = fs
+      .readFileSync(sessionFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id?: string; parentId?: string | null })
+      .find((entry) => entry.id === appended.messageId);
+    expect(appendedEntry?.parentId).toBe(rootEntry.id);
+  });
+
   it("redacts structured message content before transcript persistence", async () => {
     const sessionFile = resolveSessionTranscriptPathInDir(
       "redacted-transcript-session",

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -1,5 +1,4 @@
 // Session transcript facade resolves transcript files, appends mirror messages, and reads tails.
-import fs from "node:fs";
 import path from "node:path";
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import type { SessionManager } from "../../agents/sessions/session-manager.js";
@@ -19,28 +18,10 @@ import { resolveAndPersistSessionFile } from "./session-file.js";
 import { loadSessionStore, resolveSessionStoreEntry, updateSessionStoreEntry } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import { appendSessionTranscriptMessage } from "./transcript-append.js";
-import { createSessionTranscriptHeader } from "./transcript-header.js";
-import { writeJsonlEntry } from "./transcript-jsonl.js";
 import { resolveMirroredTranscriptText } from "./transcript-mirror.js";
 import { streamSessionTranscriptLinesReverse } from "./transcript-stream.js";
-import {
-  runWithOwnedSessionTranscriptWriteLock,
-  runWithOwnedSessionTranscriptWritePublication,
-} from "./transcript-write-context.js";
+import { runWithOwnedSessionTranscriptWriteLock } from "./transcript-write-context.js";
 import type { SessionEntry } from "./types.js";
-
-async function ensureSessionHeader(params: {
-  sessionFile: string;
-  sessionId: string;
-  cwd?: string;
-}): Promise<void> {
-  if (fs.existsSync(params.sessionFile)) {
-    return;
-  }
-  await fs.promises.mkdir(path.dirname(params.sessionFile), { recursive: true });
-  const header = createSessionTranscriptHeader({ sessionId: params.sessionId, cwd: params.cwd });
-  await writeJsonlEntry(params.sessionFile, header, { mode: 0o600 });
-}
 
 export type SessionTranscriptAppendResult =
   | { ok: true; sessionFile: string; messageId: string }
@@ -378,36 +359,28 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
         if (latestEquivalentAssistantId) {
           return { ok: true, sessionFile, messageId: latestEquivalentAssistantId };
         }
-        const appendedResult = await runWithOwnedSessionTranscriptWritePublication(
-          { sessionFile, sessionKey: resolved.normalizedKey },
-          async () => {
-            await ensureSessionHeader({
-              sessionFile,
-              sessionId: currentEntry.sessionId,
-              cwd: currentEntry.spawnedCwd,
-            });
-            return await appendSessionTranscriptMessage({
-              transcriptPath: sessionFile,
-              message: preparedUnkeyedMessage,
-              ...(explicitIdempotencyKey ? { idempotencyLookup: "scan" } : {}),
-              ...(explicitIdempotencyKey && params.beforeMessageWrite
-                ? {
-                    prepareMessageAfterIdempotencyCheck: (
-                      candidate: Parameters<SessionManager["appendMessage"]>[0],
-                    ) =>
-                      applyBeforeMessageWriteToAssistant({
-                        message: candidate,
-                        beforeMessageWrite: params.beforeMessageWrite,
-                        explicitIdempotencyKey,
-                        agentId: params.agentId,
-                        sessionKey: resolved.normalizedKey,
-                      }),
-                  }
-                : {}),
-              config: params.config,
-            });
-          },
-        );
+        const appendedResult = await appendSessionTranscriptMessage({
+          transcriptPath: sessionFile,
+          sessionId: currentEntry.sessionId,
+          cwd: currentEntry.spawnedCwd,
+          message: preparedUnkeyedMessage,
+          ...(explicitIdempotencyKey ? { idempotencyLookup: "scan" } : {}),
+          ...(explicitIdempotencyKey && params.beforeMessageWrite
+            ? {
+                prepareMessageAfterIdempotencyCheck: (
+                  candidate: Parameters<SessionManager["appendMessage"]>[0],
+                ) =>
+                  applyBeforeMessageWriteToAssistant({
+                    message: candidate,
+                    beforeMessageWrite: params.beforeMessageWrite,
+                    explicitIdempotencyKey,
+                    agentId: params.agentId,
+                    sessionKey: resolved.normalizedKey,
+                  }),
+              }
+            : {}),
+          config: params.config,
+        });
         if (!appendedResult) {
           return {
             ok: false,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1712,7 +1712,7 @@ async function findAssistantTranscriptMessageByIdempotencyKey(
   if (!trimmedIdempotencyKey) {
     return null;
   }
-  const index = await readSessionTranscriptIndex(transcriptPath);
+  const index = await readSessionTranscriptIndex(transcriptPath, { view: "all" });
   const target = index?.entries.toReversed().find((entry) => {
     const message = entry.record.message as Record<string, unknown> | undefined;
     return message?.role === "assistant" && message.idempotencyKey === trimmedIdempotencyKey;
@@ -1777,7 +1777,7 @@ async function findSourceReplyTranscriptMirrorByMetadata(params: {
   if (!expectedText) {
     return null;
   }
-  const index = await readSessionTranscriptIndex(params.transcriptPath);
+  const index = await readSessionTranscriptIndex(params.transcriptPath, { view: "all" });
   const target = index?.entries.toReversed().find((entry) => {
     const message = entry.record.message as Record<string, unknown> | undefined;
     return (
@@ -4741,8 +4741,10 @@ export const chatHandlers: GatewayRequestHandlers = {
                         const rewriteTargetIds = new Set(
                           rewriteTargets.map((target) => target.messageId),
                         );
-                        const rewriteIndex =
-                          await readSessionTranscriptIndex(resolvedTranscriptPath);
+                        const rewriteIndex = await readSessionTranscriptIndex(
+                          resolvedTranscriptPath,
+                          { view: "all" },
+                        );
                         const firstRewriteEntryIndex =
                           rewriteIndex?.entries.findIndex(
                             (entryValue) =>

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -396,7 +396,7 @@ function resolveCheckpointForkSource(
   if (preCompactionFile) {
     return {
       sourceFile: preCompactionFile,
-      sourceLeafId: checkpoint.preCompaction.leafId,
+      sourceLeafId: checkpoint.preCompaction.entryId ?? checkpoint.preCompaction.leafId,
       totalTokens: checkpoint.tokensBefore,
     };
   }
@@ -405,7 +405,7 @@ function resolveCheckpointForkSource(
     return null;
   }
   const postCompactionLeafId =
-    checkpoint.postCompaction.leafId ?? checkpoint.postCompaction.entryId;
+    checkpoint.postCompaction.entryId ?? checkpoint.postCompaction.leafId;
   if (!postCompactionLeafId) {
     return null;
   }

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -2239,6 +2239,16 @@ describe("gateway server chat", () => {
       >;
       expect(stored["agent:main:main"]?.lastChannel).toBe("whatsapp");
       expect(stored["agent:main:main"]?.lastTo).toBe("+1555");
+
+      await vi.waitFor(async () => {
+        const completed = await rpcReq<{ status?: string }>(ws, "chat.send", {
+          sessionKey: "main",
+          message: "hello",
+          idempotencyKey: "idem-route",
+        });
+        expect(completed.ok).toBe(true);
+        expect(completed.payload?.status).toBe("ok");
+      }, FAST_WAIT_OPTS);
     });
   });
 
@@ -2850,6 +2860,21 @@ describe("gateway server chat", () => {
             timestamp: Date.now(),
           },
         }),
+        JSON.stringify({
+          id: "msg-side-delivery",
+          parentId: "msg-active",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "side delivery" }],
+            timestamp: Date.now(),
+          },
+        }),
+        JSON.stringify({
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "msg-side-delivery",
+          targetId: "msg-active",
+        }),
       ]);
 
       const stale = await fetchChatMessage(ws, {
@@ -2859,12 +2884,20 @@ describe("gateway server chat", () => {
       expect(stale.ok).toBe(false);
       expect(stale.unavailableReason).toBe("not_found");
 
+      const sideDelivery = await fetchChatMessage(ws, {
+        sessionKey: "main",
+        messageId: "msg-side-delivery",
+      });
+      expect(sideDelivery.ok).toBe(false);
+      expect(sideDelivery.unavailableReason).toBe("not_found");
+
       const active = await fetchChatMessage(ws, {
         sessionKey: "main",
         messageId: "msg-active",
       });
       expect(active.ok).toBe(true);
       expect(JSON.stringify(active.message)).toContain("active branch");
+      expect(JSON.stringify(await fetchHistoryMessages(ws))).not.toContain("side delivery");
     });
   });
 

--- a/src/gateway/session-compaction-checkpoints.test.ts
+++ b/src/gateway/session-compaction-checkpoints.test.ts
@@ -19,6 +19,7 @@ import {
   persistSessionCompactionCheckpoint,
   readRuntimeSessionLeafIdFromTranscriptAsync,
   readSessionLeafIdFromTranscriptAsync,
+  readSessionLeafStateFromTranscriptAsync,
 } from "./session-compaction-checkpoints.js";
 
 const tempDirs: string[] = [];
@@ -284,6 +285,142 @@ describe("session-compaction-checkpoints", () => {
     }
   });
 
+  test("async capture follows terminal leaf controls instead of their inactive parent", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-checkpoint-leaf-control-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-leaf-control",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: dir,
+        },
+        {
+          type: "message",
+          id: "active-tail",
+          parentId: null,
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "assistant", content: "active" },
+        },
+        {
+          type: "metadata",
+          id: "plugin-metadata",
+          parentId: "active-tail",
+          payload: { source: "plugin" },
+        },
+        {
+          type: "message",
+          id: "inactive-tail",
+          parentId: "active-tail",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          message: { role: "assistant", content: "side delivery" },
+        },
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "inactive-tail",
+          timestamp: "2026-06-15T00:00:03.000Z",
+          targetId: "active-tail",
+          appendParentId: "plugin-metadata",
+        },
+        {
+          type: "metadata",
+          id: "post-leaf-metadata",
+          parentId: "plugin-metadata",
+          payload: { phase: "after-leaf" },
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+
+    expect(await readSessionLeafIdFromTranscriptAsync(sessionFile)).toBe("active-tail");
+    expect(await readSessionLeafStateFromTranscriptAsync(sessionFile)).toEqual({
+      entryId: "post-leaf-metadata",
+      leafId: "active-tail",
+    });
+    const snapshot = await captureCompactionCheckpointSnapshotAsync({ sessionFile });
+    expect(snapshot?.leafId).toBe("active-tail");
+    expect(snapshot?.entryId).toBe("post-leaf-metadata");
+
+    const forked = await forkCompactionCheckpointTranscriptAsync({
+      sourceFile: sessionFile,
+      sourceLeafId: snapshot?.entryId,
+      sessionDir: dir,
+    });
+    if (!forked) {
+      throw new Error("expected forked checkpoint transcript");
+    }
+    const restored = SessionManager.open(forked.sessionFile, dir);
+    restored.appendMessage({
+      role: "user",
+      content: "continued after restore",
+      timestamp: Date.now(),
+    });
+    const restoredEntries = (await fs.readFile(forked.sessionFile, "utf-8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(restoredEntries.at(-1)).toMatchObject({
+      type: "message",
+      parentId: "post-leaf-metadata",
+    });
+    await cleanupCompactionCheckpointSnapshot(snapshot);
+  });
+
+  test("async leaf scans ignore controls with dangling references", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-checkpoint-invalid-leaf-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-invalid-leaf",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: dir,
+        },
+        {
+          type: "message",
+          id: "active-tail",
+          parentId: null,
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "assistant", content: "active" },
+        },
+        {
+          type: "leaf",
+          id: "missing-target",
+          parentId: "active-tail",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          targetId: "missing",
+        },
+        {
+          type: "leaf",
+          id: "missing-append",
+          parentId: "active-tail",
+          timestamp: "2026-06-15T00:00:03.000Z",
+          targetId: "active-tail",
+          appendParentId: "missing",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+
+    expect(await readSessionLeafStateFromTranscriptAsync(sessionFile)).toEqual({
+      entryId: "missing-append",
+      leafId: "active-tail",
+    });
+  });
+
   test("async capture scans bounded metadata without copying oversized transcripts", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-checkpoint-async-oversized-"));
     tempDirs.push(dir);
@@ -321,6 +458,71 @@ describe("session-compaction-checkpoints", () => {
     } finally {
       copyFileSyncSpy.mockRestore();
     }
+  });
+
+  test("bounded capture falls back to a forkable raw tail when the leaf target is older", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-checkpoint-bounded-leaf-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-bounded-leaf",
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: dir,
+        },
+        {
+          type: "message",
+          id: "active-root",
+          parentId: null,
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "assistant", content: "active" },
+        },
+        {
+          type: "metadata",
+          id: "large-side-entry",
+          parentId: "active-root",
+          payload: { padding: "x".repeat(2048) },
+        },
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "large-side-entry",
+          timestamp: "2026-06-15T00:00:02.000Z",
+          targetId: "active-root",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+
+    expect(await readSessionLeafStateFromTranscriptAsync(sessionFile, 1024)).toEqual({
+      entryId: "active-leaf",
+      leafId: "active-leaf",
+    });
+    const snapshot = await captureCompactionCheckpointSnapshotAsync({
+      sessionFile,
+      maxBytes: 1024,
+    });
+    expect(snapshot).toMatchObject({
+      sessionId: "session-bounded-leaf",
+      entryId: "active-leaf",
+      leafId: "active-leaf",
+    });
+
+    const forked = await forkCompactionCheckpointTranscriptAsync({
+      sourceFile: sessionFile,
+      sourceLeafId: snapshot?.entryId,
+      sessionDir: dir,
+    });
+    if (!forked) {
+      throw new Error("expected bounded checkpoint fork");
+    }
+    expect(SessionManager.open(forked.sessionFile, dir).getLeafId()).toBe("active-root");
   });
 
   test("async fork creates a checkpoint branch transcript without SessionManager sync reads", async () => {

--- a/src/gateway/session-compaction-checkpoints.test.ts
+++ b/src/gateway/session-compaction-checkpoints.test.ts
@@ -20,6 +20,7 @@ import {
   readRuntimeSessionLeafIdFromTranscriptAsync,
   readSessionLeafIdFromTranscriptAsync,
   readSessionLeafStateFromTranscriptAsync,
+  resolveCompactionCheckpointTranscriptPosition,
 } from "./session-compaction-checkpoints.js";
 
 const tempDirs: string[] = [];
@@ -164,6 +165,21 @@ afterEach(async () => {
 });
 
 describe("session-compaction-checkpoints", () => {
+  test("keeps logical leaves separate from physical truncation cursors", () => {
+    expect(
+      resolveCompactionCheckpointTranscriptPosition({
+        preferredLeafId: "active-root",
+        transcriptState: {
+          leafId: "raw-tail",
+          entryId: "raw-tail",
+        },
+      }),
+    ).toEqual({
+      leafId: "active-root",
+      entryId: "raw-tail",
+    });
+  });
+
   test("runtime checkpoint probes do not create session metadata for missing transcripts", async () => {
     const { storePath, sessionKey } = await makeTempSessionStore(
       "openclaw-checkpoint-runtime-probe-",
@@ -505,13 +521,16 @@ describe("session-compaction-checkpoints", () => {
       leafId: "active-leaf",
     });
     const snapshot = await captureCompactionCheckpointSnapshotAsync({
+      sessionManager: {
+        getLeafId: () => "active-root",
+      },
       sessionFile,
       maxBytes: 1024,
     });
     expect(snapshot).toMatchObject({
       sessionId: "session-bounded-leaf",
       entryId: "active-leaf",
-      leafId: "active-leaf",
+      leafId: "active-root",
     });
 
     const forked = await forkCompactionCheckpointTranscriptAsync({

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -20,6 +20,7 @@ import {
   type SessionTranscriptRuntimeScope,
 } from "../config/sessions/session-accessor.js";
 import { streamSessionTranscriptLines } from "../config/sessions/transcript-stream.js";
+import { scanSessionTranscriptTree } from "../config/sessions/transcript-tree.js";
 import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -34,6 +35,7 @@ export type CapturedCompactionCheckpointSnapshot = {
   sessionId: string;
   sessionFile?: string;
   leafId: string;
+  entryId?: string;
 };
 
 type ForkedCompactionCheckpointTranscript = {
@@ -201,21 +203,16 @@ async function readSessionIdFromTranscriptHeaderAsync(sessionFile: string): Prom
   return (await readSessionHeaderFromTranscriptAsync(sessionFile))?.id ?? null;
 }
 
-function parseTranscriptLineId(
-  line: string,
-): { kind: "session" } | { kind: "entry"; id: string } | null {
+function parseTranscriptLine(line: string): Record<string, unknown> | null {
   try {
-    const parsed = JSON.parse(line) as { type?: unknown; id?: unknown };
-    if (parsed.type === "session") {
-      return { kind: "session" };
+    const parsed = JSON.parse(line) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
     }
-    if (typeof parsed.id === "string" && parsed.id.trim()) {
-      return { kind: "entry", id: parsed.id.trim() };
-    }
+    return parsed as Record<string, unknown>;
   } catch {
     return null;
   }
-  return null;
 }
 
 async function readTranscriptEntriesForForkAsync(params: {
@@ -275,10 +272,10 @@ function trimTranscriptEntriesThroughLeaf(
   return entries.slice(0, leafIndex + 1);
 }
 
-export async function readSessionLeafIdFromTranscriptAsync(
+export async function readSessionLeafStateFromTranscriptAsync(
   sessionFile: string,
   maxBytes = MAX_COMPACTION_CHECKPOINT_LEAF_SCAN_BYTES,
-): Promise<string | null> {
+): Promise<{ entryId: string; leafId: string | null } | null> {
   let fileHandle: AsyncTranscriptFileHandle | undefined;
   try {
     fileHandle = await fs.open(sessionFile, "r");
@@ -300,19 +297,29 @@ export async function readSessionLeafIdFromTranscriptAsync(
       // a larger JSONL entry. Ignore it and grow the window if no complete entry
       // is found.
       const candidateLines = readStart > 0 ? lines.slice(1) : lines;
-      for (let i = candidateLines.length - 1; i >= 0; i -= 1) {
-        const line = candidateLines[i]?.trim();
+      const records: Record<string, unknown>[] = [];
+      let latestEntryId: string | undefined;
+      for (const candidateLine of candidateLines) {
+        const line = candidateLine.trim();
         if (!line) {
           continue;
         }
-        const parsed = parseTranscriptLineId(line);
+        const parsed = parseTranscriptLine(line);
         if (!parsed) {
           continue;
         }
-        if (parsed.kind === "session") {
-          return null;
+        records.push(parsed);
+        if (parsed.type === "session") {
+          continue;
         }
-        return parsed.id;
+        const entryId = typeof parsed.id === "string" ? parsed.id.trim() : "";
+        if (entryId) {
+          latestEntryId = entryId;
+        }
+      }
+      const tree = scanSessionTranscriptTree(records);
+      if (latestEntryId && tree.hasLeafUpdate && (!tree.hasInvalidLeafControl || readStart === 0)) {
+        return { entryId: latestEntryId, leafId: tree.leafId };
       }
 
       if (readStart === 0) {
@@ -320,7 +327,10 @@ export async function readSessionLeafIdFromTranscriptAsync(
       }
       const nextReadLength = Math.min(maxReadableBytes, readLength * 2);
       if (nextReadLength === readLength) {
-        return null;
+        // The selected leaf can precede the bounded window on very large
+        // transcripts. Keep a stable raw truncation point; reopening the full
+        // fork will resolve its actual active branch.
+        return latestEntryId ? { entryId: latestEntryId, leafId: latestEntryId } : null;
       }
       readLength = nextReadLength;
     }
@@ -332,6 +342,13 @@ export async function readSessionLeafIdFromTranscriptAsync(
     }
   }
   return null;
+}
+
+export async function readSessionLeafIdFromTranscriptAsync(
+  sessionFile: string,
+  maxBytes = MAX_COMPACTION_CHECKPOINT_LEAF_SCAN_BYTES,
+): Promise<string | null> {
+  return (await readSessionLeafStateFromTranscriptAsync(sessionFile, maxBytes))?.leafId ?? null;
 }
 
 /**
@@ -431,13 +448,15 @@ export async function captureCompactionCheckpointSnapshotAsync(params: {
   }
   const maxBytes = params.maxBytes ?? MAX_COMPACTION_CHECKPOINT_LEAF_SCAN_BYTES;
   const sessionId = await readSessionIdFromTranscriptHeaderAsync(sessionFile);
-  const leafId = liveLeafId ?? (await readSessionLeafIdFromTranscriptAsync(sessionFile, maxBytes));
+  const transcriptState = await readSessionLeafStateFromTranscriptAsync(sessionFile, maxBytes);
+  const leafId = liveLeafId ?? transcriptState?.leafId;
   if (!sessionId || !leafId) {
     return null;
   }
   return {
     sessionId,
     leafId,
+    ...(transcriptState?.leafId === leafId ? { entryId: transcriptState.entryId } : {}),
   };
 }
 
@@ -521,7 +540,7 @@ export async function persistSessionCompactionCheckpoint(params: {
 }): Promise<SessionCompactionCheckpoint | null> {
   const snapshotSessionFile = params.snapshot.sessionFile?.trim();
   const postSessionFile = params.postSessionFile?.trim();
-  const postSourceLeafId = params.postLeafId?.trim() || params.postEntryId?.trim();
+  const postSourceLeafId = params.postEntryId?.trim() || params.postLeafId?.trim();
   if (!snapshotSessionFile && (!postSessionFile || !postSourceLeafId)) {
     log.warn("skipping compaction checkpoint persist: missing stable fork source", {
       sessionKey: params.sessionKey,
@@ -552,6 +571,7 @@ export async function persistSessionCompactionCheckpoint(params: {
         ? { sessionFile: params.snapshot.sessionFile.trim() }
         : {}),
       leafId: params.snapshot.leafId,
+      ...(params.snapshot.entryId?.trim() ? { entryId: params.snapshot.entryId.trim() } : {}),
     },
     postCompaction: {
       sessionId: params.sessionId,

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -38,6 +38,23 @@ export type CapturedCompactionCheckpointSnapshot = {
   entryId?: string;
 };
 
+type SessionLeafState = {
+  leafId: string | null;
+  entryId: string;
+};
+
+export function resolveCompactionCheckpointTranscriptPosition(params: {
+  preferredLeafId?: string | null;
+  transcriptState?: SessionLeafState | null;
+}): { leafId?: string; entryId?: string } {
+  const leafId = params.preferredLeafId ?? params.transcriptState?.leafId ?? undefined;
+  const entryId = params.transcriptState?.entryId ?? leafId;
+  return {
+    ...(leafId ? { leafId } : {}),
+    ...(entryId ? { entryId } : {}),
+  };
+}
+
 type ForkedCompactionCheckpointTranscript = {
   sessionId: string;
   sessionFile: string;
@@ -449,14 +466,18 @@ export async function captureCompactionCheckpointSnapshotAsync(params: {
   const maxBytes = params.maxBytes ?? MAX_COMPACTION_CHECKPOINT_LEAF_SCAN_BYTES;
   const sessionId = await readSessionIdFromTranscriptHeaderAsync(sessionFile);
   const transcriptState = await readSessionLeafStateFromTranscriptAsync(sessionFile, maxBytes);
-  const leafId = liveLeafId ?? transcriptState?.leafId;
+  const position = resolveCompactionCheckpointTranscriptPosition({
+    preferredLeafId: liveLeafId,
+    transcriptState,
+  });
+  const leafId = position.leafId;
   if (!sessionId || !leafId) {
     return null;
   }
   return {
     sessionId,
     leafId,
-    ...(transcriptState?.leafId === leafId ? { entryId: transcriptState.entryId } : {}),
+    ...(position.entryId ? { entryId: position.entryId } : {}),
   };
 }
 

--- a/src/gateway/session-transcript-index.fs.ts
+++ b/src/gateway/session-transcript-index.fs.ts
@@ -2,6 +2,10 @@
 // Streams JSONL transcript files into byte-offset indexes for history paging.
 import fs from "node:fs";
 import { StringDecoder } from "node:string_decoder";
+import {
+  parseSessionTranscriptTreeEntry,
+  scanSessionTranscriptTree,
+} from "../config/sessions/transcript-tree.js";
 
 const TRANSCRIPT_INDEX_READ_CHUNK_BYTES = 64 * 1024;
 const MAX_TRANSCRIPT_INDEX_CACHE_ENTRIES = 256;
@@ -25,8 +29,9 @@ type SessionTranscriptIndex = {
   mtimeMs: number;
   size: number;
   hasTreeEntries: boolean;
-  leafId?: string;
+  leafId?: string | null;
   entries: IndexedTranscriptEntry[];
+  allEntries: IndexedTranscriptEntry[];
 };
 
 type IndexedRawEntry = {
@@ -45,6 +50,7 @@ type CacheEntry = {
 
 type ReadSessionTranscriptIndexOptions = {
   cache?: "reuse" | "skip";
+  view?: "active" | "all";
 };
 
 const transcriptIndexCache = new Map<string, CacheEntry>();
@@ -122,6 +128,13 @@ function setCachedIndex(filePath: string, entry: CacheEntry): void {
   }
 }
 
+function selectTranscriptIndexView(
+  index: SessionTranscriptIndex,
+  view: ReadSessionTranscriptIndexOptions["view"],
+): SessionTranscriptIndex {
+  return view === "all" ? { ...index, entries: index.allEntries } : index;
+}
+
 /** Clears transcript index caches and in-flight builds between tests. */
 export function clearSessionTranscriptIndexCache(): void {
   transcriptIndexCache.clear();
@@ -134,10 +147,6 @@ function isIndexableTranscriptRecord(record: unknown): record is ParsedTranscrip
 
 function isVisibleTranscriptRecord(record: ParsedTranscriptRecord): boolean {
   return Boolean(record.message) || record.type === "compaction";
-}
-
-function isTreeTranscriptRecord(record: ParsedTranscriptRecord): boolean {
-  return record.type !== "session" && typeof record.id === "string" && "parentId" in record;
 }
 
 function buildOversizedIndexedRawEntry(params: {
@@ -168,9 +177,10 @@ function buildOversizedIndexedRawEntry(params: {
       __openclaw: { truncated: true, reason: "oversized" },
     },
   };
+  const treeEntry = parseSessionTranscriptTreeEntry(record);
   return {
     ...(id ? { id } : {}),
-    ...(parentId !== undefined ? { parentId } : {}),
+    ...(treeEntry ? { parentId: treeEntry.parentId } : parentId !== undefined ? { parentId } : {}),
     offset: params.offset,
     byteLength: params.byteLength,
     record,
@@ -224,7 +234,7 @@ async function visitTranscriptJsonLines(
 
 function buildActiveTreeEntries(params: {
   byId: Map<string, IndexedRawEntry>;
-  leafId?: string;
+  leafId?: string | null;
 }): IndexedRawEntry[] {
   const out: IndexedRawEntry[] = [];
   const seen = new Set<string>();
@@ -268,9 +278,6 @@ async function buildSessionTranscriptIndex(
   stat: fs.Stats,
 ): Promise<SessionTranscriptIndex> {
   const rawEntries: IndexedRawEntry[] = [];
-  const byId = new Map<string, IndexedRawEntry>();
-  let hasTreeEntries = false;
-  let leafId: string | undefined;
 
   await visitTranscriptJsonLines(filePath, (line, offset, byteLength) => {
     if (!line.trim()) {
@@ -282,13 +289,6 @@ async function buildSessionTranscriptIndex(
         return;
       }
       rawEntries.push(rawEntry);
-      if (rawEntry.id) {
-        byId.set(rawEntry.id, rawEntry);
-        if (isTreeTranscriptRecord(rawEntry.record)) {
-          hasTreeEntries = true;
-          leafId = rawEntry.id;
-        }
-      }
       return;
     }
     let parsed: unknown;
@@ -303,31 +303,42 @@ async function buildSessionTranscriptIndex(
     const id = normalizeOptionalString(parsed.id);
     const parentId =
       parsed.parentId === null ? null : (normalizeOptionalString(parsed.parentId) ?? undefined);
+    const treeEntry = parseSessionTranscriptTreeEntry(parsed);
     const rawEntry: IndexedRawEntry = {
       ...(id ? { id } : {}),
-      ...(parentId !== undefined ? { parentId } : {}),
+      ...(treeEntry
+        ? { parentId: treeEntry.parentId }
+        : parentId !== undefined
+          ? { parentId }
+          : {}),
       offset,
       byteLength,
       record: parsed,
     };
     rawEntries.push(rawEntry);
-    if (id) {
-      byId.set(id, rawEntry);
-      if (isTreeTranscriptRecord(parsed)) {
-        hasTreeEntries = true;
-        leafId = id;
-      }
-    }
   });
 
-  const activeRawEntries = hasTreeEntries ? buildActiveTreeEntries({ byId, leafId }) : rawEntries;
+  const tree = scanSessionTranscriptTree(rawEntries.map((entry) => entry.record));
+  const rawByRecord = new Map(rawEntries.map((entry) => [entry.record, entry]));
+  const byId = new Map<string, IndexedRawEntry>();
+  for (const node of tree.nodes) {
+    const rawEntry = rawByRecord.get(node.entry);
+    if (rawEntry) {
+      rawEntry.parentId = node.parentId;
+      byId.set(node.id, rawEntry);
+    }
+  }
+  const activeRawEntries = tree.hasExplicitLeafUpdate
+    ? buildActiveTreeEntries({ byId, leafId: tree.leafId })
+    : rawEntries;
   return {
     filePath,
     mtimeMs: stat.mtimeMs,
     size: stat.size,
-    hasTreeEntries,
-    ...(leafId ? { leafId } : {}),
+    hasTreeEntries: tree.hasExplicitLeafUpdate,
+    ...(tree.hasExplicitLeafUpdate ? { leafId: tree.leafId } : {}),
     entries: toIndexedEntries(activeRawEntries),
+    allEntries: toIndexedEntries(rawEntries),
   };
 }
 
@@ -348,15 +359,15 @@ export async function readSessionTranscriptIndex(
     return null;
   }
   if (opts.cache === "skip") {
-    return await buildSessionTranscriptIndex(filePath, stat);
+    return selectTranscriptIndexView(await buildSessionTranscriptIndex(filePath, stat), opts.view);
   }
   const cached = transcriptIndexCache.get(filePath);
   if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
-    return touchCachedIndex(filePath, cached);
+    return selectTranscriptIndexView(touchCachedIndex(filePath, cached), opts.view);
   }
   const inFlight = transcriptIndexBuilds.get(filePath);
   if (inFlight && inFlight.mtimeMs === stat.mtimeMs && inFlight.size === stat.size) {
-    return await inFlight.promise;
+    return selectTranscriptIndexView(await inFlight.promise, opts.view);
   }
   const promise = buildSessionTranscriptIndex(filePath, stat);
   transcriptIndexBuilds.set(filePath, {
@@ -375,5 +386,5 @@ export async function readSessionTranscriptIndex(
     size: stat.size,
     index,
   });
-  return index;
+  return selectTranscriptIndexView(index, opts.view);
 }

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -7,7 +7,10 @@ import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 import { estimateStringChars, estimateTokensFromChars } from "../utils/cjk-chars.js";
 import { createToolSummaryPreviewTranscriptLines } from "./session-preview.test-helpers.js";
-import { clearSessionTranscriptIndexCache } from "./session-transcript-index.fs.js";
+import {
+  clearSessionTranscriptIndexCache,
+  readSessionTranscriptIndex,
+} from "./session-transcript-index.fs.js";
 import {
   archiveSessionTranscripts,
   readFirstUserMessageFromTranscript,
@@ -410,6 +413,66 @@ describe("readSessionTitleFieldsFromTranscript cache", () => {
       lastMessagePreview: "tail preview",
     });
   });
+
+  test("uses the selected branch for the sync last-message preview", () => {
+    const sessionId = "test-cache-selected-preview";
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 3, id: sessionId },
+      {
+        type: "message",
+        id: "active-preview",
+        parentId: null,
+        message: { role: "assistant", content: "active preview" },
+      },
+      {
+        type: "message",
+        id: "inactive-preview",
+        parentId: "active-preview",
+        message: { role: "assistant", content: "inactive side delivery" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "inactive-preview",
+        targetId: "active-preview",
+      },
+    ]);
+
+    expect(readSessionTitleFieldsFromTranscript(sessionId, storePath).lastMessagePreview).toBe(
+      "active preview",
+    );
+  });
+
+  test("uses the selected branch for the async last-message preview", async () => {
+    const sessionId = "test-cache-selected-preview-async";
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 3, id: sessionId },
+      {
+        type: "message",
+        id: "active-preview",
+        parentId: null,
+        message: { role: "assistant", content: "active preview" },
+      },
+      {
+        type: "message",
+        id: "inactive-preview",
+        parentId: "active-preview",
+        message: { role: "assistant", content: "inactive side delivery" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "inactive-preview",
+        targetId: "active-preview",
+      },
+    ]);
+
+    await expect(
+      readSessionTitleFieldsFromTranscriptAsync(sessionId, storePath),
+    ).resolves.toMatchObject({
+      lastMessagePreview: "active preview",
+    });
+  });
 });
 
 describe("readSessionMessages", () => {
@@ -769,6 +832,23 @@ describe("readSessionMessages", () => {
         parentId: "assistant-1",
         message: { role: "user", content: "latest active" },
       },
+      {
+        type: "message",
+        id: "delivery-side-branch",
+        parentId: "user-2",
+        message: { role: "assistant", content: "side delivery" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "delivery-side-branch",
+        targetId: "user-2",
+      },
+      {
+        type: "metadata",
+        id: "opaque-after-leaf",
+        parentId: "delivery-side-branch",
+      },
     ]);
     clearSessionTranscriptIndexCache();
     const sessionManagerOpenSpy = vi.spyOn(SessionManager, "open");
@@ -784,6 +864,14 @@ describe("readSessionMessages", () => {
         "active branch",
         "latest active",
       ]);
+      const recentMessages = await readRecentSessionMessagesAsync(sessionId, storePath, undefined, {
+        maxMessages: 10,
+      });
+      expect(recentMessages.map((message) => (message as { content?: unknown }).content)).toEqual([
+        "root",
+        "active branch",
+        "latest active",
+      ]);
       expectMessageFields(messages[2], { openclaw: { id: "user-2", seq: 3 } });
       expect(sessionManagerOpenSpy).not.toHaveBeenCalled();
       expect(readFileSpy).not.toHaveBeenCalled();
@@ -791,6 +879,106 @@ describe("readSessionMessages", () => {
       sessionManagerOpenSpy.mockRestore();
       readFileSpy.mockRestore();
     }
+  });
+
+  test("supports file-wide identity lookup without exposing side branches to history", async () => {
+    const sessionId = "test-session-index-views";
+    const transcriptPath = writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 3, id: sessionId },
+      {
+        type: "message",
+        id: "root",
+        parentId: null,
+        message: { role: "user", content: "root" },
+      },
+      {
+        type: "message",
+        id: "side-assistant",
+        parentId: "root",
+        message: {
+          role: "assistant",
+          content: "side",
+          idempotencyKey: "side-idempotency",
+        },
+      },
+      {
+        type: "message",
+        id: "active-assistant",
+        parentId: "root",
+        message: { role: "assistant", content: "active" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "side-assistant",
+        targetId: "active-assistant",
+      },
+    ]);
+    clearSessionTranscriptIndexCache();
+
+    const activeIndex = await readSessionTranscriptIndex(transcriptPath);
+    const allIndex = await readSessionTranscriptIndex(transcriptPath, { view: "all" });
+
+    expect(activeIndex?.entries.map((entry) => entry.id)).toEqual(["root", "active-assistant"]);
+    expect(allIndex?.entries.map((entry) => entry.id)).toEqual([
+      "root",
+      "side-assistant",
+      "active-assistant",
+    ]);
+  });
+
+  test("keeps parentless linear history after a leaf control", async () => {
+    const sessionId = "test-linear-with-opaque-link";
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 3, id: sessionId },
+      {
+        type: "message",
+        id: "linear-user",
+        message: { role: "user", content: "linear root" },
+      },
+      {
+        type: "message",
+        id: "linear-assistant",
+        message: { role: "assistant", content: "linear answer" },
+      },
+      {
+        type: "metadata",
+        id: "linear-metadata",
+        parentId: "linear-assistant",
+      },
+      {
+        type: "message",
+        id: "side-assistant",
+        parentId: "linear-assistant",
+        message: { role: "assistant", content: "side answer" },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "side-assistant",
+        targetId: "linear-assistant",
+        appendParentId: "linear-metadata",
+      },
+    ]);
+    clearSessionTranscriptIndexCache();
+
+    const messages = await readSessionMessagesAsync(sessionId, storePath, undefined, {
+      mode: "full",
+      reason: "test parentless leaf selection",
+    });
+
+    expect(messages.map((message) => (message as { content?: unknown }).content)).toEqual([
+      "linear root",
+      "linear answer",
+    ]);
+    expect(await readSessionMessageCountAsync(sessionId, storePath)).toBe(2);
+    expect(
+      (
+        await readRecentSessionMessagesAsync(sessionId, storePath, undefined, {
+          maxMessages: 10,
+        })
+      ).map((message) => (message as { content?: unknown }).content),
+    ).toEqual(["linear root", "linear answer"]);
   });
 
   test("falls back to the latest reset archive when the active transcript is missing", async () => {
@@ -1322,6 +1510,20 @@ describe("readSessionMessages", () => {
           timestamp: 3,
         },
       },
+      {
+        type: "message",
+        id: "delivery-side-branch",
+        parentId: "answer",
+        timestamp: "2026-04-27T00:00:04.000Z",
+        message: { role: "assistant", content: "side delivery", timestamp: 4 },
+      },
+      {
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "delivery-side-branch",
+        timestamp: "2026-04-27T00:00:05.000Z",
+        targetId: "answer",
+      },
     ];
     fs.writeFileSync(sessionFile, lines.map((line) => JSON.stringify(line)).join("\n"), "utf-8");
     const rawTranscript = fs.readFileSync(sessionFile, "utf-8");
@@ -1340,6 +1542,7 @@ describe("readSessionMessages", () => {
         openclaw: { seq: 2 },
       });
       expect(JSON.stringify(out)).not.toContain("original wrapped prompt");
+      expect(JSON.stringify(out)).not.toContain("side delivery");
       expect(sessionManagerOpenSpy).not.toHaveBeenCalled();
     } finally {
       sessionManagerOpenSpy.mockRestore();
@@ -2305,6 +2508,96 @@ describe("oversized transcript line guards", () => {
     expect(serialized).toContain("oversized-leaf");
     expect(serialized).not.toContain(oversizedContent);
     expect(serialized).toContain("[chat.history omitted: message too large]");
+  });
+
+  test("recent readers stay bounded when a leaf target is outside the tail window", async () => {
+    const sessionId = "test-leaf-target-before-tail-window";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const lines = [
+      JSON.stringify({ type: "session", version: 3, id: sessionId }),
+      JSON.stringify({
+        type: "message",
+        id: "active-root",
+        parentId: null,
+        message: { role: "user", content: "active root" },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "side-delivery",
+        parentId: "active-root",
+        message: { role: "assistant", content: "x".repeat(16 * 1024) },
+      }),
+      JSON.stringify({
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "side-delivery",
+        targetId: "active-root",
+      }),
+    ];
+    fs.writeFileSync(transcriptPath, `${lines.join("\n")}\n`, "utf-8");
+    const options = { maxMessages: 10, maxBytes: 1024, maxLines: 10 };
+    const readFileSpy = vi.spyOn(fs, "readFileSync");
+
+    try {
+      const syncMessages = readRecentSessionMessages(sessionId, storePath, undefined, options);
+      const asyncMessages = await readRecentSessionMessagesAsync(
+        sessionId,
+        storePath,
+        undefined,
+        options,
+      );
+
+      expect(syncMessages).toEqual([]);
+      expect(asyncMessages).toEqual(syncMessages);
+      expect(readFileSpy).not.toHaveBeenCalled();
+    } finally {
+      readFileSpy.mockRestore();
+    }
+  });
+
+  test("bounded recent readers do not expose a compact inactive side message", async () => {
+    const sessionId = "test-compact-side-before-bounded-leaf-target";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const lines = [
+      JSON.stringify({ type: "session", version: 3, id: sessionId }),
+      JSON.stringify({
+        type: "message",
+        id: "active-root",
+        parentId: null,
+        message: { role: "user", content: "active root" },
+      }),
+      JSON.stringify({
+        type: "metadata",
+        id: "large-padding",
+        parentId: "active-root",
+        payload: { padding: "x".repeat(16 * 1024) },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "side-delivery",
+        parentId: "active-root",
+        message: { role: "assistant", content: "compact side delivery" },
+      }),
+      JSON.stringify({
+        type: "leaf",
+        id: "active-leaf",
+        parentId: "side-delivery",
+        targetId: "active-root",
+      }),
+    ];
+    fs.writeFileSync(transcriptPath, `${lines.join("\n")}\n`, "utf-8");
+    const options = { maxMessages: 10, maxBytes: 1024, maxLines: 10 };
+
+    const syncMessages = readRecentSessionMessages(sessionId, storePath, undefined, options);
+    const asyncMessages = await readRecentSessionMessagesAsync(
+      sessionId,
+      storePath,
+      undefined,
+      options,
+    );
+
+    expect(syncMessages).toEqual([]);
+    expect(asyncMessages).toEqual([]);
   });
 
   test("readRecentSessionUsageFromTranscriptAsync skips oversized lines", async () => {

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -8,6 +8,10 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { deriveSessionTotalTokens, hasNonzeroUsage, normalizeUsage } from "../agents/usage.js";
+import {
+  scanSessionTranscriptTree,
+  selectSessionTranscriptTreePathNodes,
+} from "../config/sessions/transcript-tree.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import { hasInterSessionUserProvenance } from "../sessions/input-provenance.js";
 import { extractAssistantVisibleText } from "../shared/chat-message-content.js";
@@ -196,8 +200,6 @@ type ReadSessionMessagesResult = {
 const RECENT_SESSION_MESSAGES_DEFAULT_MAX_BYTES = 8 * 1024 * 1024;
 
 type TailTranscriptRecord = {
-  id?: string;
-  parentId?: string | null;
   record: Record<string, unknown>;
 };
 
@@ -351,11 +353,7 @@ function buildOversizedTranscriptRecord(line: string): TailTranscriptRecord {
       __openclaw: { truncated: true, reason: "oversized" },
     },
   };
-  return {
-    ...(id ? { id } : {}),
-    ...(parentId !== undefined ? { parentId } : {}),
-    record,
-  };
+  return { record };
 }
 
 function normalizeTailEntryString(value: unknown): string | undefined {
@@ -372,59 +370,28 @@ function parseTailTranscriptRecord(line: string): TailTranscriptRecord | null {
       return null;
     }
     const record = parsed as Record<string, unknown>;
-    return {
-      ...(normalizeTailEntryString(record.id) ? { id: normalizeTailEntryString(record.id) } : {}),
-      ...(record.parentId === null
-        ? { parentId: null }
-        : normalizeTailEntryString(record.parentId)
-          ? { parentId: normalizeTailEntryString(record.parentId) }
-          : {}),
-      record,
-    };
+    return { record };
   } catch {
     return null;
   }
 }
 
-function tailRecordHasTreeLink(entry: TailTranscriptRecord): boolean {
-  return (
-    entry.record.type !== "session" &&
-    typeof entry.id === "string" &&
-    Object.hasOwn(entry.record, "parentId")
-  );
-}
-
-function selectBoundedActiveTailRecords(entries: TailTranscriptRecord[]): TailTranscriptRecord[] {
-  const byId = new Map<string, TailTranscriptRecord>();
-  let leafId: string | undefined;
-  for (const entry of entries) {
-    if (entry.id) {
-      byId.set(entry.id, entry);
-    }
-    if (tailRecordHasTreeLink(entry) && entry.id) {
-      leafId = entry.id;
-    }
+function selectBoundedActiveTailRecords(
+  entries: TailTranscriptRecord[],
+  opts?: { failClosedOnInvalidLeafControl?: boolean },
+): TailTranscriptRecord[] {
+  const tree = scanSessionTranscriptTree(entries.map((entry) => entry.record));
+  if (opts?.failClosedOnInvalidLeafControl === true && tree.hasInvalidLeafControl) {
+    return [];
   }
-  if (!leafId) {
+  if (!tree.hasExplicitLeafUpdate) {
     return entries;
   }
-
-  const selected: TailTranscriptRecord[] = [];
-  const seen = new Set<string>();
-  let currentId: string | undefined = leafId;
-  while (currentId) {
-    if (seen.has(currentId)) {
-      return [];
-    }
-    seen.add(currentId);
-    const entry = byId.get(currentId);
-    if (!entry) {
-      break;
-    }
-    selected.push(entry);
-    currentId = entry.parentId ?? undefined;
-  }
-  const activeBranch = selected.toReversed();
+  const recordsByValue = new Map(entries.map((entry) => [entry.record, entry]));
+  const activeBranch = selectSessionTranscriptTreePathNodes(tree, tree.leafId).flatMap((node) => {
+    const entry = recordsByValue.get(node.entry);
+    return entry ? [entry] : [];
+  });
   const firstActiveRecord = activeBranch[0];
   const firstActiveIndex = firstActiveRecord ? entries.indexOf(firstActiveRecord) : -1;
   if (firstActiveIndex > 0) {
@@ -453,7 +420,7 @@ function readTranscriptRecords(filePath: string): TailTranscriptRecord[] {
 }
 
 function selectActiveTranscriptRecords(records: TailTranscriptRecord[]): TailTranscriptRecord[] {
-  return records.some(tailRecordHasTreeLink) ? selectBoundedActiveTailRecords(records) : records;
+  return selectBoundedActiveTailRecords(records);
 }
 
 function readSelectedTranscriptRecords(filePath: string): TailTranscriptRecord[] {
@@ -482,7 +449,10 @@ function parseRecentTranscriptTailMessages(lines: string[], maxMessages: number)
     const entry = parseTailTranscriptRecord(line);
     return entry ? [entry] : [];
   });
-  return transcriptRecordsToMessages(selectActiveTranscriptRecords(entries)).slice(-maxMessages);
+  const selected = selectBoundedActiveTailRecords(entries, {
+    failClosedOnInvalidLeafControl: true,
+  });
+  return transcriptRecordsToMessages(selected).slice(-maxMessages);
 }
 
 function visitTranscriptLines(filePath: string, visit: (line: string) => void): void {
@@ -1268,6 +1238,27 @@ export function readFirstUserMessageFromTranscript(
 const LAST_MSG_MAX_BYTES = 16384;
 const LAST_MSG_MAX_LINES = 20;
 
+function extractLastMessagePreviewFromTranscriptLines(lines: string[]): string | null {
+  const records = lines.flatMap((line) => {
+    const parsed = parseTailTranscriptRecord(line);
+    return parsed ? [parsed] : [];
+  });
+  const selected = selectBoundedActiveTailRecords(records, {
+    failClosedOnInvalidLeafControl: true,
+  });
+  for (let index = selected.length - 1; index >= 0; index -= 1) {
+    const msg = selected[index]?.record.message as TranscriptMessage | undefined;
+    if (msg?.role !== "user" && msg?.role !== "assistant") {
+      continue;
+    }
+    const text = extractTextFromContent(msg.content);
+    if (text) {
+      return text;
+    }
+  }
+  return null;
+}
+
 function readLastMessagePreviewFromOpenTranscript(params: {
   fd: number;
   size: number;
@@ -1279,25 +1270,7 @@ function readLastMessagePreviewFromOpenTranscript(params: {
 
   const chunk = buf.toString("utf-8");
   const lines = chunk.split(/\r?\n/).filter((l) => l.trim());
-  const tailLines = lines.slice(-LAST_MSG_MAX_LINES);
-
-  for (let i = tailLines.length - 1; i >= 0; i--) {
-    const line = tailLines[i];
-    try {
-      const parsed = JSON.parse(line);
-      const msg = parsed?.message as TranscriptMessage | undefined;
-      if (msg?.role !== "user" && msg?.role !== "assistant") {
-        continue;
-      }
-      const text = extractTextFromContent(msg.content);
-      if (text) {
-        return text;
-      }
-    } catch {
-      // skip malformed
-    }
-  }
-  return null;
+  return extractLastMessagePreviewFromTranscriptLines(lines.slice(-LAST_MSG_MAX_LINES));
 }
 
 async function readLastMessagePreviewFromOpenTranscriptAsync(params: {
@@ -1314,25 +1287,7 @@ async function readLastMessagePreviewFromOpenTranscriptAsync(params: {
 
   const chunk = buffer.toString("utf-8", 0, bytesRead);
   const lines = chunk.split(/\r?\n/).filter((line) => line.trim());
-  const tailLines = lines.slice(-LAST_MSG_MAX_LINES);
-
-  for (let i = tailLines.length - 1; i >= 0; i--) {
-    const line = tailLines[i];
-    try {
-      const parsed = JSON.parse(line);
-      const msg = parsed?.message as TranscriptMessage | undefined;
-      if (msg?.role !== "user" && msg?.role !== "assistant") {
-        continue;
-      }
-      const text = extractTextFromContent(msg.content);
-      if (text) {
-        return text;
-      }
-    } catch {
-      // skip malformed
-    }
-  }
-  return null;
+  return extractLastMessagePreviewFromTranscriptLines(lines.slice(-LAST_MSG_MAX_LINES));
 }
 
 type SessionTranscriptUsageSnapshot = {

--- a/src/plugin-sdk/agent-sessions.ts
+++ b/src/plugin-sdk/agent-sessions.ts
@@ -2,4 +2,3 @@
  * Public SDK subpath for agent session entry types and persistence helpers.
  */
 export * from "../agents/sessions/index.js";
-export { selectSessionTranscriptLeafControlledPath } from "../config/sessions/transcript-tree.js";

--- a/src/plugin-sdk/agent-sessions.ts
+++ b/src/plugin-sdk/agent-sessions.ts
@@ -2,3 +2,4 @@
  * Public SDK subpath for agent session entry types and persistence helpers.
  */
 export * from "../agents/sessions/index.js";
+export { selectSessionTranscriptLeafControlledPath } from "../config/sessions/transcript-tree.js";

--- a/src/trajectory/export.test.ts
+++ b/src/trajectory/export.test.ts
@@ -660,6 +660,308 @@ describe("exportTrajectoryBundle", () => {
     ]);
   });
 
+  it("exports supported current-version linear transcripts in file order", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const outputDir = path.join(tmpDir, "bundle");
+    fs.writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-linear",
+          timestamp: "2026-04-01T05:46:39.000Z",
+          cwd: tmpDir,
+        },
+        {
+          type: "message",
+          id: "linear-user",
+          timestamp: "2026-04-01T05:46:40.000Z",
+          message: userMessage("hello"),
+        },
+        {
+          type: "message",
+          id: "linear-assistant",
+          timestamp: "2026-04-01T05:46:41.000Z",
+          message: assistantMessage([{ type: "text", text: "done" }]),
+        },
+        {
+          type: "metadata",
+          id: "linear-metadata",
+          parentId: "linear-assistant",
+          payload: { source: "plugin" },
+        },
+        {
+          type: "message",
+          id: "side-assistant",
+          parentId: "linear-assistant",
+          timestamp: "2026-04-01T05:46:42.000Z",
+          message: assistantMessage([{ type: "text", text: "side" }]),
+        },
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "side-assistant",
+          targetId: "linear-assistant",
+          appendParentId: "linear-metadata",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const bundle = await exportTrajectoryBundle({
+      outputDir,
+      sessionFile,
+      sessionId: "session-linear",
+      workspaceDir: tmpDir,
+    });
+
+    expect(eventTypes(bundle.events)).toEqual(["user.message", "assistant.message"]);
+    expect(bundle.manifest.leafId).toBe("linear-assistant");
+    expect(JSON.stringify(bundle.events)).not.toContain("side");
+  });
+
+  it("exports the branch selected by a terminal leaf control", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const outputDir = path.join(tmpDir, "bundle");
+    fs.writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-04-01T05:46:39.000Z",
+          cwd: tmpDir,
+        },
+        {
+          type: "message",
+          id: "active-tail",
+          parentId: null,
+          timestamp: "2026-04-01T05:46:40.000Z",
+          message: userMessage("active"),
+        },
+        {
+          type: "message",
+          id: "inactive-tail",
+          parentId: "active-tail",
+          timestamp: "2026-04-01T05:46:41.000Z",
+          message: assistantMessage([{ type: "text", text: "side delivery" }]),
+        },
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "inactive-tail",
+          timestamp: "2026-04-01T05:46:42.000Z",
+          targetId: "active-tail",
+          appendParentId: null,
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const bundle = await exportTrajectoryBundle({
+      outputDir,
+      sessionFile,
+      sessionId: "session-1",
+      workspaceDir: tmpDir,
+    });
+
+    expect(eventTypes(bundle.events)).toEqual(["user.message"]);
+    expect(bundle.manifest.leafId).toBe("active-tail");
+    expect(JSON.stringify(bundle.events)).not.toContain("side delivery");
+  });
+
+  it("normalizes an active descendant whose source parent is a leaf control", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const outputDir = path.join(tmpDir, "bundle");
+    fs.writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-04-01T05:46:39.000Z",
+          cwd: tmpDir,
+        },
+        {
+          type: "message",
+          id: "active-tail",
+          parentId: null,
+          timestamp: "2026-04-01T05:46:40.000Z",
+          message: userMessage("active"),
+        },
+        {
+          type: "message",
+          id: "inactive-tail",
+          parentId: "active-tail",
+          timestamp: "2026-04-01T05:46:41.000Z",
+          message: assistantMessage([{ type: "text", text: "side delivery" }]),
+        },
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "inactive-tail",
+          timestamp: "2026-04-01T05:46:42.000Z",
+          targetId: "active-tail",
+        },
+        {
+          type: "message",
+          id: "replacement",
+          parentId: "active-leaf",
+          timestamp: "2026-04-01T05:46:43.000Z",
+          message: assistantMessage([{ type: "text", text: "replacement" }]),
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const bundle = await exportTrajectoryBundle({
+      outputDir,
+      sessionFile,
+      sessionId: "session-1",
+      workspaceDir: tmpDir,
+    });
+
+    expect(eventTypes(bundle.events)).toEqual(["user.message", "assistant.message"]);
+    expect(bundle.events.find((event) => event.entryId === "replacement")?.parentEntryId).toBe(
+      "active-tail",
+    );
+    expect(JSON.stringify(bundle.events)).not.toContain("active-leaf");
+    expect(JSON.stringify(bundle.events)).not.toContain("side delivery");
+  });
+
+  it("does not export append-parent history from an explicitly empty branch", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const outputDir = path.join(tmpDir, "bundle");
+    fs.writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-empty",
+          timestamp: "2026-04-01T05:46:39.000Z",
+          cwd: tmpDir,
+        },
+        {
+          type: "message",
+          id: "inactive-root",
+          parentId: null,
+          timestamp: "2026-04-01T05:46:40.000Z",
+          message: userMessage("inactive"),
+        },
+        {
+          type: "leaf",
+          id: "empty-leaf",
+          parentId: "inactive-root",
+          timestamp: "2026-04-01T05:46:41.000Z",
+          targetId: null,
+          appendParentId: null,
+        },
+        {
+          type: "metadata",
+          id: "plugin-metadata",
+          parentId: "inactive-root",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const bundle = await exportTrajectoryBundle({
+      outputDir,
+      sessionFile,
+      sessionId: "session-empty",
+      workspaceDir: tmpDir,
+    });
+
+    expect(bundle.events).toEqual([]);
+    expect(bundle.manifest.transcriptEventCount).toBe(0);
+  });
+
+  it("traverses opaque append parents while exporting the active branch", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const outputDir = path.join(tmpDir, "bundle");
+    fs.writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-04-01T05:46:39.000Z",
+          cwd: tmpDir,
+        },
+        {
+          type: "message",
+          id: "active-root",
+          parentId: null,
+          timestamp: "2026-04-01T05:46:40.000Z",
+          message: userMessage("active"),
+        },
+        {
+          type: "metadata",
+          id: "plugin-metadata",
+          parentId: "active-root",
+        },
+        {
+          type: "message",
+          id: "side-delivery",
+          parentId: "active-root",
+          timestamp: "2026-04-01T05:46:41.000Z",
+          message: assistantMessage([{ type: "text", text: "side delivery" }]),
+        },
+        {
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "side-delivery",
+          timestamp: "2026-04-01T05:46:42.000Z",
+          targetId: "active-root",
+          appendParentId: "plugin-metadata",
+        },
+        {
+          type: "message",
+          id: "active-tail",
+          parentId: "plugin-metadata",
+          timestamp: "2026-04-01T05:46:43.000Z",
+          message: assistantMessage([{ type: "text", text: "active tail" }]),
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    const bundle = await exportTrajectoryBundle({
+      outputDir,
+      sessionFile,
+      sessionId: "session-1",
+      workspaceDir: tmpDir,
+    });
+
+    expect(eventTypes(bundle.events)).toEqual(["user.message", "assistant.message"]);
+    expect(bundle.manifest.leafId).toBe("active-tail");
+    expect(JSON.stringify(bundle.events)).toContain("active tail");
+    expect(JSON.stringify(bundle.events)).not.toContain("side delivery");
+    expect(bundle.events.find((event) => event.entryId === "active-tail")?.parentEntryId).toBe(
+      "active-root",
+    );
+  });
+
   it("stops cyclic transcript branch export instead of hanging", async () => {
     const tmpDir = makeTempDir();
     const sessionFile = path.join(tmpDir, "session.jsonl");

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -7,6 +7,10 @@ import type { AgentMessage } from "../agents/runtime/index.js";
 import type { FileEntry, SessionEntry, SessionHeader } from "../agents/sessions/session-manager.js";
 import { resolveStateDir } from "../config/paths.js";
 import {
+  isCanonicalSessionTranscriptEntry,
+  scanSessionTranscriptTree,
+} from "../config/sessions/transcript-tree.js";
+import {
   jsonSupportBundleFile,
   jsonlSupportBundleFile,
   supportBundleContents,
@@ -180,18 +184,28 @@ async function readSessionBranch(filePath: string): Promise<{
   const entries = fileEntries.filter(
     (entry): entry is SessionEntry =>
       entry.type !== "session" &&
+      isCanonicalSessionTranscriptEntry(entry) &&
       typeof (entry as { id?: unknown }).id === "string" &&
       (typeof (entry as { timestamp?: unknown }).timestamp === "string" ||
         typeof (entry as { timestamp?: unknown }).timestamp === "number"),
   );
-  const byId = new Map(entries.map((entry) => [entry.id, entry]));
-  const leafId = entries.at(-1)?.id ?? null;
+  const tree = scanSessionTranscriptTree(fileEntries);
+  if (!tree.hasLeafUpdate) {
+    return {
+      header,
+      leafId: entries.at(-1)?.id ?? null,
+      branchEntries: entries,
+      warnings,
+    };
+  }
+  const entriesById = new Map(entries.map((entry) => [entry.id, entry]));
   const branchEntries: SessionEntry[] = [];
   const seen = new Set<string>();
-  let currentId = leafId;
+  let descendantEntry: SessionEntry | undefined;
+  let currentId = tree.leafId;
   while (currentId) {
     if (seen.has(currentId)) {
-      const cycleEntry = byId.get(currentId);
+      const cycleEntry = tree.byId.get(currentId)?.entry;
       warnings.push({
         source: "session",
         code: "cyclic-session-branch",
@@ -201,7 +215,7 @@ async function readSessionBranch(filePath: string): Promise<{
       break;
     }
     seen.add(currentId);
-    const current = byId.get(currentId);
+    const current = tree.byId.get(currentId);
     if (!current) {
       warnings.push({
         source: "session",
@@ -211,20 +225,27 @@ async function readSessionBranch(filePath: string): Promise<{
       });
       break;
     }
-    branchEntries.unshift(current);
-    const parentId = typeof current.parentId === "string" ? current.parentId : null;
-    if (parentId && !byId.has(parentId)) {
+    const visibleEntry = entriesById.get(currentId);
+    if (visibleEntry) {
+      const normalizedEntry = { ...visibleEntry, parentId: current.parentId };
+      if (descendantEntry) {
+        descendantEntry.parentId = normalizedEntry.id;
+      }
+      branchEntries.unshift(normalizedEntry);
+      descendantEntry = normalizedEntry;
+    }
+    if (current.parentId && !tree.byId.has(current.parentId)) {
       warnings.push({
         source: "session",
         code: "incomplete-session-branch",
-        row: rowByEntry.get(current) ?? 0,
+        row: rowByEntry.get(current.entry) ?? 0,
         message: "Exported the reachable session branch suffix after a missing parent link.",
       });
       break;
     }
-    currentId = parentId;
+    currentId = current.parentId;
   }
-  return { header, leafId, branchEntries, warnings };
+  return { header, leafId: tree.leafId, branchEntries, warnings };
 }
 
 async function parseJsonlFile<T>(


### PR DESCRIPTION
## Summary

Fixes #93193.

Embedded attempts now preserve safe session rows appended while the prompt lock is released without treating them as a takeover or allowing a stale `SessionManager` rewrite to discard them.

- Preserve delivery mirrors and global metadata as side appends without changing active model context.
- Keep transcript navigation, checkpoints, forks, exports, and Codex history on the same leaf-controlled branch.
- Track same-process nested publications until their physical writes drain.
- Surface takeover after an otherwise successful outer write, while preserving an existing outer error.
- Repair malformed legacy leaf state through `openclaw doctor --fix`.

## Why this shape

Allowing more JSONL entry types at the fence is insufficient because an already-open manager can later rewrite accepted rows away. Reloading the whole manager is unsafe because it can drop prepared or not-yet-flushed active state. The final implementation keeps one canonical transcript graph, records side appends explicitly, centralizes leaf-controlled context selection, and carries owned-write facts through the lock scope instead of rediscovering them.

## Verification

Final head: `fe9695d717045ca156a45043793b9e097d2b65f7`

- Fresh Codex autoreview: no accepted/actionable findings, confidence 0.95.
- Focused local matrix: 179 tests passed.
- Final lock regression suite: 102 tests passed.
- `git diff --check`: passed.
- Public plugin SDK surface: no new branch-only export.

Exact-head AWS Crabbox run `run_0496c4c08e6c`:

- AWS `c7a.16xlarge`, Linux, Node 24.16.0, pnpm 11.2.2.
- Full production build passed.
- Seven real session/lock/doctor scenarios passed.
- 24-file matrix passed: 1,181 tests across eight Vitest shards, including the full context-engine integration that failed on the previous pushed head.
- `pnpm check:test-types` reached the existing `origin/main` failure only:
  `extensions/codex/src/app-server/bounded-turn.ts:223-224`.

Run: https://crabbox.openclaw.ai/portal/runs/run_0496c4c08e6c

The final Crabbox checkout is rebased onto current `origin/main` at `b5648b1d5ee0f21823ad5873f717a6532000b09a`. Its type gate asserts that these are the only two type errors and fails on any additional error; this PR does not touch `bounded-turn.ts`.

Direct Codex contract inspection:

- `../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:329-349`
- `../codex/codex-rs/core/src/session/session.rs:1068-1089`
- `../codex/codex-rs/app-server/src/request_processors/thread_lifecycle.rs:540-567`
- `../codex/codex-rs/app-server/src/request_processors/turn_processor.rs:736`
- `../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:1240-1243`

These paths confirm that thread resume/fork/history use the selected persisted rollout path and that turn start consumes the resumed thread state; OpenClaw therefore must project the canonical active transcript branch consistently before handing history to Codex.

## Real behavior proof

Behavior addressed: Prompt-time delivery mirrors, global metadata, side appends, and nested owned writes survive stale-manager operations without entering active model context or silently masking takeover.

Real environment tested: Linux AWS Crabbox using real session files, `acquireSessionWriteLock`, owned transcript publication, `SessionManager`, transcript navigation/checkpoints, Codex history projection, and the built `openclaw doctor --fix` CLI.

Exact steps or command run after this patch: `pnpm crabbox:run -- --provider aws --class fast --market on-demand --idle-timeout 90m --ttl 240m --timing-json --preflight --script /tmp/pr-93194-crabbox-e2e.ts`

Evidence after fix: Crabbox run `run_0496c4c08e6c` completed the production build, seven real scenarios, and 1,181 tests. The scenarios covered prompt-release delivery/global metadata, terminal side append after reopen, multi-controller publication, navigation/checkpoint/fork/Codex projection, malformed leaf controls, doctor repair, drained nested takeover propagation, and primary-error preservation.

Copied live terminal output:

```text
OpenClaw PR #93194 synced source hashes match local head fe9695d717
Node v24.16.0
[build-all] phase timings: total 158.9s
CRABBOX_PHASE:real-session-e2e
PR #93194 real session E2E passed
[test] passed 8 Vitest shards in 168.06s
Test Files  31 passed (31)
Tests  1181 passed (1181)
Known origin/main bounded-turn typecheck baseline confirmed; no extra type errors
PR #93194 Crabbox validation passed
```

Observed result after fix: Active context retained the intended user/assistant branch; side deliveries and metadata persisted across reopen/rewrite; navigation and Codex history selected the same canonical branch; doctor removed invalid hidden runtime state; drained takeover rejected outer success; an existing outer failure retained precedence.

What was not tested: A live external channel/provider delivery using production credentials was not exercised. The real on-disk session, lock, publication, navigation, Codex projection, and doctor paths used by that delivery were exercised directly.

## Release-note context

Fix embedded agent sessions losing or exposing concurrent prompt-time transcript updates when stale managers, transcript rewrites, or nested owned writes overlap. Thanks @snowzlm for the report and original fix.
